### PR TITLE
fix(#685): move class-level mutable dicts to instance level in SyncJobManager

### DIFF
--- a/src/nexus/services/sync_job_manager.py
+++ b/src/nexus/services/sync_job_manager.py
@@ -91,11 +91,6 @@ class SyncJobManager:
         the database status.
     """
 
-    # Class-level tracking for active jobs and cancellation flags
-    # These are shared across all instances in the same process
-    _active_jobs: dict[str, asyncio.Task] = {}
-    _cancellation_flags: dict[str, bool] = {}
-
     def __init__(self, session_factory: Any) -> None:
         """Initialize sync job manager.
 
@@ -103,6 +98,8 @@ class SyncJobManager:
             session_factory: SQLAlchemy sessionmaker instance
         """
         self.SessionLocal = session_factory
+        self._active_jobs: dict[str, asyncio.Task[Any]] = {}
+        self._cancellation_flags: dict[str, bool] = {}
 
     def create_job(
         self,
@@ -163,11 +160,11 @@ class SyncJobManager:
             raise ValueError(f"Job {job_id} is not pending (status: {job['status']})")
 
         # Initialize cancellation flag
-        SyncJobManager._cancellation_flags[job_id] = False
+        self._cancellation_flags[job_id] = False
 
         # Create and store the background task
         task = asyncio.create_task(self._run_sync(job_id, nexus_fs))
-        SyncJobManager._active_jobs[job_id] = task
+        self._active_jobs[job_id] = task
 
         logger.info(f"Started sync job {job_id}")
 
@@ -189,7 +186,7 @@ class SyncJobManager:
             return False
 
         # Set cancellation flag
-        SyncJobManager._cancellation_flags[job_id] = True
+        self._cancellation_flags[job_id] = True
         logger.info(f"Requested cancellation for sync job {job_id}")
 
         return True
@@ -288,7 +285,7 @@ class SyncJobManager:
         Raises:
             SyncCancelled: If cancellation was requested
         """
-        if SyncJobManager._cancellation_flags.get(job_id, False):
+        if self._cancellation_flags.get(job_id, False):
             raise SyncCancelled(f"Job {job_id} was cancelled")
 
     def _create_progress_callback(
@@ -404,5 +401,5 @@ class SyncJobManager:
 
         finally:
             # Cleanup
-            SyncJobManager._active_jobs.pop(job_id, None)
-            SyncJobManager._cancellation_flags.pop(job_id, None)
+            self._active_jobs.pop(job_id, None)
+            self._cancellation_flags.pop(job_id, None)


### PR DESCRIPTION
## Summary
- Move `_active_jobs` and `_cancellation_flags` from class-level attributes to instance-level in `__init__`
- Class-level mutable dicts are shared across all instances in the same process, breaking federation multi-process isolation (KERNEL-ARCHITECTURE §5)
- All internal references updated from `SyncJobManager._*` to `self._*`

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff format, mypy)
- [x] No external callers reference these class attributes directly
- [x] Single-file change, no API surface changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)