### PR TITLE
fix(#491): remove direct env var reads from kernel resolvers

### DIFF
--- a/src/nexus/core/coref_resolver.py
+++ b/src/nexus/core/coref_resolver.py
@@ -179,13 +179,9 @@ Resolved text:"""
                 method="none",
             )
 
-        # Get or create LLM provider
+        # Require injected LLM provider; fall back to heuristic if absent
         provider = self.llm_provider
         if provider is None:
-            provider = self._get_default_provider()
-
-        if provider is None:
-            # Fall back to heuristic if no LLM available
             fallback = HeuristicCorefResolver()
             result = fallback.resolve(text, context, entity_hints)
             result.method = "heuristic"
@@ -352,35 +348,6 @@ Resolved text:"""
                 )
 
         return replacements
-
-    def _get_default_provider(self) -> Any:
-        """Try to get a default LLM provider."""
-        import os
-
-        try:
-            from pydantic import SecretStr
-
-            from nexus.llm import LiteLLMProvider, LLMConfig
-
-            # Check for common API keys in environment
-            if os.environ.get("ANTHROPIC_API_KEY"):
-                config = LLMConfig(
-                    model="claude-sonnet-4-20250514",
-                    api_key=SecretStr(os.environ["ANTHROPIC_API_KEY"]),
-                    max_output_tokens=1024,
-                )
-                return LiteLLMProvider(config)
-            elif os.environ.get("OPENAI_API_KEY"):
-                config = LLMConfig(
-                    model="gpt-4o-mini",
-                    api_key=SecretStr(os.environ["OPENAI_API_KEY"]),
-                    max_output_tokens=1024,
-                )
-                return LiteLLMProvider(config)
-        except Exception:
-            pass
-
-        return None
 
 
 class HeuristicCorefResolver(CorefResolver):

--- a/src/nexus/core/temporal_resolver.py
+++ b/src/nexus/core/temporal_resolver.py
@@ -192,13 +192,9 @@ Resolved:"""
                 method="none",
             )
 
-        # Get or create LLM provider
+        # Require injected LLM provider; fall back to heuristic if absent
         provider = self.llm_provider
         if provider is None:
-            provider = self._get_default_provider()
-
-        if provider is None:
-            # Fall back to heuristic
             fallback = HeuristicTemporalResolver()
             result = fallback.resolve(text, reference_time, context)
             result.method = "heuristic"
@@ -345,34 +341,6 @@ Resolved:"""
                     )
 
         return replacements
-
-    def _get_default_provider(self) -> Any:
-        """Try to get a default LLM provider."""
-        import os
-
-        try:
-            from pydantic import SecretStr
-
-            from nexus.llm import LiteLLMProvider, LLMConfig
-
-            if os.environ.get("ANTHROPIC_API_KEY"):
-                config = LLMConfig(
-                    model="claude-sonnet-4-20250514",
-                    api_key=SecretStr(os.environ["ANTHROPIC_API_KEY"]),
-                    max_output_tokens=1024,
-                )
-                return LiteLLMProvider(config)
-            elif os.environ.get("OPENAI_API_KEY"):
-                config = LLMConfig(
-                    model="gpt-4o-mini",
-                    api_key=SecretStr(os.environ["OPENAI_API_KEY"]),
-                    max_output_tokens=1024,
-                )
-                return LiteLLMProvider(config)
-        except Exception:
-            pass
-
-        return None
 
 
 class HeuristicTemporalResolver(TemporalResolver):

--- a/tests/unit/core/test_coref_resolver.py
+++ b/tests/unit/core/test_coref_resolver.py
@@ -162,9 +162,8 @@ class TestLLMCorefResolver:
         assert "John (male)" in formatted
         assert "Alice (female)" in formatted
 
-    def test_fallback_to_heuristic(self, resolver, monkeypatch):
-        """Test fallback to heuristic when no LLM available."""
-        monkeypatch.setattr(resolver, "_get_default_provider", lambda: None)
+    def test_fallback_to_heuristic(self, resolver):
+        """Test fallback to heuristic when no LLM provider injected."""
         text = "He went to the store."
         result = resolver.resolve(
             text,


### PR DESCRIPTION
## Summary
- Delete `_get_default_provider()` from `LLMTemporalResolver` and `LLMCorefResolver` in `core/`
- These methods read `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from `os.environ`, violating KERNEL-ARCHITECTURE.md (kernel must not read env vars; config via constructor DI only)
- When no `llm_provider` is injected, resolvers now fall back directly to heuristic resolution
- Updated test that monkeypatched the deleted method

## Test plan
- [x] All 61 tests in `test_coref_resolver.py` and `test_temporal_resolver.py` pass
- [x] All pre-commit hooks pass (ruff, ruff format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)