### PR TITLE
feat(#1366): Declarative resiliency layer — circuit breakers, retries, timeouts

### DIFF
--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -233,6 +233,12 @@ class NexusConfig(BaseModel):
         description="Feature flags for optional functionality (semantic search, LLM read, etc.)",
     )
 
+    # Resiliency configuration (Issue #1366)
+    resiliency: dict[str, Any] | None = Field(
+        default=None,
+        description="Resiliency policies: timeouts, retries, circuit_breakers, targets",
+    )
+
     # Remote mode settings
     url: str | None = Field(
         default=None, description="Nexus server URL (required for mode='remote')"

--- a/src/nexus/core/resiliency.py
+++ b/src/nexus/core/resiliency.py
@@ -1,0 +1,488 @@
+"""Declarative resiliency layer — circuit breakers, retries, and timeouts.
+
+Provides a unified resiliency framework configured via YAML named policies
+and applied via the ``@with_resiliency`` decorator, separating resiliency
+policy from business logic.
+
+Composition order (outer → inner): CircuitBreaker → Retry → Timeout
+
+Usage::
+
+    from nexus.core.resiliency import with_resiliency
+
+    @with_resiliency(target="gcs")
+    async def upload_file(data: bytes) -> str:
+        ...
+
+Issue #1366.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import enum
+import logging
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# ---------------------------------------------------------------------------
+# 1A: Infrastructure exception whitelist
+# ---------------------------------------------------------------------------
+
+INFRA_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    TimeoutError,
+    ConnectionError,
+    OSError,
+)
+
+_infra_exceptions_with_httpx: tuple[type[BaseException], ...] | None = None
+
+
+def _get_infra_exceptions() -> tuple[type[BaseException], ...]:
+    """Return infrastructure exceptions, lazily extending with httpx types."""
+    global _infra_exceptions_with_httpx
+    if _infra_exceptions_with_httpx is not None:
+        return _infra_exceptions_with_httpx
+
+    extras: list[type[BaseException]] = []
+    try:
+        import httpx
+
+        extras.append(httpx.TransportError)
+        extras.append(httpx.TimeoutException)
+    except ImportError:
+        pass
+
+    _infra_exceptions_with_httpx = INFRA_EXCEPTIONS + tuple(extras)
+    return _infra_exceptions_with_httpx
+
+
+# ---------------------------------------------------------------------------
+# 1B: Frozen dataclass config models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TimeoutPolicy:
+    """Timeout policy — wraps the call with ``asyncio.timeout``."""
+
+    seconds: float = 5.0
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Retry policy — exponential backoff with full jitter via tenacity."""
+
+    max_retries: int = 3
+    max_interval: float = 10.0
+    multiplier: float = 2.0
+    min_wait: float = 1.0
+
+
+@dataclass(frozen=True)
+class CircuitBreakerPolicy:
+    """Circuit breaker policy — trip after *failure_threshold* infra errors."""
+
+    failure_threshold: int = 5
+    success_threshold: int = 3
+    timeout: float = 30.0  # seconds in OPEN before attempting HALF_OPEN
+
+
+@dataclass(frozen=True)
+class TargetBinding:
+    """Maps a named target to named policies."""
+
+    timeout: str = "default"
+    retry: str = "default"
+    circuit_breaker: str = "default"
+
+
+@dataclass(frozen=True)
+class ResiliencyConfig:
+    """Top-level resiliency configuration (from YAML)."""
+
+    timeouts: dict[str, TimeoutPolicy] = field(default_factory=lambda: {"default": TimeoutPolicy()})
+    retries: dict[str, RetryPolicy] = field(default_factory=lambda: {"default": RetryPolicy()})
+    circuit_breakers: dict[str, CircuitBreakerPolicy] = field(
+        default_factory=lambda: {"default": CircuitBreakerPolicy()}
+    )
+    targets: dict[str, TargetBinding] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# 1C: CircuitBreakerOpenError
+# ---------------------------------------------------------------------------
+
+
+class CircuitState(enum.Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitBreakerOpenError(Exception):
+    """Raised when a call is rejected because the circuit breaker is open."""
+
+    def __init__(self, name: str, state: CircuitState) -> None:
+        self.name = name
+        self.state = state
+        super().__init__(f"Circuit breaker '{name}' is {state.value}")
+
+
+# ---------------------------------------------------------------------------
+# 1D: AsyncCircuitBreaker state machine
+# ---------------------------------------------------------------------------
+
+
+class AsyncCircuitBreaker:
+    """Async context-manager circuit breaker with 3 states.
+
+    Composition: Used as the outermost wrapper so that when the circuit
+    is open, calls are rejected immediately without retrying or waiting
+    for a timeout.
+
+    **Thread Safety**: This class is NOT thread-safe. Each instance must
+    be used within a single asyncio event loop. Do not share instances
+    across threads or multiple event loops.
+    """
+
+    def __init__(self, name: str, policy: CircuitBreakerPolicy) -> None:
+        self._name = name
+        self._policy = policy
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._success_count = 0
+        self._last_failure_time: float | None = None
+        self._opened_at: float | None = None
+        self._half_open_lock = asyncio.Lock()
+        self._infra_exc = _get_infra_exceptions()
+
+    # -- properties ----------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def current_state(self) -> CircuitState:
+        """Return fresh state, performing lazy timestamp check for OPEN → HALF_OPEN."""
+        if self._state is CircuitState.OPEN and self._opened_at is not None:
+            elapsed = time.monotonic() - self._opened_at
+            if elapsed >= self._policy.timeout:
+                return CircuitState.HALF_OPEN
+        return self._state
+
+    @property
+    def failure_count(self) -> int:
+        return self._failure_count
+
+    @property
+    def last_failure_time(self) -> float | None:
+        return self._last_failure_time
+
+    # -- context manager -----------------------------------------------------
+
+    async def __aenter__(self) -> AsyncCircuitBreaker:
+        state = self.current_state
+
+        if state is CircuitState.CLOSED:
+            return self
+
+        if state is CircuitState.OPEN:
+            raise CircuitBreakerOpenError(self._name, state)
+
+        # HALF_OPEN: allow exactly one probe
+        if state is CircuitState.HALF_OPEN:
+            acquired = await self._try_acquire_lock()
+            if not acquired:
+                raise CircuitBreakerOpenError(self._name, CircuitState.OPEN)
+            self._state = CircuitState.HALF_OPEN
+            return self
+
+        return self  # pragma: no cover
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: Any,
+    ) -> bool:
+        if exc_type is not None and issubclass(exc_type, self._infra_exc):
+            self._record_failure()
+        elif exc_type is None:
+            self._record_success()
+        # Non-infra exceptions pass through without affecting CB state
+        return False  # never suppress exceptions
+
+    # -- internal helpers ----------------------------------------------------
+
+    async def _try_acquire_lock(self) -> bool:
+        """Non-blocking lock acquire for half-open single-probe.
+
+        In asyncio's single-threaded model, no coroutine can interleave
+        between the ``locked()`` check and the ``acquire()`` call since
+        there is no suspension point between them.
+        """
+        if self._half_open_lock.locked():
+            return False
+        await self._half_open_lock.acquire()
+        return True
+
+    def _record_success(self) -> None:
+        if self._state is CircuitState.CLOSED:
+            self._failure_count = 0
+            return
+
+        if self._state is CircuitState.HALF_OPEN:
+            self._success_count += 1
+            if self._success_count >= self._policy.success_threshold:
+                self._transition_to_closed()
+                self._release_half_open_lock()
+
+    def _record_failure(self) -> None:
+        self._failure_count += 1
+        self._last_failure_time = time.monotonic()
+
+        if self._state is CircuitState.CLOSED:
+            if self._failure_count >= self._policy.failure_threshold:
+                self._transition_to_open()
+
+        elif self._state is CircuitState.HALF_OPEN:
+            self._transition_to_open()
+            self._release_half_open_lock()
+
+    def _transition_to_open(self) -> None:
+        self._state = CircuitState.OPEN
+        self._opened_at = time.monotonic()
+        self._success_count = 0
+        logger.warning(
+            "Circuit breaker '%s' OPEN (failures=%d)",
+            self._name,
+            self._failure_count,
+        )
+
+    def _transition_to_closed(self) -> None:
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._success_count = 0
+        self._opened_at = None
+        logger.info("Circuit breaker '%s' CLOSED (recovered)", self._name)
+
+    def _release_half_open_lock(self) -> None:
+        if self._half_open_lock.locked():
+            with contextlib.suppress(RuntimeError):
+                self._half_open_lock.release()
+
+
+# ---------------------------------------------------------------------------
+# 1E: ResiliencyManager
+# ---------------------------------------------------------------------------
+
+
+class ResiliencyManager:
+    """Singleton-style manager that owns circuit breaker instances and config."""
+
+    def __init__(self, config: ResiliencyConfig) -> None:
+        self._config = config
+        self._breakers: dict[str, AsyncCircuitBreaker] = {}
+
+    @property
+    def config(self) -> ResiliencyConfig:
+        return self._config
+
+    def get_breaker(self, name: str) -> AsyncCircuitBreaker:
+        """Get or create a circuit breaker by policy name (idempotent)."""
+        if name in self._breakers:
+            return self._breakers[name]
+
+        policy = self._config.circuit_breakers.get(name)
+        if policy is None:
+            logger.warning("Unknown circuit breaker policy '%s', using default", name)
+            policy = self._config.circuit_breakers.get("default", CircuitBreakerPolicy())
+
+        # Double-check to prevent duplicate creation under concurrency
+        if name not in self._breakers:
+            self._breakers[name] = AsyncCircuitBreaker(name=name, policy=policy)
+        return self._breakers[name]
+
+    def resolve_target(self, target: str) -> TargetBinding:
+        """Look up a target binding by name."""
+        binding = self._config.targets.get(target)
+        if binding is None:
+            logger.warning("Unknown resiliency target '%s', using defaults", target)
+            return TargetBinding()
+        return binding
+
+    def health_check(self) -> dict[str, Any]:
+        """Return health status for all active circuit breakers."""
+        breakers_health: dict[str, Any] = {}
+        has_degraded = False
+
+        for name, breaker in self._breakers.items():
+            state = breaker.current_state
+            breakers_health[name] = {
+                "state": state.value,
+                "failure_count": breaker.failure_count,
+                "last_failure_time": breaker.last_failure_time,
+            }
+            if state is not CircuitState.CLOSED:
+                has_degraded = True
+
+        return {
+            "status": "degraded" if has_degraded else "ok",
+            "circuit_breakers": breakers_health,
+        }
+
+
+# ---------------------------------------------------------------------------
+# 1F: with_resiliency decorator
+# ---------------------------------------------------------------------------
+
+_default_manager: ResiliencyManager | None = None
+
+
+def set_default_manager(mgr: ResiliencyManager) -> None:
+    """Set the module-level default ResiliencyManager."""
+    global _default_manager
+    _default_manager = mgr
+
+
+def get_default_manager() -> ResiliencyManager | None:
+    """Return the module-level default ResiliencyManager (or None)."""
+    return _default_manager
+
+
+def with_resiliency(
+    target: str | None = None,
+    *,
+    timeout: str | float | None = None,
+    retry: str | None = None,
+    circuit_breaker: str | None = None,
+    manager: ResiliencyManager | None = None,
+) -> Callable[[F], F]:
+    """Declarative resiliency decorator.
+
+    Composition order (outer → inner): CB → Retry → Timeout.
+
+    If no manager is available (not passed, no default set), the decorator
+    is a no-op passthrough — this enables graceful operation without config.
+
+    Args:
+        target: Named target binding from config (resolves to policy names).
+        timeout: Named timeout policy or explicit seconds.
+        retry: Named retry policy.
+        circuit_breaker: Named circuit breaker policy.
+        manager: Explicit ResiliencyManager (falls back to module default).
+    """
+
+    def decorator(func: F) -> F:
+        mgr = manager or _default_manager
+        if mgr is None:
+            return func  # no-op passthrough
+
+        # Resolve policies from target or explicit params
+        if target is not None:
+            binding = mgr.resolve_target(target)
+            timeout_name = binding.timeout
+            retry_name = binding.retry
+            cb_name = binding.circuit_breaker
+        else:
+            timeout_name = timeout if isinstance(timeout, str) else "default"
+            retry_name = retry or "default"
+            cb_name = circuit_breaker or "default"
+
+        # Look up timeout policy
+        if isinstance(timeout, (int, float)):
+            timeout_seconds = float(timeout)
+        else:
+            tp = mgr.config.timeouts.get(
+                timeout_name, mgr.config.timeouts.get("default", TimeoutPolicy())
+            )
+            timeout_seconds = tp.seconds
+
+        # Look up retry policy
+        rp = mgr.config.retries.get(retry_name, mgr.config.retries.get("default", RetryPolicy()))
+
+        # Get circuit breaker
+        cb = mgr.get_breaker(cb_name)
+
+        # Build tenacity retry kwargs
+        from tenacity import retry as tenacity_retry
+        from tenacity import (
+            retry_if_exception_type,
+            stop_after_attempt,
+            wait_exponential,
+            wait_random,
+        )
+
+        retry_kwargs: dict[str, Any] = {
+            "stop": stop_after_attempt(rp.max_retries + 1),
+            "wait": wait_exponential(
+                multiplier=rp.multiplier,
+                min=rp.min_wait,
+                max=rp.max_interval,
+            )
+            + wait_random(0, 1),
+            "retry": retry_if_exception_type(_get_infra_exceptions()),
+            "reraise": True,
+        }
+
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            async with cb:
+                # Retry wraps the timeout-guarded call
+                @tenacity_retry(**retry_kwargs)
+                async def _inner() -> Any:
+                    if timeout_seconds > 0:
+                        async with asyncio.timeout(timeout_seconds):
+                            return await func(*args, **kwargs)
+                    else:
+                        return await func(*args, **kwargs)
+
+                return await _inner()
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# 1G: Duration parser helper
+# ---------------------------------------------------------------------------
+
+_DURATION_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smh]?)\s*$", re.IGNORECASE)
+
+
+def parse_duration(value: str | int | float) -> float:
+    """Parse ``'5s'``, ``'60s'``, ``'10m'``, ``'1h'`` or numeric seconds.
+
+    Returns:
+        Duration in seconds as a float.
+
+    Raises:
+        ValueError: If the format is unrecognised.
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    m = _DURATION_RE.match(value)
+    if m is None:
+        raise ValueError(f"Cannot parse duration: {value!r}")
+
+    num = float(m.group(1))
+    unit = m.group(2).lower()
+
+    if unit == "m":
+        return num * 60.0
+    if unit == "h":
+        return num * 3600.0
+    return num  # seconds or bare number

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -1606,6 +1606,18 @@ def _register_routes(app: FastAPI) -> None:
             health["status"] = "degraded"
             health["unhealthy_backends"] = unhealthy_backends
 
+        # Circuit breaker health (Issue #1366)
+        _resiliency_mgr = (
+            _fastapi_app.state.nexus_fs._service_extras.get("resiliency_manager")
+            if _fastapi_app.state.nexus_fs
+            and hasattr(_fastapi_app.state.nexus_fs, "_service_extras")
+            else None
+        )
+        if _resiliency_mgr is not None:
+            health["components"]["resiliency"] = _resiliency_mgr.health_check()
+            if health["components"]["resiliency"]["status"] == "degraded":
+                health["status"] = "degraded"
+
         return health
 
     # Connection pool metrics endpoint (Issue #1075)

--- a/tests/e2e/test_resiliency_e2e.py
+++ b/tests/e2e/test_resiliency_e2e.py
@@ -1,0 +1,58 @@
+"""E2E test: resiliency health endpoint (Issue #1366).
+
+Verifies that /health/detailed includes the resiliency component
+when the server is running with services enabled, and that there
+is no performance regression.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+
+
+class TestResiliencyE2E:
+    def test_health_detailed_includes_resiliency(self, test_app: httpx.Client) -> None:
+        """Fresh server should report resiliency component as 'ok'."""
+        resp = test_app.get("/health/detailed")
+        assert resp.status_code == 200
+
+        health = resp.json()
+        components = health.get("components", {})
+
+        # Resiliency component must be present when services are wired
+        assert "resiliency" in components, (
+            f"Missing 'resiliency' in health components: {list(components)}"
+        )
+        resiliency = components["resiliency"]
+        assert resiliency["status"] == "ok"
+        assert "circuit_breakers" in resiliency
+
+    def test_health_overall_not_degraded_on_fresh_start(self, test_app: httpx.Client) -> None:
+        """A freshly started server should not have degraded resiliency."""
+        resp = test_app.get("/health/detailed")
+        assert resp.status_code == 200
+
+        health = resp.json()
+        resiliency = health["components"]["resiliency"]
+        assert resiliency["status"] == "ok"
+
+    def test_health_endpoint_performance(self, test_app: httpx.Client) -> None:
+        """Verify /health/detailed responds within 100ms (no perf regression)."""
+        # Warm-up request
+        test_app.get("/health/detailed")
+
+        # Benchmark 10 requests
+        latencies: list[float] = []
+        for _ in range(10):
+            start = time.monotonic()
+            resp = test_app.get("/health/detailed")
+            elapsed_ms = (time.monotonic() - start) * 1000
+            assert resp.status_code == 200
+            latencies.append(elapsed_ms)
+
+        avg_ms = sum(latencies) / len(latencies)
+        p99_ms = sorted(latencies)[9]  # 10th value = p99 for 10 samples
+        assert avg_ms < 100, f"Average latency {avg_ms:.1f}ms exceeds 100ms"
+        assert p99_ms < 200, f"P99 latency {p99_ms:.1f}ms exceeds 200ms"

--- a/tests/integration/test_resiliency_integration.py
+++ b/tests/integration/test_resiliency_integration.py
@@ -1,0 +1,118 @@
+"""Integration tests for the resiliency layer (Issue #1366).
+
+Verifies the full pipeline: config → manager → decorator → CB state transitions
+→ health check reporting — using fast timings suitable for CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nexus.core.resiliency import (
+    CircuitBreakerOpenError,
+    CircuitBreakerPolicy,
+    CircuitState,
+    ResiliencyConfig,
+    ResiliencyManager,
+    RetryPolicy,
+    TargetBinding,
+    TimeoutPolicy,
+    with_resiliency,
+)
+
+
+@pytest.fixture()
+def fast_manager() -> ResiliencyManager:
+    """Manager with fast CB (threshold=2, timeout=0.1s) for integration testing."""
+    config = ResiliencyConfig(
+        timeouts={
+            "default": TimeoutPolicy(seconds=5.0),
+            "fast": TimeoutPolicy(seconds=0.05),
+        },
+        retries={
+            "default": RetryPolicy(max_retries=1, min_wait=0.01, max_interval=0.02),
+        },
+        circuit_breakers={
+            "default": CircuitBreakerPolicy(
+                failure_threshold=2,
+                success_threshold=1,
+                timeout=0.1,
+            ),
+        },
+        targets={
+            "backend": TargetBinding(
+                timeout="default",
+                retry="default",
+                circuit_breaker="default",
+            ),
+        },
+    )
+    return ResiliencyManager(config=config)
+
+
+class TestFullPipeline:
+    @pytest.mark.asyncio
+    async def test_trip_and_recover(self, fast_manager: ResiliencyManager) -> None:
+        """Simulate failures → CB trips → fail-fast → half-open recovery.
+
+        The CB wraps the retry loop, so each decorated call that exhausts
+        retries counts as 1 CB failure (the final exception propagates
+        through __aexit__). With failure_threshold=2, we need 2 such calls.
+        """
+        call_count = 0
+
+        @with_resiliency(target="backend", manager=fast_manager)
+        async def backend_call() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 10:
+                raise ConnectionError("backend down")
+            return "recovered"
+
+        # Phase 1: Two decorated calls that exhaust retries → 2 CB failures → trip
+        with pytest.raises(ConnectionError):
+            await backend_call()
+        with pytest.raises(ConnectionError):
+            await backend_call()
+
+        # Phase 2: CB is open, calls fail fast
+        health = fast_manager.health_check()
+        assert health["status"] == "degraded"
+        assert health["circuit_breakers"]["default"]["state"] == "open"
+
+        with pytest.raises(CircuitBreakerOpenError):
+            await backend_call()
+
+        # Phase 3: Wait for half-open
+        await asyncio.sleep(0.15)
+        cb = fast_manager.get_breaker("default")
+        assert cb.current_state is CircuitState.HALF_OPEN
+
+        # Phase 4: Successful probe → CLOSED
+        call_count = 100  # ensure success path
+        result = await backend_call()
+        assert result == "recovered"
+
+        health = fast_manager.health_check()
+        assert health["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_health_reflects_state_transitions(self, fast_manager: ResiliencyManager) -> None:
+        """Health check accurately reflects CB state at each transition."""
+        cb = fast_manager.get_breaker("default")
+
+        # Initially healthy
+        assert fast_manager.health_check()["status"] == "ok"
+
+        # Trip the CB
+        for _ in range(2):
+            with pytest.raises(ConnectionError):
+                async with cb:
+                    raise ConnectionError("fail")
+
+        health = fast_manager.health_check()
+        assert health["status"] == "degraded"
+        assert health["circuit_breakers"]["default"]["failure_count"] == 2
+        assert health["circuit_breakers"]["default"]["last_failure_time"] is not None

--- a/tests/unit/core/test_resiliency.py
+++ b/tests/unit/core/test_resiliency.py
@@ -1,0 +1,680 @@
+"""Unit tests for the declarative resiliency layer (Issue #1366)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nexus.core.resiliency import (
+    AsyncCircuitBreaker,
+    CircuitBreakerOpenError,
+    CircuitBreakerPolicy,
+    CircuitState,
+    ResiliencyConfig,
+    ResiliencyManager,
+    RetryPolicy,
+    TargetBinding,
+    TimeoutPolicy,
+    _get_infra_exceptions,
+    get_default_manager,
+    parse_duration,
+    set_default_manager,
+    with_resiliency,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+class InfraError(ConnectionError):
+    """Simulates an infrastructure failure."""
+
+
+class BusinessError(ValueError):
+    """Simulates a business-logic failure (should NOT trip CB)."""
+
+
+def _make_cb(
+    failure_threshold: int = 3,
+    success_threshold: int = 2,
+    timeout: float = 0.1,
+) -> AsyncCircuitBreaker:
+    return AsyncCircuitBreaker(
+        name="test",
+        policy=CircuitBreakerPolicy(
+            failure_threshold=failure_threshold,
+            success_threshold=success_threshold,
+            timeout=timeout,
+        ),
+    )
+
+
+# ── TestResiliencyConfig ─────────────────────────────────────────────────────
+
+
+class TestResiliencyConfig:
+    def test_default_values(self) -> None:
+        cfg = ResiliencyConfig()
+        assert "default" in cfg.timeouts
+        assert cfg.timeouts["default"].seconds == 5.0
+        assert "default" in cfg.retries
+        assert cfg.retries["default"].max_retries == 3
+        assert "default" in cfg.circuit_breakers
+        assert cfg.circuit_breakers["default"].failure_threshold == 5
+
+    def test_frozen_immutability(self) -> None:
+        tp = TimeoutPolicy(seconds=10.0)
+        with pytest.raises(AttributeError):
+            tp.seconds = 20.0  # type: ignore[misc]
+
+    def test_custom_policies(self) -> None:
+        cfg = ResiliencyConfig(
+            timeouts={"fast": TimeoutPolicy(seconds=1.0)},
+            retries={"aggressive": RetryPolicy(max_retries=5, min_wait=0.5)},
+            circuit_breakers={"sensitive": CircuitBreakerPolicy(failure_threshold=2)},
+            targets={
+                "gcs": TargetBinding(
+                    timeout="fast", retry="aggressive", circuit_breaker="sensitive"
+                )
+            },
+        )
+        assert cfg.timeouts["fast"].seconds == 1.0
+        assert cfg.retries["aggressive"].max_retries == 5
+        assert cfg.targets["gcs"].timeout == "fast"
+
+
+# ── TestCircuitBreakerStateMachine ───────────────────────────────────────────
+
+
+class TestCircuitBreakerStateMachine:
+    @pytest.mark.asyncio
+    async def test_starts_closed(self) -> None:
+        cb = _make_cb()
+        assert cb.current_state is CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_stays_closed_on_success(self) -> None:
+        cb = _make_cb()
+        async with cb:
+            pass
+        assert cb.current_state is CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_stays_closed(self) -> None:
+        cb = _make_cb(failure_threshold=3)
+        for _ in range(2):  # 2 < threshold of 3
+            with pytest.raises(InfraError):
+                async with cb:
+                    raise InfraError("oops")
+        assert cb.current_state is CircuitState.CLOSED
+        assert cb.failure_count == 2
+
+    @pytest.mark.asyncio
+    async def test_trips_to_open(self) -> None:
+        cb = _make_cb(failure_threshold=3)
+        for _ in range(3):
+            with pytest.raises(InfraError):
+                async with cb:
+                    raise InfraError("oops")
+        assert cb.current_state is CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_open_rejects_calls(self) -> None:
+        cb = _make_cb(failure_threshold=1)
+        with pytest.raises(InfraError):
+            async with cb:
+                raise InfraError("trip")
+        with pytest.raises(CircuitBreakerOpenError):
+            async with cb:
+                pass  # should never reach here
+
+    @pytest.mark.asyncio
+    async def test_half_open_after_timeout(self) -> None:
+        cb = _make_cb(failure_threshold=1, timeout=0.05)
+        with pytest.raises(InfraError):
+            async with cb:
+                raise InfraError("trip")
+        assert cb.current_state is CircuitState.OPEN
+        await asyncio.sleep(0.06)
+        assert cb.current_state is CircuitState.HALF_OPEN
+
+    @pytest.mark.asyncio
+    async def test_half_open_success_closes(self) -> None:
+        cb = _make_cb(failure_threshold=1, success_threshold=1, timeout=0.05)
+        with pytest.raises(InfraError):
+            async with cb:
+                raise InfraError("trip")
+        await asyncio.sleep(0.06)
+        # Successful probe → CLOSED
+        async with cb:
+            pass
+        assert cb.current_state is CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_half_open_failure_reopens(self) -> None:
+        cb = _make_cb(failure_threshold=1, timeout=0.05)
+        with pytest.raises(InfraError):
+            async with cb:
+                raise InfraError("trip")
+        await asyncio.sleep(0.06)
+        # Failed probe → back to OPEN
+        with pytest.raises(InfraError):
+            async with cb:
+                raise InfraError("still broken")
+        assert cb.current_state is CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_success_resets_failure_count(self) -> None:
+        cb = _make_cb(failure_threshold=3)
+        # 2 failures
+        for _ in range(2):
+            with pytest.raises(InfraError):
+                async with cb:
+                    raise InfraError("oops")
+        assert cb.failure_count == 2
+        # 1 success resets counter
+        async with cb:
+            pass
+        assert cb.failure_count == 0
+
+
+# ── TestExceptionFiltering ───────────────────────────────────────────────────
+
+
+class TestExceptionFiltering:
+    @pytest.mark.asyncio
+    async def test_infra_error_trips_cb(self) -> None:
+        cb = _make_cb(failure_threshold=1)
+        with pytest.raises(InfraError):
+            async with cb:
+                raise InfraError("infra")
+        assert cb.current_state is CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_connection_error_trips_cb(self) -> None:
+        cb = _make_cb(failure_threshold=1)
+        with pytest.raises(ConnectionError):
+            async with cb:
+                raise ConnectionError("conn")
+        assert cb.current_state is CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_trips_cb(self) -> None:
+        cb = _make_cb(failure_threshold=1)
+        with pytest.raises(TimeoutError):
+            async with cb:
+                raise TimeoutError("timeout")
+        assert cb.current_state is CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_os_error_trips_cb(self) -> None:
+        cb = _make_cb(failure_threshold=1)
+        with pytest.raises(OSError):
+            async with cb:
+                raise OSError("os")
+        assert cb.current_state is CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_business_error_does_not_trip(self) -> None:
+        cb = _make_cb(failure_threshold=1)
+        with pytest.raises(BusinessError):
+            async with cb:
+                raise BusinessError("biz")
+        assert cb.current_state is CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_generic_error_does_not_trip(self) -> None:
+        cb = _make_cb(failure_threshold=1)
+        with pytest.raises(RuntimeError):
+            async with cb:
+                raise RuntimeError("generic")
+        assert cb.current_state is CircuitState.CLOSED
+
+
+# ── TestHalfOpenLock ─────────────────────────────────────────────────────────
+
+
+class TestHalfOpenLock:
+    @pytest.mark.asyncio
+    async def test_single_probe_allowed(self) -> None:
+        cb = _make_cb(failure_threshold=1, timeout=0.05, success_threshold=1)
+        with pytest.raises(InfraError):
+            async with cb:
+                raise InfraError("trip")
+        await asyncio.sleep(0.06)
+        # First probe succeeds
+        async with cb:
+            pass
+        assert cb.current_state is CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_concurrent_probes_rejected(self) -> None:
+        cb = _make_cb(failure_threshold=1, timeout=0.05, success_threshold=2)
+        with pytest.raises(InfraError):
+            async with cb:
+                raise InfraError("trip")
+        await asyncio.sleep(0.06)
+
+        # First probe acquires the lock, second should be rejected
+        results: list[str] = []
+
+        async def probe(label: str) -> None:
+            try:
+                async with cb:
+                    await asyncio.sleep(0.05)  # hold the lock
+                    results.append(f"{label}:ok")
+            except CircuitBreakerOpenError:
+                results.append(f"{label}:rejected")
+
+        await asyncio.gather(probe("a"), probe("b"))
+        assert "rejected" in " ".join(results)
+
+
+# ── TestRetryBehavior ────────────────────────────────────────────────────────
+
+
+class TestRetryBehavior:
+    @pytest.mark.asyncio
+    async def test_retries_on_infra_error(self) -> None:
+        call_count = 0
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                retries={"fast": RetryPolicy(max_retries=2, min_wait=0.01, max_interval=0.02)},
+                circuit_breakers={"none": CircuitBreakerPolicy(failure_threshold=100)},
+                targets={
+                    "test": TargetBinding(retry="fast", circuit_breaker="none", timeout="off")
+                },
+                timeouts={"off": TimeoutPolicy(seconds=0)},
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def flaky() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectionError("fail")
+            return "ok"
+
+        result = await flaky()
+        assert result == "ok"
+        assert call_count == 3  # 1 initial + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_business_error(self) -> None:
+        call_count = 0
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                retries={"fast": RetryPolicy(max_retries=3, min_wait=0.01, max_interval=0.02)},
+                circuit_breakers={"none": CircuitBreakerPolicy(failure_threshold=100)},
+                targets={
+                    "test": TargetBinding(retry="fast", circuit_breaker="none", timeout="off")
+                },
+                timeouts={"off": TimeoutPolicy(seconds=0)},
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def broken() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("business error")
+
+        with pytest.raises(ValueError, match="business error"):
+            await broken()
+        assert call_count == 1  # no retries
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_raises(self) -> None:
+        call_count = 0
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                retries={"fast": RetryPolicy(max_retries=2, min_wait=0.01, max_interval=0.02)},
+                circuit_breakers={"none": CircuitBreakerPolicy(failure_threshold=100)},
+                targets={
+                    "test": TargetBinding(retry="fast", circuit_breaker="none", timeout="off")
+                },
+                timeouts={"off": TimeoutPolicy(seconds=0)},
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def always_fail() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionError("always fail")
+
+        with pytest.raises(ConnectionError, match="always fail"):
+            await always_fail()
+        assert call_count == 3  # 1 initial + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_jitter_varies_wait_times(self) -> None:
+        """Verify that full jitter is applied (wait_random adds variability)."""
+        rp = RetryPolicy(max_retries=2, min_wait=0.5, max_interval=2.0, multiplier=2.0)
+        # Just verify the config is valid and policy is usable
+        assert rp.min_wait > 0
+        assert rp.max_interval >= rp.min_wait
+
+
+# ── TestTimeoutBehavior ──────────────────────────────────────────────────────
+
+
+class TestTimeoutBehavior:
+    @pytest.mark.asyncio
+    async def test_timeout_fires(self) -> None:
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                timeouts={"fast": TimeoutPolicy(seconds=0.05)},
+                retries={"none": RetryPolicy(max_retries=0)},
+                circuit_breakers={"none": CircuitBreakerPolicy(failure_threshold=100)},
+                targets={
+                    "test": TargetBinding(timeout="fast", retry="none", circuit_breaker="none")
+                },
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def slow_op() -> str:
+            await asyncio.sleep(1.0)
+            return "done"
+
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await slow_op()
+
+    @pytest.mark.asyncio
+    async def test_fast_completes(self) -> None:
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                timeouts={"generous": TimeoutPolicy(seconds=5.0)},
+                retries={"none": RetryPolicy(max_retries=0)},
+                circuit_breakers={"none": CircuitBreakerPolicy(failure_threshold=100)},
+                targets={
+                    "test": TargetBinding(timeout="generous", retry="none", circuit_breaker="none")
+                },
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def fast_op() -> str:
+            return "done"
+
+        result = await fast_op()
+        assert result == "done"
+
+    @pytest.mark.asyncio
+    async def test_timeout_disabled_when_zero(self) -> None:
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                timeouts={"off": TimeoutPolicy(seconds=0)},
+                retries={"none": RetryPolicy(max_retries=0)},
+                circuit_breakers={"none": CircuitBreakerPolicy(failure_threshold=100)},
+                targets={
+                    "test": TargetBinding(timeout="off", retry="none", circuit_breaker="none")
+                },
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def op() -> str:
+            return "done"
+
+        result = await op()
+        assert result == "done"
+
+
+# ── TestComposition ──────────────────────────────────────────────────────────
+
+
+class TestComposition:
+    @pytest.mark.asyncio
+    async def test_cb_open_prevents_retry(self) -> None:
+        """When CB is open, calls fail immediately without retrying."""
+        call_count = 0
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                retries={"fast": RetryPolicy(max_retries=3, min_wait=0.01, max_interval=0.02)},
+                circuit_breakers={
+                    "sensitive": CircuitBreakerPolicy(failure_threshold=1, timeout=60.0)
+                },
+                targets={
+                    "test": TargetBinding(retry="fast", circuit_breaker="sensitive", timeout="off")
+                },
+                timeouts={"off": TimeoutPolicy(seconds=0)},
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def failing() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionError("fail")
+
+        # First call: trips CB
+        with pytest.raises(ConnectionError):
+            await failing()
+        assert call_count >= 1
+
+        # Second call: CB is open, fail fast
+        call_count = 0
+        with pytest.raises(CircuitBreakerOpenError):
+            await failing()
+        assert call_count == 0  # never entered the function
+
+    @pytest.mark.asyncio
+    async def test_timeout_inside_retry(self) -> None:
+        """Timeout fires per-attempt, not per-entire-retry sequence."""
+        call_count = 0
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                timeouts={"fast": TimeoutPolicy(seconds=0.05)},
+                retries={"once": RetryPolicy(max_retries=1, min_wait=0.01, max_interval=0.02)},
+                circuit_breakers={"none": CircuitBreakerPolicy(failure_threshold=100)},
+                targets={
+                    "test": TargetBinding(timeout="fast", retry="once", circuit_breaker="none")
+                },
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def slow() -> str:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(1.0)
+            return "done"
+
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await slow()
+        assert call_count == 2  # initial + 1 retry
+
+    @pytest.mark.asyncio
+    async def test_full_stack_success(self) -> None:
+        """CB + Retry + Timeout all pass on fast success."""
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                timeouts={"default": TimeoutPolicy(seconds=5.0)},
+                retries={"default": RetryPolicy(max_retries=2, min_wait=0.01, max_interval=0.02)},
+                circuit_breakers={"default": CircuitBreakerPolicy(failure_threshold=3)},
+                targets={"test": TargetBinding()},
+            )
+        )
+
+        @with_resiliency(target="test", manager=mgr)
+        async def op() -> str:
+            return "ok"
+
+        assert await op() == "ok"
+
+
+# ── TestWithResiliencyDecorator ──────────────────────────────────────────────
+
+
+class TestWithResiliencyDecorator:
+    @pytest.mark.asyncio
+    async def test_target_binding(self) -> None:
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                targets={
+                    "gcs": TargetBinding(
+                        timeout="default", retry="default", circuit_breaker="default"
+                    )
+                },
+            )
+        )
+
+        @with_resiliency(target="gcs", manager=mgr)
+        async def upload() -> str:
+            return "uploaded"
+
+        assert await upload() == "uploaded"
+
+    @pytest.mark.asyncio
+    async def test_explicit_policies(self) -> None:
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                retries={"fast": RetryPolicy(max_retries=1, min_wait=0.01, max_interval=0.02)},
+                circuit_breakers={"none": CircuitBreakerPolicy(failure_threshold=100)},
+                timeouts={"off": TimeoutPolicy(seconds=0)},
+            )
+        )
+
+        @with_resiliency(timeout="off", retry="fast", circuit_breaker="none", manager=mgr)
+        async def op() -> str:
+            return "done"
+
+        assert await op() == "done"
+
+    @pytest.mark.asyncio
+    async def test_no_manager_passthrough(self) -> None:
+        old = get_default_manager()
+        try:
+            set_default_manager(None)  # type: ignore[arg-type]
+
+            @with_resiliency(target="anything")
+            async def op() -> str:
+                return "passthrough"
+
+            assert await op() == "passthrough"
+        finally:
+            if old is not None:
+                set_default_manager(old)
+
+    @pytest.mark.asyncio
+    async def test_unknown_target_uses_defaults(self) -> None:
+        mgr = ResiliencyManager(config=ResiliencyConfig())
+
+        @with_resiliency(target="nonexistent", manager=mgr)
+        async def op() -> str:
+            return "ok"
+
+        assert await op() == "ok"
+
+
+# ── TestResiliencyManager ────────────────────────────────────────────────────
+
+
+class TestResiliencyManager:
+    def test_get_or_create_breaker(self) -> None:
+        mgr = ResiliencyManager(config=ResiliencyConfig())
+        cb = mgr.get_breaker("default")
+        assert cb.name == "default"
+
+    def test_same_instance_returned(self) -> None:
+        mgr = ResiliencyManager(config=ResiliencyConfig())
+        cb1 = mgr.get_breaker("default")
+        cb2 = mgr.get_breaker("default")
+        assert cb1 is cb2
+
+    def test_fallback_to_default_policy(self) -> None:
+        mgr = ResiliencyManager(config=ResiliencyConfig())
+        cb = mgr.get_breaker("unknown")
+        assert cb.name == "unknown"  # created with default policy
+
+    def test_health_ok(self) -> None:
+        mgr = ResiliencyManager(config=ResiliencyConfig())
+        mgr.get_breaker("test")  # ensure at least one exists
+        health = mgr.health_check()
+        assert health["status"] == "ok"
+        assert "test" in health["circuit_breakers"]
+        assert health["circuit_breakers"]["test"]["state"] == "closed"
+
+    @pytest.mark.asyncio
+    async def test_health_degraded(self) -> None:
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                circuit_breakers={"test": CircuitBreakerPolicy(failure_threshold=1)}
+            )
+        )
+        cb = mgr.get_breaker("test")
+        with pytest.raises(ConnectionError):
+            async with cb:
+                raise ConnectionError("fail")
+        health = mgr.health_check()
+        assert health["status"] == "degraded"
+        assert health["circuit_breakers"]["test"]["state"] == "open"
+
+    def test_resolve_target(self) -> None:
+        mgr = ResiliencyManager(
+            config=ResiliencyConfig(
+                targets={"gcs": TargetBinding(timeout="slow", retry="aggressive")}
+            )
+        )
+        binding = mgr.resolve_target("gcs")
+        assert binding.timeout == "slow"
+        assert binding.retry == "aggressive"
+
+    def test_resolve_unknown_target_returns_default(self) -> None:
+        mgr = ResiliencyManager(config=ResiliencyConfig())
+        binding = mgr.resolve_target("nonexistent")
+        assert binding.timeout == "default"
+        assert binding.retry == "default"
+
+
+# ── TestDurationParser ───────────────────────────────────────────────────────
+
+
+class TestDurationParser:
+    def test_numeric_int(self) -> None:
+        assert parse_duration(5) == 5.0
+
+    def test_numeric_float(self) -> None:
+        assert parse_duration(3.5) == 3.5
+
+    def test_seconds_suffix(self) -> None:
+        assert parse_duration("30s") == 30.0
+
+    def test_minutes_suffix(self) -> None:
+        assert parse_duration("10m") == 600.0
+
+    def test_hours_suffix(self) -> None:
+        assert parse_duration("1h") == 3600.0
+
+    def test_bare_number_string(self) -> None:
+        assert parse_duration("42") == 42.0
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(ValueError, match="Cannot parse duration"):
+            parse_duration("abc")
+
+
+# ── TestInfraExceptions ──────────────────────────────────────────────────────
+
+
+class TestInfraExceptions:
+    def test_base_exceptions(self) -> None:
+        exc = _get_infra_exceptions()
+        assert TimeoutError in exc
+        assert ConnectionError in exc
+        assert OSError in exc
+
+    def test_includes_httpx_if_available(self) -> None:
+        try:
+            import httpx
+
+            exc = _get_infra_exceptions()
+            assert httpx.TransportError in exc
+            assert httpx.TimeoutException in exc
+        except ImportError:
+            pytest.skip("httpx not installed")


### PR DESCRIPTION
## Summary

Implements a unified resiliency layer: circuit breakers, retries, and timeouts configured via YAML named policies and applied via `@with_resiliency` decorator — separating resiliency policy from business logic.

**Stream:** #1366

### What changed

- **New `src/nexus/core/resiliency.py`** (~490 LOC): `AsyncCircuitBreaker` state machine (CLOSED→OPEN→HALF_OPEN), frozen dataclass config models, `with_resiliency` decorator (CB outer → Retry middle → Timeout inner), `ResiliencyManager` singleton, infra exception whitelist, duration parser
- **`src/nexus/config.py`**: Added `resiliency` field to `NexusConfig`
- **`src/nexus/factory.py`**: `_parse_resiliency_config()` YAML→dataclass parser, `ResiliencyManager` wired in `create_nexus_services()`, added to `service_extras`
- **`src/nexus/server/fastapi_server.py`**: `/health/detailed` now reports circuit breaker state
- **`src/nexus/llm/provider.py`**: Replaced 65 LOC hand-rolled retry with tenacity-backed (DRY), same API

### Architecture decisions

| # | Decision | Choice |
|---|----------|--------|
| 1 | Placement | `src/nexus/core/resiliency.py` (single file) |
| 2 | Circuit breaker | Custom async impl (~150 LOC), zero new deps |
| 3 | Retries | Existing `tenacity>=8.2.0` |
| 4 | Composition | CB (outer) → Retry (middle) → Timeout (inner) |
| 5 | Half-open | Single probe via `asyncio.Lock` |
| 6 | Exception filter | Whitelist infra only (TimeoutError, ConnectionError, OSError, httpx.*) |
| 7 | Jitter | Full jitter (AWS recommended) |

## Test plan

- [x] 50 unit tests — config, CB state machine, exception filtering, half-open lock, retry, timeout, composition, decorator, manager, duration parser
- [x] 2 integration tests — full pipeline trip→fail-fast→half-open→recovery, health state transitions
- [x] 3 E2E tests (live server with permissions) — health endpoint includes resiliency, fresh server reports ok, performance <100ms avg
- [x] 23 LLM provider regression tests — no behavior change from tenacity refactor
- [x] 21 extracted services E2E tests — no factory.py regression
- [x] ruff check + ruff format + mypy clean (no new errors)