### PR TITLE
refactor(#384): replace private _request_api_key export with public API

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -134,7 +134,7 @@ curl -X POST http://localhost:8081/mcp \
 For multi-user scenarios, infrastructure (middleware, proxy, gateway) can set per-request API keys without exposing them to AI agents:
 
 ```python
-from nexus.mcp.server import set_request_api_key, _request_api_key
+from nexus.mcp import set_request_api_key, reset_request_api_key
 
 # In middleware/proxy code:
 token = set_request_api_key("sk-user-api-key-xyz")
@@ -142,7 +142,7 @@ try:
     # MCP tool calls here will use this API key
     result = mcp_server.call_tool("nexus_read_file", path="/data.txt")
 finally:
-    _request_api_key.reset(token)
+    reset_request_api_key(token)
 ```
 
 ---

--- a/src/nexus/cli/commands/mcp.py
+++ b/src/nexus/cli/commands/mcp.py
@@ -59,7 +59,7 @@ def _add_api_key_middleware(mcp_server: Any) -> None:
     try:
         from starlette.middleware.base import BaseHTTPMiddleware
 
-        from nexus.mcp import _request_api_key, set_request_api_key
+        from nexus.mcp import reset_request_api_key, set_request_api_key
 
         class APIKeyMiddleware(BaseHTTPMiddleware):
             """Middleware to extract API key from HTTP headers."""
@@ -90,7 +90,7 @@ def _add_api_key_middleware(mcp_server: Any) -> None:
                 finally:
                     # Clean up context
                     if token is not None:
-                        _request_api_key.reset(token)
+                        reset_request_api_key(token)
 
         # Add middleware to the underlying Starlette app
         # FastMCP's http_app is a method that returns the Starlette application

--- a/src/nexus/mcp/__init__.py
+++ b/src/nexus/mcp/__init__.py
@@ -24,7 +24,7 @@ Usage:
     server.run()
 
     # Infrastructure API key management
-    from nexus.mcp import set_request_api_key
+    from nexus.mcp import set_request_api_key, reset_request_api_key
 
     # In middleware/proxy code:
     token = set_request_api_key("sk-user-api-key")
@@ -32,7 +32,7 @@ Usage:
         # Tool calls here will use this API key
         pass
     finally:
-        token.reset()
+        reset_request_api_key(token)
 
     # Unified MCP connection (Klavis or local)
     from nexus.mcp import KlavisClient, MCPProviderRegistry
@@ -52,9 +52,9 @@ from nexus.mcp.provider_registry import (
     ProviderType,
 )
 from nexus.mcp.server import (
-    _request_api_key,
     create_mcp_server,
     get_request_api_key,
+    reset_request_api_key,
     set_request_api_key,
 )
 
@@ -63,7 +63,7 @@ __all__ = [
     "create_mcp_server",
     "set_request_api_key",
     "get_request_api_key",
-    "_request_api_key",
+    "reset_request_api_key",
     # Connection manager
     "MCPConnectionManager",
     "MCPConnection",

--- a/src/nexus/mcp/server.py
+++ b/src/nexus/mcp/server.py
@@ -39,8 +39,7 @@ def set_request_api_key(api_key: str) -> contextvars.Token[str | None]:
         A token that can be used to reset the context variable
 
     Example:
-        >>> from nexus.mcp import set_request_api_key
-        >>> from nexus.mcp.server import _request_api_key
+        >>> from nexus.mcp import set_request_api_key, reset_request_api_key
         >>>
         >>> # In middleware or proxy code:
         >>> token = set_request_api_key("sk-user-api-key-xyz")
@@ -49,7 +48,7 @@ def set_request_api_key(api_key: str) -> contextvars.Token[str | None]:
         ...     result = mcp_server.call_tool("nexus_read_file", path="/data.txt")
         ... finally:
         ...     # Clean up context
-        ...     _request_api_key.reset(token)
+        ...     reset_request_api_key(token)
     """
     return _request_api_key.set(api_key)
 
@@ -64,6 +63,15 @@ def get_request_api_key() -> str | None:
         The current request API key, or None if not set
     """
     return _request_api_key.get()
+
+
+def reset_request_api_key(token: contextvars.Token[str | None]) -> None:
+    """Reset the request API key context variable using a previously saved token.
+
+    Args:
+        token: The token returned by set_request_api_key()
+    """
+    _request_api_key.reset(token)
 
 
 def create_mcp_server(
@@ -92,13 +100,13 @@ def create_mcp_server(
         (e.g., HTTP middleware, proxy, gateway) without exposing them to AI agents.
 
         Infrastructure should set the API key using:
-            from nexus.mcp.server import set_request_api_key
+            from nexus.mcp import set_request_api_key, reset_request_api_key
             token = set_request_api_key("sk-user-api-key-xyz")
             try:
                 # Make MCP tool calls here
                 pass
             finally:
-                token.reset()
+                reset_request_api_key(token)
 
         The api_key parameter serves as the default when no per-request key is set.
 
@@ -1405,7 +1413,7 @@ def main() -> None:
                         return response
                     finally:
                         if token:
-                            _request_api_key.reset(token)
+                            reset_request_api_key(token)
 
             # Add middleware to the underlying Starlette app
             # FastMCP's http_app is a method that returns the Starlette application


### PR DESCRIPTION
## Summary
- Added `reset_request_api_key(token)` public function in `mcp/server.py` to replace direct access to the private `_request_api_key` ContextVar
- Updated `cli/commands/mcp.py` to use the new public function
- Removed `_request_api_key` from `mcp/__init__.py` imports and `__all__`, added `reset_request_api_key`
- Updated docs and docstring examples

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [x] No remaining external imports of `_request_api_key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)