### PR TITLE
fix: replace private _permission_enforcer access in fuse/mount with public property

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -454,6 +454,14 @@ class NexusFS(  # type: ignore[misc]
         """Public accessor for the underlying MetadataCache on the metadata store."""
         return getattr(self.metadata, "_cache", None)
 
+    @property
+    def namespace_manager(self) -> Any | None:
+        """Public accessor for the NamespaceManager (via PermissionEnforcer)."""
+        enforcer = self._permission_enforcer
+        if enforcer is not None:
+            return getattr(enforcer, "namespace_manager", None)
+        return None
+
     def _init_performance_optimizations(self) -> None:
         """Initialize performance optimizations for permission checks.
 

--- a/src/nexus/fuse/mount.py
+++ b/src/nexus/fuse/mount.py
@@ -169,12 +169,7 @@ class NexusFUSE:
             )
 
             # A2-B: Try to obtain NamespaceManager for direct visibility checks
-            try:
-                enforcer = getattr(self.nexus_fs, "_permission_enforcer", None)
-                if enforcer is not None:
-                    namespace_manager = getattr(enforcer, "namespace_manager", None)
-            except Exception:
-                pass  # Not available — fallback to is_directory() proxy
+            namespace_manager = getattr(self.nexus_fs, "namespace_manager", None)
 
         # Create FUSE operations
         operations = NexusFUSEOperations(


### PR DESCRIPTION
## Summary
- Add `NexusFS.namespace_manager` public property that returns the NamespaceManager from the PermissionEnforcer (or None)
- Replace `getattr(self.nexus_fs, "_permission_enforcer", None)` → `getattr(enforcer, "namespace_manager", None)` chain in `fuse/mount.py` with the new public property

## Test plan
- [ ] Existing FUSE mount tests pass (namespace-scoped mounts still resolve NamespaceManager)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)