### PR TITLE
feat(#1143): Propagate write(lock=True) through full RPC stack

### DIFF
--- a/src/nexus/core/scoped_filesystem.py
+++ b/src/nexus/core/scoped_filesystem.py
@@ -157,10 +157,30 @@ class ScopedFilesystem:
         if_match: str | None = None,
         if_none_match: bool = False,
         force: bool = False,
+        lock: bool = False,
+        lock_timeout: float = 30.0,
     ) -> dict[str, Any]:
-        """Write content to a file."""
+        """Write content to a file.
+
+        Args:
+            lock: If True, acquire distributed lock before writing.
+                Adds ~2-10ms latency for lock acquire/release.
+                For read-modify-write patterns, use locked() context manager instead.
+            lock_timeout: Max time to wait for lock in seconds (only used if lock=True).
+        """
+        kwargs: dict[str, Any] = {}
+        if lock:
+            kwargs["lock"] = lock
+        if lock_timeout != 30.0:
+            kwargs["lock_timeout"] = lock_timeout
         result = self._fs.write(
-            self._scope_path(path), content, context, if_match, if_none_match, force
+            self._scope_path(path),
+            content,
+            context,
+            if_match,
+            if_none_match,
+            force,
+            **kwargs,
         )
         return self._unscope_dict(result, ["path"])
 

--- a/src/nexus/remote/async_client.py
+++ b/src/nexus/remote/async_client.py
@@ -558,6 +558,8 @@ class AsyncRemoteNexusFS:
         if_match: str | None = None,
         if_none_match: bool = False,
         force: bool = False,
+        lock: bool = False,
+        lock_timeout: float = 30.0,
     ) -> dict[str, Any]:
         """Write content to a file (async).
 
@@ -568,6 +570,10 @@ class AsyncRemoteNexusFS:
             if_match: Optional etag for optimistic concurrency
             if_none_match: If True, create-only mode
             force: If True, skip version check
+            lock: If True, acquire distributed lock before writing (server-side).
+                Adds ~2-10ms latency for lock acquire/release.
+                For read-modify-write patterns, use locked() context manager instead.
+            lock_timeout: Max time to wait for lock in seconds (only used if lock=True).
 
         Returns:
             Dict with metadata (etag, version, modified_at, size)
@@ -575,16 +581,19 @@ class AsyncRemoteNexusFS:
         if isinstance(content, str):
             content = content.encode("utf-8")
 
-        result = await self._call_rpc(
-            "write",
-            {
-                "path": path,
-                "content": content,
-                "if_match": if_match,
-                "if_none_match": if_none_match,
-                "force": force,
-            },
-        )
+        params: dict[str, Any] = {
+            "path": path,
+            "content": content,
+            "if_match": if_match,
+            "if_none_match": if_none_match,
+            "force": force,
+        }
+        if lock:
+            params["lock"] = True
+        if lock_timeout != 30.0:
+            params["lock_timeout"] = lock_timeout
+
+        result = await self._call_rpc("write", params)
 
         # Invalidate negative cache after successful write (issue #858)
         self._negative_cache_invalidate(path)

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -5079,6 +5079,13 @@ def _handle_write(params: Any, context: Any) -> dict[str, Any]:
         kwargs["if_none_match"] = params.if_none_match
     if hasattr(params, "force") and params.force:
         kwargs["force"] = params.force
+    # Lock params (Issue #1143) — only forward when non-default
+    lock_val = getattr(params, "lock", None)
+    if lock_val:
+        kwargs["lock"] = lock_val
+    lock_timeout_val = getattr(params, "lock_timeout", None)
+    if lock_timeout_val is not None and lock_timeout_val != 30.0:
+        kwargs["lock_timeout"] = lock_timeout_val
 
     bytes_written = nexus_fs.write(params.path, content, **kwargs)
     return {"bytes_written": bytes_written}

--- a/src/nexus/server/protocol.py
+++ b/src/nexus/server/protocol.py
@@ -346,6 +346,8 @@ class WriteParams:
     if_match: str | None = None  # Optimistic concurrency control
     if_none_match: bool = False  # Create-only mode
     force: bool = False  # Skip version check
+    lock: bool = False  # Acquire distributed lock before writing (#1143)
+    lock_timeout: float = 30.0  # Max seconds to wait for lock
 
 
 @dataclass

--- a/tests/unit/core/test_scoped_filesystem.py
+++ b/tests/unit/core/test_scoped_filesystem.py
@@ -168,6 +168,47 @@ class TestCoreFileOperations:
         )
         assert result["path"] == "/workspace/file.txt"
 
+    def test_write_forwards_lock_param(
+        self, scoped_fs: ScopedFilesystem, mock_fs: MagicMock
+    ) -> None:
+        """Test write forwards lock=True to inner filesystem."""
+        mock_fs.write.return_value = {
+            "path": "/zones/team_12/users/user_1/workspace/file.txt",
+            "etag": "abc",
+        }
+        result = scoped_fs.write("/workspace/file.txt", b"content", lock=True)
+        mock_fs.write.assert_called_once_with(
+            "/zones/team_12/users/user_1/workspace/file.txt",
+            b"content",
+            None,
+            None,
+            False,
+            False,
+            lock=True,
+        )
+        assert result["path"] == "/workspace/file.txt"
+
+    def test_write_forwards_lock_timeout(
+        self, scoped_fs: ScopedFilesystem, mock_fs: MagicMock
+    ) -> None:
+        """Test write forwards lock_timeout to inner filesystem."""
+        mock_fs.write.return_value = {
+            "path": "/zones/team_12/users/user_1/workspace/file.txt",
+            "etag": "abc",
+        }
+        result = scoped_fs.write("/workspace/file.txt", b"content", lock=True, lock_timeout=5.0)
+        mock_fs.write.assert_called_once_with(
+            "/zones/team_12/users/user_1/workspace/file.txt",
+            b"content",
+            None,
+            None,
+            False,
+            False,
+            lock=True,
+            lock_timeout=5.0,
+        )
+        assert result["path"] == "/workspace/file.txt"
+
     def test_write_batch(self, scoped_fs: ScopedFilesystem, mock_fs: MagicMock) -> None:
         """Test write_batch with path scoping."""
         mock_fs.write_batch.return_value = [


### PR DESCRIPTION
## Summary

- Propagates existing `write(lock=True, lock_timeout=30.0)` params from the kernel (`NexusFS.write()`) through the full RPC stack, making distributed locking accessible to remote clients
- Adds `lock`/`lock_timeout` fields to `WriteParams` dataclass (protocol.py)
- Forwards lock params in `_handle_write()` RPC handler using `getattr` with `None` default
- Adds `lock`/`lock_timeout` params to `RemoteNexusFS.write()` (sync) and `AsyncRemoteNexusFS.write()` (async)
- Adds `lock`/`lock_timeout` pass-through to `ScopedFilesystem.write()` via `**kwargs`
- Lock params only sent over the wire when non-default, preserving backward compatibility

## Files Changed (5 production, 6 test)

| File | Change |
|------|--------|
| `src/nexus/server/protocol.py` | +2 fields to `WriteParams` |
| `src/nexus/server/fastapi_server.py` | Forward lock params in `_handle_write()` |
| `src/nexus/remote/client.py` | Add lock/lock_timeout to sync `write()` |
| `src/nexus/remote/async_client.py` | Add lock/lock_timeout to async `write()` |
| `src/nexus/core/scoped_filesystem.py` | Pass-through via `**kwargs` |
| `tests/unit/server/test_fastapi_server.py` | 2 tests: lock forwarding + backward compat |
| `tests/unit/remote/test_client.py` | 3 tests: lock, lock_timeout, omit when default |
| `tests/unit/remote/test_async_client.py` | 3 tests: same as sync |
| `tests/unit/core/test_scoped_filesystem.py` | 2 tests: lock + lock_timeout forwarding |
| `tests/integration/test_nexusfs_distributed_lock.py` | 2 tests: timeout contention + lock+OCC |
| `tests/e2e/test_raft_auth_permissions_e2e.py` | 2 tests: full stack RPC with auth+permissions |

## Test plan

- [x] 154 unit tests pass (12 new + 142 existing, 0 regressions)
- [x] 22 e2e tests pass (2 new, real `nexus serve` with `NEXUS_ENFORCE_PERMISSIONS=true`)
- [x] mypy clean (no new errors)
- [x] ruff lint + format clean
- [x] Integration tests added (require Redis, skipped without `REDIS_ENABLED=1`)