### PR TITLE
fix(#1727): eliminate hardcoded zone_id default in IPC constructors

### DIFF
--- a/src/nexus/ipc/delivery.py
+++ b/src/nexus/ipc/delivery.py
@@ -66,7 +66,8 @@ class MessageSender:
         self,
         vfs: VFSOperations,
         event_publisher: EventPublisher | None = None,
-        zone_id: str = "root",
+        *,
+        zone_id: str,
         max_inbox_size: int = DEFAULT_MAX_INBOX_SIZE,
         max_payload_bytes: int = DEFAULT_MAX_PAYLOAD_BYTES,
     ) -> None:
@@ -222,7 +223,8 @@ class MessageProcessor:
         vfs: VFSOperations,
         agent_id: str,
         handler: MessageHandler,
-        zone_id: str = "root",
+        *,
+        zone_id: str,
         max_dedup_size: int = 10_000,
     ) -> None:
         self._vfs = vfs

--- a/src/nexus/ipc/discovery.py
+++ b/src/nexus/ipc/discovery.py
@@ -54,7 +54,7 @@ class AgentDiscovery:
     def __init__(
         self,
         vfs: VFSOperations,
-        zone_id: str = "root",
+        zone_id: str,
         cache_ttl_seconds: float = 10.0,
     ) -> None:
         self._vfs = vfs

--- a/src/nexus/ipc/driver.py
+++ b/src/nexus/ipc/driver.py
@@ -52,7 +52,8 @@ class IPCVFSDriver(Backend):
     def __init__(
         self,
         storage: IPCStorageDriver,
-        zone_id: str = "root",
+        *,
+        zone_id: str,
         event_publisher: Any | None = None,
         max_inbox_size: int = 1000,
     ) -> None:

--- a/src/nexus/ipc/provisioning.py
+++ b/src/nexus/ipc/provisioning.py
@@ -34,7 +34,7 @@ class AgentProvisioner:
         zone_id: Zone ID for multi-zone isolation.
     """
 
-    def __init__(self, vfs: VFSOperations, zone_id: str = "root") -> None:
+    def __init__(self, vfs: VFSOperations, zone_id: str) -> None:
         self._vfs = vfs
         self._zone_id = zone_id
 

--- a/src/nexus/ipc/sweep.py
+++ b/src/nexus/ipc/sweep.py
@@ -37,7 +37,7 @@ class TTLSweeper:
     def __init__(
         self,
         vfs: VFSOperations,
-        zone_id: str = "root",
+        zone_id: str,
         interval: float = DEFAULT_SWEEP_INTERVAL,
     ) -> None:
         self._vfs = vfs

--- a/tests/unit/ipc/test_driver.py
+++ b/tests/unit/ipc/test_driver.py
@@ -51,19 +51,19 @@ class TestIPCVFSDriverProperties:
     """Tests for driver identity and capability flags."""
 
     def test_name_is_ipc(self) -> None:
-        driver = IPCVFSDriver(storage=InMemoryStorageDriver())
+        driver = IPCVFSDriver(storage=InMemoryStorageDriver(), zone_id=ZONE)
         assert driver.name == "ipc"
 
     def test_has_virtual_filesystem(self) -> None:
-        driver = IPCVFSDriver(storage=InMemoryStorageDriver())
+        driver = IPCVFSDriver(storage=InMemoryStorageDriver(), zone_id=ZONE)
         assert driver.has_virtual_filesystem is True
 
     def test_supports_rename(self) -> None:
-        driver = IPCVFSDriver(storage=InMemoryStorageDriver())
+        driver = IPCVFSDriver(storage=InMemoryStorageDriver(), zone_id=ZONE)
         assert driver.supports_rename is True
 
     def test_is_connected(self) -> None:
-        driver = IPCVFSDriver(storage=InMemoryStorageDriver())
+        driver = IPCVFSDriver(storage=InMemoryStorageDriver(), zone_id=ZONE)
         assert driver.is_connected is True
 
 
@@ -297,13 +297,13 @@ class TestIPCVFSDriverReBAC:
     """Tests for ReBAC object type mapping."""
 
     def test_object_type_is_ipc_message(self) -> None:
-        driver = IPCVFSDriver(storage=InMemoryStorageDriver())
+        driver = IPCVFSDriver(storage=InMemoryStorageDriver(), zone_id=ZONE)
         assert driver.get_object_type("agent:bob/inbox/msg.json") == "ipc:message"
 
     def test_object_type_agent_card(self) -> None:
-        driver = IPCVFSDriver(storage=InMemoryStorageDriver())
+        driver = IPCVFSDriver(storage=InMemoryStorageDriver(), zone_id=ZONE)
         assert driver.get_object_type("agent:bob/AGENT.json") == "ipc:agent"
 
     def test_object_type_directory(self) -> None:
-        driver = IPCVFSDriver(storage=InMemoryStorageDriver())
+        driver = IPCVFSDriver(storage=InMemoryStorageDriver(), zone_id=ZONE)
         assert driver.get_object_type("agent:bob/inbox") == "ipc:directory"


### PR DESCRIPTION
## Summary
- Remove default `zone_id="root"` from 6 IPC constructors: `AgentDiscovery`, `AgentProvisioner`, `MessageSender`, `MessageProcessor`, `TTLSweeper`, `IPCVFSDriver`
- Make `zone_id` a required parameter (keyword-only where needed) to enforce explicit zone specification
- Update 7 test call sites in `test_driver.py` that relied on the default to pass `zone_id=ZONE` explicitly

## Test plan
- [ ] All existing IPC unit tests pass (callers already used explicit `zone_id=ZONE`)
- [ ] CI green: ruff, mypy, pre-commit hooks all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)