### PR TITLE
fix(#581): replace hardcoded default zone_id with ROOT_ZONE_ID in scheduler

### DIFF
--- a/src/nexus/scheduler/models.py
+++ b/src/nexus/scheduler/models.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
+from nexus.raft.zone_manager import ROOT_ZONE_ID
 from nexus.scheduler.constants import TASK_STATUS_QUEUED, PriorityTier
 
 
@@ -58,5 +59,5 @@ class ScheduledTask:
     started_at: datetime | None = None
     completed_at: datetime | None = None
     error_message: str | None = None
-    zone_id: str = "default"
+    zone_id: str = ROOT_ZONE_ID
     idempotency_key: str | None = None

--- a/src/nexus/scheduler/queue.py
+++ b/src/nexus/scheduler/queue.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
+from nexus.raft.zone_manager import ROOT_ZONE_ID
 from nexus.scheduler.constants import (
     AGING_THRESHOLD_SECONDS,
     MAX_WAIT_SECONDS,
@@ -143,7 +144,7 @@ def _row_to_task(row: dict[str, Any]) -> ScheduledTask:
         started_at=row.get("started_at"),
         completed_at=row.get("completed_at"),
         error_message=row.get("error_message"),
-        zone_id=row.get("zone_id", "default"),
+        zone_id=row.get("zone_id", ROOT_ZONE_ID),
         idempotency_key=row.get("idempotency_key"),
     )
 
@@ -170,7 +171,7 @@ class TaskQueue:
         payload: dict[str, Any],
         priority_tier: int,
         effective_tier: int,
-        zone_id: str = "default",
+        zone_id: str = ROOT_ZONE_ID,
         deadline: datetime | None = None,
         boost_amount: Decimal = Decimal("0"),
         boost_tiers: int = 0,


### PR DESCRIPTION
## Summary
- Replace 3 hardcoded `"default"` zone_id instances with `ROOT_ZONE_ID` constant in scheduler
- `models.py:61` — `ScheduledTask.zone_id` dataclass field default
- `queue.py:146` — row deserialization fallback
- `queue.py:173` — `enqueue()` parameter default
- Per federation-memo.md §6.5: all code must use `ROOT_ZONE_ID`

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)