### PR TITLE
fix(#700): replace session.query() with select() in 4 more service files

### DIFF
--- a/src/nexus/services/ace/curation.py
+++ b/src/nexus/services/ace/curation.py
@@ -120,12 +120,16 @@ class Curator:
             Curation results or None if no reflections found
         """
         # Find reflection memories for this trajectory
+        from sqlalchemy import select
+
         reflection_memories = (
-            self.session.query(MemoryModel)
-            .filter_by(
-                trajectory_id=trajectory_id,
-                memory_type="reflection",
+            self.session.execute(
+                select(MemoryModel).filter_by(
+                    trajectory_id=trajectory_id,
+                    memory_type="reflection",
+                )
             )
+            .scalars()
             .all()
         )
 
@@ -144,7 +148,13 @@ class Curator:
         Returns:
             Reflection data or None if not found
         """
-        memory = self.session.query(MemoryModel).filter_by(memory_id=memory_id).first()
+        from sqlalchemy import select
+
+        memory = (
+            self.session.execute(select(MemoryModel).filter_by(memory_id=memory_id))
+            .scalars()
+            .first()
+        )
         if not memory:
             return None
 

--- a/src/nexus/services/ace/playbook.py
+++ b/src/nexus/services/ace/playbook.py
@@ -174,7 +174,13 @@ class PlaybookManager:
 
         logger = logging.getLogger(__name__)
 
-        playbook = self.session.query(PlaybookModel).filter_by(playbook_id=playbook_id).first()
+        from sqlalchemy import select
+
+        playbook = (
+            self.session.execute(select(PlaybookModel).filter_by(playbook_id=playbook_id))
+            .scalars()
+            .first()
+        )
         if not playbook:
             return None
 
@@ -250,7 +256,13 @@ class PlaybookManager:
             ...     ]
             ... )
         """
-        playbook = self.session.query(PlaybookModel).filter_by(playbook_id=playbook_id).first()
+        from sqlalchemy import select
+
+        playbook = (
+            self.session.execute(select(PlaybookModel).filter_by(playbook_id=playbook_id))
+            .scalars()
+            .first()
+        )
         if not playbook:
             raise ValueError(f"Playbook {playbook_id} not found")
 
@@ -324,7 +336,13 @@ class PlaybookManager:
         Example:
             >>> playbook_mgr.record_usage(playbook_id, success=True, improvement_score=0.8)
         """
-        playbook = self.session.query(PlaybookModel).filter_by(playbook_id=playbook_id).first()
+        from sqlalchemy import select
+
+        playbook = (
+            self.session.execute(select(PlaybookModel).filter_by(playbook_id=playbook_id))
+            .scalars()
+            .first()
+        )
         if not playbook:
             raise ValueError(f"Playbook {playbook_id} not found")
 
@@ -376,21 +394,23 @@ class PlaybookManager:
         Returns:
             List of playbook summaries (without full content), filtered by permissions
         """
-        query = self.session.query(PlaybookModel)
+        from sqlalchemy import select
+
+        stmt = select(PlaybookModel)
 
         if agent_id:
-            query = query.filter_by(agent_id=agent_id)
+            stmt = stmt.filter_by(agent_id=agent_id)
         if scope:
-            query = query.filter_by(scope=scope)
+            stmt = stmt.filter_by(scope=scope)
         if name_pattern:
-            query = query.filter(PlaybookModel.name.like(name_pattern))
+            stmt = stmt.filter(PlaybookModel.name.like(name_pattern))
         if path:
-            query = query.filter_by(path=path)
+            stmt = stmt.filter_by(path=path)
 
-        query = query.order_by(PlaybookModel.updated_at.desc()).limit(
+        stmt = stmt.order_by(PlaybookModel.updated_at.desc()).limit(
             limit * 2
         )  # Fetch extra for filtering
-        playbooks = query.all()
+        playbooks = self.session.execute(stmt).scalars().all()
 
         # Filter by permissions
         accessible_playbooks = [
@@ -423,7 +443,13 @@ class PlaybookManager:
         Returns:
             True if deleted, False if not found
         """
-        playbook = self.session.query(PlaybookModel).filter_by(playbook_id=playbook_id).first()
+        from sqlalchemy import select
+
+        playbook = (
+            self.session.execute(select(PlaybookModel).filter_by(playbook_id=playbook_id))
+            .scalars()
+            .first()
+        )
         if not playbook:
             return False
 

--- a/src/nexus/services/memory/memory_api.py
+++ b/src/nexus/services/memory/memory_api.py
@@ -1170,13 +1170,18 @@ class Memory:
 
         try:
             # Query memories that haven't hit minimum importance yet
-            memories = (
-                self.session.query(MemoryModel)
-                .filter(
-                    MemoryModel.zone_id == self.zone_id,
-                    MemoryModel.importance > min_importance,
+            from sqlalchemy import select
+
+            memories = list(
+                self.session.execute(
+                    select(MemoryModel)
+                    .where(
+                        MemoryModel.zone_id == self.zone_id,
+                        MemoryModel.importance > min_importance,
+                    )
+                    .limit(batch_size)
                 )
-                .limit(batch_size)
+                .scalars()
                 .all()
             )
 
@@ -1673,16 +1678,22 @@ class Memory:
         target_agent_id = agent_id or self.agent_id
 
         # Query trajectories
-        query = self.session.query(TrajectoryModel).filter_by(agent_id=target_agent_id)
+        from sqlalchemy import select
+
+        stmt = select(TrajectoryModel).filter_by(agent_id=target_agent_id)
 
         if since:
             since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
-            query = query.filter(TrajectoryModel.started_at >= since_dt)
+            stmt = stmt.where(TrajectoryModel.started_at >= since_dt)
 
         if task_type:
-            query = query.filter_by(task_type=task_type)
+            stmt = stmt.filter_by(task_type=task_type)
 
-        trajectories = query.order_by(TrajectoryModel.started_at.desc()).limit(100).all()
+        trajectories = list(
+            self.session.execute(stmt.order_by(TrajectoryModel.started_at.desc()).limit(100))
+            .scalars()
+            .all()
+        )
 
         if len(trajectories) < min_trajectories:
             return {

--- a/src/nexus/services/workspace/workspace_registry.py
+++ b/src/nexus/services/workspace/workspace_registry.py
@@ -147,7 +147,9 @@ class WorkspaceRegistry:
 
         with self.metadata_session_factory() as session:
             # Load workspaces - merge with existing cache (don't clear it)
-            workspaces = session.query(WorkspaceConfigModel).all()
+            from sqlalchemy import select
+
+            workspaces = session.execute(select(WorkspaceConfigModel)).scalars().all()
             for ws in workspaces:
                 metadata_dict = json.loads(ws.extra_metadata) if ws.extra_metadata else {}
                 self._workspaces[ws.path] = WorkspaceConfig(
@@ -160,7 +162,7 @@ class WorkspaceRegistry:
                 )
 
             # Load memories - merge with existing cache (don't clear it)
-            memories = session.query(MemoryConfigModel).all()
+            memories = session.execute(select(MemoryConfigModel)).scalars().all()
             for mem in memories:
                 if mem.path is None:
                     continue  # Skip invalid entries
@@ -369,7 +371,11 @@ class WorkspaceRegistry:
         from nexus.storage.models import WorkspaceConfigModel
 
         with self.metadata_session_factory() as session:
-            ws_model = session.query(WorkspaceConfigModel).filter_by(path=path).first()
+            from sqlalchemy import select
+
+            ws_model = (
+                session.execute(select(WorkspaceConfigModel).filter_by(path=path)).scalars().first()
+            )
             if ws_model:
                 if name is not None:
                     ws_model.name = name
@@ -671,7 +677,11 @@ class WorkspaceRegistry:
         from nexus.storage.models import WorkspaceConfigModel
 
         with self.metadata_session_factory() as session:
-            workspace = session.query(WorkspaceConfigModel).filter_by(path=path).first()
+            from sqlalchemy import select
+
+            workspace = (
+                session.execute(select(WorkspaceConfigModel).filter_by(path=path)).scalars().first()
+            )
             if workspace:
                 session.delete(workspace)
                 session.commit()
@@ -710,7 +720,11 @@ class WorkspaceRegistry:
         from nexus.storage.models import MemoryConfigModel
 
         with self.metadata_session_factory() as session:
-            memory = session.query(MemoryConfigModel).filter_by(path=path).first()
+            from sqlalchemy import select
+
+            memory = (
+                session.execute(select(MemoryConfigModel).filter_by(path=path)).scalars().first()
+            )
             if memory:
                 session.delete(memory)
                 session.commit()


### PR DESCRIPTION
## Summary
- Migrates 14 legacy SQLAlchemy 1.x `session.query()` calls to 2.0-style `select()` across 4 service files (batch 2, follow-up to PR #1892)
- Files updated: `ace/playbook.py` (5), `ace/curation.py` (2), `memory/memory_api.py` (2), `workspace/workspace_registry.py` (5)

## Test plan
- [ ] Verify no remaining `session.query()` in the 4 target files
- [ ] CI passes (ruff, mypy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)