### PR TITLE
fix(#580): change 3 hardcoded zone ID defaults from "default" to "root" in pay modules

### DIFF
--- a/src/nexus/pay/policy_wrapper.py
+++ b/src/nexus/pay/policy_wrapper.py
@@ -66,7 +66,7 @@ class PolicyEnforcedPayment(PaymentProtocol):
             5. Delegate to inner protocol
             6. On success → fire-and-forget ledger update
         """
-        zone_id = request.metadata.get("zone_id", "default") if request.metadata else "default"
+        zone_id = request.metadata.get("zone_id", "root") if request.metadata else "root"
         approval_id = request.metadata.get("approval_id") if request.metadata else None
 
         # 1. If approval_id provided, check it before evaluation

--- a/src/nexus/pay/protocol.py
+++ b/src/nexus/pay/protocol.py
@@ -280,7 +280,7 @@ class CreditsPaymentProtocol(PaymentProtocol):
     Catch-all for agent-to-agent transfers (non-wallet destinations).
     """
 
-    def __init__(self, service: Any, zone_id: str = "default") -> None:
+    def __init__(self, service: Any, zone_id: str = "root") -> None:
         self._service = service
         self._zone_id = zone_id
 

--- a/src/nexus/pay/sdk.py
+++ b/src/nexus/pay/sdk.py
@@ -201,7 +201,7 @@ class NexusPay:
         x402_client: X402Client | None = None,
         x402_enabled: bool = True,
         scheduler_service: Any | None = None,
-        zone_id: str = "default",
+        zone_id: str = "root",
     ) -> None:
         match = _API_KEY_PATTERN.match(api_key)
         if not match:


### PR DESCRIPTION
## Summary
- Changed 3 hardcoded `"default"` zone ID instances to `"root"` in pay subsystem
- `policy_wrapper.py`: metadata fallback
- `sdk.py`: `NexusPay.__init__` parameter default
- `protocol.py`: `CreditTransferProtocol.__init__` parameter default
- Aligns with federation-memo.md canonical zone ID (`ROOT_ZONE_ID = "root"`)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)