### PR TITLE
fix(#615): replace direct create_async_engine in search daemon with RecordStoreABC

### DIFF
--- a/src/nexus/search/daemon.py
+++ b/src/nexus/search/daemon.py
@@ -150,6 +150,7 @@ class SearchDaemon:
         self._async_session: Any | None = None  # async_sessionmaker (Issue #1597)
         self._async_search: AsyncSemanticSearch | None = None
         self._embedding_provider: Any = None
+        self._record_store: Any | None = None  # SQLAlchemyRecordStore fallback
         self._owns_engine = False  # True only when we created the engine ourselves
 
         # Accept injected session factory from RecordStoreABC
@@ -253,9 +254,13 @@ class SearchDaemon:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._refresh_task
 
-        # Close database connections (only if we created the engine)
-        if self._async_engine and self._owns_engine:
-            await self._async_engine.dispose()
+        # Close database connections (only if we created them)
+        if self._owns_engine:
+            if self._record_store is not None:
+                self._record_store.close()
+                self._record_store = None
+            elif self._async_engine:
+                await self._async_engine.dispose()
         self._async_engine = None
         self._async_session = None
 
@@ -315,30 +320,15 @@ class SearchDaemon:
         start = time.perf_counter()
 
         try:
-            from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+            from nexus.storage.record_store import SQLAlchemyRecordStore
 
-            # Convert sync URL to async
-            db_url = self.config.database_url
-            if db_url.startswith("postgresql://"):
-                db_url = db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
-            elif db_url.startswith("sqlite:///"):
-                db_url = db_url.replace("sqlite:///", "sqlite+aiosqlite:///", 1)
-
-            self._async_engine = create_async_engine(
-                db_url,
-                pool_pre_ping=True,
-                pool_size=self.config.db_pool_min_size,
-                max_overflow=self.config.db_pool_max_size - self.config.db_pool_min_size,
-                pool_recycle=self.config.db_pool_recycle,
-            )
+            # Delegate engine creation to RecordStoreABC (Issue #615).
+            # Pool settings are controlled via NEXUS_DB_POOL_SIZE / NEXUS_DB_MAX_OVERFLOW
+            # environment variables inside SQLAlchemyRecordStore.
+            self._record_store = SQLAlchemyRecordStore(db_url=self.config.database_url)
+            self._async_session = self._record_store.async_session_factory
+            self._async_engine = self._record_store._async_engine
             self._owns_engine = True
-
-            # Create session factory once (Issue #1597: avoid per-method creation).
-            # expire_on_commit=False matches RecordStoreABC convention and avoids
-            # lazy-load exceptions after commit in async context (SA2 best practice).
-            self._async_session = async_sessionmaker(
-                self._async_engine, class_=AsyncSession, expire_on_commit=False
-            )
 
             # Warm the pool by executing a simple query
             async with self._async_engine.connect() as conn:
@@ -1037,6 +1027,8 @@ def set_search_daemon(daemon: SearchDaemon) -> None:
 async def create_and_start_daemon(
     database_url: str | None = None,
     bm25s_index_dir: str | None = None,
+    *,
+    async_session_factory: Any | None = None,
 ) -> SearchDaemon:
     """Create, configure and start a search daemon.
 
@@ -1045,6 +1037,7 @@ async def create_and_start_daemon(
     Args:
         database_url: Database URL (from env if not provided)
         bm25s_index_dir: BM25S index directory
+        async_session_factory: Injected async_sessionmaker from RecordStoreABC.
 
     Returns:
         Initialized SearchDaemon instance
@@ -1054,7 +1047,7 @@ async def create_and_start_daemon(
         bm25s_index_dir=bm25s_index_dir or ".nexus-data/bm25s",
     )
 
-    daemon = SearchDaemon(config)
+    daemon = SearchDaemon(config, async_session_factory=async_session_factory)
     await daemon.startup()
 
     set_search_daemon(daemon)

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -567,13 +567,22 @@ async def lifespan(_app: FastAPI) -> Any:
                 entropy_alpha=float(os.getenv("NEXUS_ENTROPY_ALPHA", "0.5")),
             )
 
-            _app.state.search_daemon = SearchDaemon(config)
+            # Inject async_session_factory from RecordStoreABC (Issue #615)
+            _record_store = getattr(_app.state.nexus_fs, "_record_store", None)
+            _async_sf = None
+            if _record_store is not None:
+                with suppress(Exception):
+                    _async_sf = _record_store.async_session_factory
+
+            _app.state.search_daemon = SearchDaemon(config, async_session_factory=_async_sf)
             await _app.state.search_daemon.startup()
             _app.state.search_daemon_enabled = True
             set_search_daemon(_app.state.search_daemon)
 
-            # Set NexusFS reference for index refresh (Issue #1024)
-            _app.state.search_daemon._nexus_fs = _app.state.nexus_fs
+            # Issue #1520: Set FileReaderProtocol for index refresh
+            from nexus.factory import _NexusFSFileReader
+
+            _app.state.search_daemon._file_reader = _NexusFSFileReader(_app.state.nexus_fs)
 
             stats = _app.state.search_daemon.get_stats()
             logger.info(


### PR DESCRIPTION
## Summary
- **daemon.py**: Replace direct `create_async_engine()` in `_init_database_pool()` with `SQLAlchemyRecordStore` creation, delegating engine/session management to RecordStoreABC (KERNEL-ARCHITECTURE.md §7)
- **fastapi_server.py**: Inject `async_session_factory` from NexusFS's RecordStore into SearchDaemon (matching the lifespan/search.py pattern), and set FileReaderProtocol for index refresh
- **create_and_start_daemon()**: Accept optional `async_session_factory` kwarg for DI

Note: `async_search.py` already delegates to `SQLAlchemyRecordStore` — no changes needed there.

## Test plan
- [ ] Verify search daemon starts correctly with injected session factory
- [ ] Verify fallback path (no session factory) creates via RecordStoreABC
- [ ] Verify daemon shutdown cleans up RecordStore properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)