### PR TITLE
fix(#497): replace workflow engine lazy singleton with injectable DI

### DIFF
--- a/src/nexus/workflows/__init__.py
+++ b/src/nexus/workflows/__init__.py
@@ -7,7 +7,7 @@ data transformation, and multi-step operations.
 
 from nexus.workflows.actions import BUILTIN_ACTIONS, BaseAction
 from nexus.workflows.api import WorkflowAPI, get_workflow_api
-from nexus.workflows.engine import WorkflowEngine, get_engine, init_engine
+from nexus.workflows.engine import WorkflowEngine, get_engine, init_engine, reset_engine, set_engine
 from nexus.workflows.loader import WorkflowLoader
 from nexus.workflows.storage import WorkflowStore
 from nexus.workflows.triggers import BUILTIN_TRIGGERS, BaseTrigger, TriggerManager
@@ -34,6 +34,8 @@ __all__ = [
     # Engine functions
     "get_engine",
     "init_engine",
+    "set_engine",
+    "reset_engine",
     # Types
     "WorkflowDefinition",
     "WorkflowAction",

--- a/src/nexus/workflows/api.py
+++ b/src/nexus/workflows/api.py
@@ -4,7 +4,7 @@ import builtins
 from pathlib import Path
 from typing import Any
 
-from nexus.workflows.engine import WorkflowEngine, get_engine
+from nexus.workflows.engine import WorkflowEngine, get_engine, init_engine
 from nexus.workflows.loader import WorkflowLoader
 from nexus.workflows.types import (
     TriggerType,
@@ -46,9 +46,9 @@ class WorkflowAPI:
 
         Args:
             engine: Optional workflow engine instance. If not provided,
-                   uses the global engine.
+                   uses the injected engine or creates a default one.
         """
-        self.engine = engine or get_engine()
+        self.engine = engine or get_engine() or init_engine()
 
     def load(self, source: str | Path | dict | WorkflowDefinition, enabled: bool = True) -> bool:
         """Load a workflow from a file, dict, or definition.

--- a/src/nexus/workflows/engine.py
+++ b/src/nexus/workflows/engine.py
@@ -425,20 +425,32 @@ class WorkflowEngine:
         return await self.trigger_manager.fire_event(trigger_type, event_context)
 
 
-# Global workflow engine instance
+# Injectable workflow engine instance (set by server/factory layer at startup)
 _engine: WorkflowEngine | None = None
 
 
-def get_engine() -> WorkflowEngine:
-    """Get the global workflow engine instance."""
+def set_engine(engine: WorkflowEngine) -> None:
+    """Inject a workflow engine instance. Called by server/factory layer at startup."""
     global _engine
-    if _engine is None:
-        _engine = WorkflowEngine()
+    _engine = engine
+
+
+def get_engine() -> WorkflowEngine | None:
+    """Return the injected workflow engine, or None if not initialized."""
     return _engine
 
 
+def reset_engine() -> None:
+    """Reset engine to None — only for tests."""
+    global _engine
+    _engine = None
+
+
 def init_engine(metadata_store=None, plugin_registry=None, workflow_store=None) -> WorkflowEngine:  # type: ignore[no-untyped-def]
-    """Initialize the workflow engine.
+    """Create and inject a workflow engine.
+
+    Convenience helper that creates a WorkflowEngine with the given
+    stores and registers it via ``set_engine()``.
 
     Args:
         metadata_store: Metadata store instance
@@ -448,6 +460,6 @@ def init_engine(metadata_store=None, plugin_registry=None, workflow_store=None) 
     Returns:
         Initialized workflow engine
     """
-    global _engine
-    _engine = WorkflowEngine(metadata_store, plugin_registry, workflow_store)
-    return _engine
+    engine = WorkflowEngine(metadata_store, plugin_registry, workflow_store)
+    set_engine(engine)
+    return engine

--- a/tests/unit/workflows/test_engine.py
+++ b/tests/unit/workflows/test_engine.py
@@ -4,7 +4,7 @@ import uuid
 
 import pytest
 
-from nexus.workflows.engine import WorkflowEngine, get_engine, init_engine
+from nexus.workflows.engine import WorkflowEngine, get_engine, init_engine, reset_engine, set_engine
 from nexus.workflows.types import (
     TriggerType,
     WorkflowAction,
@@ -340,23 +340,40 @@ class TestWorkflowEngine:
         assert execution.action_results[1].output == 84
 
 
-class TestEngineGlobals:
-    """Test global engine functions."""
+class TestEngineInjection:
+    """Test injectable engine functions."""
 
-    def test_get_engine(self):
-        """Test getting global engine instance."""
-        engine1 = get_engine()
-        engine2 = get_engine()
-        assert engine1 is engine2
+    def test_get_engine_returns_none_by_default(self):
+        """Test that get_engine returns None when no engine is set."""
+        reset_engine()
+        assert get_engine() is None
+
+    def test_set_engine_makes_it_available(self):
+        """Test that set_engine makes the engine available via get_engine."""
+        engine = WorkflowEngine()
+        set_engine(engine)
+        assert get_engine() is engine
+        reset_engine()
+
+    def test_reset_clears_engine(self):
+        """Test that reset_engine clears the injected engine."""
+        engine = WorkflowEngine()
+        set_engine(engine)
+        assert get_engine() is engine
+        reset_engine()
+        assert get_engine() is None
 
     def test_init_engine(self):
-        """Test initializing global engine."""
+        """Test initializing and injecting engine."""
+        reset_engine()
         engine = init_engine()
         assert engine is not None
         assert get_engine() is engine
+        reset_engine()
 
     def test_init_engine_with_stores(self):
         """Test initializing engine with stores."""
+        reset_engine()
         mock_metadata_store = object()
         mock_workflow_store = object()
 
@@ -364,3 +381,15 @@ class TestEngineGlobals:
         assert engine.metadata_store is mock_metadata_store
         assert engine.plugin_registry is None
         assert engine.workflow_store is mock_workflow_store
+        assert get_engine() is engine
+        reset_engine()
+
+    def test_set_engine_overwrites_previous(self):
+        """Test that set_engine overwrites previous engine."""
+        engine_a = WorkflowEngine()
+        engine_b = WorkflowEngine()
+        set_engine(engine_a)
+        assert get_engine() is engine_a
+        set_engine(engine_b)
+        assert get_engine() is engine_b
+        reset_engine()


### PR DESCRIPTION
## Summary
- Removed lazy `WorkflowEngine()` creation from `get_engine()` — now returns `None` when no engine is injected
- Added `set_engine()` for explicit injection and `reset_engine()` for test cleanup
- `init_engine()` now delegates to `set_engine()` under the hood
- `WorkflowAPI.__init__` falls back to `init_engine()` only when no engine is available (preserves backward compatibility for CLI usage)
- Exported `set_engine` and `reset_engine` from `workflows/__init__.py`
- Tests replaced `TestEngineGlobals` with `TestEngineInjection` covering full set/get/reset lifecycle

## Test plan
- [ ] CI passes (ruff, mypy, unit tests)
- [ ] Verify `init_engine()` still works for factory.py and CLI callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)