### PR TITLE
fix(#703): replace session.query() with select() in version_manager and semantic.py

### DIFF
--- a/src/nexus/search/semantic.py
+++ b/src/nexus/search/semantic.py
@@ -760,7 +760,7 @@ class SemanticSearch:
         """Clear the entire search index."""
         with self._get_session() as session:
             # Delete all chunks
-            session.query(DocumentChunkModel).delete()
+            session.execute(delete(DocumentChunkModel))
             session.commit()
 
     def close(self) -> None:


### PR DESCRIPTION
## Summary
- Replace 2x `session.query()` calls with SQLAlchemy 2.0 `select()` in `migrations/version_manager.py`
- Replace 1x `session.query().delete()` with `session.execute(delete())` in `search/semantic.py`
- 3 total instances migrated across 2 files

## Test plan
- [ ] CI passes (ruff, mypy, tests)
- [ ] No remaining `session.query()` in either file

🤖 Generated with [Claude Code](https://claude.com/claude-code)