### PR TITLE
fix(#1391): delete backward-compat aliases from core/config.py

### DIFF
--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -161,27 +161,3 @@ class ObservabilityConfig:
     log_query_parameters: bool = False  # security: off by default
     max_query_length: int = 1000  # truncate long statements
     max_listener_errors: int = 10  # auto-disable threshold
-
-
-# ---------------------------------------------------------------------------
-# Backward-compatibility aliases (Issue #1391)
-# Old names still importable; will be removed in a future release.
-# ---------------------------------------------------------------------------
-
-LRUCacheConfig = CacheConfig
-"""Deprecated: Use ``CacheConfig`` instead."""
-
-SecurityConfig = PermissionConfig
-"""Deprecated: Use ``PermissionConfig`` instead.
-
-Note: Field names changed:
-- ``enforce_permissions`` → ``enforce``
-- ``inherit_permissions`` → ``inherit``
-"""
-
-
-class FeatureFlags:
-    """Deprecated: Fields distributed into PermissionConfig, DistributedConfig, MemoryConfig."""
-
-    def __init__(self, **_kw: Any) -> None:  # noqa: ANN401
-        pass

--- a/tests/unit/core/test_kernel_config.py
+++ b/tests/unit/core/test_kernel_config.py
@@ -5,7 +5,6 @@ Validates:
 - frozen=True prevents mutation (raises FrozenInstanceError)
 - dataclasses.replace() creates modified copies
 - KernelServices allows mutation (not frozen)
-- Backward-compat aliases (LRUCacheConfig, SecurityConfig, FeatureFlags)
 """
 
 from __future__ import annotations
@@ -17,7 +16,6 @@ import pytest
 from nexus.core.config import (
     CacheConfig,
     DistributedConfig,
-    FeatureFlags,
     KernelServices,
     MemoryConfig,
     ParseConfig,
@@ -260,27 +258,3 @@ class TestKernelServices:
             "server_extras",
         }
         assert expected_fields.issubset(field_names), f"Missing: {expected_fields - field_names}"
-
-
-# ---------------------------------------------------------------------------
-# Backward-compat aliases
-# ---------------------------------------------------------------------------
-
-
-class TestBackwardCompatAliases:
-    """Verify backward-compat aliases still work."""
-
-    def test_lru_cache_config_is_cache_config(self) -> None:
-        from nexus.core.config import LRUCacheConfig
-
-        assert LRUCacheConfig is CacheConfig
-
-    def test_security_config_is_permission_config(self) -> None:
-        from nexus.core.config import SecurityConfig
-
-        assert SecurityConfig is PermissionConfig
-
-    def test_feature_flags_accepts_kwargs(self) -> None:
-        """FeatureFlags stub accepts any kwargs without error."""
-        ff = FeatureFlags(enable_tiger_cache=True, enable_deferred=False)
-        assert ff is not None


### PR DESCRIPTION
## Summary
- Delete `LRUCacheConfig` alias (use `CacheConfig` instead)
- Delete `SecurityConfig` alias (use `PermissionConfig` instead)
- Delete `FeatureFlags` stub class (fields distributed into PermissionConfig, DistributedConfig, MemoryConfig)
- Delete `TestBackwardCompatAliases` test class that tested these aliases

Zero external consumers — aliases only referenced in config.py itself and their dedicated test class.

## Test plan
- [ ] CI green (ruff, mypy, all pre-commit hooks pass)
- [ ] No remaining imports of LRUCacheConfig/SecurityConfig/FeatureFlags

🤖 Generated with [Claude Code](https://claude.com/claude-code)