### PR TITLE
Fix: Replace ORM auto-creation with proper migration-based initialization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -124,8 +124,11 @@ nexus-frontend/
 # Examples (not needed in production)
 examples/
 
-# Scripts (dev-only)
-scripts/
+# Scripts (dev-only - exclude shell scripts and most Python scripts)
+scripts/*.sh
+scripts/*.py
+# But keep init_database.py for database initialization in Docker
+!scripts/init_database.py
 *.sh
 # But keep docker-entrypoint.sh for container startup
 !docker-entrypoint.sh

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,5 @@ examples/cli/
 # GCS credentials - never commit!
 gcs-credentials.json
 .env.railway
+aws-config
+aws-credentials

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY src/ ./src/
 COPY alembic/ ./alembic/
 COPY alembic.ini pyproject.toml README.md ./
 COPY configs/ ./configs/
+COPY scripts/init_database.py ./scripts/init_database.py
 COPY docker-entrypoint.sh /usr/local/bin/
 
 # Make entrypoint executable

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -349,19 +349,6 @@ cmd_build() {
     check_aws_credentials
     check_frontend_repo
 
-    echo "🧹 Cleaning up old sandbox containers..."
-    docker ps -a --filter "ancestor=nexus-runtime:latest" -q | xargs -r docker rm -f 2>/dev/null || true
-    echo ""
-
-    echo "🧹 Stopping and removing all existing Nexus containers..."
-    # Stop and remove all containers with 'nexus' in the name (including manually started ones)
-    docker ps -a --filter "name=nexus" -q | xargs -r docker stop 2>/dev/null || true
-    docker ps -a --filter "name=nexus" -q | xargs -r docker rm 2>/dev/null || true
-
-    # Also use docker-compose down to clean up networks and volumes
-    docker compose -f "$COMPOSE_FILE" down
-    echo ""
-
     echo "🔨 Building Docker images..."
     echo ""
 
@@ -387,7 +374,22 @@ cmd_build() {
     echo ""
     echo "✅ All images built successfully!"
     echo ""
-    echo "Starting services..."
+
+    # Only stop containers after successful build
+    echo "🧹 Cleaning up old sandbox containers..."
+    docker ps -a --filter "ancestor=nexus-runtime:latest" -q | xargs -r docker rm -f 2>/dev/null || true
+    echo ""
+
+    echo "🧹 Stopping and removing all existing Nexus containers..."
+    # Stop and remove all containers with 'nexus' in the name (including manually started ones)
+    docker ps -a --filter "name=nexus" -q | xargs -r docker stop 2>/dev/null || true
+    docker ps -a --filter "name=nexus" -q | xargs -r docker rm 2>/dev/null || true
+
+    # Also use docker-compose down to clean up networks and volumes
+    docker compose -f "$COMPOSE_FILE" down
+    echo ""
+
+    echo "🚀 Starting services with new images..."
     docker compose -f "$COMPOSE_FILE" up -d
 
     echo ""

--- a/scripts/init_database.py
+++ b/scripts/init_database.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Database initialization script for Nexus.
+
+Handles both fresh and existing databases:
+- Fresh databases: Creates schema via SQLAlchemy, stamps with latest migration
+- Existing databases: Runs pending migrations via Alembic
+
+This replaces the old ORM auto-creation approach with proper migration-based setup.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+
+from alembic import command
+
+
+def init_database(database_url: str) -> None:
+    """Initialize database schema and migrations.
+
+    Args:
+        database_url: SQLAlchemy database URL
+    """
+    print("🔍 Checking database state...")
+
+    # Create engine
+    engine = create_engine(database_url)
+    inspector = inspect(engine)
+
+    # Check if alembic_version table exists and has a version
+    has_alembic_version = "alembic_version" in inspector.get_table_names()
+    has_migration_version = False
+
+    if has_alembic_version:
+        # Check if table has any version recorded
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT version_num FROM alembic_version"))
+            has_migration_version = result.fetchone() is not None
+
+    # Check if base tables exist (check for a core table like 'file_paths')
+    has_tables = "file_paths" in inspector.get_table_names()
+
+    if has_migration_version:
+        # Database has migration history - just run pending migrations
+        print("✓ Database has migration history")
+        print("🔄 Running pending migrations...")
+
+        alembic_cfg = Config("alembic.ini")
+        command.upgrade(alembic_cfg, "head")
+
+        print("✓ Database migrations up to date")
+
+    elif has_tables:
+        # Database has tables but no migration history
+        # This is an existing database created via ORM auto-creation
+        print("⚠️  Database has tables but no migration history")
+        print("📌 Stamping database with latest migration version...")
+
+        alembic_cfg = Config("alembic.ini")
+        command.stamp(alembic_cfg, "head")
+
+        print("✓ Database stamped with current schema version")
+        print("ℹ️  Future schema changes will be applied via migrations")
+
+    else:
+        # Fresh database - create schema from models
+        print("📊 Fresh database detected - creating schema...")
+
+        from nexus.storage.models import Base
+
+        # Create all tables
+        Base.metadata.create_all(engine)
+
+        print("✓ Database schema created")
+        print("📌 Stamping with latest migration version...")
+
+        alembic_cfg = Config("alembic.ini")
+        command.stamp(alembic_cfg, "head")
+
+        print("✓ Database initialized successfully")
+
+    engine.dispose()
+
+
+def main():
+    """Main entry point."""
+    database_url = os.getenv("NEXUS_DATABASE_URL")
+    if not database_url:
+        print("ERROR: NEXUS_DATABASE_URL not set", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        init_database(database_url)
+    except Exception as e:
+        print(f"ERROR: Failed to initialize database: {e}", file=sys.stderr)
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -2338,7 +2338,7 @@ wheels = [
 
 [[package]]
 name = "nexus-ai-fs"
-version = "0.5.6"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Problem

The database initialization had two competing approaches causing an anti-pattern:
- **ORM auto-creation**: `Base.metadata.create_all()` in docker-entrypoint.sh
- **Alembic migrations**: Which silently failed with `|| true`

This resulted in:
- ❌ No single source of truth for schema
- ❌ Silent migration failures
- ❌ Unpredictable database state across deployments
- ❌ No reliable way to track schema version

## Solution

Implemented smart database initialization script that handles all scenarios:

### 1. Fresh Databases
Creates schema via SQLAlchemy + stamps with latest migration version

### 2. Legacy Databases
Has tables but no migration history → Stamps existing schema + enables future migrations

### 3. Migrated Databases  
Has migration history → Runs pending migrations only

### 4. Edge Case
Empty `alembic_version` table → Treats as legacy and stamps

## Changes

### Core Files
- **scripts/init_database.py**: New initialization script with intelligent detection
- **docker-entrypoint.sh**: Replaced 62 lines of complex bash/python with clean script call
- **Dockerfile**: Copy init_database.py into container
- **.dockerignore**: Allow init_database.py through build context

### Developer Experience
- **docker-start.sh**: Build images first, stop containers only after success (safer workflow)

## Testing

Verified all scenarios work correctly:

### SQLite
- ✅ Fresh database
- ✅ Legacy database (has tables, no migrations)
- ✅ Migrated database (has migration history)

### PostgreSQL
- ✅ Fresh database
- ✅ Legacy database
- ✅ Migrated database
- ✅ Empty alembic_version table edge case

## Benefits

1. ✅ **Single source of truth**: All schema changes go through migrations
2. ✅ **Predictable state**: Always know which migration version is applied
3. ✅ **Backward compatible**: Existing deployments seamlessly transition
4. ✅ **No silent failures**: Clear error messages and proper exit codes
5. ✅ **Simplified maintenance**: One initialization path instead of two competing ones

## Migration Path

Existing deployments will automatically:
1. Detect they have tables but no migration tracking
2. Stamp with current schema version
3. Enable future migrations

Future migrations can be created with confidence:
```bash
alembic revision --autogenerate -m "add_new_feature"
alembic upgrade head
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)