### PR TITLE
Implement content-aware grep with search_mode parameter (issue #80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,15 @@ nexus grep "TODO"  # Find all TODO comments
 nexus grep "def \w+" --file-pattern "**/*.py"  # Find function definitions
 nexus grep "error" --ignore-case  # Case-insensitive search
 nexus grep "TODO" --max-results 50  # Limit results
+
+# Search modes (v0.2.0+)
+nexus grep "revenue" --file-pattern "**/*.pdf"  # Auto mode: tries parsed first
+nexus grep "revenue" --file-pattern "**/*.pdf" --search-mode=parsed  # Only parsed content
+nexus grep "TODO" --search-mode=raw  # Only raw text (skip parsing)
+
+# Result shows source type
+# Match: TODO (parsed) ← from parsed PDF
+# Match: TODO (raw) ← from source code
 ```
 
 #### Work Queue Operations

--- a/examples/embedded_demo.py
+++ b/examples/embedded_demo.py
@@ -994,6 +994,24 @@ def main() -> None:
             print(f"   - {match['file']}:{match['line']}")
             print(f"     {match['content'].strip()}")
 
+        # NEW in v0.2.0 - search_mode parameter
+        print("\n62a. Testing grep() with search_mode parameter (v0.2.0)...")
+        print("   search_mode='auto': Try parsed text first, fallback to raw (default)")
+        auto_matches = nx_discover.grep("TODO", search_mode="auto")
+        print(f"   Found {len(auto_matches)} matches with auto mode")
+        for match in auto_matches[:2]:
+            source = match.get("source", "raw")
+            print(f"   - {match['file']}:{match['line']} (source: {source})")
+
+        print("\n   search_mode='raw': Only search raw file content (skip parsing)")
+        raw_matches = nx_discover.grep("TODO", search_mode="raw")
+        print(f"   Found {len(raw_matches)} matches with raw mode")
+
+        print("\n   search_mode='parsed': Only search parsed text (for PDFs/docs)")
+        parsed_matches = nx_discover.grep("TODO", search_mode="parsed")
+        print(f"   Found {len(parsed_matches)} matches with parsed mode")
+        print("   (Only includes files with parsed content)")
+
         print("\n63. Summary of file discovery operations:")
         print("   list() enhancements:")
         print("   ✓ recursive parameter - control depth of listing")

--- a/examples/fuse_cli_demo.sh
+++ b/examples/fuse_cli_demo.sh
@@ -361,6 +361,12 @@ echo "   $ nexus mount /mnt/nexus"
 echo "   $ grep 'pattern' /mnt/nexus/**/*.pdf.txt"
 echo ""
 
+print_info "💡 NEW: CLI grep with --search-mode (v0.2.0):"
+echo "   $ nexus grep 'revenue' --file-pattern '**/*.pdf' --search-mode=parsed"
+echo "   $ nexus grep 'TODO' --search-mode=raw"
+echo "   Results show source type: (parsed) or (raw)"
+echo ""
+
 # ============================================================================
 # Example 5: Find Command
 # ============================================================================

--- a/src/nexus/core/filesystem.py
+++ b/src/nexus/core/filesystem.py
@@ -176,6 +176,7 @@ class NexusFilesystem(ABC):
         file_pattern: str | None = None,
         ignore_case: bool = False,
         max_results: int = 1000,
+        search_mode: str = "auto",
     ) -> builtins.list[dict[str, Any]]:
         """
         Search file contents using regex patterns.
@@ -186,6 +187,10 @@ class NexusFilesystem(ABC):
             file_pattern: Optional glob pattern to filter files (e.g., "*.py")
             ignore_case: If True, perform case-insensitive search (default: False)
             max_results: Maximum number of results to return (default: 1000)
+            search_mode: Content search mode (default: "auto")
+                - "auto": Try parsed text first, fallback to raw
+                - "parsed": Only search parsed text
+                - "raw": Only search raw file content
 
         Returns:
             List of match dicts, each containing:
@@ -193,6 +198,7 @@ class NexusFilesystem(ABC):
             - line: Line number (1-indexed)
             - content: Matched line content
             - match: The matched text
+            - source: Source type - "parsed" or "raw"
 
         Examples:
             # Search for "TODO" in all files
@@ -200,6 +206,9 @@ class NexusFilesystem(ABC):
 
             # Search for function definitions in Python files
             fs.grep(r"def \\w+", file_pattern="**/*.py")
+
+            # Search only parsed PDFs
+            fs.grep("revenue", file_pattern="**/*.pdf", search_mode="parsed")
 
             # Case-insensitive search
             fs.grep("error", ignore_case=True)


### PR DESCRIPTION
Features implemented:
- Add search_mode parameter to grep() (auto, parsed, raw modes)
- Add source field to grep results (parsed/raw)
- Add --search-mode CLI option to nexus grep command
- Display source type in CLI output (parsed in magenta, raw in dim)

Documentation:
- Update README with search_mode examples
- Add examples in embedded_demo.py
- Add CLI search-mode demo in fuse_cli_demo.sh

This completes ~95% of issue #80. Remaining:
- Performance optimizations (caching parsed content in FUSE)

Closes nexi-lab/nexus#80