### PR TITLE
fix(#521): change hardcoded zone ID default from "default" to "root" in IPC modules

### DIFF
--- a/src/nexus/ipc/delivery.py
+++ b/src/nexus/ipc/delivery.py
@@ -66,7 +66,7 @@ class MessageSender:
         self,
         vfs: VFSOperations,
         event_publisher: EventPublisher | None = None,
-        zone_id: str = "default",
+        zone_id: str = "root",
         max_inbox_size: int = DEFAULT_MAX_INBOX_SIZE,
         max_payload_bytes: int = DEFAULT_MAX_PAYLOAD_BYTES,
     ) -> None:
@@ -222,7 +222,7 @@ class MessageProcessor:
         vfs: VFSOperations,
         agent_id: str,
         handler: MessageHandler,
-        zone_id: str = "default",
+        zone_id: str = "root",
         max_dedup_size: int = 10_000,
     ) -> None:
         self._vfs = vfs

--- a/src/nexus/ipc/discovery.py
+++ b/src/nexus/ipc/discovery.py
@@ -54,7 +54,7 @@ class AgentDiscovery:
     def __init__(
         self,
         vfs: VFSOperations,
-        zone_id: str = "default",
+        zone_id: str = "root",
         cache_ttl_seconds: float = 10.0,
     ) -> None:
         self._vfs = vfs

--- a/src/nexus/ipc/driver.py
+++ b/src/nexus/ipc/driver.py
@@ -53,7 +53,7 @@ class IPCVFSDriver(Backend):
     def __init__(
         self,
         storage: IPCStorageDriver,
-        zone_id: str = "default",
+        zone_id: str = "root",
         event_publisher: Any | None = None,
         max_inbox_size: int = 1000,
     ) -> None:

--- a/src/nexus/ipc/provisioning.py
+++ b/src/nexus/ipc/provisioning.py
@@ -34,7 +34,7 @@ class AgentProvisioner:
         zone_id: Zone ID for multi-zone isolation.
     """
 
-    def __init__(self, vfs: VFSOperations, zone_id: str = "default") -> None:
+    def __init__(self, vfs: VFSOperations, zone_id: str = "root") -> None:
         self._vfs = vfs
         self._zone_id = zone_id
 

--- a/src/nexus/ipc/sweep.py
+++ b/src/nexus/ipc/sweep.py
@@ -37,7 +37,7 @@ class TTLSweeper:
     def __init__(
         self,
         vfs: VFSOperations,
-        zone_id: str = "default",
+        zone_id: str = "root",
         interval: float = DEFAULT_SWEEP_INTERVAL,
     ) -> None:
         self._vfs = vfs


### PR DESCRIPTION
## Summary
- Changed 6 hardcoded `zone_id="default"` parameter defaults to `zone_id="root"` across all IPC modules
- Aligns with federation-memo.md canonical zone ID (`ROOT_ZONE_ID = "root"` in `raft/zone_manager.py`)
- Files changed: `delivery.py` (2), `sweep.py` (1), `discovery.py` (1), `provisioning.py` (1), `driver.py` (1)

## Test plan
- [x] Verified no tests pass `zone_id="default"` explicitly (tests unaffected by default change)
- [x] All pre-commit hooks pass (ruff, mypy, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)