### PR TITLE
feat(#1198): Add Agent Activity Summary endpoint

### DIFF
--- a/src/nexus/server/api/v2/models.py
+++ b/src/nexus/server/api/v2/models.py
@@ -514,3 +514,20 @@ class OperationListResponse(BaseModel):
     offset: int | None = None
     total: int | None = None
     next_cursor: str | None = None
+
+
+class AgentActivityResponse(BaseModel):
+    """Response for GET /api/v2/operations/agents/{agent_id}/activity.
+
+    Aggregated activity summary for a specific agent within a time window.
+    All fields are scoped to the since filter (default: last 24h).
+
+    Issue #1198: Add Agent Activity Summary endpoint.
+    """
+
+    agent_id: str
+    total_operations: int = 0
+    operations_by_type: dict[str, int] = Field(default_factory=dict)
+    recent_paths: list[str] = Field(default_factory=list)
+    last_active: str | None = None  # ISO-8601
+    first_seen: str | None = None  # ISO-8601

--- a/src/nexus/storage/models/operation_log.py
+++ b/src/nexus/storage/models/operation_log.py
@@ -75,6 +75,15 @@ class OperationLogModel(Base):
             "created_at",
             postgresql_using="brin",
         ),
+        # Composite B-tree for agent activity summary queries (#1198).
+        # Covers: WHERE zone_id=? AND agent_id=? AND created_at>=?
+        # + GROUP BY operation_type / GROUP BY path ORDER BY created_at DESC
+        Index(
+            "idx_operation_log_zone_agent_created",
+            "zone_id",
+            "agent_id",
+            created_at.desc(),
+        ),
     )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary

- Add `GET /api/v2/operations/agents/{agent_id}/activity` endpoint for aggregated agent activity summaries
- Returns `total_operations`, `operations_by_type`, `recent_paths`, `first_seen`, `last_active` within a configurable time window (default: last 24h)
- Add composite B-tree index `(zone_id, agent_id, created_at DESC)` for index-assisted queries on all filter columns

## Changes

| File | Change |
|------|--------|
| `src/nexus/server/api/v2/models.py` | `AgentActivityResponse` Pydantic model |
| `src/nexus/storage/operation_logger.py` | `agent_activity_summary()` — 2 SQL queries (GROUP BY type + GROUP BY path) |
| `src/nexus/server/api/v2/routers/operations.py` | `GET /agents/{agent_id}/activity` endpoint with path validation |
| `src/nexus/storage/models/operation_log.py` | Composite index for query performance |
| `tests/unit/server/api/v2/test_operations_api.py` | 8 unit tests (happy path, empty agent, zone scoping, since filter, default 24h, mixed status, path dedup, auth) |
| `tests/e2e/test_operations_e2e.py` | 6 e2e tests against real `nexus serve` with `auth_type=database` + `enforce_permissions=true` |

## Test plan

- [x] 30 unit tests pass (22 existing + 8 new)
- [x] 16 e2e tests pass (10 existing + 6 new) against real server with permissions enabled
- [x] `ruff check` — clean
- [x] `ruff format` — clean
- [x] `mypy` — 0 issues
- [x] File size check — clean
- [x] No new `type: ignore` comments
- [x] Performance benchmarked: 3ms (24h window) to 19ms (10K ops all-time) on SQLite
- [x] EXPLAIN verified: composite index used for all 3 filter columns

Closes #1198