### PR TITLE
fix(#365): remove concrete driver implementations from SDK exports

### DIFF
--- a/src/nexus/sdk/__init__.py
+++ b/src/nexus/sdk/__init__.py
@@ -62,14 +62,9 @@ __all__ = [
     # Configuration
     "Config",
     "load_config",
-    # Core interfaces
+    # Core interfaces (ABCs / protocols only)
     "Filesystem",
-    "NexusFS",
-    "RemoteNexusFS",
-    # Backends
     "Backend",
-    "LocalBackend",
-    "GCSBackend",
     # Exceptions
     "NexusError",
     "FileNotFoundError",
@@ -92,26 +87,18 @@ __all__ = [
     "SkillExportError",
     # Permissions
     "OperationContext",
-    "PermissionEnforcer",
-    # ReBAC
-    "ReBACManager",
+    # ReBAC data types
     "ReBACTuple",
     "Entity",
     "WILDCARD_SUBJECT",
-    "ConsistencyLevel",
-    "CheckResult",
-    "GraphLimitExceeded",
     # Router
     "NamespaceConfig",
 ]
 
 # Re-export from core modules with cleaner names
 from pathlib import Path
-from typing import Union
 
 from nexus.backends.backend import Backend
-from nexus.backends.gcs import GCSBackend
-from nexus.backends.local import LocalBackend
 from nexus.config import NexusConfig as Config
 from nexus.config import load_config
 from nexus.core.exceptions import (
@@ -128,20 +115,9 @@ from nexus.core.exceptions import (
     NexusPermissionError as PermissionError,
 )
 from nexus.core.filesystem import NexusFilesystem as Filesystem
-from nexus.core.nexus_fs import NexusFS
 from nexus.core.permissions import OperationContext
 from nexus.core.rebac import WILDCARD_SUBJECT, Entity, ReBACTuple
 from nexus.core.router import NamespaceConfig
-from nexus.remote import RemoteNexusFS
-from nexus.services.permissions.enforcer import PermissionEnforcer
-from nexus.services.permissions.rebac_manager_enhanced import (
-    CheckResult,
-    ConsistencyLevel,
-    GraphLimitExceeded,
-)
-from nexus.services.permissions.rebac_manager_enhanced import (
-    EnhancedReBACManager as ReBACManager,
-)
 from nexus.skills import (
     Skill,
     SkillDependencyError,

--- a/tests/unit/sdk/test_sdk.py
+++ b/tests/unit/sdk/test_sdk.py
@@ -12,19 +12,13 @@ from nexus.sdk import (
     Config,
     FileNotFoundError,
     Filesystem,
-    GCSBackend,
     InvalidPathError,
-    LocalBackend,
     MetadataError,
     NamespaceConfig,
     NexusError,
-    NexusFS,
     OperationContext,
-    PermissionEnforcer,
     PermissionError,
-    ReBACManager,
     ReBACTuple,
-    RemoteNexusFS,
     Skill,
     SkillDependencyError,
     SkillExporter,
@@ -55,16 +49,12 @@ class TestSDKImports:
         assert callable(load_config)
 
     def test_filesystem_imports(self):
-        """Test that filesystem classes are available."""
+        """Test that filesystem ABC is available."""
         assert Filesystem is not None
-        assert NexusFS is not None
-        assert RemoteNexusFS is not None
 
     def test_backend_imports(self):
-        """Test that backend classes are available."""
+        """Test that backend ABC is available."""
         assert Backend is not None
-        assert LocalBackend is not None
-        assert GCSBackend is not None
 
     def test_exception_imports(self):
         """Test that exception classes are available."""
@@ -79,11 +69,9 @@ class TestSDKImports:
     def test_permission_imports(self):
         """Test that permission classes are available."""
         assert OperationContext is not None
-        assert PermissionEnforcer is not None
 
     def test_rebac_imports(self):
         """Test that ReBAC classes are available."""
-        assert ReBACManager is not None
         assert ReBACTuple is not None
 
     def test_router_imports(self):
@@ -112,7 +100,6 @@ class TestSDKConnect:
         """Test that connect returns a Filesystem instance."""
         nx = connect(config={"data_dir": str(tmp_path)})
         assert isinstance(nx, Filesystem)
-        assert isinstance(nx, NexusFS)
 
     def test_connect_with_dict_config(self, tmp_path):
         """Test connect with dictionary configuration."""
@@ -122,7 +109,7 @@ class TestSDKConnect:
                 "backend": "local",
             }
         )
-        assert isinstance(nx, NexusFS)
+        assert isinstance(nx, Filesystem)
 
     def test_connect_with_path_config(self, tmp_path):
         """Test connect with path to config file."""
@@ -130,7 +117,7 @@ class TestSDKConnect:
         config_file.write_text("backend: local\n")
 
         nx = connect(config=str(config_file))
-        assert isinstance(nx, NexusFS)
+        assert isinstance(nx, Filesystem)
 
 
 class TestSDKOperations:


### PR DESCRIPTION
## Summary
- Removed concrete implementation exports from `nexus.sdk.__init__`: `NexusFS`, `RemoteNexusFS`, `LocalBackend`, `GCSBackend`, `PermissionEnforcer`, `ReBACManager`, `CheckResult`, `ConsistencyLevel`, `GraphLimitExceeded`
- SDK now only exposes ABCs/protocols (`Filesystem`, `Backend`) and data types — no concrete drivers
- Updated tests to use `Filesystem` ABC instead of concrete `NexusFS`

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [x] SDK imports test updated to match new exports
- [x] `TestSDKConnect` uses `Filesystem` ABC for isinstance checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)