### PR TITLE
fix(#588): replace hardcoded default zone_id with ROOT_ZONE_ID in workflows

### DIFF
--- a/src/nexus/workflows/engine.py
+++ b/src/nexus/workflows/engine.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
+from nexus.raft.zone_manager import ROOT_ZONE_ID
 from nexus.workflows.actions import BUILTIN_ACTIONS
 from nexus.workflows.triggers import BUILTIN_TRIGGERS, TriggerManager
 from nexus.workflows.types import (
@@ -279,12 +280,12 @@ class WorkflowEngine:
             logger.warning(f"No workflow_id found for {workflow_name}, using generated UUID")
 
         # Get zone_id from event context or workflow store
-        zone_id_str = event_context.get("zone_id", "default")
+        zone_id_str = event_context.get("zone_id", ROOT_ZONE_ID)
         try:
             # Try to convert to UUID if it's a valid UUID string
             import uuid as uuid_module
 
-            zone_id = uuid_module.UUID(zone_id_str) if zone_id_str != "default" else None
+            zone_id = uuid_module.UUID(zone_id_str) if zone_id_str != ROOT_ZONE_ID else None
         except (ValueError, AttributeError):
             # If not a valid UUID, use None or default
             zone_id = None

--- a/src/nexus/workflows/storage.py
+++ b/src/nexus/workflows/storage.py
@@ -11,6 +11,7 @@ from typing import Any
 import yaml
 from sqlalchemy import select
 
+from nexus.raft.zone_manager import ROOT_ZONE_ID
 from nexus.storage.models import WorkflowExecutionModel, WorkflowModel
 from nexus.workflows.loader import WorkflowLoader
 from nexus.workflows.types import WorkflowDefinition, WorkflowExecution
@@ -26,10 +27,10 @@ class WorkflowStore:
 
         Args:
             session_factory: SQLAlchemy session factory
-            zone_id: Zone ID (optional, defaults to "default")
+            zone_id: Zone ID (optional, defaults to ROOT_ZONE_ID)
         """
         self.session_factory = session_factory
-        self.zone_id = zone_id or "default"
+        self.zone_id = zone_id or ROOT_ZONE_ID
 
     def _get_zone_id(self) -> str:
         """Get current zone ID."""


### PR DESCRIPTION
## Summary
- Replace 3 hardcoded `"default"` zone_id instances with `ROOT_ZONE_ID` constant in workflows subsystem
- `storage.py:32` — `WorkflowStore.__init__` fallback
- `engine.py:282` — `event_context.get("zone_id")` default
- `engine.py:287` — comparison against wrong zone_id value
- Per federation-memo.md §6.5: all code must use `ROOT_ZONE_ID`

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] No hardcoded `"default"` zone_id remaining in workflows files

🤖 Generated with [Claude Code](https://claude.com/claude-code)