### PR TITLE
Fix directory listing duplicates and Dockerfile env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,8 @@ CMD sh -c " \
             --host ${NEXUS_HOST} \
             --port ${NEXUS_PORT} \
             --backend gcs \
-            --gcs-bucket ${NEXUS_GCS_BUCKET_NAME} \
-            ${NEXUS_GCS_PROJECT_ID:+--gcs-project $NEXUS_GCS_PROJECT_ID} \
+            --gcs-bucket ${NEXUS_GCS_BUCKET} \
+            ${NEXUS_GCS_PROJECT:+--gcs-project $NEXUS_GCS_PROJECT} \
             --data-dir ${NEXUS_DATA_DIR} \
             ${NEXUS_API_KEY:+--api-key $NEXUS_API_KEY}; \
     else \

--- a/src/nexus/core/nexus_fs_search.py
+++ b/src/nexus/core/nexus_fs_search.py
@@ -139,6 +139,12 @@ class NexusFSSearchMixin:
         # This ensures empty directories show up in listings
         directories = set()
 
+        # Extract directories from directory marker files in results (v0.3.9+)
+        # These are files with mime_type="inode/directory" created by mkdir
+        for meta in results:
+            if meta.mime_type == "inode/directory":
+                directories.add(meta.path)
+
         if not recursive:
             # For non-recursive listings, infer immediate subdirectories from file paths
             base_path = path if path != "/" else ""


### PR DESCRIPTION
## Summary

This PR fixes two critical issues:

1. **Completes the directory duplicates fix** - Directories now appear correctly in listings without duplicates
2. **Fixes Dockerfile environment variable mismatch** - Server now starts correctly with GCS backend

## Problem

### Issue 1: Directory Duplicates
The previous fix (#283) filtered out directory metadata markers from results but didn't add them to the directories set. This caused directories created with `mkdir()` to sometimes not appear correctly in non-recursive listings, leading to duplicate entries in the frontend.

### Issue 2: Dockerfile Environment Variables  
The deployment script passes `NEXUS_GCS_BUCKET` and `NEXUS_GCS_PROJECT` but the Dockerfile expected `NEXUS_GCS_BUCKET_NAME` and `NEXUS_GCS_PROJECT_ID`, causing startup failures.

## Solution

### Directory Duplicates Fix
Modified `src/nexus/core/nexus_fs_search.py` to:
- Extract directory paths from directory marker files (`mime_type="inode/directory"`)
- Add them to the `directories` set
- They're already filtered from file results (previous fix)
- Now properly represented as directory entries in output

### Dockerfile Fix
Updated `Dockerfile` CMD to use correct variable names:
- `NEXUS_GCS_BUCKET_NAME` → `NEXUS_GCS_BUCKET`
- `NEXUS_GCS_PROJECT_ID` → `NEXUS_GCS_PROJECT`

## Testing

✅ Local backend with mkdir and list operations  
✅ GCS backend deployment on nexus-server (136.117.224.98)  
✅ All unit tests passing including `test_mkdir_no_duplicate_entries_in_list`  
✅ Production API verified: **7 unique directories** (was 14 with duplicates)  
✅ All pre-commit hooks passed (ruff, mypy, RPC parity check)

## Before/After

**Before:** API returned 14 entries (7 duplicates)
```json
{
  "files": [
    {"path": "/workspace/agent1", "is_directory": false, "mime_type": "inode/directory"},
    {"path": "/workspace/agent1", "is_directory": true, "mime_type": null},
    ...
  ]
}
```

**After:** API returns 7 unique entries
```json
{
  "files": [
    {"path": "/workspace/agent1", "is_directory": true, "mime_type": null},
    {"path": "/workspace/agent2", "is_directory": true, "mime_type": null},
    ...
  ]
}
```

## Related Issues

Fixes directory duplicates visible in the frontend (screenshot provided by user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>