### PR TITLE
fix(#583): delete deprecated acl_store parameter from PermissionEnforcer

### DIFF
--- a/src/nexus/rebac/memory_permission_enforcer.py
+++ b/src/nexus/rebac/memory_permission_enforcer.py
@@ -36,7 +36,6 @@ class MemoryPermissionEnforcer(PermissionEnforcer):
     def __init__(
         self,
         metadata_store: Any = None,
-        acl_store: Any | None = None,  # Deprecated, kept for backward compatibility
         rebac_manager: EnhancedReBACManager | None = None,
         memory_router: MemoryViewRouter | None = None,
         entity_registry: EntityRegistry | None = None,
@@ -45,12 +44,11 @@ class MemoryPermissionEnforcer(PermissionEnforcer):
 
         Args:
             metadata_store: Metadata store for file permissions.
-            acl_store: Deprecated, ignored (kept for backward compatibility).
             rebac_manager: ReBAC manager for relationship-based permissions.
             memory_router: Memory view router for resolving paths.
             entity_registry: Entity registry for identity lookups.
         """
-        super().__init__(metadata_store, acl_store, rebac_manager)
+        super().__init__(metadata_store, rebac_manager=rebac_manager)
         self.memory_router = memory_router
         self.entity_registry = entity_registry
 

--- a/src/nexus/services/permissions/enforcer.py
+++ b/src/nexus/services/permissions/enforcer.py
@@ -55,7 +55,6 @@ class PermissionEnforcer:
     def __init__(
         self,
         metadata_store: Any = None,
-        acl_store: Any | None = None,  # Deprecated, kept for backward compatibility
         rebac_manager: ReBACManager | None = None,
         entity_registry: Any = None,  # Entity registry (reserved for future use)
         router: Any = None,  # PathRouter for backend object type resolution
@@ -79,7 +78,6 @@ class PermissionEnforcer:
 
         Args:
             metadata_store: Metadata store for file lookup (optional)
-            acl_store: Deprecated, ignored (kept for backward compatibility)
             rebac_manager: ReBAC manager for relationship-based permissions
             entity_registry: Entity registry (reserved for future use)
             router: PathRouter for resolving backend object types (v0.5.0+)
@@ -138,17 +136,6 @@ class PermissionEnforcer:
             self.rebac_manager.register_boundary_cache_invalidator(
                 callback_id,
                 self._boundary_cache.invalidate_permission_change,
-            )
-
-        # Warn if ACL store is provided (deprecated)
-        if acl_store is not None:
-            import warnings
-
-            warnings.warn(
-                "acl_store parameter is deprecated and will be removed in v0.7.0. "
-                "Use ReBAC for all permissions.",
-                DeprecationWarning,
-                stacklevel=2,
             )
 
     def invalidate_cache(

--- a/tests/unit/core/test_permission_enforcer.py
+++ b/tests/unit/core/test_permission_enforcer.py
@@ -258,11 +258,6 @@ class TestPermissionEnforcer:
 
         assert rebac.permissions_checked == ["read", "write", "execute"]
 
-    def test_acl_store_deprecated_warning(self):
-        """Test that providing acl_store parameter shows deprecation warning."""
-        with pytest.warns(DeprecationWarning, match="acl_store parameter is deprecated"):
-            PermissionEnforcer(acl_store="dummy_acl_store")
-
     def test_subject_type_passed_to_rebac(self):
         """Test that subject type is correctly passed to ReBAC manager."""
 


### PR DESCRIPTION
## Summary
- Remove deprecated `acl_store` parameter from `PermissionEnforcer.__init__()` and `MemoryPermissionEnforcer.__init__()`
- Delete the deprecation warning code and backward-compat test
- All permissions are now exclusively managed through ReBAC relationships

## Files changed
- `src/nexus/services/permissions/enforcer.py` — removed `acl_store` param, docstring reference, and deprecation warning
- `src/nexus/rebac/memory_permission_enforcer.py` — removed `acl_store` param and `super()` passthrough
- `tests/unit/core/test_permission_enforcer.py` — deleted `test_acl_store_deprecated_warning` test

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] No callers pass `acl_store` (verified by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)