### PR TITLE
fix(#364): replace session.query() with select() in version_manager

### DIFF
--- a/src/nexus/migrations/version_manager.py
+++ b/src/nexus/migrations/version_manager.py
@@ -191,15 +191,14 @@ class VersionManager:
         Returns:
             List of migration history entries, newest first
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import MigrationHistoryModel
 
         session = self._get_session()
         try:
-            records = (
-                session.query(MigrationHistoryModel)
-                .order_by(MigrationHistoryModel.started_at.desc())
-                .all()
-            )
+            stmt = select(MigrationHistoryModel).order_by(MigrationHistoryModel.started_at.desc())
+            records = session.execute(stmt).scalars().all()
 
             return [
                 MigrationHistoryEntry(
@@ -621,11 +620,14 @@ class VersionManager:
             status: Final status
             error_message: Error message if failed
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import MigrationHistoryModel
 
         session = self._get_session()
         try:
-            record = session.query(MigrationHistoryModel).filter_by(id=history_id).first()
+            stmt = select(MigrationHistoryModel).filter_by(id=history_id)
+            record = session.execute(stmt).scalars().first()
             if record:
                 record.status = status
                 record.completed_at = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- Replace legacy SQLAlchemy 1.x `session.query()` pattern with modern `select()` + `session.execute().scalars()` in `get_migration_history()` and `_record_migration_complete()`
- The `_get_session()` fallback already uses `SQLAlchemyRecordStore` (not the deprecated `nexus.storage.database` shim mentioned in the task)
- Fixes KERNEL-ARCHITECTURE.md §7 violation for legacy query pattern

## Test plan
- [ ] Verify `mypy` passes (confirmed in pre-commit hooks)
- [ ] CI passes lint/type checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)