### PR TITLE
Add env file check to docker init command

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -286,6 +286,9 @@ cmd_clean() {
 
 cmd_init() {
     print_banner
+    check_docker
+    check_env_file
+
     echo "🔧 INITIALIZATION MODE"
     echo ""
     echo "This will:"


### PR DESCRIPTION
## Summary
- Added `check_docker` and `check_env_file` to `cmd_init()` in docker-start.sh
- Ensures environment variables are properly loaded before initialization
- Follows the same pattern as `cmd_start()` and `cmd_build()`

## Why
The `--init` command rebuilds and starts all services from scratch, but wasn't loading environment variables from `.env.local` or `.env.production` before doing so. This could lead to containers starting with stale or missing environment configuration.

## Changes
- Added `check_docker` check after `print_banner` in `cmd_init()`
- Added `check_env_file` check to load environment files before initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)