### PR TITLE
feat(#480): Add server-side chunked streaming for reads

### DIFF
--- a/src/nexus/remote/client.py
+++ b/src/nexus/remote/client.py
@@ -1049,11 +1049,75 @@ class RemoteNexusFS(NexusFSLLMMixin, NexusFilesystem):
         )
         return result  # type: ignore[no-any-return]
 
-    def stream(self, path: str, chunk_size: int = 8192, context: Any = None) -> Any:  # noqa: ARG002
-        """Stream file content in chunks.
+    def stat(
+        self,
+        path: str,
+        context: Any = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """Get file metadata without reading content.
 
-        Note: Streaming over RPC is not efficient. This method reads the entire
-        file and yields it in chunks. For true streaming, use direct file access.
+        This is useful for getting file size before streaming, or checking
+        file properties without the overhead of reading large files.
+
+        Args:
+            path: Virtual path to stat
+            context: Unused in remote client (handled server-side)
+
+        Returns:
+            Dict with file metadata:
+                - size: File size in bytes
+                - etag: Content hash
+                - version: Version number
+                - modified_at: Last modification timestamp
+                - is_directory: Whether path is a directory
+
+        Raises:
+            NexusFileNotFoundError: If file doesn't exist
+        """
+        result = self._call_rpc("stat", {"path": path})
+        return result  # type: ignore[no-any-return]
+
+    def read_range(
+        self,
+        path: str,
+        start: int,
+        end: int,
+        context: Any = None,  # noqa: ARG002
+    ) -> bytes:
+        """Read a specific byte range from a file.
+
+        This method enables memory-efficient streaming by fetching file content
+        in chunks without loading the entire file into memory.
+
+        Args:
+            path: Virtual path to read
+            start: Start byte offset (inclusive, 0-indexed)
+            end: End byte offset (exclusive)
+            context: Unused in remote client (handled server-side)
+
+        Returns:
+            bytes: Content from start to end (exclusive)
+
+        Raises:
+            NexusFileNotFoundError: If file doesn't exist
+            ValueError: If start/end are invalid
+        """
+        result = self._call_rpc(
+            "read_range",
+            {"path": path, "start": start, "end": end},
+        )
+        # Result should be bytes (base64-decoded by protocol)
+        if isinstance(result, str):
+            import base64
+
+            return base64.b64decode(result)
+        return result  # type: ignore[no-any-return]
+
+    def stream(self, path: str, chunk_size: int = 8192, context: Any = None) -> Any:  # noqa: ARG002
+        """Stream file content in chunks using server-side range reads.
+
+        This method fetches file content in chunks using read_range() RPC calls,
+        avoiding loading the entire file into memory at once.
 
         Args:
             path: Virtual path to stream
@@ -1063,13 +1127,19 @@ class RemoteNexusFS(NexusFSLLMMixin, NexusFilesystem):
         Yields:
             bytes: Chunks of file content
         """
-        # Read entire file (RPC doesn't support true streaming)
-        content = self.read(path)
-        assert isinstance(content, bytes), "Expected bytes from read()"
+        # Get file size using stat() - does NOT read file content
+        info = self.stat(path)
+        file_size = info.get("size") or 0
 
-        # Yield in chunks
-        for i in range(0, len(content), chunk_size):
-            yield content[i : i + chunk_size]
+        # Stream using read_range() calls
+        offset = 0
+        while offset < file_size:
+            end = min(offset + chunk_size, file_size)
+            chunk = self.read_range(path, offset, end)
+            if not chunk:
+                break
+            yield chunk
+            offset += len(chunk)
 
     def write(
         self,


### PR DESCRIPTION
Implement memory-efficient streaming for large file reads over RPC:

- Add `stat()` RPC to get file metadata (size, etag, version) without reading content
- Add `read_range(path, start, end)` RPC for byte-range reads
- Add `stream_content()` to BaseBlobStorageConnector with default implementation
- Override `_stream_blob()` in GCSConnectorBackend (uses BytesIO buffer)
- Override `_stream_blob()` in S3ConnectorBackend (uses iter_chunks for true streaming)
- Update RemoteNexusFS.stream() to use stat() + read_range() instead of loading entire file
- Update AsyncRemoteNexusFS.stream() for async streaming

Benefits:
- Client memory usage is now O(chunk_size) not O(file_size)
- First chunk available immediately (no waiting for full download)
- Supports streaming GB+ files without OOM
- Fully backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)