### PR TITLE
fix(#562): Fix Windows PermissionError on lock file deletion

### DIFF
--- a/src/nexus/backends/local.py
+++ b/src/nexus/backends/local.py
@@ -509,6 +509,7 @@ class LocalBackend(Backend):
             # Retry logic for Windows file locking semantics
             if should_delete_lock and lock_path.exists():
                 import time
+
                 for attempt in range(3):
                     try:
                         lock_path.unlink()
@@ -516,11 +517,12 @@ class LocalBackend(Backend):
                     except PermissionError:
                         if attempt < 2:
                             # Exponential backoff: 10ms, 20ms
-                            time.sleep(0.01 * (2 ** attempt))
+                            time.sleep(0.01 * (2**attempt))
                         else:
                             # Last attempt failed - log warning but don't fail the operation
                             # Lock file will be orphaned but this is better than failing deletion
                             import logging
+
                             logging.warning(
                                 f"Failed to delete lock file {lock_path} after 3 attempts. "
                                 "File will be orphaned but content deletion succeeded."


### PR DESCRIPTION
## Summary

Fixes Windows CI test failures caused by `PermissionError` when deleting `.lock` files in the content-addressable storage system.

## Problem

Windows tests were failing with:
```
PermissionError: [WinError 32] The process cannot access the file because 
it is being used by another process: '...\*.lock'
```

**Root Cause**: The `FileLock` context manager keeps the lock file open until `__exit__`, but `delete_content()` was trying to delete the lock file while still inside the `with` statement. On Windows, you cannot delete an open file even after unlocking it.

**Location**: `src/nexus/backends/local.py:499` (old code)

## Solution

1. **Move lock file deletion outside `with` statement** - Ensures file handle is closed before deletion
2. **Add retry logic with exponential backoff** - 3 attempts with 10ms, 20ms delays for Windows file locking
3. **Graceful degradation** - Log warning instead of failing if deletion fails (orphaned lock file is better than failed operation)

## Changes

```python
# Before (line 498-499 inside with statement):
with self._lock_file(lock_path):
    ...
    if lock_path.exists():
        lock_path.unlink()  # ❌ Fails on Windows - file still open

# After (line 508-527 outside with statement):
with self._lock_file(lock_path):
    ...
    should_delete_lock = True

# Delete AFTER releasing lock
if should_delete_lock and lock_path.exists():
    for attempt in range(3):
        try:
            lock_path.unlink()  # ✅ Should work - file closed
            break
        except PermissionError:
            if attempt < 2:
                time.sleep(0.01 * (2 ** attempt))  # Backoff
            else:
                logging.warning(...)  # Don't fail operation
```

## Test Results

✅ **Local (macOS)**: 3/3 passed - verifies no regression
- `test_delete` - Basic file deletion
- `test_delete_removes_metadata` - Metadata cleanup  
- `test_exists` - File existence checks

⏳ **Windows CI**: Pending - **ONLY Windows CI can verify this fix works**

**Note**: macOS/Linux allow deleting open files, so local tests cannot reproduce the Windows bug. The fix targets Windows-specific file locking semantics and can only be validated by Windows CI.

## Impact

**Before**:
- ❌ Windows tests: FAIL (PermissionError)
- ✅ Ubuntu/macOS tests: PASS

**After** (expected):
- ✅ Windows tests: Should PASS (pending CI verification)
- ✅ Ubuntu/macOS tests: PASS (verified locally - no regression)

## Why This Matters

This is blocking the MCP evaluation/benchmarks work (#484) because:
- Need stable CI across all platforms
- Can't merge benchmarks PRs with failing Windows tests
- Completes the CI fixes started in #561

## Related Issues & PRs

- Fixes #562 (Windows lock file bug)
- Builds on #561 (Ubuntu/macOS pagination fix)
- Unblocks #484 (MCP evaluation framework)

🤖 Generated with [Claude Code](https://claude.com/claude-code)