### PR TITLE
feat: Add frontend development mode with hot reload support

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -264,8 +264,9 @@ services:
         max-file: "3"
 
   # ============================================
-  # Frontend (React + Vite)
+  # Frontend (React + Vite) - Production Build
   # ============================================
+  # Use --profile production to start this instead of dev
   frontend:
     build:
       context: ../nexus-frontend
@@ -290,6 +291,56 @@ services:
       - "${FRONTEND_PORT:-5173}:80"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    networks:
+      - nexus-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    profiles:
+      - production
+
+  # ============================================
+  # Frontend Dev (React + Vite) - Hot Reload
+  # ============================================
+  frontend-dev:
+    build:
+      context: ../nexus-frontend
+      dockerfile: Dockerfile
+      target: builder  # Build only the builder stage
+    image: nexus-frontend:dev
+    container_name: nexus-frontend-dev
+    restart: unless-stopped
+    depends_on:
+      nexus:
+        condition: service_healthy
+    environment:
+      # Frontend configuration
+      VITE_NEXUS_API_URL: ${VITE_NEXUS_API_URL:-http://localhost:8080}
+      VITE_LANGGRAPH_API_URL: ${VITE_LANGGRAPH_API_URL:-http://localhost:2024}
+      VITE_NEXUS_SERVER_URL: ${VITE_NEXUS_SERVER_URL:-http://nexus:8080}
+    volumes:
+      # Mount source code for hot reload
+      - ../nexus-frontend/src:/app/src:delegated
+      - ../nexus-frontend/public:/app/public:delegated
+      - ../nexus-frontend/index.html:/app/index.html:ro
+      - ../nexus-frontend/vite.config.ts:/app/vite.config.ts:ro
+      - ../nexus-frontend/tsconfig.json:/app/tsconfig.json:ro
+      - ../nexus-frontend/tsconfig.app.json:/app/tsconfig.app.json:ro
+      - ../nexus-frontend/tsconfig.node.json:/app/tsconfig.node.json:ro
+      - ../nexus-frontend/.env:/app/.env:ro
+      - ../nexus-frontend/.env.local:/app/.env.local:ro
+      # Don't mount node_modules (use container's version)
+    ports:
+      - "${FRONTEND_PORT:-5173}:5173"
+    command: ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5173"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -15,10 +15,10 @@
 #   ./docker-start.sh --env=production   # Use production environment files
 #
 # Services:
-#   - postgres:    PostgreSQL database (port 5432)
-#   - nexus:       Nexus RPC server (port 8080)
-#   - langgraph:   LangGraph agent server (port 2024)
-#   - frontend:    React web UI (port 5173)
+#   - postgres:      PostgreSQL database (port 5432)
+#   - nexus:         Nexus RPC server (port 8080)
+#   - langgraph:     LangGraph agent server (port 2024)
+#   - frontend-dev:  React web UI with hot reload (port 5173, dev mode)
 
 set -e  # Exit on error
 
@@ -247,10 +247,16 @@ check_frontend_repo() {
 show_services() {
     cat << EOF
 📦 Services:
-   • postgres    - PostgreSQL database (port 5432)
-   • nexus       - Nexus RPC server (port 8080)
-   • langgraph   - LangGraph agent (port 2024)
-   • frontend    - React web UI (port 5173)
+   • postgres      - PostgreSQL database (port 5432)
+   • nexus         - Nexus RPC server (port 8080)
+   • langgraph     - LangGraph agent (port 2024)
+   • frontend-dev  - React web UI with hot reload (port 5173)
+
+💡 Development Mode (Hot Reload Enabled):
+   Changes to nexus-frontend/src/* will auto-reload in the browser.
+
+   To use production mode instead:
+     docker compose -f docker-compose.demo.yml --profile production up frontend
 EOF
     echo ""
 }
@@ -592,14 +598,14 @@ cmd_urls() {
 ║                      🌐 Access URLs                              ║
 ╚═══════════════════════════════════════════════════════════════════╝
 
-  🎨 Frontend:        http://localhost:5173
+  🎨 Frontend (Dev):  http://localhost:5173  (Hot reload enabled)
   🔧 Nexus API:       http://localhost:8080
   🔮 LangGraph:       http://localhost:2024
   🗄️  PostgreSQL:     localhost:5432
 
   📊 Health Checks:
      • Nexus:         curl http://localhost:8080/health
-     • Frontend:      curl http://localhost:5173/health
+     • Frontend:      curl http://localhost:5173
      • LangGraph:     curl http://localhost:2024/ok
 
 ╔═══════════════════════════════════════════════════════════════════╗
@@ -614,11 +620,12 @@ cmd_urls() {
   Docker commands:
     All logs:        docker compose -f docker-compose.demo.yml logs -f
     Nexus logs:      docker logs -f nexus-server
-    Frontend logs:   docker logs -f nexus-frontend
+    Frontend logs:   docker logs -f nexus-frontend-dev
     LangGraph logs:  docker logs -f nexus-langgraph
 
   Shell access:
     Nexus:           docker exec -it nexus-server sh
+    Frontend:        docker exec -it nexus-frontend-dev sh
     PostgreSQL:      docker exec -it nexus-postgres psql -U postgres -d nexus
 
 EOF


### PR DESCRIPTION
## Summary
- Add frontend-dev service with hot reload for faster local development
- Move production frontend build to `--profile production` flag
- Update documentation in docker-start.sh to reflect dev vs prod modes

## Changes
This PR adds a new `frontend-dev` service to `docker-compose.demo.yml` that mounts the source code for live development with hot reload. The production frontend build is now available via the `production` profile.

**docker-compose.demo.yml:**
- Added `frontend-dev` service with source code volume mounts for hot reload
- Moved existing `frontend` service to `production` profile
- Configured dev service to run `npm run dev` with host binding

**docker-start.sh:**
- Updated service descriptions to distinguish dev vs prod modes
- Updated URLs and health check documentation
- Added instructions for using production mode

## Benefits
- Faster local development with instant hot reload
- No need to rebuild container for frontend changes
- Production builds still available via profile flag
- Clearer separation between dev and prod environments

## Test Plan
- [x] Start services with `./docker-start.sh`
- [x] Verify frontend-dev service starts with hot reload
- [x] Make changes to frontend source code and verify hot reload works
- [x] Test production mode with `docker compose -f docker-compose.demo.yml --profile production up frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)