### PR TITLE
fix(#592): replace direct create_async_engine in rebac async_manager with RecordStoreABC

### DIFF
--- a/src/nexus/rebac/async_manager.py
+++ b/src/nexus/rebac/async_manager.py
@@ -14,12 +14,9 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import Any
 
 from nexus.rebac.types import WriteResult
-
-logger = logging.getLogger(__name__)
 
 
 class AsyncReBACManager:
@@ -251,69 +248,21 @@ class AsyncReBACManager:
 # ── Utility ─────────────────────────────────────────────────────────
 
 
-def create_async_engine_from_url(
-    database_url: str,
-    pool_size: int | None = None,
-    max_overflow: int | None = None,
-    pool_recycle: int | None = None,
-    prepared_statement_cache_size: int = 1024,
-) -> Any:
-    """Create async SQLAlchemy engine from database URL.
+def create_async_engine_from_url(database_url: str) -> Any:
+    """Create async SQLAlchemy engine from database URL via RecordStoreABC.
 
-    Automatically selects the correct async driver:
-    - postgresql:// -> postgresql+asyncpg://
-    - sqlite:// -> sqlite+aiosqlite://
+    Delegates to SQLAlchemyRecordStore which handles URL conversion and pool
+    settings internally (Issue #592).
 
     Args:
         database_url: Standard database URL
-        pool_size: Connection pool size (default: from env or 20)
-        max_overflow: Max overflow connections (default: from env or 30)
-        pool_recycle: Seconds before connection recycling (default: from env or 1800)
-        prepared_statement_cache_size: Asyncpg statement cache size (default: 1024)
 
     Returns:
         AsyncEngine instance
     """
-    import os
+    from nexus.storage.record_store import SQLAlchemyRecordStore
 
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    # Convert to async driver URL
-    if database_url.startswith("postgresql://"):
-        async_url = database_url.replace("postgresql://", "postgresql+asyncpg://")
-    elif database_url.startswith("sqlite://"):
-        async_url = database_url.replace("sqlite://", "sqlite+aiosqlite://")
-    else:
-        async_url = database_url
-
-    engine_kwargs: dict[str, Any] = {
-        "echo": False,
-        "pool_recycle": pool_recycle or int(os.getenv("NEXUS_DB_POOL_RECYCLE", "1800")),
-    }
-
-    if "postgresql" in async_url:
-        engine_kwargs["pool_size"] = pool_size or int(os.getenv("NEXUS_DB_POOL_SIZE", "20"))
-        engine_kwargs["max_overflow"] = max_overflow or int(
-            os.getenv("NEXUS_DB_MAX_OVERFLOW", "30")
-        )
-        engine_kwargs["pool_timeout"] = int(os.getenv("NEXUS_DB_POOL_TIMEOUT", "30"))
-        engine_kwargs["pool_pre_ping"] = True
-        engine_kwargs["pool_use_lifo"] = True
-
-        statement_timeout = os.getenv("NEXUS_DB_STATEMENT_TIMEOUT", "60000")
-        engine_kwargs["connect_args"] = {
-            "prepared_statement_cache_size": prepared_statement_cache_size,
-            "server_settings": {
-                "plan_cache_mode": "force_custom_plan",
-                "statement_timeout": statement_timeout,
-            },
-        }
-
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "Async PostgreSQL engine: pool_size=%d, max_overflow=%d",
-                engine_kwargs["pool_size"],
-                engine_kwargs["max_overflow"],
-            )
-
-    return create_async_engine(async_url, **engine_kwargs)
+    store = SQLAlchemyRecordStore(db_url=database_url)
+    # Trigger lazy async engine creation and return it
+    _ = store.async_session_factory
+    return store._async_engine

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -51,10 +51,7 @@ async def _startup_async_rebac(app: FastAPI) -> None:
         return
 
     try:
-        from nexus.services.permissions.async_rebac_manager import (
-            AsyncReBACManager,
-            create_async_engine_from_url,
-        )
+        from nexus.rebac.async_manager import AsyncReBACManager, create_async_engine_from_url
 
         engine = create_async_engine_from_url(app.state.database_url)
         app.state.async_rebac_manager = AsyncReBACManager(engine)

--- a/src/nexus/services/permissions/async_rebac_manager.py
+++ b/src/nexus/services/permissions/async_rebac_manager.py
@@ -1,8 +1,0 @@
-"""Backward-compat shim: nexus.services.permissions.async_rebac_manager.
-
-Canonical location: ``nexus.rebac.async_manager``
-"""
-
-from nexus.rebac.async_manager import AsyncReBACManager, create_async_engine_from_url
-
-__all__ = ["AsyncReBACManager", "create_async_engine_from_url"]


### PR DESCRIPTION
## Summary
- **rebac/async_manager.py**: Rewrite `create_async_engine_from_url()` to delegate engine creation to `SQLAlchemyRecordStore` instead of calling `create_async_engine()` directly (KERNEL-ARCHITECTURE.md §7)
- **lifespan/permissions.py**: Import from canonical `nexus.rebac.async_manager` instead of backward-compat shim
- **Delete** `services/permissions/async_rebac_manager.py` backward-compat shim (no backward compatibility per policy)
- Remove unused `logging` import from `async_manager.py`

## Test plan
- [ ] Verify async ReBAC manager initializes correctly via lifespan
- [ ] Verify create_async_engine_from_url returns working engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)