### PR TITLE
fix(#619): replace 10 module-level None globals with __getattr__ lazy loading

### DIFF
--- a/src/nexus/backends/__init__.py
+++ b/src/nexus/backends/__init__.py
@@ -25,22 +25,8 @@ from nexus.backends.registry import (
 )
 from nexus.core.object_store import BackendObjectStore, ObjectStoreABC
 
-# Optional backends - LAZY IMPORTS for faster CLI startup
-# These are imported on-demand when actually used, not at module load time
-# This saves ~500ms+ of startup time by avoiding google.cloud imports
-GCSBackend = None
-GoogleDriveConnectorBackend = None
-GCSConnectorBackend = None
-S3ConnectorBackend = None
-XConnectorBackend = None
-HNConnectorBackend = None
-SlackConnectorBackend = None
-LocalConnectorBackend = None
-GmailConnectorBackend = None
-GoogleCalendarConnectorBackend = None
-
-# Registry: maps module-level name → (module_path, class_name)
-# Adding a new optional backend requires only one entry here.
+# Optional backends — loaded on first access via __getattr__.
+# Maps attribute name → (module_path, class_name).
 _OPTIONAL_BACKENDS: dict[str, tuple[str, str]] = {
     "GCSBackend": ("nexus.backends.gcs", "GCSBackend"),
     "GoogleDriveConnectorBackend": (
@@ -65,11 +51,25 @@ _registration_lock = threading.Lock()
 _logger = logging.getLogger(__name__)
 
 
+def __getattr__(name: str) -> object:
+    """Lazy-load optional backends on first attribute access."""
+    if name in _OPTIONAL_BACKENDS:
+        module_path, class_name = _OPTIONAL_BACKENDS[name]
+        try:
+            module = importlib.import_module(module_path)
+            attr = getattr(module, class_name)
+        except ImportError as e:
+            raise AttributeError(f"Optional backend {name!r} is not available: {e}") from e
+        # Cache in module globals so __getattr__ is not called again.
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module 'nexus.backends' has no attribute {name}")
+
+
 def _register_optional_backends() -> None:
-    """Register optional backends on first use (lazy loading)."""
+    """Import all optional backend modules to trigger @register_connector."""
     global _optional_backends_registered
 
-    # Only register once (fast path without lock)
     if _optional_backends_registered:
         return
     with _registration_lock:
@@ -77,12 +77,15 @@ def _register_optional_backends() -> None:
             return
         _optional_backends_registered = True
 
-        for global_name, (module_path, class_name) in _OPTIONAL_BACKENDS.items():
+        seen_modules: set[str] = set()
+        for module_path, _ in _OPTIONAL_BACKENDS.values():
+            if module_path in seen_modules:
+                continue
+            seen_modules.add(module_path)
             try:
-                module = importlib.import_module(module_path)
-                globals()[global_name] = getattr(module, class_name)
+                importlib.import_module(module_path)
             except ImportError as e:
-                _logger.debug("Optional backend %s not available: %s", global_name, e)
+                _logger.debug("Optional backend module %s not available: %s", module_path, e)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Remove 10 module-level `None` placeholder variables for optional backends (`GCSBackend`, `GoogleDriveConnectorBackend`, etc.)
- Add `__getattr__` for lazy loading on first access (same pattern as `skills/__init__.py`)
- Simplify `_register_optional_backends()` to just import modules (triggering `@register_connector`)

## Rationale
Per KERNEL-ARCHITECTURE.md §5, module-level global mutable state breaks federation multi-process isolation. The 10 `None` variables were mutated at runtime by `_register_optional_backends()`, which is incompatible with multi-process deployments.

## Files changed
- `src/nexus/backends/__init__.py` — replaced None globals with `__getattr__` lazy loading

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] `from nexus.backends import GCSBackend` still works (triggers lazy import)
- [ ] `_register_optional_backends()` still discovers all backends for ConnectorRegistry

🤖 Generated with [Claude Code](https://claude.com/claude-code)