### PR TITLE
fix(#602): move default_namespaces to rebac brick

### DIFF
--- a/src/nexus/rebac/default_namespaces.py
+++ b/src/nexus/rebac/default_namespaces.py
@@ -1,0 +1,228 @@
+"""Default ReBAC namespace configurations.
+
+These define the default permission schemas for each object type
+(file, group, memory, playbook, trajectory, skill).  The canonical
+definition lives in the rebac brick since it owns namespace semantics.
+
+Canonical import:
+    from nexus.rebac.default_namespaces import DEFAULT_FILE_NAMESPACE
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from nexus.core.rebac import NamespaceConfig
+
+# ---------------------------------------------------------------------------
+# File namespace (complex: parent inheritance + group + cross-zone sharing)
+# ---------------------------------------------------------------------------
+DEFAULT_FILE_NAMESPACE = NamespaceConfig(
+    namespace_id=str(uuid.uuid4()),
+    object_type="file",
+    config={
+        "relations": {
+            # Structural relation: parent directory
+            "parent": {},
+            # Direct relations (granted explicitly)
+            "direct_owner": {},
+            "direct_editor": {},
+            "direct_viewer": {},
+            # Parent inheritance via tupleToUserset
+            # FIX: Use 'owner'/'editor'/'viewer' (not direct_*) to enable RECURSIVE parent inheritance
+            # This allows permission to propagate up the entire parent chain until finding direct_owner
+            # Example: /a/b/c/d/file.txt can inherit from /a if admin has direct_owner on /a
+            # The recursion is bounded by max_depth and parent chain length (typically < 10 levels)
+            "parent_owner": {"tupleToUserset": {"tupleset": "parent", "computedUserset": "owner"}},
+            "parent_editor": {
+                "tupleToUserset": {"tupleset": "parent", "computedUserset": "editor"}
+            },
+            "parent_viewer": {
+                "tupleToUserset": {"tupleset": "parent", "computedUserset": "viewer"}
+            },
+            # Group-based permissions via tupleToUserset
+            "group_owner": {
+                "tupleToUserset": {"tupleset": "direct_owner", "computedUserset": "member"}
+            },
+            "group_editor": {
+                "tupleToUserset": {"tupleset": "direct_editor", "computedUserset": "member"}
+            },
+            "group_viewer": {
+                "tupleToUserset": {"tupleset": "direct_viewer", "computedUserset": "member"}
+            },
+            # Cross-zone sharing relations (PR #645)
+            # These enable share_with_user() to grant access across zone boundaries
+            # Inheritance works via parent_* relations checking viewer/editor/owner unions
+            "shared-viewer": {},  # Read access via cross-zone share
+            "shared-editor": {},  # Read + Write access via cross-zone share
+            "shared-owner": {},  # Full access via cross-zone share
+            # Computed relations (union of direct + parent + group + shared)
+            # HYBRID: Keep unions for better memoization caching
+            # Permission checks -> 3 unions (viewer, editor, owner) instead of 9 relations
+            # This gives better cache hit rates since many files share the same union checks
+            # IMPORTANT: Don't nest unions (e.g., editor includes owner) - causes exponential checks
+            # Note: Higher permission levels include lower ones (owner has editor, editor has viewer)
+            "owner": {"union": ["direct_owner", "parent_owner", "group_owner", "shared-owner"]},
+            "editor": {
+                "union": [
+                    "direct_editor",
+                    "parent_editor",
+                    "group_editor",
+                    "shared-editor",
+                    "shared-owner",
+                ]
+            },
+            "viewer": {
+                "union": [
+                    "direct_viewer",
+                    "parent_viewer",
+                    "group_viewer",
+                    "shared-viewer",
+                    "shared-editor",
+                    "shared-owner",
+                ]
+            },
+        },
+        # P0-1: Explicit permission-to-userset mapping (Zanzibar-style)
+        # HYBRID OPTIMIZATION: Use unions for better memoization
+        # Checking "viewer" on file1 and file2 uses same cache key
+        # vs flattened schema where each of 9 relations needs separate cache entry
+        # Result: ~3x fewer cache misses, better performance
+        # PERF FIX: Check direct relations (owner, editor) BEFORE expensive traversals (viewer)
+        # PERF FIX: Check direct relations first before expensive parent traversals
+        # editor/viewer have direct_* relations that are found quickly
+        # owner has parent_owner which triggers recursive parent traversal and can hit query limits
+        "permissions": {
+            "read": [
+                "editor",
+                "viewer",
+                "owner",
+            ],  # Check editor/viewer first, owner last (expensive)
+            "write": ["editor", "owner"],  # Check editor first (direct), owner last (expensive)
+            "execute": ["owner"],  # Execute = owner only
+        },
+    },
+)
+
+# ---------------------------------------------------------------------------
+# Group namespace
+# ---------------------------------------------------------------------------
+DEFAULT_GROUP_NAMESPACE = NamespaceConfig(
+    namespace_id=str(uuid.uuid4()),
+    object_type="group",
+    config={
+        "relations": {
+            # Direct membership
+            "member": {},
+            # Group admin
+            "admin": {},
+            # Viewer can see group members
+            "viewer": {"union": ["admin", "member"]},
+        },
+        # P0-1: Explicit permission-to-userset mapping
+        "permissions": {
+            "read": ["viewer", "member", "admin"],  # Read = can view group
+            "write": ["admin"],  # Write = admin only
+            "manage": ["admin"],  # Manage = admin only
+        },
+    },
+)
+
+# ---------------------------------------------------------------------------
+# Memory namespace
+# ---------------------------------------------------------------------------
+DEFAULT_MEMORY_NAMESPACE = NamespaceConfig(
+    namespace_id=str(uuid.uuid4()),
+    object_type="memory",
+    config={
+        "relations": {
+            # Direct relations (granted explicitly)
+            "owner": {},
+            "editor": {},
+            "viewer": {},
+        },
+        # P0-1: Explicit permission-to-userset mapping
+        "permissions": {
+            "read": ["viewer", "editor", "owner"],  # Read = viewer OR editor OR owner
+            "write": ["editor", "owner"],  # Write = editor OR owner
+            "execute": ["owner"],  # Execute = owner only
+        },
+    },
+)
+
+# ---------------------------------------------------------------------------
+# v0.5.0 ACE: Playbook namespace
+# ---------------------------------------------------------------------------
+DEFAULT_PLAYBOOK_NAMESPACE = NamespaceConfig(
+    namespace_id=str(uuid.uuid4()),
+    object_type="playbook",
+    config={
+        "relations": {
+            # Direct relations (granted explicitly)
+            "owner": {},
+            "editor": {},
+            "viewer": {},
+        },
+        # P0-1: Explicit permission-to-userset mapping
+        "permissions": {
+            "read": ["viewer", "editor", "owner"],  # Read = viewer OR editor OR owner
+            "write": ["editor", "owner"],  # Write = editor OR owner
+            "delete": ["owner"],  # Delete = owner only
+        },
+    },
+)
+
+# ---------------------------------------------------------------------------
+# v0.5.0 ACE: Trajectory namespace
+# ---------------------------------------------------------------------------
+DEFAULT_TRAJECTORY_NAMESPACE = NamespaceConfig(
+    namespace_id=str(uuid.uuid4()),
+    object_type="trajectory",
+    config={
+        "relations": {
+            # Direct relations (granted explicitly)
+            "owner": {},
+            "viewer": {},
+        },
+        # P0-1: Explicit permission-to-userset mapping
+        "permissions": {
+            "read": ["viewer", "owner"],  # Read = viewer OR owner
+            "write": ["owner"],  # Write = owner only (trajectories typically write-once)
+            "delete": ["owner"],  # Delete = owner only
+        },
+    },
+)
+
+# ---------------------------------------------------------------------------
+# v0.5.0 Skills System: Skill namespace
+# ---------------------------------------------------------------------------
+DEFAULT_SKILL_NAMESPACE = NamespaceConfig(
+    namespace_id=str(uuid.uuid4()),
+    object_type="skill",
+    config={
+        "relations": {
+            # Direct ownership relations
+            "owner": {},  # Full control over skill
+            "editor": {},  # Can modify skill content
+            "viewer": {},  # Can read and fork skill
+            # Zone membership for skill access
+            "zone": {},  # Skill belongs to this zone
+            "zone_member": {  # Inherit viewer from zone membership
+                "tupleToUserset": {"tupleset": "zone", "computedUserset": "member"}
+            },
+            # Public/system skill access
+            "public": {},  # Globally readable (system skills)
+            # Governance roles
+            "approver": {},  # Can approve skill for publication
+        },
+        # P0-1: Explicit permission-to-userset mapping
+        "permissions": {
+            "read": ["viewer", "editor", "owner", "zone_member", "public"],
+            "write": ["editor", "owner"],
+            "delete": ["owner"],
+            "fork": ["viewer", "editor", "owner", "zone_member", "public"],
+            "publish": ["owner"],  # Requires ownership (+ approval in workflow)
+            "approve": ["approver"],  # Can approve for publication
+        },
+    },
+)

--- a/src/nexus/rebac/manager.py
+++ b/src/nexus/rebac/manager.py
@@ -3388,7 +3388,7 @@ class ReBACManager:
 
     def _initialize_default_namespaces_with_conn(self, conn: Any) -> None:
         """Initialize default namespace configurations with given connection."""
-        from nexus.services.permissions.default_namespaces import (
+        from nexus.rebac.default_namespaces import (
             DEFAULT_FILE_NAMESPACE,
             DEFAULT_GROUP_NAMESPACE,
             DEFAULT_MEMORY_NAMESPACE,

--- a/src/nexus/services/permissions/default_namespaces.py
+++ b/src/nexus/services/permissions/default_namespaces.py
@@ -1,229 +1,24 @@
-"""Default ReBAC namespace configurations.
+"""Default ReBAC namespace configurations — re-exported from rebac brick.
 
-These define the default permission schemas for each object type
-(file, group, memory, playbook, trajectory, skill).  They are
-service-layer policy decisions — the kernel only provides the
-generic data structures (NamespaceConfig, Entity, ReBACTuple).
-
-Canonical import:
-    from nexus.services.permissions.default_namespaces import DEFAULT_FILE_NAMESPACE
+The canonical definition lives in ``nexus.rebac.default_namespaces`` (the brick
+owns its own namespace semantics).  This module re-exports for callers
+within ``services.permissions``.
 """
 
-from __future__ import annotations
-
-import uuid
-
-from nexus.core.rebac import NamespaceConfig
-
-# ---------------------------------------------------------------------------
-# File namespace (complex: parent inheritance + group + cross-zone sharing)
-# ---------------------------------------------------------------------------
-DEFAULT_FILE_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
-    object_type="file",
-    config={
-        "relations": {
-            # Structural relation: parent directory
-            "parent": {},
-            # Direct relations (granted explicitly)
-            "direct_owner": {},
-            "direct_editor": {},
-            "direct_viewer": {},
-            # Parent inheritance via tupleToUserset
-            # FIX: Use 'owner'/'editor'/'viewer' (not direct_*) to enable RECURSIVE parent inheritance
-            # This allows permission to propagate up the entire parent chain until finding direct_owner
-            # Example: /a/b/c/d/file.txt can inherit from /a if admin has direct_owner on /a
-            # The recursion is bounded by max_depth and parent chain length (typically < 10 levels)
-            "parent_owner": {"tupleToUserset": {"tupleset": "parent", "computedUserset": "owner"}},
-            "parent_editor": {
-                "tupleToUserset": {"tupleset": "parent", "computedUserset": "editor"}
-            },
-            "parent_viewer": {
-                "tupleToUserset": {"tupleset": "parent", "computedUserset": "viewer"}
-            },
-            # Group-based permissions via tupleToUserset
-            "group_owner": {
-                "tupleToUserset": {"tupleset": "direct_owner", "computedUserset": "member"}
-            },
-            "group_editor": {
-                "tupleToUserset": {"tupleset": "direct_editor", "computedUserset": "member"}
-            },
-            "group_viewer": {
-                "tupleToUserset": {"tupleset": "direct_viewer", "computedUserset": "member"}
-            },
-            # Cross-zone sharing relations (PR #645)
-            # These enable share_with_user() to grant access across zone boundaries
-            # Inheritance works via parent_* relations checking viewer/editor/owner unions
-            "shared-viewer": {},  # Read access via cross-zone share
-            "shared-editor": {},  # Read + Write access via cross-zone share
-            "shared-owner": {},  # Full access via cross-zone share
-            # Computed relations (union of direct + parent + group + shared)
-            # HYBRID: Keep unions for better memoization caching
-            # Permission checks -> 3 unions (viewer, editor, owner) instead of 9 relations
-            # This gives better cache hit rates since many files share the same union checks
-            # IMPORTANT: Don't nest unions (e.g., editor includes owner) - causes exponential checks
-            # Note: Higher permission levels include lower ones (owner has editor, editor has viewer)
-            "owner": {"union": ["direct_owner", "parent_owner", "group_owner", "shared-owner"]},
-            "editor": {
-                "union": [
-                    "direct_editor",
-                    "parent_editor",
-                    "group_editor",
-                    "shared-editor",
-                    "shared-owner",
-                ]
-            },
-            "viewer": {
-                "union": [
-                    "direct_viewer",
-                    "parent_viewer",
-                    "group_viewer",
-                    "shared-viewer",
-                    "shared-editor",
-                    "shared-owner",
-                ]
-            },
-        },
-        # P0-1: Explicit permission-to-userset mapping (Zanzibar-style)
-        # HYBRID OPTIMIZATION: Use unions for better memoization
-        # Checking "viewer" on file1 and file2 uses same cache key
-        # vs flattened schema where each of 9 relations needs separate cache entry
-        # Result: ~3x fewer cache misses, better performance
-        # PERF FIX: Check direct relations (owner, editor) BEFORE expensive traversals (viewer)
-        # PERF FIX: Check direct relations first before expensive parent traversals
-        # editor/viewer have direct_* relations that are found quickly
-        # owner has parent_owner which triggers recursive parent traversal and can hit query limits
-        "permissions": {
-            "read": [
-                "editor",
-                "viewer",
-                "owner",
-            ],  # Check editor/viewer first, owner last (expensive)
-            "write": ["editor", "owner"],  # Check editor first (direct), owner last (expensive)
-            "execute": ["owner"],  # Execute = owner only
-        },
-    },
+from nexus.rebac.default_namespaces import (
+    DEFAULT_FILE_NAMESPACE,
+    DEFAULT_GROUP_NAMESPACE,
+    DEFAULT_MEMORY_NAMESPACE,
+    DEFAULT_PLAYBOOK_NAMESPACE,
+    DEFAULT_SKILL_NAMESPACE,
+    DEFAULT_TRAJECTORY_NAMESPACE,
 )
 
-# ---------------------------------------------------------------------------
-# Group namespace
-# ---------------------------------------------------------------------------
-DEFAULT_GROUP_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
-    object_type="group",
-    config={
-        "relations": {
-            # Direct membership
-            "member": {},
-            # Group admin
-            "admin": {},
-            # Viewer can see group members
-            "viewer": {"union": ["admin", "member"]},
-        },
-        # P0-1: Explicit permission-to-userset mapping
-        "permissions": {
-            "read": ["viewer", "member", "admin"],  # Read = can view group
-            "write": ["admin"],  # Write = admin only
-            "manage": ["admin"],  # Manage = admin only
-        },
-    },
-)
-
-# ---------------------------------------------------------------------------
-# Memory namespace
-# ---------------------------------------------------------------------------
-DEFAULT_MEMORY_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
-    object_type="memory",
-    config={
-        "relations": {
-            # Direct relations (granted explicitly)
-            "owner": {},
-            "editor": {},
-            "viewer": {},
-        },
-        # P0-1: Explicit permission-to-userset mapping
-        "permissions": {
-            "read": ["viewer", "editor", "owner"],  # Read = viewer OR editor OR owner
-            "write": ["editor", "owner"],  # Write = editor OR owner
-            "execute": ["owner"],  # Execute = owner only
-        },
-    },
-)
-
-# ---------------------------------------------------------------------------
-# v0.5.0 ACE: Playbook namespace
-# ---------------------------------------------------------------------------
-DEFAULT_PLAYBOOK_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
-    object_type="playbook",
-    config={
-        "relations": {
-            # Direct relations (granted explicitly)
-            "owner": {},
-            "editor": {},
-            "viewer": {},
-        },
-        # P0-1: Explicit permission-to-userset mapping
-        "permissions": {
-            "read": ["viewer", "editor", "owner"],  # Read = viewer OR editor OR owner
-            "write": ["editor", "owner"],  # Write = editor OR owner
-            "delete": ["owner"],  # Delete = owner only
-        },
-    },
-)
-
-# ---------------------------------------------------------------------------
-# v0.5.0 ACE: Trajectory namespace
-# ---------------------------------------------------------------------------
-DEFAULT_TRAJECTORY_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
-    object_type="trajectory",
-    config={
-        "relations": {
-            # Direct relations (granted explicitly)
-            "owner": {},
-            "viewer": {},
-        },
-        # P0-1: Explicit permission-to-userset mapping
-        "permissions": {
-            "read": ["viewer", "owner"],  # Read = viewer OR owner
-            "write": ["owner"],  # Write = owner only (trajectories typically write-once)
-            "delete": ["owner"],  # Delete = owner only
-        },
-    },
-)
-
-# ---------------------------------------------------------------------------
-# v0.5.0 Skills System: Skill namespace
-# ---------------------------------------------------------------------------
-DEFAULT_SKILL_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
-    object_type="skill",
-    config={
-        "relations": {
-            # Direct ownership relations
-            "owner": {},  # Full control over skill
-            "editor": {},  # Can modify skill content
-            "viewer": {},  # Can read and fork skill
-            # Zone membership for skill access
-            "zone": {},  # Skill belongs to this zone
-            "zone_member": {  # Inherit viewer from zone membership
-                "tupleToUserset": {"tupleset": "zone", "computedUserset": "member"}
-            },
-            # Public/system skill access
-            "public": {},  # Globally readable (system skills)
-            # Governance roles
-            "approver": {},  # Can approve skill for publication
-        },
-        # P0-1: Explicit permission-to-userset mapping
-        "permissions": {
-            "read": ["viewer", "editor", "owner", "zone_member", "public"],
-            "write": ["editor", "owner"],
-            "delete": ["owner"],
-            "fork": ["viewer", "editor", "owner", "zone_member", "public"],
-            "publish": ["owner"],  # Requires ownership (+ approval in workflow)
-            "approve": ["approver"],  # Can approve for publication
-        },
-    },
-)
+__all__ = [
+    "DEFAULT_FILE_NAMESPACE",
+    "DEFAULT_GROUP_NAMESPACE",
+    "DEFAULT_MEMORY_NAMESPACE",
+    "DEFAULT_PLAYBOOK_NAMESPACE",
+    "DEFAULT_SKILL_NAMESPACE",
+    "DEFAULT_TRAJECTORY_NAMESPACE",
+]


### PR DESCRIPTION
## Summary
- Move `DEFAULT_*_NAMESPACE` constants from `services/permissions/default_namespaces.py` to `rebac/default_namespaces.py`
- The rebac brick owns namespace semantics; these constants define ReBAC namespace schemas
- `services/permissions/default_namespaces.py` now re-exports from rebac (preserving API for existing callers)
- Update lazy import in `rebac/manager.py` to import from local `rebac.default_namespaces`

Part of #602 (rebac services-layer circular imports — 5 of 6 imports now fixed).

## Test plan
- [ ] All 6 `DEFAULT_*_NAMESPACE` constants importable from both `nexus.rebac.default_namespaces` and `nexus.services.permissions.default_namespaces`
- [ ] `rebac/manager.py` `_initialize_default_namespaces_with_conn()` works correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)