### PR TITLE
feat(#1357): Protocol Abstraction Layer for multi-protocol payments

### DIFF
--- a/src/nexus/pay/__init__.py
+++ b/src/nexus/pay/__init__.py
@@ -51,6 +51,19 @@ from nexus.pay.credits import (
     TransferRequest,
     WalletNotFoundError,
 )
+from nexus.pay.protocol import (
+    CreditsPaymentProtocol,
+    PaymentProtocol,
+    ProtocolDetectionError,
+    ProtocolDetector,
+    ProtocolError,
+    ProtocolNotFoundError,
+    ProtocolRegistry,
+    ProtocolTransferRequest,
+    ProtocolTransferResult,
+    X402PaymentProtocol,
+    get_protocol_method_name,
+)
 from nexus.pay.sdk import (
     Balance,
     BudgetContext,
@@ -110,6 +123,18 @@ __all__ = [
     "micro_to_usdc",
     "validate_wallet_address",
     "validate_network",
+    # Protocol Abstraction Layer (#1357)
+    "PaymentProtocol",
+    "ProtocolRegistry",
+    "ProtocolDetector",
+    "ProtocolTransferRequest",
+    "ProtocolTransferResult",
+    "ProtocolError",
+    "ProtocolNotFoundError",
+    "ProtocolDetectionError",
+    "X402PaymentProtocol",
+    "CreditsPaymentProtocol",
+    "get_protocol_method_name",
     # Unified SDK (#1207)
     "NexusPay",
     "NexusPayError",

--- a/src/nexus/pay/protocol.py
+++ b/src/nexus/pay/protocol.py
@@ -1,0 +1,356 @@
+"""Protocol Abstraction Layer for multi-protocol payments.
+
+Issue #1357 Phase 1: Extensible protocol dispatch for agent commerce.
+Replaces hardcoded dual-routing (x402/credits) with a registry pattern
+that supports future protocols (ACP, AP2).
+
+Architecture:
+    PaymentProtocol (ABC) → concrete implementations (X402, Credits)
+    ProtocolDetector → ordered chain detection (auto-routing)
+    ProtocolRegistry → name-based lookup + auto-detection
+
+Detection chain order:
+    1. X402PaymentProtocol — wallet addresses (0x...)
+    2. CreditsPaymentProtocol — catch-all (agent IDs)
+    Future: ACP/AP2 insert between x402 and credits via metadata checks.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from nexus.pay.audit_types import TransactionProtocol
+from nexus.pay.x402 import validate_wallet_address
+
+if TYPE_CHECKING:
+    from nexus.pay.x402 import X402Client
+
+logger = logging.getLogger(__name__)
+
+# Legacy method name mapping: old name → TransactionProtocol value
+_LEGACY_METHOD_MAP: dict[str, str] = {
+    "credits": "internal",
+}
+
+# Reverse mapping: TransactionProtocol → user-facing method name for Receipt
+_PROTOCOL_TO_METHOD: dict[TransactionProtocol, str] = {
+    TransactionProtocol.INTERNAL: "credits",
+    TransactionProtocol.X402: "x402",
+    TransactionProtocol.ACP: "acp",
+    TransactionProtocol.AP2: "ap2",
+}
+
+
+# =============================================================================
+# Exceptions
+# =============================================================================
+
+
+class ProtocolError(Exception):
+    """Base exception for protocol operations."""
+
+
+class ProtocolNotFoundError(ProtocolError):
+    """Raised when a requested protocol is not registered."""
+
+
+class ProtocolDetectionError(ProtocolError):
+    """Raised when no protocol matches the destination."""
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class ProtocolTransferRequest:
+    """Immutable request for a protocol transfer."""
+
+    from_agent: str
+    to: str
+    amount: Decimal
+    memo: str = ""
+    idempotency_key: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProtocolTransferResult:
+    """Immutable result from a protocol transfer."""
+
+    protocol: TransactionProtocol
+    tx_id: str
+    amount: Decimal
+    from_agent: str
+    to: str
+    tx_hash: str | None = None
+    timestamp: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# =============================================================================
+# ABC
+# =============================================================================
+
+
+class PaymentProtocol(ABC):
+    """Abstract base for payment protocol implementations.
+
+    Each protocol must provide:
+        protocol_name: TransactionProtocol enum value
+        can_handle(to, metadata): sync detection (no I/O)
+        transfer(request): async payment execution
+    """
+
+    @property
+    @abstractmethod
+    def protocol_name(self) -> TransactionProtocol:
+        """Return the protocol identifier."""
+
+    @abstractmethod
+    def can_handle(self, to: str, metadata: dict[str, Any] | None = None) -> bool:
+        """Check if this protocol can handle the given destination."""
+
+    @abstractmethod
+    async def transfer(self, request: ProtocolTransferRequest) -> ProtocolTransferResult:
+        """Execute a transfer using this protocol."""
+
+
+# =============================================================================
+# Detector
+# =============================================================================
+
+
+class ProtocolDetector:
+    """Ordered chain detector that finds the first matching protocol.
+
+    Protocols are checked in registration order. The first protocol
+    whose can_handle() returns True is selected.
+    """
+
+    def __init__(self, protocols: list[PaymentProtocol]) -> None:
+        self._protocols = list(protocols)
+
+    def detect(
+        self,
+        to: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> PaymentProtocol:
+        """Detect the appropriate protocol for a destination.
+
+        Raises:
+            ProtocolDetectionError: If no protocol matches.
+        """
+        for protocol in self._protocols:
+            if protocol.can_handle(to, metadata):
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "Detected protocol %s for destination %s",
+                        protocol.protocol_name,
+                        to,
+                    )
+                return protocol
+
+        raise ProtocolDetectionError(f"No protocol can handle destination '{to}'")
+
+
+# =============================================================================
+# Registry
+# =============================================================================
+
+
+class ProtocolRegistry:
+    """Registry for payment protocols with name-based lookup and auto-detection.
+
+    Supports:
+        - register/get/unregister by protocol name
+        - resolve() with explicit method or auto-detection
+        - Legacy name mapping (e.g., 'credits' → 'internal')
+    """
+
+    def __init__(self) -> None:
+        self._protocols: dict[str, PaymentProtocol] = {}
+
+    def register(self, protocol: PaymentProtocol) -> None:
+        """Register a protocol by its name."""
+        name = str(protocol.protocol_name)
+        self._protocols[name] = protocol
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Registered protocol: %s", name)
+
+    def get(self, name: str) -> PaymentProtocol:
+        """Get a protocol by name.
+
+        Raises:
+            ProtocolNotFoundError: If protocol not found.
+        """
+        # Apply legacy mapping
+        resolved_name = _LEGACY_METHOD_MAP.get(name, name)
+        protocol = self._protocols.get(resolved_name)
+        if protocol is None:
+            raise ProtocolNotFoundError(
+                f"Protocol '{name}' not found. Available: {', '.join(self._protocols.keys())}"
+            )
+        return protocol
+
+    def unregister(self, name: str) -> None:
+        """Remove a protocol by name. No-op if not registered."""
+        resolved_name = _LEGACY_METHOD_MAP.get(name, name)
+        self._protocols.pop(resolved_name, None)
+
+    def resolve(
+        self,
+        method: str,
+        to: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> PaymentProtocol:
+        """Resolve a protocol by method name or auto-detect.
+
+        Args:
+            method: Protocol method name, or 'auto' for detection.
+            to: Destination address/agent ID.
+            metadata: Optional metadata for detection hints.
+
+        Raises:
+            ProtocolNotFoundError: If method not found.
+            ProtocolDetectionError: If auto-detect fails.
+        """
+        if method == "auto":
+            detector = ProtocolDetector(list(self._protocols.values()))
+            return detector.detect(to, metadata)
+
+        return self.get(method)
+
+    def list_protocols(self) -> list[str]:
+        """Return list of registered protocol names."""
+        return list(self._protocols.keys())
+
+
+# =============================================================================
+# Concrete: X402
+# =============================================================================
+
+
+class X402PaymentProtocol(PaymentProtocol):
+    """x402 protocol implementation wrapping X402Client.
+
+    Handles payments to EVM wallet addresses (0x...).
+    """
+
+    def __init__(self, client: X402Client) -> None:
+        self._client = client
+
+    @property
+    def protocol_name(self) -> TransactionProtocol:
+        return TransactionProtocol.X402
+
+    def can_handle(
+        self,
+        to: str,
+        metadata: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> bool:
+        return validate_wallet_address(to)
+
+    async def transfer(self, request: ProtocolTransferRequest) -> ProtocolTransferResult:
+        try:
+            receipt = await self._client.pay(
+                to_address=request.to,
+                amount=request.amount,
+            )
+            return ProtocolTransferResult(
+                protocol=TransactionProtocol.X402,
+                tx_id=receipt.tx_hash,
+                amount=request.amount,
+                from_agent=request.from_agent,
+                to=request.to,
+                tx_hash=receipt.tx_hash,
+                timestamp=receipt.timestamp,
+                metadata={"network": receipt.network, "currency": receipt.currency},
+            )
+        except Exception as e:
+            raise ProtocolError(f"x402 transfer failed: {e}") from e
+
+
+# =============================================================================
+# Concrete: Credits (Internal)
+# =============================================================================
+
+
+class CreditsPaymentProtocol(PaymentProtocol):
+    """Internal credits protocol wrapping CreditsService.
+
+    Catch-all for agent-to-agent transfers (non-wallet destinations).
+    """
+
+    def __init__(self, service: Any, zone_id: str = "default") -> None:
+        self._service = service
+        self._zone_id = zone_id
+
+    @property
+    def protocol_name(self) -> TransactionProtocol:
+        return TransactionProtocol.INTERNAL
+
+    def can_handle(
+        self,
+        to: str,
+        metadata: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> bool:
+        return not validate_wallet_address(to)
+
+    async def transfer(self, request: ProtocolTransferRequest) -> ProtocolTransferResult:
+        try:
+            tx_id = await self._service.transfer(
+                from_id=request.from_agent,
+                to_id=request.to,
+                amount=request.amount,
+                memo=request.memo,
+                idempotency_key=request.idempotency_key,
+                zone_id=self._zone_id,
+            )
+            return ProtocolTransferResult(
+                protocol=TransactionProtocol.INTERNAL,
+                tx_id=tx_id,
+                amount=request.amount,
+                from_agent=request.from_agent,
+                to=request.to,
+                tx_hash=None,
+                timestamp=datetime.now(UTC),
+                metadata={},
+            )
+        except Exception as e:
+            raise ProtocolError(f"Credits transfer failed: {e}") from e
+
+
+# =============================================================================
+# Module Exports
+# =============================================================================
+
+
+def get_protocol_method_name(protocol: TransactionProtocol) -> str:
+    """Get user-facing method name for a protocol enum value.
+
+    Maps protocol enums to backwards-compatible method names
+    (e.g., INTERNAL → "credits").
+    """
+    return _PROTOCOL_TO_METHOD.get(protocol, str(protocol))
+
+
+__all__ = [
+    "CreditsPaymentProtocol",
+    "PaymentProtocol",
+    "ProtocolDetectionError",
+    "ProtocolDetector",
+    "ProtocolError",
+    "ProtocolNotFoundError",
+    "ProtocolRegistry",
+    "ProtocolTransferRequest",
+    "ProtocolTransferResult",
+    "X402PaymentProtocol",
+    "get_protocol_method_name",
+]

--- a/tests/unit/pay/test_payment_protocol.py
+++ b/tests/unit/pay/test_payment_protocol.py
@@ -1,0 +1,627 @@
+"""Tests for Protocol Abstraction Layer.
+
+TDD tests for Issue #1357 Phase 1: PaymentProtocol ABC, ProtocolDetector,
+ProtocolRegistry, and concrete protocol implementations (X402, Credits).
+
+Test categories:
+1. ABC & data classes (cannot instantiate, frozen dataclasses)
+2. Exception hierarchy
+3. ProtocolDetector (detect, ordering, no-match error)
+4. ProtocolRegistry (register, get, unregister, resolve, legacy mapping)
+5. X402PaymentProtocol (can_handle, transfer delegation)
+6. CreditsPaymentProtocol (can_handle, transfer delegation)
+7. Error propagation
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nexus.pay.audit_types import TransactionProtocol
+
+# =============================================================================
+# 1. ABC & Data Classes
+# =============================================================================
+
+
+class TestPaymentProtocolABC:
+    """PaymentProtocol ABC cannot be instantiated directly."""
+
+    def test_abc_cannot_be_instantiated(self):
+        from nexus.pay.protocol import PaymentProtocol
+
+        with pytest.raises(TypeError):
+            PaymentProtocol()  # type: ignore[abstract]
+
+    def test_abc_requires_protocol_name(self):
+        """Subclass without protocol_name should fail."""
+        from nexus.pay.protocol import PaymentProtocol
+
+        class Incomplete(PaymentProtocol):
+            def can_handle(self, to: str, metadata: dict | None = None) -> bool:
+                return True
+
+            async def transfer(self, request):
+                pass
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    def test_abc_requires_can_handle(self):
+        """Subclass without can_handle should fail."""
+        from nexus.pay.protocol import PaymentProtocol
+
+        class Incomplete(PaymentProtocol):
+            @property
+            def protocol_name(self):
+                return TransactionProtocol.INTERNAL
+
+            async def transfer(self, request):
+                pass
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    def test_abc_requires_transfer(self):
+        """Subclass without transfer should fail."""
+        from nexus.pay.protocol import PaymentProtocol
+
+        class Incomplete(PaymentProtocol):
+            @property
+            def protocol_name(self):
+                return TransactionProtocol.INTERNAL
+
+            def can_handle(self, to: str, metadata: dict | None = None) -> bool:
+                return True
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+
+class TestProtocolTransferRequest:
+    """ProtocolTransferRequest is a frozen immutable dataclass."""
+
+    def test_create_request(self):
+        from nexus.pay.protocol import ProtocolTransferRequest
+
+        req = ProtocolTransferRequest(
+            from_agent="alice",
+            to="bob",
+            amount=Decimal("1.50"),
+            memo="test",
+        )
+        assert req.from_agent == "alice"
+        assert req.to == "bob"
+        assert req.amount == Decimal("1.50")
+        assert req.memo == "test"
+        assert req.idempotency_key is None
+        assert req.metadata == {}
+
+    def test_request_is_frozen(self):
+        from nexus.pay.protocol import ProtocolTransferRequest
+
+        req = ProtocolTransferRequest(
+            from_agent="alice",
+            to="bob",
+            amount=Decimal("1.0"),
+        )
+        with pytest.raises(AttributeError):
+            req.amount = Decimal("2.0")  # type: ignore[misc]
+
+    def test_request_with_metadata(self):
+        from nexus.pay.protocol import ProtocolTransferRequest
+
+        req = ProtocolTransferRequest(
+            from_agent="alice",
+            to="bob",
+            amount=Decimal("1.0"),
+            metadata={"tx_type": "api_call"},
+        )
+        assert req.metadata == {"tx_type": "api_call"}
+
+
+class TestProtocolTransferResult:
+    """ProtocolTransferResult is a frozen immutable dataclass."""
+
+    def test_create_result(self):
+        from nexus.pay.protocol import ProtocolTransferResult
+
+        result = ProtocolTransferResult(
+            protocol=TransactionProtocol.INTERNAL,
+            tx_id="tx-123",
+            amount=Decimal("5.0"),
+            from_agent="alice",
+            to="bob",
+        )
+        assert result.protocol == TransactionProtocol.INTERNAL
+        assert result.tx_id == "tx-123"
+        assert result.tx_hash is None
+        assert result.timestamp is None
+        assert result.metadata == {}
+
+    def test_result_is_frozen(self):
+        from nexus.pay.protocol import ProtocolTransferResult
+
+        result = ProtocolTransferResult(
+            protocol=TransactionProtocol.X402,
+            tx_id="tx-456",
+            amount=Decimal("1.0"),
+            from_agent="alice",
+            to="bob",
+        )
+        with pytest.raises(AttributeError):
+            result.tx_id = "changed"  # type: ignore[misc]
+
+    def test_result_with_all_fields(self):
+        from datetime import UTC, datetime
+
+        from nexus.pay.protocol import ProtocolTransferResult
+
+        now = datetime.now(UTC)
+        result = ProtocolTransferResult(
+            protocol=TransactionProtocol.X402,
+            tx_id="tx-789",
+            amount=Decimal("2.0"),
+            from_agent="alice",
+            to="0xwallet",
+            tx_hash="0xhash",
+            timestamp=now,
+            metadata={"network": "base"},
+        )
+        assert result.tx_hash == "0xhash"
+        assert result.timestamp == now
+        assert result.metadata == {"network": "base"}
+
+
+# =============================================================================
+# 2. Exception Hierarchy
+# =============================================================================
+
+
+class TestExceptionHierarchy:
+    """Exception classes form a proper hierarchy."""
+
+    def test_protocol_error_is_exception(self):
+        from nexus.pay.protocol import ProtocolError
+
+        assert issubclass(ProtocolError, Exception)
+
+    def test_not_found_is_protocol_error(self):
+        from nexus.pay.protocol import ProtocolError, ProtocolNotFoundError
+
+        assert issubclass(ProtocolNotFoundError, ProtocolError)
+
+    def test_detection_error_is_protocol_error(self):
+        from nexus.pay.protocol import ProtocolDetectionError, ProtocolError
+
+        assert issubclass(ProtocolDetectionError, ProtocolError)
+
+    def test_not_found_error_message(self):
+        from nexus.pay.protocol import ProtocolNotFoundError
+
+        err = ProtocolNotFoundError("unknown_proto")
+        assert "unknown_proto" in str(err)
+
+    def test_detection_error_message(self):
+        from nexus.pay.protocol import ProtocolDetectionError
+
+        err = ProtocolDetectionError("no match")
+        assert "no match" in str(err)
+
+
+# =============================================================================
+# 3. ProtocolDetector
+# =============================================================================
+
+
+class TestProtocolDetector:
+    """ProtocolDetector detects the right protocol from an ordered chain."""
+
+    def _make_stub_protocol(self, name: TransactionProtocol, handles: bool):
+        """Create a stub protocol that always returns `handles` from can_handle."""
+        from nexus.pay.protocol import PaymentProtocol
+
+        class Stub(PaymentProtocol):
+            @property
+            def protocol_name(self) -> TransactionProtocol:
+                return name
+
+            def can_handle(self, to: str, metadata: dict | None = None) -> bool:
+                return handles
+
+            async def transfer(self, request):
+                pass
+
+        return Stub()
+
+    def test_detect_returns_first_match(self):
+        from nexus.pay.protocol import ProtocolDetector
+
+        p1 = self._make_stub_protocol(TransactionProtocol.X402, handles=True)
+        p2 = self._make_stub_protocol(TransactionProtocol.INTERNAL, handles=True)
+        detector = ProtocolDetector([p1, p2])
+
+        result = detector.detect("anything")
+        assert result.protocol_name == TransactionProtocol.X402
+
+    def test_detect_skips_non_matching(self):
+        from nexus.pay.protocol import ProtocolDetector
+
+        p1 = self._make_stub_protocol(TransactionProtocol.X402, handles=False)
+        p2 = self._make_stub_protocol(TransactionProtocol.INTERNAL, handles=True)
+        detector = ProtocolDetector([p1, p2])
+
+        result = detector.detect("anything")
+        assert result.protocol_name == TransactionProtocol.INTERNAL
+
+    def test_detect_raises_on_no_match(self):
+        from nexus.pay.protocol import ProtocolDetectionError, ProtocolDetector
+
+        p1 = self._make_stub_protocol(TransactionProtocol.X402, handles=False)
+        detector = ProtocolDetector([p1])
+
+        with pytest.raises(ProtocolDetectionError):
+            detector.detect("anything")
+
+    def test_detect_empty_chain_raises(self):
+        from nexus.pay.protocol import ProtocolDetectionError, ProtocolDetector
+
+        detector = ProtocolDetector([])
+        with pytest.raises(ProtocolDetectionError):
+            detector.detect("anything")
+
+    def test_detect_passes_metadata(self):
+        """Metadata is forwarded to can_handle."""
+        from nexus.pay.protocol import PaymentProtocol, ProtocolDetector
+
+        received_metadata = {}
+
+        class MetadataCapture(PaymentProtocol):
+            @property
+            def protocol_name(self) -> TransactionProtocol:
+                return TransactionProtocol.ACP
+
+            def can_handle(self, to: str, metadata: dict | None = None) -> bool:
+                received_metadata.update(metadata or {})
+                return True
+
+            async def transfer(self, request):
+                pass
+
+        detector = ProtocolDetector([MetadataCapture()])
+        detector.detect("target", metadata={"protocol": "acp"})
+        assert received_metadata == {"protocol": "acp"}
+
+
+# =============================================================================
+# 4. ProtocolRegistry
+# =============================================================================
+
+
+class TestProtocolRegistry:
+    """ProtocolRegistry manages protocol registration and lookup."""
+
+    def _make_stub_protocol(self, name: TransactionProtocol, handles: bool):
+        from nexus.pay.protocol import PaymentProtocol
+
+        class Stub(PaymentProtocol):
+            @property
+            def protocol_name(self) -> TransactionProtocol:
+                return name
+
+            def can_handle(self, to: str, metadata: dict | None = None) -> bool:
+                return handles
+
+            async def transfer(self, request):
+                pass
+
+        return Stub()
+
+    def test_register_and_get(self):
+        from nexus.pay.protocol import ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        proto = self._make_stub_protocol(TransactionProtocol.X402, handles=True)
+        registry.register(proto)
+
+        assert registry.get("x402") is proto
+
+    def test_get_unknown_raises(self):
+        from nexus.pay.protocol import ProtocolNotFoundError, ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        with pytest.raises(ProtocolNotFoundError):
+            registry.get("nonexistent")
+
+    def test_unregister(self):
+        from nexus.pay.protocol import ProtocolNotFoundError, ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        proto = self._make_stub_protocol(TransactionProtocol.X402, handles=True)
+        registry.register(proto)
+        registry.unregister("x402")
+
+        with pytest.raises(ProtocolNotFoundError):
+            registry.get("x402")
+
+    def test_unregister_unknown_is_noop(self):
+        from nexus.pay.protocol import ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        registry.unregister("nonexistent")  # Should not raise
+
+    def test_resolve_by_method_name(self):
+        from nexus.pay.protocol import ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        proto = self._make_stub_protocol(TransactionProtocol.X402, handles=True)
+        registry.register(proto)
+
+        resolved = registry.resolve(method="x402", to="anything")
+        assert resolved is proto
+
+    def test_resolve_auto_uses_detector(self):
+        from nexus.pay.protocol import ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        x402 = self._make_stub_protocol(TransactionProtocol.X402, handles=False)
+        credits = self._make_stub_protocol(TransactionProtocol.INTERNAL, handles=True)
+        registry.register(x402)
+        registry.register(credits)
+
+        resolved = registry.resolve(method="auto", to="agent-bob")
+        assert resolved.protocol_name == TransactionProtocol.INTERNAL
+
+    def test_resolve_legacy_credits_maps_to_internal(self):
+        """method='credits' should resolve to the INTERNAL protocol."""
+        from nexus.pay.protocol import ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        proto = self._make_stub_protocol(TransactionProtocol.INTERNAL, handles=True)
+        registry.register(proto)
+
+        resolved = registry.resolve(method="credits", to="agent-bob")
+        assert resolved.protocol_name == TransactionProtocol.INTERNAL
+
+    def test_resolve_unknown_method_raises(self):
+        from nexus.pay.protocol import ProtocolNotFoundError, ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        with pytest.raises(ProtocolNotFoundError):
+            registry.resolve(method="unknown", to="bob")
+
+    def test_list_protocols(self):
+        from nexus.pay.protocol import ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        p1 = self._make_stub_protocol(TransactionProtocol.X402, handles=True)
+        p2 = self._make_stub_protocol(TransactionProtocol.INTERNAL, handles=True)
+        registry.register(p1)
+        registry.register(p2)
+
+        names = registry.list_protocols()
+        assert set(names) == {"x402", "internal"}
+
+
+# =============================================================================
+# 5. X402PaymentProtocol
+# =============================================================================
+
+
+class TestX402PaymentProtocol:
+    """X402PaymentProtocol wraps X402Client."""
+
+    def test_protocol_name(self):
+        from nexus.pay.protocol import X402PaymentProtocol
+
+        mock_client = AsyncMock()
+        proto = X402PaymentProtocol(client=mock_client)
+        assert proto.protocol_name == TransactionProtocol.X402
+
+    def test_can_handle_wallet_address(self):
+        from nexus.pay.protocol import X402PaymentProtocol
+
+        mock_client = AsyncMock()
+        proto = X402PaymentProtocol(client=mock_client)
+        assert proto.can_handle("0x1234567890abcdef1234567890abcdef12345678") is True
+
+    def test_cannot_handle_agent_id(self):
+        from nexus.pay.protocol import X402PaymentProtocol
+
+        mock_client = AsyncMock()
+        proto = X402PaymentProtocol(client=mock_client)
+        assert proto.can_handle("agent-bob") is False
+        assert proto.can_handle("my-service") is False
+
+    @pytest.mark.asyncio
+    async def test_transfer_delegates_to_client(self):
+        from datetime import UTC, datetime
+
+        from nexus.pay.protocol import ProtocolTransferRequest, X402PaymentProtocol
+        from nexus.pay.x402 import X402Receipt
+
+        now = datetime.now(UTC)
+        mock_client = AsyncMock()
+        mock_client.pay = AsyncMock(
+            return_value=X402Receipt(
+                tx_hash="0xdeadbeef",
+                network="eip155:8453",
+                amount=Decimal("1.0"),
+                currency="USDC",
+                timestamp=now,
+            )
+        )
+
+        proto = X402PaymentProtocol(client=mock_client)
+        request = ProtocolTransferRequest(
+            from_agent="alice",
+            to="0x1234567890abcdef1234567890abcdef12345678",
+            amount=Decimal("1.0"),
+            memo="pay",
+        )
+
+        result = await proto.transfer(request)
+        assert result.protocol == TransactionProtocol.X402
+        assert result.tx_id == "0xdeadbeef"
+        assert result.tx_hash == "0xdeadbeef"
+        assert result.amount == Decimal("1.0")
+        assert result.timestamp == now
+        mock_client.pay.assert_called_once_with(
+            to_address="0x1234567890abcdef1234567890abcdef12345678",
+            amount=Decimal("1.0"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_transfer_propagates_x402_error(self):
+        from nexus.pay.protocol import ProtocolError, ProtocolTransferRequest, X402PaymentProtocol
+        from nexus.pay.x402 import X402Error
+
+        mock_client = AsyncMock()
+        mock_client.pay = AsyncMock(side_effect=X402Error("Payment failed"))
+
+        proto = X402PaymentProtocol(client=mock_client)
+        request = ProtocolTransferRequest(
+            from_agent="alice",
+            to="0x1234567890abcdef1234567890abcdef12345678",
+            amount=Decimal("1.0"),
+        )
+
+        with pytest.raises(ProtocolError, match="Payment failed"):
+            await proto.transfer(request)
+
+
+# =============================================================================
+# 6. CreditsPaymentProtocol
+# =============================================================================
+
+
+class TestCreditsPaymentProtocol:
+    """CreditsPaymentProtocol wraps CreditsService."""
+
+    def test_protocol_name(self):
+        from nexus.pay.protocol import CreditsPaymentProtocol
+
+        mock_service = AsyncMock()
+        proto = CreditsPaymentProtocol(service=mock_service, zone_id="default")
+        assert proto.protocol_name == TransactionProtocol.INTERNAL
+
+    def test_can_handle_agent_id(self):
+        from nexus.pay.protocol import CreditsPaymentProtocol
+
+        mock_service = AsyncMock()
+        proto = CreditsPaymentProtocol(service=mock_service, zone_id="default")
+        assert proto.can_handle("agent-bob") is True
+        assert proto.can_handle("my-service") is True
+
+    def test_cannot_handle_wallet_address(self):
+        from nexus.pay.protocol import CreditsPaymentProtocol
+
+        mock_service = AsyncMock()
+        proto = CreditsPaymentProtocol(service=mock_service, zone_id="default")
+        assert proto.can_handle("0x1234567890abcdef1234567890abcdef12345678") is False
+
+    @pytest.mark.asyncio
+    async def test_transfer_delegates_to_service(self):
+        from nexus.pay.protocol import CreditsPaymentProtocol, ProtocolTransferRequest
+
+        mock_service = AsyncMock()
+        mock_service.transfer = AsyncMock(return_value="tx-abc")
+
+        proto = CreditsPaymentProtocol(service=mock_service, zone_id="test-zone")
+        request = ProtocolTransferRequest(
+            from_agent="alice",
+            to="bob",
+            amount=Decimal("5.0"),
+            memo="task payment",
+            idempotency_key="key-123",
+        )
+
+        result = await proto.transfer(request)
+        assert result.protocol == TransactionProtocol.INTERNAL
+        assert result.tx_id == "tx-abc"
+        assert result.amount == Decimal("5.0")
+        assert result.tx_hash is None
+        mock_service.transfer.assert_called_once_with(
+            from_id="alice",
+            to_id="bob",
+            amount=Decimal("5.0"),
+            memo="task payment",
+            idempotency_key="key-123",
+            zone_id="test-zone",
+        )
+
+    @pytest.mark.asyncio
+    async def test_transfer_propagates_credits_error(self):
+        from nexus.pay.credits import InsufficientCreditsError
+        from nexus.pay.protocol import (
+            CreditsPaymentProtocol,
+            ProtocolError,
+            ProtocolTransferRequest,
+        )
+
+        mock_service = AsyncMock()
+        mock_service.transfer = AsyncMock(side_effect=InsufficientCreditsError("Not enough"))
+
+        proto = CreditsPaymentProtocol(service=mock_service, zone_id="default")
+        request = ProtocolTransferRequest(
+            from_agent="alice",
+            to="bob",
+            amount=Decimal("1000.0"),
+        )
+
+        with pytest.raises(ProtocolError, match="Not enough"):
+            await proto.transfer(request)
+
+
+# =============================================================================
+# 7. Error Propagation
+# =============================================================================
+
+
+class TestErrorPropagation:
+    """Protocol errors preserve original exception info."""
+
+    @pytest.mark.asyncio
+    async def test_x402_error_chained(self):
+        from nexus.pay.protocol import ProtocolError, ProtocolTransferRequest, X402PaymentProtocol
+        from nexus.pay.x402 import X402Error
+
+        mock_client = AsyncMock()
+        mock_client.pay = AsyncMock(side_effect=X402Error("network timeout"))
+
+        proto = X402PaymentProtocol(client=mock_client)
+        request = ProtocolTransferRequest(
+            from_agent="alice",
+            to="0x1234567890abcdef1234567890abcdef12345678",
+            amount=Decimal("1.0"),
+        )
+
+        with pytest.raises(ProtocolError) as exc_info:
+            await proto.transfer(request)
+        assert exc_info.value.__cause__ is not None
+
+    @pytest.mark.asyncio
+    async def test_credits_error_chained(self):
+        from nexus.pay.credits import CreditsError
+        from nexus.pay.protocol import (
+            CreditsPaymentProtocol,
+            ProtocolError,
+            ProtocolTransferRequest,
+        )
+
+        mock_service = AsyncMock()
+        mock_service.transfer = AsyncMock(side_effect=CreditsError("db error"))
+
+        proto = CreditsPaymentProtocol(service=mock_service, zone_id="default")
+        request = ProtocolTransferRequest(
+            from_agent="alice",
+            to="bob",
+            amount=Decimal("1.0"),
+        )
+
+        with pytest.raises(ProtocolError) as exc_info:
+            await proto.transfer(request)
+        assert exc_info.value.__cause__ is not None

--- a/tests/unit/pay/test_protocol_conformance.py
+++ b/tests/unit/pay/test_protocol_conformance.py
@@ -1,0 +1,162 @@
+"""Parametrized conformance suite for PaymentProtocol implementations.
+
+Issue #1357 Phase 1: Verifies that all concrete protocol implementations
+conform to the PaymentProtocol ABC contract.
+
+Every protocol must:
+    - Have a valid TransactionProtocol protocol_name
+    - Return bool from can_handle()
+    - Return ProtocolTransferResult from transfer()
+    - Set valid result fields (protocol, tx_id, amount, from_agent, to)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nexus.pay.audit_types import TransactionProtocol
+from nexus.pay.protocol import (
+    CreditsPaymentProtocol,
+    PaymentProtocol,
+    ProtocolTransferRequest,
+    ProtocolTransferResult,
+    X402PaymentProtocol,
+)
+from nexus.pay.x402 import X402Receipt
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(params=["x402", "credits"])
+def protocol_with_destination(request) -> tuple[PaymentProtocol, str]:
+    """Parametrized fixture providing (protocol, valid_destination) pairs."""
+    if request.param == "x402":
+        mock_client = AsyncMock()
+        mock_client.pay = AsyncMock(
+            return_value=X402Receipt(
+                tx_hash="0xconformance",
+                network="eip155:8453",
+                amount=Decimal("1.0"),
+                currency="USDC",
+                timestamp=None,
+            )
+        )
+        proto = X402PaymentProtocol(client=mock_client)
+        return proto, "0x1234567890abcdef1234567890abcdef12345678"
+    else:
+        mock_service = AsyncMock()
+        mock_service.transfer = AsyncMock(return_value="tx-conformance")
+        proto = CreditsPaymentProtocol(service=mock_service, zone_id="default")
+        return proto, "agent-bob"
+
+
+# =============================================================================
+# Conformance Tests
+# =============================================================================
+
+
+class TestProtocolConformance:
+    """Every PaymentProtocol implementation must pass these tests."""
+
+    def test_protocol_name_is_transaction_protocol(self, protocol_with_destination):
+        proto, _ = protocol_with_destination
+        assert isinstance(proto.protocol_name, TransactionProtocol)
+
+    def test_can_handle_returns_bool(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        result = proto.can_handle(dest)
+        assert isinstance(result, bool)
+        assert result is True  # fixture provides matching destination
+
+    def test_can_handle_with_metadata_returns_bool(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        result = proto.can_handle(dest, metadata={"key": "value"})
+        assert isinstance(result, bool)
+
+    @pytest.mark.asyncio
+    async def test_transfer_returns_protocol_transfer_result(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        request = ProtocolTransferRequest(
+            from_agent="test-sender",
+            to=dest,
+            amount=Decimal("1.0"),
+            memo="conformance test",
+        )
+        result = await proto.transfer(request)
+        assert isinstance(result, ProtocolTransferResult)
+
+    @pytest.mark.asyncio
+    async def test_transfer_result_protocol_matches(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        request = ProtocolTransferRequest(
+            from_agent="test-sender",
+            to=dest,
+            amount=Decimal("1.0"),
+        )
+        result = await proto.transfer(request)
+        assert result.protocol == proto.protocol_name
+
+    @pytest.mark.asyncio
+    async def test_transfer_result_has_tx_id(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        request = ProtocolTransferRequest(
+            from_agent="test-sender",
+            to=dest,
+            amount=Decimal("1.0"),
+        )
+        result = await proto.transfer(request)
+        assert result.tx_id is not None
+        assert len(result.tx_id) > 0
+
+    @pytest.mark.asyncio
+    async def test_transfer_result_preserves_amount(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        request = ProtocolTransferRequest(
+            from_agent="test-sender",
+            to=dest,
+            amount=Decimal("42.50"),
+        )
+        result = await proto.transfer(request)
+        assert result.amount == Decimal("42.50")
+
+    @pytest.mark.asyncio
+    async def test_transfer_result_preserves_from_agent(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        request = ProtocolTransferRequest(
+            from_agent="conformance-agent",
+            to=dest,
+            amount=Decimal("1.0"),
+        )
+        result = await proto.transfer(request)
+        assert result.from_agent == "conformance-agent"
+
+    @pytest.mark.asyncio
+    async def test_transfer_result_preserves_to(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        request = ProtocolTransferRequest(
+            from_agent="sender",
+            to=dest,
+            amount=Decimal("1.0"),
+        )
+        result = await proto.transfer(request)
+        assert result.to == dest
+
+    @pytest.mark.asyncio
+    async def test_transfer_result_metadata_is_dict(self, protocol_with_destination):
+        proto, dest = protocol_with_destination
+        request = ProtocolTransferRequest(
+            from_agent="sender",
+            to=dest,
+            amount=Decimal("1.0"),
+        )
+        result = await proto.transfer(request)
+        assert isinstance(result.metadata, dict)
+
+    def test_is_payment_protocol_subclass(self, protocol_with_destination):
+        proto, _ = protocol_with_destination
+        assert isinstance(proto, PaymentProtocol)


### PR DESCRIPTION
## Summary

Phase 1 of Issue #1357 — Exchange Protocol Spec. Adds a Protocol Abstraction Layer that replaces the hardcoded `if method == "x402" ... else credits` routing in `NexusPay.transfer()` with an extensible registry dispatch pattern.

- **`PaymentProtocol` ABC** with `protocol_name`, `can_handle()`, `transfer()` — extensible for future ACP/AP2 protocols
- **`ProtocolDetector`** — ordered chain detection (x402 for wallet addresses, credits catch-all)
- **`ProtocolRegistry`** — register/get/unregister/resolve with legacy `"credits"` → `"internal"` mapping
- **`X402PaymentProtocol`** wraps `X402Client.pay()`, **`CreditsPaymentProtocol`** wraps `CreditsService.transfer()`
- **`Receipt.metadata`** new field (`dict`, default `{}`) for protocol-specific data
- **HTTP pooling fix** — `X402Client.pay()` and `pay_for_request()` now use `_get_http_client()` instead of creating new `httpx.AsyncClient()` per call
- **Full backwards compatibility** — all 68 existing SDK tests pass unchanged, `method="credits"` still works, original exceptions (X402Error, InsufficientCreditsError) propagate through

### New files
| File | LOC | Purpose |
|------|-----|---------|
| `src/nexus/pay/protocol.py` | 355 | ABC, detector, registry, concrete protocols |
| `tests/unit/pay/test_payment_protocol.py` | 428 | 41 unit tests |
| `tests/unit/pay/test_protocol_conformance.py` | 153 | 22 parametrized conformance tests |

### Modified files
| File | Change |
|------|--------|
| `src/nexus/pay/sdk.py` | `Receipt.metadata`, `_build_registry()`, registry-based `transfer()` |
| `src/nexus/pay/x402.py` | HTTP pooling fix in `pay()` and `pay_for_request()` |
| `src/nexus/pay/__init__.py` | 11 new exports |

## Test plan

- [x] 304/304 pay tests pass (`uv run pytest tests/unit/pay/ -v`)
- [x] 63 new tests (41 unit + 22 conformance)
- [x] All 68 existing SDK tests pass unchanged
- [x] `ruff check` — zero errors
- [x] `ruff format --check` — zero reformats
- [x] `mypy --ignore-missing-imports` — zero errors
- [ ] CI pipeline passes

Closes #1357 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)