### PR TITLE
fix(#602): move CROSS_ZONE_ALLOWED_RELATIONS to rebac brick

### DIFF
--- a/src/nexus/rebac/batch/bulk_checker.py
+++ b/src/nexus/rebac/batch/bulk_checker.py
@@ -23,8 +23,8 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy.exc import OperationalError
 
 from nexus.core.rebac import Entity
+from nexus.rebac.cross_zone import CROSS_ZONE_ALLOWED_RELATIONS
 from nexus.rebac.types import ConsistencyLevel
-from nexus.services.permissions.cross_zone import CROSS_ZONE_ALLOWED_RELATIONS
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/src/nexus/rebac/consistency/zone_manager.py
+++ b/src/nexus/rebac/consistency/zone_manager.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 
-from nexus.services.permissions.cross_zone import CROSS_ZONE_ALLOWED_RELATIONS
+from nexus.rebac.cross_zone import CROSS_ZONE_ALLOWED_RELATIONS
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/rebac/cross_zone.py
+++ b/src/nexus/rebac/cross_zone.py
@@ -1,0 +1,18 @@
+"""Cross-zone sharing constants for ReBAC federation.
+
+These constants define which relations are allowed to span zone boundaries.
+Cross-zone sharing is a federation-specific policy concept
+(KERNEL-ARCHITECTURE §3, federation-memo §6).
+"""
+
+from __future__ import annotations
+
+# Relations that are allowed to cross zone boundaries.
+# These relations can link subjects and objects from different zones.
+CROSS_ZONE_ALLOWED_RELATIONS: frozenset[str] = frozenset(
+    {
+        "shared-viewer",  # Read access via cross-zone share
+        "shared-editor",  # Read + Write access via cross-zone share
+        "shared-owner",  # Full access via cross-zone share
+    }
+)

--- a/src/nexus/rebac/manager.py
+++ b/src/nexus/rebac/manager.py
@@ -42,6 +42,7 @@ from nexus.rebac.consistency.zone_manager import (
     ZoneIsolationError,  # noqa: F401 — re-exported for backward compat
     ZoneManager,
 )
+from nexus.rebac.cross_zone import CROSS_ZONE_ALLOWED_RELATIONS
 from nexus.rebac.directory.expander import DirectoryExpander
 from nexus.rebac.graph.bulk_evaluator import (
     check_direct_relation as _check_direct_relation_in_graph,
@@ -83,7 +84,6 @@ from nexus.rebac.types import (
 )
 from nexus.rebac.utils.changelog import insert_changelog_entry
 from nexus.rebac.utils.zone import normalize_zone_id
-from nexus.services.permissions.cross_zone import CROSS_ZONE_ALLOWED_RELATIONS
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine

--- a/src/nexus/services/permissions/cross_zone.py
+++ b/src/nexus/services/permissions/cross_zone.py
@@ -1,18 +1,10 @@
-"""Cross-zone sharing constants for ReBAC federation.
+"""Cross-zone sharing constants — re-exported from rebac brick.
 
-These constants define which relations are allowed to span zone boundaries.
-They belong in the services layer, not in core/, because cross-zone sharing
-is a federation-specific policy concept (KERNEL-ARCHITECTURE §3).
+The canonical definition lives in ``nexus.rebac.cross_zone`` (the brick
+owns its own relation semantics).  This module re-exports for callers
+within ``services.permissions``.
 """
 
-from __future__ import annotations
+from nexus.rebac.cross_zone import CROSS_ZONE_ALLOWED_RELATIONS
 
-# Relations that are allowed to cross zone boundaries.
-# These relations can link subjects and objects from different zones.
-CROSS_ZONE_ALLOWED_RELATIONS: frozenset[str] = frozenset(
-    {
-        "shared-viewer",  # Read access via cross-zone share
-        "shared-editor",  # Read + Write access via cross-zone share
-        "shared-owner",  # Full access via cross-zone share
-    }
-)
+__all__ = ["CROSS_ZONE_ALLOWED_RELATIONS"]


### PR DESCRIPTION
## Summary
- `CROSS_ZONE_ALLOWED_RELATIONS` was defined in `services.permissions.cross_zone` but imported by 3 `rebac/` files, creating circular dependency (brick → services)
- Moved canonical definition to `nexus/rebac/cross_zone.py` where the brick owns its relation semantics
- Updated 3 rebac/ importers: `manager.py`, `batch/bulk_checker.py`, `consistency/zone_manager.py`
- `services/permissions/cross_zone.py` now re-exports from rebac (no changes needed for services/ callers)

This is a partial fix for #602 (6 rebac→services imports). The remaining 3 imports involve class/type dependencies requiring deeper refactoring.

## Test plan
- [ ] Verify cross-zone sharing still works correctly
- [ ] Verify no circular import errors at startup
- [ ] CI passes (ruff, mypy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)