### PR TITLE
Add RPC auth logging and workspace management documentation

### DIFF
--- a/docs/api/rpc-api.md
+++ b/docs/api/rpc-api.md
@@ -333,6 +333,304 @@ POST /api/nfs/delete
 
 ---
 
+### Workspace Registry
+
+Before using workspace snapshots, directories must be registered as workspaces.
+
+#### register_workspace - Register a directory as a workspace
+
+```bash
+POST /api/nfs/register_workspace
+
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "register_workspace",
+  "params": {
+    "path": "/my-workspace",
+    "name": "main",
+    "description": "My main workspace",
+    "created_by": "alice",
+    "metadata": {
+      "project_id": "12345",
+      "team": "engineering"
+    }
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "path": "/my-workspace",
+    "name": "main",
+    "description": "My main workspace",
+    "created_by": "alice",
+    "created_at": "2025-01-15T10:30:00Z",
+    "metadata": {
+      "project_id": "12345",
+      "team": "engineering"
+    }
+  }
+}
+```
+
+---
+
+#### list_workspaces - List all registered workspaces
+
+```bash
+POST /api/nfs/list_workspaces
+
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "list_workspaces",
+  "params": {}
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": [
+    {
+      "path": "/my-workspace",
+      "name": "main",
+      "description": "My main workspace",
+      "created_by": "alice",
+      "created_at": "2025-01-15T10:30:00Z"
+    },
+    {
+      "path": "/team/project",
+      "name": "team-project",
+      "description": "Team collaboration workspace",
+      "created_at": "2025-01-15T11:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+#### get_workspace_info - Get workspace information
+
+```bash
+POST /api/nfs/get_workspace_info
+
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "method": "get_workspace_info",
+  "params": {
+    "path": "/my-workspace"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "result": {
+    "path": "/my-workspace",
+    "name": "main",
+    "description": "My main workspace",
+    "created_by": "alice",
+    "created_at": "2025-01-15T10:30:00Z",
+    "metadata": {
+      "project_id": "12345",
+      "team": "engineering"
+    }
+  }
+}
+```
+
+**Note:** Returns `null` if workspace not found.
+
+---
+
+#### unregister_workspace - Unregister a workspace
+
+```bash
+POST /api/nfs/unregister_workspace
+
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "method": "unregister_workspace",
+  "params": {
+    "path": "/my-workspace"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "result": true
+}
+```
+
+**Note:** This only removes the workspace registration. Files are NOT deleted.
+
+---
+
+### Workspace Snapshots
+
+Create, restore, and compare workspace snapshots for version control.
+
+#### workspace_snapshot - Create a snapshot
+
+```bash
+POST /api/nfs/workspace_snapshot
+
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "workspace_snapshot",
+  "params": {
+    "workspace_path": "/my-workspace",
+    "description": "Before refactoring",
+    "agent_id": "agent-123"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "result": {
+    "snapshot_number": 1,
+    "timestamp": "2025-01-15T12:00:00Z",
+    "description": "Before refactoring",
+    "file_count": 42,
+    "total_size": 1048576
+  }
+}
+```
+
+---
+
+#### workspace_log - List workspace snapshots
+
+```bash
+POST /api/nfs/workspace_log
+
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "workspace_log",
+  "params": {
+    "workspace_path": "/my-workspace",
+    "limit": 10
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "result": [
+    {
+      "snapshot_number": 2,
+      "timestamp": "2025-01-15T14:00:00Z",
+      "description": "After refactoring",
+      "file_count": 45
+    },
+    {
+      "snapshot_number": 1,
+      "timestamp": "2025-01-15T12:00:00Z",
+      "description": "Before refactoring",
+      "file_count": 42
+    }
+  ]
+}
+```
+
+---
+
+#### workspace_restore - Restore a snapshot
+
+```bash
+POST /api/nfs/workspace_restore
+
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "workspace_restore",
+  "params": {
+    "snapshot_number": 1,
+    "workspace_path": "/my-workspace"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "result": {
+    "restored": true,
+    "files_restored": 42,
+    "snapshot_number": 1,
+    "timestamp": "2025-01-15T12:00:00Z"
+  }
+}
+```
+
+---
+
+#### workspace_diff - Compare snapshots
+
+```bash
+POST /api/nfs/workspace_diff
+
+{
+  "jsonrpc": "2.0",
+  "id": 13,
+  "method": "workspace_diff",
+  "params": {
+    "snapshot_1": 1,
+    "snapshot_2": 2,
+    "workspace_path": "/my-workspace"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 13,
+  "result": {
+    "added": ["/my-workspace/new-file.txt"],
+    "modified": ["/my-workspace/config.json"],
+    "deleted": ["/my-workspace/old-file.txt"],
+    "summary": {
+      "added_count": 1,
+      "modified_count": 1,
+      "deleted_count": 1
+    }
+  }
+}
+```
+
+---
+
 ### Python Client
 
 Use the remote client to connect to a Nexus RPC server:

--- a/src/nexus/server/rpc_server.py
+++ b/src/nexus/server/rpc_server.py
@@ -1281,6 +1281,7 @@ class NexusRPCServer:
         self.host = host
         self.port = port
         self.api_key = api_key
+        self.auth_provider = auth_provider
         self._event_loop = asyncio.new_event_loop()
 
         # Auto-discover all @rpc_expose decorated methods
@@ -1343,8 +1344,12 @@ class NexusRPCServer:
         """Start server and handle requests."""
         logger.info(f"Starting Nexus RPC server on {self.host}:{self.port}")
         logger.info(f"Endpoint: http://{self.host}:{self.port}/api/nfs/{{method}}")
-        if self.api_key:
-            logger.info("Authentication: API key required")
+
+        # Check both authentication methods
+        if self.auth_provider:
+            logger.info(f"Authentication: Database provider ({type(self.auth_provider).__name__})")
+        elif self.api_key:
+            logger.info("Authentication: Static API key")
         else:
             logger.info("Authentication: None (open access)")
 


### PR DESCRIPTION
## Summary

This PR cherry-picks two improvements to the RPC server and documentation:

### 1. RPC Server Auth Logging Enhancement
- Add `auth_provider` attribute to server initialization
- Improve startup logging to distinguish between authentication methods:
  - Database provider (shows provider class name)
  - Static API key
  - No authentication

### 2. Workspace Management API Documentation
- Add comprehensive documentation for workspace registry operations:
  - `register_workspace` - Register a directory as a workspace
  - `list_workspaces` - List all registered workspaces
  - `get_workspace_info` - Get workspace information
  - `unregister_workspace` - Remove workspace registration
  
- Add documentation for workspace snapshot operations:
  - `workspace_snapshot` - Create a snapshot
  - `workspace_log` - List workspace snapshots
  - `workspace_restore` - Restore a snapshot
  - `workspace_diff` - Compare snapshots

All operations include complete JSON-RPC request/response examples.

## Changes

- [src/nexus/server/rpc_server.py](src/nexus/server/rpc_server.py:1284) - Add auth_provider logging
- [docs/api/rpc-api.md](docs/api/rpc-api.md) - Add 298 lines of workspace API documentation

## Benefits

- **Better debugging**: Server logs now clearly show which authentication method is active
- **Complete documentation**: Developers have clear examples for all workspace management operations
- **Improved DX**: JSON-RPC request/response examples make the API easier to use

🤖 Generated with [Claude Code](https://claude.com/claude-code)