### PR TITLE
feat(#1243): VFS-based IPC storage drivers for agent messaging

### DIFF
--- a/src/nexus/ipc/delivery.py
+++ b/src/nexus/ipc/delivery.py
@@ -191,7 +191,10 @@ class MessageSender:
             )
 
         # CANCEL and RESPONSE must have correlation_id
-        if envelope.type in (MessageType.RESPONSE, MessageType.CANCEL) and not envelope.correlation_id:
+        if (
+            envelope.type in (MessageType.RESPONSE, MessageType.CANCEL)
+            and not envelope.correlation_id
+        ):
             raise EnvelopeValidationError(
                 f"Messages of type '{envelope.type.value}' require a correlation_id"
             )

--- a/src/nexus/ipc/driver.py
+++ b/src/nexus/ipc/driver.py
@@ -84,11 +84,13 @@ class IPCVFSDriver(Backend):
 
     # === Connection (no-op for IPC) ===
 
-    def connect(self, context: OperationContext | None = None) -> HandlerStatusResponse:        return HandlerStatusResponse(success=True, details={"backend": "ipc"})
+    def connect(self, context: OperationContext | None = None) -> HandlerStatusResponse:
+        return HandlerStatusResponse(success=True, details={"backend": "ipc"})
 
     # === Content Operations (path-oriented virtual FS) ===
 
-    def write_content(        self,
+    def write_content(
+        self,
         content: bytes,
         context: OperationContext | None = None,
     ) -> HandlerResponse[str]:
@@ -100,16 +102,13 @@ class IPCVFSDriver(Backend):
         """
         content_hash = hashlib.sha256(content).hexdigest()
         try:
-            self._run_async(
-                self._storage.write(f"/_cas/{content_hash}", content, self._zone_id)
-            )
+            self._run_async(self._storage.write(f"/_cas/{content_hash}", content, self._zone_id))
             return HandlerResponse.ok(data=content_hash, backend_name="ipc")
         except Exception as exc:
-            return HandlerResponse.error(
-                message=str(exc), code=500, backend_name="ipc"
-            )
+            return HandlerResponse.error(message=str(exc), code=500, backend_name="ipc")
 
-    def write_path(        self,
+    def write_path(
+        self,
         path: str,
         content: bytes,
         context: OperationContext | None = None,
@@ -125,11 +124,10 @@ class IPCVFSDriver(Backend):
             return HandlerResponse.ok(data=content_hash, backend_name="ipc", path=path)
         except Exception as exc:
             logger.error("IPC write failed at %s: %s", path, exc)
-            return HandlerResponse.error(
-                message=str(exc), code=500, backend_name="ipc", path=path
-            )
+            return HandlerResponse.error(message=str(exc), code=500, backend_name="ipc", path=path)
 
-    def read_content(        self,
+    def read_content(
+        self,
         content_hash: str,
         context: OperationContext | None = None,
     ) -> HandlerResponse[bytes]:
@@ -150,18 +148,18 @@ class IPCVFSDriver(Backend):
                 path=path,
             )
         except Exception as exc:
-            return HandlerResponse.error(
-                message=str(exc), code=500, backend_name="ipc", path=path
-            )
+            return HandlerResponse.error(message=str(exc), code=500, backend_name="ipc", path=path)
 
-    def delete_content(        self,
+    def delete_content(
+        self,
         content_hash: str,
         context: OperationContext | None = None,
     ) -> HandlerResponse[None]:
         """Delete content — IPC never hard-deletes (moves to dead_letter)."""
         return HandlerResponse.ok(data=None, backend_name="ipc")
 
-    def content_exists(        self,
+    def content_exists(
+        self,
         content_hash: str,
         context: OperationContext | None = None,
     ) -> HandlerResponse[bool]:
@@ -171,11 +169,10 @@ class IPCVFSDriver(Backend):
             exists = self._run_async(self._storage.exists(path, self._zone_id))
             return HandlerResponse.ok(data=exists, backend_name="ipc", path=path)
         except Exception as exc:
-            return HandlerResponse.error(
-                message=str(exc), code=500, backend_name="ipc", path=path
-            )
+            return HandlerResponse.error(message=str(exc), code=500, backend_name="ipc", path=path)
 
-    def get_content_size(        self,
+    def get_content_size(
+        self,
         content_hash: str,
         context: OperationContext | None = None,
     ) -> HandlerResponse[int]:
@@ -193,11 +190,10 @@ class IPCVFSDriver(Backend):
                 path=path,
             )
         except Exception as exc:
-            return HandlerResponse.error(
-                message=str(exc), code=500, backend_name="ipc", path=path
-            )
+            return HandlerResponse.error(message=str(exc), code=500, backend_name="ipc", path=path)
 
-    def get_ref_count(        self,
+    def get_ref_count(
+        self,
         content_hash: str,
         context: OperationContext | None = None,
     ) -> HandlerResponse[int]:
@@ -206,7 +202,8 @@ class IPCVFSDriver(Backend):
 
     # === Directory Operations ===
 
-    def mkdir(        self,
+    def mkdir(
+        self,
         path: str,
         parents: bool = False,
         exist_ok: bool = False,
@@ -217,11 +214,10 @@ class IPCVFSDriver(Backend):
             self._run_async(self._storage.mkdir(path, self._zone_id))
             return HandlerResponse.ok(data=None, backend_name="ipc", path=path)
         except Exception as exc:
-            return HandlerResponse.error(
-                message=str(exc), code=500, backend_name="ipc", path=path
-            )
+            return HandlerResponse.error(message=str(exc), code=500, backend_name="ipc", path=path)
 
-    def rmdir(        self,
+    def rmdir(
+        self,
         path: str,
         recursive: bool = False,
         context: OperationContext | EnhancedOperationContext | None = None,
@@ -235,7 +231,8 @@ class IPCVFSDriver(Backend):
             path=path,
         )
 
-    def is_directory(        self,
+    def is_directory(
+        self,
         path: str,
         context: OperationContext | None = None,
     ) -> HandlerResponse[bool]:
@@ -250,7 +247,8 @@ class IPCVFSDriver(Backend):
         except Exception:
             return HandlerResponse.ok(data=False, backend_name="ipc", path=path)
 
-    def list_dir(        self,
+    def list_dir(
+        self,
         path: str,
         context: OperationContext | None = None,
     ) -> list[str]:

--- a/tests/unit/ipc/fakes.py
+++ b/tests/unit/ipc/fakes.py
@@ -101,12 +101,12 @@ class InMemoryStorageDriver:
         results: list[str] = []
         for (fpath, fzone), _ in self._files.items():
             if fzone == zone_id and fpath.startswith(prefix):
-                rest = fpath[len(prefix):]
+                rest = fpath[len(prefix) :]
                 if "/" not in rest:
                     results.append(rest)
         for dpath, dzone in self._dirs:
             if dzone == zone_id and dpath.startswith(prefix):
-                rest = dpath[len(prefix):]
+                rest = dpath[len(prefix) :]
                 if "/" not in rest and rest:
                     results.append(rest)
         return sorted(set(results))

--- a/tests/unit/ipc/test_driver.py
+++ b/tests/unit/ipc/test_driver.py
@@ -181,9 +181,7 @@ class TestIPCVFSDriverWriteContent:
         card = json.dumps({"name": "agent:bob", "status": "idle"}).encode()
 
         # Writing to a specific path (via write_path helper)
-        response = driver.write_path(
-            f"{AGENTS_ROOT}/agent:bob/AGENT.json", card
-        )
+        response = driver.write_path(f"{AGENTS_ROOT}/agent:bob/AGENT.json", card)
         assert response.success
 
         # Verify it was written


### PR DESCRIPTION
## Summary

- **IPCStorageDriver Protocol**: Pluggable async storage interface with 7 methods (`read`, `write`, `list_dir`, `count_dir`, `rename`, `mkdir`, `exists`)
- **VFSStorageDriver**: Thin adapter delegating to existing `VFSOperations`
- **PostgreSQLStorageDriver**: SQL-backed driver using asyncpg with `ipc_messages` table, upsert writes, directory markers, and indexed lookups
- **IPCVFSDriver**: `Backend` ABC implementation mounted at `/agents/`, bridges sync Backend interface with async storage via long-lived background event loop
- **Performance optimizations**: Sweeper filename timestamp skip (P1), Discovery TTL cache ~959x speedup (P2), `count_dir` backpressure without listing (P3)
- **Hardening**: Path traversal rejection, payload size limits, `correlation_id` required for CANCEL/RESPONSE, serialization-once optimization

**Stream**: 10

## Test plan

- [x] 137 unit tests (IPCVFSDriver, PostgreSQLStorageDriver, VFSStorageDriver, protocol conformance, delivery validations, sweep lifecycle)
- [x] 8 integration tests (full round-trip, bidirectional, provisioning, discovery, dead letter, TTL sweep, backpressure)
- [x] 7 E2E tests through real FastAPI server with `--auth-type database --init` and `NEXUS_ENFORCE_PERMISSIONS=true`
- [x] Ruff lint clean
- [x] mypy type check clean (14 source files, 0 errors)
- [x] All 152 tests passing

Closes #1243