### PR TITLE
fix(#564): change hardcoded zone ID fallbacks from "default" to "root" in rpc handlers

### DIFF
--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -90,9 +90,9 @@ def generate_download_url(
 
             from nexus.server.streaming import _sign_stream_token
 
-            zone_id = "default"
+            zone_id = "root"
             if context and hasattr(context, "zone_id"):
-                zone_id = context.zone_id or "default"
+                zone_id = context.zone_id or "root"
 
             token = _sign_stream_token(path, expires_in, zone_id)
             encoded_path = quote(path.lstrip("/"), safe="")


### PR DESCRIPTION
## Summary
- Changed 2 hardcoded zone ID fallback values from `"default"` to `"root"` in `src/nexus/server/rpc/handlers/filesystem.py`
- Fixes `generate_download_url` handler fallback zone ID
- Aligns with federation-memo.md canonical `ROOT_ZONE_ID = "root"`

## Test plan
- [ ] Verify all pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Verify no remaining `"default"` zone ID fallbacks in filesystem.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>