### PR TITLE
feat(#1041): Add query router for automatic search strategy selection

### DIFF
--- a/scripts/test_query_router_api_e2e.py
+++ b/scripts/test_query_router_api_e2e.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""End-to-end test script for Query Router API (Issue #1041).
+
+Tests the /api/search/query endpoint with graph_mode=auto parameter.
+
+Usage:
+    # Start the server first:
+    NEXUS_SEARCH_DAEMON=true python -m nexus.cli.main serve
+
+    # Then run the test:
+    python scripts/test_query_router_api_e2e.py
+
+    # Or specify a different server URL:
+    python scripts/test_query_router_api_e2e.py --url http://localhost:2026
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+import httpx
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+class QueryRouterAPITest:
+    """E2E test for query router API."""
+
+    def __init__(self, base_url: str, api_key: str | None = None):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key or os.environ.get("NEXUS_API_KEY", "test-key")
+        self.passed = 0
+        self.failed = 0
+
+    def _check(self, name: str, condition: bool, message: str = ""):
+        """Check a test condition and log result."""
+        if condition:
+            self.passed += 1
+            logger.info(f"  ✓ {name}")
+        else:
+            self.failed += 1
+            logger.error(f"  ✗ {name}: {message}")
+
+    async def test_health_check(self, client: httpx.AsyncClient):
+        """Test that the server is healthy."""
+        logger.info("\n=== Test: Health Check ===")
+
+        response = await client.get(f"{self.base_url}/health")
+        self._check("Health endpoint returns 200", response.status_code == 200)
+
+        if response.status_code == 200:
+            data = response.json()
+            self._check("Status is healthy", data.get("status") == "healthy")
+
+    async def test_auto_mode_simple_query(self, client: httpx.AsyncClient):
+        """Test auto mode routes simple queries correctly."""
+        logger.info("\n=== Test: Auto Mode - Simple Query ===")
+
+        response = await client.get(
+            f"{self.base_url}/api/search/query",
+            params={
+                "q": "what is authentication",
+                "graph_mode": "auto",
+            },
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+
+        self._check("Request succeeds", response.status_code == 200)
+
+        if response.status_code == 200:
+            data = response.json()
+            self._check("Response has routing info", "routing" in data)
+
+            if "routing" in data:
+                routing = data["routing"]
+                self._check(
+                    "Complexity class is simple",
+                    routing.get("complexity_class") == "simple",
+                    f"Got: {routing.get('complexity_class')}",
+                )
+                self._check(
+                    "Graph mode is none for simple query",
+                    routing.get("graph_mode") == "none",
+                    f"Got: {routing.get('graph_mode')}",
+                )
+                self._check(
+                    "Complexity score < 0.3",
+                    routing.get("complexity_score", 1.0) < 0.3,
+                    f"Got: {routing.get('complexity_score')}",
+                )
+                self._check(
+                    "Routing latency recorded",
+                    "routing_latency_ms" in routing,
+                )
+                self._check(
+                    "Reasoning provided",
+                    "reasoning" in routing and len(routing.get("reasoning", "")) > 0,
+                )
+
+    async def test_auto_mode_moderate_query(self, client: httpx.AsyncClient):
+        """Test auto mode routes moderate queries correctly."""
+        logger.info("\n=== Test: Auto Mode - Moderate Query ===")
+
+        response = await client.get(
+            f"{self.base_url}/api/search/query",
+            params={
+                "q": "compare OAuth vs JWT for API authentication",
+                "graph_mode": "auto",
+            },
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+
+        self._check("Request succeeds", response.status_code == 200)
+
+        if response.status_code == 200:
+            data = response.json()
+            self._check("Response has routing info", "routing" in data)
+
+            if "routing" in data:
+                routing = data["routing"]
+                # Moderate queries should have complexity 0.3-0.6
+                complexity = routing.get("complexity_score", 0)
+                self._check(
+                    "Complexity in moderate range (0.3-0.6)",
+                    0.3 <= complexity < 0.6,
+                    f"Got: {complexity}",
+                )
+                self._check(
+                    "Graph mode is low for moderate query",
+                    routing.get("graph_mode") == "low",
+                    f"Got: {routing.get('graph_mode')}",
+                )
+
+    async def test_auto_mode_complex_query(self, client: httpx.AsyncClient):
+        """Test auto mode routes complex queries correctly."""
+        logger.info("\n=== Test: Auto Mode - Complex Query ===")
+
+        response = await client.get(
+            f"{self.base_url}/api/search/query",
+            params={
+                "q": "How does the AuthService authenticate users and what happens when the JWTProvider expires the token before the refresh interval",
+                "graph_mode": "auto",
+            },
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+
+        self._check("Request succeeds", response.status_code == 200)
+
+        if response.status_code == 200:
+            data = response.json()
+            self._check("Response has routing info", "routing" in data)
+
+            if "routing" in data:
+                routing = data["routing"]
+                complexity = routing.get("complexity_score", 0)
+                complexity_class = routing.get("complexity_class", "")
+
+                self._check(
+                    "Complexity class is complex or very_complex",
+                    complexity_class in ("complex", "very_complex"),
+                    f"Got: {complexity_class}",
+                )
+                self._check(
+                    "Graph mode is dual for complex query",
+                    routing.get("graph_mode") == "dual",
+                    f"Got: {routing.get('graph_mode')}",
+                )
+                self._check(
+                    "Complexity score >= 0.6",
+                    complexity >= 0.6,
+                    f"Got: {complexity}",
+                )
+
+    async def test_auto_mode_limit_adjustment(self, client: httpx.AsyncClient):
+        """Test that auto mode adjusts limit correctly."""
+        logger.info("\n=== Test: Auto Mode - Limit Adjustment ===")
+
+        # Simple query should have limit * 0.8
+        response = await client.get(
+            f"{self.base_url}/api/search/query",
+            params={
+                "q": "test",
+                "graph_mode": "auto",
+                "limit": 10,
+            },
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+
+        self._check("Request succeeds", response.status_code == 200)
+
+        if response.status_code == 200:
+            data = response.json()
+            if "routing" in data:
+                routing = data["routing"]
+                adjusted_limit = routing.get("adjusted_limit", 0)
+                complexity_class = routing.get("complexity_class", "")
+
+                if complexity_class == "simple":
+                    self._check(
+                        "Simple query limit adjusted to 8 (10 * 0.8)",
+                        adjusted_limit == 8,
+                        f"Got: {adjusted_limit}",
+                    )
+                elif complexity_class == "moderate":
+                    self._check(
+                        "Moderate query limit unchanged (10 * 1.0)",
+                        adjusted_limit == 10,
+                        f"Got: {adjusted_limit}",
+                    )
+
+    async def test_invalid_graph_mode(self, client: httpx.AsyncClient):
+        """Test that invalid graph_mode returns 400."""
+        logger.info("\n=== Test: Invalid graph_mode ===")
+
+        response = await client.get(
+            f"{self.base_url}/api/search/query",
+            params={
+                "q": "test",
+                "graph_mode": "invalid_mode",
+            },
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+
+        self._check("Invalid mode returns 400", response.status_code == 400)
+
+        if response.status_code == 400:
+            data = response.json()
+            self._check(
+                "Error mentions valid options including 'auto'",
+                "auto" in str(data.get("detail", "")),
+            )
+
+    async def test_explicit_modes_still_work(self, client: httpx.AsyncClient):
+        """Test that explicit graph modes still work (no routing)."""
+        logger.info("\n=== Test: Explicit Modes (No Routing) ===")
+
+        for mode in ["none", "low", "dual"]:
+            response = await client.get(
+                f"{self.base_url}/api/search/query",
+                params={
+                    "q": "test query",
+                    "graph_mode": mode,
+                },
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            )
+
+            self._check(f"Mode '{mode}' returns 200", response.status_code == 200)
+
+            if response.status_code == 200:
+                data = response.json()
+                # Explicit modes should NOT have routing info
+                has_routing = "routing" in data
+                self._check(
+                    f"Mode '{mode}' has no routing info (explicit mode)",
+                    not has_routing,
+                    "Unexpected routing info present",
+                )
+                self._check(
+                    f"Mode '{mode}' uses requested graph_mode",
+                    data.get("graph_mode") == mode,
+                    f"Got: {data.get('graph_mode')}",
+                )
+
+    async def test_routing_performance(self, client: httpx.AsyncClient):
+        """Test routing performance is under 5ms."""
+        logger.info("\n=== Test: Routing Performance ===")
+
+        latencies = []
+        for i in range(5):
+            response = await client.get(
+                f"{self.base_url}/api/search/query",
+                params={
+                    "q": f"How does authentication work in scenario {i}",
+                    "graph_mode": "auto",
+                },
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                if "routing" in data:
+                    latency = data["routing"].get("routing_latency_ms", 0)
+                    latencies.append(latency)
+
+        if latencies:
+            avg_latency = sum(latencies) / len(latencies)
+            max_latency = max(latencies)
+
+            logger.info(f"  Routing latencies: {[f'{lat:.3f}ms' for lat in latencies]}")
+            logger.info(f"  Average: {avg_latency:.3f}ms, Max: {max_latency:.3f}ms")
+
+            self._check(
+                "Average routing latency < 5ms",
+                avg_latency < 5.0,
+                f"Got: {avg_latency:.3f}ms",
+            )
+            self._check(
+                "Max routing latency < 10ms",
+                max_latency < 10.0,
+                f"Got: {max_latency:.3f}ms",
+            )
+
+    async def run_all_tests(self):
+        """Run all E2E tests."""
+        logger.info("=" * 60)
+        logger.info("Query Router API E2E Tests (Issue #1041)")
+        logger.info(f"Base URL: {self.base_url}")
+        logger.info("=" * 60)
+
+        # Disable proxy to connect directly to localhost
+        transport = httpx.AsyncHTTPTransport(proxy=None)
+        async with httpx.AsyncClient(timeout=30.0, transport=transport) as client:
+            await self.test_health_check(client)
+            await self.test_auto_mode_simple_query(client)
+            await self.test_auto_mode_moderate_query(client)
+            await self.test_auto_mode_complex_query(client)
+            await self.test_auto_mode_limit_adjustment(client)
+            await self.test_invalid_graph_mode(client)
+            await self.test_explicit_modes_still_work(client)
+            await self.test_routing_performance(client)
+
+        logger.info("\n" + "=" * 60)
+        logger.info(f"Results: {self.passed} passed, {self.failed} failed")
+        logger.info("=" * 60)
+
+        return self.failed == 0
+
+
+async def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="Query Router API E2E Tests")
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("NEXUS_SERVER_URL", "http://localhost:2027"),
+        help="Server URL (default: http://localhost:2027)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("NEXUS_API_KEY"),
+        help="API key for authentication",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    test = QueryRouterAPITest(base_url=args.url, api_key=args.api_key)
+    success = await test.run_all_tests()
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/nexus/search/__init__.py
+++ b/src/nexus/search/__init__.py
@@ -87,6 +87,12 @@ from nexus.search.hnsw_config import (
     get_recommended_config,
     get_vector_count,
 )
+from nexus.search.query_router import (
+    QueryRouter,
+    RoutedQuery,
+    RoutingConfig,
+    create_query_router,
+)
 from nexus.search.semantic import SemanticSearch, SemanticSearchResult
 from nexus.search.vector_db import VectorDatabase
 from nexus.search.zoekt_client import (
@@ -139,6 +145,11 @@ __all__ = [
     "GraphEnhancedSearchResult",
     "GraphContext",
     "graph_enhanced_fusion",
+    # Query Router (Issue #1041)
+    "QueryRouter",
+    "RoutedQuery",
+    "RoutingConfig",
+    "create_query_router",
     # BM25S Fast Text Search (Issue #796)
     "BM25SIndex",
     "BM25SSearchResult",

--- a/src/nexus/search/query_router.py
+++ b/src/nexus/search/query_router.py
@@ -1,0 +1,256 @@
+"""Query Router for automatic search strategy selection (Issue #1041).
+
+This module provides intelligent query routing that automatically selects
+the optimal search strategy (vector-only, hybrid, graph-enhanced) based on
+query complexity analysis.
+
+References:
+    - Issue #1041: Query router for automatic search strategy selection
+    - Issue #1022: Query Complexity Estimator (dependency)
+    - Issue #1040: Graph-Enhanced Retrieval (dependency)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.llm.context_builder import ContextBuilder
+
+logger = logging.getLogger(__name__)
+
+# Routing rules based on query complexity
+ROUTING_RULES: dict[str, dict[str, Any]] = {
+    # Simple queries (C_q < 0.3): Vector + BM25 hybrid
+    "simple": {
+        "search_mode": "hybrid",
+        "graph_mode": "none",
+        "limit_multiplier": 0.8,  # Fewer results needed
+    },
+    # Moderate queries (0.3 <= C_q < 0.6): Add entity graph
+    "moderate": {
+        "search_mode": "hybrid",
+        "graph_mode": "low",  # Entity expansion only
+        "limit_multiplier": 1.0,
+    },
+    # Complex queries (0.6 <= C_q < 0.8): Full dual-level
+    "complex": {
+        "search_mode": "hybrid",
+        "graph_mode": "dual",  # Low + high level
+        "limit_multiplier": 1.2,
+    },
+    # Very complex queries (C_q >= 0.8): Maximum retrieval
+    "very_complex": {
+        "search_mode": "hybrid",
+        "graph_mode": "dual",
+        "limit_multiplier": 1.5,
+        "include_community_summaries": True,
+    },
+}
+
+# Complexity thresholds (configurable)
+DEFAULT_THRESHOLDS = {
+    "simple_max": 0.3,
+    "moderate_max": 0.6,
+    "complex_max": 0.8,
+}
+
+
+@dataclass
+class RoutingConfig:
+    """Configuration for query routing thresholds and behavior."""
+
+    simple_max: float = 0.3
+    moderate_max: float = 0.6
+    complex_max: float = 0.8
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        """Validate thresholds."""
+        if not (0 < self.simple_max < self.moderate_max < self.complex_max <= 1.0):
+            raise ValueError(
+                f"Invalid thresholds: simple_max={self.simple_max}, "
+                f"moderate_max={self.moderate_max}, complex_max={self.complex_max}. "
+                "Must satisfy: 0 < simple_max < moderate_max < complex_max <= 1.0"
+            )
+
+
+@dataclass
+class RoutedQuery:
+    """Result of query routing with strategy decisions."""
+
+    original_query: str
+    complexity_score: float
+    complexity_class: str  # simple, moderate, complex, very_complex
+    search_mode: str
+    graph_mode: str
+    adjusted_limit: int
+    reasoning: str  # Explanation for debugging
+    routing_latency_ms: float = 0.0
+    include_community_summaries: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for API response."""
+        return {
+            "original_query": self.original_query,
+            "complexity_score": self.complexity_score,
+            "complexity_class": self.complexity_class,
+            "search_mode": self.search_mode,
+            "graph_mode": self.graph_mode,
+            "adjusted_limit": self.adjusted_limit,
+            "reasoning": self.reasoning,
+            "routing_latency_ms": self.routing_latency_ms,
+            "include_community_summaries": self.include_community_summaries,
+        }
+
+
+@dataclass
+class QueryRouter:
+    """Routes queries to optimal search strategies based on complexity.
+
+    Uses query complexity estimation from ContextBuilder to automatically
+    select the best search mode and graph mode for each query.
+
+    Example:
+        >>> from nexus.llm import ContextBuilder
+        >>> from nexus.search import QueryRouter
+        >>> context_builder = ContextBuilder()
+        >>> router = QueryRouter(context_builder)
+        >>> routed = router.route("How does authentication work?")
+        >>> print(routed.search_mode, routed.graph_mode)
+        hybrid low
+    """
+
+    context_builder: ContextBuilder | None = None
+    config: RoutingConfig = field(default_factory=RoutingConfig)
+
+    def route(self, query: str, base_limit: int = 10) -> RoutedQuery:
+        """Analyze query and determine optimal search strategy.
+
+        Args:
+            query: The search query to route
+            base_limit: Base number of results to retrieve
+
+        Returns:
+            RoutedQuery with optimal strategy parameters
+        """
+        start_time = time.perf_counter()
+
+        # Estimate complexity
+        if self.context_builder is not None:
+            complexity = self.context_builder.estimate_query_complexity(query)
+        else:
+            # Fallback to simple heuristic if no context builder
+            complexity = self._estimate_complexity_fallback(query)
+
+        # Classify and get strategy
+        complexity_class = self._classify_complexity(complexity)
+        strategy = ROUTING_RULES[complexity_class]
+
+        # Calculate adjusted limit
+        adjusted_limit = max(1, int(base_limit * strategy["limit_multiplier"]))
+
+        # Calculate routing latency
+        routing_latency_ms = (time.perf_counter() - start_time) * 1000
+
+        routed = RoutedQuery(
+            original_query=query,
+            complexity_score=complexity,
+            complexity_class=complexity_class,
+            search_mode=strategy["search_mode"],
+            graph_mode=strategy["graph_mode"],
+            adjusted_limit=adjusted_limit,
+            reasoning=f"Query classified as {complexity_class} (score={complexity:.2f})",
+            routing_latency_ms=routing_latency_ms,
+            include_community_summaries=strategy.get("include_community_summaries", False),
+        )
+
+        logger.debug(
+            f"[QUERY-ROUTER] {routed.reasoning}, "
+            f"search_mode={routed.search_mode}, graph_mode={routed.graph_mode}, "
+            f"limit={routed.adjusted_limit} (latency={routing_latency_ms:.2f}ms)"
+        )
+
+        return routed
+
+    def _classify_complexity(self, complexity: float) -> str:
+        """Classify complexity score into a category."""
+        if complexity < self.config.simple_max:
+            return "simple"
+        elif complexity < self.config.moderate_max:
+            return "moderate"
+        elif complexity < self.config.complex_max:
+            return "complex"
+        else:
+            return "very_complex"
+
+    def _estimate_complexity_fallback(self, query: str) -> float:
+        """Simple fallback complexity estimation when no context builder available.
+
+        Uses basic heuristics similar to ContextBuilder but simplified.
+        """
+        score = 0.0
+        query_lower = query.lower()
+        words = query_lower.split()
+        word_set = set(words)
+
+        # Word count factor (normalized, max 0.25)
+        score += min(len(words) / 20.0, 0.25)
+
+        # Comparison indicators (+0.2)
+        comparison_words = {"vs", "versus", "compare", "comparison", "difference", "between"}
+        if word_set & comparison_words:
+            score += 0.2
+
+        # Temporal indicators (+0.15)
+        temporal_words = {"when", "before", "after", "history", "timeline", "since", "until"}
+        if word_set & temporal_words:
+            score += 0.15
+
+        # Aggregation indicators (+0.15)
+        aggregation_words = {"all", "every", "summary", "overview", "list", "total"}
+        if word_set & aggregation_words:
+            score += 0.15
+
+        # Multi-hop patterns (+0.2)
+        multihop_patterns = [
+            "how does",
+            "how do",
+            "why does",
+            "why do",
+            "what happens when",
+            "relationship between",
+            "impact of",
+            "effect of",
+        ]
+        if any(pattern in query_lower for pattern in multihop_patterns):
+            score += 0.2
+
+        # Complex question patterns (+0.15)
+        complex_patterns = ["explain", "analyze", "evaluate", "describe how"]
+        if any(pattern in query_lower for pattern in complex_patterns):
+            score += 0.15
+
+        return min(score, 1.0)
+
+
+def create_query_router(
+    context_builder: ContextBuilder | None = None,
+    config: RoutingConfig | None = None,
+) -> QueryRouter:
+    """Factory function to create a QueryRouter.
+
+    Args:
+        context_builder: Optional ContextBuilder for complexity estimation
+        config: Optional routing configuration
+
+    Returns:
+        Configured QueryRouter instance
+    """
+    return QueryRouter(
+        context_builder=context_builder,
+        config=config or RoutingConfig(),
+    )

--- a/tests/unit/search/test_query_router.py
+++ b/tests/unit/search/test_query_router.py
@@ -1,0 +1,326 @@
+"""Tests for Query Router (Issue #1041).
+
+Tests the intelligent query routing that automatically selects
+optimal search strategies based on query complexity.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.search.query_router import (
+    ROUTING_RULES,
+    QueryRouter,
+    RoutedQuery,
+    RoutingConfig,
+    create_query_router,
+)
+
+
+class TestRoutingConfig:
+    """Test RoutingConfig validation."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = RoutingConfig()
+        assert config.simple_max == 0.3
+        assert config.moderate_max == 0.6
+        assert config.complex_max == 0.8
+        assert config.enabled is True
+
+    def test_custom_config(self):
+        """Test custom configuration values."""
+        config = RoutingConfig(
+            simple_max=0.25,
+            moderate_max=0.5,
+            complex_max=0.75,
+            enabled=True,
+        )
+        assert config.simple_max == 0.25
+        assert config.moderate_max == 0.5
+        assert config.complex_max == 0.75
+
+    def test_invalid_thresholds_order(self):
+        """Test that invalid threshold order raises error."""
+        with pytest.raises(ValueError, match="Invalid thresholds"):
+            RoutingConfig(simple_max=0.5, moderate_max=0.3, complex_max=0.8)
+
+    def test_invalid_thresholds_out_of_range(self):
+        """Test that thresholds > 1.0 raise error."""
+        with pytest.raises(ValueError, match="Invalid thresholds"):
+            RoutingConfig(simple_max=0.3, moderate_max=0.6, complex_max=1.5)
+
+
+class TestRoutedQuery:
+    """Test RoutedQuery dataclass."""
+
+    def test_to_dict(self):
+        """Test RoutedQuery serialization."""
+        routed = RoutedQuery(
+            original_query="How does authentication work?",
+            complexity_score=0.65,
+            complexity_class="complex",
+            search_mode="hybrid",
+            graph_mode="dual",
+            adjusted_limit=12,
+            reasoning="Query classified as complex (score=0.65)",
+            routing_latency_ms=1.5,
+            include_community_summaries=False,
+        )
+
+        data = routed.to_dict()
+
+        assert data["original_query"] == "How does authentication work?"
+        assert data["complexity_score"] == 0.65
+        assert data["complexity_class"] == "complex"
+        assert data["search_mode"] == "hybrid"
+        assert data["graph_mode"] == "dual"
+        assert data["adjusted_limit"] == 12
+        assert data["reasoning"] == "Query classified as complex (score=0.65)"
+        assert data["routing_latency_ms"] == 1.5
+        assert data["include_community_summaries"] is False
+
+
+class TestQueryRouter:
+    """Test QueryRouter functionality."""
+
+    def test_simple_query_routing(self):
+        """Test routing of simple queries."""
+        router = QueryRouter()
+
+        # Simple query: "what is X"
+        routed = router.route("what is authentication")
+
+        # Simple queries should use hybrid search with no graph
+        assert routed.search_mode == "hybrid"
+        assert routed.graph_mode == "none"
+        assert routed.complexity_class == "simple"
+        assert routed.complexity_score < 0.3
+
+    def test_moderate_query_routing(self):
+        """Test routing of moderate complexity queries."""
+        router = QueryRouter()
+
+        # Moderate query with comparison
+        routed = router.route("compare OAuth vs JWT for API authentication")
+
+        # Should have graph_mode="low" for entity expansion
+        assert routed.search_mode == "hybrid"
+        assert routed.complexity_class in ("moderate", "complex")
+        assert routed.graph_mode in ("low", "dual")
+
+    def test_complex_query_routing(self):
+        """Test routing of complex multi-hop queries."""
+        router = QueryRouter()
+
+        # Complex query with multi-hop reasoning and temporal aspect
+        routed = router.route(
+            "How does the AuthService authenticate users and what happens "
+            "when the JWTProvider expires the token before the refresh interval?"
+        )
+
+        # Should be complex or very_complex
+        assert routed.complexity_class in ("complex", "very_complex")
+        assert routed.graph_mode == "dual"
+
+    def test_limit_adjustment_simple(self):
+        """Test limit multiplier for simple queries."""
+        router = QueryRouter()
+        routed = router.route("what is X", base_limit=10)
+
+        # Simple queries have 0.8 multiplier
+        assert routed.adjusted_limit == 8
+
+    def test_limit_adjustment_complex(self):
+        """Test limit multiplier for complex queries."""
+        router = QueryRouter()
+        routed = router.route(
+            "explain how authentication works and compare different methods "
+            "including their security implications over time",
+            base_limit=10,
+        )
+
+        # Complex queries have >= 1.0 multiplier
+        assert routed.adjusted_limit >= 10
+
+    def test_routing_latency_recorded(self):
+        """Test that routing latency is recorded."""
+        router = QueryRouter()
+        routed = router.route("test query")
+
+        assert routed.routing_latency_ms >= 0
+        assert routed.routing_latency_ms < 100  # Should be very fast
+
+    def test_routing_with_context_builder(self):
+        """Test routing with a mock ContextBuilder."""
+        mock_context_builder = MagicMock()
+        mock_context_builder.estimate_query_complexity.return_value = 0.75
+
+        router = QueryRouter(context_builder=mock_context_builder)
+        routed = router.route("test query")
+
+        # Should use the context builder's complexity
+        assert routed.complexity_score == 0.75
+        assert routed.complexity_class == "complex"
+        mock_context_builder.estimate_query_complexity.assert_called_once_with("test query")
+
+    def test_routing_without_context_builder(self):
+        """Test fallback when no context builder is provided."""
+        router = QueryRouter(context_builder=None)
+        routed = router.route("How does authentication work?")
+
+        # Should use fallback estimation
+        assert 0.0 <= routed.complexity_score <= 1.0
+        assert routed.complexity_class in ("simple", "moderate", "complex", "very_complex")
+
+    def test_custom_thresholds(self):
+        """Test routing with custom thresholds."""
+        config = RoutingConfig(
+            simple_max=0.2,
+            moderate_max=0.4,
+            complex_max=0.6,
+        )
+
+        # Mock a query with complexity 0.5 (would be "moderate" with defaults)
+        mock_context_builder = MagicMock()
+        mock_context_builder.estimate_query_complexity.return_value = 0.5
+
+        router = QueryRouter(context_builder=mock_context_builder, config=config)
+        routed = router.route("test")
+
+        # With custom thresholds, 0.5 is "complex" (0.4 <= 0.5 < 0.6)
+        assert routed.complexity_class == "complex"
+
+
+class TestRoutingRules:
+    """Test the routing rules configuration."""
+
+    def test_simple_rules(self):
+        """Test simple query routing rules."""
+        rules = ROUTING_RULES["simple"]
+        assert rules["search_mode"] == "hybrid"
+        assert rules["graph_mode"] == "none"
+        assert rules["limit_multiplier"] == 0.8
+
+    def test_moderate_rules(self):
+        """Test moderate query routing rules."""
+        rules = ROUTING_RULES["moderate"]
+        assert rules["search_mode"] == "hybrid"
+        assert rules["graph_mode"] == "low"
+        assert rules["limit_multiplier"] == 1.0
+
+    def test_complex_rules(self):
+        """Test complex query routing rules."""
+        rules = ROUTING_RULES["complex"]
+        assert rules["search_mode"] == "hybrid"
+        assert rules["graph_mode"] == "dual"
+        assert rules["limit_multiplier"] == 1.2
+
+    def test_very_complex_rules(self):
+        """Test very complex query routing rules."""
+        rules = ROUTING_RULES["very_complex"]
+        assert rules["search_mode"] == "hybrid"
+        assert rules["graph_mode"] == "dual"
+        assert rules["limit_multiplier"] == 1.5
+        assert rules["include_community_summaries"] is True
+
+
+class TestCreateQueryRouter:
+    """Test the factory function."""
+
+    def test_create_with_defaults(self):
+        """Test creating router with defaults."""
+        router = create_query_router()
+        assert router.context_builder is None
+        assert router.config.simple_max == 0.3
+
+    def test_create_with_context_builder(self):
+        """Test creating router with context builder."""
+        mock_builder = MagicMock()
+        router = create_query_router(context_builder=mock_builder)
+        assert router.context_builder is mock_builder
+
+    def test_create_with_custom_config(self):
+        """Test creating router with custom config."""
+        config = RoutingConfig(simple_max=0.25, moderate_max=0.5, complex_max=0.75)
+        router = create_query_router(config=config)
+        assert router.config.simple_max == 0.25
+        assert router.config.moderate_max == 0.5
+        assert router.config.complex_max == 0.75
+
+
+class TestFallbackComplexityEstimation:
+    """Test the fallback complexity estimation."""
+
+    def test_word_count_factor(self):
+        """Test word count contribution."""
+        router = QueryRouter()
+
+        short_query = router.route("test")
+        long_query = router.route("this is a much longer query with many more words included")
+
+        assert long_query.complexity_score > short_query.complexity_score
+
+    def test_comparison_indicators(self):
+        """Test comparison words boost complexity."""
+        router = QueryRouter()
+
+        normal = router.route("what is authentication")
+        comparison = router.route("compare authentication methods")
+
+        assert comparison.complexity_score > normal.complexity_score
+
+    def test_temporal_indicators(self):
+        """Test temporal words boost complexity."""
+        router = QueryRouter()
+
+        normal = router.route("what is the status")
+        temporal = router.route("what was the status before the update")
+
+        assert temporal.complexity_score > normal.complexity_score
+
+    def test_multihop_patterns(self):
+        """Test multi-hop patterns boost complexity."""
+        router = QueryRouter()
+
+        simple = router.route("what is X")
+        multihop = router.route("how does X affect Y")
+
+        assert multihop.complexity_score > simple.complexity_score
+
+    def test_complex_question_patterns(self):
+        """Test complex question patterns boost complexity."""
+        router = QueryRouter()
+
+        simple = router.route("what is authentication")
+        complex_q = router.route("explain how authentication works")
+
+        assert complex_q.complexity_score > simple.complexity_score
+
+
+class TestPerformance:
+    """Test performance requirements."""
+
+    def test_routing_under_5ms(self):
+        """Test that routing completes in under 5ms."""
+        router = QueryRouter()
+
+        # Run multiple iterations to ensure consistent performance
+        for _ in range(10):
+            routed = router.route(
+                "How does the authentication system handle token refresh "
+                "when multiple services are involved?"
+            )
+            # Routing should be fast (< 5ms as per requirement)
+            assert routed.routing_latency_ms < 5.0
+
+    def test_routing_with_mock_context_builder_under_5ms(self):
+        """Test routing with mock context builder is fast."""
+        mock_builder = MagicMock()
+        mock_builder.estimate_query_complexity.return_value = 0.5
+
+        router = QueryRouter(context_builder=mock_builder)
+
+        for _ in range(10):
+            routed = router.route("test query")
+            assert routed.routing_latency_ms < 5.0


### PR DESCRIPTION
## Summary

Implements intelligent query routing that automatically selects the optimal search strategy (vector-only, hybrid, graph-enhanced) based on query complexity analysis.

- Add `QueryRouter` class with complexity-based routing
- Add `graph_mode="auto"` parameter to `/api/search/query` endpoint
- Configurable routing thresholds via `RoutingConfig`
- Include routing decision in API response for debugging
- Fallback complexity estimation when no ContextBuilder available

## Routing Rules

| Complexity Class | Score Range | Search Mode | Graph Mode | Limit Multiplier |
|-----------------|-------------|-------------|------------|------------------|
| Simple | C_q < 0.3 | hybrid | none | 0.8x |
| Moderate | 0.3 ≤ C_q < 0.6 | hybrid | low | 1.0x |
| Complex | 0.6 ≤ C_q < 0.8 | hybrid | dual | 1.2x |
| Very Complex | C_q ≥ 0.8 | hybrid | dual | 1.5x |

## Files Changed

| File | Description |
|------|-------------|
| `src/nexus/search/query_router.py` | Core implementation (256 lines) |
| `src/nexus/search/__init__.py` | Export new classes |
| `src/nexus/server/fastapi_server.py` | API integration |
| `tests/unit/search/test_query_router.py` | 28 unit tests |

## Test Plan

- [x] Unit tests pass (28 tests)
- [x] Ruff lint checks pass
- [x] Performance: <5ms routing overhead
- [ ] CI pipeline

## API Usage

```bash
# Auto-route based on query complexity
curl "http://localhost:2027/api/search/query?q=How+does+auth+work&graph_mode=auto"

# Response includes routing decision
{
    "query": "How does auth work",
    "graph_mode": "low",
    "routing": {
        "complexity_score": 0.45,
        "complexity_class": "moderate",
        "search_mode": "hybrid",
        "graph_mode": "low",
        "adjusted_limit": 10,
        "reasoning": "Query classified as moderate (score=0.45)",
        "routing_latency_ms": 0.32
    },
    "results": [...],
    "latency_ms": 15.2
}
```

## Dependencies

- Requires: #1022 (Query Complexity Estimator) ✅, #1040 (Graph-Enhanced Retrieval) ✅

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)