### PR TITLE
fix(#563): replace hardcoded "default" zone_id in streaming endpoint

### DIFF
--- a/src/nexus/server/api/core/streaming.py
+++ b/src/nexus/server/api/core/streaming.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import Response, StreamingResponse
 
 from nexus.core.exceptions import NexusFileNotFoundError, NexusPermissionError
+from nexus.raft.zone_manager import ROOT_ZONE_ID
 from nexus.server.streaming import _verify_stream_token
 
 logger = logging.getLogger(__name__)
@@ -23,7 +24,7 @@ async def stream_file(
     request: Request,
     path: str,
     token: str = Query(..., description="Signed stream token"),
-    zone_id: str = Query("default", description="Zone ID"),
+    zone_id: str = Query(ROOT_ZONE_ID, description="Zone ID"),
 ) -> Response | StreamingResponse:
     """Stream file content with HTTP Range support (RFC 9110).
 


### PR DESCRIPTION
## Summary
- Replace `zone_id: str = Query("default")` with `Query(ROOT_ZONE_ID)` in `stream_file()` endpoint
- Import `ROOT_ZONE_ID` from `nexus.raft.zone_manager` per federation-memo §6.5

## Test plan
- [ ] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] No hardcoded "default" zone_id remains in streaming.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)