### PR TITLE
fix(#589): replace hardcoded default zone_id with ROOT_ZONE_ID in FUSE ops

### DIFF
--- a/src/nexus/fuse/operations.py
+++ b/src/nexus/fuse/operations.py
@@ -30,6 +30,7 @@ from nexus.core.virtual_views import (
     should_add_virtual_views,
 )
 from nexus.fuse.cache import FUSECacheManager
+from nexus.raft.zone_manager import ROOT_ZONE_ID
 
 # Import readahead for sequential read optimization (Issue #1073)
 try:
@@ -428,7 +429,7 @@ class NexusFUSEOperations(Operations):
                             "size": event.size,
                             "timestamp": event.timestamp,
                         },
-                        zone_id=event.zone_id or "default",
+                        zone_id=event.zone_id or ROOT_ZONE_ID,
                     )
             except ImportError:
                 pass  # Subscription manager not available


### PR DESCRIPTION
## Summary
- Replace hardcoded `"default"` zone_id fallback with `ROOT_ZONE_ID` constant from `nexus.raft.zone_manager`
- Per federation-memo.md §6.5: all code MUST import `ROOT_ZONE_ID` — never hardcode `"root"` or `"default"`

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] No hardcoded `"default"` zone_id remaining in `src/nexus/fuse/operations.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)