### PR TITLE
docs(#484): Clarify tests/evaluation as MCP E2E tests

### DIFF
--- a/tests/evaluation/README.md
+++ b/tests/evaluation/README.md
@@ -1,6 +1,14 @@
-# MCP Server Evaluation Tests
+# MCP Server E2E Evaluation Tests
 
-LLM-driven evaluation tests for the Nexus MCP server. These tests verify that AI agents can effectively use the MCP tools to accomplish real-world tasks.
+LLM-driven end-to-end tests for the Nexus MCP server. These tests verify that AI agents can effectively use the MCP tools to accomplish real-world tasks.
+
+> **Note for future developers**: These are essentially **E2E tests** for the MCP server.
+> The term "evaluation" follows the `mcp-builder` skill convention for LLM-driven tests.
+>
+> **Related test directories:**
+> - `tests/evaluation/` (this) - MCP E2E tests using LLM to verify tool usability
+> - `tests/benchmarks/` - Performance benchmarks (throughput, latency) - no LLM required
+> - [nexus-benchmarks repo](https://github.com/nexi-lab/nexus-benchmarks) - BFCL benchmark for Dynamic Discovery vs Static comparison
 
 ## Why Separate from Regular Tests?
 


### PR DESCRIPTION
## Summary
- Clarify that `tests/evaluation/` contains E2E tests for MCP server
- The term "evaluation" follows the mcp-builder skill convention
- Document relationship between different test directories

## Changes
- Rename README title to "MCP Server E2E Evaluation Tests"
- Add note for future developers explaining the terminology
- Add cross-references to related directories:
  - `tests/evaluation/` - MCP E2E tests (LLM-driven)
  - `tests/benchmarks/` - Performance benchmarks (no LLM)
  - nexus-benchmarks repo - BFCL benchmark comparison

## Test plan
- [x] Documentation only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)