### PR TITLE
fix(#522): change hardcoded zone ID default from "default" to "root" in A2A modules

### DIFF
--- a/src/nexus/a2a/db.py
+++ b/src/nexus/a2a/db.py
@@ -39,7 +39,7 @@ class A2ATaskModel(Base):
     context_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
 
     # Multi-tenant isolation
-    zone_id: Mapped[str] = mapped_column(String(128), nullable=False, default="default")
+    zone_id: Mapped[str] = mapped_column(String(128), nullable=False, default="root")
     agent_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     # Task state (TaskState enum value)

--- a/src/nexus/a2a/task_manager.py
+++ b/src/nexus/a2a/task_manager.py
@@ -80,7 +80,7 @@ class TaskManager:
         self,
         message: Message,
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
         agent_id: str | None = None,
         context_id: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -107,7 +107,7 @@ class TaskManager:
         self,
         task_id: str,
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
         history_length: int | None = None,
     ) -> Task:
         """Retrieve a task by ID.
@@ -129,7 +129,7 @@ class TaskManager:
     async def list_tasks(
         self,
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
         agent_id: str | None = None,
         state: TaskState | None = None,
         limit: int = 50,
@@ -148,7 +148,7 @@ class TaskManager:
         self,
         task_id: str,
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> Task:
         """Cancel a task.
 
@@ -174,7 +174,7 @@ class TaskManager:
         task_id: str,
         new_state: TaskState,
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
         message: Message | None = None,
     ) -> Task:
         """Transition a task to a new state.
@@ -224,7 +224,7 @@ class TaskManager:
         task_id: str,
         artifact: Artifact,
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
         append: bool = True,
     ) -> Task:
         """Add an artifact to a task.


### PR DESCRIPTION
## Summary
- Changed 6 `zone_id: str = "default"` parameter defaults to `zone_id: str = "root"` in `task_manager.py`
- Changed 1 SQLAlchemy column default from `"default"` to `"root"` in `db.py`
- Aligns with federation-memo.md canonical zone ID (`ROOT_ZONE_ID = "root"`)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [x] Changes are parameter defaults only — callers passing explicit zone_id are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)