### PR TITLE
fix(#526): replace direct session.query(VersionHistoryModel) with memory_api.list_versions

### DIFF
--- a/src/nexus/server/api/v2/routers/memories.py
+++ b/src/nexus/server/api/v2/routers/memories.py
@@ -136,27 +136,7 @@ async def get_memory(
 
         if include_history:
             try:
-                from nexus.storage.models import VersionHistoryModel
-
-                session = memory_api.session
-                versions = (
-                    session.query(VersionHistoryModel)
-                    .filter(
-                        VersionHistoryModel.resource_id == memory_id,
-                        VersionHistoryModel.resource_type == "memory",
-                    )
-                    .order_by(VersionHistoryModel.version_number.desc())
-                    .all()
-                )
-                response["versions"] = [
-                    {
-                        "version": v.version_number,
-                        "content_hash": v.content_hash,
-                        "created_at": v.created_at.isoformat() if v.created_at else None,
-                        "metadata": getattr(v, "metadata", None),
-                    }
-                    for v in versions
-                ]
+                response["versions"] = memory_api.list_versions(memory_id)
             except Exception as e:
                 logger.warning(f"Failed to fetch version history: {e}")
                 response["versions"] = []


### PR DESCRIPTION
## Summary
- Remove direct `from nexus.storage.models import VersionHistoryModel` and raw `session.query()` from the memories API router
- Use existing `memory_api.list_versions(memory_id)` which properly encapsulates the query through the service layer
- Reduces 21 lines to 1 line while maintaining the same behavior

## Test plan
- [ ] Verify GET /api/v2/memories/{id}?include_history=true returns version data
- [ ] Verify version history format is consistent with GET /api/v2/memories/{id}/history

🤖 Generated with [Claude Code](https://claude.com/claude-code)