### PR TITLE
feat(#1401): Extract A2A into self-contained brick

### DIFF
--- a/src/nexus/a2a/__init__.py
+++ b/src/nexus/a2a/__init__.py
@@ -15,12 +15,16 @@ if TYPE_CHECKING:
     from fastapi import APIRouter
 
 
+__all__ = ["create_a2a_router"]
+
+
 def create_a2a_router(
     *,
     nexus_fs: Any = None,
     config: Any = None,
     base_url: str | None = None,
     auth_required: bool = False,
+    auth_fn: Any = None,
     data_dir: str | None = None,
 ) -> APIRouter:
     """Create the A2A protocol FastAPI router.
@@ -32,6 +36,8 @@ def create_a2a_router(
             If None, defaults to "http://localhost:2026".
         auth_required: When True, all A2A operational endpoints
             require a valid Authorization header.
+        auth_fn: Optional async callback ``(Request) -> dict | None``
+            for authentication.  Injected by the server layer.
         data_dir: Server data directory.  When provided, A2A tasks
             are persisted as JSON files under ``{data_dir}/a2a/tasks/``.
             When None, tasks are stored in-memory only.
@@ -57,4 +63,5 @@ def create_a2a_router(
         base_url=base_url,
         task_manager=task_manager,
         auth_required=auth_required,
+        auth_fn=auth_fn,
     )

--- a/src/nexus/a2a/db.py
+++ b/src/nexus/a2a/db.py
@@ -2,6 +2,13 @@
 
 Stores A2A task state, messages, artifacts, and push notification configs
 in the same database used by the rest of Nexus (PostgreSQL or SQLite).
+
+Note: This module imports ``Base`` from ``nexus.storage.models`` for
+SQLAlchemy model registration.  This coupling is ACCEPTED because:
+1. ``DatabaseTaskStore`` is the deprecated store path
+2. This import is lazy (only triggered when DatabaseTaskStore is used)
+3. The same pattern is used by ``nexus.identity.models`` and others
+4. The primary store paths (InMemory, VFS) have zero external imports
 """
 
 from __future__ import annotations

--- a/tests/unit/a2a/test_a2a_brick_isolation.py
+++ b/tests/unit/a2a/test_a2a_brick_isolation.py
@@ -1,0 +1,120 @@
+"""AST-based brick isolation guard for nexus.a2a.
+
+Ensures the A2A brick has zero runtime imports from ``nexus.server``
+or ``nexus.core``.  The only accepted external coupling is
+``nexus.storage.models.Base`` inside ``db.py`` (documented).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import nexus.a2a as _a2a_pkg
+
+# Root of the nexus.a2a package
+A2A_PKG = Path(_a2a_pkg.__file__).resolve().parent
+
+# Forbidden top-level prefixes
+FORBIDDEN_PREFIXES = ("nexus.server", "nexus.core")
+
+# Allowed exceptions (module basename -> allowed import prefix)
+ALLOWED_EXCEPTIONS: dict[str, set[str]] = {
+    # db.py may import nexus.storage.models for SQLAlchemy Base (accepted coupling)
+    "db.py": {"nexus.storage"},
+}
+
+
+class TestBrickIsolation:
+    """Verify that nexus.a2a has no forbidden external imports."""
+
+    def test_no_forbidden_imports(self) -> None:
+        """Walk all .py files in nexus.a2a/ and assert no forbidden imports."""
+        violations: list[str] = []
+
+        for py_file in sorted(A2A_PKG.rglob("*.py")):
+            source = py_file.read_text(encoding="utf-8")
+            try:
+                tree = ast.parse(source, filename=str(py_file))
+            except SyntaxError:
+                continue
+
+            rel = py_file.relative_to(A2A_PKG)
+            _check_file(tree, str(rel), violations)
+
+        assert violations == [], "Forbidden imports found in nexus.a2a:\n" + "\n".join(violations)
+
+    def test_no_nexus_server_import(self) -> None:
+        """Specifically verify zero nexus.server imports (the key coupling)."""
+        violations: list[str] = []
+
+        for py_file in sorted(A2A_PKG.rglob("*.py")):
+            source = py_file.read_text(encoding="utf-8")
+            try:
+                tree = ast.parse(source, filename=str(py_file))
+            except SyntaxError:
+                continue
+
+            rel = py_file.relative_to(A2A_PKG)
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.ImportFrom)
+                    and node.module
+                    and node.module.startswith("nexus.server")
+                    and not _is_type_checking_import(tree, node)
+                ):
+                    violations.append(f"  {rel}:{node.lineno} — from {node.module} import ...")
+
+        assert violations == [], "nexus.server imports found in nexus.a2a:\n" + "\n".join(
+            violations
+        )
+
+
+def _check_file(tree: ast.Module, rel_path: str, violations: list[str]) -> None:
+    """Check a single AST for forbidden imports."""
+    basename = rel_path.split("/")[-1]
+    allowed = ALLOWED_EXCEPTIONS.get(basename, set())
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not node.module:
+            continue
+
+        module = node.module
+
+        # Skip intra-package imports
+        if not module.startswith("nexus."):
+            continue
+
+        # Skip nexus.a2a internal imports
+        if module.startswith("nexus.a2a"):
+            continue
+
+        # Check forbidden prefixes
+        for prefix in FORBIDDEN_PREFIXES:
+            if module.startswith(prefix):
+                if not _is_type_checking_import(tree, node):
+                    violations.append(f"  {rel_path}:{node.lineno} — from {module} import ...")
+                break
+        else:
+            # Not a forbidden prefix — check if it's an allowed exception
+            is_allowed = any(module.startswith(a) for a in allowed)
+            if not is_allowed and not _is_type_checking_import(tree, node):
+                # External nexus import not in allowed list
+                violations.append(
+                    f"  {rel_path}:{node.lineno} — from {module} import ... "
+                    f"(not in allowed exceptions for {basename})"
+                )
+
+
+def _is_type_checking_import(tree: ast.Module, node: ast.ImportFrom) -> bool:
+    """Check if an import is inside a ``if TYPE_CHECKING:`` block."""
+    for top_node in ast.walk(tree):
+        if isinstance(top_node, ast.If):
+            # Check for `if TYPE_CHECKING:` pattern
+            test = top_node.test
+            is_tc = (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+                isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+            )
+            if is_tc and node in ast.walk(top_node):
+                return True
+    return False


### PR DESCRIPTION
## Summary

- **Break all runtime imports** from `nexus.server` / `nexus.core` in `nexus.a2a` — auth is now injected via `auth_fn: Callable[[Request], Awaitable[dict | None]]` callback
- **Add `AgentCardCache` class** replacing module-level mutable globals with per-router encapsulated instances
- **DRY SSE streaming** — extract shared `_sse_event_loop` async generator from duplicate `sendStreamingMessage` / `subscribeToTask` handlers
- **Server-side auth adapter** (`_a2a_auth_adapter`) in `fastapi_server.py` bridges `get_auth_result` → `auth_fn` without the brick knowing about server internals
- **AST-based brick isolation test** (`test_a2a_brick_isolation.py`) walks all `.py` files, parses AST, asserts zero forbidden imports — guards against future coupling leaks
- **10 new tests**: 6 auth callback integration tests + 4 cache isolation unit tests

### Files changed (8 files, +533 −171)

| File | Change |
|------|--------|
| `src/nexus/a2a/router.py` | Remove `nexus.server` import, add `auth_fn` param, closure-based auth/card handlers, SSE DRY |
| `src/nexus/a2a/agent_card.py` | `AgentCardCache` class + backward-compat wrappers |
| `src/nexus/a2a/__init__.py` | Forward `auth_fn`, add `__all__` |
| `src/nexus/a2a/db.py` | Document accepted `Base` coupling |
| `src/nexus/server/fastapi_server.py` | `_a2a_auth_adapter` + pass `auth_fn` |
| `tests/unit/a2a/test_a2a_brick_isolation.py` | **NEW** — AST import guard |
| `tests/integration/a2a/test_a2a_auth.py` | `TestAuthCallback` (6 tests) |
| `tests/unit/a2a/test_agent_card.py` | `TestAgentCardCache` (4 tests) |

## Test plan

- [x] All 232 A2A unit + integration tests pass
- [x] AST brick isolation test passes (zero forbidden imports)
- [x] Auth callback tests: injection, zone_id extraction, failure handling, auth_required enforcement
- [x] Cache isolation tests: independent instances, same-bytes caching, invalidation, force-rebuild
- [x] E2E with `nexus serve --api-key` — manual curl verification of all auth flows
- [x] ruff check + ruff format + mypy all clean
- [x] No performance regression (0.10 μs/call cached Agent Card)

Closes #1401

Stream #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)