### PR TITLE
feat: Enhance Slack connector with mount cleanup and duplicate prevention

### DIFF
--- a/src/nexus/core/nexus_fs_mounts.py
+++ b/src/nexus/core/nexus_fs_mounts.py
@@ -323,6 +323,16 @@ class NexusFSMountsMixin:
                         f"Failed to revoke OAuth credentials (non-fatal): {e}"
                     )
 
+        # Step 4: Delete mount point directory
+        try:
+            self.rmdir(mount_point, recursive=True, context=context)  # type: ignore[attr-defined]  # allowed
+            result["directory_deleted"] = True
+            logger.info(f"Deleted mount point directory: {mount_point}")
+        except Exception as e:
+            # Directory deletion is non-fatal
+            result["warnings"].append(f"Failed to delete mount point directory (non-fatal): {e}")
+            logger.warning(f"Failed to delete mount point directory {mount_point}: {e}")
+
         return result
 
     @rpc_expose(description="List available connector types")
@@ -337,7 +347,7 @@ class NexusFSMountsMixin:
         """
         return self._mount_core_service.list_connectors(category)
 
-    @rpc_expose(description="List all backend mounts")
+    @rpc_expose(description="List all active mounts")
     def list_mounts(self, context: OperationContext | None = None) -> list[dict[str, Any]]:
         """List all active backend mounts.
 

--- a/src/nexus/services/mount_persist_service.py
+++ b/src/nexus/services/mount_persist_service.py
@@ -164,6 +164,14 @@ class MountPersistService:
         """
         self._check_manager()
 
+        # Check if mount is already active
+        if self._mounts.has_mount(mount_point):
+            logger.info(f"[LOAD_MOUNT] Mount already active: {mount_point}")
+            # Return the mount_id from database
+            assert self._manager is not None
+            config = self._manager.get_mount(mount_point)
+            return str(config["mount_id"]) if config else mount_point
+
         assert self._manager is not None
         config = self._manager.get_mount(mount_point)
         if not config:


### PR DESCRIPTION
## Summary
This PR enhances the Slack connector functionality with several improvements:

### Changes
- **Mount directory cleanup**: Automatically delete mount point directory when disconnecting (non-fatal on failure)
- **Duplicate mount prevention**: Prevent loading mounts that are already active
- **Description update**: Updated list_mounts RPC description to 'List all active mounts'

### Related
This builds on the Slack connector backend with OAuth 2.0 integration.

## Testing
- Tested mount/unmount flow with directory cleanup
- Verified duplicate mount loading is prevented