### PR TITLE
fix(#1159): replace zone_id "default" with "root" in cache, core, factory, remote, search, server, workflows

### DIFF
--- a/src/nexus/portability/import_service.py
+++ b/src/nexus/portability/import_service.py
@@ -555,7 +555,7 @@ class ZoneImportService:
                     object_id = options.remap_path(object_id)
 
                 # Determine target zone
-                target_zone = options.target_zone_id or "default"
+                target_zone = options.target_zone_id or "root"
 
                 # Write tuple to ReBAC
                 rebac_manager.rebac_write(

--- a/src/nexus/remote/base_client.py
+++ b/src/nexus/remote/base_client.py
@@ -72,7 +72,7 @@ class BaseRemoteNexusFS:
 
     def _negative_cache_key(self, path: str) -> str:
         """Generate cache key with zone isolation."""
-        return f"{self._zone_id or 'default'}:{path}"
+        return f"{self._zone_id or 'root'}:{path}"
 
     def _negative_cache_check(self, path: str) -> bool:
         """Check if path is known to not exist (in negative cache).

--- a/src/nexus/remote/domain/admin.py
+++ b/src/nexus/remote/domain/admin.py
@@ -19,7 +19,7 @@ class AsyncAdminClient:
         self,
         user_id: str,
         name: str,
-        zone_id: str = "default",
+        zone_id: str = "root",
         is_admin: bool = False,
         expires_days: int | None = None,
         subject_type: str | None = None,

--- a/src/nexus/server/rate_limiting.py
+++ b/src/nexus/server/rate_limiting.py
@@ -49,7 +49,7 @@ def _get_rate_limit_key(request: Request) -> str:
         token = auth_header[7:]
         parsed = parse_sk_token(token)
         if parsed is not None:
-            zone = parsed.zone or "default"
+            zone = parsed.zone or "root"
             user = parsed.user or "unknown"
             return f"user:{zone}:{user}"
         # For other tokens, use hash as key

--- a/src/nexus/server/rpc/dispatch.py
+++ b/src/nexus/server/rpc/dispatch.py
@@ -168,7 +168,7 @@ async def fire_rpc_event(
         return
 
     try:
-        zone_id = getattr(context, "zone_id", None) or "default"
+        zone_id = getattr(context, "zone_id", None) or "root"
         data: dict[str, Any] = {"file_path": path}
         if old_path:
             data["old_path"] = old_path


### PR DESCRIPTION
## Summary
- Replace all hardcoded `zone_id = "default"` fallbacks with `"root"` across 17 files
- Covers cache/, core/, factory.py, portability/, remote/, search/, server/, and workflows/ layers
- Canonical root zone is `"root"` per federation-memo.md (`ROOT_ZONE_ID = "root"`)

## Files changed (17)
- `cache/warmer.py` — 7 method parameter defaults
- `cache/persistent_view_postgres.py` — 3 instances (save_view, load_view, comparison)
- `core/event_bus.py`, `core/nexus_fs_events.py`, `core/trigram_fast.py`, `core/types.py` — fallback zone_id values
- `factory.py` — `_provision_wallet` default + WorkflowStore construction
- `portability/import_service.py` — target zone fallback
- `remote/base_client.py`, `remote/domain/admin.py` — zone_id defaults
- `search/graph_store.py` — constructor default
- `server/fastapi_server.py`, `server/rate_limiting.py`, `server/rpc/dispatch.py` — request handling fallbacks
- `workflows/engine.py`, `workflows/storage.py`, `workflows/types.py` — workflow context defaults

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, brick zero-core-imports)
- [ ] CI lint/test/quality workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)