### PR TITLE
feat(#1619): Trust-based routing API

### DIFF
--- a/src/nexus/server/api/v2/dependencies.py
+++ b/src/nexus/server/api/v2/dependencies.py
@@ -348,6 +348,9 @@ async def get_reputation_context(
 ) -> tuple[Any, Any, dict[str, Any]]:
     """Get ReputationService + DisputeService + auth context.
 
+    Prefers the singleton ReputationService on app.state (#1619),
+    falling back to per-request instantiation for backward compat.
+
     Returns:
         Tuple of (ReputationService, DisputeService, auth_context dict).
     """
@@ -358,11 +361,16 @@ async def get_reputation_context(
     session_factory = (
         _record_store.session_factory if _record_store is not None else nexus_fs.SessionLocal
     )
-    reputation_service = ReputationService(
-        session_factory=session_factory,
-        cache_maxsize=10_000,
-        cache_ttl=60,
-    )
+
+    # Prefer singleton from lifespan DI (#1619)
+    app_state = _get_app_state()
+    reputation_service = getattr(app_state, "reputation_service", None)
+    if reputation_service is None:
+        reputation_service = ReputationService(
+            session_factory=session_factory,
+            cache_maxsize=10_000,
+            cache_ttl=60,
+        )
     dispute_service = DisputeService(session_factory=session_factory)
 
     context = _get_operation_context(auth_result)

--- a/src/nexus/server/api/v2/routers/delegation.py
+++ b/src/nexus/server/api/v2/routers/delegation.py
@@ -90,6 +90,12 @@ class DelegateRequest(BaseModel):
     scope: DelegationScopeModel | None = Field(
         default=None, description="Fine-grained scope constraints"
     )
+    min_trust_score: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Minimum trust score threshold for coordinator (0.0 = disabled)",
+    )
 
 
 class DelegateResponse(BaseModel):
@@ -147,6 +153,15 @@ class DelegationChainResponse(BaseModel):
 
     chain: list[DelegationChainItem]
     total_depth: int
+
+
+class CompleteDelegationRequest(BaseModel):
+    """Request to complete a delegation with outcome feedback (#1619)."""
+
+    outcome: str = Field(description="Delegation outcome: 'completed', 'failed', or 'timeout'")
+    quality_score: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Optional quality rating (0.0-1.0)"
+    )
 
 
 # =============================================================================
@@ -223,6 +238,7 @@ async def create_delegation(
             intent=request.intent,
             can_sub_delegate=request.can_sub_delegate,
             scope=scope,
+            min_trust_score=request.min_trust_score,
         )
     except Exception as e:
         _handle_delegation_error(e)
@@ -373,6 +389,64 @@ async def get_delegation_chain(
     return DelegationChainResponse(chain=items, total_depth=len(chain) - 1)
 
 
+@router.post("/{delegation_id}/complete")
+async def complete_delegation(
+    delegation_id: str,
+    request: CompleteDelegationRequest,
+    http_request: Request,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),
+) -> dict[str, Any]:
+    """Complete a delegation and submit outcome feedback (#1619)."""
+    subject_type = auth_result.get("subject_type", "")
+    if subject_type != "agent":
+        raise HTTPException(
+            status_code=403,
+            detail="Only agents can complete delegations.",
+        )
+
+    service = _get_delegation_service(http_request)
+
+    # Ownership check: only the parent agent can complete its delegation
+    record = service.get_delegation_by_id(delegation_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Delegation {delegation_id} not found.")
+
+    agent_id = auth_result.get("subject_id", "")
+    if record.parent_agent_id != agent_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the parent agent can complete a delegation.",
+        )
+
+    # Parse outcome
+    from nexus.services.delegation.models import DelegationOutcome
+
+    try:
+        outcome = DelegationOutcome(request.outcome)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid outcome: {request.outcome!r}. "
+            "Must be 'completed', 'failed', or 'timeout'.",
+        ) from e
+
+    try:
+        updated = service.complete_delegation(
+            delegation_id=delegation_id,
+            outcome=outcome,
+            quality_score=request.quality_score,
+        )
+    except Exception as e:
+        _handle_delegation_error(e)
+        raise  # unreachable, but satisfies type checker
+
+    return {
+        "status": updated.status.value,
+        "delegation_id": delegation_id,
+        "outcome": request.outcome,
+    }
+
+
 # =============================================================================
 # Error handling
 # =============================================================================
@@ -385,10 +459,13 @@ def _handle_delegation_error(e: Exception) -> None:
         DelegationNotFoundError,
         DepthExceededError,
         EscalationError,
+        InsufficientTrustError,
         InvalidPrefixError,
         TooManyGrantsError,
     )
 
+    if isinstance(e, InsufficientTrustError):
+        raise HTTPException(status_code=403, detail=str(e)) from e
     if isinstance(e, EscalationError):
         raise HTTPException(status_code=403, detail=str(e)) from e
     if isinstance(e, TooManyGrantsError):

--- a/src/nexus/server/api/v2/routers/reputation.py
+++ b/src/nexus/server/api/v2/routers/reputation.py
@@ -60,6 +60,16 @@ class ReputationScoreResponse(BaseModel):
     updated_at: datetime
 
 
+class TrustScoreResponse(BaseModel):
+    """Lightweight trust score for routing decisions (#1619)."""
+
+    agent_id: str
+    dimension: str
+    score: float
+    confidence: float
+    zone_id: str | None
+
+
 class ReputationLeaderboardResponse(BaseModel):
     """Leaderboard of agents ranked by reputation."""
 
@@ -243,6 +253,54 @@ def get_agent_reputation(
         raise HTTPException(status_code=404, detail="Reputation score not found")
 
     return _score_to_response(score)
+
+
+_VALID_DIMENSIONS = {"composite", "reliability", "quality", "timeliness", "fairness"}
+
+
+@router.get("/api/v2/agents/{agent_id}/trust-score")
+def get_trust_score(
+    agent_id: str,
+    dimension: str = "composite",
+    zone_id: str | None = None,
+    deps: tuple[Any, Any, dict[str, Any]] = Depends(get_reputation_context),
+) -> TrustScoreResponse:
+    """Get lightweight trust score for routing decisions (#1619)."""
+    if dimension not in _VALID_DIMENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid dimension: {dimension!r}. Must be one of: {sorted(_VALID_DIMENSIONS)}",
+        )
+
+    reputation_service, _dispute_service, _auth_ctx = deps
+
+    score = reputation_service.get_reputation(agent_id)
+    if score is None:
+        raise HTTPException(
+            status_code=404, detail=f"No reputation score found for agent {agent_id}"
+        )
+
+    if dimension == "composite":
+        return TrustScoreResponse(
+            agent_id=agent_id,
+            dimension="composite",
+            score=score.composite_score,
+            confidence=score.composite_confidence,
+            zone_id=zone_id,
+        )
+
+    # Per-dimension score from alpha/beta
+    from nexus.services.reputation.reputation_math import compute_beta_score, compute_confidence
+
+    alpha = getattr(score, f"{dimension}_alpha")
+    beta = getattr(score, f"{dimension}_beta")
+    return TrustScoreResponse(
+        agent_id=agent_id,
+        dimension=dimension,
+        score=compute_beta_score(alpha, beta),
+        confidence=compute_confidence(alpha, beta),
+        zone_id=zone_id,
+    )
 
 
 @router.get("/api/v2/reputation/leaderboard")

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -198,7 +198,7 @@ def build_v2_registry(
     try:
         from nexus.server.api.v2.routers.delegation import router as delegation_router
 
-        registry.add(RouterEntry(router=delegation_router, name="delegation", endpoint_count=3))
+        registry.add(RouterEntry(router=delegation_router, name="delegation", endpoint_count=5))
     except ImportError as e:
         logger.warning("Failed to import Delegation routes: %s", e)
 

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -274,6 +274,8 @@ def create_app(
     app.state.key_service = None
     app.state.rebac_circuit_breaker = None
     app.state.chunked_upload_service = None
+    app.state.delegation_service = None
+    app.state.reputation_service = None
 
     # Initialize subscription manager if we have a metadata store
     try:

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -31,6 +31,7 @@ async def startup_services(app: FastAPI) -> list[asyncio.Task]:
 
     _startup_agent_registry(app)
     _startup_key_service(app)
+    _startup_reputation_service(app)
     _startup_delegation_service(app)
     _startup_sandbox_auth(app)
 
@@ -206,6 +207,26 @@ def _startup_key_service(app: FastAPI) -> None:
         app.state.key_service = None
 
 
+def _startup_reputation_service(app: FastAPI) -> None:
+    """Initialize ReputationService singleton for trust routing (#1619)."""
+    if not (app.state.nexus_fs and getattr(app.state.nexus_fs, "SessionLocal", None)):
+        app.state.reputation_service = None
+        return
+
+    try:
+        from nexus.services.reputation.reputation_service import ReputationService
+
+        app.state.reputation_service = ReputationService(
+            session_factory=app.state.nexus_fs.SessionLocal,
+            cache_maxsize=10_000,
+            cache_ttl=60,
+        )
+        logger.info("[REPUTATION] ReputationService initialized (singleton)")
+    except Exception as e:
+        logger.warning("[REPUTATION] Failed to initialize: %s", e, exc_info=True)
+        app.state.reputation_service = None
+
+
 def _startup_delegation_service(app: FastAPI) -> None:
     """Initialize DelegationService for agent delegation (Issue #1618)."""
     if not (app.state.nexus_fs and getattr(app.state.nexus_fs, "SessionLocal", None)):
@@ -223,6 +244,7 @@ def _startup_delegation_service(app: FastAPI) -> None:
         namespace_manager = getattr(app.state.nexus_fs, "_namespace_manager", None)
         entity_registry = getattr(app.state.nexus_fs, "_entity_registry", None)
         agent_registry = getattr(app.state, "agent_registry", None)
+        reputation_service = getattr(app.state, "reputation_service", None)
 
         app.state.delegation_service = DelegationService(
             session_factory=app.state.nexus_fs.SessionLocal,
@@ -230,6 +252,7 @@ def _startup_delegation_service(app: FastAPI) -> None:
             namespace_manager=namespace_manager,
             entity_registry=entity_registry,
             agent_registry=agent_registry,
+            reputation_service=reputation_service,
         )
         logger.info("[DELEGATION] DelegationService initialized and wired")
     except Exception as e:

--- a/src/nexus/services/delegation/__init__.py
+++ b/src/nexus/services/delegation/__init__.py
@@ -11,6 +11,7 @@ Public API:
     DelegationMode        — Enum: COPY, CLEAN, SHARED
     DelegationStatus      — Enum: ACTIVE, REVOKED, EXPIRED, COMPLETED
     DelegationScope       — Fine-grained scope constraints
+    DelegationOutcome     — Enum: COMPLETED, FAILED, TIMEOUT (#1619)
     derive_grants         — Pure function: parent grants → child grants
     GrantSpec             — Single grant to materialize
 
@@ -23,6 +24,7 @@ Errors:
     DelegationChainError  — Delegated agent tries to delegate
     DepthExceededError    — Sub-delegation depth exceeded
     InvalidPrefixError    — Malformed scope_prefix
+    InsufficientTrustError — Trust score below threshold (#1619)
 """
 
 from nexus.services.delegation.derivation import GrantSpec as GrantSpec
@@ -32,12 +34,14 @@ from nexus.services.delegation.errors import DelegationError as DelegationError
 from nexus.services.delegation.errors import DelegationNotFoundError as DelegationNotFoundError
 from nexus.services.delegation.errors import DepthExceededError as DepthExceededError
 from nexus.services.delegation.errors import EscalationError as EscalationError
+from nexus.services.delegation.errors import InsufficientTrustError as InsufficientTrustError
 from nexus.services.delegation.errors import (
     InvalidDelegationModeError as InvalidDelegationModeError,
 )
 from nexus.services.delegation.errors import InvalidPrefixError as InvalidPrefixError
 from nexus.services.delegation.errors import TooManyGrantsError as TooManyGrantsError
 from nexus.services.delegation.models import DelegationMode as DelegationMode
+from nexus.services.delegation.models import DelegationOutcome as DelegationOutcome
 from nexus.services.delegation.models import DelegationRecord as DelegationRecord
 from nexus.services.delegation.models import DelegationResult as DelegationResult
 from nexus.services.delegation.models import DelegationScope as DelegationScope

--- a/src/nexus/services/delegation/errors.py
+++ b/src/nexus/services/delegation/errors.py
@@ -6,7 +6,8 @@ Hierarchy:
     ├── TooManyGrantsError     - Exceeds MAX_DELEGATABLE_GRANTS
     ├── InvalidDelegationModeError - Unknown mode value
     ├── DelegationNotFoundError   - Delegation ID not found
-    └── DelegationChainError      - Delegated agent tries to delegate
+    ├── DelegationChainError      - Delegated agent tries to delegate
+    └── InsufficientTrustError    - Agent trust score below threshold (#1619)
 """
 
 from __future__ import annotations
@@ -49,3 +50,22 @@ class DepthExceededError(DelegationError):
 
 class InvalidPrefixError(DelegationError):
     """Raised when scope_prefix fails validation (empty, relative, malformed)."""
+
+
+class InsufficientTrustError(DelegationError):
+    """Raised when agent trust score is below the required threshold (#1619).
+
+    Attributes:
+        agent_id: The agent whose trust score was checked.
+        score: The agent's current trust score (None if no score exists).
+        threshold: The minimum required trust score.
+    """
+
+    def __init__(self, agent_id: str, score: float | None, threshold: float) -> None:
+        self.agent_id = agent_id
+        self.score = score
+        self.threshold = threshold
+        score_str = f"{score:.3f}" if score is not None else "None"
+        super().__init__(
+            f"Agent {agent_id} trust score {score_str} is below threshold {threshold:.3f}"
+        )

--- a/src/nexus/services/delegation/models.py
+++ b/src/nexus/services/delegation/models.py
@@ -29,6 +29,20 @@ class DelegationMode(Enum):
     SHARED = "shared"
 
 
+class DelegationOutcome(Enum):
+    """Outcome of a completed delegation (#1619).
+
+    Used by ``complete_delegation()`` to determine feedback signal:
+    - COMPLETED: Positive feedback on reliability + quality.
+    - FAILED: Negative feedback on reliability.
+    - TIMEOUT: Negative feedback on timeliness.
+    """
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+
+
 class DelegationStatus(Enum):
     """Delegation lifecycle state.
 

--- a/src/nexus/services/delegation/service.py
+++ b/src/nexus/services/delegation/service.py
@@ -37,9 +37,11 @@ from nexus.services.delegation.errors import (
     DelegationError,
     DelegationNotFoundError,
     DepthExceededError,
+    InsufficientTrustError,
 )
 from nexus.services.delegation.models import (
     DelegationMode,
+    DelegationOutcome,
     DelegationRecord,
     DelegationResult,
     DelegationScope,
@@ -53,6 +55,7 @@ if TYPE_CHECKING:
     from nexus.services.permissions.entity_registry import EntityRegistry
     from nexus.services.permissions.namespace_manager import NamespaceManager
     from nexus.services.permissions.rebac_manager_enhanced import EnhancedReBACManager
+    from nexus.services.reputation.reputation_service import ReputationService
 
 logger = logging.getLogger(__name__)
 
@@ -77,12 +80,14 @@ class DelegationService:
         namespace_manager: NamespaceManager | None = None,
         entity_registry: EntityRegistry | None = None,
         agent_registry: AgentRegistry | None = None,
+        reputation_service: ReputationService | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._rebac_manager = rebac_manager
         self._namespace_manager = namespace_manager
         self._entity_registry = entity_registry
         self._agent_registry: AgentRegistry | None = agent_registry
+        self._reputation_service = reputation_service
         logger.info("[DelegationService] Initialized")
 
     @contextmanager
@@ -119,6 +124,7 @@ class DelegationService:
         intent: str = "",
         can_sub_delegate: bool = False,
         scope: DelegationScope | None = None,
+        min_trust_score: float = 0.0,
     ) -> DelegationResult:
         """Create a delegated worker agent with narrowed permissions.
 
@@ -137,6 +143,7 @@ class DelegationService:
             intent: Immutable purpose description for audit trail.
             can_sub_delegate: Whether worker can create further delegations.
             scope: Fine-grained operation/resource/budget constraints.
+            min_trust_score: Minimum trust score for coordinator (0.0 = disabled).
 
         Returns:
             DelegationResult with worker agent ID, API key, and mount table.
@@ -146,10 +153,21 @@ class DelegationService:
             DepthExceededError: If chain depth exceeds max_depth.
             DelegationError: If coordinator is not registered.
             EscalationError: If grants would exceed parent's permissions.
+            InsufficientTrustError: If coordinator trust score < min_trust_score.
             TooManyGrantsError: If too many grants derived.
         """
         # 1. Validate coordinator is registered and can delegate
         parent_delegation = self._validate_coordinator(coordinator_agent_id)
+
+        # 1b. Trust gate: reject if coordinator trust score is below threshold (#1619)
+        if min_trust_score > 0.0 and self._reputation_service is not None:
+            score = self._reputation_service.get_reputation(coordinator_agent_id)
+            if score is None or score.composite_score < min_trust_score:
+                raise InsufficientTrustError(
+                    agent_id=coordinator_agent_id,
+                    score=score.composite_score if score else None,
+                    threshold=min_trust_score,
+                )
 
         # 2. Compute chain depth
         depth = 0
@@ -406,6 +424,106 @@ class DelegationService:
             current_id = record.parent_delegation_id
 
         return chain
+
+    def complete_delegation(
+        self,
+        delegation_id: str,
+        outcome: DelegationOutcome,
+        quality_score: float | None = None,
+    ) -> DelegationRecord:
+        """Complete a delegation and submit feedback to the reputation system (#1619).
+
+        Args:
+            delegation_id: The delegation to complete.
+            outcome: How the delegation ended (COMPLETED/FAILED/TIMEOUT).
+            quality_score: Optional quality rating (0.0-1.0) for COMPLETED outcome.
+
+        Returns:
+            Updated DelegationRecord.
+
+        Raises:
+            DelegationNotFoundError: If delegation_id not found.
+            DelegationError: If delegation is not ACTIVE or quality_score out of range.
+        """
+        if quality_score is not None and not (0.0 <= quality_score <= 1.0):
+            raise DelegationError(f"quality_score must be between 0.0 and 1.0, got {quality_score}")
+
+        record = self._load_delegation_record(delegation_id)
+        if record is None:
+            raise DelegationNotFoundError(f"Delegation {delegation_id} not found")
+
+        if record.status != DelegationStatus.ACTIVE:
+            raise DelegationError(
+                f"Delegation {delegation_id} is not active (status={record.status.value})"
+            )
+
+        # Update status to COMPLETED
+        self._update_delegation_status(delegation_id, DelegationStatus.COMPLETED)
+
+        # Submit feedback to reputation service if available
+        if self._reputation_service is not None:
+            self._submit_delegation_feedback(record, outcome, quality_score)
+
+        # Return updated record
+        updated = self._load_delegation_record(delegation_id)
+        if updated is None:
+            raise DelegationNotFoundError(f"Delegation {delegation_id} not found after update")
+        return updated
+
+    def _submit_delegation_feedback(
+        self,
+        record: DelegationRecord,
+        outcome: DelegationOutcome,
+        quality_score: float | None,
+    ) -> None:
+        """Submit delegation outcome as reputation feedback (#1619).
+
+        Coordinator (parent) rates the worker based on delegation outcome:
+        - COMPLETED → positive reliability (1.0) + quality (quality_score or 0.8)
+        - FAILED → negative reliability (0.0)
+        - TIMEOUT → negative timeliness (0.0)
+        """
+        if self._reputation_service is None:
+            return  # Caller should have checked; defensive no-op
+
+        zone_id = record.zone_id or "default"
+
+        try:
+            if outcome == DelegationOutcome.COMPLETED:
+                self._reputation_service.submit_feedback(
+                    rater_agent_id=record.parent_agent_id,
+                    rated_agent_id=record.agent_id,
+                    exchange_id=record.delegation_id,
+                    zone_id=zone_id,
+                    outcome="positive",
+                    reliability_score=1.0,
+                    quality_score=quality_score if quality_score is not None else 0.8,
+                )
+            elif outcome == DelegationOutcome.FAILED:
+                self._reputation_service.submit_feedback(
+                    rater_agent_id=record.parent_agent_id,
+                    rated_agent_id=record.agent_id,
+                    exchange_id=record.delegation_id,
+                    zone_id=zone_id,
+                    outcome="negative",
+                    reliability_score=0.0,
+                )
+            elif outcome == DelegationOutcome.TIMEOUT:
+                self._reputation_service.submit_feedback(
+                    rater_agent_id=record.parent_agent_id,
+                    rated_agent_id=record.agent_id,
+                    exchange_id=record.delegation_id,
+                    zone_id=zone_id,
+                    outcome="negative",
+                    timeliness_score=0.0,
+                )
+        except Exception as e:
+            # Feedback is best-effort; don't fail the completion
+            logger.warning(
+                "[Delegation] Failed to submit reputation feedback for delegation=%s: %s",
+                record.delegation_id,
+                e,
+            )
 
     # -------------------------------------------------------------------------
     # Private helpers

--- a/tests/e2e/server/test_trust_routing_e2e.py
+++ b/tests/e2e/server/test_trust_routing_e2e.py
@@ -1,0 +1,346 @@
+"""End-to-end test for trust-based routing API (#1619).
+
+Full integration test with real services (SQLite in-memory):
+1. Submit feedback to build an agent's reputation
+2. Query trust score via ReputationService
+3. Create delegation with min_trust_score — verify trust gate
+4. Complete delegation — verify feedback submitted
+5. Query reputation again — verify score updated
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from nexus.services.agents.agent_registry import AgentRegistry
+from nexus.services.delegation.errors import InsufficientTrustError
+from nexus.services.delegation.models import (
+    DelegationMode,
+    DelegationOutcome,
+    DelegationStatus,
+)
+from nexus.services.delegation.service import DelegationService
+from nexus.services.permissions.entity_registry import EntityRegistry
+from nexus.services.permissions.rebac_manager_enhanced import EnhancedReBACManager
+from nexus.services.reputation.reputation_service import ReputationService
+from nexus.storage.models import Base
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def engine():
+    """Shared SQLite in-memory engine."""
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture()
+def session_factory(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture()
+def rebac_manager(engine):
+    manager = EnhancedReBACManager(
+        engine=engine,
+        cache_ttl_seconds=0,
+        max_depth=10,
+    )
+    yield manager
+    manager.close()
+
+
+@pytest.fixture()
+def entity_registry(engine):
+    return EntityRegistry(engine)
+
+
+@pytest.fixture()
+def agent_registry(session_factory, entity_registry):
+    return AgentRegistry(
+        session_factory=session_factory,
+        entity_registry=entity_registry,
+    )
+
+
+@pytest.fixture()
+def reputation_service(session_factory):
+    return ReputationService(
+        session_factory=session_factory,
+        cache_maxsize=100,
+        cache_ttl=0,  # no caching for test determinism
+    )
+
+
+@pytest.fixture()
+def delegation_service(
+    session_factory, rebac_manager, entity_registry, agent_registry, reputation_service
+):
+    return DelegationService(
+        session_factory=session_factory,
+        rebac_manager=rebac_manager,
+        entity_registry=entity_registry,
+        agent_registry=agent_registry,
+        reputation_service=reputation_service,
+    )
+
+
+def _setup_coordinator(entity_registry, rebac_manager, agent_id="coordinator_agent"):
+    """Register a coordinator agent with file grants."""
+    entity_registry.register_entity(entity_type="user", entity_id="alice")
+    entity_registry.register_entity(
+        entity_type="agent",
+        entity_id=agent_id,
+        parent_type="user",
+        parent_id="alice",
+    )
+    rebac_manager.rebac_write_batch(
+        [
+            {
+                "subject": ("agent", agent_id),
+                "relation": "direct_editor",
+                "object": ("file", "/workspace/project/src/main.py"),
+                "zone_id": "default",
+            },
+            {
+                "subject": ("agent", agent_id),
+                "relation": "direct_editor",
+                "object": ("file", "/workspace/project/src/utils.py"),
+                "zone_id": "default",
+            },
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrustRoutingE2E:
+    """Full trust-based routing integration test."""
+
+    def test_trust_gate_allows_high_reputation(
+        self,
+        delegation_service,
+        reputation_service,
+        entity_registry,
+        rebac_manager,
+    ):
+        """Agent with good reputation passes the trust gate."""
+        _setup_coordinator(entity_registry, rebac_manager)
+
+        # Build up coordinator's reputation with positive feedback
+        for i in range(5):
+            reputation_service.submit_feedback(
+                rater_agent_id=f"rater-{i}",
+                rated_agent_id="coordinator_agent",
+                exchange_id=f"exchange-{i}",
+                zone_id="default",
+                outcome="positive",
+                reliability_score=1.0,
+                quality_score=0.9,
+            )
+
+        # Verify trust score is high
+        score = reputation_service.get_reputation("coordinator_agent")
+        assert score is not None
+        assert score.composite_score > 0.6
+
+        # Delegation with min_trust_score=0.5 should succeed
+        result = delegation_service.delegate(
+            coordinator_agent_id="coordinator_agent",
+            coordinator_owner_id="alice",
+            worker_id="worker-trust-ok",
+            worker_name="Trusted Worker",
+            delegation_mode=DelegationMode.COPY,
+            zone_id="default",
+            min_trust_score=0.5,
+        )
+
+        assert result.worker_agent_id == "worker-trust-ok"
+        assert result.delegation_id is not None
+
+    def test_trust_gate_rejects_low_reputation(
+        self,
+        delegation_service,
+        reputation_service,
+        entity_registry,
+        rebac_manager,
+    ):
+        """Agent with poor reputation is rejected by the trust gate."""
+        _setup_coordinator(entity_registry, rebac_manager)
+
+        # Build negative reputation
+        for i in range(5):
+            reputation_service.submit_feedback(
+                rater_agent_id=f"rater-{i}",
+                rated_agent_id="coordinator_agent",
+                exchange_id=f"neg-exchange-{i}",
+                zone_id="default",
+                outcome="negative",
+                reliability_score=0.0,
+            )
+
+        # Delegation with min_trust_score=0.7 should fail
+        with pytest.raises(InsufficientTrustError) as exc_info:
+            delegation_service.delegate(
+                coordinator_agent_id="coordinator_agent",
+                coordinator_owner_id="alice",
+                worker_id="worker-trust-fail",
+                worker_name="Untrusted Worker",
+                delegation_mode=DelegationMode.COPY,
+                zone_id="default",
+                min_trust_score=0.7,
+            )
+
+        assert exc_info.value.agent_id == "coordinator_agent"
+        assert exc_info.value.threshold == 0.7
+
+    def test_trust_gate_rejects_unknown_agent(
+        self,
+        delegation_service,
+        entity_registry,
+        rebac_manager,
+    ):
+        """Agent with no reputation data is rejected when threshold > 0."""
+        _setup_coordinator(entity_registry, rebac_manager)
+
+        with pytest.raises(InsufficientTrustError) as exc_info:
+            delegation_service.delegate(
+                coordinator_agent_id="coordinator_agent",
+                coordinator_owner_id="alice",
+                worker_id="worker-no-rep",
+                worker_name="Unknown Worker",
+                delegation_mode=DelegationMode.COPY,
+                zone_id="default",
+                min_trust_score=0.5,
+            )
+
+        assert exc_info.value.score is None
+
+    def test_complete_delegation_updates_reputation(
+        self,
+        delegation_service,
+        reputation_service,
+        entity_registry,
+        rebac_manager,
+    ):
+        """Completing a delegation submits feedback that updates reputation."""
+        _setup_coordinator(entity_registry, rebac_manager)
+
+        # Create delegation (no trust gate)
+        result = delegation_service.delegate(
+            coordinator_agent_id="coordinator_agent",
+            coordinator_owner_id="alice",
+            worker_id="worker-complete",
+            worker_name="Completable Worker",
+            delegation_mode=DelegationMode.COPY,
+            zone_id="default",
+        )
+
+        # Complete the delegation with positive outcome
+        updated = delegation_service.complete_delegation(
+            delegation_id=result.delegation_id,
+            outcome=DelegationOutcome.COMPLETED,
+            quality_score=0.95,
+        )
+
+        assert updated.status == DelegationStatus.COMPLETED
+
+        # Verify reputation was updated for the worker
+        worker_score = reputation_service.get_reputation("worker-complete")
+        assert worker_score is not None
+        assert worker_score.positive_interactions >= 1
+
+    def test_complete_delegation_failed_outcome(
+        self,
+        delegation_service,
+        reputation_service,
+        entity_registry,
+        rebac_manager,
+    ):
+        """Failed delegation submits negative reliability feedback."""
+        _setup_coordinator(entity_registry, rebac_manager)
+
+        result = delegation_service.delegate(
+            coordinator_agent_id="coordinator_agent",
+            coordinator_owner_id="alice",
+            worker_id="worker-fail",
+            worker_name="Failing Worker",
+            delegation_mode=DelegationMode.COPY,
+            zone_id="default",
+        )
+
+        updated = delegation_service.complete_delegation(
+            delegation_id=result.delegation_id,
+            outcome=DelegationOutcome.FAILED,
+        )
+
+        assert updated.status == DelegationStatus.COMPLETED
+
+        worker_score = reputation_service.get_reputation("worker-fail")
+        assert worker_score is not None
+        assert worker_score.negative_interactions >= 1
+
+    def test_full_trust_routing_lifecycle(
+        self,
+        delegation_service,
+        reputation_service,
+        entity_registry,
+        rebac_manager,
+    ):
+        """Full lifecycle: build reputation -> trust gate -> complete -> verify."""
+        _setup_coordinator(entity_registry, rebac_manager)
+
+        # Phase 1: Build coordinator's reputation
+        for i in range(3):
+            reputation_service.submit_feedback(
+                rater_agent_id=f"external-{i}",
+                rated_agent_id="coordinator_agent",
+                exchange_id=f"lifecycle-{i}",
+                zone_id="default",
+                outcome="positive",
+                reliability_score=1.0,
+                quality_score=0.9,
+                timeliness_score=0.8,
+            )
+
+        # Phase 2: Trust-gated delegation
+        score_before = reputation_service.get_reputation("coordinator_agent")
+        assert score_before is not None
+        assert score_before.composite_score > 0.5
+
+        result = delegation_service.delegate(
+            coordinator_agent_id="coordinator_agent",
+            coordinator_owner_id="alice",
+            worker_id="worker-lifecycle",
+            worker_name="Lifecycle Worker",
+            delegation_mode=DelegationMode.COPY,
+            zone_id="default",
+            min_trust_score=0.5,
+        )
+
+        # Phase 3: Complete delegation
+        updated = delegation_service.complete_delegation(
+            delegation_id=result.delegation_id,
+            outcome=DelegationOutcome.COMPLETED,
+            quality_score=0.9,
+        )
+        assert updated.status == DelegationStatus.COMPLETED
+
+        # Phase 4: Verify worker reputation was created
+        worker_score = reputation_service.get_reputation("worker-lifecycle")
+        assert worker_score is not None
+        assert worker_score.composite_score > 0.5

--- a/tests/unit/api/test_trust_score_endpoint.py
+++ b/tests/unit/api/test_trust_score_endpoint.py
@@ -1,0 +1,148 @@
+"""Unit tests for the trust-score endpoint (#1619).
+
+Tests the GET /api/v2/agents/{agent_id}/trust-score endpoint:
+1. Returns composite score
+2. Returns per-dimension score
+3. Returns 404 for unknown agent
+4. Returns 400 for invalid dimension
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+
+from nexus.server.api.v2.routers.reputation import (
+    _VALID_DIMENSIONS,
+    TrustScoreResponse,
+    get_trust_score,
+)
+
+
+@dataclass(frozen=True)
+class FakeReputationScore:
+    """Minimal ReputationScore for endpoint testing."""
+
+    agent_id: str = "agent-1"
+    context: str = "general"
+    window: str = "all_time"
+    composite_score: float = 0.75
+    composite_confidence: float = 0.82
+    reliability_alpha: float = 8.0
+    reliability_beta: float = 2.0
+    quality_alpha: float = 6.0
+    quality_beta: float = 1.5
+    timeliness_alpha: float = 4.0
+    timeliness_beta: float = 1.0
+    fairness_alpha: float = 3.0
+    fairness_beta: float = 2.0
+    total_interactions: int = 15
+    positive_interactions: int = 12
+    negative_interactions: int = 3
+    disputed_interactions: int = 0
+    global_trust_score: float | None = None
+    updated_at: datetime = datetime(2025, 1, 1)
+    zone_id: str = "default"
+
+
+class FakeReputationService:
+    """Fake ReputationService for testing."""
+
+    def __init__(self, scores: dict[str, FakeReputationScore | None] | None = None):
+        self._scores = scores or {}
+
+    def get_reputation(self, agent_id: str, **kwargs) -> FakeReputationScore | None:
+        return self._scores.get(agent_id)
+
+
+class TestGetTrustScore:
+    """Tests for the get_trust_score endpoint function."""
+
+    def test_get_trust_score_composite(self):
+        """Returns composite score and confidence."""
+        score = FakeReputationScore(composite_score=0.85, composite_confidence=0.9)
+        rep_service = FakeReputationService({"agent-1": score})
+        deps = (rep_service, None, {})
+
+        result = get_trust_score(agent_id="agent-1", dimension="composite", deps=deps)
+
+        assert isinstance(result, TrustScoreResponse)
+        assert result.agent_id == "agent-1"
+        assert result.dimension == "composite"
+        assert result.score == 0.85
+        assert result.confidence == 0.9
+
+    def test_get_trust_score_reliability_dimension(self):
+        """Returns per-dimension score computed from alpha/beta."""
+        score = FakeReputationScore(reliability_alpha=8.0, reliability_beta=2.0)
+        rep_service = FakeReputationService({"agent-1": score})
+        deps = (rep_service, None, {})
+
+        result = get_trust_score(agent_id="agent-1", dimension="reliability", deps=deps)
+
+        assert result.dimension == "reliability"
+        # Expected: alpha / (alpha + beta) = 8.0 / 10.0 = 0.8
+        assert abs(result.score - 0.8) < 0.001
+        assert result.confidence > 0.0
+
+    def test_get_trust_score_quality_dimension(self):
+        """Returns quality dimension score."""
+        score = FakeReputationScore(quality_alpha=6.0, quality_beta=1.5)
+        rep_service = FakeReputationService({"agent-1": score})
+        deps = (rep_service, None, {})
+
+        result = get_trust_score(agent_id="agent-1", dimension="quality", deps=deps)
+
+        assert result.dimension == "quality"
+        # Expected: 6.0 / 7.5 = 0.8
+        assert abs(result.score - 0.8) < 0.001
+
+    def test_get_trust_score_not_found(self):
+        """Returns 404 for unknown agent."""
+        rep_service = FakeReputationService({})
+        deps = (rep_service, None, {})
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_trust_score(agent_id="unknown-agent", dimension="composite", deps=deps)
+
+        assert exc_info.value.status_code == 404
+
+    def test_get_trust_score_invalid_dimension(self):
+        """Returns 400 for invalid dimension name."""
+        score = FakeReputationScore()
+        rep_service = FakeReputationService({"agent-1": score})
+        deps = (rep_service, None, {})
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_trust_score(agent_id="agent-1", dimension="bogus", deps=deps)
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid dimension" in str(exc_info.value.detail)
+
+    def test_valid_dimensions_set(self):
+        """Verify the set of valid dimensions."""
+        assert {
+            "composite",
+            "reliability",
+            "quality",
+            "timeliness",
+            "fairness",
+        } == _VALID_DIMENSIONS
+
+    def test_get_trust_score_with_zone_id(self):
+        """Zone ID is passed through to response."""
+        score = FakeReputationScore()
+        rep_service = FakeReputationService({"agent-1": score})
+        deps = (rep_service, None, {})
+
+        result = get_trust_score(
+            agent_id="agent-1", dimension="composite", zone_id="my-zone", deps=deps
+        )
+
+        assert result.zone_id == "my-zone"

--- a/tests/unit/services/test_delegation_feedback.py
+++ b/tests/unit/services/test_delegation_feedback.py
@@ -1,0 +1,251 @@
+"""Unit tests for delegation feedback loop (#1619).
+
+Tests that complete_delegation() correctly:
+1. Submits positive feedback on COMPLETED outcome
+2. Submits negative reliability feedback on FAILED outcome
+3. Submits negative timeliness feedback on TIMEOUT outcome
+4. Skips feedback when reputation_service is None
+5. Raises on delegation not found
+6. Raises on already-completed delegation
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.services.delegation.errors import DelegationError, DelegationNotFoundError
+from nexus.services.delegation.models import (
+    DelegationMode,
+    DelegationOutcome,
+    DelegationRecord,
+    DelegationStatus,
+)
+from nexus.services.delegation.service import DelegationService
+
+
+def _make_record(
+    delegation_id: str = "del-1",
+    agent_id: str = "worker-1",
+    parent_agent_id: str = "coordinator-1",
+    status: DelegationStatus = DelegationStatus.ACTIVE,
+    zone_id: str | None = "zone-1",
+) -> DelegationRecord:
+    """Create a minimal DelegationRecord for testing."""
+    return DelegationRecord(
+        delegation_id=delegation_id,
+        agent_id=agent_id,
+        parent_agent_id=parent_agent_id,
+        delegation_mode=DelegationMode.COPY,
+        status=status,
+        zone_id=zone_id,
+    )
+
+
+@pytest.fixture()
+def mock_reputation_service():
+    service = MagicMock()
+    service.submit_feedback.return_value = MagicMock()
+    return service
+
+
+@pytest.fixture()
+def delegation_service(mock_reputation_service):
+    """DelegationService with mocked internals."""
+    service = DelegationService(
+        session_factory=MagicMock(),
+        rebac_manager=MagicMock(),
+        reputation_service=mock_reputation_service,
+    )
+    return service
+
+
+class TestCompleteDelegation:
+    def test_complete_delegation_success_submits_positive_feedback(
+        self, delegation_service, mock_reputation_service
+    ):
+        """COMPLETED -> positive reliability + quality feedback."""
+        active_record = _make_record(status=DelegationStatus.ACTIVE)
+        completed_record = _make_record(status=DelegationStatus.COMPLETED)
+
+        with (
+            patch.object(
+                delegation_service,
+                "_load_delegation_record",
+                side_effect=[active_record, completed_record],
+            ),
+            patch.object(delegation_service, "_update_delegation_status"),
+        ):
+            result = delegation_service.complete_delegation(
+                delegation_id="del-1",
+                outcome=DelegationOutcome.COMPLETED,
+                quality_score=0.95,
+            )
+
+        assert result.status == DelegationStatus.COMPLETED
+        mock_reputation_service.submit_feedback.assert_called_once_with(
+            rater_agent_id="coordinator-1",
+            rated_agent_id="worker-1",
+            exchange_id="del-1",
+            zone_id="zone-1",
+            outcome="positive",
+            reliability_score=1.0,
+            quality_score=0.95,
+        )
+
+    def test_complete_delegation_success_default_quality(
+        self, delegation_service, mock_reputation_service
+    ):
+        """COMPLETED with no quality_score uses 0.8 default."""
+        active_record = _make_record()
+        completed_record = _make_record(status=DelegationStatus.COMPLETED)
+
+        with (
+            patch.object(
+                delegation_service,
+                "_load_delegation_record",
+                side_effect=[active_record, completed_record],
+            ),
+            patch.object(delegation_service, "_update_delegation_status"),
+        ):
+            delegation_service.complete_delegation(
+                delegation_id="del-1",
+                outcome=DelegationOutcome.COMPLETED,
+            )
+
+        mock_reputation_service.submit_feedback.assert_called_once()
+        call_kwargs = mock_reputation_service.submit_feedback.call_args.kwargs
+        assert call_kwargs["quality_score"] == 0.8
+
+    def test_complete_delegation_failure_submits_negative_feedback(
+        self, delegation_service, mock_reputation_service
+    ):
+        """FAILED -> negative reliability feedback."""
+        active_record = _make_record()
+        completed_record = _make_record(status=DelegationStatus.COMPLETED)
+
+        with (
+            patch.object(
+                delegation_service,
+                "_load_delegation_record",
+                side_effect=[active_record, completed_record],
+            ),
+            patch.object(delegation_service, "_update_delegation_status"),
+        ):
+            delegation_service.complete_delegation(
+                delegation_id="del-1",
+                outcome=DelegationOutcome.FAILED,
+            )
+
+        mock_reputation_service.submit_feedback.assert_called_once_with(
+            rater_agent_id="coordinator-1",
+            rated_agent_id="worker-1",
+            exchange_id="del-1",
+            zone_id="zone-1",
+            outcome="negative",
+            reliability_score=0.0,
+        )
+
+    def test_complete_delegation_timeout_submits_timeliness_feedback(
+        self, delegation_service, mock_reputation_service
+    ):
+        """TIMEOUT -> negative timeliness feedback."""
+        active_record = _make_record()
+        completed_record = _make_record(status=DelegationStatus.COMPLETED)
+
+        with (
+            patch.object(
+                delegation_service,
+                "_load_delegation_record",
+                side_effect=[active_record, completed_record],
+            ),
+            patch.object(delegation_service, "_update_delegation_status"),
+        ):
+            delegation_service.complete_delegation(
+                delegation_id="del-1",
+                outcome=DelegationOutcome.TIMEOUT,
+            )
+
+        mock_reputation_service.submit_feedback.assert_called_once_with(
+            rater_agent_id="coordinator-1",
+            rated_agent_id="worker-1",
+            exchange_id="del-1",
+            zone_id="zone-1",
+            outcome="negative",
+            timeliness_score=0.0,
+        )
+
+    def test_complete_delegation_no_reputation_service_skips_feedback(self):
+        """No reputation_service -> feedback skipped, completion still succeeds."""
+        service = DelegationService(
+            session_factory=MagicMock(),
+            rebac_manager=MagicMock(),
+            reputation_service=None,
+        )
+        active_record = _make_record()
+        completed_record = _make_record(status=DelegationStatus.COMPLETED)
+
+        with (
+            patch.object(
+                service,
+                "_load_delegation_record",
+                side_effect=[active_record, completed_record],
+            ),
+            patch.object(service, "_update_delegation_status"),
+        ):
+            result = service.complete_delegation(
+                delegation_id="del-1",
+                outcome=DelegationOutcome.COMPLETED,
+            )
+
+        assert result.status == DelegationStatus.COMPLETED
+
+    def test_complete_delegation_not_found_raises(self, delegation_service):
+        """Non-existent delegation -> DelegationNotFoundError."""
+        with (
+            patch.object(delegation_service, "_load_delegation_record", return_value=None),
+            pytest.raises(DelegationNotFoundError, match="not found"),
+        ):
+            delegation_service.complete_delegation(
+                delegation_id="nonexistent",
+                outcome=DelegationOutcome.COMPLETED,
+            )
+
+    def test_complete_delegation_already_completed_raises(self, delegation_service):
+        """Already-completed delegation -> DelegationError."""
+        completed_record = _make_record(status=DelegationStatus.COMPLETED)
+
+        with (
+            patch.object(
+                delegation_service, "_load_delegation_record", return_value=completed_record
+            ),
+            pytest.raises(DelegationError, match="not active"),
+        ):
+            delegation_service.complete_delegation(
+                delegation_id="del-1",
+                outcome=DelegationOutcome.COMPLETED,
+            )
+
+    def test_complete_delegation_null_zone_defaults_to_default(
+        self, delegation_service, mock_reputation_service
+    ):
+        """zone_id=None uses 'default' for feedback."""
+        active_record = _make_record(zone_id=None)
+        completed_record = _make_record(zone_id=None, status=DelegationStatus.COMPLETED)
+
+        with (
+            patch.object(
+                delegation_service,
+                "_load_delegation_record",
+                side_effect=[active_record, completed_record],
+            ),
+            patch.object(delegation_service, "_update_delegation_status"),
+        ):
+            delegation_service.complete_delegation(
+                delegation_id="del-1",
+                outcome=DelegationOutcome.COMPLETED,
+            )
+
+        call_kwargs = mock_reputation_service.submit_feedback.call_args.kwargs
+        assert call_kwargs["zone_id"] == "default"

--- a/tests/unit/services/test_trust_gate.py
+++ b/tests/unit/services/test_trust_gate.py
@@ -1,0 +1,206 @@
+"""Unit tests for trust gate in DelegationService (#1619).
+
+Tests that the trust gate in delegate() correctly:
+1. Passes when score is above threshold
+2. Rejects when score is below threshold
+3. Rejects when no score exists and threshold > 0
+4. Is disabled by default (min_trust_score=0.0)
+5. Is skipped when reputation_service is None
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.services.delegation.errors import InsufficientTrustError
+from nexus.services.delegation.models import DelegationMode
+from nexus.services.delegation.service import DelegationService
+
+
+@dataclass(frozen=True)
+class FakeReputationScore:
+    """Minimal ReputationScore for testing."""
+
+    agent_id: str = "coordinator-1"
+    context: str = "general"
+    window: str = "all_time"
+    composite_score: float = 0.8
+    composite_confidence: float = 0.7
+    reliability_alpha: float = 5.0
+    reliability_beta: float = 1.0
+    quality_alpha: float = 4.0
+    quality_beta: float = 1.0
+    timeliness_alpha: float = 3.0
+    timeliness_beta: float = 1.0
+    fairness_alpha: float = 3.0
+    fairness_beta: float = 1.0
+    total_interactions: int = 10
+    positive_interactions: int = 8
+    negative_interactions: int = 2
+    disputed_interactions: int = 0
+    global_trust_score: float | None = None
+    updated_at: datetime = datetime(2025, 1, 1)
+    zone_id: str = "default"
+
+
+@pytest.fixture()
+def mock_reputation_service():
+    """Mock ReputationService with controllable get_reputation."""
+    service = MagicMock()
+    service.get_reputation.return_value = FakeReputationScore(composite_score=0.8)
+    return service
+
+
+@pytest.fixture()
+def mock_deps():
+    """Mock dependencies for DelegationService (session_factory, rebac_manager)."""
+    session_factory = MagicMock()
+    rebac_manager = MagicMock()
+    entity_registry = MagicMock()
+    agent_registry = MagicMock()
+    return session_factory, rebac_manager, entity_registry, agent_registry
+
+
+def _make_service(mock_deps, reputation_service=None):
+    """Create DelegationService with mock dependencies."""
+    sf, rebac, entity_reg, agent_reg = mock_deps
+    return DelegationService(
+        session_factory=sf,
+        rebac_manager=rebac,
+        entity_registry=entity_reg,
+        agent_registry=agent_reg,
+        reputation_service=reputation_service,
+    )
+
+
+class TestTrustGate:
+    """Tests for the trust gate in delegate()."""
+
+    def test_delegate_trust_gate_passes(self, mock_deps, mock_reputation_service):
+        """Score above threshold -> delegation proceeds (trust gate passes)."""
+        mock_reputation_service.get_reputation.return_value = FakeReputationScore(
+            composite_score=0.9
+        )
+        service = _make_service(mock_deps, reputation_service=mock_reputation_service)
+
+        # Mock internal methods to isolate trust gate testing
+        with (
+            patch.object(service, "_validate_coordinator", return_value=None),
+            patch.object(service, "_compute_lease_expiry", return_value=None),
+            patch.object(service, "_enumerate_parent_grants", return_value=[]),
+            patch.object(service, "_create_grant_tuples"),
+            patch.object(service, "_persist_delegation_record"),
+            patch.object(service, "_create_worker_api_key", return_value="nxk_test"),
+            patch.object(service, "_get_worker_mount_table", return_value=[]),
+        ):
+            result = service.delegate(
+                coordinator_agent_id="coordinator-1",
+                coordinator_owner_id="owner-1",
+                worker_id="worker-1",
+                worker_name="Worker 1",
+                delegation_mode=DelegationMode.COPY,
+                min_trust_score=0.5,
+            )
+
+        assert result.worker_agent_id == "worker-1"
+        mock_reputation_service.get_reputation.assert_called_once_with("coordinator-1")
+
+    def test_delegate_trust_gate_rejects_low_score(self, mock_deps, mock_reputation_service):
+        """Score below threshold -> InsufficientTrustError."""
+        mock_reputation_service.get_reputation.return_value = FakeReputationScore(
+            composite_score=0.3
+        )
+        service = _make_service(mock_deps, reputation_service=mock_reputation_service)
+
+        with (
+            patch.object(service, "_validate_coordinator", return_value=None),
+            pytest.raises(InsufficientTrustError) as exc_info,
+        ):
+            service.delegate(
+                coordinator_agent_id="coordinator-1",
+                coordinator_owner_id="owner-1",
+                worker_id="worker-1",
+                worker_name="Worker 1",
+                delegation_mode=DelegationMode.COPY,
+                min_trust_score=0.5,
+            )
+
+        assert exc_info.value.agent_id == "coordinator-1"
+        assert exc_info.value.score == 0.3
+        assert exc_info.value.threshold == 0.5
+
+    def test_delegate_trust_gate_rejects_no_score(self, mock_deps, mock_reputation_service):
+        """No score + threshold > 0 -> InsufficientTrustError."""
+        mock_reputation_service.get_reputation.return_value = None
+        service = _make_service(mock_deps, reputation_service=mock_reputation_service)
+
+        with (
+            patch.object(service, "_validate_coordinator", return_value=None),
+            pytest.raises(InsufficientTrustError) as exc_info,
+        ):
+            service.delegate(
+                coordinator_agent_id="coordinator-1",
+                coordinator_owner_id="owner-1",
+                worker_id="worker-1",
+                worker_name="Worker 1",
+                delegation_mode=DelegationMode.COPY,
+                min_trust_score=0.5,
+            )
+
+        assert exc_info.value.score is None
+        assert exc_info.value.threshold == 0.5
+
+    def test_delegate_trust_gate_disabled_by_default(self, mock_deps, mock_reputation_service):
+        """min_trust_score=0.0 (default) -> trust gate skipped."""
+        service = _make_service(mock_deps, reputation_service=mock_reputation_service)
+
+        with (
+            patch.object(service, "_validate_coordinator", return_value=None),
+            patch.object(service, "_compute_lease_expiry", return_value=None),
+            patch.object(service, "_enumerate_parent_grants", return_value=[]),
+            patch.object(service, "_create_grant_tuples"),
+            patch.object(service, "_persist_delegation_record"),
+            patch.object(service, "_create_worker_api_key", return_value="nxk_test"),
+            patch.object(service, "_get_worker_mount_table", return_value=[]),
+        ):
+            result = service.delegate(
+                coordinator_agent_id="coordinator-1",
+                coordinator_owner_id="owner-1",
+                worker_id="worker-1",
+                worker_name="Worker 1",
+                delegation_mode=DelegationMode.COPY,
+                min_trust_score=0.0,  # default — disabled
+            )
+
+        assert result.worker_agent_id == "worker-1"
+        # get_reputation should NOT have been called
+        mock_reputation_service.get_reputation.assert_not_called()
+
+    def test_delegate_no_reputation_service(self, mock_deps):
+        """reputation_service=None -> trust gate skipped entirely."""
+        service = _make_service(mock_deps, reputation_service=None)
+
+        with (
+            patch.object(service, "_validate_coordinator", return_value=None),
+            patch.object(service, "_compute_lease_expiry", return_value=None),
+            patch.object(service, "_enumerate_parent_grants", return_value=[]),
+            patch.object(service, "_create_grant_tuples"),
+            patch.object(service, "_persist_delegation_record"),
+            patch.object(service, "_create_worker_api_key", return_value="nxk_test"),
+            patch.object(service, "_get_worker_mount_table", return_value=[]),
+        ):
+            # Even with high threshold, should succeed since no reputation_service
+            result = service.delegate(
+                coordinator_agent_id="coordinator-1",
+                coordinator_owner_id="owner-1",
+                worker_id="worker-1",
+                worker_name="Worker 1",
+                delegation_mode=DelegationMode.COPY,
+                min_trust_score=0.99,
+            )
+
+        assert result.worker_agent_id == "worker-1"


### PR DESCRIPTION
## Summary

Wires the existing `ReputationService` (Bayesian Beta scoring, 4 dimensions) into delegation routing decisions via:

- **Trust gate** in `DelegationService.delegate()` — rejects delegations when coordinator trust score is below `min_trust_score` threshold (default 0.0 = disabled)
- **`complete_delegation()` method** — completes a delegation and auto-submits feedback (reliability/quality/timeliness) to the reputation system based on outcome
- **`GET /api/v2/agents/{agent_id}/trust-score`** endpoint — lightweight trust score query for routing decisions, supports composite and per-dimension scores
- **`POST /api/v2/agents/delegate/{id}/complete`** endpoint — delegation completion with outcome feedback
- **Singleton `ReputationService`** on `app.state` — eliminates per-request cache waste, wired via lifespan DI

**Stream:** 6

## Changes

| File | Change |
|------|--------|
| `services/delegation/errors.py` | `InsufficientTrustError` with agent_id, score, threshold |
| `services/delegation/models.py` | `DelegationOutcome` enum (COMPLETED/FAILED/TIMEOUT) |
| `services/delegation/service.py` | Trust gate, `complete_delegation()`, feedback loop |
| `services/delegation/__init__.py` | Export new types |
| `server/api/v2/routers/reputation.py` | `GET /trust-score` endpoint + `TrustScoreResponse` |
| `server/api/v2/routers/delegation.py` | `min_trust_score` param, `POST /complete` endpoint, error handling |
| `server/lifespan/services.py` | `_startup_reputation_service()` singleton, wired into DelegationService |
| `server/api/v2/dependencies.py` | Singleton preference with per-request fallback |
| `server/fastapi_server.py` | Default `app.state` entries |
| `server/api/v2/versioning.py` | Updated endpoint count 3→5 |

## Tests (26 total)

- `tests/unit/services/test_trust_gate.py` — 5 tests (pass/reject/disabled/no-service)
- `tests/unit/services/test_delegation_feedback.py` — 8 tests (all outcomes + edge cases)
- `tests/unit/api/test_trust_score_endpoint.py` — 7 tests (composite/dimension/404/400)
- `tests/e2e/server/test_trust_routing_e2e.py` — 6 tests (full lifecycle with real SQLite + ReBAC)

## Test plan

- [x] All 26 new tests pass (unit + E2E)
- [x] `ruff check` clean on all files
- [x] `ruff format` clean on all files
- [x] `mypy` clean on modified production files
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)