### PR TITLE
fix(#160): remove misleading skip guards from gRPC E2E tests

### DIFF
--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -27,6 +27,10 @@ import uuid
 import httpx
 import pytest
 
+from nexus.core._metadata_generated import FileMetadata
+from nexus.raft.client import RaftClient
+from nexus.raft.zone_manager import ROOT_ZONE_ID
+
 # All tests share one Docker cluster — run sequentially in a single xdist worker.
 pytestmark = [pytest.mark.xdist_group("federation-e2e")]
 
@@ -604,12 +608,6 @@ class TestgRPCDirectOperations:
     async def test_grpc_cluster_info(self, cluster):
         """Get cluster info via gRPC — verify leader_id, term, is_leader."""
         try:
-            from nexus.raft.client import RaftClient
-            from nexus.raft.zone_manager import ROOT_ZONE_ID
-        except ImportError:
-            pytest.skip("RaftClient not available (requires Rust extension)")
-
-        try:
             async with RaftClient(GRPC_ADDR, zone_id=ROOT_ZONE_ID) as client:
                 info = await client.get_cluster_info()
                 assert info is not None
@@ -633,13 +631,6 @@ class TestgRPCDirectOperations:
     @pytest.mark.asyncio
     async def test_grpc_metadata_roundtrip(self, cluster):
         """Write FileMetadata via gRPC, read it back."""
-        try:
-            from nexus.core._metadata_generated import FileMetadata
-            from nexus.raft.client import RaftClient
-            from nexus.raft.zone_manager import ROOT_ZONE_ID
-        except ImportError:
-            pytest.skip("RaftClient or FileMetadata not available")
-
         uid = _uid()
         try:
             async with RaftClient(GRPC_ADDR, zone_id=ROOT_ZONE_ID) as client:
@@ -663,12 +654,6 @@ class TestgRPCDirectOperations:
     @pytest.mark.asyncio
     async def test_grpc_list_metadata(self, cluster):
         """List metadata entries via gRPC."""
-        try:
-            from nexus.raft.client import RaftClient
-            from nexus.raft.zone_manager import ROOT_ZONE_ID
-        except ImportError:
-            pytest.skip("RaftClient not available")
-
         try:
             async with RaftClient(GRPC_ADDR, zone_id=ROOT_ZONE_ID) as client:
                 entries = await client.list_metadata(prefix="/")


### PR DESCRIPTION
## Summary
- Move `RaftClient`, `FileMetadata`, `ROOT_ZONE_ID` imports to module-level in `test_federation_e2e.py`
- Remove 3 `try/except ImportError` skip guards that silently skipped gRPC tests with misleading "requires Rust extension" messages
- These are pure Python dependencies (`grpcio` + checked-in protobuf stubs), not Rust extensions — tests should fail hard on import error, not skip

## Context
The 3 gRPC tests (`test_grpc_cluster_info`, `test_grpc_metadata_roundtrip`, `test_grpc_list_metadata`) had `try/except ImportError` guards that would skip tests if imports failed, with messages claiming "requires Rust extension". In reality, `RaftClient` is pure Python using `grpcio` (a core dependency) and checked-in `*_pb2.py` stubs.

Runtime connection-error handling (`pytest.skip` for unreachable gRPC) is preserved — only the incorrect import-error guards are removed.

## Test plan
- [ ] Docker E2E tests pass: `docker compose -f dockerfiles/docker-compose.cross-platform-test.yml up`
- [ ] gRPC tests no longer show as "skipped" due to import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)