### PR TITLE
refactor(#1254): reduce broad exception handlers

### DIFF
--- a/src/nexus/backends/cache_mixin.py
+++ b/src/nexus/backends/cache_mixin.py
@@ -1418,8 +1418,8 @@ class CacheConnectorMixin:
                 blob_path = self._get_blob_path(path)
                 content: bytes = self._download_blob(blob_path)
                 return content
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Direct blob download failed for %s: %s", path, e)
 
         # Fall back to read_content (may use cache)
         if hasattr(self, "read_content"):
@@ -1427,7 +1427,8 @@ class CacheConnectorMixin:
                 # read_content expects (content_hash, context) for GCS connector
                 # Pass empty content_hash and let it use context.backend_path
                 return self.read_content("", context)  # type: ignore
-            except Exception:
+            except Exception as e:
+                logger.debug("Fallback read_content failed for %s: %s", path, e)
                 return None
         return None
 
@@ -1475,8 +1476,8 @@ class CacheConnectorMixin:
             if result and result.text:
                 return result.text, ext.lstrip("."), {"chunks": len(result.chunks)}
 
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Content parsing failed for %s: %s", path, e)
 
         return None, None, None
 

--- a/src/nexus/backends/gmail_connector.py
+++ b/src/nexus/backends/gmail_connector.py
@@ -437,8 +437,10 @@ class GmailConnectorBackend(
                     elif mime_type == "text/html" and not body_html:
                         # Only set if not already set (prefer first occurrence)
                         body_html = decoded
-                except Exception:
-                    # Skip parts that fail to decode
+                except Exception as e:
+                    logger.debug(
+                        "Failed to decode email body part (mime_type=%s): %s", mime_type, e
+                    )
                     continue
 
         return body_text, body_html
@@ -716,8 +718,8 @@ class GmailConnectorBackend(
                     backend_version=IMMUTABLE_VERSION,  # Emails are immutable, use fixed version
                     zone_id=zone_id,
                 )
-            except Exception:
-                pass  # Don't fail on cache write errors
+            except Exception as e:
+                logger.debug("Gmail cache write failed for %s: %s", cache_path, e)
 
         return HandlerResponse.ok(
             data=content,
@@ -769,8 +771,9 @@ class GmailConnectorBackend(
 
                 message_id = filename_parts[1]  # Get msg_id from "thread_id-msg_id"
                 path_to_message_id[path] = message_id
-            except Exception:
-                continue  # Skip paths that fail to parse
+            except Exception as e:
+                logger.debug("Failed to parse Gmail path %s: %s", path, e)
+                continue
 
         if not path_to_message_id:
             return {}
@@ -792,9 +795,10 @@ class GmailConnectorBackend(
                 parse_message_func=self._parse_gmail_message,
                 email_cache=email_cache,
             )
-        except Exception:
+        except Exception as e:
             # If batch fetch fails, fall back to empty results
             # The cache mixin will retry with sequential reads
+            logger.debug("Gmail batch fetch failed, falling back to sequential reads: %s", e)
             return {}
 
         # Format results as YAML
@@ -805,8 +809,9 @@ class GmailConnectorBackend(
                     email_data = email_cache[message_id]
                     content = self._format_email_as_yaml(email_data)
                     results[path] = content
-                except Exception:
-                    continue  # Skip emails that fail to format
+                except Exception as e:
+                    logger.debug("Failed to format email %s as YAML: %s", message_id, e)
+                    continue
 
         return results
 
@@ -868,10 +873,12 @@ class GmailConnectorBackend(
                 service = self._get_gmail_service(context)
                 service.users().messages().get(userId="me", id=message_id, format="full").execute()
                 return True
-            except Exception:
+            except Exception as e:
+                logger.debug("Gmail API check for message %s failed: %s", message_id, e)
                 return False
 
-        except Exception:
+        except Exception as e:
+            logger.debug("Gmail content existence check failed: %s", e)
             return False
 
     def get_content_size(self, content_hash: str, context: "OperationContext | None" = None) -> int:
@@ -970,7 +977,8 @@ class GmailConnectorBackend(
             # Return fixed version for immutable Gmail emails
             return IMMUTABLE_VERSION
 
-        except Exception:
+        except Exception as e:
+            logger.debug("Gmail version check failed: %s", e)
             return None
 
     def _batch_get_versions(

--- a/src/nexus/backends/slack_connector.py
+++ b/src/nexus/backends/slack_connector.py
@@ -518,7 +518,8 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
                             }
                         }
                     ]
-            except Exception:
+            except Exception as e:
+                logger.debug("Failed to get channel info for %s: %s", channel_name, e)
                 # If we can't get channel info, just note that no messages were found
                 messages = [
                     {
@@ -544,8 +545,8 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
                     backend_version=IMMUTABLE_VERSION,  # Messages are immutable
                     zone_id=zone_id,
                 )
-            except Exception:
-                pass  # Don't fail on cache write errors
+            except Exception as e:
+                logger.debug("Slack cache write failed for %s: %s", cache_path, e)
 
         return HandlerResponse.ok(
             data=content,
@@ -587,7 +588,8 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
             # Try to read the message
             self.read_content(content_hash, context).unwrap()
             return True
-        except Exception:
+        except Exception as e:
+            logger.debug("Slack content existence check failed: %s", e)
             return False
 
     def get_content_size(self, content_hash: str, context: "OperationContext | None" = None) -> int:
@@ -661,7 +663,8 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
             # Return fixed version for immutable Slack messages
             return IMMUTABLE_VERSION
 
-        except Exception:
+        except Exception as e:
+            logger.debug("Slack version check failed: %s", e)
             return None
 
     def mkdir(

--- a/src/nexus/backends/sync_pipeline.py
+++ b/src/nexus/backends/sync_pipeline.py
@@ -521,7 +521,7 @@ class SyncPipelineService:
                     files.extend(self._list_files_recursive(full_path, context))
                 else:
                     files.append(full_path)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to list files recursively in %s: %s", path, e)
 
         return files

--- a/src/nexus/backends/x_connector.py
+++ b/src/nexus/backends/x_connector.py
@@ -1288,7 +1288,8 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
                         if len(results) >= max_results:
                             break
 
-            except Exception:
+            except Exception as e:
+                logger.debug("Failed to search cached tweet file %s: %s", file, e)
                 continue
 
         return results

--- a/src/nexus/cache/warmer.py
+++ b/src/nexus/cache/warmer.py
@@ -802,8 +802,8 @@ class CacheWarmer:
                 metadata = self._nexus.metadata.get(path)
                 if metadata and metadata.size and metadata.size < threshold:
                     small_files.append(path)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Failed to check metadata for path %s: %s", path, e)
 
         return small_files
 
@@ -845,8 +845,8 @@ class CacheWarmer:
                         common.append(entry)
                     elif isinstance(entry, dict) and "path" in entry:
                         common.append(entry["path"])
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to list root directory for common paths: %s", e)
 
         # Add known common paths
         common.extend(["/workspace", "/config", "/data"])

--- a/src/nexus/connectors/base.py
+++ b/src/nexus/connectors/base.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
+from nexus.core.exceptions import ValidationError as CoreValidationError
+
 if TYPE_CHECKING:
     from nexus.skills.registry import SkillRegistry
 
@@ -134,8 +136,11 @@ class ErrorDef:
     details: dict[str, Any] = field(default_factory=dict)
 
 
-class ValidationError(Exception):
+class ValidationError(CoreValidationError):
     """Validation error with self-correcting information.
+
+    Inherits from core.exceptions.ValidationError so centralized error handlers
+    can catch both connector and core validation errors uniformly.
 
     Contains error code, message, skill reference, and fix example
     so agents can self-correct their requests.

--- a/src/nexus/core/exceptions.py
+++ b/src/nexus/core/exceptions.py
@@ -136,6 +136,71 @@ class BackendError(NexusError):
         super().__init__(message, path)
 
 
+class DatabaseError(BackendError):
+    """Database operation failed. Wraps SQLAlchemy errors at storage boundary.
+
+    This is an unexpected error — indicates database infrastructure failure.
+    """
+
+    is_expected = False
+
+    def __init__(self, message: str, path: str | None = None):
+        super().__init__(message, path=path)
+
+
+class DatabaseConnectionError(DatabaseError):
+    """Database connection failed (transient, should retry)."""
+
+
+class DatabaseTimeoutError(DatabaseError):
+    """Database query timed out."""
+
+
+class DatabaseIntegrityError(DatabaseError):
+    """Database integrity constraint violated (permanent, should not retry).
+
+    This is an expected error — caused by user actions (e.g., duplicate key).
+    """
+
+    is_expected = True
+
+
+class ConnectorError(BackendError):
+    """External connector/API operation failed."""
+
+    is_expected = False
+
+    def __init__(self, message: str, path: str | None = None):
+        super().__init__(message, path=path)
+
+
+class ConnectorAuthError(ConnectorError):
+    """Connector authentication/token refresh failed.
+
+    This is an expected error — user needs to re-authenticate.
+    """
+
+    is_expected = True
+
+
+class ConnectorRateLimitError(ConnectorError):
+    """Connector hit rate limit (transient, should retry with backoff).
+
+    This is an expected error — external API rate limiting.
+    """
+
+    is_expected = True
+
+
+class ConnectorQuotaError(ConnectorError):
+    """Connector quota exceeded.
+
+    This is an expected error — user/org quota limit reached.
+    """
+
+    is_expected = True
+
+
 class ServiceUnavailableError(NexusError):
     """Service temporarily unavailable (e.g., circuit breaker open).
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1695,8 +1695,9 @@ class NexusFS(  # type: ignore[misc]
 
         try:
             all_descendants = self.metadata.list(prefix)
-        except Exception:
+        except Exception as exc:
             # If metadata query fails, return False
+            logger.debug("Metadata query failed for prefix %s: %s", prefix, exc)
             return False
 
         # OPTIMIZATION 5 (legacy): Use Tiger Cache for batch descendant check
@@ -4151,10 +4152,10 @@ class NexusFS(  # type: ignore[misc]
                             if isinstance(config_content, bytes):
                                 config_data = yaml.safe_load(config_content.decode("utf-8"))
                                 inherit_perms = config_data.get("inherit_permissions")
-                        except Exception:
-                            pass  # If can't read config, will use default
-                except Exception:
-                    pass
+                        except Exception as exc:
+                            logger.debug("Failed to read agent config at %s: %s", config_path, exc)
+                except Exception as exc:
+                    logger.debug("Failed to parse agent entity_id for config lookup: %s", exc)
 
                 # Default to True if not found (agents without API keys inherit by default)
                 agent_info["inherit_permissions"] = (
@@ -4283,11 +4284,10 @@ class NexusFS(  # type: ignore[misc]
                                 agent_info["system_prompt"] = config_data["system_prompt"]
                             if config_data.get("tools"):
                                 agent_info["tools"] = config_data["tools"]
-                        except Exception:
-                            # If can't read config, that's okay - agent might not have config file yet
-                            pass
-                except Exception:
-                    pass
+                        except Exception as exc:
+                            logger.debug("Failed to read agent config for %s: %s", agent_id, exc)
+                except Exception as exc:
+                    logger.debug("Failed to parse agent_id %s for config lookup: %s", agent_id, exc)
             else:
                 agent_info["has_api_key"] = False
                 # If no API key, try to read from config.yaml or use default True
@@ -4338,10 +4338,10 @@ class NexusFS(  # type: ignore[misc]
                                     agent_info["system_prompt"] = config_data["system_prompt"]
                                 if config_data.get("tools"):
                                     agent_info["tools"] = config_data["tools"]
-                        except Exception:
-                            pass  # If can't read config, will use default
-                except Exception:
-                    pass
+                        except Exception as exc:
+                            logger.debug("Failed to read agent config at %s: %s", config_path, exc)
+                except Exception as exc:
+                    logger.debug("Failed to parse agent entity_id for config lookup: %s", exc)
 
                 # Default to True if not found (agents without API keys inherit by default)
                 agent_info["inherit_permissions"] = (
@@ -5170,8 +5170,8 @@ class NexusFS(  # type: ignore[misc]
                             try:
                                 self.rebac_delete(tuple_id)
                                 deleted_count += 1
-                            except Exception:
-                                pass  # Continue with other tuples
+                            except Exception as exc:
+                                logger.warning("Failed to delete ReBAC tuple %s: %s", tuple_id, exc)
                     result["deleted_permissions"] = deleted_count
                     logger.info(f"Deleted {deleted_count} ReBAC permissions for user {user_id}")
                 else:
@@ -5317,8 +5317,10 @@ class NexusFS(  # type: ignore[misc]
                     # Clear cache for parent too
                     if parent_path:
                         self._exists_cache.pop(parent_path, None)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(
+                    "Failed to invalidate caches after directory deletion of %s: %s", dir_path, exc
+                )
 
             # Clear tiger cache entries for the directory and children
             if hasattr(self, "rebac_manager") and hasattr(self.rebac_manager, "_tiger_cache"):
@@ -5371,8 +5373,8 @@ class NexusFS(  # type: ignore[misc]
                     try:
                         self.list(child_path, recursive=False, context=context)
                         is_dir = True
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug("Path %s is not a listable directory: %s", child_path, exc)
                 elif isinstance(item, dict):
                     child_path = item.get("path")
                     if not child_path:

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -1116,7 +1116,8 @@ class NexusFSCoreMixin:
             try:
                 validated_path = self._validate_path(path)
                 validated_paths.append(validated_path)
-            except Exception:
+            except Exception as exc:
+                logger.debug("Path validation failed in read_bulk for %s: %s", path, exc)
                 if skip_errors:
                     results[path] = None
                     continue
@@ -1391,7 +1392,10 @@ class NexusFSCoreMixin:
                                         "size": len(content),
                                     }
                                 )
-                            except Exception:
+                            except Exception as exc:
+                                logger.debug(
+                                    "Failed to read content for %s during batch read: %s", path, exc
+                                )
                                 if skip_errors:
                                     results[path] = None
                                 else:
@@ -2005,8 +2009,8 @@ class NexusFSCoreMixin:
                 self.metadata.set_file_metadata(path, "parsed_text", None)
                 self.metadata.set_file_metadata(path, "parsed_at", None)
                 self.metadata.set_file_metadata(path, "parser_name", None)
-            except Exception:
-                pass  # Ignore errors - cache invalidation is best-effort
+            except Exception as e:
+                logger.debug("Failed to invalidate parsed_text cache for %s: %s", path, e)
 
         # P0-3: Create parent relationship tuples for file inheritance
         # This enables permission inheritance from parent directories
@@ -3543,7 +3547,8 @@ class NexusFSCoreMixin:
 
                     size_context = replace(context, backend_path=route.backend_path)
                 size = route.backend.get_content_size(meta.etag, context=size_context).unwrap()
-            except Exception:
+            except Exception as exc:
+                logger.debug("Failed to get content size for %s: %s", path, exc)
                 size = None
 
         # Convert datetime to ISO string for wire compatibility with Rust FUSE client
@@ -3604,7 +3609,8 @@ class NexusFSCoreMixin:
             try:
                 validated_path = self._validate_path(path)
                 validated_paths.append(validated_path)
-            except Exception:
+            except Exception as exc:
+                logger.debug("Path validation failed in metadata_bulk for %s: %s", path, exc)
                 if skip_errors:
                     results[path] = None
                     continue
@@ -3785,8 +3791,9 @@ class NexusFSCoreMixin:
         for path in paths:
             try:
                 results[path] = self.exists(path, context=context)
-            except Exception:
+            except Exception as exc:
                 # Any error means file doesn't exist or isn't accessible
+                logger.debug("Exists check failed for %s: %s", path, exc)
                 results[path] = False
         return results
 
@@ -3829,7 +3836,8 @@ class NexusFSCoreMixin:
             try:
                 validated = self._validate_path(path)
                 valid_paths.append(validated)
-            except Exception:
+            except Exception as exc:
+                logger.debug("Path validation failed in metadata_batch for %s: %s", path, exc)
                 results[path] = None
 
         # Batch fetch metadata from database
@@ -3871,7 +3879,8 @@ class NexusFSCoreMixin:
                     "zone_id": meta.zone_id,
                     "is_directory": is_dir,
                 }
-            except Exception:
+            except Exception as exc:
+                logger.debug("Failed to build metadata result for %s: %s", path, exc)
                 results[path] = None
 
         return results

--- a/src/nexus/core/virtual_views.py
+++ b/src/nexus/core/virtual_views.py
@@ -239,8 +239,8 @@ def add_virtual_views_to_listing(
             elif is_dir:
                 # Already know it's a directory from the dict
                 continue
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Error checking directory status for %s: %s", file_path, e)
 
         # Check if we should add virtual views
         if should_add_virtual_views(file_path):

--- a/src/nexus/ipc/delivery.py
+++ b/src/nexus/ipc/delivery.py
@@ -301,8 +301,10 @@ class MessageProcessor:
                     self._agent_id, envelope.id, envelope.timestamp
                 )
                 await self._vfs.rename(msg_path, dl_path, self._zone_id)
-            except Exception:
-                pass  # best-effort cleanup of duplicate
+            except Exception as e:
+                logger.debug(
+                    "Best-effort cleanup of duplicate message %s failed: %s", envelope.id, e
+                )
             return
 
         # TTL check

--- a/src/nexus/llm/document_reader.py
+++ b/src/nexus/llm/document_reader.py
@@ -6,12 +6,15 @@ to answer questions about documents.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from nexus.llm.citation import Citation, CitationExtractor, DocumentReadResult
 from nexus.llm.context_builder import ContextBuilder
 from nexus.llm.message import Message, MessageRole, TextContent
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from nexus.core.filesystem import NexusFilesystem
@@ -326,8 +329,8 @@ class LLMDocumentReader:
                             "end_offset": None,
                         }
                     )
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Failed to parse chunk for %s: %s", path, e)
 
         if not chunks:
             raise ValueError(f"No content found for path: {path}")

--- a/src/nexus/mcp/middleware.py
+++ b/src/nexus/mcp/middleware.py
@@ -254,7 +254,8 @@ class ToolNamespaceMiddleware(Middleware):
         """Get current zone revision bucket."""
         try:
             revision = self._rebac_manager._get_zone_revision(self._zone_id)
-        except Exception:
+        except Exception as e:
+            logger.debug("Failed to get zone revision for %s: %s", self._zone_id, e)
             return 0
         return revision // self._revision_window
 
@@ -328,15 +329,15 @@ class ToolNamespaceMiddleware(Middleware):
             subject_id = ctx.get_state("subject_id")
             if subject_type and subject_id:
                 return (subject_type, subject_id)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to extract subject identity from context: %s", e)
 
         try:
             api_key = ctx.get_state("api_key")
             if api_key:
                 return ("api_key", api_key)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to extract API key from context: %s", e)
 
         return None
 

--- a/src/nexus/mcp/server.py
+++ b/src/nexus/mcp/server.py
@@ -234,8 +234,8 @@ def create_mcp_server(
                             ) or http_request.headers.get("Authorization", "").replace(
                                 "Bearer ", ""
                             )
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Failed to extract API key from request: %s", e)
 
             # Store in FastMCP's context state so tools can access it via Context.get_state()
             if api_key and context.fastmcp_context:
@@ -516,8 +516,8 @@ def create_mcp_server(
                 content = nx_instance.read(path)
                 if isinstance(content, bytes):
                     info_dict["size"] = len(content)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Failed to read file size for %s: %s", path, e)
 
         return json.dumps(info_dict, indent=2)
 

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -14,6 +14,8 @@ from fastapi.responses import JSONResponse, Response
 
 from nexus.core.exceptions import (
     ConflictError,
+    ConnectorError,
+    DatabaseError,
     InvalidPathError,
     NexusError,
     NexusFileNotFoundError,
@@ -171,8 +173,14 @@ async def rpc_endpoint(
                 "current_etag": e.current_etag,
             },
         )
+    except DatabaseError as e:
+        logger.warning("Database error in method %s: %s", method, e)
+        return _error_response(None, RPCErrorCode.INTERNAL_ERROR, f"Database error: {e}")
+    except ConnectorError as e:
+        logger.warning("Connector error in method %s: %s", method, e)
+        return _error_response(None, RPCErrorCode.INTERNAL_ERROR, f"Backend error: {e}")
     except NexusError as e:
-        logger.warning(f"NexusError in method {method}: {e}")
+        logger.warning("NexusError in method %s: %s", method, e)
         return _error_response(None, RPCErrorCode.INTERNAL_ERROR, f"Nexus error: {e}")
     except Exception as e:
         logger.exception(f"Error executing method {method}")

--- a/src/nexus/server/auth/auth_routes.py
+++ b/src/nexus/server/auth/auth_routes.py
@@ -405,7 +405,9 @@ async def login(
                                 break
                     except Exception as e:
                         # Decryption failed or key invalid, continue to next one
-                        logger.warning(f"Failed to decrypt API key {oauth_key.key_id}: {e}")
+                        logger.warning(
+                            "Failed to decrypt API key %s: %s", oauth_key.key_id, e, exc_info=True
+                        )
                         continue
 
         return LoginResponse(
@@ -551,7 +553,7 @@ async def setup_zone(
                 raise ValueError("Failed to create API key during provisioning")
 
         except Exception as e:
-            logger.error(f"Failed to provision password user resources: {e}")
+            logger.error("Failed to provision password user resources: %s", e, exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to provision user resources: {e}",
@@ -605,7 +607,7 @@ async def setup_zone(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Zone setup failed: {e}")
+        logger.error("Zone setup failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Zone setup failed: {e}",
@@ -1021,7 +1023,9 @@ async def oauth_check(
                                 break
                     except Exception as e:
                         # Decryption failed or key invalid, continue to next one
-                        logger.warning(f"Failed to decrypt API key {oauth_key.key_id}: {e}")
+                        logger.warning(
+                            "Failed to decrypt API key %s: %s", oauth_key.key_id, e, exc_info=True
+                        )
                         continue
 
                 # Only create a NEW API key if user has NO oauth_api_keys entries at all

--- a/src/nexus/server/auth/oauth_user_auth.py
+++ b/src/nexus/server/auth/oauth_user_auth.py
@@ -156,7 +156,7 @@ class OAuthUserAuth:
                 code, redirect_uri=redirect_uri
             )
         except Exception as e:
-            logger.error(f"Failed to exchange OAuth code: {e}")
+            logger.error("Failed to exchange OAuth code: %s", e, exc_info=True)
             raise ValueError(f"OAuth token exchange failed: {e}") from e
 
         # Extract user info from ID token
@@ -234,7 +234,7 @@ class OAuthUserAuth:
                 result: dict[str, Any] = response.json()
                 return result
         except Exception as e:
-            logger.error(f"Failed to fetch Google userinfo: {e}")
+            logger.error("Failed to fetch Google userinfo: %s", e, exc_info=True)
             raise ValueError(f"Failed to fetch user info: {e}") from e
 
     async def _get_or_create_oauth_user(

--- a/src/nexus/server/auth/oidc.py
+++ b/src/nexus/server/auth/oidc.py
@@ -151,7 +151,7 @@ class OIDCAuth(AuthProvider):
             result: dict[str, Any] = dict(jwks)
             return result
         except Exception as e:
-            logger.error(f"Failed to fetch JWKS from {self.jwks_uri}: {e}")
+            logger.error("Failed to fetch JWKS from %s: %s", self.jwks_uri, e, exc_info=True)
             # P0-3: Fail closed on JWKS fetch error
             raise ValueError(f"INDETERMINATE: Cannot fetch JWKS - {e}") from e
 

--- a/src/nexus/server/auth/user_helpers.py
+++ b/src/nexus/server/auth/user_helpers.py
@@ -7,6 +7,7 @@ Provides utility functions for:
 - User creation with uniqueness checks
 """
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
@@ -17,6 +18,8 @@ from nexus.storage.models import (
     UserModel,
     UserOAuthAccountModel,
 )
+
+logger = logging.getLogger(__name__)
 
 # ==============================================================================
 # ReBAC Group Naming Helpers
@@ -302,8 +305,8 @@ def get_user_zones(rebac_manager: Any, user_id: str) -> list[str]:
                 zid = row[0] if isinstance(row, (tuple, list)) else row["zone_id"]
                 if zid and zid not in zone_ids:
                     zone_ids.append(zid)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to fetch zone IDs for user %s: %s", user_id, e)
     return zone_ids
 
 

--- a/src/nexus/server/auth/zone_routes.py
+++ b/src/nexus/server/auth/zone_routes.py
@@ -133,7 +133,9 @@ async def create_zone_endpoint(
                     )
                     logger.info(f"Added user {user_id} as owner of zone {zone_id}")
                 except Exception as e:
-                    logger.error(f"Failed to add user {user_id} as zone owner: {e}")
+                    logger.error(
+                        "Failed to add user %s as zone owner: %s", user_id, e, exc_info=True
+                    )
                     raise HTTPException(
                         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                         detail=f"Failed to assign creator as zone owner: {e}",

--- a/src/nexus/server/error_handlers.py
+++ b/src/nexus/server/error_handlers.py
@@ -28,6 +28,8 @@ def nexus_error_handler(_request: Request, exc: Exception) -> JSONResponse:
         AuthenticationError,
         BackendError,
         ConflictError,
+        ConnectorAuthError,
+        ConnectorRateLimitError,
         InvalidPathError,
         NexusError,
         NexusFileNotFoundError,
@@ -38,6 +40,7 @@ def nexus_error_handler(_request: Request, exc: Exception) -> JSONResponse:
     )
 
     # Determine HTTP status code and error type based on exception.
+    # Order matters: more specific types must come before their parents.
     # NexusPermissionError check catches PermissionDeniedError (subclass).
     if isinstance(exc, (NexusFileNotFoundError, PathNotMountedError)):
         status_code = 404
@@ -45,7 +48,7 @@ def nexus_error_handler(_request: Request, exc: Exception) -> JSONResponse:
     elif isinstance(exc, (NexusPermissionError, AccessDeniedError)):
         status_code = 403
         error_type = "Forbidden"
-    elif isinstance(exc, AuthenticationError):
+    elif isinstance(exc, (ConnectorAuthError, AuthenticationError)):
         status_code = 401
         error_type = "Unauthorized"
     elif isinstance(exc, (InvalidPathError, ValidationError)):
@@ -57,7 +60,11 @@ def nexus_error_handler(_request: Request, exc: Exception) -> JSONResponse:
     elif isinstance(exc, ParserError):
         status_code = 422
         error_type = "Unprocessable Entity"
+    elif isinstance(exc, ConnectorRateLimitError):
+        status_code = 429
+        error_type = "Too Many Requests"
     elif isinstance(exc, BackendError):
+        # Catches DatabaseError, ConnectorError, and other BackendError subtypes
         status_code = 502
         error_type = "Bad Gateway"
     elif isinstance(exc, NexusError):

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -421,8 +421,8 @@ def create_app(
         obs_sub = getattr(nexus_fs, "_service_extras", {}).get("observability_subsystem")
         if obs_sub is not None:
             REGISTRY.register(QueryObserverCollector(obs_sub.observer))
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("QueryObserver metrics collector not registered: %s", e)
 
     # Register WriteBuffer → Prometheus collector bridge (Issue #1370)
     try:
@@ -527,7 +527,8 @@ def _discover_exposed_methods(nexus_fs: NexusFS) -> dict[str, Any]:
                 method_name = getattr(attr, "_rpc_name", name)
                 exposed[method_name] = attr
                 logger.debug(f"Discovered RPC method: {method_name}")
-        except Exception:
+        except Exception as e:
+            logger.debug("Failed to discover RPC method %s: %s", name, e)
             continue
 
     logger.info(f"Auto-discovered {len(exposed)} RPC methods")
@@ -625,7 +626,8 @@ def _register_routes(app: FastAPI) -> None:
                     x_nexus_subject=request.headers.get("X-Nexus-Subject"),
                     x_nexus_zone_id=request.headers.get("X-Nexus-Zone-ID"),
                 )
-            except Exception:
+            except Exception as e:
+                logger.debug("A2A auth extraction failed: %s", e)
                 return None
 
         a2a_router = create_a2a_router(

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -120,10 +120,10 @@ async def _startup_async_rebac(app: FastAPI) -> None:
                 f"tenant={tenant_id}, enforce_permissions={enforce_permissions})"
             )
         except Exception as e:
-            logger.warning(f"Failed to initialize AsyncNexusFS: {e}")
+            logger.warning("Failed to initialize AsyncNexusFS: %s", e, exc_info=True)
 
     except Exception as e:
-        logger.warning(f"Failed to initialize async ReBAC manager: {e}")
+        logger.warning("Failed to initialize async ReBAC manager: %s", e, exc_info=True)
 
 
 async def _startup_cache_factory(app: FastAPI) -> None:
@@ -159,7 +159,7 @@ async def _startup_cache_factory(app: FastAPI) -> None:
                     "L1 (memory) -> L2 (Dragonfly) -> L3 (PostgreSQL)"
                 )
     except Exception as e:
-        logger.warning(f"Failed to initialize cache factory: {e}")
+        logger.warning("Failed to initialize cache factory: %s", e, exc_info=True)
 
 
 def _startup_tiger_cache(app: FastAPI) -> list[asyncio.Task]:
@@ -181,7 +181,7 @@ def _startup_tiger_cache(app: FastAPI) -> list[asyncio.Task]:
             bg_tasks.append(task)
             logger.info("Tiger Cache queue processor started (explicit enable)")
         except Exception as e:
-            logger.warning(f"Failed to start Tiger Cache queue processor: {e}")
+            logger.warning("Failed to start Tiger Cache queue processor: %s", e, exc_info=True)
     else:
         logger.debug("Tiger Cache queue processor disabled (write-through handles grants)")
 

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -63,7 +63,7 @@ async def shutdown_services(app: FastAPI) -> None:
             await task_runner.shutdown()
             logger.info("Task Queue runner stopped")
         except Exception as e:
-            logger.warning(f"Error shutting down Task Queue runner: {e}")
+            logger.warning("Error shutting down Task Queue runner: %s", e, exc_info=True)
 
     # Shutdown scheduler pool (Issue #1212)
     if _scheduler_pool:
@@ -71,7 +71,7 @@ async def shutdown_services(app: FastAPI) -> None:
             await _scheduler_pool.close()
             logger.info("Scheduler pool closed")
         except Exception as e:
-            logger.warning(f"Error closing scheduler pool: {e}")
+            logger.warning("Error closing scheduler pool: %s", e, exc_info=True)
         _scheduler_pool = None
 
     # Cancel agent background tasks and final flush (Issue #1240)
@@ -102,7 +102,7 @@ async def shutdown_services(app: FastAPI) -> None:
             await app.state.async_nexus_fs.close()
             logger.info("AsyncNexusFS stopped")
         except Exception as e:
-            logger.warning(f"Error shutting down AsyncNexusFS: {e}")
+            logger.warning("Error shutting down AsyncNexusFS: %s", e, exc_info=True)
 
     # Shutdown Search Daemon (Issue #951)
     if app.state.search_daemon:
@@ -110,7 +110,7 @@ async def shutdown_services(app: FastAPI) -> None:
             await app.state.search_daemon.shutdown()
             logger.info("Search Daemon stopped")
         except Exception as e:
-            logger.warning(f"Error shutting down Search Daemon: {e}")
+            logger.warning("Error shutting down Search Daemon: %s", e, exc_info=True)
 
     # Stop DirectoryGrantExpander worker
     if hasattr(app.state, "directory_grant_expander") and app.state.directory_grant_expander:
@@ -162,7 +162,7 @@ def _startup_agent_registry(app: FastAPI) -> None:
 
             logger.info("[AGENT-REG] AgentRegistry initialized and wired")
         except Exception as e:
-            logger.warning(f"[AGENT-REG] Failed to initialize AgentRegistry: {e}")
+            logger.warning("[AGENT-REG] Failed to initialize AgentRegistry: %s", e, exc_info=True)
             app.state.agent_registry = None
             app.state.async_agent_registry = None
     else:
@@ -198,7 +198,7 @@ def _startup_key_service(app: FastAPI) -> None:
 
             logger.info("[KYA] KeyService initialized and wired")
         except Exception as e:
-            logger.warning(f"[KYA] Failed to initialize KeyService: {e}")
+            logger.warning("[KYA] Failed to initialize KeyService: %s", e, exc_info=True)
             app.state.key_service = None
     else:
         app.state.key_service = None
@@ -273,7 +273,9 @@ def _startup_sandbox_auth(app: FastAPI) -> None:
         )
         logger.info("[SANDBOX-AUTH] SandboxAuthService initialized")
     except Exception as e:
-        logger.warning(f"[SANDBOX-AUTH] Failed to initialize SandboxAuthService: {e}")
+        logger.warning(
+            "[SANDBOX-AUTH] Failed to initialize SandboxAuthService: %s", e, exc_info=True
+        )
 
 
 def _startup_agent_tasks(app: FastAPI) -> list[asyncio.Task]:
@@ -390,7 +392,7 @@ async def _startup_scheduler(app: FastAPI) -> None:
     except ImportError as e:
         logger.debug(f"Scheduler service not available: {e}")
     except Exception as e:
-        logger.warning(f"Failed to initialize Scheduler service: {e}")
+        logger.warning("Failed to initialize Scheduler service: %s", e, exc_info=True)
 
 
 def _startup_task_queue(app: FastAPI) -> asyncio.Task | None:
@@ -416,6 +418,6 @@ def _startup_task_queue(app: FastAPI) -> asyncio.Task | None:
         else:
             logger.debug("Task Queue: nexus_tasks Rust extension not available")
     except Exception as e:
-        logger.warning(f"Task Queue runner not started: {e}")
+        logger.warning("Task Queue runner not started: %s", e, exc_info=True)
 
     return None

--- a/src/nexus/server/rpc/handlers/memory.py
+++ b/src/nexus/server/rpc/handlers/memory.py
@@ -81,8 +81,10 @@ def handle_query_memories(nexus_fs: NexusFS, params: Any, context: Any) -> dict[
                 embedding_provider_obj = create_embedding_provider(
                     provider=params.embedding_provider
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(
+                    "Failed to create embedding provider %s: %s", params.embedding_provider, e
+                )
 
         search_mode = params.search_mode or "hybrid"
         memories = memory_api.search(

--- a/src/nexus/services/change_log_store.py
+++ b/src/nexus/services/change_log_store.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from nexus.core.exceptions import DatabaseError
 from nexus.storage.sync_store_base import SyncStoreBase
 
 if TYPE_CHECKING:
@@ -67,37 +68,32 @@ class ChangeLogStore(SyncStoreBase):
         """
         from nexus.storage.models import BackendChangeLogModel
 
-        session = self._get_session()
-        if session is None:
-            return None
-
         try:
-            entry = (
-                session.query(BackendChangeLogModel)
-                .filter(
-                    BackendChangeLogModel.path == path,
-                    BackendChangeLogModel.backend_name == backend_name,
-                    BackendChangeLogModel.zone_id == zone_id,
+            with self._with_session() as session:
+                entry = (
+                    session.query(BackendChangeLogModel)
+                    .filter(
+                        BackendChangeLogModel.path == path,
+                        BackendChangeLogModel.backend_name == backend_name,
+                        BackendChangeLogModel.zone_id == zone_id,
+                    )
+                    .first()
                 )
-                .first()
-            )
 
-            if entry:
-                return ChangeLogEntry(
-                    path=entry.path,
-                    backend_name=entry.backend_name,
-                    size_bytes=entry.size_bytes,
-                    mtime=entry.mtime,
-                    backend_version=entry.backend_version,
-                    content_hash=entry.content_hash,
-                    synced_at=entry.synced_at,
-                )
+                if entry:
+                    return ChangeLogEntry(
+                        path=entry.path,
+                        backend_name=entry.backend_name,
+                        size_bytes=entry.size_bytes,
+                        mtime=entry.mtime,
+                        backend_version=entry.backend_version,
+                        content_hash=entry.content_hash,
+                        synced_at=entry.synced_at,
+                    )
+                return None
+        except (RuntimeError, DatabaseError) as e:
+            logger.warning("Failed to get change log for %s: %s", path, e)
             return None
-        except Exception as e:
-            logger.warning(f"Failed to get change log for {path}: {e}")
-            return None
-        finally:
-            session.close()
 
     def upsert_change_log(
         self,
@@ -125,46 +121,39 @@ class ChangeLogStore(SyncStoreBase):
         """
         from nexus.storage.models import BackendChangeLogModel
 
-        session = self._get_session()
-        if session is None:
-            return False
-
         try:
-            now = datetime.now(UTC)
-            values = {
-                "path": path,
-                "backend_name": backend_name,
-                "zone_id": zone_id,
-                "size_bytes": size_bytes,
-                "mtime": mtime,
-                "backend_version": backend_version,
-                "content_hash": content_hash,
-                "synced_at": now,
-            }
-            update_set = {
-                "size_bytes": size_bytes,
-                "mtime": mtime,
-                "backend_version": backend_version,
-                "content_hash": content_hash,
-                "synced_at": now,
-            }
+            with self._with_session() as session:
+                now = datetime.now(UTC)
+                values = {
+                    "path": path,
+                    "backend_name": backend_name,
+                    "zone_id": zone_id,
+                    "size_bytes": size_bytes,
+                    "mtime": mtime,
+                    "backend_version": backend_version,
+                    "content_hash": content_hash,
+                    "synced_at": now,
+                }
+                update_set = {
+                    "size_bytes": size_bytes,
+                    "mtime": mtime,
+                    "backend_version": backend_version,
+                    "content_hash": content_hash,
+                    "synced_at": now,
+                }
 
-            self._dialect_upsert(
-                session,
-                BackendChangeLogModel,
-                values,
-                pg_constraint="uq_backend_change_log",
-                sqlite_index_elements=["path", "backend_name", "zone_id"],
-                update_set=update_set,
-            )
-            session.commit()
+                self._dialect_upsert(
+                    session,
+                    BackendChangeLogModel,
+                    values,
+                    pg_constraint="uq_backend_change_log",
+                    sqlite_index_elements=["path", "backend_name", "zone_id"],
+                    update_set=update_set,
+                )
             return True
-        except Exception as e:
-            logger.warning(f"Failed to upsert change log for {path}: {e}")
-            session.rollback()
+        except (RuntimeError, DatabaseError) as e:
+            logger.warning("Failed to upsert change log for %s: %s", path, e)
             return False
-        finally:
-            session.close()
 
     def get_last_sync_time(self, backend_name: str, zone_id: str = "default") -> datetime | None:
         """Get the most recent sync time for a backend.
@@ -180,25 +169,20 @@ class ChangeLogStore(SyncStoreBase):
 
         from nexus.storage.models import BackendChangeLogModel
 
-        session = self._get_session()
-        if session is None:
-            return None
-
         try:
-            result = (
-                session.query(func.max(BackendChangeLogModel.synced_at))
-                .filter(
-                    BackendChangeLogModel.backend_name == backend_name,
-                    BackendChangeLogModel.zone_id == zone_id,
+            with self._with_session() as session:
+                result = (
+                    session.query(func.max(BackendChangeLogModel.synced_at))
+                    .filter(
+                        BackendChangeLogModel.backend_name == backend_name,
+                        BackendChangeLogModel.zone_id == zone_id,
+                    )
+                    .scalar()
                 )
-                .scalar()
-            )
-            return result  # type: ignore[no-any-return]
-        except Exception as e:
-            logger.warning(f"Failed to get last sync time for {backend_name}: {e}")
+                return result  # type: ignore[no-any-return]
+        except (RuntimeError, DatabaseError) as e:
+            logger.warning("Failed to get last sync time for %s: %s", backend_name, e)
             return None
-        finally:
-            session.close()
 
     def get_change_logs_batch(
         self, backend_name: str, zone_id: str, path_prefix: str
@@ -218,40 +202,35 @@ class ChangeLogStore(SyncStoreBase):
         """
         from nexus.storage.models import BackendChangeLogModel
 
-        session = self._get_session()
-        if session is None:
-            return {}
-
         try:
-            # Escape SQL LIKE wildcards in prefix to prevent unintended matching
-            escaped = path_prefix.replace("%", r"\%").replace("_", r"\_")
-            entries = (
-                session.query(BackendChangeLogModel)
-                .filter(
-                    BackendChangeLogModel.backend_name == backend_name,
-                    BackendChangeLogModel.zone_id == zone_id,
-                    BackendChangeLogModel.path.like(f"{escaped}%", escape="\\"),
+            with self._with_session() as session:
+                # Escape SQL LIKE wildcards in prefix to prevent unintended matching
+                escaped = path_prefix.replace("%", r"\%").replace("_", r"\_")
+                entries = (
+                    session.query(BackendChangeLogModel)
+                    .filter(
+                        BackendChangeLogModel.backend_name == backend_name,
+                        BackendChangeLogModel.zone_id == zone_id,
+                        BackendChangeLogModel.path.like(f"{escaped}%", escape="\\"),
+                    )
+                    .all()
                 )
-                .all()
-            )
 
-            return {
-                entry.path: ChangeLogEntry(
-                    path=entry.path,
-                    backend_name=entry.backend_name,
-                    size_bytes=entry.size_bytes,
-                    mtime=entry.mtime,
-                    backend_version=entry.backend_version,
-                    content_hash=entry.content_hash,
-                    synced_at=entry.synced_at,
-                )
-                for entry in entries
-            }
-        except Exception as e:
-            logger.warning(f"Failed to batch-fetch change logs for {path_prefix}: {e}")
+                return {
+                    entry.path: ChangeLogEntry(
+                        path=entry.path,
+                        backend_name=entry.backend_name,
+                        size_bytes=entry.size_bytes,
+                        mtime=entry.mtime,
+                        backend_version=entry.backend_version,
+                        content_hash=entry.content_hash,
+                        synced_at=entry.synced_at,
+                    )
+                    for entry in entries
+                }
+        except (RuntimeError, DatabaseError) as e:
+            logger.warning("Failed to batch-fetch change logs for %s: %s", path_prefix, e)
             return {}
-        finally:
-            session.close()
 
     def upsert_change_logs_batch(self, entries: list[ChangeLogEntry]) -> bool:
         """Bulk upsert change log entries in a single transaction.
@@ -270,77 +249,70 @@ class ChangeLogStore(SyncStoreBase):
 
         from nexus.storage.models import BackendChangeLogModel
 
-        session = self._get_session()
-        if session is None:
-            return False
-
         try:
-            now = datetime.now(UTC)
-            is_pg = self._detect_dialect()
+            with self._with_session() as session:
+                now = datetime.now(UTC)
+                is_pg = self._detect_dialect()
 
-            # Build all value dicts upfront
-            all_values = [
-                {
-                    "path": entry.path,
-                    "backend_name": entry.backend_name,
-                    "zone_id": getattr(entry, "zone_id", "default") or "default",
-                    "size_bytes": entry.size_bytes,
-                    "mtime": entry.mtime,
-                    "backend_version": entry.backend_version,
-                    "content_hash": entry.content_hash,
-                    "synced_at": now,
-                }
-                for entry in entries
-            ]
+                # Build all value dicts upfront
+                all_values = [
+                    {
+                        "path": entry.path,
+                        "backend_name": entry.backend_name,
+                        "zone_id": getattr(entry, "zone_id", "default") or "default",
+                        "size_bytes": entry.size_bytes,
+                        "mtime": entry.mtime,
+                        "backend_version": entry.backend_version,
+                        "content_hash": entry.content_hash,
+                        "synced_at": now,
+                    }
+                    for entry in entries
+                ]
 
-            # Use multi-row insert for true batch performance
-            # SQLite has a variable limit (~999), so chunk to be safe
-            chunk_size = 500
-            for i in range(0, len(all_values), chunk_size):
-                chunk = all_values[i : i + chunk_size]
+                # Use multi-row insert for true batch performance
+                # SQLite has a variable limit (~999), so chunk to be safe
+                chunk_size = 500
+                for i in range(0, len(all_values), chunk_size):
+                    chunk = all_values[i : i + chunk_size]
 
-                if is_pg:
-                    # PG supports multi-row insert with stmt.excluded references
-                    stmt = self._dialect_insert(BackendChangeLogModel).values(chunk)
-                    stmt = stmt.on_conflict_do_update(
-                        constraint="uq_backend_change_log",
-                        set_={
-                            "size_bytes": stmt.excluded.size_bytes,
-                            "mtime": stmt.excluded.mtime,
-                            "backend_version": stmt.excluded.backend_version,
-                            "content_hash": stmt.excluded.content_hash,
-                            "synced_at": stmt.excluded.synced_at,
-                        },
-                    )
-                    session.execute(stmt)
-                else:
-                    # SQLite doesn't support multi-row on_conflict_do_update
-                    # with excluded references, so use per-row upserts
-                    for row in chunk:
-                        self._dialect_upsert(
-                            session,
-                            BackendChangeLogModel,
-                            row,
-                            pg_constraint="uq_backend_change_log",
-                            sqlite_index_elements=["path", "backend_name", "zone_id"],
-                            update_set={
-                                "size_bytes": row["size_bytes"],
-                                "mtime": row["mtime"],
-                                "backend_version": row["backend_version"],
-                                "content_hash": row["content_hash"],
-                                "synced_at": now,
+                    if is_pg:
+                        # PG supports multi-row insert with stmt.excluded references
+                        stmt = self._dialect_insert(BackendChangeLogModel).values(chunk)
+                        stmt = stmt.on_conflict_do_update(
+                            constraint="uq_backend_change_log",
+                            set_={
+                                "size_bytes": stmt.excluded.size_bytes,
+                                "mtime": stmt.excluded.mtime,
+                                "backend_version": stmt.excluded.backend_version,
+                                "content_hash": stmt.excluded.content_hash,
+                                "synced_at": stmt.excluded.synced_at,
                             },
                         )
+                        session.execute(stmt)
+                    else:
+                        # SQLite doesn't support multi-row on_conflict_do_update
+                        # with excluded references, so use per-row upserts
+                        for row in chunk:
+                            self._dialect_upsert(
+                                session,
+                                BackendChangeLogModel,
+                                row,
+                                pg_constraint="uq_backend_change_log",
+                                sqlite_index_elements=["path", "backend_name", "zone_id"],
+                                update_set={
+                                    "size_bytes": row["size_bytes"],
+                                    "mtime": row["mtime"],
+                                    "backend_version": row["backend_version"],
+                                    "content_hash": row["content_hash"],
+                                    "synced_at": now,
+                                },
+                            )
 
-            session.commit()
-            logger.debug(f"[DELTA_SYNC] Batch upserted {len(entries)} change log entries")
+                logger.debug("[DELTA_SYNC] Batch upserted %d change log entries", len(entries))
             return True
-        except Exception as e:
-            logger.warning(f"Failed to batch-upsert {len(entries)} change logs: {e}")
-            session.rollback()
+        except (RuntimeError, DatabaseError) as e:
+            logger.warning("Failed to batch-upsert %d change logs: %s", len(entries), e)
             return False
-        finally:
-            session.close()
 
     def delete_change_log(self, path: str, backend_name: str, zone_id: str = "default") -> bool:
         """Delete change log entry for a path.
@@ -358,24 +330,17 @@ class ChangeLogStore(SyncStoreBase):
         """
         from nexus.storage.models import BackendChangeLogModel
 
-        session = self._get_session()
-        if session is None:
-            return False
-
         try:
-            session.query(BackendChangeLogModel).filter(
-                BackendChangeLogModel.path == path,
-                BackendChangeLogModel.backend_name == backend_name,
-                BackendChangeLogModel.zone_id == zone_id,
-            ).delete()
-            session.commit()
+            with self._with_session() as session:
+                session.query(BackendChangeLogModel).filter(
+                    BackendChangeLogModel.path == path,
+                    BackendChangeLogModel.backend_name == backend_name,
+                    BackendChangeLogModel.zone_id == zone_id,
+                ).delete()
             return True
-        except Exception as e:
-            logger.warning(f"Failed to delete change log for {path}: {e}")
-            session.rollback()
+        except (RuntimeError, DatabaseError) as e:
+            logger.warning("Failed to delete change log for %s: %s", path, e)
             return False
-        finally:
-            session.close()
 
     def delete_change_logs_batch(
         self, paths: list[str], backend_name: str, zone_id: str = "default"
@@ -399,37 +364,31 @@ class ChangeLogStore(SyncStoreBase):
 
         from nexus.storage.models import BackendChangeLogModel
 
-        session = self._get_session()
-        if session is None:
-            return False
-
         try:
-            # SQLite has a variable limit (~999), so chunk to be safe
-            chunk_size = 500
-            total_deleted = 0
+            with self._with_session() as session:
+                # SQLite has a variable limit (~999), so chunk to be safe
+                chunk_size = 500
+                total_deleted = 0
 
-            for i in range(0, len(paths), chunk_size):
-                chunk = paths[i : i + chunk_size]
-                deleted = (
-                    session.query(BackendChangeLogModel)
-                    .filter(
-                        BackendChangeLogModel.path.in_(chunk),
-                        BackendChangeLogModel.backend_name == backend_name,
-                        BackendChangeLogModel.zone_id == zone_id,
+                for i in range(0, len(paths), chunk_size):
+                    chunk = paths[i : i + chunk_size]
+                    deleted = (
+                        session.query(BackendChangeLogModel)
+                        .filter(
+                            BackendChangeLogModel.path.in_(chunk),
+                            BackendChangeLogModel.backend_name == backend_name,
+                            BackendChangeLogModel.zone_id == zone_id,
+                        )
+                        .delete(synchronize_session="fetch")
                     )
-                    .delete(synchronize_session="fetch")
-                )
-                total_deleted += deleted
+                    total_deleted += deleted
 
-            session.commit()
-            logger.debug(
-                f"[DELTA_SYNC] Batch deleted {total_deleted} change log entries "
-                f"for {len(paths)} paths"
-            )
+                logger.debug(
+                    "[DELTA_SYNC] Batch deleted %d change log entries for %d paths",
+                    total_deleted,
+                    len(paths),
+                )
             return True
-        except Exception as e:
-            logger.warning(f"Failed to batch-delete {len(paths)} change logs: {e}")
-            session.rollback()
+        except (RuntimeError, DatabaseError) as e:
+            logger.warning("Failed to batch-delete %d change logs: %s", len(paths), e)
             return False
-        finally:
-            session.close()

--- a/src/nexus/services/memory/memory_api.py
+++ b/src/nexus/services/memory/memory_api.py
@@ -10,6 +10,7 @@ inspired by SimpleMem (arXiv:2601.02553).
 from __future__ import annotations
 
 import builtins
+import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -21,6 +22,8 @@ from nexus.core.temporal import parse_datetime, validate_temporal_params
 from nexus.services.memory.memory_router import MemoryViewRouter
 from nexus.services.permissions.entity_registry import EntityRegistry
 from nexus.services.permissions.memory_permission_enforcer import MemoryPermissionEnforcer
+
+logger = logging.getLogger(__name__)
 
 # Importance decay configuration (Issue #1030)
 DEFAULT_DECAY_FACTOR = 0.95  # 5% decay per day
@@ -215,7 +218,8 @@ class Memory:
                 return content_bytes.decode("utf-8")
             except UnicodeDecodeError:
                 return content_bytes.hex()
-        except Exception:
+        except Exception as e:
+            logger.debug("Failed to read memory content %s: %s", content_hash, e)
             return f"<content not available: {content_hash}>"
 
     def _batch_operation(
@@ -531,7 +535,8 @@ class Memory:
                 url = getattr(bind, "url", None)
                 if url:
                     sync_url = str(url)
-            except Exception:
+            except Exception as e:
+                logger.debug("Failed to extract database URL from session: %s", e)
                 return
 
         if not sync_url:
@@ -941,8 +946,11 @@ class Memory:
                 # Try to create an embedding provider (checks for API keys in env)
                 try:
                     embedding_provider = create_embedding_provider(provider="openrouter")
-                except Exception:
+                except Exception as e:
                     # Fall back to keyword search if no provider available
+                    logger.debug(
+                        "Failed to create embedding provider, falling back to keyword search: %s", e
+                    )
                     return self._keyword_search(
                         query, scope, memory_type, limit, after_dt, before_dt
                     )
@@ -1013,8 +1021,8 @@ class Memory:
                         ).unwrap()
                         content = content_bytes.decode("utf-8")
                         keyword_score = self._compute_keyword_score(query, content)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug("Failed to read content for keyword scoring: %s", e)
 
                 # Combined score for hybrid mode
                 if search_mode == "hybrid":
@@ -1137,8 +1145,9 @@ class Memory:
                 memory.importance_original = memory.importance
 
             self.session.commit()
-        except Exception:
+        except Exception as e:
             # Don't fail the read operation if tracking fails
+            logger.debug("Failed to track memory access: %s", e)
             self.session.rollback()
 
     def apply_decay_batch(
@@ -1742,8 +1751,10 @@ class Memory:
                 all_helpful.extend(reflection.get("helpful_strategies", []))
                 all_harmful.extend(reflection.get("harmful_patterns", []))
                 reflection_ids.append(reflection.get("memory_id"))
-            except Exception:
-                # Skip failed reflections
+            except Exception as e:
+                logger.debug(
+                    "Skipping failed reflection for trajectory %s: %s", traj.trajectory_id, e
+                )
                 continue
 
         # Aggregate common patterns (simple frequency analysis)
@@ -2064,8 +2075,11 @@ class Memory:
                         memory.embedding_dim = len(embedding_vec)
 
                         success_count += 1
-                    except Exception:
+                    except Exception as e:
                         # Failed to generate embedding for this memory
+                        logger.debug(
+                            "Failed to generate embedding for memory %s: %s", memory.memory_id, e
+                        )
                         error_count += 1
                         continue
 

--- a/src/nexus/services/memory/relationship_extractor.py
+++ b/src/nexus/services/memory/relationship_extractor.py
@@ -18,10 +18,13 @@ Example:
 from __future__ import annotations
 
 import json
+import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
 
 # Relationship type definitions
 RelationshipType = Literal[
@@ -499,8 +502,8 @@ Output:"""
                     temperature=0.1,
                 )
                 return LiteLLMProvider(config)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to create LLM provider for relationship extraction: %s", e)
 
         return None
 

--- a/src/nexus/services/mount_core_service.py
+++ b/src/nexus/services/mount_core_service.py
@@ -178,6 +178,9 @@ class MountCoreService:
         result["removed"] = True
         logger.info(f"Removed mount from router: {mount_point}")
 
+        # Extract zone_id once for all cleanup operations
+        zone_id = get_zone_id(context)
+
         # Delete all metadata entries (mount point + children)
         try:
             dir_prefix = mount_point if mount_point.endswith("/") else mount_point + "/"
@@ -192,7 +195,6 @@ class MountCoreService:
 
         # Clean up sparse directory index entries
         try:
-            zone_id = get_zone_id(context)
             dir_entries_deleted = self._gw.delete_directory_entries_recursive(mount_point, zone_id)
             result["directory_entries_deleted"] = dir_entries_deleted
             logger.info(
@@ -203,7 +205,6 @@ class MountCoreService:
 
         # Clean up hierarchy tuples
         try:
-            zone_id = get_zone_id(context)
             removed = self._gw.remove_parent_tuples(mount_point, zone_id)
             result["permissions_cleaned"] += removed
             logger.info(f"Removed {removed} parent tuples for {mount_point}")
@@ -212,7 +213,6 @@ class MountCoreService:
 
         # Remove permission tuples
         try:
-            zone_id = get_zone_id(context)
             deleted = self._gw.rebac_delete_object_tuples(
                 object=("file", mount_point),
                 zone_id=zone_id,

--- a/src/nexus/services/oauth_service.py
+++ b/src/nexus/services/oauth_service.py
@@ -1384,8 +1384,8 @@ class OAuthService:
                         if "email" in token_info:
                             email = token_info.get("email")
                             return str(email) if email else None
-                    except Exception:
-                        pass
+                    except httpx.HTTPError as e:
+                        logger.debug("Google tokeninfo lookup failed: %s", e)
 
                     # If tokeninfo doesn't have email, try userinfo endpoint
                     try:
@@ -1398,8 +1398,8 @@ class OAuthService:
                         if "email" in user_info:
                             email = user_info.get("email")
                             return str(email) if email else None
-                    except Exception:
-                        pass
+                    except httpx.HTTPError as e:
+                        logger.debug("Google userinfo lookup failed: %s", e)
 
             # Microsoft: Use Microsoft Graph API
             elif provider_name == "microsoft-onedrive":
@@ -1417,8 +1417,8 @@ class OAuthService:
                         elif "userPrincipalName" in user_info:
                             email = user_info.get("userPrincipalName")
                             return str(email) if email else None
-                    except Exception:
-                        pass
+                    except httpx.HTTPError as e:
+                        logger.debug("Microsoft Graph user lookup failed: %s", e)
 
             # X/Twitter: Use X API v2
             elif provider_name == "x":
@@ -1434,8 +1434,8 @@ class OAuthService:
                         if "data" in user_info and "email" in user_info["data"]:
                             email = user_info["data"].get("email")
                             return str(email) if email else None
-                    except Exception:
-                        pass
+                    except httpx.HTTPError as e:
+                        logger.debug("X/Twitter user lookup failed: %s", e)
 
         except Exception as e:
             logger.warning(f"Failed to fetch user email from provider {provider_name}: {e}")

--- a/src/nexus/services/permissions/enforcer.py
+++ b/src/nexus/services/permissions/enforcer.py
@@ -255,7 +255,9 @@ class PermissionEnforcer:
             return False
 
         except Exception as e:
-            logger.warning(f"[HAS-DESCENDANTS] Error: {e}, returning True (fallback)")
+            logger.warning(
+                "[HAS-DESCENDANTS] Error: %s, returning True (fallback)", e, exc_info=True
+            )
             return True  # Fallback: assume accessible
 
     def has_accessible_descendants_batch(
@@ -353,8 +355,11 @@ class PermissionEnforcer:
 
         except Exception as e:
             logger.warning(
-                f"[BATCH-OPT] has_accessible_descendants_batch error: {e}, "
-                f"returning all True for {len(prefixes)} prefixes (fallback)"
+                "[BATCH-OPT] has_accessible_descendants_batch error: %s, "
+                "returning all True for %d prefixes (fallback)",
+                e,
+                len(prefixes),
+                exc_info=True,
             )
             return dict.fromkeys(prefixes, True)
 
@@ -560,7 +565,9 @@ class PermissionEnforcer:
             except Exception as e:
                 # If routing fails, fall back to default "file" type with virtual path
                 logger.warning(
-                    f"[_check_rebac] Failed to route path for object type: {e}, using default 'file'"
+                    "[_check_rebac] Failed to route path for object type: %s, using default 'file'",
+                    e,
+                    exc_info=True,
                 )
 
         # Check ReBAC permission using backend-provided object type

--- a/src/nexus/services/permissions/permission_filter_chain.py
+++ b/src/nexus/services/permissions/permission_filter_chain.py
@@ -271,8 +271,8 @@ class BulkReBACStrategy:
                     )
                     if hasattr(route, "namespace") and route.namespace:
                         obj_type = route.namespace
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Route resolution failed for path %s: %s", path, e)
             checks.append((subject, "read", (obj_type, path)))
 
         # Retry-once on transient I/O failures only

--- a/src/nexus/services/permissions/rebac_manager.py
+++ b/src/nexus/services/permissions/rebac_manager.py
@@ -218,10 +218,12 @@ class ReBACManager:
                     logger.info("Default namespaces initialized successfully")
                 except Exception as e:
                     sa_conn.rollback()
-                    logger.warning(f"Failed to initialize namespaces: {type(e).__name__}: {e}")
-                    import traceback
-
-                    logger.debug(traceback.format_exc())
+                    logger.warning(
+                        "Failed to initialize namespaces: %s: %s",
+                        type(e).__name__,
+                        e,
+                        exc_info=True,
+                    )
 
     def _fix_sql_placeholders(self, sql: str) -> str:
         """Convert SQLite ? placeholders to PostgreSQL %s. Delegates to TupleRepository (Issue #1459)."""
@@ -304,10 +306,9 @@ class ReBACManager:
             import logging
 
             logger = logging.getLogger(__name__)
-            logger.warning(f"Failed to register default namespaces: {type(e).__name__}: {e}")
-            import traceback
-
-            logger.debug(traceback.format_exc())
+            logger.warning(
+                "Failed to register default namespaces: %s: %s", type(e).__name__, e, exc_info=True
+            )
 
     def _initialize_default_namespaces(self) -> None:
         """Initialize default namespace configurations if not present."""

--- a/src/nexus/services/search_semantic.py
+++ b/src/nexus/services/search_semantic.py
@@ -314,8 +314,10 @@ class SemanticSearchMixin:
             await asyncio.to_thread(self._read, path)
             num_chunks = await self._semantic_search.index_document(path)
             return {path: num_chunks}
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(
+                "Failed to index single document %s, falling back to directory: %s", path, e
+            )
 
         if recursive:
             return await self._semantic_search.index_directory(path)

--- a/src/nexus/services/search_service.py
+++ b/src/nexus/services/search_service.py
@@ -723,7 +723,8 @@ class SearchService(SemanticSearchMixin):
                 try:
                     backend_relative = entry_path[len(path) :].lstrip("/")
                     is_dir = route.backend.is_directory(backend_relative, context=list_context)
-                except Exception:
+                except Exception as e:
+                    logger.debug("Failed to check if %s is a directory: %s", entry_path, e)
                     is_dir = False
             name = entry_path.rstrip("/").split("/")[-1]
             results_with_details.append(
@@ -1556,7 +1557,8 @@ class SearchService(SemanticSearchMixin):
             accessible_files: builtins.list[str] = cast(
                 builtins.list[str], self.list(path, recursive=True, context=context)
             )
-        except Exception:
+        except Exception as e:
+            logger.debug("Failed to list accessible files for glob at %s: %s", path, e)
             for pattern in patterns:
                 results[pattern] = []
             return results
@@ -1844,7 +1846,8 @@ class SearchService(SemanticSearchMixin):
                                     "match": match_obj.group(0),
                                 }
                             )
-                except Exception:
+                except Exception as e:
+                    logger.debug("Failed to grep file %s: %s", file_path, e)
                     continue
 
         return results
@@ -1997,7 +2000,8 @@ class SearchService(SemanticSearchMixin):
                                 "match": match_obj.group(0),
                             }
                         )
-            except Exception:
+            except Exception as e:
+                logger.debug("Failed to read/search trigram candidate %s: %s", file_path, e)
                 continue
 
         return results
@@ -2037,8 +2041,11 @@ class SearchService(SemanticSearchMixin):
                 content = self._read(file_path, context=context)
                 if isinstance(content, bytes):
                     entries.append((file_path, content))
-            except Exception:
-                continue  # Skip unreadable files.
+            except Exception as e:
+                logger.debug(
+                    "Skipping unreadable file during trigram indexing %s: %s", file_path, e
+                )
+                continue
 
         success = trigram_fast.build_index_from_entries(entries, index_path)
         if not success:
@@ -2117,7 +2124,8 @@ class SearchService(SemanticSearchMixin):
                             )
                             if len(chunk_results) >= max_results:
                                 break
-                except Exception:
+                except Exception as e:
+                    logger.debug("Failed to grep file in parallel chunk %s: %s", file_path, e)
                     continue
             return chunk_results
 

--- a/src/nexus/services/skill_service.py
+++ b/src/nexus/services/skill_service.py
@@ -978,8 +978,8 @@ class SkillService:
                         if self._gw.exists(skill_md, context=context):
                             skill_paths.append(skill_path)
                             seen_skills.add(skill_name)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug("Failed to check skill existence at %s: %s", skill_md, e)
         except Exception as e:
             logger.warning(f"Failed to find skills in {base_dir}: {e}")
 

--- a/src/nexus/storage/session_scope.py
+++ b/src/nexus/storage/session_scope.py
@@ -1,0 +1,55 @@
+"""Transactional session scope context manager (Issue #1254).
+
+Replaces repeated try/commit/rollback/finally/close boilerplate with a single
+context manager that also translates SQLAlchemy errors to Nexus DatabaseError
+hierarchy at the storage boundary.
+"""
+
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
+from sqlalchemy.exc import OperationalError as SAOperationalError
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from nexus.core.exceptions import (
+    DatabaseConnectionError,
+    DatabaseError,
+    DatabaseIntegrityError,
+    DatabaseTimeoutError,
+)
+
+
+@contextmanager
+def session_scope(session_factory: Callable[[], Session]) -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations.
+
+    Commits on success, rolls back on exception, always closes.
+    Translates SQLAlchemy errors to Nexus DatabaseError hierarchy.
+
+    Usage:
+        with session_scope(self._session_factory) as session:
+            session.add(model)
+            # auto-commits on exit
+    """
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except SAIntegrityError as e:
+        session.rollback()
+        raise DatabaseIntegrityError(str(e)) from e
+    except SAOperationalError as e:
+        session.rollback()
+        if "timeout" in str(e).lower():
+            raise DatabaseTimeoutError(str(e)) from e
+        raise DatabaseConnectionError(str(e)) from e
+    except SQLAlchemyError as e:
+        session.rollback()
+        raise DatabaseError(str(e)) from e
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/src/nexus/storage/sync_store_base.py
+++ b/src/nexus/storage/sync_store_base.py
@@ -123,21 +123,19 @@ class SyncStoreBase:
         """Context manager for database sessions.
 
         Handles commit on success, rollback on error, and close on exit.
+        Translates SQLAlchemy errors to Nexus DatabaseError hierarchy.
 
         Yields:
             SQLAlchemy session
 
         Raises:
             RuntimeError: If no session factory is available
+            DatabaseError: On SQLAlchemy failures (translated from SA errors)
         """
-        session = self._get_session()
-        if session is None:
+        if not hasattr(self._gw, "session_factory") or self._gw.session_factory is None:
             raise RuntimeError("No database session factory available")
-        try:
+
+        from nexus.storage.session_scope import session_scope
+
+        with session_scope(self._gw.session_factory) as session:
             yield session
-            session.commit()
-        except Exception:
-            session.rollback()
-            raise
-        finally:
-            session.close()

--- a/tests/unit/core/test_exceptions.py
+++ b/tests/unit/core/test_exceptions.py
@@ -8,6 +8,14 @@ from nexus.core.exceptions import (
     AuthenticationError,
     BackendError,
     ConflictError,
+    ConnectorAuthError,
+    ConnectorError,
+    ConnectorQuotaError,
+    ConnectorRateLimitError,
+    DatabaseConnectionError,
+    DatabaseError,
+    DatabaseIntegrityError,
+    DatabaseTimeoutError,
     InvalidPathError,
     MetadataError,
     NexusError,
@@ -404,3 +412,129 @@ def test_router_uses_canonical_exceptions() -> None:
             assert issubclass(cls, NexusError), (
                 f"router.{name} must be a NexusError subclass, got bases: {cls.__bases__}"
             )
+
+
+# ============================================================================
+# Database & Connector Exception Hierarchy Tests (Issue #1254)
+# ============================================================================
+
+
+def test_database_error_hierarchy() -> None:
+    """Test DatabaseError inherits BackendError → NexusError."""
+    assert issubclass(DatabaseError, BackendError)
+    assert issubclass(DatabaseError, NexusError)
+    assert issubclass(DatabaseConnectionError, DatabaseError)
+    assert issubclass(DatabaseTimeoutError, DatabaseError)
+    assert issubclass(DatabaseIntegrityError, DatabaseError)
+
+
+def test_database_error_creation() -> None:
+    """Test DatabaseError can be created with message and optional path."""
+    error = DatabaseError("Connection lost")
+    assert "Connection lost" in str(error)
+    assert error.is_expected is False
+
+    error = DatabaseError("Query failed", path="/data/table")
+    assert "Query failed" in str(error)
+    assert error.path == "/data/table"
+
+
+def test_database_children_is_expected() -> None:
+    """Test is_expected classification for DatabaseError subtypes."""
+    # Connection errors are unexpected (infrastructure failure)
+    assert DatabaseConnectionError("Connection refused").is_expected is False
+    # Timeout errors are unexpected (infrastructure failure)
+    assert DatabaseTimeoutError("Query timed out").is_expected is False
+    # Integrity errors are expected (user-caused, e.g., duplicate key)
+    assert DatabaseIntegrityError("Duplicate key").is_expected is True
+
+
+def test_database_error_caught_by_backend_error() -> None:
+    """Test that except BackendError catches DatabaseError and children."""
+    with_caught = []
+    for exc_class in (
+        DatabaseError,
+        DatabaseConnectionError,
+        DatabaseTimeoutError,
+        DatabaseIntegrityError,
+    ):
+        try:
+            raise exc_class("test")
+        except BackendError:
+            with_caught.append(exc_class.__name__)
+    assert len(with_caught) == 4
+
+
+def test_connector_error_hierarchy() -> None:
+    """Test ConnectorError inherits BackendError → NexusError."""
+    assert issubclass(ConnectorError, BackendError)
+    assert issubclass(ConnectorError, NexusError)
+    assert issubclass(ConnectorAuthError, ConnectorError)
+    assert issubclass(ConnectorRateLimitError, ConnectorError)
+    assert issubclass(ConnectorQuotaError, ConnectorError)
+
+
+def test_connector_error_creation() -> None:
+    """Test ConnectorError can be created with message and optional path."""
+    error = ConnectorError("API call failed")
+    assert "API call failed" in str(error)
+    assert error.is_expected is False
+
+    error = ConnectorError("Timeout", path="/mnt/gmail")
+    assert error.path == "/mnt/gmail"
+
+
+def test_connector_children_is_expected() -> None:
+    """Test is_expected classification for ConnectorError subtypes."""
+    # Auth errors are expected (user needs to re-authenticate)
+    assert ConnectorAuthError("Token expired").is_expected is True
+    # Rate limit errors are expected (transient)
+    assert ConnectorRateLimitError("Rate limited").is_expected is True
+    # Quota errors are expected (user-caused)
+    assert ConnectorQuotaError("Quota exceeded").is_expected is True
+    # Base connector error is unexpected (generic failure)
+    assert ConnectorError("Unknown failure").is_expected is False
+
+
+def test_connector_error_caught_by_backend_error() -> None:
+    """Test that except BackendError catches ConnectorError and children."""
+    with_caught = []
+    for exc_class in (
+        ConnectorError,
+        ConnectorAuthError,
+        ConnectorRateLimitError,
+        ConnectorQuotaError,
+    ):
+        try:
+            raise exc_class("test")
+        except BackendError:
+            with_caught.append(exc_class.__name__)
+    assert len(with_caught) == 4
+
+
+def test_connector_validation_error_caught_by_core() -> None:
+    """Test that connectors.base.ValidationError is caught by core ValidationError."""
+    from nexus.connectors.base import ValidationError as ConnectorValidationError
+
+    assert issubclass(ConnectorValidationError, ValidationError)
+
+    # Verify catch works
+    try:
+        raise ConnectorValidationError(
+            code="TEST",
+            message="test error",
+        )
+    except ValidationError:
+        pass  # Should be caught
+
+
+def test_is_expected_defaults_new_types() -> None:
+    """Test is_expected class attributes for new exception types."""
+    assert DatabaseError.is_expected is False
+    assert DatabaseConnectionError.is_expected is False
+    assert DatabaseTimeoutError.is_expected is False
+    assert DatabaseIntegrityError.is_expected is True
+    assert ConnectorError.is_expected is False
+    assert ConnectorAuthError.is_expected is True
+    assert ConnectorRateLimitError.is_expected is True
+    assert ConnectorQuotaError.is_expected is True

--- a/tests/unit/server/test_error_handlers.py
+++ b/tests/unit/server/test_error_handlers.py
@@ -1,0 +1,202 @@
+"""Unit tests for error handler HTTP status code mappings (Issue #1254).
+
+Tests that every NexusError subclass maps to the correct HTTP status code
+via the centralized nexus_error_handler.
+"""
+
+from unittest.mock import MagicMock
+
+from nexus.core.exceptions import (
+    AuditLogError,
+    AuthenticationError,
+    BackendError,
+    ConflictError,
+    ConnectorAuthError,
+    ConnectorError,
+    ConnectorQuotaError,
+    ConnectorRateLimitError,
+    DatabaseConnectionError,
+    DatabaseError,
+    DatabaseIntegrityError,
+    DatabaseTimeoutError,
+    InvalidPathError,
+    MetadataError,
+    NexusError,
+    NexusFileNotFoundError,
+    NexusPermissionError,
+    ParserError,
+    PermissionDeniedError,
+    ServiceUnavailableError,
+    StaleSessionError,
+    ValidationError,
+)
+from nexus.server.error_handlers import nexus_error_handler
+
+
+def _call_handler(exc: Exception) -> tuple[int, dict]:
+    """Helper to call nexus_error_handler and return (status_code, content)."""
+    request = MagicMock()
+    response = nexus_error_handler(request, exc)
+    return response.status_code, response.body
+
+
+class TestExpectedErrors:
+    """Test HTTP mappings for expected (user) errors."""
+
+    def test_file_not_found_returns_404(self) -> None:
+        resp = nexus_error_handler(MagicMock(), NexusFileNotFoundError("/test"))
+        assert resp.status_code == 404
+
+    def test_permission_error_returns_403(self) -> None:
+        resp = nexus_error_handler(MagicMock(), NexusPermissionError("/test"))
+        assert resp.status_code == 403
+
+    def test_permission_denied_error_returns_403(self) -> None:
+        resp = nexus_error_handler(MagicMock(), PermissionDeniedError("No access"))
+        assert resp.status_code == 403
+
+    def test_authentication_error_returns_401(self) -> None:
+        resp = nexus_error_handler(MagicMock(), AuthenticationError("Token expired"))
+        assert resp.status_code == 401
+
+    def test_invalid_path_returns_400(self) -> None:
+        resp = nexus_error_handler(MagicMock(), InvalidPathError("../../etc/passwd"))
+        assert resp.status_code == 400
+
+    def test_validation_error_returns_400(self) -> None:
+        resp = nexus_error_handler(MagicMock(), ValidationError("Invalid input"))
+        assert resp.status_code == 400
+
+    def test_conflict_error_returns_409(self) -> None:
+        resp = nexus_error_handler(MagicMock(), ConflictError("/test", "etag1", "etag2"))
+        assert resp.status_code == 409
+
+    def test_stale_session_error_returns_409(self) -> None:
+        resp = nexus_error_handler(MagicMock(), StaleSessionError("agent-1"))
+        assert resp.status_code == 409
+
+    def test_parser_error_returns_422(self) -> None:
+        resp = nexus_error_handler(MagicMock(), ParserError("Cannot parse"))
+        assert resp.status_code == 422
+
+
+class TestUnexpectedErrors:
+    """Test HTTP mappings for unexpected (system) errors."""
+
+    def test_backend_error_returns_502(self) -> None:
+        resp = nexus_error_handler(MagicMock(), BackendError("Connection failed"))
+        assert resp.status_code == 502
+
+    def test_metadata_error_returns_500(self) -> None:
+        resp = nexus_error_handler(MagicMock(), MetadataError("DB error"))
+        assert resp.status_code == 500
+
+    def test_service_unavailable_returns_500(self) -> None:
+        resp = nexus_error_handler(MagicMock(), ServiceUnavailableError("Down"))
+        assert resp.status_code == 500
+
+    def test_audit_log_error_returns_500(self) -> None:
+        resp = nexus_error_handler(MagicMock(), AuditLogError("Audit failed"))
+        assert resp.status_code == 500
+
+    def test_generic_nexus_error_returns_500(self) -> None:
+        resp = nexus_error_handler(MagicMock(), NexusError("Something broke"))
+        assert resp.status_code == 500
+
+    def test_unknown_exception_returns_500(self) -> None:
+        resp = nexus_error_handler(MagicMock(), RuntimeError("unknown"))
+        assert resp.status_code == 500
+
+
+class TestNewExceptionTypes:
+    """Test HTTP mappings for new Database/Connector exception types (Issue #1254)."""
+
+    def test_database_error_returns_502(self) -> None:
+        resp = nexus_error_handler(MagicMock(), DatabaseError("Connection lost"))
+        assert resp.status_code == 502
+
+    def test_database_connection_error_returns_502(self) -> None:
+        resp = nexus_error_handler(MagicMock(), DatabaseConnectionError("Refused"))
+        assert resp.status_code == 502
+
+    def test_database_timeout_error_returns_502(self) -> None:
+        resp = nexus_error_handler(MagicMock(), DatabaseTimeoutError("Timed out"))
+        assert resp.status_code == 502
+
+    def test_database_integrity_error_returns_502(self) -> None:
+        resp = nexus_error_handler(MagicMock(), DatabaseIntegrityError("Dup key"))
+        assert resp.status_code == 502
+
+    def test_connector_error_returns_502(self) -> None:
+        resp = nexus_error_handler(MagicMock(), ConnectorError("API failed"))
+        assert resp.status_code == 502
+
+    def test_connector_auth_error_returns_401(self) -> None:
+        resp = nexus_error_handler(MagicMock(), ConnectorAuthError("Token expired"))
+        assert resp.status_code == 401
+
+    def test_connector_rate_limit_error_returns_429(self) -> None:
+        resp = nexus_error_handler(MagicMock(), ConnectorRateLimitError("Rate limited"))
+        assert resp.status_code == 429
+
+    def test_connector_quota_error_returns_502(self) -> None:
+        resp = nexus_error_handler(MagicMock(), ConnectorQuotaError("Quota exceeded"))
+        assert resp.status_code == 502
+
+
+class TestResponseContent:
+    """Test response content structure."""
+
+    def test_response_includes_is_expected(self) -> None:
+        import json
+
+        resp = nexus_error_handler(MagicMock(), ValidationError("Bad input"))
+        body = json.loads(resp.body)
+        assert body["is_expected"] is True
+
+        resp = nexus_error_handler(MagicMock(), BackendError("System failure"))
+        body = json.loads(resp.body)
+        assert body["is_expected"] is False
+
+    def test_response_includes_path_when_present(self) -> None:
+        import json
+
+        resp = nexus_error_handler(MagicMock(), NexusFileNotFoundError("/missing/file"))
+        body = json.loads(resp.body)
+        assert body["path"] == "/missing/file"
+
+    def test_conflict_response_includes_etag_data(self) -> None:
+        import json
+
+        resp = nexus_error_handler(MagicMock(), ConflictError("/test", "etag-old", "etag-new"))
+        body = json.loads(resp.body)
+        assert body["expected_etag"] == "etag-old"
+        assert body["current_etag"] == "etag-new"
+
+    def test_is_expected_controls_classification(self) -> None:
+        """Verify is_expected flag matches exception class defaults."""
+        import json
+
+        # Expected errors
+        for exc in [
+            NexusFileNotFoundError("/test"),
+            ValidationError("Bad"),
+            AuthenticationError("Expired"),
+            ConnectorAuthError("Token revoked"),
+            ConnectorRateLimitError("Rate limited"),
+            DatabaseIntegrityError("Duplicate"),
+        ]:
+            resp = nexus_error_handler(MagicMock(), exc)
+            body = json.loads(resp.body)
+            assert body["is_expected"] is True, f"{type(exc).__name__} should be expected"
+
+        # Unexpected errors
+        for exc in [
+            BackendError("Failed"),
+            DatabaseError("Connection lost"),
+            ConnectorError("API failed"),
+            DatabaseConnectionError("Refused"),
+        ]:
+            resp = nexus_error_handler(MagicMock(), exc)
+            body = json.loads(resp.body)
+            assert body["is_expected"] is False, f"{type(exc).__name__} should be unexpected"

--- a/tests/unit/server/test_silent_swallower_regression.py
+++ b/tests/unit/server/test_silent_swallower_regression.py
@@ -1,0 +1,110 @@
+"""Regression tests for silent swallower fixes (Issue #1254, Phase 3).
+
+Verifies that formerly-silent exception handlers now log errors
+instead of silently swallowing them.
+"""
+
+import ast
+import inspect
+import logging
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _has_silent_swallower(source: str) -> tuple[bool, int]:
+    """Check if source has any `except Exception: pass` patterns.
+
+    Returns:
+        Tuple of (found, line_number). line_number is 0 if not found.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ExceptHandler)
+            and node.type
+            and isinstance(node.type, ast.Name)
+            and node.type.id == "Exception"
+            and len(node.body) == 1
+            and isinstance(node.body[0], ast.Pass)
+        ):
+            return True, node.lineno
+    return False, 0
+
+
+class TestAuthHelperLogging:
+    """Verify auth helper errors are logged, not silently swallowed."""
+
+    def test_get_user_zones_logs_on_db_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """get_user_zones should log warning when DB query fails."""
+        from nexus.server.auth.user_helpers import get_user_zones
+
+        @contextmanager
+        def failing_connection():
+            raise RuntimeError("DB connection lost")
+            yield  # type: ignore[misc]  # noqa: F401
+
+        mock_rebac = MagicMock()
+        mock_rebac._connection = failing_connection
+
+        with caplog.at_level(logging.WARNING, logger="nexus.server.auth.user_helpers"):
+            result = get_user_zones(mock_rebac, "user-123")
+
+        assert result == []
+        assert "Failed to fetch zone IDs" in caplog.text
+
+
+class TestOAuthCleanupLogging:
+    """Verify OAuth cleanup errors are logged with specific types."""
+
+    def test_oauth_service_uses_specific_exceptions(self) -> None:
+        """oauth_service.py should not have except Exception: pass."""
+        from nexus.services import oauth_service
+
+        found, line = _has_silent_swallower(inspect.getsource(oauth_service))
+        assert not found, f"Silent swallower found at line {line}"
+
+
+class TestPermissionFilterLogging:
+    """Verify permission filter chain errors are logged."""
+
+    def test_no_silent_swallowers_in_filter_chain(self) -> None:
+        """permission_filter_chain.py should not have except Exception: pass."""
+        from nexus.services.permissions import permission_filter_chain
+
+        found, line = _has_silent_swallower(inspect.getsource(permission_filter_chain))
+        assert not found, f"Silent swallower found at line {line}"
+
+
+class TestCacheWarmerLogging:
+    """Verify cache warmer errors are logged."""
+
+    def test_no_silent_swallowers_in_warmer(self) -> None:
+        """warmer.py should not have except Exception: pass."""
+        from nexus.cache import warmer
+
+        found, line = _has_silent_swallower(inspect.getsource(warmer))
+        assert not found, f"Silent swallower found at line {line}"
+
+
+class TestFastAPIServerLogging:
+    """Verify FastAPI server silent swallowers are fixed."""
+
+    def test_no_silent_swallowers_in_fastapi_server(self) -> None:
+        """fastapi_server.py should not have except Exception: pass."""
+        from nexus.server import fastapi_server
+
+        found, line = _has_silent_swallower(inspect.getsource(fastapi_server))
+        assert not found, f"Silent swallower found at line {line}"
+
+
+class TestNexusFSCoreLogging:
+    """Verify nexus_fs_core.py silent swallowers are fixed."""
+
+    def test_no_silent_swallowers_in_nexus_fs_core(self) -> None:
+        """nexus_fs_core.py should not have except Exception: pass."""
+        from nexus.core import nexus_fs_core
+
+        found, line = _has_silent_swallower(inspect.getsource(nexus_fs_core))
+        assert not found, f"Silent swallower found at line {line}"

--- a/tests/unit/storage/test_session_scope.py
+++ b/tests/unit/storage/test_session_scope.py
@@ -1,0 +1,146 @@
+"""Unit tests for session_scope context manager (Issue #1254).
+
+TDD: Tests written first, then implementation.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
+from sqlalchemy.exc import OperationalError as SAOperationalError
+from sqlalchemy.exc import SQLAlchemyError
+
+from nexus.core.exceptions import (
+    DatabaseConnectionError,
+    DatabaseError,
+    DatabaseIntegrityError,
+    DatabaseTimeoutError,
+)
+from nexus.storage.session_scope import session_scope
+
+
+def _make_session_factory():
+    """Create a mock session factory that returns a mock session."""
+    session = MagicMock()
+    factory = MagicMock(return_value=session)
+    return factory, session
+
+
+class TestSessionScopeCommit:
+    """Test successful commit path."""
+
+    def test_commits_on_success(self) -> None:
+        """session_scope commits when block completes without exception."""
+        factory, session = _make_session_factory()
+
+        with session_scope(factory) as s:
+            s.add("something")
+
+        session.commit.assert_called_once()
+        session.rollback.assert_not_called()
+        session.close.assert_called_once()
+
+    def test_yields_session(self) -> None:
+        """session_scope yields the session from the factory."""
+        factory, session = _make_session_factory()
+
+        with session_scope(factory) as s:
+            assert s is session
+
+
+class TestSessionScopeRollback:
+    """Test rollback on exception."""
+
+    def test_rollbacks_on_exception(self) -> None:
+        """session_scope rolls back when block raises an exception."""
+        factory, session = _make_session_factory()
+
+        with pytest.raises(ValueError, match="oops"), session_scope(factory):
+            raise ValueError("oops")
+
+        session.rollback.assert_called_once()
+        session.commit.assert_not_called()
+        session.close.assert_called_once()
+
+    def test_closes_session_always(self) -> None:
+        """session_scope closes session even on exception."""
+        factory, session = _make_session_factory()
+
+        with pytest.raises(RuntimeError), session_scope(factory):
+            raise RuntimeError("fatal")
+
+        session.close.assert_called_once()
+
+
+class TestSessionScopeSQLAlchemyTranslation:
+    """Test SQLAlchemy error → DatabaseError translation."""
+
+    def test_translates_integrity_error(self) -> None:
+        """SAIntegrityError → DatabaseIntegrityError."""
+        factory, session = _make_session_factory()
+
+        with pytest.raises(DatabaseIntegrityError) as exc_info, session_scope(factory):
+            raise SAIntegrityError("INSERT", {}, Exception("duplicate key"))
+
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, SAIntegrityError)
+        session.rollback.assert_called_once()
+        session.close.assert_called_once()
+
+    def test_translates_operational_error_timeout(self) -> None:
+        """SAOperationalError with 'timeout' → DatabaseTimeoutError."""
+        factory, session = _make_session_factory()
+
+        with pytest.raises(DatabaseTimeoutError), session_scope(factory):
+            raise SAOperationalError("SELECT", {}, Exception("connection timeout expired"))
+
+        session.rollback.assert_called_once()
+
+    def test_translates_operational_error_connection(self) -> None:
+        """SAOperationalError without 'timeout' → DatabaseConnectionError."""
+        factory, session = _make_session_factory()
+
+        with pytest.raises(DatabaseConnectionError), session_scope(factory):
+            raise SAOperationalError("SELECT", {}, Exception("could not connect to server"))
+
+        session.rollback.assert_called_once()
+
+    def test_translates_generic_sqlalchemy_error(self) -> None:
+        """Generic SQLAlchemyError → DatabaseError."""
+        factory, session = _make_session_factory()
+
+        with pytest.raises(DatabaseError), session_scope(factory):
+            raise SQLAlchemyError("something went wrong")
+
+        session.rollback.assert_called_once()
+
+    def test_preserves_non_sqlalchemy_exceptions(self) -> None:
+        """Non-SQLAlchemy exceptions pass through unmodified."""
+        factory, session = _make_session_factory()
+
+        with pytest.raises(KeyError, match="missing"), session_scope(factory):
+            raise KeyError("missing")
+
+        session.rollback.assert_called_once()
+        session.close.assert_called_once()
+
+    def test_chains_cause_for_all_translations(self) -> None:
+        """All SQLAlchemy translations preserve __cause__ for debugging."""
+        factory, _session = _make_session_factory()
+
+        # IntegrityError
+        with pytest.raises(DatabaseIntegrityError) as exc_info, session_scope(factory):
+            raise SAIntegrityError("stmt", {}, Exception("dup"))
+        assert isinstance(exc_info.value.__cause__, SAIntegrityError)
+
+        # OperationalError (connection)
+        factory2, _session2 = _make_session_factory()
+        with pytest.raises(DatabaseConnectionError) as exc_info, session_scope(factory2):
+            raise SAOperationalError("stmt", {}, Exception("refused"))
+        assert isinstance(exc_info.value.__cause__, SAOperationalError)
+
+        # Generic SQLAlchemy
+        factory3, _session3 = _make_session_factory()
+        with pytest.raises(DatabaseError) as exc_info, session_scope(factory3):
+            raise SQLAlchemyError("generic")
+        assert isinstance(exc_info.value.__cause__, SQLAlchemyError)


### PR DESCRIPTION
## Summary

Closes #1254 — S5 code hardening: reduce broad exception handlers.

- Add `DatabaseError`/`ConnectorError` exception hierarchies under `BackendError` with typed children (`ConnectionError`, `TimeoutError`, `IntegrityError`, `AuthError`, `RateLimitError`, `QuotaError`)
- Add `session_scope` context manager: commit/rollback/close + SQLAlchemy→DatabaseError translation at storage boundary
- Sweep ~60 silent swallowers (`except Exception: pass`) across 25 files — add logging (debug for internal, warning for auth/security)
- Wire new exception types into RPC handler chain and HTTP error handler mappings (`DatabaseError`→502, `ConnectorAuthError`→401, `ConnectorRateLimitError`→429)
- Add `exc_info=True` to 20+ critical-path loggers (auth, permissions, lifespan)
- Refactor `change_log_store.py` and `sync_store_base._with_session()` to use `session_scope`

## Verification

| Check | Result |
|-------|--------|
| New tests | 69/69 pass (26 exception + 10 session_scope + 27 error_handlers + 6 regression) |
| Full unit suite | 942 passed (1 pre-existing failure, unrelated) |
| Bare `except:` | 0 remaining |
| Silent swallowers (in-scope) | 0 remaining |
| Ruff | All checks passed |
| Mypy | No new errors (1 pre-existing yaml stubs warning) |

## Files Changed

**New (4):** `session_scope.py`, `test_session_scope.py`, `test_error_handlers.py`, `test_silent_swallower_regression.py`
**Modified (40):** 44 files total across core exceptions, storage, server, backends, services, and tests

## Test plan

- [x] `test_exceptions.py` — 26 tests for new exception hierarchy + inheritance
- [x] `test_session_scope.py` — 10 TDD tests for context manager
- [x] `test_error_handlers.py` — 27 tests for HTTP status code mapping
- [x] `test_silent_swallower_regression.py` — 6 AST-based regression guards
- [x] Full unit suite passes (942/943, 1 pre-existing failure)
- [x] Ruff lint clean
- [x] Mypy clean (no new errors)