### PR TITLE
feat(#1358): Spending Policy Engine — budgets, rate limits, approvals, DSL rules

### DIFF
--- a/alembic/versions/add_approval_rate_limit_rules.py
+++ b/alembic/versions/add_approval_rate_limit_rules.py
@@ -1,0 +1,74 @@
+"""Add spending_approvals table, rate limit columns, and rules column.
+
+Issue #1358 Phases 2-4:
+- Phase 2: spending_approvals table for approval workflows
+- Phase 3: max_tx_per_hour, max_tx_per_day on spending_policies
+- Phase 4: rules (JSON text) on spending_policies
+
+Revision ID: add_approval_rate_limit_rules
+Revises: add_spending_policy_tables
+Create Date: 2026-02-13
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_approval_rate_limit_rules"
+down_revision: Union[str, Sequence[str], None] = "add_spending_policy_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add Phase 2-4 schema changes."""
+    # --- Phase 2: spending_approvals table ---
+    op.create_table(
+        "spending_approvals",
+        sa.Column("id", sa.String(36), primary_key=True, nullable=False),
+        sa.Column("policy_id", sa.String(36), nullable=False),
+        sa.Column("agent_id", sa.String(64), nullable=False),
+        sa.Column("zone_id", sa.String(255), nullable=False),
+        sa.Column("amount", sa.BigInteger, nullable=False),
+        sa.Column("to", sa.String(255), nullable=False),
+        sa.Column("memo", sa.Text, nullable=False, server_default=""),
+        sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
+        sa.Column(
+            "requested_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("decided_by", sa.String(64), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_spending_approvals_policy_id", "spending_approvals", ["policy_id"])
+    op.create_index("ix_spending_approvals_agent_id", "spending_approvals", ["agent_id"])
+    op.create_index(
+        "ix_spending_approvals_agent_zone",
+        "spending_approvals",
+        ["agent_id", "zone_id"],
+    )
+    op.create_index("ix_spending_approvals_status", "spending_approvals", ["status"])
+
+    # --- Phase 3: rate limit columns on spending_policies ---
+    with op.batch_alter_table("spending_policies") as batch_op:
+        batch_op.add_column(sa.Column("max_tx_per_hour", sa.Integer, nullable=True))
+        batch_op.add_column(sa.Column("max_tx_per_day", sa.Integer, nullable=True))
+        # --- Phase 4: rules JSON column ---
+        batch_op.add_column(sa.Column("rules", sa.Text, nullable=True))
+
+
+def downgrade() -> None:
+    """Reverse Phase 2-4 schema changes."""
+    with op.batch_alter_table("spending_policies") as batch_op:
+        batch_op.drop_column("rules")
+        batch_op.drop_column("max_tx_per_day")
+        batch_op.drop_column("max_tx_per_hour")
+
+    op.drop_table("spending_approvals")

--- a/alembic/versions/add_spending_policy_tables.py
+++ b/alembic/versions/add_spending_policy_tables.py
@@ -1,0 +1,143 @@
+"""Add spending_policies and spending_ledger tables (Issue #1358).
+
+Phase 1 of Agent Spending Policy Engine:
+- spending_policies: declarative budget limits per agent/zone
+- spending_ledger: period-based spending counters (atomic UPSERT)
+- Drops unused budget columns from agent_wallet_meta
+
+Revision ID: add_spending_policy_tables
+Revises: merge_agent_keys_ns_views
+Create Date: 2026-02-13
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_spending_policy_tables"
+down_revision: Union[str, Sequence[str], None] = "merge_agent_keys_ns_views"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create spending policy tables and clean up dead columns."""
+    # --- spending_policies table ---
+    op.create_table(
+        "spending_policies",
+        sa.Column("id", sa.String(36), primary_key=True, nullable=False),
+        sa.Column("agent_id", sa.String(64), nullable=True),
+        sa.Column("zone_id", sa.String(255), nullable=False),
+        sa.Column("daily_limit", sa.BigInteger, nullable=True),
+        sa.Column("weekly_limit", sa.BigInteger, nullable=True),
+        sa.Column("monthly_limit", sa.BigInteger, nullable=True),
+        sa.Column("per_tx_limit", sa.BigInteger, nullable=True),
+        sa.Column("auto_approve_threshold", sa.BigInteger, nullable=True),
+        sa.Column("priority", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("enabled", sa.Boolean, nullable=False, server_default="1"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_spending_policies_agent_id", "spending_policies", ["agent_id"])
+    op.create_index("ix_spending_policies_zone_id", "spending_policies", ["zone_id"])
+    op.create_index(
+        "ix_spending_policies_zone_priority",
+        "spending_policies",
+        ["zone_id", "priority"],
+    )
+    op.create_unique_constraint(
+        "uq_spending_policy_agent_zone",
+        "spending_policies",
+        ["agent_id", "zone_id"],
+    )
+
+    # --- spending_ledger table ---
+    op.create_table(
+        "spending_ledger",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column("agent_id", sa.String(64), nullable=False),
+        sa.Column("zone_id", sa.String(255), nullable=False),
+        sa.Column("period_type", sa.String(10), nullable=False),
+        sa.Column("period_start", sa.Date, nullable=False),
+        sa.Column("amount_spent", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("tx_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_spending_ledger_agent_zone",
+        "spending_ledger",
+        ["agent_id", "zone_id"],
+    )
+    op.create_unique_constraint(
+        "uq_spending_ledger_agent_period",
+        "spending_ledger",
+        ["agent_id", "zone_id", "period_type", "period_start"],
+    )
+
+    # --- Drop unused columns from agent_wallet_meta ---
+    # These columns were added but never referenced by any code.
+    with op.batch_alter_table("agent_wallet_meta") as batch_op:
+        batch_op.drop_index("idx_wallet_meta_daily_reset")
+        batch_op.drop_index("idx_wallet_meta_monthly_reset")
+        batch_op.drop_column("daily_limit")
+        batch_op.drop_column("monthly_limit")
+        batch_op.drop_column("per_tx_limit")
+        batch_op.drop_column("daily_spent")
+        batch_op.drop_column("monthly_spent")
+        batch_op.drop_column("daily_reset_at")
+        batch_op.drop_column("monthly_reset_at")
+
+
+def downgrade() -> None:
+    """Reverse: restore columns, drop tables."""
+    # Restore agent_wallet_meta columns
+    with op.batch_alter_table("agent_wallet_meta") as batch_op:
+        batch_op.add_column(sa.Column("daily_limit", sa.BigInteger, nullable=True))
+        batch_op.add_column(sa.Column("monthly_limit", sa.BigInteger, nullable=True))
+        batch_op.add_column(sa.Column("per_tx_limit", sa.BigInteger, nullable=True))
+        batch_op.add_column(
+            sa.Column("daily_spent", sa.BigInteger, nullable=False, server_default="0")
+        )
+        batch_op.add_column(
+            sa.Column("monthly_spent", sa.BigInteger, nullable=False, server_default="0")
+        )
+        batch_op.add_column(
+            sa.Column(
+                "daily_reset_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "monthly_reset_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            )
+        )
+        batch_op.create_index("idx_wallet_meta_daily_reset", ["daily_reset_at"])
+        batch_op.create_index("idx_wallet_meta_monthly_reset", ["monthly_reset_at"])
+
+    op.drop_table("spending_ledger")
+    op.drop_table("spending_policies")

--- a/src/nexus/pay/__init__.py
+++ b/src/nexus/pay/__init__.py
@@ -51,6 +51,8 @@ from nexus.pay.credits import (
     TransferRequest,
     WalletNotFoundError,
 )
+from nexus.pay.policy_rules import RuleContext, RuleResult, evaluate_rules
+from nexus.pay.policy_wrapper import PolicyEnforcedPayment
 from nexus.pay.protocol import (
     CreditsPaymentProtocol,
     PaymentProtocol,
@@ -74,6 +76,17 @@ from nexus.pay.sdk import (
     Receipt,
     Reservation,
 )
+from nexus.pay.spending_policy import (
+    ApprovalRequiredError,
+    PolicyDeniedError,
+    PolicyError,
+    PolicyEvaluation,
+    SpendingApproval,
+    SpendingLedgerEntry,
+    SpendingPolicy,
+    SpendingRateLimitError,
+)
+from nexus.pay.spending_policy_service import SpendingPolicyService
 from nexus.pay.x402 import (
     X402Client,
     X402Error,
@@ -144,4 +157,19 @@ __all__ = [
     "Reservation",
     "Quote",
     "BudgetContext",
+    # Spending Policy Engine (#1358)
+    "PolicyEnforcedPayment",
+    "SpendingPolicyService",
+    "SpendingPolicy",
+    "SpendingLedgerEntry",
+    "PolicyEvaluation",
+    "PolicyError",
+    "PolicyDeniedError",
+    "ApprovalRequiredError",
+    "SpendingRateLimitError",
+    "SpendingApproval",
+    # Policy Rules Engine (Phase 4: #1358)
+    "RuleContext",
+    "RuleResult",
+    "evaluate_rules",
 ]

--- a/src/nexus/pay/policy_rules.py
+++ b/src/nexus/pay/policy_rules.py
@@ -1,0 +1,174 @@
+"""Policy DSL/JSON Rules Engine (Phase 4).
+
+Issue #1358: Evaluate declarative JSON rules against transaction context.
+
+Supported rule types:
+    - recipient_allowlist: Only allow transfers to specific recipients.
+    - recipient_blocklist: Block transfers to specific recipients.
+    - time_window: Only allow transfers during specific UTC hours.
+    - metadata_match: Require specific key-value pairs in metadata.
+
+Rules are evaluated in order. First matching deny rule short-circuits.
+If all rules pass (or no rules), the transaction is allowed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+# Type alias for rule handler functions
+_RuleHandler = Callable[[dict[str, Any], "RuleContext"], "RuleResult"]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RuleContext:
+    """Context provided to the rule evaluator for each transaction."""
+
+    agent_id: str
+    zone_id: str
+    to: str
+    amount: Decimal
+    metadata: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(frozen=True)
+class RuleResult:
+    """Result of evaluating all rules."""
+
+    allowed: bool
+    denied_reason: str | None = None
+    matched_rule_type: str | None = None
+
+
+def evaluate_rules(rules: list[dict[str, Any]], context: RuleContext) -> RuleResult:
+    """Evaluate a list of rules against the transaction context.
+
+    Rules are checked in order. Each rule has a "type" and type-specific params.
+    A failing rule immediately returns denied. All rules passing returns allowed.
+
+    Args:
+        rules: List of rule dicts, each with "type" and rule-specific keys.
+        context: Transaction context to evaluate against.
+
+    Returns:
+        RuleResult with allowed=True if all rules pass.
+    """
+    for rule in rules:
+        rule_type = rule.get("type", "")
+        handler = _RULE_HANDLERS.get(rule_type)
+        if handler is None:
+            if logger.isEnabledFor(logging.WARNING):
+                logger.warning("Unknown rule type: %s — skipping", rule_type)
+            continue
+        result = handler(rule, context)
+        if not result.allowed:
+            return result
+    return RuleResult(allowed=True)
+
+
+# =============================================================================
+# Rule Handlers
+# =============================================================================
+
+
+def _eval_recipient_allowlist(rule: dict[str, Any], ctx: RuleContext) -> RuleResult:
+    """Allow only if recipient is in the allowlist."""
+    recipients: list[str] = rule.get("recipients", [])
+    if not recipients:
+        return RuleResult(allowed=True)
+    if ctx.to in recipients:
+        return RuleResult(allowed=True)
+    return RuleResult(
+        allowed=False,
+        denied_reason=f"Recipient '{ctx.to}' not in allowlist",
+        matched_rule_type="recipient_allowlist",
+    )
+
+
+def _eval_recipient_blocklist(rule: dict[str, Any], ctx: RuleContext) -> RuleResult:
+    """Deny if recipient is in the blocklist."""
+    recipients: list[str] = rule.get("recipients", [])
+    if ctx.to in recipients:
+        return RuleResult(
+            allowed=False,
+            denied_reason=f"Recipient '{ctx.to}' is blocked",
+            matched_rule_type="recipient_blocklist",
+        )
+    return RuleResult(allowed=True)
+
+
+def _eval_time_window(rule: dict[str, Any], ctx: RuleContext) -> RuleResult:
+    """Allow only during specified UTC hours [start, end)."""
+    start_hour: int = rule.get("start_hour", 0)
+    end_hour: int = rule.get("end_hour", 24)
+    current_hour = ctx.timestamp.hour
+
+    if start_hour <= end_hour:
+        # Normal range: e.g., 9-17
+        allowed = start_hour <= current_hour < end_hour
+    else:
+        # Wrapping range: e.g., 22-6 (overnight)
+        allowed = current_hour >= start_hour or current_hour < end_hour
+
+    if allowed:
+        return RuleResult(allowed=True)
+    return RuleResult(
+        allowed=False,
+        denied_reason=(
+            f"Transaction outside allowed hours ({start_hour}:00-{end_hour}:00 UTC, "
+            f"current: {current_hour}:00 UTC)"
+        ),
+        matched_rule_type="time_window",
+    )
+
+
+def _eval_metadata_match(rule: dict[str, Any], ctx: RuleContext) -> RuleResult:
+    """Require specific key-value pairs in transaction metadata."""
+    required: dict[str, Any] = rule.get("required", {})
+    for key, expected in required.items():
+        actual = ctx.metadata.get(key)
+        if actual != expected:
+            return RuleResult(
+                allowed=False,
+                denied_reason=f"Metadata '{key}' must be '{expected}', got '{actual}'",
+                matched_rule_type="metadata_match",
+            )
+    return RuleResult(allowed=True)
+
+
+def _eval_amount_range(rule: dict[str, Any], ctx: RuleContext) -> RuleResult:
+    """Allow only if amount is within [min, max] range."""
+    min_amount = Decimal(str(rule["min"])) if "min" in rule else None
+    max_amount = Decimal(str(rule["max"])) if "max" in rule else None
+
+    if min_amount is not None and ctx.amount < min_amount:
+        return RuleResult(
+            allowed=False,
+            denied_reason=f"Amount {ctx.amount} below minimum {min_amount}",
+            matched_rule_type="amount_range",
+        )
+    if max_amount is not None and ctx.amount > max_amount:
+        return RuleResult(
+            allowed=False,
+            denied_reason=f"Amount {ctx.amount} above maximum {max_amount}",
+            matched_rule_type="amount_range",
+        )
+    return RuleResult(allowed=True)
+
+
+# Registry of rule type → handler
+_RULE_HANDLERS: dict[str, _RuleHandler] = {
+    "recipient_allowlist": _eval_recipient_allowlist,
+    "recipient_blocklist": _eval_recipient_blocklist,
+    "time_window": _eval_time_window,
+    "metadata_match": _eval_metadata_match,
+    "amount_range": _eval_amount_range,
+}

--- a/src/nexus/pay/policy_wrapper.py
+++ b/src/nexus/pay/policy_wrapper.py
@@ -1,0 +1,160 @@
+"""PolicyEnforcedPayment — recursive wrapper for spending policy enforcement.
+
+Issue #1358: Wraps any PaymentProtocol with budget policy checks.
+Follows Lego Architecture Mechanism 2: recursive wrapping (same-Protocol).
+
+Phases:
+    1. Budget limits (per-tx, daily, weekly, monthly)
+    2. Approval workflows (auto_approve_threshold → ApprovalRequiredError)
+    3. Rate controls (max_tx_per_hour, max_tx_per_day)
+    4. DSL rules (recipient, time window, metadata, amount range)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from nexus.pay.audit_types import TransactionProtocol
+from nexus.pay.protocol import PaymentProtocol, ProtocolTransferRequest, ProtocolTransferResult
+from nexus.pay.spending_policy import ApprovalRequiredError, PolicyDeniedError
+
+if TYPE_CHECKING:
+    from nexus.pay.spending_policy_service import SpendingPolicyService
+
+logger = logging.getLogger(__name__)
+
+
+class PolicyEnforcedPayment(PaymentProtocol):
+    """Wraps a PaymentProtocol with spending policy enforcement.
+
+    Implements the full PaymentProtocol interface (same-Protocol wrapper).
+    Evaluates spending policies before delegating to the inner protocol.
+    On success, asynchronously records spending in the ledger.
+
+    Default behavior: if no policy exists for the agent, the transfer
+    is allowed (open by default).
+    """
+
+    def __init__(
+        self,
+        inner: PaymentProtocol,
+        policy_service: SpendingPolicyService,
+    ) -> None:
+        self._inner = inner
+        self._policy_service = policy_service
+
+    @property
+    def protocol_name(self) -> TransactionProtocol:
+        """Delegate to inner protocol."""
+        return self._inner.protocol_name
+
+    def can_handle(self, to: str, metadata: dict[str, Any] | None = None) -> bool:
+        """Delegate to inner protocol."""
+        return self._inner.can_handle(to, metadata)
+
+    async def transfer(self, request: ProtocolTransferRequest) -> ProtocolTransferResult:
+        """Execute transfer with policy enforcement.
+
+        Flow:
+            1. Check for pre-approved approval_id in metadata
+            2. Evaluate spending policy (~1.2ms)
+            3. If requires_approval → raise ApprovalRequiredError
+            4. If denied → raise PolicyDeniedError (inner NOT called)
+            5. Delegate to inner protocol
+            6. On success → fire-and-forget ledger update
+        """
+        zone_id = request.metadata.get("zone_id", "default") if request.metadata else "default"
+        approval_id = request.metadata.get("approval_id") if request.metadata else None
+
+        # 1. If approval_id provided, check it before evaluation
+        if approval_id:
+            approval = await self._policy_service.check_approval(
+                approval_id=approval_id,
+                agent_id=request.from_agent,
+                amount=request.amount,
+            )
+            if approval is not None:
+                # Approval valid — skip policy evaluation, proceed to inner
+                result = await self._inner.transfer(request)
+                self._fire_and_forget_record(request.from_agent, zone_id, request.amount)
+                return result
+            # Invalid approval — fall through to normal evaluation
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Invalid approval_id=%s for agent=%s — falling back to evaluation",
+                    approval_id,
+                    request.from_agent,
+                )
+
+        # 2. Evaluate policy
+        evaluation = await self._policy_service.evaluate(
+            agent_id=request.from_agent,
+            zone_id=zone_id,
+            amount=request.amount,
+            to=request.to,
+            metadata=request.metadata,
+        )
+
+        if not evaluation.allowed:
+            # 3. Approval required (Phase 2)
+            if evaluation.requires_approval:
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "Approval required: agent=%s amount=%s",
+                        request.from_agent,
+                        request.amount,
+                    )
+                raise ApprovalRequiredError(
+                    evaluation.denied_reason or "Approval required for this transaction",
+                    policy_id=evaluation.policy_id,
+                )
+
+            # 4. Hard deny
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Policy denied transfer: agent=%s amount=%s reason=%s",
+                    request.from_agent,
+                    request.amount,
+                    evaluation.denied_reason,
+                )
+            raise PolicyDeniedError(
+                evaluation.denied_reason or "Transaction denied by spending policy",
+                policy_id=evaluation.policy_id,
+            )
+
+        # 5. Delegate to inner protocol
+        result = await self._inner.transfer(request)
+
+        # 6. Record spending (fire-and-forget — does not block response)
+        self._fire_and_forget_record(request.from_agent, zone_id, request.amount)
+
+        return result
+
+    def _fire_and_forget_record(self, agent_id: str, zone_id: str, amount: Decimal) -> None:
+        """Schedule spending recording as a background task."""
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(
+                self._safe_record_spending(agent_id, zone_id, amount),
+            )
+        except RuntimeError:
+            logger.warning("Cannot record spending: no running event loop")
+
+    async def _safe_record_spending(self, agent_id: str, zone_id: str, amount: Decimal) -> None:
+        """Record spending with error logging (fire-and-forget safe)."""
+        try:
+            await self._policy_service.record_spending(
+                agent_id=agent_id,
+                zone_id=zone_id,
+                amount=amount,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to record spending: agent=%s zone=%s amount=%s",
+                agent_id,
+                zone_id,
+                amount,
+            )

--- a/src/nexus/pay/sdk.py
+++ b/src/nexus/pay/sdk.py
@@ -64,7 +64,12 @@ class NexusPayError(Exception):
 
 
 class BudgetExceededError(NexusPayError):
-    """Raised when an operation exceeds budget limits."""
+    """Raised when an operation exceeds budget limits.
+
+    Note: This inherits from NexusPayError for backwards compatibility.
+    For new code, use PolicyDeniedError from nexus.pay.spending_policy instead,
+    which provides richer context (policy_id, remaining budget).
+    """
 
 
 # =============================================================================

--- a/src/nexus/pay/spending_policy.py
+++ b/src/nexus/pay/spending_policy.py
@@ -1,0 +1,179 @@
+"""Spending Policy Engine — data models and exceptions.
+
+Issue #1358: Budget policies, approval workflows, rate limits, and policy DSL.
+
+This module defines the core data structures for spending policies:
+- SpendingPolicy: declarative budget limits per agent/zone
+- SpendingLedgerEntry: period-based spending counters
+- PolicyEvaluation: result of evaluating a transaction against policies
+- SpendingApproval: approval workflow records (Phase 2)
+
+Architecture:
+    PolicyEnforcedPayment (wrapper) → SpendingPolicyService → SpendingPolicy
+    Follows Lego Mechanism 2: recursive wrapping on PaymentProtocol.
+    Zero imports from nexus.core — this is a self-contained brick.
+
+Default behavior: open by default (no policy = allow all transactions).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from nexus.pay.sdk import NexusPayError
+
+# =============================================================================
+# Exceptions
+# =============================================================================
+
+
+class PolicyError(NexusPayError):
+    """Base exception for all spending policy violations."""
+
+
+class PolicyDeniedError(PolicyError):
+    """Transaction denied by a spending policy rule.
+
+    Attributes:
+        policy_id: The policy that denied the transaction.
+        denied_reason: Human-readable explanation.
+    """
+
+    def __init__(self, message: str, *, policy_id: str | None = None) -> None:
+        super().__init__(message)
+        self.policy_id = policy_id
+        self.denied_reason = message
+
+
+class ApprovalRequiredError(PolicyError):
+    """Transaction requires approval before execution (Phase 2).
+
+    Raised when the amount exceeds auto_approve_threshold.
+    The caller must create an approval request and retry with approval_id.
+
+    Attributes:
+        approval_id: ID of the pending approval request.
+        policy_id: The policy that requires approval.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        approval_id: str | None = None,
+        policy_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.approval_id = approval_id
+        self.policy_id = policy_id
+
+
+class SpendingRateLimitError(PolicyError):
+    """Transaction rate limit exceeded (Phase 3).
+
+    Raised when the transaction count exceeds per-hour or per-day limits.
+
+    Attributes:
+        policy_id: The policy that enforces the rate limit.
+        limit_type: "hourly" or "daily".
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        policy_id: str | None = None,
+        limit_type: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.policy_id = policy_id
+        self.limit_type = limit_type
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class SpendingPolicy:
+    """Declarative spending policy for an agent or zone.
+
+    Resolution: agent-specific (highest priority) → zone default.
+    All limit amounts are in credits (Decimal), not micro-credits.
+
+    Fields with None mean "no limit for this period."
+    """
+
+    policy_id: str
+    zone_id: str
+    agent_id: str | None = None  # None = zone-level default
+    daily_limit: Decimal | None = None
+    weekly_limit: Decimal | None = None
+    monthly_limit: Decimal | None = None
+    per_tx_limit: Decimal | None = None
+    auto_approve_threshold: Decimal | None = None  # Phase 2: approval workflows
+    max_tx_per_hour: int | None = None  # Phase 3: rate controls
+    max_tx_per_day: int | None = None  # Phase 3: rate controls
+    rules: list[dict[str, Any]] | None = None  # Phase 4: policy DSL
+    priority: int = 0  # Higher value overrides lower
+    enabled: bool = True
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class SpendingLedgerEntry:
+    """Period-based spending counter for an agent.
+
+    One entry per (agent_id, zone_id, period_type, period_start).
+    Updated atomically via PostgreSQL UPSERT on each successful transfer.
+    """
+
+    agent_id: str
+    zone_id: str
+    period_type: str  # "daily" | "weekly" | "monthly"
+    period_start: date
+    amount_spent: Decimal = Decimal("0")
+    tx_count: int = 0
+
+
+@dataclass(frozen=True)
+class SpendingApproval:
+    """A pending or resolved approval for a transaction (Phase 2).
+
+    Created when a transaction exceeds the auto_approve_threshold.
+    An admin approves/rejects, then the agent retries with the approval_id.
+    """
+
+    approval_id: str
+    policy_id: str
+    agent_id: str
+    zone_id: str
+    amount: Decimal
+    to: str
+    memo: str = ""
+    status: str = "pending"  # pending | approved | rejected | expired
+    requested_at: datetime | None = None
+    decided_at: datetime | None = None
+    decided_by: str | None = None
+    expires_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class PolicyEvaluation:
+    """Result of evaluating a transaction against spending policies.
+
+    On denial, provides the specific reason and policy that blocked it.
+    On approval, optionally provides remaining budget information.
+    """
+
+    allowed: bool
+    denied_reason: str | None = None
+    policy_id: str | None = None
+    remaining_budget: dict[str, Decimal] = field(default_factory=dict)
+    requires_approval: bool = False  # Phase 2: needs admin approval
+    approval_id: str | None = None  # Phase 2: pending approval ID

--- a/src/nexus/pay/spending_policy_service.py
+++ b/src/nexus/pay/spending_policy_service.py
@@ -1,0 +1,910 @@
+"""Spending Policy Service — CRUD, evaluation, ledger, approvals, and rate limits.
+
+Issue #1358: Full spending policy engine (Phases 1-4).
+
+Hot path (evaluate):
+    1. Policy cache lookup (~0ms, 60s TTL)
+    2. Spending ledger read (~1ms, single indexed row)
+    3. Rule evaluation (~0.1ms, Python field comparisons)
+    4. Rate limit check (~0ms, in-memory sliding window)
+    Total: ~1.2ms — well under 5ms target.
+
+Ledger update (record_spending):
+    Fire-and-forget async UPSERT after successful transfer.
+    Does not block the transfer response.
+
+Default behavior: open by default (no policy = allow all transactions).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections import deque
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from nexus.pay.constants import credits_to_micro, micro_to_credits
+from nexus.pay.policy_rules import RuleContext, evaluate_rules
+from nexus.pay.spending_policy import (
+    PolicyEvaluation,
+    SpendingApproval,
+    SpendingPolicy,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from nexus.storage.models.spending_policy import SpendingPolicyModel
+
+logger = logging.getLogger(__name__)
+
+# Default approval expiry: 24 hours
+_APPROVAL_EXPIRY_HOURS = 24
+
+
+def _current_period_start(period_type: str, ref: date | None = None) -> date:
+    """Calculate the start of the current period.
+
+    Args:
+        period_type: "daily", "weekly", or "monthly".
+        ref: Reference date (defaults to today).
+
+    Returns:
+        Start date of the current period.
+    """
+    ref = ref or date.today()
+    if period_type == "daily":
+        return ref
+    if period_type == "weekly":
+        # Monday-based week
+        return ref - timedelta(days=ref.weekday())
+    if period_type == "monthly":
+        return ref.replace(day=1)
+    msg = f"Unknown period_type: {period_type}"
+    raise ValueError(msg)
+
+
+class SpendingPolicyService:
+    """Manages spending policies and evaluates transactions against them.
+
+    Safe for concurrent coroutines within a single event loop.
+    Cache invalidation via TTL (60s). Policy changes take up to 60s to propagate.
+    """
+
+    _CACHE_TTL: float = 60.0  # seconds
+
+    def __init__(self, session_factory: Callable[[], AsyncSession]) -> None:
+        self._session_factory = session_factory
+        # Cache: (agent_id, zone_id) → (policy | None, expires_at)
+        self._cache: dict[tuple[str, str], tuple[SpendingPolicy | None, float]] = {}
+        # Phase 3: in-memory sliding window for hourly rate limits
+        # Key: (agent_id, zone_id) → deque of monotonic timestamps
+        self._hourly_counters: dict[tuple[str, str], deque[float]] = {}
+        # Phase 3: daily tx counts (in-memory, auto-resets on day change)
+        self._daily_tx_counts: dict[tuple[str, str], int] = {}
+        self._daily_tx_date: date | None = None
+
+    # =========================================================================
+    # CRUD
+    # =========================================================================
+
+    async def create_policy(
+        self,
+        *,
+        zone_id: str,
+        agent_id: str | None = None,
+        daily_limit: Decimal | None = None,
+        weekly_limit: Decimal | None = None,
+        monthly_limit: Decimal | None = None,
+        per_tx_limit: Decimal | None = None,
+        auto_approve_threshold: Decimal | None = None,
+        max_tx_per_hour: int | None = None,
+        max_tx_per_day: int | None = None,
+        rules: list[dict[str, Any]] | None = None,
+        priority: int = 0,
+        enabled: bool = True,
+    ) -> SpendingPolicy:
+        """Create a new spending policy."""
+        from nexus.storage.models.spending_policy import SpendingPolicyModel
+
+        policy_id = str(uuid.uuid4())
+        now = datetime.now(UTC)
+
+        model = SpendingPolicyModel(
+            id=policy_id,
+            agent_id=agent_id,
+            zone_id=zone_id,
+            daily_limit=_to_micro_or_none(daily_limit),
+            weekly_limit=_to_micro_or_none(weekly_limit),
+            monthly_limit=_to_micro_or_none(monthly_limit),
+            per_tx_limit=_to_micro_or_none(per_tx_limit),
+            auto_approve_threshold=_to_micro_or_none(auto_approve_threshold),
+            max_tx_per_hour=max_tx_per_hour,
+            max_tx_per_day=max_tx_per_day,
+            rules=json.dumps(rules) if rules is not None else None,
+            priority=priority,
+            enabled=enabled,
+        )
+
+        async with self._session_factory() as session, session.begin():
+            session.add(model)
+
+        policy = SpendingPolicy(
+            policy_id=policy_id,
+            zone_id=zone_id,
+            agent_id=agent_id,
+            daily_limit=daily_limit,
+            weekly_limit=weekly_limit,
+            monthly_limit=monthly_limit,
+            per_tx_limit=per_tx_limit,
+            auto_approve_threshold=auto_approve_threshold,
+            max_tx_per_hour=max_tx_per_hour,
+            max_tx_per_day=max_tx_per_day,
+            rules=rules,
+            priority=priority,
+            enabled=enabled,
+            created_at=now,
+            updated_at=now,
+        )
+
+        # Invalidate cache for this agent+zone
+        cache_key = (agent_id or "", zone_id)
+        self._cache.pop(cache_key, None)
+
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Created spending policy %s for agent=%s zone=%s", policy_id, agent_id, zone_id
+            )
+
+        return policy
+
+    async def get_policy(self, agent_id: str | None, zone_id: str) -> SpendingPolicy | None:
+        """Get a specific policy by agent_id and zone_id."""
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingPolicyModel
+
+        async with self._session_factory() as session:
+            stmt = select(SpendingPolicyModel).where(
+                SpendingPolicyModel.zone_id == zone_id,
+                SpendingPolicyModel.enabled.is_(True),
+            )
+            if agent_id is not None:
+                stmt = stmt.where(SpendingPolicyModel.agent_id == agent_id)
+            else:
+                stmt = stmt.where(SpendingPolicyModel.agent_id.is_(None))
+
+            result = await session.execute(stmt)
+            model = result.scalar_one_or_none()
+            if model is None:
+                return None
+            return _model_to_policy(model)
+
+    _UPDATABLE_FIELDS = frozenset(
+        {
+            "daily_limit",
+            "weekly_limit",
+            "monthly_limit",
+            "per_tx_limit",
+            "auto_approve_threshold",
+            "max_tx_per_hour",
+            "max_tx_per_day",
+            "rules",
+            "priority",
+            "enabled",
+        }
+    )
+    _MICRO_FIELDS = frozenset(
+        {
+            "daily_limit",
+            "weekly_limit",
+            "monthly_limit",
+            "per_tx_limit",
+            "auto_approve_threshold",
+        }
+    )
+
+    async def update_policy(self, policy_id: str, **updates: Any) -> SpendingPolicy | None:
+        """Update a spending policy by ID. Returns updated policy or None if not found."""
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingPolicyModel
+
+        async with self._session_factory() as session, session.begin():
+            stmt = select(SpendingPolicyModel).where(SpendingPolicyModel.id == policy_id)
+            result = await session.execute(stmt)
+            model = result.scalar_one_or_none()
+            if model is None:
+                return None
+
+            for key, value in updates.items():
+                if key not in self._UPDATABLE_FIELDS:
+                    continue
+                if key in self._MICRO_FIELDS:
+                    setattr(model, key, _to_micro_or_none(value))
+                elif key == "rules":
+                    setattr(model, key, json.dumps(value) if value is not None else None)
+                else:
+                    setattr(model, key, value)
+
+            # Invalidate cache
+            cache_key = (model.agent_id or "", model.zone_id)
+            self._cache.pop(cache_key, None)
+
+            await session.flush()
+            return _model_to_policy(model)
+
+    async def delete_policy(self, policy_id: str) -> bool:
+        """Delete a spending policy by ID. Returns True if deleted."""
+        from sqlalchemy import delete, select
+
+        from nexus.storage.models.spending_policy import SpendingPolicyModel
+
+        async with self._session_factory() as session, session.begin():
+            # Fetch first to invalidate cache
+            stmt = select(SpendingPolicyModel).where(SpendingPolicyModel.id == policy_id)
+            result = await session.execute(stmt)
+            model = result.scalar_one_or_none()
+            if model is None:
+                return False
+
+            cache_key = (model.agent_id or "", model.zone_id)
+            self._cache.pop(cache_key, None)
+
+            del_stmt = delete(SpendingPolicyModel).where(SpendingPolicyModel.id == policy_id)
+            await session.execute(del_stmt)
+
+        return True
+
+    async def list_policies(self, zone_id: str) -> list[SpendingPolicy]:
+        """List all policies for a zone."""
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingPolicyModel
+
+        async with self._session_factory() as session:
+            stmt = (
+                select(SpendingPolicyModel)
+                .where(SpendingPolicyModel.zone_id == zone_id)
+                .order_by(SpendingPolicyModel.priority.desc())
+            )
+            result = await session.execute(stmt)
+            models = result.scalars().all()
+            return [_model_to_policy(m) for m in models]
+
+    # =========================================================================
+    # Evaluation (hot path — must be <5ms)
+    # =========================================================================
+
+    async def evaluate(
+        self,
+        agent_id: str,
+        zone_id: str,
+        amount: Decimal,
+        *,
+        to: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> PolicyEvaluation:
+        """Evaluate a transaction against the agent's spending policy.
+
+        Resolution order:
+            1. Agent-specific policy (highest priority if multiple)
+            2. Zone-level default (agent_id=NULL)
+            3. No policy found → allow (open by default)
+
+        Checks (in order):
+            1. Per-transaction limit
+            2. Period-based budget limits (daily/weekly/monthly)
+            3. Rate limits (Phase 3: max_tx_per_hour, max_tx_per_day)
+            4. DSL rules (Phase 4: recipient, time window, metadata, amount range)
+            5. Approval threshold (Phase 2: auto_approve_threshold)
+        """
+        policy = await self._resolve_policy(agent_id, zone_id)
+        if policy is None:
+            return PolicyEvaluation(allowed=True)
+
+        if not policy.enabled:
+            return PolicyEvaluation(allowed=True)
+
+        # 1. Per-transaction limit (no DB read needed)
+        if policy.per_tx_limit is not None and amount > policy.per_tx_limit:
+            return PolicyEvaluation(
+                allowed=False,
+                denied_reason=(
+                    f"Amount {amount} exceeds per-transaction limit {policy.per_tx_limit}"
+                ),
+                policy_id=policy.policy_id,
+            )
+
+        # 2. Period-based checks (requires ledger read)
+        spending = await self._get_spending(agent_id, zone_id)
+        remaining: dict[str, Decimal] = {}
+
+        for period_type, limit in [
+            ("daily", policy.daily_limit),
+            ("weekly", policy.weekly_limit),
+            ("monthly", policy.monthly_limit),
+        ]:
+            if limit is None:
+                continue
+            spent = spending.get(period_type, Decimal("0"))
+            left = limit - spent
+            remaining[period_type] = left
+
+            if spent + amount > limit:
+                return PolicyEvaluation(
+                    allowed=False,
+                    denied_reason=(
+                        f"Amount {amount} would exceed {period_type} limit {limit} "
+                        f"(already spent: {spent})"
+                    ),
+                    policy_id=policy.policy_id,
+                    remaining_budget=remaining,
+                )
+
+        # 3. Rate limits (Phase 3)
+        rate_result = self._check_rate_limits(agent_id, zone_id, policy)
+        if rate_result is not None:
+            return rate_result
+
+        # 4. DSL rules (Phase 4)
+        if policy.rules:
+            rule_ctx = RuleContext(
+                agent_id=agent_id,
+                zone_id=zone_id,
+                to=to,
+                amount=amount,
+                metadata=metadata or {},
+            )
+            rule_result = evaluate_rules(policy.rules, rule_ctx)
+            if not rule_result.allowed:
+                return PolicyEvaluation(
+                    allowed=False,
+                    denied_reason=rule_result.denied_reason,
+                    policy_id=policy.policy_id,
+                    remaining_budget=remaining,
+                )
+
+        # 5. Approval threshold (Phase 2)
+        if policy.auto_approve_threshold is not None and amount > policy.auto_approve_threshold:
+            return PolicyEvaluation(
+                allowed=False,
+                denied_reason=(
+                    f"Amount {amount} exceeds auto-approve threshold "
+                    f"{policy.auto_approve_threshold} — approval required"
+                ),
+                policy_id=policy.policy_id,
+                remaining_budget=remaining,
+                requires_approval=True,
+            )
+
+        return PolicyEvaluation(
+            allowed=True,
+            policy_id=policy.policy_id,
+            remaining_budget=remaining,
+        )
+
+    def _check_rate_limits(
+        self,
+        agent_id: str,
+        zone_id: str,
+        policy: SpendingPolicy,
+    ) -> PolicyEvaluation | None:
+        """Check transaction rate limits. Returns PolicyEvaluation if denied, else None."""
+        # Reset daily counters on calendar day change
+        today = date.today()
+        if self._daily_tx_date != today:
+            self._daily_tx_counts.clear()
+            self._daily_tx_date = today
+
+        # Daily tx rate limit (from in-memory counter)
+        if policy.max_tx_per_day is not None:
+            daily_tx = self._daily_tx_counts.get((agent_id, zone_id), 0)
+            if daily_tx >= policy.max_tx_per_day:
+                return PolicyEvaluation(
+                    allowed=False,
+                    denied_reason=(
+                        f"Daily transaction limit reached ({policy.max_tx_per_day} tx/day)"
+                    ),
+                    policy_id=policy.policy_id,
+                )
+
+        # Hourly tx rate limit (sliding window)
+        if policy.max_tx_per_hour is not None:
+            key = (agent_id, zone_id)
+            now = time.monotonic()
+            window = self._hourly_counters.get(key, deque())
+            # Remove timestamps older than 1 hour
+            cutoff = now - 3600
+            while window and window[0] < cutoff:
+                window.popleft()
+            # Evict empty deques to prevent unbounded dict growth
+            if not window:
+                self._hourly_counters.pop(key, None)
+            if len(window) >= policy.max_tx_per_hour:
+                return PolicyEvaluation(
+                    allowed=False,
+                    denied_reason=(
+                        f"Hourly transaction limit reached ({policy.max_tx_per_hour} tx/hour)"
+                    ),
+                    policy_id=policy.policy_id,
+                )
+
+        return None
+
+    def record_rate_limit_hit(self, agent_id: str, zone_id: str) -> None:
+        """Record a transaction for rate limiting purposes.
+
+        Called after a successful transfer to update counters.
+        """
+        key = (agent_id, zone_id)
+        now = time.monotonic()
+
+        # Update hourly sliding window
+        if key not in self._hourly_counters:
+            self._hourly_counters[key] = deque()
+        self._hourly_counters[key].append(now)
+
+        # Update daily tx count
+        self._daily_tx_counts[key] = self._daily_tx_counts.get(key, 0) + 1
+
+    # =========================================================================
+    # Approvals (Phase 2)
+    # =========================================================================
+
+    async def request_approval(
+        self,
+        *,
+        policy_id: str,
+        agent_id: str,
+        zone_id: str,
+        amount: Decimal,
+        to: str,
+        memo: str = "",
+    ) -> SpendingApproval:
+        """Create a pending approval request."""
+        from nexus.storage.models.spending_policy import SpendingApprovalModel
+
+        approval_id = str(uuid.uuid4())
+        now = datetime.now(UTC)
+        expires_at = now + timedelta(hours=_APPROVAL_EXPIRY_HOURS)
+
+        model = SpendingApprovalModel(
+            id=approval_id,
+            policy_id=policy_id,
+            agent_id=agent_id,
+            zone_id=zone_id,
+            amount=credits_to_micro(amount),
+            to=to,
+            memo=memo,
+            status="pending",
+            requested_at=now,
+            expires_at=expires_at,
+        )
+
+        async with self._session_factory() as session, session.begin():
+            session.add(model)
+
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Approval requested: id=%s agent=%s amount=%s",
+                approval_id,
+                agent_id,
+                amount,
+            )
+
+        return SpendingApproval(
+            approval_id=approval_id,
+            policy_id=policy_id,
+            agent_id=agent_id,
+            zone_id=zone_id,
+            amount=amount,
+            to=to,
+            memo=memo,
+            status="pending",
+            requested_at=now,
+            expires_at=expires_at,
+        )
+
+    async def check_approval(
+        self,
+        approval_id: str,
+        agent_id: str,
+        amount: Decimal,
+    ) -> SpendingApproval | None:
+        """Check if an approval exists and is valid for this transfer.
+
+        Returns the approval if it is approved, not expired, matches agent/amount.
+        Returns None if not found, wrong agent, wrong amount, or not approved.
+        """
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingApprovalModel
+
+        async with self._session_factory() as session:
+            stmt = select(SpendingApprovalModel).where(
+                SpendingApprovalModel.id == approval_id,
+            )
+            result = await session.execute(stmt)
+            model = result.scalar_one_or_none()
+
+        if model is None:
+            return None
+
+        # Validate
+        if model.agent_id != agent_id:
+            return None
+        if model.status != "approved":
+            return None
+        if datetime.now(UTC) > model.expires_at:
+            return None
+        if credits_to_micro(amount) != model.amount:
+            return None
+
+        return _approval_model_to_dataclass(model)
+
+    async def approve_request(self, approval_id: str, decided_by: str) -> SpendingApproval | None:
+        """Approve a pending approval request. Returns updated approval or None."""
+        return await self._decide_approval(approval_id, "approved", decided_by)
+
+    async def reject_request(self, approval_id: str, decided_by: str) -> SpendingApproval | None:
+        """Reject a pending approval request. Returns updated approval or None."""
+        return await self._decide_approval(approval_id, "rejected", decided_by)
+
+    async def list_pending_approvals(self, zone_id: str) -> list[SpendingApproval]:
+        """List all pending approvals for a zone."""
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingApprovalModel
+
+        now = datetime.now(UTC)
+        async with self._session_factory() as session:
+            stmt = (
+                select(SpendingApprovalModel)
+                .where(
+                    SpendingApprovalModel.zone_id == zone_id,
+                    SpendingApprovalModel.status == "pending",
+                    SpendingApprovalModel.expires_at > now,
+                )
+                .order_by(SpendingApprovalModel.requested_at.desc())
+            )
+            result = await session.execute(stmt)
+            models = result.scalars().all()
+            return [_approval_model_to_dataclass(m) for m in models]
+
+    async def _decide_approval(
+        self, approval_id: str, decision: str, decided_by: str
+    ) -> SpendingApproval | None:
+        """Set approval status to approved/rejected."""
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingApprovalModel
+
+        now = datetime.now(UTC)
+        async with self._session_factory() as session, session.begin():
+            stmt = select(SpendingApprovalModel).where(
+                SpendingApprovalModel.id == approval_id,
+                SpendingApprovalModel.status == "pending",
+            )
+            result = await session.execute(stmt)
+            model = result.scalar_one_or_none()
+            if model is None:
+                return None
+
+            model.status = decision
+            model.decided_at = now
+            model.decided_by = decided_by
+
+            await session.flush()
+            return _approval_model_to_dataclass(model)
+
+    # =========================================================================
+    # Ledger
+    # =========================================================================
+
+    async def record_spending(
+        self,
+        agent_id: str,
+        zone_id: str,
+        amount: Decimal,
+    ) -> None:
+        """Atomically increment spending counters for all active periods.
+
+        Uses PostgreSQL UPSERT (INSERT ON CONFLICT DO UPDATE) for atomicity.
+        Called fire-and-forget after a successful transfer.
+        Also updates in-memory rate limit counters.
+        """
+        from sqlalchemy import text as sa_text
+
+        micro_amount = credits_to_micro(amount)
+
+        async with self._session_factory() as session, session.begin():
+            for period_type in ("daily", "weekly", "monthly"):
+                period_start = _current_period_start(period_type)
+                # UPSERT: insert or increment
+                stmt = sa_text("""
+                    INSERT INTO spending_ledger
+                        (agent_id, zone_id, period_type, period_start,
+                         amount_spent, tx_count, updated_at)
+                    VALUES (:agent_id, :zone_id, :period_type,
+                            :period_start, :amount, 1, NOW())
+                    ON CONFLICT (agent_id, zone_id, period_type, period_start)
+                    DO UPDATE SET
+                        amount_spent = spending_ledger.amount_spent + :amount,
+                        tx_count = spending_ledger.tx_count + 1,
+                        updated_at = NOW()
+                """)
+                await session.execute(
+                    stmt,
+                    {
+                        "agent_id": agent_id,
+                        "zone_id": zone_id,
+                        "period_type": period_type,
+                        "period_start": period_start,
+                        "amount": micro_amount,
+                    },
+                )
+
+        # Update rate limit counters
+        self.record_rate_limit_hit(agent_id, zone_id)
+
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Recorded spending: agent=%s zone=%s amount=%s",
+                agent_id,
+                zone_id,
+                amount,
+            )
+
+    async def get_budget_summary(
+        self,
+        agent_id: str,
+        zone_id: str,
+    ) -> dict[str, Any]:
+        """Get budget summary for an agent (for API response).
+
+        Returns remaining budget per period and the active policy.
+        """
+        policy = await self._resolve_policy(agent_id, zone_id)
+        if policy is None:
+            return {"has_policy": False, "policy_id": None, "limits": {}, "remaining": {}}
+
+        spending = await self._get_spending(agent_id, zone_id)
+        limits: dict[str, str] = {}
+        remaining: dict[str, str] = {}
+
+        for period_type, limit in [
+            ("daily", policy.daily_limit),
+            ("weekly", policy.weekly_limit),
+            ("monthly", policy.monthly_limit),
+            ("per_tx", policy.per_tx_limit),
+        ]:
+            if limit is not None:
+                limits[period_type] = str(limit)
+                if period_type != "per_tx":
+                    spent = spending.get(period_type, Decimal("0"))
+                    remaining[period_type] = str(limit - spent)
+                else:
+                    remaining[period_type] = str(limit)
+
+        # Phase 2: approval threshold
+        if policy.auto_approve_threshold is not None:
+            limits["auto_approve"] = str(policy.auto_approve_threshold)
+
+        # Phase 3: rate limits
+        rate_limits: dict[str, int] = {}
+        if policy.max_tx_per_hour is not None:
+            rate_limits["max_tx_per_hour"] = policy.max_tx_per_hour
+        if policy.max_tx_per_day is not None:
+            rate_limits["max_tx_per_day"] = policy.max_tx_per_day
+
+        return {
+            "has_policy": True,
+            "policy_id": policy.policy_id,
+            "limits": limits,
+            "spent": {k: str(v) for k, v in spending.items()},
+            "remaining": remaining,
+            "rate_limits": rate_limits,
+            "has_rules": bool(policy.rules),
+        }
+
+    # =========================================================================
+    # Internal
+    # =========================================================================
+
+    async def _resolve_policy(self, agent_id: str, zone_id: str) -> SpendingPolicy | None:
+        """Resolve effective policy with 60s TTL cache.
+
+        Resolution: agent-specific → zone default. Highest priority wins.
+        """
+        # Check cache for agent-specific
+        cache_key = (agent_id, zone_id)
+        now = time.monotonic()
+        cached = self._cache.get(cache_key)
+        if cached is not None and cached[1] > now:
+            return cached[0]
+
+        # DB lookup: agent-specific policies
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingPolicyModel
+
+        async with self._session_factory() as session:
+            # Agent-specific policy (highest priority)
+            stmt = (
+                select(SpendingPolicyModel)
+                .where(
+                    SpendingPolicyModel.zone_id == zone_id,
+                    SpendingPolicyModel.agent_id == agent_id,
+                    SpendingPolicyModel.enabled.is_(True),
+                )
+                .order_by(SpendingPolicyModel.priority.desc())
+                .limit(1)
+            )
+            result = await session.execute(stmt)
+            model = result.scalar_one_or_none()
+
+            if model is not None:
+                policy = _model_to_policy(model)
+                self._cache[cache_key] = (policy, now + self._CACHE_TTL)
+                return policy
+
+            # Zone-level default (agent_id IS NULL)
+            stmt = (
+                select(SpendingPolicyModel)
+                .where(
+                    SpendingPolicyModel.zone_id == zone_id,
+                    SpendingPolicyModel.agent_id.is_(None),
+                    SpendingPolicyModel.enabled.is_(True),
+                )
+                .order_by(SpendingPolicyModel.priority.desc())
+                .limit(1)
+            )
+            result = await session.execute(stmt)
+            model = result.scalar_one_or_none()
+
+            resolved: SpendingPolicy | None = _model_to_policy(model) if model is not None else None
+
+        self._cache[cache_key] = (resolved, now + self._CACHE_TTL)
+        return resolved
+
+    async def _get_spending(self, agent_id: str, zone_id: str) -> dict[str, Decimal]:
+        """Get current spending for all active periods (single query).
+
+        Returns dict like {"daily": Decimal("42.50"), "weekly": Decimal("150"), ...}
+        """
+        import sqlalchemy as sa
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingLedgerModel
+
+        periods = {pt: _current_period_start(pt) for pt in ("daily", "weekly", "monthly")}
+
+        async with self._session_factory() as session:
+            stmt = select(
+                SpendingLedgerModel.period_type,
+                SpendingLedgerModel.amount_spent,
+            ).where(
+                SpendingLedgerModel.agent_id == agent_id,
+                SpendingLedgerModel.zone_id == zone_id,
+                sa.or_(
+                    *[
+                        sa.and_(
+                            SpendingLedgerModel.period_type == pt,
+                            SpendingLedgerModel.period_start == start,
+                        )
+                        for pt, start in periods.items()
+                    ]
+                ),
+            )
+            result = await session.execute(stmt)
+            rows = result.all()
+
+        result_map: dict[str, Decimal] = {}
+        for period_type, micro in rows:
+            result_map[period_type] = micro_to_credits(micro) if micro is not None else Decimal("0")
+
+        # Fill in missing periods with zero
+        for pt in periods:
+            if pt not in result_map:
+                result_map[pt] = Decimal("0")
+
+        return result_map
+
+    async def _get_daily_tx_count(self, agent_id: str, zone_id: str) -> int:
+        """Get today's transaction count from the ledger."""
+        from sqlalchemy import select
+
+        from nexus.storage.models.spending_policy import SpendingLedgerModel
+
+        today = _current_period_start("daily")
+        async with self._session_factory() as session:
+            stmt = select(SpendingLedgerModel.tx_count).where(
+                SpendingLedgerModel.agent_id == agent_id,
+                SpendingLedgerModel.zone_id == zone_id,
+                SpendingLedgerModel.period_type == "daily",
+                SpendingLedgerModel.period_start == today,
+            )
+            result = await session.execute(stmt)
+            row = result.scalar_one_or_none()
+        return row or 0
+
+    def clear_cache(self) -> None:
+        """Clear the policy cache and rate limit counters (for testing)."""
+        self._cache.clear()
+        self._hourly_counters.clear()
+        self._daily_tx_counts.clear()
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _to_micro_or_none(value: Decimal | None) -> int | None:
+    """Convert credits Decimal to micro-credits int, or None."""
+    if value is None:
+        return None
+    return credits_to_micro(value)
+
+
+def _model_to_policy(model: SpendingPolicyModel) -> SpendingPolicy:
+    """Convert SQLAlchemy model to frozen dataclass."""
+    rules_parsed: list[dict[str, Any]] | None = None
+    if model.rules is not None:
+        try:
+            rules_parsed = json.loads(model.rules)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Invalid rules JSON for policy %s", model.id)
+
+    return SpendingPolicy(
+        policy_id=model.id,
+        zone_id=model.zone_id,
+        agent_id=model.agent_id,
+        daily_limit=micro_to_credits(model.daily_limit) if model.daily_limit is not None else None,
+        weekly_limit=micro_to_credits(model.weekly_limit)
+        if model.weekly_limit is not None
+        else None,
+        monthly_limit=micro_to_credits(model.monthly_limit)
+        if model.monthly_limit is not None
+        else None,
+        per_tx_limit=micro_to_credits(model.per_tx_limit)
+        if model.per_tx_limit is not None
+        else None,
+        auto_approve_threshold=(
+            micro_to_credits(model.auto_approve_threshold)
+            if model.auto_approve_threshold is not None
+            else None
+        ),
+        max_tx_per_hour=model.max_tx_per_hour,
+        max_tx_per_day=model.max_tx_per_day,
+        rules=rules_parsed,
+        priority=model.priority,
+        enabled=model.enabled,
+        created_at=model.created_at,
+        updated_at=model.updated_at,
+    )
+
+
+def _approval_model_to_dataclass(model: Any) -> SpendingApproval:
+    """Convert SpendingApprovalModel to SpendingApproval dataclass."""
+    return SpendingApproval(
+        approval_id=model.id,
+        policy_id=model.policy_id,
+        agent_id=model.agent_id,
+        zone_id=model.zone_id,
+        amount=micro_to_credits(model.amount),
+        to=model.to,
+        memo=model.memo,
+        status=model.status,
+        requested_at=model.requested_at,
+        decided_at=model.decided_at,
+        decided_by=model.decided_by,
+        expires_at=model.expires_at,
+    )

--- a/src/nexus/storage/models/payments.py
+++ b/src/nexus/storage/models/payments.py
@@ -16,7 +16,10 @@ from nexus.storage.models._base import Base, uuid_pk
 
 
 class AgentWalletMeta(Base):
-    """Wallet metadata for Nexus Pay. Balances in TigerBeetle, settings here."""
+    """Wallet metadata for Nexus Pay. Balances in TigerBeetle, settings here.
+
+    Note: Budget limits moved to spending_policies table (Issue #1358).
+    """
 
     __tablename__ = "agent_wallet_meta"
 
@@ -25,17 +28,6 @@ class AgentWalletMeta(Base):
     tigerbeetle_account_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
     x402_address: Mapped[str | None] = mapped_column(String(64), nullable=True)
     x402_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    daily_limit: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
-    monthly_limit: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
-    per_tx_limit: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
-    daily_spent: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
-    monthly_spent: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
-    daily_reset_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
-    )
-    monthly_reset_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
-    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
     )
@@ -49,8 +41,6 @@ class AgentWalletMeta(Base):
     __table_args__ = (
         Index("idx_wallet_meta_zone", "zone_id"),
         Index("idx_wallet_meta_tb_id", "tigerbeetle_account_id"),
-        Index("idx_wallet_meta_daily_reset", "daily_reset_at"),
-        Index("idx_wallet_meta_monthly_reset", "monthly_reset_at"),
     )
 
 

--- a/src/nexus/storage/models/spending_policy.py
+++ b/src/nexus/storage/models/spending_policy.py
@@ -1,0 +1,136 @@
+"""SQLAlchemy models for spending policies, ledger, and approvals.
+
+Issue #1358: Agent Spending Policy Engine (Phases 1-4).
+
+Tables:
+    spending_policies — declarative budget limits per agent/zone
+    spending_ledger   — period-based spending counters (atomic UPSERT)
+    spending_approvals — approval workflow records (Phase 2)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Date,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from nexus.storage.models._base import Base, uuid_pk
+
+
+class SpendingPolicyModel(Base):
+    """Declarative spending policy for an agent or zone.
+
+    agent_id=NULL means zone-level default policy.
+    All limit amounts stored as micro-credits (BigInteger) for precision.
+    """
+
+    __tablename__ = "spending_policies"
+
+    id: Mapped[str] = uuid_pk()
+    agent_id: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    daily_limit: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    weekly_limit: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    monthly_limit: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    per_tx_limit: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    auto_approve_threshold: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # Phase 3: rate controls
+    max_tx_per_hour: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_tx_per_day: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Phase 4: policy DSL rules (JSON stored as text)
+    rules: Mapped[str | None] = mapped_column(Text, nullable=True)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("agent_id", "zone_id", name="uq_spending_policy_agent_zone"),
+        Index("ix_spending_policies_zone_priority", "zone_id", "priority"),
+    )
+
+
+class SpendingLedgerModel(Base):
+    """Period-based spending counter.
+
+    Updated atomically via UPSERT on each successful transfer.
+    One row per (agent_id, zone_id, period_type, period_start).
+    All amounts in micro-credits (BigInteger).
+    """
+
+    __tablename__ = "spending_ledger"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    period_type: Mapped[str] = mapped_column(String(10), nullable=False)  # daily|weekly|monthly
+    period_start: Mapped[date] = mapped_column(Date, nullable=False)
+    amount_spent: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tx_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "agent_id",
+            "zone_id",
+            "period_type",
+            "period_start",
+            name="uq_spending_ledger_agent_period",
+        ),
+        Index("ix_spending_ledger_agent_zone", "agent_id", "zone_id"),
+    )
+
+
+class SpendingApprovalModel(Base):
+    """Approval workflow record (Phase 2).
+
+    Created when a transaction exceeds auto_approve_threshold.
+    Admin approves/rejects via API. Agent retries with approval_id.
+    """
+
+    __tablename__ = "spending_approvals"
+
+    id: Mapped[str] = uuid_pk()
+    policy_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    agent_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    amount: Mapped[int] = mapped_column(BigInteger, nullable=False)  # micro-credits
+    to: Mapped[str] = mapped_column(String(255), nullable=False)
+    memo: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending"
+    )  # pending|approved|rejected|expired
+    requested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    decided_by: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        Index("ix_spending_approvals_agent_zone", "agent_id", "zone_id"),
+        Index("ix_spending_approvals_status", "status"),
+    )

--- a/tests/e2e/test_spending_policy_e2e.py
+++ b/tests/e2e/test_spending_policy_e2e.py
@@ -1,0 +1,598 @@
+"""E2E tests for Spending Policy enforcement through FastAPI.
+
+Issue #1358: Tests the full HTTP path for policy enforcement:
+- Budget endpoint returns remaining budget
+- Transfer blocked by per-tx limit → 403
+- Transfer blocked by daily limit → 403
+- Transfer allowed when within all limits
+- Policy CRUD endpoints (admin-only)
+- Real DB integration with SpendingPolicyService (SQLite async)
+
+Section 1: Lightweight mocked tests (no DB)
+Section 2: Full integration tests with real SpendingPolicyService + SQLite
+"""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, Header
+from httpx import ASGITransport, AsyncClient
+
+from nexus.pay.spending_policy import PolicyDeniedError, PolicyEvaluation, SpendingPolicy
+from nexus.server.api.v2.routers.pay import _register_pay_exception_handlers, router
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _create_test_app(
+    *,
+    mock_credits_service: AsyncMock,
+    mock_policy_service: AsyncMock,
+    is_admin: bool = False,
+    agent_id: str = "test-agent",
+    zone_id: str = "default",
+) -> FastAPI:
+    """Create a lightweight FastAPI app with pay router + policy service."""
+    app = FastAPI()
+    app.include_router(router)
+    _register_pay_exception_handlers(app)
+
+    # Wire services into app state
+    app.state.credits_service = mock_credits_service
+    app.state.spending_policy_service = mock_policy_service
+    app.state.x402_client = None
+
+    # Override auth dependency
+    from nexus.server.api.v2.routers.pay import _get_require_auth
+
+    async def mock_auth(
+        authorization: str | None = Header(None, alias="Authorization"),
+        x_agent_id: str | None = Header(None, alias="X-Agent-ID"),
+        x_nexus_subject: str | None = Header(None, alias="X-Nexus-Subject"),
+        x_nexus_zone_id: str | None = Header(None, alias="X-Nexus-Zone-ID"),
+    ) -> dict[str, Any]:
+        return {
+            "authenticated": True,
+            "subject_type": "agent",
+            "subject_id": agent_id,
+            "zone_id": zone_id,
+            "is_admin": is_admin,
+            "x_agent_id": None,
+            "metadata": {},
+        }
+
+    app.dependency_overrides[_get_require_auth()] = mock_auth
+    return app
+
+
+@pytest.fixture
+def mock_credits_service():
+    """Mock CreditsService."""
+    service = AsyncMock()
+    service.get_balance.return_value = Decimal("100.0")
+    service.get_balance_with_reserved.return_value = (Decimal("100.0"), Decimal("5.0"))
+    service.check_budget.return_value = True
+    service.transfer.return_value = "tx-123"
+    service.reserve.return_value = "res-123"
+    service.commit_reservation.return_value = None
+    service.release_reservation.return_value = None
+    service.deduct_fast.return_value = True
+    service.transfer_batch.return_value = ["tx-1"]
+    service.provision_wallet.return_value = None
+    return service
+
+
+@pytest.fixture
+def mock_policy_service():
+    """Mock SpendingPolicyService."""
+    service = AsyncMock()
+    service.evaluate.return_value = PolicyEvaluation(allowed=True)
+    service.record_spending.return_value = None
+    service.get_budget_summary.return_value = {
+        "has_policy": True,
+        "policy_id": "p1",
+        "limits": {"daily": "100", "per_tx": "50"},
+        "spent": {"daily": "25"},
+        "remaining": {"daily": "75", "per_tx": "50"},
+    }
+    service.create_policy.return_value = SpendingPolicy(
+        policy_id="new-p1",
+        zone_id="default",
+        agent_id="agent-a",
+        daily_limit=Decimal("100"),
+        per_tx_limit=Decimal("50"),
+    )
+    service.list_policies.return_value = []
+    service.delete_policy.return_value = True
+    return service
+
+
+# =============================================================================
+# Budget Endpoint Tests
+# =============================================================================
+
+
+class TestBudgetEndpoint:
+    """GET /api/v2/pay/budget returns spending summary."""
+
+    @pytest.mark.asyncio
+    async def test_budget_returns_summary(self, mock_credits_service, mock_policy_service):
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/v2/pay/budget")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["has_policy"] is True
+            assert data["limits"]["daily"] == "100"
+            assert data["remaining"]["daily"] == "75"
+
+    @pytest.mark.asyncio
+    async def test_budget_no_policy(self, mock_credits_service, mock_policy_service):
+        mock_policy_service.get_budget_summary.return_value = {
+            "has_policy": False,
+            "policy_id": None,
+            "limits": {},
+            "remaining": {},
+        }
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/v2/pay/budget")
+            assert resp.status_code == 200
+            assert resp.json()["has_policy"] is False
+
+
+# =============================================================================
+# Policy Denial via Exception Handler Tests
+# =============================================================================
+
+
+class TestPolicyDenialResponse:
+    """PolicyDeniedError mapped to 403 with error_code 'policy_denied'."""
+
+    @pytest.mark.asyncio
+    async def test_policy_denied_returns_403(self, mock_credits_service, mock_policy_service):
+        """Transfer blocked by policy returns 403 with policy_denied error."""
+        # The credits_service.transfer is what gets called by NexusPay.transfer(),
+        # but PolicyDeniedError is raised by the wrapper BEFORE the inner protocol.
+        # Since we're testing through NexusPay SDK (not the wrapper directly),
+        # we mock credits_service.transfer to raise PolicyDeniedError
+        # to simulate the wrapper's behavior at the router level.
+        mock_credits_service.transfer.side_effect = PolicyDeniedError(
+            "Amount 100 exceeds per-transaction limit 50",
+            policy_id="p1",
+        )
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v2/pay/transfer",
+                json={"to": "agent-bob", "amount": "100", "memo": "test"},
+            )
+            assert resp.status_code == 403
+            data = resp.json()
+            assert data["error_code"] == "policy_denied"
+            assert "per-transaction limit" in data["detail"]
+
+
+# =============================================================================
+# Policy CRUD Endpoint Tests
+# =============================================================================
+
+
+class TestPolicyCRUDEndpoints:
+    """Policy CRUD requires admin access."""
+
+    @pytest.mark.asyncio
+    async def test_create_policy_requires_admin(self, mock_credits_service, mock_policy_service):
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+            is_admin=False,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v2/pay/policies",
+                json={"agent_id": "agent-a", "daily_limit": "100"},
+            )
+            assert resp.status_code == 403
+            assert "Admin" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_policy_as_admin(self, mock_credits_service, mock_policy_service):
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+            is_admin=True,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v2/pay/policies",
+                json={"agent_id": "agent-a", "daily_limit": "100", "per_tx_limit": "50"},
+            )
+            assert resp.status_code == 201
+            data = resp.json()
+            assert data["policy_id"] == "new-p1"
+            assert data["daily_limit"] == "100"
+
+    @pytest.mark.asyncio
+    async def test_list_policies_requires_admin(self, mock_credits_service, mock_policy_service):
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+            is_admin=False,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/v2/pay/policies")
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_delete_policy_as_admin(self, mock_credits_service, mock_policy_service):
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+            is_admin=True,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.delete("/api/v2/pay/policies/p1")
+            assert resp.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_policy(self, mock_credits_service, mock_policy_service):
+        mock_policy_service.delete_policy.return_value = False
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+            is_admin=True,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.delete("/api/v2/pay/policies/nonexistent")
+            assert resp.status_code == 404
+
+
+# =============================================================================
+# Concurrency Tests (Decision #10A)
+# =============================================================================
+
+
+class TestConcurrentTransfers:
+    """Verify policy enforcement under concurrent requests."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_transfers_all_evaluated(
+        self, mock_credits_service, mock_policy_service
+    ):
+        """Multiple concurrent transfers each get independent policy evaluation."""
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            # Fire 10 concurrent transfer requests
+            tasks = [
+                client.post(
+                    "/api/v2/pay/transfer",
+                    json={"to": f"agent-{i}", "amount": "5", "memo": f"test-{i}"},
+                )
+                for i in range(10)
+            ]
+            responses = await asyncio.gather(*tasks)
+
+            # All should succeed (policy allows all) — transfer returns 201
+            for resp in responses:
+                assert resp.status_code == 201
+
+            # Each transfer should have triggered credits_service.transfer
+            assert mock_credits_service.transfer.call_count == 10
+
+    @pytest.mark.asyncio
+    async def test_concurrent_transfers_with_policy_denial(
+        self, mock_credits_service, mock_policy_service
+    ):
+        """Mix of allowed and denied transfers handled correctly under concurrency."""
+        call_count = 0
+
+        async def alternating_transfer(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise PolicyDeniedError(
+                    "Amount exceeds per-transaction limit",
+                    policy_id="p1",
+                )
+            return "tx-ok"
+
+        mock_credits_service.transfer.side_effect = alternating_transfer
+
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            tasks = [
+                client.post(
+                    "/api/v2/pay/transfer",
+                    json={"to": f"agent-{i}", "amount": "10", "memo": f"test-{i}"},
+                )
+                for i in range(6)
+            ]
+            responses = await asyncio.gather(*tasks)
+
+            statuses = sorted(resp.status_code for resp in responses)
+            # 3 allowed (201), 3 denied (403)
+            assert statuses.count(201) == 3
+            assert statuses.count(403) == 3
+
+    @pytest.mark.asyncio
+    async def test_concurrent_budget_reads(self, mock_credits_service, mock_policy_service):
+        """Multiple concurrent budget reads don't interfere."""
+        app = _create_test_app(
+            mock_credits_service=mock_credits_service,
+            mock_policy_service=mock_policy_service,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            tasks = [client.get("/api/v2/pay/budget") for _ in range(20)]
+            responses = await asyncio.gather(*tasks)
+
+            for resp in responses:
+                assert resp.status_code == 200
+                assert resp.json()["has_policy"] is True
+
+
+# =============================================================================
+# Section 2: Real DB Integration Tests (SQLite async)
+# =============================================================================
+
+
+def _create_integration_app(
+    *,
+    policy_service: Any,
+    mock_credits_service: AsyncMock,
+    is_admin: bool = False,
+    agent_id: str = "test-agent",
+    zone_id: str = "default",
+) -> FastAPI:
+    """Create FastAPI app with REAL SpendingPolicyService + mocked CreditsService."""
+    app = FastAPI()
+    app.include_router(router)
+    _register_pay_exception_handlers(app)
+
+    app.state.credits_service = mock_credits_service
+    app.state.spending_policy_service = policy_service
+    app.state.x402_client = None
+
+    from nexus.server.api.v2.routers.pay import _get_require_auth
+
+    async def mock_auth(
+        authorization: str | None = Header(None, alias="Authorization"),
+        x_agent_id: str | None = Header(None, alias="X-Agent-ID"),
+        x_nexus_subject: str | None = Header(None, alias="X-Nexus-Subject"),
+        x_nexus_zone_id: str | None = Header(None, alias="X-Nexus-Zone-ID"),
+    ) -> dict[str, Any]:
+        return {
+            "authenticated": True,
+            "subject_type": "agent",
+            "subject_id": agent_id,
+            "zone_id": zone_id,
+            "is_admin": is_admin,
+            "x_agent_id": None,
+            "metadata": {},
+        }
+
+    app.dependency_overrides[_get_require_auth()] = mock_auth
+    return app
+
+
+@pytest.fixture
+async def async_session_factory():
+    """Create an async SQLite in-memory database with spending policy tables."""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    import nexus.storage.models.spending_policy  # noqa: F401 - ensure models registered
+    from nexus.storage.models._base import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def real_policy_service(async_session_factory):
+    """Create a real SpendingPolicyService backed by SQLite."""
+    from nexus.pay.spending_policy_service import SpendingPolicyService
+
+    return SpendingPolicyService(session_factory=async_session_factory)
+
+
+class TestRealDBPolicyCRUD:
+    """Integration tests: real SpendingPolicyService + real SQLite + FastAPI."""
+
+    @pytest.mark.asyncio
+    async def test_create_and_get_budget(self, real_policy_service, mock_credits_service):
+        """Admin creates policy → agent sees it in budget summary."""
+        # Step 1: Admin creates a policy
+        admin_app = _create_integration_app(
+            policy_service=real_policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v2/pay/policies",
+                json={
+                    "agent_id": "test-agent",
+                    "daily_limit": "100",
+                    "per_tx_limit": "50",
+                },
+            )
+            assert resp.status_code == 201
+            policy_data = resp.json()
+            assert policy_data["daily_limit"] == "100"
+            assert policy_data["per_tx_limit"] == "50"
+            assert policy_data["policy_id"]  # verify non-empty
+
+        # Step 2: Agent checks budget (no spending yet → full budget remaining)
+        agent_app = _create_integration_app(
+            policy_service=real_policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+            agent_id="test-agent",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=agent_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v2/pay/budget")
+            assert resp.status_code == 200
+            budget = resp.json()
+            assert budget["has_policy"] is True
+            assert budget["limits"]["daily"] == "100"
+            assert budget["limits"]["per_tx"] == "50"
+            assert budget["remaining"]["daily"] == "100"
+
+    @pytest.mark.asyncio
+    async def test_list_and_delete_policies(self, real_policy_service, mock_credits_service):
+        """Admin creates, lists, and deletes policies."""
+        app = _create_integration_app(
+            policy_service=real_policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            # Create two policies
+            resp1 = await client.post(
+                "/api/v2/pay/policies",
+                json={"agent_id": "agent-a", "daily_limit": "200"},
+            )
+            assert resp1.status_code == 201
+            pid1 = resp1.json()["policy_id"]
+
+            resp2 = await client.post(
+                "/api/v2/pay/policies",
+                json={"agent_id": "agent-b", "monthly_limit": "1000"},
+            )
+            assert resp2.status_code == 201
+
+            # List policies
+            resp = await client.get("/api/v2/pay/policies")
+            assert resp.status_code == 200
+            policies = resp.json()
+            assert len(policies) == 2
+
+            # Delete one
+            resp = await client.delete(f"/api/v2/pay/policies/{pid1}")
+            assert resp.status_code == 204
+
+            # List again → only 1 left
+            resp = await client.get("/api/v2/pay/policies")
+            assert resp.status_code == 200
+            assert len(resp.json()) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_policy_returns_open_budget(self, real_policy_service, mock_credits_service):
+        """Agent with no policy sees has_policy=False (open by default)."""
+        app = _create_integration_app(
+            policy_service=real_policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+            agent_id="unmanaged-agent",
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/v2/pay/budget")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["has_policy"] is False
+            assert data["limits"] == {}
+
+    @pytest.mark.asyncio
+    async def test_zone_default_policy_applies(self, real_policy_service, mock_credits_service):
+        """Zone-level default policy (agent_id=None) applies to any agent."""
+        # Create zone default policy (no agent_id)
+        admin_app = _create_integration_app(
+            policy_service=real_policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v2/pay/policies",
+                json={"daily_limit": "500"},  # No agent_id → zone default
+            )
+            assert resp.status_code == 201
+
+        # Check budget for a random agent → should see zone default
+        agent_app = _create_integration_app(
+            policy_service=real_policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+            agent_id="random-agent-xyz",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=agent_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v2/pay/budget")
+            assert resp.status_code == 200
+            budget = resp.json()
+            assert budget["has_policy"] is True
+            assert budget["limits"]["daily"] == "500"
+
+    @pytest.mark.asyncio
+    async def test_agent_specific_overrides_zone_default(
+        self, real_policy_service, mock_credits_service
+    ):
+        """Agent-specific policy takes priority over zone default."""
+        admin_app = _create_integration_app(
+            policy_service=real_policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            # Zone default: daily=500
+            await client.post(
+                "/api/v2/pay/policies",
+                json={"daily_limit": "500"},
+            )
+            # Agent-specific override: daily=50
+            await client.post(
+                "/api/v2/pay/policies",
+                json={"agent_id": "special-agent", "daily_limit": "50"},
+            )
+
+        # special-agent should see daily=50 (not zone default 500)
+        agent_app = _create_integration_app(
+            policy_service=real_policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+            agent_id="special-agent",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=agent_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v2/pay/budget")
+            assert resp.status_code == 200
+            budget = resp.json()
+            assert budget["has_policy"] is True
+            assert budget["limits"]["daily"] == "50"

--- a/tests/e2e/test_spending_policy_phases_e2e.py
+++ b/tests/e2e/test_spending_policy_phases_e2e.py
@@ -1,0 +1,489 @@
+"""E2E tests for Spending Policy Phases 2-4 through FastAPI.
+
+Issue #1358:
+- Phase 2: Approval workflows (request, approve, reject, list)
+- Phase 3: Rate limits (max_tx_per_hour, max_tx_per_day)
+- Phase 4: DSL rules (recipient, time window, amount range)
+
+All tests use real SpendingPolicyService + SQLite async backend.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, Header
+from httpx import ASGITransport, AsyncClient
+
+from nexus.pay.spending_policy import (
+    ApprovalRequiredError,
+    SpendingRateLimitError,
+)
+from nexus.server.api.v2.routers.pay import _register_pay_exception_handlers, router
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _create_app(
+    *,
+    policy_service: Any,
+    mock_credits_service: AsyncMock,
+    is_admin: bool = False,
+    agent_id: str = "test-agent",
+    zone_id: str = "default",
+) -> FastAPI:
+    """Create FastAPI app with real policy service + mocked credits."""
+    app = FastAPI()
+    app.include_router(router)
+    _register_pay_exception_handlers(app)
+
+    app.state.credits_service = mock_credits_service
+    app.state.spending_policy_service = policy_service
+    app.state.x402_client = None
+
+    from nexus.server.api.v2.routers.pay import _get_require_auth
+
+    async def mock_auth(
+        authorization: str | None = Header(None, alias="Authorization"),
+        x_agent_id: str | None = Header(None, alias="X-Agent-ID"),
+        x_nexus_subject: str | None = Header(None, alias="X-Nexus-Subject"),
+        x_nexus_zone_id: str | None = Header(None, alias="X-Nexus-Zone-ID"),
+    ) -> dict[str, Any]:
+        return {
+            "authenticated": True,
+            "subject_type": "agent",
+            "subject_id": agent_id,
+            "zone_id": zone_id,
+            "is_admin": is_admin,
+            "x_agent_id": None,
+            "metadata": {},
+        }
+
+    app.dependency_overrides[_get_require_auth()] = mock_auth
+    return app
+
+
+@pytest.fixture
+def mock_credits_service():
+    service = AsyncMock()
+    service.get_balance.return_value = Decimal("1000.0")
+    service.get_balance_with_reserved.return_value = (Decimal("1000.0"), Decimal("0"))
+    service.check_budget.return_value = True
+    service.transfer.return_value = "tx-123"
+    service.reserve.return_value = "res-123"
+    service.commit_reservation.return_value = None
+    service.release_reservation.return_value = None
+    service.deduct_fast.return_value = True
+    service.transfer_batch.return_value = ["tx-1"]
+    service.provision_wallet.return_value = None
+    return service
+
+
+@pytest.fixture
+async def async_session_factory():
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    import nexus.storage.models.spending_policy  # noqa: F401
+    from nexus.storage.models._base import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def policy_service(async_session_factory):
+    from nexus.pay.spending_policy_service import SpendingPolicyService
+
+    return SpendingPolicyService(session_factory=async_session_factory)
+
+
+# =============================================================================
+# Phase 2: Approval Workflow E2E Tests
+# =============================================================================
+
+
+class TestApprovalWorkflow:
+    """Full approval lifecycle: create policy → request approval → approve → list."""
+
+    @pytest.mark.asyncio
+    async def test_approval_required_exception_returns_402(self, mock_credits_service):
+        """ApprovalRequiredError mapped to HTTP 402."""
+        mock_credits_service.transfer.side_effect = ApprovalRequiredError(
+            "Amount exceeds auto-approve threshold",
+            policy_id="p1",
+        )
+        from nexus.server.api.v2.routers.pay import _get_require_auth
+
+        app = FastAPI()
+        app.include_router(router)
+        _register_pay_exception_handlers(app)
+        app.state.credits_service = mock_credits_service
+        app.state.spending_policy_service = AsyncMock()
+        app.state.x402_client = None
+
+        async def mock_auth(
+            authorization: str | None = Header(None, alias="Authorization"),
+            x_agent_id: str | None = Header(None, alias="X-Agent-ID"),
+            x_nexus_subject: str | None = Header(None, alias="X-Nexus-Subject"),
+            x_nexus_zone_id: str | None = Header(None, alias="X-Nexus-Zone-ID"),
+        ) -> dict[str, Any]:
+            return {
+                "authenticated": True,
+                "subject_type": "agent",
+                "subject_id": "test-agent",
+                "zone_id": "default",
+                "is_admin": False,
+                "x_agent_id": None,
+                "metadata": {},
+            }
+
+        app.dependency_overrides[_get_require_auth()] = mock_auth
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v2/pay/transfer",
+                json={"to": "bob", "amount": "100", "memo": "test"},
+            )
+            assert resp.status_code == 402
+            assert resp.json()["error_code"] == "approval_required"
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_exception_returns_429(self, mock_credits_service):
+        """SpendingRateLimitError mapped to HTTP 429."""
+        mock_credits_service.transfer.side_effect = SpendingRateLimitError(
+            "Hourly limit exceeded",
+            policy_id="p1",
+            limit_type="hourly",
+        )
+        from nexus.server.api.v2.routers.pay import _get_require_auth
+
+        app = FastAPI()
+        app.include_router(router)
+        _register_pay_exception_handlers(app)
+        app.state.credits_service = mock_credits_service
+        app.state.spending_policy_service = AsyncMock()
+        app.state.x402_client = None
+
+        async def mock_auth(
+            authorization: str | None = Header(None, alias="Authorization"),
+            x_agent_id: str | None = Header(None, alias="X-Agent-ID"),
+            x_nexus_subject: str | None = Header(None, alias="X-Nexus-Subject"),
+            x_nexus_zone_id: str | None = Header(None, alias="X-Nexus-Zone-ID"),
+        ) -> dict[str, Any]:
+            return {
+                "authenticated": True,
+                "subject_type": "agent",
+                "subject_id": "test-agent",
+                "zone_id": "default",
+                "is_admin": False,
+                "x_agent_id": None,
+                "metadata": {},
+            }
+
+        app.dependency_overrides[_get_require_auth()] = mock_auth
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v2/pay/transfer",
+                json={"to": "bob", "amount": "10", "memo": "test"},
+            )
+            assert resp.status_code == 429
+            assert resp.json()["error_code"] == "rate_limit_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_full_approval_lifecycle(self, policy_service, mock_credits_service):
+        """Admin creates policy → agent requests approval → admin approves → list."""
+        # 1. Admin creates policy with auto_approve_threshold
+        admin_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v2/pay/policies",
+                json={
+                    "agent_id": "test-agent",
+                    "daily_limit": "1000",
+                    "auto_approve_threshold": "50",
+                },
+            )
+            assert resp.status_code == 201
+            assert resp.json()["auto_approve_threshold"] == "50"
+
+        # 2. Agent requests approval
+        agent_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+            agent_id="test-agent",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=agent_app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v2/pay/approvals",
+                json={"amount": "75", "to": "vendor-x", "memo": "large purchase"},
+            )
+            assert resp.status_code == 201
+            approval = resp.json()
+            assert approval["status"] == "pending"
+            assert approval["amount"] == "75"
+            approval_id = approval["approval_id"]
+
+        # 3. Admin lists pending approvals
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v2/pay/approvals")
+            assert resp.status_code == 200
+            pending = resp.json()
+            assert len(pending) == 1
+            assert pending[0]["approval_id"] == approval_id
+
+        # 4. Admin approves
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            resp = await client.post(f"/api/v2/pay/approvals/{approval_id}/approve")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "approved"
+
+        # 5. Pending list now empty
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v2/pay/approvals")
+            assert resp.status_code == 200
+            assert len(resp.json()) == 0
+
+    @pytest.mark.asyncio
+    async def test_reject_approval(self, policy_service, mock_credits_service):
+        """Admin rejects an approval request."""
+        admin_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        # Create policy + request approval
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v2/pay/policies",
+                json={"agent_id": "test-agent", "auto_approve_threshold": "10"},
+            )
+
+        agent_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+            agent_id="test-agent",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=agent_app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v2/pay/approvals",
+                json={"amount": "50", "to": "vendor"},
+            )
+            approval_id = resp.json()["approval_id"]
+
+        # Admin rejects
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            resp = await client.post(f"/api/v2/pay/approvals/{approval_id}/reject")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_approval_endpoints_require_admin(self, policy_service, mock_credits_service):
+        """List/approve/reject require admin."""
+        agent_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=agent_app), base_url="http://test"
+        ) as client:
+            assert (await client.get("/api/v2/pay/approvals")).status_code == 403
+            assert (await client.post("/api/v2/pay/approvals/x/approve")).status_code == 403
+            assert (await client.post("/api/v2/pay/approvals/x/reject")).status_code == 403
+
+
+# =============================================================================
+# Phase 3: Rate Limit E2E Tests
+# =============================================================================
+
+
+class TestRateLimits:
+    """Policy with rate limits creates policies with rate fields."""
+
+    @pytest.mark.asyncio
+    async def test_create_policy_with_rate_limits(self, policy_service, mock_credits_service):
+        """Admin creates policy with rate limit fields."""
+        app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v2/pay/policies",
+                json={
+                    "agent_id": "rate-agent",
+                    "max_tx_per_hour": 10,
+                    "max_tx_per_day": 50,
+                    "daily_limit": "500",
+                },
+            )
+            assert resp.status_code == 201
+            data = resp.json()
+            assert data["max_tx_per_hour"] == 10
+            assert data["max_tx_per_day"] == 50
+
+    @pytest.mark.asyncio
+    async def test_budget_shows_rate_limits(self, policy_service, mock_credits_service):
+        """Budget summary includes rate limit info."""
+        admin_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v2/pay/policies",
+                json={
+                    "agent_id": "test-agent",
+                    "max_tx_per_hour": 5,
+                    "max_tx_per_day": 20,
+                },
+            )
+
+        agent_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+            agent_id="test-agent",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=agent_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v2/pay/budget")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["rate_limits"]["max_tx_per_hour"] == 5
+            assert data["rate_limits"]["max_tx_per_day"] == 20
+
+
+# =============================================================================
+# Phase 4: DSL Rules E2E Tests
+# =============================================================================
+
+
+class TestDSLRules:
+    """Policy with JSON rules creates and returns rules correctly."""
+
+    @pytest.mark.asyncio
+    async def test_create_policy_with_rules(self, policy_service, mock_credits_service):
+        """Admin creates policy with DSL rules."""
+        app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        rules = [
+            {"type": "recipient_blocklist", "recipients": ["banned-agent"]},
+            {"type": "amount_range", "min": "1", "max": "500"},
+        ]
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v2/pay/policies",
+                json={
+                    "agent_id": "rules-agent",
+                    "daily_limit": "1000",
+                    "rules": rules,
+                },
+            )
+            assert resp.status_code == 201
+            data = resp.json()
+            assert data["rules"] == rules
+
+    @pytest.mark.asyncio
+    async def test_budget_shows_has_rules(self, policy_service, mock_credits_service):
+        """Budget summary shows has_rules=True when rules configured."""
+        admin_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/v2/pay/policies",
+                json={
+                    "agent_id": "test-agent",
+                    "rules": [{"type": "recipient_blocklist", "recipients": ["x"]}],
+                },
+            )
+
+        agent_app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=False,
+            agent_id="test-agent",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=agent_app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v2/pay/budget")
+            assert resp.status_code == 200
+            assert resp.json()["has_rules"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_policies_includes_all_fields(self, policy_service, mock_credits_service):
+        """List policies returns all phase 2-4 fields."""
+        app = _create_app(
+            policy_service=policy_service,
+            mock_credits_service=mock_credits_service,
+            is_admin=True,
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await client.post(
+                "/api/v2/pay/policies",
+                json={
+                    "agent_id": "full-agent",
+                    "daily_limit": "100",
+                    "auto_approve_threshold": "25",
+                    "max_tx_per_hour": 3,
+                    "max_tx_per_day": 10,
+                    "rules": [{"type": "amount_range", "max": "50"}],
+                },
+            )
+            resp = await client.get("/api/v2/pay/policies")
+            assert resp.status_code == 200
+            policies = resp.json()
+            assert len(policies) == 1
+            p = policies[0]
+            assert p["daily_limit"] == "100"
+            assert p["auto_approve_threshold"] == "25"
+            assert p["max_tx_per_hour"] == 3
+            assert p["max_tx_per_day"] == 10
+            assert len(p["rules"]) == 1

--- a/tests/unit/pay/test_policy_rules.py
+++ b/tests/unit/pay/test_policy_rules.py
@@ -1,0 +1,204 @@
+"""Tests for Policy DSL/JSON Rules Engine (Phase 4).
+
+Issue #1358: Tests rule evaluation against transaction context.
+
+Rule types tested:
+    1. recipient_allowlist
+    2. recipient_blocklist
+    3. time_window
+    4. metadata_match
+    5. amount_range
+    6. Unknown rule types (skip gracefully)
+    7. Multiple rules (first deny short-circuits)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from nexus.pay.policy_rules import RuleContext, RuleResult, evaluate_rules
+
+
+def _ctx(
+    *,
+    agent_id: str = "agent-a",
+    zone_id: str = "default",
+    to: str = "agent-b",
+    amount: Decimal = Decimal("10"),
+    metadata: dict | None = None,
+    timestamp: datetime | None = None,
+) -> RuleContext:
+    kwargs: dict = {
+        "agent_id": agent_id,
+        "zone_id": zone_id,
+        "to": to,
+        "amount": amount,
+        "metadata": metadata or {},
+    }
+    if timestamp is not None:
+        kwargs["timestamp"] = timestamp
+    return RuleContext(**kwargs)
+
+
+class TestRecipientAllowlist:
+    def test_allowed_recipient(self):
+        rules = [{"type": "recipient_allowlist", "recipients": ["agent-b", "agent-c"]}]
+        result = evaluate_rules(rules, _ctx(to="agent-b"))
+        assert result.allowed is True
+
+    def test_blocked_recipient(self):
+        rules = [{"type": "recipient_allowlist", "recipients": ["agent-b"]}]
+        result = evaluate_rules(rules, _ctx(to="agent-x"))
+        assert result.allowed is False
+        assert "not in allowlist" in result.denied_reason
+
+    def test_empty_allowlist_allows_all(self):
+        rules = [{"type": "recipient_allowlist", "recipients": []}]
+        result = evaluate_rules(rules, _ctx(to="anyone"))
+        assert result.allowed is True
+
+
+class TestRecipientBlocklist:
+    def test_blocked_recipient(self):
+        rules = [{"type": "recipient_blocklist", "recipients": ["bad-agent"]}]
+        result = evaluate_rules(rules, _ctx(to="bad-agent"))
+        assert result.allowed is False
+        assert "blocked" in result.denied_reason
+
+    def test_allowed_recipient(self):
+        rules = [{"type": "recipient_blocklist", "recipients": ["bad-agent"]}]
+        result = evaluate_rules(rules, _ctx(to="good-agent"))
+        assert result.allowed is True
+
+
+class TestTimeWindow:
+    def test_within_window(self):
+        rules = [{"type": "time_window", "start_hour": 9, "end_hour": 17}]
+        ts = datetime(2026, 2, 13, 12, 0, 0, tzinfo=UTC)  # noon
+        result = evaluate_rules(rules, _ctx(timestamp=ts))
+        assert result.allowed is True
+
+    def test_outside_window(self):
+        rules = [{"type": "time_window", "start_hour": 9, "end_hour": 17}]
+        ts = datetime(2026, 2, 13, 20, 0, 0, tzinfo=UTC)  # 8pm
+        result = evaluate_rules(rules, _ctx(timestamp=ts))
+        assert result.allowed is False
+        assert "outside allowed hours" in result.denied_reason
+
+    def test_overnight_window_within(self):
+        rules = [{"type": "time_window", "start_hour": 22, "end_hour": 6}]
+        ts = datetime(2026, 2, 13, 23, 0, 0, tzinfo=UTC)  # 11pm
+        result = evaluate_rules(rules, _ctx(timestamp=ts))
+        assert result.allowed is True
+
+    def test_overnight_window_outside(self):
+        rules = [{"type": "time_window", "start_hour": 22, "end_hour": 6}]
+        ts = datetime(2026, 2, 13, 12, 0, 0, tzinfo=UTC)  # noon
+        result = evaluate_rules(rules, _ctx(timestamp=ts))
+        assert result.allowed is False
+
+    def test_at_start_hour_allowed(self):
+        rules = [{"type": "time_window", "start_hour": 9, "end_hour": 17}]
+        ts = datetime(2026, 2, 13, 9, 0, 0, tzinfo=UTC)
+        result = evaluate_rules(rules, _ctx(timestamp=ts))
+        assert result.allowed is True
+
+    def test_at_end_hour_denied(self):
+        rules = [{"type": "time_window", "start_hour": 9, "end_hour": 17}]
+        ts = datetime(2026, 2, 13, 17, 0, 0, tzinfo=UTC)  # end_hour is exclusive
+        result = evaluate_rules(rules, _ctx(timestamp=ts))
+        assert result.allowed is False
+
+
+class TestMetadataMatch:
+    def test_matching_metadata(self):
+        rules = [{"type": "metadata_match", "required": {"purpose": "salary"}}]
+        result = evaluate_rules(rules, _ctx(metadata={"purpose": "salary"}))
+        assert result.allowed is True
+
+    def test_mismatched_metadata(self):
+        rules = [{"type": "metadata_match", "required": {"purpose": "salary"}}]
+        result = evaluate_rules(rules, _ctx(metadata={"purpose": "bonus"}))
+        assert result.allowed is False
+        assert "must be" in result.denied_reason
+
+    def test_missing_metadata_key(self):
+        rules = [{"type": "metadata_match", "required": {"purpose": "salary"}}]
+        result = evaluate_rules(rules, _ctx(metadata={}))
+        assert result.allowed is False
+
+
+class TestAmountRange:
+    def test_within_range(self):
+        rules = [{"type": "amount_range", "min": "1", "max": "100"}]
+        result = evaluate_rules(rules, _ctx(amount=Decimal("50")))
+        assert result.allowed is True
+
+    def test_below_min(self):
+        rules = [{"type": "amount_range", "min": "10"}]
+        result = evaluate_rules(rules, _ctx(amount=Decimal("5")))
+        assert result.allowed is False
+        assert "below minimum" in result.denied_reason
+
+    def test_above_max(self):
+        rules = [{"type": "amount_range", "max": "100"}]
+        result = evaluate_rules(rules, _ctx(amount=Decimal("150")))
+        assert result.allowed is False
+        assert "above maximum" in result.denied_reason
+
+    def test_at_boundaries(self):
+        rules = [{"type": "amount_range", "min": "10", "max": "10"}]
+        result = evaluate_rules(rules, _ctx(amount=Decimal("10")))
+        assert result.allowed is True
+
+
+class TestMultipleRules:
+    def test_all_pass(self):
+        rules = [
+            {"type": "recipient_allowlist", "recipients": ["agent-b"]},
+            {"type": "amount_range", "max": "100"},
+        ]
+        result = evaluate_rules(rules, _ctx(to="agent-b", amount=Decimal("50")))
+        assert result.allowed is True
+
+    def test_first_deny_short_circuits(self):
+        rules = [
+            {"type": "recipient_blocklist", "recipients": ["agent-b"]},
+            {"type": "amount_range", "max": "100"},
+        ]
+        result = evaluate_rules(rules, _ctx(to="agent-b"))
+        assert result.allowed is False
+        assert result.matched_rule_type == "recipient_blocklist"
+
+    def test_second_rule_denies(self):
+        rules = [
+            {"type": "recipient_allowlist", "recipients": ["agent-b"]},
+            {"type": "amount_range", "max": "5"},
+        ]
+        result = evaluate_rules(rules, _ctx(to="agent-b", amount=Decimal("10")))
+        assert result.allowed is False
+        assert result.matched_rule_type == "amount_range"
+
+
+class TestUnknownRuleType:
+    def test_unknown_type_skipped(self):
+        rules = [{"type": "unknown_rule_xyz"}]
+        result = evaluate_rules(rules, _ctx())
+        assert result.allowed is True
+
+    def test_empty_rules(self):
+        result = evaluate_rules([], _ctx())
+        assert result.allowed is True
+
+
+class TestRuleResult:
+    def test_allowed_result(self):
+        r = RuleResult(allowed=True)
+        assert r.allowed is True
+        assert r.denied_reason is None
+
+    def test_denied_result(self):
+        r = RuleResult(allowed=False, denied_reason="blocked", matched_rule_type="blocklist")
+        assert r.allowed is False
+        assert r.denied_reason == "blocked"

--- a/tests/unit/pay/test_policy_wrapper.py
+++ b/tests/unit/pay/test_policy_wrapper.py
@@ -1,0 +1,262 @@
+"""Tests for PolicyEnforcedPayment wrapper.
+
+Issue #1358: Recursive wrapper (Lego Mechanism 2) that enforces
+spending policies before delegating to inner PaymentProtocol.
+
+Test categories:
+1. Protocol interface delegation (can_handle, protocol_name)
+2. Transfer allowed → delegates to inner + records spending
+3. Transfer denied → raises PolicyDeniedError, inner NOT called
+4. Error propagation from inner protocol
+5. Fire-and-forget spending recording
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.pay.audit_types import TransactionProtocol
+from nexus.pay.policy_wrapper import PolicyEnforcedPayment
+from nexus.pay.protocol import ProtocolTransferRequest, ProtocolTransferResult
+from nexus.pay.spending_policy import PolicyDeniedError, PolicyEvaluation
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_inner_protocol():
+    """Mock PaymentProtocol (inner) with sensible defaults."""
+    inner = MagicMock()
+    inner.protocol_name = TransactionProtocol.INTERNAL
+    inner.can_handle = MagicMock(return_value=True)
+    inner.transfer = AsyncMock(
+        return_value=ProtocolTransferResult(
+            protocol=TransactionProtocol.INTERNAL,
+            tx_id="tx-123",
+            amount=Decimal("10"),
+            from_agent="agent-a",
+            to="agent-b",
+        )
+    )
+    return inner
+
+
+@pytest.fixture
+def mock_policy_service():
+    """Mock SpendingPolicyService."""
+    service = AsyncMock()
+    service.evaluate = AsyncMock(return_value=PolicyEvaluation(allowed=True))
+    service.record_spending = AsyncMock()
+    service.check_approval = AsyncMock(return_value=None)
+    return service
+
+
+@pytest.fixture
+def wrapper(mock_inner_protocol, mock_policy_service):
+    """PolicyEnforcedPayment wrapper with mocked dependencies."""
+    return PolicyEnforcedPayment(inner=mock_inner_protocol, policy_service=mock_policy_service)
+
+
+def _make_request(
+    from_agent: str = "agent-a",
+    to: str = "agent-b",
+    amount: Decimal = Decimal("10"),
+    zone_id: str = "default",
+) -> ProtocolTransferRequest:
+    return ProtocolTransferRequest(
+        from_agent=from_agent,
+        to=to,
+        amount=amount,
+        metadata={"zone_id": zone_id},
+    )
+
+
+# =============================================================================
+# 1. Protocol Interface Delegation
+# =============================================================================
+
+
+class TestProtocolDelegation:
+    """Wrapper delegates protocol_name and can_handle to inner."""
+
+    def test_protocol_name_delegates(self, wrapper, mock_inner_protocol):
+        assert wrapper.protocol_name == TransactionProtocol.INTERNAL
+
+    def test_can_handle_delegates(self, wrapper, mock_inner_protocol):
+        result = wrapper.can_handle("agent-b", {"foo": "bar"})
+        assert result is True
+        mock_inner_protocol.can_handle.assert_called_once_with("agent-b", {"foo": "bar"})
+
+    def test_can_handle_returns_false(self, wrapper, mock_inner_protocol):
+        mock_inner_protocol.can_handle.return_value = False
+        assert wrapper.can_handle("unknown") is False
+
+
+# =============================================================================
+# 2. Transfer Allowed
+# =============================================================================
+
+
+class TestTransferAllowed:
+    """When policy allows, wrapper delegates to inner and records spending."""
+
+    @pytest.mark.asyncio
+    async def test_transfer_delegates_to_inner(
+        self, wrapper, mock_inner_protocol, mock_policy_service
+    ):
+        request = _make_request()
+        result = await wrapper.transfer(request)
+
+        assert result.tx_id == "tx-123"
+        mock_inner_protocol.transfer.assert_called_once_with(request)
+        mock_policy_service.evaluate.assert_called_once_with(
+            agent_id="agent-a",
+            zone_id="default",
+            amount=Decimal("10"),
+            to="agent-b",
+            metadata={"zone_id": "default"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_records_spending_on_success(self, wrapper, mock_policy_service):
+        """After successful transfer, spending is recorded."""
+        request = _make_request()
+        await wrapper.transfer(request)
+
+        # Give the fire-and-forget task a moment
+        import asyncio
+
+        await asyncio.sleep(0.01)
+
+        mock_policy_service.record_spending.assert_called_once_with(
+            agent_id="agent-a",
+            zone_id="default",
+            amount=Decimal("10"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_uses_zone_from_metadata(self, wrapper, mock_policy_service):
+        """Zone ID is extracted from request metadata."""
+        request = _make_request(zone_id="custom-zone")
+        await wrapper.transfer(request)
+
+        mock_policy_service.evaluate.assert_called_once_with(
+            agent_id="agent-a",
+            zone_id="custom-zone",
+            amount=Decimal("10"),
+            to="agent-b",
+            metadata={"zone_id": "custom-zone"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_zone_when_no_metadata(
+        self, wrapper, mock_policy_service, mock_inner_protocol
+    ):
+        """Uses 'default' zone when metadata is empty."""
+        request = ProtocolTransferRequest(
+            from_agent="agent-a",
+            to="agent-b",
+            amount=Decimal("10"),
+        )
+        await wrapper.transfer(request)
+
+        mock_policy_service.evaluate.assert_called_once_with(
+            agent_id="agent-a",
+            zone_id="default",
+            amount=Decimal("10"),
+            to="agent-b",
+            metadata={},
+        )
+
+
+# =============================================================================
+# 3. Transfer Denied
+# =============================================================================
+
+
+class TestTransferDenied:
+    """When policy denies, wrapper raises PolicyDeniedError and does NOT call inner."""
+
+    @pytest.mark.asyncio
+    async def test_raises_policy_denied(self, wrapper, mock_inner_protocol, mock_policy_service):
+        mock_policy_service.evaluate.return_value = PolicyEvaluation(
+            allowed=False,
+            denied_reason="Exceeds daily limit",
+            policy_id="p1",
+        )
+
+        with pytest.raises(PolicyDeniedError) as exc_info:
+            await wrapper.transfer(_make_request())
+
+        assert "daily limit" in str(exc_info.value)
+        assert exc_info.value.policy_id == "p1"
+        mock_inner_protocol.transfer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_spending_recorded_on_denial(self, wrapper, mock_policy_service):
+        mock_policy_service.evaluate.return_value = PolicyEvaluation(
+            allowed=False, denied_reason="Over budget"
+        )
+
+        with pytest.raises(PolicyDeniedError):
+            await wrapper.transfer(_make_request())
+
+        mock_policy_service.record_spending.assert_not_called()
+
+
+# =============================================================================
+# 4. Error Propagation
+# =============================================================================
+
+
+class TestErrorPropagation:
+    """Errors from inner protocol propagate without spending recorded."""
+
+    @pytest.mark.asyncio
+    async def test_inner_error_propagates(self, wrapper, mock_inner_protocol, mock_policy_service):
+        from nexus.pay.protocol import ProtocolError
+
+        mock_inner_protocol.transfer.side_effect = ProtocolError("TigerBeetle down")
+
+        with pytest.raises(ProtocolError, match="TigerBeetle down"):
+            await wrapper.transfer(_make_request())
+
+    @pytest.mark.asyncio
+    async def test_no_spending_on_inner_error(
+        self, wrapper, mock_inner_protocol, mock_policy_service
+    ):
+        from nexus.pay.credits import InsufficientCreditsError
+
+        mock_inner_protocol.transfer.side_effect = InsufficientCreditsError("No balance")
+
+        with pytest.raises(InsufficientCreditsError):
+            await wrapper.transfer(_make_request())
+
+        # Wait for any potential fire-and-forget tasks
+        import asyncio
+
+        await asyncio.sleep(0.01)
+
+        mock_policy_service.record_spending.assert_not_called()
+
+
+# =============================================================================
+# 5. Multiple Sequential Transfers
+# =============================================================================
+
+
+class TestSequentialTransfers:
+    """Multiple transfers accumulate correctly."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_transfers_evaluate_independently(self, wrapper, mock_policy_service):
+        """Each transfer triggers its own evaluation."""
+        for i in range(3):
+            await wrapper.transfer(_make_request(amount=Decimal(str(i + 1))))
+
+        assert mock_policy_service.evaluate.call_count == 3

--- a/tests/unit/pay/test_spending_policy.py
+++ b/tests/unit/pay/test_spending_policy.py
@@ -1,0 +1,431 @@
+"""Tests for spending policy data models and evaluation logic.
+
+Issue #1358: Agent Spending Policy Engine — Phase 1.
+
+Test categories:
+1. Data model construction and immutability
+2. Exception hierarchy
+3. Policy evaluation via SpendingPolicyService.evaluate()
+4. Policy resolution (agent-specific → zone default → no policy)
+5. Period-based spending checks
+6. Edge cases
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.pay.sdk import NexusPayError
+from nexus.pay.spending_policy import (
+    ApprovalRequiredError,
+    PolicyDeniedError,
+    PolicyError,
+    PolicyEvaluation,
+    SpendingLedgerEntry,
+    SpendingPolicy,
+    SpendingRateLimitError,
+)
+
+# =============================================================================
+# 1. Data Model Tests
+# =============================================================================
+
+
+class TestSpendingPolicy:
+    """SpendingPolicy frozen dataclass tests."""
+
+    def test_create_minimal(self):
+        policy = SpendingPolicy(policy_id="p1", zone_id="default")
+        assert policy.policy_id == "p1"
+        assert policy.zone_id == "default"
+        assert policy.agent_id is None
+        assert policy.daily_limit is None
+        assert policy.per_tx_limit is None
+        assert policy.priority == 0
+        assert policy.enabled is True
+
+    def test_create_full(self):
+        policy = SpendingPolicy(
+            policy_id="p2",
+            zone_id="zone-1",
+            agent_id="agent-a",
+            daily_limit=Decimal("100"),
+            weekly_limit=Decimal("500"),
+            monthly_limit=Decimal("2000"),
+            per_tx_limit=Decimal("50"),
+            auto_approve_threshold=Decimal("10"),
+            priority=5,
+            enabled=True,
+        )
+        assert policy.agent_id == "agent-a"
+        assert policy.daily_limit == Decimal("100")
+        assert policy.weekly_limit == Decimal("500")
+        assert policy.monthly_limit == Decimal("2000")
+        assert policy.per_tx_limit == Decimal("50")
+        assert policy.priority == 5
+
+    def test_frozen(self):
+        policy = SpendingPolicy(policy_id="p1", zone_id="default")
+        with pytest.raises(AttributeError):
+            policy.daily_limit = Decimal("100")  # type: ignore[misc]
+
+
+class TestSpendingLedgerEntry:
+    """SpendingLedgerEntry frozen dataclass tests."""
+
+    def test_create_with_defaults(self):
+        entry = SpendingLedgerEntry(
+            agent_id="agent-a",
+            zone_id="default",
+            period_type="daily",
+            period_start=date.today(),
+        )
+        assert entry.amount_spent == Decimal("0")
+        assert entry.tx_count == 0
+
+    def test_frozen(self):
+        entry = SpendingLedgerEntry(
+            agent_id="a", zone_id="z", period_type="daily", period_start=date.today()
+        )
+        with pytest.raises(AttributeError):
+            entry.amount_spent = Decimal("10")  # type: ignore[misc]
+
+
+class TestPolicyEvaluation:
+    """PolicyEvaluation frozen dataclass tests."""
+
+    def test_allowed(self):
+        ev = PolicyEvaluation(allowed=True, policy_id="p1")
+        assert ev.allowed is True
+        assert ev.denied_reason is None
+
+    def test_denied(self):
+        ev = PolicyEvaluation(
+            allowed=False,
+            denied_reason="Over daily limit",
+            policy_id="p1",
+        )
+        assert ev.allowed is False
+        assert ev.denied_reason == "Over daily limit"
+
+    def test_remaining_budget(self):
+        ev = PolicyEvaluation(
+            allowed=True,
+            remaining_budget={"daily": Decimal("42.50"), "monthly": Decimal("1500")},
+        )
+        assert ev.remaining_budget["daily"] == Decimal("42.50")
+
+
+# =============================================================================
+# 2. Exception Hierarchy Tests
+# =============================================================================
+
+
+class TestExceptionHierarchy:
+    """Verify exception inheritance chain."""
+
+    def test_policy_error_is_nexuspay_error(self):
+        assert issubclass(PolicyError, NexusPayError)
+
+    def test_policy_denied_is_policy_error(self):
+        assert issubclass(PolicyDeniedError, PolicyError)
+
+    def test_approval_required_is_policy_error(self):
+        assert issubclass(ApprovalRequiredError, PolicyError)
+
+    def test_rate_limit_is_policy_error(self):
+        assert issubclass(SpendingRateLimitError, PolicyError)
+
+    def test_policy_denied_has_policy_id(self):
+        err = PolicyDeniedError("Over limit", policy_id="p1")
+        assert err.policy_id == "p1"
+        assert err.denied_reason == "Over limit"
+        assert str(err) == "Over limit"
+
+    def test_catch_all_policy_errors(self):
+        """All policy exceptions can be caught with `except PolicyError`."""
+        for exc_cls in (PolicyDeniedError, ApprovalRequiredError, SpendingRateLimitError):
+            with pytest.raises(PolicyError):
+                raise exc_cls("test")
+
+
+# =============================================================================
+# 3. Policy Evaluation Tests (via SpendingPolicyService)
+# =============================================================================
+
+
+class TestPolicyEvaluationLogic:
+    """Test evaluate() method on SpendingPolicyService."""
+
+    @pytest.fixture
+    def mock_session_factory(self):
+        """Mock async session factory."""
+        session = AsyncMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        session.begin = MagicMock(
+            return_value=AsyncMock(
+                __aenter__=AsyncMock(),
+                __aexit__=AsyncMock(return_value=False),
+            )
+        )
+        session.execute = AsyncMock()
+
+        factory = MagicMock()
+        factory.return_value = session
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+        return factory
+
+    @pytest.fixture
+    def service(self, mock_session_factory):
+        from nexus.pay.spending_policy_service import SpendingPolicyService
+
+        return SpendingPolicyService(session_factory=mock_session_factory)
+
+    @pytest.mark.asyncio
+    async def test_no_policy_allows_transfer(self, service):
+        """No policy = open by default."""
+        # Prepopulate cache with no policy
+        import time
+
+        service._cache[("agent-a", "default")] = (None, time.monotonic() + 60)
+
+        result = await service.evaluate("agent-a", "default", Decimal("1000"))
+        assert result.allowed is True
+        assert result.policy_id is None
+
+    @pytest.mark.asyncio
+    async def test_per_tx_limit_exceeded(self, service):
+        """Per-tx limit blocks single large transaction."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            per_tx_limit=Decimal("10"),
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+
+        result = await service.evaluate("agent-a", "default", Decimal("15"))
+        assert result.allowed is False
+        assert "per-transaction limit" in result.denied_reason
+        assert result.policy_id == "p1"
+
+    @pytest.mark.asyncio
+    async def test_per_tx_limit_within_budget(self, service):
+        """Transfer within per-tx limit is allowed."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            per_tx_limit=Decimal("10"),
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+
+        # Mock _get_spending to return zero
+        service._get_spending = AsyncMock(
+            return_value={"daily": Decimal("0"), "weekly": Decimal("0"), "monthly": Decimal("0")}
+        )
+
+        result = await service.evaluate("agent-a", "default", Decimal("5"))
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_exceeded(self, service):
+        """Daily limit blocks when cumulative spend exceeds limit."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            daily_limit=Decimal("100"),
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+        service._get_spending = AsyncMock(
+            return_value={"daily": Decimal("95"), "weekly": Decimal("0"), "monthly": Decimal("0")}
+        )
+
+        result = await service.evaluate("agent-a", "default", Decimal("10"))
+        assert result.allowed is False
+        assert "daily limit" in result.denied_reason
+        assert result.remaining_budget.get("daily") == Decimal("5")
+
+    @pytest.mark.asyncio
+    async def test_weekly_limit_exceeded(self, service):
+        """Weekly limit blocks when cumulative spend exceeds limit."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            weekly_limit=Decimal("500"),
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+        service._get_spending = AsyncMock(
+            return_value={"daily": Decimal("0"), "weekly": Decimal("495"), "monthly": Decimal("0")}
+        )
+
+        result = await service.evaluate("agent-a", "default", Decimal("10"))
+        assert result.allowed is False
+        assert "weekly limit" in result.denied_reason
+
+    @pytest.mark.asyncio
+    async def test_monthly_limit_exceeded(self, service):
+        """Monthly limit blocks when cumulative spend exceeds limit."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            monthly_limit=Decimal("2000"),
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+        service._get_spending = AsyncMock(
+            return_value={"daily": Decimal("0"), "weekly": Decimal("0"), "monthly": Decimal("1995")}
+        )
+
+        result = await service.evaluate("agent-a", "default", Decimal("10"))
+        assert result.allowed is False
+        assert "monthly limit" in result.denied_reason
+
+    @pytest.mark.asyncio
+    async def test_all_limits_within_budget(self, service):
+        """Transfer within all limits is allowed with remaining budget info."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            daily_limit=Decimal("100"),
+            weekly_limit=Decimal("500"),
+            monthly_limit=Decimal("2000"),
+            per_tx_limit=Decimal("50"),
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+        service._get_spending = AsyncMock(
+            return_value={
+                "daily": Decimal("20"),
+                "weekly": Decimal("100"),
+                "monthly": Decimal("500"),
+            }
+        )
+
+        result = await service.evaluate("agent-a", "default", Decimal("10"))
+        assert result.allowed is True
+        assert result.remaining_budget["daily"] == Decimal("80")
+        assert result.remaining_budget["weekly"] == Decimal("400")
+        assert result.remaining_budget["monthly"] == Decimal("1500")
+
+    @pytest.mark.asyncio
+    async def test_disabled_policy_allows_all(self, service):
+        """Disabled policy does not enforce limits."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            per_tx_limit=Decimal("1"),
+            enabled=False,
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+
+        result = await service.evaluate("agent-a", "default", Decimal("1000"))
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_none_limits_allow_all(self, service):
+        """Policy with all None limits allows everything."""
+        import time
+
+        policy = SpendingPolicy(policy_id="p1", zone_id="default", agent_id="agent-a")
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+        service._get_spending = AsyncMock(
+            return_value={"daily": Decimal("0"), "weekly": Decimal("0"), "monthly": Decimal("0")}
+        )
+
+        result = await service.evaluate("agent-a", "default", Decimal("999999"))
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_exact_limit_amount_allowed(self, service):
+        """Transfer exactly at the limit should be allowed (not >)."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            per_tx_limit=Decimal("10"),
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+        service._get_spending = AsyncMock(
+            return_value={"daily": Decimal("0"), "weekly": Decimal("0"), "monthly": Decimal("0")}
+        )
+
+        result = await service.evaluate("agent-a", "default", Decimal("10"))
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_exact_daily_limit_with_spending(self, service):
+        """Transfer that would exactly hit the daily limit is allowed."""
+        import time
+
+        policy = SpendingPolicy(
+            policy_id="p1",
+            zone_id="default",
+            agent_id="agent-a",
+            daily_limit=Decimal("100"),
+        )
+        service._cache[("agent-a", "default")] = (policy, time.monotonic() + 60)
+        service._get_spending = AsyncMock(
+            return_value={"daily": Decimal("90"), "weekly": Decimal("0"), "monthly": Decimal("0")}
+        )
+
+        # 90 + 10 = 100, exactly at limit
+        result = await service.evaluate("agent-a", "default", Decimal("10"))
+        assert result.allowed is True
+
+
+# =============================================================================
+# 4. Period Calculation Tests
+# =============================================================================
+
+
+class TestPeriodCalculation:
+    """Test _current_period_start helper."""
+
+    def test_daily_period(self):
+        from nexus.pay.spending_policy_service import _current_period_start
+
+        assert _current_period_start("daily") == date.today()
+
+    def test_weekly_period_monday(self):
+        from nexus.pay.spending_policy_service import _current_period_start
+
+        result = _current_period_start("weekly", ref=date(2026, 2, 11))  # Wednesday
+        assert result == date(2026, 2, 9)  # Monday
+
+    def test_monthly_period(self):
+        from nexus.pay.spending_policy_service import _current_period_start
+
+        result = _current_period_start("monthly", ref=date(2026, 2, 15))
+        assert result == date(2026, 2, 1)
+
+    def test_unknown_period_raises(self):
+        from nexus.pay.spending_policy_service import _current_period_start
+
+        with pytest.raises(ValueError, match="Unknown period_type"):
+            _current_period_start("hourly")


### PR DESCRIPTION
## Summary

Implements the full Spending Policy Engine (Issue #1358) across 4 phases:

- **Phase 1**: Core policy engine with per-tx/daily/weekly/monthly spending limits, `PolicyEnforcedPayment` wrapper (recursive Lego Mechanism 2), CRUD endpoints, budget summary, and spending ledger with fire-and-forget async recording
- **Phase 2**: Approval workflows with `auto_approve_threshold`, request/approve/reject lifecycle, admin-only endpoints, `ApprovalRequiredError` → HTTP 402
- **Phase 3**: Transaction rate controls with `max_tx_per_hour` (in-memory sliding window) and `max_tx_per_day` (auto-resetting daily counter), `SpendingRateLimitError` → HTTP 429, budget summary includes rate limit info
- **Phase 4**: DSL/JSON rules engine with 5 rule types (recipient allowlist/blocklist, time window, metadata match, amount range), sequential evaluation with first-deny short-circuit

### Key Design Decisions
- Open by default: no policy = allow all transactions
- Hot path ~1.2ms: cache-first (60s TTL) → single indexed query → in-memory rule eval
- Frozen dataclasses for all domain objects (immutable)
- Fire-and-forget ledger writes don't block transfer response
- Admin-only: policy CRUD, approval list/approve/reject
- Agent-accessible: budget query, approval request, transfers

### Stream 8

## Test plan
- [x] 370 unit tests pass (all `tests/unit/pay/`)
- [x] 16 Phase 1 e2e tests pass (budget, CRUD, policy denial, concurrent transfers, zone resolution)
- [x] 10 Phase 2-4 e2e tests pass (approval lifecycle, rate limits, DSL rules)
- [x] 23 NexusPay SDK e2e tests pass (transfer, reserve, meter, x402, batch)
- [x] 20 NexusPay server e2e tests pass (auth, permissions, agent-scoped operations)
- [x] Permission enforcement verified: 6 admin-only endpoints return 403 for agents
- [x] Ruff lint clean
- [x] Mypy clean (0 errors in 6 source files)
- [x] No performance regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)