### PR TITLE
fix: check permission on first existing ancestor for mkdir with parents=True

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1413,12 +1413,20 @@ class NexusFS(  # type: ignore[misc]
         # Use provided context or default
         ctx = context if context is not None else self._default_context
 
-        # Check write permission on parent directory
-        # Only check if parent exists and we're not creating it with --parents
-        # Skip check if parent will be created as part of this mkdir operation
+        # Check write permission on the appropriate ancestor directory
+        # - parents=False: check immediate parent (must exist)
+        # - parents=True: check first existing ancestor (will create missing parents)
         parent_path = self._get_parent_path(path)
-        if parent_path and self.metadata.exists(parent_path) and not parents:
-            self._check_permission(parent_path, Permission.WRITE, ctx)
+        if parent_path:
+            check_path: str | None = parent_path
+            if parents:
+                # Find the first existing ancestor to check permission on
+                while check_path and check_path != "/" and not self.metadata.exists(check_path):
+                    check_path = self._get_parent_path(check_path)
+
+            # Check WRITE permission on the existing ancestor
+            if check_path and self.metadata.exists(check_path):
+                self._check_permission(check_path, Permission.WRITE, ctx)
 
         # Route to backend with write access check (mkdir requires write permission)
         route = self.router.route(


### PR DESCRIPTION
## Summary

Fixes the `parents=True` permission bypass bug in `mkdir()`.

## The Bug

Previously, `mkdir(path, parents=True)` bypassed the WRITE permission check entirely when the immediate parent didn't exist:

```python
# OLD (buggy)
if parent_path and self.metadata.exists(parent_path) and not parents:
    self._check_permission(parent_path, Permission.WRITE, ctx)
```

This meant:
- `/a` exists (user has **no** write permission)
- `mkdir("/a/b/c/d", parents=True)` → **succeeds!** (bug)
- Because `/a/b/c` doesn't exist, no permission check happened at all

## The Fix

Now we walk up to find the **first existing ancestor** and check permission there:

```python
# NEW (correct)
check_path: str | None = parent_path
if parents:
    # Find the first existing ancestor to check permission on
    while check_path and check_path != "/" and not self.metadata.exists(check_path):
        check_path = self._get_parent_path(check_path)

if check_path and self.metadata.exists(check_path):
    self._check_permission(check_path, Permission.WRITE, ctx)
```

## Behavior

| Scenario | `parents=False` | `parents=True` |
|----------|-----------------|----------------|
| `/a` exists, create `/a/b` | Check `/a` | Check `/a` |
| `/a` exists, create `/a/b/c/d` | Error (parent missing) | Check `/a` ✓ |
| `/a/b` exists, create `/a/b/c` | Check `/a/b` | Check `/a/b` |

This matches Unix `mkdir -p` semantics: you need write permission on the closest existing ancestor to create directories under it.

## Test Plan

- [ ] `mkdir("/a/b", parents=True)` fails when user lacks WRITE on `/a`
- [ ] `mkdir("/a/b/c/d", parents=True)` fails when user lacks WRITE on `/a`
- [ ] `mkdir("/user/dir", parents=True)` succeeds when user has WRITE on `/user`

Fixes #1200

Made with [Cursor](https://cursor.com)