### PR TITLE
fix(#504): change 11 hardcoded zone ID defaults from "default" to "root" in pay/credits.py

### DIFF
--- a/src/nexus/pay/credits.py
+++ b/src/nexus/pay/credits.py
@@ -164,7 +164,7 @@ class CreditsService:
         currency: str = "credits",
         status: str,
         application: str = "gateway",
-        zone_id: str = "default",
+        zone_id: str = "root",
         trace_id: str | None = None,
         transfer_id: str | None = None,
     ) -> None:
@@ -268,7 +268,7 @@ class CreditsService:
                 # Log but don't fail - system might still work
                 pass
 
-    def _to_tb_id(self, agent_id: str, zone_id: str = "default") -> int:
+    def _to_tb_id(self, agent_id: str, zone_id: str = "root") -> int:
         """Convert agent_id to TigerBeetle account ID."""
         return make_tb_account_id(zone_id, agent_id)
 
@@ -289,7 +289,7 @@ class CreditsService:
     # Balance Operations
     # =========================================================================
 
-    async def get_balance(self, agent_id: str, zone_id: str = "default") -> Decimal:
+    async def get_balance(self, agent_id: str, zone_id: str = "root") -> Decimal:
         """Get available balance (credits_posted - debits_posted).
 
         Args:
@@ -314,7 +314,7 @@ class CreditsService:
         return Decimal(str(micro_to_credits(micro_balance)))
 
     async def get_balance_with_reserved(
-        self, agent_id: str, zone_id: str = "default"
+        self, agent_id: str, zone_id: str = "root"
     ) -> tuple[Decimal, Decimal]:
         """Get available balance and reserved (pending) amount.
 
@@ -352,7 +352,7 @@ class CreditsService:
         *,
         memo: str = "",  # noqa: ARG002 - stored in PostgreSQL, not TigerBeetle
         idempotency_key: str | None = None,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> str:
         """Execute atomic credit transfer between agents.
 
@@ -449,7 +449,7 @@ class CreditsService:
         source: str,  # noqa: ARG002 - stored in PostgreSQL metadata
         *,
         external_tx_id: str | None = None,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> str:
         """Add credits from external source (treasury -> agent).
 
@@ -515,7 +515,7 @@ class CreditsService:
         amount: Decimal,
         timeout_seconds: int = 300,
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> str:
         """Reserve credits for a pending operation.
 
@@ -706,7 +706,7 @@ class CreditsService:
         amount: Decimal,
         *,
         code: int = TRANSFER_CODE_API_USAGE,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> bool:
         """Fast credit deduction for API metering / rate limiting.
 
@@ -761,7 +761,7 @@ class CreditsService:
         self,
         transfers: list[TransferRequest],
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> list[str]:
         """Execute atomic batch transfer - all succeed or all fail.
 
@@ -837,7 +837,7 @@ class CreditsService:
     async def provision_wallet(
         self,
         agent_id: str,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> None:
         """Create TigerBeetle account for a new agent.
 
@@ -877,7 +877,7 @@ class CreditsService:
         agent_id: str,
         amount: Decimal,
         *,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> bool:
         """Check if agent has sufficient balance for an amount.
 


### PR DESCRIPTION
## Summary
- Changed 11 `zone_id: str = "default"` parameter defaults to `zone_id: str = "root"` in `pay/credits.py`
- Aligns with federation-memo.md canonical zone ID (`ROOT_ZONE_ID = "root"`)
- Affects: `_audit_transfer`, `_to_tb_id`, `get_balance`, `get_balance_with_reserved`, `transfer`, `topup`, `reserve`, `deduct_fast`, `transfer_batch`, `provision_wallet`, `check_budget`

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [x] Changes are parameter defaults only — callers passing explicit zone_id are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)