### PR TITLE
fix(#1159): replace zone_id "default" with "root" in storage layer

### DIFF
--- a/src/nexus/storage/models/persistent_namespace_view.py
+++ b/src/nexus/storage/models/persistent_namespace_view.py
@@ -28,7 +28,7 @@ class PersistentNamespaceViewModel(Base):
         id: UUID primary key
         subject_type: Subject type (e.g., "user", "agent")
         subject_id: Subject identifier
-        zone_id: Zone for multi-zone isolation (default: "default")
+        zone_id: Zone for multi-zone isolation (default: "root")
         mount_paths_json: JSON array of sorted mount path strings
         grants_hash: 16-char SHA-256 hex digest of sorted grants
         revision_bucket: Zone revision bucket when view was built

--- a/src/nexus/storage/write_buffer.py
+++ b/src/nexus/storage/write_buffer.py
@@ -19,7 +19,7 @@ Usage:
     buffer.start()
 
     # Hot path — returns immediately
-    buffer.enqueue_write(metadata, is_new=True, path="/file.txt", zone_id="default")
+    buffer.enqueue_write(metadata, is_new=True, path="/file.txt", zone_id="root")
 
     # Graceful shutdown — drains remaining events
     buffer.stop()


### PR DESCRIPTION
## Summary
- Replace all hardcoded `zone_id = "default"` fallbacks with canonical `"root"` across 6 storage files
- Per KERNEL-ARCHITECTURE.md, the canonical root zone is `ROOT_ZONE_ID = "root"`, not `"default"`

## Changes
- `exchange_audit_logger.py`: param default `"default"` → `"root"`
- `secrets_audit_logger.py`: param default `"default"` → `"root"`
- `write_buffer.py`: fallback `or "default"` → `or "root"`, docstring example
- `_metadata_mapper_generated.py`: fallback `or "default"` → `or "root"`
- `raft_metadata_store.py`: 3 zone_id comparisons, 2 docstring/example blocks (13 lines total)
- `models/persistent_namespace_view.py`: docstring `"default"` → `"root"`

## Test plan
- [ ] Verify storage operations still work with root zone_id
- [ ] Confirm no remaining "default" zone_id literals in storage/

🤖 Generated with [Claude Code](https://claude.com/claude-code)