### PR TITLE
fix(#1106): Add L2 write-through to Tiger Cache grant/revoke operations

### DIFF
--- a/src/nexus/core/tiger_cache.py
+++ b/src/nexus/core/tiger_cache.py
@@ -1551,7 +1551,19 @@ class TigerCache:
                 )
                 # Commit happens automatically when exiting 'with' block
 
-            # Step 4: Update in-memory cache
+            # Step 4: Update L2 cache (Dragonfly) for cross-instance consistency
+            if self._dragonfly:
+                self._run_dragonfly_op(
+                    operation="set",
+                    subject_type=subject_type,
+                    subject_id=subject_id,
+                    permission=permission,
+                    resource_type=resource_type,
+                    bitmap_data=bitmap_data,
+                    revision=revision,
+                )
+
+            # Step 5: Update L1 in-memory cache
             with self._lock:
                 self._evict_if_needed()
                 self._cache[key] = (bitmap, revision, time.time())
@@ -1691,7 +1703,19 @@ class TigerCache:
                     },
                 )
 
-            # Step 5: Update in-memory cache
+            # Step 5: Update L2 cache (Dragonfly) for cross-instance consistency
+            if self._dragonfly:
+                self._run_dragonfly_op(
+                    operation="set",
+                    subject_type=subject_type,
+                    subject_id=subject_id,
+                    permission=permission,
+                    resource_type=resource_type,
+                    bitmap_data=bitmap_data,
+                    revision=revision,
+                )
+
+            # Step 6: Update L1 in-memory cache
             with self._lock:
                 self._evict_if_needed()
                 self._cache[key] = (bitmap, revision, time.time())


### PR DESCRIPTION
## Summary
- Add Dragonfly L2 cache updates after database commits in `persist_single_grant()` and `persist_single_revoke()`
- Ensures cross-instance consistency when permissions are modified
- Write-through pattern: L3 (PostgreSQL) -> L2 (Dragonfly) -> L1 (memory)

## Changes
- `persist_single_grant()`: Added Step 4 (L2 update) between DB commit and L1 update
- `persist_single_revoke()`: Added Step 5 (L2 update) between DB commit and L1 update

## Test plan
- [x] Verified ruff check passes
- [x] Verified ruff format passes
- [ ] CI Docker Integration tests
- [ ] Manual e2e test with `nexus serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)