### PR TITLE
fix(#560): change _extract_zone_id fallback from "default" to "root" in a2a/router.py

### DIFF
--- a/src/nexus/a2a/router.py
+++ b/src/nexus/a2a/router.py
@@ -229,7 +229,7 @@ def _extract_zone_id(auth_result: dict[str, Any] | None) -> str:
     if auth_result and auth_result.get("zone_id"):
         zone_id: str = auth_result["zone_id"]
         return zone_id
-    return "default"
+    return "root"
 
 
 def _extract_agent_id(auth_result: dict[str, Any] | None) -> str | None:


### PR DESCRIPTION
## Summary
- Changed `_extract_zone_id()` fallback return value from `"default"` to `"root"`
- Aligns with federation-memo.md canonical zone ID (`ROOT_ZONE_ID = "root"`)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)