### PR TITLE
fix(#702): replace session.query() with select() in conflict_log_store and sync_backlog_store

### DIFF
--- a/src/nexus/services/conflict_log_store.py
+++ b/src/nexus/services/conflict_log_store.py
@@ -91,20 +91,22 @@ class ConflictLogStore(SyncStoreBase):
         Returns:
             List of ConflictRecord entries
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import ConflictLogModel
 
         with self._with_session() as session:
-            query = session.query(ConflictLogModel)
+            stmt = select(ConflictLogModel)
 
             if status is not None:
-                query = query.filter(ConflictLogModel.status == status)
+                stmt = stmt.where(ConflictLogModel.status == status)
             if backend_name is not None:
-                query = query.filter(ConflictLogModel.backend_name == backend_name)
+                stmt = stmt.where(ConflictLogModel.backend_name == backend_name)
             if zone_id is not None:
-                query = query.filter(ConflictLogModel.zone_id == zone_id)
+                stmt = stmt.where(ConflictLogModel.zone_id == zone_id)
 
-            query = query.order_by(ConflictLogModel.created_at.desc())
-            rows = query.offset(offset).limit(limit).all()
+            stmt = stmt.order_by(ConflictLogModel.created_at.desc())
+            rows = session.execute(stmt.offset(offset).limit(limit)).scalars().all()
             return [self._row_to_record(row) for row in rows]
 
     def count_conflicts(
@@ -124,17 +126,19 @@ class ConflictLogStore(SyncStoreBase):
         Returns:
             Total count matching filters
         """
+        from sqlalchemy import func, select
+
         from nexus.storage.models import ConflictLogModel
 
         with self._with_session() as session:
-            query = session.query(ConflictLogModel)
+            stmt = select(func.count()).select_from(ConflictLogModel)
             if status is not None:
-                query = query.filter(ConflictLogModel.status == status)
+                stmt = stmt.where(ConflictLogModel.status == status)
             if backend_name is not None:
-                query = query.filter(ConflictLogModel.backend_name == backend_name)
+                stmt = stmt.where(ConflictLogModel.backend_name == backend_name)
             if zone_id is not None:
-                query = query.filter(ConflictLogModel.zone_id == zone_id)
-            return int(query.count())
+                stmt = stmt.where(ConflictLogModel.zone_id == zone_id)
+            return int(session.execute(stmt).scalar() or 0)
 
     def get_conflict(self, conflict_id: str) -> ConflictRecord | None:
         """Look up a conflict record by ID.
@@ -145,10 +149,16 @@ class ConflictLogStore(SyncStoreBase):
         Returns:
             ConflictRecord if found, None otherwise
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import ConflictLogModel
 
         with self._with_session() as session:
-            row = session.query(ConflictLogModel).filter_by(id=conflict_id).first()
+            row = (
+                session.execute(select(ConflictLogModel).filter_by(id=conflict_id))
+                .scalars()
+                .first()
+            )
             if row is None:
                 return None
             return self._row_to_record(row)
@@ -163,25 +173,24 @@ class ConflictLogStore(SyncStoreBase):
         Returns:
             True if updated, False if not found or already resolved
         """
+        from sqlalchemy import update
+
         from nexus.storage.models import ConflictLogModel
 
         with self._with_session() as session:
-            updated = (
-                session.query(ConflictLogModel)
-                .filter(
+            result: Any = session.execute(
+                update(ConflictLogModel)
+                .where(
                     ConflictLogModel.id == conflict_id,
                     ConflictLogModel.status == ConflictStatus.MANUAL_PENDING,
                 )
-                .update(
-                    {
-                        "status": ConflictStatus.MANUALLY_RESOLVED,
-                        "outcome": str(outcome),
-                        "resolved_at": datetime.now(UTC),
-                    },
-                    synchronize_session="fetch",
+                .values(
+                    status=ConflictStatus.MANUALLY_RESOLVED,
+                    outcome=str(outcome),
+                    resolved_at=datetime.now(UTC),
                 )
             )
-            return bool(updated > 0)
+            return bool(result.rowcount > 0)
 
     def expire_stale(self, ttl_seconds: int = 2592000, max_entries: int = 10000) -> int:
         """Expire old conflict records by TTL (30 days) and cap (10K).
@@ -193,6 +202,8 @@ class ConflictLogStore(SyncStoreBase):
         Returns:
             Number of records deleted
         """
+        from sqlalchemy import delete, func, select
+
         from nexus.storage.models import ConflictLogModel
 
         with self._with_session() as session:
@@ -200,30 +211,29 @@ class ConflictLogStore(SyncStoreBase):
             cutoff = datetime.fromtimestamp(now.timestamp() - ttl_seconds, tz=UTC)
 
             # Phase 1: TTL — delete records older than cutoff
-            ttl_deleted = (
-                session.query(ConflictLogModel)
-                .filter(ConflictLogModel.created_at < cutoff)
-                .delete(synchronize_session="fetch")
+            result: Any = session.execute(
+                delete(ConflictLogModel).where(ConflictLogModel.created_at < cutoff)
             )
+            ttl_deleted = result.rowcount
 
             # Phase 2: Cap — if still over limit, delete oldest
-            total_count = session.query(ConflictLogModel).count()
+            total_count = int(
+                session.execute(select(func.count()).select_from(ConflictLogModel)).scalar() or 0
+            )
             cap_deleted = 0
             if total_count > max_entries:
                 overflow = total_count - max_entries
-                oldest_ids = (
-                    session.query(ConflictLogModel.id)
+                oldest_ids = session.execute(
+                    select(ConflictLogModel.id)
                     .order_by(ConflictLogModel.created_at)
                     .limit(overflow)
-                    .all()
-                )
+                ).all()
                 if oldest_ids:
                     ids = [row[0] for row in oldest_ids]
-                    cap_deleted = (
-                        session.query(ConflictLogModel)
-                        .filter(ConflictLogModel.id.in_(ids))
-                        .delete(synchronize_session="fetch")
+                    result = session.execute(
+                        delete(ConflictLogModel).where(ConflictLogModel.id.in_(ids))
                     )
+                    cap_deleted = result.rowcount
 
             total: int = ttl_deleted + cap_deleted
             if total > 0:
@@ -238,16 +248,14 @@ class ConflictLogStore(SyncStoreBase):
         Returns:
             Dict with status counts and total
         """
-        from sqlalchemy import func
+        from sqlalchemy import func, select
 
         from nexus.storage.models import ConflictLogModel
 
         with self._with_session() as session:
-            rows = (
-                session.query(ConflictLogModel.status, func.count())
-                .group_by(ConflictLogModel.status)
-                .all()
-            )
+            rows = session.execute(
+                select(ConflictLogModel.status, func.count()).group_by(ConflictLogModel.status)
+            ).all()
             result: dict[str, Any] = dict(rows)
             result["total"] = sum(result.values())
             return result

--- a/src/nexus/services/sync_backlog_store.py
+++ b/src/nexus/services/sync_backlog_store.py
@@ -126,6 +126,8 @@ class SyncBacklogStore(SyncStoreBase):
         Returns:
             List of (backend_name, zone_id) tuples that have pending work.
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import SyncBacklogModel
 
         session = self._get_session()
@@ -133,15 +135,15 @@ class SyncBacklogStore(SyncStoreBase):
             return []
 
         try:
-            rows = (
-                session.query(
+            stmt = (
+                select(
                     SyncBacklogModel.backend_name,
                     SyncBacklogModel.zone_id,
                 )
-                .filter(SyncBacklogModel.status == "pending")
+                .where(SyncBacklogModel.status == "pending")
                 .distinct()
-                .all()
             )
+            rows = session.execute(stmt).all()
             return [(row[0], row[1]) for row in rows]
         except Exception as e:
             logger.warning(f"Failed to fetch distinct backend zones: {e}")
@@ -165,6 +167,8 @@ class SyncBacklogStore(SyncStoreBase):
         Returns:
             List of pending SyncBacklogEntry objects
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import SyncBacklogModel
 
         session = self._get_session()
@@ -172,17 +176,17 @@ class SyncBacklogStore(SyncStoreBase):
             return []
 
         try:
-            rows = (
-                session.query(SyncBacklogModel)
-                .filter(
+            stmt = (
+                select(SyncBacklogModel)
+                .where(
                     SyncBacklogModel.backend_name == backend_name,
                     SyncBacklogModel.zone_id == zone_id,
                     SyncBacklogModel.status == "pending",
                 )
                 .order_by(SyncBacklogModel.created_at)
                 .limit(limit)
-                .all()
             )
+            rows = session.execute(stmt).scalars().all()
             return [self._to_entry(row) for row in rows]
         except Exception as e:
             logger.warning(f"Failed to fetch pending backlog for {backend_name}: {e}")
@@ -222,6 +226,8 @@ class SyncBacklogStore(SyncStoreBase):
         Returns:
             True if update succeeded
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import SyncBacklogModel
 
         session = self._get_session()
@@ -229,7 +235,8 @@ class SyncBacklogStore(SyncStoreBase):
             return False
 
         try:
-            row = session.query(SyncBacklogModel).filter_by(id=entry_id).first()
+            stmt = select(SyncBacklogModel).filter_by(id=entry_id)
+            row = session.execute(stmt).scalars().first()
             if row is None:
                 return False
 
@@ -272,42 +279,47 @@ class SyncBacklogStore(SyncStoreBase):
             cutoff = datetime.fromtimestamp(now.timestamp() - ttl_seconds, tz=UTC)
 
             # Phase 1: TTL expiry
-            ttl_expired = (
-                session.query(SyncBacklogModel)
-                .filter(
+            from sqlalchemy import select, update
+
+            stmt = (
+                update(SyncBacklogModel)
+                .where(
                     SyncBacklogModel.status == "pending",
                     SyncBacklogModel.created_at < cutoff,
                 )
-                .update(
-                    {"status": "expired", "updated_at": now},
-                    synchronize_session="fetch",
-                )
+                .values(status="expired", updated_at=now)
             )
+            result: Any = session.execute(stmt)
+            ttl_expired = result.rowcount
 
             # Phase 2: Cap-based expiry (oldest first)
-            pending_count = (
-                session.query(SyncBacklogModel).filter(SyncBacklogModel.status == "pending").count()
+            from sqlalchemy import func
+
+            count_stmt = (
+                select(func.count())
+                .select_from(SyncBacklogModel)
+                .where(SyncBacklogModel.status == "pending")
             )
+            pending_count = session.execute(count_stmt).scalar() or 0
             cap_expired = 0
             if pending_count > max_entries:
                 overflow = pending_count - max_entries
-                oldest_ids = (
-                    session.query(SyncBacklogModel.id)
-                    .filter(SyncBacklogModel.status == "pending")
+                id_stmt = (
+                    select(SyncBacklogModel.id)
+                    .where(SyncBacklogModel.status == "pending")
                     .order_by(SyncBacklogModel.created_at)
                     .limit(overflow)
-                    .all()
                 )
+                oldest_ids = session.execute(id_stmt).all()
                 if oldest_ids:
                     ids = [row[0] for row in oldest_ids]
-                    cap_expired = (
-                        session.query(SyncBacklogModel)
-                        .filter(SyncBacklogModel.id.in_(ids))
-                        .update(
-                            {"status": "expired", "updated_at": now},
-                            synchronize_session="fetch",
-                        )
+                    cap_stmt = (
+                        update(SyncBacklogModel)
+                        .where(SyncBacklogModel.id.in_(ids))
+                        .values(status="expired", updated_at=now)
                     )
+                    cap_result: Any = session.execute(cap_stmt)
+                    cap_expired = cap_result.rowcount
 
             session.commit()
             total: int = ttl_expired + cap_expired
@@ -332,7 +344,7 @@ class SyncBacklogStore(SyncStoreBase):
         Returns:
             Dict mapping status -> count
         """
-        from sqlalchemy import func
+        from sqlalchemy import func, select
 
         from nexus.storage.models import SyncBacklogModel
 
@@ -341,15 +353,16 @@ class SyncBacklogStore(SyncStoreBase):
             return {}
 
         try:
-            query = session.query(
+            stmt = select(
                 SyncBacklogModel.status,
                 func.count(SyncBacklogModel.id),
             ).group_by(SyncBacklogModel.status)
 
             if backend_name:
-                query = query.filter(SyncBacklogModel.backend_name == backend_name)
+                stmt = stmt.where(SyncBacklogModel.backend_name == backend_name)
 
-            return dict(query.all())
+            rows = session.execute(stmt).all()
+            return dict(rows)
         except Exception as e:
             logger.warning(f"Failed to get backlog stats: {e}")
             return {}
@@ -367,6 +380,8 @@ class SyncBacklogStore(SyncStoreBase):
         Returns:
             True if transition succeeded
         """
+        from sqlalchemy import update
+
         from nexus.storage.models import SyncBacklogModel
 
         session = self._get_session()
@@ -375,23 +390,24 @@ class SyncBacklogStore(SyncStoreBase):
 
         try:
             now = datetime.now(UTC)
-            updated = {
+            values = {
                 "status": new_status,
                 "updated_at": now,
             }
             if new_status == "in_progress":
-                updated["last_attempted_at"] = now
+                values["last_attempted_at"] = now
 
-            count = (
-                session.query(SyncBacklogModel)
-                .filter(
+            stmt = (
+                update(SyncBacklogModel)
+                .where(
                     SyncBacklogModel.id == entry_id,
                     SyncBacklogModel.status == from_status,
                 )
-                .update(updated, synchronize_session="fetch")
+                .values(**values)
             )
+            result: Any = session.execute(stmt)
             session.commit()
-            return int(count) > 0
+            return bool(result.rowcount > 0)
         except Exception as e:
             logger.warning(
                 f"Failed to transition backlog {entry_id} from {from_status} to {new_status}: {e}"


### PR DESCRIPTION
## Summary
- Replace 9x `session.query()` calls with SQLAlchemy 2.0 `select()`/`delete()`/`update()` in `conflict_log_store.py`
- Replace 9x `session.query()` calls with SQLAlchemy 2.0 `select()`/`update()` in `sync_backlog_store.py`
- 18 total instances migrated across 2 files

## Test plan
- [ ] CI passes (ruff, mypy, tests)
- [ ] No remaining `session.query()` in either file

🤖 Generated with [Claude Code](https://claude.com/claude-code)