### PR TITLE
refactor(#1519): extract cache invalidation from kernel into observer pattern

### DIFF
--- a/src/nexus/core/cache_invalidation.py
+++ b/src/nexus/core/cache_invalidation.py
@@ -1,0 +1,81 @@
+"""Cache invalidation observer — decouples kernel from ReadSetAwareCache.
+
+The kernel calls the observer on mutations (write/delete/rename) and reads
+(to register cache dependencies). The concrete ``ReadSetCacheObserver``
+bridges these calls to ``ReadSetAwareCache``, following the same pattern
+used by ``_write_observer`` / ``_notify_observer`` in the kernel.
+
+Issue #1169 / #1519.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from nexus.core._metadata_generated import FileMetadata
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class CacheInvalidationObserver(Protocol):
+    """Observer for kernel mutation events that require cache invalidation.
+
+    Injected into the kernel via ``KernelServices.cache_observer``.
+    The kernel calls these methods; the observer handles cache orchestration.
+    """
+
+    def on_write(self, path: str, revision: int, zone_id: str) -> None: ...
+
+    def on_delete(self, path: str, revision: int, zone_id: str) -> None: ...
+
+    def on_rename(self, old_path: str, new_path: str, revision: int, zone_id: str) -> None: ...
+
+    def on_read(
+        self,
+        path: str,
+        metadata: FileMetadata | None,
+        revision: int,
+        zone_id: str,
+        resource_type: str = "file",
+    ) -> None: ...
+
+
+class ReadSetCacheObserver:
+    """Bridges kernel mutation/read events to ReadSetAwareCache.
+
+    Wraps the existing ``ReadSetAwareCache`` and ``ReadSetRegistry``,
+    translating kernel observer calls into the cache's native API.
+    """
+
+    def __init__(self, read_set_cache: Any) -> None:
+        self._cache = read_set_cache
+
+    def on_write(self, path: str, revision: int, zone_id: str) -> None:
+        self._cache.invalidate_for_write(path, revision, zone_id=zone_id)
+
+    def on_delete(self, path: str, revision: int, zone_id: str) -> None:
+        self._cache.invalidate_for_write(path, revision, zone_id=zone_id)
+
+    def on_rename(self, old_path: str, new_path: str, revision: int, zone_id: str) -> None:
+        self._cache.invalidate_for_write(old_path, revision, zone_id=zone_id)
+        self._cache.invalidate_for_write(new_path, revision, zone_id=zone_id)
+
+    def on_read(
+        self,
+        path: str,
+        metadata: FileMetadata | None,
+        revision: int,
+        zone_id: str,
+        resource_type: str = "file",
+    ) -> None:
+        if metadata is None:
+            return
+
+        from nexus.core.read_set import ReadSet
+
+        rs = ReadSet(query_id=f"cache:{path}", zone_id=zone_id)
+        rs.record_read(resource_type, path, revision=revision)
+        self._cache.put_path(path, metadata, read_set=rs, zone_revision=revision)

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -133,6 +133,9 @@ class KernelServices:
     overlay_resolver: Any = None
     wallet_provisioner: Any = None
 
+    # Cache invalidation (Issue #1169 / #1519)
+    cache_observer: Any = None  # CacheInvalidationObserver protocol
+
     # Infrastructure (moved from _service_extras dict)
     event_bus: Any = None
     lock_manager: Any = None

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -325,6 +325,13 @@ class NexusFS(  # type: ignore[misc]
             )
             self._read_tracking_enabled = True
 
+        # Issue #1519: Cache observer — decouples kernel from ReadSetAwareCache
+        self._cache_observer = svc.cache_observer
+        if self._cache_observer is None and self._read_set_cache is not None:
+            from nexus.core.cache_invalidation import ReadSetCacheObserver
+
+            self._cache_observer = ReadSetCacheObserver(self._read_set_cache)
+
         # OPTIMIZATION: Initialize TRAVERSE permissions and Tiger Cache
         self._init_performance_optimizations()
 

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -524,25 +524,20 @@ class NexusFSCoreMixin:
         the given path, enabling precise invalidation when the path is written.
 
         Called after metadata reads (get/stat) to associate read sets with
-        cache entries. This is a no-op when ReadSetAwareCache is not configured.
+        cache entries. This is a no-op when cache observer is not configured.
 
         Args:
             path: Virtual path of the cached entry
             metadata: File metadata (None means not found — skip)
             resource_type: Type of resource (file, directory)
         """
-        read_set_cache = getattr(self, "_read_set_cache", None)
-        if read_set_cache is None or metadata is None:
+        cache_observer = getattr(self, "_cache_observer", None)
+        if cache_observer is None or metadata is None:
             return
-
-        from nexus.core.read_set import ReadSet
 
         zone_id = getattr(self, "zone_id", None) or "default"
         revision = self._get_zone_revision()
-
-        rs = ReadSet(query_id=f"cache:{path}", zone_id=zone_id)
-        rs.record_read(resource_type, path, revision=revision)
-        read_set_cache.put_path(path, metadata, read_set=rs, zone_revision=revision)
+        cache_observer.on_read(path, metadata, revision, zone_id, resource_type)
 
     # =========================================================================
     # Sync Lock Helpers for write(lock=True) - Issue #1106 Block 3
@@ -1975,12 +1970,10 @@ class NexusFSCoreMixin:
         # Issue #1169: Advance zone revision counter after mutation
         new_revision = self._increment_zone_revision()
 
-        # Issue #1169: Precise cache invalidation via read sets
-        # Invalidates other cache entries whose read sets depend on this path
-        # (e.g., directory listings that included this file)
-        read_set_cache = getattr(self, "_read_set_cache", None)
-        if read_set_cache is not None:
-            read_set_cache.invalidate_for_write(path, new_revision, zone_id=zone_id or "default")
+        # Issue #1169: Precise cache invalidation via cache observer
+        cache_observer = getattr(self, "_cache_observer", None)
+        if cache_observer is not None:
+            cache_observer.on_write(path, new_revision, zone_id or "default")
 
         # Leopard-style: Add new file to ancestor directory grants
         # When a file is created in a directory that has been granted to users,
@@ -3017,10 +3010,10 @@ class NexusFSCoreMixin:
         # Issue #1169: Advance zone revision counter after delete
         new_revision = self._increment_zone_revision()
 
-        # Issue #1169: Precise cache invalidation via read sets
-        read_set_cache = getattr(self, "_read_set_cache", None)
-        if read_set_cache is not None:
-            read_set_cache.invalidate_for_write(path, new_revision, zone_id=zone_id or "default")
+        # Issue #1169: Precise cache invalidation via cache observer
+        cache_observer = getattr(self, "_cache_observer", None)
+        if cache_observer is not None:
+            cache_observer.on_delete(path, new_revision, zone_id or "default")
 
         # v0.7.0: Fire workflow event for automatic trigger execution
         from nexus.workflows.types import TriggerType
@@ -3197,14 +3190,9 @@ class NexusFSCoreMixin:
 
         # Issue #1169: Advance zone revision + invalidate both old and new paths
         new_revision = self._increment_zone_revision()
-        read_set_cache = getattr(self, "_read_set_cache", None)
-        if read_set_cache is not None:
-            read_set_cache.invalidate_for_write(
-                old_path, new_revision, zone_id=zone_id or "default"
-            )
-            read_set_cache.invalidate_for_write(
-                new_path, new_revision, zone_id=zone_id or "default"
-            )
+        cache_observer = getattr(self, "_cache_observer", None)
+        if cache_observer is not None:
+            cache_observer.on_rename(old_path, new_path, new_revision, zone_id or "default")
 
         # Update ReBAC permissions to follow the renamed file/directory
         # This ensures permissions are preserved when files are moved

--- a/src/nexus/core/nexus_fs_events.py
+++ b/src/nexus/core/nexus_fs_events.py
@@ -660,13 +660,13 @@ class NexusFSEventsMixin:
                 if not virtual_path.startswith("/"):
                     virtual_path = "/" + virtual_path
 
-        # Issue #1169: Use read-set-aware invalidation when available
-        read_set_cache = getattr(self, "_read_set_cache", None)
-        if read_set_cache is not None:
+        # Issue #1169: Use cache observer for precise invalidation when available
+        cache_observer = getattr(self, "_cache_observer", None)
+        if cache_observer is not None:
             revision = self._get_zone_revision()
-            zone_id = getattr(self, "zone_id", None)
-            count = read_set_cache.invalidate_for_write(virtual_path, revision, zone_id=zone_id)
-            logger.debug(f"Cache invalidated (read-set): {virtual_path} ({count} entries)")
+            zone_id = getattr(self, "zone_id", None) or "default"
+            cache_observer.on_write(virtual_path, revision, zone_id)
+            logger.debug(f"Cache invalidated (observer): {virtual_path}")
         else:
             cache.invalidate_path(virtual_path)
             logger.debug(f"Cache invalidated: {virtual_path}")


### PR DESCRIPTION
## Summary
- Kernel core mixin (`nexus_fs_core.py`) was directly referencing `ReadSetAwareCache` for cache invalidation in write/delete/rename paths — coupling kernel to specific cache implementation
- Introduced `CacheInvalidationObserver` protocol + `ReadSetCacheObserver` concrete implementation following the existing `_write_observer` pattern
- Kernel now calls `observer.on_write/on_delete/on_rename/on_read` instead of directly calling `read_set_cache.invalidate_for_write()`
- Zero `read_set_cache` references remain in `nexus_fs_core.py` or `nexus_fs_events.py`
- Observer lives in `core/` because it serves the kernel's own metadata (inode) cache

## Test plan
- [ ] Existing read-set cache unit tests pass
- [ ] Read-set cache E2E tests pass
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)