### PR TITLE
ci: add develop branch to CI workflow triggers

### DIFF
--- a/.github/workflows/api-surface.yml
+++ b/.github/workflows/api-surface.yml
@@ -2,7 +2,7 @@ name: API Surface Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'src/nexus/**/*.py'
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,9 +2,9 @@ name: Benchmark
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: write

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,7 +2,7 @@ name: Code Quality Standards
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'src/**/*.py'
       - 'tests/**/*.py'
@@ -10,7 +10,7 @@ on:
       - '.pre-commit-config.yaml'
       - 'pyproject.toml'
   push:
-    branches: [main, refactor/**]
+    branches: [main, develop, refactor/**]
     paths:
       - 'src/**/*.py'
       - 'tests/**/*.py'

--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -13,9 +13,9 @@ name: Docker Integration Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       # Docker-related files
       - 'Dockerfile'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
     paths:
       - '.github/labels.yml'
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [main, SETUP]
+    branches: [main, develop, SETUP]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -2,13 +2,13 @@ name: Protocol
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "proto/**"
       - "buf.yaml"
       - "buf.gen.yaml"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "proto/**"
       - "buf.yaml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main, SETUP]
+    branches: [main, develop, SETUP]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `develop` to `on.push.branches` and `on.pull_request.branches` in all CI workflow files
- The repo's default branch was changed from `main` to `develop`, but CI workflows were still only triggering on `main`
- Updated 9 workflow files: api-surface, benchmark, code-quality, docker-integration, docs, label-sync, lint, proto, test
- Skipped `release.yml` (triggers on tags only, not branches)

## Files changed
- `.github/workflows/api-surface.yml` — added `develop` to `pull_request.branches`
- `.github/workflows/benchmark.yml` — added `develop` to both `push.branches` and `pull_request.branches`
- `.github/workflows/code-quality.yml` — added `develop` to both `push.branches` and `pull_request.branches`
- `.github/workflows/docker-integration.yml` — added `develop` to both `push.branches` and `pull_request.branches`
- `.github/workflows/docs.yml` — added `develop` to `push.branches`
- `.github/workflows/label-sync.yml` — added `develop` to `push.branches`
- `.github/workflows/lint.yml` — added `develop` to both `push.branches` and `pull_request.branches`
- `.github/workflows/proto.yml` — added `develop` to both `push.branches` and `pull_request.branches`
- `.github/workflows/test.yml` — added `develop` to both `push.branches` and `pull_request.branches`

## Test plan
- [ ] Verify CI runs on this PR itself (since the PR targets `develop`, the updated triggers should activate)
- [ ] After merge, verify pushes to `develop` trigger the relevant workflows