### PR TITLE
fix(#893): standardize nexus_fast import path

### DIFF
--- a/src/nexus/core/grep_fast.py
+++ b/src/nexus/core/grep_fast.py
@@ -19,21 +19,13 @@ _rust_grep_bulk: Callable[..., list[dict[str, Any]]] | None = None
 _rust_grep_files_mmap: Callable[..., list[dict[str, Any]]] | None = None
 
 try:
-    from nexus._nexus_fast import grep_bulk as _rust_grep_bulk  # type: ignore[no-redef]
-    from nexus._nexus_fast import grep_files_mmap as _rust_grep_files_mmap  # type: ignore[no-redef]
+    from nexus_fast import grep_bulk as _rust_grep_bulk  # type: ignore[no-redef]
+    from nexus_fast import grep_files_mmap as _rust_grep_files_mmap  # type: ignore[no-redef]
 
     RUST_AVAILABLE = True
     MMAP_AVAILABLE = True
 except ImportError:
-    try:
-        # Fallback to external nexus_fast package
-        from nexus_fast import grep_bulk as _rust_grep_bulk  # type: ignore[no-redef]
-        from nexus_fast import grep_files_mmap as _rust_grep_files_mmap  # type: ignore[no-redef]
-
-        RUST_AVAILABLE = True
-        MMAP_AVAILABLE = True
-    except ImportError:
-        pass
+    pass
 
 
 def grep_bulk(

--- a/src/nexus/core/hash_fast.py
+++ b/src/nexus/core/hash_fast.py
@@ -36,10 +36,10 @@ _rust_hash_content_smart: Any = None
 
 # Priority 1: Rust-accelerated BLAKE3
 try:
-    import nexus._nexus_fast as _nexus_fast_mod
+    from nexus_fast import hash_content_py, hash_content_smart_py
 
-    _rust_hash_content = _nexus_fast_mod.hash_content
-    _rust_hash_content_smart = _nexus_fast_mod.hash_content_smart
+    _rust_hash_content = hash_content_py
+    _rust_hash_content_smart = hash_content_smart_py
     _RUST_AVAILABLE = True
     logger.debug("Using Rust BLAKE3 acceleration")
 except (ImportError, AttributeError):

--- a/src/nexus/core/trigram_fast.py
+++ b/src/nexus/core/trigram_fast.py
@@ -29,50 +29,28 @@ _trigram_index_stats: Callable[..., dict[str, Any]] | None = None
 _invalidate_trigram_cache: Callable[..., None] | None = None
 
 try:
-    from nexus._nexus_fast import (  # type: ignore[no-redef]
+    from nexus_fast import (  # type: ignore[no-redef]
         build_trigram_index as _build_trigram_index,
     )
-    from nexus._nexus_fast import (  # type: ignore[no-redef]
+    from nexus_fast import (  # type: ignore[no-redef]
         build_trigram_index_from_entries as _build_trigram_index_from_entries,
     )
-    from nexus._nexus_fast import (  # type: ignore[no-redef]
+    from nexus_fast import (  # type: ignore[no-redef]
         invalidate_trigram_cache as _invalidate_trigram_cache,
     )
-    from nexus._nexus_fast import (  # type: ignore[no-redef]
+    from nexus_fast import (  # type: ignore[no-redef]
         trigram_grep as _trigram_grep,
     )
-    from nexus._nexus_fast import (  # type: ignore[no-redef]
+    from nexus_fast import (  # type: ignore[no-redef]
         trigram_index_stats as _trigram_index_stats,
     )
-    from nexus._nexus_fast import (  # type: ignore[no-redef]
+    from nexus_fast import (  # type: ignore[no-redef]
         trigram_search_candidates as _trigram_search_candidates,
     )
 
     TRIGRAM_AVAILABLE = True
 except ImportError:
-    try:
-        from nexus_fast import (  # type: ignore[no-redef]
-            build_trigram_index as _build_trigram_index,
-        )
-        from nexus_fast import (  # type: ignore[no-redef]
-            build_trigram_index_from_entries as _build_trigram_index_from_entries,
-        )
-        from nexus_fast import (  # type: ignore[no-redef]
-            invalidate_trigram_cache as _invalidate_trigram_cache,
-        )
-        from nexus_fast import (  # type: ignore[no-redef]
-            trigram_grep as _trigram_grep,
-        )
-        from nexus_fast import (  # type: ignore[no-redef]
-            trigram_index_stats as _trigram_index_stats,
-        )
-        from nexus_fast import (  # type: ignore[no-redef]
-            trigram_search_candidates as _trigram_search_candidates,
-        )
-
-        TRIGRAM_AVAILABLE = True
-    except ImportError:
-        pass
+    pass
 
 
 def is_available() -> bool:

--- a/src/nexus/rebac/utils/fast.py
+++ b/src/nexus/rebac/utils/fast.py
@@ -28,30 +28,19 @@ NamespaceConfigDict = dict[str, Any]  # Contains 'relations' and 'permissions' k
 
 logger = logging.getLogger(__name__)
 
-# Try to import Rust extensions
-# - nexus._nexus_fast: Internal module (faster bulk operations)
-# - nexus_fast: External package (has compute_permission_single)
+# Try to import Rust extension (nexus_fast PyO3 crate)
 _internal_module: Any = None
 _external_module: Any = None
 RUST_AVAILABLE = False
 
 try:
-    from nexus import _nexus_fast as _internal_module  # type: ignore[no-redef]
+    import nexus_fast as _rust_module
 
+    _internal_module = _rust_module
+    _external_module = _rust_module
     RUST_AVAILABLE = True
-    logger.info("✓ Rust bulk acceleration available (nexus._nexus_fast)")
+    logger.info("✓ Rust acceleration available (nexus_fast)")
 except ImportError:
-    pass
-
-try:
-    import nexus_fast as _external_module  # type: ignore[no-redef]
-
-    RUST_AVAILABLE = True
-    logger.info("✓ Rust single-check acceleration available (nexus_fast)")
-except ImportError:
-    pass
-
-if not RUST_AVAILABLE:
     logger.info("✗ Rust acceleration not available")
 
 

--- a/src/nexus/services/permissions/utils/fast.py
+++ b/src/nexus/services/permissions/utils/fast.py
@@ -28,30 +28,19 @@ NamespaceConfigDict = dict[str, Any]  # Contains 'relations' and 'permissions' k
 
 logger = logging.getLogger(__name__)
 
-# Try to import Rust extensions
-# - nexus._nexus_fast: Internal module (faster bulk operations)
-# - nexus_fast: External package (has compute_permission_single)
+# Try to import Rust extension (nexus_fast PyO3 crate)
 _internal_module: Any = None
 _external_module: Any = None
 RUST_AVAILABLE = False
 
 try:
-    from nexus import _nexus_fast as _internal_module  # type: ignore[no-redef]
+    import nexus_fast as _rust_module
 
+    _internal_module = _rust_module
+    _external_module = _rust_module
     RUST_AVAILABLE = True
-    logger.info("✓ Rust bulk acceleration available (nexus._nexus_fast)")
+    logger.info("✓ Rust acceleration available (nexus_fast)")
 except ImportError:
-    pass
-
-try:
-    import nexus_fast as _external_module  # type: ignore[no-redef]
-
-    RUST_AVAILABLE = True
-    logger.info("✓ Rust single-check acceleration available (nexus_fast)")
-except ImportError:
-    pass
-
-if not RUST_AVAILABLE:
     logger.info("✗ Rust acceleration not available")
 
 


### PR DESCRIPTION
## Summary
- Remove dead `nexus._nexus_fast` import paths from 5 fast-acceleration modules
- All 5 modules now consistently import from `nexus_fast` (the actual PyO3 top-level package)
- The old `nexus._nexus_fast` path was a non-existent submodule — imports silently fell back to Python, negating the Rust speedup

## Changes
- `hash_fast.py` — Fix import path + correct Rust function names (`hash_content_py`, `hash_content_smart_py`)
- `grep_fast.py` — Remove dead `nexus._nexus_fast` try block
- `trigram_fast.py` — Remove dead `nexus._nexus_fast` try block (12 imports)
- `rebac/utils/fast.py` — Merge dual-module pattern into single `nexus_fast`
- `services/permissions/utils/fast.py` — Same as rebac

## Test plan
- [ ] `python -c "from nexus.core.hash_fast import get_hash_backend; print(get_hash_backend())"` returns `rust-blake3`
- [ ] All 5 modules detect Rust when `nexus_fast` is installed
- [ ] `grep -r "nexus._nexus_fast" src/` returns no matches
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)