### PR TITLE
fix: Add e2b-code-interpreter to Dockerfile for sandbox_run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ COPY alembic.ini ./
 ENV UV_HTTP_TIMEOUT=300
 RUN uv pip install --system .
 
-# Install sandbox providers
-RUN uv pip install --system docker e2b
+# Install sandbox providers (e2b-code-interpreter required for sandbox_run)
+RUN uv pip install --system docker e2b e2b-code-interpreter
 
 # Build and install Rust extension (nexus_fast)
 COPY rust/ ./rust/


### PR DESCRIPTION
The sandbox_run RPC was failing with "e2b_code_interpreter package not installed" because only the base e2b package was installed, not e2b-code-interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)