### PR TITLE
fix(#1159): replace zone_id "default" with "root" in server/api layer

### DIFF
--- a/src/nexus/server/api/v1/routers/graph.py
+++ b/src/nexus/server/api/v1/routers/graph.py
@@ -48,8 +48,8 @@ async def _graph_session(async_session_factory: Any, zone_id: str) -> AsyncItera
 
 
 def _zone_id_from(nexus_fs: Any) -> str:
-    """Extract zone_id from a NexusFS instance, defaulting to ``"default"``."""
-    return getattr(nexus_fs, "zone_id", None) or "default"
+    """Extract zone_id from a NexusFS instance, defaulting to ``"root"``."""
+    return getattr(nexus_fs, "zone_id", None) or "root"
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/server/rate_limiting.py
+++ b/src/nexus/server/rate_limiting.py
@@ -49,7 +49,7 @@ def _get_rate_limit_key(request: Request) -> str:
         token = auth_header[7:]
         parsed = parse_sk_token(token)
         if parsed is not None:
-            zone = parsed.zone or "default"
+            zone = parsed.zone or "root"
             user = parsed.user or "unknown"
             return f"user:{zone}:{user}"
         # For other tokens, use hash as key

--- a/src/nexus/server/rpc/dispatch.py
+++ b/src/nexus/server/rpc/dispatch.py
@@ -168,7 +168,7 @@ async def fire_rpc_event(
         return
 
     try:
-        zone_id = getattr(context, "zone_id", None) or "default"
+        zone_id = getattr(context, "zone_id", None) or "root"
         data: dict[str, Any] = {"file_path": path}
         if old_path:
             data["old_path"] = old_path


### PR DESCRIPTION
## Summary
- Replace 22+ hardcoded `zone_id="default"` fallbacks with `"root"` across 12 server files
- Canonical root zone is `ROOT_ZONE_ID="root"` per federation-memo.md
- Affects: routers (cache, events, share, search, graph, governance, reputation, sync_push, tus_uploads), fastapi_server, rpc/dispatch, rate_limiting

## Test plan
- [ ] Verify all zone_id defaults now use `"root"` in server/ directory
- [ ] Run existing API tests to confirm no regressions
- [ ] Check CI passes (ruff, mypy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)