### PR TITLE
fix(#86): structured log redaction — secret masking via structlog processor

### DIFF
--- a/src/nexus/cli/commands/server.py
+++ b/src/nexus/cli/commands/server.py
@@ -370,7 +370,7 @@ def _mount_fuse(
             assert log_file is not None, "log_file must be set in daemon mode"
 
             # Configure logging to file with secret redaction (Issue #86)
-            from nexus.core.logging_utils import RedactingFormatter
+            from nexus.server.logging_processors import RedactingFormatter
 
             _fuse_formatter = RedactingFormatter(
                 "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -590,17 +590,14 @@ def serve(
         from nexus.fuse import mount_nexus
         mount_nexus(nx, "/mnt/nexus")
     """
-    import logging
     import os
     import subprocess
 
-    from nexus.core.logging_utils import setup_logging
+    from nexus.server.logging_config import configure_logging
 
-    # Set up logging with secret redaction (Issue #86)
-    # Read redaction setting from env var (config hasn't loaded yet at this point)
-    _redaction_env = os.getenv("NEXUS_LOG_REDACTION_ENABLED", "true").lower()
-    _redaction_enabled = _redaction_env in ("true", "1", "yes", "on")
-    setup_logging(level=logging.INFO, redaction_enabled=_redaction_enabled)
+    # Set up structured logging with secret redaction (Issue #86 + #1002)
+    # configure_logging() reads NEXUS_LOG_REDACTION_ENABLED env var internally
+    configure_logging(env=os.getenv("NEXUS_ENV", "dev"), log_level="INFO")
 
     try:
         # ============================================

--- a/src/nexus/server/logging_config.py
+++ b/src/nexus/server/logging_config.py
@@ -1,6 +1,7 @@
 """Centralized structured logging configuration.
 
 Issue #1002: Structured JSON logging with request correlation.
+Issue #86: Secret redaction in log output.
 
 Provides a single ``configure_logging()`` function that sets up structlog
 with a processor pipeline and routes ALL loggers (stdlib, uvicorn, sqlalchemy,
@@ -8,6 +9,9 @@ etc.) through structlog's ``ProcessorFormatter``.
 
 - **Dev mode**: Pretty, colored console output via ``ConsoleRenderer``
 - **Prod mode**: Machine-readable JSON via ``JSONRenderer`` + ``orjson``
+- **Secret redaction**: Enabled by default (``NEXUS_LOG_REDACTION_ENABLED``).
+  Masks API keys, tokens, passwords, and connection strings via
+  ``secret_redaction_processor`` in the structlog pipeline.
 
 **Relationship to ObservabilitySubsystem (#1301):**
 This module handles *log formatting and routing* — it is server-level
@@ -25,6 +29,7 @@ Usage::
     configure_logging(env="prod")              # JSON output
     configure_logging(env="dev")               # Pretty console
     configure_logging(env="prod", log_level="DEBUG")  # Override level
+    configure_logging(env="prod", redaction_enabled=False)  # Disable redaction
 """
 
 from __future__ import annotations
@@ -41,6 +46,7 @@ import structlog
 from nexus.server.logging_processors import (
     add_service_name,
     error_classification_processor,
+    make_secret_redaction_processor,
     otel_trace_processor,
 )
 
@@ -62,6 +68,7 @@ def _orjson_serializer(data: dict[str, Any], **_kw: Any) -> str:
 def configure_logging(
     env: str = "dev",
     log_level: str | None = None,
+    redaction_enabled: bool | None = None,
     _handler_override: logging.Handler | None = None,
 ) -> None:
     """Configure structured logging for the entire application.
@@ -73,6 +80,9 @@ def configure_logging(
         env: Environment mode. ``"dev"`` for pretty console, ``"prod"`` for JSON.
         log_level: Override log level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
             If ``None``, reads ``LOG_LEVEL`` env var, defaulting to ``"INFO"``.
+        redaction_enabled: Whether to enable secret redaction in log output.
+            If ``None``, reads ``NEXUS_LOG_REDACTION_ENABLED`` env var,
+            defaulting to ``True`` (secure by default).
         _handler_override: Internal testing parameter. When set, this handler
             is used instead of the default ``StreamHandler(sys.stderr)``.
     """
@@ -90,7 +100,18 @@ def configure_logging(
             "Valid levels: DEBUG, INFO, WARNING, ERROR, CRITICAL"
         )
 
+    # Resolve redaction setting (Issue #86)
+    if redaction_enabled is None:
+        _redact_env = os.environ.get("NEXUS_LOG_REDACTION_ENABLED", "true").lower()
+        redaction_enabled = _redact_env in ("true", "1", "yes", "on")
+
+    # Create the redaction processor with captured enabled state (immutable closure).
+    redaction_processor = make_secret_redaction_processor(enabled=redaction_enabled)
+
     # Shared processors run for BOTH structlog-native and stdlib-bridged logs.
+    # redaction_processor runs AFTER format_exc_info so tracebacks
+    # containing secrets (e.g., connection strings in error messages) are
+    # also redacted.
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_log_level,
@@ -102,6 +123,7 @@ def configure_logging(
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
+        redaction_processor,
     ]
 
     # Renderer: JSON for prod, pretty console for dev

--- a/src/nexus/server/logging_processors.py
+++ b/src/nexus/server/logging_processors.py
@@ -1,20 +1,36 @@
 """Custom structlog processors for Nexus.
 
 Issue #1002: Structured JSON logging with request correlation.
+Issue #86: Secret redaction in log output.
 
 Processors:
+- ``secret_redaction_processor``: Masks secrets (API keys, tokens, passwords,
+  connection strings) in log event text. Aligned with Templar TS patterns.
 - ``otel_trace_processor``: Injects OTel trace_id/span_id into log events.
 - ``error_classification_processor``: Classifies errors as expected/unexpected.
 - ``add_service_name``: Adds ``service`` to every log event (configurable via
   ``NEXUS_SERVICE_NAME`` env var, defaults to ``"nexus"``).
+
+Secret Redaction (Issue #86):
+    Uses a structlog processor to redact secrets from the ``event`` field
+    (and optionally other string fields) before rendering. Patterns are
+    aligned with Templar TypeScript @templar/middleware/audit/redaction.ts.
+
+    A ``RedactingFormatter`` is also provided for stdlib-only contexts
+    (e.g., FUSE daemon process) where structlog is not available.
+
+    Performance: Heuristic pre-check skips regex for ~95% of log lines
+    that contain no trigger substrings. Target: <1ms overhead per line.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import re
 import sys
 from collections.abc import MutableMapping
-from typing import Any
+from typing import Any, Literal
 
 # Cache OTel availability at module level (Issue #1002 / Issue 13).
 # Python does NOT cache failed imports in sys.modules, so a per-call
@@ -33,6 +49,307 @@ except ImportError:
 # Configurable service name (Issue #1002 / Issue 8).
 # Matches OTel convention (OTEL_SERVICE_NAME).
 _SERVICE_NAME = os.environ.get("NEXUS_SERVICE_NAME", "nexus")
+
+# ============================================================================
+# SECRET REDACTION (Issue #86)
+# ============================================================================
+#
+# Cross-reference: These patterns are aligned with the Templar TypeScript
+# audit middleware at @templar/middleware/src/audit/redaction.ts.
+# When adding/modifying patterns here, update the TS counterpart too.
+#
+# Pattern names must match between Python and TypeScript for consistency.
+# ============================================================================
+
+_REDACTED = "[REDACTED]"
+
+
+class _RedactionPattern:
+    """A named, pre-compiled redaction pattern."""
+
+    __slots__ = ("name", "regex", "replacement")
+
+    def __init__(
+        self,
+        name: str,
+        pattern: str,
+        flags: int = re.IGNORECASE,
+        replacement: str = _REDACTED,
+    ) -> None:
+        self.name = name
+        self.regex = re.compile(pattern, flags)
+        self.replacement = replacement
+
+
+# --- Templar TS parity patterns (10 patterns) ---
+
+_BEARER_TOKEN = _RedactionPattern(
+    "bearer_token",
+    r"Bearer\s+[\w\-._~+/]{10,}=*",
+)
+
+_SK_API_KEY = _RedactionPattern(
+    "sk_api_key",
+    r"sk-[a-zA-Z0-9]{20,}",
+)
+
+_POSTGRES_URL = _RedactionPattern(
+    "postgres_url",
+    r"postgres(?:ql)?://[^\s\"']+",
+)
+
+_MYSQL_URL = _RedactionPattern(
+    "mysql_url",
+    r"mysql://[^\s\"']+",
+)
+
+_MONGODB_URL = _RedactionPattern(
+    "mongodb_url",
+    r"mongodb(?:\+srv)?://[^\s\"']+",
+)
+
+_REDIS_URL = _RedactionPattern(
+    "redis_url",
+    r"redis://[^\s\"']+",
+)
+
+_PEM_PRIVATE_KEY = _RedactionPattern(
+    "pem_private_key",
+    r"-----BEGIN [A-Z\s]*PRIVATE KEY-----[\s\S]*?-----END [A-Z\s]*PRIVATE KEY-----",
+)
+
+_AWS_ACCESS_KEY = _RedactionPattern(
+    "aws_access_key",
+    r"(?:AKIA|ASIA)[A-Z0-9]{16}",
+    flags=0,  # Case-sensitive for AWS keys
+)
+
+_AWS_SECRET_KEY = _RedactionPattern(
+    "aws_secret_key",
+    r"(?:aws_secret_access_key|AWS_SECRET_ACCESS_KEY)\s*[=:]\s*[A-Za-z0-9/+=]{40}",
+)
+
+_GENERIC_PASSWORD = _RedactionPattern(
+    "generic_password",
+    r"(?:password|passwd|pwd)\s*[=:]\s*[\"']?[^\s\"']{8,}[\"']?",
+)
+
+# --- Python-specific patterns (additional to Templar TS) ---
+
+_NEXUS_API_KEY = _RedactionPattern(
+    "nexus_api_key",
+    r"sk-[a-zA-Z0-9]+_[a-zA-Z0-9]+_[a-f0-9\-]+_[a-f0-9]+",
+)
+
+_DJANGO_SECRET_KEY = _RedactionPattern(
+    "django_secret_key",
+    r"(?:SECRET_KEY|DJANGO_SECRET_KEY)\s*[=:]\s*[\"']?[^\s\"']{20,}[\"']?",
+)
+
+_FERNET_KEY = _RedactionPattern(
+    "fernet_key",
+    r"(?:FERNET_KEY|fernet_key|encryption_key)\s*[=:]\s*[A-Za-z0-9_\-]{43}=",
+    flags=0,  # Case-sensitive; require keyword context to avoid false positives
+)
+
+_JWT_TOKEN = _RedactionPattern(
+    "jwt_token",
+    r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}",
+    flags=0,  # Case-sensitive for base64url
+)
+
+_GENERIC_API_KEY_ASSIGNMENT = _RedactionPattern(
+    "generic_api_key_assignment",
+    r"(?:api_key|apikey|api-key|access_token|auth_token)\s*[=:]\s*[\"']?[^\s\"']{10,}[\"']?",
+)
+
+
+# The default set of patterns, ordered from most specific to least specific
+# to minimize false-positive overlap.
+BUILT_IN_SECRET_PATTERNS: tuple[_RedactionPattern, ...] = (
+    _PEM_PRIVATE_KEY,  # Most distinctive (multi-line)
+    _NEXUS_API_KEY,  # Before generic sk- (more specific)
+    _BEARER_TOKEN,  # "Bearer " prefix is distinctive
+    _JWT_TOKEN,  # "eyJ" prefix is distinctive
+    _AWS_ACCESS_KEY,  # AKIA/ASIA prefix
+    _AWS_SECRET_KEY,  # Named key assignment
+    _SK_API_KEY,  # sk- prefix (generic)
+    _POSTGRES_URL,  # Protocol-specific URLs
+    _MYSQL_URL,
+    _MONGODB_URL,
+    _REDIS_URL,
+    _DJANGO_SECRET_KEY,  # Named key assignment
+    _GENERIC_API_KEY_ASSIGNMENT,  # Named key assignment (broad)
+    _GENERIC_PASSWORD,  # Named value assignment (broadest)
+    _FERNET_KEY,  # Base64 string (broadest, last)
+)
+
+# Trigger substrings for heuristic pre-check (all lowercase).
+# If none of these appear in a lowercased log line, skip all regex matching.
+# This optimizes the common case (~95%+ of log lines have no secrets).
+# Using lowercase + one .lower() call is cheaper and more maintainable
+# than listing case variants for every keyword.
+_TRIGGER_SUBSTRINGS_LOWER: tuple[str, ...] = (
+    "bearer",
+    "sk-",
+    "://",
+    "key",
+    "password",
+    "passwd",
+    "pwd",
+    "begin",
+    "akia",
+    "asia",
+    "eyj",
+    "token",
+    "api_key",
+    "apikey",
+    "api-key",
+    "fernet",
+    "encryption_key",
+)
+
+
+def redact_text(
+    text: str,
+    patterns: tuple[_RedactionPattern, ...] | None = None,
+) -> str:
+    """Apply redaction patterns to a text string.
+
+    Uses a heuristic pre-check: if the text contains none of the trigger
+    substrings, skips all regex matching for performance. The pre-check
+    only applies to built-in patterns; custom patterns always run regex
+    since their triggers are unknown.
+
+    Args:
+        text: The text to redact.
+        patterns: Redaction patterns to apply. Defaults to BUILT_IN_SECRET_PATTERNS.
+
+    Returns:
+        Text with secrets replaced by [REDACTED].
+    """
+    if not text:
+        return text
+
+    if patterns is None:
+        patterns = BUILT_IN_SECRET_PATTERNS
+
+    # Heuristic pre-check: only for built-in patterns (we know their triggers).
+    # Custom patterns skip this check since we don't know their trigger strings.
+    # One .lower() call is cheaper than scanning for case variants of every keyword.
+    if patterns is BUILT_IN_SECRET_PATTERNS:
+        text_lower = text.lower()
+        if not any(trigger in text_lower for trigger in _TRIGGER_SUBSTRINGS_LOWER):
+            return text
+
+    result = text
+    for rp in patterns:
+        result = rp.regex.sub(rp.replacement, result)
+    return result
+
+
+# Fields that never contain user-supplied secrets — skip for performance.
+_SKIP_FIELDS: frozenset[str] = frozenset(
+    {
+        "log_level",
+        "timestamp",
+        "logger",
+        "logger_name",
+        "service",
+        "trace_id",
+        "span_id",
+        "error_expected",
+        "should_alert",
+        "level",
+    }
+)
+
+
+def make_secret_redaction_processor(
+    *,
+    enabled: bool = True,
+) -> Any:
+    """Factory that creates a structlog processor with captured enabled state.
+
+    Uses a closure instead of a mutable module-level flag, following
+    immutability principles. The ``enabled`` state is captured at creation
+    time and cannot be changed afterward.
+
+    Args:
+        enabled: Whether to enable secret redaction. Defaults to True
+            (secure by default).
+
+    Returns:
+        A structlog processor function with the standard
+        ``(logger, method_name, event_dict) -> event_dict`` signature.
+    """
+
+    def _processor(
+        _logger: Any, _method_name: Any, event_dict: MutableMapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        """Redact secrets from all string fields in the log event dict.
+
+        Scans the ``event`` (message) string and all other string-valued fields
+        for known secret patterns (API keys, tokens, passwords, connection
+        strings) and replaces them with ``[REDACTED]``.
+
+        Skips structlog-internal fields (log_level, timestamp, etc.) for
+        performance — these never contain user-supplied secrets.
+
+        Uses a heuristic pre-check to skip regex for ~95% of log lines that
+        contain no trigger substrings, keeping overhead negligible.
+
+        Patterns are aligned with Templar TypeScript
+        @templar/middleware/src/audit/redaction.ts.
+        """
+        if not enabled:
+            return event_dict
+
+        # structlog convention: processors mutate event_dict in place
+        for key, value in event_dict.items():
+            if key not in _SKIP_FIELDS and isinstance(value, str):
+                event_dict[key] = redact_text(value)
+
+        return event_dict
+
+    return _processor
+
+
+# Default processor instance (enabled=True) for backward compatibility
+# and direct use without factory.
+secret_redaction_processor = make_secret_redaction_processor(enabled=True)
+
+
+class RedactingFormatter(logging.Formatter):
+    """A logging.Formatter that masks secrets in log output.
+
+    For use in stdlib-only logging contexts (e.g., FUSE daemon process)
+    where structlog is not available. For structlog pipelines, use
+    ``secret_redaction_processor`` instead.
+
+    Includes a heuristic pre-check that skips regex matching for log lines
+    that don't contain any trigger substrings, optimizing the common case.
+    """
+
+    def __init__(
+        self,
+        fmt: str | None = None,
+        datefmt: str | None = None,
+        style: Literal["%", "{", "$"] = "%",
+        *,
+        patterns: tuple[_RedactionPattern, ...] | None = None,
+        enabled: bool = True,
+    ) -> None:
+        super().__init__(fmt, datefmt, style)
+        self._patterns = patterns if patterns is not None else BUILT_IN_SECRET_PATTERNS
+        self._enabled = enabled
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log record and redact secrets from the output."""
+        formatted = super().format(record)
+        if not self._enabled:
+            return formatted
+        return redact_text(formatted, self._patterns)
 
 
 def otel_trace_processor(

--- a/tests/benchmarks/bench_log_redaction.py
+++ b/tests/benchmarks/bench_log_redaction.py
@@ -10,7 +10,7 @@ import logging
 
 import pytest
 
-from nexus.core.logging_utils import RedactingFormatter, redact_text
+from nexus.server.logging_processors import RedactingFormatter, redact_text
 
 # --- Test data ---
 

--- a/tests/e2e/server/test_log_redaction_e2e.py
+++ b/tests/e2e/server/test_log_redaction_e2e.py
@@ -82,7 +82,7 @@ def redaction_server(tmp_path, monkeypatch):
             (
                 f"from nexus.cli import main; "
                 f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
-                f"'--data-dir', '{tmp_path}'])"
+                f"'--data-dir', '{tmp_path}', '--init', '--auth-type', 'database'])"
             ),
         ],
         env=env,
@@ -234,7 +234,7 @@ def test_log_redaction_disabled_e2e(tmp_path, monkeypatch) -> None:
             (
                 f"from nexus.cli import main; "
                 f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
-                f"'--data-dir', '{tmp_path}'])"
+                f"'--data-dir', '{tmp_path}', '--init', '--auth-type', 'database'])"
             ),
         ],
         env=env,

--- a/tests/unit/server/test_log_redaction.py
+++ b/tests/unit/server/test_log_redaction.py
@@ -1,0 +1,557 @@
+"""Unit tests for log redaction / secret masking (Issue #86).
+
+Tests cover:
+- Individual pattern matching (parametrized)
+- Edge cases (empty strings, no secrets, partial matches)
+- RedactingFormatter integration with real Logger
+- Structlog secret_redaction_processor
+- Heuristic pre-check optimization
+- Pattern ordering (specific before generic)
+- Cross-reference with Templar TS pattern names
+"""
+
+import logging
+
+import pytest
+
+from nexus.server.logging_processors import (
+    BUILT_IN_SECRET_PATTERNS,
+    RedactingFormatter,
+    _RedactionPattern,
+    make_secret_redaction_processor,
+    redact_text,
+    secret_redaction_processor,
+)
+
+# ============================================================================
+# Pattern name parity with Templar TypeScript
+# ============================================================================
+
+# These names MUST match @templar/middleware/src/audit/redaction.ts
+# If a name is added/removed in TS, update this set AND the Python patterns.
+TEMPLAR_TS_PATTERN_NAMES = {
+    "bearer_token",
+    "sk_api_key",
+    "postgres_url",
+    "mysql_url",
+    "mongodb_url",
+    "redis_url",
+    "pem_private_key",
+    "aws_access_key",
+    "aws_secret_key",
+    "generic_password",
+}
+
+# Python-only patterns (not in Templar TS)
+PYTHON_ONLY_PATTERN_NAMES = {
+    "nexus_api_key",
+    "django_secret_key",
+    "fernet_key",
+    "jwt_token",
+    "generic_api_key_assignment",
+}
+
+
+def test_pattern_name_parity_with_templar_ts() -> None:
+    """Verify all Templar TS pattern names exist in Python patterns."""
+    python_names = {p.name for p in BUILT_IN_SECRET_PATTERNS}
+    missing_from_python = TEMPLAR_TS_PATTERN_NAMES - python_names
+    assert not missing_from_python, (
+        f"Templar TS patterns missing from Python: {missing_from_python}. "
+        f"See @templar/middleware/src/audit/redaction.ts"
+    )
+
+
+def test_all_expected_patterns_present() -> None:
+    """Verify the complete set of expected pattern names."""
+    python_names = {p.name for p in BUILT_IN_SECRET_PATTERNS}
+    expected = TEMPLAR_TS_PATTERN_NAMES | PYTHON_ONLY_PATTERN_NAMES
+    assert python_names == expected, (
+        f"Pattern set mismatch. "
+        f"Extra: {python_names - expected}. "
+        f"Missing: {expected - python_names}."
+    )
+
+
+# ============================================================================
+# Parametrized pattern tests
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "pattern_name,input_text,expected_contains_redacted",
+    [
+        # --- bearer_token ---
+        (
+            "bearer_token",
+            "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9",
+            True,
+        ),
+        (
+            "bearer_token",
+            "Bearer abc123def456ghi789jkl012mno345pqr678",
+            True,
+        ),
+        (
+            "bearer_token",
+            "bearer abc123def456ghi789jkl012mno345pqr678",
+            True,
+        ),
+        ("bearer_token", "no bearer here", False),
+        # --- sk_api_key ---
+        ("sk_api_key", "Using key sk-1234567890abcdefghijklmno", True),
+        ("sk_api_key", "sk-abcdefghijklmnopqrstuvwxyz12345", True),
+        ("sk_api_key", "sk-short", False),  # Too short (<20 chars)
+        # --- nexus_api_key ---
+        (
+            "nexus_api_key",
+            "api_key=sk-test_admin_550e8400-e29b-41d4-a716-446655440000_a1b2c3d4",
+            True,
+        ),
+        # --- postgres_url ---
+        (
+            "postgres_url",
+            "Connecting to postgresql://user:secret@host:5432/mydb",
+            True,
+        ),
+        (
+            "postgres_url",
+            "postgres://admin:p4ssw0rd@db.example.com/prod",
+            True,
+        ),
+        ("postgres_url", "no database url here", False),
+        # --- mysql_url ---
+        ("mysql_url", "mysql://root:password@localhost:3306/app", True),
+        # --- mongodb_url ---
+        ("mongodb_url", "mongodb://user:pass@cluster.mongodb.net/db", True),
+        (
+            "mongodb_url",
+            "mongodb+srv://user:pass@cluster.mongodb.net/db",
+            True,
+        ),
+        # --- redis_url ---
+        ("redis_url", "redis://default:password@redis-host:6379/0", True),
+        # --- pem_private_key ---
+        (
+            "pem_private_key",
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----",
+            True,
+        ),
+        (
+            "pem_private_key",
+            "-----BEGIN PRIVATE KEY-----\nbase64content\n-----END PRIVATE KEY-----",
+            True,
+        ),
+        # --- aws_access_key ---
+        ("aws_access_key", "Key: AKIAIOSFODNN7EXAMPLE", True),
+        ("aws_access_key", "ASIAJEXAMPLEKEYID1234", True),
+        ("aws_access_key", "not an aws key", False),
+        # --- aws_secret_key ---
+        (
+            "aws_secret_key",
+            "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY12",
+            True,
+        ),
+        (
+            "aws_secret_key",
+            "AWS_SECRET_ACCESS_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY12",
+            True,
+        ),
+        # --- generic_password ---
+        ("generic_password", "password=my_super_secret_p4ss", True),
+        ("generic_password", "pwd: longpassword123", True),
+        ("generic_password", "passwd='verysecretvalue'", True),
+        ("generic_password", "password=short", False),  # Too short (<8 chars)
+        # --- django_secret_key ---
+        (
+            "django_secret_key",
+            "SECRET_KEY='django-insecure-abc123def456ghi789'",
+            True,
+        ),
+        # --- fernet_key (requires keyword context) ---
+        (
+            "fernet_key",
+            "FERNET_KEY=ZmDfcTF7_60GrrY167zsiPd67pEvs0aGOv2oasOM1Pg=",
+            True,
+        ),
+        (
+            "fernet_key",
+            "encryption_key: ZmDfcTF7_60GrrY167zsiPd67pEvs0aGOv2oasOM1Pg=",
+            True,
+        ),
+        (
+            "fernet_key",
+            "Random base64: ZmDfcTF7_60GrrY167zsiPd67pEvs0aGOv2oasOM1Pg=",
+            False,  # No keyword context — not redacted (avoids false positives)
+        ),
+        # --- jwt_token ---
+        (
+            "jwt_token",
+            "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+            True,
+        ),
+        # --- generic_api_key_assignment ---
+        ("generic_api_key_assignment", "api_key=sk-1234567890abcdef", True),
+        (
+            "generic_api_key_assignment",
+            "access_token: very_long_secret_token_value",
+            True,
+        ),
+        (
+            "generic_api_key_assignment",
+            "api_key=short",
+            False,
+        ),  # Too short (<10 chars)
+    ],
+    ids=lambda x: str(x)[:60],
+)
+def test_individual_pattern(
+    pattern_name: str, input_text: str, expected_contains_redacted: bool
+) -> None:
+    """Test each redaction pattern individually."""
+    result = redact_text(input_text)
+    if expected_contains_redacted:
+        assert "[REDACTED]" in result, (
+            f"Pattern '{pattern_name}' should redact: {input_text!r}\nGot: {result!r}"
+        )
+    else:
+        assert "[REDACTED]" not in result, (
+            f"Pattern '{pattern_name}' should NOT redact: {input_text!r}\nGot: {result!r}"
+        )
+
+
+# ============================================================================
+# Edge case tests
+# ============================================================================
+
+
+def test_empty_string() -> None:
+    """Empty string returns empty string."""
+    assert redact_text("") == ""
+
+
+def test_no_secrets() -> None:
+    """String with no secrets is returned unchanged."""
+    text = "2024-01-15 - nexus.core - INFO - File uploaded: /workspace/report.pdf"
+    assert redact_text(text) == text
+
+
+def test_multiple_secrets_in_one_line() -> None:
+    """Multiple different secret types in one line are all redacted."""
+    text = (
+        "Connecting to postgresql://admin:secret@db:5432/prod "
+        "with api_key=sk-abcdefghijklmnopqrstuvwxyz "
+        "and password=my_super_secret"
+    )
+    result = redact_text(text)
+    assert "admin:secret" not in result
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in result
+    assert "my_super_secret" not in result
+    assert result.count("[REDACTED]") >= 3
+
+
+def test_same_secret_multiple_times() -> None:
+    """Same secret appearing multiple times is redacted everywhere."""
+    key = "sk-abcdefghijklmnopqrstuvwxyz12345"
+    text = f"First: {key}, Second: {key}"
+    result = redact_text(text)
+    assert key not in result
+    assert result.count("[REDACTED]") == 2
+
+
+def test_surrounding_text_preserved() -> None:
+    """Non-secret text around a secret is preserved."""
+    text = "Connecting to postgresql://user:password@host/db for operation X"
+    result = redact_text(text)
+    assert "Connecting to" in result
+    assert "for operation X" in result
+    assert "[REDACTED]" in result
+
+
+def test_no_false_positive_on_normal_text() -> None:
+    """Common log messages should not trigger false redaction."""
+    normal_messages = [
+        "File /workspace/data.csv uploaded successfully",
+        "Permission check passed for user alice on /files/report.pdf",
+        "Agent agent-123 started session",
+        "Request processed in 42ms",
+        "Cache hit for path /workspace/config.json",
+        "WebSocket connection established from 192.168.1.100",
+    ]
+    for msg in normal_messages:
+        result = redact_text(msg)
+        assert "[REDACTED]" not in result, f"False positive on: {msg!r}\nGot: {result!r}"
+
+
+# ============================================================================
+# Heuristic pre-check tests
+# ============================================================================
+
+
+def test_heuristic_skip_no_triggers() -> None:
+    """Lines without trigger substrings skip regex entirely."""
+    text = "File uploaded: /data/report.pdf (1024 bytes)"
+    result = redact_text(text)
+    assert result == text  # Unchanged, regex never ran
+
+
+def test_heuristic_triggers_on_url_protocol() -> None:
+    """Lines containing '://' trigger regex check."""
+    text = "Connecting to postgresql://user:secret@host/db"
+    result = redact_text(text)
+    assert "[REDACTED]" in result
+
+
+# ============================================================================
+# Structlog processor tests
+# ============================================================================
+
+
+def test_processor_redacts_event() -> None:
+    """secret_redaction_processor redacts the event field."""
+    processor = make_secret_redaction_processor(enabled=True)
+    event_dict: dict = {
+        "event": "Connecting to postgresql://admin:secret@db:5432/prod",
+        "log_level": "info",
+    }
+    result = processor(None, None, event_dict)
+    assert "admin:secret" not in result["event"]
+    assert "[REDACTED]" in result["event"]
+
+
+def test_processor_preserves_non_secret_events() -> None:
+    """secret_redaction_processor leaves clean events unchanged."""
+    processor = make_secret_redaction_processor(enabled=True)
+    event_dict: dict = {
+        "event": "Normal operation completed successfully",
+        "log_level": "info",
+    }
+    result = processor(None, None, event_dict)
+    assert result["event"] == "Normal operation completed successfully"
+
+
+def test_processor_disabled() -> None:
+    """Processor created with enabled=False is a no-op."""
+    processor = make_secret_redaction_processor(enabled=False)
+    secret_msg = "api_key=sk-12345678901234567890abcdef"
+    event_dict: dict = {"event": secret_msg, "log_level": "info"}
+    result = processor(None, None, event_dict)
+    assert result["event"] == secret_msg  # Not redacted
+
+
+def test_processor_handles_non_string_event() -> None:
+    """secret_redaction_processor handles non-string event gracefully."""
+    processor = make_secret_redaction_processor(enabled=True)
+    event_dict: dict = {"event": 42, "log_level": "info"}
+    result = processor(None, None, event_dict)
+    assert result["event"] == 42  # Unchanged
+
+
+def test_processor_redacts_all_string_fields() -> None:
+    """Processor redacts secrets in non-event string fields too."""
+    processor = make_secret_redaction_processor(enabled=True)
+    event_dict: dict = {
+        "event": "auth failed",
+        "db_url": "postgresql://admin:secret@db:5432/prod",
+        "token": "sk-abcdefghijklmnopqrstuvwxyz12345",
+        "log_level": "error",  # Should be skipped (internal field)
+        "count": 42,  # Should be skipped (not a string)
+    }
+    result = processor(None, None, event_dict)
+    assert "admin:secret" not in result["db_url"]
+    assert "[REDACTED]" in result["db_url"]
+    assert "sk-abcdefghijklmnopqrstuvwxyz12345" not in result["token"]
+    assert "[REDACTED]" in result["token"]
+    assert result["log_level"] == "error"  # Unchanged (skipped field)
+    assert result["count"] == 42  # Unchanged (not string)
+
+
+def test_default_processor_is_enabled() -> None:
+    """The module-level secret_redaction_processor is enabled by default."""
+    event_dict: dict = {
+        "event": "Connecting to postgresql://admin:secret@db:5432/prod",
+        "log_level": "info",
+    }
+    result = secret_redaction_processor(None, None, event_dict)
+    assert "admin:secret" not in result["event"]
+    assert "[REDACTED]" in result["event"]
+
+
+# ============================================================================
+# RedactingFormatter tests (for FUSE daemon / stdlib fallback)
+# ============================================================================
+
+
+def test_formatter_redacts_message() -> None:
+    """RedactingFormatter redacts secrets in formatted output."""
+    formatter = RedactingFormatter("%(message)s")
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Connecting to postgresql://admin:secret@db:5432/mydb",
+        args=None,
+        exc_info=None,
+    )
+    result = formatter.format(record)
+    assert "admin:secret" not in result
+    assert "[REDACTED]" in result
+
+
+def test_formatter_preserves_non_secret_messages() -> None:
+    """RedactingFormatter leaves clean messages unchanged."""
+    formatter = RedactingFormatter("%(message)s")
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Normal operation completed successfully",
+        args=None,
+        exc_info=None,
+    )
+    result = formatter.format(record)
+    assert result == "Normal operation completed successfully"
+
+
+def test_formatter_disabled() -> None:
+    """RedactingFormatter with enabled=False passes through unchanged."""
+    formatter = RedactingFormatter("%(message)s", enabled=False)
+    secret_msg = "api_key=sk-12345678901234567890abcdef"
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg=secret_msg,
+        args=None,
+        exc_info=None,
+    )
+    result = formatter.format(record)
+    assert result == secret_msg  # Not redacted
+
+
+def test_formatter_custom_patterns() -> None:
+    """RedactingFormatter accepts custom patterns."""
+    custom = (_RedactionPattern("custom_secret", r"MYSECRET-[0-9]+"),)
+    formatter = RedactingFormatter("%(message)s", patterns=custom)
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Using MYSECRET-12345678",
+        args=None,
+        exc_info=None,
+    )
+    result = formatter.format(record)
+    assert "MYSECRET-12345678" not in result
+    assert "[REDACTED]" in result
+
+
+def test_formatter_with_format_string() -> None:
+    """RedactingFormatter works with full format string including timestamp."""
+    formatter = RedactingFormatter("%(name)s - %(levelname)s - %(message)s")
+    record = logging.LogRecord(
+        name="nexus.auth",
+        level=logging.WARNING,
+        pathname="auth.py",
+        lineno=42,
+        msg="Token expired: Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature_data",
+        args=None,
+        exc_info=None,
+    )
+    result = formatter.format(record)
+    assert "nexus.auth" in result
+    assert "WARNING" in result
+    assert "Token expired:" in result
+    assert "eyJhbGciOiJIUzI1NiJ9" not in result
+
+
+# ============================================================================
+# Integration: MemoryHandler + RedactingFormatter
+# ============================================================================
+
+
+class _MemoryHandler(logging.Handler):
+    """Simple in-memory handler for testing."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(self.format(record))
+
+
+def test_integration_real_logger_redacts() -> None:
+    """Integration test: real Logger with MemoryHandler + RedactingFormatter."""
+    handler = _MemoryHandler()
+    handler.setFormatter(RedactingFormatter("%(message)s"))
+
+    logger = logging.getLogger("test_integration_redact")
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    # Log messages with secrets
+    logger.info("Connecting to postgresql://admin:secret@db:5432/prod")
+    logger.warning("API key: sk-abcdefghijklmnopqrstuvwxyz12345")
+    logger.error("Auth failed with Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig")
+    logger.debug("Normal debug message without secrets")
+
+    assert len(handler.records) == 4
+
+    # Secrets are redacted
+    assert "admin:secret" not in handler.records[0]
+    assert "[REDACTED]" in handler.records[0]
+
+    assert "sk-abcdefghijklmnopqrstuvwxyz12345" not in handler.records[1]
+    assert "[REDACTED]" in handler.records[1]
+
+    assert "eyJhbGciOiJIUzI1NiJ9" not in handler.records[2]
+    assert "[REDACTED]" in handler.records[2]
+
+    # Normal message unchanged
+    assert handler.records[3] == "Normal debug message without secrets"
+
+
+# ============================================================================
+# Traceback redaction
+# ============================================================================
+
+
+def test_traceback_secrets_redacted() -> None:
+    """Secrets in traceback messages are redacted."""
+    handler = _MemoryHandler()
+    handler.setFormatter(RedactingFormatter("%(message)s"))
+
+    logger = logging.getLogger("test_traceback_redact")
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.ERROR)
+    logger.propagate = False
+
+    try:
+        raise ConnectionError("Failed to connect to postgresql://admin:secret@db:5432/prod")
+    except ConnectionError:
+        logger.exception("Database connection failed")
+
+    assert len(handler.records) == 1
+    assert "admin:secret" not in handler.records[0]
+    assert "[REDACTED]" in handler.records[0]
+
+
+# ============================================================================
+# Pattern ordering
+# ============================================================================
+
+
+def test_nexus_api_key_takes_precedence_over_generic_sk() -> None:
+    """Nexus API key pattern (more specific) runs before generic sk- pattern."""
+    text = "key=sk-test_admin_550e8400-e29b-41d4-a716-446655440000_a1b2c3d4"
+    result = redact_text(text)
+    assert "sk-test_admin" not in result
+    assert "[REDACTED]" in result


### PR DESCRIPTION
## Summary

- Consolidate secret redaction into `server/logging_processors.py` as a structlog processor, replacing the deleted `core/logging_utils.py`
- Fix 3 broken imports left behind when `logging_utils.py` was deleted on develop
- Wire redaction into `configure_logging()` pipeline with immutable closure factory pattern (`make_secret_redaction_processor`)

## What Changed

| File | Change |
|------|--------|
| `src/nexus/server/logging_processors.py` | +319 lines — 15 regex patterns, `redact_text()`, `make_secret_redaction_processor()`, `RedactingFormatter`, heuristic pre-check |
| `src/nexus/server/logging_config.py` | +22 lines — Wired redaction processor into structlog pipeline with env var config |
| `src/nexus/cli/commands/server.py` | Fixed 3 broken imports from deleted `logging_utils.py`, unified to `configure_logging()` |
| `tests/unit/server/test_log_redaction.py` | NEW — 58 unit tests covering all patterns, edge cases, factory, formatter |
| `tests/benchmarks/bench_log_redaction.py` | Fixed import path |
| `tests/e2e/server/test_log_redaction_e2e.py` | Added `--init --auth-type database` flags for server startup |

## Key Design Decisions

- **15 regex patterns** (10 Templar TS parity + 5 Python-specific) with heuristic pre-check that skips regex for ~95% of log lines
- **All string fields scanned** in structlog event dict (not just `event` message), with `_SKIP_FIELDS` exclusion for internal fields
- **Immutable closure factory** (`make_secret_redaction_processor(enabled=True)`) — no mutable global state
- **RedactingFormatter** retained for FUSE daemon (stdlib-only, no structlog)
- **Placement**: `server/logging_processors.py` per LEGO Architecture — log formatting is presentation layer, not kernel

## Performance

| Scenario | Median | Target |
|---|---|---|
| Clean line (no secrets) | 1.7μs | < 1ms |
| One secret | 7.4μs | < 1ms |
| Multi-secret (worst case) | 16.9μs | < 1ms |

## Test Plan

- [x] 58 unit tests (all 15 patterns, edge cases, factory, formatter, all-field scanning)
- [x] 5 benchmark tests (performance regression guard)
- [x] 2 e2e tests (real `nexus serve` with `--auth-type database`)
- [x] Manual live server validation: 7 secret types verified NOT in logs
- [x] Ruff lint + format clean
- [x] mypy clean (no type errors)
- [ ] CI passes

**Stream:** #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)