### PR TITLE
feat(#1331): NATS JetStream event bus — durable event delivery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,38 @@ services:
         max-file: "3"
 
   # ============================================================================
+  # NATS JetStream - Durable Event Bus (Issue #1331)
+  # Replaces Dragonfly pub/sub for event delivery.
+  # Provides: durable streams, replay, consumer groups, exactly-once semantics.
+  # Dragonfly remains for hot caching only.
+  # ============================================================================
+  nats:
+    image: nats:2.10-alpine
+    container_name: nexus-nats
+    restart: unless-stopped
+    profiles:
+      - events  # Only starts with: docker compose --profile events up
+    command: ["--jetstream", "--store_dir=/data", "-m", "8222"]
+    ports:
+      - "${NATS_PORT:-4222}:4222"    # Client connections
+      - "${NATS_MONITOR_PORT:-8222}:8222"  # HTTP monitoring
+    volumes:
+      - nats-data:/data
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -q --spider http://localhost:8222/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - nexus-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # ============================================================================
   # NOTE: dragonfly-coordination has been REMOVED (Architecture Change)
   #
   # Previous role:
@@ -244,6 +276,8 @@ volumes:
   nexus-data:
     driver: local
   dragonfly-data:
+    driver: local
+  nats-data:
     driver: local
   nexus-test-data:
     driver: local

--- a/dockerfiles/docker-compose.demo.yml
+++ b/dockerfiles/docker-compose.demo.yml
@@ -193,6 +193,11 @@ services:
       # Tiger Cache - materialized permissions cache
       # Set to 'true' to enable Tiger Cache (disabled by default for simpler debugging)
       NEXUS_ENABLE_TIGER_CACHE: ${NEXUS_ENABLE_TIGER_CACHE:-false}
+
+      # Event bus backend (Issue #1331)
+      # "redis" = Dragonfly pub/sub (legacy), "nats" = NATS JetStream (durable)
+      NEXUS_EVENT_BUS_BACKEND: ${NEXUS_EVENT_BUS_BACKEND:-redis}
+      NEXUS_NATS_URL: ${NEXUS_NATS_URL:-nats://nats:4222}
     volumes:
       # Persistent data directory (local backend) - shared with local development
       - ../nexus-data:/app/data
@@ -439,6 +444,35 @@ services:
       - nexus-network
 
   # ============================================
+  # NATS JetStream - Durable Event Bus (Issue #1331)
+  # Replaces Dragonfly pub/sub for event delivery.
+  # Provides: durable streams, replay, consumer groups, exactly-once semantics.
+  # ============================================
+  nats:
+    image: nats:2.10-alpine
+    container_name: nexus-nats
+    restart: unless-stopped
+    command: ["--jetstream", "--store_dir=/data", "-m", "8222"]
+    ports:
+      - "${NATS_PORT:-4222}:4222"
+      - "${NATS_MONITOR_PORT:-8222}:8222"
+    volumes:
+      - nats-data:/data
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -q --spider http://localhost:8222/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - nexus-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # ============================================
   # DragonflyDB - High-Performance Cache (Issue #950)
   # Redis-compatible in-memory cache for:
   # - Embedding cache (reduces API calls by 90%)
@@ -530,6 +564,8 @@ volumes:
   postgres-wal-archive:
     driver: local
   dragonfly-data:
+    driver: local
+  nats-data:
     driver: local
   # nexus-data: Using local directory ./nexus-data instead of Docker volume
   # This allows sharing data between Docker and local development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     # Caching
     "cachetools>=6.2.2",
     "redis>=7.0.0", # Redis/Dragonfly client (async support)
+    "nats-py>=2.9.0",  # NATS JetStream event bus (Issue #1331)
     # Authentication
     "authlib>=1.6.5", # JWT and OAuth support for OIDC auth
     "bcrypt>=4.0.0", # Password hashing for local auth

--- a/src/nexus/cache/settings.py
+++ b/src/nexus/cache/settings.py
@@ -5,6 +5,15 @@ Architecture Note:
     - All SSOT data (metadata, locks) is in Raft state machine (sled)
     - dragonfly-coordination has been removed - locks are now linearizable via Raft
 
+Event Bus Configuration (Issue #1331):
+    NEXUS_NATS_URL: NATS server URL for JetStream event bus
+        Example: nats://localhost:4222
+        If not set, Redis/Dragonfly pub/sub is used for events
+
+    NEXUS_EVENT_BUS_BACKEND: Event bus backend selection
+        - "redis": Use Dragonfly/Redis pub/sub (default, legacy)
+        - "nats": Use NATS JetStream (durable, recommended)
+
 Environment variables:
     NEXUS_DRAGONFLY_URL: Redis-compatible URL for Dragonfly cache instance
         Example: redis://localhost:6379
@@ -125,6 +134,12 @@ class CacheSettings:
         default_factory=lambda: (
             os.environ.get("NEXUS_DRAGONFLY_RETRY_ON_TIMEOUT", "true").lower() == "true"
         )
+    )
+
+    # Event bus configuration (Issue #1331)
+    nats_url: str | None = field(default_factory=lambda: os.environ.get("NEXUS_NATS_URL"))
+    event_bus_backend: str = field(
+        default_factory=lambda: os.environ.get("NEXUS_EVENT_BUS_BACKEND", "redis")
     )
 
     # L1 in-memory cache (optional layer before Dragonfly)

--- a/src/nexus/core/event_bus.py
+++ b/src/nexus/core/event_bus.py
@@ -185,6 +185,14 @@ class FileEvent:
             old_path=getattr(change, "old_path", None),
         )
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FileEvent):
+            return NotImplemented
+        return self.event_id == other.event_id
+
+    def __hash__(self) -> int:
+        return hash(self.event_id)
+
     def matches_path_pattern(self, pattern: str) -> bool:
         """Check if this event matches a path pattern.
 
@@ -235,6 +243,36 @@ class FileEvent:
                 return True
 
         return False
+
+
+@dataclass
+class AckableEvent:
+    """Wrapper around FileEvent with acknowledgment semantics.
+
+    Used by durable subscribers (e.g., NATS JetStream pull consumers) to
+    explicitly acknowledge or reject event processing. For backends without
+    native ack support (e.g., Redis pub/sub), ack/nack are no-ops.
+    """
+
+    event: FileEvent
+    _ack_fn: Callable[[], Awaitable[None]] | None = field(default=None, repr=False)
+    _nack_fn: Callable[[float | None], Awaitable[None]] | None = field(default=None, repr=False)
+    _in_progress_fn: Callable[[], Awaitable[None]] | None = field(default=None, repr=False)
+
+    async def ack(self) -> None:
+        """Acknowledge the event (prevent redelivery)."""
+        if self._ack_fn:
+            await self._ack_fn()
+
+    async def nack(self, delay: float | None = None) -> None:
+        """Negative acknowledge (trigger redelivery after optional delay)."""
+        if self._nack_fn:
+            await self._nack_fn(delay)
+
+    async def in_progress(self) -> None:
+        """Signal that processing is ongoing (extend ack deadline)."""
+        if self._in_progress_fn:
+            await self._in_progress_fn()
 
 
 # =============================================================================
@@ -302,13 +340,54 @@ class EventBusProtocol(Protocol):
         """Subscribe to all events for a zone (async generator)."""
         ...
 
+    def subscribe_durable(
+        self,
+        zone_id: str,
+        consumer_name: str,
+        deliver_policy: str = "all",
+    ) -> AsyncIterator[AckableEvent]:
+        """Subscribe with durable consumer semantics.
+
+        Args:
+            zone_id: Zone ID to subscribe to
+            consumer_name: Durable consumer name (survives reconnects)
+            deliver_policy: Delivery policy ("all", "last", "new")
+
+        Yields:
+            AckableEvent objects with ack/nack support
+        """
+        ...
+
 
 class EventBusBase(ABC):
     """Abstract base class for event bus implementations.
 
     Provides common functionality and enforces the interface contract.
     Subclasses must implement all abstract methods.
+
+    Shared logic (node ID, checkpoints, startup sync) lives here so
+    every backend gets it for free.
     """
+
+    CHECKPOINT_KEY_PREFIX = "node_sync_checkpoint"
+
+    def __init__(
+        self,
+        session_factory: Any | None = None,
+        node_id: str | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._node_id = node_id or self._generate_node_id()
+
+    @staticmethod
+    def _generate_node_id() -> str:
+        """Generate a unique node ID based on hostname and process."""
+        import os
+        import socket
+
+        hostname = socket.gethostname()
+        pid = os.getpid()
+        return f"{hostname}-{pid}"
 
     @abstractmethod
     async def start(self) -> None:
@@ -365,6 +444,25 @@ class EventBusBase(ABC):
         """
         pass
 
+    @abstractmethod
+    def subscribe_durable(
+        self,
+        zone_id: str,
+        consumer_name: str,
+        deliver_policy: str = "all",
+    ) -> AsyncIterator[AckableEvent]:
+        """Subscribe with durable consumer semantics.
+
+        Args:
+            zone_id: Zone ID to subscribe to
+            consumer_name: Durable consumer name (survives reconnects)
+            deliver_policy: Delivery policy ("all", "last", "new")
+
+        Yields:
+            AckableEvent objects with ack/nack support
+        """
+        pass
+
     async def get_stats(self) -> dict[str, Any]:
         """Get event bus statistics. Override in subclasses for more details."""
         return {
@@ -372,296 +470,8 @@ class EventBusBase(ABC):
             "status": "running" if await self.health_check() else "stopped",
         }
 
-
-# =============================================================================
-# Redis Pub/Sub Implementation
-# =============================================================================
-
-
-class RedisEventBus(EventBusBase):
-    """Redis Pub/Sub implementation of the event bus with PG SSOT.
-
-    Uses per-zone channels for efficient event routing.
-    Channel format: nexus:events:{zone_id}
-
-    SSOT Architecture:
-        - PostgreSQL (operation_log) is the source of truth
-        - Redis Pub/Sub is best-effort notification
-        - Startup sync reconciles missed events from PG
-
-    Optional WAL integration (Issue #1397):
-        When an ``event_log`` is provided, every published event is
-        durably persisted *before* being broadcast via Redis Pub/Sub.
-        This gives subscribers a reliable replay log for catch-up.
-
-    Example:
-        >>> bus = RedisEventBus(redis_client, session_factory=SessionLocal)
-        >>> await bus.start()
-        >>> await bus.startup_sync()  # Sync missed events from PG
-        >>>
-        >>> # Publish event
-        >>> event = FileEvent(
-        ...     type=FileEventType.FILE_WRITE,
-        ...     path="/inbox/test.txt",
-        ...     zone_id="default",
-        ... )
-        >>> await bus.publish(event)
-    """
-
-    CHANNEL_PREFIX = "nexus:events"
-    CHECKPOINT_KEY_PREFIX = "node_sync_checkpoint"
-
-    def __init__(
-        self,
-        redis_client: DragonflyClient,
-        session_factory: Any | None = None,
-        node_id: str | None = None,
-        event_log: Any | None = None,
-    ):
-        """Initialize RedisEventBus.
-
-        Args:
-            redis_client: DragonflyClient instance for Redis connection
-            session_factory: SQLAlchemy SessionLocal for PG SSOT (optional)
-            node_id: Unique node identifier for checkpoint tracking (auto-generated if None)
-            event_log: Optional EventLogProtocol for durable WAL persistence (Issue #1397)
-        """
-        self._redis = redis_client
-        self._session_factory = session_factory
-        self._node_id = node_id or self._generate_node_id()
-        self._event_log = event_log
-        self._pubsub: Any = None
-        self._started = False
-        self._lock = asyncio.Lock()
-
-    @staticmethod
-    def _generate_node_id() -> str:
-        """Generate a unique node ID based on hostname and process."""
-        import os
-        import socket
-
-        hostname = socket.gethostname()
-        pid = os.getpid()
-        return f"{hostname}-{pid}"
-
-    def _channel_name(self, zone_id: str) -> str:
-        """Get Redis channel name for a zone."""
-        return f"{self.CHANNEL_PREFIX}:{zone_id}"
-
-    async def start(self) -> None:
-        """Start the event bus listener."""
-        if self._started:
-            return
-
-        async with self._lock:
-            if self._started:
-                return
-
-            self._pubsub = self._redis.client.pubsub()
-            self._started = True
-            logger.info("RedisEventBus started")
-
-    async def stop(self) -> None:
-        """Stop the event bus listener and clean up."""
-        if not self._started:
-            return
-
-        async with self._lock:
-            if not self._started:
-                return
-
-            if self._pubsub:
-                await self._pubsub.aclose()
-                self._pubsub = None
-
-            self._started = False
-            logger.info("RedisEventBus stopped")
-
-    async def publish(self, event: FileEvent) -> int:
-        """Publish an event to the zone's channel.
-
-        If an event_log is configured (Issue #1397), the event is durably
-        persisted to the WAL *before* being broadcast via Redis Pub/Sub.
-        """
-        if not self._started:
-            raise RuntimeError("RedisEventBus not started. Call start() first.")
-
-        # WAL-first: persist before fan-out (Issue #1397)
-        if self._event_log is not None:
-            try:
-                await self._event_log.append(event)
-            except Exception as e:
-                logger.error(f"Event log append failed (event still published): {e}")
-
-        zone_id = event.zone_id or "default"
-        channel = self._channel_name(zone_id)
-        message = event.to_json()
-
-        try:
-            num_subscribers: int = await self._redis.client.publish(channel, message)
-            logger.debug(
-                f"Published {event.type} event for {event.path} to {channel} "
-                f"({num_subscribers} subscribers)"
-            )
-            return num_subscribers
-        except Exception as e:
-            logger.error(f"Failed to publish event: {e}")
-            raise
-
-    async def wait_for_event(
-        self,
-        zone_id: str,
-        path_pattern: str,
-        timeout: float = 30.0,
-        since_revision: int | None = None,
-    ) -> FileEvent | None:
-        """Wait for an event matching the path pattern.
-
-        Args:
-            zone_id: Zone ID to subscribe to
-            path_pattern: Path pattern to match
-            timeout: Maximum time to wait in seconds
-            since_revision: Only return events with revision > this value (Issue #1187).
-                           Events with revision <= since_revision are skipped.
-
-        Returns:
-            FileEvent if matched, None on timeout
-        """
-        if not self._started:
-            raise RuntimeError("RedisEventBus not started. Call start() first.")
-
-        channel = self._channel_name(zone_id)
-        pubsub = self._redis.client.pubsub()
-
-        try:
-            await pubsub.subscribe(channel)
-            logger.debug(f"Subscribed to {channel} for pattern {path_pattern}")
-
-            deadline = asyncio.get_event_loop().time() + timeout
-
-            while True:
-                remaining = deadline - asyncio.get_event_loop().time()
-                if remaining <= 0:
-                    logger.debug(f"Timeout waiting for event on {channel}")
-                    return None
-
-                try:
-                    message = await asyncio.wait_for(
-                        pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
-                        timeout=min(remaining, 1.0),
-                    )
-
-                    if message is None:
-                        continue
-
-                    if message["type"] != "message":
-                        continue
-
-                    try:
-                        event = FileEvent.from_json(message["data"])
-                    except (json.JSONDecodeError, KeyError) as e:
-                        logger.warning(f"Invalid event message: {e}")
-                        continue
-
-                    if event.matches_path_pattern(path_pattern):
-                        # Issue #1187: Filter by revision if specified
-                        if since_revision is not None and (
-                            event.revision is None or event.revision <= since_revision
-                        ):
-                            logger.debug(
-                                f"Skipping event {event.type} on {event.path}: "
-                                f"revision {event.revision} <= since_revision {since_revision}"
-                            )
-                            continue
-                        logger.debug(f"Matched event: {event.type} on {event.path}")
-                        return event
-
-                except TimeoutError:
-                    if asyncio.get_event_loop().time() >= deadline:
-                        return None
-                    continue
-
-        finally:
-            await pubsub.unsubscribe(channel)
-            await pubsub.close()
-
-    async def subscribe(
-        self,
-        zone_id: str,
-    ) -> AsyncIterator[FileEvent]:
-        """Subscribe to all events for a zone.
-
-        This is an async generator that yields FileEvent objects as they are received.
-        Use this for background listeners like cache invalidation.
-
-        Args:
-            zone_id: Zone ID to subscribe to
-
-        Yields:
-            FileEvent objects as they are received
-
-        Example:
-            >>> async for event in bus.subscribe("zone1"):
-            ...     print(f"Received {event.type} on {event.path}")
-            ...     # Handle event (e.g., invalidate cache)
-        """
-        if not self._started:
-            raise RuntimeError("RedisEventBus not started. Call start() first.")
-
-        channel = self._channel_name(zone_id)
-        pubsub = self._redis.client.pubsub()
-
-        try:
-            await pubsub.subscribe(channel)
-            logger.debug(f"Subscribed to {channel} for cache invalidation")
-
-            while True:
-                try:
-                    message = await pubsub.get_message(
-                        ignore_subscribe_messages=True,
-                        timeout=1.0,
-                    )
-
-                    if message is None:
-                        # Yield control to allow cancellation
-                        await asyncio.sleep(0)
-                        continue
-
-                    if message["type"] != "message":
-                        continue
-
-                    try:
-                        event = FileEvent.from_json(message["data"])
-                        yield event
-                    except (json.JSONDecodeError, KeyError) as e:
-                        logger.warning(f"Invalid event message: {e}")
-                        continue
-
-                except asyncio.CancelledError:
-                    logger.debug(f"Subscription to {channel} cancelled")
-                    raise
-                except Exception as e:
-                    logger.warning(f"Error receiving message: {e}")
-                    await asyncio.sleep(1.0)  # Back off on errors
-                    continue
-
-        finally:
-            await pubsub.unsubscribe(channel)
-            await pubsub.close()
-
-    async def health_check(self) -> bool:
-        """Check if the event bus is healthy."""
-        if not self._started:
-            return False
-
-        try:
-            return await self._redis.health_check()
-        except Exception as e:
-            logger.warning(f"Event bus health check failed: {e}")
-            return False
-
     # =========================================================================
-    # SSOT: Startup Sync (Phase E)
+    # SSOT: Checkpoint & Startup Sync (shared across backends)
     # =========================================================================
 
     def _get_checkpoint_key(self) -> str:
@@ -669,49 +479,75 @@ class RedisEventBus(EventBusBase):
         return f"{self.CHECKPOINT_KEY_PREFIX}:{self._node_id}"
 
     async def _get_checkpoint(self) -> datetime | None:
-        """Get the last sync checkpoint from PG."""
+        """Get the last sync checkpoint from the database.
+
+        Runs synchronous SQLAlchemy in a thread executor to avoid blocking
+        the event loop. Handles missing system_settings table gracefully
+        (e.g. SQLite embedded mode).
+        """
         if not self._session_factory:
             return None
 
-        from sqlalchemy import select
+        session_factory = self._session_factory  # bind for mypy narrowing
 
-        from nexus.storage.models import SystemSettingsModel
+        def _query() -> datetime | None:
+            from sqlalchemy import select
+            from sqlalchemy.exc import OperationalError, ProgrammingError
 
-        with self._session_factory() as session:
-            stmt = select(SystemSettingsModel).where(
-                SystemSettingsModel.key == self._get_checkpoint_key()
-            )
-            setting = session.execute(stmt).scalar_one_or_none()
+            from nexus.storage.models import SystemSettingsModel
 
-            if setting:
-                return datetime.fromisoformat(setting.value)
-            return None
+            try:
+                with session_factory() as session:
+                    stmt = select(SystemSettingsModel).where(
+                        SystemSettingsModel.key == self._get_checkpoint_key()
+                    )
+                    setting = session.execute(stmt).scalar_one_or_none()
+
+                    if setting:
+                        return datetime.fromisoformat(setting.value)
+                    return None
+            except (OperationalError, ProgrammingError):
+                # Table may not exist in SQLite embedded mode
+                return None
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _query)
 
     async def _update_checkpoint(self, timestamp: datetime) -> None:
-        """Update the sync checkpoint in PG."""
+        """Update the sync checkpoint in the database.
+
+        Runs synchronous SQLAlchemy in a thread executor to avoid blocking
+        the event loop.
+        """
         if not self._session_factory:
             return
 
-        from sqlalchemy import select
+        session_factory = self._session_factory  # bind for mypy narrowing
 
-        from nexus.storage.models import SystemSettingsModel
+        def _update() -> None:
+            from sqlalchemy import select
 
-        with self._session_factory() as session:
-            key = self._get_checkpoint_key()
-            stmt = select(SystemSettingsModel).where(SystemSettingsModel.key == key)
-            setting = session.execute(stmt).scalar_one_or_none()
+            from nexus.storage.models import SystemSettingsModel
 
-            if setting:
-                setting.value = timestamp.isoformat()
-            else:
-                setting = SystemSettingsModel(
-                    key=key,
-                    value=timestamp.isoformat(),
-                    description=f"Event sync checkpoint for node {self._node_id}",
-                )
-                session.add(setting)
+            with session_factory() as session:
+                key = self._get_checkpoint_key()
+                stmt = select(SystemSettingsModel).where(SystemSettingsModel.key == key)
+                setting = session.execute(stmt).scalar_one_or_none()
 
-            session.commit()
+                if setting:
+                    setting.value = timestamp.isoformat()
+                else:
+                    setting = SystemSettingsModel(
+                        key=key,
+                        value=timestamp.isoformat(),
+                        description=f"Event sync checkpoint for node {self._node_id}",
+                    )
+                    session.add(setting)
+
+                session.commit()
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _update)
 
     async def startup_sync(
         self,
@@ -814,6 +650,297 @@ class RedisEventBus(EventBusBase):
         }
         return mapping.get(op_type, op_type)
 
+
+# =============================================================================
+# Redis Pub/Sub Implementation
+# =============================================================================
+
+
+class RedisEventBus(EventBusBase):
+    """Redis Pub/Sub implementation of the event bus with PG SSOT.
+
+    Uses per-zone channels for efficient event routing.
+    Channel format: nexus:events:{zone_id}
+
+    SSOT Architecture:
+        - PostgreSQL (operation_log) is the source of truth
+        - Redis Pub/Sub is best-effort notification
+        - Startup sync reconciles missed events from PG
+
+    Optional WAL integration (Issue #1397):
+        When an ``event_log`` is provided, every published event is
+        durably persisted *before* being broadcast via Redis Pub/Sub.
+        This gives subscribers a reliable replay log for catch-up.
+
+    Example:
+        >>> bus = RedisEventBus(redis_client, session_factory=SessionLocal)
+        >>> await bus.start()
+        >>> await bus.startup_sync()  # Sync missed events from PG
+        >>>
+        >>> # Publish event
+        >>> event = FileEvent(
+        ...     type=FileEventType.FILE_WRITE,
+        ...     path="/inbox/test.txt",
+        ...     zone_id="default",
+        ... )
+        >>> await bus.publish(event)
+    """
+
+    CHANNEL_PREFIX = "nexus:events"
+
+    def __init__(
+        self,
+        redis_client: DragonflyClient,
+        session_factory: Any | None = None,
+        node_id: str | None = None,
+        event_log: Any | None = None,
+    ):
+        """Initialize RedisEventBus.
+
+        Args:
+            redis_client: DragonflyClient instance for Redis connection
+            session_factory: SQLAlchemy SessionLocal for PG SSOT (optional)
+            node_id: Unique node identifier for checkpoint tracking (auto-generated if None)
+            event_log: Optional EventLogProtocol for durable WAL persistence (Issue #1397)
+        """
+        super().__init__(session_factory=session_factory, node_id=node_id)
+        self._redis = redis_client
+        self._event_log = event_log
+        self._pubsub: Any = None
+        self._started = False
+        self._lock = asyncio.Lock()
+
+    def _channel_name(self, zone_id: str) -> str:
+        """Get Redis channel name for a zone."""
+        return f"{self.CHANNEL_PREFIX}:{zone_id}"
+
+    async def start(self) -> None:
+        """Start the event bus listener."""
+        if self._started:
+            return
+
+        async with self._lock:
+            if self._started:
+                return
+
+            self._pubsub = self._redis.client.pubsub()
+            self._started = True
+            logger.info("RedisEventBus started")
+
+    async def stop(self) -> None:
+        """Stop the event bus listener and clean up."""
+        if not self._started:
+            return
+
+        async with self._lock:
+            if not self._started:
+                return
+
+            if self._pubsub:
+                await self._pubsub.aclose()
+                self._pubsub = None
+
+            self._started = False
+            logger.info("RedisEventBus stopped")
+
+    async def publish(self, event: FileEvent) -> int:
+        """Publish an event to the zone's channel.
+
+        If an event_log is configured (Issue #1397), the event is durably
+        persisted to the WAL *before* being broadcast via Redis Pub/Sub.
+        """
+        if not self._started:
+            raise RuntimeError("RedisEventBus not started. Call start() first.")
+
+        # WAL-first: persist before fan-out (Issue #1397)
+        if self._event_log is not None:
+            try:
+                await self._event_log.append(event)
+            except Exception as e:
+                logger.error(f"Event log append failed (event still published): {e}")
+
+        zone_id = event.zone_id or "default"
+        channel = self._channel_name(zone_id)
+        message = event.to_json()
+
+        try:
+            num_subscribers: int = await self._redis.client.publish(channel, message)
+            logger.debug(
+                f"Published {event.type} event for {event.path} to {channel} "
+                f"({num_subscribers} subscribers)"
+            )
+            return num_subscribers
+        except Exception as e:
+            logger.error(f"Failed to publish event: {e}")
+            raise
+
+    async def wait_for_event(
+        self,
+        zone_id: str,
+        path_pattern: str,
+        timeout: float = 30.0,
+        since_revision: int | None = None,
+    ) -> FileEvent | None:
+        """Wait for an event matching the path pattern.
+
+        Args:
+            zone_id: Zone ID to subscribe to
+            path_pattern: Path pattern to match
+            timeout: Maximum time to wait in seconds
+            since_revision: Only return events with revision > this value (Issue #1187).
+                           Events with revision <= since_revision are skipped.
+
+        Returns:
+            FileEvent if matched, None on timeout
+        """
+        if not self._started:
+            raise RuntimeError("RedisEventBus not started. Call start() first.")
+
+        channel = self._channel_name(zone_id)
+        pubsub = self._redis.client.pubsub()
+
+        try:
+            await pubsub.subscribe(channel)
+            logger.debug(f"Subscribed to {channel} for pattern {path_pattern}")
+
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + timeout
+
+            while True:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    logger.debug(f"Timeout waiting for event on {channel}")
+                    return None
+
+                try:
+                    message = await asyncio.wait_for(
+                        pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
+                        timeout=min(remaining, 1.0),
+                    )
+
+                    if message is None:
+                        continue
+
+                    if message["type"] != "message":
+                        continue
+
+                    try:
+                        event = FileEvent.from_json(message["data"])
+                    except (json.JSONDecodeError, KeyError) as e:
+                        logger.warning(f"Invalid event message: {e}")
+                        continue
+
+                    if event.matches_path_pattern(path_pattern):
+                        # Issue #1187: Filter by revision if specified
+                        if since_revision is not None and (
+                            event.revision is None or event.revision <= since_revision
+                        ):
+                            logger.debug(
+                                f"Skipping event {event.type} on {event.path}: "
+                                f"revision {event.revision} <= since_revision {since_revision}"
+                            )
+                            continue
+                        logger.debug(f"Matched event: {event.type} on {event.path}")
+                        return event
+
+                except TimeoutError:
+                    if loop.time() >= deadline:
+                        return None
+                    continue
+
+        finally:
+            await pubsub.unsubscribe(channel)
+            await pubsub.aclose()
+
+    async def subscribe(
+        self,
+        zone_id: str,
+    ) -> AsyncIterator[FileEvent]:
+        """Subscribe to all events for a zone.
+
+        This is an async generator that yields FileEvent objects as they are received.
+        Use this for background listeners like cache invalidation.
+
+        Args:
+            zone_id: Zone ID to subscribe to
+
+        Yields:
+            FileEvent objects as they are received
+
+        Example:
+            >>> async for event in bus.subscribe("zone1"):
+            ...     print(f"Received {event.type} on {event.path}")
+            ...     # Handle event (e.g., invalidate cache)
+        """
+        if not self._started:
+            raise RuntimeError("RedisEventBus not started. Call start() first.")
+
+        channel = self._channel_name(zone_id)
+        pubsub = self._redis.client.pubsub()
+
+        try:
+            await pubsub.subscribe(channel)
+            logger.debug(f"Subscribed to {channel} for cache invalidation")
+
+            while True:
+                try:
+                    message = await pubsub.get_message(
+                        ignore_subscribe_messages=True,
+                        timeout=1.0,
+                    )
+
+                    if message is None:
+                        # Yield control to allow cancellation
+                        await asyncio.sleep(0)
+                        continue
+
+                    if message["type"] != "message":
+                        continue
+
+                    try:
+                        event = FileEvent.from_json(message["data"])
+                        yield event
+                    except (json.JSONDecodeError, KeyError) as e:
+                        logger.warning(f"Invalid event message: {e}")
+                        continue
+
+                except asyncio.CancelledError:
+                    logger.debug(f"Subscription to {channel} cancelled")
+                    raise
+                except Exception as e:
+                    logger.warning(f"Error receiving message: {e}")
+                    await asyncio.sleep(1.0)  # Back off on errors
+                    continue
+
+        finally:
+            await pubsub.unsubscribe(channel)
+            await pubsub.aclose()
+
+    async def health_check(self) -> bool:
+        """Check if the event bus is healthy."""
+        if not self._started:
+            return False
+
+        try:
+            return await self._redis.health_check()
+        except Exception as e:
+            logger.warning(f"Event bus health check failed: {e}")
+            return False
+
+    async def subscribe_durable(
+        self,
+        zone_id: str,
+        consumer_name: str,  # noqa: ARG002
+        deliver_policy: str = "all",  # noqa: ARG002
+    ) -> AsyncIterator[AckableEvent]:
+        """Subscribe with durable semantics (Redis compat wrapper).
+
+        Redis pub/sub has no native durability, so this wraps subscribe()
+        and yields AckableEvents with no-op ack/nack callbacks.
+        """
+        async for event in self.subscribe(zone_id):
+            yield AckableEvent(event=event)
+
     async def get_stats(self) -> dict[str, Any]:
         """Get event bus statistics."""
         redis_info = await self._redis.get_info()
@@ -841,34 +968,34 @@ GlobalEventBus = RedisEventBus
 def create_event_bus(
     backend: str = "redis",
     redis_client: DragonflyClient | None = None,
-    **kwargs: Any,  # noqa: ARG001 - Reserved for future backends
+    nats_url: str | None = None,
+    **kwargs: Any,
 ) -> EventBusBase:
     """Factory function to create an event bus instance.
 
     Args:
-        backend: Backend type ("redis", future: "etcd", "zookeeper", "p2p")
+        backend: Backend type ("redis" or "nats")
         redis_client: DragonflyClient for Redis backend
-        **kwargs: Additional backend-specific arguments
+        nats_url: NATS server URL for NATS backend
+        **kwargs: Additional backend-specific arguments (session_factory, node_id, etc.)
 
     Returns:
         EventBusBase implementation
 
     Raises:
-        ValueError: If backend is not supported
-        ValueError: If required arguments are missing
+        ValueError: If backend is not supported or required arguments are missing
     """
+    if backend == "nats":
+        if nats_url is None:
+            raise ValueError("nats_url is required for NATS backend")
+        from nexus.core.event_bus_nats import NatsEventBus
+
+        return NatsEventBus(nats_url=nats_url, **kwargs)
+
     if backend == "redis":
         if redis_client is None:
             raise ValueError("redis_client is required for Redis backend")
-        return RedisEventBus(redis_client)
-
-    # Future backends
-    # elif backend == "etcd":
-    #     return EtcdEventBus(...)
-    # elif backend == "zookeeper":
-    #     return ZooKeeperEventBus(...)
-    # elif backend == "p2p":
-    #     return P2PEventBus(...)
+        return RedisEventBus(redis_client, **kwargs)
 
     raise ValueError(f"Unsupported event bus backend: {backend}")
 
@@ -884,6 +1011,21 @@ def get_global_event_bus() -> EventBusBase | None:
         EventBusBase instance if initialized, None otherwise
     """
     return _global_event_bus
+
+
+def require_global_event_bus() -> EventBusBase:
+    """Get the global event bus, raising if not initialized.
+
+    Returns:
+        The global EventBusBase instance.
+
+    Raises:
+        RuntimeError: If no global event bus has been set.
+    """
+    bus = _global_event_bus
+    if bus is None:
+        raise RuntimeError("Global event bus not initialized. Call set_global_event_bus() first.")
+    return bus
 
 
 def set_global_event_bus(bus: EventBusBase | None) -> None:

--- a/src/nexus/core/event_bus_nats.py
+++ b/src/nexus/core/event_bus_nats.py
@@ -1,0 +1,478 @@
+"""NATS JetStream event bus implementation.
+
+Communication brick implementing EventBusProtocol via NATS JetStream.
+Provides durable event delivery, stream replay, and consumer groups.
+
+Subject hierarchy: nexus.events.{zone_id}.{event_type}
+Stream: NEXUS_EVENTS (limits-based, 7d retention, file storage)
+Consumers: Pull-based, durable, per consumer_name
+
+Issue #1331: Replace Dragonfly pub/sub with NATS JetStream.
+Keep Dragonfly for caching only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+import nats
+from nats.aio.client import Client as NatsClient
+from nats.errors import (
+    ConnectionClosedError,
+    NoServersError,
+)
+from nats.errors import (
+    TimeoutError as NatsTimeoutError,
+)
+from nats.js import JetStreamContext
+from nats.js.api import (
+    ConsumerConfig,
+    DeliverPolicy,
+    RetentionPolicy,
+    StorageType,
+    StreamConfig,
+)
+from nats.js.errors import NotFoundError
+
+from nexus.core.event_bus import (
+    AckableEvent,
+    EventBusBase,
+    FileEvent,
+    FileEventType,
+)
+
+if TYPE_CHECKING:
+    from nats.aio.msg import Msg
+
+logger = logging.getLogger(__name__)
+
+
+def _deliver_policy_from_str(policy: str) -> DeliverPolicy:
+    """Convert string deliver policy to NATS DeliverPolicy enum."""
+    mapping = {
+        "all": DeliverPolicy.ALL,
+        "last": DeliverPolicy.LAST,
+        "new": DeliverPolicy.NEW,
+    }
+    result = mapping.get(policy)
+    if result is None:
+        raise ValueError(f"Unknown deliver_policy: {policy!r}. Use 'all', 'last', or 'new'.")
+    return result
+
+
+class NatsEventBus(EventBusBase):
+    """NATS JetStream implementation of EventBusBase.
+
+    Provides durable event delivery with exactly-once semantics via
+    JetStream message deduplication and pull-based consumers.
+    """
+
+    STREAM_NAME = "NEXUS_EVENTS"
+    SUBJECT_PREFIX = "nexus.events"
+
+    # Stream limits (nats-py accepts seconds for time fields)
+    MAX_AGE_SECS = 7 * 24 * 3600  # 7 days
+    MAX_BYTES = 1 * 1024 * 1024 * 1024  # 1 GB
+    DUPLICATE_WINDOW_SECS = 120  # 2 min dedup window
+
+    def __init__(
+        self,
+        nats_url: str = "nats://localhost:4222",
+        session_factory: Any | None = None,
+        node_id: str | None = None,
+        max_reconnect_attempts: int = -1,
+        reconnect_time_wait: float = 2.0,
+    ) -> None:
+        """Initialize NatsEventBus.
+
+        Args:
+            nats_url: NATS server URL (e.g., "nats://localhost:4222")
+            session_factory: SQLAlchemy SessionLocal for PG SSOT (optional)
+            node_id: Unique node identifier (auto-generated if None)
+            max_reconnect_attempts: Max reconnect attempts (-1 = infinite)
+            reconnect_time_wait: Seconds between reconnect attempts
+        """
+        super().__init__(session_factory=session_factory, node_id=node_id)
+        self._nats_url = nats_url
+        self._max_reconnect_attempts = max_reconnect_attempts
+        self._reconnect_time_wait = reconnect_time_wait
+        self._nc: NatsClient | None = None
+        self._js: JetStreamContext | None = None
+        self._started = False
+        self._lock = asyncio.Lock()
+
+    def _subject(self, zone_id: str, event_type: str) -> str:
+        """Build subject for a specific zone and event type."""
+        return f"{self.SUBJECT_PREFIX}.{zone_id}.{event_type}"
+
+    def _zone_wildcard(self, zone_id: str) -> str:
+        """Build wildcard subject matching all event types in a zone."""
+        return f"{self.SUBJECT_PREFIX}.{zone_id}.>"
+
+    # =========================================================================
+    # Lifecycle
+    # =========================================================================
+
+    async def start(self) -> None:
+        """Connect to NATS and ensure JetStream stream exists."""
+        if self._started:
+            return
+
+        async with self._lock:
+            if self._started:
+                return
+
+            try:
+                self._nc = await nats.connect(
+                    self._nats_url,
+                    max_reconnect_attempts=self._max_reconnect_attempts,
+                    reconnect_time_wait=self._reconnect_time_wait,
+                    disconnected_cb=self._on_disconnect,
+                    reconnected_cb=self._on_reconnect,
+                    error_cb=self._on_error,
+                )
+                self._js = self._nc.jetstream()
+
+                # Ensure stream exists (idempotent — update if config changed)
+                await self._js.add_stream(
+                    StreamConfig(
+                        name=self.STREAM_NAME,
+                        subjects=[f"{self.SUBJECT_PREFIX}.>"],
+                        retention=RetentionPolicy.LIMITS,
+                        max_age=self.MAX_AGE_SECS,
+                        storage=StorageType.FILE,
+                        num_replicas=1,
+                        duplicate_window=self.DUPLICATE_WINDOW_SECS,
+                        max_bytes=self.MAX_BYTES,
+                    )
+                )
+
+                self._started = True
+                logger.info(f"NatsEventBus started (url={self._nats_url})")
+
+            except (NoServersError, ConnectionClosedError, OSError) as e:
+                logger.error(f"Failed to connect to NATS: {e}")
+                raise
+
+    async def stop(self) -> None:
+        """Drain and close NATS connection."""
+        if not self._started:
+            return
+
+        async with self._lock:
+            if not self._started:
+                return
+
+            if self._nc and self._nc.is_connected:
+                try:
+                    await self._nc.drain()
+                except Exception as e:
+                    logger.warning(f"Error draining NATS connection: {e}")
+
+            self._js = None
+            self._nc = None
+            self._started = False
+            logger.info("NatsEventBus stopped")
+
+    # =========================================================================
+    # Publish
+    # =========================================================================
+
+    async def publish(self, event: FileEvent) -> int:
+        """Publish event to JetStream with synchronous ack.
+
+        Args:
+            event: FileEvent to publish.
+
+        Returns:
+            Stream sequence number (ack.seq) as int.
+
+        Raises:
+            RuntimeError: If the bus is not started.
+        """
+        if not self._started or self._js is None:
+            raise RuntimeError("NatsEventBus not started. Call start() first.")
+
+        zone_id = event.zone_id or "default"
+        event_type = event.type.value if isinstance(event.type, FileEventType) else event.type
+        subject = self._subject(zone_id, event_type)
+
+        payload = event.to_json().encode("utf-8")
+
+        # Headers for metadata and deduplication
+        headers = {
+            "Nats-Msg-Id": event.event_id,  # JetStream dedup key
+            "zone_id": zone_id,
+        }
+
+        try:
+            ack = await self._js.publish(subject, payload, headers=headers)
+            logger.debug(
+                f"Published {event_type} event for {event.path} to {subject} (seq={ack.seq})"
+            )
+            return ack.seq
+        except Exception as e:
+            logger.error(f"Failed to publish event to NATS: {e}")
+            raise
+
+    # =========================================================================
+    # Subscribe (backward-compat wrapper)
+    # =========================================================================
+
+    async def subscribe(self, zone_id: str) -> AsyncIterator[FileEvent]:
+        """Subscribe with auto-ack (backward compatibility wrapper).
+
+        Wraps subscribe_durable() and auto-acks each message so callers
+        that don't need explicit ack/nack can use the simple interface.
+        """
+        async for ackable in self.subscribe_durable(zone_id, f"auto-{self._node_id}"):
+            await ackable.ack()
+            yield ackable.event
+
+    # =========================================================================
+    # Durable Subscribe (pull consumer)
+    # =========================================================================
+
+    async def subscribe_durable(
+        self,
+        zone_id: str,
+        consumer_name: str,
+        deliver_policy: str = "all",
+    ) -> AsyncIterator[AckableEvent]:
+        """Subscribe with durable pull consumer.
+
+        Creates or binds to a durable consumer and fetches messages in batches.
+        Each message is wrapped in AckableEvent with ack/nack/in_progress callbacks.
+
+        Args:
+            zone_id: Zone ID to subscribe to.
+            consumer_name: Durable consumer name (survives reconnects).
+            deliver_policy: "all", "last", or "new".
+
+        Yields:
+            AckableEvent objects with ack/nack support.
+        """
+        if not self._started or self._js is None:
+            raise RuntimeError("NatsEventBus not started. Call start() first.")
+
+        subject = self._zone_wildcard(zone_id)
+        policy = _deliver_policy_from_str(deliver_policy)
+
+        # Create or bind durable pull consumer
+        consumer_config = ConsumerConfig(
+            durable_name=consumer_name,
+            filter_subject=subject,
+            deliver_policy=policy,
+            ack_wait=30,  # 30s ack timeout
+        )
+
+        try:
+            sub = await self._js.pull_subscribe(
+                subject,
+                durable=consumer_name,
+                config=consumer_config,
+            )
+        except Exception as e:
+            logger.error(f"Failed to create pull subscription: {e}")
+            raise
+
+        try:
+            while True:
+                try:
+                    msgs = await sub.fetch(batch=10, timeout=5)
+                except NatsTimeoutError:
+                    # No messages available — yield control and retry
+                    await asyncio.sleep(0)
+                    continue
+                except (ConnectionClosedError, asyncio.CancelledError):
+                    raise
+                except Exception as e:
+                    logger.warning(f"Error fetching messages: {e}")
+                    await asyncio.sleep(1.0)
+                    continue
+
+                for msg in msgs:
+                    try:
+                        event = FileEvent.from_json(msg.data)
+                    except (json.JSONDecodeError, KeyError) as e:
+                        logger.warning(f"Invalid event message on {msg.subject}: {e}")
+                        await msg.ack()  # Ack bad messages to prevent redelivery
+                        continue
+
+                    yield AckableEvent(
+                        event=event,
+                        _ack_fn=self._make_ack_fn(msg),
+                        _nack_fn=self._make_nack_fn(msg),
+                        _in_progress_fn=self._make_in_progress_fn(msg),
+                    )
+
+        except asyncio.CancelledError:
+            logger.debug(f"Durable subscription {consumer_name} cancelled")
+            raise
+        finally:
+            with contextlib.suppress(Exception):
+                await sub.unsubscribe()
+
+    @staticmethod
+    def _make_ack_fn(msg: Msg) -> Any:
+        async def _ack() -> None:
+            await msg.ack()
+
+        return _ack
+
+    @staticmethod
+    def _make_nack_fn(msg: Msg) -> Any:
+        async def _nack(delay: float | None = None) -> None:
+            if delay is not None:
+                await msg.nak(delay=delay)
+            else:
+                await msg.nak()
+
+        return _nack
+
+    @staticmethod
+    def _make_in_progress_fn(msg: Msg) -> Any:
+        async def _in_progress() -> None:
+            await msg.in_progress()
+
+        return _in_progress
+
+    # =========================================================================
+    # Wait for event (ephemeral consumer)
+    # =========================================================================
+
+    async def wait_for_event(
+        self,
+        zone_id: str,
+        path_pattern: str,
+        timeout: float = 30.0,
+        since_revision: int | None = None,
+    ) -> FileEvent | None:
+        """Wait for a matching event using an ephemeral consumer.
+
+        Args:
+            zone_id: Zone ID to subscribe to.
+            path_pattern: Path pattern to match.
+            timeout: Maximum time to wait in seconds.
+            since_revision: Only return events with revision > this value.
+
+        Returns:
+            FileEvent if matched, None on timeout.
+        """
+        if not self._started or self._js is None:
+            raise RuntimeError("NatsEventBus not started. Call start() first.")
+
+        subject = self._zone_wildcard(zone_id)
+
+        try:
+            sub = await self._js.subscribe(subject, ordered_consumer=True)
+        except Exception as e:
+            logger.error(f"Failed to create ephemeral subscription: {e}")
+            raise
+
+        try:
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + timeout
+
+            while True:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return None
+
+                try:
+                    msg = await asyncio.wait_for(
+                        sub.next_msg(),
+                        timeout=min(remaining, 1.0),
+                    )
+                except (TimeoutError, NatsTimeoutError):
+                    if loop.time() >= deadline:
+                        return None
+                    continue
+
+                try:
+                    event = FileEvent.from_json(msg.data)
+                except (json.JSONDecodeError, KeyError):
+                    continue
+
+                if not event.matches_path_pattern(path_pattern):
+                    continue
+
+                # Filter by revision if specified
+                if since_revision is not None and (
+                    event.revision is None or event.revision <= since_revision
+                ):
+                    continue
+
+                return event
+
+        finally:
+            with contextlib.suppress(Exception):
+                await sub.unsubscribe()
+
+    # =========================================================================
+    # Health & Stats
+    # =========================================================================
+
+    async def health_check(self) -> bool:
+        """Check NATS connection and JetStream availability."""
+        if not self._started or self._nc is None:
+            return False
+
+        try:
+            if not self._nc.is_connected:
+                return False
+            # Verify JetStream stream exists
+            if self._js:
+                await self._js.find_stream_name_by_subject(f"{self.SUBJECT_PREFIX}.>")
+            return True
+        except (NotFoundError, Exception) as e:
+            logger.warning(f"NATS health check failed: {e}")
+            return False
+
+    async def get_stats(self) -> dict[str, Any]:
+        """Return NATS/JetStream statistics."""
+        checkpoint = await self._get_checkpoint()
+
+        stats: dict[str, Any] = {
+            "backend": "nats_jetstream",
+            "status": "running" if self._started else "stopped",
+            "nats_url": self._nats_url,
+            "node_id": self._node_id,
+            "last_checkpoint": checkpoint.isoformat() if checkpoint else None,
+            "ssot_enabled": self._session_factory is not None,
+        }
+
+        if self._started and self._js is not None:
+            try:
+                stream_info = await self._js.stream_info(self.STREAM_NAME)
+                state = stream_info.state
+                stats["stream"] = {
+                    "name": self.STREAM_NAME,
+                    "messages": state.messages,
+                    "bytes": state.bytes,
+                    "first_seq": state.first_seq,
+                    "last_seq": state.last_seq,
+                    "consumer_count": state.consumer_count,
+                }
+            except Exception as e:
+                stats["stream_error"] = str(e)
+
+        return stats
+
+    # =========================================================================
+    # Reconnection callbacks
+    # =========================================================================
+
+    async def _on_disconnect(self) -> None:
+        logger.warning("NATS disconnected")
+
+    async def _on_reconnect(self) -> None:
+        logger.info("NATS reconnected")
+
+    async def _on_error(self, e: Exception) -> None:
+        logger.error(f"NATS error: {e}")

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -471,8 +471,26 @@ class NexusFS(  # type: ignore[misc]
                             "Lock manager will not be initialized."
                         )
 
-                # Initialize event bus if enabled (can use evictable dragonfly)
-                if enable_distributed_events and event_url_resolved:
+                # Initialize event bus if enabled
+                import os as _os
+
+                event_bus_backend = _os.environ.get("NEXUS_EVENT_BUS_BACKEND", "redis")
+
+                if event_bus_backend == "nats":
+                    # NATS JetStream event bus (Issue #1331)
+                    from nexus.core.event_bus import create_event_bus, set_global_event_bus
+
+                    nats_url = _os.environ.get("NEXUS_NATS_URL", "nats://localhost:4222")
+                    self._event_bus = create_event_bus(
+                        backend="nats",
+                        nats_url=nats_url,
+                        session_factory=self.SessionLocal,
+                    )
+                    set_global_event_bus(self._event_bus)
+                    logger.info(
+                        f"🔔 Distributed event bus initialized (NATS JetStream: {nats_url}, SSOT: PostgreSQL)"
+                    )
+                elif enable_distributed_events and event_url_resolved:
                     from nexus.core.event_bus import RedisEventBus, set_global_event_bus
 
                     # Reuse coordination client if same URL, otherwise create new
@@ -1558,6 +1576,14 @@ class NexusFS(  # type: ignore[misc]
                 logger.debug(f"mkdir: Granted direct_owner permission to {ctx.user} for {path}")
             except Exception as e:
                 logger.warning(f"Failed to grant direct_owner permission for {path}: {e}")
+
+        # Issue #1331: Publish dir_create event to event bus
+        self._publish_file_event(
+            event_type="dir_create",
+            path=path,
+            zone_id=ctx.zone_id,
+            agent_id=ctx.agent_id,
+        )
 
     @rpc_expose(description="Remove directory")
     def rmdir(

--- a/tests/e2e/test_nats_event_bus_e2e.py
+++ b/tests/e2e/test_nats_event_bus_e2e.py
@@ -1,0 +1,556 @@
+"""E2E tests for NATS event bus with FastAPI server and permissions.
+
+Tests the full flow:
+1. FastAPI server starts with NATS event bus backend
+2. File writes via JSON-RPC → events published to NATS JetStream
+3. Permission enforcement: unauthorized requests rejected, no events published
+4. Events received by durable subscribers
+5. Event deduplication works end-to-end
+
+Requires: NATS JetStream server (port 4222)
+Related: Issue #1331
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+import time
+import uuid
+from typing import Any
+
+import pytest
+
+# ============================================================================
+# Skip conditions
+# ============================================================================
+
+
+def _is_port_open(host: str, port: int) -> bool:
+    try:
+        sock = socket.create_connection((host, port), timeout=2)
+        sock.close()
+        return True
+    except OSError:
+        return False
+
+
+NATS_URL = os.environ.get("NEXUS_NATS_URL", "nats://localhost:4222")
+nats_available = _is_port_open("localhost", 4222)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(not nats_available, reason="NATS not available on :4222"),
+]
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _rpc_call(
+    client: Any, method: str, params: dict, api_key: str | None = None
+) -> tuple[int, dict]:
+    """Make a JSON-RPC call to the test server.
+
+    Returns (status_code, response_json) so tests can check both HTTP status
+    and body content.
+    """
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": method,
+        "params": params,
+    }
+    response = client.post(f"/api/nfs/{method}", json=payload, headers=headers)
+    return response.status_code, response.json()
+
+
+def _run_async(coro: Any) -> Any:
+    """Run an async coroutine from sync test code."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+async def _find_event_in_nats(
+    path: str, event_type: str | None = None, timeout: float = 5.0
+) -> bool:
+    """Connect to NATS and scan the stream for an event matching the given path."""
+    import nats as nats_lib
+
+    nc = await nats_lib.connect(NATS_URL)
+    js = nc.jetstream()
+    sub = await js.subscribe("nexus.events.>", ordered_consumer=True)
+
+    found = False
+    try:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                msg = await asyncio.wait_for(sub.next_msg(), timeout=2.0)
+                data = json.loads(msg.data)
+                if data.get("path") == path and (
+                    event_type is None or data.get("type") == event_type
+                ):
+                    found = True
+                    break
+            except TimeoutError:
+                break
+    finally:
+        await sub.unsubscribe()
+        await nc.close()
+
+    return found
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def server_app():
+    """Create a FastAPI app with NATS event bus and API key auth."""
+    import nats as nats_lib
+
+    # Clean NATS stream before tests
+    async def _cleanup():
+        nc = await nats_lib.connect(NATS_URL)
+        js = nc.jetstream()
+        try:
+            await js.delete_stream("NEXUS_EVENTS")
+        except Exception:
+            pass
+        await nc.close()
+
+    _run_async(_cleanup())
+
+    # Set env vars BEFORE creating NexusFS
+    os.environ["NEXUS_EVENT_BUS_BACKEND"] = "nats"
+    os.environ["NEXUS_NATS_URL"] = NATS_URL
+
+    import tempfile
+
+    import nexus
+    from nexus.core.nexus_fs import NexusFS
+    from nexus.server.fastapi_server import create_app
+
+    data_dir = tempfile.mkdtemp(prefix="nexus_e2e_nats_")
+
+    nexus_fs = nexus.connect(
+        config={
+            "mode": "embedded",
+            "data_dir": data_dir,
+            # Filesystem-level permissions off (SQLite lacks rebac_tuples table).
+            # Auth enforcement is tested at the HTTP layer via require_auth.
+            "enforce_permissions": False,
+            "allow_admin_bypass": True,
+        }
+    )
+
+    assert isinstance(nexus_fs, NexusFS)
+
+    # Disable audit strict mode — SQLite embedded mode lacks operation_log table.
+    # We're testing the NATS event bus, not audit logging.
+    nexus_fs._audit_strict_mode = False
+
+    # Verify event bus is NATS
+    from nexus.core.event_bus_nats import NatsEventBus
+
+    assert nexus_fs._event_bus is not None
+    assert isinstance(nexus_fs._event_bus, NatsEventBus)
+
+    app = create_app(
+        nexus_fs=nexus_fs,
+        api_key="test-e2e-key-1331",
+    )
+
+    yield app, nexus_fs
+
+    # Cleanup
+    try:
+        nexus_fs.close()
+    except Exception:
+        pass
+
+    # Clean NATS stream after tests
+    _run_async(_cleanup())
+
+    os.environ.pop("NEXUS_EVENT_BUS_BACKEND", None)
+    os.environ.pop("NEXUS_NATS_URL", None)
+
+
+@pytest.fixture(scope="module")
+def client(server_app):
+    """Create test client — triggers lifespan which starts event bus + creates stream."""
+    from starlette.testclient import TestClient
+
+    app, _ = server_app
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def nexus_fs(server_app):
+    _, nfs = server_app
+    return nfs
+
+
+@pytest.fixture(scope="module")
+def api_key():
+    return "test-e2e-key-1331"
+
+
+# ============================================================================
+# Test: Server starts with NATS event bus
+# ============================================================================
+
+
+class TestServerStartup:
+    """Verify the server initializes NATS event bus correctly."""
+
+    def test_event_bus_is_nats(self, client, nexus_fs):
+        """Event bus should be NatsEventBus."""
+        from nexus.core.event_bus_nats import NatsEventBus
+
+        assert isinstance(nexus_fs._event_bus, NatsEventBus)
+
+    def test_event_bus_started(self, client, nexus_fs):
+        """Event bus should be started after lifespan init."""
+        assert nexus_fs._event_bus._started is True
+
+    def test_health_endpoint(self, client):
+        """Server health endpoint should respond."""
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_event_bus_health(self, client, nexus_fs):
+        """NATS event bus health check should pass."""
+        result = _run_async(nexus_fs._event_bus.health_check())
+        assert result is True
+
+    def test_main_event_loop_set(self, client, nexus_fs):
+        """Lifespan should set _main_event_loop for cross-thread publishing."""
+        assert hasattr(nexus_fs, "_main_event_loop")
+        assert nexus_fs._main_event_loop is not None
+        assert nexus_fs._main_event_loop.is_running()
+
+
+# ============================================================================
+# Test: Direct event bus publish (bypasses threading complexity)
+# ============================================================================
+
+
+class TestDirectPublish:
+    """Test direct event bus publish → NATS receive."""
+
+    def test_direct_publish_received(self, client, nexus_fs):
+        """Events published directly to bus should appear in NATS stream."""
+        from nexus.core.event_bus import FileEvent, FileEventType
+
+        unique_path = f"/e2e-nats-test/direct-{uuid.uuid4().hex[:8]}.txt"
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path=unique_path,
+            zone_id="default",
+        )
+
+        # Publish directly to NATS via the bus (schedule on main loop)
+        future = asyncio.run_coroutine_threadsafe(
+            nexus_fs._event_bus.publish(event),
+            nexus_fs._main_event_loop,
+        )
+        seq = future.result(timeout=10)
+        assert isinstance(seq, int)
+        assert seq > 0
+
+        # Verify event in stream
+        found = _run_async(_find_event_in_nats(unique_path, "file_write"))
+        assert found, f"Direct publish event for {unique_path} not found in NATS"
+
+
+# ============================================================================
+# Test: File writes via RPC trigger NATS events
+# ============================================================================
+
+
+class TestFileWriteEvents:
+    """Test that RPC file operations produce events in NATS JetStream."""
+
+    def test_write_file_via_rpc(self, client, api_key):
+        """Write a file via RPC and verify success."""
+        status, body = _rpc_call(
+            client,
+            "write",
+            {"path": "/e2e-nats-test/hello.txt", "content": "SGVsbG8gTkFUUw=="},
+            api_key=api_key,
+        )
+        assert status == 200, f"Write returned HTTP {status}: {body}"
+        assert body.get("error") is None, f"Write failed: {body}"
+
+    def test_write_triggers_nats_event(self, client, api_key):
+        """Write a file via RPC and verify NATS event was published."""
+        unique_path = f"/e2e-nats-test/rpc-event-{uuid.uuid4().hex[:8]}.txt"
+
+        status, body = _rpc_call(
+            client,
+            "write",
+            {"path": unique_path, "content": "dGVzdA=="},
+            api_key=api_key,
+        )
+        assert status == 200, f"Write returned HTTP {status}: {body}"
+        assert body.get("error") is None, f"Write failed: {body}"
+
+        # Give event time to propagate (published async from thread pool → main loop)
+        time.sleep(3.0)
+
+        found = _run_async(_find_event_in_nats(unique_path, "file_write"))
+        assert found, f"Event for {unique_path} not found in NATS stream"
+
+    def test_mkdir_triggers_nats_event(self, client, api_key):
+        """mkdir via RPC should publish a dir_create event."""
+        unique_dir = f"/e2e-nats-test/dir-{uuid.uuid4().hex[:8]}"
+
+        # Ensure parent /e2e-nats-test exists (mkdir_p creates intermediate dirs)
+        status, body = _rpc_call(
+            client,
+            "mkdir",
+            {"path": unique_dir, "parents": True},
+            api_key=api_key,
+        )
+        assert status == 200, f"mkdir returned HTTP {status}: {body}"
+        assert body.get("error") is None, f"mkdir failed: {body}"
+
+        time.sleep(3.0)
+
+        found = _run_async(_find_event_in_nats(unique_dir, "dir_create"))
+        assert found, f"dir_create event for {unique_dir} not found in NATS"
+
+    def test_delete_triggers_nats_event(self, client, api_key):
+        """delete via RPC should publish a file_delete event."""
+        unique_path = f"/e2e-nats-test/del-{uuid.uuid4().hex[:8]}.txt"
+
+        # Create file first
+        status, _ = _rpc_call(
+            client,
+            "write",
+            {"path": unique_path, "content": "dGVzdA=="},
+            api_key=api_key,
+        )
+        assert status == 200
+        time.sleep(1.0)
+
+        # Delete it
+        status, body = _rpc_call(
+            client,
+            "delete",
+            {"path": unique_path},
+            api_key=api_key,
+        )
+        assert status == 200, f"delete returned HTTP {status}: {body}"
+        assert body.get("error") is None, f"delete failed: {body}"
+
+        time.sleep(3.0)
+
+        found = _run_async(_find_event_in_nats(unique_path, "file_delete"))
+        assert found, f"file_delete event for {unique_path} not found in NATS"
+
+
+# ============================================================================
+# Test: Durable consumer receives events
+# ============================================================================
+
+
+class TestDurableSubscriber:
+    """Test durable consumer subscription via NATS JetStream."""
+
+    def test_durable_consumer_receives_events(self, client, nexus_fs):
+        """A durable consumer should receive events from direct NexusFS writes."""
+        import nats as nats_lib
+
+        from nexus.core.event_bus import FileEvent, FileEventType
+
+        unique_path = f"/e2e-nats-test/durable-{uuid.uuid4().hex[:8]}.txt"
+
+        async def _test():
+            nc = await nats_lib.connect(NATS_URL)
+            js = nc.jetstream()
+
+            consumer_name = f"e2e-{uuid.uuid4().hex[:8]}"
+            from nats.js.api import ConsumerConfig, DeliverPolicy
+
+            sub = await js.pull_subscribe(
+                "nexus.events.>",
+                durable=consumer_name,
+                config=ConsumerConfig(
+                    durable_name=consumer_name,
+                    deliver_policy=DeliverPolicy.NEW,
+                ),
+            )
+
+            # Publish event directly to NATS via bus (using main loop)
+            event = FileEvent(
+                type=FileEventType.FILE_WRITE,
+                path=unique_path,
+                zone_id="default",
+            )
+            future = asyncio.run_coroutine_threadsafe(
+                nexus_fs._event_bus.publish(event),
+                nexus_fs._main_event_loop,
+            )
+            future.result(timeout=10)
+
+            await asyncio.sleep(2.0)
+
+            from nats.errors import TimeoutError as NatsTimeoutError
+
+            found = False
+            for _ in range(10):
+                try:
+                    msgs = await sub.fetch(batch=10, timeout=3)
+                    for msg in msgs:
+                        data = json.loads(msg.data)
+                        if data.get("path") == unique_path:
+                            found = True
+                            await msg.ack()
+                            break
+                    if found:
+                        break
+                except NatsTimeoutError:
+                    continue
+
+            await sub.unsubscribe()
+            await nc.close()
+            return found
+
+        found = _run_async(_test())
+        assert found, f"Durable consumer did not receive event for {unique_path}"
+
+
+# ============================================================================
+# Test: Permission enforcement
+# ============================================================================
+
+
+class TestPermissionEnforcement:
+    """Test that auth is enforced and unauthorized writes produce no events."""
+
+    def test_unauthenticated_write_rejected(self, client):
+        """Write without API key should be rejected with 401."""
+        status, body = _rpc_call(
+            client,
+            "write",
+            {"path": "/e2e-nats-test/unauthed.txt", "content": "dGVzdA=="},
+            api_key=None,
+        )
+        assert status == 401, f"Expected 401 for unauthenticated write, got {status}: {body}"
+
+    def test_wrong_api_key_rejected(self, client):
+        """Write with wrong API key should be rejected with 401."""
+        status, body = _rpc_call(
+            client,
+            "write",
+            {"path": "/e2e-nats-test/wrong-key.txt", "content": "dGVzdA=="},
+            api_key="wrong-key-12345",
+        )
+        assert status == 401, f"Expected 401 for wrong API key, got {status}: {body}"
+
+    def test_authorized_write_succeeds(self, client, api_key):
+        """Write with correct API key should succeed."""
+        unique_path = f"/e2e-nats-test/authed-{uuid.uuid4().hex[:8]}.txt"
+        status, body = _rpc_call(
+            client,
+            "write",
+            {"path": unique_path, "content": "dGVzdA=="},
+            api_key=api_key,
+        )
+        assert status == 200, f"Expected 200 for authorized write, got {status}: {body}"
+        assert body.get("error") is None
+
+    def test_no_event_for_rejected_write(self, client):
+        """A rejected write should NOT produce a NATS event."""
+        unique_path = f"/e2e-nats-test/no-event-{uuid.uuid4().hex[:8]}.txt"
+
+        # Attempt unauthorized write
+        status, _ = _rpc_call(
+            client,
+            "write",
+            {"path": unique_path, "content": "dGVzdA=="},
+            api_key=None,
+        )
+        assert status == 401
+
+        time.sleep(2.0)
+
+        found = _run_async(_find_event_in_nats(unique_path, timeout=3.0))
+        assert not found, f"Unexpected event for rejected write to {unique_path}"
+
+
+# ============================================================================
+# Test: Event bus stats
+# ============================================================================
+
+
+class TestEventBusStats:
+    """Test NATS event bus statistics."""
+
+    def test_get_stats(self, client, nexus_fs):
+        """NATS event bus should return meaningful stats."""
+        future = asyncio.run_coroutine_threadsafe(
+            nexus_fs._event_bus.get_stats(),
+            nexus_fs._main_event_loop,
+        )
+        stats = future.result(timeout=10)
+
+        assert stats["backend"] == "nats_jetstream"
+        assert stats["status"] == "running"
+        assert "stream" in stats
+        assert stats["stream"]["messages"] >= 0
+        assert stats["nats_url"] == NATS_URL
+
+
+# ============================================================================
+# Test: Event deduplication
+# ============================================================================
+
+
+class TestDeduplication:
+    """Test JetStream message deduplication end-to-end."""
+
+    def test_duplicate_events_deduplicated(self, client, nexus_fs):
+        """Publishing the same event_id twice should be deduplicated."""
+        from nexus.core.event_bus import FileEvent, FileEventType
+
+        dedup_id = f"dedup-e2e-{uuid.uuid4().hex[:8]}"
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path=f"/e2e-nats-test/dedup-{dedup_id}.txt",
+            zone_id="default",
+            event_id=dedup_id,
+        )
+
+        # Publish twice via main loop
+        f1 = asyncio.run_coroutine_threadsafe(
+            nexus_fs._event_bus.publish(event),
+            nexus_fs._main_event_loop,
+        )
+        seq1 = f1.result(timeout=10)
+
+        f2 = asyncio.run_coroutine_threadsafe(
+            nexus_fs._event_bus.publish(event),
+            nexus_fs._main_event_loop,
+        )
+        seq2 = f2.result(timeout=10)
+
+        # Same sequence = deduplicated
+        assert seq1 == seq2, f"Expected dedup (same seq), got seq1={seq1}, seq2={seq2}"

--- a/tests/integration/test_event_bus_nats_integration.py
+++ b/tests/integration/test_event_bus_nats_integration.py
@@ -1,0 +1,258 @@
+"""Integration tests for NatsEventBus with a real NATS server.
+
+Requires: nats-server running with JetStream enabled.
+Start with:
+  docker run -d --name nats-test -p 4222:4222 -p 8222:8222 \
+    nats:2.10-alpine --jetstream -m 8222
+
+Set NEXUS_NATS_URL to override the default nats://localhost:4222.
+
+Related: Issue #1331
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from nexus.core.event_bus import FileEvent, FileEventType
+
+NATS_URL = os.environ.get("NEXUS_NATS_URL", "nats://localhost:4222")
+
+
+def _is_nats_available() -> bool:
+    """Check if NATS server is reachable."""
+    import socket
+
+    try:
+        # Parse host:port from nats://host:port
+        url = NATS_URL.replace("nats://", "")
+        host, port_str = url.split(":")
+        port = int(port_str)
+        sock = socket.create_connection((host, port), timeout=2)
+        sock.close()
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _is_nats_available(), reason="NATS not available"),
+    pytest.mark.xdist_group("nats"),  # All NATS tests share one stream; run sequentially
+]
+
+
+@pytest.fixture
+async def nats_bus():
+    """Create, start, and clean up a NatsEventBus for testing."""
+    from nexus.core.event_bus_nats import NatsEventBus
+
+    bus = NatsEventBus(nats_url=NATS_URL)
+    await bus.start()
+
+    yield bus
+
+    # Clean up: delete the stream to avoid test pollution
+    if bus._js:
+        try:
+            await bus._js.delete_stream(bus.STREAM_NAME)
+        except Exception:
+            pass
+    await bus.stop()
+
+
+class TestNatsEventBusIntegration:
+    """Integration tests with a real NATS server."""
+
+    @pytest.mark.asyncio
+    async def test_publish_and_subscribe_roundtrip(self, nats_bus):
+        """Test that a published event can be received via subscribe."""
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/test.txt",
+            zone_id="integration-zone",
+        )
+
+        # Publish
+        seq = await nats_bus.publish(event)
+        assert isinstance(seq, int)
+        assert seq > 0
+
+        # Subscribe and receive
+        received = []
+        async for ackable in nats_bus.subscribe_durable(
+            "integration-zone", "test-roundtrip", deliver_policy="all"
+        ):
+            received.append(ackable)
+            await ackable.ack()
+            break
+
+        assert len(received) == 1
+        assert received[0].event.path == "/inbox/test.txt"
+        assert received[0].event.type == "file_write"
+
+    @pytest.mark.asyncio
+    async def test_ack_prevents_redelivery(self, nats_bus):
+        """Test that acked messages are not redelivered."""
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/ack-test.txt",
+            zone_id="ack-zone",
+        )
+
+        await nats_bus.publish(event)
+
+        # First consumer acks
+        async for ackable in nats_bus.subscribe_durable(
+            "ack-zone", "ack-consumer", deliver_policy="all"
+        ):
+            await ackable.ack()
+            break
+
+        # Second read from same consumer — should not get same message
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        got_message = False
+        try:
+            sub = await nats_bus._js.pull_subscribe(
+                "nexus.events.ack-zone.>",
+                durable="ack-consumer",
+            )
+            msgs = await sub.fetch(batch=1, timeout=1)
+            if msgs:
+                got_message = True
+            await sub.unsubscribe()
+        except NatsTimeoutError:
+            pass
+
+        assert not got_message, "Acked message should not be redelivered"
+
+    @pytest.mark.asyncio
+    async def test_publish_deduplication(self, nats_bus):
+        """Test that duplicate event_ids are deduplicated."""
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/dedup.txt",
+            zone_id="dedup-zone",
+            event_id="same-id-12345",
+        )
+
+        seq1 = await nats_bus.publish(event)
+        seq2 = await nats_bus.publish(event)
+
+        # Both publishes succeed, but second should be deduplicated
+        # (same sequence number = duplicate detected)
+        assert seq1 == seq2
+
+    @pytest.mark.asyncio
+    async def test_multiple_zones_independent(self, nats_bus):
+        """Test that events in different zones are independent."""
+        event_a = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/a.txt",
+            zone_id="zone-a",
+        )
+        event_b = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/b.txt",
+            zone_id="zone-b",
+        )
+
+        await nats_bus.publish(event_a)
+        await nats_bus.publish(event_b)
+
+        # Consumer for zone-a should only get event_a
+        received_a = []
+        async for ackable in nats_bus.subscribe_durable(
+            "zone-a", "zone-a-consumer", deliver_policy="all"
+        ):
+            received_a.append(ackable.event)
+            await ackable.ack()
+            break
+
+        assert len(received_a) == 1
+        assert received_a[0].path == "/inbox/a.txt"
+
+    @pytest.mark.asyncio
+    async def test_health_check(self, nats_bus):
+        """Test health check against live NATS."""
+        result = await nats_bus.health_check()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_get_stats(self, nats_bus):
+        """Test get_stats against live NATS."""
+        # Publish one event so stream has data
+        await nats_bus.publish(
+            FileEvent(
+                type=FileEventType.FILE_WRITE,
+                path="/inbox/stats-test.txt",
+                zone_id="stats-zone",
+            )
+        )
+
+        stats = await nats_bus.get_stats()
+
+        assert stats["backend"] == "nats_jetstream"
+        assert stats["status"] == "running"
+        assert "stream" in stats
+        assert stats["stream"]["messages"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_wait_for_event(self, nats_bus):
+        """Test wait_for_event with live NATS."""
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/wait-test.txt",
+            zone_id="wait-zone",
+        )
+
+        # Publish after a short delay
+        async def delayed_publish():
+            await asyncio.sleep(0.2)
+            await nats_bus.publish(event)
+
+        task = asyncio.create_task(delayed_publish())
+
+        result = await nats_bus.wait_for_event("wait-zone", "/inbox/", timeout=5.0)
+
+        await task
+
+        assert result is not None
+        assert result.path == "/inbox/wait-test.txt"
+
+    @pytest.mark.asyncio
+    async def test_consumer_group_independent_delivery(self, nats_bus):
+        """Test that different consumer names get independent delivery."""
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/group-test.txt",
+            zone_id="group-zone",
+        )
+
+        await nats_bus.publish(event)
+
+        # Consumer A
+        received_a = []
+        async for ackable in nats_bus.subscribe_durable(
+            "group-zone", "consumer-a", deliver_policy="all"
+        ):
+            received_a.append(ackable.event)
+            await ackable.ack()
+            break
+
+        # Consumer B — same event, independent consumer
+        received_b = []
+        async for ackable in nats_bus.subscribe_durable(
+            "group-zone", "consumer-b", deliver_policy="all"
+        ):
+            received_b.append(ackable.event)
+            await ackable.ack()
+            break
+
+        assert len(received_a) == 1
+        assert len(received_b) == 1
+        assert received_a[0].event_id == received_b[0].event_id

--- a/tests/unit/core/test_event_bus_contract.py
+++ b/tests/unit/core/test_event_bus_contract.py
@@ -1,0 +1,175 @@
+"""Parametrized contract tests for event bus backends.
+
+Ensures that both Redis and NATS backends satisfy the same EventBusBase
+contract. Each test is run once per backend.
+
+Related: Issue #1331
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nexus.core.event_bus import (
+    EventBusBase,
+    EventBusProtocol,
+    FileEvent,
+    FileEventType,
+    RedisEventBus,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_redis_client():
+    """Create a mock DragonflyClient for Redis backend."""
+    client = MagicMock()
+    client.client = MagicMock()
+    client.health_check = AsyncMock(return_value=True)
+    client.get_info = AsyncMock(return_value={"status": "ok"})
+
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+    pubsub.aclose = AsyncMock()
+    pubsub.get_message = AsyncMock(return_value=None)
+    client.client.pubsub.return_value = pubsub
+    client.client.publish = AsyncMock(return_value=1)
+
+    return client
+
+
+@pytest.fixture
+def mock_nats_connect():
+    """Patch nats.connect and return mock objects."""
+    with patch("nexus.core.event_bus_nats.nats.connect", new_callable=AsyncMock) as mock_connect:
+        nc = AsyncMock()
+        nc.is_connected = True
+        nc.drain = AsyncMock()
+
+        js = AsyncMock()
+        js.add_stream = AsyncMock()
+        js.find_stream_name_by_subject = AsyncMock(return_value="NEXUS_EVENTS")
+
+        @dataclass
+        class MockAck:
+            seq: int = 1
+
+        js.publish = AsyncMock(return_value=MockAck())
+        # jetstream() is synchronous in nats-py
+        nc.jetstream = MagicMock(return_value=js)
+
+        mock_connect.return_value = nc
+        yield mock_connect, nc, js
+
+
+@pytest.fixture(params=["redis", "nats"])
+async def event_bus(request, mock_redis_client, mock_nats_connect):
+    """Create and start an event bus for each backend."""
+    if request.param == "redis":
+        bus = RedisEventBus(mock_redis_client)
+        await bus.start()
+        yield bus
+        await bus.stop()
+    else:
+        from nexus.core.event_bus_nats import NatsEventBus
+
+        bus = NatsEventBus(nats_url="nats://mock:4222")
+        await bus.start()
+        yield bus
+        await bus.stop()
+
+
+@pytest.fixture
+def sample_event():
+    return FileEvent(
+        type=FileEventType.FILE_WRITE,
+        path="/inbox/test.txt",
+        zone_id="zone1",
+        event_id="evt-contract-1",
+    )
+
+
+# ============================================================================
+# Contract Tests
+# ============================================================================
+
+
+class TestEventBusContract:
+    """Tests that both backends satisfy the same contract."""
+
+    @pytest.mark.asyncio
+    async def test_implements_protocol(self, event_bus):
+        """Both backends implement EventBusProtocol."""
+        assert isinstance(event_bus, EventBusProtocol)
+        assert isinstance(event_bus, EventBusBase)
+
+    @pytest.mark.asyncio
+    async def test_start_stop_lifecycle(self, event_bus):
+        """start() and stop() are idempotent."""
+        # Already started by fixture — start again should be fine
+        await event_bus.start()
+        assert event_bus._started is True
+
+        await event_bus.stop()
+        assert event_bus._started is False
+
+        # Double stop is fine
+        await event_bus.stop()
+
+    @pytest.mark.asyncio
+    async def test_publish_returns_int(self, event_bus, sample_event):
+        """publish() returns an integer (subscriber count or sequence)."""
+        result = await event_bus.publish(sample_event)
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_health_check(self, event_bus):
+        """health_check() returns a boolean."""
+        result = await event_bus.health_check()
+        assert isinstance(result, bool)
+
+    @pytest.mark.asyncio
+    async def test_get_stats(self, event_bus):
+        """get_stats() returns a dict with backend and status keys."""
+        stats = await event_bus.get_stats()
+        assert isinstance(stats, dict)
+        assert "backend" in stats
+        assert "status" in stats
+
+    @pytest.mark.asyncio
+    async def test_has_subscribe(self, event_bus):
+        """subscribe() method exists and is callable."""
+        assert hasattr(event_bus, "subscribe")
+        assert callable(event_bus.subscribe)
+
+    @pytest.mark.asyncio
+    async def test_has_subscribe_durable(self, event_bus):
+        """subscribe_durable() method exists and is callable."""
+        assert hasattr(event_bus, "subscribe_durable")
+        assert callable(event_bus.subscribe_durable)
+
+    @pytest.mark.asyncio
+    async def test_has_wait_for_event(self, event_bus):
+        """wait_for_event() method exists and is callable."""
+        assert hasattr(event_bus, "wait_for_event")
+        assert callable(event_bus.wait_for_event)
+
+    @pytest.mark.asyncio
+    async def test_has_startup_sync(self, event_bus):
+        """startup_sync() method exists (inherited from EventBusBase)."""
+        assert hasattr(event_bus, "startup_sync")
+        assert callable(event_bus.startup_sync)
+
+    @pytest.mark.asyncio
+    async def test_has_node_id(self, event_bus):
+        """Each backend gets a node_id from EventBusBase."""
+        assert hasattr(event_bus, "_node_id")
+        assert isinstance(event_bus._node_id, str)
+        assert len(event_bus._node_id) > 0

--- a/tests/unit/core/test_event_bus_nats.py
+++ b/tests/unit/core/test_event_bus_nats.py
@@ -1,0 +1,808 @@
+"""Unit tests for NatsEventBus (mocked NATS).
+
+Tests cover:
+- Connection lifecycle (start/stop)
+- Subject construction
+- Publish with JetStream ack, headers, dedup ID
+- Subscribe (auto-ack wrapper)
+- Durable subscribe (pull consumer, ack/nack/in_progress)
+- Wait for event (ephemeral consumer)
+- Health check
+- Reconnection callbacks
+- Error handling (malformed messages, NATS errors)
+
+Related: Issue #1331
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nexus.core.event_bus import AckableEvent, FileEvent, FileEventType
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_nats_connect():
+    """Patch nats.connect to return a mock NATS client."""
+    with patch("nexus.core.event_bus_nats.nats.connect", new_callable=AsyncMock) as mock_connect:
+        nc = AsyncMock()
+        nc.is_connected = True
+        nc.drain = AsyncMock()
+
+        js = AsyncMock()
+        js.add_stream = AsyncMock()
+        # jetstream() is synchronous in nats-py
+        nc.jetstream = MagicMock(return_value=js)
+
+        mock_connect.return_value = nc
+        yield mock_connect, nc, js
+
+
+@pytest.fixture
+def make_bus():
+    """Create a NatsEventBus with default test settings."""
+
+    def _make(**kwargs):
+        from nexus.core.event_bus_nats import NatsEventBus
+
+        defaults = {"nats_url": "nats://test:4222"}
+        defaults.update(kwargs)
+        return NatsEventBus(**defaults)
+
+    return _make
+
+
+@pytest.fixture
+def sample_event():
+    """A sample FileEvent for testing."""
+    return FileEvent(
+        type=FileEventType.FILE_WRITE,
+        path="/inbox/test.txt",
+        zone_id="zone1",
+        event_id="evt-123",
+    )
+
+
+# ============================================================================
+# Start / Stop Tests
+# ============================================================================
+
+
+class TestNatsEventBusStartStop:
+    """Tests for connection lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_start_connects_and_creates_stream(self, mock_nats_connect, make_bus):
+        mock_connect, nc, js = mock_nats_connect
+        bus = make_bus()
+
+        await bus.start()
+
+        assert bus._started is True
+        mock_connect.assert_called_once()
+        js.add_stream.assert_called_once()
+
+        # Verify stream config
+        call_args = js.add_stream.call_args
+        config = call_args[0][0]
+        assert config.name == "NEXUS_EVENTS"
+        assert "nexus.events.>" in config.subjects
+
+    @pytest.mark.asyncio
+    async def test_start_idempotent(self, mock_nats_connect, make_bus):
+        mock_connect, nc, js = mock_nats_connect
+        bus = make_bus()
+
+        await bus.start()
+        await bus.start()
+
+        # Should only connect once
+        mock_connect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_drains_connection(self, mock_nats_connect, make_bus):
+        _, nc, _ = mock_nats_connect
+        bus = make_bus()
+
+        await bus.start()
+        await bus.stop()
+
+        assert bus._started is False
+        nc.drain.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_idempotent(self, mock_nats_connect, make_bus):
+        _, nc, _ = mock_nats_connect
+        bus = make_bus()
+
+        await bus.start()
+        await bus.stop()
+        await bus.stop()
+
+        # Drain called only once
+        nc.drain.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_before_start_is_noop(self, make_bus):
+        bus = make_bus()
+        await bus.stop()
+        assert bus._started is False
+
+
+# ============================================================================
+# Publish Tests
+# ============================================================================
+
+
+class TestNatsEventBusPublish:
+    """Tests for event publishing."""
+
+    @pytest.mark.asyncio
+    async def test_publish_builds_correct_subject(self, mock_nats_connect, make_bus, sample_event):
+        _, _, js = mock_nats_connect
+
+        @dataclass
+        class MockAck:
+            seq: int = 42
+
+        js.publish = AsyncMock(return_value=MockAck())
+        bus = make_bus()
+        await bus.start()
+
+        seq = await bus.publish(sample_event)
+
+        assert seq == 42
+        call_args = js.publish.call_args
+        assert call_args[0][0] == "nexus.events.zone1.file_write"
+
+    @pytest.mark.asyncio
+    async def test_publish_sends_json_payload(self, mock_nats_connect, make_bus, sample_event):
+        _, _, js = mock_nats_connect
+
+        @dataclass
+        class MockAck:
+            seq: int = 1
+
+        js.publish = AsyncMock(return_value=MockAck())
+        bus = make_bus()
+        await bus.start()
+
+        await bus.publish(sample_event)
+
+        call_args = js.publish.call_args
+        payload = call_args[0][1]
+        parsed = json.loads(payload.decode())
+        assert parsed["type"] == "file_write"
+        assert parsed["path"] == "/inbox/test.txt"
+
+    @pytest.mark.asyncio
+    async def test_publish_includes_dedup_header(self, mock_nats_connect, make_bus, sample_event):
+        _, _, js = mock_nats_connect
+
+        @dataclass
+        class MockAck:
+            seq: int = 1
+
+        js.publish = AsyncMock(return_value=MockAck())
+        bus = make_bus()
+        await bus.start()
+
+        await bus.publish(sample_event)
+
+        call_args = js.publish.call_args
+        headers = call_args[1]["headers"]
+        assert headers["Nats-Msg-Id"] == "evt-123"
+        assert headers["zone_id"] == "zone1"
+
+    @pytest.mark.asyncio
+    async def test_publish_default_zone(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+
+        @dataclass
+        class MockAck:
+            seq: int = 1
+
+        js.publish = AsyncMock(return_value=MockAck())
+        bus = make_bus()
+        await bus.start()
+
+        event = FileEvent(type=FileEventType.FILE_WRITE, path="/test.txt", zone_id=None)
+        await bus.publish(event)
+
+        call_args = js.publish.call_args
+        assert call_args[0][0] == "nexus.events.default.file_write"
+
+    @pytest.mark.asyncio
+    async def test_publish_requires_start(self, make_bus, sample_event):
+        bus = make_bus()
+        with pytest.raises(RuntimeError, match="not started"):
+            await bus.publish(sample_event)
+
+    @pytest.mark.asyncio
+    async def test_publish_propagates_nats_error(self, mock_nats_connect, make_bus, sample_event):
+        _, _, js = mock_nats_connect
+        js.publish = AsyncMock(side_effect=Exception("NATS unavailable"))
+        bus = make_bus()
+        await bus.start()
+
+        with pytest.raises(Exception, match="NATS unavailable"):
+            await bus.publish(sample_event)
+
+
+# ============================================================================
+# Subscribe Tests (auto-ack wrapper)
+# ============================================================================
+
+
+class TestNatsEventBusSubscribe:
+    """Tests for the backward-compat subscribe() wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_subscribe_yields_events(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        # Mock the pull subscription
+        mock_sub = AsyncMock()
+        js.pull_subscribe = AsyncMock(return_value=mock_sub)
+
+        event1 = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/test/file1.txt",
+            zone_id="z1",
+        )
+        event2 = FileEvent(
+            type=FileEventType.FILE_DELETE,
+            path="/test/file2.txt",
+            zone_id="z1",
+        )
+
+        msg1 = MagicMock()
+        msg1.data = event1.to_json().encode()
+        msg1.subject = "nexus.events.z1.file_write"
+        msg1.ack = AsyncMock()
+        msg1.nak = AsyncMock()
+        msg1.in_progress = AsyncMock()
+
+        msg2 = MagicMock()
+        msg2.data = event2.to_json().encode()
+        msg2.subject = "nexus.events.z1.file_delete"
+        msg2.ack = AsyncMock()
+        msg2.nak = AsyncMock()
+        msg2.in_progress = AsyncMock()
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        call_count = [0]
+
+        async def mock_fetch(batch=10, timeout=5):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [msg1, msg2]
+            raise NatsTimeoutError
+
+        mock_sub.fetch = mock_fetch
+        mock_sub.unsubscribe = AsyncMock()
+
+        received = []
+        count = 0
+        async for event in bus.subscribe("z1"):
+            received.append(event)
+            count += 1
+            if count >= 2:
+                break
+
+        assert len(received) == 2
+        assert received[0].path == "/test/file1.txt"
+        assert received[1].path == "/test/file2.txt"
+        # Auto-ack should have been called
+        msg1.ack.assert_called_once()
+        msg2.ack.assert_called_once()
+
+
+# ============================================================================
+# Durable Subscribe Tests
+# ============================================================================
+
+
+class TestNatsEventBusSubscribeDurable:
+    """Tests for durable pull consumer subscription."""
+
+    @pytest.mark.asyncio
+    async def test_durable_creates_consumer(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        mock_sub = AsyncMock()
+        js.pull_subscribe = AsyncMock(return_value=mock_sub)
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        async def mock_fetch(batch=10, timeout=5):
+            raise NatsTimeoutError
+
+        mock_sub.fetch = mock_fetch
+        mock_sub.unsubscribe = AsyncMock()
+
+        # Just verify the subscription is created
+        gen = bus.subscribe_durable("z1", "test-consumer", deliver_policy="all")
+        # Need to actually iterate to trigger the pull_subscribe call
+        task = asyncio.ensure_future(gen.__anext__())
+        await asyncio.sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, StopAsyncIteration):
+            pass
+
+        js.pull_subscribe.assert_called_once()
+        call_args = js.pull_subscribe.call_args
+        assert call_args[1]["durable"] == "test-consumer"
+
+    @pytest.mark.asyncio
+    async def test_durable_yields_ackable_events(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        mock_sub = AsyncMock()
+        js.pull_subscribe = AsyncMock(return_value=mock_sub)
+
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/test/file.txt",
+            zone_id="z1",
+        )
+
+        msg = MagicMock()
+        msg.data = event.to_json().encode()
+        msg.subject = "nexus.events.z1.file_write"
+        msg.ack = AsyncMock()
+        msg.nak = AsyncMock()
+        msg.in_progress = AsyncMock()
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        call_count = [0]
+
+        async def mock_fetch(batch=10, timeout=5):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [msg]
+            raise NatsTimeoutError
+
+        mock_sub.fetch = mock_fetch
+        mock_sub.unsubscribe = AsyncMock()
+
+        received = []
+        async for ackable in bus.subscribe_durable("z1", "consumer-1"):
+            assert isinstance(ackable, AckableEvent)
+            assert ackable.event.path == "/test/file.txt"
+            received.append(ackable)
+            break
+
+        assert len(received) == 1
+
+    @pytest.mark.asyncio
+    async def test_durable_ack_calls_msg_ack(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        mock_sub = AsyncMock()
+        js.pull_subscribe = AsyncMock(return_value=mock_sub)
+
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/test/file.txt",
+            zone_id="z1",
+        )
+
+        msg = MagicMock()
+        msg.data = event.to_json().encode()
+        msg.subject = "nexus.events.z1.file_write"
+        msg.ack = AsyncMock()
+        msg.nak = AsyncMock()
+        msg.in_progress = AsyncMock()
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        call_count = [0]
+
+        async def mock_fetch(batch=10, timeout=5):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [msg]
+            raise NatsTimeoutError
+
+        mock_sub.fetch = mock_fetch
+        mock_sub.unsubscribe = AsyncMock()
+
+        async for ackable in bus.subscribe_durable("z1", "consumer-1"):
+            await ackable.ack()
+            break
+
+        msg.ack.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_durable_nack_calls_msg_nak(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        mock_sub = AsyncMock()
+        js.pull_subscribe = AsyncMock(return_value=mock_sub)
+
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/test/file.txt",
+            zone_id="z1",
+        )
+
+        msg = MagicMock()
+        msg.data = event.to_json().encode()
+        msg.subject = "nexus.events.z1.file_write"
+        msg.ack = AsyncMock()
+        msg.nak = AsyncMock()
+        msg.in_progress = AsyncMock()
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        call_count = [0]
+
+        async def mock_fetch(batch=10, timeout=5):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [msg]
+            raise NatsTimeoutError
+
+        mock_sub.fetch = mock_fetch
+        mock_sub.unsubscribe = AsyncMock()
+
+        async for ackable in bus.subscribe_durable("z1", "consumer-1"):
+            await ackable.nack(delay=5.0)
+            break
+
+        msg.nak.assert_called_once_with(delay=5.0)
+
+    @pytest.mark.asyncio
+    async def test_durable_in_progress(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        mock_sub = AsyncMock()
+        js.pull_subscribe = AsyncMock(return_value=mock_sub)
+
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/test/file.txt",
+            zone_id="z1",
+        )
+
+        msg = MagicMock()
+        msg.data = event.to_json().encode()
+        msg.subject = "nexus.events.z1.file_write"
+        msg.ack = AsyncMock()
+        msg.nak = AsyncMock()
+        msg.in_progress = AsyncMock()
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        call_count = [0]
+
+        async def mock_fetch(batch=10, timeout=5):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [msg]
+            raise NatsTimeoutError
+
+        mock_sub.fetch = mock_fetch
+        mock_sub.unsubscribe = AsyncMock()
+
+        async for ackable in bus.subscribe_durable("z1", "consumer-1"):
+            await ackable.in_progress()
+            break
+
+        msg.in_progress.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_durable_skips_malformed_messages(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        mock_sub = AsyncMock()
+        js.pull_subscribe = AsyncMock(return_value=mock_sub)
+
+        good_event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/test/good.txt",
+            zone_id="z1",
+        )
+
+        bad_msg = MagicMock()
+        bad_msg.data = b"not valid json{{{"
+        bad_msg.subject = "nexus.events.z1.file_write"
+        bad_msg.ack = AsyncMock()
+
+        good_msg = MagicMock()
+        good_msg.data = good_event.to_json().encode()
+        good_msg.subject = "nexus.events.z1.file_write"
+        good_msg.ack = AsyncMock()
+        good_msg.nak = AsyncMock()
+        good_msg.in_progress = AsyncMock()
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        call_count = [0]
+
+        async def mock_fetch(batch=10, timeout=5):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [bad_msg, good_msg]
+            raise NatsTimeoutError
+
+        mock_sub.fetch = mock_fetch
+        mock_sub.unsubscribe = AsyncMock()
+
+        received = []
+        async for ackable in bus.subscribe_durable("z1", "consumer-1"):
+            received.append(ackable)
+            break
+
+        assert len(received) == 1
+        assert received[0].event.path == "/test/good.txt"
+        # Bad message should have been acked to prevent redelivery
+        bad_msg.ack.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_durable_requires_start(self, make_bus):
+        bus = make_bus()
+        with pytest.raises(RuntimeError, match="not started"):
+            async for _ in bus.subscribe_durable("z1", "consumer-1"):
+                pass
+
+
+# ============================================================================
+# Wait For Event Tests
+# ============================================================================
+
+
+class TestNatsEventBusWaitForEvent:
+    """Tests for wait_for_event with ephemeral consumer."""
+
+    @pytest.mark.asyncio
+    async def test_wait_for_event_returns_matching(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/test.txt",
+            zone_id="z1",
+        )
+
+        mock_sub = AsyncMock()
+        mock_msg = MagicMock()
+        mock_msg.data = event.to_json().encode()
+        mock_sub.next_msg = AsyncMock(return_value=mock_msg)
+        mock_sub.unsubscribe = AsyncMock()
+        js.subscribe = AsyncMock(return_value=mock_sub)
+
+        result = await bus.wait_for_event("z1", "/inbox/", timeout=5.0)
+
+        assert result is not None
+        assert result.path == "/inbox/test.txt"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_event_timeout(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        mock_sub = AsyncMock()
+        mock_sub.next_msg = AsyncMock(side_effect=TimeoutError)
+        mock_sub.unsubscribe = AsyncMock()
+        js.subscribe = AsyncMock(return_value=mock_sub)
+
+        result = await bus.wait_for_event("z1", "/inbox/", timeout=0.1)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_wait_for_event_ignores_non_matching(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        non_matching = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/other/test.txt",
+            zone_id="z1",
+        )
+        matching = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/test.txt",
+            zone_id="z1",
+        )
+
+        mock_sub = AsyncMock()
+        msg1 = MagicMock()
+        msg1.data = non_matching.to_json().encode()
+        msg2 = MagicMock()
+        msg2.data = matching.to_json().encode()
+        mock_sub.next_msg = AsyncMock(side_effect=[msg1, msg2])
+        mock_sub.unsubscribe = AsyncMock()
+        js.subscribe = AsyncMock(return_value=mock_sub)
+
+        result = await bus.wait_for_event("z1", "/inbox/", timeout=5.0)
+
+        assert result is not None
+        assert result.path == "/inbox/test.txt"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_event_respects_since_revision(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        old_event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/test.txt",
+            zone_id="z1",
+            revision=5,
+        )
+        new_event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/inbox/test.txt",
+            zone_id="z1",
+            revision=10,
+        )
+
+        mock_sub = AsyncMock()
+        msg1 = MagicMock()
+        msg1.data = old_event.to_json().encode()
+        msg2 = MagicMock()
+        msg2.data = new_event.to_json().encode()
+        mock_sub.next_msg = AsyncMock(side_effect=[msg1, msg2])
+        mock_sub.unsubscribe = AsyncMock()
+        js.subscribe = AsyncMock(return_value=mock_sub)
+
+        result = await bus.wait_for_event("z1", "/inbox/", timeout=5.0, since_revision=7)
+
+        assert result is not None
+        assert result.revision == 10
+
+    @pytest.mark.asyncio
+    async def test_wait_for_event_requires_start(self, make_bus):
+        bus = make_bus()
+        with pytest.raises(RuntimeError, match="not started"):
+            await bus.wait_for_event("z1", "/inbox/")
+
+
+# ============================================================================
+# Health Check Tests
+# ============================================================================
+
+
+class TestNatsEventBusHealthCheck:
+    """Tests for health check."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_when_connected(self, mock_nats_connect, make_bus):
+        _, nc, js = mock_nats_connect
+        js.find_stream_name_by_subject = AsyncMock(return_value="NEXUS_EVENTS")
+        bus = make_bus()
+        await bus.start()
+
+        result = await bus.health_check()
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_health_check_when_not_started(self, make_bus):
+        bus = make_bus()
+        result = await bus.health_check()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_health_check_when_disconnected(self, mock_nats_connect, make_bus):
+        _, nc, _ = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        nc.is_connected = False
+        result = await bus.health_check()
+
+        assert result is False
+
+
+# ============================================================================
+# Reconnection Callback Tests
+# ============================================================================
+
+
+class TestNatsEventBusReconnection:
+    """Tests for disconnect/reconnect callbacks."""
+
+    @pytest.mark.asyncio
+    async def test_on_disconnect_logs(self, make_bus):
+        bus = make_bus()
+        # Should not raise
+        await bus._on_disconnect()
+
+    @pytest.mark.asyncio
+    async def test_on_reconnect_logs(self, make_bus):
+        bus = make_bus()
+        await bus._on_reconnect()
+
+    @pytest.mark.asyncio
+    async def test_on_error_logs(self, make_bus):
+        bus = make_bus()
+        await bus._on_error(Exception("test error"))
+
+
+# ============================================================================
+# Error Handling Tests
+# ============================================================================
+
+
+class TestNatsEventBusErrors:
+    """Tests for error scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_start_raises_on_connection_failure(self, make_bus):
+        from nats.errors import NoServersError
+
+        with patch(
+            "nexus.core.event_bus_nats.nats.connect",
+            new_callable=AsyncMock,
+            side_effect=NoServersError,
+        ):
+            bus = make_bus()
+            with pytest.raises(NoServersError):
+                await bus.start()
+
+    @pytest.mark.asyncio
+    async def test_subject_construction(self, make_bus):
+        bus = make_bus()
+        assert bus._subject("zone1", "file_write") == "nexus.events.zone1.file_write"
+        assert bus._zone_wildcard("zone1") == "nexus.events.zone1.>"
+
+    @pytest.mark.asyncio
+    async def test_get_stats_includes_stream_info(self, mock_nats_connect, make_bus):
+        _, _, js = mock_nats_connect
+        bus = make_bus()
+        await bus.start()
+
+        mock_state = MagicMock()
+        mock_state.messages = 100
+        mock_state.bytes = 5000
+        mock_state.first_seq = 1
+        mock_state.last_seq = 100
+        mock_state.consumer_count = 3
+
+        mock_info = MagicMock()
+        mock_info.state = mock_state
+
+        js.stream_info = AsyncMock(return_value=mock_info)
+
+        stats = await bus.get_stats()
+
+        assert stats["backend"] == "nats_jetstream"
+        assert stats["status"] == "running"
+        assert stats["stream"]["messages"] == 100
+        assert stats["stream"]["consumer_count"] == 3


### PR DESCRIPTION
## Summary

- **NATS JetStream event bus** (`NatsEventBus`) replacing Dragonfly Redis pub/sub for durable event delivery (Issue #1331)
- `EventBusBase` ABC with shared checkpoint/startup-sync logic, `AckableEvent` wrapper, `subscribe_durable` abstract method
- Factory function `create_event_bus()` + singleton management for backend selection (`redis` or `nats`)
- Cross-thread event publishing: RPC thread pool → main event loop via `asyncio.run_coroutine_threadsafe` with error callbacks
- FastAPI lifespan: eager event bus start + `_main_event_loop` reference for cross-thread scheduling
- `mkdir()` now emits `dir_create` events (was missing)
- Performance: `run_in_executor` for sync SQLAlchemy checkpoint ops, no blocking in async path

## Stream #1331

## Files Changed

| File | Change |
|------|--------|
| `src/nexus/core/event_bus.py` | `EventBusBase` with checkpoint/SSOT methods, `RedisEventBus` with WAL (#1397), `subscribe_durable`, factory |
| `src/nexus/core/event_bus_nats.py` | **New** — Full `NatsEventBus`: publish, subscribe (auto-ack + durable pull), wait_for_event, health, stats, dedup |
| `src/nexus/core/nexus_fs_core.py` | Cross-thread publishing via `run_coroutine_threadsafe` with `add_done_callback` |
| `src/nexus/core/nexus_fs.py` | Added `_publish_file_event("dir_create")` to `mkdir()` |
| `src/nexus/server/fastapi_server.py` | Lifespan: eager event bus start/stop + `_main_event_loop` ref |
| `src/nexus/cache/settings.py` | Added `nats_url`, `event_bus_backend` fields |
| `pyproject.toml` | Added `nats-py>=2.9.0` dependency |
| `docker-compose.yml` / `dockerfiles/docker-compose.demo.yml` | NATS JetStream service containers |

## Test Coverage

- **116 unit tests** — event bus base, Redis, NATS mock, contract tests
- **8 integration tests** — NATS JetStream with real server (nats-server subprocess)
- **17 e2e tests** — FastAPI server with SQLite, RPC write/mkdir/delete → NATS events, durable consumer, auth enforcement, stats, dedup

**141 total tests, all passing.**

## Test plan

- [x] `ruff check` + `ruff format` — clean
- [x] `mypy` — no new errors (pre-existing cachetools stubs only)
- [x] Unit tests (116 passed)
- [x] Integration tests (8 passed)
- [x] E2E tests (17 passed)
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)