### PR TITLE
refactor: delete MCP backward-compat re-exports from nexus.skills

### DIFF
--- a/src/nexus/skills/__init__.py
+++ b/src/nexus/skills/__init__.py
@@ -8,8 +8,6 @@ The Skills System provides:
 - Vendor-neutral skill export to .zip packages
 - Skill lifecycle management (create, fork, publish)
 - Template system for common skill patterns
-- MCP tool integration for dynamic tool discovery
-
 Example:
     >>> from nexus import connect
     >>> from nexus.skills import SkillRegistry, SkillManager, SkillExporter
@@ -46,23 +44,6 @@ Example:
     >>> # Export skill
     >>> exporter = SkillExporter(registry)
     >>> await exporter.export_skill("analyze-code", "output.zip", format="claude")
-    >>>
-    >>> # MCP Tools Integration
-    >>> from nexus.skills import MCPToolExporter, MCPMountManager
-    >>>
-    >>> # Export Nexus MCP tools as skills
-    >>> mcp_exporter = MCPToolExporter(nx)
-    >>> await mcp_exporter.export_nexus_tools()
-    >>>
-    >>> # Mount external MCP servers
-    >>> mcp_manager = MCPMountManager(nx)
-    >>> await mcp_manager.mount(MCPMount(
-    ...     name="github",
-    ...     transport="stdio",
-    ...     command="npx",
-    ...     args=["-y", "@modelcontextprotocol/server-github"]
-    ... ))
-    >>> await mcp_manager.sync_tools("github")
 """
 
 import importlib
@@ -104,22 +85,11 @@ _LAZY_IMPORTS: dict[str, str] = {
     "list_templates": "nexus.skills.templates",
     "get_template_description": "nexus.skills.templates",
     "TemplateError": "nexus.skills.templates",
-    # MCP Integration (backward-compat re-exports, moved to nexus.mcp)
-    "MCPToolConfig": "nexus.mcp.models",
-    "MCPToolDefinition": "nexus.mcp.models",
-    "MCPToolExample": "nexus.mcp.models",
-    "MCPMount": "nexus.mcp.models",
-    "MCPMountManager": "nexus.mcp.mount",
-    "MCPMountError": "nexus.mcp.mount",
-    "MCPToolExporter": "nexus.mcp.exporter",
 }
 
 
 # TYPE_CHECKING imports — lets mypy resolve lazy types without runtime cost
 if TYPE_CHECKING:
-    from nexus.mcp.exporter import MCPToolExporter
-    from nexus.mcp.models import MCPMount, MCPToolConfig, MCPToolDefinition, MCPToolExample
-    from nexus.mcp.mount import MCPMountError, MCPMountManager
     from nexus.skills.analytics import (
         DashboardMetrics,
         SkillAnalytics,
@@ -188,12 +158,4 @@ __all__ = [
     "AuditAction",
     # Protocols
     "NexusFilesystem",
-    # MCP Integration
-    "MCPToolConfig",
-    "MCPToolDefinition",
-    "MCPToolExample",
-    "MCPMount",
-    "MCPMountManager",
-    "MCPMountError",
-    "MCPToolExporter",
 ]

--- a/tests/unit/skills/test_skills_brick_contract.py
+++ b/tests/unit/skills/test_skills_brick_contract.py
@@ -209,26 +209,6 @@ class TestModuleBoundary:
         assert "xml" in pc_fields
 
 
-class TestMCPBackwardCompat:
-    """Verify MCP backward-compat re-exports from nexus.skills."""
-
-    def test_mcp_models_importable_from_skills(self):
-        """MCP models are still importable from nexus.skills (backward compat)."""
-        from nexus.skills import MCPMount, MCPToolConfig, MCPToolDefinition, MCPToolExample
-
-        assert MCPMount is not None
-        assert MCPToolConfig is not None
-        assert MCPToolDefinition is not None
-        assert MCPToolExample is not None
-
-    def test_mcp_classes_match_canonical_source(self):
-        """Backward-compat re-exports point to the same classes as nexus.mcp."""
-        from nexus.mcp.models import MCPMount as Canonical
-        from nexus.skills import MCPMount as Compat
-
-        assert Canonical is Compat
-
-
 # =============================================================================
 # AST Helpers: detect guarded / scoped imports
 # =============================================================================


### PR DESCRIPTION
## Summary
- Remove 7 MCP backward-compat re-export entries from `nexus/skills/__init__.py`
- MCP types should be imported from their canonical location `nexus.mcp.*`
- Delete `TestMCPBackwardCompat` test class that tested the removed re-exports
- Per no-backward-compat policy: shims must be fully deleted

**Removed re-exports:** `MCPToolConfig`, `MCPToolDefinition`, `MCPToolExample`, `MCPMount`, `MCPMountManager`, `MCPMountError`, `MCPToolExporter`

**Canonical imports (unchanged):**
- `from nexus.mcp.models import MCPToolConfig, MCPMount, ...`
- `from nexus.mcp.mount import MCPMountManager, ...`
- `from nexus.mcp.exporter import MCPToolExporter`

## Test plan
- [ ] `from nexus.mcp.models import MCPMount` still works
- [ ] `from nexus.skills import SkillRegistry` still works
- [ ] Skills unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)