### PR TITLE
fix(#569): replace hardcoded "default" zone_id with "root" in nexus_fs_core.py

### DIFF
--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -175,7 +175,7 @@ class NexusFSCoreMixin:
         Args:
             event_type: Event type string (e.g., "file_write", "file_delete", "file_rename")
             path: Path of the affected file
-            zone_id: Zone ID (defaults to "default" if None)
+            zone_id: Zone ID (defaults to "root" if None)
             size: File size in bytes (optional)
             etag: Content hash (optional)
             agent_id: Agent that performed the operation (optional)
@@ -201,7 +201,7 @@ class NexusFSCoreMixin:
             event = FileEvent(
                 type=file_event_type,
                 path=path,
-                zone_id=zone_id or "default",
+                zone_id=zone_id or "root",
                 size=size,
                 etag=etag,
                 agent_id=agent_id,
@@ -268,7 +268,7 @@ class NexusFSCoreMixin:
                 self.subscription_manager.broadcast(  # type: ignore[attr-defined]
                     event_type,
                     event_context,
-                    event_context.get("zone_id", "default"),
+                    event_context.get("zone_id", "root"),
                 )
             )
 
@@ -575,7 +575,7 @@ class NexusFSCoreMixin:
         if cache_observer is None or metadata is None:
             return
 
-        zone_id = getattr(self, "zone_id", None) or "default"
+        zone_id = getattr(self, "zone_id", None) or "root"
         revision = self._get_zone_revision()
         cache_observer.on_read(path, metadata, revision, zone_id, resource_type)
 
@@ -1757,7 +1757,7 @@ class NexusFSCoreMixin:
             created_at=meta.created_at if meta else now,
             modified_at=now,
             created_by=self._get_created_by(context),
-            zone_id=zone_id or "default",  # Issue #904, #773: Store zone_id for PREWHERE filtering
+            zone_id=zone_id or "root",  # Issue #904, #773: Store zone_id for PREWHERE filtering
         )
 
         self.metadata.put(new_meta)
@@ -2004,7 +2004,7 @@ class NexusFSCoreMixin:
             modified_at=now,
             version=new_version,
             created_by=self._get_created_by(context),  # Track who created/modified this version
-            zone_id=zone_id or "default",  # Issue #904, #773: Store zone_id for PREWHERE filtering
+            zone_id=zone_id or "root",  # Issue #904, #773: Store zone_id for PREWHERE filtering
             owner_id=owner_id,  # Issue #920: O(1) owner permission checks
         )
 
@@ -2016,7 +2016,7 @@ class NexusFSCoreMixin:
         # Issue #1169: Precise cache invalidation via cache observer
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_write(path, new_revision, zone_id or "default")
+            cache_observer.on_write(path, new_revision, zone_id or "root")
 
         # Leopard-style: Add new file to ancestor directory grants
         # When a file is created in a directory that has been granted to users,
@@ -2028,7 +2028,7 @@ class NexusFSCoreMixin:
                 if tiger_cache:
                     added_count = tiger_cache.add_file_to_ancestor_grants(
                         file_path=path,
-                        zone_id=zone_id or "default",
+                        zone_id=zone_id or "root",
                     )
                     if added_count > 0:
                         import logging
@@ -2071,9 +2071,9 @@ class NexusFSCoreMixin:
             # DEFERRED PATH: Queue permission operations for background batch processing
             # Owner can still access file immediately via owner_id fast-path
             try:
-                deferred_buffer.queue_hierarchy(path, ctx.zone_id or "default")
+                deferred_buffer.queue_hierarchy(path, ctx.zone_id or "root")
                 if meta is None and ctx.user and not ctx.is_system:
-                    deferred_buffer.queue_owner_grant(ctx.user, path, ctx.zone_id or "default")
+                    deferred_buffer.queue_owner_grant(ctx.user, path, ctx.zone_id or "root")
             except Exception as e:
                 logger.warning(f"write: Failed to queue deferred permissions for {path}: {e}")
         else:
@@ -2084,7 +2084,7 @@ class NexusFSCoreMixin:
                         f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or 'default'}"
                     )
                     created_count = self._hierarchy_manager.ensure_parent_tuples(
-                        path, zone_id=ctx.zone_id or "default"
+                        path, zone_id=ctx.zone_id or "root"
                     )
                     logger.info(f"write: Created {created_count} parent tuples for {path}")
                 except Exception as e:
@@ -2103,7 +2103,7 @@ class NexusFSCoreMixin:
                             subject=("user", ctx.user),
                             relation="direct_owner",
                             object=("file", path),
-                            zone_id=ctx.zone_id or "default",
+                            zone_id=ctx.zone_id or "root",
                         )
                         logger.debug(
                             f"write: Granted direct_owner permission to {ctx.user} for {path}"
@@ -2150,7 +2150,7 @@ class NexusFSCoreMixin:
                 "size": len(content),
                 "etag": content_hash,
                 "version": new_version,
-                "zone_id": zone_id or "default",
+                "zone_id": zone_id or "root",
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "created": is_new_file,
@@ -2691,8 +2691,7 @@ class NexusFSCoreMixin:
                 version=new_version,
                 created_by=getattr(self, "agent_id", None)
                 or getattr(self, "user_id", None),  # Track who created/modified this version
-                zone_id=zone_id
-                or "default",  # Issue #904, #773: Store zone_id for PREWHERE filtering
+                zone_id=zone_id or "root",  # Issue #904, #773: Store zone_id for PREWHERE filtering
             )
             metadata_list.append(metadata)
 
@@ -2730,7 +2729,7 @@ class NexusFSCoreMixin:
 
         logger = logging.getLogger(__name__)
         ctx = context if context is not None else self._default_context
-        zone_id_for_perms = ctx.zone_id or "default"
+        zone_id_for_perms = ctx.zone_id or "root"
 
         # PERF: Batch hierarchy tuple creation (single transaction instead of N)
         _hierarchy_start = _time.perf_counter()
@@ -3067,7 +3066,7 @@ class NexusFSCoreMixin:
         # Issue #1169: Precise cache invalidation via cache observer
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_delete(path, new_revision, zone_id or "default")
+            cache_observer.on_delete(path, new_revision, zone_id or "root")
 
         # v0.7.0: Fire workflow event for automatic trigger execution
         self._fire_workflow_event(
@@ -3076,7 +3075,7 @@ class NexusFSCoreMixin:
                 "file_path": path,
                 "size": meta.size,
                 "etag": meta.etag,
-                "zone_id": zone_id or "default",
+                "zone_id": zone_id or "root",
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "timestamp": datetime.now(UTC).isoformat(),
@@ -3242,7 +3241,7 @@ class NexusFSCoreMixin:
         new_revision = self._increment_zone_revision()
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_rename(old_path, new_path, new_revision, zone_id or "default")
+            cache_observer.on_rename(old_path, new_path, new_revision, zone_id or "root")
 
         # Update ReBAC permissions to follow the renamed file/directory
         # This ensures permissions are preserved when files are moved
@@ -3295,7 +3294,7 @@ class NexusFSCoreMixin:
                         old_path=old_path,
                         new_path=new_path,
                         is_directory=bool(is_directory),
-                        zone_id=zone_id or "default",
+                        zone_id=zone_id or "root",
                     )
             except Exception as e:
                 # Log but don't fail the rename operation
@@ -3322,7 +3321,7 @@ class NexusFSCoreMixin:
                 "new_path": new_path,
                 "size": meta.size if meta else 0,
                 "etag": meta.etag if meta else None,
-                "zone_id": zone_id or "default",
+                "zone_id": zone_id or "root",
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "timestamp": datetime.now(UTC).isoformat(),


### PR DESCRIPTION
## Summary
- Replace all ~20 hardcoded `"default"` zone_id fallbacks with `"root"` in `nexus_fs_core.py`
- Per federation-memo §6.5: root zone is `"root"`, never `"default"`
- Companion to PR #1743 (nexus_fs.py, types.py) and PR #1908 (9 non-core files)

Patterns fixed:
- `zone_id or "default"` → `zone_id or "root"` (15 occurrences)
- `ctx.zone_id or "default"` → `ctx.zone_id or "root"` (4 occurrences)
- `event_context.get("zone_id", "default")` → `event_context.get("zone_id", "root")`
- `getattr(self, "zone_id", None) or "default"` → `getattr(self, "zone_id", None) or "root"`
- Docstring update

## Test plan
- [ ] Pre-commit hooks pass (ruff, mypy)
- [ ] No remaining `"default"` zone_id references in nexus_fs_core.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)