### PR TITLE
feat: Add local development workflow without Docker rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,37 @@ pre-commit install  # Install pre-commit hooks for code quality checks
 pytest tests/
 ```
 
+#### Local Development (Without Docker Rebuild)
+
+For faster development iteration, run the Nexus server locally while keeping other services in Docker:
+
+```bash
+# 1. Start Docker services (postgres, langgraph, frontend)
+./docker-start.sh
+
+# 2. Stop the Docker nexus-server (we'll run it locally)
+docker stop nexus-server
+
+# 3. Start the local Nexus server
+./local-nexus.sh --start
+
+# 4. Make code changes and restart as needed
+# Press Ctrl+C to stop, then ./local-nexus.sh --start again
+
+# 5. When done, restart Docker nexus-server
+docker start nexus-server
+```
+
+**Benefits:**
+- ⚡ **Fast iteration**: No Docker rebuild needed (saves 30-60 seconds per change)
+- 🐛 **Easy debugging**: Attach debugger directly to Python process
+- 🔄 **Shared data**: Docker and local both use `./nexus-data/` directory
+- 🎯 **Simple**: One script, reuses existing config
+
+**Commands:**
+- `./local-nexus.sh --start` - Start local server
+- `./local-nexus.sh --stop` - Stop local server
+
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/nexi-lab/nexus/issues)

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -132,8 +132,8 @@ services:
       # Configuration file path (defaults to config.demo.yaml if not specified)
       NEXUS_CONFIG_FILE: ${NEXUS_CONFIG_FILE:-/app/configs/config.demo.yaml}
     volumes:
-      # Persistent data directory (local backend)
-      - nexus-data:/app/data
+      # Persistent data directory (local backend) - shared with local development
+      - ./nexus-data:/app/data
       # Configuration files (includes config.demo.yaml for auto-mounting backends)
       - ./configs:/app/configs:ro
       # GCS credentials (auto-detected - see docker-gcs-setup.sh)
@@ -308,8 +308,8 @@ services:
 volumes:
   postgres-data:
     driver: local
-  nexus-data:
-    driver: local
+  # nexus-data: Using local directory ./nexus-data instead of Docker volume
+  # This allows sharing data between Docker and local development
 
 # ============================================
 # Networks

--- a/examples/langgraph/pyproject.toml
+++ b/examples/langgraph/pyproject.toml
@@ -2,13 +2,14 @@
 name = "nexus-langgraph-examples"
 version = "0.1.0"
 description = "LangGraph ReAct Agent Examples with Nexus Filesystem Integration"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "langgraph>=0.2.0",
     "langchain-core>=0.3.0",
     "langchain-anthropic>=0.2.0",
     "langchain-openai>=0.2.0",
     "nexus-ai-fs>=0.5.3",
+    # "nexus-ai-fs @ file:///Users/jinjingzhou/nexi-lab/nexus",
     "langgraph-cli==0.3.6",
     "langgraph-api==0.2.130",
     "langgraph-checkpoint-sqlite>=2.0.0",  # Required for .langgraph_api persistence

--- a/local-nexus.sh
+++ b/local-nexus.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+# local-nexus.sh - Run Nexus server locally (outside Docker)
+#
+# This script allows running the Nexus server locally for faster development
+# iteration while keeping other services (postgres, langgraph, frontend) in Docker.
+#
+# Usage:
+#   ./local-nexus.sh --start    # Start the local server
+#   ./local-nexus.sh --stop     # Stop the local server
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to get data directory path
+get_data_path() {
+    # Use local directory that's shared with Docker
+    DATA_DIR="./nexus-data"
+
+    # Create directory if it doesn't exist
+    if [ ! -d "$DATA_DIR" ]; then
+        echo -e "${GREEN}Creating data directory: $DATA_DIR${NC}" >&2
+        mkdir -p "$DATA_DIR"
+    fi
+
+    echo "$DATA_DIR"
+}
+
+# Function to start the server
+start_server() {
+    echo ""
+    echo "╔═══════════════════════════════════════════╗"
+    echo "║     Starting Nexus Server Locally        ║"
+    echo "╚═══════════════════════════════════════════╝"
+    echo ""
+
+    # Check Docker postgres is running
+    if ! docker ps | grep -q nexus-postgres; then
+        echo -e "${RED}ERROR: PostgreSQL container not running${NC}"
+        echo ""
+        echo "Please start Docker services first:"
+        echo "  ./docker-start.sh"
+        echo ""
+        exit 1
+    fi
+
+    # Check if 'postgres' hostname resolves to localhost for connectors
+    if ! grep -q "127.0.0.1.*postgres" /etc/hosts 2>/dev/null; then
+        echo ""
+        echo -e "${YELLOW}⚠  For connectors to work, add this to /etc/hosts:${NC}"
+        echo ""
+        echo "    127.0.0.1    postgres"
+        echo ""
+        echo "  Run: sudo bash -c 'echo \"127.0.0.1    postgres\" >> /etc/hosts'"
+        echo ""
+        echo "  (This allows 'postgres:5432' in connector configs to resolve to localhost)"
+        echo ""
+        read -p "Continue without it? (connectors will fail but core server works) [Y/n] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]] && [[ ! -z $REPLY ]]; then
+            exit 1
+        fi
+    fi
+
+    # Check if PostgreSQL is healthy
+    if ! docker exec nexus-postgres pg_isready -U postgres > /dev/null 2>&1; then
+        echo -e "${YELLOW}WARNING: PostgreSQL is not ready yet${NC}"
+        echo "Waiting for PostgreSQL..."
+        sleep 3
+    fi
+
+    # Check if port 8080 is already in use
+    if lsof -ti :8080 >/dev/null 2>&1; then
+        echo -e "${YELLOW}WARNING: Port 8080 is already in use${NC}"
+        echo ""
+        echo "This is likely the Docker nexus-server. Stop it first:"
+        echo "  docker stop nexus-server"
+        echo ""
+        exit 1
+    fi
+
+    # Load environment variables from .env.local
+    if [ -f .env.local ]; then
+        set -a
+        source .env.local
+        set +a
+        echo -e "${GREEN}✓${NC} Loaded environment from .env.local"
+    else
+        echo -e "${YELLOW}⚠${NC}  No .env.local file found (using defaults)"
+    fi
+
+    # Get data directory path (shared with Docker)
+    DATA_PATH=$(get_data_path)
+
+    # Override for local development
+    # NEXUS_DB_PATH overrides the db_path setting in config.demo.yaml
+    export NEXUS_DB_PATH="postgresql://postgres:nexus@localhost:5432/nexus"
+    export NEXUS_DATA_DIR="$DATA_PATH"
+
+    # Also set the database URL for components that use it directly
+    export NEXUS_DATABASE_URL="postgresql://postgres:nexus@localhost:5432/nexus"
+
+    # Override token_manager_db for connectors (GDrive, Gmail, etc.)
+    # This ensures connectors use localhost instead of the Docker "postgres" hostname
+    export TOKEN_MANAGER_DB="postgresql://postgres:nexus@localhost:5432/nexus"
+
+    # Activate virtual environment
+    if [ ! -d .venv ]; then
+        echo -e "${RED}ERROR: Virtual environment not found${NC}"
+        echo ""
+        echo "Create it with:"
+        echo "  python -m venv .venv"
+        echo "  source .venv/bin/activate"
+        echo "  pip install -e ."
+        echo ""
+        exit 1
+    fi
+
+    source .venv/bin/activate
+
+    # Optional: Rebuild Rust extension for better performance
+    # Only needed if you've modified the Rust code
+    # Uncomment below to rebuild on each start:
+    # if command -v maturin &> /dev/null || command -v ~/.local/bin/maturin &> /dev/null; then
+    #     echo "Building Rust extension..."
+    #     MATURIN_CMD=$(command -v maturin || echo ~/.local/bin/maturin)
+    #     [ -d "rust/nexus_fast" ] && (cd rust/nexus_fast && $MATURIN_CMD develop --release --quiet && cd ../..)
+    # fi
+
+    # Display configuration
+    echo ""
+    echo -e "${BLUE}Configuration:${NC}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Config File:  ./configs/config.demo.yaml"
+    echo "  Database:     $NEXUS_DB_PATH"
+    echo "  Data Dir:     $DATA_PATH"
+    echo "  Host:         ${NEXUS_HOST:-0.0.0.0}"
+    echo "  Port:         ${NEXUS_PORT:-8080}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo -e "${GREEN}Starting server...${NC}"
+    echo ""
+    echo "Press Ctrl+C to stop"
+    echo ""
+
+    # Start the Nexus server
+    nexus serve \
+        --config ./configs/config.demo.yaml \
+        --auth-type database \
+        --async
+}
+
+# Function to stop the server
+stop_server() {
+    echo ""
+    echo "Stopping local Nexus server..."
+
+    # Get all PIDs using port 8080
+    PIDS=$(lsof -ti :8080 2>/dev/null || true)
+
+    if [ -n "$PIDS" ]; then
+        echo "Found process(es) on port 8080"
+
+        # Kill each PID
+        for PID in $PIDS; do
+            echo "Stopping PID: $PID"
+
+            # Send SIGTERM for graceful shutdown
+            if kill -0 $PID 2>/dev/null; then
+                kill -TERM $PID 2>/dev/null || true
+            fi
+        done
+
+        sleep 2
+
+        # Force kill any remaining processes
+        for PID in $PIDS; do
+            if kill -0 $PID 2>/dev/null; then
+                echo "Force killing PID: $PID"
+                kill -9 $PID 2>/dev/null || true
+            fi
+        done
+
+        echo -e "${GREEN}✓ Server stopped${NC}"
+        echo ""
+    else
+        echo "No server running on port 8080"
+        echo ""
+    fi
+}
+
+# Main script logic
+case "$1" in
+    --start)
+        start_server
+        ;;
+    --stop)
+        stop_server
+        ;;
+    *)
+        echo ""
+        echo "Usage: $0 {--start|--stop}"
+        echo ""
+        echo "Commands:"
+        echo "  --start    Start Nexus server locally (outside Docker)"
+        echo "  --stop     Stop local Nexus server"
+        echo ""
+        echo "Workflow:"
+        echo "  1. Start Docker services:       ./docker-start.sh"
+        echo "  2. Stop Docker nexus-server:    docker stop nexus-server"
+        echo "  3. Start local nexus:           ./local-nexus.sh --start"
+        echo "  4. Make changes and restart:    Ctrl+C then ./local-nexus.sh --start"
+        echo "  5. When done:                   docker start nexus-server"
+        echo ""
+        echo "Optional: Enable connectors (GDrive, Gmail) in local mode:"
+        echo "  sudo bash -c 'echo \"127.0.0.1    postgres\" >> /etc/hosts'"
+        echo "  This maps 'postgres' hostname to localhost for connector database access."
+        echo ""
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Introduces a fast local development workflow that allows running the Nexus server locally (outside Docker) while keeping other services in Docker. This eliminates the need to rebuild Docker images on every code change, saving **30-60 seconds per iteration**.

## Changes

### New Script: `local-nexus.sh`
- ✅ `--start` command to run Nexus server locally
- ✅ `--stop` command to stop local server
- ✅ Environment variable overrides for database URLs (postgres → localhost)
- ✅ Shared data directory with Docker (`./nexus-data`)
- ✅ Automatic checks for PostgreSQL availability
- ✅ Optional hosts file setup for connector support

### Docker Configuration
- Changed `docker-compose.demo.yml` to use bind mount (`./nexus-data`) instead of Docker volume
- This allows both Docker and local server to access the same data directory

### Documentation
- Added "Local Development (Without Docker Rebuild)" section to README.md
- Clear step-by-step instructions for the workflow
- Benefits and use cases explained

### LangGraph Examples
- Updated `examples/langgraph/pyproject.toml` to require Python `>=3.13` (matching nexus core requirements)

## Benefits

- ⚡ **Fast iteration**: No Docker rebuild needed (saves 30-60 seconds per change)
- 🐛 **Easy debugging**: Attach debugger directly to Python process
- 🔄 **Shared data**: Docker and local both use `./nexus-data/` directory
- 🎯 **Simple**: One script, reuses existing `config.demo.yaml`

## Usage

```bash
# 1. Start Docker services (postgres, langgraph, frontend)
./docker-start.sh

# 2. Stop the Docker nexus-server (we'll run it locally)
docker stop nexus-server

# 3. Start the local Nexus server
./local-nexus.sh --start

# 4. Make code changes and restart as needed
# Press Ctrl+C to stop, then ./local-nexus.sh --start again

# 5. When done, restart Docker nexus-server
docker start nexus-server
```

## Technical Details

### Environment Variable Overrides
The script overrides these environment variables to redirect connections from Docker hostnames to localhost:
- `NEXUS_DB_PATH` → `postgresql://postgres:nexus@localhost:5432/nexus`
- `NEXUS_DATABASE_URL` → `postgresql://postgres:nexus@localhost:5432/nexus`
- `TOKEN_MANAGER_DB` → `postgresql://postgres:nexus@localhost:5432/nexus` (for connectors)

### Optional Connector Support
For connectors (GDrive, Gmail, GCS) to work in local mode, add this to `/etc/hosts`:
```
127.0.0.1    postgres
```
This allows the `postgres` hostname to resolve to localhost.

## Test Plan

- [x] Test local server starts successfully
- [x] Verify database connection works
- [x] Confirm data directory is shared between Docker and local
- [x] Test stopping and restarting local server
- [x] Verify configuration reuse from config.demo.yaml
- [x] Test LangGraph examples with Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)