### PR TITLE
fix(#520): skills — change zone ID fallback from "default" to "root"

### DIFF
--- a/src/nexus/skills/importer.py
+++ b/src/nexus/skills/importer.py
@@ -375,7 +375,7 @@ class SkillImporter:
         if not context:
             raise ValueError("Context required for personal/zone tier skills")
 
-        zone_id = context.zone_id or "default"
+        zone_id = context.zone_id or "root"
 
         if tier == "personal":
             # Personal: /zone/{tid}/user/{uid}/skill/{skill_name}/

--- a/src/nexus/skills/manager.py
+++ b/src/nexus/skills/manager.py
@@ -151,7 +151,7 @@ class SkillManager:
 
         try:
             # Get zone_id from context if not provided
-            effective_zone_id = zone_id or (context.zone_id if context else None) or "default"
+            effective_zone_id = zone_id or (context.zone_id if context else None) or "root"
 
             # For user-level skills: Owner gets direct_owner on the skill directory
             # This allows them full control (read, write, delete)
@@ -184,7 +184,7 @@ class SkillManager:
                     subject=("role", "public"),
                     relation="viewer",
                     object=("file", skill_dir.rstrip("/")),
-                    zone_id="default",  # System skills use default zone
+                    zone_id="root",  # System skills use root zone
                 )
                 logger.debug(f"Created public viewer permission on {skill_dir}")
 

--- a/src/nexus/skills/registry.py
+++ b/src/nexus/skills/registry.py
@@ -87,7 +87,7 @@ class SkillRegistry:
         paths = {"system": "/skill/"}
 
         if context:
-            zone_id = context.zone_id or "default"
+            zone_id = context.zone_id or "root"
 
             # Zone-level skills: /zone/{tid}/skill/
             paths["zone"] = f"/zone/{zone_id}/skill/"


### PR DESCRIPTION
## Summary
- Changed hardcoded zone ID fallback from `"default"` to `"root"` in 4 places across 3 skills files
- `skills/manager.py`: 2 instances (permission creation fallback + system skills zone)
- `skills/registry.py`: 1 instance (tier path resolution fallback)
- `skills/importer.py`: 1 instance (skill path computation fallback)
- Per federation-memo.md, canonical zone ID is `"root"` (`ROOT_ZONE_ID` in `raft/zone_manager.py`)

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, format)
- [ ] Existing skills tests still pass (changes only affect fallback when zone_id is None/empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)