### PR TITLE
refactor(#1341): Context manifest v2 — protocol typing, async I/O, bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "aiosqlite>=0.20.0", # SQLite driver (async)
     # Caching
     "cachetools>=6.2.2",
-    "redis>=7.0.0",  # Redis/Dragonfly client (async support)
+    "redis>=7.0.0", # Redis/Dragonfly client (async support)
     # Authentication
     "authlib>=1.6.5", # JWT and OAuth support for OIDC auth
     "bcrypt>=4.0.0", # Password hashing for local auth
@@ -120,6 +120,7 @@ dependencies = [
     # Affinity-based memory consolidation (Issue #1026 - SimpleMem-inspired)
     "numpy>=1.26.0",
     "scikit-learn>=1.4.0",
+    "aiofiles>=25.1.0",
 ]
 
 [project.optional-dependencies]
@@ -625,6 +626,7 @@ dev = [
     "freezegun>=1.5.5",
     "grpcio-tools>=1.76.0",
     "pytest-cov>=7.0.0",
+    "types-aiofiles>=25.1.0.20251011",
     "types-protobuf>=6.32.1.20251210",
     "types-redis>=4.6.0.20241004",
 ]

--- a/src/nexus/core/context_manifest/__init__.py
+++ b/src/nexus/core/context_manifest/__init__.py
@@ -29,6 +29,7 @@ References:
 
 from nexus.core.context_manifest.models import (
     ContextSource,
+    ContextSourceProtocol,
     FileGlobSource,
     ManifestResolutionError,
     ManifestResult,
@@ -43,6 +44,7 @@ from nexus.core.context_manifest.template import ALLOWED_VARIABLES, resolve_temp
 __all__ = [
     # Models
     "ContextSource",
+    "ContextSourceProtocol",
     "FileGlobSource",
     "ManifestResolutionError",
     "ManifestResult",

--- a/src/nexus/core/protocols/__init__.py
+++ b/src/nexus/core/protocols/__init__.py
@@ -1,6 +1,6 @@
 """Kernel protocol interfaces for the Nexus architecture.
 
-Only VFSRouterProtocol lives here — it is a kernel concern (virtual path routing).
+VFSRouterProtocol and ContextManifestProtocol live here — they are kernel concerns.
 
 Service-layer protocols (EventLogProtocol, etc.) live in nexus.services/
 per the Four Pillars architecture (data-storage-matrix.md).
@@ -8,11 +8,14 @@ per the Four Pillars architecture (data-storage-matrix.md).
 References:
     - docs/architecture/data-storage-matrix.md
     - Issue #1383: Define 6 kernel protocol interfaces
+    - Issue #1341: Context manifest protocol
 """
 
+from nexus.core.protocols.context_manifest import ContextManifestProtocol
 from nexus.core.protocols.vfs_router import MountInfo, ResolvedPath, VFSRouterProtocol
 
 __all__ = [
+    "ContextManifestProtocol",
     "MountInfo",
     "ResolvedPath",
     "VFSRouterProtocol",

--- a/src/nexus/core/protocols/context_manifest.py
+++ b/src/nexus/core/protocols/context_manifest.py
@@ -1,0 +1,59 @@
+"""Context manifest kernel protocol (Nexus Lego Architecture, Issue #1341).
+
+Defines the contract for resolving context manifests — deterministic
+pre-execution of sources before agent reasoning starts.
+
+The kernel knows *that* manifests get resolved, but not *how*.
+The ``ManifestResolver`` in ``nexus.core.context_manifest.resolver``
+is the current implementation.
+
+References:
+    - docs/design/NEXUS-LEGO-ARCHITECTURE.md Part 2
+    - Issue #1341: Context manifest with deterministic pre-execution
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from nexus.core.context_manifest.models import (
+    ContextSourceProtocol,
+    ManifestResult,
+)
+
+
+@runtime_checkable
+class ContextManifestProtocol(Protocol):
+    """Protocol for resolving a context manifest.
+
+    Implementations execute all declared sources (in parallel where possible),
+    write result files to an output directory, and return a ``ManifestResult``.
+    """
+
+    async def resolve(
+        self,
+        sources: Sequence[ContextSourceProtocol],
+        variables: dict[str, str],
+        output_dir: Path,
+    ) -> ManifestResult:
+        """Resolve all sources and write results to *output_dir*.
+
+        Args:
+            sources: Sequence of context sources to resolve.
+            variables: Template variable values for substitution.
+            output_dir: Directory to write result files into.
+
+        Returns:
+            ManifestResult with all source results.
+
+        Raises:
+            ManifestResolutionError: If any required source fails.
+            ValueError: If template variables are invalid.
+
+        Note:
+            Output files are written even when ``ManifestResolutionError``
+            is raised, allowing callers to inspect partial results.
+        """
+        ...

--- a/tests/integration/core/test_context_manifest_integration.py
+++ b/tests/integration/core/test_context_manifest_integration.py
@@ -38,24 +38,15 @@ class IntegrationOkExecutor:
     def __init__(self, data_factory: Any = None) -> None:
         self._factory = data_factory
 
-    async def execute(self, source: Any, variables: dict[str, str]) -> SourceResult:
-        name = _name(source)
+    async def execute(self, source: Any, variables: dict[str, str]) -> SourceResult:  # noqa: ARG002
         data = self._factory(source, variables) if self._factory else {"files": ["a.py", "b.py"]}
         return SourceResult(
             source_type=source.type,
-            source_name=name,
+            source_name=source.source_name,
             status="ok",
             data=data,
             elapsed_ms=5.0,
         )
-
-
-def _name(source: Any) -> str:
-    for attr in ("tool_name", "snapshot_id", "pattern", "query"):
-        v = getattr(source, attr, None)
-        if v is not None:
-            return str(v)
-    return "unknown"
 
 
 def _make_all_ok_executors() -> dict[str, Any]:
@@ -156,11 +147,10 @@ class TestIndexJsonSchema:
 
 
 class LargeDataExecutor:
-    async def execute(self, source: Any, variables: dict[str, str]) -> SourceResult:
-        name = _name(source)
+    async def execute(self, source: Any, variables: dict[str, str]) -> SourceResult:  # noqa: ARG002
         return SourceResult(
             source_type=source.type,
-            source_name=name,
+            source_name=source.source_name,
             status="ok",
             data="A" * 500_000,  # 500KB
             elapsed_ms=3.0,

--- a/tests/unit/tools/langgraph/test_nexus_tools.py
+++ b/tests/unit/tools/langgraph/test_nexus_tools.py
@@ -14,6 +14,16 @@ from nexus.remote import RemoteNexusFS
 from nexus.tools.langgraph.nexus_tools import get_nexus_tools
 
 
+def _get_tool_by_name(name: str):
+    """Look up a LangGraph tool by name (avoids fragile index-based access)."""
+    tools = get_nexus_tools()
+    by_name = {t.name: t for t in tools}
+    if name not in by_name:
+        available = ", ".join(sorted(by_name))
+        raise KeyError(f"Tool {name!r} not found. Available: {available}")
+    return by_name[name]
+
+
 class TestGetNexusTools:
     """Tests for get_nexus_tools function."""
 
@@ -52,8 +62,7 @@ class TestGrepFilesTool:
 
     def test_grep_basic_search(self):
         """Test basic grep search."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.grep.return_value = [
@@ -82,8 +91,7 @@ class TestGrepFilesTool:
 
     def test_grep_with_path(self):
         """Test grep with custom path."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.grep.return_value = []
@@ -108,8 +116,7 @@ class TestGrepFilesTool:
 
     def test_grep_case_insensitive(self):
         """Test grep with case insensitive flag."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.grep.return_value = []
@@ -132,8 +139,7 @@ class TestGrepFilesTool:
 
     def test_grep_with_file_pattern(self):
         """Test grep with file_pattern parameter."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.grep.return_value = [
@@ -159,8 +165,7 @@ class TestGrepFilesTool:
 
     def test_grep_with_max_results(self):
         """Test grep with custom max_results."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.grep.return_value = []
@@ -183,8 +188,7 @@ class TestGrepFilesTool:
 
     def test_grep_with_all_parameters(self):
         """Test grep with all parameters specified."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.grep.return_value = [
@@ -219,8 +223,7 @@ class TestGrepFilesTool:
 
     def test_grep_from_state_context(self):
         """Test getting auth from state context."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.grep.return_value = []
@@ -257,8 +260,7 @@ class TestGrepFilesTool:
 
     def test_grep_missing_auth(self):
         """Test error when auth is missing."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         state = {}
         config: RunnableConfig = {"metadata": {}}
@@ -268,8 +270,7 @@ class TestGrepFilesTool:
 
     def test_grep_invalid_auth_format(self):
         """Test error with invalid auth format."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         state = {}
         config: RunnableConfig = {
@@ -281,8 +282,7 @@ class TestGrepFilesTool:
 
     def test_grep_truncates_long_lines(self):
         """Test that grep truncates very long lines."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         long_content = "x" * 500
@@ -301,8 +301,7 @@ class TestGrepFilesTool:
 
     def test_grep_limits_results(self):
         """Test that grep limits display to first 50 matches."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         matches = [{"file": f"/file{i}.py", "line": i, "content": "match"} for i in range(100)]
@@ -321,8 +320,7 @@ class TestGrepFilesTool:
 
     def test_grep_respects_max_results_display_limit(self):
         """Test that grep display limit respects max_results parameter."""
-        tools = get_nexus_tools()
-        grep_tool = tools[0].func
+        grep_tool = _get_tool_by_name("grep_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         # Simulate nx.grep returning fewer results due to max_results=10
@@ -350,8 +348,7 @@ class TestGlobFilesTool:
 
     def test_glob_basic_pattern(self):
         """Test basic glob pattern."""
-        tools = get_nexus_tools()
-        glob_tool = tools[1].func
+        glob_tool = _get_tool_by_name("glob_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.glob.return_value = ["/file1.py", "/file2.py", "/file3.py"]
@@ -370,8 +367,7 @@ class TestGlobFilesTool:
 
     def test_glob_with_path(self):
         """Test glob with custom path."""
-        tools = get_nexus_tools()
-        glob_tool = tools[1].func
+        glob_tool = _get_tool_by_name("glob_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.glob.return_value = ["/workspace/test.md"]
@@ -388,8 +384,7 @@ class TestGlobFilesTool:
 
     def test_glob_no_matches(self):
         """Test glob with no matches."""
-        tools = get_nexus_tools()
-        glob_tool = tools[1].func
+        glob_tool = _get_tool_by_name("glob_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.glob.return_value = []
@@ -406,8 +401,7 @@ class TestGlobFilesTool:
 
     def test_glob_limits_results(self):
         """Test that glob limits to first 100 files."""
-        tools = get_nexus_tools()
-        glob_tool = tools[1].func
+        glob_tool = _get_tool_by_name("glob_files").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         files = [f"/file{i}.py" for i in range(150)]
@@ -429,8 +423,7 @@ class TestReadFileTool:
 
     def test_read_file_cat(self):
         """Test reading file with cat command."""
-        tools = get_nexus_tools()
-        read_tool = tools[2].func
+        read_tool = _get_tool_by_name("read_file").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.read.return_value = b"Hello World\nLine 2\nLine 3"
@@ -449,8 +442,7 @@ class TestReadFileTool:
 
     def test_read_file_less(self):
         """Test reading file with less command (preview)."""
-        tools = get_nexus_tools()
-        read_tool = tools[2].func
+        read_tool = _get_tool_by_name("read_file").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         lines = [f"Line {i}" for i in range(150)]
@@ -470,8 +462,7 @@ class TestReadFileTool:
 
     def test_read_file_with_line_range(self):
         """Test reading file with line range."""
-        tools = get_nexus_tools()
-        read_tool = tools[2].func
+        read_tool = _get_tool_by_name("read_file").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         lines = [f"Line {i}" for i in range(1, 21)]
@@ -492,8 +483,7 @@ class TestReadFileTool:
 
     def test_read_file_too_large(self):
         """Test error when file is too large."""
-        tools = get_nexus_tools()
-        read_tool = tools[2].func
+        read_tool = _get_tool_by_name("read_file").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         large_content = "x" * 40000
@@ -511,8 +501,7 @@ class TestReadFileTool:
 
     def test_read_file_not_found(self):
         """Test error when file not found."""
-        tools = get_nexus_tools()
-        read_tool = tools[2].func
+        read_tool = _get_tool_by_name("read_file").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.read.side_effect = FileNotFoundError("File not found")
@@ -533,8 +522,7 @@ class TestWriteFileTool:
 
     def test_write_file_success(self):
         """Test successful file write."""
-        tools = get_nexus_tools()
-        write_tool = tools[3].func
+        write_tool = _get_tool_by_name("write_file").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.exists.return_value = True
@@ -553,8 +541,7 @@ class TestWriteFileTool:
 
     def test_write_file_strips_mnt_nexus_prefix(self):
         """Test that /mnt/nexus prefix is stripped."""
-        tools = get_nexus_tools()
-        write_tool = tools[3].func
+        write_tool = _get_tool_by_name("write_file").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.exists.return_value = True
@@ -571,8 +558,7 @@ class TestWriteFileTool:
 
     def test_write_file_error_handling(self):
         """Test write error handling."""
-        tools = get_nexus_tools()
-        write_tool = tools[3].func
+        write_tool = _get_tool_by_name("write_file").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.write.side_effect = Exception("Permission denied")
@@ -594,8 +580,7 @@ class TestEditFileTool:
 
     def _get_edit_tool(self):
         """Get the edit_file tool function."""
-        tools = get_nexus_tools()
-        return tools[4].func
+        return _get_tool_by_name("edit_file").func
 
     def _make_config(self) -> RunnableConfig:
         """Create a standard test config."""
@@ -802,8 +787,7 @@ class TestPythonTool:
 
     def test_python_execution_success(self):
         """Test successful Python execution."""
-        tools = get_nexus_tools()
-        python_tool = tools[5].func
+        python_tool = _get_tool_by_name("python").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.sandbox_run.return_value = {
@@ -838,8 +822,7 @@ class TestPythonTool:
 
     def test_python_execution_with_error(self):
         """Test Python execution with errors."""
-        tools = get_nexus_tools()
-        python_tool = tools[5].func
+        python_tool = _get_tool_by_name("python").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.sandbox_run.return_value = {
@@ -866,8 +849,7 @@ class TestPythonTool:
 
     def test_python_missing_sandbox_id(self):
         """Test error when sandbox_id is missing."""
-        tools = get_nexus_tools()
-        python_tool = tools[5].func
+        python_tool = _get_tool_by_name("python").func
 
         state = {}
         config: RunnableConfig = {
@@ -883,8 +865,7 @@ class TestBashTool:
 
     def test_bash_execution_success(self):
         """Test successful bash execution."""
-        tools = get_nexus_tools()
-        bash_tool = tools[6].func
+        bash_tool = _get_tool_by_name("bash").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.sandbox_run.return_value = {
@@ -911,8 +892,7 @@ class TestBashTool:
 
     def test_bash_missing_sandbox_id(self):
         """Test error when sandbox_id is missing."""
-        tools = get_nexus_tools()
-        bash_tool = tools[6].func
+        bash_tool = _get_tool_by_name("bash").func
 
         state = {}
         config: RunnableConfig = {
@@ -928,8 +908,7 @@ class TestQueryMemoriesTool:
 
     def test_query_memories_success(self):
         """Test successful memory query."""
-        tools = get_nexus_tools()
-        memory_tool = tools[7].func
+        memory_tool = _get_tool_by_name("query_memories").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.memory = Mock()
@@ -957,8 +936,7 @@ class TestQueryMemoriesTool:
 
     def test_query_memories_empty(self):
         """Test query with no memories."""
-        tools = get_nexus_tools()
-        memory_tool = tools[7].func
+        memory_tool = _get_tool_by_name("query_memories").func
 
         mock_nx = Mock(spec=RemoteNexusFS)
         mock_nx.memory = Mock()

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3070,6 +3079,7 @@ name = "nexus-ai-fs"
 version = "0.7.1.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "alembic" },
@@ -3202,12 +3212,14 @@ dev = [
     { name = "freezegun" },
     { name = "grpcio-tools" },
     { name = "pytest-cov" },
+    { name = "types-aiofiles" },
     { name = "types-protobuf" },
     { name = "types-redis" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiohttp", specifier = ">=3.11.0" },
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.13.0" },
@@ -3317,6 +3329,7 @@ dev = [
     { name = "freezegun", specifier = ">=1.5.5" },
     { name = "grpcio-tools", specifier = ">=1.76.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "types-aiofiles", specifier = ">=25.1.0.20251011" },
     { name = "types-protobuf", specifier = ">=6.32.1.20251210" },
     { name = "types-redis", specifier = ">=4.6.0.20241004" },
 ]
@@ -5467,6 +5480,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "25.1.0.20251011"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6c/6d23908a8217e36704aa9c79d99a620f2fdd388b66a4b7f72fbc6b6ff6c6/types_aiofiles-25.1.0.20251011.tar.gz", hash = "sha256:1c2b8ab260cb3cd40c15f9d10efdc05a6e1e6b02899304d80dfa0410e028d3ff", size = 14535, upload-time = "2025-10-11T02:44:51.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/0f/76917bab27e270bb6c32addd5968d69e558e5b6f7fb4ac4cbfa282996a96/types_aiofiles-25.1.0.20251011-py3-none-any.whl", hash = "sha256:8ff8de7f9d42739d8f0dadcceeb781ce27cd8d8c4152d4a7c52f6b20edb8149c", size = 14338, upload-time = "2025-10-11T02:44:50.054Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Review-driven improvements to the context manifest system (Issue #1341). Addresses 13 action items from a 4-section architecture/quality/test/performance review.

- **ContextSourceProtocol** + **ContextManifestProtocol**: Structural typing replaces `Sequence[Any]` throughout the resolver, with a kernel-level protocol in `core/protocols/`
- **Async file I/O**: `aiofiles` for non-blocking writes in the resolver pipeline
- **Bug fixes**: Global timeout now preserves completed results; truncation uses `json.dumps()` instead of `str()` for correct serialization
- **DRY cleanup**: `source_name` property on all models, `@classmethod` factories on `SourceResult`, `Field(default_factory=dict)` for mutable defaults
- **+172 tests**: RaisingExecutor error paths, `_sanitize_filename` edge cases (13 parametrized), protocol compliance, partial-results preservation, name-based LangGraph tool lookup

## Test plan

- [x] 121/121 context manifest unit + integration tests pass
- [x] 48/48 E2E tests pass (test_api_v2_e2e + test_operations_e2e — real `nexus serve`)
- [x] ruff lint + format clean
- [x] mypy clean (added `types-aiofiles` stubs)
- [x] Performance: 1.78ms avg for 5-source resolution (under 50ms budget)
- [x] Import chain verified: all models, resolver, protocols load correctly
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)