### PR TITLE
fix: Add read_bulk and write_batch to METHOD_PARAMS

### DIFF
--- a/src/nexus/server/protocol.py
+++ b/src/nexus/server/protocol.py
@@ -1757,7 +1757,9 @@ class MCPSyncParams:
 # Mapping of method names to parameter dataclasses
 METHOD_PARAMS = {
     "read": ReadParams,
+    "read_bulk": ReadBulkParams,
     "write": WriteParams,
+    "write_batch": WriteBatchParams,
     "append": AppendParams,
     "delete": DeleteParams,
     "rename": RenameParams,


### PR DESCRIPTION
## Summary
- Add `read_bulk`: `ReadBulkParams` to METHOD_PARAMS dictionary
- Add `write_batch`: `WriteBatchParams` to METHOD_PARAMS dictionary

Missing entries caused parameter parsing to fail for these bulk RPC operations.

## Test plan
- [ ] Verify bulk read/write operations work via RPC client

🤖 Generated with [Claude Code](https://claude.com/claude-code)