### PR TITLE
feat(#1211): Add Nexus Pay TypeScript SDK (@nexus/pay)

### DIFF
--- a/packages/nexus-pay-ts/.gitignore
+++ b/packages/nexus-pay-ts/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+*.tsbuildinfo

--- a/packages/nexus-pay-ts/README.md
+++ b/packages/nexus-pay-ts/README.md
@@ -1,0 +1,109 @@
+# @nexus/pay
+
+TypeScript SDK for Nexus Pay — agent payment API.
+
+Zero dependencies. Works in Node.js 18+, browsers, Deno, Bun, and edge runtimes.
+
+## Install
+
+```bash
+npm install @nexus/pay
+```
+
+## Quick Start
+
+```typescript
+import { NexusPay } from '@nexus/pay';
+
+const pay = new NexusPay({ apiKey: 'nx_live_myagent' });
+
+// Check balance
+const balance = await pay.getBalance();
+console.log(`Available: ${balance.available}`);
+
+// Transfer credits
+const receipt = await pay.transfer({
+  to: 'agent-bob',
+  amount: '10.00',
+  memo: 'Task payment',
+});
+
+// Reserve credits (two-phase)
+const reservation = await pay.reserve({ amount: '25.00', purpose: 'compute' });
+await pay.commit(reservation.id);
+// or: await pay.release(reservation.id);
+```
+
+## Configuration
+
+```typescript
+const pay = new NexusPay({
+  apiKey: 'nx_live_myagent',           // Required
+  baseUrl: 'https://nexus.example.com', // Default: https://nexus.sudorouter.ai
+  timeout: 30_000,                      // Default: 30s
+  maxRetries: 3,                        // Default: 3 (0 to disable)
+  fetch: customFetch,                   // Optional: custom fetch implementation
+});
+```
+
+## API Reference
+
+| Method | Description |
+|--------|-------------|
+| `getBalance(options?)` | Get available, reserved, and total balance |
+| `canAfford(amount, options?)` | Check if agent can afford an amount |
+| `transfer(params, options?)` | Transfer credits (auto-routes credits/x402) |
+| `transferBatch(items, options?)` | Atomic batch transfer (max 1000) |
+| `reserve(params, options?)` | Reserve credits for two-phase operations |
+| `commit(reservationId, params?, options?)` | Commit a reservation |
+| `release(reservationId, options?)` | Release a reservation (refund) |
+| `meter(params, options?)` | Fast credit deduction for API metering |
+
+All amounts are `string` type to prevent floating-point precision loss.
+
+## Error Handling
+
+```typescript
+import { NexusPay, InsufficientCreditsError, NexusPayError } from '@nexus/pay';
+
+try {
+  await pay.transfer({ to: 'agent-bob', amount: '9999.00' });
+} catch (error) {
+  if (error instanceof InsufficientCreditsError) {
+    console.log('Not enough credits');
+  } else if (error instanceof NexusPayError) {
+    console.log(`API error: ${error.message} (status: ${error.status})`);
+  }
+}
+```
+
+### Error Classes
+
+| Class | HTTP Status | When |
+|-------|-------------|------|
+| `AuthenticationError` | 401 | Invalid or expired API key |
+| `InsufficientCreditsError` | 402 | Not enough credits for operation |
+| `BudgetExceededError` | 403 | Operation exceeds budget limits |
+| `WalletNotFoundError` | 404 | Agent wallet does not exist |
+| `ReservationError` | 409 | Reservation conflict (double-commit, etc.) |
+| `RateLimitError` | 429 | Rate limited (check `.retryAfter`) |
+| `NexusPayError` | any | Base class for all SDK errors |
+
+## Per-Request Options
+
+Every method accepts an optional second argument for request-level overrides:
+
+```typescript
+await pay.transfer(
+  { to: 'bob', amount: '10.00' },
+  {
+    timeout: 60_000,           // Override timeout for this request
+    signal: controller.signal,  // AbortController for cancellation
+    idempotencyKey: 'key-123',  // Retry-safe deduplication
+  },
+);
+```
+
+## License
+
+MIT

--- a/packages/nexus-pay-ts/package-lock.json
+++ b/packages/nexus-pay-ts/package-lock.json
@@ -1,0 +1,2974 @@
+{
+  "name": "@nexus/pay",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nexus/pay",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^2.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/nexus-pay-ts/package.json
+++ b/packages/nexus-pay-ts/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@nexus/pay",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for Nexus Pay — agent payment API",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0",
+    "@vitest/coverage-v8": "^2.0.0"
+  },
+  "keywords": [
+    "nexus",
+    "pay",
+    "agent",
+    "payments",
+    "credits",
+    "sdk"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nexi-lab/nexus",
+    "directory": "packages/nexus-pay-ts"
+  }
+}

--- a/packages/nexus-pay-ts/src/client.ts
+++ b/packages/nexus-pay-ts/src/client.ts
@@ -1,0 +1,284 @@
+/**
+ * NexusPay TypeScript SDK — main client class.
+ *
+ * Mirrors the Python SDK's DX with idiomatic TypeScript conventions.
+ * All HTTP logic is delegated to the internal FetchClient.
+ *
+ * @example
+ * ```typescript
+ * import { NexusPay } from '@nexus/pay';
+ *
+ * const pay = new NexusPay({ apiKey: 'sk-your-api-key' });
+ * const balance = await pay.getBalance();
+ * const receipt = await pay.transfer({ to: 'agent-bob', amount: '10.00', memo: 'Task' });
+ * ```
+ */
+
+import { NexusPayError } from "./errors.js";
+import { FetchClient } from "./fetch-client.js";
+import type {
+  ApiBalance,
+  ApiCanAfford,
+  ApiMeter,
+  ApiReceipt,
+  ApiReservation,
+  Balance,
+  BatchTransferItem,
+  CanAffordResult,
+  CommitParams,
+  MeterParams,
+  MeterResult,
+  NexusPayOptions,
+  Receipt,
+  RequestOptions,
+  ReserveParams,
+  Reservation,
+  TransferParams,
+} from "./types.js";
+
+/** Matches internal nx_live_<id> or nx_test_<id> format (optional). */
+const NX_KEY_PATTERN = /^nx_(live|test)_(.+)$/;
+const MAX_DECIMAL_PLACES = 6;
+const MAX_BATCH_SIZE = 1000;
+
+export class NexusPay {
+  /**
+   * Agent ID extracted from the API key (if key uses nx_live_/nx_test_ format),
+   * or undefined for standard API keys (sk-*).
+   */
+  readonly agentId: string | undefined;
+
+  private readonly client: FetchClient;
+
+  constructor(options: NexusPayOptions) {
+    if (!options.apiKey) {
+      throw new NexusPayError("API key must not be empty", 0, "invalid_api_key");
+    }
+
+    // Extract agentId if key uses internal nx_live_/nx_test_ format
+    const match = NX_KEY_PATTERN.exec(options.apiKey);
+    this.agentId = match?.[2];
+
+    this.client = new FetchClient(options);
+  }
+
+  // ===========================================================================
+  // Balance operations
+  // ===========================================================================
+
+  async getBalance(options?: RequestOptions): Promise<Balance> {
+    const raw = await this.client.get<ApiBalance>("/api/v2/pay/balance", options);
+    return toBalance(raw);
+  }
+
+  async canAfford(amount: string, options?: RequestOptions): Promise<CanAffordResult> {
+    validateAmountNonEmpty(amount);
+    const raw = await this.client.get<ApiCanAfford>(
+      `/api/v2/pay/can-afford?amount=${encodeURIComponent(amount)}`,
+      options,
+    );
+    return toCanAffordResult(raw);
+  }
+
+  // ===========================================================================
+  // Transfer operations
+  // ===========================================================================
+
+  async transfer(params: TransferParams, options?: RequestOptions): Promise<Receipt> {
+    validateRecipient(params.to);
+    validateAmount(params.amount);
+
+    const body = {
+      to: params.to,
+      amount: params.amount,
+      memo: params.memo ?? "",
+      method: params.method ?? "auto",
+      idempotency_key: options?.idempotencyKey ?? null,
+    };
+
+    const raw = await this.client.post<ApiReceipt>("/api/v2/pay/transfer", body, options);
+    return toReceipt(raw);
+  }
+
+  async transferBatch(
+    transfers: readonly BatchTransferItem[],
+    options?: RequestOptions,
+  ): Promise<Receipt[]> {
+    if (transfers.length > MAX_BATCH_SIZE) {
+      throw new NexusPayError(
+        `Batch size ${transfers.length} exceeds maximum of ${MAX_BATCH_SIZE}`,
+        0,
+        "batch_too_large",
+      );
+    }
+
+    const body = {
+      transfers: transfers.map((t) => ({
+        to: t.to,
+        amount: t.amount,
+        memo: t.memo ?? "",
+      })),
+    };
+
+    const raw = await this.client.post<ApiReceipt[]>(
+      "/api/v2/pay/transfer/batch",
+      body,
+      options,
+    );
+    return raw.map(toReceipt);
+  }
+
+  // ===========================================================================
+  // Reservation operations (two-phase)
+  // ===========================================================================
+
+  async reserve(params: ReserveParams, options?: RequestOptions): Promise<Reservation> {
+    validateAmount(params.amount);
+
+    const body = {
+      amount: params.amount,
+      timeout: params.timeout,
+      purpose: params.purpose,
+      task_id: params.taskId,
+    };
+
+    const raw = await this.client.post<ApiReservation>("/api/v2/pay/reserve", body, options);
+    return toReservation(raw);
+  }
+
+  async commit(
+    reservationId: string,
+    params?: CommitParams,
+    options?: RequestOptions,
+  ): Promise<void> {
+    const body = {
+      actual_amount: params?.actualAmount,
+    };
+
+    await this.client.postNoContent(
+      `/api/v2/pay/reserve/${encodeURIComponent(reservationId)}/commit`,
+      body,
+      options,
+    );
+  }
+
+  async release(reservationId: string, options?: RequestOptions): Promise<void> {
+    await this.client.postNoContent(
+      `/api/v2/pay/reserve/${encodeURIComponent(reservationId)}/release`,
+      undefined,
+      options,
+    );
+  }
+
+  // ===========================================================================
+  // Metering
+  // ===========================================================================
+
+  async meter(params: MeterParams, options?: RequestOptions): Promise<MeterResult> {
+    validateAmount(params.amount);
+
+    const body = {
+      amount: params.amount,
+      event_type: params.eventType ?? "api_call",
+    };
+
+    const raw = await this.client.post<ApiMeter>("/api/v2/pay/meter", body, options);
+    return toMeterResult(raw);
+  }
+}
+
+// =============================================================================
+// Validation helpers (pure functions, no mutation)
+// =============================================================================
+
+/** Regex: positive decimal number (digits, optional dot + digits, no leading minus). */
+const AMOUNT_PATTERN = /^\d+(\.\d+)?$/;
+/** Regex: zero in all forms — "0", "0.0", "0.000000". */
+const ZERO_PATTERN = /^0+(\.0+)?$/;
+
+function validateAmount(amount: string): void {
+  if (!amount) {
+    throw new NexusPayError("Amount must not be empty", 0, "validation_error");
+  }
+
+  if (!AMOUNT_PATTERN.test(amount)) {
+    throw new NexusPayError(`Invalid amount: '${amount}'`, 0, "validation_error");
+  }
+
+  if (ZERO_PATTERN.test(amount)) {
+    throw new NexusPayError("Amount must be positive", 0, "validation_error");
+  }
+
+  // Check decimal places
+  const dotIndex = amount.indexOf(".");
+  if (dotIndex !== -1) {
+    const decimals = amount.length - dotIndex - 1;
+    if (decimals > MAX_DECIMAL_PLACES) {
+      throw new NexusPayError(
+        `Amount must have at most ${MAX_DECIMAL_PLACES} decimal places`,
+        0,
+        "validation_error",
+      );
+    }
+  }
+}
+
+function validateAmountNonEmpty(amount: string): void {
+  if (!amount) {
+    throw new NexusPayError("Amount must not be empty", 0, "validation_error");
+  }
+}
+
+function validateRecipient(to: string): void {
+  if (!to) {
+    throw new NexusPayError("Recipient 'to' must not be empty", 0, "validation_error");
+  }
+}
+
+// =============================================================================
+// Response mappers (snake_case API → camelCase SDK, immutable)
+// =============================================================================
+
+function toBalance(raw: ApiBalance): Balance {
+  return {
+    available: raw.available,
+    reserved: raw.reserved,
+    total: raw.total,
+  };
+}
+
+function toReceipt(raw: ApiReceipt): Receipt {
+  return {
+    id: raw.id,
+    method: raw.method,
+    amount: raw.amount,
+    fromAgent: raw.from_agent,
+    toAgent: raw.to_agent,
+    memo: raw.memo,
+    timestamp: raw.timestamp,
+    txHash: raw.tx_hash,
+  };
+}
+
+function toReservation(raw: ApiReservation): Reservation {
+  return {
+    id: raw.id,
+    amount: raw.amount,
+    purpose: raw.purpose,
+    expiresAt: raw.expires_at,
+    status: raw.status,
+  };
+}
+
+function toCanAffordResult(raw: ApiCanAfford): CanAffordResult {
+  return {
+    canAfford: raw.can_afford,
+    amount: raw.amount,
+  };
+}
+
+function toMeterResult(raw: ApiMeter): MeterResult {
+  return {
+    success: raw.success,
+  };
+}

--- a/packages/nexus-pay-ts/src/errors.ts
+++ b/packages/nexus-pay-ts/src/errors.ts
@@ -1,0 +1,69 @@
+/**
+ * Error classes for the Nexus Pay SDK.
+ *
+ * Hierarchy mirrors the Python SDK's exception classes:
+ *   NexusPayError (base)
+ *   ├── AuthenticationError      (401)
+ *   ├── InsufficientCreditsError (402)
+ *   ├── BudgetExceededError      (403)
+ *   ├── WalletNotFoundError      (404)
+ *   ├── ReservationError         (409)
+ *   └── RateLimitError           (429)
+ */
+
+export class NexusPayError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(message: string, status: number, code: string) {
+    super(message);
+    this.name = "NexusPayError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export class AuthenticationError extends NexusPayError {
+  constructor(message: string) {
+    super(message, 401, "authentication_error");
+    this.name = "AuthenticationError";
+  }
+}
+
+export class InsufficientCreditsError extends NexusPayError {
+  constructor(message: string) {
+    super(message, 402, "insufficient_credits");
+    this.name = "InsufficientCreditsError";
+  }
+}
+
+export class BudgetExceededError extends NexusPayError {
+  constructor(message: string) {
+    super(message, 403, "budget_exceeded");
+    this.name = "BudgetExceededError";
+  }
+}
+
+export class WalletNotFoundError extends NexusPayError {
+  constructor(message: string) {
+    super(message, 404, "wallet_not_found");
+    this.name = "WalletNotFoundError";
+  }
+}
+
+export class ReservationError extends NexusPayError {
+  constructor(message: string) {
+    super(message, 409, "reservation_error");
+    this.name = "ReservationError";
+  }
+}
+
+export class RateLimitError extends NexusPayError {
+  readonly retryAfter: number | undefined;
+
+  constructor(message: string, retryAfter?: number) {
+    super(message, 429, "rate_limit_error");
+    this.name = "RateLimitError";
+    this.retryAfter = retryAfter;
+  }
+}

--- a/packages/nexus-pay-ts/src/fetch-client.ts
+++ b/packages/nexus-pay-ts/src/fetch-client.ts
@@ -1,0 +1,243 @@
+/**
+ * Internal HTTP client with retry, timeout, auth, and error mapping.
+ *
+ * Not exported from the public API — used only by the NexusPay client class.
+ */
+
+import {
+  AuthenticationError,
+  BudgetExceededError,
+  InsufficientCreditsError,
+  NexusPayError,
+  RateLimitError,
+  ReservationError,
+  WalletNotFoundError,
+} from "./errors.js";
+import type { ApiError, NexusPayOptions, RequestOptions } from "./types.js";
+
+const DEFAULT_BASE_URL = "https://nexus.sudorouter.ai";
+const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_MAX_RETRIES = 3;
+const INITIAL_RETRY_DELAY = 500;
+const MAX_RETRY_DELAY = 8_000;
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+
+export class FetchClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly timeout: number;
+  private readonly maxRetries: number;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(options: NexusPayOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.timeout = options.timeout ?? DEFAULT_TIMEOUT;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  async get<T>(path: string, options?: RequestOptions): Promise<T> {
+    return this.request<T>("GET", path, undefined, options);
+  }
+
+  async post<T>(path: string, body: unknown, options?: RequestOptions): Promise<T> {
+    return this.request<T>("POST", path, body, options);
+  }
+
+  async postNoContent(path: string, body?: unknown, options?: RequestOptions): Promise<void> {
+    await this.requestRaw("POST", path, body, options);
+  }
+
+  // ===========================================================================
+  // Core request logic
+  // ===========================================================================
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body: unknown,
+    options?: RequestOptions,
+  ): Promise<T> {
+    const response = await this.requestRaw(method, path, body, options);
+    return (await response.json()) as T;
+  }
+
+  private async requestRaw(
+    method: string,
+    path: string,
+    body: unknown,
+    options?: RequestOptions,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    const headers = this.buildHeaders(method, options);
+    const effectiveTimeout = options?.timeout ?? this.timeout;
+
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      // Wait before retry (not on first attempt)
+      if (attempt > 0 && lastError) {
+        const delay = this.computeRetryDelay(attempt, lastError);
+        await sleep(delay);
+      }
+
+      try {
+        const response = await this.executeFetch(url, method, headers, body, effectiveTimeout, options?.signal);
+
+        if (response.ok || response.status === 204) {
+          return response;
+        }
+
+        // Map HTTP status to typed error
+        const error = await this.buildError(response);
+
+        // Only retry on retryable status codes
+        if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < this.maxRetries) {
+          lastError = error;
+          continue;
+        }
+
+        throw error;
+      } catch (error) {
+        // If it's already a NexusPayError that isn't retryable, rethrow immediately
+        if (error instanceof NexusPayError && !RETRYABLE_STATUS_CODES.has(error.status)) {
+          throw error;
+        }
+
+        // Network errors (TypeError from fetch) are retryable
+        if (attempt < this.maxRetries) {
+          lastError = error instanceof Error ? error : new Error(String(error));
+          continue;
+        }
+
+        // Retries exhausted
+        if (error instanceof NexusPayError) {
+          throw error;
+        }
+        throw new NexusPayError(
+          error instanceof Error ? error.message : "Request failed",
+          0,
+          "network_error",
+        );
+      }
+    }
+
+    // Should not reach here, but just in case
+    throw lastError ?? new NexusPayError("Request failed", 0, "unknown_error");
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  private async executeFetch(
+    url: string,
+    method: string,
+    headers: Record<string, string>,
+    body: unknown,
+    timeout: number,
+    userSignal?: AbortSignal,
+  ): Promise<Response> {
+    // Fail fast if already aborted
+    if (userSignal?.aborted) {
+      throw new NexusPayError("Request aborted", 0, "abort_error");
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+    const onUserAbort = (): void => controller.abort();
+
+    if (userSignal) {
+      userSignal.addEventListener("abort", onUserAbort, { once: true });
+    }
+
+    try {
+      return await this.fetchFn(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        if (userSignal?.aborted) {
+          throw new NexusPayError("Request aborted", 0, "abort_error");
+        }
+        throw new NexusPayError("Request timed out", 0, "timeout_error");
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      if (userSignal) {
+        userSignal.removeEventListener("abort", onUserAbort);
+      }
+    }
+  }
+
+  private buildHeaders(method: string, options?: RequestOptions): Record<string, string> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      Accept: "application/json",
+    };
+
+    if (method === "POST") {
+      headers["Content-Type"] = "application/json";
+    }
+
+    if (options?.idempotencyKey) {
+      headers["Idempotency-Key"] = options.idempotencyKey;
+    }
+
+    return headers;
+  }
+
+  private async buildError(response: Response): Promise<NexusPayError> {
+    let message: string;
+    try {
+      const body = (await response.json()) as ApiError;
+      message = body.detail ?? `HTTP ${response.status}`;
+    } catch {
+      message = `HTTP ${response.status}`;
+    }
+
+    switch (response.status) {
+      case 401:
+        return new AuthenticationError(message);
+      case 402:
+        return new InsufficientCreditsError(message);
+      case 403:
+        return new BudgetExceededError(message);
+      case 404:
+        return new WalletNotFoundError(message);
+      case 409:
+        return new ReservationError(message);
+      case 429: {
+        const retryAfterHeader = response.headers.get("Retry-After");
+        const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : undefined;
+        return new RateLimitError(
+          message,
+          Number.isNaN(retryAfter) ? undefined : retryAfter,
+        );
+      }
+      default:
+        return new NexusPayError(message, response.status, "api_error");
+    }
+  }
+
+  private computeRetryDelay(attempt: number, lastError: Error): number {
+    // For 429 with Retry-After, use that value (in seconds → ms)
+    if (lastError instanceof RateLimitError && lastError.retryAfter !== undefined) {
+      return lastError.retryAfter * 1000;
+    }
+
+    // Exponential backoff with full jitter
+    const exponentialDelay = INITIAL_RETRY_DELAY * Math.pow(2, attempt - 1);
+    const cappedDelay = Math.min(exponentialDelay, MAX_RETRY_DELAY);
+    return Math.random() * cappedDelay;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/nexus-pay-ts/src/index.ts
+++ b/packages/nexus-pay-ts/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * @nexus/pay — TypeScript SDK for Nexus Pay agent payments.
+ *
+ * @example
+ * ```typescript
+ * import { NexusPay } from '@nexus/pay';
+ *
+ * const pay = new NexusPay({ apiKey: 'nx_live_myagent' });
+ * const balance = await pay.getBalance();
+ * console.log(`Available: ${balance.available}`);
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Client
+export { NexusPay } from "./client.js";
+
+// Errors
+export {
+  NexusPayError,
+  AuthenticationError,
+  InsufficientCreditsError,
+  BudgetExceededError,
+  WalletNotFoundError,
+  ReservationError,
+  RateLimitError,
+} from "./errors.js";
+
+// Types
+export type {
+  NexusPayOptions,
+  RequestOptions,
+  Balance,
+  Receipt,
+  Reservation,
+  CanAffordResult,
+  MeterResult,
+  TransferParams,
+  BatchTransferItem,
+  ReserveParams,
+  CommitParams,
+  MeterParams,
+} from "./types.js";

--- a/packages/nexus-pay-ts/src/types.ts
+++ b/packages/nexus-pay-ts/src/types.ts
@@ -1,0 +1,181 @@
+/**
+ * Type definitions for the Nexus Pay SDK.
+ *
+ * All monetary amounts are `string` to prevent floating-point precision loss.
+ * This matches the REST API wire format (JSON string amounts).
+ */
+
+// =============================================================================
+// SDK Configuration
+// =============================================================================
+
+export interface NexusPayOptions {
+  /** API key in format `nx_live_<id>` or `nx_test_<id>`. */
+  readonly apiKey: string;
+
+  /** Base URL of the Nexus API server. Default: "https://nexus.sudorouter.ai" */
+  readonly baseUrl?: string;
+
+  /** Request timeout in milliseconds. Default: 30000 */
+  readonly timeout?: number;
+
+  /** Maximum number of retries for retryable errors. Default: 3. Set to 0 to disable. */
+  readonly maxRetries?: number;
+
+  /** Custom fetch implementation for testing or proxying. Default: global fetch */
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+export interface RequestOptions {
+  /** Per-request timeout in milliseconds (overrides global timeout). */
+  readonly timeout?: number;
+
+  /** AbortSignal for cancellation. */
+  readonly signal?: AbortSignal;
+
+  /** Idempotency key for retry-safe operations. */
+  readonly idempotencyKey?: string;
+}
+
+// =============================================================================
+// Response Types (match REST API Pydantic models in pay.py)
+// =============================================================================
+
+export interface Balance {
+  readonly available: string;
+  readonly reserved: string;
+  readonly total: string;
+}
+
+export interface Receipt {
+  readonly id: string;
+  readonly method: string;
+  readonly amount: string;
+  readonly fromAgent: string;
+  readonly toAgent: string;
+  readonly memo: string | null;
+  readonly timestamp: string | null;
+  readonly txHash: string | null;
+}
+
+export interface Reservation {
+  readonly id: string;
+  readonly amount: string;
+  readonly purpose: string;
+  readonly expiresAt: string | null;
+  readonly status: string;
+}
+
+export interface CanAffordResult {
+  readonly canAfford: boolean;
+  readonly amount: string;
+}
+
+export interface MeterResult {
+  readonly success: boolean;
+}
+
+// =============================================================================
+// Request Types (match REST API Pydantic models in pay.py)
+// =============================================================================
+
+export interface TransferParams {
+  /** Recipient agent ID or wallet address. */
+  readonly to: string;
+
+  /** Amount as decimal string (e.g. "10.50"). */
+  readonly amount: string;
+
+  /** Optional memo/description. */
+  readonly memo?: string;
+
+  /** Payment method: "auto" (default), "credits", or "x402". */
+  readonly method?: "auto" | "credits" | "x402";
+}
+
+export interface BatchTransferItem {
+  /** Recipient agent ID. */
+  readonly to: string;
+
+  /** Amount as decimal string. */
+  readonly amount: string;
+
+  /** Optional memo. */
+  readonly memo?: string;
+}
+
+export interface ReserveParams {
+  /** Amount to reserve as decimal string. */
+  readonly amount: string;
+
+  /** Auto-release timeout in seconds (1-86400). Default: 300. */
+  readonly timeout?: number;
+
+  /** Purpose of reservation. Default: "general". */
+  readonly purpose?: string;
+
+  /** Optional task identifier. */
+  readonly taskId?: string;
+}
+
+export interface CommitParams {
+  /** Actual amount to charge (omit for full reserved amount). */
+  readonly actualAmount?: string;
+}
+
+export interface MeterParams {
+  /** Amount to deduct as decimal string. */
+  readonly amount: string;
+
+  /** Type of metered event. Default: "api_call". */
+  readonly eventType?: string;
+}
+
+// =============================================================================
+// Internal API wire types (snake_case, matching JSON responses)
+// =============================================================================
+
+/** @internal */
+export interface ApiBalance {
+  readonly available: string;
+  readonly reserved: string;
+  readonly total: string;
+}
+
+/** @internal */
+export interface ApiReceipt {
+  readonly id: string;
+  readonly method: string;
+  readonly amount: string;
+  readonly from_agent: string;
+  readonly to_agent: string;
+  readonly memo: string | null;
+  readonly timestamp: string | null;
+  readonly tx_hash: string | null;
+}
+
+/** @internal */
+export interface ApiReservation {
+  readonly id: string;
+  readonly amount: string;
+  readonly purpose: string;
+  readonly expires_at: string | null;
+  readonly status: string;
+}
+
+/** @internal */
+export interface ApiCanAfford {
+  readonly can_afford: boolean;
+  readonly amount: string;
+}
+
+/** @internal */
+export interface ApiMeter {
+  readonly success: boolean;
+}
+
+/** @internal */
+export interface ApiError {
+  readonly detail: string;
+  readonly error_code?: string;
+}

--- a/packages/nexus-pay-ts/tests/client.test.ts
+++ b/packages/nexus-pay-ts/tests/client.test.ts
@@ -1,0 +1,473 @@
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NexusPay } from "../src/client.js";
+import {
+  BudgetExceededError,
+  InsufficientCreditsError,
+  NexusPayError,
+  ReservationError,
+} from "../src/errors.js";
+import type { Balance, CanAffordResult, MeterResult, Receipt, Reservation } from "../src/types.js";
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Wire-format balance (snake_case). */
+const BALANCE_API = { available: "100.50", reserved: "5.00", total: "105.50" };
+
+/** Wire-format receipt (snake_case). */
+const RECEIPT_API = {
+  id: "tx_001",
+  method: "credits",
+  amount: "10.00",
+  from_agent: "agent1",
+  to_agent: "agent-bob",
+  memo: "Task payment",
+  timestamp: "2025-06-01T12:00:00Z",
+  tx_hash: null,
+};
+
+/** Wire-format reservation (snake_case). */
+const RESERVATION_API = {
+  id: "res_001",
+  amount: "25.00",
+  purpose: "compute",
+  expires_at: null,
+  status: "pending",
+};
+
+// =============================================================================
+// Constructor tests
+// =============================================================================
+
+describe("NexusPay constructor", () => {
+  const mockFetch = vi.fn();
+
+  it("accepts nx_live_* key and extracts agentId", () => {
+    const pay = new NexusPay({ apiKey: "nx_live_myagent", fetch: mockFetch });
+    expect(pay.agentId).toBe("myagent");
+  });
+
+  it("accepts nx_test_* key and extracts agentId", () => {
+    const pay = new NexusPay({ apiKey: "nx_test_agent42", fetch: mockFetch });
+    expect(pay.agentId).toBe("agent42");
+  });
+
+  it("accepts sk-* keys (standard API keys)", () => {
+    const pay = new NexusPay({ apiKey: "sk-default_admin_abc123", fetch: mockFetch });
+    expect(pay.agentId).toBeUndefined();
+  });
+
+  it("accepts any non-empty key string", () => {
+    const pay = new NexusPay({ apiKey: "my-custom-key", fetch: mockFetch });
+    expect(pay.agentId).toBeUndefined();
+  });
+
+  it("throws on empty string", () => {
+    expect(() => new NexusPay({ apiKey: "", fetch: mockFetch })).toThrow(NexusPayError);
+  });
+
+  it("uses default baseUrl when not provided", () => {
+    const pay = new NexusPay({ apiKey: "nx_test_x", fetch: mockFetch });
+    expect(pay.agentId).toBe("x");
+  });
+
+  it("accepts custom baseUrl", () => {
+    const pay = new NexusPay({
+      apiKey: "nx_test_x",
+      baseUrl: "http://localhost:2026",
+      fetch: mockFetch,
+    });
+    expect(pay.agentId).toBe("x");
+  });
+});
+
+// =============================================================================
+// Method tests
+// =============================================================================
+
+describe("NexusPay methods", () => {
+  let mockFetch: Mock;
+  let pay: NexusPay;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    pay = new NexusPay({
+      apiKey: "nx_test_agent1",
+      baseUrl: "https://api.example.com",
+      maxRetries: 0,
+      fetch: mockFetch,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // =========================================================================
+  // getBalance
+  // =========================================================================
+
+  describe("getBalance", () => {
+    it("returns Balance with camelCase fields", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(BALANCE_API));
+      const balance = await pay.getBalance();
+
+      expect(balance).toEqual<Balance>({
+        available: "100.50",
+        reserved: "5.00",
+        total: "105.50",
+      });
+    });
+
+    it("calls GET /api/v2/pay/balance", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(BALANCE_API));
+      await pay.getBalance();
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.example.com/api/v2/pay/balance");
+      expect(init.method).toBe("GET");
+    });
+
+    it("passes request options through", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(BALANCE_API));
+      await pay.getBalance({ timeout: 5000 });
+      // Doesn't throw — timeout option accepted
+    });
+  });
+
+  // =========================================================================
+  // canAfford
+  // =========================================================================
+
+  describe("canAfford", () => {
+    it("returns CanAffordResult", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ can_afford: true, amount: "50.00" }),
+      );
+      const result = await pay.canAfford("50.00");
+
+      expect(result).toEqual<CanAffordResult>({ canAfford: true, amount: "50.00" });
+    });
+
+    it("sends amount as query parameter", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ can_afford: false, amount: "999.00" }),
+      );
+      await pay.canAfford("999.00");
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/api/v2/pay/can-afford?amount=999.00");
+    });
+
+    it("validates amount is not empty", async () => {
+      await expect(pay.canAfford("")).rejects.toThrow(NexusPayError);
+    });
+  });
+
+  // =========================================================================
+  // transfer
+  // =========================================================================
+
+  describe("transfer", () => {
+    it("returns Receipt with camelCase fields", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(RECEIPT_API, 201));
+      const receipt = await pay.transfer({ to: "agent-bob", amount: "10.00", memo: "Task" });
+
+      expect(receipt).toEqual<Receipt>({
+        id: "tx_001",
+        method: "credits",
+        amount: "10.00",
+        fromAgent: "agent1",
+        toAgent: "agent-bob",
+        memo: "Task payment",
+        timestamp: "2025-06-01T12:00:00Z",
+        txHash: null,
+      });
+    });
+
+    it("sends POST /api/v2/pay/transfer with body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(RECEIPT_API, 201));
+      await pay.transfer({ to: "bob", amount: "5.00", memo: "test" });
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.example.com/api/v2/pay/transfer");
+      expect(init.method).toBe("POST");
+
+      const body = JSON.parse(init.body as string);
+      expect(body.to).toBe("bob");
+      expect(body.amount).toBe("5.00");
+      expect(body.memo).toBe("test");
+    });
+
+    it("sends method field when specified", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(RECEIPT_API, 201));
+      await pay.transfer({ to: "0x1234", amount: "1.00", method: "x402" });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.method).toBe("x402");
+    });
+
+    it("passes idempotency key to request options", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(RECEIPT_API, 201));
+      await pay.transfer(
+        { to: "bob", amount: "10.00" },
+        { idempotencyKey: "idem-key-1" },
+      );
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = new Headers(init.headers);
+      expect(headers.get("Idempotency-Key")).toBe("idem-key-1");
+    });
+
+    it("handles 402 InsufficientCreditsError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Insufficient balance" }, 402),
+      );
+      await expect(
+        pay.transfer({ to: "bob", amount: "9999.00" }),
+      ).rejects.toThrow(InsufficientCreditsError);
+    });
+
+    it("validates amount is positive", async () => {
+      await expect(
+        pay.transfer({ to: "bob", amount: "-1.00" }),
+      ).rejects.toThrow(NexusPayError);
+    });
+
+    it("validates amount is a valid decimal", async () => {
+      await expect(
+        pay.transfer({ to: "bob", amount: "abc" }),
+      ).rejects.toThrow(NexusPayError);
+    });
+
+    it("validates 'to' is not empty", async () => {
+      await expect(
+        pay.transfer({ to: "", amount: "1.00" }),
+      ).rejects.toThrow(NexusPayError);
+    });
+
+    it("validates amount has at most 6 decimal places", async () => {
+      await expect(
+        pay.transfer({ to: "bob", amount: "1.1234567" }),
+      ).rejects.toThrow(NexusPayError);
+    });
+  });
+
+  // =========================================================================
+  // transferBatch
+  // =========================================================================
+
+  describe("transferBatch", () => {
+    it("returns array of Receipts", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([RECEIPT_API], 201));
+      const receipts = await pay.transferBatch([
+        { to: "agent-bob", amount: "10.00", memo: "Task" },
+      ]);
+
+      expect(receipts).toHaveLength(1);
+      expect(receipts[0]?.fromAgent).toBe("agent1");
+    });
+
+    it("sends POST /api/v2/pay/transfer/batch", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([], 201));
+      await pay.transferBatch([]);
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.example.com/api/v2/pay/transfer/batch");
+      expect(init.method).toBe("POST");
+    });
+
+    it("sends transfers in body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([RECEIPT_API, RECEIPT_API], 201));
+      await pay.transferBatch([
+        { to: "alice", amount: "5.00" },
+        { to: "bob", amount: "3.00", memo: "bonus" },
+      ]);
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.transfers).toHaveLength(2);
+      expect(body.transfers[0].to).toBe("alice");
+      expect(body.transfers[1].memo).toBe("bonus");
+    });
+
+    it("validates batch size <= 1000", async () => {
+      const bigBatch = Array.from({ length: 1001 }, (_, i) => ({
+        to: `agent-${i}`,
+        amount: "1.00",
+      }));
+      await expect(pay.transferBatch(bigBatch)).rejects.toThrow(NexusPayError);
+    });
+  });
+
+  // =========================================================================
+  // reserve
+  // =========================================================================
+
+  describe("reserve", () => {
+    it("returns Reservation with camelCase fields", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(RESERVATION_API, 201));
+      const reservation = await pay.reserve({ amount: "25.00", purpose: "compute" });
+
+      expect(reservation).toEqual<Reservation>({
+        id: "res_001",
+        amount: "25.00",
+        purpose: "compute",
+        expiresAt: null,
+        status: "pending",
+      });
+    });
+
+    it("sends POST /api/v2/pay/reserve", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(RESERVATION_API, 201));
+      await pay.reserve({ amount: "10.00" });
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.example.com/api/v2/pay/reserve");
+      expect(init.method).toBe("POST");
+    });
+
+    it("includes optional fields in body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(RESERVATION_API, 201));
+      await pay.reserve({ amount: "10.00", timeout: 600, purpose: "gpu", taskId: "task-99" });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.timeout).toBe(600);
+      expect(body.purpose).toBe("gpu");
+      expect(body.task_id).toBe("task-99");
+    });
+
+    it("validates amount is positive", async () => {
+      await expect(pay.reserve({ amount: "0" })).rejects.toThrow(NexusPayError);
+    });
+  });
+
+  // =========================================================================
+  // commit
+  // =========================================================================
+
+  describe("commit", () => {
+    it("sends POST /api/v2/pay/reserve/{id}/commit with 204", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+      await pay.commit("res_001");
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.example.com/api/v2/pay/reserve/res_001/commit");
+      expect(init.method).toBe("POST");
+    });
+
+    it("sends actual_amount in body when provided", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+      await pay.commit("res_001", { actualAmount: "15.00" });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.actual_amount).toBe("15.00");
+    });
+
+    it("sends empty body when no params", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+      await pay.commit("res_001");
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.actual_amount).toBeUndefined();
+    });
+
+    it("handles 409 ReservationError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Already committed" }, 409),
+      );
+      await expect(pay.commit("res_001")).rejects.toThrow(ReservationError);
+    });
+  });
+
+  // =========================================================================
+  // release
+  // =========================================================================
+
+  describe("release", () => {
+    it("sends POST /api/v2/pay/reserve/{id}/release with 204", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+      await pay.release("res_001");
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.example.com/api/v2/pay/reserve/res_001/release");
+      expect(init.method).toBe("POST");
+    });
+
+    it("handles 409 ReservationError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Already released" }, 409),
+      );
+      await expect(pay.release("res_001")).rejects.toThrow(ReservationError);
+    });
+  });
+
+  // =========================================================================
+  // meter
+  // =========================================================================
+
+  describe("meter", () => {
+    it("returns MeterResult", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ success: true }));
+      const result = await pay.meter({ amount: "0.01" });
+
+      expect(result).toEqual<MeterResult>({ success: true });
+    });
+
+    it("sends POST /api/v2/pay/meter", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ success: true }));
+      await pay.meter({ amount: "0.01", eventType: "api_call" });
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.example.com/api/v2/pay/meter");
+      expect(init.method).toBe("POST");
+
+      const body = JSON.parse(init.body as string);
+      expect(body.amount).toBe("0.01");
+      expect(body.event_type).toBe("api_call");
+    });
+
+    it("returns success=false for insufficient credits", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ success: false }));
+      const result = await pay.meter({ amount: "9999.00" });
+      expect(result.success).toBe(false);
+    });
+
+    it("validates amount is positive", async () => {
+      await expect(pay.meter({ amount: "0" })).rejects.toThrow(NexusPayError);
+    });
+  });
+
+  // =========================================================================
+  // Auth propagation
+  // =========================================================================
+
+  describe("auth propagation", () => {
+    it("sends Bearer token on every request", async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(BALANCE_API))
+        .mockResolvedValueOnce(jsonResponse(BALANCE_API));
+
+      await pay.getBalance();
+      await pay.getBalance();
+
+      for (const call of mockFetch.mock.calls) {
+        const [, init] = call as [string, RequestInit];
+        const headers = new Headers(init.headers);
+        expect(headers.get("Authorization")).toBe("Bearer nx_test_agent1");
+      }
+    });
+  });
+});

--- a/packages/nexus-pay-ts/tests/contract.test.ts
+++ b/packages/nexus-pay-ts/tests/contract.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Contract tests: validate that SDK types align with the REST API's
+ * Pydantic model field names and structure.
+ *
+ * These tests don't hit a live server — they verify the mapping between
+ * snake_case API responses and camelCase SDK types is correct by testing
+ * with realistic payloads that match the Pydantic model structure.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { NexusPay } from "../src/client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makePay(mockFetch: ReturnType<typeof vi.fn>): NexusPay {
+  return new NexusPay({
+    apiKey: "nx_test_contract",
+    baseUrl: "https://api.test.com",
+    maxRetries: 0,
+    fetch: mockFetch,
+  });
+}
+
+describe("contract: BalanceResponse", () => {
+  it("maps API snake_case fields to SDK camelCase", async () => {
+    // Matches pay.py BalanceResponse model exactly
+    const apiPayload = {
+      available: "123.456000",
+      reserved: "10.000000",
+      total: "133.456000",
+    };
+
+    const mockFetch = vi.fn().mockResolvedValueOnce(jsonResponse(apiPayload));
+    const pay = makePay(mockFetch);
+    const balance = await pay.getBalance();
+
+    expect(balance).toHaveProperty("available");
+    expect(balance).toHaveProperty("reserved");
+    expect(balance).toHaveProperty("total");
+    // No snake_case keys should leak through
+    expect(balance).not.toHaveProperty("available_balance");
+  });
+});
+
+describe("contract: ReceiptResponse", () => {
+  it("maps API snake_case fields to SDK camelCase", async () => {
+    // Matches pay.py ReceiptResponse model exactly
+    const apiPayload = {
+      id: "tx_12345",
+      method: "credits",
+      amount: "10.000000",
+      from_agent: "sender-agent",
+      to_agent: "receiver-agent",
+      memo: "Payment for task",
+      timestamp: "2025-06-01T12:00:00Z",
+      tx_hash: null,
+    };
+
+    const mockFetch = vi.fn().mockResolvedValueOnce(jsonResponse(apiPayload, 201));
+    const pay = makePay(mockFetch);
+    const receipt = await pay.transfer({ to: "receiver-agent", amount: "10.00" });
+
+    // Verify camelCase mapping
+    expect(receipt.fromAgent).toBe("sender-agent");
+    expect(receipt.toAgent).toBe("receiver-agent");
+    expect(receipt.txHash).toBeNull();
+    // Verify no snake_case leaks
+    expect(receipt).not.toHaveProperty("from_agent");
+    expect(receipt).not.toHaveProperty("to_agent");
+    expect(receipt).not.toHaveProperty("tx_hash");
+  });
+});
+
+describe("contract: ReservationResponse", () => {
+  it("maps API snake_case fields to SDK camelCase", async () => {
+    // Matches pay.py ReservationResponse model exactly
+    const apiPayload = {
+      id: "res_99",
+      amount: "50.000000",
+      purpose: "gpu-compute",
+      expires_at: "2025-06-01T13:00:00Z",
+      status: "pending",
+    };
+
+    const mockFetch = vi.fn().mockResolvedValueOnce(jsonResponse(apiPayload, 201));
+    const pay = makePay(mockFetch);
+    const reservation = await pay.reserve({ amount: "50.00" });
+
+    expect(reservation.expiresAt).toBe("2025-06-01T13:00:00Z");
+    expect(reservation).not.toHaveProperty("expires_at");
+  });
+});
+
+describe("contract: CanAffordResponse", () => {
+  it("maps API snake_case fields to SDK camelCase", async () => {
+    // Matches pay.py CanAffordResponse model exactly
+    const apiPayload = {
+      can_afford: true,
+      amount: "25.000000",
+    };
+
+    const mockFetch = vi.fn().mockResolvedValueOnce(jsonResponse(apiPayload));
+    const pay = makePay(mockFetch);
+    const result = await pay.canAfford("25.00");
+
+    expect(result.canAfford).toBe(true);
+    expect(result).not.toHaveProperty("can_afford");
+  });
+});
+
+describe("contract: MeterResponse", () => {
+  it("maps API fields correctly (no snake_case conversion needed)", async () => {
+    // Matches pay.py MeterResponse model exactly
+    const apiPayload = {
+      success: true,
+    };
+
+    const mockFetch = vi.fn().mockResolvedValueOnce(jsonResponse(apiPayload));
+    const pay = makePay(mockFetch);
+    const result = await pay.meter({ amount: "0.01" });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("contract: request body field names", () => {
+  it("transfer sends snake_case field names matching API", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { id: "x", method: "credits", amount: "1", from_agent: "a", to_agent: "b", memo: null, timestamp: null, tx_hash: null },
+          201,
+        ),
+      );
+    const pay = makePay(mockFetch);
+    await pay.transfer(
+      { to: "bob", amount: "1.00", method: "credits" },
+      { idempotencyKey: "key-1" },
+    );
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    // API expects snake_case
+    expect(body).toHaveProperty("idempotency_key");
+    expect(body).not.toHaveProperty("idempotencyKey");
+  });
+
+  it("reserve sends snake_case field names matching API", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ id: "r1", amount: "10", purpose: "x", expires_at: null, status: "pending" }, 201),
+      );
+    const pay = makePay(mockFetch);
+    await pay.reserve({ amount: "10.00", taskId: "task-1" });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body).toHaveProperty("task_id");
+    expect(body).not.toHaveProperty("taskId");
+  });
+
+  it("commit sends snake_case field names matching API", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const pay = makePay(mockFetch);
+    await pay.commit("res_1", { actualAmount: "5.00" });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body).toHaveProperty("actual_amount");
+    expect(body).not.toHaveProperty("actualAmount");
+  });
+
+  it("meter sends snake_case field names matching API", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce(jsonResponse({ success: true }));
+    const pay = makePay(mockFetch);
+    await pay.meter({ amount: "0.01", eventType: "llm_call" });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body).toHaveProperty("event_type");
+    expect(body).not.toHaveProperty("eventType");
+  });
+});

--- a/packages/nexus-pay-ts/tests/e2e-server.py
+++ b/packages/nexus-pay-ts/tests/e2e-server.py
@@ -1,0 +1,124 @@
+"""Minimal FastAPI test server for TypeScript SDK E2E tests.
+
+Starts the actual pay router with:
+- Static API key authentication (require_auth enabled)
+- CreditsService in disabled mode (unlimited credits, no TigerBeetle needed)
+- X402Client disabled (no blockchain needed)
+
+Usage:
+    python tests/e2e-server.py
+    # Server runs on http://localhost:4219 with API key "sk-e2e-test-key"
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import uvicorn
+from fastapi import FastAPI
+
+# Import the actual pay router and exception handlers
+from nexus.pay.credits import CreditsService
+from nexus.pay.sdk import NexusPay
+from nexus.server.api.v2.routers.pay import (
+    _register_pay_exception_handlers,
+    get_nexuspay,
+)
+from nexus.server.api.v2.routers.pay import (
+    router as pay_router,
+)
+
+# Static API key for E2E tests
+API_KEY = "sk-e2e-test-key"
+PORT = 4219
+
+
+def create_e2e_app() -> FastAPI:
+    """Create a minimal FastAPI app with real pay router + auth."""
+    app = FastAPI(title="NexusPay E2E Test Server")
+
+    # Mount the real pay router (includes all 8 endpoints)
+    app.include_router(pay_router)
+    _register_pay_exception_handlers(app)
+
+    # --- Mock CreditsService (disabled mode behavior) ---
+    credits_service = AsyncMock(spec=CreditsService)
+    credits_service.get_balance = AsyncMock(return_value=Decimal("100.000000"))
+    credits_service.get_balance_with_reserved = AsyncMock(
+        return_value=(Decimal("100.000000"), Decimal("5.000000"))
+    )
+    credits_service.check_budget = AsyncMock(return_value=True)
+    credits_service.transfer = AsyncMock(return_value="tx-e2e-ts-001")
+    credits_service.transfer_batch = AsyncMock(return_value=["tx-batch-001", "tx-batch-002"])
+    credits_service.reserve = AsyncMock(return_value="res-e2e-ts-001")
+    credits_service.commit_reservation = AsyncMock()
+    credits_service.release_reservation = AsyncMock()
+    credits_service.deduct_fast = AsyncMock(return_value=True)
+
+    app.state.credits_service = credits_service
+    app.state.x402_client = None  # No x402 for E2E tests
+
+    # --- Auth: override get_nexuspay to enforce static API key ---
+    from fastapi import Depends, Header, HTTPException
+
+    async def e2e_require_auth(
+        authorization: str | None = Header(None, alias="Authorization"),
+        x_agent_id: str | None = Header(None, alias="X-Agent-ID"),
+    ) -> dict:
+        """Real auth check: validates Bearer token against static API key."""
+        if not authorization:
+            raise HTTPException(status_code=401, detail="Missing Authorization header")
+
+        token = ""
+        if authorization.startswith("Bearer "):
+            token = authorization[7:]
+        elif authorization.startswith("sk-"):
+            token = authorization
+        else:
+            raise HTTPException(status_code=401, detail="Invalid Authorization format")
+
+        if token != API_KEY:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+
+        return {
+            "authenticated": True,
+            "is_admin": True,
+            "subject_type": "user",
+            "subject_id": "e2e-agent",
+            "zone_id": "default",
+            "x_agent_id": x_agent_id or "e2e-agent",
+        }
+
+    async def e2e_get_nexuspay(
+        auth_result: dict = Depends(e2e_require_auth),
+    ) -> NexusPay:
+        """Create NexusPay SDK instance from auth context — same as production."""
+        agent_id = auth_result.get("x_agent_id") or auth_result.get("subject_id", "anonymous")
+        zone_id = auth_result.get("zone_id", "default")
+
+        return NexusPay(
+            api_key=f"nx_live_{agent_id}",
+            credits_service=credits_service,
+            x402_client=None,
+            x402_enabled=False,
+            zone_id=zone_id,
+        )
+
+    # Override the dependency to use our auth
+    app.dependency_overrides[get_nexuspay] = e2e_get_nexuspay
+
+    # Health endpoint for readiness check
+    @app.get("/health")
+    async def health() -> dict[str, object]:
+        return {"status": "ok", "auth": "static", "api_key_required": True}
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_e2e_app()
+    print(f"E2E test server starting on http://localhost:{PORT}")
+    print(f"API Key: {API_KEY}")
+    print(f"Auth: Bearer {API_KEY}")
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")

--- a/packages/nexus-pay-ts/tests/e2e.test.ts
+++ b/packages/nexus-pay-ts/tests/e2e.test.ts
@@ -1,0 +1,268 @@
+/**
+ * End-to-end tests: TypeScript SDK → real FastAPI server with auth.
+ *
+ * Requires the E2E test server running:
+ *   cd packages/nexus-pay-ts
+ *   .venv/bin/python tests/e2e-server.py &
+ *   npx vitest run tests/e2e.test.ts
+ *
+ * Or use the run-e2e.sh script which handles server lifecycle.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { NexusPay } from "../src/client.js";
+import {
+  AuthenticationError,
+  NexusPayError,
+} from "../src/errors.js";
+import type { Balance, CanAffordResult, MeterResult, Receipt, Reservation } from "../src/types.js";
+
+const E2E_BASE_URL = process.env["E2E_BASE_URL"] ?? "http://localhost:4219";
+const E2E_API_KEY = process.env["E2E_API_KEY"] ?? "sk-e2e-test-key";
+
+// Check if the E2E server is running before proceeding
+async function isServerReady(): Promise<boolean> {
+  try {
+    const response = await fetch(`${E2E_BASE_URL}/health`);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+describe("E2E: NexusPay TypeScript SDK → FastAPI server", () => {
+  let pay: NexusPay;
+
+  beforeAll(async () => {
+    const ready = await isServerReady();
+    if (!ready) {
+      console.warn(
+        `\n⚠ E2E test server not running at ${E2E_BASE_URL}. Skipping E2E tests.\n` +
+          "  Start it with: .venv/bin/python tests/e2e-server.py\n",
+      );
+      return;
+    }
+
+    pay = new NexusPay({
+      apiKey: E2E_API_KEY,
+      baseUrl: E2E_BASE_URL,
+      maxRetries: 0,
+    });
+  });
+
+  // Helper to skip if server not running
+  function requireServer(): void {
+    if (!pay) {
+      throw new Error("E2E server not running — test skipped");
+    }
+  }
+
+  // =========================================================================
+  // Authentication
+  // =========================================================================
+
+  describe("authentication", () => {
+    it("rejects requests with invalid API key", async () => {
+      const badPay = new NexusPay({
+        apiKey: "sk-wrong-key-12345",
+        baseUrl: E2E_BASE_URL,
+        maxRetries: 0,
+      });
+
+      await expect(badPay.getBalance()).rejects.toThrow(AuthenticationError);
+    });
+
+    it("rejects requests with random bearer token", async () => {
+      const badPay = new NexusPay({
+        apiKey: "totally-invalid-token",
+        baseUrl: E2E_BASE_URL,
+        maxRetries: 0,
+      });
+
+      await expect(badPay.getBalance()).rejects.toThrow(AuthenticationError);
+    });
+
+    it("accepts requests with valid API key", async () => {
+      requireServer();
+      // Should not throw
+      const balance = await pay.getBalance();
+      expect(balance).toBeDefined();
+    });
+  });
+
+  // =========================================================================
+  // GET /api/v2/pay/balance
+  // =========================================================================
+
+  describe("getBalance", () => {
+    it("returns balance with correct shape", async () => {
+      requireServer();
+      const balance = await pay.getBalance();
+
+      expect(balance).toHaveProperty("available");
+      expect(balance).toHaveProperty("reserved");
+      expect(balance).toHaveProperty("total");
+      expect(typeof balance.available).toBe("string");
+      expect(typeof balance.reserved).toBe("string");
+      expect(typeof balance.total).toBe("string");
+    });
+
+    it("returns expected mock values from E2E server", async () => {
+      requireServer();
+      const balance = await pay.getBalance();
+
+      // E2E server returns available=100.000000, reserved=5.000000
+      expect(balance.available).toBe("100.000000");
+      expect(balance.reserved).toBe("5.000000");
+      expect(balance.total).toBe("105.000000");
+    });
+  });
+
+  // =========================================================================
+  // GET /api/v2/pay/can-afford
+  // =========================================================================
+
+  describe("canAfford", () => {
+    it("returns true for affordable amount", async () => {
+      requireServer();
+      const result = await pay.canAfford("50.00");
+
+      expect(result.canAfford).toBe(true);
+      expect(result.amount).toBe("50.00");
+    });
+  });
+
+  // =========================================================================
+  // POST /api/v2/pay/transfer
+  // =========================================================================
+
+  describe("transfer", () => {
+    it("completes a credits transfer", async () => {
+      requireServer();
+      const receipt = await pay.transfer({
+        to: "agent-bob",
+        amount: "10.00",
+        memo: "E2E test payment",
+      });
+
+      expect(receipt.id).toBe("tx-e2e-ts-001");
+      expect(receipt.method).toBe("credits");
+      expect(receipt.amount).toBe("10.00");
+      expect(receipt.toAgent).toBe("agent-bob");
+      expect(receipt.memo).toBe("E2E test payment");
+      expect(receipt.fromAgent).toBeDefined();
+    });
+
+    it("handles idempotency key", async () => {
+      requireServer();
+      const receipt = await pay.transfer(
+        { to: "agent-alice", amount: "5.00" },
+        { idempotencyKey: "e2e-idem-001" },
+      );
+
+      expect(receipt.id).toBeDefined();
+    });
+  });
+
+  // =========================================================================
+  // POST /api/v2/pay/transfer/batch
+  // =========================================================================
+
+  describe("transferBatch", () => {
+    it("completes a batch transfer", async () => {
+      requireServer();
+      const receipts = await pay.transferBatch([
+        { to: "agent-a", amount: "5.00", memo: "Batch A" },
+        { to: "agent-b", amount: "3.00", memo: "Batch B" },
+      ]);
+
+      expect(receipts).toHaveLength(2);
+      expect(receipts[0]?.id).toBe("tx-batch-001");
+      expect(receipts[1]?.id).toBe("tx-batch-002");
+    });
+  });
+
+  // =========================================================================
+  // POST /api/v2/pay/reserve → commit → release
+  // =========================================================================
+
+  describe("reserve/commit/release", () => {
+    it("completes reserve → commit flow", async () => {
+      requireServer();
+      const reservation = await pay.reserve({
+        amount: "25.00",
+        purpose: "e2e-test",
+        timeout: 600,
+      });
+
+      expect(reservation.id).toBe("res-e2e-ts-001");
+      expect(reservation.amount).toBe("25.00");
+      expect(reservation.purpose).toBe("e2e-test");
+      expect(reservation.status).toBe("pending");
+
+      // Commit (should return 204 → void)
+      await expect(
+        pay.commit(reservation.id, { actualAmount: "20.00" }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("completes reserve → release flow", async () => {
+      requireServer();
+      const reservation = await pay.reserve({ amount: "10.00" });
+
+      // Release (should return 204 → void)
+      await expect(pay.release(reservation.id)).resolves.toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // POST /api/v2/pay/meter
+  // =========================================================================
+
+  describe("meter", () => {
+    it("records metered usage", async () => {
+      requireServer();
+      const result = await pay.meter({
+        amount: "0.01",
+        eventType: "api_call",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Full lifecycle
+  // =========================================================================
+
+  describe("full lifecycle", () => {
+    it("balance → transfer → meter → reserve → commit", async () => {
+      requireServer();
+
+      // 1. Check balance
+      const balance = await pay.getBalance();
+      expect(parseFloat(balance.available)).toBeGreaterThan(0);
+
+      // 2. Check affordability
+      const affordable = await pay.canAfford("10.00");
+      expect(affordable.canAfford).toBe(true);
+
+      // 3. Transfer
+      const receipt = await pay.transfer({
+        to: "worker-agent",
+        amount: "10.00",
+        memo: "Lifecycle test",
+      });
+      expect(receipt.method).toBe("credits");
+
+      // 4. Meter
+      const meterResult = await pay.meter({ amount: "0.001" });
+      expect(meterResult.success).toBe(true);
+
+      // 5. Reserve → commit
+      const reservation = await pay.reserve({ amount: "15.00", purpose: "lifecycle" });
+      expect(reservation.status).toBe("pending");
+      await pay.commit(reservation.id);
+    });
+  });
+});

--- a/packages/nexus-pay-ts/tests/errors.test.ts
+++ b/packages/nexus-pay-ts/tests/errors.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  NexusPayError,
+  AuthenticationError,
+  InsufficientCreditsError,
+  BudgetExceededError,
+  WalletNotFoundError,
+  ReservationError,
+  RateLimitError,
+} from "../src/errors.js";
+
+describe("NexusPayError", () => {
+  it("has correct name, message, status, and code", () => {
+    const error = new NexusPayError("something broke", 400, "pay_error");
+    expect(error.name).toBe("NexusPayError");
+    expect(error.message).toBe("something broke");
+    expect(error.status).toBe(400);
+    expect(error.code).toBe("pay_error");
+  });
+
+  it("is an instance of Error", () => {
+    const error = new NexusPayError("test", 400, "pay_error");
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(NexusPayError);
+  });
+
+  it("has a stack trace", () => {
+    const error = new NexusPayError("test", 400, "pay_error");
+    expect(error.stack).toBeDefined();
+  });
+});
+
+describe("AuthenticationError", () => {
+  it("has status 401 and correct code", () => {
+    const error = new AuthenticationError("invalid key");
+    expect(error.status).toBe(401);
+    expect(error.code).toBe("authentication_error");
+    expect(error.name).toBe("AuthenticationError");
+  });
+
+  it("is an instance of NexusPayError", () => {
+    const error = new AuthenticationError("invalid key");
+    expect(error).toBeInstanceOf(NexusPayError);
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("InsufficientCreditsError", () => {
+  it("has status 402 and correct code", () => {
+    const error = new InsufficientCreditsError("not enough credits");
+    expect(error.status).toBe(402);
+    expect(error.code).toBe("insufficient_credits");
+    expect(error.name).toBe("InsufficientCreditsError");
+  });
+
+  it("is an instance of NexusPayError", () => {
+    const error = new InsufficientCreditsError("test");
+    expect(error).toBeInstanceOf(NexusPayError);
+  });
+});
+
+describe("BudgetExceededError", () => {
+  it("has status 403 and correct code", () => {
+    const error = new BudgetExceededError("budget limit");
+    expect(error.status).toBe(403);
+    expect(error.code).toBe("budget_exceeded");
+    expect(error.name).toBe("BudgetExceededError");
+  });
+
+  it("is an instance of NexusPayError", () => {
+    const error = new BudgetExceededError("test");
+    expect(error).toBeInstanceOf(NexusPayError);
+  });
+});
+
+describe("WalletNotFoundError", () => {
+  it("has status 404 and correct code", () => {
+    const error = new WalletNotFoundError("wallet missing");
+    expect(error.status).toBe(404);
+    expect(error.code).toBe("wallet_not_found");
+    expect(error.name).toBe("WalletNotFoundError");
+  });
+
+  it("is an instance of NexusPayError", () => {
+    const error = new WalletNotFoundError("test");
+    expect(error).toBeInstanceOf(NexusPayError);
+  });
+});
+
+describe("ReservationError", () => {
+  it("has status 409 and correct code", () => {
+    const error = new ReservationError("reservation conflict");
+    expect(error.status).toBe(409);
+    expect(error.code).toBe("reservation_error");
+    expect(error.name).toBe("ReservationError");
+  });
+
+  it("is an instance of NexusPayError", () => {
+    const error = new ReservationError("test");
+    expect(error).toBeInstanceOf(NexusPayError);
+  });
+});
+
+describe("RateLimitError", () => {
+  it("has status 429 and correct code", () => {
+    const error = new RateLimitError("rate limited", 30);
+    expect(error.status).toBe(429);
+    expect(error.code).toBe("rate_limit_error");
+    expect(error.name).toBe("RateLimitError");
+  });
+
+  it("exposes retryAfter property", () => {
+    const error = new RateLimitError("slow down", 60);
+    expect(error.retryAfter).toBe(60);
+  });
+
+  it("handles undefined retryAfter", () => {
+    const error = new RateLimitError("slow down");
+    expect(error.retryAfter).toBeUndefined();
+  });
+
+  it("is an instance of NexusPayError", () => {
+    const error = new RateLimitError("test");
+    expect(error).toBeInstanceOf(NexusPayError);
+  });
+});

--- a/packages/nexus-pay-ts/tests/fetch-client.test.ts
+++ b/packages/nexus-pay-ts/tests/fetch-client.test.ts
@@ -1,0 +1,434 @@
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FetchClient } from "../src/fetch-client.js";
+import {
+  AuthenticationError,
+  BudgetExceededError,
+  InsufficientCreditsError,
+  NexusPayError,
+  RateLimitError,
+  ReservationError,
+  WalletNotFoundError,
+} from "../src/errors.js";
+
+function jsonResponse(body: unknown, status = 200, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { "Content-Type": "text/plain" } });
+}
+
+describe("FetchClient", () => {
+  let mockFetch: Mock;
+  let client: FetchClient;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    client = new FetchClient({
+      apiKey: "nx_test_agent1",
+      baseUrl: "https://api.example.com",
+      timeout: 5000,
+      maxRetries: 0,
+      fetch: mockFetch,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // =========================================================================
+  // Auth header
+  // =========================================================================
+
+  describe("auth header", () => {
+    it("attaches Bearer token from API key", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await client.get("/test");
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = new Headers(init.headers);
+      expect(headers.get("Authorization")).toBe("Bearer nx_test_agent1");
+    });
+
+    it("sets Content-Type for POST requests", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await client.post("/test", { data: 1 });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = new Headers(init.headers);
+      expect(headers.get("Content-Type")).toBe("application/json");
+    });
+  });
+
+  // =========================================================================
+  // URL construction
+  // =========================================================================
+
+  describe("URL construction", () => {
+    it("joins base URL with path", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await client.get("/api/v2/pay/balance");
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe("https://api.example.com/api/v2/pay/balance");
+    });
+
+    it("handles base URL with trailing slash", async () => {
+      const c = new FetchClient({
+        apiKey: "nx_test_x",
+        baseUrl: "https://api.example.com/",
+        maxRetries: 0,
+        fetch: mockFetch,
+      });
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await c.get("/api/v2/pay/balance");
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe("https://api.example.com/api/v2/pay/balance");
+    });
+  });
+
+  // =========================================================================
+  // GET / POST / POST-no-content
+  // =========================================================================
+
+  describe("request methods", () => {
+    it("GET sends no body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ value: 42 }));
+      const result = await client.get<{ value: number }>("/data");
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe("GET");
+      expect(init.body).toBeUndefined();
+      expect(result).toEqual({ value: 42 });
+    });
+
+    it("POST sends JSON body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "tx_1" }));
+      const result = await client.post<{ id: string }>("/transfer", { to: "bob", amount: "10" });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe("POST");
+      expect(init.body).toBe(JSON.stringify({ to: "bob", amount: "10" }));
+      expect(result).toEqual({ id: "tx_1" });
+    });
+
+    it("postNoContent handles 204 response", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+      await expect(client.postNoContent("/commit", { amount: "5" })).resolves.toBeUndefined();
+    });
+
+    it("postNoContent handles 200 with empty body", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+      await expect(client.postNoContent("/commit")).resolves.toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Error mapping (HTTP status → typed error)
+  // =========================================================================
+
+  describe("error mapping", () => {
+    it("401 → AuthenticationError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Invalid token", error_code: "auth_error" }, 401),
+      );
+      await expect(client.get("/test")).rejects.toThrow(AuthenticationError);
+    });
+
+    it("402 → InsufficientCreditsError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Not enough", error_code: "insufficient_credits" }, 402),
+      );
+      await expect(client.get("/test")).rejects.toThrow(InsufficientCreditsError);
+    });
+
+    it("403 → BudgetExceededError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Over budget", error_code: "budget_exceeded" }, 403),
+      );
+      await expect(client.get("/test")).rejects.toThrow(BudgetExceededError);
+    });
+
+    it("404 → WalletNotFoundError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "No wallet", error_code: "wallet_not_found" }, 404),
+      );
+      await expect(client.get("/test")).rejects.toThrow(WalletNotFoundError);
+    });
+
+    it("409 → ReservationError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Conflict", error_code: "reservation_error" }, 409),
+      );
+      await expect(client.get("/test")).rejects.toThrow(ReservationError);
+    });
+
+    it("429 → RateLimitError with retryAfter", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Slow down" }, 429, { "Retry-After": "30" }),
+      );
+      try {
+        await client.get("/test");
+        expect.fail("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(RateLimitError);
+        expect((e as RateLimitError).retryAfter).toBe(30);
+      }
+    });
+
+    it("429 → RateLimitError without Retry-After header", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ detail: "Slow down" }, 429));
+      try {
+        await client.get("/test");
+        expect.fail("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(RateLimitError);
+        expect((e as RateLimitError).retryAfter).toBeUndefined();
+      }
+    });
+
+    it("other 4xx → NexusPayError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Bad request" }, 400),
+      );
+      try {
+        await client.get("/test");
+        expect.fail("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(NexusPayError);
+        expect((e as NexusPayError).status).toBe(400);
+      }
+    });
+
+    it("5xx → NexusPayError", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Server error" }, 500),
+      );
+      await expect(client.get("/test")).rejects.toThrow(NexusPayError);
+    });
+
+    it("non-JSON error response uses status text", async () => {
+      mockFetch.mockResolvedValueOnce(textResponse("Internal Server Error", 500));
+      try {
+        await client.get("/test");
+        expect.fail("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(NexusPayError);
+        expect((e as NexusPayError).message).toContain("500");
+      }
+    });
+
+    it("error includes detail from JSON response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Insufficient balance for transfer of 100 credits" }, 402),
+      );
+      try {
+        await client.get("/test");
+        expect.fail("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(InsufficientCreditsError);
+        expect((e as NexusPayError).message).toBe(
+          "Insufficient balance for transfer of 100 credits",
+        );
+      }
+    });
+  });
+
+  // =========================================================================
+  // Retry logic
+  // =========================================================================
+
+  describe("retry", () => {
+    let retryClient: FetchClient;
+
+    beforeEach(() => {
+      retryClient = new FetchClient({
+        apiKey: "nx_test_agent1",
+        baseUrl: "https://api.example.com",
+        timeout: 5000,
+        maxRetries: 2,
+        fetch: mockFetch,
+      });
+    });
+
+    it("retries on 500 and succeeds", async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ detail: "err" }, 500))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const result = await retryClient.get<{ ok: boolean }>("/test");
+      expect(result.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries on 502, 503, 504", async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ detail: "err" }, 502))
+        .mockResolvedValueOnce(jsonResponse({ detail: "err" }, 503))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const result = await retryClient.get<{ ok: boolean }>("/test");
+      expect(result.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("throws after max retries exhausted on 500", async () => {
+      mockFetch
+        .mockResolvedValue(jsonResponse({ detail: "server down" }, 500));
+
+      await expect(retryClient.get("/test")).rejects.toThrow(NexusPayError);
+      // 1 initial + 2 retries = 3 calls
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("does NOT retry on 400", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ detail: "bad" }, 400));
+      await expect(retryClient.get("/test")).rejects.toThrow(NexusPayError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry on 401", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ detail: "unauth" }, 401));
+      await expect(retryClient.get("/test")).rejects.toThrow(AuthenticationError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry on 402", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ detail: "no credits" }, 402));
+      await expect(retryClient.get("/test")).rejects.toThrow(InsufficientCreditsError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry on 403", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ detail: "forbidden" }, 403));
+      await expect(retryClient.get("/test")).rejects.toThrow(BudgetExceededError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry on 404", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ detail: "not found" }, 404));
+      await expect(retryClient.get("/test")).rejects.toThrow(WalletNotFoundError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on 429 and respects Retry-After", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({ detail: "rate limited" }, 429, { "Retry-After": "0" }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const result = await retryClient.get<{ ok: boolean }>("/test");
+      expect(result.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries on network error (fetch rejects)", async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const result = await retryClient.get<{ ok: boolean }>("/test");
+      expect(result.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws NexusPayError after network error retries exhausted", async () => {
+      mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+
+      await expect(retryClient.get("/test")).rejects.toThrow(NexusPayError);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  // =========================================================================
+  // Timeout
+  // =========================================================================
+
+  describe("timeout", () => {
+    it("aborts request on timeout", async () => {
+      const slowClient = new FetchClient({
+        apiKey: "nx_test_x",
+        baseUrl: "https://api.example.com",
+        timeout: 50, // 50ms timeout
+        maxRetries: 0,
+        fetch: mockFetch,
+      });
+
+      mockFetch.mockImplementationOnce(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            // Simulate slow response — listen for abort
+            init.signal?.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          }),
+      );
+
+      await expect(slowClient.get("/slow")).rejects.toThrow(NexusPayError);
+    });
+
+    it("per-request timeout overrides global", async () => {
+      // Global timeout is 5000ms but per-request is 50ms
+      mockFetch.mockImplementationOnce(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          }),
+      );
+
+      await expect(client.get("/slow", { timeout: 50 })).rejects.toThrow(NexusPayError);
+    });
+
+    it("user-provided AbortSignal is respected", async () => {
+      const controller = new AbortController();
+
+      mockFetch.mockImplementationOnce(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          }),
+      );
+
+      // Abort immediately
+      controller.abort();
+
+      await expect(client.get("/test", { signal: controller.signal })).rejects.toThrow(
+        NexusPayError,
+      );
+    });
+  });
+
+  // =========================================================================
+  // Idempotency key
+  // =========================================================================
+
+  describe("idempotency key", () => {
+    it("sends Idempotency-Key header when provided", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "tx_1" }));
+      await client.post("/transfer", { to: "bob" }, { idempotencyKey: "key-123" });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = new Headers(init.headers);
+      expect(headers.get("Idempotency-Key")).toBe("key-123");
+    });
+
+    it("omits Idempotency-Key header when not provided", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "tx_1" }));
+      await client.post("/transfer", { to: "bob" });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = new Headers(init.headers);
+      expect(headers.get("Idempotency-Key")).toBeNull();
+    });
+  });
+});

--- a/packages/nexus-pay-ts/tests/run-e2e.sh
+++ b/packages/nexus-pay-ts/tests/run-e2e.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Run E2E tests: start Python test server, run TS tests, cleanup.
+#
+# Usage:
+#   cd packages/nexus-pay-ts
+#   bash tests/run-e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PKG_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$(dirname "$PKG_DIR")")"
+
+PORT=4219
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "Stopping E2E test server (PID $SERVER_PID)..."
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT
+
+echo "=== NexusPay TypeScript SDK E2E Tests ==="
+echo ""
+
+# 1. Start the Python E2E test server
+echo "Starting E2E test server on port $PORT..."
+cd "$REPO_ROOT"
+.venv/bin/python "$SCRIPT_DIR/e2e-server.py" &
+SERVER_PID=$!
+
+# 2. Wait for server to be ready
+echo "Waiting for server to be ready..."
+for i in $(seq 1 30); do
+  if curl -s "http://localhost:$PORT/health" > /dev/null 2>&1; then
+    echo "Server ready!"
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "ERROR: Server process died. Check Python dependencies."
+    exit 1
+  fi
+  sleep 0.5
+done
+
+# Verify server is actually responding
+if ! curl -s "http://localhost:$PORT/health" > /dev/null 2>&1; then
+  echo "ERROR: Server failed to start within 15 seconds."
+  exit 1
+fi
+
+# 3. Run TypeScript E2E tests
+echo ""
+echo "Running E2E tests..."
+cd "$PKG_DIR"
+E2E_BASE_URL="http://localhost:$PORT" E2E_API_KEY="sk-e2e-test-key" \
+  npx vitest run tests/e2e.test.ts

--- a/packages/nexus-pay-ts/tsconfig.json
+++ b/packages/nexus-pay-ts/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": false,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/nexus-pay-ts/tsup.config.ts
+++ b/packages/nexus-pay-ts/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  treeshake: true,
+});

--- a/packages/nexus-pay-ts/vitest.config.ts
+++ b/packages/nexus-pay-ts/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Hand-written TypeScript SDK (`@nexus/pay`) for all 8 NexusPay REST API endpoints (`/api/v2/pay/*`)
- Zero runtime dependencies — native `fetch` with configurable retry (exponential backoff + full jitter), `AbortController` timeouts, and typed error hierarchy mirroring the Python SDK
- 3.3KB gzipped ESM bundle, dual ESM/CJS + `.d.ts` output via tsup

### SDK Methods

| Method | HTTP Call |
|--------|-----------|
| `getBalance()` | `GET /api/v2/pay/balance` |
| `canAfford(amount)` | `GET /api/v2/pay/can-afford?amount=X` |
| `transfer(params)` | `POST /api/v2/pay/transfer` |
| `transferBatch(transfers)` | `POST /api/v2/pay/transfer/batch` |
| `reserve(params)` | `POST /api/v2/pay/reserve` |
| `commit(id, params?)` | `POST /api/v2/pay/reserve/{id}/commit` |
| `release(id)` | `POST /api/v2/pay/reserve/{id}/release` |
| `meter(params)` | `POST /api/v2/pay/meter` |

### Architecture Decisions (16 approved)

1. Hand-written SDK (not auto-generated)
2. tsup build (ESM + CJS + .d.ts)
3. Native fetch, zero deps
4. Typed error hierarchy (AuthenticationError, InsufficientCreditsError, etc.)
5. String amounts everywhere (no float precision loss)
6. Configurable retry (3 retries, 500ms initial, 8s max, full jitter, Retry-After)
7. AbortController timeout (global + per-request)
8. Stripe-pattern `method(params, requestOptions)` signatures

### Quality

| Metric | Value |
|--------|-------|
| Unit tests | 102 |
| E2E tests (real FastAPI + auth) | 13 |
| Statement coverage | 97.8% |
| Branch coverage | 91.4% |
| Bundle size (gzipped) | 3.3KB |
| ruff / mypy / tsc | All clean |

### Files

```
packages/nexus-pay-ts/
├── src/
│   ├── index.ts          # Public API exports
│   ├── client.ts         # NexusPay class (8 methods)
│   ├── types.ts          # Request/response types
│   ├── errors.ts         # Error class hierarchy
│   └── fetch-client.ts   # Internal: retry, timeout, auth
├── tests/
│   ├── client.test.ts    # 41 method tests
│   ├── fetch-client.test.ts # 35 retry/timeout/auth tests
│   ├── errors.test.ts    # 17 error class tests
│   ├── contract.test.ts  # 9 snake→camelCase mapping tests
│   ├── e2e.test.ts       # 13 E2E tests
│   ├── e2e-server.py     # Minimal FastAPI test server
│   └── run-e2e.sh        # E2E orchestration script
├── package.json, tsconfig.json, tsup.config.ts, vitest.config.ts
└── README.md
```

## Test plan

- [x] `npx vitest run` — 115/115 tests pass
- [x] `npx vitest run --coverage` — 97.8% statements, 91.4% branches
- [x] `npx tsc --noEmit` — clean
- [x] `npx tsup` — ESM + CJS + .d.ts build
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean
- [x] E2E: real FastAPI server with auth enforcement
- [ ] CI checks

Closes #1211