### PR TITLE
chore(#1633, #1504): brick zero-core-imports lint + gRPC docs sync

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -120,6 +120,26 @@ jobs:
           find src -name '*.py' -exec wc -l {} \; | sort -rn | head -10 >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
+  brick-imports-check:
+    name: Brick Zero-Core-Imports Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check brick imports
+        run: |
+          python .pre-commit-hooks/check_brick_imports.py
+
+      - name: Report violations
+        if: failure()
+        run: |
+          echo "::error::Bricks must not import from nexus.core or nexus.services internals. See NEXUS-LEGO-ARCHITECTURE.md §1.2."
+
   type-ignore-baseline:
     name: Track Type Ignore Baseline
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,13 @@ repos:
         files: \.py$
         exclude: ^\.pre-commit-hooks/
 
+      - id: check-brick-imports
+        name: Brick Zero-Core-Imports Check
+        entry: python .pre-commit-hooks/check_brick_imports.py
+        language: python
+        files: \.py$
+        pass_filenames: true
+
       # DISABLED: RPC Parity test (pytest, slow) - runs in CI instead
       # Uncomment to re-enable:
       # - id: rpc-parity

--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Pre-commit hook and CI check to enforce zero-core-imports in bricks/.
+
+LEGO Architecture Principle 3: "Bricks don't know about each other"
+and bricks must never import from nexus.core (the kernel).
+
+Bricks communicate with the kernel exclusively through protocols defined
+in core/protocols/ and services/protocols/. Direct imports from nexus.core
+or nexus.services internals are architectural violations.
+
+Reference: docs/design/NEXUS-LEGO-ARCHITECTURE.md §1.2, Principle 3
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Path to bricks directory relative to project root
+BRICKS_RELATIVE_PATH = Path("src") / "nexus" / "bricks"
+
+# Forbidden import patterns for files under bricks/
+# Bricks may only import from:
+#   - nexus.core.protocols.*  (kernel protocol interfaces)
+#   - nexus.services.protocols.*  (system service protocol interfaces)
+#   - nexus.storage.*  (storage pillar ABCs)
+#   - Third-party packages
+#   - Other bricks' public APIs (through protocols, not direct imports)
+#
+# Note: TYPE_CHECKING imports are also flagged intentionally — bricks should
+# not even type-reference kernel internals (use protocols for type annotations).
+# Multiline strings containing import-like text may produce false positives;
+# this is a known limitation (unlikely in practice for brick modules).
+FORBIDDEN_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Direct core imports (excluding protocols — \b ensures protocols_extra etc. are caught)
+    (re.compile(r"^\s*from\s+nexus\.core(?!\.protocols\b)"), "nexus.core"),
+    (re.compile(r"^\s*import\s+nexus\.core(?!\.protocols\b)"), "nexus.core"),
+    # Direct services imports (excluding protocols)
+    (re.compile(r"^\s*from\s+nexus\.services(?!\.protocols\b)"), "nexus.services"),
+    (re.compile(r"^\s*import\s+nexus\.services(?!\.protocols\b)"), "nexus.services"),
+]
+
+# Lines matching these patterns are not actual imports (comments, strings, etc.)
+SKIP_PATTERNS = [
+    re.compile(r"^\s*#"),  # Comments
+    re.compile(r'^\s*["\']'),  # String literals
+    re.compile(r"^\s*$"),  # Empty lines
+]
+
+
+def is_import_line(line: str) -> bool:
+    """Check if a line is an actual import statement (not a comment or string)."""
+    return not any(p.match(line) for p in SKIP_PATTERNS)
+
+
+def check_file(file_path: Path) -> list[tuple[int, str, str]]:
+    """
+    Check a single file for forbidden imports.
+
+    Returns:
+        List of (line_number, line_content, matched_pattern_description) tuples.
+    """
+    violations = []
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            for line_num, line in enumerate(f, start=1):
+                if not is_import_line(line):
+                    continue
+                for pattern, desc in FORBIDDEN_PATTERNS:
+                    if pattern.search(line):
+                        violations.append((line_num, line.rstrip(), desc))
+                        break  # One violation per line is enough
+    except Exception as e:
+        print(f"Warning: Could not read {file_path}: {e}")
+
+    return violations
+
+
+def find_brick_files(root: Path) -> list[Path]:
+    """Find all Python files under the bricks/ directory."""
+    bricks_dir = root / BRICKS_RELATIVE_PATH
+    if not bricks_dir.exists():
+        return []
+    return sorted(bricks_dir.rglob("*.py"))
+
+
+def main() -> int:
+    """Main entry point for pre-commit hook and CI check.
+
+    Usage:
+        # CI mode: scan all bricks/ files automatically
+        python check_brick_imports.py
+
+        # Pre-commit mode: check specific files
+        python check_brick_imports.py <file1> [file2] ...
+    """
+    if len(sys.argv) > 1:
+        # Pre-commit mode: check specified files, filter to bricks/ only
+        files = [
+            Path(f)
+            for f in sys.argv[1:]
+            if f.endswith(".py") and "/bricks/" in f.replace("\\", "/")
+        ]
+    else:
+        # CI mode: scan entire bricks/ directory
+        files = find_brick_files(Path.cwd())
+
+    if not files:
+        # No brick files to check — this is expected until bricks/ is created
+        return 0
+
+    all_violations: list[tuple[Path, list[tuple[int, str, str]]]] = []
+
+    for file_path in files:
+        violations = check_file(file_path)
+        if violations:
+            all_violations.append((file_path, violations))
+
+    if all_violations:
+        print("\n❌ Brick import check failed!")
+        print("\n🧱 Bricks must not import from kernel internals:\n")
+
+        for file_path, violations in all_violations:
+            print(f"  {file_path}:")
+            for line_num, line_content, desc in violations:
+                print(f"    Line {line_num}: {line_content}")
+                print(f"             ↳ Forbidden: direct import from {desc}")
+            print()
+
+        print("📋 LEGO Architecture Principle 3: Bricks don't know about the kernel")
+        print("🎯 Bricks may only import from:")
+        print("     nexus.core.protocols.*      (kernel protocol interfaces)")
+        print("     nexus.services.protocols.*   (system service protocol interfaces)")
+        print("     nexus.storage.*              (storage pillar ABCs)")
+        print()
+        print("💡 See docs/design/NEXUS-LEGO-ARCHITECTURE.md §1.2")
+        print()
+
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -173,12 +173,15 @@ Driver selection is config-time: same binary, different `NEXUS_METASTORE`, `NEXU
 
 ## 6. gRPC Services
 
-| Proto Service | Scope | Purpose |
-|---------------|-------|---------|
-| `ZoneTransportService` | Internal | Node-to-node Raft messages (StepMessage, ReplicateEntries) |
-| `ZoneApiService` | Internal | Client-facing zone ops (Propose, Query, JoinZone, InviteZone) |
+> **SSOT:** Proto files in `proto/` are the source of truth for RPC definitions. This table is a summary for architectural orientation — see the proto files for exact request/response types and detailed comments.
 
-Named `Zone*` to match `ZoneConsensus` (Rust). Neither is an external API.
+| Proto Service | Proto File | Scope | Purpose |
+|---------------|-----------|-------|---------|
+| `ZoneTransportService` | `proto/nexus/raft/transport.proto` | Internal | Node-to-node Raft messages (StepMessage, ReplicateEntries) |
+| `ZoneApiService` | `proto/nexus/raft/transport.proto` | Internal | Client-facing zone ops (Propose, Query, GetClusterInfo, JoinZone, InviteZone) |
+| `ExchangeService` | `proto/nexus/exchange/v1/exchange.proto` | External | Agent Exchange API — identity (4 RPCs), payment (8 RPCs), audit (5 RPCs). REST-only Phase 1; Connect-RPC planned Phase 2/3. |
+
+Named `Zone*` to match `ZoneConsensus` (Rust). Zone services are internal — not exposed as external APIs. `ExchangeService` is the external-facing API for agent-to-agent value exchange.
 
 ---
 

--- a/tests/unit/scripts/test_check_brick_imports.py
+++ b/tests/unit/scripts/test_check_brick_imports.py
@@ -1,0 +1,249 @@
+"""Tests for .pre-commit-hooks/check_brick_imports.py.
+
+Validates that the brick import checker correctly identifies forbidden imports
+from nexus.core and nexus.services internals, while allowing imports from
+protocol interfaces and storage ABCs.
+"""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / ".pre-commit-hooks" / "check_brick_imports.py"
+_spec = importlib.util.spec_from_file_location("check_brick_imports", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+check_file = _mod.check_file
+find_brick_files = _mod.find_brick_files
+is_import_line = _mod.is_import_line
+main = _mod.main
+
+
+@pytest.fixture()
+def brick_file(tmp_path: Path):
+    """Helper to create a temporary Python file simulating a brick module."""
+
+    def _make(content: str) -> Path:
+        f = tmp_path / "brick_module.py"
+        f.write_text(textwrap.dedent(content))
+        return f
+
+    return _make
+
+
+class TestCheckFile:
+    """Tests for check_file()."""
+
+    def test_clean_file_no_violations(self, brick_file):
+        path = brick_file("""\
+            from nexus.core.protocols.vfs_router import VFSRouterProtocol
+            from nexus.services.protocols.event_log import EventLogProtocol
+            from nexus.storage.record_store import RecordStoreABC
+            import os
+        """)
+        assert check_file(path) == []
+
+    def test_detects_from_nexus_core_import(self, brick_file):
+        path = brick_file("""\
+            from nexus.core.nexus_fs import NexusFS
+        """)
+        violations = check_file(path)
+        assert len(violations) == 1
+        assert violations[0][0] == 1  # line number
+        assert "nexus.core" in violations[0][2]  # description
+
+    def test_detects_import_nexus_core(self, brick_file):
+        path = brick_file("""\
+            import nexus.core.nexus_fs
+        """)
+        violations = check_file(path)
+        assert len(violations) == 1
+        assert violations[0][0] == 1
+
+    def test_detects_from_nexus_services_import(self, brick_file):
+        path = brick_file("""\
+            from nexus.services.search_service import SearchService
+        """)
+        violations = check_file(path)
+        assert len(violations) == 1
+        assert "nexus.services" in violations[0][2]
+
+    def test_detects_import_nexus_services(self, brick_file):
+        path = brick_file("""\
+            import nexus.services.rebac_service
+        """)
+        violations = check_file(path)
+        assert len(violations) == 1
+
+    def test_allows_nexus_core_protocols(self, brick_file):
+        path = brick_file("""\
+            from nexus.core.protocols import VFSRouterProtocol
+            from nexus.core.protocols.vfs_router import VFSRouterProtocol
+        """)
+        assert check_file(path) == []
+
+    def test_allows_nexus_services_protocols(self, brick_file):
+        path = brick_file("""\
+            from nexus.services.protocols import EventLogProtocol
+            from nexus.services.protocols.hook_engine import HookEngineProtocol
+        """)
+        assert check_file(path) == []
+
+    def test_allows_nexus_storage(self, brick_file):
+        path = brick_file("""\
+            from nexus.storage.record_store import RecordStoreABC
+            import nexus.storage
+        """)
+        assert check_file(path) == []
+
+    def test_skips_comments(self, brick_file):
+        path = brick_file("""\
+            # from nexus.core.nexus_fs import NexusFS
+            # import nexus.services.search_service
+        """)
+        assert check_file(path) == []
+
+    def test_skips_string_literals(self, brick_file):
+        path = brick_file("""\
+            "from nexus.core.nexus_fs import NexusFS"
+            'import nexus.services.search_service'
+        """)
+        assert check_file(path) == []
+
+    def test_skips_empty_lines(self, brick_file):
+        path = brick_file("""\
+
+        """)
+        assert check_file(path) == []
+
+    def test_multiple_violations(self, brick_file):
+        path = brick_file("""\
+            from nexus.core.nexus_fs import NexusFS
+            from nexus.core.protocols.vfs_router import VFSRouterProtocol
+            from nexus.services.search_service import SearchService
+            import os
+        """)
+        violations = check_file(path)
+        assert len(violations) == 2  # line 1 and line 3
+        assert violations[0][0] == 1
+        assert violations[1][0] == 3
+
+    def test_correct_line_numbers(self, brick_file):
+        path = brick_file("""\
+            import os
+            import sys
+            from nexus.core.nexus_fs import NexusFS
+        """)
+        violations = check_file(path)
+        assert len(violations) == 1
+        assert violations[0][0] == 3
+
+    def test_empty_file(self, brick_file):
+        path = brick_file("")
+        assert check_file(path) == []
+
+    def test_nonexistent_file(self, tmp_path: Path):
+        """Non-existent file should not crash, just return empty."""
+        fake_path = tmp_path / "nonexistent.py"
+        assert check_file(fake_path) == []
+
+    def test_catches_protocols_extra_module(self, brick_file):
+        """Ensure protocols_extra (not a real protocols subpackage) is caught."""
+        path = brick_file("""\
+            from nexus.core.protocols_extra import Foo
+        """)
+        violations = check_file(path)
+        assert len(violations) == 1
+
+    def test_catches_services_protocols_extra_module(self, brick_file):
+        """Ensure services.protocols_extra is caught."""
+        path = brick_file("""\
+            from nexus.services.protocols_extra import Bar
+        """)
+        violations = check_file(path)
+        assert len(violations) == 1
+
+
+class TestFindBrickFiles:
+    """Tests for find_brick_files()."""
+
+    def test_returns_empty_when_no_bricks_dir(self, tmp_path: Path):
+        assert find_brick_files(tmp_path) == []
+
+    def test_finds_python_files_in_bricks(self, tmp_path: Path):
+        bricks = tmp_path / "src" / "nexus" / "bricks" / "my_brick"
+        bricks.mkdir(parents=True)
+        (bricks / "handler.py").write_text("pass")
+        (bricks / "README.md").write_text("docs")
+        result = find_brick_files(tmp_path)
+        assert len(result) == 1
+        assert result[0].name == "handler.py"
+
+    def test_finds_nested_python_files(self, tmp_path: Path):
+        bricks = tmp_path / "src" / "nexus" / "bricks"
+        (bricks / "brick_a").mkdir(parents=True)
+        (bricks / "brick_b").mkdir(parents=True)
+        (bricks / "brick_a" / "__init__.py").write_text("")
+        (bricks / "brick_b" / "__init__.py").write_text("")
+        result = find_brick_files(tmp_path)
+        assert len(result) == 2
+
+
+class TestMain:
+    """Tests for main() entry point."""
+
+    def test_returns_zero_when_no_bricks_dir(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr("sys.argv", ["check_brick_imports.py"])
+        monkeypatch.chdir(tmp_path)
+        assert main() == 0
+
+    def test_returns_zero_for_clean_bricks(self, monkeypatch, tmp_path: Path):
+        bricks = tmp_path / "src" / "nexus" / "bricks"
+        bricks.mkdir(parents=True)
+        (bricks / "clean.py").write_text("import os\n")
+        monkeypatch.setattr("sys.argv", ["check_brick_imports.py"])
+        monkeypatch.chdir(tmp_path)
+        assert main() == 0
+
+    def test_returns_one_when_violations_found(self, monkeypatch, tmp_path: Path):
+        bricks = tmp_path / "src" / "nexus" / "bricks"
+        bricks.mkdir(parents=True)
+        (bricks / "bad.py").write_text("from nexus.core.nexus_fs import NexusFS\n")
+        monkeypatch.setattr("sys.argv", ["check_brick_imports.py"])
+        monkeypatch.chdir(tmp_path)
+        assert main() == 1
+
+    def test_precommit_mode_filters_to_bricks(self, monkeypatch, tmp_path: Path):
+        """Pre-commit mode only checks files with /bricks/ in path."""
+        bricks = tmp_path / "src" / "nexus" / "bricks"
+        bricks.mkdir(parents=True)
+        bad_file = bricks / "bad.py"
+        bad_file.write_text("from nexus.core.nexus_fs import NexusFS\n")
+        # Pass a non-brick file — should be filtered out
+        monkeypatch.setattr(
+            "sys.argv",
+            ["check_brick_imports.py", str(tmp_path / "src" / "nexus" / "core" / "foo.py")],
+        )
+        assert main() == 0  # Non-brick file is filtered out
+
+
+class TestIsImportLine:
+    """Tests for is_import_line()."""
+
+    def test_actual_import(self):
+        assert is_import_line("from nexus.core import foo") is True
+
+    def test_comment(self):
+        assert is_import_line("# from nexus.core import foo") is False
+
+    def test_string(self):
+        assert is_import_line('"from nexus.core import foo"') is False
+
+    def test_empty(self):
+        assert is_import_line("") is False
+
+    def test_indented_comment(self):
+        assert is_import_line("    # from nexus.core import foo") is False


### PR DESCRIPTION
## Summary

- **#1633**: Add automated CI check + pre-commit hook enforcing LEGO Architecture Principle 3 — bricks must not import from `nexus.core` or `nexus.services` internals (only `*.protocols.*` and `nexus.storage.*`)
- **#1504**: Update `KERNEL-ARCHITECTURE.md` §6 gRPC table — add missing `GetClusterInfo` RPC, add `ExchangeService` (17 RPCs), add SSOT note pointing to proto files

## Changes

| File | What |
|------|------|
| `.pre-commit-hooks/check_brick_imports.py` | New ~145 LOC lint script with CI + pre-commit support |
| `.github/workflows/code-quality.yml` | New parallel `brick-imports-check` job |
| `.pre-commit-config.yaml` | Register `check-brick-imports` hook |
| `docs/design/KERNEL-ARCHITECTURE.md` | Fix §6 gRPC table + SSOT note |
| `tests/unit/scripts/test_check_brick_imports.py` | 29 unit tests |

## Design decisions

- **Custom script over `import-linter`**: No `bricks/` dir exists yet — right-sized for current state, migrate to `import-linter` when bricks materialize
- **Regex `\b` after `protocols`**: Prevents `protocols_extra`-type bypasses
- **TYPE_CHECKING imports flagged intentionally**: Bricks should use protocols for type annotations too
- **SSOT note in docs**: Prevents future drift between proto files and architecture docs

## Test plan

- [x] 29 unit tests pass (check_file, find_brick_files, main, is_import_line)
- [x] Script exits cleanly with code 0 when no `bricks/` dir exists
- [x] Ruff lint + format clean
- [x] mypy clean
- [x] E2E audit tests pass (29/29) with `NEXUS_ENFORCE_PERMISSIONS=true`
- [x] E2E API v2 tests pass (32/32) with `NEXUS_ENFORCE_PERMISSIONS=true`
- [ ] CI passes

**Stream 13**

🤖 Generated with [Claude Code](https://claude.com/claude-code)