### PR TITLE
fix(#1440): review fixes for async wrappers

### DIFF
--- a/src/nexus/services/routing/async_router.py
+++ b/src/nexus/services/routing/async_router.py
@@ -17,11 +17,11 @@ from typing import TYPE_CHECKING, Any
 from nexus.core.protocols.vfs_router import MountInfo, ResolvedPath
 
 if TYPE_CHECKING:
-    from nexus.core.router import MountConfig, PathRouter
+    from nexus.core.router import MountConfig, PathRouter, RouteResult
 
 
 def _to_resolved_path(
-    result: Any,
+    result: RouteResult,
     virtual_path: str,
     zone_id: str | None,
 ) -> ResolvedPath:


### PR DESCRIPTION
## Summary

Review fixes for the async wrappers (Issue #1440) identified during stream13 code review session:

- **Type safety**: Fix `result: Any` → `result: RouteResult` type annotation in `async_router._to_resolved_path()`
- **Test coverage**: Add 3 exception propagation tests for `AsyncNamespaceManager` (RuntimeError, PermissionError, ValueError through `asyncio.to_thread`)
- **Concurrency test**: Add `test_concurrent_register_fire_unregister` for `AsyncHookEngine` verifying API safety under interleaved hook lifecycle operations
- **Resource cleanup**: Add `engine.dispose()` to all e2e tests creating SQLAlchemy engines (via `try/finally` blocks and yield fixture) to prevent `ResourceWarning: unclosed database` leaks
- **Type fix**: Change `Generator` → `Iterator` in `sqlite_registry` fixture return type

## Files Changed

| File | Change |
|------|--------|
| `src/nexus/services/routing/async_router.py` | Type annotation fix |
| `tests/unit/services/test_async_namespace_manager.py` | +3 exception propagation tests |
| `tests/e2e/test_async_wrappers_e2e.py` | Concurrent test, engine cleanup, type fix |

## Stream

stream13

## Test plan

- [ ] Ruff lint passes (verified locally)
- [ ] Ruff format passes (verified locally)
- [ ] Mypy passes on changed files (verified locally, pre-existing AppState issue unrelated)
- [ ] All new tests pass with `pytest tests/e2e/test_async_wrappers_e2e.py tests/unit/services/test_async_namespace_manager.py -v`
- [ ] No ResourceWarning from unclosed SQLite databases in e2e tests
- [ ] CI checks pass