### PR TITLE
refactor(#1709): converge A2A TaskManager onto IPC filesystem paths (§17.6)

### DIFF
--- a/src/nexus/a2a/__init__.py
+++ b/src/nexus/a2a/__init__.py
@@ -39,7 +39,8 @@ def create_a2a_router(
         auth_fn: Optional async callback ``(Request) -> dict | None``
             for authentication.  Injected by the server layer.
         data_dir: Server data directory.  When provided, A2A tasks
-            are persisted as JSON files under ``{data_dir}/a2a/tasks/``.
+            are persisted as MessageEnvelope JSON files under
+            ``{data_dir}/agents/{agent_id}/tasks/`` (§17.6 convergence).
             When None, tasks are stored in-memory only.
 
     Returns:

--- a/src/nexus/a2a/stores/database.py
+++ b/src/nexus/a2a/stores/database.py
@@ -28,6 +28,11 @@ _DB_EXECUTOR = ThreadPoolExecutor(max_workers=20, thread_name_prefix="a2a-db")
 class DatabaseTaskStore:
     """SQLAlchemy-backed task store.
 
+    .. deprecated::
+        DatabaseTaskStore is deprecated.  Use ``VFSTaskStore`` for
+        filesystem-backed persistence (§17.6 convergence).  This store
+        will be removed in a future release.
+
     Parameters
     ----------
     session_factory:
@@ -35,6 +40,15 @@ class DatabaseTaskStore:
     """
 
     def __init__(self, session_factory: Any) -> None:
+        import warnings
+
+        warnings.warn(
+            "DatabaseTaskStore is deprecated. Use VFSTaskStore for "
+            "filesystem-backed persistence. This store will be removed "
+            "in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._session_factory = session_factory
 
     async def _run_in_session(self, fn: Callable[..., _T]) -> _T:

--- a/src/nexus/a2a/stores/vfs.py
+++ b/src/nexus/a2a/stores/vfs.py
@@ -1,61 +1,86 @@
-"""VFS-backed task store — tasks as JSON files.
+"""VFS-backed task store — tasks as MessageEnvelopes under agent directories.
 
 File layout::
 
-    {base_path}/{zone_id}/{timestamp}_{task_id}.json
+    /agents/{agent_id}/tasks/{timestamp}_{task_id}.json
+
+Agent-scoped paths enable unified VFS/ReBAC/EventBus access (§17.6
+convergence).  Tasks are wrapped in ``MessageEnvelope`` format for
+interoperability with the IPC messaging system.
 
 Timestamp prefix enables efficient sorting by creation time without
 reading file contents.  The same pattern is used by the IPC
-``TTLSweeper`` (Plan P1: filename timestamp skip).
-
-Serialization uses Pydantic's built-in ``model_dump_json()`` /
-``model_validate_json()`` for zero-copy roundtrips.
+``TTLSweeper``.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import re
 import time
-from collections import defaultdict
+from collections import OrderedDict
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from nexus.a2a.models import Task, TaskState
+from nexus.ipc.conventions import AGENTS_ROOT, task_dead_letter_path, tasks_path
+from nexus.ipc.envelope import MessageEnvelope, MessageType
 
 if TYPE_CHECKING:
     from nexus.ipc.storage.protocol import IPCStorageDriver
 
 logger = logging.getLogger(__name__)
 
-_ZONE_ID_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9_.@:-]+$")
+
+# Default maximum entries in the LRU task index
+_DEFAULT_MAX_CACHE_SIZE = 10_000
+
+# Fallback agent ID when no agent is specified
+_UNASSIGNED_AGENT = "_unassigned"
+
+
+class _IndexEntry:
+    """Lightweight cache entry mapping task_id to its location."""
+
+    __slots__ = ("zone_id", "agent_id", "filename")
+
+    def __init__(self, zone_id: str, agent_id: str, filename: str) -> None:
+        self.zone_id = zone_id
+        self.agent_id = agent_id
+        self.filename = filename
 
 
 class VFSTaskStore:
-    """Stores A2A tasks as flat JSON files on a VFS backend.
+    """Stores A2A tasks as ``MessageEnvelope`` files under agent directories.
+
+    File layout: ``/agents/{agent_id}/tasks/{timestamp}_{task_id}.json``
 
     Parameters
     ----------
     storage:
         An ``IPCStorageDriver`` implementation (VFS-backed, PostgreSQL,
         or in-memory fake).
-    base_path:
-        Root directory for task files.  Defaults to ``/a2a/tasks``.
+    max_cache_size:
+        Maximum entries in the task index before LRU eviction.
     """
 
     def __init__(
         self,
         storage: IPCStorageDriver,
-        base_path: str = "/a2a/tasks",
+        max_cache_size: int = _DEFAULT_MAX_CACHE_SIZE,
     ) -> None:
         self._storage = storage
-        self._base_path = base_path.rstrip("/")
-        # Cache: (zone_id, task_id) -> filename for fast lookups after save
-        self._filename_cache: dict[tuple[str, str], str] = {}
-        # Per-key lock prevents duplicate file creation on concurrent saves
-        self._locks: defaultdict[tuple[str, str], asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._max_cache_size = max_cache_size
+        # LRU index: task_id -> _IndexEntry (location on disk)
+        self._task_index: OrderedDict[str, _IndexEntry] = OrderedDict()
+        # Per-task lock prevents duplicate file creation on concurrent saves
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    # ------------------------------------------------------------------
+    # Public API (TaskStoreProtocol)
+    # ------------------------------------------------------------------
 
     async def save(
         self,
@@ -64,82 +89,122 @@ class VFSTaskStore:
         zone_id: str,
         agent_id: str | None = None,
     ) -> None:
-        _validate_zone_id(zone_id)
+        effective_agent_id = agent_id or _UNASSIGNED_AGENT
+        _validate_id(effective_agent_id, "agent_id")
+        _validate_id(task.id, "task_id")
+        _validate_id(zone_id, "zone_id")
+
         t0 = time.monotonic()
-        zone_dir = f"{self._base_path}/{zone_id}"
-        await self._storage.mkdir(zone_dir, zone_id)
+        tasks_dir = tasks_path(effective_agent_id)
+        await self._storage.mkdir(tasks_dir, zone_id)
 
-        # Build envelope with agent_id (not part of Task model)
-        envelope: dict[str, Any] = {
-            "agent_id": agent_id,
-            "task": task.model_dump(mode="json"),
-        }
-        data = _serialize_envelope(envelope)
+        # Wrap task in MessageEnvelope (§17.6 convergence)
+        # Use model_validate with alias keys ("from"/"to") to satisfy mypy;
+        # Pydantic's populate_by_name works at runtime but mypy only sees aliases.
+        envelope = MessageEnvelope.model_validate(
+            {
+                "from": "a2a_gateway",
+                "to": effective_agent_id,
+                "type": MessageType.TASK,
+                "correlation_id": task.id,
+                "payload": task.model_dump(mode="json"),
+            }
+        )
+        data = envelope.to_bytes()
 
-        # Lock per (zone_id, task_id) to prevent duplicate file creation
-        cache_key = (zone_id, task.id)
-        async with self._locks[cache_key]:
-            existing_filename = self._filename_cache.get(cache_key)
+        # Lock per task_id to prevent duplicate file creation
+        lock = self._locks.setdefault(task.id, asyncio.Lock())
+        async with lock:
+            existing = self._task_index.get(task.id)
 
-            if existing_filename is None:
-                existing_filename = await self._find_filename(task.id, zone_id)
+            if existing is None:
+                existing_filename = await self._scan_for_task(
+                    task.id,
+                    effective_agent_id,
+                    zone_id,
+                )
+                if existing_filename is not None:
+                    existing = _IndexEntry(zone_id, effective_agent_id, existing_filename)
 
-            if existing_filename is not None:
+            if existing is not None:
                 # Update existing file in place
-                path = f"{zone_dir}/{existing_filename}"
+                path = f"{tasks_path(existing.agent_id)}/{existing.filename}"
                 await self._storage.write(path, data, zone_id)
+                # Refresh LRU position
+                self._task_index.move_to_end(task.id)
             else:
                 # New file with timestamp prefix
                 ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
                 filename = f"{ts}_{task.id}.json"
-                path = f"{zone_dir}/{filename}"
+                path = f"{tasks_dir}/{filename}"
                 await self._storage.write(path, data, zone_id)
-                self._filename_cache[cache_key] = filename
+                self._index_put(
+                    task.id,
+                    _IndexEntry(zone_id, effective_agent_id, filename),
+                )
 
         elapsed_ms = (time.monotonic() - t0) * 1000
-        logger.debug("vfs_task_store.save task_id=%s duration_ms=%.1f", task.id, elapsed_ms)
+        logger.debug(
+            "vfs_task_store.save task_id=%s agent_id=%s duration_ms=%.1f",
+            task.id,
+            effective_agent_id,
+            elapsed_ms,
+        )
 
     async def get(self, task_id: str, *, zone_id: str) -> Task | None:
-        filename = self._filename_cache.get((zone_id, task_id))
-        if filename is None:
-            filename = await self._find_filename(task_id, zone_id)
-        if filename is None:
-            return None
+        _validate_id(task_id, "task_id")
+        _validate_id(zone_id, "zone_id")
 
-        zone_dir = f"{self._base_path}/{zone_id}"
-        path = f"{zone_dir}/{filename}"
-        try:
-            data = await self._storage.read(path, zone_id)
-        except FileNotFoundError:
-            self._filename_cache.pop((zone_id, task_id), None)
-            return None
+        entry = self._task_index.get(task_id)
 
-        envelope = _deserialize_envelope(data)
-        return Task.model_validate(envelope["task"])
+        if entry is not None and entry.zone_id == zone_id:
+            # Cache hit with matching zone — refresh LRU position
+            self._task_index.move_to_end(task_id)
+            path = f"{tasks_path(entry.agent_id)}/{entry.filename}"
+            try:
+                data = await self._storage.read(path, zone_id)
+            except FileNotFoundError:
+                self._task_index.pop(task_id, None)
+                self._locks.pop(task_id, None)
+                return None
+            return _extract_task(data)
+
+        # Cache miss or zone mismatch — lazy scan all agent directories
+        return await self._scan_all_agents_for_task(task_id, zone_id)
 
     async def delete(self, task_id: str, *, zone_id: str) -> bool:
-        filename = self._filename_cache.get((zone_id, task_id))
-        if filename is None:
-            filename = await self._find_filename(task_id, zone_id)
-        if filename is None:
-            return False
+        _validate_id(task_id, "task_id")
+        _validate_id(zone_id, "zone_id")
 
-        zone_dir = f"{self._base_path}/{zone_id}"
-        path = f"{zone_dir}/{filename}"
+        entry = self._task_index.get(task_id)
 
-        # Overwrite with empty to "delete" (some VFS backends don't support real delete)
-        # For IPCStorageDriver we can just write an empty marker then remove from cache.
-        # Actually, we need a real delete. Use rename to a dead_letter path.
-        dead_letter_dir = f"{self._base_path}/_dead_letter/{zone_id}"
-        await self._storage.mkdir(dead_letter_dir, zone_id)
-        dead_path = f"{dead_letter_dir}/{filename}"
+        # Zone isolation: ignore cross-zone cache hit
+        if entry is not None and entry.zone_id != zone_id:
+            entry = None
+
+        if entry is None:
+            # Try to find it via scan
+            task = await self._scan_all_agents_for_task(task_id, zone_id)
+            if task is None:
+                return False
+            entry = self._task_index.get(task_id)
+            if entry is None:
+                return False
+
+        src_path = f"{tasks_path(entry.agent_id)}/{entry.filename}"
+        dl_dir = task_dead_letter_path(entry.agent_id)
+        await self._storage.mkdir(dl_dir, zone_id)
+        dst_path = f"{dl_dir}/{entry.filename}"
+
         try:
-            await self._storage.rename(path, dead_path, zone_id)
+            await self._storage.rename(src_path, dst_path, zone_id)
         except FileNotFoundError:
-            self._filename_cache.pop((zone_id, task_id), None)
+            self._task_index.pop(task_id, None)
+            self._locks.pop(task_id, None)
             return False
 
-        self._filename_cache.pop((zone_id, task_id), None)
+        self._task_index.pop(task_id, None)
+        self._locks.pop(task_id, None)
         return True
 
     async def list_tasks(
@@ -151,66 +216,214 @@ class VFSTaskStore:
         limit: int = 50,
         offset: int = 0,
     ) -> list[Task]:
-        zone_dir = f"{self._base_path}/{zone_id}"
+        if agent_id is not None:
+            return await self._list_agent_tasks(
+                agent_id=agent_id,
+                zone_id=zone_id,
+                state=state,
+                limit=limit,
+                offset=offset,
+            )
+
+        # Zone-wide listing: scan all agent directories
+        return await self._list_all_agents_tasks(
+            zone_id=zone_id,
+            state=state,
+            limit=limit,
+            offset=offset,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal: per-agent listing
+    # ------------------------------------------------------------------
+
+    async def _list_agent_tasks(
+        self,
+        *,
+        agent_id: str,
+        zone_id: str,
+        state: TaskState | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Task]:
+        tasks_dir = tasks_path(agent_id)
         try:
-            entries = await self._storage.list_dir(zone_dir, zone_id)
+            entries = await self._storage.list_dir(tasks_dir, zone_id)
         except FileNotFoundError:
             return []
 
-        # Filter to .json files only (skip directories like _dead_letter)
-        json_files = [e for e in entries if e.endswith(".json")]
+        json_files = sorted(
+            (e for e in entries if e.endswith(".json")),
+            reverse=True,
+        )
 
-        # Sort by filename descending (timestamp prefix = newest first)
-        json_files.sort(reverse=True)
-
-        # Read and filter
         results: list[Task] = []
         skipped = 0
         for filename in json_files:
-            path = f"{zone_dir}/{filename}"
+            path = f"{tasks_dir}/{filename}"
             try:
                 data = await self._storage.read(path, zone_id)
             except FileNotFoundError:
                 continue
 
-            envelope = _deserialize_envelope(data)
-            task = Task.model_validate(envelope["task"])
+            task = _extract_task(data)
+            if task is None:
+                continue
 
-            # Apply filters
             if state is not None and task.status.state != state:
                 continue
-            if agent_id is not None and envelope.get("agent_id") != agent_id:
-                continue
 
-            # Apply offset
             if skipped < offset:
                 skipped += 1
                 continue
 
             results.append(task)
-
-            # Cache the filename for future lookups
-            self._filename_cache[(zone_id, task.id)] = filename
+            self._index_put(task.id, _IndexEntry(zone_id, agent_id, filename))
 
             if len(results) >= limit:
                 break
 
         return results
 
-    async def _find_filename(self, task_id: str, zone_id: str) -> str | None:
-        """Scan directory to find the file for a given task_id."""
-        zone_dir = f"{self._base_path}/{zone_id}"
+    async def _list_all_agents_tasks(
+        self,
+        *,
+        zone_id: str,
+        state: TaskState | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Task]:
+        """Scan all agent directories for tasks (zone-wide listing)."""
+        try:
+            agent_dirs = await self._storage.list_dir(AGENTS_ROOT, zone_id)
+        except FileNotFoundError:
+            return []
+
+        # Collect (filename, agent_id) tuples across all agents for sorting
+        all_entries: list[tuple[str, str]] = []
+        for agent_dir_name in agent_dirs:
+            tasks_dir = tasks_path(agent_dir_name)
+            try:
+                entries = await self._storage.list_dir(tasks_dir, zone_id)
+            except FileNotFoundError:
+                continue
+            for entry in entries:
+                if entry.endswith(".json"):
+                    all_entries.append((entry, agent_dir_name))
+
+        # Sort by filename descending (timestamp prefix = newest first)
+        all_entries.sort(key=lambda pair: pair[0], reverse=True)
+
+        results: list[Task] = []
+        skipped = 0
+        for filename, agent_dir_name in all_entries:
+            path = f"{tasks_path(agent_dir_name)}/{filename}"
+            try:
+                data = await self._storage.read(path, zone_id)
+            except FileNotFoundError:
+                continue
+
+            task = _extract_task(data)
+            if task is None:
+                continue
+
+            if state is not None and task.status.state != state:
+                continue
+
+            if skipped < offset:
+                skipped += 1
+                continue
+
+            results.append(task)
+            self._index_put(
+                task.id,
+                _IndexEntry(zone_id, agent_dir_name, filename),
+            )
+
+            if len(results) >= limit:
+                break
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal: scanning and indexing
+    # ------------------------------------------------------------------
+
+    async def _scan_for_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        zone_id: str,
+    ) -> str | None:
+        """Scan a specific agent's tasks/ directory for a task file."""
+        tasks_dir = tasks_path(agent_id)
         suffix = f"_{task_id}.json"
         try:
-            entries = await self._storage.list_dir(zone_dir, zone_id)
+            entries = await self._storage.list_dir(tasks_dir, zone_id)
         except FileNotFoundError:
             return None
 
         for entry in entries:
             if entry.endswith(suffix):
-                self._filename_cache[(zone_id, task_id)] = entry
+                self._index_put(
+                    task_id,
+                    _IndexEntry(zone_id, agent_id, entry),
+                )
                 return entry
         return None
+
+    async def _scan_all_agents_for_task(
+        self,
+        task_id: str,
+        zone_id: str,
+    ) -> Task | None:
+        """Scan all agent directories to find a task by ID (cold start fallback)."""
+        logger.debug(
+            "vfs_task_store: index miss for task_id=%s, scanning agent dirs",
+            task_id,
+        )
+
+        try:
+            agent_dirs = await self._storage.list_dir(AGENTS_ROOT, zone_id)
+        except FileNotFoundError:
+            return None
+
+        suffix = f"_{task_id}.json"
+        for agent_dir_name in agent_dirs:
+            tasks_dir = tasks_path(agent_dir_name)
+            try:
+                entries = await self._storage.list_dir(tasks_dir, zone_id)
+            except FileNotFoundError:
+                continue
+
+            for entry in entries:
+                if entry.endswith(suffix):
+                    path = f"{tasks_dir}/{entry}"
+                    try:
+                        data = await self._storage.read(path, zone_id)
+                    except FileNotFoundError:
+                        continue
+
+                    task = _extract_task(data)
+                    if task is not None:
+                        self._index_put(
+                            task_id,
+                            _IndexEntry(zone_id, agent_dir_name, entry),
+                        )
+                        return task
+
+        return None
+
+    def _index_put(self, task_id: str, entry: _IndexEntry) -> None:
+        """Add or update an index entry with LRU eviction."""
+        if task_id in self._task_index:
+            self._task_index.move_to_end(task_id)
+        self._task_index[task_id] = entry
+
+        # Evict oldest entries if over capacity
+        while len(self._task_index) > self._max_cache_size:
+            evicted_id, _ = self._task_index.popitem(last=False)
+            self._locks.pop(evicted_id, None)
 
 
 # ======================================================================
@@ -218,18 +431,20 @@ class VFSTaskStore:
 # ======================================================================
 
 
-def _validate_zone_id(zone_id: str) -> None:
-    """Validate zone_id to prevent path traversal."""
-    if not zone_id or not _ZONE_ID_RE.match(zone_id):
-        raise ValueError(f"Invalid zone_id: {zone_id!r}")
+def _validate_id(value: str, name: str) -> None:
+    """Validate an ID string to prevent path traversal."""
+    if not value or not _SAFE_ID_RE.match(value):
+        raise ValueError(f"Invalid {name}: {value!r}")
 
 
-def _serialize_envelope(envelope: dict[str, Any]) -> bytes:
-    """Serialize task envelope to JSON bytes."""
-    return json.dumps(envelope, default=str, indent=2).encode("utf-8")
+def _extract_task(data: bytes) -> Task | None:
+    """Extract a Task from MessageEnvelope bytes.
 
-
-def _deserialize_envelope(data: bytes) -> dict[str, Any]:
-    """Deserialize task envelope from JSON bytes."""
-    result: dict[str, Any] = json.loads(data)
-    return result
+    Returns *None* if the data is not a valid task envelope.
+    """
+    try:
+        envelope = MessageEnvelope.from_bytes(data)
+        return Task.model_validate(envelope.payload)
+    except Exception:
+        logger.warning("Failed to extract task from envelope", exc_info=True)
+        return None

--- a/src/nexus/ipc/conventions.py
+++ b/src/nexus/ipc/conventions.py
@@ -8,6 +8,7 @@ Defines the directory layout for agent communication:
         outbox/             # Sent messages (audit trail)
         processed/          # Successfully processed messages
         dead_letter/        # Failed messages
+        tasks/              # A2A task persistence (§17.6 convergence)
 
 All functions are pure — they compose path strings with no I/O.
 """
@@ -23,6 +24,7 @@ INBOX_DIR = "inbox"
 OUTBOX_DIR = "outbox"
 PROCESSED_DIR = "processed"
 DEAD_LETTER_DIR = "dead_letter"
+TASKS_DIR = "tasks"
 AGENT_CARD_FILENAME = "AGENT.json"
 
 # All directories auto-provisioned for each agent
@@ -31,6 +33,7 @@ AGENT_SUBDIRS: tuple[str, ...] = (
     OUTBOX_DIR,
     PROCESSED_DIR,
     DEAD_LETTER_DIR,
+    TASKS_DIR,
 )
 
 
@@ -62,6 +65,28 @@ def dead_letter_path(agent_id: str) -> str:
 def agent_card_path(agent_id: str) -> str:
     """Agent card file: ``/agents/{agent_id}/AGENT.json``."""
     return f"{AGENTS_ROOT}/{agent_id}/{AGENT_CARD_FILENAME}"
+
+
+def tasks_path(agent_id: str) -> str:
+    """Tasks directory: ``/agents/{agent_id}/tasks``."""
+    return f"{AGENTS_ROOT}/{agent_id}/{TASKS_DIR}"
+
+
+def task_file_path(agent_id: str, task_id: str, timestamp: datetime) -> str:
+    """Full path for a task file in an agent's tasks directory.
+
+    Format: ``/agents/{agent_id}/tasks/{ISO_timestamp}_{task_id}.json``
+
+    The timestamp prefix ensures ``ls --sort=name`` gives chronological
+    ordering.  The task_id suffix ensures uniqueness.
+    """
+    ts = timestamp.strftime("%Y%m%dT%H%M%S%fZ")
+    return f"{tasks_path(agent_id)}/{ts}_{task_id}.json"
+
+
+def task_dead_letter_path(agent_id: str) -> str:
+    """Dead letter directory for deleted tasks: ``/agents/{agent_id}/tasks/_dead_letter``."""
+    return f"{tasks_path(agent_id)}/_dead_letter"
 
 
 def message_filename(msg_id: str, timestamp: datetime) -> str:

--- a/tests/e2e/server/test_a2a_auth_e2e.py
+++ b/tests/e2e/server/test_a2a_auth_e2e.py
@@ -3,8 +3,9 @@
 These tests start `nexus serve` with --api-key to verify:
 1. A2A endpoints enforce auth when server has auth configured
 2. Agent Card remains public (no auth required)
-3. Tasks are persisted to disk via VFSTaskStore
+3. Tasks are persisted to disk via VFSTaskStore under agent-scoped paths
 4. Full lifecycle works with Bearer token auth
+5. On-disk format uses MessageEnvelope (§17.6 convergence)
 
 Separate from test_a2a_e2e.py which tests in open-access mode.
 """
@@ -16,6 +17,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -23,12 +25,25 @@ from typing import Any
 import httpx
 import pytest
 
-# Reuse port finder from conftest
-from tests.e2e.conftest import find_free_port, wait_for_server
+from tests.e2e.conftest import find_free_port
 
 _src_path = str(Path(__file__).resolve().parent.parent.parent / "src")
 
 API_KEY = "test-a2a-auth-e2e-key-42"
+
+
+def _drain_pipe(pipe, lines: list[str], ready: threading.Event | None = None):
+    """Read lines from a subprocess pipe (daemon thread)."""
+    try:
+        for raw in iter(pipe.readline, b""):
+            decoded = raw.decode(errors="replace")
+            lines.append(decoded)
+            if ready and "Application startup complete" in decoded:
+                ready.set()
+    except ValueError:
+        pass
+    finally:
+        pipe.close()
 
 
 @pytest.fixture(scope="function")
@@ -62,13 +77,27 @@ def auth_server(isolated_db, tmp_path):
         preexec_fn=os.setsid if sys.platform != "win32" else None,
     )
 
-    if not wait_for_server(base_url, timeout=30.0):
+    # Event-driven readiness (same pattern as conftest.nexus_server)
+    stderr_lines: list[str] = []
+    stdout_lines: list[str] = []
+    ready = threading.Event()
+
+    t_err = threading.Thread(
+        target=_drain_pipe, args=(process.stderr, stderr_lines, ready), daemon=True
+    )
+    t_out = threading.Thread(target=_drain_pipe, args=(process.stdout, stdout_lines), daemon=True)
+    t_err.start()
+    t_out.start()
+
+    if not ready.wait(timeout=120.0):
         process.terminate()
-        stdout, stderr = process.communicate(timeout=5)
+        t_err.join(timeout=2)
+        t_out.join(timeout=2)
         pytest.fail(
-            f"Auth server failed to start on port {port}.\n"
-            f"stdout: {stdout.decode()}\n"
-            f"stderr: {stderr.decode()}"
+            f"Auth server failed to start on port {port} "
+            f"(never saw 'Application startup complete').\n"
+            f"stdout: {''.join(stdout_lines)}\n"
+            f"stderr: {''.join(stderr_lines)}"
         )
 
     yield {
@@ -155,15 +184,22 @@ class TestA2AAuthEnforcement:
 
 
 # ======================================================================
-# Persistence (data_dir wiring)
+# Persistence — agent-scoped paths + MessageEnvelope (§17.6)
 # ======================================================================
 
 
 class TestA2APersistenceE2E:
-    """Verify tasks are persisted to disk via VFSTaskStore."""
+    """Verify tasks are persisted to disk via VFSTaskStore.
+
+    After §17.6 convergence, tasks are stored under agent-scoped paths:
+        {data_dir}/agents/{agent_id}/tasks/{ts}_{task_id}.json
+
+    When no agent_id is extracted from auth, the fallback is "_unassigned".
+    Files are wrapped in MessageEnvelope format for IPC interoperability.
+    """
 
     def test_task_creates_json_file_on_disk(self, auth_server):
-        """Creating a task via A2A produces a .json file in data_dir."""
+        """Creating a task via A2A produces a .json file under agents/ directory."""
         body = _rpc(
             "a2a.tasks.send",
             {"message": {"role": "user", "parts": [{"type": "text", "text": "persist check"}]}},
@@ -180,19 +216,33 @@ class TestA2APersistenceE2E:
             assert resp.status_code == 200
             task_id = resp.json()["result"]["id"]
 
-        # Check disk for the task file
+        # Check disk — tasks now live under /agents/{agent_id}/tasks/
         data_dir = auth_server["data_dir"]
-        a2a_tasks_dir = data_dir / "a2a" / "tasks"
-        assert a2a_tasks_dir.exists(), f"A2A tasks directory not found: {a2a_tasks_dir}"
+        agents_dir = data_dir / "agents"
+        assert agents_dir.exists(), f"Agents directory not found: {agents_dir}"
 
-        # Find the task JSON file
-        all_json = list(a2a_tasks_dir.rglob(f"*_{task_id}.json"))
+        # Find the task JSON file under any agent's tasks/ directory
+        all_json = list(agents_dir.rglob(f"*_{task_id}.json"))
         assert len(all_json) == 1, f"Expected 1 file for task {task_id}, found {len(all_json)}"
 
-        # Verify file content
-        content = json.loads(all_json[0].read_bytes())
-        assert content["task"]["id"] == task_id
-        assert content["task"]["status"]["state"] == "submitted"
+        # Verify the file is inside a tasks/ directory
+        task_file = all_json[0]
+        assert task_file.parent.name == "tasks", (
+            f"Task file should be in a tasks/ directory, got: {task_file.parent}"
+        )
+
+        # Verify on-disk format is MessageEnvelope (§17.6 convergence)
+        content = json.loads(task_file.read_bytes())
+        assert content["type"] == "task", (
+            f"Expected MessageEnvelope type='task', got: {content.get('type')}"
+        )
+        assert "payload" in content, "MessageEnvelope should have 'payload' field"
+        assert content["payload"]["id"] == task_id
+        assert content["payload"]["status"]["state"] == "submitted"
+
+        # Verify envelope metadata
+        assert content["from"] == "a2a_gateway"
+        assert content["correlation_id"] == task_id
 
     def test_full_lifecycle_with_persistence(self, auth_server):
         """Create -> Get -> Cancel with all state changes persisted."""
@@ -229,9 +279,14 @@ class TestA2APersistenceE2E:
             )
             assert cancel_resp.json()["result"]["status"]["state"] == "canceled"
 
-        # Verify canceled state is persisted on disk
+        # Verify canceled state is persisted on disk under agent-scoped path
         data_dir = auth_server["data_dir"]
-        task_files = list((data_dir / "a2a" / "tasks").rglob(f"*_{task_id}.json"))
+        agents_dir = data_dir / "agents"
+        task_files = list(agents_dir.rglob(f"*_{task_id}.json"))
         assert len(task_files) == 1
         content = json.loads(task_files[0].read_bytes())
-        assert content["task"]["status"]["state"] == "canceled"
+
+        # Verify MessageEnvelope wraps the canceled task
+        assert content["type"] == "task"
+        assert content["payload"]["status"]["state"] == "canceled"
+        assert content["payload"]["id"] == task_id

--- a/tests/unit/a2a/test_task_store.py
+++ b/tests/unit/a2a/test_task_store.py
@@ -1,0 +1,576 @@
+"""Protocol conformance tests for all TaskStore implementations.
+
+Each test class is parameterized across backends so that every store
+gets identical coverage.  Restored from #1699 prune and extended for
+§17.6 convergence (agent-scoped paths + MessageEnvelope format).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import warnings
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from nexus.a2a.models import (
+    Artifact,
+    DataPart,
+    Message,
+    Task,
+    TaskState,
+    TaskStatus,
+    TextPart,
+)
+from nexus.a2a.task_store import TaskStoreProtocol
+
+# ======================================================================
+# Fakes / helpers
+# ======================================================================
+
+
+class InMemoryStorageDriver:
+    """Minimal fake for IPCStorageDriver used by VFSTaskStore tests."""
+
+    def __init__(self) -> None:
+        self._files: dict[tuple[str, str], bytes] = {}
+        self._dirs: set[tuple[str, str]] = set()
+
+    async def read(self, path: str, zone_id: str) -> bytes:
+        key = (path, zone_id)
+        if key not in self._files:
+            raise FileNotFoundError(path)
+        return self._files[key]
+
+    async def write(self, path: str, data: bytes, zone_id: str) -> None:
+        self._files[(path, zone_id)] = data
+
+    async def list_dir(self, path: str, zone_id: str) -> list[str]:
+        prefix = path.rstrip("/") + "/"
+        entries: set[str] = set()
+        for (p, z), _ in self._files.items():
+            if z == zone_id and p.startswith(prefix):
+                relative = p[len(prefix) :]
+                # Only direct children (no deeper slashes)
+                if "/" not in relative:
+                    entries.add(relative)
+        for d, z in self._dirs:
+            if z == zone_id and d.startswith(prefix):
+                relative = d[len(prefix) :]
+                if "/" not in relative.rstrip("/"):
+                    entries.add(relative.rstrip("/"))
+        if not entries:
+            norm = path.rstrip("/")
+            dir_exists = (norm, zone_id) in self._dirs
+            has_children = any(p.startswith(norm + "/") and z == zone_id for (p, z) in self._files)
+            if not dir_exists and not has_children:
+                raise FileNotFoundError(path)
+        return sorted(entries)
+
+    async def count_dir(self, path: str, zone_id: str) -> int:
+        entries = await self.list_dir(path, zone_id)
+        return len(entries)
+
+    async def rename(self, src: str, dst: str, zone_id: str) -> None:
+        key = (src, zone_id)
+        if key not in self._files:
+            raise FileNotFoundError(src)
+        self._files[(dst, zone_id)] = self._files.pop(key)
+
+    async def mkdir(self, path: str, zone_id: str) -> None:
+        # Create all parent directories (matches LocalStorageDriver parents=True)
+        norm = path.rstrip("/")
+        parts = norm.split("/")
+        for i in range(1, len(parts) + 1):
+            parent = "/".join(parts[:i])
+            if parent:
+                self._dirs.add((parent, zone_id))
+
+    async def exists(self, path: str, zone_id: str) -> bool:
+        if (path, zone_id) in self._files:
+            return True
+        norm = path.rstrip("/")
+        return (norm, zone_id) in self._dirs
+
+
+def _make_task(
+    task_id: str = "task-001",
+    state: TaskState = TaskState.SUBMITTED,
+    text: str = "hello",
+    context_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Task:
+    """Create a minimal Task for testing."""
+    return Task(
+        id=task_id,
+        contextId=context_id or f"ctx-{task_id}",
+        status=TaskStatus(state=state, timestamp=datetime.now(UTC)),
+        history=[
+            Message(
+                role="user",
+                parts=[TextPart(text=text)],
+            )
+        ],
+        metadata=metadata,
+    )
+
+
+def _make_task_with_artifact(task_id: str = "task-art") -> Task:
+    """Create a Task with an artifact for testing."""
+    return Task(
+        id=task_id,
+        contextId=f"ctx-{task_id}",
+        status=TaskStatus(state=TaskState.COMPLETED, timestamp=datetime.now(UTC)),
+        history=[
+            Message(role="user", parts=[TextPart(text="analyze this")]),
+            Message(role="agent", parts=[TextPart(text="done")]),
+        ],
+        artifacts=[
+            Artifact(
+                artifactId="art-1",
+                name="result.json",
+                parts=[DataPart(data={"key": "value"})],
+            )
+        ],
+    )
+
+
+# ======================================================================
+# Fixtures — parameterized across backends
+# ======================================================================
+
+
+@pytest.fixture(params=["in_memory", "vfs"])
+def store(request: pytest.FixtureRequest) -> TaskStoreProtocol:
+    """Create a TaskStore instance for each backend."""
+    if request.param == "in_memory":
+        from nexus.a2a.stores.in_memory import InMemoryTaskStore
+
+        return InMemoryTaskStore()
+    elif request.param == "vfs":
+        from nexus.a2a.stores.vfs import VFSTaskStore
+
+        driver = InMemoryStorageDriver()
+        return VFSTaskStore(storage=driver)
+    else:
+        pytest.skip(f"Unknown backend: {request.param}")
+
+
+@pytest.fixture()
+def vfs_store() -> tuple[Any, Any]:
+    """VFSTaskStore with exposed driver for index tests."""
+    from nexus.a2a.stores.vfs import VFSTaskStore
+
+    driver = InMemoryStorageDriver()
+    store = VFSTaskStore(storage=driver, max_cache_size=5)
+    return store, driver
+
+
+# ======================================================================
+# Save + Get
+# ======================================================================
+
+
+class TestSaveAndGet:
+    @pytest.mark.asyncio
+    async def test_save_and_get_roundtrip(self, store: TaskStoreProtocol) -> None:
+        task = _make_task("t1")
+        await store.save(task, zone_id="z1", agent_id="agent-a")
+
+        loaded = await store.get("t1", zone_id="z1")
+        assert loaded is not None
+        assert loaded.id == "t1"
+        assert loaded.status.state == TaskState.SUBMITTED
+        assert len(loaded.history) == 1
+        assert loaded.history[0].parts[0].text == "hello"  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_returns_none(self, store: TaskStoreProtocol) -> None:
+        result = await store.get("nonexistent", zone_id="z1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_save_with_agent_id(self, store: TaskStoreProtocol) -> None:
+        task = _make_task("t-agent")
+        await store.save(task, zone_id="z1", agent_id="agent-alice")
+
+        loaded = await store.get("t-agent", zone_id="z1")
+        assert loaded is not None
+        assert loaded.id == "t-agent"
+
+    @pytest.mark.asyncio
+    async def test_save_without_agent_id(self, store: TaskStoreProtocol) -> None:
+        """Tasks saved without agent_id should still be retrievable."""
+        task = _make_task("t-noagent")
+        await store.save(task, zone_id="z1")
+
+        loaded = await store.get("t-noagent", zone_id="z1")
+        assert loaded is not None
+        assert loaded.id == "t-noagent"
+
+    @pytest.mark.asyncio
+    async def test_save_overwrites_existing(self, store: TaskStoreProtocol) -> None:
+        task1 = _make_task("t-up", state=TaskState.SUBMITTED)
+        await store.save(task1, zone_id="z1", agent_id="agent-a")
+
+        task2 = _make_task("t-up", state=TaskState.WORKING, text="updated")
+        await store.save(task2, zone_id="z1", agent_id="agent-a")
+
+        loaded = await store.get("t-up", zone_id="z1")
+        assert loaded is not None
+        assert loaded.status.state == TaskState.WORKING
+        assert loaded.history[0].parts[0].text == "updated"  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_roundtrip_preserves_artifacts(self, store: TaskStoreProtocol) -> None:
+        task = _make_task_with_artifact("t-art")
+        await store.save(task, zone_id="z1", agent_id="agent-a")
+
+        loaded = await store.get("t-art", zone_id="z1")
+        assert loaded is not None
+        assert len(loaded.artifacts) == 1
+        assert loaded.artifacts[0].artifactId == "art-1"
+        assert loaded.artifacts[0].name == "result.json"
+
+    @pytest.mark.asyncio
+    async def test_roundtrip_preserves_metadata(self, store: TaskStoreProtocol) -> None:
+        task = _make_task("t-meta", metadata={"priority": "high", "tags": [1, 2]})
+        await store.save(task, zone_id="z1", agent_id="agent-a")
+
+        loaded = await store.get("t-meta", zone_id="z1")
+        assert loaded is not None
+        assert loaded.metadata == {"priority": "high", "tags": [1, 2]}
+
+    @pytest.mark.asyncio
+    async def test_roundtrip_preserves_context_id(self, store: TaskStoreProtocol) -> None:
+        task = _make_task("t-ctx", context_id="my-context-123")
+        await store.save(task, zone_id="z1", agent_id="agent-a")
+
+        loaded = await store.get("t-ctx", zone_id="z1")
+        assert loaded is not None
+        assert loaded.contextId == "my-context-123"
+
+
+# ======================================================================
+# Zone Isolation (Security boundary — critical)
+# ======================================================================
+
+
+class TestZoneIsolation:
+    @pytest.mark.asyncio
+    async def test_get_wrong_zone_returns_none(self, store: TaskStoreProtocol) -> None:
+        task = _make_task("t-zone")
+        await store.save(task, zone_id="alpha", agent_id="agent-a")
+
+        result = await store.get("t-zone", zone_id="beta")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_list_excludes_other_zone(self, store: TaskStoreProtocol) -> None:
+        await store.save(_make_task("t-a"), zone_id="alpha", agent_id="agent-a")
+        await store.save(_make_task("t-b"), zone_id="beta", agent_id="agent-a")
+
+        alpha_tasks = await store.list_tasks(zone_id="alpha")
+        assert len(alpha_tasks) == 1
+        assert alpha_tasks[0].id == "t-a"
+
+        beta_tasks = await store.list_tasks(zone_id="beta")
+        assert len(beta_tasks) == 1
+        assert beta_tasks[0].id == "t-b"
+
+    @pytest.mark.asyncio
+    async def test_delete_wrong_zone_returns_false(self, store: TaskStoreProtocol) -> None:
+        await store.save(_make_task("t-del"), zone_id="alpha", agent_id="agent-a")
+
+        result = await store.delete("t-del", zone_id="beta")
+        assert result is False
+
+        # Still exists in the correct zone
+        loaded = await store.get("t-del", zone_id="alpha")
+        assert loaded is not None
+
+    @pytest.mark.asyncio
+    async def test_same_task_id_different_zones(self, store: TaskStoreProtocol) -> None:
+        """Same task ID can exist in different zones independently."""
+        task_a = _make_task("shared-id", text="alpha version")
+        task_b = _make_task("shared-id", text="beta version")
+
+        await store.save(task_a, zone_id="alpha", agent_id="agent-a")
+        await store.save(task_b, zone_id="beta", agent_id="agent-a")
+
+        loaded_a = await store.get("shared-id", zone_id="alpha")
+        loaded_b = await store.get("shared-id", zone_id="beta")
+
+        assert loaded_a is not None
+        assert loaded_b is not None
+        assert loaded_a.history[0].parts[0].text == "alpha version"  # type: ignore[union-attr]
+        assert loaded_b.history[0].parts[0].text == "beta version"  # type: ignore[union-attr]
+
+
+# ======================================================================
+# Delete
+# ======================================================================
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_delete_existing_returns_true(self, store: TaskStoreProtocol) -> None:
+        await store.save(_make_task("t-del"), zone_id="z1", agent_id="agent-a")
+
+        result = await store.delete("t-del", zone_id="z1")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_task(self, store: TaskStoreProtocol) -> None:
+        await store.save(_make_task("t-del2"), zone_id="z1", agent_id="agent-a")
+        await store.delete("t-del2", zone_id="z1")
+
+        loaded = await store.get("t-del2", zone_id="z1")
+        assert loaded is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_returns_false(self, store: TaskStoreProtocol) -> None:
+        result = await store.delete("nonexistent", zone_id="z1")
+        assert result is False
+
+
+# ======================================================================
+# List Tasks
+# ======================================================================
+
+
+class TestListTasks:
+    @pytest.mark.asyncio
+    async def test_list_empty(self, store: TaskStoreProtocol) -> None:
+        result = await store.list_tasks(zone_id="empty-zone")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_returns_all_in_zone(self, store: TaskStoreProtocol) -> None:
+        for i in range(3):
+            await store.save(_make_task(f"t-{i}"), zone_id="z1", agent_id="agent-a")
+            await asyncio.sleep(0.01)
+
+        result = await store.list_tasks(zone_id="z1")
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_state(self, store: TaskStoreProtocol) -> None:
+        await store.save(
+            _make_task("t-sub", state=TaskState.SUBMITTED),
+            zone_id="z1",
+            agent_id="agent-a",
+        )
+        await store.save(
+            _make_task("t-work", state=TaskState.WORKING),
+            zone_id="z1",
+            agent_id="agent-a",
+        )
+        await store.save(
+            _make_task("t-done", state=TaskState.COMPLETED),
+            zone_id="z1",
+            agent_id="agent-a",
+        )
+
+        working = await store.list_tasks(zone_id="z1", state=TaskState.WORKING)
+        assert len(working) == 1
+        assert working[0].id == "t-work"
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_agent_id(self, store: TaskStoreProtocol) -> None:
+        await store.save(_make_task("t-alice"), zone_id="z1", agent_id="agent-alice")
+        await store.save(_make_task("t-bob"), zone_id="z1", agent_id="agent-bob")
+
+        alice_tasks = await store.list_tasks(zone_id="z1", agent_id="agent-alice")
+        assert len(alice_tasks) == 1
+        assert alice_tasks[0].id == "t-alice"
+
+    @pytest.mark.asyncio
+    async def test_list_pagination_limit(self, store: TaskStoreProtocol) -> None:
+        for i in range(5):
+            await store.save(_make_task(f"t-{i}"), zone_id="z1", agent_id="agent-a")
+            await asyncio.sleep(0.01)
+
+        result = await store.list_tasks(zone_id="z1", limit=2)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_pagination_offset(self, store: TaskStoreProtocol) -> None:
+        for i in range(5):
+            await store.save(_make_task(f"t-{i}"), zone_id="z1", agent_id="agent-a")
+            await asyncio.sleep(0.01)
+
+        all_tasks = await store.list_tasks(zone_id="z1", limit=100)
+        offset_tasks = await store.list_tasks(zone_id="z1", offset=2, limit=100)
+        assert len(offset_tasks) == 3
+        assert offset_tasks[0].id == all_tasks[2].id
+
+    @pytest.mark.asyncio
+    async def test_list_ordered_newest_first(self, store: TaskStoreProtocol) -> None:
+        for i in range(3):
+            await store.save(_make_task(f"t-{i}"), zone_id="z1", agent_id="agent-a")
+            await asyncio.sleep(0.02)
+
+        result = await store.list_tasks(zone_id="z1")
+        assert len(result) == 3
+        # Newest first — t-2 was created last
+        assert result[0].id == "t-2"
+        assert result[2].id == "t-0"
+
+
+# ======================================================================
+# VFS Task Index (VFSTaskStore-specific)
+# ======================================================================
+
+
+class TestVFSTaskIndex:
+    """Tests for the task_id → agent_id LRU index in VFSTaskStore."""
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_avoids_scan(self, vfs_store: tuple[Any, Any]) -> None:
+        store, _driver = vfs_store
+        task = _make_task("t-idx")
+        await store.save(task, zone_id="z1", agent_id="agent-a")
+
+        # Second get should be a cache hit (no scan logged)
+        loaded = await store.get("t-idx", zone_id="z1")
+        assert loaded is not None
+        assert loaded.id == "t-idx"
+
+    @pytest.mark.asyncio
+    async def test_cold_start_scan_finds_task(self, vfs_store: tuple[Any, Any]) -> None:
+        store, _driver = vfs_store
+        task = _make_task("t-cold")
+        await store.save(task, zone_id="z1", agent_id="agent-a")
+
+        # Clear the index to simulate cold start
+        store._task_index.clear()
+        store._locks.clear()
+
+        loaded = await store.get("t-cold", zone_id="z1")
+        assert loaded is not None
+        assert loaded.id == "t-cold"
+
+    @pytest.mark.asyncio
+    async def test_lru_eviction(self, vfs_store: tuple[Any, Any]) -> None:
+        store, _driver = vfs_store
+        # max_cache_size=5, save 7 tasks
+        for i in range(7):
+            await store.save(
+                _make_task(f"t-{i}"),
+                zone_id="z1",
+                agent_id="agent-a",
+            )
+            await asyncio.sleep(0.01)
+
+        # First 2 should have been evicted
+        assert len(store._task_index) == 5
+
+        # Evicted task should still be findable via scan
+        loaded = await store.get("t-0", zone_id="z1")
+        assert loaded is not None
+        assert loaded.id == "t-0"
+
+    @pytest.mark.asyncio
+    async def test_delete_clears_index(self, vfs_store: tuple[Any, Any]) -> None:
+        store, _driver = vfs_store
+        await store.save(_make_task("t-rm"), zone_id="z1", agent_id="agent-a")
+        assert "t-rm" in store._task_index
+
+        await store.delete("t-rm", zone_id="z1")
+        assert "t-rm" not in store._task_index
+
+    @pytest.mark.asyncio
+    async def test_concurrent_saves_both_indexed(self, vfs_store: tuple[Any, Any]) -> None:
+        store, _driver = vfs_store
+
+        async def save_task(task_id: str, agent_id: str) -> None:
+            await store.save(_make_task(task_id), zone_id="z1", agent_id=agent_id)
+
+        await asyncio.gather(
+            save_task("t-1", "agent-a"),
+            save_task("t-2", "agent-b"),
+        )
+
+        assert "t-1" in store._task_index
+        assert "t-2" in store._task_index
+
+    @pytest.mark.asyncio
+    async def test_cross_agent_tasks_listed_zone_wide(
+        self,
+        vfs_store: tuple[Any, Any],
+    ) -> None:
+        store, _driver = vfs_store
+        await store.save(_make_task("t-a"), zone_id="z1", agent_id="agent-a")
+        await store.save(_make_task("t-b"), zone_id="z1", agent_id="agent-b")
+
+        all_tasks = await store.list_tasks(zone_id="z1")
+        assert len(all_tasks) == 2
+        task_ids = {t.id for t in all_tasks}
+        assert task_ids == {"t-a", "t-b"}
+
+
+# ======================================================================
+# MessageEnvelope format verification (VFSTaskStore-specific)
+# ======================================================================
+
+
+class TestVFSEnvelopeFormat:
+    """Verify tasks are stored as MessageEnvelope on disk."""
+
+    @pytest.mark.asyncio
+    async def test_stored_as_message_envelope(self, vfs_store: tuple[Any, Any]) -> None:
+        from nexus.ipc.envelope import MessageEnvelope
+
+        store, driver = vfs_store
+        task = _make_task("t-env")
+        await store.save(task, zone_id="z1", agent_id="agent-a")
+
+        # Find the stored file
+        files = [(p, z) for (p, z) in driver._files if "t-env" in p and z == "z1"]
+        assert len(files) == 1
+        path, zone = files[0]
+        data = driver._files[(path, zone)]
+
+        # Verify it's a valid MessageEnvelope
+        envelope = MessageEnvelope.from_bytes(data)
+        assert envelope.type.value == "task"
+        assert envelope.sender == "a2a_gateway"
+        assert envelope.recipient == "agent-a"
+        assert envelope.correlation_id == "t-env"
+
+    @pytest.mark.asyncio
+    async def test_task_payload_roundtrips(self, vfs_store: tuple[Any, Any]) -> None:
+        store, _driver = vfs_store
+        original = _make_task_with_artifact("t-roundtrip")
+        await store.save(original, zone_id="z1", agent_id="agent-a")
+
+        loaded = await store.get("t-roundtrip", zone_id="z1")
+        assert loaded is not None
+        assert loaded.id == original.id
+        assert loaded.status.state == original.status.state
+        assert len(loaded.artifacts) == 1
+        assert loaded.artifacts[0].artifactId == "art-1"
+
+
+# ======================================================================
+# DatabaseTaskStore deprecation warning
+# ======================================================================
+
+
+class TestDatabaseTaskStoreDeprecation:
+    def test_emits_deprecation_warning(self) -> None:
+        # Create a minimal fake session factory
+        def _fake_session_factory() -> None:
+            return None
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            from nexus.a2a.stores.database import DatabaseTaskStore
+
+            DatabaseTaskStore(_fake_session_factory)
+
+        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecation_warnings) >= 1
+        assert "deprecated" in str(deprecation_warnings[0].message).lower()

--- a/tests/unit/ipc/test_conventions.py
+++ b/tests/unit/ipc/test_conventions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from nexus.ipc.conventions import (
+    AGENT_SUBDIRS,
     AGENTS_ROOT,
     agent_card_path,
     agent_dir,
@@ -17,6 +18,9 @@ from nexus.ipc.conventions import (
     message_path_in_processed,
     outbox_path,
     processed_path,
+    task_dead_letter_path,
+    task_file_path,
+    tasks_path,
 )
 
 
@@ -89,3 +93,28 @@ class TestFullPaths:
         ts = datetime(2026, 2, 12, 10, 0, 0, tzinfo=UTC)
         path = message_path_in_dead_letter("reviewer", "msg_abc", ts)
         assert path == "/agents/reviewer/dead_letter/20260212T100000_msg_abc.json"
+
+
+class TestTaskPaths:
+    """Tests for A2A task path builders (§17.6 convergence)."""
+
+    def test_tasks_path(self) -> None:
+        assert tasks_path("reviewer") == "/agents/reviewer/tasks"
+
+    def test_task_file_path(self) -> None:
+        ts = datetime(2026, 2, 14, 10, 30, 45, tzinfo=UTC)
+        path = task_file_path("reviewer", "task-001", ts)
+        assert path == "/agents/reviewer/tasks/20260214T103045000000Z_task-001.json"
+
+    def test_task_file_sortable_by_timestamp(self) -> None:
+        ts1 = datetime(2026, 2, 14, 10, 0, 0, tzinfo=UTC)
+        ts2 = datetime(2026, 2, 14, 10, 0, 1, tzinfo=UTC)
+        path1 = task_file_path("a", "task-1", ts1)
+        path2 = task_file_path("a", "task-2", ts2)
+        assert path1 < path2  # Lexicographic sort = chronological
+
+    def test_task_dead_letter_path(self) -> None:
+        assert task_dead_letter_path("reviewer") == "/agents/reviewer/tasks/_dead_letter"
+
+    def test_tasks_dir_in_agent_subdirs(self) -> None:
+        assert "tasks" in AGENT_SUBDIRS


### PR DESCRIPTION
## Summary

Unifies A2A task storage with IPC agent-scoped paths per LEGO §17.6 convergence. Tasks now stored as `MessageEnvelope` files under `/agents/{agent_id}/tasks/` instead of the old `/a2a/tasks/{zone_id}/` layout.

- **VFSTaskStore** rewritten: agent-scoped paths, `MessageEnvelope` format, LRU index (`OrderedDict`) with zone isolation on cache hit + input validation (`task_id`, `zone_id`, `agent_id`)
- **conventions.py**: add `TASKS_DIR`, `tasks_path()`, `task_file_path()`, `task_dead_letter_path()`, `"tasks"` in `AGENT_SUBDIRS`
- **DatabaseTaskStore**: add `DeprecationWarning` (kept for backward compat)
- **E2E tests**: fix broken `wait_for_server` import, verify new agent-scoped paths + `MessageEnvelope` format on disk
- **Unit tests**: 53 tests restored from git + extended (LRU eviction, cold-start scan, concurrent saves, zone isolation, envelope format)

### Security fixes (from code review)
- Zone isolation on LRU cache hit — `get()`/`delete()` reject cross-zone entries, fall through to scan
- Input validation — `task_id` and `zone_id` validated via `_SAFE_ID_RE` in all public methods

**Stream 10**

Closes #1709

## Test plan

- [x] 268 unit + integration tests pass
- [x] 19 E2E tests pass (real `nexus serve` subprocess with auth)
- [x] E2E verifies agent-scoped paths on disk + `MessageEnvelope` format
- [x] ruff check + format clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)