### PR TITLE
perf(#1298): batch-optimize top 5 N+1 query paths

### DIFF
--- a/src/nexus/core/async_nexus_fs.py
+++ b/src/nexus/core/async_nexus_fs.py
@@ -740,33 +740,69 @@ class AsyncNexusFS:
         """
         Read multiple files in batch.
 
+        Uses batch permission filtering and batch metadata lookup to avoid
+        N+1 query patterns (Issue #1298). Denied paths return None instead
+        of raising, matching list_dir's filter-then-return pattern.
+
         Args:
             paths: List of virtual paths to read
             context: Operation context for permission checking
 
         Returns:
-            Dict mapping path to content (or None if not found)
+            Dict mapping path to content (or None if not found/denied)
         """
+        import time as _time
+
+        _start = _time.perf_counter()
         result: dict[str, bytes | None] = {}
 
-        # Check READ permission for all paths (Phase 4 - Issue #940)
-        for path in paths:
-            validated_path = self._validate_path(path)
-            await self._acheck_permission(validated_path, Permission.READ, context)
+        # Validate all paths upfront
+        validated_paths = [self._validate_path(p) for p in paths]
 
-        # Get metadata for all paths
+        # Batch permission filter (Issue #1298: replaces N individual checks)
+        readable_paths = validated_paths
+        if self._enforce_permissions and self._permission_enforcer:
+            ctx = self._get_context(context)
+            if not ctx.is_system and not ctx.is_admin:
+                _perm_start = _time.perf_counter()
+                allowed = await self._permission_enforcer.filter_paths_by_permission(
+                    validated_paths, ctx
+                )
+                allowed_set = set(allowed)
+                denied_count = 0
+                for vp in validated_paths:
+                    if vp not in allowed_set:
+                        result[vp] = None
+                        denied_count += 1
+                readable_paths = [vp for vp in validated_paths if vp in allowed_set]
+                _perm_elapsed = (_time.perf_counter() - _perm_start) * 1000
+                if denied_count > 0:
+                    logger.debug(
+                        f"[BATCH-OPT] batch_read permission filter: "
+                        f"{len(readable_paths)} allowed, {denied_count} denied "
+                        f"in {_perm_elapsed:.1f}ms"
+                    )
+
+        if not readable_paths:
+            return result
+
+        # Batch metadata lookup (Issue #1298: replaces N individual aget() calls)
+        _meta_start = _time.perf_counter()
+        batch_meta = await self.metadata.aget_batch(readable_paths)
+        _meta_elapsed = (_time.perf_counter() - _meta_start) * 1000
+
+        # Build etag-to-paths map from batch results
         etag_to_paths: dict[str, list[str]] = {}
-        for path in paths:
-            path = self._validate_path(path)
-            meta = await self.metadata.aget(path)
+        for rp in readable_paths:
+            meta = batch_meta.get(rp)
             if meta is None or meta.etag is None:
-                result[path] = None
+                result[rp] = None
             else:
                 if meta.etag not in etag_to_paths:
                     etag_to_paths[meta.etag] = []
-                etag_to_paths[meta.etag].append(path)
+                etag_to_paths[meta.etag].append(rp)
 
-        # Batch read content by etag
+        # Batch read content by etag (already batched)
         if etag_to_paths:
             content_results = await self.backend.batch_read_content(list(etag_to_paths.keys()))
 
@@ -776,4 +812,9 @@ class AsyncNexusFS:
                 for file_path in file_paths:
                     result[file_path] = content
 
+        _total_elapsed = (_time.perf_counter() - _start) * 1000
+        logger.debug(
+            f"[BATCH-OPT] batch_read: {len(paths)} paths, "
+            f"meta={_meta_elapsed:.1f}ms, total={_total_elapsed:.1f}ms"
+        )
         return result

--- a/tests/e2e/test_batch_optimization_e2e.py
+++ b/tests/e2e/test_batch_optimization_e2e.py
@@ -1,0 +1,370 @@
+"""E2E tests for batch optimization (Issue #1298).
+
+Starts a real `nexus serve` process with:
+- NEXUS_ENFORCE_PERMISSIONS=true (ReBAC enforced)
+- Multi-key static auth (admin + alice + bob)
+
+Validates that:
+1. batch_read with mixed permissions returns correct data for allowed, None for denied
+2. list with permissions filters correctly
+3. No performance regression from batch optimizations
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+# === Helpers ===
+
+PYTHON = sys.executable
+SERVER_STARTUP_TIMEOUT = 30
+
+ADMIN_API_KEY = "sk-admin-batch-e2e"
+ALICE_API_KEY = "sk-alice-batch-e2e"
+BOB_API_KEY = "sk-bob-batch-e2e"
+
+# Clear proxy env vars
+for _key in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+    os.environ.pop(_key, None)
+os.environ["NO_PROXY"] = "*"
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _make_client() -> httpx.Client:
+    return httpx.Client(timeout=30)
+
+
+def _wait_for_health(base_url: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    with _make_client() as client:
+        while time.monotonic() < deadline:
+            try:
+                resp = client.get(f"{base_url}/health")
+                if resp.status_code == 200:
+                    return
+            except httpx.ConnectError:
+                pass
+            time.sleep(0.3)
+    raise TimeoutError(f"Server did not start within {timeout}s at {base_url}")
+
+
+def _build_startup_script(port: int, data_dir: str) -> str:
+    return textwrap.dedent(f"""\
+        import os, sys, logging
+        logging.basicConfig(level=logging.DEBUG)
+
+        sys.path.insert(0, os.getenv("PYTHONPATH", ""))
+
+        from nexus.server.auth.static_key import StaticAPIKeyAuth
+        from nexus.cli import main as cli_main
+
+        auth_config = {{
+            "api_keys": {{
+                "{ADMIN_API_KEY}": {{
+                    "subject_type": "user",
+                    "subject_id": "admin",
+                    "zone_id": "test",
+                    "is_admin": True,
+                }},
+                "{ALICE_API_KEY}": {{
+                    "subject_type": "user",
+                    "subject_id": "alice",
+                    "zone_id": "test",
+                    "is_admin": False,
+                }},
+                "{BOB_API_KEY}": {{
+                    "subject_type": "user",
+                    "subject_id": "bob",
+                    "zone_id": "test",
+                    "is_admin": False,
+                }},
+            }}
+        }}
+
+        import nexus.server.auth.factory as factory
+        _orig = factory.create_auth_provider
+        def _patched(auth_type, auth_config_arg=None, **kwargs):
+            if auth_type == "static":
+                return StaticAPIKeyAuth.from_config(auth_config)
+            return _orig(auth_type, auth_config_arg, **kwargs)
+        factory.create_auth_provider = _patched
+
+        # Disable NamespaceManager cache for deterministic tests
+        import nexus.core.namespace_manager as ns_mod
+        _OrigNS = ns_mod.NamespaceManager
+        class _NoCacheNS(_OrigNS):
+            def __init__(self, **kwargs):
+                kwargs["cache_ttl"] = 0
+                super().__init__(**kwargs)
+        ns_mod.NamespaceManager = _NoCacheNS
+
+        cli_main([
+            'serve', '--host', '127.0.0.1', '--port', '{port}',
+            '--data-dir', '{data_dir}',
+            '--auth-type', 'static', '--api-key', '{ADMIN_API_KEY}',
+        ])
+    """)
+
+
+# === Fixtures ===
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Start nexus serve with permissions enabled."""
+    port = _find_free_port()
+    data_dir = tempfile.mkdtemp(prefix="nexus_batch_e2e_")
+    backend_root = os.path.join(data_dir, "backend")
+    os.makedirs(backend_root, exist_ok=True)
+
+    base_url = f"http://127.0.0.1:{port}"
+    db_path = os.path.join(data_dir, "nexus_e2e.db")
+
+    env = {
+        **os.environ,
+        "HTTP_PROXY": "",
+        "HTTPS_PROXY": "",
+        "http_proxy": "",
+        "https_proxy": "",
+        "NO_PROXY": "*",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
+        "NEXUS_DATABASE_URL": f"sqlite:///{db_path}",
+        "NEXUS_BACKEND_ROOT": backend_root,
+        "NEXUS_TENANT_ID": "batch-e2e",
+        "NEXUS_ENFORCE_PERMISSIONS": "true",
+        "NEXUS_ENFORCE_ZONE_ISOLATION": "true",
+        "NEXUS_SEARCH_DAEMON": "false",
+        "NEXUS_RATE_LIMIT_ENABLED": "false",
+    }
+
+    startup_script = _build_startup_script(port, data_dir)
+
+    proc = subprocess.Popen(
+        [PYTHON, "-c", startup_script],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        preexec_fn=os.setsid if sys.platform != "win32" else None,
+    )
+
+    try:
+        _wait_for_health(base_url)
+        yield {
+            "base_url": base_url,
+            "port": port,
+            "data_dir": data_dir,
+            "process": proc,
+        }
+    except Exception:
+        if sys.platform != "win32":
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                pass
+        else:
+            proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=3)
+        stdout = proc.stdout.read() if proc.stdout else ""
+        pytest.fail(f"Server failed to start. Output:\n{stdout}")
+    finally:
+        if proc.poll() is None:
+            if sys.platform != "win32":
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                except (ProcessLookupError, PermissionError):
+                    proc.terminate()
+            else:
+                proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        shutil.rmtree(data_dir, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def client(server: dict) -> httpx.Client:
+    with _make_client() as c:
+        yield c
+
+
+@pytest.fixture()
+def base_url(server: dict) -> str:
+    return server["base_url"]
+
+
+@pytest.fixture()
+def admin_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {ADMIN_API_KEY}"}
+
+
+@pytest.fixture()
+def alice_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {ALICE_API_KEY}"}
+
+
+@pytest.fixture()
+def bob_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {BOB_API_KEY}"}
+
+
+def _grant_permission(
+    client: httpx.Client,
+    base_url: str,
+    admin_headers: dict,
+    *,
+    subject_id: str,
+    relation: str,
+    object_id: str,
+    zone_id: str = "test",
+) -> str:
+    """Grant via RPC endpoint using a fresh client to avoid connection reuse."""
+    with httpx.Client(timeout=30) as fresh_client:
+        resp = fresh_client.post(
+            f"{base_url}/api/nfs/rebac_create",
+            json={
+                "method": "rebac_create",
+                "params": {
+                    "subject": ["user", subject_id],
+                    "relation": relation,
+                    "object": ["file", object_id],
+                    "zone_id": zone_id,
+                },
+            },
+            headers=admin_headers,
+        )
+    assert resp.status_code == 200, f"Grant failed: {resp.text}"
+    result = resp.json()
+    if "result" in result:
+        return result["result"].get("tuple_id", "")
+    return result.get("tuple_id", "")
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+def test_health(base_url: str, client: httpx.Client) -> None:
+    """Server is healthy with permissions enabled."""
+    resp = client.get(f"{base_url}/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+def test_batch_read_and_list_with_permissions(
+    base_url: str, client: httpx.Client, alice_headers: dict, admin_headers: dict
+) -> None:
+    """Comprehensive E2E: batch_read + list with mixed permissions (Issue #1298).
+
+    All validations in a single test to avoid server state issues between tests.
+    Validates:
+    1. Admin can create files (200)
+    2. Admin can grant permissions via ReBAC
+    3. batch_read returns data for granted files, None for denied
+    4. list as admin sees all files (no regression)
+    5. Performance: all operations complete within 5s
+    """
+    # --- Setup: Admin creates files with mixed grants for alice ---
+    granted_paths = [
+        "/workspace/batch-opt/allowed1.txt",
+        "/workspace/batch-opt/allowed2.txt",
+        "/workspace/batch-opt/allowed3.txt",
+    ]
+    denied_paths = [
+        "/workspace/batch-opt/secret1.txt",
+        "/workspace/batch-opt/secret2.txt",
+    ]
+    all_paths = granted_paths + denied_paths
+
+    # Admin creates all files
+    for p in all_paths:
+        resp = client.post(
+            f"{base_url}/api/v2/files/write",
+            json={"path": p, "content": f"content-{p.split('/')[-1]}"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200, f"Admin write {p} failed: {resp.text}"
+
+    # Grant alice viewer on allowed files only
+    for p in granted_paths:
+        _grant_permission(
+            client,
+            base_url,
+            admin_headers,
+            subject_id="alice",
+            relation="direct_viewer",
+            object_id=p,
+        )
+
+    # --- Test 1: batch_read with mixed permissions ---
+    t_start = time.monotonic()
+    resp = client.post(
+        f"{base_url}/api/v2/files/batch-read",
+        json={"paths": all_paths},
+        headers=alice_headers,
+    )
+    t_batch = time.monotonic() - t_start
+    assert resp.status_code == 200, f"Batch read failed: {resp.text}"
+
+    data = resp.json()
+
+    # Allowed files should have content
+    for p in granted_paths:
+        assert p in data, f"Granted path {p} missing from response"
+        assert data[p] is not None, f"Granted path {p} returned None"
+        assert data[p]["content"] == f"content-{p.split('/')[-1]}"
+
+    # Denied files should be None or missing
+    for p in denied_paths:
+        if p in data:
+            assert data[p] is None or data[p].get("content") is None, (
+                f"Denied path {p} should be None but got: {data[p]}"
+            )
+
+    # --- Test 2: Admin list sees all files (no regression) ---
+    t_start = time.monotonic()
+    resp = client.get(
+        f"{base_url}/api/v2/files/list",
+        params={"path": "/workspace/batch-opt"},
+        headers=admin_headers,
+    )
+    t_list = time.monotonic() - t_start
+    assert resp.status_code == 200, f"Admin list failed: {resp.text}"
+    list_data = resp.json()
+    items = list_data.get("items", list_data.get("entries", []))
+    assert len(items) >= len(all_paths), (
+        f"Admin should see all {len(all_paths)} files, got {len(items)}"
+    )
+
+    # --- Performance assertions ---
+    assert t_batch < 5.0, f"batch_read took {t_batch:.1f}s (expected <5s)"
+    assert t_list < 5.0, f"list took {t_list:.1f}s (expected <5s)"
+
+    print(
+        f"\n  [PERF] batch_read ({len(all_paths)} files, mixed perms): {t_batch * 1000:.0f}ms"
+        f"\n  [PERF] admin list ({len(items)} items): {t_list * 1000:.0f}ms"
+    )

--- a/tests/unit/core/test_async_nexus_fs.py
+++ b/tests/unit/core/test_async_nexus_fs.py
@@ -557,6 +557,141 @@ async def test_batch_read_with_missing(async_fs: AsyncNexusFS) -> None:
     assert results["/batch/missing.txt"] is None
 
 
+@pytest.mark.asyncio
+async def test_batch_read_permission_filter(tmp_path: Path) -> None:
+    """Test batch_read uses batch permission filter, denied paths return None."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nexus.core._metadata_generated import FileMetadata
+    from nexus.core.permissions import OperationContext
+
+    mock_enforcer = AsyncMock()
+    mock_enforcer.filter_paths_by_permission = AsyncMock(
+        return_value=["/allowed/file1.txt", "/allowed/file2.txt"]
+    )
+
+    async def mock_aget_batch(paths):
+        return {
+            p: FileMetadata(
+                path=p,
+                backend_name="local",
+                physical_path=p,
+                size=10,
+                etag=f"etag_{i}",
+            )
+            for i, p in enumerate(paths)
+        }
+
+    mock_metadata = MagicMock()
+    mock_metadata.aget_batch = mock_aget_batch
+
+    mock_backend = AsyncMock()
+    mock_backend.batch_read_content = AsyncMock(
+        side_effect=lambda etags: {e: f"content_{e}".encode() for e in etags}
+    )
+
+    fs = AsyncNexusFS(
+        backend_root=tmp_path / "backend",
+        metadata_store=mock_metadata,
+        tenant_id="test-tenant",
+        enforce_permissions=True,
+        permission_enforcer=mock_enforcer,
+    )
+    # Manually set initialized components
+    fs._initialized = True
+    fs._metadata = mock_metadata
+    fs._backend = mock_backend
+
+    ctx_user = OperationContext(user="alice", groups=["dev"])
+    results = await fs.batch_read(
+        ["/allowed/file1.txt", "/denied/file3.txt", "/allowed/file2.txt"],
+        context=ctx_user,
+    )
+
+    # Denied path returns None
+    assert results["/denied/file3.txt"] is None
+    # Allowed paths return content
+    assert results["/allowed/file1.txt"] is not None
+    assert results["/allowed/file2.txt"] is not None
+
+    # Verify filter was called once (batch, not per-path)
+    mock_enforcer.filter_paths_by_permission.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_batch_read_all_denied(tmp_path: Path) -> None:
+    """Test batch_read when all paths are denied returns all None, no exception."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nexus.core.permissions import OperationContext
+
+    mock_enforcer = AsyncMock()
+    mock_enforcer.filter_paths_by_permission = AsyncMock(return_value=[])
+
+    mock_metadata = MagicMock()
+
+    fs = AsyncNexusFS(
+        backend_root=tmp_path / "backend",
+        metadata_store=mock_metadata,
+        tenant_id="test-tenant",
+        enforce_permissions=True,
+        permission_enforcer=mock_enforcer,
+    )
+    fs._initialized = True
+    fs._metadata = mock_metadata
+
+    ctx_user = OperationContext(user="alice", groups=["dev"])
+    results = await fs.batch_read(["/secret/a.txt", "/secret/b.txt"], context=ctx_user)
+
+    assert results["/secret/a.txt"] is None
+    assert results["/secret/b.txt"] is None
+
+
+@pytest.mark.asyncio
+async def test_batch_read_permissions_disabled(tmp_path: Path) -> None:
+    """Test backward compat: batch_read returns all data when permissions disabled."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nexus.core._metadata_generated import FileMetadata
+
+    mock_metadata = MagicMock()
+
+    async def mock_aget_batch(paths):
+        return {
+            p: FileMetadata(
+                path=p,
+                backend_name="local",
+                physical_path=p,
+                size=10,
+                etag=f"etag_{i}",
+            )
+            for i, p in enumerate(paths)
+        }
+
+    mock_metadata.aget_batch = mock_aget_batch
+
+    mock_backend = AsyncMock()
+    mock_backend.batch_read_content = AsyncMock(
+        side_effect=lambda etags: {e: f"content_{e}".encode() for e in etags}
+    )
+
+    fs = AsyncNexusFS(
+        backend_root=tmp_path / "backend",
+        metadata_store=mock_metadata,
+        tenant_id="test-tenant",
+        enforce_permissions=False,
+    )
+    fs._initialized = True
+    fs._metadata = mock_metadata
+    fs._backend = mock_backend
+
+    results = await fs.batch_read(["/open/file1.txt", "/open/file2.txt"])
+
+    # Both files returned with content
+    assert results["/open/file1.txt"] is not None
+    assert results["/open/file2.txt"] is not None
+
+
 # === Path Validation Tests ===
 
 


### PR DESCRIPTION
## Summary

- **Batch permission checks**: Added `has_accessible_descendants_batch()` to `PermissionEnforcer` — loads Tiger bitmap once, scans all directory prefixes in a single pass instead of N individual calls
- **Batch `batch_read()`**: Replaced N individual `_acheck_permission()` + `aget()` calls with single `filter_paths_by_permission()` + `aget_batch()` calls
- **4 batch optimizations in `list()`**: Cross-zone metadata fetch, connector details metadata, connector dir filtering, and fast-path dir filtering — all converted from per-item to batch API calls

## Test plan

- [x] 6 unit tests for `has_accessible_descendants_batch()` (empty, no cache, no bitmap, all accessible, mixed, decode error)
- [x] 3 unit tests for `batch_read()` permission filtering (mixed perms, all denied, permissions disabled)
- [x] E2E test with real `nexus serve` + permissions enabled: batch_read 5 files mixed perms = 9ms, admin list = 1ms
- [x] All 29 permission enforcer tests pass
- [x] All 35 async_nexus_fs tests pass
- [x] ruff check + ruff format clean

Closes #1298