### PR TITLE
fix(#1300): delete dead executor fields and backward-compat from rpc_server

### DIFF
--- a/src/nexus/server/rpc_server.py
+++ b/src/nexus/server/rpc_server.py
@@ -76,10 +76,6 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
     # that shadows this class default. Each thread has its own handler.
     _cached_auth_result: Any = None
 
-    # Legacy executor fields kept for backward compatibility (now unused — Issue #1300)
-    _async_executor: Any = None
-    _async_executor_lock: Any = None
-
     def log_message(self, format: str, *args: Any) -> None:
         """Override to use Python logging instead of stderr."""
         logger.info(f"{self.address_string()} - {format % args}")
@@ -197,7 +193,6 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
                             "subject_id": context.subject_id,
                             "zone_id": context.zone_id,
                             "is_admin": context.is_admin,
-                            "user": context.user,  # For backward compatibility
                         },
                     )
                 else:
@@ -1065,7 +1060,7 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         # Extract authentication context for manual dispatch
         context = self._get_operation_context()
 
-        # Fall back to manual dispatch for backward compatibility
+        # Manual dispatch for methods requiring special handling (virtual views, metadata wrapping, etc.)
         # Core file operations
         if method == "read":
             # Check if this is a virtual view request (.txt or .md)
@@ -1797,12 +1792,6 @@ class NexusRPCServer:
         logger.info("Shutting down server...")
         self.server.shutdown()
         self.server.server_close()
-
-        # Cleanup shared async executor
-        if RPCRequestHandler._async_executor is not None:
-            RPCRequestHandler._async_executor.shutdown(wait=True)
-            RPCRequestHandler._async_executor = None
-            logger.debug("Shared async executor shutdown complete")
 
         if hasattr(self.nexus_fs, "close"):
             self.nexus_fs.close()

--- a/tests/e2e/test_rpc_auth_e2e.py
+++ b/tests/e2e/test_rpc_auth_e2e.py
@@ -1,6 +1,6 @@
 """E2E tests for RPC server with authentication.
 
-Tests the _run_async_safe optimization with real auth_provider calls.
+Tests _run_async_safe via sync_bridge with real auth_provider calls.
 """
 
 from nexus.server.auth.database_key import DatabaseAPIKeyAuth
@@ -16,10 +16,6 @@ class TestRPCServerAuthQuickCheck:
         from sqlalchemy.orm import sessionmaker
 
         from nexus.server.rpc_server import RPCRequestHandler
-
-        # Reset executor state
-        RPCRequestHandler._async_executor = None
-        RPCRequestHandler._async_executor_lock = None
 
         # Setup database
         db_path = tmp_path / "auth.db"
@@ -54,23 +50,15 @@ class TestRPCServerAuthQuickCheck:
         handler._validate_auth = lambda: RPCRequestHandler._validate_auth(handler)
 
         try:
-            # Test authentication - this exercises _run_async_safe
+            # Test authentication - this exercises _run_async_safe via sync_bridge
             result = handler._validate_auth()
             assert result is True, "Authentication should succeed"
 
-            # Verify executor was created
-            assert RPCRequestHandler._async_executor is not None
-
-            # Test multiple calls reuse executor
-            executor1 = RPCRequestHandler._async_executor
+            # Test multiple calls work correctly
             result2 = handler._validate_auth()
             assert result2 is True
-            assert RPCRequestHandler._async_executor is executor1
         finally:
             handler.event_loop.close()
-            if RPCRequestHandler._async_executor is not None:
-                RPCRequestHandler._async_executor.shutdown(wait=True)
-                RPCRequestHandler._async_executor = None
 
     def test_run_async_safe_with_invalid_token(self, tmp_path):
         """Test _run_async_safe with invalid token."""
@@ -78,10 +66,6 @@ class TestRPCServerAuthQuickCheck:
         from sqlalchemy.orm import sessionmaker
 
         from nexus.server.rpc_server import RPCRequestHandler
-
-        # Reset
-        RPCRequestHandler._async_executor = None
-        RPCRequestHandler._async_executor_lock = None
 
         # Setup
         db_path = tmp_path / "auth.db"
@@ -108,6 +92,3 @@ class TestRPCServerAuthQuickCheck:
             assert result is False, "Invalid token should fail auth"
         finally:
             handler.event_loop.close()
-            if RPCRequestHandler._async_executor is not None:
-                RPCRequestHandler._async_executor.shutdown(wait=True)
-                RPCRequestHandler._async_executor = None


### PR DESCRIPTION
## Summary
- Delete unused `_async_executor` / `_async_executor_lock` class fields from `RPCRequestHandler` (Issue #1300 — now uses `sync_bridge.run_sync()`)
- Remove dead executor cleanup from `shutdown()`
- Remove backward-compat `"user"` field from `/api/auth/whoami` response (already has `"subject_id"`)
- Fix misleading "backward compatibility" comment on manual dispatch section
- Update e2e tests to remove assertions on deleted executor fields

## Test plan
- [ ] CI passes (ruff, mypy, tests)
- [ ] Verify no external code references `_async_executor` (grep confirmed zero callers outside deleted code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)