### PR TITLE
fix(#611): implement executor-scoped task dequeue

### DIFF
--- a/src/nexus/scheduler/queue.py
+++ b/src/nexus/scheduler/queue.py
@@ -62,12 +62,56 @@ RETURNING
     request_state, priority_class, executor_state, estimated_service_time
 """
 
+_SQL_DEQUEUE_BY_EXECUTOR = """
+UPDATE scheduled_tasks
+SET status = 'running', started_at = now()
+WHERE id = (
+    SELECT id FROM scheduled_tasks
+    WHERE status = 'queued' AND executor_id = $1
+    ORDER BY effective_tier ASC, enqueued_at ASC
+    FOR UPDATE SKIP LOCKED
+    LIMIT 1
+)
+RETURNING
+    id::text, agent_id, executor_id, task_type,
+    payload::text, priority_tier, effective_tier,
+    enqueued_at, status, deadline,
+    boost_amount, boost_tiers, boost_reservation_id,
+    started_at, completed_at, error_message,
+    zone_id, idempotency_key,
+    request_state, priority_class, executor_state, estimated_service_time
+"""
+
 _SQL_DEQUEUE_HRRN = """
 UPDATE scheduled_tasks
 SET status = 'running', started_at = now()
 WHERE id = (
     SELECT id FROM scheduled_tasks
     WHERE status = 'queued'
+      AND executor_state IN ('CONNECTED', 'IDLE', 'UNKNOWN')
+    ORDER BY
+        priority_class ASC,
+        hrrn_score(enqueued_at, estimated_service_time) DESC,
+        enqueued_at ASC
+    FOR UPDATE SKIP LOCKED
+    LIMIT 1
+)
+RETURNING
+    id::text, agent_id, executor_id, task_type,
+    payload::text, priority_tier, effective_tier,
+    enqueued_at, status, deadline,
+    boost_amount, boost_tiers, boost_reservation_id,
+    started_at, completed_at, error_message,
+    zone_id, idempotency_key,
+    request_state, priority_class, executor_state, estimated_service_time
+"""
+
+_SQL_DEQUEUE_HRRN_BY_EXECUTOR = """
+UPDATE scheduled_tasks
+SET status = 'running', started_at = now()
+WHERE id = (
+    SELECT id FROM scheduled_tasks
+    WHERE status = 'queued' AND executor_id = $1
       AND executor_state IN ('CONNECTED', 'IDLE', 'UNKNOWN')
     ORDER BY
         priority_class ASC,
@@ -303,24 +347,40 @@ class TaskQueue:
 
         return str(task_id)
 
-    async def dequeue(self, conn: Any) -> ScheduledTask | None:
+    async def dequeue(self, conn: Any, *, executor_id: str | None = None) -> ScheduledTask | None:
         """Dequeue the highest-priority task (classic effective_tier ordering).
 
         Uses FOR UPDATE SKIP LOCKED to safely handle concurrent workers.
         Atomically sets status to 'running'.
+
+        Args:
+            conn: Database connection.
+            executor_id: If provided, only dequeue tasks assigned to this executor.
         """
-        row = await conn.fetchrow(_SQL_DEQUEUE)
+        if executor_id is not None:
+            row = await conn.fetchrow(_SQL_DEQUEUE_BY_EXECUTOR, executor_id)
+        else:
+            row = await conn.fetchrow(_SQL_DEQUEUE)
         if row is None:
             return None
         return _row_to_task(row)
 
-    async def dequeue_hrrn(self, conn: Any) -> ScheduledTask | None:
+    async def dequeue_hrrn(
+        self, conn: Any, *, executor_id: str | None = None
+    ) -> ScheduledTask | None:
         """Dequeue using HRRN scoring within priority classes (Astraea).
 
         Orders by: priority_class ASC, hrrn_score DESC, enqueued_at ASC.
         Filters out tasks whose executor is SUSPENDED.
+
+        Args:
+            conn: Database connection.
+            executor_id: If provided, only dequeue tasks assigned to this executor.
         """
-        row = await conn.fetchrow(_SQL_DEQUEUE_HRRN)
+        if executor_id is not None:
+            row = await conn.fetchrow(_SQL_DEQUEUE_HRRN_BY_EXECUTOR, executor_id)
+        else:
+            row = await conn.fetchrow(_SQL_DEQUEUE_HRRN)
         if row is None:
             return None
         return _row_to_task(row)

--- a/src/nexus/scheduler/service.py
+++ b/src/nexus/scheduler/service.py
@@ -116,9 +116,9 @@ class SchedulerService:
         task = await self.submit_task(submission)
         return task.id
 
-    async def next(self, *, executor_id: str | None = None) -> AgentRequest | None:  # noqa: ARG002
+    async def next(self, *, executor_id: str | None = None) -> AgentRequest | None:
         """Dequeue the next task and return as AgentRequest."""
-        task = await self.dequeue_next()
+        task = await self.dequeue_next(executor_id=executor_id)
         if task is None:
             return None
 
@@ -317,17 +317,20 @@ class SchedulerService:
 
             return cancelled
 
-    async def dequeue_next(self) -> ScheduledTask | None:
+    async def dequeue_next(self, *, executor_id: str | None = None) -> ScheduledTask | None:
         """Dequeue the highest-priority task for execution.
 
         Uses HRRN dequeue when enabled, falls back to classic ordering.
         Updates fair-share counter on successful dequeue.
+
+        Args:
+            executor_id: If provided, only dequeue tasks assigned to this executor.
         """
         async with self._pool.acquire() as conn:
             if self._use_hrrn:
-                task = await self._queue.dequeue_hrrn(conn)
+                task = await self._queue.dequeue_hrrn(conn, executor_id=executor_id)
             else:
-                task = await self._queue.dequeue(conn)
+                task = await self._queue.dequeue(conn, executor_id=executor_id)
 
         if task is not None:
             self._fair_share.record_start(task.agent_id)


### PR DESCRIPTION
## Summary
- Wire `executor_id` parameter through `SchedulerService.next()` → `dequeue_next()` → `TaskQueue.dequeue()`/`dequeue_hrrn()`
- Add `_SQL_DEQUEUE_BY_EXECUTOR` and `_SQL_DEQUEUE_HRRN_BY_EXECUTOR` queries that filter by executor_id
- When `executor_id` is None, behavior is unchanged (dequeue any task)
- When `executor_id` is provided, only tasks assigned to that executor are dequeued
- Remove `noqa: ARG002` suppression from `next()` method

Part of #611 — scheduler operations should not ignore identity/isolation parameters.

## Test plan
- [ ] `next()` without executor_id dequeues any task (backward compatible)
- [ ] `next(executor_id="agent-1")` only dequeues tasks where executor_id matches
- [ ] Both classic and HRRN dequeue modes support executor filtering
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)