### PR TITLE
fix(#367): CLI commands — lazy-import concrete NexusFS

### DIFF
--- a/src/nexus/cli/commands/metadata.py
+++ b/src/nexus/cli/commands/metadata.py
@@ -19,7 +19,6 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
-from nexus.core.nexus_fs import NexusFS
 
 
 @click.command()
@@ -35,6 +34,8 @@ def info(
         nexus info /workspace/data.txt
     """
     try:
+        from nexus.core.nexus_fs import NexusFS
+
         nx = get_filesystem(backend_config)
 
         # Check if file exists first
@@ -132,6 +133,7 @@ def export_metadata(
     """
     try:
         from nexus.core.export_import import ExportFilter
+        from nexus.core.nexus_fs import NexusFS
 
         nx = get_filesystem(backend_config)
 
@@ -243,6 +245,7 @@ def import_metadata(
     """
     try:
         from nexus.core.export_import import ImportOptions
+        from nexus.core.nexus_fs import NexusFS
 
         nx = get_filesystem(backend_config)
 

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -14,7 +14,6 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
-from nexus.core.nexus_fs import NexusFS
 
 
 def register_commands(cli: click.Group) -> None:
@@ -253,6 +252,8 @@ def find_duplicates(path: str, json_output: bool, backend_config: BackendConfig)
         nexus find-duplicates --json
     """
     try:
+        from nexus.core.nexus_fs import NexusFS
+
         nx = get_filesystem(backend_config)
 
         # Only standalone mode supports batch_get_content_ids
@@ -416,6 +417,8 @@ def search_init(
     import asyncio
 
     try:
+        from nexus.core.nexus_fs import NexusFS
+
         nx = get_filesystem(backend_config)
 
         with console.status("[yellow]Initializing search engine...[/yellow]", spinner="dots"):
@@ -478,6 +481,8 @@ def search_index(
     import asyncio
 
     try:
+        from nexus.core.nexus_fs import NexusFS
+
         nx = get_filesystem(backend_config)
 
         with console.status(f"[yellow]Indexing {path}...[/yellow]", spinner="dots"):
@@ -567,6 +572,8 @@ def search_query(
     import asyncio
 
     try:
+        from nexus.core.nexus_fs import NexusFS
+
         nx = get_filesystem(backend_config)
 
         with console.status(f"[yellow]Searching for: {query}[/yellow]", spinner="dots"):
@@ -630,6 +637,8 @@ def search_stats(backend_config: BackendConfig) -> None:
     import asyncio
 
     try:
+        from nexus.core.nexus_fs import NexusFS
+
         nx = get_filesystem(backend_config)
 
         async def get_stats() -> dict[str, Any]:

--- a/src/nexus/cli/commands/work.py
+++ b/src/nexus/cli/commands/work.py
@@ -14,7 +14,6 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
-from nexus.core.nexus_fs import NexusFS
 
 
 def register_commands(cli: click.Group) -> None:
@@ -52,6 +51,8 @@ def work(
         nexus work ready --json
     """
     try:
+        from nexus.core.nexus_fs import NexusFS
+
         nx = get_filesystem(backend_config)
 
         # Only standalone mode has metadata store with work views

--- a/src/nexus/cli/commands/zone.py
+++ b/src/nexus/cli/commands/zone.py
@@ -33,7 +33,6 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
-from nexus.core.nexus_fs import NexusFS
 
 
 @click.group()
@@ -460,6 +459,7 @@ def export_zone(
         nexus zone export acme-corp -o /backup/acme.nexus --after 2025-01-01T00:00:00
     """
     try:
+        from nexus.core.nexus_fs import NexusFS
         from nexus.portability import ZoneExportOptions, ZoneExportService
 
         # Parse after time if provided
@@ -603,6 +603,7 @@ def import_zone(
         nexus zone import /backup/acme.nexus --dry-run
     """
     try:
+        from nexus.core.nexus_fs import NexusFS
         from nexus.portability import ConflictMode, ZoneImportOptions, ZoneImportService
 
         # Parse path remappings


### PR DESCRIPTION
## Summary
- Moved top-level `from nexus.core.nexus_fs import NexusFS` to function-level lazy imports in 4 CLI command files
- `metadata.py`: lazy import in `info()`, `export_metadata()`, `import_metadata()`
- `zone.py`: lazy import in `export_zone()`, `import_zone()`
- `search.py`: lazy import in `find_duplicates()`, `search_init()`, `search_index()`, `search_query()`, `search_stats()`
- `work.py`: lazy import in `work()`
- `directory.py` and `operations.py` already had function-level imports — no changes needed

This fixes the kernel architecture violation where CLI layer had top-level imports of concrete kernel classes instead of using lazy imports.

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, format)
- [ ] CLI commands still work correctly (isinstance checks preserved at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)