### PR TITLE
ci: temporarily disable Docker integration workflow

### DIFF
--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -1,5 +1,7 @@
 name: Docker Integration Test
 
+# TEMPORARILY DISABLED - TODO: Re-enable later. See https://github.com/nexi-lab/nexus/issues/1720
+
 # Required GitHub Secrets:
 # - ANTHROPIC_API_KEY: Claude API key for AI integration testing
 # - NEXUS_GCS_CREDENTIALS: GCS service account JSON credentials (content of gcs-credentials.json)
@@ -35,6 +37,7 @@ concurrency:
 
 jobs:
   docker-build-and-init:
+    if: false  # Re-enable when addressing https://github.com/nexi-lab/nexus/issues/1720
     name: Docker Build & Init Test
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

Disables the Docker integration test workflow so it no longer runs on push/PR. The workflow is left in place with `if: false` on the job so it can be re-enabled easily.

## Tracking

- **Re-enable tracked in:** #1720
- To turn the workflow back on: remove the `if: false` line from `.github/workflows/docker-integration.yml` (see issue for TODO list).