### PR TITLE
fix(#621): replace direct create_engine in AsyncReBACBridge with RecordStoreABC

### DIFF
--- a/src/nexus/core/async_bridge.py
+++ b/src/nexus/core/async_bridge.py
@@ -10,8 +10,8 @@ non-blocking I/O.
 Usage:
     from nexus.core.async_bridge import AsyncReBACBridge
 
-    # Initialize once at server startup
-    bridge = AsyncReBACBridge(database_url)
+    # Initialize once at server startup (prefer injecting engine via DI)
+    bridge = AsyncReBACBridge(database_url, engine=record_store.engine)
     bridge.start()
 
     # Use in sync request handlers
@@ -56,6 +56,8 @@ class AsyncReBACBridge:
         enable_l1_cache: bool = True,
         l1_cache_size: int = 10000,
         l1_cache_ttl: int = 300,
+        *,
+        engine: Any | None = None,
     ):
         """Initialize the async bridge.
 
@@ -66,6 +68,8 @@ class AsyncReBACBridge:
             enable_l1_cache: Enable in-memory L1 cache
             l1_cache_size: L1 cache max entries
             l1_cache_ttl: L1 cache TTL in seconds
+            engine: Pre-built SQLAlchemy Engine from RecordStoreABC (Issue #621).
+                When provided, skips creating a private engine.
         """
         self.database_url = database_url
         self.cache_ttl_seconds = cache_ttl_seconds
@@ -73,10 +77,12 @@ class AsyncReBACBridge:
         self.enable_l1_cache = enable_l1_cache
         self.l1_cache_size = l1_cache_size
         self.l1_cache_ttl = l1_cache_ttl
+        self._injected_engine = engine
 
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._manager: AsyncReBACManager | None = None
+        self._record_store: Any | None = None  # SQLAlchemyRecordStore fallback
         self._started = False
         self._lock = threading.Lock()
 
@@ -116,6 +122,9 @@ class AsyncReBACBridge:
             self._loop = None
             self._thread = None
             self._manager = None
+            if self._record_store is not None:
+                self._record_store.close()
+                self._record_store = None
             self._started = False
             logger.info("AsyncReBACBridge stopped")
 
@@ -147,13 +156,21 @@ class AsyncReBACBridge:
 
         Issue #1385: AsyncReBACManager is now a thin asyncio.to_thread() wrapper
         around the sync ReBACManager. We create a sync manager and wrap it.
-        """
-        from sqlalchemy import create_engine
 
+        Issue #621: Engine creation delegates to RecordStoreABC instead of
+        calling create_engine() directly.
+        """
         from nexus.rebac.async_manager import AsyncReBACManager
         from nexus.rebac.manager import ReBACManager
 
-        sync_engine = create_engine(self.database_url)
+        if self._injected_engine is not None:
+            sync_engine = self._injected_engine
+        else:
+            from nexus.storage.record_store import SQLAlchemyRecordStore
+
+            self._record_store = SQLAlchemyRecordStore(db_url=self.database_url)
+            sync_engine = self._record_store.engine
+
         sync_manager = ReBACManager(
             engine=sync_engine,
             cache_ttl_seconds=self.cache_ttl_seconds,
@@ -284,11 +301,17 @@ class AsyncReBACBridge:
 _global_bridge: AsyncReBACBridge | None = None
 
 
-def get_async_rebac_bridge(database_url: str | None = None, **kwargs: Any) -> AsyncReBACBridge:
+def get_async_rebac_bridge(
+    database_url: str | None = None,
+    *,
+    engine: Any | None = None,
+    **kwargs: Any,
+) -> AsyncReBACBridge:
     """Get or create the global async ReBAC bridge.
 
     Args:
-        database_url: Database URL (required on first call)
+        database_url: Database URL (required on first call unless engine given)
+        engine: Pre-built SQLAlchemy Engine from RecordStoreABC (Issue #621).
         **kwargs: Additional arguments for AsyncReBACBridge
 
     Returns:
@@ -299,7 +322,7 @@ def get_async_rebac_bridge(database_url: str | None = None, **kwargs: Any) -> As
     if _global_bridge is None:
         if database_url is None:
             raise ValueError("database_url required on first call")
-        _global_bridge = AsyncReBACBridge(database_url, **kwargs)
+        _global_bridge = AsyncReBACBridge(database_url, engine=engine, **kwargs)
         _global_bridge.start()
 
     return _global_bridge


### PR DESCRIPTION
## Summary
- **async_bridge.py**: `_init_manager()` no longer calls `create_engine()` directly. Instead accepts an injected `engine` via constructor DI and falls back to `SQLAlchemyRecordStore` creation (KERNEL-ARCHITECTURE.md §7)
- Added `engine` kwarg to `AsyncReBACBridge.__init__` and `get_async_rebac_bridge()`
- Properly closes `_record_store` on `stop()`

## Test plan
- [ ] Verify AsyncReBACBridge works with injected engine
- [ ] Verify fallback path creates engine via SQLAlchemyRecordStore
- [ ] Verify stop() cleans up RecordStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)