### PR TITLE
fix(#314): expose is_leader() on RaftMetadataStore to avoid private attr access

### DIFF
--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -722,8 +722,7 @@ class ZoneManager:
         """
         # Standard Raft: only leader can propose
         try:
-            engine = root_store._engine  # noqa: SLF001
-            if engine is None or not hasattr(engine, "is_leader") or not engine.is_leader():
+            if not root_store.is_leader():
                 return False
         except Exception:
             return False

--- a/src/nexus/storage/raft_metadata_store.py
+++ b/src/nexus/storage/raft_metadata_store.py
@@ -152,6 +152,19 @@ class RaftMetadataStore(FileMetadataProtocol):
         """True if this store has an embedded engine (not a gRPC client)."""
         return self._engine is not None
 
+    def is_leader(self) -> bool:
+        """Check if this node is the Raft leader for its zone.
+
+        Returns:
+            True if the embedded engine is a ZoneHandle and is the leader,
+            False if not leader, no engine, or engine doesn't support leadership.
+        """
+        if self._engine is None:
+            return False
+        if not hasattr(self._engine, "is_leader"):
+            return False
+        return self._engine.is_leader()
+
     # =========================================================================
     # Shared Engine Helpers — DRY extraction
     # Used by both sync and async public methods for engine mode operations.


### PR DESCRIPTION
## Summary
- Add public `is_leader()` method to `RaftMetadataStore` that safely delegates to the underlying PyO3 engine
- Update `ZoneManager._try_apply_topology()` to call `root_store.is_leader()` instead of accessing `root_store._engine` (private attribute with `# noqa: SLF001`)
- Preserves the same behavior: returns `False` if no engine, engine doesn't support leadership, or not leader

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] `is_leader()` returns `False` for engines without the method (same as before)
- [x] Existing Raft tests still pass (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)