### PR TITLE
feat(#763): Pyroscope continuous profiling with trace-to-profile correlation

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -22,6 +22,8 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
       - OTEL_SERVICE_NAME=nexus
       - NEXUS_ENV=prod
+      - PYROSCOPE_ENABLED=true
+      - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
     networks:
       - nexus-network
 
@@ -126,6 +128,7 @@ services:
       - prometheus
       - loki
       - tempo
+      - pyroscope
     profiles:
       - observability
 
@@ -184,10 +187,34 @@ services:
     profiles:
       - observability
 
+  # =========================================================================
+  # Pyroscope — Continuous profiling (Issue #763)
+  # =========================================================================
+  pyroscope:
+    image: grafana/pyroscope:1.16.1
+    container_name: nexus-pyroscope
+    restart: unless-stopped
+    ports:
+      - "4040:4040"
+    volumes:
+      - ./observability/pyroscope/pyroscope.yml:/etc/pyroscope/config.yaml:ro
+      - pyroscope-data:/data
+    command:
+      - "-config.file=/etc/pyroscope/config.yaml"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    networks:
+      - nexus-network
+    profiles:
+      - observability
+
 volumes:
   prometheus-data:
   loki-data:
   tempo-data:
+  pyroscope-data:
   grafana-data:
 
 networks:

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -46,6 +46,14 @@ datasources:
         tags:
           - key: "service.name"
             value: "compose_service"
+      tracesToProfiles:
+        datasourceUid: pyroscope
+        tags:
+          - key: "service.name"
+            value: "service_name"
+        profileTypeId: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+        customQuery: true
+        query: '{service_name="${__span.tags["service.name"]}"}'
       nodeGraph:
         enabled: true
       tracesToMetrics:
@@ -53,3 +61,11 @@ datasources:
         tags:
           - key: "service.name"
             value: "job"
+
+  # ── Pyroscope ────────────────────────────────────────────────────────────
+  - name: Pyroscope
+    uid: pyroscope
+    type: grafana-pyroscope-datasource
+    access: proxy
+    url: http://pyroscope:4040
+    editable: false

--- a/observability/pyroscope/pyroscope.yml
+++ b/observability/pyroscope/pyroscope.yml
@@ -1,0 +1,20 @@
+# Pyroscope continuous profiling server config (Issue #763)
+#
+# Runs in monolithic mode with local filesystem storage.
+# No authentication — relies on Docker network isolation.
+
+target: all
+
+server:
+  http_listen_port: 4040
+
+storage:
+  backend: filesystem
+  filesystem:
+    dir: /data
+
+limits:
+  max_nodes_per_profile: 16384
+
+self_profiling:
+  disable_push: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,11 @@ sentry = [
     "sentry-sdk[fastapi]>=2.0.0",
 ]
 
+profiling = [
+    # Pyroscope continuous profiling (Issue #763)
+    "pyroscope-io>=0.8.16",
+    "pyroscope-otel",
+]
 dev = [
     # Testing
     "pytest>=9.0.2",

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -257,6 +257,14 @@ async def lifespan(_app: FastAPI) -> Any:
     except ImportError:
         logger.debug("OpenTelemetry not available")
 
+    # Initialize Pyroscope continuous profiling (Issue #763)
+    try:
+        from nexus.server.profiling import setup_profiling
+
+        setup_profiling()
+    except ImportError:
+        logger.debug("Pyroscope not available")
+
     # Initialize Prometheus metrics (Issue #761)
     try:
         from nexus.server.metrics import setup_prometheus
@@ -1141,6 +1149,14 @@ async def lifespan(_app: FastAPI) -> Any:
             logger.info("Cache factory stopped")
         except Exception as e:
             logger.warning(f"Error shutting down cache factory: {e}")
+
+    # Shutdown Pyroscope continuous profiling (Issue #763)
+    try:
+        from nexus.server.profiling import shutdown_profiling
+
+        shutdown_profiling()
+    except ImportError:
+        pass
 
     # Shutdown OpenTelemetry (Issue #764)
     try:

--- a/src/nexus/server/profiling.py
+++ b/src/nexus/server/profiling.py
@@ -1,0 +1,215 @@
+"""Pyroscope continuous profiling for Nexus.
+
+Issue #763: Continuous profiling via Grafana Pyroscope.
+
+This module provides a standalone Pyroscope integration that sends CPU
+profiles to a Pyroscope server for flame-graph analysis, diff flame graphs
+across deployments, and trace-to-profile correlation (click a slow Tempo
+span to see its flame graph).
+
+Environment Variables:
+    PYROSCOPE_ENABLED: Enable/disable profiling (default: "false")
+    PYROSCOPE_SERVER_ADDRESS: Pyroscope server URL (default: "http://pyroscope:4040")
+    PYROSCOPE_APPLICATION_NAME: Application name tag (default: "nexus.api")
+    PYROSCOPE_SAMPLE_RATE: CPU sampling rate in Hz (default: "100")
+    PYROSCOPE_AUTH_TOKEN: Optional auth token for Pyroscope Cloud
+
+Usage:
+    from nexus.server.profiling import setup_profiling, shutdown_profiling
+
+    # Initialize once at startup (in lifespan)
+    setup_profiling()
+
+    # Shutdown at teardown
+    shutdown_profiling()
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Global state
+_initialized = False
+
+
+def _parse_sample_rate_hz(env_var: str, default: int = 100) -> int:
+    """Parse CPU sampling rate in Hz from an environment variable.
+
+    Args:
+        env_var: Environment variable name.
+        default: Fallback value if the env var is missing or invalid.
+
+    Returns:
+        An integer in [1, 1000].
+    """
+    raw = os.environ.get(env_var, str(default))
+    try:
+        rate = int(raw)
+    except (ValueError, TypeError):
+        logger.warning("Invalid sample rate %r for %s, using default %d Hz", raw, env_var, default)
+        return default
+    return max(1, min(1000, rate))
+
+
+def is_profiling_enabled() -> bool:
+    """Check if profiling is enabled via PYROSCOPE_ENABLED environment variable."""
+    return os.environ.get("PYROSCOPE_ENABLED", "false").lower() in ("true", "1", "yes")
+
+
+def setup_profiling(
+    application_name: str | None = None,
+    server_address: str | None = None,
+    sample_rate: int | None = None,
+    auth_token: str | None = None,
+    tags: dict[str, str] | None = None,
+) -> bool:
+    """Initialize Pyroscope continuous profiling.
+
+    Lazy-imports pyroscope inside function body for graceful fallback
+    when the pyroscope-io package is not installed.
+
+    Also registers PyroscopeSpanProcessor on the existing OTel TracerProvider
+    if OpenTelemetry is active, enabling trace-to-profile correlation.
+
+    Note:
+        Must be called exactly once from the main thread during
+        application startup (e.g., in the FastAPI lifespan handler).
+
+    Args:
+        application_name: Override PYROSCOPE_APPLICATION_NAME env var.
+        server_address: Override PYROSCOPE_SERVER_ADDRESS env var.
+        sample_rate: Override PYROSCOPE_SAMPLE_RATE env var (Hz).
+        auth_token: Override PYROSCOPE_AUTH_TOKEN env var.
+        tags: Additional static tags to attach to profiles.
+
+    Returns:
+        True if profiling was initialized, False if disabled or error.
+    """
+    global _initialized
+
+    if _initialized:
+        logger.debug("Pyroscope already initialized, skipping")
+        return False
+
+    if not is_profiling_enabled():
+        logger.info("Pyroscope disabled (set PYROSCOPE_ENABLED=true to enable)")
+        return False
+
+    try:
+        import pyroscope
+
+        _app_name = (
+            application_name
+            if application_name is not None
+            else os.environ.get("PYROSCOPE_APPLICATION_NAME", "nexus.api")
+        )
+        _server_address = (
+            server_address
+            if server_address is not None
+            else os.environ.get("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040")
+        )
+        _sample_rate = (
+            sample_rate
+            if sample_rate is not None
+            else _parse_sample_rate_hz("PYROSCOPE_SAMPLE_RATE")
+        )
+        _auth_token = (
+            auth_token if auth_token is not None else os.environ.get("PYROSCOPE_AUTH_TOKEN", "")
+        )
+
+        # Build static tags
+        _tags = {
+            "env": os.environ.get("NEXUS_ENV", "development"),
+            "service": "nexus",
+        }
+
+        # Add version if available
+        try:
+            from nexus.server._version import get_nexus_version
+
+            _tags["version"] = get_nexus_version()
+        except ImportError:
+            pass
+
+        if tags:
+            _tags.update(tags)
+
+        pyroscope.configure(
+            application_name=_app_name,
+            server_address=_server_address,
+            sample_rate=_sample_rate,
+            auth_token=_auth_token,
+            tags=_tags,
+            oncpu=True,
+            gil_only=True,
+            detect_subprocesses=False,  # avoid profiling uvicorn worker forks
+        )
+
+        # Register PyroscopeSpanProcessor for trace-to-profile correlation
+        _register_otel_processor()
+
+        _initialized = True
+        logger.info(
+            "Pyroscope initialized: app=%s, server=%s, sample_rate=%d",
+            _app_name,
+            _server_address,
+            _sample_rate,
+        )
+        return True
+
+    except ImportError:
+        logger.info("pyroscope-io not installed (pip install 'nexus-ai-fs[profiling]' to enable)")
+        return False
+    except Exception as e:
+        logger.error("Failed to initialize Pyroscope: %s", e)
+        return False
+
+
+def _register_otel_processor() -> None:
+    """Register PyroscopeSpanProcessor on the active OTel TracerProvider.
+
+    This enables trace-to-profile correlation: each OTel span gets a
+    profile annotation so Grafana can link Tempo spans to Pyroscope
+    flame graphs.
+
+    Silently skips if OTel or pyroscope-otel is not available.
+    """
+    try:
+        from opentelemetry import trace
+        from pyroscope.otel import PyroscopeSpanProcessor
+
+        provider = trace.get_tracer_provider()
+        if hasattr(provider, "add_span_processor"):
+            provider.add_span_processor(PyroscopeSpanProcessor())
+            logger.debug("Registered PyroscopeSpanProcessor on TracerProvider")
+    except ImportError:
+        logger.debug("pyroscope-otel not available, skipping trace-to-profile correlation")
+    except Exception as e:
+        logger.warning("Failed to register PyroscopeSpanProcessor: %s", e)
+
+
+def shutdown_profiling() -> None:
+    """Shutdown Pyroscope profiling. Idempotent.
+
+    Call this during application shutdown to flush pending profile data.
+    """
+    global _initialized
+
+    if not _initialized:
+        return
+
+    try:
+        import pyroscope
+
+        if hasattr(pyroscope, "shutdown"):
+            pyroscope.shutdown()
+        logger.info("Pyroscope shutdown complete")
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.warning("Error during Pyroscope shutdown: %s", e)
+    finally:
+        _initialized = False

--- a/tests/e2e/test_profiling_e2e.py
+++ b/tests/e2e/test_profiling_e2e.py
@@ -1,0 +1,224 @@
+"""E2E tests for Pyroscope continuous profiling (Issue #763).
+
+Validates the complete profiling pipeline end-to-end:
+1. Config validation (pyroscope.yml structure, docker-compose service)
+2. Module wiring (setup_profiling/shutdown_profiling callable from server)
+3. Grafana datasource provisioning (Pyroscope + trace-to-profile)
+4. Environment variable injection in docker-compose
+5. Graceful degradation when pyroscope-io not installed
+
+Following the pattern of tests/e2e/test_pg_metrics_e2e.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+OBSERVABILITY_DIR = PROJECT_ROOT / "observability"
+
+
+def _load_yaml(path: Path) -> dict:
+    """Load and parse a YAML file, failing the test on syntax errors."""
+    assert path.exists(), f"Config file missing: {path}"
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), f"Expected top-level dict in {path.name}"
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestPyroscopeConfigE2E:
+    """Validate pyroscope.yml has production-ready settings."""
+
+    CONFIG = OBSERVABILITY_DIR / "pyroscope" / "pyroscope.yml"
+
+    def test_config_exists_and_parseable(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert "server" in data
+        assert "storage" in data
+
+    def test_monolithic_mode(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert data.get("target") == "all"
+
+    def test_server_http_port(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert data["server"]["http_listen_port"] == 4040
+
+    def test_filesystem_storage(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert data["storage"]["backend"] == "filesystem"
+        assert data["storage"]["filesystem"]["dir"] == "/data"
+
+    def test_self_profiling_disabled(self) -> None:
+        """Self-profiling should be disabled to reduce noise."""
+        data = _load_yaml(self.CONFIG)
+        assert data["self_profiling"]["disable_push"] is True
+
+    def test_node_limit(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert data["limits"]["max_nodes_per_profile"] == 16384
+
+
+# ---------------------------------------------------------------------------
+# Docker Compose service validation
+# ---------------------------------------------------------------------------
+
+
+class TestDockerComposeServiceE2E:
+    """Validate pyroscope service is correctly wired in docker-compose."""
+
+    COMPOSE = PROJECT_ROOT / "docker-compose.observability.yml"
+
+    def test_pyroscope_service_exists(self) -> None:
+        data = _load_yaml(self.COMPOSE)
+        assert "pyroscope" in data["services"]
+
+    def test_pyroscope_image_pinned(self) -> None:
+        """Image should be pinned to a specific version, not :latest."""
+        data = _load_yaml(self.COMPOSE)
+        image = data["services"]["pyroscope"]["image"]
+        assert "grafana/pyroscope:" in image
+        assert ":latest" not in image
+
+    def test_pyroscope_memory_limit(self) -> None:
+        data = _load_yaml(self.COMPOSE)
+        svc = data["services"]["pyroscope"]
+        mem = svc["deploy"]["resources"]["limits"]["memory"]
+        assert mem == "512M"
+
+    def test_pyroscope_config_mount(self) -> None:
+        data = _load_yaml(self.COMPOSE)
+        svc = data["services"]["pyroscope"]
+        volumes = svc["volumes"]
+        config_mount = [v for v in volumes if "pyroscope.yml" in str(v)]
+        assert len(config_mount) == 1
+
+    def test_nexus_server_pyroscope_env_vars(self) -> None:
+        """nexus-server should have PYROSCOPE_ENABLED and PYROSCOPE_SERVER_ADDRESS."""
+        data = _load_yaml(self.COMPOSE)
+        env = data["services"]["nexus-server"]["environment"]
+        env_set = set(env)
+        assert "PYROSCOPE_ENABLED=true" in env_set
+        assert "PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040" in env_set
+
+    def test_grafana_depends_on_pyroscope(self) -> None:
+        data = _load_yaml(self.COMPOSE)
+        deps = data["services"]["grafana"]["depends_on"]
+        assert "pyroscope" in deps
+
+    def test_pyroscope_data_volume(self) -> None:
+        data = _load_yaml(self.COMPOSE)
+        assert "pyroscope-data" in data["volumes"]
+
+
+# ---------------------------------------------------------------------------
+# Grafana datasource provisioning
+# ---------------------------------------------------------------------------
+
+
+class TestDatasourceProvisioningE2E:
+    """Validate Grafana auto-provisions Pyroscope datasource."""
+
+    DS = OBSERVABILITY_DIR / "grafana" / "provisioning" / "datasources" / "datasources.yml"
+
+    def test_four_datasources(self) -> None:
+        """Should now have Prometheus, Loki, Tempo, and Pyroscope."""
+        data = _load_yaml(self.DS)
+        names = {ds["name"] for ds in data["datasources"]}
+        assert names == {"Prometheus", "Loki", "Tempo", "Pyroscope"}
+
+    def test_pyroscope_datasource_config(self) -> None:
+        data = _load_yaml(self.DS)
+        ds = next(d for d in data["datasources"] if d["name"] == "Pyroscope")
+        assert ds["uid"] == "pyroscope"
+        assert ds["type"] == "grafana-pyroscope-datasource"
+        assert ds["url"] == "http://pyroscope:4040"
+        assert ds["access"] == "proxy"
+
+    def test_tempo_traces_to_profiles(self) -> None:
+        """Tempo datasource should have tracesToProfiles pointing to Pyroscope."""
+        data = _load_yaml(self.DS)
+        tempo = next(d for d in data["datasources"] if d["name"] == "Tempo")
+        t2p = tempo["jsonData"]["tracesToProfiles"]
+        assert t2p["datasourceUid"] == "pyroscope"
+        assert "cpu" in t2p["profileTypeId"]
+        assert t2p["customQuery"] is True
+
+
+# ---------------------------------------------------------------------------
+# Module wiring
+# ---------------------------------------------------------------------------
+
+
+class TestModuleWiringE2E:
+    """Validate the profiling module is importable and callable."""
+
+    def test_setup_profiling_importable(self) -> None:
+        from nexus.server.profiling import setup_profiling
+
+        assert callable(setup_profiling)
+
+    def test_shutdown_profiling_importable(self) -> None:
+        from nexus.server.profiling import shutdown_profiling
+
+        assert callable(shutdown_profiling)
+
+    def test_is_profiling_enabled_importable(self) -> None:
+        from nexus.server.profiling import is_profiling_enabled
+
+        assert callable(is_profiling_enabled)
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradationE2E:
+    """Profiling should degrade gracefully when dependencies are missing."""
+
+    def test_setup_returns_false_when_disabled(self, monkeypatch) -> None:
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "false")
+
+        from nexus.server import profiling as p
+
+        p._initialized = False
+        assert p.setup_profiling() is False
+
+    def test_setup_returns_false_when_pyroscope_missing(self, monkeypatch) -> None:
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+
+        from nexus.server import profiling as p
+
+        p._initialized = False
+        with patch.dict("sys.modules", {"pyroscope": None}):
+            assert p.setup_profiling() is False
+
+    def test_shutdown_noop_when_not_initialized(self) -> None:
+        from nexus.server import profiling as p
+
+        p._initialized = False
+        p.shutdown_profiling()  # should not raise
+
+    def test_zero_overhead_when_disabled(self, monkeypatch) -> None:
+        """When disabled, no pyroscope imports should be attempted."""
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "false")
+
+        from nexus.server import profiling as p
+
+        p._initialized = False
+
+        # If pyroscope were imported, this would fail
+        with patch.dict("sys.modules", {"pyroscope": None}):
+            result = p.setup_profiling()
+
+        assert result is False

--- a/tests/integration/test_profiling_integration.py
+++ b/tests/integration/test_profiling_integration.py
@@ -1,0 +1,163 @@
+"""Integration tests for Pyroscope continuous profiling (Issue #763).
+
+Validates that infrastructure config files are correct and that
+the profiling module integrates properly with existing observability
+components (Grafana datasources, Docker Compose, Tempo correlation).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+OBSERVABILITY_DIR = Path(__file__).resolve().parents[2] / "observability"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_yaml(path: Path) -> dict:
+    """Load and parse a YAML file, failing the test on syntax errors."""
+    assert path.exists(), f"Config file missing: {path}"
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), f"Expected top-level dict in {path.name}"
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Pyroscope config validation
+# ---------------------------------------------------------------------------
+
+
+class TestPyroscopeConfig:
+    """Validate observability/pyroscope/pyroscope.yml structure."""
+
+    CONFIG = OBSERVABILITY_DIR / "pyroscope" / "pyroscope.yml"
+
+    def test_file_is_valid_yaml(self) -> None:
+        _load_yaml(self.CONFIG)
+
+    def test_server_port_4040(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert data["server"]["http_listen_port"] == 4040
+
+    def test_storage_backend_filesystem(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert data["storage"]["backend"] == "filesystem"
+
+    def test_self_profiling_disabled(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert data["self_profiling"]["disable_push"] is True
+
+    def test_max_nodes_limit(self) -> None:
+        data = _load_yaml(self.CONFIG)
+        assert data["limits"]["max_nodes_per_profile"] == 16384
+
+
+# ---------------------------------------------------------------------------
+# Grafana datasource validation
+# ---------------------------------------------------------------------------
+
+
+class TestGrafanaDatasourceIntegration:
+    """Validate Pyroscope entry in Grafana datasource provisioning."""
+
+    DS_PATH = OBSERVABILITY_DIR / "grafana" / "provisioning" / "datasources" / "datasources.yml"
+
+    def test_pyroscope_datasource_present(self) -> None:
+        data = _load_yaml(self.DS_PATH)
+        names = {ds["name"] for ds in data["datasources"]}
+        assert "Pyroscope" in names
+
+    def test_pyroscope_datasource_type(self) -> None:
+        data = _load_yaml(self.DS_PATH)
+        pyroscope_ds = next(ds for ds in data["datasources"] if ds["name"] == "Pyroscope")
+        assert pyroscope_ds["type"] == "grafana-pyroscope-datasource"
+
+    def test_pyroscope_datasource_uid(self) -> None:
+        data = _load_yaml(self.DS_PATH)
+        pyroscope_ds = next(ds for ds in data["datasources"] if ds["name"] == "Pyroscope")
+        assert pyroscope_ds["uid"] == "pyroscope"
+
+    def test_pyroscope_url(self) -> None:
+        data = _load_yaml(self.DS_PATH)
+        pyroscope_ds = next(ds for ds in data["datasources"] if ds["name"] == "Pyroscope")
+        assert pyroscope_ds["url"] == "http://pyroscope:4040"
+
+
+# ---------------------------------------------------------------------------
+# Tempo trace-to-profile correlation
+# ---------------------------------------------------------------------------
+
+
+class TestTempoTraceToProfile:
+    """Validate tracesToProfiles config on Tempo datasource."""
+
+    DS_PATH = OBSERVABILITY_DIR / "grafana" / "provisioning" / "datasources" / "datasources.yml"
+
+    def test_tempo_has_traces_to_profiles(self) -> None:
+        data = _load_yaml(self.DS_PATH)
+        tempo_ds = next(ds for ds in data["datasources"] if ds["name"] == "Tempo")
+        assert "tracesToProfiles" in tempo_ds["jsonData"]
+
+    def test_traces_to_profiles_points_to_pyroscope(self) -> None:
+        data = _load_yaml(self.DS_PATH)
+        tempo_ds = next(ds for ds in data["datasources"] if ds["name"] == "Tempo")
+        t2p = tempo_ds["jsonData"]["tracesToProfiles"]
+        assert t2p["datasourceUid"] == "pyroscope"
+
+    def test_traces_to_profiles_has_profile_type(self) -> None:
+        data = _load_yaml(self.DS_PATH)
+        tempo_ds = next(ds for ds in data["datasources"] if ds["name"] == "Tempo")
+        t2p = tempo_ds["jsonData"]["tracesToProfiles"]
+        assert "profileTypeId" in t2p
+        assert "cpu" in t2p["profileTypeId"]
+
+
+# ---------------------------------------------------------------------------
+# Docker Compose validation
+# ---------------------------------------------------------------------------
+
+
+class TestDockerComposeIntegration:
+    """Validate pyroscope service in docker-compose.observability.yml."""
+
+    COMPOSE_PATH = PROJECT_ROOT / "docker-compose.observability.yml"
+
+    def test_compose_is_valid_yaml(self) -> None:
+        _load_yaml(self.COMPOSE_PATH)
+
+    def test_pyroscope_service_present(self) -> None:
+        data = _load_yaml(self.COMPOSE_PATH)
+        assert "pyroscope" in data["services"]
+
+    def test_pyroscope_image(self) -> None:
+        data = _load_yaml(self.COMPOSE_PATH)
+        svc = data["services"]["pyroscope"]
+        assert "grafana/pyroscope" in svc["image"]
+
+    def test_pyroscope_port_4040(self) -> None:
+        data = _load_yaml(self.COMPOSE_PATH)
+        svc = data["services"]["pyroscope"]
+        ports = [str(p) for p in svc["ports"]]
+        assert any("4040" in p for p in ports)
+
+    def test_pyroscope_has_observability_profile(self) -> None:
+        data = _load_yaml(self.COMPOSE_PATH)
+        svc = data["services"]["pyroscope"]
+        assert "observability" in svc["profiles"]
+
+    def test_pyroscope_volume_defined(self) -> None:
+        data = _load_yaml(self.COMPOSE_PATH)
+        assert "pyroscope-data" in data["volumes"]
+
+    def test_nexus_server_has_pyroscope_env(self) -> None:
+        data = _load_yaml(self.COMPOSE_PATH)
+        env = data["services"]["nexus-server"]["environment"]
+        assert "PYROSCOPE_ENABLED=true" in env
+        assert "PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040" in env
+
+    def test_grafana_depends_on_pyroscope(self) -> None:
+        data = _load_yaml(self.COMPOSE_PATH)
+        deps = data["services"]["grafana"]["depends_on"]
+        assert "pyroscope" in deps

--- a/tests/unit/server/test_profiling.py
+++ b/tests/unit/server/test_profiling.py
@@ -1,0 +1,294 @@
+"""Tests for Pyroscope continuous profiling module.
+
+Issue #763: Continuous profiling via Grafana Pyroscope.
+
+Tests cover setup, shutdown, environment variable parsing,
+trace-to-profile OTel integration, and graceful degradation.
+
+Mirrors the structure of test_sentry.py and test_telemetry.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.server import profiling
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_profiling_state():
+    """Reset profiling module state before each test."""
+    profiling._initialized = False
+    yield
+    profiling._initialized = False
+
+
+@pytest.fixture
+def _clean_env(monkeypatch):
+    """Remove all PYROSCOPE_ env vars for a clean test."""
+    for var in (
+        "PYROSCOPE_ENABLED",
+        "PYROSCOPE_SERVER_ADDRESS",
+        "PYROSCOPE_APPLICATION_NAME",
+        "PYROSCOPE_SAMPLE_RATE",
+        "PYROSCOPE_AUTH_TOKEN",
+        "NEXUS_ENV",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# is_profiling_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestIsProfilingEnabled:
+    def test_enabled_true(self, monkeypatch) -> None:
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+        assert profiling.is_profiling_enabled() is True
+
+    def test_enabled_1(self, monkeypatch) -> None:
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "1")
+        assert profiling.is_profiling_enabled() is True
+
+    def test_enabled_yes(self, monkeypatch) -> None:
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "yes")
+        assert profiling.is_profiling_enabled() is True
+
+    def test_disabled_false(self, monkeypatch) -> None:
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "false")
+        assert profiling.is_profiling_enabled() is False
+
+    def test_disabled_default(self, _clean_env) -> None:
+        assert profiling.is_profiling_enabled() is False
+
+    def test_disabled_random_string(self, monkeypatch) -> None:
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "maybe")
+        assert profiling.is_profiling_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# setup_profiling
+# ---------------------------------------------------------------------------
+
+
+class TestSetupProfiling:
+    def test_disabled_returns_false(self, _clean_env) -> None:
+        """When PYROSCOPE_ENABLED is not set, setup returns False."""
+        assert profiling.setup_profiling() is False
+
+    def test_disabled_explicit_false(self, monkeypatch) -> None:
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "false")
+        assert profiling.setup_profiling() is False
+
+    def test_import_error_returns_false(self, monkeypatch) -> None:
+        """When pyroscope-io is not installed, setup returns False gracefully."""
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+        with patch.dict("sys.modules", {"pyroscope": None}):
+            assert profiling.setup_profiling() is False
+
+    def test_success_with_mock(self, monkeypatch) -> None:
+        """When pyroscope is available, setup returns True."""
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+        monkeypatch.setenv("PYROSCOPE_SERVER_ADDRESS", "http://localhost:4040")
+
+        mock_pyroscope = MagicMock()
+        with (
+            patch.dict("sys.modules", {"pyroscope": mock_pyroscope}),
+            patch.object(profiling, "_register_otel_processor"),
+        ):
+            result = profiling.setup_profiling()
+
+        assert result is True
+        assert profiling._initialized is True
+        mock_pyroscope.configure.assert_called_once()
+
+    def test_configure_called_with_correct_args(self, monkeypatch) -> None:
+        """Verify pyroscope.configure() receives the expected parameters."""
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+        monkeypatch.setenv("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040")
+        monkeypatch.setenv("PYROSCOPE_APPLICATION_NAME", "test.app")
+        monkeypatch.setenv("PYROSCOPE_SAMPLE_RATE", "50")
+        monkeypatch.setenv("NEXUS_ENV", "staging")
+
+        mock_pyroscope = MagicMock()
+        with (
+            patch.dict("sys.modules", {"pyroscope": mock_pyroscope}),
+            patch.object(profiling, "_register_otel_processor"),
+        ):
+            profiling.setup_profiling()
+
+        call_kwargs = mock_pyroscope.configure.call_args[1]
+        assert call_kwargs["application_name"] == "test.app"
+        assert call_kwargs["server_address"] == "http://pyroscope:4040"
+        assert call_kwargs["sample_rate"] == 50
+        assert call_kwargs["oncpu"] is True
+        assert call_kwargs["gil_only"] is True
+        assert call_kwargs["detect_subprocesses"] is False
+
+    def test_static_tags_include_env(self, monkeypatch) -> None:
+        """Tags should include env and service."""
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+        monkeypatch.setenv("NEXUS_ENV", "production")
+
+        mock_pyroscope = MagicMock()
+        with (
+            patch.dict("sys.modules", {"pyroscope": mock_pyroscope}),
+            patch.object(profiling, "_register_otel_processor"),
+        ):
+            profiling.setup_profiling()
+
+        tags = mock_pyroscope.configure.call_args[1]["tags"]
+        assert tags["env"] == "production"
+        assert tags["service"] == "nexus"
+
+    def test_custom_tags_merged(self, monkeypatch) -> None:
+        """Custom tags should be merged with defaults."""
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+
+        mock_pyroscope = MagicMock()
+        with (
+            patch.dict("sys.modules", {"pyroscope": mock_pyroscope}),
+            patch.object(profiling, "_register_otel_processor"),
+        ):
+            profiling.setup_profiling(tags={"region": "us-west-1"})
+
+        tags = mock_pyroscope.configure.call_args[1]["tags"]
+        assert tags["region"] == "us-west-1"
+        assert tags["service"] == "nexus"
+
+    def test_double_init_returns_false(self, monkeypatch) -> None:
+        """Second call to setup_profiling should return False."""
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+
+        mock_pyroscope = MagicMock()
+        with (
+            patch.dict("sys.modules", {"pyroscope": mock_pyroscope}),
+            patch.object(profiling, "_register_otel_processor"),
+        ):
+            assert profiling.setup_profiling() is True
+            assert profiling.setup_profiling() is False
+
+    def test_parameter_overrides_env(self, monkeypatch) -> None:
+        """Function parameters should override env vars."""
+        monkeypatch.setenv("PYROSCOPE_ENABLED", "true")
+        monkeypatch.setenv("PYROSCOPE_APPLICATION_NAME", "env.app")
+
+        mock_pyroscope = MagicMock()
+        with (
+            patch.dict("sys.modules", {"pyroscope": mock_pyroscope}),
+            patch.object(profiling, "_register_otel_processor"),
+        ):
+            profiling.setup_profiling(
+                application_name="override.app",
+                server_address="http://custom:9999",
+                sample_rate=200,
+            )
+
+        call_kwargs = mock_pyroscope.configure.call_args[1]
+        assert call_kwargs["application_name"] == "override.app"
+        assert call_kwargs["server_address"] == "http://custom:9999"
+        assert call_kwargs["sample_rate"] == 200
+
+
+# ---------------------------------------------------------------------------
+# _register_otel_processor
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterOtelProcessor:
+    def test_registers_when_otel_active(self) -> None:
+        """Should register PyroscopeSpanProcessor on TracerProvider."""
+        mock_provider = MagicMock()
+        mock_processor_cls = MagicMock()
+        mock_trace = MagicMock()
+        mock_trace.get_tracer_provider.return_value = mock_provider
+
+        mock_pyroscope_otel = MagicMock()
+        mock_pyroscope_otel.PyroscopeSpanProcessor = mock_processor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry": MagicMock(trace=mock_trace),
+                "opentelemetry.trace": mock_trace,
+                "pyroscope": MagicMock(),
+                "pyroscope.otel": mock_pyroscope_otel,
+            },
+        ):
+            profiling._register_otel_processor()
+
+        mock_provider.add_span_processor.assert_called_once()
+
+    def test_skips_when_otel_missing(self) -> None:
+        """Should silently skip when OTel is not installed."""
+        # Force ImportError by making the module None
+        with patch.dict(
+            "sys.modules",
+            {"opentelemetry": None, "opentelemetry.trace": None},
+        ):
+            profiling._register_otel_processor()  # should not raise
+
+    def test_skips_when_pyroscope_otel_missing(self) -> None:
+        """Should silently skip when pyroscope-otel is not installed."""
+        mock_trace = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry": MagicMock(trace=mock_trace),
+                "opentelemetry.trace": mock_trace,
+                "pyroscope.otel": None,
+            },
+        ):
+            profiling._register_otel_processor()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# shutdown_profiling
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownProfiling:
+    def test_idempotent_when_not_initialized(self) -> None:
+        """shutdown_profiling should be a no-op when not initialized."""
+        profiling._initialized = False
+        profiling.shutdown_profiling()  # should not raise
+
+    def test_calls_pyroscope_shutdown(self) -> None:
+        """Should call pyroscope.shutdown() when initialized."""
+        profiling._initialized = True
+
+        mock_pyroscope = MagicMock()
+        mock_pyroscope.shutdown = MagicMock()
+        with patch.dict("sys.modules", {"pyroscope": mock_pyroscope}):
+            profiling.shutdown_profiling()
+
+        assert profiling._initialized is False
+        mock_pyroscope.shutdown.assert_called_once()
+
+    def test_resets_state_on_error(self) -> None:
+        """Should reset _initialized even if shutdown raises."""
+        profiling._initialized = True
+
+        mock_pyroscope = MagicMock()
+        mock_pyroscope.shutdown.side_effect = RuntimeError("boom")
+        with patch.dict("sys.modules", {"pyroscope": mock_pyroscope}):
+            profiling.shutdown_profiling()
+
+        assert profiling._initialized is False
+
+    def test_handles_missing_shutdown_method(self) -> None:
+        """Should handle pyroscope without shutdown() gracefully."""
+        profiling._initialized = True
+
+        mock_pyroscope = MagicMock(spec=[])  # no shutdown attr
+        with patch.dict("sys.modules", {"pyroscope": mock_pyroscope}):
+            profiling.shutdown_profiling()
+
+        assert profiling._initialized is False

--- a/tests/unit/test_observability_configs.py
+++ b/tests/unit/test_observability_configs.py
@@ -86,13 +86,13 @@ class TestDatasourcesConfig:
             OBSERVABILITY_DIR / "grafana" / "provisioning" / "datasources" / "datasources.yml"
         )
 
-    def test_has_three_datasources(self) -> None:
+    def test_has_four_datasources(self) -> None:
         data = _load_yaml(
             OBSERVABILITY_DIR / "grafana" / "provisioning" / "datasources" / "datasources.yml"
         )
         assert "datasources" in data
         names = {ds["name"] for ds in data["datasources"]}
-        assert names == {"Prometheus", "Loki", "Tempo"}
+        assert names == {"Prometheus", "Loki", "Tempo", "Pyroscope"}
 
     def test_prometheus_is_default(self) -> None:
         data = _load_yaml(
@@ -153,6 +153,21 @@ class TestDashboardJson:
             assert ds.get("uid") == "prometheus", (
                 f"Panel '{panel.get('title')}' uses datasource UID '{ds.get('uid')}', expected 'prometheus'"
             )
+
+
+class TestPyroscopeConfig:
+    """Validate observability/pyroscope/pyroscope.yml (Issue #763)."""
+
+    def test_file_parseable(self) -> None:
+        _load_yaml(OBSERVABILITY_DIR / "pyroscope" / "pyroscope.yml")
+
+    def test_has_server_port(self) -> None:
+        data = _load_yaml(OBSERVABILITY_DIR / "pyroscope" / "pyroscope.yml")
+        assert data["server"]["http_listen_port"] == 4040
+
+    def test_filesystem_storage(self) -> None:
+        data = _load_yaml(OBSERVABILITY_DIR / "pyroscope" / "pyroscope.yml")
+        assert data["storage"]["backend"] == "filesystem"
 
 
 class TestAllYamlFilesParseable:


### PR DESCRIPTION
## Summary

Adds **Grafana Pyroscope** as the final observability pillar (alongside Metrics, Logs, Traces) for Issue #763.

- **Infrastructure**: Pyroscope server config (`pyroscope.yml`), Docker Compose service (pinned `grafana/pyroscope:1.16.1`, 512M limit, `observability` profile), Grafana datasource provisioning
- **Trace-to-profile correlation**: `tracesToProfiles` config on Tempo datasource — click a slow Tempo span → see its flame graph in Pyroscope
- **Python SDK**: `src/nexus/server/profiling.py` following `sentry.py`/`telemetry.py` pattern — lazy imports, env var config, `PyroscopeSpanProcessor` registration on OTel TracerProvider
- **Zero overhead when disabled**: checks `PYROSCOPE_ENABLED` env var and returns immediately without importing pyroscope
- **92 tests** across unit (22), integration (20), e2e (23), config validation (27) — all pass

### Stream: #763

## Test plan

- [x] `ruff check` — all checks passed
- [x] `ruff format` — all files formatted
- [x] `mypy` — no new errors (pre-existing stubs missing in dependencies)
- [x] Unit tests: 22 passed (`tests/unit/server/test_profiling.py`)
- [x] Integration tests: 20 passed (`tests/integration/test_profiling_integration.py`)
- [x] E2E tests: 23 passed (`tests/e2e/test_profiling_e2e.py`)
- [x] Config validation: 27 passed (`tests/unit/test_observability_configs.py`)
- [x] Real server + permissions e2e: 20 passed (`tests/e2e/test_pg_metrics_e2e.py`)
- [x] Observability integration: 11 passed (`tests/integration/test_observability_pipeline.py`)
- [x] Performance tests: all latency tests pass, no regression
- [ ] Manual: `docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d` → `curl http://localhost:4040/ready`