### PR TITLE
feat(#1370): write-path Prometheus metrics for WriteBuffer

### DIFF
--- a/src/nexus/server/wb_metrics_collector.py
+++ b/src/nexus/server/wb_metrics_collector.py
@@ -1,0 +1,102 @@
+"""Custom Prometheus collector bridging WriteBuffer to /metrics (Issue #1370).
+
+Reads write-path counters from a WriteBuffer-backed write observer and
+exposes them as Prometheus ``GaugeMetricFamily`` values.  All metrics use
+gauges because the counters are plain integers that reset on process restart.
+
+Usage:
+    Wired automatically in ``fastapi_server.create_app()``::
+
+        from prometheus_client import REGISTRY
+        from nexus.server.wb_metrics_collector import WriteBufferCollector
+
+        REGISTRY.register(WriteBufferCollector(write_observer))
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from prometheus_client.core import GaugeMetricFamily
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@runtime_checkable
+class MetricsProvider(Protocol):
+    """Duck-typed interface for objects exposing a ``metrics`` property."""
+
+    @property
+    def metrics(self) -> dict[str, Any]: ...
+
+
+class WriteBufferCollector:
+    """Prometheus custom collector for WriteBuffer metrics.
+
+    Takes the write observer (BufferedRecordStoreSyncer or any object with
+    a ``metrics`` property returning the WriteBuffer metrics dict) as a
+    constructor arg -- storage layer stays Prometheus-free.
+    """
+
+    def __init__(self, write_observer: MetricsProvider) -> None:
+        self._write_observer = write_observer
+
+    def describe(self) -> Iterable[GaugeMetricFamily]:
+        """Return empty -- dynamic collector convention."""
+        return []
+
+    def collect(self) -> Iterable[GaugeMetricFamily]:
+        """Yield gauge metric families from the write observer's counters."""
+        metrics = self._write_observer.metrics
+
+        # Per-event-type enqueued breakdown
+        enqueued = GaugeMetricFamily(
+            "nexus_write_buffer_events_enqueued_total",
+            "Total events enqueued into WriteBuffer by event type",
+            labels=["event_type"],
+        )
+        for event_type, count in metrics.get("enqueued_by_type", {}).items():
+            enqueued.add_metric([event_type], count)
+        yield enqueued
+
+        yield GaugeMetricFamily(
+            "nexus_write_buffer_events_flushed_total",
+            "Total events successfully flushed from WriteBuffer",
+            value=metrics["total_flushed"],
+        )
+        yield GaugeMetricFamily(
+            "nexus_write_buffer_events_failed_total",
+            "Total events dropped after exhausting retries",
+            value=metrics["total_failed"],
+        )
+        yield GaugeMetricFamily(
+            "nexus_write_buffer_retries_total",
+            "Total flush retry attempts",
+            value=metrics["total_retries"],
+        )
+        yield GaugeMetricFamily(
+            "nexus_write_buffer_pending_events",
+            "Number of events waiting to be flushed",
+            value=metrics["pending"],
+        )
+        yield GaugeMetricFamily(
+            "nexus_write_buffer_flush_duration_seconds_sum",
+            "Cumulative flush duration in seconds",
+            value=metrics["flush_duration_sum"],
+        )
+        yield GaugeMetricFamily(
+            "nexus_write_buffer_flush_duration_seconds_count",
+            "Total number of flush operations",
+            value=metrics["flush_count"],
+        )
+        yield GaugeMetricFamily(
+            "nexus_write_buffer_flush_batch_size_sum",
+            "Cumulative number of events across all flush batches",
+            value=metrics["flush_batch_size_sum"],
+        )
+        yield GaugeMetricFamily(
+            "nexus_write_buffer_flush_batch_size_count",
+            "Total number of flush operations (for batch size average)",
+            value=metrics["flush_count"],
+        )

--- a/src/nexus/storage/record_store_syncer.py
+++ b/src/nexus/storage/record_store_syncer.py
@@ -199,7 +199,7 @@ class BufferedRecordStoreSyncer:
         self._buffer.stop(timeout=timeout)
 
     @property
-    def metrics(self) -> dict[str, int]:
+    def metrics(self) -> dict[str, int | float | dict[str, int]]:
         """Return buffer metrics."""
         return self._buffer.metrics
 

--- a/tests/integration/test_wb_metrics_integration.py
+++ b/tests/integration/test_wb_metrics_integration.py
@@ -1,0 +1,215 @@
+"""Integration tests for WriteBuffer Prometheus metrics pipeline (Issue #1370).
+
+Validates that nexus_write_buffer_* metrics appear on the /metrics endpoint
+when the real FastAPI application is wired with a WriteBuffer-enabled NexusFS.
+
+Uses an in-process TestClient (no subprocess) for speed and determinism.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+from starlette.testclient import TestClient
+
+from nexus.backends.local import LocalBackend
+from nexus.factory import create_nexus_fs
+from nexus.storage.raft_metadata_store import RaftMetadataStore
+from nexus.storage.record_store import SQLAlchemyRecordStore
+
+# All 9 metric families emitted by WriteBufferCollector
+_EXPECTED_WB_METRICS = [
+    "nexus_write_buffer_events_enqueued_total",
+    "nexus_write_buffer_events_flushed_total",
+    "nexus_write_buffer_events_failed_total",
+    "nexus_write_buffer_retries_total",
+    "nexus_write_buffer_pending_events",
+    "nexus_write_buffer_flush_duration_seconds_sum",
+    "nexus_write_buffer_flush_duration_seconds_count",
+    "nexus_write_buffer_flush_batch_size_sum",
+    "nexus_write_buffer_flush_batch_size_count",
+]
+
+
+@pytest.fixture()
+def app_and_key(tmp_path):
+    """Build a real FastAPI app with NexusFS + WriteBuffer enabled."""
+    from nexus.server.fastapi_server import create_app
+
+    os.environ.setdefault("NEXUS_JWT_SECRET", "test-secret-wb-metrics")
+
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir(exist_ok=True)
+    backend = LocalBackend(root_path=str(storage_dir))
+
+    metadata_store = RaftMetadataStore.embedded(str(tmp_path / "raft-metadata"))
+
+    db_url = f"sqlite:///{tmp_path / 'records.db'}"
+    record_store = SQLAlchemyRecordStore(db_url=db_url)
+
+    nx = create_nexus_fs(
+        backend=backend,
+        metadata_store=metadata_store,
+        record_store=record_store,
+        is_admin=True,
+        enable_tiger_cache=False,
+        enable_write_buffer=True,  # Force-enable for SQLite
+    )
+
+    api_key = "test-wb-metrics-key"
+    app = create_app(nexus_fs=nx, api_key=api_key, database_url=db_url)
+
+    return app, api_key, nx
+
+
+@pytest.fixture()
+def client(app_and_key):
+    app, _, _ = app_and_key
+    return TestClient(app)
+
+
+@pytest.fixture()
+def auth_headers(app_and_key):
+    _, key, _ = app_and_key
+    return {"Authorization": f"Bearer {key}"}
+
+
+@pytest.fixture()
+def nexus_fs(app_and_key):
+    _, _, nx = app_and_key
+    return nx
+
+
+# ---------------------------------------------------------------------------
+# WriteBuffer metrics in /metrics output
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBufferMetricsPresent:
+    """Verify all nexus_write_buffer_* metric families appear on /metrics."""
+
+    def test_all_wb_metric_families_present(self, client) -> None:
+        """All 9 WriteBufferCollector families must appear."""
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        for metric in _EXPECTED_WB_METRICS:
+            assert metric in resp.text, f"Missing metric: {metric}"
+
+    def test_enqueued_has_event_type_labels(self, client) -> None:
+        """The enqueued metric should have write/delete/rename labels."""
+        resp = client.get("/metrics")
+        body = resp.text
+        assert 'event_type="write"' in body
+        assert 'event_type="delete"' in body
+        assert 'event_type="rename"' in body
+
+    def test_wb_metrics_start_at_zero(self, client) -> None:
+        """Before any writes, all counters should be 0."""
+        resp = client.get("/metrics")
+        body = resp.text
+        # Flushed, failed, retries should all be 0
+        assert "nexus_write_buffer_events_flushed_total 0.0" in body
+        assert "nexus_write_buffer_events_failed_total 0.0" in body
+        assert "nexus_write_buffer_retries_total 0.0" in body
+
+
+# ---------------------------------------------------------------------------
+# WriteBuffer metrics update after writes
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBufferMetricsAfterWrites:
+    """After performing writes via the API, counters should increase."""
+
+    def test_enqueued_increases_after_write(self, client, auth_headers) -> None:
+        """Writing a file should increment the enqueued counter."""
+        # Write a file via the API
+        client.put(
+            "/v1/write",
+            params={"path": "/test/wb_metrics.txt"},
+            content=b"hello world",
+            headers=auth_headers,
+        )
+
+        # Give the write buffer a moment to process
+        time.sleep(0.5)
+
+        resp = client.get("/metrics")
+        body = resp.text
+        # At minimum, the write enqueue count should be > 0
+        # Find the line: nexus_write_buffer_events_enqueued_total{event_type="write"} N
+        assert "nexus_write_buffer_events_enqueued_total" in body
+
+
+# ---------------------------------------------------------------------------
+# No auth required for /metrics (even with permissions enabled)
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsNoAuthRequired:
+    """The /metrics endpoint should be accessible without authentication."""
+
+    def test_unauthenticated_can_read_wb_metrics(self, client) -> None:
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert "nexus_write_buffer_events_flushed_total" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Performance: verify negligible overhead
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBufferMetricsPerformance:
+    """Verify that the WriteBuffer collector adds no measurable latency."""
+
+    @pytest.mark.benchmark
+    def test_metrics_latency_under_50ms(self, client) -> None:
+        """/metrics must still respond in <50ms with WriteBuffer collector."""
+        client.get("/metrics")  # warm-up
+
+        n = 20
+        start = time.perf_counter()
+        for _ in range(n):
+            resp = client.get("/metrics")
+            assert resp.status_code == 200
+        elapsed = time.perf_counter() - start
+
+        per_req_ms = (elapsed / n) * 1000
+        assert per_req_ms < 50, f"/metrics: {per_req_ms:.1f}ms per request -- too slow"
+
+    @pytest.mark.benchmark
+    def test_collector_scrape_overhead(self, nexus_fs) -> None:
+        """Reading metrics dict directly must be sub-millisecond."""
+        wo = nexus_fs._write_observer
+        assert wo is not None
+
+        n = 10000
+        start = time.perf_counter()
+        for _ in range(n):
+            _ = wo.metrics
+        elapsed = time.perf_counter() - start
+
+        per_call_us = (elapsed / n) * 1_000_000
+        assert per_call_us < 100, f"metrics property: {per_call_us:.1f}us -- too slow"
+
+
+# ---------------------------------------------------------------------------
+# Existing metrics still present (co-existence)
+# ---------------------------------------------------------------------------
+
+
+class TestExistingMetricsCoexistence:
+    """Existing HTTP and DB metrics should still appear alongside WB metrics."""
+
+    def test_http_metrics_still_present(self, client, auth_headers) -> None:
+        client.get("/health")
+        resp = client.get("/metrics")
+        assert "http_requests_total" in resp.text
+        assert "http_request_duration_seconds" in resp.text
+
+    def test_nexus_info_still_present(self, client) -> None:
+        resp = client.get("/metrics")
+        assert "nexus_info" in resp.text

--- a/tests/unit/server/test_wb_metrics_collector.py
+++ b/tests/unit/server/test_wb_metrics_collector.py
@@ -1,0 +1,235 @@
+"""Tests for WriteBufferCollector Prometheus bridge (Issue #1370).
+
+Unit tests use a mocked write observer; integration tests use a real
+WriteBuffer backed by an in-memory SQLite database.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from nexus.core._metadata_generated import FileMetadata
+from nexus.server.wb_metrics_collector import WriteBufferCollector
+
+# Expected metric family names emitted by the collector
+_EXPECTED_FAMILIES = {
+    "nexus_write_buffer_events_enqueued_total",
+    "nexus_write_buffer_events_flushed_total",
+    "nexus_write_buffer_events_failed_total",
+    "nexus_write_buffer_retries_total",
+    "nexus_write_buffer_pending_events",
+    "nexus_write_buffer_flush_duration_seconds_sum",
+    "nexus_write_buffer_flush_duration_seconds_count",
+    "nexus_write_buffer_flush_batch_size_sum",
+    "nexus_write_buffer_flush_batch_size_count",
+}
+
+
+def _make_observer(**overrides: object) -> MagicMock:
+    """Build a mock write observer returning a metrics dict."""
+    defaults: dict[str, object] = {
+        "total_enqueued": 0,
+        "total_flushed": 0,
+        "total_failed": 0,
+        "total_retries": 0,
+        "pending": 0,
+        "flush_count": 0,
+        "flush_duration_sum": 0.0,
+        "flush_batch_size_sum": 0,
+        "enqueued_by_type": {"write": 0, "delete": 0, "rename": 0},
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    mock.metrics = defaults
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (mocked write observer)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBufferCollectorUnit:
+    """Unit tests with mocked WriteBuffer metrics."""
+
+    def test_collect_yields_all_metric_families(self) -> None:
+        """Collector should yield all 9 expected metric families."""
+        collector = WriteBufferCollector(_make_observer())
+        families = list(collector.collect())
+        names = {f.name for f in families}
+        assert names == _EXPECTED_FAMILIES
+
+    def test_enqueued_has_event_type_labels(self) -> None:
+        """Enqueued metric should have write/delete/rename labels."""
+        observer = _make_observer(
+            enqueued_by_type={"write": 10, "delete": 3, "rename": 1},
+        )
+        collector = WriteBufferCollector(observer)
+        families = {f.name: f for f in collector.collect()}
+
+        enqueued = families["nexus_write_buffer_events_enqueued_total"]
+        label_values = {s.labels["event_type"]: s.value for s in enqueued.samples}
+        assert label_values == {"write": 10, "delete": 3, "rename": 1}
+
+    def test_zero_values_when_idle(self) -> None:
+        """All metrics should be zero when no events have been processed."""
+        collector = WriteBufferCollector(_make_observer())
+        families = list(collector.collect())
+        for family in families:
+            for sample in family.samples:
+                assert sample.value == 0
+
+    def test_describe_returns_empty(self) -> None:
+        """Custom collector convention: describe returns empty."""
+        collector = WriteBufferCollector(_make_observer())
+        assert list(collector.describe()) == []
+
+    def test_collector_reads_observer_values(self) -> None:
+        """Collector should faithfully mirror observer metric values."""
+        observer = _make_observer(
+            total_flushed=50,
+            total_failed=2,
+            total_retries=5,
+            pending=3,
+            flush_count=10,
+            flush_duration_sum=1.23,
+            flush_batch_size_sum=48,
+        )
+        collector = WriteBufferCollector(observer)
+        families = {f.name: f for f in collector.collect()}
+
+        assert families["nexus_write_buffer_events_flushed_total"].samples[0].value == 50
+        assert families["nexus_write_buffer_events_failed_total"].samples[0].value == 2
+        assert families["nexus_write_buffer_retries_total"].samples[0].value == 5
+        assert families["nexus_write_buffer_pending_events"].samples[0].value == 3
+        assert families["nexus_write_buffer_flush_duration_seconds_sum"].samples[0].value == 1.23
+        assert families["nexus_write_buffer_flush_duration_seconds_count"].samples[0].value == 10
+        assert families["nexus_write_buffer_flush_batch_size_sum"].samples[0].value == 48
+        assert families["nexus_write_buffer_flush_batch_size_count"].samples[0].value == 10
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (real WriteBuffer)
+# ---------------------------------------------------------------------------
+
+
+def _make_metadata(
+    path: str = "/test/file.txt",
+    etag: str | None = "sha256-abc",
+) -> FileMetadata:
+    now = datetime(2026, 2, 10, 12, 0, 0)
+    return FileMetadata(
+        path=path,
+        backend_name="local",
+        physical_path="/data/abc123",
+        size=1024,
+        etag=etag,
+        mime_type="text/plain",
+        version=1,
+        zone_id="default",
+        created_by="user-1",
+        owner_id="owner-1",
+        created_at=now,
+        modified_at=now,
+    )
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    from nexus.storage.models import Base
+
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def session_factory(engine):
+    return sessionmaker(bind=engine)
+
+
+class TestWriteBufferCollectorIntegration:
+    """Integration tests with real WriteBuffer + in-memory SQLite."""
+
+    def test_collector_reads_real_buffer_after_enqueue(self, session_factory) -> None:
+        """Enqueuing events should update per-type counters visible via collector."""
+        from nexus.storage.record_store_syncer import BufferedRecordStoreSyncer
+
+        syncer = BufferedRecordStoreSyncer(session_factory, flush_interval_ms=10000)
+        collector = WriteBufferCollector(syncer)
+
+        syncer.on_write(_make_metadata(), is_new=True, path="/a.txt")
+        syncer.on_delete(path="/b.txt", zone_id="default")
+        syncer.on_rename(old_path="/c.txt", new_path="/d.txt")
+
+        families = {f.name: f for f in collector.collect()}
+        enqueued = families["nexus_write_buffer_events_enqueued_total"]
+        label_values = {s.labels["event_type"]: s.value for s in enqueued.samples}
+        assert label_values == {"write": 1, "delete": 1, "rename": 1}
+        assert families["nexus_write_buffer_pending_events"].samples[0].value == 3
+
+    def test_collector_reads_real_buffer_after_flush(self, session_factory) -> None:
+        """Flushing should update flushed/duration/batch metrics."""
+        from nexus.storage.record_store_syncer import BufferedRecordStoreSyncer
+
+        syncer = BufferedRecordStoreSyncer(session_factory, flush_interval_ms=10000)
+        syncer.start()
+        collector = WriteBufferCollector(syncer)
+
+        syncer.on_write(_make_metadata(path="/f1.txt", etag="h1"), is_new=True, path="/f1.txt")
+        syncer.on_write(_make_metadata(path="/f2.txt", etag="h2"), is_new=True, path="/f2.txt")
+        syncer.stop(timeout=5.0)
+
+        families = {f.name: f for f in collector.collect()}
+        assert families["nexus_write_buffer_events_flushed_total"].samples[0].value == 2
+        assert families["nexus_write_buffer_flush_duration_seconds_count"].samples[0].value >= 1
+        assert families["nexus_write_buffer_flush_duration_seconds_sum"].samples[0].value > 0
+        assert families["nexus_write_buffer_flush_batch_size_sum"].samples[0].value == 2
+
+    def test_collector_tracks_retries_on_failure(self, session_factory) -> None:
+        """Transient failures should increment the retry counter."""
+        from nexus.storage.write_buffer import WriteBuffer
+
+        call_count = 0
+        real_factory = session_factory
+
+        def flaky_factory():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                raise RuntimeError("Transient failure")
+            return real_factory()
+
+        buf = WriteBuffer(flaky_factory, flush_interval_ms=10000, max_retries=3)
+        buf.enqueue_write(_make_metadata(), is_new=True, path="/retry.txt")
+        buf._flush_buffer()
+
+        collector = WriteBufferCollector(MagicMock(metrics=buf.metrics))
+        families = {f.name: f for f in collector.collect()}
+        assert families["nexus_write_buffer_retries_total"].samples[0].value >= 1
+
+    def test_collector_tracks_failed_events(self) -> None:
+        """Exhausting retries should increment the failed counter."""
+        from nexus.storage.write_buffer import WriteBuffer
+
+        def always_fail():
+            raise RuntimeError("Permanent failure")
+
+        buf = WriteBuffer(always_fail, flush_interval_ms=10000, max_retries=2)
+        buf.enqueue_write(_make_metadata(), is_new=True, path="/fail.txt")
+        buf._flush_buffer()
+
+        collector = WriteBufferCollector(MagicMock(metrics=buf.metrics))
+        families = {f.name: f for f in collector.collect()}
+        assert families["nexus_write_buffer_events_failed_total"].samples[0].value == 1
+        assert families["nexus_write_buffer_retries_total"].samples[0].value == 2


### PR DESCRIPTION
## Summary

- Add Prometheus-visible metrics for WriteBuffer write-path health (flush latency, retry rates, buffer depth, per-event-type enqueue counts)
- New `WriteBufferCollector` custom collector in `server/` layer — storage stays Prometheus-free
- Fix shutdown gap: drain WriteBuffer before `nexus_fs.close()` to prevent event loss
- Thread-safe counter updates with consistent snapshot reads under lock

**Stream**: stream5

## Metrics Exposed (~11 time series)

| Prometheus Name | Type | Description |
|----------------|------|-------------|
| `nexus_write_buffer_events_enqueued_total{event_type}` | Gauge (labeled) | Per-type enqueue counts (write/delete/rename) |
| `nexus_write_buffer_events_flushed_total` | Gauge | Total flushed events |
| `nexus_write_buffer_events_failed_total` | Gauge | Events dropped after retry exhaustion |
| `nexus_write_buffer_retries_total` | Gauge | Total retry attempts |
| `nexus_write_buffer_pending_events` | Gauge | Current buffer depth |
| `nexus_write_buffer_flush_duration_seconds_{sum,count}` | Gauge pair | For computing average flush latency |
| `nexus_write_buffer_flush_batch_size_{sum,count}` | Gauge pair | For computing average batch size |

## Files Changed

| File | Action |
|------|--------|
| `src/nexus/storage/write_buffer.py` | Add 5 new counters, thread-safe instrumentation |
| `src/nexus/server/wb_metrics_collector.py` | **New** — Prometheus custom collector (~100 lines) |
| `src/nexus/server/fastapi_server.py` | Wire collector + shutdown fix |
| `src/nexus/storage/record_store_syncer.py` | Update metrics return type |
| `tests/unit/server/test_wb_metrics_collector.py` | **New** — 9 unit/integration tests |
| `tests/unit/storage/test_write_buffer.py` | 3 new enhanced metrics tests |
| `tests/integration/test_wb_metrics_integration.py` | **New** — 9 E2E tests with real FastAPI app |

## Test plan

- [x] 9 unit tests (mocked observer + real WriteBuffer): all metric families, labels, zero values, retries, failures
- [x] 9 integration tests (real `create_app` + `TestClient`): metrics on `/metrics`, no-auth access, performance < 50ms, existing metrics coexistence
- [x] 3 new WriteBuffer unit tests: timing fields, per-type tracking, retry counter
- [x] All 18 existing metrics tests pass (no regression)
- [x] Ruff lint + format clean
- [x] mypy clean (zero errors from changed files)
- [x] Performance: `/metrics` < 50ms, `metrics` property < 100μs (dict read, no DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)