### PR TITLE
fix: Convert datetime to ISO string in stat response for FUSE client

### DIFF
--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -2287,11 +2287,15 @@ class NexusFSCoreMixin:
             except Exception:
                 size = None
 
+        # Convert datetime to ISO string for wire compatibility with Rust FUSE client
+        # The client expects a plain string, not the wrapped {"__type__": "datetime", ...} format
+        modified_at_str = meta.modified_at.isoformat() if meta.modified_at else None
+
         return {
             "size": size,
             "etag": meta.etag,
             "version": meta.version,
-            "modified_at": meta.modified_at,
+            "modified_at": modified_at_str,
             "is_directory": False,
         }
 


### PR DESCRIPTION
## Summary
- Fix FUSE client deserialization error when accessing files via `stat` API
- The Rust client expects `modified_at` as a plain ISO string, but the server was returning a wrapped datetime object `{"__type__": "datetime", "data": "..."}`
- Convert datetime to ISO string in `stat()` response before returning

## Root Cause
The server's `encode_rpc_message` wraps datetime objects for Python-to-Python compatibility, but the Rust FUSE client's `FileMetadata` struct expects `modified_at: Option<String>`.

Error message: `invalid type: map, expected a string at line 1 column 145`

## Test plan
- [ ] Deploy to nexus-server and verify FUSE mount can access files without errors
- [ ] Run `python /mnt/nexus/path/to/file.py` through FUSE mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)