### PR TITLE
fix(#371): remove FUSE→server layer inversion and private metadata access

### DIFF
--- a/src/nexus/fuse/mount.py
+++ b/src/nexus/fuse/mount.py
@@ -178,6 +178,7 @@ class NexusFUSE:
 
         # Create FUSE operations
         event_bus = getattr(self.nexus_fs, "_event_bus", None)
+        subscription_manager = getattr(self.nexus_fs, "subscription_manager", None)
         operations = NexusFUSEOperations(
             self.nexus_fs,
             self.mode,
@@ -185,6 +186,7 @@ class NexusFUSE:
             context=context,
             namespace_manager=namespace_manager,
             event_bus=event_bus,
+            subscription_manager=subscription_manager,
         )
 
         # Issue #1115: Set up event loop for async event dispatch

--- a/src/nexus/fuse/operations.py
+++ b/src/nexus/fuse/operations.py
@@ -190,6 +190,7 @@ class NexusFUSEOperations(Operations):
         context: OperationContext | None = None,
         namespace_manager: NamespaceManager | None = None,
         event_bus: Any | None = None,
+        subscription_manager: Any | None = None,
     ) -> None:
         """Initialize FUSE operations.
 
@@ -209,12 +210,15 @@ class NexusFUSEOperations(Operations):
                     checks (A2-B). When provided, _check_namespace_visible() bypasses the
                     full RPC/PermissionEnforcer pipeline and calls is_visible() directly.
             event_bus: Optional EventBusBase instance for distributing file events.
+            subscription_manager: Optional subscription manager for webhook broadcasts.
+                    Injected from server layer to avoid FUSE→server layer inversion.
         """
         self.nexus_fs = nexus_fs
         self.mode = mode
         self._context = context
         self._namespace_manager = namespace_manager
         self._event_bus = event_bus
+        self._subscription_manager = subscription_manager
         self.fd_counter = 0
         self.open_files: dict[int, dict[str, Any]] = {}
         self._files_lock = threading.RLock()
@@ -410,12 +414,9 @@ class NexusFUSEOperations(Operations):
                 except Exception as e:
                     logger.debug(f"[FUSE-EVENT] Event bus publish failed: {e}")
 
-            # 2. Broadcast to webhook subscriptions
-            # Import here to avoid circular imports
+            # 2. Broadcast to webhook subscriptions via injected manager
             try:
-                from nexus.server.subscriptions import get_subscription_manager
-
-                sub_manager = get_subscription_manager()
+                sub_manager = self._subscription_manager
                 if sub_manager is not None:
                     event_type_str = (
                         event.type.value if hasattr(event.type, "value") else str(event.type)
@@ -430,8 +431,6 @@ class NexusFUSEOperations(Operations):
                         },
                         zone_id=event.zone_id or "default",
                     )
-            except ImportError:
-                pass  # Subscription manager not available
             except Exception as e:
                 logger.debug(f"[FUSE-EVENT] Webhook broadcast failed: {e}")
 
@@ -1562,11 +1561,6 @@ class NexusFUSEOperations(Operations):
             if metadata_dict:
                 # C2-B: Use module-level frozen dataclass instead of inner class
                 return MetadataObj.from_dict(metadata_dict)
-            return None
-
-        # Fall back to direct metadata access (for local NexusFS)
-        if hasattr(self.nexus_fs, "metadata"):
-            return self.nexus_fs.metadata.get(path)
 
         return None
 


### PR DESCRIPTION
## Summary
- Inject `subscription_manager` via constructor instead of runtime `from nexus.server.subscriptions import get_subscription_manager` (FUSE→server layer inversion)
- Remove dead-code fallback to `nexus_fs.metadata.get()` (private attribute access across module boundary)
- Pass `subscription_manager` from `mount.py` using existing public `NexusFS.subscription_manager` attribute

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] `grep -r "from nexus.server" src/nexus/fuse/` returns no results
- [x] `grep "nexus_fs.metadata.get" src/nexus/fuse/` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)