### PR TITLE
fix(#576): change hardcoded zone ID fallbacks from "default" to "root" in backend connectors

### DIFF
--- a/src/nexus/backends/gcalendar_connector.py
+++ b/src/nexus/backends/gcalendar_connector.py
@@ -330,7 +330,7 @@ send_notifications: true
             zone_id = (
                 context.zone_id
                 if context and hasattr(context, "zone_id") and context.zone_id
-                else "default"
+                else "root"
             )
 
             access_token = run_sync(

--- a/src/nexus/backends/gdrive_connector.py
+++ b/src/nexus/backends/gdrive_connector.py
@@ -280,7 +280,7 @@ class GoogleDriveConnectorBackend(Backend):
             zone_id = (
                 context.zone_id
                 if context and hasattr(context, "zone_id") and context.zone_id
-                else "default"
+                else "root"
             )
 
             # Try to get a valid token (will refresh if needed)
@@ -399,11 +399,11 @@ class GoogleDriveConnectorBackend(Backend):
         from nexus.core.sync_bridge import run_sync
 
         try:
-            # Default to 'default' zone if not specified to match mount configurations
+            # Default to 'root' zone if not specified to match mount configurations
             zone_id = (
                 context.zone_id
                 if context and hasattr(context, "zone_id") and context.zone_id
-                else "default"
+                else "root"
             )
             access_token = run_sync(
                 self.token_manager.get_valid_token(

--- a/src/nexus/backends/slack_connector.py
+++ b/src/nexus/backends/slack_connector.py
@@ -232,11 +232,11 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
         from nexus.core.sync_bridge import run_sync
 
         try:
-            # Default to 'default' zone if not specified
+            # Default to 'root' zone if not specified
             zone_id = (
                 context.zone_id
                 if context and hasattr(context, "zone_id") and context.zone_id
-                else "default"
+                else "root"
             )
 
             access_token = run_sync(

--- a/src/nexus/backends/x_connector.py
+++ b/src/nexus/backends/x_connector.py
@@ -209,8 +209,8 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
 
         # Get OAuth token
         zone_id: str = (
-            context.zone_id if context and hasattr(context, "zone_id") else "default"
-        ) or "default"
+            context.zone_id if context and hasattr(context, "zone_id") else "root"
+        ) or "root"
 
         try:
             access_token = await self.token_manager.get_valid_token(


### PR DESCRIPTION
## Summary
- Changed 5 hardcoded zone ID fallback values from `"default"` to `"root"` across 4 backend connector files
- Files: `x_connector.py`, `gdrive_connector.py`, `gcalendar_connector.py`, `slack_connector.py`
- Aligns with federation-memo.md canonical `ROOT_ZONE_ID = "root"`

## Test plan
- [ ] Verify all pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Verify no remaining `"default"` zone ID fallbacks in connector files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>