### PR TITLE
refactor(#387): remove backward-compat aliases from CacheSettings

### DIFF
--- a/src/nexus/cache/settings.py
+++ b/src/nexus/cache/settings.py
@@ -62,11 +62,7 @@ class CacheSettings:
     """
 
     # Dragonfly cache connection (optional - if not set, use PostgreSQL)
-    dragonfly_url: str | None = field(
-        default_factory=lambda: (
-            os.environ.get("NEXUS_DRAGONFLY_URL") or os.environ.get("NEXUS_DRAGONFLY_CACHE_URL")
-        )  # Backward compatibility
-    )
+    dragonfly_url: str | None = field(default_factory=lambda: os.environ.get("NEXUS_DRAGONFLY_URL"))
 
     # Backend selection: auto, dragonfly, postgres
     cache_backend: Literal["auto", "dragonfly", "postgres"] = field(
@@ -150,12 +146,6 @@ class CacheSettings:
         default_factory=lambda: int(os.environ.get("NEXUS_CACHE_L1_SIZE", "50000"))
     )
 
-    # Backward compatibility aliases
-    @property
-    def dragonfly_cache_url(self) -> str | None:
-        """Backward compatibility alias."""
-        return self.dragonfly_url
-
     def should_use_dragonfly(self) -> bool:
         """Determine if Dragonfly should be used for caching."""
         if self.cache_backend == "dragonfly":
@@ -166,9 +156,6 @@ class CacheSettings:
             return False
         # "auto" mode - use Dragonfly if URL is set
         return self.dragonfly_url is not None
-
-    # Backward compatibility alias
-    should_use_dragonfly_cache = should_use_dragonfly
 
     def validate(self) -> None:
         """Validate configuration."""

--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -707,7 +707,7 @@ def _create_distributed_infra(
             import os
 
             coordination_url_resolved = coordination_url or os.getenv("NEXUS_REDIS_URL")
-            event_url_resolved = coordination_url_resolved or os.getenv("NEXUS_DRAGONFLY_CACHE_URL")
+            event_url_resolved = coordination_url_resolved or os.getenv("NEXUS_DRAGONFLY_URL")
             if event_url_resolved:
                 from nexus.cache.dragonfly import DragonflyClient
                 from nexus.core.event_bus import RedisEventBus, set_global_event_bus


### PR DESCRIPTION
## Summary
- Remove `NEXUS_DRAGONFLY_CACHE_URL` env var fallback from `dragonfly_url` field (use `NEXUS_DRAGONFLY_URL` only)
- Remove `dragonfly_cache_url` property alias
- Remove `should_use_dragonfly_cache` method alias
- Update `factory.py` to use `NEXUS_DRAGONFLY_URL` instead of deprecated env var

Per project policy: no backward compatibility — obsoleted code must be cleaned.

## Test plan
- [x] Smoke test: CacheSettings instantiation works correctly
- [x] No external consumers of removed aliases found via grep
- [x] Pre-commit hooks (ruff, mypy, format) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)