### PR TITLE
feat(#1192): Contextual chunking with surrounding context

### DIFF
--- a/src/nexus/search/contextual_chunking.py
+++ b/src/nexus/search/contextual_chunking.py
@@ -312,10 +312,7 @@ def _heuristic_context(
     when the LLM is unavailable, at zero API cost.
     """
     # 1. Position context
-    if position == 0:
-        position_text = "Opening section"
-    else:
-        position_text = f"Section {position + 1}"
+    position_text = "Opening section" if position == 0 else f"Section {position + 1}"
 
     # 2. Extract entities from chunk (capitalized multi-word phrases)
     entities = list(dict.fromkeys(_CAPITALIZED_WORDS.findall(chunk_text)))[:5]
@@ -367,7 +364,7 @@ def create_heuristic_generator() -> ContextGenerator:
         doc_summary: str,
         chunk_text: str,
         prev_chunks: list[str],
-        next_chunks: list[str],
+        _next_chunks: list[str],
     ) -> ChunkContext:
         # Position is not directly available here, but we can infer from prev_chunks
         position = len(prev_chunks)

--- a/tests/e2e/test_contextual_chunking_e2e.py
+++ b/tests/e2e/test_contextual_chunking_e2e.py
@@ -38,12 +38,11 @@ SMALL_CHUNKER = DocumentChunker(chunk_size=40, strategy=ChunkStrategy.FIXED)
 async def _create_tables_and_path(db_url: str, async_session_factory, virtual_path: str, size: int) -> str:
     """Create DB tables and insert a file_paths row via ORM. Returns the path_id."""
     from sqlalchemy.ext.asyncio import create_async_engine
-    from nexus.storage.models._base import Base
-    from nexus.storage.models.file_path import FilePathModel
 
-    # Import models so their tables are registered on Base.metadata
     import nexus.storage.models.file_path  # noqa: F401
     import nexus.storage.models.filesystem  # noqa: F401
+    from nexus.storage.models._base import Base
+    from nexus.storage.models.file_path import FilePathModel
 
     engine = create_async_engine(db_url)
     async with engine.begin() as conn:

--- a/tests/unit/search/test_contextual_chunking.py
+++ b/tests/unit/search/test_contextual_chunking.py
@@ -26,7 +26,6 @@ from nexus.search.contextual_chunking import (
     create_heuristic_generator,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -569,7 +568,7 @@ class TestCreateContextGenerator:
         mock_llm = AsyncMock(return_value="not valid json")
         gen = await create_context_generator(mock_llm)
 
-        with pytest.raises(Exception):  # ValidationError or JSONDecodeError
+        with pytest.raises((ValueError, KeyError)):
             await gen("summary", "chunk", [], [])
 
 


### PR DESCRIPTION
## Summary

- Implements Anthropic's Contextual Retrieval pattern — enriches each document chunk with LLM-generated situating context before embedding, making chunks self-contained
- Adds `ContextualChunker` with callable `context_generator` (no direct LLM coupling), bounded parallelism via `asyncio.Semaphore`, single retry + heuristic fallback
- Adds heuristic context generator (rule-based, zero API cost) using markdown headings, capitalized entity extraction, and position info
- Fixes double-chunking performance bug in `async_search.py` and `semantic.py`; pre-computes JSON serialization outside insert loops
- Adds Alembic migration for `chunk_context`, `chunk_position`, `source_document_id` columns on `document_chunks`
- Adds comprehensive documentation in `docs/api/semantic-search.md`

## Files Changed

| File | Change |
|------|--------|
| `src/nexus/search/contextual_chunking.py` | New — core module with data models, chunker, heuristic fallback, LLM generator factory |
| `src/nexus/search/async_search.py` | Fixed double-chunking, integrated contextual chunking path |
| `src/nexus/search/semantic.py` | Fixed double-chunking, integrated contextual chunking path |
| `src/nexus/search/__init__.py` | Added public exports for all contextual chunking types |
| `src/nexus/services/search_service.py` | Added `contextual_chunking` and `context_generator` params |
| `src/nexus/storage/models/filesystem.py` | Added 3 nullable columns + index to `DocumentChunkModel` |
| `alembic/versions/add_contextual_chunk_fields.py` | Migration for new columns |
| `docs/api/semantic-search.md` | Contextual chunking documentation section |

## Test plan

- [x] 37 unit tests — data models, happy path, failure modes, concurrency, heuristic generator
- [x] 4 integration tests — full pipeline, embedding text, separate storage, backwards compatibility
- [x] 10 e2e tests — direct chunker, async search integration, performance benchmarks
- [ ] Server permission e2e tests (require Rust `nexus_raft` build — will run in CI)
- [ ] CI pipeline passes

Closes #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)