### PR TITLE
fix(#705): replace db.query() with select()/delete() in chunked_upload_service.py

### DIFF
--- a/src/nexus/services/chunked_upload_service.py
+++ b/src/nexus/services/chunked_upload_service.py
@@ -410,12 +410,16 @@ class ChunkedUploadService:
         def _query_expired() -> list[dict[str, Any]]:
             db = self._session_factory()
             try:
+                from sqlalchemy import select
+
                 rows = (
-                    db.query(UploadSessionModel)
-                    .filter(
-                        UploadSessionModel.expires_at < now,
-                        UploadSessionModel.status.in_(["created", "in_progress"]),
+                    db.execute(
+                        select(UploadSessionModel).where(
+                            UploadSessionModel.expires_at < now,
+                            UploadSessionModel.status.in_(["created", "in_progress"]),
+                        )
                     )
+                    .scalars()
                     .all()
                 )
                 return [row.to_session_dict() for row in rows]
@@ -494,7 +498,13 @@ class ChunkedUploadService:
         def _read(uid: str) -> dict[str, Any] | None:
             db = self._session_factory()
             try:
-                model = db.query(UploadSessionModel).filter_by(upload_id=uid).first()
+                from sqlalchemy import select
+
+                model = (
+                    db.execute(select(UploadSessionModel).filter_by(upload_id=uid))
+                    .scalars()
+                    .first()
+                )
                 if model is None:
                     return None
                 return model.to_session_dict()
@@ -512,7 +522,13 @@ class ChunkedUploadService:
         def _write(s: UploadSession) -> None:
             db = self._session_factory()
             try:
-                model = db.query(UploadSessionModel).filter_by(upload_id=s.upload_id).first()
+                from sqlalchemy import select
+
+                model = (
+                    db.execute(select(UploadSessionModel).filter_by(upload_id=s.upload_id))
+                    .scalars()
+                    .first()
+                )
                 if model is None:
                     raise UploadNotFoundError(s.upload_id)
                 model.upload_offset = s.upload_offset
@@ -535,7 +551,9 @@ class ChunkedUploadService:
         def _delete(uid: str) -> None:
             db = self._session_factory()
             try:
-                db.query(UploadSessionModel).filter_by(upload_id=uid).delete()
+                from sqlalchemy import delete
+
+                db.execute(delete(UploadSessionModel).filter_by(upload_id=uid))
                 db.commit()
             except Exception:
                 db.rollback()


### PR DESCRIPTION
## Summary
- Replace 4x `db.query()` calls with SQLAlchemy 2.0 `select()`/`delete()` in `services/chunked_upload_service.py`
- 3x SELECT queries, 1x DELETE query migrated

## Test plan
- [ ] CI passes (ruff, mypy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)