### PR TITLE
Fix memory user_id context parsing bug

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -563,7 +563,7 @@ class NexusFS(
         """Parse context dict or OperationContext into OperationContext.
 
         Args:
-            context: Optional context dict or OperationContext with user, groups, tenant_id, etc.
+            context: Optional context dict or OperationContext with user_id, groups, tenant_id, etc.
 
         Returns:
             OperationContext instance
@@ -578,7 +578,7 @@ class NexusFS(
             context = {}
 
         return OperationContext(
-            user=context.get("user", "system"),
+            user=context.get("user_id", "system"),
             groups=context.get("groups", []),
             tenant_id=context.get("tenant_id"),
             agent_id=context.get("agent_id"),


### PR DESCRIPTION
## Summary
Fix critical bug where stored memories were incorrectly assigned `user_id="system"` instead of the authenticated user's ID.

## Problem
There was a **key mismatch** between two files:
- [`rpc_server.py:401`](../blob/main/src/nexus/server/rpc_server.py#L401) was setting `context_dict["user_id"] = context.user_id`
- [`nexus_fs.py:581`](../blob/main/src/nexus/core/nexus_fs.py#L581) was looking for `context.get("user", "system")`

This mismatch caused the context parsing to default to `"system"` because the expected key wasn't found.

## Example
**Before fix:**
```bash
# Store memory with authenticated user "admin"
nexus memory store --content "test" --namespace "/memory/admin/test"

# Query the stored memory
nexus memory query --namespace "/memory/admin/test"
# Result: user_id = "system"  ❌
```

**After fix:**
```bash
# Query the stored memory
nexus memory query --namespace "/memory/admin/test"
# Result: user_id = "admin"  ✅
```

## Solution
Changed `_parse_context()` in [`nexus_fs.py:581`](../blob/fix/memory-user-id-context/src/nexus/core/nexus_fs.py#L581) to use `"user_id"` key consistently:

```python
return OperationContext(
    user=context.get("user_id", "system"),  # Changed from "user" to "user_id"
    groups=context.get("groups", []),
    tenant_id=context.get("tenant_id"),
    agent_id=context.get("agent_id"),
    # ...
)
```

Also updated the docstring to reflect that the context dict uses `"user_id"` instead of `"user"`.

## Impact
- ✅ Memories now correctly store the authenticated user's ID
- ✅ Access control properly attributes memory ownership
- ✅ No backward compatibility concerns - using only `"user_id"` going forward

## Related Issues
- Discovered while implementing memory management features
- Related to #405 (update_memory implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)