### PR TITLE
fix(#1829): pass zone_id in RaftClient Propose/Query RPCs

### DIFF
--- a/dockerfiles/docker-compose.cross-platform-test.yml
+++ b/dockerfiles/docker-compose.cross-platform-test.yml
@@ -586,8 +586,8 @@ services:
       bash -c '
         echo "Installing test dependencies..."
         pip install -q pytest pytest-asyncio pytest-timeout httpx grpcio grpcio-tools protobuf
-        echo "Running E2E tests..."
-        python -m pytest tests/e2e/ -v --no-header -o "addopts=" -x --timeout=120
+        echo "Running Docker E2E tests (raft smoke + federation)..."
+        python -m pytest tests/e2e/docker/ -v --no-header -o "addopts=" -x --timeout=120
       '
     networks:
       - nexus-network

--- a/src/nexus/raft/client.py
+++ b/src/nexus/raft/client.py
@@ -225,6 +225,7 @@ class RaftClient:
         request = transport_pb2.ProposeRequest(
             command=command,
             request_id=request_id or "",
+            zone_id=self.zone_id or "",
         )
 
         try:
@@ -267,6 +268,7 @@ class RaftClient:
         request = transport_pb2.QueryRequest(
             query=query,
             read_from_leader=read_from_leader,
+            zone_id=self.zone_id or "",
         )
 
         try:
@@ -455,7 +457,7 @@ class RaftClient:
             version=metadata.version,
             zone_id=zone,
             created_by=metadata.created_by or "",
-            entry_type=metadata.entry_type,
+            entry_type=str(metadata.entry_type) if metadata.entry_type else "",
             target_zone_id=metadata.target_zone_id or "",
             owner_id=metadata.owner_id or "",
         )


### PR DESCRIPTION
## Summary
- `RaftClient._propose()` and `_query()` were constructing gRPC requests without setting the `zone_id` field, causing multi-zone federation to fail with `zone '<empty>' not found on this node`
- Scoped Docker E2E test runner from `tests/e2e/` to `tests/e2e/docker/` to avoid picking up non-Docker tests
- Fixed pre-existing mypy error on `entry_type` int→str conversion

## Test plan
- [x] All 22 Docker E2E tests pass (including previously failing `test_grpc_metadata_roundtrip`)
- [x] 40 tests correctly skipped (sandbox/validation requiring different infra)
- [x] 1 xfail (leader failover — known issue #163)

Closes #1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)