### PR TITLE
fix(#1588): fix PermissionEnforcer import in 3 remaining test files

### DIFF
--- a/tests/unit/core/test_permission_enforcer.py
+++ b/tests/unit/core/test_permission_enforcer.py
@@ -5,8 +5,8 @@ import pytest
 from nexus.core.permissions import (
     OperationContext,
     Permission,
-    PermissionEnforcer,
 )
+from nexus.services.permissions.enforcer import PermissionEnforcer
 
 
 class TestOperationContext:

--- a/tests/unit/core/test_permissions_security.py
+++ b/tests/unit/core/test_permissions_security.py
@@ -20,8 +20,8 @@ import pytest
 from nexus.core.permissions import (
     OperationContext,
     Permission,
-    PermissionEnforcer,
 )
+from nexus.services.permissions.enforcer import PermissionEnforcer
 
 # ---------------------------------------------------------------------------
 # OperationContext creation and validation

--- a/tests/unit/core/test_rebac_security.py
+++ b/tests/unit/core/test_rebac_security.py
@@ -21,8 +21,8 @@ import pytest
 from nexus.core.permissions import (
     OperationContext,
     Permission,
-    PermissionEnforcer,
 )
+from nexus.services.permissions.enforcer import PermissionEnforcer
 from nexus.services.permissions.rebac_manager_enhanced import (
     CheckResult,
     ConsistencyLevel,


### PR DESCRIPTION
## Summary

- Fix `ImportError: cannot import name 'PermissionEnforcer' from 'nexus.core.permissions'` in 3 test files that were missed by PR #1630 / commit 5218b9d
- Updates imports to use the new canonical path `nexus.services.permissions.enforcer`

**Affected files:**
- `tests/unit/core/test_permission_enforcer.py`
- `tests/unit/core/test_permissions_security.py`
- `tests/unit/core/test_rebac_security.py`

This fixes the `Test Python 3.13 on macos-latest` and `Test Python 3.13 on ubuntu-latest` CI failures (3 collection errors each).

## Test plan
- [x] All 168 tests in the 3 affected files pass locally
- [x] Ruff lint clean
- [ ] CI passes on both macOS and Ubuntu

Stream 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)