### PR TITLE
feat(#1522): extract workflows into zero-dependency Lego Brick with REST API

### DIFF
--- a/src/nexus/cli/commands/workflows.py
+++ b/src/nexus/cli/commands/workflows.py
@@ -15,35 +15,50 @@ from nexus.cli.utils import console, handle_error
 def _get_engine_with_storage():  # type: ignore[no-untyped-def]
     """Get or create workflow engine with persistent storage.
 
-    This initializes the workflow engine with database persistence enabled.
+    Constructs engine directly via DI (no global singletons).
     """
     import nexus
-    from nexus.workflows import init_engine
+    from nexus.storage.models import WorkflowExecutionModel, WorkflowModel
+    from nexus.workflows.engine import WorkflowEngine
+    from nexus.workflows.protocol import WorkflowServices
     from nexus.workflows.storage import WorkflowStore
 
     # Get data directory from env or default
     data_dir = os.getenv("NEXUS_DATA_DIR", "./nexus-data")
 
-    # Connect to Nexus to get the metadata store
+    # Connect to Nexus to get the record store
     nx = nexus.connect(config={"data_dir": str(data_dir)})
 
-    # Get session factory from NexusFS
-    session_factory = getattr(nx, "SessionLocal", None)
-    if session_factory is None:
-        raise RuntimeError("Workflow storage requires a local NexusFS instance with SessionLocal")
+    # Get record_store for async session factory
+    record_store = getattr(nx, "_record_store", None)
+    if record_store is None:
+        raise RuntimeError("Workflow storage requires a NexusFS instance with a record store")
 
     # Get zone_id from Nexus filesystem (or use default)
     zone_id = getattr(nx, "zone_id", None) or "default"
 
-    # Create workflow store with zone_id
-    workflow_store = WorkflowStore(session_factory, zone_id=zone_id)
+    # Try to get Rust glob_match for production performance
+    glob_match_fn = None
+    try:
+        from nexus.core import glob_fast
 
-    # Initialize engine with storage
-    engine = init_engine(
-        metadata_store=getattr(nx, "metadata", None),
-        plugin_registry=None,
-        workflow_store=workflow_store,
+        glob_match_fn = glob_fast.glob_match
+    except ImportError:
+        pass
+
+    # Create workflow store with async session factory and injected models
+    workflow_store = WorkflowStore(
+        session_factory=record_store.async_session_factory,
+        workflow_model=WorkflowModel,
+        execution_model=WorkflowExecutionModel,
+        zone_id=zone_id,
     )
+
+    services = WorkflowServices(glob_match=glob_match_fn)
+    engine = WorkflowEngine(workflow_store=workflow_store, services=services)
+
+    # Load workflows from storage (async startup)
+    asyncio.run(engine.startup())
 
     return engine
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -271,6 +271,12 @@ class NexusFS(  # type: ignore[misc]
         self.enable_workflows = distributed.enable_workflows
         self.workflow_engine = svc.workflow_engine
 
+        # Bounded workflow event queue (#1522)
+        self._workflow_queue: asyncio.Queue[tuple[str, dict]] | None = None
+        self._workflow_consumer_task: asyncio.Task[None] | None = None  # type: ignore[assignment]  # allowed
+        if self.enable_workflows and self.workflow_engine:
+            self._workflow_queue = asyncio.Queue(maxsize=1000)
+
         # Initialize OAuth token manager (lazy initialization in mixin)
         self._token_manager = None
 

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -228,7 +228,7 @@ class NexusFSCoreMixin:
 
     def _fire_workflow_event(
         self,
-        trigger_type: Any,
+        trigger_type: str,
         event_context: dict[str, Any],
         label: str,
     ) -> None:
@@ -238,19 +238,31 @@ class NexusFSCoreMixin:
         Does nothing if workflows are not enabled.
 
         Args:
-            trigger_type: TriggerType enum value (FILE_WRITE, FILE_DELETE, FILE_RENAME).
+            trigger_type: String trigger type (e.g. "file_write", "file_delete").
             event_context: Event payload dict.
             label: Human-readable label for task/thread naming (e.g. "file_write:/foo.txt").
         """
         if not (self.enable_workflows and self.workflow_engine):  # type: ignore[attr-defined]
             return
 
-        from nexus.core.sync_bridge import fire_and_forget
+        # Bounded queue: try to enqueue, drop on overflow
+        queue = getattr(self, "_workflow_queue", None)
+        if queue is not None:
+            try:
+                queue.put_nowait((trigger_type, event_context))
+            except Exception:
+                logger.warning("Workflow event queue full, dropping event: %s", label)
+        else:
+            # Fallback: fire-and-forget (no queue — CLI or pre-startup)
+            from nexus.core.sync_bridge import fire_and_forget
 
-        fire_and_forget(
-            self.workflow_engine.fire_event(trigger_type, event_context)  # type: ignore[attr-defined]
-        )
+            fire_and_forget(
+                self.workflow_engine.fire_event(trigger_type, event_context)  # type: ignore[attr-defined]
+            )
+
         if self.subscription_manager:  # type: ignore[attr-defined]
+            from nexus.core.sync_bridge import fire_and_forget
+
             event_type = label.split(":")[0] if ":" in label else label
             fire_and_forget(
                 self.subscription_manager.broadcast(  # type: ignore[attr-defined]
@@ -259,6 +271,34 @@ class NexusFSCoreMixin:
                     event_context.get("zone_id", "default"),
                 )
             )
+
+    async def _start_workflow_consumer(self) -> None:
+        """Background consumer for bounded workflow event queue (#1522)."""
+        queue = self._workflow_queue  # type: ignore[attr-defined]
+        engine = self.workflow_engine  # type: ignore[attr-defined]
+        while True:
+            trigger_type, event_context = await queue.get()
+            try:
+                await engine.fire_event(trigger_type, event_context)
+            except Exception as e:
+                logger.error("Workflow event processing failed: %s", e)
+            finally:
+                queue.task_done()
+
+    def ensure_workflow_consumer(self) -> None:
+        """Start the workflow consumer task if not already running."""
+        if (
+            getattr(self, "_workflow_queue", None) is None
+            or getattr(self, "_workflow_consumer_task", None) is not None
+        ):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            self._workflow_consumer_task = loop.create_task(  # type: ignore[attr-defined]
+                self._start_workflow_consumer()
+            )
+        except RuntimeError:
+            pass  # No event loop — consumer starts when server starts
 
     # =========================================================================
     # Zookie Consistency Token Support - Issue #1187
@@ -2087,11 +2127,9 @@ class NexusFSCoreMixin:
         )
 
         # v0.7.0: Fire workflow event for automatic trigger execution
-        from nexus.workflows.types import TriggerType
-
         is_new_file = meta is None or meta.etag is None
         self._fire_workflow_event(
-            TriggerType.FILE_WRITE,
+            "file_write",
             {
                 "file_path": path,
                 "size": len(content),
@@ -3011,10 +3049,8 @@ class NexusFSCoreMixin:
             cache_observer.on_delete(path, new_revision, zone_id or "default")
 
         # v0.7.0: Fire workflow event for automatic trigger execution
-        from nexus.workflows.types import TriggerType
-
         self._fire_workflow_event(
-            TriggerType.FILE_DELETE,
+            "file_delete",
             {
                 "file_path": path,
                 "size": meta.size,
@@ -3258,10 +3294,8 @@ class NexusFSCoreMixin:
         )
 
         # v0.7.0: Fire workflow event for automatic trigger execution
-        from nexus.workflows.types import TriggerType
-
         self._fire_workflow_event(
-            TriggerType.FILE_RENAME,
+            "file_rename",
             {
                 "old_path": old_path,
                 "new_path": new_path,

--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -665,7 +665,15 @@ def create_nexus_services(
     # --- Workflow engine (moved from NexusFS.__init__) ---
     workflow_engine: Any = None
     if dist.enable_workflows:
-        workflow_engine = _create_workflow_engine(session_factory, metadata_store)
+        # Try to get Rust glob_match for performance (falls back to fnmatch)
+        _glob_match_fn: Any = None
+        try:
+            from nexus.core import glob_fast
+
+            _glob_match_fn = glob_fast.glob_match
+        except ImportError:
+            pass
+        workflow_engine = _create_workflow_engine(record_store, _glob_match_fn)
 
     return _KernelServices(
         router=router,
@@ -777,31 +785,37 @@ def _create_distributed_infra(
     return event_bus, lock_manager
 
 
-def _create_workflow_engine(session_factory: Any, metadata_store: Any) -> Any:
-    """Create workflow engine (was NexusFS.__init__ lines 529-555).
+def _create_workflow_engine(record_store: Any, glob_match_fn: Any = None) -> Any:
+    """Create workflow engine with async store and DI.
+
+    Args:
+        record_store: RecordStoreABC instance (has async_session_factory property).
+        glob_match_fn: Optional glob match function (Rust glob_fast in production).
 
     Returns workflow engine or None if unavailable.
     """
     import logging
 
     logger = logging.getLogger(__name__)
-    if session_factory is None:
-        logger.warning("Workflows require record_store (session_factory), skipping")
+    if record_store is None:
+        logger.warning("Workflows require record_store, skipping")
         return None
     try:
-        from nexus.workflows.engine import init_engine
+        from nexus.storage.models import WorkflowExecutionModel, WorkflowModel
+        from nexus.workflows.engine import WorkflowEngine
+        from nexus.workflows.protocol import WorkflowServices
         from nexus.workflows.storage import WorkflowStore
 
         workflow_store = WorkflowStore(
-            session_factory=session_factory,
+            session_factory=record_store.async_session_factory,
+            workflow_model=WorkflowModel,
+            execution_model=WorkflowExecutionModel,
             zone_id="default",
         )
-        return init_engine(
-            metadata_store=metadata_store,
-            plugin_registry=None,
-            workflow_store=workflow_store,
-        )
-    except Exception:
+        services = WorkflowServices(glob_match=glob_match_fn)
+        return WorkflowEngine(workflow_store=workflow_store, services=services)
+    except Exception as e:
+        logger.warning("Failed to create workflow engine: %s", e)
         return None
 
 

--- a/src/nexus/server/api/v2/routers/__init__.py
+++ b/src/nexus/server/api/v2/routers/__init__.py
@@ -14,6 +14,7 @@ from nexus.server.api.v2.routers import (
     reputation,
     sync_push,
     trajectories,
+    workflows,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "pay",
     "reputation",
     "sync_push",
+    "workflows",
 ]

--- a/src/nexus/server/api/v2/routers/workflows.py
+++ b/src/nexus/server/api/v2/routers/workflows.py
@@ -1,0 +1,340 @@
+"""Nexus Workflow REST API endpoints.
+
+Provides 8 endpoints for workflow management:
+- GET    /api/v2/workflows                       - List all workflows
+- POST   /api/v2/workflows                       - Load workflow from JSON body
+- GET    /api/v2/workflows/{name}                - Get workflow definition
+- DELETE /api/v2/workflows/{name}                - Unload workflow
+- POST   /api/v2/workflows/{name}/enable         - Enable workflow
+- POST   /api/v2/workflows/{name}/disable        - Disable workflow
+- POST   /api/v2/workflows/{name}/execute        - Manual execution
+- GET    /api/v2/workflows/{name}/executions     - Execution history
+
+Related: Issue #1522
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/workflows", tags=["workflows"])
+
+
+# =============================================================================
+# Pydantic Request/Response Models
+# =============================================================================
+
+
+class WorkflowTriggerModel(BaseModel):
+    """A workflow trigger definition."""
+
+    type: str = Field(..., description="Trigger type (e.g. 'file_write', 'file_delete')")
+    config: dict[str, Any] = Field(default_factory=dict, description="Trigger configuration")
+
+
+class WorkflowActionModel(BaseModel):
+    """A workflow action definition."""
+
+    name: str = Field(..., description="Action name")
+    type: str = Field(..., description="Action type (e.g. 'python', 'bash', 'parse')")
+    config: dict[str, Any] = Field(default_factory=dict, description="Action configuration")
+
+
+class CreateWorkflowRequest(BaseModel):
+    """Request to load a workflow definition."""
+
+    name: str = Field(..., description="Workflow name")
+    version: str = Field(default="1.0", description="Workflow version")
+    description: str | None = Field(default=None, description="Workflow description")
+    triggers: list[WorkflowTriggerModel] = Field(
+        default_factory=list, description="Trigger definitions"
+    )
+    actions: list[WorkflowActionModel] = Field(..., description="Action definitions")
+    variables: dict[str, Any] = Field(default_factory=dict, description="Default variables")
+    enabled: bool = Field(default=True, description="Enable workflow after loading")
+
+
+class ExecuteWorkflowRequest(BaseModel):
+    """Request for manual workflow execution."""
+
+    file_path: str | None = Field(
+        default=None, description="Optional file path for trigger context"
+    )
+    context: dict[str, Any] = Field(
+        default_factory=dict, description="Additional execution context"
+    )
+
+
+class WorkflowSummary(BaseModel):
+    """Summary of a loaded workflow."""
+
+    name: str
+    version: str
+    description: str | None = None
+    enabled: bool
+    triggers: int
+    actions: int
+
+
+class WorkflowDetail(BaseModel):
+    """Full workflow definition."""
+
+    name: str
+    version: str
+    description: str | None = None
+    triggers: list[WorkflowTriggerModel] = Field(default_factory=list)
+    actions: list[WorkflowActionModel] = Field(default_factory=list)
+    variables: dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+
+
+class ExecutionSummary(BaseModel):
+    """Summary of a workflow execution."""
+
+    execution_id: str
+    workflow_id: str
+    trigger_type: str
+    status: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    actions_completed: int = 0
+    actions_total: int = 0
+    error_message: str | None = None
+
+
+class ExecutionResult(BaseModel):
+    """Result from a manual execution."""
+
+    execution_id: str
+    status: str
+    actions_completed: int = 0
+    actions_total: int = 0
+    error_message: str | None = None
+
+
+# =============================================================================
+# Dependencies
+# =============================================================================
+
+
+def _get_require_auth() -> Any:
+    """Lazy import to avoid circular imports."""
+    from nexus.server.fastapi_server import require_auth
+
+    return require_auth
+
+
+def _get_workflow_engine(request: Request) -> Any:
+    """Get WorkflowEngine from app state via NexusFS."""
+    nexus_fs = getattr(request.app.state, "nexus_fs", None)
+    if not nexus_fs:
+        raise HTTPException(status_code=503, detail="NexusFS not initialized")
+
+    engine = getattr(nexus_fs, "workflow_engine", None)
+    if not engine:
+        raise HTTPException(status_code=503, detail="Workflow engine not available")
+
+    return engine
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+
+@router.get("", response_model=list[WorkflowSummary])
+async def list_workflows(
+    engine: Any = Depends(_get_workflow_engine),
+    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> list[WorkflowSummary]:
+    """List all loaded workflows."""
+    workflows = engine.list_workflows()
+    return [
+        WorkflowSummary(
+            name=w["name"],
+            version=w["version"],
+            description=w.get("description"),
+            enabled=w["enabled"],
+            triggers=w["triggers"],
+            actions=w["actions"],
+        )
+        for w in workflows
+    ]
+
+
+@router.post("", response_model=WorkflowSummary, status_code=201)
+async def create_workflow(
+    body: CreateWorkflowRequest,
+    engine: Any = Depends(_get_workflow_engine),
+    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> WorkflowSummary:
+    """Load a workflow definition.
+
+    Accepts a JSON workflow definition and loads it into the engine.
+    """
+    from nexus.workflows.loader import WorkflowLoader
+
+    # Convert request to dict for WorkflowLoader
+    workflow_dict: dict[str, Any] = {
+        "name": body.name,
+        "version": body.version,
+        "description": body.description,
+        "triggers": [{"type": t.type, **t.config} for t in body.triggers],
+        "actions": [{"name": a.name, "type": a.type, **a.config} for a in body.actions],
+        "variables": body.variables,
+    }
+
+    try:
+        definition = WorkflowLoader.load_from_dict(workflow_dict)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid workflow definition: {e}") from e
+
+    success = engine.load_workflow(definition, enabled=body.enabled)
+    if not success:
+        raise HTTPException(status_code=400, detail="Failed to load workflow")
+
+    return WorkflowSummary(
+        name=definition.name,
+        version=definition.version,
+        description=definition.description,
+        enabled=body.enabled,
+        triggers=len(definition.triggers),
+        actions=len(definition.actions),
+    )
+
+
+@router.get("/{name}", response_model=WorkflowDetail)
+async def get_workflow(
+    name: str,
+    engine: Any = Depends(_get_workflow_engine),
+    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> WorkflowDetail:
+    """Get a workflow definition by name."""
+    definition = engine.workflows.get(name)
+    if not definition:
+        raise HTTPException(status_code=404, detail=f"Workflow '{name}' not found")
+
+    return WorkflowDetail(
+        name=definition.name,
+        version=definition.version,
+        description=definition.description,
+        triggers=[
+            WorkflowTriggerModel(type=t.type.value, config=t.config) for t in definition.triggers
+        ],
+        actions=[
+            WorkflowActionModel(name=a.name, type=a.type, config=a.config)
+            for a in definition.actions
+        ],
+        variables=definition.variables or {},
+        enabled=engine.enabled_workflows.get(name, False),
+    )
+
+
+@router.delete("/{name}", status_code=204)
+async def delete_workflow(
+    name: str,
+    engine: Any = Depends(_get_workflow_engine),
+    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> None:
+    """Unload a workflow by name."""
+    success = engine.unload_workflow(name)
+    if not success:
+        raise HTTPException(status_code=404, detail=f"Workflow '{name}' not found")
+
+
+@router.post("/{name}/enable", status_code=204)
+async def enable_workflow(
+    name: str,
+    engine: Any = Depends(_get_workflow_engine),
+    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> None:
+    """Enable a workflow."""
+    if name not in engine.workflows:
+        raise HTTPException(status_code=404, detail=f"Workflow '{name}' not found")
+    engine.enable_workflow(name)
+
+
+@router.post("/{name}/disable", status_code=204)
+async def disable_workflow(
+    name: str,
+    engine: Any = Depends(_get_workflow_engine),
+    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> None:
+    """Disable a workflow."""
+    if name not in engine.workflows:
+        raise HTTPException(status_code=404, detail=f"Workflow '{name}' not found")
+    engine.disable_workflow(name)
+
+
+@router.post("/{name}/execute", response_model=ExecutionResult)
+async def execute_workflow(
+    name: str,
+    body: ExecuteWorkflowRequest | None = None,
+    engine: Any = Depends(_get_workflow_engine),
+    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> ExecutionResult:
+    """Manually trigger a workflow execution."""
+    event_context: dict[str, Any] = {}
+    if body:
+        event_context = dict(body.context)
+        if body.file_path:
+            event_context["file_path"] = body.file_path
+
+    execution = await engine.trigger_workflow(name, event_context)
+    if not execution:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Workflow '{name}' not found or disabled",
+        )
+
+    return ExecutionResult(
+        execution_id=str(execution.execution_id),
+        status=execution.status.value,
+        actions_completed=execution.actions_completed,
+        actions_total=execution.actions_total,
+        error_message=execution.error_message,
+    )
+
+
+@router.get("/{name}/executions", response_model=list[ExecutionSummary])
+async def get_executions(
+    name: str,
+    limit: int = Query(default=10, ge=1, le=100, description="Max results to return"),
+    engine: Any = Depends(_get_workflow_engine),
+    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> list[ExecutionSummary]:
+    """Get execution history for a workflow."""
+    if name not in engine.workflows:
+        raise HTTPException(status_code=404, detail=f"Workflow '{name}' not found")
+
+    if not engine.workflow_store:
+        return []
+
+    executions = await engine.workflow_store.get_executions_by_name(name, limit=limit)
+    return [
+        ExecutionSummary(
+            execution_id=e["execution_id"],
+            workflow_id=e["workflow_id"],
+            trigger_type=e["trigger_type"],
+            status=e["status"],
+            started_at=str(e["started_at"]) if e.get("started_at") else None,
+            completed_at=str(e["completed_at"]) if e.get("completed_at") else None,
+            actions_completed=e.get("actions_completed", 0),
+            actions_total=e.get("actions_total", 0),
+            error_message=e.get("error_message"),
+        )
+        for e in executions
+    ]
+
+
+# =============================================================================
+# Module Exports
+# =============================================================================
+
+__all__ = ["router"]

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -202,6 +202,14 @@ def build_v2_registry(
     except ImportError as e:
         logger.warning("Failed to import Delegation routes: %s", e)
 
+    # ---- Workflows router (Issue #1522) ----
+    try:
+        from nexus.server.api.v2.routers.workflows import router as workflows_router
+
+        registry.add(RouterEntry(router=workflows_router, name="workflows", endpoint_count=8))
+    except ImportError as e:
+        logger.warning("Failed to import Workflows routes: %s", e)
+
     return registry
 
 

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -49,6 +49,8 @@ async def startup_services(app: FastAPI) -> list[asyncio.Task]:
     if task_runner_task:
         bg_tasks.append(task_runner_task)
 
+    await _startup_workflow_engine(app)
+
     return bg_tasks
 
 
@@ -386,3 +388,17 @@ def _startup_task_queue(app: FastAPI) -> asyncio.Task | None:
         logger.warning(f"Task Queue runner not started: {e}")
 
     return None
+
+
+async def _startup_workflow_engine(app: FastAPI) -> None:
+    """Load workflows from persistent storage (Issue #1522)."""
+    if not app.state.nexus_fs:
+        return
+
+    engine = getattr(app.state.nexus_fs, "workflow_engine", None)
+    if engine and hasattr(engine, "startup"):
+        try:
+            await engine.startup()
+            logger.info("Workflow engine started — loaded workflows from storage")
+        except Exception as e:
+            logger.warning(f"Workflow engine startup failed (non-fatal): {e}")

--- a/src/nexus/workflows/__init__.py
+++ b/src/nexus/workflows/__init__.py
@@ -6,9 +6,17 @@ data transformation, and multi-step operations.
 """
 
 from nexus.workflows.actions import BUILTIN_ACTIONS, BaseAction
-from nexus.workflows.api import WorkflowAPI, get_workflow_api
-from nexus.workflows.engine import WorkflowEngine, get_engine, init_engine, reset_engine, set_engine
+from nexus.workflows.api import WorkflowAPI
+from nexus.workflows.engine import WorkflowEngine
 from nexus.workflows.loader import WorkflowLoader
+from nexus.workflows.protocol import (
+    GlobMatchFn,
+    LLMProviderProtocol,
+    MetadataStoreProtocol,
+    NexusOperationsProtocol,
+    WorkflowProtocol,
+    WorkflowServices,
+)
 from nexus.workflows.storage import WorkflowStore
 from nexus.workflows.triggers import BUILTIN_TRIGGERS, BaseTrigger, TriggerManager
 from nexus.workflows.types import (
@@ -25,17 +33,18 @@ from nexus.workflows.types import (
 __all__ = [
     # High-level API
     "WorkflowAPI",
-    "get_workflow_api",
     # Core classes
     "WorkflowEngine",
     "WorkflowLoader",
     "WorkflowStore",
     "TriggerManager",
-    # Engine functions
-    "get_engine",
-    "init_engine",
-    "set_engine",
-    "reset_engine",
+    # Protocols
+    "WorkflowProtocol",
+    "WorkflowServices",
+    "GlobMatchFn",
+    "NexusOperationsProtocol",
+    "MetadataStoreProtocol",
+    "LLMProviderProtocol",
     # Types
     "WorkflowDefinition",
     "WorkflowAction",

--- a/src/nexus/workflows/actions.py
+++ b/src/nexus/workflows/actions.py
@@ -1,4 +1,8 @@
-"""Built-in workflow actions."""
+"""Built-in workflow actions.
+
+Zero imports from nexus.core or nexus.llm — all Nexus operations are accessed
+via ``context.services`` (a WorkflowServices dataclass injected by the engine).
+"""
 
 import json
 import logging
@@ -23,30 +27,14 @@ class BaseAction(ABC):
 
     @abstractmethod
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute the action.
-
-        Args:
-            context: Workflow execution context
-
-        Returns:
-            ActionResult with execution status and output
-        """
+        """Execute the action."""
         pass
 
     def interpolate(self, value: str, context: WorkflowContext) -> str:
-        """Interpolate variables in a string value.
-
-        Args:
-            value: String with {variable} placeholders
-            context: Workflow context with variables
-
-        Returns:
-            Interpolated string
-        """
+        """Interpolate variables in a string value."""
         if not isinstance(value, str):
             return value
 
-        # Combine context variables with file metadata
         variables = {**context.variables}
         if context.file_path:
             variables["file_path"] = context.file_path
@@ -66,18 +54,20 @@ class ParseAction(BaseAction):
     """Parse a document."""
 
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute parse action."""
         try:
-            from nexus import connect
+            if not context.services or not context.services.nexus_ops:
+                return ActionResult(
+                    action_name=self.name,
+                    success=False,
+                    error="nexus_ops service not injected",
+                )
 
-            nx = connect()
             file_path = self.interpolate(
                 str(self.config.get("file_path", context.file_path)), context
             )
             parser = self.config.get("parser", "auto")
 
-            # Parse the file
-            result = await nx.parse(file_path, parser=parser)  # type: ignore[attr-defined]
+            result = await context.services.nexus_ops.parse(file_path, parser=parser)
 
             return ActionResult(
                 action_name=self.name, success=True, output={"parsed_content": result}
@@ -91,28 +81,28 @@ class TagAction(BaseAction):
     """Add or remove tags."""
 
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute tag action."""
         try:
-            from nexus import connect
+            if not context.services or not context.services.nexus_ops:
+                return ActionResult(
+                    action_name=self.name,
+                    success=False,
+                    error="nexus_ops service not injected",
+                )
 
-            nx = connect()
             file_path = self.interpolate(
                 str(self.config.get("file_path", context.file_path)), context
             )
             tags = self.config.get("tags", [])
             remove = self.config.get("remove", False)
 
-            # Interpolate tags
             interpolated_tags = [self.interpolate(tag, context) for tag in tags]
 
             if remove:
-                # Remove tags
                 for tag in interpolated_tags:
-                    await nx.remove_tag(file_path, tag)  # type: ignore[attr-defined]
+                    await context.services.nexus_ops.remove_tag(file_path, tag)
             else:
-                # Add tags
                 for tag in interpolated_tags:
-                    await nx.add_tag(file_path, tag)  # type: ignore[attr-defined]
+                    await context.services.nexus_ops.add_tag(file_path, tag)
 
             return ActionResult(
                 action_name=self.name,
@@ -128,23 +118,24 @@ class MoveAction(BaseAction):
     """Move or rename a file."""
 
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute move action."""
         try:
-            from nexus import connect
+            if not context.services or not context.services.nexus_ops:
+                return ActionResult(
+                    action_name=self.name,
+                    success=False,
+                    error="nexus_ops service not injected",
+                )
 
-            nx = connect()
             source = self.interpolate(str(self.config.get("source", context.file_path)), context)
             destination = self.interpolate(self.config["destination"], context)
             create_parents = self.config.get("create_parents", False)
 
-            # Create parent directories if needed
             if create_parents:
                 dest_path = Path(destination)
                 if not dest_path.parent.exists():
-                    nx.mkdir(str(dest_path.parent), parents=True)
+                    context.services.nexus_ops.mkdir(str(dest_path.parent), parents=True)
 
-            # Move/rename the file
-            nx.rename(source, destination)
+            context.services.nexus_ops.rename(source, destination)
 
             return ActionResult(
                 action_name=self.name,
@@ -160,27 +151,27 @@ class MetadataAction(BaseAction):
     """Update file metadata."""
 
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute metadata action."""
         try:
-            from nexus import connect
+            if not context.services or not context.services.metadata_store:
+                return ActionResult(
+                    action_name=self.name,
+                    success=False,
+                    error="metadata_store service not injected",
+                )
 
-            nx = connect()
             file_path = self.interpolate(
                 str(self.config.get("file_path", context.file_path)), context
             )
             metadata = self.config.get("metadata", {})
 
-            # Interpolate metadata values
             interpolated_metadata = {
                 key: self.interpolate(str(value), context) for key, value in metadata.items()
             }
 
-            # Update metadata
             for key, value in interpolated_metadata.items():
-                # Use metadata store directly since NexusFilesystem doesn't have set_metadata
-                path_rec = nx.metadata.get_path(file_path)  # type: ignore[attr-defined]
+                path_rec = context.services.metadata_store.get_path(file_path)
                 if path_rec:
-                    nx.metadata.set_file_metadata(path_rec.path_id, key, value)  # type: ignore[attr-defined]
+                    context.services.metadata_store.set_file_metadata(path_rec.path_id, key, value)
 
             return ActionResult(
                 action_name=self.name,
@@ -196,11 +187,14 @@ class LLMAction(BaseAction):
     """Execute LLM-powered action."""
 
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute LLM action."""
         try:
-            from nexus import connect
+            if not context.services or not context.services.llm_provider:
+                return ActionResult(
+                    action_name=self.name,
+                    success=False,
+                    error="llm_provider service not injected",
+                )
 
-            nx = connect()
             file_path = self.interpolate(
                 str(self.config.get("file_path", context.file_path)), context
             )
@@ -209,8 +203,8 @@ class LLMAction(BaseAction):
             output_format = self.config.get("output_format", "text")
 
             # Read file content if specified
-            if file_path:
-                content_bytes = nx.read(file_path)
+            if file_path and context.services.nexus_ops:
+                content_bytes = context.services.nexus_ops.read(file_path)
                 content = (
                     content_bytes.decode()
                     if isinstance(content_bytes, bytes)
@@ -220,13 +214,10 @@ class LLMAction(BaseAction):
             else:
                 full_prompt = prompt
 
-            # Execute LLM query
-            from nexus.llm import get_provider  # type: ignore[attr-defined]
+            response = await context.services.llm_provider.generate(
+                model=model, prompt=full_prompt, system=""
+            )
 
-            provider = get_provider()
-            response = await provider.generate(model=model, prompt=full_prompt, system="")
-
-            # Parse output if JSON format requested
             if output_format == "json":
                 try:
                     output = json.loads(response)
@@ -235,7 +226,6 @@ class LLMAction(BaseAction):
             else:
                 output = response
 
-            # Store output in context for subsequent actions
             context.variables[f"{self.name}_output"] = output
 
             return ActionResult(action_name=self.name, success=True, output=output)
@@ -248,14 +238,12 @@ class WebhookAction(BaseAction):
     """Send HTTP webhook."""
 
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute webhook action."""
         try:
             url = self.interpolate(self.config["url"], context)
             method = self.config.get("method", "POST").upper()
             headers = self.config.get("headers", {})
             body = self.config.get("body", {})
 
-            # Interpolate body values
             interpolated_body = {
                 key: self.interpolate(str(value), context) for key, value in body.items()
             }
@@ -281,7 +269,6 @@ class PythonAction(BaseAction):
     """Execute Python code."""
 
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute Python action."""
         import sys
         from io import StringIO
 
@@ -289,69 +276,52 @@ class PythonAction(BaseAction):
             code = self.config.get("code", "")
             file_path = context.file_path
 
-            print(f"[PYTHON ACTION DEBUG] Code length: {len(code)} bytes", file=sys.stderr)
-            print(f"[PYTHON ACTION DEBUG] First 200 chars of code: {code[:200]}", file=sys.stderr)
-            print(f"[PYTHON ACTION DEBUG] file_path: {file_path}", file=sys.stderr)
+            logger.debug("PythonAction: code=%d bytes, file_path=%s", len(code), file_path)
 
-            # Create execution context
             exec_globals: dict[str, Any] = {
                 "context": context,
                 "file_path": file_path,
                 "variables": context.variables,
             }
 
-            # Capture stdout and stderr
             old_stdout = sys.stdout
             old_stderr = sys.stderr
             captured_stdout = StringIO()
             captured_stderr = StringIO()
 
             try:
-                # Redirect stdout/stderr
                 sys.stdout = captured_stdout
                 sys.stderr = captured_stderr
 
-                # Add print function that explicitly uses the redirected stdout
-                # This ensures print() in exec'd code uses our captured stream
                 def _print(*args: Any, **kwargs: Any) -> None:
                     import builtins
 
                     kwargs.setdefault("file", captured_stdout)
                     builtins.print(*args, **kwargs)
 
-                # Add to exec globals so print uses our captured stream
                 exec_globals["print"] = _print
 
-                # Execute code
                 try:
                     exec(code, exec_globals)
                 except Exception as exec_error:
-                    # Capture any errors during code execution
                     import traceback
 
                     error_msg = f"Error during exec: {exec_error}\n{traceback.format_exc()}"
                     captured_stderr.write(error_msg)
-                    print(f"[PYTHON ACTION ERROR] {error_msg}", file=sys.stderr)
+                    logger.debug("PythonAction exec error: %s", error_msg)
             finally:
-                # Restore stdout/stderr
                 sys.stdout = old_stdout
                 sys.stderr = old_stderr
 
-            # Get captured output
             stdout_value = captured_stdout.getvalue()
             stderr_value = captured_stderr.getvalue()
 
-            # Print captured output to stderr so it's visible
-            print(
-                f"[PYTHON ACTION] stdout length: {len(stdout_value)}, stderr length: {len(stderr_value)}",
-                file=sys.stderr,
+            logger.debug(
+                "PythonAction: stdout=%d bytes, stderr=%d bytes",
+                len(stdout_value),
+                len(stderr_value),
             )
-            if stdout_value:
-                print(f"[PYTHON ACTION STDOUT]\n{stdout_value}", file=sys.stderr, end="")
-            if stderr_value:
-                print(f"[PYTHON ACTION STDERR]\n{stderr_value}", file=sys.stderr, end="")
 
-            # Check if there was an error during execution
             if stderr_value:
                 return ActionResult(
                     action_name=self.name,
@@ -359,7 +329,6 @@ class PythonAction(BaseAction):
                     error=stderr_value,
                 )
 
-            # Get result if 'result' variable was set
             result = exec_globals.get("result")
 
             return ActionResult(
@@ -371,7 +340,6 @@ class PythonAction(BaseAction):
             import traceback
 
             full_error = f"Python action failed: {e}\n{traceback.format_exc()}"
-            print(f"[PYTHON ACTION EXCEPTION] {full_error}", file=sys.stderr)
             logger.error(full_error)
             return ActionResult(action_name=self.name, success=False, error=str(e))
 
@@ -380,11 +348,9 @@ class BashAction(BaseAction):
     """Execute shell command."""
 
     async def execute(self, context: WorkflowContext) -> ActionResult:
-        """Execute bash action."""
         try:
             command = self.interpolate(self.config.get("command", ""), context)
 
-            # Execute command
             result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=30)
 
             return ActionResult(

--- a/src/nexus/workflows/api.py
+++ b/src/nexus/workflows/api.py
@@ -1,10 +1,13 @@
-"""Python SDK API for workflow system."""
+"""Python SDK API for workflow system.
+
+No global engine — the engine must be explicitly provided.
+"""
 
 import builtins
 from pathlib import Path
 from typing import Any
 
-from nexus.workflows.engine import WorkflowEngine, get_engine, init_engine
+from nexus.workflows.engine import WorkflowEngine
 from nexus.workflows.loader import WorkflowLoader
 from nexus.workflows.types import (
     TriggerType,
@@ -16,58 +19,25 @@ from nexus.workflows.types import (
 class WorkflowAPI:
     """High-level API for workflow management.
 
-    This class provides a clean Python API for managing and executing workflows.
-    It wraps the underlying workflow engine with a more user-friendly interface.
-
     Examples:
         >>> from nexus.workflows import WorkflowAPI
         >>>
-        >>> # Create API instance
-        >>> workflows = WorkflowAPI()
-        >>>
-        >>> # Load a workflow
+        >>> workflows = WorkflowAPI(engine=engine)
         >>> workflows.load("invoice-processor.yaml")
-        >>>
-        >>> # List workflows
         >>> for workflow in workflows.list():
-        ...     print(f"{workflow['name']}: {workflow['status']}")
-        >>>
-        >>> # Execute a workflow
-        >>> result = workflows.execute("invoice-processor", file_path="/inbox/invoice.pdf")
-        >>> print(f"Status: {result.status}")
-        >>>
-        >>> # Enable/disable workflows
-        >>> workflows.enable("invoice-processor")
-        >>> workflows.disable("invoice-processor")
+        ...     print(f"{workflow['name']}: enabled={workflow['enabled']}")
     """
 
-    def __init__(self, engine: WorkflowEngine | None = None):
+    def __init__(self, engine: WorkflowEngine) -> None:
         """Initialize workflow API.
 
         Args:
-            engine: Optional workflow engine instance. If not provided,
-                   uses the injected engine or creates a default one.
+            engine: Workflow engine instance (required).
         """
-        self.engine = engine or get_engine() or init_engine()
+        self.engine = engine
 
     def load(self, source: str | Path | dict | WorkflowDefinition, enabled: bool = True) -> bool:
-        """Load a workflow from a file, dict, or definition.
-
-        Args:
-            source: Workflow source:
-                - str/Path: Path to YAML file
-                - dict: Workflow definition as dictionary
-                - WorkflowDefinition: Already parsed definition
-            enabled: Whether to enable the workflow after loading
-
-        Returns:
-            True if loaded successfully
-
-        Examples:
-            >>> workflows.load("process-invoices.yaml")
-            >>> workflows.load({"name": "test", "actions": [...]})
-        """
-        # Parse source into WorkflowDefinition
+        """Load a workflow from a file, dict, or definition."""
         if isinstance(source, WorkflowDefinition):
             definition = source
         elif isinstance(source, dict):
@@ -78,37 +48,11 @@ class WorkflowAPI:
         return self.engine.load_workflow(definition, enabled=enabled)
 
     def list(self) -> list[dict[str, Any]]:
-        """List all loaded workflows.
-
-        Returns:
-            List of workflow info dictionaries with keys:
-                - name: Workflow name
-                - version: Workflow version
-                - description: Workflow description
-                - enabled: Whether workflow is enabled
-                - triggers: Number of triggers
-                - actions: Number of actions
-
-        Examples:
-            >>> for workflow in workflows.list():
-            ...     print(f"{workflow['name']}: {workflow['enabled']}")
-        """
+        """List all loaded workflows."""
         return self.engine.list_workflows()
 
     def get(self, name: str) -> WorkflowDefinition | None:
-        """Get a workflow definition by name.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            WorkflowDefinition or None if not found
-
-        Examples:
-            >>> workflow = workflows.get("invoice-processor")
-            >>> if workflow:
-            ...     print(f"Actions: {len(workflow.actions)}")
-        """
+        """Get a workflow definition by name."""
         return self.engine.workflows.get(name)
 
     async def execute(
@@ -117,24 +61,7 @@ class WorkflowAPI:
         file_path: str | None = None,
         context: dict[str, Any] | None = None,
     ) -> WorkflowExecution | None:
-        """Execute a workflow manually.
-
-        Args:
-            name: Workflow name
-            file_path: Optional file path to process
-            context: Optional additional context
-
-        Returns:
-            WorkflowExecution record or None if failed
-
-        Examples:
-            >>> result = await workflows.execute(
-            ...     "invoice-processor",
-            ...     file_path="/inbox/invoice.pdf"
-            ... )
-            >>> print(f"Status: {result.status}")
-            >>> print(f"Actions completed: {result.actions_completed}")
-        """
+        """Execute a workflow manually."""
         event_context = context or {}
         if file_path:
             event_context["file_path"] = file_path
@@ -142,72 +69,27 @@ class WorkflowAPI:
         return await self.engine.trigger_workflow(name, event_context)
 
     def enable(self, name: str) -> bool:
-        """Enable a workflow.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            True if workflow exists and was enabled
-
-        Examples:
-            >>> workflows.enable("invoice-processor")
-        """
+        """Enable a workflow."""
         if name in self.engine.workflows:
             self.engine.enable_workflow(name)
             return True
         return False
 
     def disable(self, name: str) -> bool:
-        """Disable a workflow.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            True if workflow exists and was disabled
-
-        Examples:
-            >>> workflows.disable("invoice-processor")
-        """
+        """Disable a workflow."""
         if name in self.engine.workflows:
             self.engine.disable_workflow(name)
             return True
         return False
 
     def unload(self, name: str) -> bool:
-        """Unload a workflow.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            True if workflow was unloaded
-
-        Examples:
-            >>> workflows.unload("invoice-processor")
-        """
+        """Unload a workflow."""
         return self.engine.unload_workflow(name)
 
     def discover(
         self, directory: str | Path, load: bool = False
     ) -> builtins.list[WorkflowDefinition]:
-        """Discover workflows in a directory.
-
-        Args:
-            directory: Directory to search for workflow files
-            load: Whether to load discovered workflows
-
-        Returns:
-            List of discovered workflow definitions
-
-        Examples:
-            >>> discovered = workflows.discover(".nexus/workflows")
-            >>> print(f"Found {len(discovered)} workflows")
-            >>>
-            >>> # Load all discovered workflows
-            >>> workflows.discover(".nexus/workflows", load=True)
-        """
+        """Discover workflows in a directory."""
         definitions = WorkflowLoader.discover_workflows(directory)
 
         if load:
@@ -216,72 +98,18 @@ class WorkflowAPI:
 
         return definitions
 
-    async def fire_event(self, trigger_type: TriggerType, event_context: dict[str, Any]) -> int:
-        """Fire an event that may trigger workflows.
-
-        Args:
-            trigger_type: Type of event (FILE_WRITE, FILE_DELETE, etc.)
-            event_context: Event data
-
-        Returns:
-            Number of workflows triggered
-
-        Examples:
-            >>> # Trigger file write event
-            >>> count = await workflows.fire_event(
-            ...     TriggerType.FILE_WRITE,
-            ...     {"file_path": "/inbox/document.pdf"}
-            ... )
-            >>> print(f"Triggered {count} workflows")
-        """
+    async def fire_event(
+        self, trigger_type: TriggerType | str, event_context: dict[str, Any]
+    ) -> int:
+        """Fire an event that may trigger workflows."""
         return await self.engine.fire_event(trigger_type, event_context)
 
     def is_enabled(self, name: str) -> bool:
-        """Check if a workflow is enabled.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            True if workflow exists and is enabled
-
-        Examples:
-            >>> if workflows.is_enabled("invoice-processor"):
-            ...     print("Workflow is active")
-        """
+        """Check if a workflow is enabled."""
         return self.engine.enabled_workflows.get(name, False)
 
     def get_status(self, name: str) -> str | None:
-        """Get the status of a workflow.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            "enabled", "disabled", or None if not found
-
-        Examples:
-            >>> status = workflows.get_status("invoice-processor")
-            >>> print(f"Workflow status: {status}")
-        """
+        """Get the status of a workflow."""
         if name not in self.engine.workflows:
             return None
         return "enabled" if self.is_enabled(name) else "disabled"
-
-
-# Convenience function for quick access
-def get_workflow_api() -> WorkflowAPI:
-    """Get a WorkflowAPI instance.
-
-    This is a convenience function for quick access to workflow functionality.
-
-    Returns:
-        WorkflowAPI instance
-
-    Examples:
-        >>> from nexus.workflows import get_workflow_api
-        >>>
-        >>> workflows = get_workflow_api()
-        >>> workflows.load("process-invoices.yaml")
-    """
-    return WorkflowAPI()

--- a/src/nexus/workflows/engine.py
+++ b/src/nexus/workflows/engine.py
@@ -1,4 +1,7 @@
-"""Workflow execution engine."""
+"""Workflow execution engine.
+
+No global singletons. Engine is constructed via DI and wired by factory.py.
+"""
 
 import logging
 import time
@@ -6,8 +9,8 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-from nexus.raft.zone_manager import ROOT_ZONE_ID
 from nexus.workflows.actions import BUILTIN_ACTIONS
+from nexus.workflows.protocol import WorkflowServices
 from nexus.workflows.triggers import BUILTIN_TRIGGERS, TriggerManager
 from nexus.workflows.types import (
     TriggerType,
@@ -23,24 +26,26 @@ logger = logging.getLogger(__name__)
 class WorkflowEngine:
     """Core workflow execution engine."""
 
-    def __init__(self, metadata_store=None, plugin_registry=None, workflow_store=None):  # type: ignore[no-untyped-def]
-        self.metadata_store = metadata_store
-        self.plugin_registry = plugin_registry
+    def __init__(
+        self,
+        *,
+        workflow_store: Any | None = None,
+        services: WorkflowServices | None = None,
+        plugin_registry: Any | None = None,
+    ) -> None:
         self.workflow_store = workflow_store
-        self.trigger_manager = TriggerManager()
+        self._services = services
+        self.plugin_registry = plugin_registry
+        glob_match = services.glob_match if services else None
+        self.trigger_manager = TriggerManager(glob_match=glob_match)
         self.workflows: dict[str, WorkflowDefinition] = {}
         self.enabled_workflows: dict[str, bool] = {}
-        self.workflow_ids: dict[str, str] = {}  # name -> workflow_id mapping
+        self.workflow_ids: dict[str, str] = {}
         self.action_registry = BUILTIN_ACTIONS.copy()
         self.trigger_registry = BUILTIN_TRIGGERS.copy()
 
-        # Discover plugin actions and triggers
         if plugin_registry:
             self._discover_plugin_extensions()
-
-        # Load workflows from storage if available
-        if workflow_store:
-            self._load_workflows_from_storage()
 
     def _discover_plugin_extensions(self) -> None:
         """Discover actions and triggers from plugins."""
@@ -48,187 +53,165 @@ class WorkflowEngine:
             return
 
         for plugin in self.plugin_registry.get_enabled_plugins():
-            # Discover plugin actions
             if hasattr(plugin, "workflow_actions"):
                 plugin_actions = plugin.workflow_actions()
                 self.action_registry.update(plugin_actions)
                 logger.info(f"Registered {len(plugin_actions)} actions from plugin {plugin.name}")
 
-            # Discover plugin triggers
             if hasattr(plugin, "workflow_triggers"):
                 plugin_triggers = plugin.workflow_triggers()
                 self.trigger_registry.update(plugin_triggers)
                 logger.info(f"Registered {len(plugin_triggers)} triggers from plugin {plugin.name}")
 
-    def _load_workflows_from_storage(self) -> None:
-        """Load all workflows from storage."""
+    async def startup(self) -> None:
+        """Load workflows from storage (must be called post-construction in async context)."""
         if not self.workflow_store:
             return
 
         try:
-            workflows_list = self.workflow_store.list_workflows()
+            workflows_list = await self.workflow_store.list_workflows()
             for workflow_info in workflows_list:
-                definition = self.workflow_store.load_workflow(workflow_info["workflow_id"])
+                definition = await self.workflow_store.load_workflow(workflow_info["workflow_id"])
                 if definition:
                     self.workflows[definition.name] = definition
                     self.enabled_workflows[definition.name] = workflow_info["enabled"]
                     self.workflow_ids[definition.name] = workflow_info["workflow_id"]
 
-                    # Register triggers
-                    for trigger_def in definition.triggers:
-                        trigger_class = self.trigger_registry.get(trigger_def.type)
-                        if trigger_class:
-                            trigger = trigger_class(trigger_def.config)  # type: ignore[abstract]
-
-                            # Bind definition.name to avoid closure issue
-                            async def trigger_callback(
-                                event_context: dict[str, Any], wf_name: str = definition.name
-                            ) -> None:
-                                await self.trigger_workflow(wf_name, event_context)
-
-                            self.trigger_manager.register_trigger(trigger, trigger_callback)  # type: ignore[arg-type]
+                    self._register_triggers_for(definition)
 
             logger.info(f"Loaded {len(workflows_list)} workflow(s) from storage")
         except Exception as e:
             logger.error(f"Failed to load workflows from storage: {e}")
 
-    def load_workflow(self, definition: WorkflowDefinition, enabled: bool = True) -> bool:
-        """Load a workflow definition.
+    def _register_triggers_for(self, definition: WorkflowDefinition) -> None:
+        """Register triggers for a workflow definition."""
+        glob_match = self._services.glob_match if self._services else None
+        for trigger_def in definition.triggers:
+            trigger_class = self.trigger_registry.get(trigger_def.type)
+            if not trigger_class:
+                logger.warning(f"Unknown trigger type: {trigger_def.type}, skipping")
+                continue
 
-        Args:
-            definition: Workflow definition
-            enabled: Whether workflow is enabled
+            trigger = trigger_class(trigger_def.config, glob_match=glob_match)  # type: ignore[abstract]
 
-        Returns:
-            True if loaded successfully
-        """
+            async def trigger_callback(
+                event_context: dict[str, Any], wf_name: str = definition.name
+            ) -> None:
+                await self.trigger_workflow(wf_name, event_context)
+
+            self.trigger_manager.register_trigger(trigger, trigger_callback)  # type: ignore[arg-type]
+
+    def load_workflow(self, definition: WorkflowDefinition, *, enabled: bool = True) -> bool:
+        """Load a workflow definition."""
         try:
-            # Validate workflow
             if not definition.name:
                 raise ValueError("Workflow must have a name")
 
             if not definition.actions:
                 raise ValueError("Workflow must have at least one action")
 
-            # Save to storage if available
+            # Save to storage if available (async store — fire and forget in sync context)
             if self.workflow_store:
-                workflow_id = self.workflow_store.save_workflow(definition, enabled)
-                self.workflow_ids[definition.name] = workflow_id
-                logger.info(f"Saved workflow to storage: {definition.name} (id={workflow_id})")
+                import asyncio
+
+                try:
+                    loop = asyncio.get_running_loop()
+                    # We're in an async context — create a task
+                    task = loop.create_task(self._save_workflow_async(definition, enabled))
+                    # Store reference to prevent GC
+                    task.add_done_callback(lambda t: t.result() if not t.cancelled() else None)
+                except RuntimeError:
+                    # No running loop — run synchronously
+                    asyncio.run(self._save_workflow_async(definition, enabled))
 
             # Store workflow in memory
             self.workflows[definition.name] = definition
             self.enabled_workflows[definition.name] = enabled
 
             # Register triggers
-            import sys
-
-            print(f"[ENGINE] Registering triggers for workflow: {definition.name}", file=sys.stderr)
-            print(f"[ENGINE] Number of triggers: {len(definition.triggers)}", file=sys.stderr)
-            print(
-                f"[ENGINE] Trigger registry has: {list(self.trigger_registry.keys())}",
-                file=sys.stderr,
-            )
-
-            for trigger_def in definition.triggers:
-                print(
-                    f"[ENGINE] Processing trigger_def: type={trigger_def.type}, config={trigger_def.config}",
-                    file=sys.stderr,
-                )
-                trigger_class = self.trigger_registry.get(trigger_def.type)
-                print(f"[ENGINE] Got trigger_class: {trigger_class}", file=sys.stderr)
-                if not trigger_class:
-                    logger.warning(f"Unknown trigger type: {trigger_def.type}, skipping")
-                    print(
-                        f"[ENGINE] WARNING: Unknown trigger type {trigger_def.type}, skipping",
-                        file=sys.stderr,
-                    )
-                    continue
-
-                trigger = trigger_class(trigger_def.config)  # type: ignore[abstract]
-                print(f"[ENGINE] Created trigger instance: {trigger}", file=sys.stderr)
-
-                # Create callback that executes this workflow
-                # Bind definition.name to avoid closure issue
-                async def trigger_callback(
-                    event_context: dict[str, Any], wf_name: str = definition.name
-                ) -> None:
-                    await self.trigger_workflow(wf_name, event_context)
-
-                print("[ENGINE] Registering trigger with trigger_manager...", file=sys.stderr)
-                self.trigger_manager.register_trigger(trigger, trigger_callback)  # type: ignore[arg-type]
-                print("[ENGINE] Trigger registered successfully", file=sys.stderr)
+            logger.debug("Registering triggers for workflow: %s", definition.name)
+            self._register_triggers_for(definition)
 
             logger.info(f"Loaded workflow: {definition.name} (enabled={enabled})")
-            print(f"[ENGINE] Workflow loaded successfully: {definition.name}", file=sys.stderr)
             return True
 
         except Exception as e:
             logger.error(f"Failed to load workflow {definition.name}: {e}")
             return False
 
+    async def _save_workflow_async(self, definition: WorkflowDefinition, enabled: bool) -> None:
+        """Save workflow to store (async helper)."""
+        try:
+            workflow_id = await self.workflow_store.save_workflow(definition, enabled)  # type: ignore[union-attr]
+            self.workflow_ids[definition.name] = workflow_id
+            logger.info(f"Saved workflow to storage: {definition.name} (id={workflow_id})")
+        except Exception as e:
+            logger.error(f"Failed to save workflow to storage: {e}")
+
     def unload_workflow(self, name: str) -> bool:
-        """Unload a workflow.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            True if unloaded successfully
-        """
+        """Unload a workflow."""
         if name not in self.workflows:
             return False
 
-        # Delete from storage if available
         if self.workflow_store:
-            self.workflow_store.delete_workflow_by_name(name)
+            import asyncio
 
-        # Remove workflow from memory
+            try:
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(self.workflow_store.delete_workflow_by_name(name))
+                except RuntimeError:
+                    asyncio.run(self.workflow_store.delete_workflow_by_name(name))
+            except Exception as e:
+                logger.error(f"Failed to delete workflow from storage: {e}")
+
         del self.workflows[name]
-        if name in self.enabled_workflows:
-            del self.enabled_workflows[name]
-        if name in self.workflow_ids:
-            del self.workflow_ids[name]
+        self.enabled_workflows.pop(name, None)
+        self.workflow_ids.pop(name, None)
 
         logger.info(f"Unloaded workflow: {name}")
         return True
 
     def enable_workflow(self, name: str) -> None:
-        """Enable a workflow.
-
-        Args:
-            name: Workflow name
-        """
+        """Enable a workflow."""
         if name in self.workflows:
             self.enabled_workflows[name] = True
 
-            # Update storage if available
             if self.workflow_store:
-                self.workflow_store.set_enabled_by_name(name, True)
+                import asyncio
+
+                try:
+                    try:
+                        loop = asyncio.get_running_loop()
+                        loop.create_task(self.workflow_store.set_enabled_by_name(name, True))
+                    except RuntimeError:
+                        asyncio.run(self.workflow_store.set_enabled_by_name(name, True))
+                except Exception as e:
+                    logger.error(f"Failed to persist workflow enable state: {e}")
 
             logger.info(f"Enabled workflow: {name}")
 
     def disable_workflow(self, name: str) -> None:
-        """Disable a workflow.
-
-        Args:
-            name: Workflow name
-        """
+        """Disable a workflow."""
         if name in self.workflows:
             self.enabled_workflows[name] = False
 
-            # Update storage if available
             if self.workflow_store:
-                self.workflow_store.set_enabled_by_name(name, False)
+                import asyncio
+
+                try:
+                    try:
+                        loop = asyncio.get_running_loop()
+                        loop.create_task(self.workflow_store.set_enabled_by_name(name, False))
+                    except RuntimeError:
+                        asyncio.run(self.workflow_store.set_enabled_by_name(name, False))
+                except Exception as e:
+                    logger.error(f"Failed to persist workflow disable state: {e}")
 
             logger.info(f"Disabled workflow: {name}")
 
     def list_workflows(self) -> list[dict[str, Any]]:
-        """List all loaded workflows.
-
-        Returns:
-            List of workflow info dicts
-        """
+        """List all loaded workflows."""
         result = []
         for name, definition in self.workflows.items():
             result.append(
@@ -246,16 +229,7 @@ class WorkflowEngine:
     async def trigger_workflow(
         self, workflow_name: str, event_context: dict[str, Any]
     ) -> WorkflowExecution | None:
-        """Trigger a workflow execution.
-
-        Args:
-            workflow_name: Name of workflow to execute
-            event_context: Event context data
-
-        Returns:
-            WorkflowExecution record or None if failed
-        """
-        # Check if workflow exists and is enabled
+        """Trigger a workflow execution."""
         if workflow_name not in self.workflows:
             logger.warning(f"Workflow not found: {workflow_name}")
             return None
@@ -266,29 +240,14 @@ class WorkflowEngine:
 
         definition = self.workflows[workflow_name]
 
-        # Create execution context
         execution_id = uuid.uuid4()
 
-        # Get the actual workflow_id from storage (stored when workflow was loaded)
         workflow_id_str = self.workflow_ids.get(workflow_name)
-        if workflow_id_str:
-            # Convert string UUID to UUID object
-            workflow_id = uuid.UUID(workflow_id_str)
-        else:
-            # Fallback: generate a new UUID if not found (shouldn't happen in normal operation)
-            workflow_id = uuid.uuid4()
+        workflow_id = uuid.UUID(workflow_id_str) if workflow_id_str else uuid.uuid4()
+        if not workflow_id_str:
             logger.warning(f"No workflow_id found for {workflow_name}, using generated UUID")
 
-        # Get zone_id from event context or workflow store
-        zone_id_str = event_context.get("zone_id", ROOT_ZONE_ID)
-        try:
-            # Try to convert to UUID if it's a valid UUID string
-            import uuid as uuid_module
-
-            zone_id = uuid_module.UUID(zone_id_str) if zone_id_str != ROOT_ZONE_ID else None
-        except (ValueError, AttributeError):
-            # If not a valid UUID, use None or default
-            zone_id = None
+        zone_id = str(event_context.get("zone_id", "default"))
 
         context = WorkflowContext(
             workflow_id=workflow_id,
@@ -299,24 +258,16 @@ class WorkflowEngine:
             variables=definition.variables.copy(),
             file_path=event_context.get("file_path"),
             file_metadata=event_context.get("metadata"),
+            services=self._services,
         )
 
-        # Execute workflow
         execution = await self.execute_workflow(definition, context)
         return execution
 
     async def execute_workflow(
         self, definition: WorkflowDefinition, context: WorkflowContext
     ) -> WorkflowExecution:
-        """Execute a workflow.
-
-        Args:
-            definition: Workflow definition
-            context: Execution context
-
-        Returns:
-            WorkflowExecution record
-        """
+        """Execute a workflow."""
         execution = WorkflowExecution(
             execution_id=context.execution_id,
             workflow_id=context.workflow_id,
@@ -330,58 +281,49 @@ class WorkflowEngine:
         )
 
         logger.info(f"Executing workflow: {definition.name} (execution_id={context.execution_id})")
-
-        import sys
-
-        print(f"[EXECUTE_WORKFLOW] Starting workflow: {definition.name}", file=sys.stderr)
-        print(f"[EXECUTE_WORKFLOW] Number of actions: {len(definition.actions)}", file=sys.stderr)
+        logger.debug("Number of actions: %d", len(definition.actions))
 
         try:
-            # Execute actions sequentially
             for i, action_def in enumerate(definition.actions, 1):
-                print(
-                    f"[EXECUTE_WORKFLOW] Processing action {i}/{len(definition.actions)}: {action_def.name} (type={action_def.type})",
-                    file=sys.stderr,
+                logger.debug(
+                    "Processing action %d/%d: %s (type=%s)",
+                    i,
+                    len(definition.actions),
+                    action_def.name,
+                    action_def.type,
                 )
                 action_class = self.action_registry.get(action_def.type)
-                print(f"[EXECUTE_WORKFLOW] Got action_class: {action_class}", file=sys.stderr)
                 if not action_class:
                     raise ValueError(f"Unknown action type: {action_def.type}")
 
-                # Create action instance
                 action = action_class(action_def.name, action_def.config)  # type: ignore[abstract]
-                print(f"[EXECUTE_WORKFLOW] Created action instance: {action}", file=sys.stderr)
 
-                # Execute action
-                print("[EXECUTE_WORKFLOW] Executing action...", file=sys.stderr)
                 start_time = time.time()
                 result = await action.execute(context)
                 result.duration_ms = (time.time() - start_time) * 1000
-                print(
-                    f"[EXECUTE_WORKFLOW] Action completed. Success={result.success}, Output={result.output}",
-                    file=sys.stderr,
+                logger.debug(
+                    "Action completed: success=%s, duration=%.2fms",
+                    result.success,
+                    result.duration_ms,
                 )
 
-                # Record result
                 execution.action_results.append(result)
 
                 if result.success:
                     execution.actions_completed += 1
                     logger.info(
-                        f"Action '{action_def.name}' completed successfully in {result.duration_ms:.2f}ms"
+                        f"Action '{action_def.name}' completed successfully "
+                        f"in {result.duration_ms:.2f}ms"
                     )
 
-                    # Store action output in context for next actions
                     if result.output:
                         context.variables[f"{action_def.name}_output"] = result.output
                 else:
-                    # Action failed, stop workflow
                     execution.status = WorkflowStatus.FAILED
                     execution.error_message = f"Action '{action_def.name}' failed: {result.error}"
                     logger.error(execution.error_message)
                     break
 
-            # Workflow completed successfully if we got here
             if execution.status == WorkflowStatus.RUNNING:
                 execution.status = WorkflowStatus.SUCCEEDED
 
@@ -395,9 +337,8 @@ class WorkflowEngine:
 
         logger.info(f"Workflow '{definition.name}' finished with status: {execution.status}")
 
-        # Store execution record (if metadata store available)
-        if self.metadata_store:
-            await self._store_execution(execution)
+        # Store execution record
+        await self._store_execution(execution)
 
         return execution
 
@@ -407,60 +348,23 @@ class WorkflowEngine:
             return
 
         try:
-            self.workflow_store.save_execution(execution)
+            await self.workflow_store.save_execution(execution)
             logger.info(f"Saved execution record: {execution.execution_id}")
         except Exception as e:
             logger.error(f"Failed to save execution record: {e}")
 
-    async def fire_event(self, trigger_type: TriggerType, event_context: dict[str, Any]) -> int:
+    async def fire_event(
+        self, trigger_type: TriggerType | str, event_context: dict[str, Any]
+    ) -> int:
         """Fire an event that may trigger workflows.
 
         Args:
-            trigger_type: Type of event
-            event_context: Event data
+            trigger_type: TriggerType enum or string value (e.g. "file_write").
+            event_context: Event data.
 
         Returns:
-            Number of workflows triggered
+            Number of workflows triggered.
         """
-        event_context["trigger_type"] = trigger_type.value
-        return await self.trigger_manager.fire_event(trigger_type, event_context)
-
-
-# Injectable workflow engine instance (set by server/factory layer at startup)
-_engine: WorkflowEngine | None = None
-
-
-def set_engine(engine: WorkflowEngine) -> None:
-    """Inject a workflow engine instance. Called by server/factory layer at startup."""
-    global _engine
-    _engine = engine
-
-
-def get_engine() -> WorkflowEngine | None:
-    """Return the injected workflow engine, or None if not initialized."""
-    return _engine
-
-
-def reset_engine() -> None:
-    """Reset engine to None — only for tests."""
-    global _engine
-    _engine = None
-
-
-def init_engine(metadata_store=None, plugin_registry=None, workflow_store=None) -> WorkflowEngine:  # type: ignore[no-untyped-def]
-    """Create and inject a workflow engine.
-
-    Convenience helper that creates a WorkflowEngine with the given
-    stores and registers it via ``set_engine()``.
-
-    Args:
-        metadata_store: Metadata store instance
-        plugin_registry: Plugin registry instance
-        workflow_store: Workflow store instance
-
-    Returns:
-        Initialized workflow engine
-    """
-    engine = WorkflowEngine(metadata_store, plugin_registry, workflow_store)
-    set_engine(engine)
-    return engine
+        key = trigger_type if isinstance(trigger_type, str) else trigger_type.value
+        event_context["trigger_type"] = key
+        return await self.trigger_manager.fire_event(key, event_context)

--- a/src/nexus/workflows/protocol.py
+++ b/src/nexus/workflows/protocol.py
@@ -1,0 +1,114 @@
+"""Workflow brick protocols — zero-dependency interfaces.
+
+All protocols are @runtime_checkable for duck-typed conformance.
+No imports from nexus.core, nexus.storage, or nexus.server.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Dependency-injection callables
+# ---------------------------------------------------------------------------
+
+
+class GlobMatchFn(Protocol):
+    """Callable that checks whether *path* matches any of *patterns*."""
+
+    def __call__(self, path: str, patterns: list[str]) -> bool: ...
+
+
+# ---------------------------------------------------------------------------
+# Service protocols (what actions need)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class NexusOperationsProtocol(Protocol):
+    """Filesystem operations that workflow actions may invoke."""
+
+    async def parse(self, path: str, *, parser: str = "auto") -> Any: ...
+
+    async def add_tag(self, path: str, tag: str) -> None: ...
+
+    async def remove_tag(self, path: str, tag: str) -> None: ...
+
+    def rename(self, old_path: str, new_path: str) -> None: ...
+
+    def mkdir(self, path: str, *, parents: bool = False) -> None: ...
+
+    def read(self, path: str) -> bytes: ...
+
+
+@runtime_checkable
+class MetadataStoreProtocol(Protocol):
+    """Minimal metadata store surface used by MetadataAction."""
+
+    def get_path(self, path: str) -> Any: ...
+
+    def set_file_metadata(self, path_id: Any, key: str, value: str) -> None: ...
+
+
+@runtime_checkable
+class LLMProviderProtocol(Protocol):
+    """LLM provider surface used by LLMAction."""
+
+    async def generate(self, *, model: str, prompt: str, system: str) -> str: ...
+
+
+# ---------------------------------------------------------------------------
+# Main brick protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class WorkflowProtocol(Protocol):
+    """Public contract for the workflow engine brick."""
+
+    async def fire_event(
+        self,
+        trigger_type: str,
+        event_context: dict[str, Any],
+    ) -> int: ...
+
+    async def trigger_workflow(
+        self,
+        workflow_name: str,
+        event_context: dict[str, Any],
+    ) -> Any: ...
+
+    def load_workflow(
+        self,
+        definition: Any,
+        *,
+        enabled: bool = True,
+    ) -> bool: ...
+
+    def unload_workflow(self, name: str) -> bool: ...
+
+    def enable_workflow(self, name: str) -> None: ...
+
+    def disable_workflow(self, name: str) -> None: ...
+
+    def list_workflows(self) -> list[dict[str, Any]]: ...
+
+
+# ---------------------------------------------------------------------------
+# Services bundle injected into WorkflowContext
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorkflowServices:
+    """Services injected into workflow context for action execution.
+
+    All fields are optional — actions that need a missing service
+    return ``ActionResult(success=False, error="… service not injected")``.
+    """
+
+    nexus_ops: NexusOperationsProtocol | None = None
+    metadata_store: MetadataStoreProtocol | None = None
+    llm_provider: LLMProviderProtocol | None = None
+    glob_match: GlobMatchFn | None = None

--- a/src/nexus/workflows/storage.py
+++ b/src/nexus/workflows/storage.py
@@ -1,4 +1,9 @@
-"""Workflow storage layer for database persistence."""
+"""Workflow storage layer — async, zero model imports.
+
+Model classes (WorkflowModel, WorkflowExecutionModel) are injected via
+the constructor so this module has no imports from nexus.storage.
+All methods are async using SQLAlchemy AsyncSession.
+"""
 
 import hashlib
 import json
@@ -11,8 +16,6 @@ from typing import Any
 import yaml
 from sqlalchemy import select
 
-from nexus.raft.zone_manager import ROOT_ZONE_ID
-from nexus.storage.models import WorkflowExecutionModel, WorkflowModel
 from nexus.workflows.loader import WorkflowLoader
 from nexus.workflows.types import WorkflowDefinition, WorkflowExecution
 
@@ -20,45 +23,60 @@ logger = logging.getLogger(__name__)
 
 
 class WorkflowStore:
-    """Storage layer for workflow persistence."""
+    """Async storage layer for workflow persistence."""
 
-    def __init__(self, session_factory: Callable[..., Any], zone_id: str | None = None) -> None:
+    def __init__(
+        self,
+        session_factory: Callable[..., Any],
+        *,
+        workflow_model: type[Any],
+        execution_model: type[Any],
+        zone_id: str | None = None,
+    ) -> None:
         """Initialize workflow store.
 
         Args:
-            session_factory: SQLAlchemy session factory
-            zone_id: Zone ID (optional, defaults to ROOT_ZONE_ID)
+            session_factory: Async session factory (returns AsyncSession context manager).
+            workflow_model: SQLAlchemy model class for workflows.
+            execution_model: SQLAlchemy model class for workflow executions.
+            zone_id: Zone ID (defaults to "default").
         """
         self.session_factory = session_factory
-        self.zone_id = zone_id or ROOT_ZONE_ID
+        self._workflow_model = workflow_model
+        self._execution_model = execution_model
+        self.zone_id = zone_id or "default"
 
     def _get_zone_id(self) -> str:
-        """Get current zone ID."""
         return self.zone_id
 
     def _compute_hash(self, definition_yaml: str) -> str:
-        """Compute SHA256 hash of workflow definition.
-
-        Args:
-            definition_yaml: YAML workflow definition
-
-        Returns:
-            SHA256 hash hex string
-        """
         return hashlib.sha256(definition_yaml.encode()).hexdigest()
 
-    def save_workflow(self, definition: WorkflowDefinition, enabled: bool = True) -> str:
-        """Save a workflow definition to database.
+    async def _get_workflow(
+        self,
+        session: Any,
+        *,
+        workflow_id: str | None = None,
+        name: str | None = None,
+    ) -> Any | None:
+        """Fetch a single workflow by ID or name (DRY helper)."""
+        if workflow_id is not None:
+            stmt = select(self._workflow_model).where(
+                self._workflow_model.workflow_id == workflow_id
+            )
+        elif name is not None:
+            stmt = select(self._workflow_model).where(
+                self._workflow_model.zone_id == self._get_zone_id(),
+                self._workflow_model.name == name,
+            )
+        else:
+            return None
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
 
-        Args:
-            definition: Workflow definition
-            enabled: Whether workflow is enabled
-
-        Returns:
-            Workflow ID (UUID string)
-        """
-        with self.session_factory() as session:
-            # Convert definition to YAML
+    async def save_workflow(self, definition: WorkflowDefinition, enabled: bool = True) -> str:
+        """Save a workflow definition to database."""
+        async with self.session_factory() as session:
             definition_dict: dict[str, Any] = {
                 "name": definition.name,
                 "version": definition.version,
@@ -82,15 +100,9 @@ class WorkflowStore:
             definition_yaml = yaml.dump(definition_dict, default_flow_style=False)
             definition_hash = self._compute_hash(definition_yaml)
 
-            # Check if workflow already exists
-            stmt = select(WorkflowModel).where(
-                WorkflowModel.zone_id == self._get_zone_id(),
-                WorkflowModel.name == definition.name,
-            )
-            existing = session.execute(stmt).scalar_one_or_none()
+            existing = await self._get_workflow(session, name=definition.name)
 
             if existing:
-                # Update existing workflow
                 existing.version = definition.version
                 existing.description = definition.description
                 existing.definition = definition_yaml
@@ -100,8 +112,7 @@ class WorkflowStore:
                 workflow_id = str(existing.workflow_id)
                 logger.info(f"Updated workflow: {definition.name} (id={workflow_id})")
             else:
-                # Create new workflow
-                workflow = WorkflowModel(
+                workflow = self._workflow_model(
                     workflow_id=str(uuid.uuid4()),
                     zone_id=self._get_zone_id(),
                     name=definition.name,
@@ -115,72 +126,47 @@ class WorkflowStore:
                 workflow_id = str(workflow.workflow_id)
                 logger.info(f"Created workflow: {definition.name} (id={workflow_id})")
 
-            session.commit()
+            await session.commit()
             return workflow_id
 
-    def load_workflow(self, workflow_id: str) -> WorkflowDefinition | None:
-        """Load a workflow definition from database.
-
-        Args:
-            workflow_id: Workflow UUID
-
-        Returns:
-            WorkflowDefinition or None if not found
-        """
-        with self.session_factory() as session:
-            stmt = select(WorkflowModel).where(WorkflowModel.workflow_id == workflow_id)
-            workflow = session.execute(stmt).scalar_one_or_none()
-
+    async def load_workflow(self, workflow_id: str) -> WorkflowDefinition | None:
+        """Load a workflow definition by ID."""
+        async with self.session_factory() as session:
+            workflow = await self._get_workflow(session, workflow_id=workflow_id)
             if not workflow:
                 return None
-
-            # Parse YAML definition
             try:
                 return WorkflowLoader.load_from_string(workflow.definition)
             except Exception as e:
                 logger.error(f"Failed to parse workflow {workflow_id}: {e}")
                 return None
 
-    def load_workflow_by_name(self, name: str) -> WorkflowDefinition | None:
-        """Load a workflow by name.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            WorkflowDefinition or None if not found
-        """
-        with self.session_factory() as session:
-            stmt = select(WorkflowModel).where(
-                WorkflowModel.zone_id == self._get_zone_id(),
-                WorkflowModel.name == name,
-            )
-            workflow = session.execute(stmt).scalar_one_or_none()
-
+    async def load_workflow_by_name(self, name: str) -> WorkflowDefinition | None:
+        """Load a workflow by name."""
+        async with self.session_factory() as session:
+            workflow = await self._get_workflow(session, name=name)
             if not workflow:
                 return None
-
             try:
                 return WorkflowLoader.load_from_string(workflow.definition)
             except Exception as e:
                 logger.error(f"Failed to parse workflow {name}: {e}")
                 return None
 
-    def list_workflows(self) -> list[dict[str, Any]]:
-        """List all workflows.
+    async def list_workflows(self) -> list[dict[str, Any]]:
+        """List all workflows."""
+        async with self.session_factory() as session:
+            stmt = select(self._workflow_model).where(
+                self._workflow_model.zone_id == self._get_zone_id()
+            )
+            result = await session.execute(stmt)
+            workflows = result.scalars().all()
 
-        Returns:
-            List of workflow info dictionaries
-        """
-        with self.session_factory() as session:
-            stmt = select(WorkflowModel).where(WorkflowModel.zone_id == self._get_zone_id())
-            workflows = session.execute(stmt).scalars().all()
-
-            result = []
+            items = []
             for workflow in workflows:
                 try:
                     definition = WorkflowLoader.load_from_string(workflow.definition)
-                    result.append(
+                    items.append(
                         {
                             "workflow_id": workflow.workflow_id,
                             "name": workflow.name,
@@ -196,113 +182,57 @@ class WorkflowStore:
                 except Exception as e:
                     logger.error(f"Failed to parse workflow {workflow.workflow_id}: {e}")
 
-            return result
+            return items
 
-    def delete_workflow(self, workflow_id: str) -> bool:
-        """Delete a workflow.
-
-        Args:
-            workflow_id: Workflow UUID
-
-        Returns:
-            True if deleted, False if not found
-        """
-        with self.session_factory() as session:
-            stmt = select(WorkflowModel).where(WorkflowModel.workflow_id == workflow_id)
-            workflow = session.execute(stmt).scalar_one_or_none()
-
+    async def delete_workflow(self, workflow_id: str) -> bool:
+        """Delete a workflow by ID."""
+        async with self.session_factory() as session:
+            workflow = await self._get_workflow(session, workflow_id=workflow_id)
             if not workflow:
                 return False
-
-            session.delete(workflow)
-            session.commit()
+            await session.delete(workflow)
+            await session.commit()
             logger.info(f"Deleted workflow: {workflow.name} (id={workflow_id})")
             return True
 
-    def delete_workflow_by_name(self, name: str) -> bool:
-        """Delete a workflow by name.
-
-        Args:
-            name: Workflow name
-
-        Returns:
-            True if deleted, False if not found
-        """
-        with self.session_factory() as session:
-            stmt = select(WorkflowModel).where(
-                WorkflowModel.zone_id == self._get_zone_id(),
-                WorkflowModel.name == name,
-            )
-            workflow = session.execute(stmt).scalar_one_or_none()
-
+    async def delete_workflow_by_name(self, name: str) -> bool:
+        """Delete a workflow by name."""
+        async with self.session_factory() as session:
+            workflow = await self._get_workflow(session, name=name)
             if not workflow:
                 return False
-
-            session.delete(workflow)
-            session.commit()
+            await session.delete(workflow)
+            await session.commit()
             logger.info(f"Deleted workflow: {name}")
             return True
 
-    def set_enabled(self, workflow_id: str, enabled: bool) -> bool:
-        """Enable or disable a workflow.
-
-        Args:
-            workflow_id: Workflow UUID
-            enabled: True to enable, False to disable
-
-        Returns:
-            True if updated, False if not found
-        """
-        with self.session_factory() as session:
-            stmt = select(WorkflowModel).where(WorkflowModel.workflow_id == workflow_id)
-            workflow = session.execute(stmt).scalar_one_or_none()
-
+    async def set_enabled(self, workflow_id: str, enabled: bool) -> bool:
+        """Enable or disable a workflow by ID."""
+        async with self.session_factory() as session:
+            workflow = await self._get_workflow(session, workflow_id=workflow_id)
             if not workflow:
                 return False
-
             workflow.enabled = 1 if enabled else 0
             workflow.updated_at = datetime.now(UTC)
-            session.commit()
+            await session.commit()
             logger.info(f"Set workflow {workflow.name} enabled={enabled}")
             return True
 
-    def set_enabled_by_name(self, name: str, enabled: bool) -> bool:
-        """Enable or disable a workflow by name.
-
-        Args:
-            name: Workflow name
-            enabled: True to enable, False to disable
-
-        Returns:
-            True if updated, False if not found
-        """
-        with self.session_factory() as session:
-            stmt = select(WorkflowModel).where(
-                WorkflowModel.zone_id == self._get_zone_id(),
-                WorkflowModel.name == name,
-            )
-            workflow = session.execute(stmt).scalar_one_or_none()
-
+    async def set_enabled_by_name(self, name: str, enabled: bool) -> bool:
+        """Enable or disable a workflow by name."""
+        async with self.session_factory() as session:
+            workflow = await self._get_workflow(session, name=name)
             if not workflow:
                 return False
-
             workflow.enabled = 1 if enabled else 0
             workflow.updated_at = datetime.now(UTC)
-            session.commit()
+            await session.commit()
             logger.info(f"Set workflow {name} enabled={enabled}")
             return True
 
-    def save_execution(self, execution: WorkflowExecution) -> str:
-        """Save workflow execution record.
-
-        Args:
-            execution: Workflow execution record
-
-        Returns:
-            Execution ID (UUID string)
-        """
-        with self.session_factory() as session:
-            # Convert action results to JSON
+    async def save_execution(self, execution: WorkflowExecution) -> str:
+        """Save workflow execution record."""
+        async with self.session_factory() as session:
             action_results_json = json.dumps(
                 [
                     {
@@ -316,10 +246,9 @@ class WorkflowStore:
                 ]
             )
 
-            # Combine context with action results
             context_dict = {**execution.context, "action_results": action_results_json}
 
-            execution_model = WorkflowExecutionModel(
+            execution_model = self._execution_model(
                 execution_id=str(execution.execution_id),
                 workflow_id=str(execution.workflow_id),
                 trigger_type=execution.trigger_type.value,
@@ -334,34 +263,27 @@ class WorkflowStore:
             )
 
             session.add(execution_model)
-            session.commit()
+            await session.commit()
             logger.info(
                 f"Saved execution: {execution.execution_id} (status={execution.status.value})"
             )
             return str(execution.execution_id)
 
-    def get_executions(self, workflow_id: str, limit: int = 10) -> list[dict[str, Any]]:
-        """Get execution history for a workflow.
-
-        Args:
-            workflow_id: Workflow UUID
-            limit: Maximum number of executions to return
-
-        Returns:
-            List of execution records
-        """
-        with self.session_factory() as session:
+    async def get_executions(self, workflow_id: str, limit: int = 10) -> list[dict[str, Any]]:
+        """Get execution history for a workflow."""
+        async with self.session_factory() as session:
             stmt = (
-                select(WorkflowExecutionModel)
-                .where(WorkflowExecutionModel.workflow_id == workflow_id)
-                .order_by(WorkflowExecutionModel.started_at.desc())
+                select(self._execution_model)
+                .where(self._execution_model.workflow_id == workflow_id)
+                .order_by(self._execution_model.started_at.desc())
                 .limit(limit)
             )
-            executions = session.execute(stmt).scalars().all()
+            result = await session.execute(stmt)
+            executions = result.scalars().all()
 
-            result = []
+            items = []
             for execution in executions:
-                result.append(
+                items.append(
                     {
                         "execution_id": execution.execution_id,
                         "workflow_id": execution.workflow_id,
@@ -375,27 +297,12 @@ class WorkflowStore:
                     }
                 )
 
-            return result
+            return items
 
-    def get_executions_by_name(self, name: str, limit: int = 10) -> list[dict[str, Any]]:
-        """Get execution history for a workflow by name.
-
-        Args:
-            name: Workflow name
-            limit: Maximum number of executions to return
-
-        Returns:
-            List of execution records
-        """
-        # First get workflow ID
-        with self.session_factory() as session:
-            stmt = select(WorkflowModel).where(
-                WorkflowModel.zone_id == self._get_zone_id(),
-                WorkflowModel.name == name,
-            )
-            workflow = session.execute(stmt).scalar_one_or_none()
-
+    async def get_executions_by_name(self, name: str, limit: int = 10) -> list[dict[str, Any]]:
+        """Get execution history for a workflow by name."""
+        async with self.session_factory() as session:
+            workflow = await self._get_workflow(session, name=name)
             if not workflow:
                 return []
-
-            return self.get_executions(workflow.workflow_id, limit)
+            return await self.get_executions(workflow.workflow_id, limit)

--- a/src/nexus/workflows/triggers.py
+++ b/src/nexus/workflows/triggers.py
@@ -1,33 +1,52 @@
-"""Workflow trigger system."""
+"""Workflow trigger system.
 
+Zero imports from nexus.core — glob matching is injected via GlobMatchFn.
+Falls back to fnmatch when no Rust glob_fast is available (tests, embedded).
+"""
+
+import fnmatch
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
 
-from nexus.core import glob_fast
+from nexus.workflows.protocol import GlobMatchFn
 from nexus.workflows.types import TriggerType, WorkflowContext
 
 logger = logging.getLogger(__name__)
+
+_fnmatch_warned = False
+
+
+def _default_glob_match(path: str, patterns: list[str]) -> bool:
+    """Fallback glob match using stdlib fnmatch (no Rust dependency)."""
+    global _fnmatch_warned
+    if not _fnmatch_warned:
+        logger.warning(
+            "Using fnmatch fallback for workflow triggers — "
+            "inject glob_match for production performance"
+        )
+        _fnmatch_warned = True
+    return any(fnmatch.fnmatch(path, p) for p in patterns)
 
 
 class BaseTrigger(ABC):
     """Base class for workflow triggers."""
 
-    def __init__(self, trigger_type: TriggerType, config: dict[str, Any]):
+    def __init__(
+        self,
+        trigger_type: TriggerType,
+        config: dict[str, Any],
+        *,
+        glob_match: GlobMatchFn | None = None,
+    ):
         self.trigger_type = trigger_type
         self.config = config
+        self._glob_match: GlobMatchFn = glob_match or _default_glob_match
 
     @abstractmethod
     def matches(self, event_context: dict[str, Any]) -> bool:
-        """Check if this trigger matches the given event.
-
-        Args:
-            event_context: Event context with file path, metadata, etc.
-
-        Returns:
-            True if trigger matches
-        """
+        """Check if this trigger matches the given event."""
         pass
 
     def get_pattern(self) -> str | None:
@@ -38,41 +57,38 @@ class BaseTrigger(ABC):
 class FileWriteTrigger(BaseTrigger):
     """Trigger on file write events."""
 
-    def __init__(self, config: dict[str, Any]):
-        super().__init__(TriggerType.FILE_WRITE, config)
+    def __init__(self, config: dict[str, Any], *, glob_match: GlobMatchFn | None = None):
+        super().__init__(TriggerType.FILE_WRITE, config, glob_match=glob_match)
         self.pattern = config.get("pattern", "*")
 
     def matches(self, event_context: dict[str, Any]) -> bool:
-        """Check if file path matches the pattern."""
         file_path = event_context.get("file_path", "")
-        return glob_fast.glob_match(file_path, [self.pattern])
+        return self._glob_match(file_path, [self.pattern])
 
 
 class FileDeleteTrigger(BaseTrigger):
     """Trigger on file delete events."""
 
-    def __init__(self, config: dict[str, Any]):
-        super().__init__(TriggerType.FILE_DELETE, config)
+    def __init__(self, config: dict[str, Any], *, glob_match: GlobMatchFn | None = None):
+        super().__init__(TriggerType.FILE_DELETE, config, glob_match=glob_match)
         self.pattern = config.get("pattern", "*")
 
     def matches(self, event_context: dict[str, Any]) -> bool:
-        """Check if file path matches the pattern."""
         file_path = event_context.get("file_path", "")
-        return glob_fast.glob_match(file_path, [self.pattern])
+        return self._glob_match(file_path, [self.pattern])
 
 
 class FileRenameTrigger(BaseTrigger):
     """Trigger on file rename events."""
 
-    def __init__(self, config: dict[str, Any]):
-        super().__init__(TriggerType.FILE_RENAME, config)
+    def __init__(self, config: dict[str, Any], *, glob_match: GlobMatchFn | None = None):
+        super().__init__(TriggerType.FILE_RENAME, config, glob_match=glob_match)
         self.pattern = config.get("pattern", "*")
 
     def matches(self, event_context: dict[str, Any]) -> bool:
-        """Check if old or new file path matches the pattern."""
         old_path = event_context.get("old_path", "")
         new_path = event_context.get("new_path", "")
-        return glob_fast.glob_match(old_path, [self.pattern]) or glob_fast.glob_match(
+        return self._glob_match(old_path, [self.pattern]) or self._glob_match(
             new_path, [self.pattern]
         )
 
@@ -80,57 +96,51 @@ class FileRenameTrigger(BaseTrigger):
 class MetadataChangeTrigger(BaseTrigger):
     """Trigger on metadata change events."""
 
-    def __init__(self, config: dict[str, Any]):
-        super().__init__(TriggerType.METADATA_CHANGE, config)
+    def __init__(self, config: dict[str, Any], *, glob_match: GlobMatchFn | None = None):
+        super().__init__(TriggerType.METADATA_CHANGE, config, glob_match=glob_match)
         self.pattern = config.get("pattern", "*")
         self.metadata_key = config.get("metadata_key")
 
     def matches(self, event_context: dict[str, Any]) -> bool:
-        """Check if metadata change matches criteria."""
         file_path = event_context.get("file_path", "")
         changed_key = event_context.get("metadata_key")
 
-        # Check file path pattern
-        if not glob_fast.glob_match(file_path, [self.pattern]):
+        if not self._glob_match(file_path, [self.pattern]):
             return False
 
-        # Check specific metadata key if specified
         return not (self.metadata_key and changed_key != self.metadata_key)
 
 
 class ScheduleTrigger(BaseTrigger):
     """Trigger on a schedule (cron-like)."""
 
-    def __init__(self, config: dict[str, Any]):
-        super().__init__(TriggerType.SCHEDULE, config)
-        self.cron = config.get("cron", "0 * * * *")  # Default: hourly
+    def __init__(self, config: dict[str, Any], *, glob_match: GlobMatchFn | None = None):
+        super().__init__(TriggerType.SCHEDULE, config, glob_match=glob_match)
+        self.cron = config.get("cron", "0 * * * *")
         self.interval_seconds = config.get("interval_seconds")
 
     def matches(self, _event_context: dict[str, Any]) -> bool:
-        """Schedule triggers don't match events directly."""
         return False
 
 
 class WebhookTrigger(BaseTrigger):
     """Trigger via HTTP webhook."""
 
-    def __init__(self, config: dict[str, Any]):
-        super().__init__(TriggerType.WEBHOOK, config)
+    def __init__(self, config: dict[str, Any], *, glob_match: GlobMatchFn | None = None):
+        super().__init__(TriggerType.WEBHOOK, config, glob_match=glob_match)
         self.webhook_id = config.get("webhook_id")
 
     def matches(self, event_context: dict[str, Any]) -> bool:
-        """Check if webhook ID matches."""
         return event_context.get("webhook_id") == self.webhook_id
 
 
 class ManualTrigger(BaseTrigger):
     """Manual trigger (via CLI/API)."""
 
-    def __init__(self, config: dict[str, Any]):
-        super().__init__(TriggerType.MANUAL, config)
+    def __init__(self, config: dict[str, Any], *, glob_match: GlobMatchFn | None = None):
+        super().__init__(TriggerType.MANUAL, config, glob_match=glob_match)
 
     def matches(self, _event_context: dict[str, Any]) -> bool:
-        """Manual triggers always match when explicitly invoked."""
         return True
 
 
@@ -149,7 +159,8 @@ BUILTIN_TRIGGERS = {
 class TriggerManager:
     """Manages workflow triggers and event routing."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, glob_match: GlobMatchFn | None = None) -> None:
+        self._glob_match = glob_match
         self.triggers: dict[str, list[tuple[BaseTrigger, Callable]]] = {}
         for trigger_type in TriggerType:
             self.triggers[trigger_type.value] = []
@@ -157,39 +168,33 @@ class TriggerManager:
     def register_trigger(
         self, trigger: BaseTrigger, callback: Callable[[WorkflowContext], None]
     ) -> None:
-        """Register a trigger with a callback.
-
-        Args:
-            trigger: Trigger instance
-            callback: Function to call when trigger fires
-        """
+        """Register a trigger with a callback."""
         trigger_type = trigger.trigger_type.value
         self.triggers[trigger_type].append((trigger, callback))
         logger.info(f"Registered {trigger_type} trigger with pattern: {trigger.get_pattern()}")
 
     def unregister_trigger(self, trigger: BaseTrigger) -> None:
-        """Unregister a trigger.
-
-        Args:
-            trigger: Trigger instance to remove
-        """
+        """Unregister a trigger."""
         trigger_type = trigger.trigger_type.value
         self.triggers[trigger_type] = [
             (t, cb) for t, cb in self.triggers[trigger_type] if t != trigger
         ]
 
-    async def fire_event(self, trigger_type: TriggerType, event_context: dict[str, Any]) -> int:
+    async def fire_event(
+        self, trigger_type: TriggerType | str, event_context: dict[str, Any]
+    ) -> int:
         """Fire an event and execute matching triggers.
 
         Args:
-            trigger_type: Type of trigger event
-            event_context: Event context data
+            trigger_type: TriggerType enum or string value.
+            event_context: Event context data.
 
         Returns:
-            Number of workflows triggered
+            Number of workflows triggered.
         """
+        key = trigger_type.value if isinstance(trigger_type, TriggerType) else trigger_type
         triggered_count = 0
-        trigger_list = self.triggers.get(trigger_type.value, [])
+        trigger_list = self.triggers.get(key, [])
 
         for trigger, callback in trigger_list:
             if trigger.matches(event_context):
@@ -202,18 +207,10 @@ class TriggerManager:
         return triggered_count
 
     def get_triggers(self, trigger_type: TriggerType | None = None) -> list[tuple]:
-        """Get registered triggers.
-
-        Args:
-            trigger_type: Optional filter by trigger type
-
-        Returns:
-            List of (trigger, callback) tuples
-        """
+        """Get registered triggers."""
         if trigger_type:
             return self.triggers.get(trigger_type.value, [])
 
-        # Return all triggers
         all_triggers = []
         for trigger_list in self.triggers.values():
             all_triggers.extend(trigger_list)

--- a/src/nexus/workflows/types.py
+++ b/src/nexus/workflows/types.py
@@ -64,12 +64,13 @@ class WorkflowContext:
 
     workflow_id: UUID
     execution_id: UUID
-    zone_id: UUID | None  # Allow None for default/global workflows
-    trigger_type: TriggerType
+    zone_id: str = "default"
+    trigger_type: TriggerType = TriggerType.MANUAL
     trigger_context: dict[str, Any] = field(default_factory=dict)
     variables: dict[str, Any] = field(default_factory=dict)
     file_path: str | None = None
     file_metadata: dict[str, Any] | None = None
+    services: Any | None = None
 
 
 @dataclass

--- a/tests/unit/server/api/v2/routers/test_workflows_router.py
+++ b/tests/unit/server/api/v2/routers/test_workflows_router.py
@@ -1,0 +1,377 @@
+"""Unit tests for the workflows API router.
+
+Issue #1522: Tests for all 8 workflow endpoints using FastAPI TestClient
+with a mock workflow engine.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.workflows import (
+    _get_require_auth,
+    _get_workflow_engine,
+    router,
+)
+from nexus.workflows.engine import WorkflowEngine
+from nexus.workflows.types import (
+    TriggerType,
+    WorkflowAction,
+    WorkflowDefinition,
+    WorkflowExecution,
+    WorkflowStatus,
+    WorkflowTrigger,
+)
+
+# ---------------------------------------------------------------------------
+# App setup
+# ---------------------------------------------------------------------------
+
+_test_app = FastAPI()
+_test_app.include_router(router)
+
+
+def _make_mock_engine() -> Mock:
+    """Create a mock workflow engine with default return values."""
+    engine = Mock(spec=WorkflowEngine)
+    engine.workflows = {}
+    engine.enabled_workflows = {}
+    engine.workflow_ids = {}
+    engine.workflow_store = None
+    engine.list_workflows.return_value = []
+    engine.load_workflow.return_value = True
+    engine.unload_workflow.return_value = True
+    return engine
+
+
+_mock_engine = _make_mock_engine()
+
+
+def _override_engine() -> Mock:
+    return _mock_engine
+
+
+def _override_auth() -> dict:
+    """Override auth dependency — return a dummy auth result."""
+    return {"subject_id": "test-user", "zone_id": "root", "is_admin": True}
+
+
+# Override dependencies
+_test_app.dependency_overrides[_get_workflow_engine] = _override_engine
+_test_app.dependency_overrides[_get_require_auth()] = _override_auth
+
+client = TestClient(_test_app)
+
+
+@pytest.fixture(autouse=True)
+def reset_engine():
+    """Reset mock engine before each test."""
+    global _mock_engine
+    _mock_engine = _make_mock_engine()
+    _test_app.dependency_overrides[_get_workflow_engine] = lambda: _mock_engine
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestListWorkflows:
+    """Test GET /api/v2/workflows."""
+
+    def test_list_empty(self):
+        """Test listing when no workflows loaded."""
+        _mock_engine.list_workflows.return_value = []
+        resp = client.get("/api/v2/workflows")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_workflows(self):
+        """Test listing loaded workflows."""
+        _mock_engine.list_workflows.return_value = [
+            {
+                "name": "wf1",
+                "version": "1.0",
+                "description": "First",
+                "enabled": True,
+                "triggers": 1,
+                "actions": 2,
+            },
+            {
+                "name": "wf2",
+                "version": "2.0",
+                "description": None,
+                "enabled": False,
+                "triggers": 0,
+                "actions": 1,
+            },
+        ]
+
+        resp = client.get("/api/v2/workflows")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["name"] == "wf1"
+        assert data[0]["enabled"] is True
+        assert data[1]["name"] == "wf2"
+        assert data[1]["enabled"] is False
+
+
+class TestCreateWorkflow:
+    """Test POST /api/v2/workflows."""
+
+    @patch("nexus.workflows.loader.WorkflowLoader")
+    def test_create_workflow(self, mock_loader):
+        """Test creating a workflow."""
+        definition = WorkflowDefinition(
+            name="test-wf",
+            version="1.0",
+            description="Test workflow",
+            actions=[WorkflowAction(name="a1", type="python", config={"code": "pass"})],
+        )
+        mock_loader.load_from_dict.return_value = definition
+
+        resp = client.post(
+            "/api/v2/workflows",
+            json={
+                "name": "test-wf",
+                "version": "1.0",
+                "description": "Test workflow",
+                "actions": [{"name": "a1", "type": "python", "code": "pass"}],
+                "enabled": True,
+            },
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "test-wf"
+        assert data["version"] == "1.0"
+        assert data["enabled"] is True
+        _mock_engine.load_workflow.assert_called_once()
+
+    @patch("nexus.workflows.loader.WorkflowLoader")
+    def test_create_workflow_invalid(self, mock_loader):
+        """Test creating a workflow with invalid definition."""
+        mock_loader.load_from_dict.side_effect = ValueError("bad definition")
+
+        resp = client.post(
+            "/api/v2/workflows",
+            json={
+                "name": "bad-wf",
+                "actions": [{"name": "a1", "type": "python"}],
+            },
+        )
+
+        assert resp.status_code == 400
+        assert "Invalid workflow definition" in resp.json()["detail"]
+
+    @patch("nexus.workflows.loader.WorkflowLoader")
+    def test_create_workflow_load_failure(self, mock_loader):
+        """Test creating a workflow when engine load fails."""
+        definition = WorkflowDefinition(
+            name="fail-wf",
+            version="1.0",
+            actions=[WorkflowAction(name="a1", type="python")],
+        )
+        mock_loader.load_from_dict.return_value = definition
+        _mock_engine.load_workflow.return_value = False
+
+        resp = client.post(
+            "/api/v2/workflows",
+            json={
+                "name": "fail-wf",
+                "actions": [{"name": "a1", "type": "python"}],
+            },
+        )
+
+        assert resp.status_code == 400
+        assert "Failed to load workflow" in resp.json()["detail"]
+
+
+class TestGetWorkflow:
+    """Test GET /api/v2/workflows/{name}."""
+
+    def test_get_existing(self):
+        """Test getting an existing workflow."""
+        definition = WorkflowDefinition(
+            name="my-wf",
+            version="1.0",
+            description="My workflow",
+            triggers=[WorkflowTrigger(type=TriggerType.FILE_WRITE, config={"pattern": "*.md"})],
+            actions=[WorkflowAction(name="a1", type="python", config={"code": "pass"})],
+            variables={"env": "prod"},
+        )
+        _mock_engine.workflows = {"my-wf": definition}
+        _mock_engine.enabled_workflows = {"my-wf": True}
+
+        resp = client.get("/api/v2/workflows/my-wf")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "my-wf"
+        assert data["version"] == "1.0"
+        assert data["enabled"] is True
+        assert len(data["triggers"]) == 1
+        assert len(data["actions"]) == 1
+        assert data["variables"] == {"env": "prod"}
+
+    def test_get_nonexistent(self):
+        """Test getting a non-existent workflow."""
+        _mock_engine.workflows = {}
+        resp = client.get("/api/v2/workflows/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestDeleteWorkflow:
+    """Test DELETE /api/v2/workflows/{name}."""
+
+    def test_delete_existing(self):
+        """Test deleting an existing workflow."""
+        _mock_engine.unload_workflow.return_value = True
+        resp = client.delete("/api/v2/workflows/my-wf")
+        assert resp.status_code == 204
+        _mock_engine.unload_workflow.assert_called_once_with("my-wf")
+
+    def test_delete_nonexistent(self):
+        """Test deleting a non-existent workflow."""
+        _mock_engine.unload_workflow.return_value = False
+        resp = client.delete("/api/v2/workflows/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestEnableWorkflow:
+    """Test POST /api/v2/workflows/{name}/enable."""
+
+    def test_enable_existing(self):
+        """Test enabling an existing workflow."""
+        _mock_engine.workflows = {"my-wf": Mock()}
+        resp = client.post("/api/v2/workflows/my-wf/enable")
+        assert resp.status_code == 204
+        _mock_engine.enable_workflow.assert_called_once_with("my-wf")
+
+    def test_enable_nonexistent(self):
+        """Test enabling a non-existent workflow."""
+        _mock_engine.workflows = {}
+        resp = client.post("/api/v2/workflows/nonexistent/enable")
+        assert resp.status_code == 404
+
+
+class TestDisableWorkflow:
+    """Test POST /api/v2/workflows/{name}/disable."""
+
+    def test_disable_existing(self):
+        """Test disabling an existing workflow."""
+        _mock_engine.workflows = {"my-wf": Mock()}
+        resp = client.post("/api/v2/workflows/my-wf/disable")
+        assert resp.status_code == 204
+        _mock_engine.disable_workflow.assert_called_once_with("my-wf")
+
+    def test_disable_nonexistent(self):
+        """Test disabling a non-existent workflow."""
+        _mock_engine.workflows = {}
+        resp = client.post("/api/v2/workflows/nonexistent/disable")
+        assert resp.status_code == 404
+
+
+class TestExecuteWorkflow:
+    """Test POST /api/v2/workflows/{name}/execute."""
+
+    def test_execute_success(self):
+        """Test successful workflow execution."""
+        execution = WorkflowExecution(
+            execution_id=uuid.uuid4(),
+            workflow_id=uuid.uuid4(),
+            workflow_name="my-wf",
+            status=WorkflowStatus.SUCCEEDED,
+            trigger_type=TriggerType.MANUAL,
+            trigger_context={},
+            actions_completed=2,
+            actions_total=2,
+        )
+        _mock_engine.trigger_workflow = AsyncMock(return_value=execution)
+
+        resp = client.post(
+            "/api/v2/workflows/my-wf/execute",
+            json={"file_path": "/test/file.txt", "context": {"env": "test"}},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "succeeded"
+        assert data["actions_completed"] == 2
+        assert data["actions_total"] == 2
+
+    def test_execute_not_found(self):
+        """Test executing non-existent or disabled workflow."""
+        _mock_engine.trigger_workflow = AsyncMock(return_value=None)
+
+        resp = client.post("/api/v2/workflows/nonexistent/execute")
+        assert resp.status_code == 404
+
+    def test_execute_no_body(self):
+        """Test executing with no request body."""
+        execution = WorkflowExecution(
+            execution_id=uuid.uuid4(),
+            workflow_id=uuid.uuid4(),
+            workflow_name="my-wf",
+            status=WorkflowStatus.SUCCEEDED,
+            trigger_type=TriggerType.MANUAL,
+            trigger_context={},
+        )
+        _mock_engine.trigger_workflow = AsyncMock(return_value=execution)
+
+        resp = client.post("/api/v2/workflows/my-wf/execute")
+        assert resp.status_code == 200
+
+
+class TestGetExecutions:
+    """Test GET /api/v2/workflows/{name}/executions."""
+
+    def test_get_executions_no_store(self):
+        """Test getting executions when no store is available."""
+        _mock_engine.workflows = {"my-wf": Mock()}
+        _mock_engine.workflow_store = None
+
+        resp = client.get("/api/v2/workflows/my-wf/executions")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_get_executions_not_found(self):
+        """Test getting executions for non-existent workflow."""
+        _mock_engine.workflows = {}
+
+        resp = client.get("/api/v2/workflows/nonexistent/executions")
+        assert resp.status_code == 404
+
+    def test_get_executions_with_store(self):
+        """Test getting executions with mock store."""
+        _mock_engine.workflows = {"my-wf": Mock()}
+        mock_store = Mock()
+        mock_store.get_executions_by_name = AsyncMock(
+            return_value=[
+                {
+                    "execution_id": str(uuid.uuid4()),
+                    "workflow_id": str(uuid.uuid4()),
+                    "trigger_type": "manual",
+                    "status": "succeeded",
+                    "started_at": "2025-01-01T00:00:00",
+                    "completed_at": "2025-01-01T00:00:01",
+                    "actions_completed": 1,
+                    "actions_total": 1,
+                    "error_message": None,
+                }
+            ]
+        )
+        _mock_engine.workflow_store = mock_store
+
+        resp = client.get("/api/v2/workflows/my-wf/executions?limit=5")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["status"] == "succeeded"
+        mock_store.get_executions_by_name.assert_called_once_with("my-wf", limit=5)

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -292,6 +292,8 @@ def test_all_public_methods_are_exposed_or_excluded():
         "locked",  # Async context manager - distributed lock acquisition
         # Consistency migration - server-side orchestration only (Issue #1180)
         "migrate_consistency_mode",  # Internal - SC↔EC migration orchestrator, exposed via PATCH endpoint
+        # Workflow event queue - server-side background task (Issue #1522)
+        "ensure_workflow_consumer",  # Internal - starts bounded workflow event queue consumer
     }
 
     # Get all public methods

--- a/tests/unit/workflows/test_actions.py
+++ b/tests/unit/workflows/test_actions.py
@@ -1,0 +1,353 @@
+"""Tests for workflow actions."""
+
+import uuid
+
+import pytest
+
+from nexus.workflows.actions import (
+    BUILTIN_ACTIONS,
+    BaseAction,
+    BashAction,
+    MetadataAction,
+    MoveAction,
+    PythonAction,
+    TagAction,
+    WebhookAction,
+)
+from nexus.workflows.types import TriggerType, WorkflowContext
+
+
+class MockAction(BaseAction):
+    """Mock action for testing base class."""
+
+    async def execute(self, context: WorkflowContext):
+        """Execute mock action."""
+        return {"success": True}
+
+
+class TestBaseAction:
+    """Test BaseAction base class."""
+
+    def test_create_action(self):
+        """Test creating base action."""
+        action = MockAction(name="test", config={"key": "value"})
+        assert action.name == "test"
+        assert action.config == {"key": "value"}
+
+    def test_interpolate_simple(self):
+        """Test simple variable interpolation."""
+        action = MockAction(name="test", config={})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+            variables={"name": "world"},
+        )
+
+        result = action.interpolate("Hello {name}!", context)
+        assert result == "Hello world!"
+
+    def test_interpolate_file_path(self):
+        """Test interpolating file path variables."""
+        action = MockAction(name="test", config={})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.FILE_WRITE,
+            file_path="/docs/readme.md",
+        )
+
+        assert action.interpolate("{file_path}", context) == "/docs/readme.md"
+        assert action.interpolate("{filename}", context) == "readme.md"
+        assert action.interpolate("{dirname}", context) == "/docs"
+
+    def test_interpolate_file_metadata(self):
+        """Test interpolating file metadata."""
+        action = MockAction(name="test", config={})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.FILE_WRITE,
+            file_path="/docs/readme.md",
+            file_metadata={"author": "test_user", "size": 1024},
+        )
+
+        assert action.interpolate("Author: {author}", context) == "Author: test_user"
+        assert action.interpolate("Size: {size}", context) == "Size: 1024"
+
+    def test_interpolate_missing_variable(self):
+        """Test interpolating missing variable."""
+        action = MockAction(name="test", config={})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+            variables={},
+        )
+
+        # Should return original string if variable not found
+        result = action.interpolate("Hello {missing}!", context)
+        assert result == "Hello {missing}!"
+
+    def test_interpolate_non_string(self):
+        """Test interpolating non-string value."""
+        action = MockAction(name="test", config={})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+        )
+
+        # Should return value unchanged if not string
+        assert action.interpolate(123, context) == 123
+        assert action.interpolate(True, context) is True
+
+
+class TestTagAction:
+    """Test TagAction."""
+
+    def test_create_tag_action(self):
+        """Test creating tag action."""
+        action = TagAction(name="add_tag", config={"tags": ["important", "reviewed"]})
+        assert action.name == "add_tag"
+        assert action.config["tags"] == ["important", "reviewed"]
+
+    @pytest.mark.asyncio
+    async def test_tag_action_no_services(self):
+        """Test tag action without services returns graceful error."""
+        action = TagAction(name="add_tag", config={"tags": ["important"]})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.FILE_WRITE,
+            file_path="/docs/readme.md",
+            services=None,
+        )
+
+        result = await action.execute(context)
+        assert result.success is False
+        assert "not injected" in result.error or "not available" in result.error
+
+
+class TestMoveAction:
+    """Test MoveAction."""
+
+    def test_create_move_action(self):
+        """Test creating move action."""
+        action = MoveAction(
+            name="move_file", config={"source": "/old/path.txt", "destination": "/new/path.txt"}
+        )
+        assert action.name == "move_file"
+        assert action.config["source"] == "/old/path.txt"
+        assert action.config["destination"] == "/new/path.txt"
+
+    def test_interpolate_paths(self):
+        """Test interpolating move action paths."""
+        action = MoveAction(
+            name="move_file",
+            config={"source": "{file_path}", "destination": "/archive/{filename}"},
+        )
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.FILE_WRITE,
+            file_path="/docs/readme.md",
+        )
+
+        source = action.interpolate(action.config["source"], context)
+        destination = action.interpolate(action.config["destination"], context)
+
+        assert source == "/docs/readme.md"
+        assert destination == "/archive/readme.md"
+
+    @pytest.mark.asyncio
+    async def test_move_action_no_services(self):
+        """Test move action without services returns graceful error."""
+        action = MoveAction(
+            name="move_file", config={"source": "/old/path.txt", "destination": "/new/path.txt"}
+        )
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.FILE_WRITE,
+            file_path="/old/path.txt",
+            services=None,
+        )
+
+        result = await action.execute(context)
+        assert result.success is False
+        assert "not injected" in result.error or "not available" in result.error
+
+
+class TestMetadataAction:
+    """Test MetadataAction."""
+
+    def test_create_metadata_action(self):
+        """Test creating metadata action."""
+        action = MetadataAction(
+            name="set_metadata", config={"metadata": {"status": "processed", "version": "1.0"}}
+        )
+        assert action.name == "set_metadata"
+        assert action.config["metadata"] == {"status": "processed", "version": "1.0"}
+
+    @pytest.mark.asyncio
+    async def test_metadata_action_no_services(self):
+        """Test metadata action without services returns graceful error."""
+        action = MetadataAction(name="set_metadata", config={"metadata": {"status": "done"}})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.FILE_WRITE,
+            file_path="/docs/readme.md",
+            services=None,
+        )
+
+        result = await action.execute(context)
+        assert result.success is False
+        assert "not injected" in result.error or "not available" in result.error
+
+
+class TestPythonAction:
+    """Test PythonAction."""
+
+    def test_create_python_action(self):
+        """Test creating Python action."""
+        code = "result = 2 + 2"
+        action = PythonAction(name="calc", config={"code": code})
+        assert action.name == "calc"
+        assert action.config["code"] == code
+
+    @pytest.mark.asyncio
+    async def test_execute_python_action(self):
+        """Test executing Python action."""
+        code = "result = variables['x'] + variables['y']"
+        action = PythonAction(name="calc", config={"code": code})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+            variables={"x": 10, "y": 20},
+        )
+
+        result = await action.execute(context)
+        assert result.success is True
+        assert result.output == 30
+
+    @pytest.mark.asyncio
+    async def test_execute_python_action_error(self):
+        """Test executing Python action with error."""
+        code = "raise ValueError('test error')"
+        action = PythonAction(name="calc", config={"code": code})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+        )
+
+        result = await action.execute(context)
+        assert result.success is False
+        assert "test error" in result.error
+
+
+class TestBashAction:
+    """Test BashAction."""
+
+    def test_create_bash_action(self):
+        """Test creating bash action."""
+        action = BashAction(name="list_files", config={"command": "ls -la"})
+        assert action.name == "list_files"
+        assert action.config["command"] == "ls -la"
+
+    @pytest.mark.asyncio
+    async def test_execute_bash_action(self):
+        """Test executing bash action."""
+        action = BashAction(name="echo_test", config={"command": "echo 'hello world'"})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+        )
+
+        result = await action.execute(context)
+        assert result.success is True
+        assert "hello world" in result.output["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_execute_bash_action_error(self):
+        """Test executing bash action with error."""
+        action = BashAction(name="fail", config={"command": "exit 1"})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+        )
+
+        result = await action.execute(context)
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_bash_action_interpolation(self):
+        """Test bash action with variable interpolation."""
+        action = BashAction(name="echo_var", config={"command": "echo {greeting}"})
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+            variables={"greeting": "hello"},
+        )
+
+        result = await action.execute(context)
+        assert result.success is True
+        assert "hello" in result.output["stdout"]
+
+
+class TestWebhookAction:
+    """Test WebhookAction."""
+
+    def test_create_webhook_action(self):
+        """Test creating webhook action."""
+        action = WebhookAction(
+            name="notify",
+            config={
+                "url": "https://example.com/webhook",
+                "method": "POST",
+                "body": {"status": "done"},
+            },
+        )
+        assert action.name == "notify"
+        assert action.config["url"] == "https://example.com/webhook"
+        assert action.config["method"] == "POST"
+
+
+class TestBuiltinActions:
+    """Test built-in action registry."""
+
+    def test_all_actions_registered(self):
+        """Test all action types are in registry."""
+        assert "parse" in BUILTIN_ACTIONS
+        assert "tag" in BUILTIN_ACTIONS
+        assert "move" in BUILTIN_ACTIONS
+        assert "metadata" in BUILTIN_ACTIONS
+        assert "llm" in BUILTIN_ACTIONS
+        assert "webhook" in BUILTIN_ACTIONS
+        assert "python" in BUILTIN_ACTIONS
+        assert "bash" in BUILTIN_ACTIONS
+
+    def test_action_classes(self):
+        """Test action classes are correct type."""
+        for _action_type, action_class in BUILTIN_ACTIONS.items():
+            assert issubclass(action_class, BaseAction)

--- a/tests/unit/workflows/test_api.py
+++ b/tests/unit/workflows/test_api.py
@@ -1,0 +1,417 @@
+"""Tests for workflow API."""
+
+import tempfile
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from nexus.workflows.api import WorkflowAPI
+from nexus.workflows.engine import WorkflowEngine
+from nexus.workflows.types import (
+    TriggerType,
+    WorkflowAction,
+    WorkflowDefinition,
+    WorkflowExecution,
+    WorkflowStatus,
+    WorkflowTrigger,
+)
+
+
+@pytest.fixture
+def mock_engine():
+    """Create a mock workflow engine."""
+    engine = Mock(spec=WorkflowEngine)
+    engine.workflows = {}
+    engine.enabled_workflows = {}
+    engine.list_workflows.return_value = []
+    engine.load_workflow.return_value = True
+    engine.unload_workflow.return_value = True
+    return engine
+
+
+@pytest.fixture
+def workflow_api(mock_engine):
+    """Create a workflow API instance with mock engine."""
+    return WorkflowAPI(engine=mock_engine)
+
+
+@pytest.fixture
+def sample_workflow():
+    """Create a sample workflow definition."""
+    return WorkflowDefinition(
+        name="test_workflow",
+        version="1.0",
+        description="Test workflow",
+        triggers=[WorkflowTrigger(type=TriggerType.FILE_WRITE, config={"pattern": "*.txt"})],
+        actions=[WorkflowAction(name="test_action", type="parse")],
+        variables={"env": "test"},
+    )
+
+
+class TestWorkflowAPIInit:
+    """Test WorkflowAPI initialization."""
+
+    def test_init_with_engine(self, mock_engine):
+        """Test initializing with provided engine."""
+        api = WorkflowAPI(engine=mock_engine)
+        assert api.engine == mock_engine
+
+    def test_init_requires_engine(self):
+        """Test initializing without engine raises TypeError."""
+        with pytest.raises(TypeError):
+            WorkflowAPI()
+
+
+class TestLoad:
+    """Test loading workflows."""
+
+    def test_load_from_definition(self, workflow_api, mock_engine, sample_workflow):
+        """Test loading from WorkflowDefinition."""
+        result = workflow_api.load(sample_workflow)
+
+        assert result is True
+        mock_engine.load_workflow.assert_called_once_with(sample_workflow, enabled=True)
+
+    @patch("nexus.workflows.api.WorkflowLoader")
+    def test_load_from_dict(self, mock_loader, workflow_api, mock_engine, sample_workflow):
+        """Test loading from dictionary."""
+        workflow_dict = {
+            "name": "test_workflow",
+            "version": "1.0",
+            "actions": [{"name": "test", "type": "parse"}],
+        }
+        mock_loader.load_from_dict.return_value = sample_workflow
+
+        result = workflow_api.load(workflow_dict)
+
+        assert result is True
+        mock_loader.load_from_dict.assert_called_once_with(workflow_dict)
+        mock_engine.load_workflow.assert_called_once_with(sample_workflow, enabled=True)
+
+    @patch("nexus.workflows.api.WorkflowLoader")
+    def test_load_from_file(self, mock_loader, workflow_api, mock_engine, sample_workflow):
+        """Test loading from file path."""
+        file_path = Path("/test/workflow.yaml")
+        mock_loader.load_from_file.return_value = sample_workflow
+
+        result = workflow_api.load(file_path)
+
+        assert result is True
+        mock_loader.load_from_file.assert_called_once_with(file_path)
+        mock_engine.load_workflow.assert_called_once_with(sample_workflow, enabled=True)
+
+    def test_load_disabled(self, workflow_api, mock_engine, sample_workflow):
+        """Test loading workflow in disabled state."""
+        workflow_api.load(sample_workflow, enabled=False)
+
+        mock_engine.load_workflow.assert_called_once_with(sample_workflow, enabled=False)
+
+
+class TestList:
+    """Test listing workflows."""
+
+    def test_list_empty(self, workflow_api, mock_engine):
+        """Test listing when no workflows loaded."""
+        mock_engine.list_workflows.return_value = []
+
+        workflows = workflow_api.list()
+
+        assert workflows == []
+        mock_engine.list_workflows.assert_called_once()
+
+    def test_list_workflows(self, workflow_api, mock_engine):
+        """Test listing loaded workflows."""
+        expected = [
+            {
+                "name": "workflow1",
+                "version": "1.0",
+                "description": "First workflow",
+                "enabled": True,
+                "triggers": 1,
+                "actions": 2,
+            },
+            {
+                "name": "workflow2",
+                "version": "2.0",
+                "description": "Second workflow",
+                "enabled": False,
+                "triggers": 2,
+                "actions": 3,
+            },
+        ]
+        mock_engine.list_workflows.return_value = expected
+
+        workflows = workflow_api.list()
+
+        assert len(workflows) == 2
+        assert workflows[0]["name"] == "workflow1"
+        assert workflows[1]["name"] == "workflow2"
+
+
+class TestGet:
+    """Test getting workflow by name."""
+
+    def test_get_existing_workflow(self, workflow_api, mock_engine, sample_workflow):
+        """Test getting an existing workflow."""
+        mock_engine.workflows = {"test_workflow": sample_workflow}
+
+        result = workflow_api.get("test_workflow")
+
+        assert result == sample_workflow
+
+    def test_get_nonexistent_workflow(self, workflow_api, mock_engine):
+        """Test getting a non-existent workflow."""
+        mock_engine.workflows = {}
+
+        result = workflow_api.get("nonexistent")
+
+        assert result is None
+
+
+class TestExecute:
+    """Test executing workflows."""
+
+    @pytest.mark.asyncio
+    async def test_execute_with_file_path(self, workflow_api, mock_engine):
+        """Test executing workflow with file path."""
+        execution = WorkflowExecution(
+            execution_id=uuid.uuid4(),
+            workflow_id=uuid.uuid4(),
+            workflow_name="test_workflow",
+            status=WorkflowStatus.SUCCEEDED,
+            trigger_type=TriggerType.MANUAL,
+            trigger_context={},
+        )
+        mock_engine.trigger_workflow = AsyncMock(return_value=execution)
+
+        result = await workflow_api.execute("test_workflow", file_path="/test/file.txt")
+
+        assert result == execution
+        mock_engine.trigger_workflow.assert_called_once_with(
+            "test_workflow", {"file_path": "/test/file.txt"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_with_context(self, workflow_api, mock_engine):
+        """Test executing workflow with custom context."""
+        execution = WorkflowExecution(
+            execution_id=uuid.uuid4(),
+            workflow_id=uuid.uuid4(),
+            workflow_name="test_workflow",
+            status=WorkflowStatus.SUCCEEDED,
+            trigger_type=TriggerType.MANUAL,
+            trigger_context={},
+        )
+        mock_engine.trigger_workflow = AsyncMock(return_value=execution)
+        context = {"custom": "data", "env": "test"}
+
+        result = await workflow_api.execute("test_workflow", context=context)
+
+        assert result == execution
+        mock_engine.trigger_workflow.assert_called_once_with("test_workflow", context)
+
+    @pytest.mark.asyncio
+    async def test_execute_with_file_and_context(self, workflow_api, mock_engine):
+        """Test executing workflow with both file path and context."""
+        execution = WorkflowExecution(
+            execution_id=uuid.uuid4(),
+            workflow_id=uuid.uuid4(),
+            workflow_name="test_workflow",
+            status=WorkflowStatus.SUCCEEDED,
+            trigger_type=TriggerType.MANUAL,
+            trigger_context={},
+        )
+        mock_engine.trigger_workflow = AsyncMock(return_value=execution)
+
+        result = await workflow_api.execute(
+            "test_workflow", file_path="/test/file.txt", context={"env": "prod"}
+        )
+
+        assert result == execution
+        # File path should be merged into context
+        expected_context = {"env": "prod", "file_path": "/test/file.txt"}
+        mock_engine.trigger_workflow.assert_called_once_with("test_workflow", expected_context)
+
+    @pytest.mark.asyncio
+    async def test_execute_failed(self, workflow_api, mock_engine):
+        """Test executing workflow that returns None (failed)."""
+        mock_engine.trigger_workflow = AsyncMock(return_value=None)
+
+        result = await workflow_api.execute("test_workflow")
+
+        assert result is None
+
+
+class TestEnable:
+    """Test enabling workflows."""
+
+    def test_enable_existing_workflow(self, workflow_api, mock_engine, sample_workflow):
+        """Test enabling an existing workflow."""
+        mock_engine.workflows = {"test_workflow": sample_workflow}
+
+        result = workflow_api.enable("test_workflow")
+
+        assert result is True
+        mock_engine.enable_workflow.assert_called_once_with("test_workflow")
+
+    def test_enable_nonexistent_workflow(self, workflow_api, mock_engine):
+        """Test enabling a non-existent workflow."""
+        mock_engine.workflows = {}
+
+        result = workflow_api.enable("nonexistent")
+
+        assert result is False
+        mock_engine.enable_workflow.assert_not_called()
+
+
+class TestDisable:
+    """Test disabling workflows."""
+
+    def test_disable_existing_workflow(self, workflow_api, mock_engine, sample_workflow):
+        """Test disabling an existing workflow."""
+        mock_engine.workflows = {"test_workflow": sample_workflow}
+
+        result = workflow_api.disable("test_workflow")
+
+        assert result is True
+        mock_engine.disable_workflow.assert_called_once_with("test_workflow")
+
+    def test_disable_nonexistent_workflow(self, workflow_api, mock_engine):
+        """Test disabling a non-existent workflow."""
+        mock_engine.workflows = {}
+
+        result = workflow_api.disable("nonexistent")
+
+        assert result is False
+        mock_engine.disable_workflow.assert_not_called()
+
+
+class TestUnload:
+    """Test unloading workflows."""
+
+    def test_unload_workflow(self, workflow_api, mock_engine):
+        """Test unloading a workflow."""
+        mock_engine.unload_workflow.return_value = True
+
+        result = workflow_api.unload("test_workflow")
+
+        assert result is True
+        mock_engine.unload_workflow.assert_called_once_with("test_workflow")
+
+
+class TestDiscover:
+    """Test discovering workflows."""
+
+    @patch("nexus.workflows.api.WorkflowLoader")
+    def test_discover_without_loading(self, mock_loader, workflow_api, sample_workflow):
+        """Test discovering workflows without loading them."""
+        workflow2 = WorkflowDefinition(name="workflow2", version="1.0")
+        mock_loader.discover_workflows.return_value = [sample_workflow, workflow2]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            discovered = workflow_api.discover(tmpdir, load=False)
+
+        assert len(discovered) == 2
+        assert discovered[0] == sample_workflow
+        assert discovered[1] == workflow2
+        mock_loader.discover_workflows.assert_called_once_with(tmpdir)
+
+    @patch("nexus.workflows.api.WorkflowLoader")
+    def test_discover_with_loading(self, mock_loader, workflow_api, mock_engine, sample_workflow):
+        """Test discovering and loading workflows."""
+        workflow2 = WorkflowDefinition(name="workflow2", version="1.0")
+        mock_loader.discover_workflows.return_value = [sample_workflow, workflow2]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            discovered = workflow_api.discover(tmpdir, load=True)
+
+        assert len(discovered) == 2
+        assert mock_engine.load_workflow.call_count == 2
+        mock_engine.load_workflow.assert_any_call(sample_workflow, enabled=True)
+        mock_engine.load_workflow.assert_any_call(workflow2, enabled=True)
+
+
+class TestFireEvent:
+    """Test firing events."""
+
+    @pytest.mark.asyncio
+    async def test_fire_event(self, workflow_api, mock_engine):
+        """Test firing an event."""
+        mock_engine.fire_event = AsyncMock(return_value=2)
+        event_context = {"file_path": "/test/file.txt"}
+
+        count = await workflow_api.fire_event(TriggerType.FILE_WRITE, event_context)
+
+        assert count == 2
+        mock_engine.fire_event.assert_called_once_with(TriggerType.FILE_WRITE, event_context)
+
+    @pytest.mark.asyncio
+    async def test_fire_event_with_string_type(self, workflow_api, mock_engine):
+        """Test firing an event with string trigger type."""
+        mock_engine.fire_event = AsyncMock(return_value=1)
+        event_context = {"file_path": "/test/file.txt"}
+
+        count = await workflow_api.fire_event("file_write", event_context)
+
+        assert count == 1
+        mock_engine.fire_event.assert_called_once_with("file_write", event_context)
+
+
+class TestIsEnabled:
+    """Test checking if workflow is enabled."""
+
+    def test_is_enabled_true(self, workflow_api, mock_engine):
+        """Test checking enabled workflow."""
+        mock_engine.enabled_workflows = {"test_workflow": True}
+
+        result = workflow_api.is_enabled("test_workflow")
+
+        assert result is True
+
+    def test_is_enabled_false(self, workflow_api, mock_engine):
+        """Test checking disabled workflow."""
+        mock_engine.enabled_workflows = {"test_workflow": False}
+
+        result = workflow_api.is_enabled("test_workflow")
+
+        assert result is False
+
+    def test_is_enabled_nonexistent(self, workflow_api, mock_engine):
+        """Test checking non-existent workflow."""
+        mock_engine.enabled_workflows = {}
+
+        result = workflow_api.is_enabled("nonexistent")
+
+        assert result is False
+
+
+class TestGetStatus:
+    """Test getting workflow status."""
+
+    def test_get_status_enabled(self, workflow_api, mock_engine, sample_workflow):
+        """Test getting status of enabled workflow."""
+        mock_engine.workflows = {"test_workflow": sample_workflow}
+        mock_engine.enabled_workflows = {"test_workflow": True}
+
+        status = workflow_api.get_status("test_workflow")
+
+        assert status == "enabled"
+
+    def test_get_status_disabled(self, workflow_api, mock_engine, sample_workflow):
+        """Test getting status of disabled workflow."""
+        mock_engine.workflows = {"test_workflow": sample_workflow}
+        mock_engine.enabled_workflows = {"test_workflow": False}
+
+        status = workflow_api.get_status("test_workflow")
+
+        assert status == "disabled"
+
+    def test_get_status_nonexistent(self, workflow_api, mock_engine):
+        """Test getting status of non-existent workflow."""
+        mock_engine.workflows = {}
+
+        status = workflow_api.get_status("nonexistent")
+
+        assert status is None

--- a/tests/unit/workflows/test_engine.py
+++ b/tests/unit/workflows/test_engine.py
@@ -1,0 +1,357 @@
+"""Tests for workflow engine."""
+
+import uuid
+
+import pytest
+
+from nexus.workflows.engine import WorkflowEngine
+from nexus.workflows.types import (
+    TriggerType,
+    WorkflowAction,
+    WorkflowContext,
+    WorkflowDefinition,
+    WorkflowStatus,
+    WorkflowTrigger,
+)
+
+
+class TestWorkflowEngine:
+    """Test WorkflowEngine."""
+
+    def test_create_engine(self):
+        """Test creating workflow engine."""
+        engine = WorkflowEngine()
+        assert engine is not None
+        assert engine.workflows == {}
+        assert engine.enabled_workflows == {}
+
+    def test_load_workflow(self):
+        """Test loading a workflow."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python", config={"code": "pass"})],
+        )
+
+        result = engine.load_workflow(definition, enabled=True)
+        assert result is True
+        assert "test_workflow" in engine.workflows
+        assert engine.enabled_workflows["test_workflow"] is True
+
+    def test_load_workflow_validation_no_name(self):
+        """Test loading workflow without name fails."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        result = engine.load_workflow(definition)
+        assert result is False
+
+    def test_load_workflow_validation_no_actions(self):
+        """Test loading workflow without actions fails."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(name="test_workflow", version="1.0", actions=[])
+
+        result = engine.load_workflow(definition)
+        assert result is False
+
+    def test_unload_workflow(self):
+        """Test unloading a workflow."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        engine.load_workflow(definition)
+        assert "test_workflow" in engine.workflows
+
+        result = engine.unload_workflow("test_workflow")
+        assert result is True
+        assert "test_workflow" not in engine.workflows
+
+    def test_unload_nonexistent_workflow(self):
+        """Test unloading non-existent workflow."""
+        engine = WorkflowEngine()
+        result = engine.unload_workflow("nonexistent")
+        assert result is False
+
+    def test_enable_workflow(self):
+        """Test enabling a workflow."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        engine.load_workflow(definition, enabled=False)
+        assert engine.enabled_workflows["test_workflow"] is False
+
+        engine.enable_workflow("test_workflow")
+        assert engine.enabled_workflows["test_workflow"] is True
+
+    def test_disable_workflow(self):
+        """Test disabling a workflow."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        engine.load_workflow(definition, enabled=True)
+        assert engine.enabled_workflows["test_workflow"] is True
+
+        engine.disable_workflow("test_workflow")
+        assert engine.enabled_workflows["test_workflow"] is False
+
+    def test_list_workflows(self):
+        """Test listing workflows."""
+        engine = WorkflowEngine()
+        definition1 = WorkflowDefinition(
+            name="workflow1",
+            version="1.0",
+            description="First workflow",
+            actions=[WorkflowAction(name="action1", type="python")],
+            triggers=[WorkflowTrigger(type=TriggerType.FILE_WRITE, config={"pattern": "*.md"})],
+        )
+        definition2 = WorkflowDefinition(
+            name="workflow2",
+            version="2.0",
+            description="Second workflow",
+            actions=[
+                WorkflowAction(name="action1", type="python"),
+                WorkflowAction(name="action2", type="bash"),
+            ],
+        )
+
+        engine.load_workflow(definition1, enabled=True)
+        engine.load_workflow(definition2, enabled=False)
+
+        workflows = engine.list_workflows()
+        assert len(workflows) == 2
+
+        # Check first workflow
+        wf1 = next(w for w in workflows if w["name"] == "workflow1")
+        assert wf1["version"] == "1.0"
+        assert wf1["description"] == "First workflow"
+        assert wf1["enabled"] is True
+        assert wf1["triggers"] == 1
+        assert wf1["actions"] == 1
+
+        # Check second workflow
+        wf2 = next(w for w in workflows if w["name"] == "workflow2")
+        assert wf2["version"] == "2.0"
+        assert wf2["enabled"] is False
+        assert wf2["triggers"] == 0
+        assert wf2["actions"] == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_workflow(self):
+        """Test executing a workflow."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="calc", type="python", config={"code": "result = 2 + 2"})],
+        )
+
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+        )
+
+        execution = await engine.execute_workflow(definition, context)
+        assert execution.status == WorkflowStatus.SUCCEEDED
+        assert execution.actions_completed == 1
+        assert execution.actions_total == 1
+        assert len(execution.action_results) == 1
+        assert execution.action_results[0].success is True
+
+    @pytest.mark.asyncio
+    async def test_execute_workflow_with_failure(self):
+        """Test executing workflow with action failure."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[
+                WorkflowAction(
+                    name="fail", type="python", config={"code": "raise ValueError('test error')"}
+                ),
+                WorkflowAction(name="after_fail", type="python", config={"code": "pass"}),
+            ],
+        )
+
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+        )
+
+        execution = await engine.execute_workflow(definition, context)
+        assert execution.status == WorkflowStatus.FAILED
+        assert execution.actions_completed == 0
+        assert len(execution.action_results) == 1
+        assert execution.action_results[0].success is False
+        assert "test error" in execution.error_message
+
+    @pytest.mark.asyncio
+    async def test_execute_workflow_unknown_action(self):
+        """Test executing workflow with unknown action type."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="unknown", type="nonexistent_action")],
+        )
+
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+        )
+
+        execution = await engine.execute_workflow(definition, context)
+        assert execution.status == WorkflowStatus.FAILED
+        assert "Unknown action type" in execution.error_message
+
+    @pytest.mark.asyncio
+    async def test_trigger_workflow(self):
+        """Test triggering a workflow."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python", config={"code": "pass"})],
+        )
+
+        engine.load_workflow(definition, enabled=True)
+
+        execution = await engine.trigger_workflow("test_workflow", {"trigger_type": "manual"})
+        assert execution is not None
+        assert execution.status == WorkflowStatus.SUCCEEDED
+
+    @pytest.mark.asyncio
+    async def test_trigger_nonexistent_workflow(self):
+        """Test triggering non-existent workflow."""
+        engine = WorkflowEngine()
+        execution = await engine.trigger_workflow("nonexistent", {})
+        assert execution is None
+
+    @pytest.mark.asyncio
+    async def test_trigger_disabled_workflow(self):
+        """Test triggering disabled workflow."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        engine.load_workflow(definition, enabled=False)
+        execution = await engine.trigger_workflow("test_workflow", {})
+        assert execution is None
+
+    @pytest.mark.asyncio
+    async def test_fire_event(self):
+        """Test firing an event."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            triggers=[WorkflowTrigger(type=TriggerType.FILE_WRITE, config={"pattern": "*.md"})],
+            actions=[WorkflowAction(name="action1", type="python", config={"code": "pass"})],
+        )
+
+        engine.load_workflow(definition, enabled=True)
+
+        # Fire matching event
+        count = await engine.fire_event(TriggerType.FILE_WRITE, {"file_path": "/docs/readme.md"})
+        assert count >= 0  # May be 0 or 1 depending on trigger implementation
+
+    @pytest.mark.asyncio
+    async def test_fire_event_with_string_type(self):
+        """Test firing an event with string trigger type."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            triggers=[WorkflowTrigger(type=TriggerType.FILE_WRITE, config={"pattern": "*.md"})],
+            actions=[WorkflowAction(name="action1", type="python", config={"code": "pass"})],
+        )
+
+        engine.load_workflow(definition, enabled=True)
+
+        # Fire matching event using string type
+        count = await engine.fire_event("file_write", {"file_path": "/docs/readme.md"})
+        assert count >= 0
+
+    @pytest.mark.asyncio
+    async def test_workflow_context_variables(self):
+        """Test workflow context variables are passed to actions."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[
+                WorkflowAction(
+                    name="calc",
+                    type="python",
+                    config={"code": "result = variables.get('x', 0) * 2"},
+                )
+            ],
+            variables={"x": 10},
+        )
+
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+            variables={"x": 10},
+        )
+
+        execution = await engine.execute_workflow(definition, context)
+        assert execution.status == WorkflowStatus.SUCCEEDED
+        assert execution.action_results[0].output == 20
+
+    @pytest.mark.asyncio
+    async def test_action_output_stored_in_context(self):
+        """Test action output is stored in context for next actions."""
+        engine = WorkflowEngine()
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[
+                WorkflowAction(
+                    name="action1", type="python", config={"code": "result = {'value': 42}"}
+                ),
+                WorkflowAction(
+                    name="action2",
+                    type="python",
+                    config={"code": "result = variables['action1_output']['value'] * 2"},
+                ),
+            ],
+        )
+
+        context = WorkflowContext(
+            workflow_id=uuid.uuid4(),
+            execution_id=uuid.uuid4(),
+            zone_id="test-zone",
+            trigger_type=TriggerType.MANUAL,
+        )
+
+        execution = await engine.execute_workflow(definition, context)
+        assert execution.status == WorkflowStatus.SUCCEEDED
+        assert execution.action_results[1].output == 84

--- a/tests/unit/workflows/test_protocol.py
+++ b/tests/unit/workflows/test_protocol.py
@@ -1,0 +1,63 @@
+"""Tests for workflow protocol conformance."""
+
+from nexus.workflows.engine import WorkflowEngine
+from nexus.workflows.protocol import WorkflowProtocol, WorkflowServices
+
+
+class TestWorkflowProtocol:
+    """Test WorkflowProtocol conformance."""
+
+    def test_engine_conforms_to_protocol(self):
+        """Test that WorkflowEngine satisfies WorkflowProtocol."""
+        engine = WorkflowEngine()
+        assert isinstance(engine, WorkflowProtocol)
+
+    def test_protocol_methods_exist(self):
+        """Test that all protocol methods exist on engine."""
+        engine = WorkflowEngine()
+        assert hasattr(engine, "fire_event")
+        assert hasattr(engine, "trigger_workflow")
+        assert hasattr(engine, "load_workflow")
+        assert hasattr(engine, "unload_workflow")
+        assert hasattr(engine, "enable_workflow")
+        assert hasattr(engine, "disable_workflow")
+        assert hasattr(engine, "list_workflows")
+
+    def test_protocol_methods_are_callable(self):
+        """Test that all protocol methods are callable."""
+        engine = WorkflowEngine()
+        assert callable(engine.fire_event)
+        assert callable(engine.trigger_workflow)
+        assert callable(engine.load_workflow)
+        assert callable(engine.unload_workflow)
+        assert callable(engine.enable_workflow)
+        assert callable(engine.disable_workflow)
+        assert callable(engine.list_workflows)
+
+
+class TestWorkflowServices:
+    """Test WorkflowServices dataclass."""
+
+    def test_default_services_all_none(self):
+        """Test that all services default to None."""
+        services = WorkflowServices()
+        assert services.nexus_ops is None
+        assert services.metadata_store is None
+        assert services.llm_provider is None
+        assert services.glob_match is None
+
+    def test_services_with_glob_match(self):
+        """Test creating services with glob_match."""
+
+        def mock_glob(path: str, patterns: list[str]) -> bool:
+            return any(path.endswith(p.lstrip("*")) for p in patterns)
+
+        services = WorkflowServices(glob_match=mock_glob)
+        assert services.glob_match is mock_glob
+        assert services.glob_match("/docs/readme.md", ["*.md"]) is True
+
+    def test_services_are_independent(self):
+        """Test that services are independent (no shared state)."""
+        s1 = WorkflowServices()
+        s2 = WorkflowServices()
+        assert s1 is not s2

--- a/tests/unit/workflows/test_storage.py
+++ b/tests/unit/workflows/test_storage.py
@@ -1,0 +1,467 @@
+"""Tests for workflow storage (async)."""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from nexus.storage.models import Base, WorkflowExecutionModel, WorkflowModel
+from nexus.workflows.storage import WorkflowStore
+from nexus.workflows.types import (
+    TriggerType,
+    WorkflowAction,
+    WorkflowDefinition,
+    WorkflowExecution,
+    WorkflowStatus,
+    WorkflowTrigger,
+)
+
+
+@pytest.fixture
+async def async_engine():
+    """Create in-memory async SQLite database."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+def async_session_factory(async_engine):
+    """Create async session factory."""
+    return async_sessionmaker(bind=async_engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture
+def workflow_store(async_session_factory):
+    """Create workflow store with injected models."""
+    return WorkflowStore(
+        async_session_factory,
+        workflow_model=WorkflowModel,
+        execution_model=WorkflowExecutionModel,
+        zone_id="test-zone",
+    )
+
+
+class TestWorkflowStore:
+    """Test WorkflowStore."""
+
+    def test_create_store(self, workflow_store):
+        """Test creating workflow store."""
+        assert workflow_store is not None
+        assert workflow_store.zone_id == "test-zone"
+
+    @pytest.mark.asyncio
+    async def test_save_workflow(self, workflow_store):
+        """Test saving a workflow."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            description="Test workflow",
+            actions=[WorkflowAction(name="action1", type="python", config={"code": "pass"})],
+        )
+
+        workflow_id = await workflow_store.save_workflow(definition, enabled=True)
+        assert workflow_id is not None
+        assert isinstance(workflow_id, str)
+
+    @pytest.mark.asyncio
+    async def test_save_workflow_with_triggers(self, workflow_store):
+        """Test saving workflow with triggers."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            triggers=[WorkflowTrigger(type=TriggerType.FILE_WRITE, config={"pattern": "*.md"})],
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        workflow_id = await workflow_store.save_workflow(definition)
+        loaded = await workflow_store.load_workflow(workflow_id)
+
+        assert loaded is not None
+        assert len(loaded.triggers) == 1
+        assert loaded.triggers[0].type == TriggerType.FILE_WRITE
+
+    @pytest.mark.asyncio
+    async def test_save_workflow_with_variables(self, workflow_store):
+        """Test saving workflow with variables."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            variables={"env": "test", "debug": True},
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        workflow_id = await workflow_store.save_workflow(definition)
+        loaded = await workflow_store.load_workflow(workflow_id)
+
+        assert loaded is not None
+        assert loaded.variables == {"env": "test", "debug": True}
+
+    @pytest.mark.asyncio
+    async def test_update_existing_workflow(self, workflow_store):
+        """Test updating an existing workflow."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        workflow_id1 = await workflow_store.save_workflow(definition)
+
+        # Update the workflow
+        updated_definition = WorkflowDefinition(
+            name="test_workflow",
+            version="2.0",
+            description="Updated",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        workflow_id2 = await workflow_store.save_workflow(updated_definition)
+
+        # Should be the same workflow ID (update not create new)
+        assert workflow_id1 == workflow_id2
+
+        loaded = await workflow_store.load_workflow(workflow_id1)
+        assert loaded.version == "2.0"
+        assert loaded.description == "Updated"
+
+    @pytest.mark.asyncio
+    async def test_load_workflow(self, workflow_store):
+        """Test loading a workflow."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            description="Test workflow",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        workflow_id = await workflow_store.save_workflow(definition)
+        loaded = await workflow_store.load_workflow(workflow_id)
+
+        assert loaded is not None
+        assert loaded.name == "test_workflow"
+        assert loaded.version == "1.0"
+        assert loaded.description == "Test workflow"
+        assert len(loaded.actions) == 1
+
+    @pytest.mark.asyncio
+    async def test_load_nonexistent_workflow(self, workflow_store):
+        """Test loading non-existent workflow."""
+        loaded = await workflow_store.load_workflow(str(uuid.uuid4()))
+        assert loaded is None
+
+    @pytest.mark.asyncio
+    async def test_load_workflow_by_name(self, workflow_store):
+        """Test loading workflow by name."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        await workflow_store.save_workflow(definition)
+        loaded = await workflow_store.load_workflow_by_name("test_workflow")
+
+        assert loaded is not None
+        assert loaded.name == "test_workflow"
+
+    @pytest.mark.asyncio
+    async def test_load_workflow_by_name_nonexistent(self, workflow_store):
+        """Test loading non-existent workflow by name."""
+        loaded = await workflow_store.load_workflow_by_name("nonexistent")
+        assert loaded is None
+
+    @pytest.mark.asyncio
+    async def test_list_workflows(self, workflow_store):
+        """Test listing workflows."""
+        definition1 = WorkflowDefinition(
+            name="workflow1",
+            version="1.0",
+            description="First workflow",
+            triggers=[WorkflowTrigger(type=TriggerType.FILE_WRITE, config={"pattern": "*.md"})],
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+        definition2 = WorkflowDefinition(
+            name="workflow2",
+            version="2.0",
+            description="Second workflow",
+            actions=[
+                WorkflowAction(name="action1", type="python"),
+                WorkflowAction(name="action2", type="bash"),
+            ],
+        )
+
+        await workflow_store.save_workflow(definition1, enabled=True)
+        await workflow_store.save_workflow(definition2, enabled=False)
+
+        workflows = await workflow_store.list_workflows()
+        assert len(workflows) == 2
+
+        # Check first workflow
+        wf1 = next(w for w in workflows if w["name"] == "workflow1")
+        assert wf1["version"] == "1.0"
+        assert wf1["description"] == "First workflow"
+        assert wf1["enabled"] is True
+        assert wf1["triggers"] == 1
+        assert wf1["actions"] == 1
+
+        # Check second workflow
+        wf2 = next(w for w in workflows if w["name"] == "workflow2")
+        assert wf2["version"] == "2.0"
+        assert wf2["enabled"] is False
+        assert wf2["triggers"] == 0
+        assert wf2["actions"] == 2
+
+    @pytest.mark.asyncio
+    async def test_list_workflows_empty(self, workflow_store):
+        """Test listing workflows when none exist."""
+        workflows = await workflow_store.list_workflows()
+        assert workflows == []
+
+    @pytest.mark.asyncio
+    async def test_delete_workflow(self, workflow_store):
+        """Test deleting a workflow."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        workflow_id = await workflow_store.save_workflow(definition)
+        result = await workflow_store.delete_workflow(workflow_id)
+        assert result is True
+
+        # Verify it's deleted
+        loaded = await workflow_store.load_workflow(workflow_id)
+        assert loaded is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_workflow(self, workflow_store):
+        """Test deleting non-existent workflow."""
+        result = await workflow_store.delete_workflow(str(uuid.uuid4()))
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_workflow_by_name(self, workflow_store):
+        """Test deleting workflow by name."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        await workflow_store.save_workflow(definition)
+        result = await workflow_store.delete_workflow_by_name("test_workflow")
+        assert result is True
+
+        # Verify it's deleted
+        loaded = await workflow_store.load_workflow_by_name("test_workflow")
+        assert loaded is None
+
+    @pytest.mark.asyncio
+    async def test_delete_workflow_by_name_nonexistent(self, workflow_store):
+        """Test deleting non-existent workflow by name."""
+        result = await workflow_store.delete_workflow_by_name("nonexistent")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_set_enabled(self, workflow_store):
+        """Test enabling/disabling workflow."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        workflow_id = await workflow_store.save_workflow(definition, enabled=True)
+
+        # Disable
+        result = await workflow_store.set_enabled(workflow_id, False)
+        assert result is True
+
+        workflows = await workflow_store.list_workflows()
+        assert workflows[0]["enabled"] is False
+
+        # Enable
+        result = await workflow_store.set_enabled(workflow_id, True)
+        assert result is True
+
+        workflows = await workflow_store.list_workflows()
+        assert workflows[0]["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_set_enabled_nonexistent(self, workflow_store):
+        """Test setting enabled on non-existent workflow."""
+        result = await workflow_store.set_enabled(str(uuid.uuid4()), True)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_set_enabled_by_name(self, workflow_store):
+        """Test enabling/disabling workflow by name."""
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+
+        await workflow_store.save_workflow(definition, enabled=True)
+
+        # Disable
+        result = await workflow_store.set_enabled_by_name("test_workflow", False)
+        assert result is True
+
+        workflows = await workflow_store.list_workflows()
+        assert workflows[0]["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_set_enabled_by_name_nonexistent(self, workflow_store):
+        """Test setting enabled by name on non-existent workflow."""
+        result = await workflow_store.set_enabled_by_name("nonexistent", True)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_save_execution(self, workflow_store):
+        """Test saving workflow execution."""
+        from datetime import UTC, datetime
+
+        execution = WorkflowExecution(
+            execution_id=uuid.uuid4(),
+            workflow_id=uuid.uuid4(),
+            workflow_name="test_workflow",
+            status=WorkflowStatus.SUCCEEDED,
+            trigger_type=TriggerType.MANUAL,
+            trigger_context={},
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            actions_completed=2,
+            actions_total=2,
+        )
+
+        execution_id = await workflow_store.save_execution(execution)
+        assert execution_id is not None
+        assert isinstance(execution_id, str)
+
+    @pytest.mark.asyncio
+    async def test_get_executions(self, workflow_store):
+        """Test getting execution history."""
+        from datetime import UTC, datetime
+
+        # Save a workflow first
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+        workflow_id_str = await workflow_store.save_workflow(definition)
+
+        # Create executions
+        for _i in range(3):
+            execution = WorkflowExecution(
+                execution_id=uuid.uuid4(),
+                workflow_id=uuid.UUID(workflow_id_str),
+                workflow_name="test_workflow",
+                status=WorkflowStatus.SUCCEEDED,
+                trigger_type=TriggerType.MANUAL,
+                trigger_context={},
+                started_at=datetime.now(UTC),
+                actions_total=1,
+            )
+            await workflow_store.save_execution(execution)
+
+        # Get executions
+        executions = await workflow_store.get_executions(workflow_id_str, limit=10)
+        assert len(executions) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_executions_with_limit(self, workflow_store):
+        """Test getting execution history with limit."""
+        from datetime import UTC, datetime
+
+        # Save a workflow first
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+        workflow_id_str = await workflow_store.save_workflow(definition)
+
+        # Create more executions than limit
+        for _i in range(5):
+            execution = WorkflowExecution(
+                execution_id=uuid.uuid4(),
+                workflow_id=uuid.UUID(workflow_id_str),
+                workflow_name="test_workflow",
+                status=WorkflowStatus.SUCCEEDED,
+                trigger_type=TriggerType.MANUAL,
+                trigger_context={},
+                started_at=datetime.now(UTC),
+                actions_total=1,
+            )
+            await workflow_store.save_execution(execution)
+
+        # Get executions with limit
+        executions = await workflow_store.get_executions(workflow_id_str, limit=3)
+        assert len(executions) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_executions_by_name(self, workflow_store):
+        """Test getting execution history by workflow name."""
+        from datetime import UTC, datetime
+
+        # Save a workflow first
+        definition = WorkflowDefinition(
+            name="test_workflow",
+            version="1.0",
+            actions=[WorkflowAction(name="action1", type="python")],
+        )
+        workflow_id_str = await workflow_store.save_workflow(definition)
+
+        # Create execution
+        execution = WorkflowExecution(
+            execution_id=uuid.uuid4(),
+            workflow_id=uuid.UUID(workflow_id_str),
+            workflow_name="test_workflow",
+            status=WorkflowStatus.SUCCEEDED,
+            trigger_type=TriggerType.MANUAL,
+            trigger_context={},
+            started_at=datetime.now(UTC),
+            actions_total=1,
+        )
+        await workflow_store.save_execution(execution)
+
+        # Get executions by name
+        executions = await workflow_store.get_executions_by_name("test_workflow")
+        assert len(executions) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_executions_by_name_nonexistent(self, workflow_store):
+        """Test getting execution history for non-existent workflow."""
+        executions = await workflow_store.get_executions_by_name("nonexistent")
+        assert executions == []
+
+    def test_compute_hash(self, workflow_store):
+        """Test computing workflow hash."""
+        yaml_content1 = "name: test\nversion: 1.0"
+        yaml_content2 = "name: test\nversion: 2.0"
+
+        hash1 = workflow_store._compute_hash(yaml_content1)
+        hash2 = workflow_store._compute_hash(yaml_content2)
+
+        assert hash1 != hash2
+        assert len(hash1) == 64  # SHA256 hex
+        assert len(hash2) == 64
+
+    def test_get_zone_id(self, workflow_store):
+        """Test getting zone ID."""
+        assert workflow_store._get_zone_id() == "test-zone"
+
+    def test_default_zone_id(self, async_session_factory):
+        """Test default zone ID."""
+        store = WorkflowStore(
+            async_session_factory,
+            workflow_model=WorkflowModel,
+            execution_model=WorkflowExecutionModel,
+        )
+        assert store._get_zone_id() == "default"


### PR DESCRIPTION
## Summary

- Extract `nexus/workflows/` (~2,179 LOC) into a fully decoupled **Lego Brick** with zero imports from `nexus.core`, `nexus.storage`, or `nexus.server`
- Add `WorkflowProtocol` + `WorkflowServices` dataclass for dependency injection (new `protocol.py`)
- Decouple triggers via `GlobMatchFn` callable injection (fnmatch fallback for tests, Rust in prod)
- Decouple actions via `context.services` pattern — no more `nexus.connect()` lazy imports
- Convert `WorkflowStore` to fully async (`AsyncSession`) with injected model classes
- Remove global singleton (`get_engine`/`init_engine`) — explicit DI everywhere
- Add `engine.startup()` async method for post-construction DB loading
- Add bounded event queue (`maxsize=1000`) with backpressure in `nexus_fs_core.py`
- Add 8 REST API endpoints at `/api/v2/workflows` following `pay.py` exemplar pattern
- Add graceful error handling for storage operations in enable/disable/unload
- Convert all debug `print()` to `logger.debug()`
- Standardize `zone_id` from `UUID` to `str`

## 16 Architectural Decisions Implemented

| # | Issue | Decision |
|---|-------|----------|
| 1 | triggers.py core import | DI GlobMatchFn callable |
| 2 | actions.py kernel coupling | Context services pattern |
| 3 | Global singleton | Removed entirely |
| 4 | Storage model imports | Inject model classes |
| 5 | Debug prints | Convert to logger.debug() |
| 6 | DRY storage | Extract _get_workflow helper |
| 7 | Missing Protocol | @runtime_checkable Protocol |
| 8 | zone_id inconsistency | Standardize to str |
| 9-14 | Tests + REST API | Full coverage (189 tests) |
| 15 | YAML caching | Keep as-is |
| 16 | Event queue | Bounded asyncio.Queue |

## Files Changed (22 files, +1,653 / -974)

**New files (4):**
- `src/nexus/workflows/protocol.py` — Protocol + WorkflowServices
- `src/nexus/server/api/v2/routers/workflows.py` — 8 REST endpoints
- `tests/unit/workflows/test_protocol.py` — Protocol conformance tests
- `tests/unit/server/api/v2/routers/test_workflows_router.py` — Router tests (19 tests)

**Modified:** workflows brick (7 files), integration points (7 files), tests (4 files)

## Test plan

- [x] All 189 unit tests pass (170 workflow + 19 router)
- [x] Zero-import verification: no imports from nexus.core/storage/server in workflows/
- [x] Ruff lint: all checks pass
- [x] Ruff format: all files formatted
- [x] E2E smoke test: full CRUD lifecycle (load→list→disable→enable→execute→unload) passes
- [x] Performance benchmark: no regression (<0.1ms per operation)
- [ ] CI pipeline

**Stream: 7**

🤖 Generated with [Claude Code](https://claude.com/claude-code)