### PR TITLE
fix(#1602): eliminate post-init private attribute mutations in server lifespan

### DIFF
--- a/src/nexus/core/event_bus.py
+++ b/src/nexus/core/event_bus.py
@@ -729,6 +729,14 @@ class RedisEventBus(EventBusBase):
         self._started = False
         self._lock = asyncio.Lock()
 
+    def set_event_log(self, event_log: Any) -> None:
+        """Wire an event log for WAL-first durability (Issue #1397).
+
+        Called during server startup after the event log is initialized,
+        since the event bus may be constructed before the event log is available.
+        """
+        self._event_log = event_log
+
     def _channel_name(self, zone_id: str) -> str:
         """Get Redis channel name for a zone."""
         return f"{self.CHANNEL_PREFIX}:{zone_id}"

--- a/src/nexus/server/lifespan/realtime.py
+++ b/src/nexus/server/lifespan/realtime.py
@@ -147,8 +147,8 @@ async def _startup_event_bus(app: FastAPI) -> None:
     app.state.nexus_fs._main_event_loop = asyncio.get_running_loop()
 
     # Wire event_log into EventBus for WAL-first durability (Issue #1397)
-    if app.state.event_log is not None:
-        event_bus_ref._event_log = app.state.event_log
+    if app.state.event_log is not None and hasattr(event_bus_ref, "set_event_log"):
+        event_bus_ref.set_event_log(app.state.event_log)
         logger.info("Event log wired into EventBus (WAL-first before pub/sub)")
 
 


### PR DESCRIPTION
## Summary
- **SearchDaemon**: accept `nexus_fs` via constructor parameter instead of post-init `_nexus_fs` direct assignment
- **RedisEventBus**: add public `set_event_log()` method instead of direct `_event_log` private attribute mutation in lifespan startup

Both violations break "immutable after init" (KERNEL-ARCHITECTURE.md Rule 6).

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] No runtime behavior changes — same wiring, proper public API
- [ ] Existing search and event bus tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)