### PR TITLE
fix(#534): delete dead DatabaseConnection protocol and raw SQL code paths

### DIFF
--- a/src/nexus/cli/commands/skills.py
+++ b/src/nexus/cli/commands/skills.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import json
 import re
 import sys
-from typing import Any
 from urllib.parse import urlparse
 
 import click
@@ -28,67 +27,6 @@ from nexus.cli.utils import (
     handle_error,
 )
 from nexus.raft.zone_manager import ROOT_ZONE_ID
-
-
-class SQLAlchemyDatabaseConnection:
-    """Wrapper for SQLAlchemy session to match DatabaseConnection protocol."""
-
-    def __init__(self, session: Any) -> None:
-        self._session = session
-
-    def execute(self, query: str, params: dict | None = None) -> Any:
-        """Execute a query."""
-        from sqlalchemy import text
-
-        return self._session.execute(text(query), params or {})
-
-    def fetchall(self, query: str, params: dict | None = None) -> list[dict]:
-        """Fetch all results from a query."""
-        from sqlalchemy import text
-
-        result = self._session.execute(text(query), params or {})
-        return [dict(row._mapping) for row in result]
-
-    def fetchone(self, query: str, params: dict | None = None) -> dict | None:
-        """Fetch one result from a query."""
-        from sqlalchemy import text
-
-        result = self._session.execute(text(query), params or {})
-        row = result.fetchone()
-        return dict(row._mapping) if row else None
-
-    def commit(self) -> None:
-        """Commit the transaction."""
-        self._session.commit()
-
-
-def _get_database_connection() -> SQLAlchemyDatabaseConnection | None:
-    """Get database connection for skill governance.
-
-    Returns wrapped SQLAlchemy session using NEXUS_DATABASE_URL environment variable.
-    Returns None if not configured (falls back to in-memory storage).
-
-    TODO(#1597): Replace ad-hoc create_engine + sessionmaker with injected
-    session_factory when CLI gains proper DI support.
-    """
-    import os
-
-    db_url = os.getenv("NEXUS_DATABASE_URL")
-    if not db_url:
-        return None
-
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import sessionmaker
-
-    try:
-        engine = create_engine(db_url, echo=False)
-        SessionLocal = sessionmaker(bind=engine)
-        session = SessionLocal()
-        return SQLAlchemyDatabaseConnection(session)
-    except Exception as e:
-        console.print(f"[yellow]Warning:[/yellow] Could not connect to database: {e}")
-        console.print("[dim]Falling back to in-memory governance storage[/dim]")
-        return None
 
 
 def register_commands(cli: click.Group) -> None:

--- a/src/nexus/skills/analytics.py
+++ b/src/nexus/skills/analytics.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
 
 from nexus.skills.exceptions import SkillValidationError
-from nexus.skills.types import DatabaseConnection
 
 logger = logging.getLogger(__name__)
 
@@ -94,8 +91,8 @@ class SkillAnalyticsTracker:
     Example:
         >>> from nexus.skills import SkillAnalyticsTracker
         >>>
-        >>> # Initialize tracker with database connection
-        >>> tracker = SkillAnalyticsTracker(db_connection)
+        >>> # Initialize tracker
+        >>> tracker = SkillAnalyticsTracker()
         >>>
         >>> # Track skill usage
         >>> await tracker.track_usage(
@@ -114,13 +111,8 @@ class SkillAnalyticsTracker:
         >>> print(f"Total skills: {metrics.total_skills}")
     """
 
-    def __init__(self, db_connection: DatabaseConnection | None = None):
-        """Initialize analytics tracker.
-
-        Args:
-            db_connection: Optional database connection (defaults to in-memory)
-        """
-        self._db = db_connection
+    def __init__(self) -> None:
+        """Initialize analytics tracker."""
         self._in_memory_records: list[SkillUsageRecord] = []
 
     async def track_usage(
@@ -169,35 +161,7 @@ class SkillAnalyticsTracker:
 
         record.validate()
 
-        if self._db:
-            # Insert into database
-            query = """
-            INSERT INTO skill_usage (
-                usage_id, skill_name, agent_id, zone_id,
-                execution_time, success, error_message, timestamp
-            ) VALUES (
-                :usage_id, :skill_name, :agent_id, :zone_id,
-                :execution_time, :success, :error_message, :timestamp
-            )
-            """
-            await asyncio.to_thread(
-                self._db.execute,
-                query,
-                {
-                    "usage_id": usage_id,
-                    "skill_name": skill_name,
-                    "agent_id": agent_id,
-                    "zone_id": zone_id,
-                    "execution_time": execution_time,
-                    "success": success,
-                    "error_message": error_message,
-                    "timestamp": timestamp,
-                },
-            )
-            await asyncio.to_thread(self._db.commit)
-        else:
-            # Store in memory
-            self._in_memory_records.append(record)
+        self._in_memory_records.append(record)
 
         logger.debug(f"Tracked usage for skill '{skill_name}': success={success}")
         return usage_id
@@ -220,83 +184,41 @@ class SkillAnalyticsTracker:
             >>> print(f"Success rate: {analytics.success_rate:.2%}")
             >>> print(f"Avg time: {analytics.avg_execution_time:.2f}s")
         """
-        if self._db:
-            # Query database
-            query = """
-            SELECT
-                COUNT(*) as usage_count,
-                SUM(CASE WHEN success THEN 1 ELSE 0 END) as success_count,
-                SUM(CASE WHEN NOT success THEN 1 ELSE 0 END) as failure_count,
-                AVG(CASE WHEN execution_time IS NOT NULL THEN execution_time END) as avg_execution_time,
-                SUM(COALESCE(execution_time, 0)) as total_execution_time,
-                COUNT(DISTINCT agent_id) as unique_users,
-                MAX(timestamp) as last_used,
-                MIN(timestamp) as first_used
-            FROM skill_usage
-            WHERE skill_name = :skill_name
-            """
-            params = {"skill_name": skill_name}
+        records = [r for r in self._in_memory_records if r.skill_name == skill_name]
 
-            if zone_id:
-                query += " AND zone_id = :zone_id"
-                params["zone_id"] = zone_id
+        if zone_id:
+            records = [r for r in records if r.zone_id == zone_id]
 
-            result = await asyncio.to_thread(self._db.fetchone, query, params)
+        if not records:
+            return SkillAnalytics(skill_name=skill_name)
 
-            if not result:
-                return SkillAnalytics(skill_name=skill_name)
+        usage_count = len(records)
+        success_count = sum(1 for r in records if r.success)
+        failure_count = usage_count - success_count
 
-            analytics = SkillAnalytics(
-                skill_name=skill_name,
-                usage_count=result.get("usage_count", 0),
-                success_count=result.get("success_count", 0),
-                failure_count=result.get("failure_count", 0),
-                avg_execution_time=result.get("avg_execution_time"),
-                total_execution_time=result.get("total_execution_time", 0.0),
-                unique_users=result.get("unique_users", 0),
-                last_used=result.get("last_used"),
-                first_used=result.get("first_used"),
-            )
-            analytics.calculate_success_rate()
-            return analytics
+        execution_times = [r.execution_time for r in records if r.execution_time is not None]
+        avg_execution_time = (
+            sum(execution_times) / len(execution_times) if execution_times else None
+        )
+        total_execution_time = sum(execution_times) if execution_times else 0.0
 
-        else:
-            # Calculate from in-memory records
-            records = [r for r in self._in_memory_records if r.skill_name == skill_name]
+        unique_users = len({r.agent_id for r in records if r.agent_id})
+        last_used = max(r.timestamp for r in records) if records else None
+        first_used = min(r.timestamp for r in records) if records else None
 
-            if zone_id:
-                records = [r for r in records if r.zone_id == zone_id]
-
-            if not records:
-                return SkillAnalytics(skill_name=skill_name)
-
-            usage_count = len(records)
-            success_count = sum(1 for r in records if r.success)
-            failure_count = usage_count - success_count
-
-            execution_times = [r.execution_time for r in records if r.execution_time is not None]
-            avg_execution_time = (
-                sum(execution_times) / len(execution_times) if execution_times else None
-            )
-            total_execution_time = sum(execution_times) if execution_times else 0.0
-
-            unique_users = len({r.agent_id for r in records if r.agent_id})
-            last_used = max(r.timestamp for r in records) if records else None
-            first_used = min(r.timestamp for r in records) if records else None
-
-            analytics = SkillAnalytics(
-                skill_name=skill_name,
-                usage_count=usage_count,
-                success_count=success_count,
-                failure_count=failure_count,
-                avg_execution_time=avg_execution_time,
-                total_execution_time=total_execution_time,
-                unique_users=unique_users,
-                last_used=last_used,
-                first_used=first_used,
-            )
-            analytics.calculate_success_rate()
-            return analytics
+        analytics = SkillAnalytics(
+            skill_name=skill_name,
+            usage_count=usage_count,
+            success_count=success_count,
+            failure_count=failure_count,
+            avg_execution_time=avg_execution_time,
+            total_execution_time=total_execution_time,
+            unique_users=unique_users,
+            last_used=last_used,
+            first_used=first_used,
+        )
+        analytics.calculate_success_rate()
+        return analytics
 
     async def get_dashboard_metrics(self, zone_id: str | None = None) -> DashboardMetrics:
         """Get organization-wide dashboard metrics.
@@ -313,145 +235,47 @@ class SkillAnalyticsTracker:
             >>> print(f"Most used: {metrics.most_used_skills[:5]}")
             >>> print(f"Top contributors: {metrics.top_contributors[:5]}")
         """
-        if self._db:
-            # Query database for dashboard metrics
-            # Most used skills
-            query = """
-            SELECT skill_name, COUNT(*) as usage_count
-            FROM skill_usage
-            """
-            params: dict[str, Any] = {}
+        records = self._in_memory_records
 
-            if zone_id:
-                query += " WHERE zone_id = :zone_id"
-                params["zone_id"] = zone_id
+        if zone_id:
+            records = [r for r in records if r.zone_id == zone_id]
 
-            query += " GROUP BY skill_name ORDER BY usage_count DESC LIMIT 10"
-            most_used = await asyncio.to_thread(self._db.fetchall, query, params)
-            most_used_skills = [(row["skill_name"], row["usage_count"]) for row in most_used]
+        # Count usage by skill
+        usage_by_skill: dict[str, int] = {}
+        for record in records:
+            usage_by_skill[record.skill_name] = usage_by_skill.get(record.skill_name, 0) + 1
 
-            # Top contributors
-            query = """
-            SELECT agent_id, COUNT(*) as contribution_count
-            FROM skill_usage
-            WHERE agent_id IS NOT NULL
-            """
+        most_used_skills = sorted(usage_by_skill.items(), key=lambda x: x[1], reverse=True)[:10]
 
-            if zone_id:
-                query += " AND zone_id = :zone_id"
+        # Count contributions by agent
+        contributions: dict[str, int] = {}
+        for record in records:
+            if record.agent_id:
+                contributions[record.agent_id] = contributions.get(record.agent_id, 0) + 1
 
-            query += " GROUP BY agent_id ORDER BY contribution_count DESC LIMIT 10"
-            top_contrib = await asyncio.to_thread(
-                self._db.fetchall, query, params if zone_id else None
-            )
-            top_contributors = [(row["agent_id"], row["contribution_count"]) for row in top_contrib]
+        top_contributors = sorted(contributions.items(), key=lambda x: x[1], reverse=True)[:10]
 
-            # Overall stats
-            query = """
-            SELECT
-                COUNT(DISTINCT skill_name) as total_skills,
-                COUNT(*) as total_usage,
-                COUNT(DISTINCT agent_id) as total_users
-            FROM skill_usage
-            """
+        # Success rates
+        success_rates = {}
+        for skill_name in usage_by_skill:
+            skill_records = [r for r in records if r.skill_name == skill_name]
+            successes = sum(1 for r in skill_records if r.success)
+            success_rates[skill_name] = successes / len(skill_records) if skill_records else 0.0
 
-            if zone_id:
-                query += " WHERE zone_id = :zone_id"
+        # Avg execution times
+        avg_execution_times = {}
+        for skill_name in usage_by_skill:
+            skill_records = [r for r in records if r.skill_name == skill_name]
+            times = [r.execution_time for r in skill_records if r.execution_time is not None]
+            if times:
+                avg_execution_times[skill_name] = sum(times) / len(times)
 
-            stats = await asyncio.to_thread(self._db.fetchone, query, params if zone_id else None)
-
-            # Success rates per skill
-            query = """
-            SELECT
-                skill_name,
-                CAST(SUM(CASE WHEN success THEN 1 ELSE 0 END) AS FLOAT) / COUNT(*) as success_rate
-            FROM skill_usage
-            """
-
-            if zone_id:
-                query += " WHERE zone_id = :zone_id"
-
-            query += " GROUP BY skill_name"
-            success_rates_rows = await asyncio.to_thread(
-                self._db.fetchall, query, params if zone_id else None
-            )
-            success_rates = {row["skill_name"]: row["success_rate"] for row in success_rates_rows}
-
-            # Avg execution times
-            query = """
-            SELECT
-                skill_name,
-                AVG(execution_time) as avg_time
-            FROM skill_usage
-            WHERE execution_time IS NOT NULL
-            """
-
-            if zone_id:
-                query += " AND zone_id = :zone_id"
-
-            query += " GROUP BY skill_name"
-            avg_times_rows = await asyncio.to_thread(
-                self._db.fetchall, query, params if zone_id else None
-            )
-            avg_execution_times = {
-                row["skill_name"]: row["avg_time"]
-                for row in avg_times_rows
-                if row["avg_time"] is not None
-            }
-
-            return DashboardMetrics(
-                total_skills=stats.get("total_skills", 0) if stats else 0,
-                total_usage_count=stats.get("total_usage", 0) if stats else 0,
-                total_users=stats.get("total_users", 0) if stats else 0,
-                most_used_skills=most_used_skills,
-                top_contributors=top_contributors,
-                success_rates=success_rates,
-                avg_execution_times=avg_execution_times,
-            )
-
-        else:
-            # Calculate from in-memory records
-            records = self._in_memory_records
-
-            if zone_id:
-                records = [r for r in records if r.zone_id == zone_id]
-
-            # Count usage by skill
-            usage_by_skill: dict[str, int] = {}
-            for record in records:
-                usage_by_skill[record.skill_name] = usage_by_skill.get(record.skill_name, 0) + 1
-
-            most_used_skills = sorted(usage_by_skill.items(), key=lambda x: x[1], reverse=True)[:10]
-
-            # Count contributions by agent
-            contributions: dict[str, int] = {}
-            for record in records:
-                if record.agent_id:
-                    contributions[record.agent_id] = contributions.get(record.agent_id, 0) + 1
-
-            top_contributors = sorted(contributions.items(), key=lambda x: x[1], reverse=True)[:10]
-
-            # Success rates
-            success_rates = {}
-            for skill_name in usage_by_skill:
-                skill_records = [r for r in records if r.skill_name == skill_name]
-                successes = sum(1 for r in skill_records if r.success)
-                success_rates[skill_name] = successes / len(skill_records) if skill_records else 0.0
-
-            # Avg execution times
-            avg_execution_times = {}
-            for skill_name in usage_by_skill:
-                skill_records = [r for r in records if r.skill_name == skill_name]
-                times = [r.execution_time for r in skill_records if r.execution_time is not None]
-                if times:
-                    avg_execution_times[skill_name] = sum(times) / len(times)
-
-            return DashboardMetrics(
-                total_skills=len(usage_by_skill),
-                total_usage_count=len(records),
-                total_users=len(contributions),
-                most_used_skills=most_used_skills,
-                top_contributors=top_contributors,
-                success_rates=success_rates,
-                avg_execution_times=avg_execution_times,
-            )
+        return DashboardMetrics(
+            total_skills=len(usage_by_skill),
+            total_usage_count=len(records),
+            total_users=len(contributions),
+            most_used_skills=most_used_skills,
+            top_contributors=top_contributors,
+            success_rates=success_rates,
+            avg_execution_times=avg_execution_times,
+        )

--- a/src/nexus/skills/audit.py
+++ b/src/nexus/skills/audit.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
 from dataclasses import dataclass
@@ -11,7 +10,6 @@ from enum import StrEnum
 from typing import Any
 
 from nexus.skills.exceptions import SkillValidationError
-from nexus.skills.types import DatabaseConnection
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +67,7 @@ class SkillAuditLogger:
         >>> from nexus.skills import SkillAuditLogger, AuditAction
         >>>
         >>> # Initialize logger
-        >>> audit = SkillAuditLogger(db_connection)
+        >>> audit = SkillAuditLogger()
         >>>
         >>> # Log skill execution
         >>> await audit.log(
@@ -89,13 +87,8 @@ class SkillAuditLogger:
         ...     print(f"{log.action.value} by {log.agent_id} at {log.timestamp}")
     """
 
-    def __init__(self, db_connection: DatabaseConnection | None = None):
-        """Initialize audit logger.
-
-        Args:
-            db_connection: Optional database connection (defaults to in-memory)
-        """
-        self._db = db_connection
+    def __init__(self) -> None:
+        """Initialize audit logger."""
         self._in_memory_logs: list[AuditLogEntry] = []
 
     async def log(
@@ -146,36 +139,7 @@ class SkillAuditLogger:
 
         entry.validate()
 
-        if self._db:
-            # Insert into database
-            query = """
-            INSERT INTO skill_audit_log (
-                audit_id, skill_name, action, agent_id,
-                zone_id, details, timestamp
-            ) VALUES (
-                :audit_id, :skill_name, :action, :agent_id,
-                :zone_id, :details, :timestamp
-            )
-            """
-            import json
-
-            await asyncio.to_thread(
-                self._db.execute,
-                query,
-                {
-                    "audit_id": audit_id,
-                    "skill_name": skill_name,
-                    "action": action.value,
-                    "agent_id": agent_id,
-                    "zone_id": zone_id,
-                    "details": json.dumps(details) if details else None,
-                    "timestamp": timestamp,
-                },
-            )
-            await asyncio.to_thread(self._db.commit)
-        else:
-            # Store in memory
-            self._in_memory_logs.append(entry)
+        self._in_memory_logs.append(entry)
 
         logger.debug(f"Logged {action.value} for skill '{skill_name}' (ID: {audit_id})")
         return audit_id
@@ -219,89 +183,34 @@ class SkillAuditLogger:
             >>> yesterday = datetime.now(timezone.utc) - timedelta(days=1)
             >>> logs = await audit.query_logs(start_time=yesterday)
         """
-        if self._db:
-            # Build query
-            query = "SELECT * FROM skill_audit_log WHERE 1=1"
-            params: dict[str, Any] = {}
+        logs = self._in_memory_logs
 
-            if skill_name:
-                query += " AND skill_name = :skill_name"
-                params["skill_name"] = skill_name
+        if skill_name:
+            logs = [log for log in logs if log.skill_name == skill_name]
 
-            if action:
-                query += " AND action = :action"
-                params["action"] = action.value
+        if action:
+            logs = [log for log in logs if log.action == action]
 
-            if agent_id:
-                query += " AND agent_id = :agent_id"
-                params["agent_id"] = agent_id
+        if agent_id:
+            logs = [log for log in logs if log.agent_id == agent_id]
 
-            if zone_id:
-                query += " AND zone_id = :zone_id"
-                params["zone_id"] = zone_id
+        if zone_id:
+            logs = [log for log in logs if log.zone_id == zone_id]
 
-            if start_time:
-                query += " AND timestamp >= :start_time"
-                params["start_time"] = start_time
+        if start_time:
+            logs = [log for log in logs if log.timestamp >= start_time]
 
-            if end_time:
-                query += " AND timestamp <= :end_time"
-                params["end_time"] = end_time
+        if end_time:
+            logs = [log for log in logs if log.timestamp <= end_time]
 
-            query += " ORDER BY timestamp DESC"
+        # Sort by timestamp descending
+        logs = sorted(logs, key=lambda x: x.timestamp, reverse=True)
 
-            if limit:
-                query += f" LIMIT {limit}"
+        # Limit results
+        if limit:
+            logs = logs[:limit]
 
-            import json
-
-            results = await asyncio.to_thread(self._db.fetchall, query, params)
-            logs = []
-            for row in results:
-                details = json.loads(row["details"]) if row.get("details") else None
-                logs.append(
-                    AuditLogEntry(
-                        audit_id=row["audit_id"],
-                        skill_name=row["skill_name"],
-                        action=AuditAction(row["action"]),
-                        agent_id=row.get("agent_id"),
-                        zone_id=row.get("zone_id"),
-                        details=details,
-                        timestamp=row["timestamp"],
-                    )
-                )
-            return logs
-
-        else:
-            # Filter in-memory logs
-            logs = self._in_memory_logs
-
-            if skill_name:
-                logs = [log for log in logs if log.skill_name == skill_name]
-
-            if action:
-                logs = [log for log in logs if log.action == action]
-
-            if agent_id:
-                logs = [log for log in logs if log.agent_id == agent_id]
-
-            if zone_id:
-                logs = [log for log in logs if log.zone_id == zone_id]
-
-            if start_time:
-                logs = [log for log in logs if log.timestamp >= start_time]
-
-            if end_time:
-                logs = [log for log in logs if log.timestamp <= end_time]
-
-            # Sort by timestamp descending
-            logs = sorted(logs, key=lambda x: x.timestamp, reverse=True)
-
-            # Limit results
-            if limit:
-                logs = logs[:limit]
-
-            return logs
+        return logs
 
     async def get_skill_activity(self, skill_name: str) -> dict[str, Any]:
         """Get activity summary for a skill.

--- a/src/nexus/skills/governance.py
+++ b/src/nexus/skills/governance.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from nexus.skills.exceptions import SkillPermissionDeniedError, SkillValidationError
-from nexus.skills.types import DatabaseConnection
 
 if TYPE_CHECKING:
     from nexus.rebac.manager import ReBACManager
@@ -79,7 +77,7 @@ class SkillGovernance:
         >>> from nexus.skills import SkillGovernance
         >>>
         >>> # Initialize governance
-        >>> gov = SkillGovernance(db_connection)
+        >>> gov = SkillGovernance()
         >>>
         >>> # Submit skill for approval
         >>> approval_id = await gov.submit_for_approval(
@@ -101,16 +99,13 @@ class SkillGovernance:
 
     def __init__(
         self,
-        db_connection: DatabaseConnection | None = None,
         rebac_manager: ReBACManager | None = None,
     ):
         """Initialize governance system.
 
         Args:
-            db_connection: Optional database connection (defaults to in-memory)
             rebac_manager: Optional ReBAC manager for permission checks
         """
-        self._db = db_connection
         self._rebac = rebac_manager
         self._in_memory_approvals: dict[str, SkillApproval] = {}
 
@@ -165,36 +160,7 @@ class SkillGovernance:
 
         approval.validate()
 
-        if self._db:
-            # Insert into database
-            query = """
-            INSERT INTO skill_approvals (
-                approval_id, skill_name, submitted_by, status,
-                reviewers, comments, submitted_at
-            ) VALUES (
-                :approval_id, :skill_name, :submitted_by, :status,
-                :reviewers, :comments, :submitted_at
-            )
-            """
-            import json
-
-            await asyncio.to_thread(
-                self._db.execute,
-                query,
-                {
-                    "approval_id": approval_id,
-                    "skill_name": skill_name,
-                    "submitted_by": submitted_by,
-                    "status": approval.status.value,
-                    "reviewers": json.dumps(reviewers) if reviewers else None,
-                    "comments": comments,
-                    "submitted_at": submitted_at,
-                },
-            )
-            await asyncio.to_thread(self._db.commit)
-        else:
-            # Store in memory
-            self._in_memory_approvals[approval_id] = approval
+        self._in_memory_approvals[approval_id] = approval
 
         logger.info(f"Submitted skill '{skill_name}' for approval (ID: {approval_id})")
         return approval_id
@@ -257,39 +223,14 @@ class SkillGovernance:
                 logger.warning(
                     f"ReBAC check failed for approval of skill '{approval.skill_name}': {e}"
                 )
-                # Continue if ReBAC check fails (backward compatibility)
 
         reviewed_at = datetime.now(UTC)
 
-        if self._db:
-            # Update in database
-            query = """
-            UPDATE skill_approvals
-            SET status = :status,
-                reviewed_by = :reviewed_by,
-                reviewed_at = :reviewed_at,
-                comments = :comments
-            WHERE approval_id = :approval_id
-            """
-            await asyncio.to_thread(
-                self._db.execute,
-                query,
-                {
-                    "status": ApprovalStatus.APPROVED.value,
-                    "reviewed_by": reviewed_by,
-                    "reviewed_at": reviewed_at,
-                    "comments": comments or approval.comments,
-                    "approval_id": approval_id,
-                },
-            )
-            await asyncio.to_thread(self._db.commit)
-        else:
-            # Update in memory
-            approval.status = ApprovalStatus.APPROVED
-            approval.reviewed_by = reviewed_by
-            approval.reviewed_at = reviewed_at
-            if comments:
-                approval.comments = comments
+        approval.status = ApprovalStatus.APPROVED
+        approval.reviewed_by = reviewed_by
+        approval.reviewed_at = reviewed_at
+        if comments:
+            approval.comments = comments
 
         logger.info(f"Approved skill '{approval.skill_name}' (ID: {approval_id}) by {reviewed_by}")
 
@@ -351,39 +292,14 @@ class SkillGovernance:
                 logger.warning(
                     f"ReBAC check failed for rejection of skill '{approval.skill_name}': {e}"
                 )
-                # Continue if ReBAC check fails (backward compatibility)
 
         reviewed_at = datetime.now(UTC)
 
-        if self._db:
-            # Update in database
-            query = """
-            UPDATE skill_approvals
-            SET status = :status,
-                reviewed_by = :reviewed_by,
-                reviewed_at = :reviewed_at,
-                comments = :comments
-            WHERE approval_id = :approval_id
-            """
-            await asyncio.to_thread(
-                self._db.execute,
-                query,
-                {
-                    "status": ApprovalStatus.REJECTED.value,
-                    "reviewed_by": reviewed_by,
-                    "reviewed_at": reviewed_at,
-                    "comments": comments or approval.comments,
-                    "approval_id": approval_id,
-                },
-            )
-            await asyncio.to_thread(self._db.commit)
-        else:
-            # Update in memory
-            approval.status = ApprovalStatus.REJECTED
-            approval.reviewed_by = reviewed_by
-            approval.reviewed_at = reviewed_at
-            if comments:
-                approval.comments = comments
+        approval.status = ApprovalStatus.REJECTED
+        approval.reviewed_by = reviewed_by
+        approval.reviewed_at = reviewed_at
+        if comments:
+            approval.comments = comments
 
         logger.info(f"Rejected skill '{approval.skill_name}' (ID: {approval_id}) by {reviewed_by}")
 
@@ -400,33 +316,14 @@ class SkillGovernance:
             >>> if await gov.is_approved("analyze-code"):
             ...     print("Skill is approved!")
         """
-        if self._db:
-            # Query database
-            query = """
-            SELECT status FROM skill_approvals
-            WHERE skill_name = :skill_name
-            ORDER BY submitted_at DESC
-            LIMIT 1
-            """
-            result = await asyncio.to_thread(self._db.fetchone, query, {"skill_name": skill_name})
+        approvals = [a for a in self._in_memory_approvals.values() if a.skill_name == skill_name]
 
-            if not result:
-                return False
+        if not approvals:
+            return False
 
-            return result.get("status") == ApprovalStatus.APPROVED.value
-
-        else:
-            # Check in-memory approvals
-            approvals = [
-                a for a in self._in_memory_approvals.values() if a.skill_name == skill_name
-            ]
-
-            if not approvals:
-                return False
-
-            # Get most recent approval
-            latest = max(approvals, key=lambda a: a.submitted_at or datetime.min)
-            return latest.status == ApprovalStatus.APPROVED
+        # Get most recent approval
+        latest = max(approvals, key=lambda a: a.submitted_at or datetime.min)
+        return latest.status == ApprovalStatus.APPROVED
 
     async def get_pending_approvals(self, reviewer: str | None = None) -> list[SkillApproval]:
         """Get all pending approval requests.
@@ -445,58 +342,14 @@ class SkillGovernance:
             >>> # Get approvals assigned to specific reviewer
             >>> my_approvals = await gov.get_pending_approvals(reviewer="bob")
         """
-        if self._db:
-            # Query database
-            query = """
-            SELECT * FROM skill_approvals
-            WHERE status = :status
-            """
-            params: dict[str, Any] = {"status": ApprovalStatus.PENDING.value}
+        approvals = [
+            a for a in self._in_memory_approvals.values() if a.status == ApprovalStatus.PENDING
+        ]
 
-            if reviewer:
-                # Check if reviewer is in the reviewers list (JSON array)
-                # This is database-specific; adjust for your DB
-                query += " AND :reviewer IN (SELECT value FROM json_each(reviewers))"
-                params["reviewer"] = reviewer
+        if reviewer:
+            approvals = [a for a in approvals if a.reviewers and reviewer in a.reviewers]
 
-            query += " ORDER BY submitted_at DESC"
-
-            import json
-
-            results = await asyncio.to_thread(self._db.fetchall, query, params)
-            approvals = []
-            for row in results:
-                # Handle JSON column - PostgreSQL auto-deserializes, SQLite returns string
-                reviewers_data = row.get("reviewers")
-                if isinstance(reviewers_data, str):
-                    reviewers = json.loads(reviewers_data)
-                else:
-                    reviewers = reviewers_data  # Already deserialized (PostgreSQL)
-                approvals.append(
-                    SkillApproval(
-                        approval_id=row["approval_id"],
-                        skill_name=row["skill_name"],
-                        submitted_by=row["submitted_by"],
-                        status=ApprovalStatus(row["status"]),
-                        reviewers=reviewers,
-                        comments=row.get("comments"),
-                        submitted_at=row.get("submitted_at"),
-                        reviewed_at=row.get("reviewed_at"),
-                        reviewed_by=row.get("reviewed_by"),
-                    )
-                )
-            return approvals
-
-        else:
-            # Filter in-memory approvals
-            approvals = [
-                a for a in self._in_memory_approvals.values() if a.status == ApprovalStatus.PENDING
-            ]
-
-            if reviewer:
-                approvals = [a for a in approvals if a.reviewers and reviewer in a.reviewers]
-
-            return sorted(approvals, key=lambda a: a.submitted_at or datetime.min, reverse=True)
+        return sorted(approvals, key=lambda a: a.submitted_at or datetime.min, reverse=True)
 
     async def get_approval_history(self, skill_name: str) -> list[SkillApproval]:
         """Get approval history for a skill.
@@ -512,46 +365,8 @@ class SkillGovernance:
             >>> for approval in history:
             ...     print(f"{approval.status.value} by {approval.reviewed_by} at {approval.reviewed_at}")
         """
-        if self._db:
-            # Query database
-            query = """
-            SELECT * FROM skill_approvals
-            WHERE skill_name = :skill_name
-            ORDER BY submitted_at DESC
-            """
-
-            import json
-
-            results = await asyncio.to_thread(self._db.fetchall, query, {"skill_name": skill_name})
-            approvals = []
-            for row in results:
-                # Handle JSON column - PostgreSQL auto-deserializes, SQLite returns string
-                reviewers_data = row.get("reviewers")
-                if isinstance(reviewers_data, str):
-                    reviewers = json.loads(reviewers_data)
-                else:
-                    reviewers = reviewers_data  # Already deserialized (PostgreSQL)
-                approvals.append(
-                    SkillApproval(
-                        approval_id=row["approval_id"],
-                        skill_name=row["skill_name"],
-                        submitted_by=row["submitted_by"],
-                        status=ApprovalStatus(row["status"]),
-                        reviewers=reviewers,
-                        comments=row.get("comments"),
-                        submitted_at=row.get("submitted_at"),
-                        reviewed_at=row.get("reviewed_at"),
-                        reviewed_by=row.get("reviewed_by"),
-                    )
-                )
-            return approvals
-
-        else:
-            # Filter in-memory approvals
-            approvals = [
-                a for a in self._in_memory_approvals.values() if a.skill_name == skill_name
-            ]
-            return sorted(approvals, key=lambda a: a.submitted_at or datetime.min, reverse=True)
+        approvals = [a for a in self._in_memory_approvals.values() if a.skill_name == skill_name]
+        return sorted(approvals, key=lambda a: a.submitted_at or datetime.min, reverse=True)
 
     async def list_approvals(
         self, status: str | None = None, skill_name: str | None = None
@@ -575,139 +390,31 @@ class SkillGovernance:
             >>> # List approvals for a specific skill
             >>> skill_approvals = await gov.list_approvals(skill_name="my-analyzer")
         """
-        if self._db:
-            # Build query with filters
-            query = "SELECT * FROM skill_approvals WHERE 1=1"
-            params: dict[str, Any] = {}
+        approvals = list(self._in_memory_approvals.values())
 
-            if status:
-                query += " AND status = :status"
-                params["status"] = status
+        if status:
+            status_enum = ApprovalStatus(status)
+            approvals = [a for a in approvals if a.status == status_enum]
 
-            if skill_name:
-                query += " AND skill_name = :skill_name"
-                params["skill_name"] = skill_name
+        if skill_name:
+            approvals = [a for a in approvals if a.skill_name == skill_name]
 
-            query += " ORDER BY submitted_at DESC"
-
-            import json
-
-            results = await asyncio.to_thread(self._db.fetchall, query, params)
-            approvals = []
-            for row in results:
-                # Handle JSON column - PostgreSQL auto-deserializes, SQLite returns string
-                reviewers_data = row.get("reviewers")
-                if isinstance(reviewers_data, str):
-                    reviewers = json.loads(reviewers_data)
-                else:
-                    reviewers = reviewers_data  # Already deserialized (PostgreSQL)
-                approvals.append(
-                    SkillApproval(
-                        approval_id=row["approval_id"],
-                        skill_name=row["skill_name"],
-                        submitted_by=row["submitted_by"],
-                        status=ApprovalStatus(row["status"]),
-                        reviewers=reviewers,
-                        comments=row.get("comments"),
-                        submitted_at=row.get("submitted_at"),
-                        reviewed_at=row.get("reviewed_at"),
-                        reviewed_by=row.get("reviewed_by"),
-                    )
-                )
-            return approvals
-
-        else:
-            # Filter in-memory approvals
-            approvals = list(self._in_memory_approvals.values())
-
-            if status:
-                status_enum = ApprovalStatus(status)
-                approvals = [a for a in approvals if a.status == status_enum]
-
-            if skill_name:
-                approvals = [a for a in approvals if a.skill_name == skill_name]
-
-            return sorted(approvals, key=lambda a: a.submitted_at or datetime.min, reverse=True)
+        return sorted(approvals, key=lambda a: a.submitted_at or datetime.min, reverse=True)
 
     async def _get_approval(self, approval_id: str) -> SkillApproval | None:
         """Get approval by ID (internal helper)."""
-        if self._db:
-            query = "SELECT * FROM skill_approvals WHERE approval_id = :approval_id"
-
-            import json
-
-            result = await asyncio.to_thread(self._db.fetchone, query, {"approval_id": approval_id})
-            if not result:
-                return None
-
-            # Handle JSON column - PostgreSQL auto-deserializes, SQLite returns string
-            reviewers_data = result.get("reviewers")
-            if isinstance(reviewers_data, str):
-                reviewers = json.loads(reviewers_data)
-            else:
-                reviewers = reviewers_data  # Already deserialized (PostgreSQL)
-            return SkillApproval(
-                approval_id=result["approval_id"],
-                skill_name=result["skill_name"],
-                submitted_by=result["submitted_by"],
-                status=ApprovalStatus(result["status"]),
-                reviewers=reviewers,
-                comments=result.get("comments"),
-                submitted_at=result.get("submitted_at"),
-                reviewed_at=result.get("reviewed_at"),
-                reviewed_by=result.get("reviewed_by"),
-            )
-        else:
-            return self._in_memory_approvals.get(approval_id)
+        return self._in_memory_approvals.get(approval_id)
 
     async def _get_pending_approval(self, skill_name: str) -> SkillApproval | None:
         """Get pending approval for a skill (internal helper)."""
-        if self._db:
-            query = """
-            SELECT * FROM skill_approvals
-            WHERE skill_name = :skill_name AND status = :status
-            ORDER BY submitted_at DESC
-            LIMIT 1
-            """
+        pending = [
+            a
+            for a in self._in_memory_approvals.values()
+            if a.skill_name == skill_name and a.status == ApprovalStatus.PENDING
+        ]
 
-            import json
+        if not pending:
+            return None
 
-            result = await asyncio.to_thread(
-                self._db.fetchone,
-                query,
-                {"skill_name": skill_name, "status": ApprovalStatus.PENDING.value},
-            )
-
-            if not result:
-                return None
-
-            # Handle JSON column - PostgreSQL auto-deserializes, SQLite returns string
-            reviewers_data = result.get("reviewers")
-            if isinstance(reviewers_data, str):
-                reviewers = json.loads(reviewers_data)
-            else:
-                reviewers = reviewers_data  # Already deserialized (PostgreSQL)
-            return SkillApproval(
-                approval_id=result["approval_id"],
-                skill_name=result["skill_name"],
-                submitted_by=result["submitted_by"],
-                status=ApprovalStatus(result["status"]),
-                reviewers=reviewers,
-                comments=result.get("comments"),
-                submitted_at=result.get("submitted_at"),
-                reviewed_at=result.get("reviewed_at"),
-                reviewed_by=result.get("reviewed_by"),
-            )
-        else:
-            # Find in memory
-            pending = [
-                a
-                for a in self._in_memory_approvals.values()
-                if a.skill_name == skill_name and a.status == ApprovalStatus.PENDING
-            ]
-
-            if not pending:
-                return None
-
-            # Return most recent
-            return max(pending, key=lambda a: a.submitted_at or datetime.min)
+        # Return most recent
+        return max(pending, key=lambda a: a.submitted_at or datetime.min)

--- a/src/nexus/skills/types.py
+++ b/src/nexus/skills/types.py
@@ -32,32 +32,6 @@ class SkillOperationContext(Protocol):
     def is_admin(self) -> bool: ...
 
 
-@runtime_checkable
-class DatabaseConnection(Protocol):
-    """Protocol for database connections.
-
-    This allows analytics, audit, and governance to work with
-    different database backends. Single source of truth for all
-    skills module database interaction.
-    """
-
-    def execute(self, query: str, params: dict[str, Any] | None = None) -> Any:
-        """Execute a query."""
-        ...
-
-    def fetchall(self, query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-        """Fetch all results from a query."""
-        ...
-
-    def fetchone(self, query: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
-        """Fetch one result from a query."""
-        ...
-
-    def commit(self) -> None:
-        """Commit the transaction."""
-        ...
-
-
 @dataclass
 class SkillInfo:
     """Skill information returned by discovery operations.


### PR DESCRIPTION
## Summary
- Delete the unused `DatabaseConnection` protocol from `skills/types.py` — never instantiated in production (all 3 consumers always run in-memory mode with `db_connection=None`)
- Remove `db_connection` parameter and all raw SQL code branches from `SkillAuditLogger`, `SkillAnalyticsTracker`, and `SkillGovernance`
- Delete dead `SQLAlchemyDatabaseConnection` class and `_get_database_connection()` function from `cli/commands/skills.py` (defined but never called)
- Net deletion: ~650 lines of dead code

## Test plan
- [x] All existing unit tests pass (they already use no-argument constructors)
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] No production callers pass `db_connection` — verified via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)