### PR TITLE
feat(subscriptions): use subject_type and subject_id in webhook event data

### DIFF
--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -1896,8 +1896,6 @@ class NexusFSCoreMixin:
                 "etag": content_hash,
                 "version": new_version,
                 "zone_id": zone_id or "default",
-                "agent_id": agent_id,
-                "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "subject_type": getattr(context, "subject_type", None) if context else None,
                 "subject_id": (
                     getattr(context, "subject_id", None) or getattr(context, "user", None)
@@ -2836,8 +2834,6 @@ class NexusFSCoreMixin:
                 "size": meta.size,
                 "etag": meta.etag,
                 "zone_id": zone_id or "default",
-                "agent_id": agent_id,
-                "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "subject_type": getattr(context, "subject_type", None) if context else None,
                 "subject_id": (
                     getattr(context, "subject_id", None) or getattr(context, "user", None)
@@ -3148,8 +3144,6 @@ class NexusFSCoreMixin:
                 "size": meta.size if meta else 0,
                 "etag": meta.etag if meta else None,
                 "zone_id": zone_id or "default",
-                "agent_id": agent_id,
-                "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "subject_type": getattr(context, "subject_type", None) if context else None,
                 "subject_id": (
                     getattr(context, "subject_id", None) or getattr(context, "user", None)

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -4169,18 +4169,12 @@ async def _fire_rpc_event(
 
     try:
         zone_id = getattr(context, "zone_id", None) or "default"
+        # Identity: subject_type + subject_id only (no user_id/agent_id in event data)
         data: dict[str, Any] = {"file_path": path, "zone_id": zone_id}
         if old_path:
             data["old_path"] = old_path
         if size is not None:
             data["size"] = size
-        # Backward-compat: keep agent_id/user_id alongside subject_type/subject_id
-        agent_id = getattr(context, "agent_id", None)
-        user_id = getattr(context, "user_id", None) or getattr(context, "user", None)
-        if agent_id is not None:
-            data["agent_id"] = agent_id
-        if user_id is not None:
-            data["user_id"] = user_id
         st = getattr(context, "subject_type", None)
         sid = getattr(context, "subject_id", None) or getattr(context, "user", None)
         if st is not None:


### PR DESCRIPTION
- RPC (_fire_rpc_event): add subject_type and subject_id to broadcast data from request context
- NexusFS: add subject_type and subject_id to event_context for file_write, file_delete, file_rename
- Drop user_id/agent_id from event data; receivers use subject_type/subject_id only

Co-authored-by: Cursor <cursoragent@cursor.com>