### PR TITLE
feat(#762): pg_stat_statements monitoring dashboard

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -156,6 +156,34 @@ services:
     profiles:
       - observability
 
+  # =========================================================================
+  # postgres_exporter — PostgreSQL metrics for Prometheus (Issue #762)
+  # =========================================================================
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:latest
+    container_name: nexus-postgres-exporter
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://nexus_monitor:${POSTGRES_EXPORTER_PASSWORD:-nexus_monitor}@postgres:5432/${POSTGRES_DB:-nexus}?sslmode=disable"
+    command:
+      - "--collector.stat_statements"
+      - "--collector.stat_activity"
+      - "--collector.stat_bgwriter"
+      - "--collector.stat_database"
+      - "--collector.stat_user_tables"
+      - "--collector.locks"
+      - "--collector.wal"
+    ports:
+      - "9187:9187"
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+    networks:
+      - nexus-network
+    profiles:
+      - observability
+
 volumes:
   prometheus-data:
   loki-data:

--- a/dockerfiles/docker-compose.demo.yml
+++ b/dockerfiles/docker-compose.demo.yml
@@ -45,6 +45,7 @@ services:
       # NOTE: this compose file lives in dockerfiles/, so use ../ for repo-root paths.
       - ../postgres-init/01-pg-stat-statements.sql:/docker-entrypoint-initdb.d/01-pg-stat-statements.sql:ro
       - ../postgres-init/02-wal-archiving.sql:/docker-entrypoint-initdb.d/02-wal-archiving.sql:ro
+      - ../postgres-init/03-monitoring-user.sql:/docker-entrypoint-initdb.d/03-monitoring-user.sql:ro
     # PostgreSQL 18 optimizations:
     # - io_method=worker: Async I/O for 2-3x I/O performance
     # - effective_io_concurrency=16: Concurrent I/O requests (tuned for SSD)

--- a/observability/grafana/provisioning/dashboards/pg-stat-statements.json
+++ b/observability/grafana/provisioning/dashboards/pg-stat-statements.json
@@ -1,0 +1,499 @@
+{
+  "uid": "nexus-pg-stat-statements",
+  "title": "PostgreSQL — pg_stat_statements",
+  "description": "PostgreSQL query performance monitoring via pg_stat_statements and app-level QueryObserver (Issue #762)",
+  "tags": ["postgresql", "nexus", "observability"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "label": "Datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Overview",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "Queries per Second",
+      "description": "Application-level query rate from QueryObserver",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "expr": "rate(nexus_db_queries_total[5m])",
+          "legendFormat": "QPS"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Slow Query Rate",
+      "description": "Rate of queries exceeding the slow threshold",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "targets": [
+        {
+          "expr": "rate(nexus_db_slow_queries_total[5m])",
+          "legendFormat": "Slow/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Active Connections",
+      "description": "Current active database connections",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "targets": [
+        {
+          "expr": "pg_stat_activity_count{state=\"active\"}",
+          "legendFormat": "Active"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 80 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Cache Hit Ratio",
+      "description": "Buffer cache hit ratio (target >99%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "targets": [
+        {
+          "expr": "pg_stat_database_blks_hit{datname=\"nexus\"} / (pg_stat_database_blks_hit{datname=\"nexus\"} + pg_stat_database_blks_read{datname=\"nexus\"}) * 100",
+          "legendFormat": "Hit %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 95 },
+              { "color": "green", "value": 99 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Top Queries",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false
+    },
+    {
+      "type": "table",
+      "title": "Top 10 by Total Time",
+      "description": "Queries consuming the most total execution time",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "expr": "topk(10, pg_stat_statements_seconds_total)",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true },
+            "renameByName": { "query": "Query", "Value": "Total Time (s)" }
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Top 10 by Calls",
+      "description": "Most frequently executed queries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 6 },
+      "targets": [
+        {
+          "expr": "topk(10, pg_stat_statements_calls_total)",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true },
+            "renameByName": { "query": "Query", "Value": "Calls" }
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Top 10 by Rows",
+      "description": "Queries returning the most rows",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
+      "targets": [
+        {
+          "expr": "topk(10, pg_stat_statements_rows_total)",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true },
+            "renameByName": { "query": "Query", "Value": "Rows" }
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Query Performance",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "title": "Mean Execution Time",
+      "description": "Average query execution time from pg_stat_statements",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_statements_seconds_total[5m]) / rate(pg_stat_statements_calls_total[5m])",
+          "legendFormat": "Mean exec time"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Blocks Hit / Read Ratio",
+      "description": "Shared buffer hit rate vs disk reads",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 15 },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_statements_block_read_seconds_total[5m])",
+          "legendFormat": "Block reads/s"
+        },
+        {
+          "expr": "rate(pg_stat_database_blks_hit{datname=\"nexus\"}[5m])",
+          "legendFormat": "Block hits/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Temp Blocks",
+      "description": "Temporary block usage (indicates queries needing more work_mem)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 15 },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_database_temp_bytes{datname=\"nexus\"}[5m])",
+          "legendFormat": "Temp bytes/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Connection Pool",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "title": "Pool Activity",
+      "description": "SQLAlchemy connection pool events from QueryObserver",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "expr": "rate(nexus_db_pool_checkouts_total[5m])",
+          "legendFormat": "Checkouts/s"
+        },
+        {
+          "expr": "rate(nexus_db_pool_checkins_total[5m])",
+          "legendFormat": "Checkins/s"
+        },
+        {
+          "expr": "rate(nexus_db_pool_connects_total[5m])",
+          "legendFormat": "New connects/s"
+        },
+        {
+          "expr": "rate(nexus_db_pool_invalidations_total[5m])",
+          "legendFormat": "Invalidations/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Observer Health",
+      "description": "QueryObserver circuit breaker status (0=OK, 1=Disabled)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "expr": "nexus_db_observer_disabled",
+          "legendFormat": "Disabled"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "OK", "color": "green" } } },
+            { "type": "value", "options": { "1": { "text": "DISABLED", "color": "red" } } }
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Observer Errors",
+      "description": "Total QueryObserver listener errors",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 24 },
+      "targets": [
+        {
+          "expr": "nexus_db_observer_errors_total",
+          "legendFormat": "Errors"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total Pool Checkouts",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 28 },
+      "targets": [
+        {
+          "expr": "nexus_db_pool_checkouts_total",
+          "legendFormat": "Checkouts"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Total Pool Invalidations",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 28 },
+      "targets": [
+        {
+          "expr": "nexus_db_pool_invalidations_total",
+          "legendFormat": "Invalidations"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Database Health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "Database Size",
+      "description": "Total database size on disk",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 33 },
+      "targets": [
+        {
+          "expr": "pg_database_size_bytes{datname=\"nexus\"}",
+          "legendFormat": "Size"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Dead Tuples",
+      "description": "Total dead tuples across user tables",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 33 },
+      "targets": [
+        {
+          "expr": "sum(pg_stat_user_tables_n_dead_tup)",
+          "legendFormat": "Dead tuples"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10000 },
+              { "color": "red", "value": 100000 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "WAL Rate",
+      "description": "Write-Ahead Log generation rate",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 33 },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_bgwriter_buffers_alloc[5m])",
+          "legendFormat": "Buffers allocated/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Lock Waits",
+      "description": "Current lock wait count",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 33 },
+      "targets": [
+        {
+          "expr": "pg_locks_count{mode=\"ExclusiveLock\"}",
+          "legendFormat": "Exclusive locks"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -10,3 +10,10 @@ scrape_configs:
       - targets: ["nexus-server:2026"]
         labels:
           service: "nexus"
+
+  - job_name: "postgres"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+        labels:
+          service: "postgres"

--- a/postgres-init/03-monitoring-user.sql
+++ b/postgres-init/03-monitoring-user.sql
@@ -1,0 +1,13 @@
+-- Create a dedicated monitoring user for postgres_exporter (Issue #762)
+-- Grants read-only access to system statistics views.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'nexus_monitor') THEN
+        CREATE ROLE nexus_monitor LOGIN PASSWORD 'nexus_monitor';
+    END IF;
+END
+$$;
+
+GRANT pg_monitor TO nexus_monitor;
+GRANT SELECT ON pg_stat_statements TO nexus_monitor;

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -1383,6 +1383,18 @@ def create_app(
     except ImportError:
         pass
 
+    # Register QueryObserver → Prometheus collector bridge (Issue #762)
+    try:
+        from prometheus_client import REGISTRY
+
+        from nexus.server.pg_metrics_collector import QueryObserverCollector
+
+        obs_sub = nexus_fs._service_extras.get("observability_subsystem")
+        if obs_sub is not None:
+            REGISTRY.register(QueryObserverCollector(obs_sub.observer))
+    except Exception:
+        pass
+
     # Instrument FastAPI with OpenTelemetry (Issue #764)
     try:
         from nexus.server.telemetry import instrument_fastapi_app

--- a/src/nexus/server/pg_metrics_collector.py
+++ b/src/nexus/server/pg_metrics_collector.py
@@ -1,0 +1,85 @@
+"""Custom Prometheus collector bridging QueryObserver to /metrics (Issue #762).
+
+Reads app-level database counters from a ``QueryObserver`` instance and
+exposes them as Prometheus ``GaugeMetricFamily`` values.  All metrics use
+gauges because the counters are plain integers that reset on process restart.
+
+Usage:
+    Wired automatically in ``fastapi_server.create_app()``::
+
+        from prometheus_client import REGISTRY
+        from nexus.server.pg_metrics_collector import QueryObserverCollector
+
+        REGISTRY.register(QueryObserverCollector(observer))
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from prometheus_client.core import GaugeMetricFamily
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from nexus.services.subsystems.observability_subsystem import QueryObserver
+
+
+class QueryObserverCollector:
+    """Prometheus custom collector that reads from a QueryObserver.
+
+    Takes the observer as a constructor arg — no import of the
+    observability subsystem at collection time.
+    """
+
+    def __init__(self, observer: QueryObserver) -> None:
+        self._observer = observer
+
+    def describe(self) -> Iterable[GaugeMetricFamily]:
+        """Return empty — dynamic collector convention."""
+        return []
+
+    def collect(self) -> Iterable[GaugeMetricFamily]:
+        """Yield gauge metric families from the observer's counters."""
+        obs = self._observer
+
+        yield GaugeMetricFamily(
+            "nexus_db_queries_total",
+            "Total SQL queries observed by QueryObserver",
+            value=obs.total_queries,
+        )
+        yield GaugeMetricFamily(
+            "nexus_db_slow_queries_total",
+            "Total slow SQL queries (above threshold)",
+            value=obs.slow_queries,
+        )
+        yield GaugeMetricFamily(
+            "nexus_db_observer_errors_total",
+            "Total QueryObserver listener errors",
+            value=obs.error_count,
+        )
+        yield GaugeMetricFamily(
+            "nexus_db_observer_disabled",
+            "Whether QueryObserver is disabled (circuit breaker tripped)",
+            value=int(obs.disabled),
+        )
+        yield GaugeMetricFamily(
+            "nexus_db_pool_checkouts_total",
+            "Total connection pool checkouts",
+            value=obs.pool_checkouts,
+        )
+        yield GaugeMetricFamily(
+            "nexus_db_pool_checkins_total",
+            "Total connection pool checkins",
+            value=obs.pool_checkins,
+        )
+        yield GaugeMetricFamily(
+            "nexus_db_pool_connects_total",
+            "Total new pool connections created",
+            value=obs.pool_connects,
+        )
+        yield GaugeMetricFamily(
+            "nexus_db_pool_invalidations_total",
+            "Total pool connection invalidations",
+            value=obs.pool_invalidations,
+        )

--- a/tests/e2e/test_pg_metrics_e2e.py
+++ b/tests/e2e/test_pg_metrics_e2e.py
@@ -1,0 +1,298 @@
+"""E2E tests for pg_stat_statements monitoring dashboard (Issue #762).
+
+Validates the complete metrics pipeline end-to-end:
+1. Start real FastAPI server with permissions enabled
+2. Verify /metrics endpoint is accessible (no auth required)
+3. Verify QueryObserver metrics appear after DB-hitting requests
+4. Verify non-admin users can still access /metrics
+5. Performance: /metrics latency stays under threshold
+6. Verify collector doesn't leak sensitive data
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+PYTHON = sys.executable
+SERVER_STARTUP_TIMEOUT = 30
+_src_path = Path(__file__).parent.parent.parent / "src"
+
+# Clear proxy env vars so localhost connections work
+for _key in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+    os.environ.pop(_key, None)
+os.environ["NO_PROXY"] = "*"
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_health(base_url: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    with httpx.Client(timeout=5, trust_env=False) as client:
+        while time.monotonic() < deadline:
+            try:
+                resp = client.get(f"{base_url}/health")
+                if resp.status_code == 200:
+                    return
+            except httpx.ConnectError:
+                pass
+            time.sleep(0.3)
+    raise TimeoutError(f"Server did not start within {timeout}s at {base_url}")
+
+
+@pytest.fixture(scope="module")
+def server(tmp_path_factory):
+    """Start a real nexus server with permissions enforced."""
+    tmp = tmp_path_factory.mktemp("pg_metrics_e2e")
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    api_key = "e2e-pg-metrics-test-key"
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "NEXUS_JWT_SECRET": "test-secret-pg-metrics-e2e",
+            "NEXUS_DATABASE_URL": f"sqlite:///{tmp / 'e2e.db'}",
+            "NEXUS_API_KEY": api_key,
+            "NEXUS_ENFORCE_PERMISSIONS": "true",
+            "NEXUS_SKIP_PERMISSIONS": "false",
+            "PYTHONPATH": str(_src_path),
+        }
+    )
+
+    proc = subprocess.Popen(
+        [
+            PYTHON,
+            "-c",
+            (
+                f"from nexus.cli import main; "
+                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                f"'--data-dir', '{tmp}'])"
+            ),
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        preexec_fn=os.setsid if sys.platform != "win32" else None,
+    )
+
+    try:
+        _wait_for_health(base_url)
+    except TimeoutError:
+        proc.terminate()
+        stdout, stderr = proc.communicate(timeout=5)
+        pytest.fail(
+            f"Server failed to start on port {port}.\n"
+            f"stdout: {stdout.decode()}\nstderr: {stderr.decode()}"
+        )
+
+    yield {"base_url": base_url, "api_key": api_key, "process": proc}
+
+    # Cleanup
+    if sys.platform != "win32":
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+    else:
+        proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+@pytest.fixture()
+def client(server):
+    with httpx.Client(base_url=server["base_url"], timeout=30.0, trust_env=False) as c:
+        yield c
+
+
+@pytest.fixture()
+def admin_headers(server):
+    return {"Authorization": f"Bearer {server['api_key']}"}
+
+
+# ---------------------------------------------------------------------------
+# /metrics availability
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsEndpointAvailability:
+    """The /metrics endpoint should be publicly accessible (no auth)."""
+
+    def test_metrics_returns_200_no_auth(self, client) -> None:
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+
+    def test_metrics_content_type_is_prometheus(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "text/plain" in resp.headers["content-type"]
+
+    def test_metrics_no_auth_required_even_with_permissions_enabled(self, client) -> None:
+        """Permissions enforcement should not block /metrics."""
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert "nexus_info" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# QueryObserver metrics in /metrics output
+# ---------------------------------------------------------------------------
+
+
+class TestQueryObserverMetrics:
+    """Verify app-level DB metrics appear after DB-hitting requests."""
+
+    def test_db_queries_total_present(self, client, admin_headers) -> None:
+        # Fire a DB-hitting request first
+        client.get("/v1/stat?path=/nonexistent", headers=admin_headers)
+        resp = client.get("/metrics")
+        assert "nexus_db_queries_total" in resp.text
+
+    def test_slow_queries_total_present(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "nexus_db_slow_queries_total" in resp.text
+
+    def test_observer_disabled_present(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "nexus_db_observer_disabled" in resp.text
+
+    def test_observer_errors_present(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "nexus_db_observer_errors_total" in resp.text
+
+    def test_pool_checkouts_present(self, client, admin_headers) -> None:
+        client.get("/v1/stat?path=/test", headers=admin_headers)
+        resp = client.get("/metrics")
+        assert "nexus_db_pool_checkouts_total" in resp.text
+
+    def test_pool_checkins_present(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "nexus_db_pool_checkins_total" in resp.text
+
+    def test_pool_connects_present(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "nexus_db_pool_connects_total" in resp.text
+
+    def test_pool_invalidations_present(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "nexus_db_pool_invalidations_total" in resp.text
+
+    def test_all_eight_metric_families_present(self, client, admin_headers) -> None:
+        """All 8 QueryObserverCollector families must appear."""
+        client.get("/v1/stat?path=/warmup", headers=admin_headers)
+        resp = client.get("/metrics")
+        expected = [
+            "nexus_db_queries_total",
+            "nexus_db_slow_queries_total",
+            "nexus_db_observer_errors_total",
+            "nexus_db_observer_disabled",
+            "nexus_db_pool_checkouts_total",
+            "nexus_db_pool_checkins_total",
+            "nexus_db_pool_connects_total",
+            "nexus_db_pool_invalidations_total",
+        ]
+        for metric in expected:
+            assert metric in resp.text, f"Missing metric: {metric}"
+
+
+# ---------------------------------------------------------------------------
+# Non-admin user access to /metrics
+# ---------------------------------------------------------------------------
+
+
+class TestNonAdminMetricsAccess:
+    """Non-admin users (and unauthenticated requests) can read /metrics."""
+
+    def test_unauthenticated_can_read_metrics(self, client) -> None:
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert "nexus_db_queries_total" in resp.text
+
+    def test_invalid_token_can_still_read_metrics(self, client) -> None:
+        resp = client.get("/metrics", headers={"Authorization": "Bearer invalid-key"})
+        assert resp.status_code == 200
+
+    def test_metrics_does_not_leak_sql_statements(self, client) -> None:
+        """Metrics output should not contain SQL query text."""
+        resp = client.get("/metrics")
+        body = resp.text
+        assert "SELECT" not in body or "select" not in body.lower().split("nexus")[0]
+        assert "pg_stat_statements" not in body
+
+
+# ---------------------------------------------------------------------------
+# Performance
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsPerformanceE2E:
+    """Verify /metrics endpoint has acceptable latency under real server."""
+
+    @pytest.mark.benchmark
+    def test_metrics_latency_under_50ms(self, client) -> None:
+        # Warm up
+        client.get("/metrics")
+
+        n = 20
+        start = time.perf_counter()
+        for _ in range(n):
+            resp = client.get("/metrics")
+            assert resp.status_code == 200
+        elapsed = time.perf_counter() - start
+
+        per_req_ms = (elapsed / n) * 1000
+        assert per_req_ms < 50, f"/metrics: {per_req_ms:.1f}ms per request — too slow"
+
+    @pytest.mark.benchmark
+    def test_db_request_with_metrics_no_regression(self, client, admin_headers) -> None:
+        """DB-hitting requests should not be slowed by the collector."""
+        # Warm up
+        client.get("/v1/stat?path=/warmup", headers=admin_headers)
+
+        n = 50
+        start = time.perf_counter()
+        for _ in range(n):
+            client.get("/v1/stat?path=/perf-test", headers=admin_headers)
+        elapsed = time.perf_counter() - start
+
+        per_req_ms = (elapsed / n) * 1000
+        # With collector overhead, each request should still be <100ms
+        assert per_req_ms < 100, f"DB request: {per_req_ms:.1f}ms per request — regression"
+
+
+# ---------------------------------------------------------------------------
+# HTTP metrics co-existence
+# ---------------------------------------------------------------------------
+
+
+class TestHTTPMetricsCoexistence:
+    """Existing HTTP metrics should still work alongside new DB metrics."""
+
+    def test_http_request_duration_still_present(self, client, admin_headers) -> None:
+        client.get("/v1/stat?path=/test", headers=admin_headers)
+        resp = client.get("/metrics")
+        assert "http_request_duration_seconds" in resp.text
+
+    def test_http_requests_total_still_present(self, client, admin_headers) -> None:
+        client.get("/v1/stat?path=/test", headers=admin_headers)
+        resp = client.get("/metrics")
+        assert "http_requests_total" in resp.text
+
+    def test_nexus_info_still_present(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "nexus_info" in resp.text

--- a/tests/unit/server/test_pg_metrics_collector.py
+++ b/tests/unit/server/test_pg_metrics_collector.py
@@ -1,0 +1,91 @@
+"""Unit tests for QueryObserverCollector Prometheus bridge (Issue #762).
+
+Validates that the custom collector correctly translates QueryObserver
+counters into Prometheus GaugeMetricFamily values.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from nexus.server.pg_metrics_collector import QueryObserverCollector
+
+# Expected metric family names emitted by the collector
+_EXPECTED_FAMILIES = {
+    "nexus_db_queries_total",
+    "nexus_db_slow_queries_total",
+    "nexus_db_observer_errors_total",
+    "nexus_db_observer_disabled",
+    "nexus_db_pool_checkouts_total",
+    "nexus_db_pool_checkins_total",
+    "nexus_db_pool_connects_total",
+    "nexus_db_pool_invalidations_total",
+}
+
+
+def _make_observer(**overrides: int | bool) -> MagicMock:
+    """Build a mock QueryObserver with sensible defaults."""
+    defaults = {
+        "total_queries": 0,
+        "slow_queries": 0,
+        "error_count": 0,
+        "disabled": False,
+        "pool_checkouts": 0,
+        "pool_checkins": 0,
+        "pool_connects": 0,
+        "pool_invalidations": 0,
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for attr, val in defaults.items():
+        setattr(mock, attr, val)
+    return mock
+
+
+class TestQueryObserverCollector:
+    """Tests for the custom Prometheus collector."""
+
+    def test_collector_yields_expected_metric_families(self) -> None:
+        collector = QueryObserverCollector(_make_observer())
+        families = list(collector.collect())
+        names = {f.name for f in families}
+        assert names == _EXPECTED_FAMILIES
+
+    def test_collector_reads_observer_values(self) -> None:
+        observer = _make_observer(
+            total_queries=42,
+            slow_queries=3,
+            error_count=1,
+            disabled=False,
+            pool_checkouts=100,
+            pool_checkins=98,
+            pool_connects=5,
+            pool_invalidations=2,
+        )
+        collector = QueryObserverCollector(observer)
+        families = {f.name: f for f in collector.collect()}
+
+        assert families["nexus_db_queries_total"].samples[0].value == 42
+        assert families["nexus_db_slow_queries_total"].samples[0].value == 3
+        assert families["nexus_db_observer_errors_total"].samples[0].value == 1
+        assert families["nexus_db_observer_disabled"].samples[0].value == 0
+        assert families["nexus_db_pool_checkouts_total"].samples[0].value == 100
+        assert families["nexus_db_pool_checkins_total"].samples[0].value == 98
+        assert families["nexus_db_pool_connects_total"].samples[0].value == 5
+        assert families["nexus_db_pool_invalidations_total"].samples[0].value == 2
+
+    def test_collector_handles_disabled_observer(self) -> None:
+        observer = _make_observer(disabled=True)
+        collector = QueryObserverCollector(observer)
+        families = {f.name: f for f in collector.collect()}
+        assert families["nexus_db_observer_disabled"].samples[0].value == 1
+
+    def test_collector_with_zero_counters(self) -> None:
+        collector = QueryObserverCollector(_make_observer())
+        families = list(collector.collect())
+        for family in families:
+            assert family.samples[0].value == 0
+
+    def test_describe_returns_empty(self) -> None:
+        collector = QueryObserverCollector(_make_observer())
+        assert list(collector.describe()) == []

--- a/tests/unit/storage/test_pg_monitor.py
+++ b/tests/unit/storage/test_pg_monitor.py
@@ -1,0 +1,64 @@
+"""Unit tests for PgMonitor graceful degradation on SQLite (Issue #762).
+
+PgMonitor methods that rely on pg_stat_statements should return empty /
+false values when running against a non-PostgreSQL backend (e.g. SQLite).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from nexus.storage.pg_monitor import PgMonitor
+
+
+@pytest.fixture()
+def sqlite_session():
+    """In-memory SQLite session (not PostgreSQL)."""
+    engine = create_engine("sqlite:///:memory:")
+    with Session(engine) as session:
+        yield session
+
+
+class TestPgMonitorSQLiteDegradation:
+    """PgMonitor should degrade gracefully when backed by SQLite."""
+
+    def test_is_postgres_returns_false_for_sqlite(self, sqlite_session: Session) -> None:
+        monitor = PgMonitor(sqlite_session)
+        assert monitor.is_postgres() is False
+
+    def test_is_pg_stat_statements_enabled_returns_false_for_sqlite(
+        self, sqlite_session: Session
+    ) -> None:
+        monitor = PgMonitor(sqlite_session)
+        assert monitor.is_pg_stat_statements_enabled() is False
+
+    def test_get_slowest_queries_returns_empty_when_not_pg(self, sqlite_session: Session) -> None:
+        monitor = PgMonitor(sqlite_session)
+        assert monitor.get_slowest_queries() == []
+
+    def test_get_most_frequent_queries_returns_empty_when_not_pg(
+        self, sqlite_session: Session
+    ) -> None:
+        monitor = PgMonitor(sqlite_session)
+        assert monitor.get_most_frequent_queries() == []
+
+    def test_get_slow_average_queries_returns_empty_when_not_pg(
+        self, sqlite_session: Session
+    ) -> None:
+        monitor = PgMonitor(sqlite_session)
+        assert monitor.get_slow_average_queries() == []
+
+    def test_reset_stats_returns_false_when_not_pg(self, sqlite_session: Session) -> None:
+        monitor = PgMonitor(sqlite_session)
+        assert monitor.reset_stats() is False
+
+    def test_generate_report_for_non_pg(self, sqlite_session: Session) -> None:
+        monitor = PgMonitor(sqlite_session)
+        report = monitor.generate_report()
+        assert report["is_postgres"] is False
+        assert report["pg_stat_statements_enabled"] is False
+        assert report["slowest_queries"] == []
+        assert report["most_frequent_queries"] == []
+        assert report["slow_average_queries"] == []


### PR DESCRIPTION
## Summary

Closes #762 — **Stream 5**

- Add `postgres_exporter` container for PG system metrics via Prometheus (128MB cap, `observability` profile)
- Create `nexus_monitor` DB user with `pg_monitor` role for secure read-only access
- Build custom `QueryObserverCollector` bridging app-level `QueryObserver` counters (8 gauge families) to `/metrics`
- Wire collector into `create_app()` after PrometheusMiddleware with graceful degradation
- Create 5-row Grafana dashboard: Overview, Top Queries, Query Performance, Connection Pool, Database Health
- DRY refactor `PgMonitor` — extract `_STAT_COLUMNS` + `_row_to_query_stats()` helper
- Add `postgres` scrape job (30s interval) to Prometheus config

## Files Changed (13)

| File | Type |
|------|------|
| `postgres-init/03-monitoring-user.sql` | New |
| `src/nexus/server/pg_metrics_collector.py` | New |
| `observability/grafana/provisioning/dashboards/pg-stat-statements.json` | New |
| `docker-compose.observability.yml` | Modified |
| `dockerfiles/docker-compose.demo.yml` | Modified |
| `observability/prometheus/prometheus.yml` | Modified |
| `src/nexus/storage/pg_monitor.py` | Modified |
| `src/nexus/server/fastapi_server.py` | Modified |
| `tests/unit/storage/test_pg_monitor.py` | New |
| `tests/unit/server/test_pg_metrics_collector.py` | New |
| `tests/unit/test_observability_configs.py` | Modified |
| `tests/integration/test_observability_pipeline.py` | Modified |
| `tests/e2e/test_pg_metrics_e2e.py` | New |

## Test plan

- [x] **35 unit tests** — PgMonitor SQLite degradation (7), QueryObserverCollector (5), config/dashboard validation (23)
- [x] **11 integration tests** — /metrics endpoint with real FastAPI app, DB metrics presence, performance benchmarks
- [x] **20 e2e tests** — Real server process with `NEXUS_ENFORCE_PERMISSIONS=true`:
  - /metrics accessible without auth (even with permissions enforced)
  - All 8 QueryObserver metric families present after DB-hitting requests
  - Non-admin/unauthenticated users can read /metrics
  - No SQL statement leakage in metrics output
  - /metrics latency <50ms, DB requests <100ms (no performance regression)
  - Existing HTTP metrics (duration, count, nexus_info) coexist with new DB metrics
- [x] `ruff check` — all clean
- [x] `ruff format` — all clean
- [x] `mypy` — no new errors (7 pre-existing in unrelated files)