### PR TITLE
fix(#479): replace rebac_tracing global singleton with injectable set_tracer()

### DIFF
--- a/src/nexus/server/telemetry.py
+++ b/src/nexus/server/telemetry.py
@@ -147,6 +147,11 @@ def setup_telemetry(
         # Auto-instrument libraries
         _instrument_libraries()
 
+        # Inject rebac tracer into permission tracing module
+        from nexus.services.permissions.rebac_tracing import set_tracer as _set_rebac_tracer
+
+        _set_rebac_tracer(trace.get_tracer("nexus.rebac"))
+
         _initialized = True
         logger.info(
             f"OpenTelemetry initialized: service={_service_name}, "
@@ -339,3 +344,7 @@ def shutdown_telemetry() -> None:
     finally:
         _initialized = False
         _tracer = None
+        # Reset rebac tracer
+        from nexus.services.permissions.rebac_tracing import reset_tracer as _reset_rebac_tracer
+
+        _reset_rebac_tracer()

--- a/src/nexus/services/permissions/rebac_tracing.py
+++ b/src/nexus/services/permissions/rebac_tracing.py
@@ -3,8 +3,8 @@
 Issue #702: OTel tracing for ReBAC permission debugging.
 
 This module provides zero-overhead tracing helpers for the ReBAC permission
-subsystem.  When OTel is disabled (``OTEL_ENABLED != true``), every public
-function reduces to a no-op — no spans, no attributes, no allocations.
+subsystem.  When no tracer is injected, every public function reduces to a
+no-op — no spans, no attributes, no allocations.
 
 Span hierarchy::
 
@@ -19,6 +19,7 @@ authorization (no official semantic convention exists yet).
 Usage::
 
     from nexus.services.permissions.rebac_tracing import (
+        set_tracer,
         start_check_span,
         record_check_result,
         start_cache_lookup_span,
@@ -33,8 +34,6 @@ Usage::
 from __future__ import annotations
 
 import logging
-import os
-import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from typing import Any, TypeVar
@@ -44,46 +43,30 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Module-level lazy tracer (Decision #3A — zero overhead when disabled)
+# Injectable tracer (server layer calls set_tracer() at startup)
 # ---------------------------------------------------------------------------
 
-_tracer_resolved = False
 _tracer: Any = None  # opentelemetry.trace.Tracer | None
-_tracer_lock = threading.Lock()
+
+
+def set_tracer(tracer: Any) -> None:
+    """Inject a tracer instance.
+
+    Called by the server layer (``setup_telemetry()``) at startup.
+    When not called, all tracing helpers are no-ops.
+    """
+    global _tracer
+    _tracer = tracer
 
 
 def _get_tracer() -> Any:
-    """Return a cached tracer instance, or *None* when OTel is disabled.
-
-    Thread-safe via double-checked locking: the fast path (already resolved)
-    requires no lock acquisition.
-    """
-    global _tracer_resolved, _tracer
-    if _tracer_resolved:
-        return _tracer
-    with _tracer_lock:
-        if not _tracer_resolved:
-            _tracer = _resolve_tracer()
-            _tracer_resolved = True
+    """Return the injected tracer, or *None* when tracing is disabled."""
     return _tracer
 
 
-def _resolve_tracer() -> Any:
-    """Resolve tracer without importing from server layer."""
-    if os.environ.get("OTEL_ENABLED", "false").lower() not in ("true", "1", "yes"):
-        return None
-    try:
-        from opentelemetry import trace
-
-        return trace.get_tracer("nexus.rebac")
-    except ImportError:
-        return None
-
-
 def reset_tracer() -> None:
-    """Reset cached tracer — only for tests."""
-    global _tracer_resolved, _tracer
-    _tracer_resolved = False
+    """Reset tracer to None — only for tests."""
+    global _tracer
     _tracer = None
 
 

--- a/tests/integration/test_rebac_otel_integration.py
+++ b/tests/integration/test_rebac_otel_integration.py
@@ -142,10 +142,9 @@ def otel_exporter():
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
 
-    # Inject tracer directly into rebac_tracing module
+    # Inject tracer via set_tracer (DI pattern)
     tracer = provider.get_tracer("nexus.rebac")
-    _rebac_tracing_mod._tracer = tracer
-    _rebac_tracing_mod._tracer_resolved = True
+    _rebac_tracing_mod.set_tracer(tracer)
 
     yield exporter
 
@@ -254,8 +253,7 @@ class TestRealPermissionCheckSpans:
     def test_no_spans_when_otel_disabled(self, manager):
         """When no TracerProvider is configured, no spans should be created."""
         # Ensure tracer is None (OTel disabled)
-        _rebac_tracing_mod._tracer = None
-        _rebac_tracing_mod._tracer_resolved = True
+        _rebac_tracing_mod.reset_tracer()
 
         manager.rebac_write(
             subject=("user", "bob"),

--- a/tests/unit/services/permissions/test_rebac_tracing.py
+++ b/tests/unit/services/permissions/test_rebac_tracing.py
@@ -560,29 +560,33 @@ class TestEngineAttribute:
 # ---------------------------------------------------------------------------
 
 
-class TestTracerCaching:
-    """Test that _get_tracer() caches its result."""
+class TestTracerInjection:
+    """Test set_tracer / _get_tracer / reset_tracer lifecycle."""
 
-    def test_tracer_resolved_once(self):
+    def test_set_tracer_makes_it_available(self):
         mock_tracer = MagicMock()
-        resolve_tracer = MagicMock(return_value=mock_tracer)
+        rebac_tracing.set_tracer(mock_tracer)
 
-        with patch.object(rebac_tracing, "_resolve_tracer", resolve_tracer):
-            rebac_tracing.reset_tracer()
-            t1 = rebac_tracing._get_tracer()
-            t2 = rebac_tracing._get_tracer()
+        assert rebac_tracing._get_tracer() is mock_tracer
 
-        assert t1 is mock_tracer
-        assert t2 is mock_tracer
-        assert resolve_tracer.call_count == 1  # Only resolved once
+    def test_get_tracer_returns_none_by_default(self):
+        rebac_tracing.reset_tracer()
+        assert rebac_tracing._get_tracer() is None
 
-    def test_reset_allows_re_resolution(self):
-        resolve_tracer = MagicMock(side_effect=[MagicMock(), MagicMock()])
+    def test_reset_clears_tracer(self):
+        mock_tracer = MagicMock()
+        rebac_tracing.set_tracer(mock_tracer)
+        assert rebac_tracing._get_tracer() is mock_tracer
 
-        with patch.object(rebac_tracing, "_resolve_tracer", resolve_tracer):
-            rebac_tracing.reset_tracer()
-            rebac_tracing._get_tracer()
-            rebac_tracing.reset_tracer()
-            rebac_tracing._get_tracer()
+        rebac_tracing.reset_tracer()
+        assert rebac_tracing._get_tracer() is None
 
-        assert resolve_tracer.call_count == 2
+    def test_set_tracer_overwrites_previous(self):
+        tracer_a = MagicMock()
+        tracer_b = MagicMock()
+
+        rebac_tracing.set_tracer(tracer_a)
+        assert rebac_tracing._get_tracer() is tracer_a
+
+        rebac_tracing.set_tracer(tracer_b)
+        assert rebac_tracing._get_tracer() is tracer_b


### PR DESCRIPTION
## Summary
- Replaced global singleton pattern (`_tracer_resolved`, `_tracer_lock`, `_resolve_tracer()`) in `rebac_tracing.py` with injectable `set_tracer()` / `_get_tracer()` pattern
- Removed direct `os.environ.get("OTEL_ENABLED")` read from services layer — server layer now injects tracer via `setup_telemetry()`
- Updated `server/telemetry.py` to inject rebac tracer at startup and reset on shutdown
- Updated unit and integration tests to use `set_tracer()` / `reset_tracer()` instead of poking private module state

## Test plan
- [ ] Verify unit tests pass (`pytest tests/unit/services/permissions/test_rebac_tracing.py`)
- [ ] Verify integration tests pass (`pytest tests/integration/test_rebac_otel_integration.py`)
- [ ] Verify OTel tracing works end-to-end when `OTEL_ENABLED=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)