### PR TITLE
chore(#1443): clean up commented-out code in 4 files

### DIFF
--- a/src/nexus/cli/commands/workflows.py
+++ b/src/nexus/cli/commands/workflows.py
@@ -213,12 +213,7 @@ def workflows_runs(workflow_name: str, limit: int) -> None:
     try:
         console.print("[yellow]Workflow execution history not yet implemented.[/yellow]")
         console.print(f"This will show the last {limit} executions of '{workflow_name}'")
-
-        # TODO: Implement when database storage is ready
-        # from nexus.workflows import get_engine
-        # engine = get_engine()
-        # executions = engine.get_executions(workflow_name, limit=limit)
-        # ... display in table ...
+        # TODO(#1443): implement workflow execution history when database storage is ready
 
     except Exception as e:
         handle_error(e)

--- a/src/nexus/migrations/config_migrator.py
+++ b/src/nexus/migrations/config_migrator.py
@@ -232,11 +232,6 @@ class ConfigMigrator:
             Dictionary mapping old names to new names
         """
         renames: dict[str, str] = {}
-
-        # Add version-specific renames
-        # if from_version < "0.7.0" <= to_version:
-        #     renames["old_field"] = "new_field"
-
         return renames
 
     def _get_new_required_fields(
@@ -254,9 +249,4 @@ class ConfigMigrator:
             Dictionary mapping field names to default values
         """
         new_fields: dict[str, Any] = {}
-
-        # Add version-specific new fields
-        # if from_version < "0.7.0" <= to_version:
-        #     new_fields["new_required_field"] = "default_value"
-
         return new_fields

--- a/src/nexus/migrations/registry.py
+++ b/src/nexus/migrations/registry.py
@@ -276,19 +276,18 @@ def _register_builtin_migrations(registry: MigrationRegistry) -> None:
     This function registers the standard migration steps between
     Nexus versions. Custom migrations can be registered separately.
 
+    To add a migration, import the step module and call::
+
+        registry.register(MigrationStep(
+            from_version="X.Y.0",
+            to_version="X.Z.0",
+            name="short_name",
+            description="What the migration does",
+            migrate_fn=step_module.upgrade,
+            rollback_fn=step_module.downgrade,
+        ))
+
     Args:
         registry: The registry to populate
     """
-    # Migrations will be added as they are implemented
-    # Example structure:
-    #
-    # from nexus.migrations.steps import migrate_0_5_to_0_6
-    # registry.register(MigrationStep(
-    #     from_version="0.5.0",
-    #     to_version="0.6.0",
-    #     name="add_rebac_v2",
-    #     description="Upgrade ReBAC schema to v2",
-    #     migrate_fn=migrate_0_5_to_0_6.upgrade,
-    #     rollback_fn=migrate_0_5_to_0_6.downgrade,
-    # ))
     pass

--- a/src/nexus/services/skill_service.py
+++ b/src/nexus/services/skill_service.py
@@ -313,10 +313,7 @@ class SkillService:
                 )
             return results
 
-        # TODO: Implement "zone" filter - skills shared with the zone
-        # if filter == "zone":
-        #     zone_skill_paths = self._find_zone_shared_skills(context)
-        #     ...
+        # TODO(#1443): implement "zone" filter for skills shared with the zone
 
         # "all" filter: batch-collect paths and pre-compute permission sets
         # to avoid per-skill ReBAC calls (O(1) set lookups instead of O(n) queries)


### PR DESCRIPTION
## Summary

- **migrations/registry.py**: Moved scaffold example from commented-out code into docstring (proper documentation)
- **migrations/config_migrator.py**: Removed 2 commented-out placeholder blocks (pattern is self-evident from method signatures)
- **cli/commands/workflows.py**: Replaced 5-line commented block with single-line `TODO(#1443)` reference
- **services/skill_service.py**: Replaced 4-line commented block with single-line `TODO(#1443)` reference

**Note:** Issue #1432 (dead RevisionNotifier import) was already fixed in PR #1455 — no action needed, recommend closing.

## Test plan

- [x] Unit tests pass for all 4 affected modules (31 passed, 13 skipped/Redis, 3 xfailed)
- [x] E2E permission tests pass (27 passed across 3 SQLite-backed test suites)
- [x] PostgreSQL-dependent e2e tests fail with pre-existing infra issue (no local PG)
- [x] Zero runtime code changed — comment-only cleanup, no performance impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)