### PR TITLE
refactor(#1459): extract PermissionProtocol + types module (Phase 3)

### DIFF
--- a/src/nexus/services/permissions/rebac_manager_enhanced.py
+++ b/src/nexus/services/permissions/rebac_manager_enhanced.py
@@ -28,14 +28,22 @@ from __future__ import annotations
 
 import threading
 import time
-from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from enum import Enum
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from nexus.core.rebac import CROSS_ZONE_ALLOWED_RELATIONS, Entity
 from nexus.services.permissions.rebac_manager_zone_aware import ZoneAwareReBACManager
+from nexus.services.permissions.types import (
+    CheckResult,
+    ConsistencyLevel,
+    ConsistencyMode,  # noqa: F401 — re-exported for backward compatibility
+    ConsistencyRequirement,
+    GraphLimitExceeded,
+    GraphLimits,
+    TraversalStats,
+    WriteResult,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -43,228 +51,6 @@ if TYPE_CHECKING:
     from nexus.services.permissions.leopard import LeopardIndex
     from nexus.services.permissions.rebac_iterator_cache import IteratorCache
     from nexus.services.permissions.tiger_cache import TigerCache, TigerCacheUpdater
-
-
-# ============================================================================
-# P0-1: Consistency Levels and Version Tokens
-# ============================================================================
-
-
-class ConsistencyLevel(Enum):
-    """Consistency levels for permission checks.
-
-    Controls cache behavior and staleness guarantees:
-    - EVENTUAL: Use cache (up to 5min staleness), fastest
-    - BOUNDED: Max 1s staleness
-    - STRONG: Bypass cache, fresh read, slowest but most accurate
-
-    Note: For new code, prefer ConsistencyMode with ConsistencyRequirement
-    which aligns with SpiceDB/Zanzibar naming conventions.
-    """
-
-    EVENTUAL = "eventual"  # Use cache (5min staleness)
-    BOUNDED = "bounded"  # Max 1s staleness
-    STRONG = "strong"  # Bypass cache, fresh read
-
-
-class ConsistencyMode(Enum):
-    """Per-request consistency modes aligned with SpiceDB/Zanzibar (Issue #1081).
-
-    Provides fine-grained control over cache behavior on a per-request basis,
-    following industry best practices from Google Zanzibar and SpiceDB.
-
-    Modes:
-    - MINIMIZE_LATENCY: Use cache for fastest response (~99% of requests)
-    - AT_LEAST_AS_FRESH: Cache must be >= min_revision (read-after-write)
-    - FULLY_CONSISTENT: Bypass cache entirely (security audits, <1% of requests)
-
-    See:
-    - https://authzed.com/docs/spicedb/concepts/consistency
-    - https://www.usenix.org/system/files/atc19-pang.pdf (Zanzibar paper)
-    """
-
-    MINIMIZE_LATENCY = "minimize_latency"  # Default: use cache, fastest
-    AT_LEAST_AS_FRESH = "at_least_as_fresh"  # Cache if revision >= min_revision
-    FULLY_CONSISTENT = "fully_consistent"  # Bypass cache, slowest but freshest
-
-
-@dataclass(slots=True)
-class ConsistencyRequirement:
-    """Per-request consistency requirement (Issue #1081).
-
-    Combines a consistency mode with optional parameters like min_revision.
-    This follows the SpiceDB/Zanzibar pattern for per-request consistency control.
-
-    Examples:
-        # Default: maximize cache usage (99% of requests)
-        ConsistencyRequirement()
-
-        # Read-after-write: ensure we see a recent write
-        ConsistencyRequirement(
-            mode=ConsistencyMode.AT_LEAST_AS_FRESH,
-            min_revision=write_result.revision
-        )
-
-        # Security audit: bypass all caches
-        ConsistencyRequirement(mode=ConsistencyMode.FULLY_CONSISTENT)
-
-    Attributes:
-        mode: The consistency mode to use
-        min_revision: Required for AT_LEAST_AS_FRESH - minimum acceptable revision
-    """
-
-    mode: ConsistencyMode = ConsistencyMode.MINIMIZE_LATENCY
-    min_revision: int | None = None
-
-    def __post_init__(self) -> None:
-        """Validate consistency requirement."""
-        if self.mode == ConsistencyMode.AT_LEAST_AS_FRESH and self.min_revision is None:
-            raise ValueError(
-                "min_revision is required for AT_LEAST_AS_FRESH mode. "
-                "Pass the revision from a previous write operation."
-            )
-
-    def to_legacy_level(self) -> ConsistencyLevel:
-        """Convert to legacy ConsistencyLevel for backward compatibility."""
-        if self.mode == ConsistencyMode.FULLY_CONSISTENT:
-            return ConsistencyLevel.STRONG
-        elif self.mode == ConsistencyMode.AT_LEAST_AS_FRESH:
-            return ConsistencyLevel.BOUNDED
-        else:
-            return ConsistencyLevel.EVENTUAL
-
-
-@dataclass(slots=True)
-class WriteResult:
-    """Result of a permission write with consistency metadata (Issue #1081).
-
-    Following the Zanzibar zookie pattern, writes return a consistency token
-    that can be used for subsequent read-your-writes queries.
-
-    Example:
-        # Write a permission
-        result = manager.rebac_write(subject, relation, object, zone_id=zone)
-
-        # Immediately check with read-your-writes guarantee
-        allowed = manager.rebac_check(
-            subject, permission, object,
-            consistency=ConsistencyRequirement(
-                mode=ConsistencyMode.AT_LEAST_AS_FRESH,
-                min_revision=result.revision
-            )
-        )
-
-    Attributes:
-        tuple_id: UUID of the created relationship tuple
-        revision: The revision number after this write (for AT_LEAST_AS_FRESH)
-        consistency_token: Opaque token encoding the revision (for clients)
-        written_at_ms: Timestamp when write was persisted (epoch ms)
-    """
-
-    tuple_id: str
-    revision: int
-    consistency_token: str
-    written_at_ms: float
-
-
-@dataclass(slots=True)
-class CheckResult:
-    """Result of a permission check with consistency metadata.
-
-    Attributes:
-        allowed: Whether permission is granted
-        consistency_token: Version token for this check (monotonic counter)
-        decision_time_ms: Time taken to compute decision
-        cached: Whether result came from cache
-        cache_age_ms: Age of cached result (None if not cached)
-        traversal_stats: Graph traversal statistics
-        indeterminate: Whether decision was indeterminate (denied due to limits, not policy)
-        limit_exceeded: The limit that was exceeded (if indeterminate=True)
-    """
-
-    allowed: bool
-    consistency_token: str
-    decision_time_ms: float
-    cached: bool
-    cache_age_ms: float | None = None
-    traversal_stats: TraversalStats | None = None
-    indeterminate: bool = False  # BUGFIX (Issue #5): Track limit-driven denials
-    limit_exceeded: GraphLimitExceeded | None = None  # BUGFIX (Issue #5): Which limit was hit
-
-
-@dataclass(slots=True)
-class TraversalStats:
-    """Statistics from graph traversal (P0-5).
-
-    Used for monitoring and debugging graph limits.
-    """
-
-    queries: int = 0
-    nodes_visited: int = 0
-    max_depth_reached: int = 0
-    cache_hits: int = 0
-    cache_misses: int = 0
-    duration_ms: float = 0.0
-
-
-# ============================================================================
-# P0-5: Graph Limits and DoS Protection
-# ============================================================================
-
-
-class GraphLimits:
-    """Hard limits for graph traversal to prevent DoS attacks.
-
-    These limits ensure permission checks complete within bounded time
-    and memory, even with pathological graphs.
-    """
-
-    MAX_DEPTH = 50  # Max recursion depth (increased for deep directory hierarchies)
-    MAX_FAN_OUT = 1000  # Max edges per union/expand
-    MAX_EXECUTION_TIME_MS = 1000  # 1 second timeout for permission computation
-    MAX_VISITED_NODES = 10000  # Memory bound
-    MAX_TUPLE_QUERIES = 100  # DB query limit
-
-
-class GraphLimitExceeded(Exception):
-    """Raised when graph traversal exceeds limits.
-
-    Attributes:
-        limit_type: Type of limit exceeded (depth, fan_out, timeout, nodes, queries)
-        limit_value: Configured limit value
-        actual_value: Actual value when limit was hit
-        path: Partial proof path before limit
-    """
-
-    def __init__(
-        self,
-        limit_type: str,
-        limit_value: int | float,
-        actual_value: int | float,
-        path: list[str] | None = None,
-    ):
-        self.limit_type = limit_type
-        self.limit_value = limit_value
-        self.actual_value = actual_value
-        self.path = path or []
-        super().__init__(f"Graph {limit_type} limit exceeded: {actual_value} > {limit_value}")
-
-    def to_http_error(self) -> dict[str, Any]:
-        """Convert to HTTP error response."""
-        if self.limit_type == "timeout":
-            return {
-                "code": 503,
-                "message": "Permission check timeout",
-                "limit": self.limit_value,
-                "actual": self.actual_value,
-            }
-        else:
-            return {
-                "code": 429,
-                "message": f"Graph {self.limit_type} limit exceeded",
-                "limit": self.limit_value,
-                "actual": self.actual_value,
-            }
 
 
 # ============================================================================
@@ -3379,8 +3165,6 @@ class EnhancedReBACManager(ZoneAwareReBACManager):
                 # This handles nested groups, union expansion, etc.
                 # NOTE: We create a fresh stats object for this sub-check to avoid
                 # conflating limits across different code paths
-                from nexus.services.permissions.rebac_manager_enhanced import TraversalStats
-
                 sub_stats = TraversalStats()
                 userset_entity = Entity(userset_type, userset_id)
 

--- a/src/nexus/services/permissions/types.py
+++ b/src/nexus/services/permissions/types.py
@@ -1,0 +1,246 @@
+"""Shared type definitions for the permissions subsystem.
+
+This module holds enums, dataclasses, and exception types used across the
+permissions package (e.g., rebac_manager_enhanced, nexus_fs_rebac).  Keeping
+them in a dedicated module avoids circular imports and clarifies the public
+API surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+__all__ = [
+    "ConsistencyLevel",
+    "ConsistencyMode",
+    "ConsistencyRequirement",
+    "WriteResult",
+    "CheckResult",
+    "TraversalStats",
+    "GraphLimits",
+    "GraphLimitExceeded",
+]
+
+
+# ============================================================================
+# P0-1: Consistency Levels and Version Tokens
+# ============================================================================
+
+
+class ConsistencyLevel(Enum):
+    """Consistency levels for permission checks.
+
+    Controls cache behavior and staleness guarantees:
+    - EVENTUAL: Use cache (up to 5min staleness), fastest
+    - BOUNDED: Max 1s staleness
+    - STRONG: Bypass cache, fresh read, slowest but most accurate
+
+    Note: For new code, prefer ConsistencyMode with ConsistencyRequirement
+    which aligns with SpiceDB/Zanzibar naming conventions.
+    """
+
+    EVENTUAL = "eventual"  # Use cache (5min staleness)
+    BOUNDED = "bounded"  # Max 1s staleness
+    STRONG = "strong"  # Bypass cache, fresh read
+
+
+class ConsistencyMode(Enum):
+    """Per-request consistency modes aligned with SpiceDB/Zanzibar (Issue #1081).
+
+    Provides fine-grained control over cache behavior on a per-request basis,
+    following industry best practices from Google Zanzibar and SpiceDB.
+
+    Modes:
+    - MINIMIZE_LATENCY: Use cache for fastest response (~99% of requests)
+    - AT_LEAST_AS_FRESH: Cache must be >= min_revision (read-after-write)
+    - FULLY_CONSISTENT: Bypass cache entirely (security audits, <1% of requests)
+
+    See:
+    - https://authzed.com/docs/spicedb/concepts/consistency
+    - https://www.usenix.org/system/files/atc19-pang.pdf (Zanzibar paper)
+    """
+
+    MINIMIZE_LATENCY = "minimize_latency"  # Default: use cache, fastest
+    AT_LEAST_AS_FRESH = "at_least_as_fresh"  # Cache if revision >= min_revision
+    FULLY_CONSISTENT = "fully_consistent"  # Bypass cache, slowest but freshest
+
+
+@dataclass(slots=True)
+class ConsistencyRequirement:
+    """Per-request consistency requirement (Issue #1081).
+
+    Combines a consistency mode with optional parameters like min_revision.
+    This follows the SpiceDB/Zanzibar pattern for per-request consistency control.
+
+    Examples:
+        # Default: maximize cache usage (99% of requests)
+        ConsistencyRequirement()
+
+        # Read-after-write: ensure we see a recent write
+        ConsistencyRequirement(
+            mode=ConsistencyMode.AT_LEAST_AS_FRESH,
+            min_revision=write_result.revision
+        )
+
+        # Security audit: bypass all caches
+        ConsistencyRequirement(mode=ConsistencyMode.FULLY_CONSISTENT)
+
+    Attributes:
+        mode: The consistency mode to use
+        min_revision: Required for AT_LEAST_AS_FRESH - minimum acceptable revision
+    """
+
+    mode: ConsistencyMode = ConsistencyMode.MINIMIZE_LATENCY
+    min_revision: int | None = None
+
+    def __post_init__(self) -> None:
+        """Validate consistency requirement."""
+        if self.mode == ConsistencyMode.AT_LEAST_AS_FRESH and self.min_revision is None:
+            raise ValueError(
+                "min_revision is required for AT_LEAST_AS_FRESH mode. "
+                "Pass the revision from a previous write operation."
+            )
+
+    def to_legacy_level(self) -> ConsistencyLevel:
+        """Convert to legacy ConsistencyLevel for backward compatibility."""
+        if self.mode == ConsistencyMode.FULLY_CONSISTENT:
+            return ConsistencyLevel.STRONG
+        elif self.mode == ConsistencyMode.AT_LEAST_AS_FRESH:
+            return ConsistencyLevel.BOUNDED
+        else:
+            return ConsistencyLevel.EVENTUAL
+
+
+@dataclass(slots=True)
+class WriteResult:
+    """Result of a permission write with consistency metadata (Issue #1081).
+
+    Following the Zanzibar zookie pattern, writes return a consistency token
+    that can be used for subsequent read-your-writes queries.
+
+    Example:
+        # Write a permission
+        result = manager.rebac_write(subject, relation, object, zone_id=zone)
+
+        # Immediately check with read-your-writes guarantee
+        allowed = manager.rebac_check(
+            subject, permission, object,
+            consistency=ConsistencyRequirement(
+                mode=ConsistencyMode.AT_LEAST_AS_FRESH,
+                min_revision=result.revision
+            )
+        )
+
+    Attributes:
+        tuple_id: UUID of the created relationship tuple
+        revision: The revision number after this write (for AT_LEAST_AS_FRESH)
+        consistency_token: Opaque token encoding the revision (for clients)
+        written_at_ms: Timestamp when write was persisted (epoch ms)
+    """
+
+    tuple_id: str
+    revision: int
+    consistency_token: str
+    written_at_ms: float
+
+
+@dataclass(slots=True)
+class TraversalStats:
+    """Statistics from graph traversal (P0-5).
+
+    Used for monitoring and debugging graph limits.
+    """
+
+    queries: int = 0
+    nodes_visited: int = 0
+    max_depth_reached: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    duration_ms: float = 0.0
+
+
+@dataclass(slots=True)
+class CheckResult:
+    """Result of a permission check with consistency metadata.
+
+    Attributes:
+        allowed: Whether permission is granted
+        consistency_token: Version token for this check (monotonic counter)
+        decision_time_ms: Time taken to compute decision
+        cached: Whether result came from cache
+        cache_age_ms: Age of cached result (None if not cached)
+        traversal_stats: Graph traversal statistics
+        indeterminate: Whether decision was indeterminate (denied due to limits, not policy)
+        limit_exceeded: The limit that was exceeded (if indeterminate=True)
+    """
+
+    allowed: bool
+    consistency_token: str
+    decision_time_ms: float
+    cached: bool
+    cache_age_ms: float | None = None
+    traversal_stats: TraversalStats | None = None
+    indeterminate: bool = False  # BUGFIX (Issue #5): Track limit-driven denials
+    limit_exceeded: GraphLimitExceeded | None = None  # BUGFIX (Issue #5): Which limit was hit
+
+
+# ============================================================================
+# P0-5: Graph Limits and DoS Protection
+# ============================================================================
+
+
+class GraphLimits:
+    """Hard limits for graph traversal to prevent DoS attacks.
+
+    These limits ensure permission checks complete within bounded time
+    and memory, even with pathological graphs.
+    """
+
+    MAX_DEPTH = 50  # Max recursion depth (increased for deep directory hierarchies)
+    MAX_FAN_OUT = 1000  # Max edges per union/expand
+    MAX_EXECUTION_TIME_MS = 1000  # 1 second timeout for permission computation
+    MAX_VISITED_NODES = 10000  # Memory bound
+    MAX_TUPLE_QUERIES = 100  # DB query limit
+
+
+class GraphLimitExceeded(Exception):
+    """Raised when graph traversal exceeds limits.
+
+    Attributes:
+        limit_type: Type of limit exceeded (depth, fan_out, timeout, nodes, queries)
+        limit_value: Configured limit value
+        actual_value: Actual value when limit was hit
+        path: Partial proof path before limit
+    """
+
+    def __init__(
+        self,
+        limit_type: str,
+        limit_value: int | float,
+        actual_value: int | float,
+        path: list[str] | None = None,
+    ):
+        self.limit_type = limit_type
+        self.limit_value = limit_value
+        self.actual_value = actual_value
+        self.path = path or []
+        super().__init__(f"Graph {limit_type} limit exceeded: {actual_value} > {limit_value}")
+
+    def to_http_error(self) -> dict[str, Any]:
+        """Convert to HTTP error response."""
+        if self.limit_type == "timeout":
+            return {
+                "code": 503,
+                "message": "Permission check timeout",
+                "limit": self.limit_value,
+                "actual": self.actual_value,
+            }
+        else:
+            return {
+                "code": 429,
+                "message": f"Graph {self.limit_type} limit exceeded",
+                "limit": self.limit_value,
+                "actual": self.actual_value,
+            }

--- a/src/nexus/services/protocols/__init__.py
+++ b/src/nexus/services/protocols/__init__.py
@@ -13,6 +13,7 @@ Storage Affinity (per data-storage-matrix.md):
     - EventLogProtocol       → RecordStore (append-only BRIN audit log)
     - HookEngineProtocol     → CacheStore (ephemeral hook registration)
     - NamespaceManagerProtocol → RecordStore + CacheStore (ReBAC views)
+    - PermissionProtocol     → RecordStore (Zanzibar relationship tuples)
     - SchedulerProtocol      → CacheStore or RecordStore (work queue)
 
 References:
@@ -41,6 +42,7 @@ from nexus.services.protocols.hook_engine import (
     HookSpec,
 )
 from nexus.services.protocols.namespace_manager import NamespaceManagerProtocol, NamespaceMount
+from nexus.services.protocols.permission import PermissionProtocol
 from nexus.services.protocols.scheduler import AgentRequest, SchedulerProtocol
 
 __all__ = [
@@ -58,6 +60,7 @@ __all__ = [
     "KernelEvent",
     "NamespaceManagerProtocol",
     "NamespaceMount",
+    "PermissionProtocol",
     "POST_COPY",
     "POST_DELETE",
     "POST_MKDIR",

--- a/src/nexus/services/protocols/permission.py
+++ b/src/nexus/services/protocols/permission.py
@@ -1,0 +1,78 @@
+"""Permission service protocol for Zanzibar-style authorization (Issue #1459).
+
+Defines the contract for relationship-based access control (ReBAC).
+Existing implementation: ``nexus.services.permissions.rebac_manager_enhanced.EnhancedReBACManager``.
+
+The 6 core Zanzibar APIs:
+    - check: Does subject have permission on object?
+    - check_bulk: Batch permission check for multiple subjects/objects
+    - write: Create a relationship tuple
+    - delete: Delete a relationship tuple
+    - expand: Find all subjects with a given permission on an object
+    - list_objects: Find all objects a subject can access
+
+Storage Affinity: **RecordStore** — relationship tuples stored in SQL.
+
+References:
+    - https://www.usenix.org/system/files/atc19-pang.pdf (Zanzibar paper)
+    - docs/design/KERNEL-ARCHITECTURE.md
+    - Issue #1459: Decompose ReBAC module
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class PermissionProtocol(Protocol):
+    """Service contract for relationship-based access control (ReBAC).
+
+    Implements the 6 core Zanzibar APIs for authorization.
+    All methods are synchronous (async wrappers exist separately).
+    """
+
+    def rebac_check(
+        self,
+        subject: tuple[str, str],
+        permission: str,
+        object: tuple[str, str],
+        context: dict[str, Any] | None = None,
+        zone_id: str | None = None,
+    ) -> bool: ...
+
+    def rebac_check_bulk(
+        self,
+        checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
+        zone_id: str,
+    ) -> dict[tuple[tuple[str, str], str, tuple[str, str]], bool]: ...
+
+    def rebac_write(
+        self,
+        subject: tuple[str, str] | tuple[str, str, str],
+        relation: str,
+        object: tuple[str, str],
+        expires_at: Any | None = None,
+        conditions: dict[str, Any] | None = None,
+        zone_id: str | None = None,
+    ) -> Any: ...
+
+    def rebac_delete(self, tuple_id: str) -> bool: ...
+
+    def rebac_expand(
+        self,
+        permission: str,
+        object: tuple[str, str],
+        zone_id: str | None = None,
+    ) -> list[tuple[str, str]]: ...
+
+    def rebac_list_objects(
+        self,
+        subject: tuple[str, str],
+        permission: str,
+        object_type: str = "file",
+        zone_id: str | None = None,
+        path_prefix: str | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> list[tuple[str, str]]: ...


### PR DESCRIPTION
## Summary
- Extract 8 dataclass/enum types from `rebac_manager_enhanced.py` (lines 53-268) into `services/permissions/types.py`
- Create `@runtime_checkable` `PermissionProtocol` with 6 Zanzibar APIs in `services/protocols/permission.py`
- Backward-compat re-exports preserved in enhanced manager
- Part of Phase 3 of the ReBAC decomposition (#1459)

## Changes
| File | Action |
|------|--------|
| `services/permissions/types.py` | **New** — 8 types extracted (247 LOC) |
| `services/protocols/permission.py` | **New** — PermissionProtocol (79 LOC) |
| `services/permissions/rebac_manager_enhanced.py` | Remove type defs, import from types.py |
| `services/protocols/__init__.py` | Add PermissionProtocol to exports |

## Test plan
- [x] `from nexus.services.permissions.types import ConsistencyLevel, ...` works
- [x] `from nexus.services.protocols import PermissionProtocol` works
- [x] Backward-compat: `from nexus.services.permissions.rebac_manager_enhanced import ConsistencyLevel` works
- [x] `ruff check` passes clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)