### PR TITLE
refactor(#677): migrate subscriptions manager to SQLAlchemy 2.0

### DIFF
--- a/src/nexus/server/subscriptions/manager.py
+++ b/src/nexus/server/subscriptions/manager.py
@@ -104,15 +104,19 @@ class SubscriptionManager:
         Returns:
             Subscription if found, None otherwise
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import SubscriptionModel
 
         with self._session_factory() as session:
             model = (
-                session.query(SubscriptionModel)
-                .filter(
-                    SubscriptionModel.subscription_id == subscription_id,
-                    SubscriptionModel.zone_id == zone_id,
+                session.execute(
+                    select(SubscriptionModel).where(
+                        SubscriptionModel.subscription_id == subscription_id,
+                        SubscriptionModel.zone_id == zone_id,
+                    )
                 )
+                .scalars()
                 .first()
             )
             if model is None:
@@ -137,16 +141,18 @@ class SubscriptionManager:
         Returns:
             List of subscriptions
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import SubscriptionModel
 
         with self._session_factory() as session:
-            query = session.query(SubscriptionModel).filter(SubscriptionModel.zone_id == zone_id)
+            stmt = select(SubscriptionModel).where(SubscriptionModel.zone_id == zone_id)
             if enabled_only:
-                query = query.filter(SubscriptionModel.enabled == 1)
-            query = query.order_by(SubscriptionModel.created_at.desc())
-            query = query.limit(limit).offset(offset)
+                stmt = stmt.where(SubscriptionModel.enabled == 1)
+            stmt = stmt.order_by(SubscriptionModel.created_at.desc())
+            stmt = stmt.limit(limit).offset(offset)
 
-            return [self._to_subscription(m) for m in query.all()]
+            return [self._to_subscription(m) for m in session.execute(stmt).scalars().all()]
 
     def update(
         self,
@@ -164,15 +170,19 @@ class SubscriptionManager:
         Returns:
             Updated subscription if found, None otherwise
         """
+        from sqlalchemy import select
+
         from nexus.storage.models import SubscriptionModel
 
         with self._session_factory() as session:
             model = (
-                session.query(SubscriptionModel)
-                .filter(
-                    SubscriptionModel.subscription_id == subscription_id,
-                    SubscriptionModel.zone_id == zone_id,
+                session.execute(
+                    select(SubscriptionModel).where(
+                        SubscriptionModel.subscription_id == subscription_id,
+                        SubscriptionModel.zone_id == zone_id,
+                    )
                 )
+                .scalars()
                 .first()
             )
             if model is None:
@@ -216,20 +226,20 @@ class SubscriptionManager:
         Returns:
             True if deleted, False if not found
         """
+        from sqlalchemy import delete
+
         from nexus.storage.models import SubscriptionModel
 
         with self._session_factory() as session:
-            result = (
-                session.query(SubscriptionModel)
-                .filter(
+            result: Any = session.execute(
+                delete(SubscriptionModel).where(
                     SubscriptionModel.subscription_id == subscription_id,
                     SubscriptionModel.zone_id == zone_id,
                 )
-                .delete()
             )
             session.commit()
 
-            if result > 0:
+            if result.rowcount > 0:
                 logger.info(f"Deleted subscription {subscription_id}")
                 return True
             return False
@@ -314,16 +324,20 @@ class SubscriptionManager:
         zone_id: str,
     ) -> list[Subscription]:
         """Sync implementation of _get_matching_subscriptions."""
+        from sqlalchemy import select
+
         from nexus.storage.models import SubscriptionModel
 
         with self._session_factory() as session:
             # Get enabled subscriptions for zone
             models = (
-                session.query(SubscriptionModel)
-                .filter(
-                    SubscriptionModel.zone_id == zone_id,
-                    SubscriptionModel.enabled == 1,
+                session.execute(
+                    select(SubscriptionModel).where(
+                        SubscriptionModel.zone_id == zone_id,
+                        SubscriptionModel.enabled == 1,
+                    )
                 )
+                .scalars()
                 .all()
             )
 
@@ -494,12 +508,18 @@ class SubscriptionManager:
 
     def _compute_signature_sync(self, subscription_id: str, payload: bytes) -> str | None:
         """Sync implementation of _compute_signature."""
+        from sqlalchemy import select
+
         from nexus.storage.models import SubscriptionModel
 
         with self._session_factory() as session:
             model = (
-                session.query(SubscriptionModel)
-                .filter(SubscriptionModel.subscription_id == subscription_id)
+                session.execute(
+                    select(SubscriptionModel).where(
+                        SubscriptionModel.subscription_id == subscription_id
+                    )
+                )
+                .scalars()
                 .first()
             )
             if model is None or not model.secret:
@@ -539,12 +559,18 @@ class SubscriptionManager:
         error: str | None = None,  # noqa: ARG002 - reserved for future logging
     ) -> None:
         """Sync implementation of _update_delivery_status."""
+        from sqlalchemy import select
+
         from nexus.storage.models import SubscriptionModel
 
         with self._session_factory() as session:
             model = (
-                session.query(SubscriptionModel)
-                .filter(SubscriptionModel.subscription_id == subscription_id)
+                session.execute(
+                    select(SubscriptionModel).where(
+                        SubscriptionModel.subscription_id == subscription_id
+                    )
+                )
+                .scalars()
                 .first()
             )
             if model is None:


### PR DESCRIPTION
## Summary
- Migrated all `session.query()` calls to SQLAlchemy 2.0 style in `src/nexus/server/subscriptions/manager.py`
- Replaced 7 query methods with `select()`, `delete()` constructs
- Added lazy imports for SQLAlchemy functions inside methods (following existing pattern)
- Used `result: Any` typing for delete operations to access `rowcount` without type ignores

## Changes
**Modified methods:**
1. `get()`: `query().filter().first()` → `select().where()` with `scalars().first()`
2. `list_subscriptions()`: `query().filter()` → `select().where()` with `scalars().all()`
3. `update()`: `query().filter().first()` → `select().where()` with `scalars().first()`
4. `delete()`: `query().filter().delete()` → `delete().where()` with `result.rowcount`
5. `_get_matching_subscriptions_sync()`: `query().filter().all()` → `select().where()` with `scalars().all()`
6. `_compute_signature_sync()`: `query().filter().first()` → `select().where()` with `scalars().first()`
7. `_update_delivery_status_sync()`: `query().filter().first()` → `select().where()` with `scalars().first()`

## Test plan
- [ ] Verify all pre-commit hooks pass (ruff, mypy, formatting)
- [ ] Run subscription-related tests
- [ ] Check CI passes completely
- [ ] Verify no remaining `session.query()` calls in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)