### PR TITLE
fix(#453): remove core/ import of remote/ in async_scoped_filesystem

### DIFF
--- a/src/nexus/core/async_scoped_filesystem.py
+++ b/src/nexus/core/async_scoped_filesystem.py
@@ -17,10 +17,7 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from nexus.remote.async_client import AsyncRemoteNexusFS
+from typing import Any
 
 
 class AsyncScopedFilesystem:
@@ -34,11 +31,11 @@ class AsyncScopedFilesystem:
     after path translation.
 
     Attributes:
-        _fs: The underlying AsyncRemoteNexusFS instance
+        _fs: The underlying async filesystem instance
         _root: The root path prefix to prepend to all paths
     """
 
-    def __init__(self, fs: AsyncRemoteNexusFS, root: str) -> None:
+    def __init__(self, fs: Any, root: str) -> None:
         """Initialize AsyncScopedFilesystem.
 
         Args:
@@ -116,7 +113,7 @@ class AsyncScopedFilesystem:
         return self._root
 
     @property
-    def wrapped_fs(self) -> AsyncRemoteNexusFS:
+    def wrapped_fs(self) -> Any:
         """The underlying wrapped filesystem."""
         return self._fs
 
@@ -262,8 +259,8 @@ class AsyncScopedFilesystem:
             self._scope_path(path), recursive, details, scoped_prefix, show_parsed, context
         )
         if details:
-            return [self._unscope_dict(r, ["path", "virtual_path"]) for r in result]  # type: ignore
-        return self._unscope_paths(result)  # type: ignore
+            return [self._unscope_dict(r, ["path", "virtual_path"]) for r in result]
+        return self._unscope_paths(result)
 
     async def glob(
         self,


### PR DESCRIPTION
## Summary
- Remove `TYPE_CHECKING` import of `AsyncRemoteNexusFS` from `nexus.remote.async_client` in `core/async_scoped_filesystem.py`
- Core layer must not depend on remote layer per KERNEL-ARCHITECTURE.md
- Replace concrete type hints with `Any`, remove now-unused `# type: ignore` comments

## Test plan
- [x] All 34 async scoped filesystem tests pass
- [x] mypy passes (no unused type: ignore errors)
- [x] ruff + ruff format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)