### PR TITLE
fix(#500): remove top-level services import from sandbox/auth_service

### DIFF
--- a/src/nexus/sandbox/auth_service.py
+++ b/src/nexus/sandbox/auth_service.py
@@ -22,11 +22,10 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from nexus.services.agents.agent_record import AgentRecord, AgentState
-
 if TYPE_CHECKING:
     from nexus.sandbox.events import AgentEventLog
     from nexus.sandbox.sandbox_manager import SandboxManager
+    from nexus.services.agents.agent_record import AgentRecord
     from nexus.services.agents.agent_registry import AgentRegistry
     from nexus.services.permissions.namespace_manager import NamespaceManager
 
@@ -160,6 +159,8 @@ class SandboxAuthService:
             )
 
         # Step 3: Transition agent to CONNECTED (new session)
+        from nexus.services.agents.agent_record import AgentState
+
         connected_record = await asyncio.to_thread(
             self._registry.transition, agent_id, AgentState.CONNECTED
         )
@@ -242,6 +243,8 @@ class SandboxAuthService:
 
         # Transition agent to IDLE (best-effort — don't fail the stop)
         try:
+            from nexus.services.agents.agent_record import AgentState
+
             await asyncio.to_thread(self._registry.transition, agent_id, AgentState.IDLE)
         except Exception:
             logger.warning(


### PR DESCRIPTION
## Summary
- Move `AgentRecord` from top-level runtime import to `TYPE_CHECKING` block
- Use lazy imports for `AgentState` enum values at point of use in `create_sandbox` and `stop_sandbox`
- Sandbox layer should not directly import from services layer at module level

## Test plan
- [x] mypy passes
- [x] ruff + ruff format pass
- [x] No runtime behavior change — AgentState lazy imports are functionally equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)