### PR TITLE
fix(#565): replace hardcoded default zone_id with ROOT_ZONE_ID in CLI skills

### DIFF
--- a/src/nexus/cli/commands/skills.py
+++ b/src/nexus/cli/commands/skills.py
@@ -27,6 +27,7 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
+from nexus.raft.zone_manager import ROOT_ZONE_ID
 
 
 class SQLAlchemyDatabaseConnection:
@@ -1673,7 +1674,9 @@ def skills_mcp_mount(
 
                 # First check if credential exists
                 async def check_credential() -> bool:
-                    cred = await token_manager.get_credential(oauth_provider, oauth_user, "default")
+                    cred = await token_manager.get_credential(
+                        oauth_provider, oauth_user, ROOT_ZONE_ID
+                    )
                     return cred is not None
 
                 credential_exists = asyncio.run(check_credential())
@@ -1782,7 +1785,7 @@ def skills_mcp_mount(
                             provider=oauth_provider if oauth_provider != "x" else "twitter",
                             user_email=oauth_user,
                             credential=credential,
-                            zone_id="default",
+                            zone_id=ROOT_ZONE_ID,
                             created_by=oauth_user,
                         )
 
@@ -1797,7 +1800,7 @@ def skills_mcp_mount(
 
                 async def get_oauth_token() -> str:
                     return await token_manager.get_valid_token(
-                        oauth_provider, oauth_user, "default"
+                        oauth_provider, oauth_user, ROOT_ZONE_ID
                     )
 
                 # Get the token


### PR DESCRIPTION
## Summary
- Replace 3 hardcoded `"default"` zone_id instances with `ROOT_ZONE_ID` in CLI skills OAuth flows
- Lines 1676, 1785, 1800 — `get_credential()`, `store_credential()`, `get_valid_token()` calls
- Per federation-memo.md §6.5: all code must use `ROOT_ZONE_ID`

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)