### PR TITLE
fix: propagate auth context through skills RPC

### DIFF
--- a/src/nexus/core/nexus_fs_skills.py
+++ b/src/nexus/core/nexus_fs_skills.py
@@ -136,7 +136,7 @@ class NexusFSSkillsMixin:
         template: str = "basic",
         tier: str = "user",
         author: str | None = None,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> dict[str, Any]:
         """Create a new skill from template.
 
@@ -160,7 +160,7 @@ class NexusFSSkillsMixin:
                 template=template,
                 tier=tier,
                 author=author,
-                context=_context,
+                context=context,
             )
             return {
                 "skill_path": skill_path,
@@ -181,7 +181,7 @@ class NexusFSSkillsMixin:
         author: str | None = None,
         source_url: str | None = None,
         metadata: dict[str, Any] | None = None,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> dict[str, Any]:
         """Create a skill from custom content.
 
@@ -209,7 +209,7 @@ class NexusFSSkillsMixin:
                 author=author,
                 source_url=source_url,
                 metadata=metadata,
-                context=_context,
+                context=context,
             )
             return {
                 "skill_path": skill_path,
@@ -233,7 +233,7 @@ class NexusFSSkillsMixin:
         extract_tables: bool = False,
         extract_images: bool = False,
         _author: str | None = None,  # Unused: plugin manages authorship
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         """Create a skill from file or URL (auto-detects type).
 
@@ -349,7 +349,7 @@ class NexusFSSkillsMixin:
         self,
         tier: str | None = None,
         include_metadata: bool = True,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> dict[str, Any]:
         """List all skills.
 
@@ -364,7 +364,7 @@ class NexusFSSkillsMixin:
         registry = self._get_skill_registry()
 
         async def list_skills() -> dict[str, Any]:
-            await registry.discover(context=_context)
+            await registry.discover(context=context)
             skills = registry.list_skills(tier=tier, include_metadata=include_metadata)
 
             # Convert SkillMetadata objects to dicts
@@ -398,7 +398,7 @@ class NexusFSSkillsMixin:
     def skills_info(
         self,
         skill_name: str,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> dict[str, Any]:
         """Get detailed skill information.
 
@@ -412,7 +412,7 @@ class NexusFSSkillsMixin:
         registry = self._get_skill_registry()
 
         async def get_info() -> dict[str, Any]:
-            await registry.discover(context=_context)
+            await registry.discover(context=context)
             metadata = registry.get_metadata(skill_name)
 
             skill_info = {
@@ -446,7 +446,7 @@ class NexusFSSkillsMixin:
         target_name: str,
         tier: str = "agent",
         author: str | None = None,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> dict[str, Any]:
         """Fork an existing skill.
 
@@ -464,7 +464,7 @@ class NexusFSSkillsMixin:
         registry = self._get_skill_registry()
 
         async def fork() -> dict[str, Any]:
-            await registry.discover(context=_context)
+            await registry.discover(context=context)
             forked_path = await manager.fork_skill(
                 source_name=source_name,
                 target_name=target_name,
@@ -486,7 +486,7 @@ class NexusFSSkillsMixin:
         skill_name: str,
         source_tier: str = "agent",
         target_tier: str = "tenant",
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         """Publish skill to another tier.
 
@@ -522,7 +522,7 @@ class NexusFSSkillsMixin:
         query: str,
         tier: str | None = None,
         limit: int = 10,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         """Search skills by description.
 
@@ -552,7 +552,7 @@ class NexusFSSkillsMixin:
         submitted_by: str,
         reviewers: list[str] | None = None,
         comments: str | None = None,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         """Submit a skill for approval.
 
@@ -592,7 +592,7 @@ class NexusFSSkillsMixin:
         reviewer_type: str = "user",
         comments: str | None = None,
         tenant_id: str | None = None,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         """Approve a skill for publication.
 
@@ -634,7 +634,7 @@ class NexusFSSkillsMixin:
         reviewer_type: str = "user",
         comments: str | None = None,
         tenant_id: str | None = None,
-        _context: OperationContext | None = None,
+        context: OperationContext | None = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         """Reject a skill for publication.
 

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -612,8 +612,10 @@ async def _auto_dispatch(method: str, params: Any, context: Any) -> Any:
     for param_name, _param in sig.parameters.items():
         if param_name == "self":
             continue
-        elif param_name == "context":
-            kwargs["context"] = context
+        # Support both "context" and "_context" parameter names.
+        # Skills methods intentionally use "_context" to avoid shadowing/conflicts.
+        elif param_name in ("context", "_context"):
+            kwargs[param_name] = context
         elif hasattr(params, param_name):
             kwargs[param_name] = getattr(params, param_name)
 

--- a/tests/unit/skills/test_skill_exporter.py
+++ b/tests/unit/skills/test_skill_exporter.py
@@ -27,7 +27,7 @@ class MockFilesystem:
         search_path = path if path.endswith("/") else path + "/"
         return any(f.startswith(search_path) for f in self._files)
 
-    def is_directory(self, path: str) -> bool:
+    def is_directory(self, path: str, context=None) -> bool:
         if path in self._files:
             return False
         # Handle paths that may or may not end with /
@@ -40,6 +40,8 @@ class MockFilesystem:
         recursive: bool = True,
         details: bool = False,
         prefix: str | None = None,
+        show_parsed: bool = True,
+        context=None,
     ) -> list[str] | list[dict]:
         if not path.endswith("/"):
             path += "/"
@@ -57,9 +59,11 @@ class MockFilesystem:
             return [{"path": f, "size": len(self._files[f])} for f in files]
         return files
 
-    def read(self, path: str) -> bytes:
+    def read(self, path: str, context=None, return_metadata: bool = False) -> bytes:
         if path not in self._files:
             raise FileNotFoundError(f"File not found: {path}")
+        if return_metadata:
+            return {"content": self._files[path]}
         return self._files[path]
 
 

--- a/tests/unit/skills/test_skill_manager.py
+++ b/tests/unit/skills/test_skill_manager.py
@@ -27,7 +27,7 @@ class MockFilesystem:
         search_path = path if path.endswith("/") else path + "/"
         return any(f.startswith(search_path) for f in list(self._files) + list(self._directories))
 
-    def is_directory(self, path: str) -> bool:
+    def is_directory(self, path: str, context=None) -> bool:
         """Check if path is a directory."""
         if path in self._files:
             return False
@@ -40,6 +40,8 @@ class MockFilesystem:
         recursive: bool = True,
         details: bool = False,
         prefix: str | None = None,
+        show_parsed: bool = True,
+        context=None,
     ) -> list[str] | list[dict]:
         """List files in directory."""
         if not path.endswith("/"):
@@ -60,10 +62,12 @@ class MockFilesystem:
             return [{"path": f, "size": len(self._files[f])} for f in files]
         return files
 
-    def read(self, path: str) -> bytes:
+    def read(self, path: str, context=None, return_metadata: bool = False) -> bytes:
         """Read file content."""
         if path not in self._files:
             raise FileNotFoundError(f"File not found: {path}")
+        if return_metadata:
+            return {"content": self._files[path]}
         return self._files[path]
 
     def write(self, path: str, content: bytes) -> None:

--- a/tests/unit/skills/test_skill_registry.py
+++ b/tests/unit/skills/test_skill_registry.py
@@ -31,7 +31,7 @@ class MockFilesystem:
         search_path = path if path.endswith("/") else path + "/"
         return any(f.startswith(search_path) for f in self._files)
 
-    def is_directory(self, path: str) -> bool:
+    def is_directory(self, path: str, context=None) -> bool:
         """Check if path is a directory."""
         if path in self._files:
             return False  # It's a file
@@ -46,6 +46,8 @@ class MockFilesystem:
         recursive: bool = True,
         details: bool = False,
         prefix: str | None = None,
+        show_parsed: bool = True,
+        context=None,
     ) -> list[str] | list[dict]:
         """List files in directory."""
         if not path.endswith("/"):
@@ -67,10 +69,13 @@ class MockFilesystem:
             return [{"path": f, "size": len(self._files[f])} for f in files]
         return files
 
-    def read(self, path: str) -> bytes:
+    def read(self, path: str, context=None, return_metadata: bool = False) -> bytes:
         """Read file content."""
         if path not in self._files:
             raise FileNotFoundError(f"File not found: {path}")
+        if return_metadata:
+            # Minimal shape needed by protocol; tests here only expect bytes.
+            return {"content": self._files[path]}
         return self._files[path]
 
 


### PR DESCRIPTION
## Summary
- Propagate OperationContext through SkillRegistry discovery/reads so skill discovery respects caller permissions.
- Update FastAPI RPC auto-dispatch to inject auth context into both `context` and `_context`.
- Align skills RPC methods on canonical `context` parameter and update unit test mocks accordingly.

## Test plan
- Run `pytest tests/unit/server/test_fastapi_server.py`
- Run `pytest tests/unit/skills/test_skill_registry.py`
- Run `pytest tests/unit/skills/test_skill_manager.py`
- Run `pytest tests/unit/skills/test_skill_exporter.py`