### PR TITLE
feat: Add configurable tenant isolation with secure defaults

### DIFF
--- a/configs/config.demo.yaml
+++ b/configs/config.demo.yaml
@@ -103,6 +103,10 @@ auth:
   token_expiry_hours: 24
   api_key_expiry_days: 365
 
+# Permission and Security Settings
+enforce_permissions: true            # Enable permission enforcement by default (use --no-permissions to disable)
+enforce_tenant_isolation: true       # Enable tenant isolation by default (use --no-tenant-isolation to disable)
+
 # Features
 features:
   semantic_search: false  # Disabled for demo

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -343,6 +343,16 @@ def connect(
             # Dict config without explicit enforce_permissions - use embedded default
             enforce_permissions = False
 
+        # Handle tenant isolation configuration
+        # Default: enabled for security unless explicitly disabled
+        enforce_tenant_isolation = cfg.enforce_tenant_isolation
+        if config is None:
+            # No explicit config - use secure default (enabled)
+            enforce_tenant_isolation = True
+        elif isinstance(config, dict) and "enforce_tenant_isolation" not in config:
+            # Dict config without explicit setting - use secure default
+            enforce_tenant_isolation = True
+
         # Create NexusFS instance
         nx_fs = NexusFS(
             backend=backend,
@@ -360,6 +370,7 @@ def connect(
             parse_providers=cfg.parse_providers,
             enforce_permissions=enforce_permissions,
             allow_admin_bypass=cfg.allow_admin_bypass,  # P0-4: Admin bypass setting
+            enforce_tenant_isolation=enforce_tenant_isolation,  # P0-2: Tenant isolation setting
             enable_workflows=cfg.enable_workflows,  # v0.7.0: Workflow automation
         )
 

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -185,6 +185,7 @@ def get_filesystem(
     enforce_permissions: bool | None = None,
     force_local: bool = False,
     allow_admin_bypass: bool | None = None,
+    enforce_tenant_isolation: bool | None = None,
 ) -> NexusFilesystem:
     """Get Nexus filesystem instance from backend configuration.
 
@@ -193,6 +194,7 @@ def get_filesystem(
         enforce_permissions: Whether to enforce permissions (None = use environment/config default)
         force_local: If True, always use local NexusFS even if NEXUS_URL is set (for server mode)
         allow_admin_bypass: Whether admin keys can bypass permission checks (None = use default False)
+        enforce_tenant_isolation: Whether to enforce tenant isolation (None = use default True)
 
     Returns:
         NexusFilesystem instance
@@ -221,6 +223,8 @@ def get_filesystem(
                     config_dict["enforce_permissions"] = enforce_permissions
                 if allow_admin_bypass is not None:
                     config_dict["allow_admin_bypass"] = allow_admin_bypass
+                if enforce_tenant_isolation is not None:
+                    config_dict["enforce_tenant_isolation"] = enforce_tenant_isolation
                 nx_fs = nexus.connect(config=config_dict)
                 # Store full config object for OAuth factory access
                 if hasattr(nx_fs, "_config") or hasattr(nx_fs, "__dict__"):
@@ -250,6 +254,8 @@ def get_filesystem(
                 config["enforce_permissions"] = enforce_permissions
             if allow_admin_bypass is not None:
                 config["allow_admin_bypass"] = allow_admin_bypass
+            if enforce_tenant_isolation is not None:
+                config["enforce_tenant_isolation"] = enforce_tenant_isolation
             nx_fs = nexus.connect(config=config)
             # Note: For dict configs, _config is already set in nexus.connect()
             return nx_fs
@@ -263,6 +269,8 @@ def get_filesystem(
                 config["enforce_permissions"] = enforce_permissions
             if allow_admin_bypass is not None:
                 config["allow_admin_bypass"] = allow_admin_bypass
+            if enforce_tenant_isolation is not None:
+                config["enforce_tenant_isolation"] = enforce_tenant_isolation
             nx_fs = nexus.connect(config=config)
             # Note: For dict configs, _config is already set in nexus.connect()
             return nx_fs

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -186,6 +186,15 @@ class NexusConfig(BaseModel):
         description="Allow admin keys to bypass permission checks (default True for dev experience)",
     )
 
+    # Tenant isolation setting (P0-2)
+    # Default: True for multi-tenant security
+    # Set to False ONLY for single-tenant environments or development
+    # WARNING: Disabling tenant isolation allows cross-tenant data access
+    enforce_tenant_isolation: bool = Field(
+        default=True,
+        description="Enable tenant isolation enforcement (default True for security)",
+    )
+
     # Workspace and Memory registry (v0.7.0)
     workspaces: list[dict[str, Any]] | None = Field(
         default=None,
@@ -397,6 +406,7 @@ def _load_from_environment() -> NexusConfig:
         "NEXUS_IS_ADMIN": "is_admin",
         "NEXUS_ENFORCE_PERMISSIONS": "enforce_permissions",
         "NEXUS_ALLOW_ADMIN_BYPASS": "allow_admin_bypass",
+        "NEXUS_ENFORCE_TENANT_ISOLATION": "enforce_tenant_isolation",
         "NEXUS_URL": "url",
         "NEXUS_API_KEY": "api_key",
         "NEXUS_TIMEOUT": "timeout",
@@ -441,6 +451,7 @@ def _load_from_environment() -> NexusConfig:
                 "is_admin",
                 "enforce_permissions",
                 "allow_admin_bypass",
+                "enforce_tenant_isolation",
             ]:
                 converted_value = value.lower() in ["true", "1", "yes", "on"]
             else:

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -107,6 +107,7 @@ class NexusFS(  # type: ignore[misc]
         enforce_permissions: bool = True,  # P0-6: ENABLED by default for security
         inherit_permissions: bool = True,  # P0-3: Enable automatic parent tuple creation for directory inheritance
         allow_admin_bypass: bool = False,  # P0-4: Allow admin bypass (DEFAULT OFF for production security)
+        enforce_tenant_isolation: bool = True,  # P0-2: Enable tenant isolation (DEFAULT ON for security)
         audit_strict_mode: bool = True,  # P0 COMPLIANCE: Fail writes if audit logging fails (DEFAULT ON)
         enable_workflows: bool = True,  # v0.7.0: Enable automatic workflow triggering (DEFAULT ON)
         workflow_engine: Any
@@ -140,6 +141,7 @@ class NexusFS(  # type: ignore[misc]
             enforce_permissions: Enable permission enforcement on file operations (default: True)
             inherit_permissions: Enable automatic parent tuple creation for directory inheritance (default: True, P0-3)
             allow_admin_bypass: Allow admin users to bypass permission checks (default: False for security, P0-4)
+            enforce_tenant_isolation: Enable tenant isolation to prevent cross-tenant access (default: True for security, P0-2)
             enable_workflows: Enable automatic workflow triggering on file operations (default: True, v0.7.0)
             workflow_engine: Optional workflow engine instance. If None and enable_workflows=True, auto-creates engine (v0.7.0)
 
@@ -286,7 +288,7 @@ class NexusFS(  # type: ignore[misc]
             engine=self.metadata.engine,  # Use SQLAlchemy engine (supports SQLite + PostgreSQL)
             cache_ttl_seconds=cache_ttl_seconds or 300,
             max_depth=10,
-            enforce_tenant_isolation=True,  # P0-2: Tenant scoping
+            enforce_tenant_isolation=enforce_tenant_isolation,  # P0-2: Tenant scoping (configurable)
             enable_graph_limits=True,  # P0-5: DoS protection
             enable_tiger_cache=enable_tiger_cache,  # Tiger Cache for materialized permissions
         )
@@ -337,6 +339,10 @@ class NexusFS(  # type: ignore[misc]
         # Permission enforcement is opt-in for backward compatibility
         # Set enforce_permissions=True in init to enable permission checks
         self._enforce_permissions = enforce_permissions
+
+        # P0-2: Tenant isolation enforcement
+        # Set enforce_tenant_isolation=False ONLY for single-tenant environments
+        self._enforce_tenant_isolation = enforce_tenant_isolation
 
         # P0-3: Initialize HierarchyManager for automatic parent tuple creation
         from nexus.core.hierarchy_manager import HierarchyManager


### PR DESCRIPTION
## Summary

This PR makes tenant isolation independently configurable from permissions, allowing fine-grained control over security settings for testing and production.

## Changes

### Core Configuration
- **Add `enforce_tenant_isolation` config field** with default `True` (secure by default)
- **Add `NEXUS_ENFORCE_TENANT_ISOLATION` environment variable** support
- **Update configuration priority**: Environment variable → Config file → Default value

### Command-Line Tools
- **Update `/local-demo.sh`** (root) with `--no-tenant-isolation` flag
- **Update `/nexus/local-demo.sh`** with `--no-permissions`, `--no-tenant-isolation`, `--no-auth` flags
- Both scripts now show security status in configuration output

### API & Debugging
- **Extend `/health` endpoint** to expose security configuration:
  - `enforce_permissions`: boolean
  - `enforce_tenant_isolation`: boolean  
  - `has_auth`: boolean

### Bug Fixes
- **Fix bug in `connect()` function** where `enforce_tenant_isolation` wasn't passed to `NexusFS` constructor

### Configuration Updates
- **Update `config.demo.yaml`** to use secure defaults (all security features enabled by default)

## Security Model

This PR establishes a dual-layer security model:

1. **Permissions** (`enforce_permissions`): Controls whether operations require specific permissions (READ, WRITE, etc.)
2. **Tenant Isolation** (`enforce_tenant_isolation`): Controls whether users can access data across tenant boundaries

Both layers are:
- Independent (can be disabled separately)
- Secure-by-default (enabled unless explicitly disabled)
- Configurable via environment variables, config files, or command-line flags

## Usage Examples

```bash
# Secure default: All security enabled
./local-demo.sh

# Auth enabled, but no permission checks
./local-demo.sh --no-permissions

# Auth + permissions enabled, isolation disabled  
./local-demo.sh --no-tenant-isolation

# All security disabled (testing only)
./local-demo.sh --no-auth --no-permissions --no-tenant-isolation
```

## Testing

Tested with:
- ✅ All security enabled (default)
- ✅ Permissions disabled, tenant isolation enabled
- ✅ Tenant isolation disabled, permissions enabled  
- ✅ All security disabled
- ✅ Health endpoint correctly reports configuration
- ✅ Cross-tenant file access works when isolation is disabled
- ✅ Cross-tenant file access blocked when isolation is enabled

## Files Changed

- `src/nexus/config.py` - Add enforce_tenant_isolation field
- `src/nexus/core/nexus_fs.py` - Add parameter to constructor
- `src/nexus/cli/commands/server.py` - Config loading with env var support
- `src/nexus/__init__.py` - Fix bug where setting wasn't passed to NexusFS
- `src/nexus/server/fastapi_server.py` - Add health endpoint fields
- `src/nexus/cli/utils.py` - Propagate setting through utilities
- `local-demo.sh` - Add --no-tenant-isolation flag
- `nexus/local-demo.sh` - Add --no-permissions, --no-tenant-isolation, --no-auth flags  
- `configs/config.demo.yaml` - Set secure defaults

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>