### PR TITLE
fix(#587): replace hardcoded default with ROOT_ZONE_ID in raft zone resolver

### DIFF
--- a/src/nexus/raft/zone_aware_metadata.py
+++ b/src/nexus/raft/zone_aware_metadata.py
@@ -5,7 +5,7 @@ correct zone's RaftMetadataStore via ZonePathResolver.
 
 Usage:
     # Create from ZoneManager
-    proxy = ZoneAwareMetadataStore.from_zone_manager(zone_manager, root_zone_id="default")
+    proxy = ZoneAwareMetadataStore.from_zone_manager(zone_manager, root_zone_id=ROOT_ZONE_ID)
 
     # Inject into NexusFS — no NexusFS changes needed
     fs = NexusFS(backend=backend, metadata_store=proxy)

--- a/src/nexus/raft/zone_path_resolver.py
+++ b/src/nexus/raft/zone_path_resolver.py
@@ -19,6 +19,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from nexus.raft.zone_manager import ROOT_ZONE_ID
+
 if TYPE_CHECKING:
     from nexus.raft.zone_manager import ZoneManager
     from nexus.storage.raft_metadata_store import RaftMetadataStore
@@ -50,12 +52,12 @@ class ZonePathResolver:
     """Resolve paths across zone boundaries via DT_MOUNT entries.
 
     Usage:
-        resolver = ZonePathResolver(zone_manager, root_zone_id="default")
+        resolver = ZonePathResolver(zone_manager, root_zone_id=ROOT_ZONE_ID)
         resolved = resolver.resolve("/shared/docs/file.txt")
         metadata = resolved.store.get(resolved.path)
     """
 
-    def __init__(self, zone_manager: ZoneManager, root_zone_id: str = "default"):
+    def __init__(self, zone_manager: ZoneManager, root_zone_id: str = ROOT_ZONE_ID):
         self._zone_manager = zone_manager
         self._root_zone_id = root_zone_id
 


### PR DESCRIPTION
## Summary
- Fix critical self-contradiction: `ZonePathResolver` defaulted to `"default"` while `ROOT_ZONE_ID = "root"` in `zone_manager.py`
- Replace hardcoded `"default"` parameter default and docstring examples with `ROOT_ZONE_ID` constant
- Also fix docstring in `zone_aware_metadata.py` that referenced `"default"`

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] No hardcoded `"default"` zone_id remaining in raft zone resolver files

🤖 Generated with [Claude Code](https://claude.com/claude-code)