### PR TITLE
fix(#514): change 5 hardcoded zone ID fallbacks from "default" to "root" in locks router

### DIFF
--- a/src/nexus/server/api/v1/routers/locks.py
+++ b/src/nexus/server/api/v1/routers/locks.py
@@ -48,7 +48,7 @@ async def acquire_lock(
     Supports both mutex (max_holders=1) and semaphore (max_holders>1) modes.
     Use blocking=false for non-blocking acquisition (returns immediately).
     """
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
 
     # Normalize path to ensure leading slash
     path = request.path if request.path.startswith("/") else "/" + request.path
@@ -107,7 +107,7 @@ async def list_locks(
     lock_manager: Any = Depends(get_lock_manager),
 ) -> LockListResponse:
     """List active locks for the current zone."""
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
 
     lock_infos = await lock_manager.list_locks(zone_id, pattern=pattern, limit=limit)
 
@@ -153,7 +153,7 @@ async def get_lock_status(
     lock_manager: Any = Depends(get_lock_manager),
 ) -> LockStatusResponse:
     """Get lock status for a specific path."""
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
 
     # Normalize path to ensure leading slash (URL path captures without leading /)
     if not path.startswith("/"):
@@ -206,7 +206,7 @@ async def release_lock(
     The lock_id must match the ID returned during acquisition.
     Use force=true for admin recovery of stuck locks (requires admin role).
     """
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
 
     # Normalize path to ensure leading slash (URL path captures without leading /)
     if not path.startswith("/"):
@@ -243,7 +243,7 @@ async def extend_lock(
     Call this periodically (e.g., every TTL/2) to keep long-running
     operations alive. The lock must be owned by the caller (lock_id match).
     """
-    zone_id = auth_result.get("zone_id") or "default"
+    zone_id = auth_result.get("zone_id") or "root"
 
     # Normalize path to ensure leading slash (URL path captures without leading /)
     if not path.startswith("/"):


### PR DESCRIPTION
## Summary
- Changed 5 `auth_result.get("zone_id") or "default"` fallbacks to `or "root"` in `server/api/v1/routers/locks.py`
- Aligns with federation-memo.md canonical zone ID (`ROOT_ZONE_ID = "root"`)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)