### PR TITLE
refactor(#547-#555): remove placeholder Protocol re-exports

### DIFF
--- a/src/nexus/services/protocols/__init__.py
+++ b/src/nexus/services/protocols/__init__.py
@@ -30,7 +30,6 @@ from nexus.services.event_log.protocol import EventLogConfig, EventLogProtocol
 from nexus.services.governance.protocols import AnomalyDetectorProtocol
 from nexus.services.protocols.agent_registry import AgentInfo, AgentRegistryProtocol
 from nexus.services.protocols.chunked_upload import ChunkedUploadProtocol
-from nexus.services.protocols.governance import GovernanceProtocol
 from nexus.services.protocols.hook_engine import (
     POST_COPY,
     POST_DELETE,
@@ -59,9 +58,7 @@ from nexus.services.protocols.oauth import OAuthProtocol
 from nexus.services.protocols.parse import ParseProtocol
 from nexus.services.protocols.payment import PaymentProtocol
 from nexus.services.protocols.permission import PermissionProtocol
-from nexus.services.protocols.plugin import PluginProtocol
 from nexus.services.protocols.rebac import ReBACBrickProtocol
-from nexus.services.protocols.reputation import ReputationProtocol
 from nexus.services.protocols.scheduler import AgentRequest, SchedulerProtocol
 from nexus.services.protocols.search import SearchBrickProtocol
 from nexus.services.protocols.share_link import ShareLinkProtocol
@@ -75,7 +72,6 @@ from nexus.workflows.protocol import (
     LLMProviderProtocol,
     MetadataStoreProtocol,
     NexusOperationsProtocol,
-    WorkflowProtocol,
 )
 
 __all__ = [
@@ -86,7 +82,6 @@ __all__ = [
     "ChunkedUploadProtocol",
     "EventLogConfig",
     "EventLogProtocol",
-    "GovernanceProtocol",
     "HookContext",
     "HookEngineProtocol",
     "HookId",
@@ -118,10 +113,8 @@ __all__ = [
     "ParseProtocol",
     "PaymentProtocol",
     "PermissionProtocol",
-    "PluginProtocol",
     "ProgressCallback",
     "ReBACBrickProtocol",
-    "ReputationProtocol",
     "SchedulerProtocol",
     "SearchBrickProtocol",
     "ShareLinkProtocol",
@@ -132,6 +125,5 @@ __all__ = [
     "SyncServiceProtocol",
     "TaskQueueProtocol",
     "WatchProtocol",
-    "WorkflowProtocol",
     "WriteBackProtocol",
 ]


### PR DESCRIPTION
## Summary
- Remove 4 placeholder Protocol re-exports from `services/protocols/__init__.py`: `GovernanceProtocol`, `PluginProtocol`, `ReputationProtocol`, `WorkflowProtocol`
- These are stub-only definitions (all method bodies are `...`) with no concrete implementations wired via DI
- Re-exporting gives false impression of readiness; per project convention (no backward-compat), direct imports from definition modules are preferred
- Reopened tasks #547-#555 with findings: all 9 Protocols are placeholders, need concrete implementations wired

## Verified
- No code imports these 4 via `nexus.services.protocols` (grep confirmed zero references)
- All pre-commit hooks pass (ruff, mypy, etc.)

## Test plan
- [ ] CI passes (no import breakage)
- [ ] Verify `from nexus.services.protocols import PermissionProtocol` still works (non-placeholder protocols unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)