### PR TITLE
fix: Copy webapp.py into LangGraph Docker image to fix CI

### DIFF
--- a/dockerfiles/langgraph.Dockerfile
+++ b/dockerfiles/langgraph.Dockerfile
@@ -22,6 +22,7 @@ COPY nexus-langgraph/pyproject.toml ./
 COPY nexus-langgraph/langgraph.json ./
 COPY nexus-langgraph/agents ./agents
 COPY nexus-langgraph/shared ./shared
+COPY nexus-langgraph/webapp.py ./
 
 # Install dependencies (nexus-fs-python from PyPI, not local build)
 # Pin langgraph-api to exact version to avoid 0.7.21 thread_ttl import error
@@ -47,6 +48,7 @@ WORKDIR /app
 COPY nexus-langgraph/langgraph.json ./
 COPY nexus-langgraph/agents ./agents
 COPY nexus-langgraph/shared ./shared
+COPY nexus-langgraph/webapp.py ./
 
 # Create non-root user for security
 RUN useradd -r -m -u 1000 -s /bin/bash nexus && \


### PR DESCRIPTION
The nexus-langgraph repo added webapp.py (custom HTTP app referenced
in langgraph.json's "http.app" field) on Feb 8, but the Dockerfile
was not updated to COPY it. This caused LangGraph to crash on startup
with FileNotFoundError: '/app/webapp.py', breaking all Docker
integration CI runs since then.

https://claude.ai/code/session_01VqmR1u5pWJK8hVwNmyNN1p