### PR TITLE
fix(#1272): review improvements — DRY, error handling, tests, E2E

### DIFF
--- a/src/nexus/mcp/server.py
+++ b/src/nexus/mcp/server.py
@@ -250,40 +250,16 @@ def create_mcp_server(
     def _get_visible_tool_names(ctx: Context | None) -> frozenset[str] | None:
         """Get visible tool names for the current subject via namespace middleware.
 
+        Delegates to ``ToolNamespaceMiddleware.resolve_visible_tools()`` to
+        avoid duplicating subject extraction logic (#1A DRY fix).
+
         Returns:
             frozenset of visible tool names, or None if namespace filtering
             is not configured (backward compat → all tools visible).
         """
         if tool_namespace_middleware is None:
             return None
-
-        if ctx is None:
-            return None
-
-        # Build a minimal fake middleware context to extract subject
-        # The middleware's _extract_subject uses fastmcp_context.get_state()
-        subject = None
-        if hasattr(ctx, "get_state"):
-            try:
-                subject_type = ctx.get_state("subject_type")
-                subject_id = ctx.get_state("subject_id")
-                if subject_type and subject_id:
-                    subject = (subject_type, subject_id)
-            except Exception:
-                pass
-
-            if subject is None:
-                try:
-                    ak = ctx.get_state("api_key")
-                    if ak:
-                        subject = ("api_key", ak)
-                except Exception:
-                    pass
-
-        if subject is None:
-            return None  # No subject → no filtering
-
-        result: frozenset[str] = tool_namespace_middleware._get_visible_tools(subject)
+        result: frozenset[str] | None = tool_namespace_middleware.resolve_visible_tools(ctx)
         return result
 
     # =========================================================================
@@ -1170,6 +1146,7 @@ def create_mcp_server(
             "openWorldHint": True,
         }
     )
+    @handle_tool_errors("searching tools")
     def nexus_discovery_search_tools(query: str, top_k: int = 5, ctx: Context | None = None) -> str:
         """Search for MCP tools by query.
 
@@ -1210,6 +1187,7 @@ def create_mcp_server(
             "openWorldHint": True,
         }
     )
+    @handle_tool_errors("listing servers")
     def nexus_discovery_list_servers(ctx: Context | None = None) -> str:
         """List all available MCP servers.
 
@@ -1250,6 +1228,7 @@ def create_mcp_server(
             "openWorldHint": True,
         }
     )
+    @handle_tool_errors("getting tool details")
     def nexus_discovery_get_tool_details(tool_name: str, ctx: Context | None = None) -> str:
         """Get detailed information about a specific tool.
 
@@ -1288,6 +1267,7 @@ def create_mcp_server(
             "openWorldHint": True,
         }
     )
+    @handle_tool_errors("loading tools")
     def nexus_discovery_load_tools(tool_names: list[str], ctx: Context | None = None) -> str:
         """Load specified tools into the active context.
 

--- a/src/nexus/mcp/tool_utils.py
+++ b/src/nexus/mcp/tool_utils.py
@@ -20,6 +20,7 @@ References:
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import logging
 from typing import Any
@@ -104,6 +105,12 @@ def handle_tool_errors(operation: str) -> Any:
     """
 
     def decorator(fn: Any) -> Any:
+        if asyncio.iscoroutinefunction(fn):
+            raise TypeError(
+                f"@handle_tool_errors cannot wrap async function '{fn.__name__}'. "
+                "All MCP tools must be synchronous."
+            )
+
         @functools.wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> str:
             try:

--- a/tests/e2e/test_mcp_tool_namespace_e2e.py
+++ b/tests/e2e/test_mcp_tool_namespace_e2e.py
@@ -1,0 +1,441 @@
+"""E2E test for MCP tool namespace — full grant → discover → call → revoke lifecycle.
+
+Issue #1272: Validates the complete flow with a real ReBAC backend:
+    1. Grant tools via profile → verify discovery filtering
+    2. Verify invisible tools return "not found"
+    3. Verify resolve_visible_tools() DRY path
+    4. Verify revocation removes visibility
+    5. Validate [TOOL-NS] and [PROFILES] log output
+    6. Performance: cold + hot lookups under threshold
+
+Uses real EnhancedReBACManager with in-memory SQLite (not mocks).
+
+Usage:
+    uv run pytest tests/e2e/test_mcp_tool_namespace_e2e.py -v --tb=short -p no:xdist -o "addopts=" --log-cli-level=INFO
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import create_engine
+
+from nexus.mcp.middleware import ToolNamespaceMiddleware
+from nexus.mcp.profiles import (
+    grant_tools_for_profile,
+    load_profiles_from_dict,
+    revoke_tools_by_tuple_ids,
+)
+from nexus.mcp.server import create_mcp_server
+from nexus.services.permissions.rebac_manager_enhanced import EnhancedReBACManager
+from nexus.storage.models import Base
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rebac_engine():
+    """In-memory SQLite engine with all ReBAC tables."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def rebac_manager(rebac_engine):
+    """Real EnhancedReBACManager on in-memory SQLite."""
+    return EnhancedReBACManager(engine=rebac_engine, cache_ttl_seconds=1)
+
+
+@pytest.fixture
+def middleware(rebac_manager):
+    """ToolNamespaceMiddleware with real ReBAC backend."""
+    return ToolNamespaceMiddleware(
+        rebac_manager=rebac_manager,
+        zone_id=None,
+        cache_ttl=60,
+        revision_window=1,
+    )
+
+
+@pytest.fixture
+def mock_nx():
+    """Minimal mock NexusFS for server creation."""
+    nx = Mock()
+    nx.read = Mock(return_value=b"hello world")
+    nx.write = Mock()
+    nx.delete = Mock()
+    nx.list = Mock(return_value=[])
+    nx.glob = Mock(return_value=[])
+    nx.grep = Mock(return_value=[])
+    nx.exists = Mock(return_value=True)
+    nx.is_directory = Mock(return_value=False)
+    nx.mkdir = Mock()
+    nx.rmdir = Mock()
+    nx.edit = Mock(
+        return_value={
+            "success": True,
+            "diff": "",
+            "applied_count": 0,
+            "matches": [],
+            "errors": [],
+        }
+    )
+    return nx
+
+
+@pytest.fixture
+def profiles():
+    """Test profile config: reader (3 tools) and writer (6 tools)."""
+    return load_profiles_from_dict(
+        {
+            "profiles": {
+                "reader": {
+                    "description": "Read-only tools",
+                    "tools": [
+                        "nexus_read_file",
+                        "nexus_list_files",
+                        "nexus_file_info",
+                    ],
+                },
+                "writer": {
+                    "extends": "reader",
+                    "description": "Read-write tools",
+                    "tools": [
+                        "nexus_write_file",
+                        "nexus_edit_file",
+                        "nexus_delete_file",
+                    ],
+                },
+            },
+            "default_profile": "reader",
+        }
+    )
+
+
+def _make_ctx(subject_type: str, subject_id: str) -> Mock:
+    """Create a mock FastMCP Context with subject state."""
+    ctx = Mock()
+    ctx.get_state = Mock(
+        side_effect=lambda key: {
+            "subject_type": subject_type,
+            "subject_id": subject_id,
+        }.get(key)
+    )
+    return ctx
+
+
+def _get_tool(server, name):
+    """Get a tool callable from the MCP server."""
+    return server._tool_manager._tools[name]
+
+
+# ---------------------------------------------------------------------------
+# E2E Lifecycle Test
+# ---------------------------------------------------------------------------
+
+
+class TestToolNamespaceE2E:
+    """Full lifecycle: grant → discover → call → revoke → verify gone."""
+
+    def test_full_lifecycle(self, rebac_manager, middleware, mock_nx, profiles):
+        """Complete grant → discover → use → revoke → verify lifecycle."""
+        server = create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
+        ctx = _make_ctx("agent", "lifecycle-agent")
+
+        # --- Phase 1: No grants → no tools visible ---
+        search_fn = _get_tool(server, "nexus_discovery_search_tools")
+        result = json.loads(search_fn.fn(query="file", top_k=20, ctx=ctx))
+        assert result["count"] == 0, "Agent with no grants should see zero tools"
+
+        # --- Phase 2: Grant reader profile ---
+        reader_profile = profiles.get_profile("reader")
+        write_results = grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "lifecycle-agent"),
+            profile=reader_profile,
+        )
+        assert len(write_results) == 3
+        middleware.invalidate()
+
+        # Discover: should see only reader tools (no invisible tools leak)
+        result = json.loads(search_fn.fn(query="file read list", top_k=20, ctx=ctx))
+        visible_names = {t["name"] for t in result["tools"]}
+        allowed = {"nexus_read_file", "nexus_list_files", "nexus_file_info"}
+        assert visible_names <= allowed, f"Invisible tools leaked: {visible_names - allowed}"
+        assert len(visible_names) > 0, "At least one tool should match"
+        assert "nexus_write_file" not in visible_names, "Write tool should be invisible"
+
+        # Use: read_file should work
+        read_fn = _get_tool(server, "nexus_read_file")
+        read_result = read_fn.fn(path="/test.txt", ctx=ctx)
+        assert "hello world" in read_result
+
+        # Get details: visible tool returns details, invisible returns not found
+        details_fn = _get_tool(server, "nexus_discovery_get_tool_details")
+        visible_detail = json.loads(details_fn.fn(tool_name="nexus_read_file", ctx=ctx))
+        assert visible_detail["found"] is True
+
+        invisible_detail = json.loads(details_fn.fn(tool_name="nexus_delete_file", ctx=ctx))
+        assert invisible_detail["found"] is False
+        assert "not found" in invisible_detail["error"]
+
+        # Load tools: visible loads, invisible goes to not_found
+        load_fn = _get_tool(server, "nexus_discovery_load_tools")
+        load_result = json.loads(
+            load_fn.fn(
+                tool_names=["nexus_read_file", "nexus_delete_file"],
+                ctx=ctx,
+            )
+        )
+        assert "nexus_read_file" in load_result["loaded"]
+        assert "nexus_delete_file" in load_result["not_found"]
+
+        # List servers: tool counts reflect filtering
+        list_fn = _get_tool(server, "nexus_discovery_list_servers")
+        list_result = json.loads(list_fn.fn(ctx=ctx))
+        assert list_result["total_tools"] <= 3, "Reader sees at most 3 tools"
+
+        # --- Phase 3: Revoke all grants ---
+        tid_strings = [wr.tuple_id for wr in write_results]
+        deleted = revoke_tools_by_tuple_ids(
+            rebac_manager=rebac_manager,
+            tuple_ids=tid_strings,
+        )
+        assert deleted == 3
+        middleware.invalidate()
+
+        # --- Phase 4: Verify tools are gone ---
+        result = json.loads(search_fn.fn(query="file", top_k=20, ctx=ctx))
+        assert result["count"] == 0, "After revocation, no tools should be visible"
+
+        logger.info("PASS: Full lifecycle test completed successfully")
+
+
+# ---------------------------------------------------------------------------
+# resolve_visible_tools() DRY path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveVisibleToolsDRY:
+    """Verify the DRY path: middleware.resolve_visible_tools() → server._get_visible_tool_names()."""
+
+    def test_middleware_and_server_agree(self, rebac_manager, middleware, profiles):
+        """resolve_visible_tools() returns same set as _get_visible_tools()."""
+        reader_profile = profiles.get_profile("reader")
+        grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "dry-agent"),
+            profile=reader_profile,
+        )
+        middleware.invalidate()
+
+        ctx = _make_ctx("agent", "dry-agent")
+
+        # Direct path (middleware internal)
+        direct = middleware._get_visible_tools(("agent", "dry-agent"))
+        # DRY path (middleware public API, used by discovery tools)
+        via_public = middleware.resolve_visible_tools(ctx)
+
+        assert direct == via_public
+        assert "nexus_read_file" in direct
+        assert "nexus_write_file" not in direct
+
+    def test_resolve_none_ctx_returns_none(self, middleware):
+        """None ctx → None (no filtering)."""
+        assert middleware.resolve_visible_tools(None) is None
+
+    def test_resolve_no_subject_returns_none(self, middleware):
+        """Ctx without subject → None (backward compat)."""
+        ctx = Mock()
+        ctx.get_state = Mock(return_value=None)
+        assert middleware.resolve_visible_tools(ctx) is None
+
+
+# ---------------------------------------------------------------------------
+# Log validation
+# ---------------------------------------------------------------------------
+
+
+class TestLogOutput:
+    """Verify [TOOL-NS] and [PROFILES] log messages are emitted."""
+
+    def test_grant_emits_profiles_log(self, rebac_manager, profiles, caplog):
+        """grant_tools_for_profile() logs [PROFILES] message."""
+        reader_profile = profiles.get_profile("reader")
+
+        with caplog.at_level(logging.INFO, logger="nexus.mcp.profiles"):
+            grant_tools_for_profile(
+                rebac_manager=rebac_manager,
+                subject=("agent", "log-agent"),
+                profile=reader_profile,
+            )
+
+        assert "[PROFILES]" in caplog.text
+        assert "Granted 3 tools" in caplog.text
+        assert "log-agent" in caplog.text
+        logger.info("PASS: Grant log validation")
+
+    def test_revoke_emits_profiles_log(self, rebac_manager, profiles, caplog):
+        """revoke_tools_by_tuple_ids() logs [PROFILES] message."""
+        reader_profile = profiles.get_profile("reader")
+        results = grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "revoke-log-agent"),
+            profile=reader_profile,
+        )
+
+        tid_strings = [wr.tuple_id for wr in results]
+
+        with caplog.at_level(logging.INFO, logger="nexus.mcp.profiles"):
+            revoke_tools_by_tuple_ids(
+                rebac_manager=rebac_manager,
+                tuple_ids=tid_strings,
+            )
+
+        assert "[PROFILES]" in caplog.text
+        assert "Revoked" in caplog.text
+        logger.info("PASS: Revoke log validation")
+
+    def test_tool_rebuild_emits_debug_log(self, rebac_manager, middleware, profiles, caplog):
+        """_rebuild_tool_set() emits [TOOL-NS] debug log."""
+        reader_profile = profiles.get_profile("reader")
+        grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "rebuild-log-agent"),
+            profile=reader_profile,
+        )
+        middleware.invalidate()
+
+        with caplog.at_level(logging.DEBUG, logger="nexus.mcp.middleware"):
+            middleware._get_visible_tools(("agent", "rebuild-log-agent"))
+
+        assert "[TOOL-NS]" in caplog.text
+        assert "Rebuilt tool set" in caplog.text
+        logger.info("PASS: Rebuild log validation")
+
+
+# ---------------------------------------------------------------------------
+# Performance validation
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceE2E:
+    """E2E performance benchmarks for tool namespace operations."""
+
+    def test_grant_performance(self, rebac_manager, profiles):
+        """Granting a 6-tool profile completes under 100ms."""
+        writer_profile = profiles.get_profile("writer")
+
+        start = time.perf_counter()
+        results = grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "perf-grant-agent"),
+            profile=writer_profile,
+        )
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert len(results) == 6
+        assert elapsed_ms < 100, f"Grant took {elapsed_ms:.1f}ms (expected <100ms)"
+        logger.info("Grant performance: %.1fms for %d tools", elapsed_ms, len(results))
+
+    def test_cold_lookup_performance(self, rebac_manager, middleware, profiles):
+        """Cold lookup (cache miss + ReBAC query) under 50ms."""
+        writer_profile = profiles.get_profile("writer")
+        grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "perf-cold-agent"),
+            profile=writer_profile,
+        )
+        middleware.invalidate()
+
+        start = time.perf_counter()
+        visible = middleware._get_visible_tools(("agent", "perf-cold-agent"))
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert len(visible) == 6
+        assert elapsed_ms < 50, f"Cold lookup took {elapsed_ms:.1f}ms (expected <50ms)"
+        logger.info("Cold lookup: %.1fms for %d tools", elapsed_ms, len(visible))
+
+    def test_hot_lookup_performance(self, rebac_manager, middleware, profiles):
+        """Hot lookup (cache hit) under 1ms."""
+        writer_profile = profiles.get_profile("writer")
+        grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "perf-hot-agent"),
+            profile=writer_profile,
+        )
+        middleware.invalidate()
+
+        # Prime the cache
+        middleware._get_visible_tools(("agent", "perf-hot-agent"))
+
+        start = time.perf_counter()
+        visible = middleware._get_visible_tools(("agent", "perf-hot-agent"))
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert len(visible) == 6
+        assert elapsed_ms < 1, f"Hot lookup took {elapsed_ms:.3f}ms (expected <1ms)"
+        logger.info("Hot lookup: %.3fms (cache hit)", elapsed_ms)
+
+    def test_discovery_search_performance(self, rebac_manager, middleware, mock_nx, profiles):
+        """Discovery search with namespace filtering under 50ms."""
+        reader_profile = profiles.get_profile("reader")
+        grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "perf-disco-agent"),
+            profile=reader_profile,
+        )
+        middleware.invalidate()
+
+        server = create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
+        search_fn = _get_tool(server, "nexus_discovery_search_tools")
+        ctx = _make_ctx("agent", "perf-disco-agent")
+
+        # Warm up
+        search_fn.fn(query="file", top_k=5, ctx=ctx)
+        middleware.invalidate()
+
+        # Cold search (includes ReBAC + BM25 + filtering)
+        start = time.perf_counter()
+        result = json.loads(search_fn.fn(query="read file", top_k=5, ctx=ctx))
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert result["count"] > 0
+        assert elapsed_ms < 50, f"Discovery search took {elapsed_ms:.1f}ms (expected <50ms)"
+        logger.info("Discovery search: %.1fms, found %d tools", elapsed_ms, result["count"])
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    """No middleware → all tools visible (backward compat)."""
+
+    def test_no_middleware_returns_all_tools(self, mock_nx):
+        """Server without middleware returns unfiltered tool results."""
+        server = create_mcp_server(nx=mock_nx)
+        search_fn = _get_tool(server, "nexus_discovery_search_tools")
+
+        result = json.loads(search_fn.fn(query="file", top_k=20, ctx=None))
+        assert result["count"] > 3, "Without middleware, all tools should be visible"
+        logger.info("PASS: Backward compat — %d tools visible", result["count"])
+
+    def test_no_ctx_returns_all_tools(self, mock_nx, middleware):
+        """With middleware but no ctx, all tools visible."""
+        server = create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
+        search_fn = _get_tool(server, "nexus_discovery_search_tools")
+
+        result = json.loads(search_fn.fn(query="file", top_k=20, ctx=None))
+        assert result["count"] > 3, "No ctx → no filtering"
+        logger.info("PASS: No ctx — %d tools visible", result["count"])

--- a/tests/unit/mcp/test_tool_profiles.py
+++ b/tests/unit/mcp/test_tool_profiles.py
@@ -373,6 +373,98 @@ class TestRevokeToolsByTupleIds:
         rebac.rebac_delete.assert_not_called()
 
 
+class TestGrantToolsFailure:
+    """#9B: Verify grant_tools_for_profile raises on rebac_write failure."""
+
+    def test_rebac_write_failure_propagates(self):
+        """rebac_write() failure should propagate — caller handles atomicity."""
+        rebac = MagicMock()
+        rebac.rebac_write.side_effect = RuntimeError("DB connection lost")
+
+        profile = ToolProfile(
+            name="test",
+            tools=frozenset(["nexus_read_file"]),
+        )
+
+        with pytest.raises(RuntimeError, match="DB connection lost"):
+            grant_tools_for_profile(
+                rebac_manager=rebac,
+                subject=("agent", "A"),
+                profile=profile,
+            )
+
+
+# ---------------------------------------------------------------------------
+# YAML config validation (#12A)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConfigValidity:
+    """Validate that default tool_profiles.yaml tool names match registered MCP tools."""
+
+    def test_default_yaml_tool_names_exist_in_server(self):
+        """All tool names in default YAML should match registered MCP tools.
+
+        Sandbox tools (nexus_python, nexus_bash, nexus_sandbox_*) are
+        conditionally registered and are excluded from this check.
+        """
+        from pathlib import Path
+        from unittest.mock import Mock
+
+        from nexus.mcp.server import create_mcp_server
+
+        # Tools from optional features (conditionally registered)
+        OPTIONAL_TOOL_PREFIXES = ("nexus_python", "nexus_bash", "nexus_sandbox_")
+
+        # Load the default config
+        config_path = Path(__file__).parents[3] / "src" / "nexus" / "config" / "tool_profiles.yaml"
+        if not config_path.exists():
+            pytest.skip("Default tool_profiles.yaml not found")
+
+        config = load_profiles(config_path)
+
+        # Create a server to get registered tool names
+        mock_nx = Mock()
+        mock_nx.read = Mock(return_value=b"test")
+        mock_nx.write = Mock()
+        mock_nx.delete = Mock()
+        mock_nx.list = Mock(return_value=[])
+        mock_nx.glob = Mock(return_value=[])
+        mock_nx.grep = Mock(return_value=[])
+        mock_nx.exists = Mock(return_value=True)
+        mock_nx.is_directory = Mock(return_value=False)
+        mock_nx.mkdir = Mock()
+        mock_nx.rmdir = Mock()
+        mock_nx.edit = Mock(
+            return_value={
+                "success": True,
+                "diff": "",
+                "applied_count": 0,
+                "matches": [],
+                "errors": [],
+            }
+        )
+        server = create_mcp_server(nx=mock_nx)
+        registered_tools = set(server._tool_manager._tools.keys())
+
+        # Check all non-optional profile tool names exist
+        missing_tools: dict[str, list[str]] = {}
+        for profile_name, profile in config.profiles.items():
+            missing = [
+                t
+                for t in profile.tools
+                if t not in registered_tools
+                and not any(t.startswith(prefix) for prefix in OPTIONAL_TOOL_PREFIXES)
+            ]
+            if missing:
+                missing_tools[profile_name] = missing
+
+        assert not missing_tools, (
+            f"Tool profile(s) reference tools not registered in MCP server: {missing_tools}. "
+            f"Registered tools: {sorted(registered_tools)}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_tool_utils.py
+++ b/tests/unit/mcp/test_tool_utils.py
@@ -150,6 +150,16 @@ class TestHandleToolErrors:
         assert result.startswith("Error:")
         assert "not found" in result.lower()
 
+    def test_rejects_async_functions(self):
+        """#7B: Decorating an async function should raise TypeError."""
+        import pytest
+
+        with pytest.raises(TypeError, match="cannot wrap async function"):
+
+            @handle_tool_errors("async op")
+            async def my_async_tool(path: str) -> str:
+                return "ok"
+
 
 # ---------------------------------------------------------------------------
 # _extract_path_hint()


### PR DESCRIPTION
## Summary

Post-merge review improvements for #1272 (MCP tool-level namespace — per-tool ReBAC grants):

- **#1A DRY fix**: Add `resolve_visible_tools()` public API on `ToolNamespaceMiddleware`, eliminating duplicated subject extraction logic between middleware and server
- **#4B**: Remove dead `_extract_zone_id()` method (unused after #1272 design change)
- **#5A**: Add `@handle_tool_errors` decorator to 4 discovery tools for consistent error handling
- **#7B**: Add async guard — `@handle_tool_errors` raises `TypeError` on async functions (all MCP tools must be sync)
- **#9B**: Test that `grant_tools_for_profile()` propagates `rebac_write()` failures
- **#12A**: Validate default `tool_profiles.yaml` tool names match registered MCP server tools
- **#11A**: 13 new E2E tests covering full lifecycle, DRY path, log validation, performance benchmarks, and backward compatibility
- Replace `TestZoneIdExtraction` with `TestResolveVisibleTools` (5 tests)
- Fix mypy `no-any-return` in `_get_visible_tool_names()`

**Stream: 1**

## Performance (from E2E)

| Operation | Latency |
|-----------|---------|
| Grant 6 tools | 2.4ms |
| Cold lookup (cache miss + ReBAC) | 0.5ms |
| Hot lookup (cache hit) | 0.014ms |
| Discovery search with namespace | 0.5ms |

## Test plan

- [x] 114 #1272-specific tests pass (unit + integration + E2E)
- [x] ruff check — all passed
- [x] ruff format — all formatted
- [x] mypy — no new errors (pre-existing yaml stubs issue only)
- [ ] CI checks pass