### PR TITLE
fix(#363): replace raw SQL and raw Session in identity memory migration

### DIFF
--- a/src/nexus/migrations/version_manager.py
+++ b/src/nexus/migrations/version_manager.py
@@ -191,15 +191,14 @@ class VersionManager:
         Returns:
             List of migration history entries, newest first
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import MigrationHistoryModel
 
         session = self._get_session()
         try:
-            records = (
-                session.query(MigrationHistoryModel)
-                .order_by(MigrationHistoryModel.started_at.desc())
-                .all()
-            )
+            stmt = select(MigrationHistoryModel).order_by(MigrationHistoryModel.started_at.desc())
+            records = session.execute(stmt).scalars().all()
 
             return [
                 MigrationHistoryEntry(
@@ -621,11 +620,14 @@ class VersionManager:
             status: Final status
             error_message: Error message if failed
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import MigrationHistoryModel
 
         session = self._get_session()
         try:
-            record = session.query(MigrationHistoryModel).filter_by(id=history_id).first()
+            stmt = select(MigrationHistoryModel).filter_by(id=history_id)
+            record = session.execute(stmt).scalars().first()
             if record:
                 record.status = status
                 record.completed_at = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- Replace `text()` raw SQL queries with SQLAlchemy ORM `select()` using `FilePathModel` — fixes KERNEL-ARCHITECTURE.md §7 violation ("Direct SQL or raw driver access is an abstraction break")
- Change constructor from raw `Session` to `sessionmaker[Session]` (session factory pattern) — aligns with RecordStoreABC conventions
- Pass `session_factory` to `EntityRegistry` instead of raw session (EntityRegistry already supports this since v0.5.0)
- Remove references to nonexistent columns (`owner`, `group`, `mode`) that no longer exist on `FilePathModel` or `MemoryModel` — the old raw SQL would have failed at runtime

## Test plan
- [ ] Verify `mypy` passes (confirmed in pre-commit hooks)
- [ ] No external callers of `IdentityMemoryMigration` or `run_migration_from_config` exist — changes are self-contained
- [ ] CI passes lint/type checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)