### PR TITLE
fix(#1590): replace global mutable cache in agent_card.py

### DIFF
--- a/src/nexus/a2a/agent_card.py
+++ b/src/nexus/a2a/agent_card.py
@@ -24,11 +24,17 @@ logger = logging.getLogger(__name__)
 
 
 class AgentCardCache:
-    """Encapsulates the mutable cache state for a single Agent Card.
+    """Write-once cache for a single Agent Card.
 
     Each ``AgentCardCache`` instance is independent — no shared globals.
-    The class is intentionally simple: GIL + write-once semantics make
-    a ``threading.Lock`` unnecessary.
+    The cache is **write-once**: the first call to ``get_card_bytes()``
+    builds and caches the card; all subsequent calls return the cached
+    value.  To rebuild, create a new ``AgentCardCache`` instance.
+
+    Thread-safety: the write-once contract means no lock is required.
+    After the first ``get_card_bytes()`` call completes, the cached
+    values are effectively immutable.  Concurrent initial calls may
+    redundantly build the card, but the result is identical and harmless.
     """
 
     __slots__ = ("_card_bytes", "_card")
@@ -44,14 +50,13 @@ class AgentCardCache:
         skills: list[Any] | None = None,
         base_url: str = DEFAULT_NEXUS_URL,
         auth_provider: Any = None,
-        force_rebuild: bool = False,
     ) -> bytes:
         """Return the Agent Card as pre-serialised JSON bytes.
 
-        Builds on first call and caches the result.  Pass
-        ``force_rebuild=True`` to invalidate and rebuild.
+        Builds on first call and caches the result.  The cache is
+        write-once — to rebuild, create a new ``AgentCardCache``.
         """
-        if self._card_bytes is not None and not force_rebuild:
+        if self._card_bytes is not None:
             return self._card_bytes
 
         card = build_agent_card(
@@ -77,46 +82,6 @@ class AgentCardCache:
     def get_card(self) -> AgentCard | None:
         """Return the cached ``AgentCard`` instance, or *None* if not yet built."""
         return self._card
-
-    def invalidate(self) -> None:
-        """Clear the cache so the card will be rebuilt on next access."""
-        self._card_bytes = None
-        self._card = None
-
-
-# Module-level default instance (backward-compatible with existing callers)
-_default_cache = AgentCardCache()
-
-
-def get_cached_card_bytes(
-    *,
-    config: Any = None,
-    skills: list[Any] | None = None,
-    base_url: str = DEFAULT_NEXUS_URL,
-    auth_provider: Any = None,
-    force_rebuild: bool = False,
-) -> bytes:
-    """Get the Agent Card as pre-serialized JSON bytes.
-
-    Thin wrapper around the default ``AgentCardCache`` instance.
-    """
-    return _default_cache.get_card_bytes(
-        config=config,
-        skills=skills,
-        base_url=base_url,
-        auth_provider=auth_provider,
-        force_rebuild=force_rebuild,
-    )
-
-
-def get_cached_card() -> AgentCard | None:
-    """Return the cached ``AgentCard`` instance, or *None* if not yet built."""
-    return _default_cache.get_card()
-
-
-def invalidate_cache() -> None:
-    """Clear the cached Agent Card so it will be rebuilt on next access."""
-    _default_cache.invalidate()
 
 
 def build_agent_card(

--- a/tests/unit/a2a/test_agent_card.py
+++ b/tests/unit/a2a/test_agent_card.py
@@ -1,0 +1,324 @@
+"""Unit tests for A2A Agent Card builder and cache.
+
+Tests cover:
+- ``AgentCardCache`` write-once caching behaviour
+- ``build_agent_card()`` with various inputs
+- ``_map_skills()`` edge cases
+- ``_detect_auth_schemes()`` all provider branches
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from nexus.a2a.agent_card import (
+    AgentCardCache,
+    _detect_auth_schemes,
+    _map_skills,
+    build_agent_card,
+)
+from nexus.a2a.models import AgentCard
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_skill(
+    name: str = "search",
+    description: str = "Search files",
+    tags: list[str] | None = None,
+) -> SimpleNamespace:
+    """Create a fake SkillMetadata-like object."""
+    return SimpleNamespace(name=name, description=description, tags=tags or [])
+
+
+def _make_config(
+    a2a_agent_name: str | None = None,
+    a2a_agent_description: str | None = None,
+) -> SimpleNamespace:
+    """Create a fake NexusConfig-like object."""
+    return SimpleNamespace(
+        a2a_agent_name=a2a_agent_name,
+        a2a_agent_description=a2a_agent_description,
+    )
+
+
+def _make_auth_provider(class_name: str) -> object:
+    """Create a fake auth provider with a specific class name."""
+    cls = type(class_name, (), {})
+    return cls()
+
+
+# ------------------------------------------------------------------
+# AgentCardCache
+# ------------------------------------------------------------------
+
+
+class TestAgentCardCache:
+    """Tests for the write-once ``AgentCardCache``."""
+
+    def test_get_card_returns_none_before_build(self) -> None:
+        cache = AgentCardCache()
+        assert cache.get_card() is None
+
+    def test_get_card_bytes_builds_and_caches(self) -> None:
+        cache = AgentCardCache()
+        result = cache.get_card_bytes()
+
+        assert isinstance(result, bytes)
+        parsed = json.loads(result)
+        assert parsed["name"] == "Nexus Agent"
+
+    def test_get_card_bytes_returns_same_object_on_second_call(self) -> None:
+        cache = AgentCardCache()
+        first = cache.get_card_bytes()
+        second = cache.get_card_bytes()
+
+        # Same object identity — not just equal, but the *same* bytes.
+        assert first is second
+
+    def test_get_card_returns_card_after_build(self) -> None:
+        cache = AgentCardCache()
+        cache.get_card_bytes()
+
+        card = cache.get_card()
+        assert card is not None
+        assert isinstance(card, AgentCard)
+        assert card.name == "Nexus Agent"
+
+    def test_write_once_ignores_different_config_on_second_call(self) -> None:
+        """After the first build, new params are ignored (write-once)."""
+        cache = AgentCardCache()
+        first = cache.get_card_bytes(config=_make_config(a2a_agent_name="First"))
+        second = cache.get_card_bytes(config=_make_config(a2a_agent_name="Second"))
+
+        assert first is second
+        assert json.loads(first)["name"] == "First"
+
+    def test_new_instance_allows_rebuild(self) -> None:
+        """To rebuild, create a new instance (the write-once contract)."""
+        cache1 = AgentCardCache()
+        bytes1 = cache1.get_card_bytes(config=_make_config(a2a_agent_name="Alpha"))
+
+        cache2 = AgentCardCache()
+        bytes2 = cache2.get_card_bytes(config=_make_config(a2a_agent_name="Beta"))
+
+        assert json.loads(bytes1)["name"] == "Alpha"
+        assert json.loads(bytes2)["name"] == "Beta"
+
+    def test_get_card_bytes_with_skills(self) -> None:
+        cache = AgentCardCache()
+        skills = [_make_skill("search", "Search files", ["fs"])]
+        result = cache.get_card_bytes(skills=skills)
+
+        parsed = json.loads(result)
+        assert len(parsed["skills"]) == 1
+        assert parsed["skills"][0]["name"] == "search"
+
+    def test_get_card_bytes_custom_base_url(self) -> None:
+        cache = AgentCardCache()
+        result = cache.get_card_bytes(base_url="https://example.com")
+
+        parsed = json.loads(result)
+        assert parsed["url"] == "https://example.com/a2a"
+
+
+# ------------------------------------------------------------------
+# build_agent_card()
+# ------------------------------------------------------------------
+
+
+class TestBuildAgentCard:
+    """Tests for the pure ``build_agent_card()`` function."""
+
+    def test_defaults(self) -> None:
+        card = build_agent_card()
+
+        assert card.name == "Nexus Agent"
+        assert card.description == "AI-native distributed filesystem agent"
+        assert card.version == "0.7.1"
+        assert card.url == "http://localhost:2026/a2a"
+        assert card.capabilities.streaming is True
+        assert card.capabilities.pushNotifications is False
+        assert card.skills == []
+        assert card.authentication == []
+
+    def test_custom_config(self) -> None:
+        config = _make_config(
+            a2a_agent_name="Custom Agent",
+            a2a_agent_description="A custom agent",
+        )
+        card = build_agent_card(config=config)
+
+        assert card.name == "Custom Agent"
+        assert card.description == "A custom agent"
+
+    def test_config_none_values_use_defaults(self) -> None:
+        config = _make_config(a2a_agent_name=None, a2a_agent_description=None)
+        card = build_agent_card(config=config)
+
+        assert card.name == "Nexus Agent"
+        assert card.description == "AI-native distributed filesystem agent"
+
+    def test_config_empty_strings_use_defaults(self) -> None:
+        config = _make_config(a2a_agent_name="", a2a_agent_description="")
+        card = build_agent_card(config=config)
+
+        assert card.name == "Nexus Agent"
+        assert card.description == "AI-native distributed filesystem agent"
+
+    def test_custom_base_url(self) -> None:
+        card = build_agent_card(base_url="https://nexus.example.com")
+        assert card.url == "https://nexus.example.com/a2a"
+
+    def test_provider(self) -> None:
+        card = build_agent_card()
+        assert card.provider is not None
+        assert card.provider.organization == "Nexus"
+
+    def test_default_io_modes(self) -> None:
+        card = build_agent_card()
+        assert "text/plain" in card.defaultInputModes
+        assert "application/json" in card.defaultInputModes
+        assert "text/plain" in card.defaultOutputModes
+        assert "application/json" in card.defaultOutputModes
+
+    def test_with_multiple_skills(self) -> None:
+        skills = [
+            _make_skill("search", "Search files"),
+            _make_skill("write", "Write files"),
+            _make_skill("read", "Read files"),
+        ]
+        card = build_agent_card(skills=skills)
+        assert len(card.skills) == 3
+        assert [s.name for s in card.skills] == ["search", "write", "read"]
+
+
+# ------------------------------------------------------------------
+# _map_skills()
+# ------------------------------------------------------------------
+
+
+class TestMapSkills:
+    """Tests for the ``_map_skills()`` helper."""
+
+    def test_empty_list(self) -> None:
+        assert _map_skills([]) == []
+
+    def test_valid_skill(self) -> None:
+        skills = _map_skills([_make_skill("search", "Search files", ["fs"])])
+
+        assert len(skills) == 1
+        assert skills[0].id == "search"
+        assert skills[0].name == "search"
+        assert skills[0].description == "Search files"
+        assert skills[0].tags == ["fs"]
+
+    def test_skill_missing_name_is_skipped(self) -> None:
+        skill = SimpleNamespace(name=None, description="Has description", tags=[])
+        assert _map_skills([skill]) == []
+
+    def test_skill_missing_description_is_skipped(self) -> None:
+        skill = SimpleNamespace(name="has_name", description=None, tags=[])
+        assert _map_skills([skill]) == []
+
+    def test_skill_empty_name_is_skipped(self) -> None:
+        skill = SimpleNamespace(name="", description="Has description", tags=[])
+        assert _map_skills([skill]) == []
+
+    def test_skill_empty_description_is_skipped(self) -> None:
+        skill = SimpleNamespace(name="has_name", description="", tags=[])
+        assert _map_skills([skill]) == []
+
+    def test_skill_none_tags_default_to_empty(self) -> None:
+        skill = SimpleNamespace(name="s", description="d", tags=None)
+        result = _map_skills([skill])
+
+        assert len(result) == 1
+        assert result[0].tags == []
+
+    def test_skill_missing_tags_attribute(self) -> None:
+        """Object without a tags attribute should get empty tags."""
+        skill = SimpleNamespace(name="s", description="d")
+        result = _map_skills([skill])
+
+        assert len(result) == 1
+        assert result[0].tags == []
+
+    def test_mixed_valid_and_invalid(self) -> None:
+        skills = [
+            _make_skill("good", "Valid skill"),
+            SimpleNamespace(name=None, description="No name", tags=[]),
+            _make_skill("also_good", "Another valid skill"),
+        ]
+        result = _map_skills(skills)
+
+        assert len(result) == 2
+        assert result[0].name == "good"
+        assert result[1].name == "also_good"
+
+
+# ------------------------------------------------------------------
+# _detect_auth_schemes()
+# ------------------------------------------------------------------
+
+
+class TestDetectAuthSchemes:
+    """Tests for the ``_detect_auth_schemes()`` helper."""
+
+    def test_none_provider(self) -> None:
+        assert _detect_auth_schemes(None) == []
+
+    def test_api_key_provider(self) -> None:
+        provider = _make_auth_provider("APIKeyAuthProvider")
+        schemes = _detect_auth_schemes(provider)
+
+        assert len(schemes) == 1
+        assert schemes[0].type == "apiKey"
+
+    def test_static_key_provider(self) -> None:
+        provider = _make_auth_provider("StaticKeyProvider")
+        schemes = _detect_auth_schemes(provider)
+
+        assert len(schemes) == 1
+        assert schemes[0].type == "apiKey"
+
+    def test_oauth_provider(self) -> None:
+        provider = _make_auth_provider("OAuthProvider")
+        schemes = _detect_auth_schemes(provider)
+
+        assert len(schemes) == 2
+        types = {s.type for s in schemes}
+        assert types == {"oauth2", "openIdConnect"}
+
+    def test_oidc_provider(self) -> None:
+        provider = _make_auth_provider("OIDCProvider")
+        schemes = _detect_auth_schemes(provider)
+
+        assert len(schemes) == 2
+        types = {s.type for s in schemes}
+        assert types == {"oauth2", "openIdConnect"}
+
+    def test_database_local_provider(self) -> None:
+        provider = _make_auth_provider("DatabaseLocalAuthProvider")
+        schemes = _detect_auth_schemes(provider)
+
+        assert len(schemes) == 1
+        assert schemes[0].type == "httpBearer"
+
+    def test_discriminating_provider(self) -> None:
+        provider = _make_auth_provider("DiscriminatingAuthProvider")
+        schemes = _detect_auth_schemes(provider)
+
+        assert len(schemes) == 2
+        types = [s.type for s in schemes]
+        assert types == ["apiKey", "httpBearer"]
+
+    def test_unknown_provider_defaults_to_bearer(self) -> None:
+        provider = _make_auth_provider("SomethingUnknown")
+        schemes = _detect_auth_schemes(provider)
+
+        assert len(schemes) == 1
+        assert schemes[0].type == "httpBearer"


### PR DESCRIPTION
## Summary

- Remove thread-unsafe module-level `_default_cache` singleton and 3 dead wrapper functions (`get_cached_card_bytes`, `get_cached_card`, `invalidate_cache`) that had zero callers in the codebase
- Make `AgentCardCache` truly write-once by removing `invalidate()` and `force_rebuild` — to rebuild, create a new instance
- Add 33 unit tests (93% coverage) for cache behavior, `build_agent_card`, `_map_skills`, and `_detect_auth_schemes`

**Stream:** stream10

## Details

**Problem:** `agent_card.py` had a module-level `_default_cache = AgentCardCache()` singleton with no thread synchronization. The class docstring incorrectly claimed "GIL + write-once semantics make a `threading.Lock` unnecessary" while `invalidate()` and `force_rebuild` broke write-once semantics. The singleton and its 3 wrapper functions were dead code (zero callers — `router.py` creates its own per-router instance).

**Solution:** Delete dead code (33 lines), enforce true write-once contract (immutable after first build), update docstring to accurately document thread-safety properties. Follows the Lego Architecture principle of DI over module-level globals.

**Validation:**
- ruff lint: clean
- ruff format: clean  
- mypy: no errors in changed file
- Unit tests: 33/33 passed (93% coverage)
- E2E tests: 14/14 passed (real `nexus serve` subprocess)
- Integration tests: all agent_card-related tests pass

## Test plan

- [x] `pytest tests/unit/a2a/test_agent_card.py` — 33 tests, 93% coverage
- [x] `pytest tests/e2e/test_a2a_e2e.py` — 14 E2E tests against real server
- [x] `pytest tests/integration/a2a/test_a2a_auth.py` — auth integration (15/17, 2 pre-existing failures from #1591)
- [x] `pytest tests/integration/a2a/test_a2a_endpoints.py` — endpoint integration (23/24, 1 pre-existing failure from #1591)
- [x] ruff check + format — clean
- [x] mypy — no errors in changed files

Closes #1590