### PR TITLE
fix(#668): move parse_fn creation from NexusFS kernel to factory.py

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -108,6 +108,7 @@ class NexusFS(  # type: ignore[misc]
         memory: MemoryConfig | None = None,
         parsing: ParseConfig | None = None,
         services: KernelServices | None = None,
+        parse_fn: Any | None = None,
     ):
         """Initialize NexusFS kernel.
 
@@ -124,6 +125,8 @@ class NexusFS(  # type: ignore[misc]
             memory: Memory paging config. Defaults to MemoryConfig().
             parsing: File parsing config. Defaults to ParseConfig().
             services: Injected service dependencies. Defaults to KernelServices().
+            parse_fn: Pre-built parse callback ``(bytes, str) -> bytes | None``
+                for virtual views. Created by factory.py via create_default_parse_fn().
         """
         # Apply defaults — config dataclasses are SSOT for default values
         cache = cache or CacheConfig()
@@ -198,10 +201,8 @@ class NexusFS(  # type: ignore[misc]
         self.parser_registry = ParserRegistry()
         self.parser_registry.register(MarkItDownParser())
 
-        # Provide parse callback for virtual views (core/ must not import parsers directly)
-        from nexus.parsers import create_default_parse_fn
-
-        self._virtual_view_parse_fn = create_default_parse_fn()
+        # Parse callback for virtual views — injected by factory.py (Issue #668)
+        self._virtual_view_parse_fn = parse_fn
 
         # Initialize new provider registry for read(parsed=True) support
         from nexus.parsers.providers import ProviderRegistry

--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -1351,6 +1351,11 @@ def create_nexus_fs(
 
         services = _dc_replace(services, workflow_engine=workflow_engine)
 
+    # Create parse callback for virtual views (Issue #668: factory creates services)
+    from nexus.parsers import create_default_parse_fn
+
+    _parse_fn = create_default_parse_fn()
+
     nx = NexusFS(
         backend=backend,
         metadata_store=metadata_store,
@@ -1364,6 +1369,7 @@ def create_nexus_fs(
         memory=memory,
         parsing=parsing,
         services=services,
+        parse_fn=_parse_fn,
     )
 
     # Post-construction I/O (mount restoration, etc.)


### PR DESCRIPTION
## Summary
- Move `create_default_parse_fn()` call from `NexusFS.__init__()` to `factory.py` per KERNEL-ARCHITECTURE.md ("factory.py is systemd — all service creation happens there")
- Add `parse_fn` parameter to `NexusFS.__init__()` for dependency injection
- Callers that don't pass `parse_fn` (e.g., tests) get `None` — virtual view parsing gracefully degrades

## Test plan
- [ ] Factory-created NexusFS instances still have parse_fn injected
- [ ] Test NexusFS instances (no parse_fn) don't break — virtual views return None
- [ ] No regressions in existing parse/virtual view tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)