### PR TITLE
fix(#611): implement zone-scoped scheduler metrics

### DIFF
--- a/src/nexus/scheduler/queue.py
+++ b/src/nexus/scheduler/queue.py
@@ -189,6 +189,17 @@ WHERE status = 'queued'
 GROUP BY priority_class
 """
 
+_SQL_PENDING_METRICS_BY_ZONE = """
+SELECT
+    priority_class,
+    count(*) AS cnt,
+    avg(EXTRACT(EPOCH FROM (now() - enqueued_at))) AS avg_wait,
+    max(EXTRACT(EPOCH FROM (now() - enqueued_at))) AS max_wait
+FROM scheduled_tasks
+WHERE status = 'queued' AND zone_id = $1
+GROUP BY priority_class
+"""
+
 
 # =============================================================================
 # Row-to-Model Conversion
@@ -368,7 +379,17 @@ class TaskQueue:
         rows = await conn.fetch(_SQL_STARVATION_PROMOTE, threshold_seconds)
         return len(rows)
 
-    async def get_queue_metrics(self, conn: Any) -> list[dict[str, Any]]:
-        """Get aggregated queue metrics by priority_class."""
-        rows = await conn.fetch(_SQL_PENDING_METRICS)
+    async def get_queue_metrics(
+        self, conn: Any, *, zone_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Get aggregated queue metrics by priority_class.
+
+        Args:
+            conn: Database connection.
+            zone_id: If provided, filter metrics to this zone only.
+        """
+        if zone_id is not None:
+            rows = await conn.fetch(_SQL_PENDING_METRICS_BY_ZONE, zone_id)
+        else:
+            rows = await conn.fetch(_SQL_PENDING_METRICS)
         return [dict(row) for row in rows]

--- a/src/nexus/scheduler/service.py
+++ b/src/nexus/scheduler/service.py
@@ -184,10 +184,10 @@ class SchedulerService:
 
         return classify_request(tier, req_state)
 
-    async def metrics(self, *, zone_id: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+    async def metrics(self, *, zone_id: str | None = None) -> dict[str, Any]:
         """Get scheduler metrics including queue stats and fair-share."""
         async with self._pool.acquire() as conn:
-            queue_metrics = await self._queue.get_queue_metrics(conn)
+            queue_metrics = await self._queue.get_queue_metrics(conn, zone_id=zone_id)
 
         return {
             "queue_by_class": queue_metrics,


### PR DESCRIPTION
## Summary
- Wire `zone_id` parameter through `SchedulerService.metrics()` → `TaskQueue.get_queue_metrics()`
- Add `_SQL_PENDING_METRICS_BY_ZONE` query that filters by `zone_id`
- Remove `noqa: ARG002` suppression from `metrics()` method
- `pending_count()` already delegates to `metrics(zone_id=...)`, so it inherits zone filtering

Per KERNEL-ARCHITECTURE.md §4: Zone is the fundamental isolation unit. Scheduler metrics should be scoped per-zone when requested.

## Test plan
- [ ] `metrics()` without zone_id returns all zones (backward compatible)
- [ ] `metrics(zone_id="org_acme")` returns only that zone's queue stats
- [ ] `pending_count(zone_id="org_acme")` returns zone-scoped count
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)