### PR TITLE
🚨 HOTFIX: Restore missing sync_mount function name (main branch broken)

### DIFF
--- a/src/nexus/core/nexus_fs_mounts.py
+++ b/src/nexus/core/nexus_fs_mounts.py
@@ -680,8 +680,7 @@ class NexusFSMountsMixin:
         return {"loaded": loaded, "synced": synced, "failed": failed, "errors": errors}
 
     @rpc_expose(description="Sync metadata from connector backend")
-    def 
-    (
+    def sync_mount(
         self,
         mount_point: str,
         recursive: bool = True,


### PR DESCRIPTION
## 🚨 CRITICAL HOTFIX

The main branch is currently broken due to a syntax error introduced in PR #471.

## Problem
Line 683 in `src/nexus/core/nexus_fs_mounts.py` has an incomplete function definition:
```python
def 
(
    self,
```

This causes a `SyntaxError` that prevents all imports, breaking:
- All tests on main branch
- Any PRs merging with main
- Any deployments from main

## Root Cause
PR #471 was merged with a missing function name - the `sync_mount` identifier was accidentally deleted.

## Solution
Restore the function name: `def` → `def sync_mount`

## Testing
- ✅ Python syntax validation passes locally
- ✅ All pre-commit hooks pass

## Impact
This is a one-line fix that restores basic Python syntax. Once merged, all downstream PRs and tests will be unblocked.

## Related
- Fixes errors from: https://github.com/nexi-lab/nexus/actions/runs/19521794284/job/55886617561
- Unblocks PR #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)