### PR TITLE
feat: Add cross-tenant sharing APIs

### DIFF
--- a/src/nexus/core/rebac.py
+++ b/src/nexus/core/rebac.py
@@ -42,6 +42,14 @@ from typing import Any
 # Wildcard subject for public access
 WILDCARD_SUBJECT = ("*", "*")
 
+# Relations that are allowed to cross tenant boundaries
+# These relations can link subjects and objects from different tenants
+CROSS_TENANT_ALLOWED_RELATIONS = frozenset(
+    {
+        "shared-with",  # Direct user-to-resource sharing across tenants
+    }
+)
+
 
 class RelationType(StrEnum):
     """Standard relationship types in ReBAC."""

--- a/src/nexus/remote/client.py
+++ b/src/nexus/remote/client.py
@@ -26,7 +26,7 @@ import logging
 import time
 import uuid
 from collections.abc import Iterator
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
@@ -2654,6 +2654,167 @@ class RemoteNexusFS(NexusFSLLMMixin, NexusFilesystem):
             >>> made_private = nx.make_private(("profile", "alice"))
         """
         result = self._call_rpc("make_private", {"resource": resource})
+        return result  # type: ignore[no-any-return]
+
+    # ============================================================
+    # Cross-Tenant Sharing
+    # ============================================================
+
+    def share_with_user(
+        self,
+        resource: tuple[str, str],
+        user_id: str,
+        relation: str = "viewer",
+        tenant_id: str | None = None,
+        user_tenant_id: str | None = None,
+        expires_at: datetime | None = None,
+    ) -> str:
+        """Share a resource with a specific user (same or different tenant).
+
+        This enables cross-tenant sharing - users from different organizations
+        can be granted access to specific resources.
+
+        Args:
+            resource: Resource to share (e.g., ("file", "/path/to/doc.txt"))
+            user_id: User to share with (e.g., "bob@partner-company.com")
+            relation: Permission level - "viewer" (read) or "editor" (read/write)
+            tenant_id: Resource owner's tenant ID (defaults to current tenant)
+            user_tenant_id: Recipient user's tenant ID (for cross-tenant shares)
+            expires_at: Optional expiration datetime for the share
+
+        Returns:
+            Share ID (tuple_id) that can be used to revoke the share
+
+        Examples:
+            >>> # Share with same-tenant user
+            >>> share_id = nx.share_with_user(
+            ...     resource=("file", "/project/doc.txt"),
+            ...     user_id="alice@mycompany.com",
+            ...     relation="editor"
+            ... )
+
+            >>> # Share with cross-tenant user
+            >>> share_id = nx.share_with_user(
+            ...     resource=("file", "/project/doc.txt"),
+            ...     user_id="bob@partner.com",
+            ...     user_tenant_id="partner-tenant",
+            ...     relation="viewer"
+            ... )
+        """
+        result = self._call_rpc(
+            "share_with_user",
+            {
+                "resource": resource,
+                "user_id": user_id,
+                "relation": relation,
+                "tenant_id": tenant_id,
+                "user_tenant_id": user_tenant_id,
+                "expires_at": expires_at.isoformat() if expires_at else None,
+            },
+        )
+        return result  # type: ignore[no-any-return]
+
+    def revoke_share(self, resource: tuple[str, str], user_id: str) -> bool:
+        """Revoke a share for a specific user on a resource.
+
+        Args:
+            resource: Resource to unshare (e.g., ("file", "/path/to/doc.txt"))
+            user_id: User to revoke access from
+
+        Returns:
+            True if share was revoked, False if no share existed
+
+        Examples:
+            >>> nx.revoke_share(
+            ...     resource=("file", "/project/doc.txt"),
+            ...     user_id="bob@partner.com"
+            ... )
+            True
+        """
+        result = self._call_rpc(
+            "revoke_share",
+            {"resource": resource, "user_id": user_id},
+        )
+        return result  # type: ignore[no-any-return]
+
+    def revoke_share_by_id(self, share_id: str) -> bool:
+        """Revoke a share using its ID.
+
+        Args:
+            share_id: The share ID returned by share_with_user()
+
+        Returns:
+            True if share was revoked, False if share didn't exist
+
+        Examples:
+            >>> share_id = nx.share_with_user(resource, user_id)
+            >>> nx.revoke_share_by_id(share_id)
+            True
+        """
+        result = self._call_rpc("revoke_share_by_id", {"share_id": share_id})
+        return result  # type: ignore[no-any-return]
+
+    def list_outgoing_shares(
+        self,
+        resource: tuple[str, str] | None = None,
+        tenant_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> builtins.list[dict[str, Any]]:
+        """List shares created by the current tenant (resources shared with others).
+
+        Args:
+            resource: Filter by specific resource (optional)
+            tenant_id: Tenant ID to list shares for (defaults to current tenant)
+            limit: Maximum number of results
+            offset: Number of results to skip
+
+        Returns:
+            List of share info dictionaries
+
+        Examples:
+            >>> shares = nx.list_outgoing_shares()
+            >>> for share in shares:
+            ...     print(f"{share['resource_id']} -> {share['recipient_id']}")
+        """
+        result = self._call_rpc(
+            "list_outgoing_shares",
+            {
+                "resource": resource,
+                "tenant_id": tenant_id,
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        return result  # type: ignore[no-any-return]
+
+    def list_incoming_shares(
+        self,
+        user_id: str,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> builtins.list[dict[str, Any]]:
+        """List shares received by a user (resources shared with me).
+
+        This includes cross-tenant shares from other organizations.
+
+        Args:
+            user_id: User ID to list incoming shares for
+            limit: Maximum number of results
+            offset: Number of results to skip
+
+        Returns:
+            List of share info dictionaries
+
+        Examples:
+            >>> shares = nx.list_incoming_shares(user_id="alice@mycompany.com")
+            >>> for share in shares:
+            ...     print(f"{share['resource_id']} from {share['owner_tenant_id']}")
+        """
+        result = self._call_rpc(
+            "list_incoming_shares",
+            {"user_id": user_id, "limit": limit, "offset": offset},
+        )
         return result  # type: ignore[no-any-return]
 
     # ============================================================

--- a/src/nexus/server/protocol.py
+++ b/src/nexus/server/protocol.py
@@ -452,6 +452,53 @@ class RebacListTuplesParams:
     object: tuple[str, str] | None = None
 
 
+# Cross-tenant sharing params
+@dataclass
+class ShareWithUserParams:
+    """Parameters for share_with_user() method."""
+
+    resource: tuple[str, str]
+    user_id: str
+    relation: str = "viewer"
+    tenant_id: str | None = None
+    user_tenant_id: str | None = None
+    expires_at: str | None = None
+
+
+@dataclass
+class RevokeShareParams:
+    """Parameters for revoke_share() method."""
+
+    resource: tuple[str, str]
+    user_id: str
+
+
+@dataclass
+class RevokeShareByIdParams:
+    """Parameters for revoke_share_by_id() method."""
+
+    share_id: str
+
+
+@dataclass
+class ListOutgoingSharesParams:
+    """Parameters for list_outgoing_shares() method."""
+
+    resource: tuple[str, str] | None = None
+    tenant_id: str | None = None
+    limit: int = 100
+    offset: int = 0
+
+
+@dataclass
+class ListIncomingSharesParams:
+    """Parameters for list_incoming_shares() method."""
+
+    user_id: str
+    limit: int = 100
+    offset: int = 0
+
+
 @dataclass
 class NamespaceCreateParams:
     """Parameters for namespace_create() method."""
@@ -1533,6 +1580,12 @@ METHOD_PARAMS = {
     "rebac_explain": RebacExplainParams,
     "rebac_delete": RebacDeleteParams,
     "rebac_list_tuples": RebacListTuplesParams,
+    # Cross-tenant sharing methods
+    "share_with_user": ShareWithUserParams,
+    "revoke_share": RevokeShareParams,
+    "revoke_share_by_id": RevokeShareByIdParams,
+    "list_outgoing_shares": ListOutgoingSharesParams,
+    "list_incoming_shares": ListIncomingSharesParams,
     "namespace_create": NamespaceCreateParams,
     "namespace_get": NamespaceGetParams,
     "namespace_list": NamespaceListParams,
@@ -1684,11 +1737,17 @@ def parse_method_params(method: str, params: dict[str, Any] | None) -> Any:
         "rebac_expand",
         "rebac_list_tuples",
         "rebac_explain",
+        # Cross-tenant sharing methods
+        "share_with_user",
+        "revoke_share",
+        "list_outgoing_shares",
     ]:
         if "subject" in params and isinstance(params["subject"], list):
             params["subject"] = tuple(params["subject"])
         if "object" in params and isinstance(params["object"], list):
             params["object"] = tuple(params["object"])
+        if "resource" in params and isinstance(params["resource"], list):
+            params["resource"] = tuple(params["resource"])
 
     try:
         return param_class(**params)

--- a/tests/unit/core/test_cross_tenant_sharing.py
+++ b/tests/unit/core/test_cross_tenant_sharing.py
@@ -1,0 +1,324 @@
+"""Unit tests for Cross-Tenant Sharing feature.
+
+Tests cover:
+- share_with_user API (same and cross-tenant)
+- revoke_share API
+- list_incoming_shares and list_outgoing_shares
+- Permission checks with cross-tenant shares
+- Tuple fetching includes cross-tenant shares
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+
+from nexus.core.rebac import CROSS_TENANT_ALLOWED_RELATIONS
+from nexus.core.rebac_manager_tenant_aware import TenantAwareReBACManager, TenantIsolationError
+from nexus.storage.models import Base
+
+
+@pytest.fixture
+def engine():
+    """Create in-memory SQLite database for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def tenant_aware_manager(engine):
+    """Create a tenant-aware ReBAC manager for testing.
+
+    Uses cache_ttl_seconds=0 to disable caching for predictable test behavior.
+    """
+    manager = TenantAwareReBACManager(
+        engine=engine,
+        cache_ttl_seconds=0,  # Disable cache for predictable tests
+        max_depth=10,
+        enforce_tenant_isolation=True,
+    )
+    yield manager
+    manager.close()
+
+
+class TestCrossTenantAllowedRelations:
+    """Tests for CROSS_TENANT_ALLOWED_RELATIONS configuration."""
+
+    def test_shared_with_is_cross_tenant_allowed(self):
+        """Verify shared-with relation is in the allowed list."""
+        assert "shared-with" in CROSS_TENANT_ALLOWED_RELATIONS
+
+    def test_regular_relations_not_cross_tenant_allowed(self):
+        """Verify regular relations are NOT in the allowed list."""
+        assert "viewer" not in CROSS_TENANT_ALLOWED_RELATIONS
+        assert "editor" not in CROSS_TENANT_ALLOWED_RELATIONS
+        assert "owner" not in CROSS_TENANT_ALLOWED_RELATIONS
+        assert "member-of" not in CROSS_TENANT_ALLOWED_RELATIONS
+
+
+class TestCrossTenantSharingWrite:
+    """Tests for creating cross-tenant shares."""
+
+    def test_shared_with_allows_cross_tenant(self, tenant_aware_manager):
+        """Test that shared-with relation allows cross-tenant relationships."""
+        # This should succeed - shared-with is allowed to cross tenants
+        tuple_id = tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="partner-tenant",  # Different tenant!
+            object_tenant_id="acme-tenant",
+        )
+        assert tuple_id is not None
+
+    def test_regular_relation_blocks_cross_tenant(self, tenant_aware_manager):
+        """Test that regular relations still block cross-tenant."""
+        # This should fail - viewer is NOT allowed to cross tenants
+        with pytest.raises(TenantIsolationError, match="Cannot create cross-tenant"):
+            tenant_aware_manager.rebac_write(
+                subject=("user", "bob@partner.com"),
+                relation="viewer",  # NOT in CROSS_TENANT_ALLOWED_RELATIONS
+                object=("file", "/project/doc.txt"),
+                tenant_id="acme-tenant",
+                subject_tenant_id="partner-tenant",
+                object_tenant_id="acme-tenant",
+            )
+
+    def test_same_tenant_shared_with_allowed(self, tenant_aware_manager):
+        """Test that shared-with also works for same-tenant sharing."""
+        # Same-tenant sharing should work too
+        tuple_id = tenant_aware_manager.rebac_write(
+            subject=("user", "alice@acme.com"),
+            relation="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="acme-tenant",
+            object_tenant_id="acme-tenant",
+        )
+        assert tuple_id is not None
+
+    def test_cross_tenant_share_stored_with_object_tenant(self, tenant_aware_manager):
+        """Test that cross-tenant shares are stored with object's tenant_id."""
+        # Create cross-tenant share
+        tuple_id = tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="partner-tenant",
+            object_tenant_id="acme-tenant",
+        )
+        assert tuple_id is not None  # Verify share was created
+
+        # Verify tuple exists by checking permission
+        result = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+        )
+        assert result is True
+
+
+class TestCrossTenantSharingPermissionCheck:
+    """Tests for permission checks with cross-tenant shares."""
+
+    def test_cross_tenant_user_can_check_shared_resource(self, tenant_aware_manager):
+        """Test that cross-tenant user can check permission on shared resource."""
+        # Create cross-tenant share
+        tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="partner-tenant",
+            object_tenant_id="acme-tenant",
+        )
+
+        # Check permission - bob should have shared-with on the file
+        result = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+        )
+        assert result is True
+
+    def test_unshared_cross_tenant_user_denied(self, tenant_aware_manager):
+        """Test that cross-tenant users without shares are denied."""
+        # No share created for charlie
+        result = tenant_aware_manager.rebac_check(
+            subject=("user", "charlie@other.com"),
+            permission="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+        )
+        assert result is False
+
+
+class TestCrossTenantMultipleShares:
+    """Tests for multiple cross-tenant shares."""
+
+    def test_multiple_cross_tenant_shares(self, tenant_aware_manager):
+        """Test creating shares to multiple cross-tenant users."""
+        # Create shares from two different tenants
+        tuple_id_1 = tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/acme/doc1.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="partner-tenant",
+            object_tenant_id="acme-tenant",
+        )
+        tuple_id_2 = tenant_aware_manager.rebac_write(
+            subject=("user", "charlie@other.com"),
+            relation="shared-with",
+            object=("file", "/acme/doc2.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="other-tenant",
+            object_tenant_id="acme-tenant",
+        )
+
+        # Both shares should exist
+        assert tuple_id_1 is not None
+        assert tuple_id_2 is not None
+
+        # Both users should have access
+        result_bob = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/acme/doc1.txt"),
+            tenant_id="acme-tenant",
+        )
+        result_charlie = tenant_aware_manager.rebac_check(
+            subject=("user", "charlie@other.com"),
+            permission="shared-with",
+            object=("file", "/acme/doc2.txt"),
+            tenant_id="acme-tenant",
+        )
+        assert result_bob is True
+        assert result_charlie is True
+
+    def test_user_with_multiple_shares_from_different_tenants(self, tenant_aware_manager):
+        """Test that a user can receive shares from multiple tenants."""
+        # Bob receives shares from two different tenants
+        tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/acme/doc.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="partner-tenant",
+            object_tenant_id="acme-tenant",
+        )
+        tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/xyz/doc.txt"),
+            tenant_id="xyz-tenant",
+            subject_tenant_id="partner-tenant",
+            object_tenant_id="xyz-tenant",
+        )
+
+        # Bob should have access to both resources (checking each in its own tenant)
+        result_acme = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/acme/doc.txt"),
+            tenant_id="acme-tenant",
+        )
+        result_xyz = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/xyz/doc.txt"),
+            tenant_id="xyz-tenant",
+        )
+        assert result_acme is True
+        assert result_xyz is True
+
+
+class TestCrossTenantSharingRevoke:
+    """Tests for revoking cross-tenant shares."""
+
+    def test_revoke_cross_tenant_share(self, tenant_aware_manager):
+        """Test revoking a cross-tenant share."""
+        # Create cross-tenant share
+        tuple_id = tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="partner-tenant",
+            object_tenant_id="acme-tenant",
+        )
+
+        # Verify share exists
+        result = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+        )
+        assert result is True
+
+        # Revoke share
+        deleted = tenant_aware_manager.rebac_delete(tuple_id)
+        assert deleted is True
+
+        # Verify share is gone
+        result = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+        )
+        assert result is False
+
+
+class TestCrossTenantSharingWithExpiration:
+    """Tests for cross-tenant shares with expiration."""
+
+    def test_expired_cross_tenant_share_denied(self, tenant_aware_manager):
+        """Test that expired cross-tenant shares are denied."""
+        # Create share that expires in the past
+        tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="partner-tenant",
+            object_tenant_id="acme-tenant",
+            expires_at=datetime.now(UTC) - timedelta(hours=1),  # Already expired
+        )
+
+        # Permission check should fail (expired)
+        result = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+        )
+        assert result is False
+
+    def test_non_expired_cross_tenant_share_allowed(self, tenant_aware_manager):
+        """Test that non-expired cross-tenant shares are allowed."""
+        # Create share that expires in the future
+        tenant_aware_manager.rebac_write(
+            subject=("user", "bob@partner.com"),
+            relation="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+            subject_tenant_id="partner-tenant",
+            object_tenant_id="acme-tenant",
+            expires_at=datetime.now(UTC) + timedelta(days=7),  # Expires in a week
+        )
+
+        # Permission check should succeed
+        result = tenant_aware_manager.rebac_check(
+            subject=("user", "bob@partner.com"),
+            permission="shared-with",
+            object=("file", "/project/doc.txt"),
+            tenant_id="acme-tenant",
+        )
+        assert result is True


### PR DESCRIPTION
Enable sharing resources with users from different tenants through new `shared-with` relation that bypasses tenant isolation.

New APIs:
- share_with_user(resource, user_id, relation, expires_at) - Share with any user
- revoke_share(resource, user_id) - Revoke by resource + user
- revoke_share_by_id(share_id) - Revoke by ID
- list_outgoing_shares() - List shares I created
- list_incoming_shares(user_id) - List shares received

Implementation:
- CROSS_TENANT_ALLOWED_RELATIONS config in rebac.py
- TenantAwareReBACManager allows `shared-with` to cross tenant boundaries
- Tuple fetching includes cross-tenant shares for permission checks
- Full sync/async client support
- RPC protocol params for all new methods

No Rust changes needed - cross-tenant tuples flow through existing graph traversal with no performance impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)