### PR TITLE
Add server startup script and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,21 @@ Nexus includes a JSON-RPC server that exposes the full NexusFileSystem interface
 
 ### Quick Start
 
+#### Method 1: Using the Startup Script (Recommended)
+
+```bash
+# Navigate to nexus directory
+cd /path/to/nexus
+
+# Start with defaults (host: 0.0.0.0, port: 8080, no auth)
+./start-server.sh
+
+# Or with custom options
+./start-server.sh --host localhost --port 8080 --api-key mysecret
+```
+
+#### Method 2: Direct Command
+
 ```bash
 # Start the server (optional API key authentication)
 nexus serve --host 0.0.0.0 --port 8080 --api-key mysecret
@@ -548,6 +563,60 @@ nexus serve --backend=gcs --gcs-bucket=my-bucket --api-key mysecret
 
 # Custom data directory
 nexus serve --data-dir /path/to/data
+```
+
+### Testing the Server
+
+Once the server is running, verify it's working:
+
+```bash
+# Health check
+curl http://localhost:8080/health
+# Expected: {"status": "healthy", "service": "nexus-rpc"}
+
+# Check available methods
+curl http://localhost:8080/api/nfs/status
+# Expected: {"status": "running", "service": "nexus-rpc", "version": "1.0", "methods": [...]}
+
+# List files (JSON-RPC)
+curl -X POST http://localhost:8080/api/nfs/list \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "list",
+    "params": {"path": "/", "recursive": false, "details": true},
+    "id": 1
+  }'
+
+# With API key
+curl -X POST http://localhost:8080/api/nfs/list \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer mysecretkey" \
+  -d '{"jsonrpc": "2.0", "method": "list", "params": {"path": "/"}, "id": 1}'
+```
+
+### Troubleshooting
+
+**Port Already in Use:**
+```bash
+# Find and kill process using port 8080
+lsof -ti:8080 | xargs kill -9
+
+# Or use a different port
+nexus serve --port 8081
+```
+
+**Module Not Found:**
+```bash
+# Activate virtual environment and install
+source .venv/bin/activate
+pip install -e .
+```
+
+**Permission Denied:**
+```bash
+# Use a directory you have write access to
+nexus serve --data-dir ~/nexus-data
 ```
 
 ### Deploying Nexus Server

--- a/src/nexus/server/rpc_server.py
+++ b/src/nexus/server/rpc_server.py
@@ -55,6 +55,19 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         """Override to use Python logging instead of stderr."""
         logger.info(f"{self.address_string()} - {format % args}")
 
+    def _set_cors_headers(self) -> None:
+        """Set CORS headers to allow requests from frontend."""
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Max-Age", "86400")
+
+    def do_OPTIONS(self) -> None:
+        """Handle OPTIONS requests (CORS preflight)."""
+        self.send_response(200)
+        self._set_cors_headers()
+        self.end_headers()
+
     def do_POST(self) -> None:
         """Handle POST requests (all RPC methods)."""
         try:
@@ -337,6 +350,7 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         body = encode_rpc_message(response_dict)
 
         self.send_response(200)
+        self._set_cors_headers()
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
@@ -366,6 +380,7 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         body = encode_rpc_message(data)
 
         self.send_response(status_code)
+        self._set_cors_headers()
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Nexus RPC Server Startup Script
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Starting Nexus RPC Server...${NC}"
+
+# Check if virtual environment exists
+if [ ! -d ".venv" ]; then
+    echo -e "${RED}Error: Virtual environment not found at .venv${NC}"
+    echo "Please run: python -m venv .venv && source .venv/bin/activate && pip install -e ."
+    exit 1
+fi
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Check if nexus is installed
+if ! python -c "import nexus" 2>/dev/null; then
+    echo -e "${RED}Error: Nexus package not found${NC}"
+    echo "Please run: pip install -e ."
+    exit 1
+fi
+
+# Default values
+HOST="${HOST:-0.0.0.0}"
+PORT="${PORT:-8080}"
+DATA_DIR="${DATA_DIR:-./nexus-data}"
+API_KEY="${API_KEY:-}"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        --data-dir)
+            DATA_DIR="$2"
+            shift 2
+            ;;
+        --api-key)
+            API_KEY="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--host HOST] [--port PORT] [--data-dir DIR] [--api-key KEY]"
+            exit 1
+            ;;
+    esac
+done
+
+# Create data directory if it doesn't exist
+if [ ! -d "$DATA_DIR" ]; then
+    echo -e "${BLUE}Creating data directory: $DATA_DIR${NC}"
+    mkdir -p "$DATA_DIR"
+fi
+
+# Build command
+CMD="python -m nexus.cli serve --host $HOST --port $PORT --data-dir $DATA_DIR"
+
+if [ -n "$API_KEY" ]; then
+    CMD="$CMD --api-key $API_KEY"
+fi
+
+echo -e "${GREEN}Configuration:${NC}"
+echo "  Host: $HOST"
+echo "  Port: $PORT"
+echo "  Data Directory: $DATA_DIR"
+if [ -n "$API_KEY" ]; then
+    echo "  Authentication: Enabled (API key required)"
+else
+    echo "  Authentication: Disabled (open access)"
+fi
+echo ""
+echo -e "${GREEN}Starting server...${NC}"
+echo "  Endpoint: http://$HOST:$PORT/api/nfs/{method}"
+echo "  Health check: http://$HOST:$PORT/health"
+echo ""
+echo -e "${BLUE}Press Ctrl+C to stop the server${NC}"
+echo ""
+
+# Run the server
+exec $CMD


### PR DESCRIPTION
## Summary

This PR adds a convenient startup script for the Nexus RPC server and consolidates server startup documentation into the main README.

## Changes

### New Files
- **start-server.sh**: Automated startup script with argument parsing
  - Supports `--host`, `--port`, `--data-dir`, `--api-key` flags
  - Activates virtual environment automatically
  - Provides clear usage instructions
  - Makes server startup more accessible

### Modified Files
- **README.md**: Enhanced server documentation
  - Added "Method 1: Using the Startup Script" section
  - Added "Testing the Server" section with curl examples
  - Added "Troubleshooting" section for common issues
  - Consolidated all server startup information in one place
  - Removed separate `SERVER_STARTUP.md` (now integrated)

- **src/nexus/server/rpc_server.py**: CORS support for frontend
  - Added `_set_cors_headers()` method
  - Added `do_OPTIONS()` handler for preflight requests
  - Applied CORS headers to all responses
  - Enables frontend integration without proxy

## Benefits
- ✅ **Easier Server Startup**: One command instead of manual activation + nexus serve
- ✅ **Better Documentation**: All server info in README instead of separate file
- ✅ **Frontend Integration**: CORS headers allow direct API calls from browser
- ✅ **Developer Experience**: Clear troubleshooting steps and testing examples

## Testing
Tested with:
- Default startup: `./start-server.sh`
- Custom options: `./start-server.sh --host localhost --port 8080`
- Health checks and API calls with curl
- Frontend integration with [nexus-frontend](https://github.com/nexi-lab/nexus-frontend) repository

## Usage Example

```bash
# Start server with defaults
./start-server.sh

# Start with custom configuration
./start-server.sh --host localhost --port 8080 --api-key mysecret --data-dir ./my-data

# Test the server
curl http://localhost:8080/health
```

## Related
- Supports frontend integration with nexi-lab/nexus-frontend
- Addresses feedback from Phase 1 frontend development
- Makes local development setup easier for new contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)