### PR TITLE
fix(#1177): Add flush() calls to ensure HTTP responses are fully sent

### DIFF
--- a/src/nexus/server/rpc_server.py
+++ b/src/nexus/server/rpc_server.py
@@ -1616,6 +1616,7 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+        self.wfile.flush()  # Ensure all data is sent before connection closes
 
     def _send_error_response(
         self,
@@ -1661,6 +1662,7 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+        self.wfile.flush()  # Ensure all data is sent before connection closes
 
 
 class NexusRPCServer:


### PR DESCRIPTION
## Summary
- Add `self.wfile.flush()` calls after writing response bodies in RPC request handler
- Ensures all buffered data is transmitted before connection closes
- Prevents potential response truncation under high load or network latency

## Changes
- Modified `_send_success_response()` method in `src/nexus/server/rpc_server.py:1619`
- Modified `_send_error_response()` method in `src/nexus/server/rpc_server.py:1665`

## Testing
- All existing RPC endpoints should function correctly
- No performance impact expected (flush overhead is negligible)

Fixes #1177

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>