### PR TITLE
fix: delete deprecated EnhancedOperationContext and EnhancedPermissionEnforcer aliases

### DIFF
--- a/src/nexus/rebac/permissions_enhanced.py
+++ b/src/nexus/rebac/permissions_enhanced.py
@@ -19,11 +19,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-# Import Permission and OperationContext from the original module (don't duplicate)
 from sqlalchemy.exc import OperationalError, ProgrammingError
-
-from nexus.core.permissions import OperationContext
-from nexus.services.permissions.enforcer import PermissionEnforcer
 
 # ============================================================================
 # P0-4: Admin Capabilities and Audit System
@@ -397,30 +393,3 @@ class AuditStore:
                 )
 
             return results
-
-
-# ============================================================================
-# Enhanced Operation Context with Admin Capabilities (P0-4)
-# ============================================================================
-# DEPRECATED: EnhancedOperationContext is now an alias for OperationContext.
-# OperationContext now includes all features (admin_capabilities, request_id).
-# Use OperationContext directly instead of EnhancedOperationContext.
-# ============================================================================
-
-
-# EnhancedOperationContext is now just an alias for OperationContext
-# This maintains backward compatibility while we migrate code to use OperationContext
-EnhancedOperationContext = OperationContext
-
-
-# ============================================================================
-# Enhanced Permission Enforcer with P0-4 Fix
-# ============================================================================
-# DEPRECATED: EnhancedPermissionEnforcer is now an alias for PermissionEnforcer.
-# PermissionEnforcer now includes all features (scoped bypass, audit logging, etc.).
-# Use PermissionEnforcer directly instead of EnhancedPermissionEnforcer.
-# ============================================================================
-
-# EnhancedPermissionEnforcer is now just an alias for PermissionEnforcer
-# This maintains backward compatibility while we migrate code to use PermissionEnforcer
-EnhancedPermissionEnforcer = PermissionEnforcer

--- a/src/nexus/services/permissions/permissions_enhanced.py
+++ b/src/nexus/services/permissions/permissions_enhanced.py
@@ -7,14 +7,10 @@ from nexus.rebac.permissions_enhanced import (
     AdminCapability,
     AuditLogEntry,
     AuditStore,
-    EnhancedOperationContext,
-    EnhancedPermissionEnforcer,
 )
 
 __all__ = [
     "AdminCapability",
     "AuditLogEntry",
     "AuditStore",
-    "EnhancedOperationContext",
-    "EnhancedPermissionEnforcer",
 ]


### PR DESCRIPTION
## Summary
- Delete `EnhancedOperationContext = OperationContext` alias from `rebac/permissions_enhanced.py`
- Delete `EnhancedPermissionEnforcer = PermissionEnforcer` alias from `rebac/permissions_enhanced.py`
- Remove deprecated re-exports from `services/permissions/permissions_enhanced.py`
- Clean up now-unused imports of `OperationContext` and `PermissionEnforcer`
- No production code or tests use these deprecated aliases

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff format, mypy)
- [x] Verified no production code imports `EnhancedOperationContext` or `EnhancedPermissionEnforcer`
- [x] Verified no test files reference these aliases
- [x] Valid types (`AdminCapability`, `AuditLogEntry`, `AuditStore`) still exported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)