### PR TITLE
fix(#513): change 6 hardcoded zone ID fallbacks from "default" to "root" in subscriptions router

### DIFF
--- a/src/nexus/server/api/v1/routers/subscriptions.py
+++ b/src/nexus/server/api/v1/routers/subscriptions.py
@@ -41,7 +41,7 @@ async def create_subscription(
 
     body = await request.json()
     data = SubscriptionCreate(**body)
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
     created_by = auth_result.get("subject_id")
 
     subscription = subscription_manager.create(
@@ -61,7 +61,7 @@ async def list_subscriptions(
     subscription_manager: Any = Depends(get_subscription_manager),
 ) -> JSONResponse:
     """List webhook subscriptions for the current zone."""
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
     subscriptions = subscription_manager.list_subscriptions(
         zone_id=zone_id,
         enabled_only=enabled_only,
@@ -80,7 +80,7 @@ async def get_subscription(
     subscription_manager: Any = Depends(get_subscription_manager),
 ) -> JSONResponse:
     """Get a webhook subscription by ID."""
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
     subscription = subscription_manager.get(subscription_id, zone_id)
     if subscription is None:
         raise HTTPException(status_code=404, detail="Subscription not found")
@@ -99,7 +99,7 @@ async def update_subscription(
 
     body = await request.json()
     data = SubscriptionUpdate(**body)
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
 
     subscription = subscription_manager.update(
         subscription_id=subscription_id,
@@ -118,7 +118,7 @@ async def delete_subscription(
     subscription_manager: Any = Depends(get_subscription_manager),
 ) -> JSONResponse:
     """Delete a webhook subscription."""
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
     deleted = subscription_manager.delete(subscription_id, zone_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Subscription not found")
@@ -132,6 +132,6 @@ async def test_subscription(
     subscription_manager: Any = Depends(get_subscription_manager),
 ) -> JSONResponse:
     """Send a test event to a webhook subscription."""
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
     result = await subscription_manager.test(subscription_id, zone_id)
     return JSONResponse(content=result)


### PR DESCRIPTION
## Summary
- Changed 6 `auth_result.get("zone_id") or "default"` fallbacks to `or "root"` in `server/api/v1/routers/subscriptions.py`
- Aligns with federation-memo.md canonical zone ID (`ROOT_ZONE_ID = "root"`)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)