### PR TITLE
fix(#620): enforce zone isolation in A2A LocalStorageDriver

### DIFF
--- a/src/nexus/a2a/stores/local_driver.py
+++ b/src/nexus/a2a/stores/local_driver.py
@@ -30,31 +30,35 @@ class LocalStorageDriver:
         self._root = Path(root)
         self._root.mkdir(parents=True, exist_ok=True)
 
-    def _resolve(self, path: str) -> Path:
-        """Resolve a virtual path to an absolute filesystem path."""
-        # Strip leading slash for relative resolution
+    def _resolve(self, path: str, zone_id: str) -> Path:
+        """Resolve a virtual path to a zone-scoped absolute filesystem path.
+
+        All paths are scoped under ``<root>/<zone_id>/`` so that each
+        zone's data is isolated on disk.
+        """
         clean = path.lstrip("/")
-        resolved = (self._root / clean).resolve()
-        # Guard against path traversal using is_relative_to for safety
+        zone_root = (self._root / zone_id).resolve()
+        resolved = (zone_root / clean).resolve()
+        # Guard against path traversal
         try:
-            resolved.relative_to(self._root.resolve())
+            resolved.relative_to(zone_root)
         except ValueError:
             raise ValueError(f"Path traversal blocked: {path}") from None
         return resolved
 
-    async def read(self, path: str, zone_id: str) -> bytes:  # noqa: ARG002
-        real = self._resolve(path)
+    async def read(self, path: str, zone_id: str) -> bytes:
+        real = self._resolve(path, zone_id)
         try:
             return await asyncio.to_thread(real.read_bytes)
         except FileNotFoundError:
             raise FileNotFoundError(f"Not found: {path}") from None
 
-    async def write(self, path: str, data: bytes, zone_id: str) -> None:  # noqa: ARG002
-        real = self._resolve(path)
+    async def write(self, path: str, data: bytes, zone_id: str) -> None:
+        real = self._resolve(path, zone_id)
         await asyncio.to_thread(self._write_sync, real, data)
 
-    async def list_dir(self, path: str, zone_id: str) -> list[str]:  # noqa: ARG002
-        real = self._resolve(path)
+    async def list_dir(self, path: str, zone_id: str) -> list[str]:
+        real = self._resolve(path, zone_id)
         if not real.is_dir():
             raise FileNotFoundError(f"Directory not found: {path}")
         entries = await asyncio.to_thread(list, real.iterdir())
@@ -64,19 +68,19 @@ class LocalStorageDriver:
         entries = await self.list_dir(path, zone_id)
         return len(entries)
 
-    async def rename(self, src: str, dst: str, zone_id: str) -> None:  # noqa: ARG002
-        real_src = self._resolve(src)
-        real_dst = self._resolve(dst)
+    async def rename(self, src: str, dst: str, zone_id: str) -> None:
+        real_src = self._resolve(src, zone_id)
+        real_dst = self._resolve(dst, zone_id)
         if not real_src.exists():
             raise FileNotFoundError(f"Not found: {src}")
         await asyncio.to_thread(real_src.rename, real_dst)
 
-    async def mkdir(self, path: str, zone_id: str) -> None:  # noqa: ARG002
-        real = self._resolve(path)
+    async def mkdir(self, path: str, zone_id: str) -> None:
+        real = self._resolve(path, zone_id)
         await asyncio.to_thread(real.mkdir, parents=True, exist_ok=True)
 
-    async def exists(self, path: str, zone_id: str) -> bool:  # noqa: ARG002
-        real = self._resolve(path)
+    async def exists(self, path: str, zone_id: str) -> bool:
+        real = self._resolve(path, zone_id)
         return await asyncio.to_thread(real.exists)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- A2A `LocalStorageDriver` accepted `zone_id` in 6 methods but silently ignored it (`noqa: ARG002`), meaning all zones shared the same flat directory
- Now all paths are scoped under `<root>/<zone_id>/` providing proper zone isolation on disk
- Path traversal guard updated to use the zone-scoped root
- Removed all 6 `noqa: ARG002` suppressions

This is a subset of #620 (34 zone_id ARG002 suppressions across 11 files). This PR fixes the 6 in `a2a/stores/local_driver.py`.

## Test plan
- [ ] Verify A2A tasks write to zone-scoped directories
- [ ] Verify path traversal guard still works correctly
- [ ] CI passes (ruff, mypy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)