### PR TITLE
fix: delete deprecated EnhancedOperationContext and EnhancedPermissionEnforcer aliases

### DIFF
--- a/src/nexus/backends/backend.py
+++ b/src/nexus/backends/backend.py
@@ -14,7 +14,6 @@ from nexus.core.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.core.permissions import OperationContext
-    from nexus.rebac.permissions_enhanced import EnhancedOperationContext
 
 
 @dataclass
@@ -634,7 +633,7 @@ class Backend(ABC):
         path: str,
         parents: bool = False,
         exist_ok: bool = False,
-        context: "OperationContext | EnhancedOperationContext | None" = None,
+        context: "OperationContext | None" = None,
     ) -> "HandlerResponse[None]":
         """
         Create a directory.
@@ -662,7 +661,7 @@ class Backend(ABC):
         self,
         path: str,
         recursive: bool = False,
-        context: "OperationContext | EnhancedOperationContext | None" = None,
+        context: "OperationContext | None" = None,
     ) -> "HandlerResponse[None]":
         """
         Remove a directory.

--- a/src/nexus/backends/base_blob_connector.py
+++ b/src/nexus/backends/base_blob_connector.py
@@ -31,7 +31,6 @@ from nexus.core.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.core.permissions import OperationContext
-    from nexus.rebac.permissions_enhanced import EnhancedOperationContext
 
 logger = logging.getLogger(__name__)
 
@@ -858,7 +857,7 @@ class BaseBlobStorageConnector(Backend):
         path: str,
         parents: bool = False,
         exist_ok: bool = False,
-        context: "OperationContext | EnhancedOperationContext | None" = None,
+        context: "OperationContext | None" = None,
     ) -> HandlerResponse[None]:
         """
         Create directory marker in blob storage.
@@ -945,7 +944,7 @@ class BaseBlobStorageConnector(Backend):
         self,
         path: str,
         recursive: bool = False,
-        context: "OperationContext | EnhancedOperationContext | None" = None,
+        context: "OperationContext | None" = None,
     ) -> HandlerResponse[None]:
         """
         Remove directory from blob storage.

--- a/src/nexus/backends/gcs.py
+++ b/src/nexus/backends/gcs.py
@@ -27,7 +27,6 @@ from nexus.core.hash_fast import hash_content
 
 if TYPE_CHECKING:
     from nexus.core.permissions import OperationContext
-    from nexus.rebac.permissions_enhanced import EnhancedOperationContext
 
 logger = logging.getLogger(__name__)
 
@@ -563,7 +562,7 @@ class GCSBackend(Backend):
         path: str,
         parents: bool = False,
         exist_ok: bool = False,
-        context: "OperationContext | EnhancedOperationContext | None" = None,
+        context: "OperationContext | None" = None,
     ) -> None:
         """
         Create directory marker in GCS.
@@ -605,7 +604,7 @@ class GCSBackend(Backend):
         self,
         path: str,
         recursive: bool = False,
-        context: "OperationContext | EnhancedOperationContext | None" = None,
+        context: "OperationContext | None" = None,
     ) -> None:
         """Remove directory from GCS."""
         # Normalize path

--- a/src/nexus/backends/passthrough.py
+++ b/src/nexus/backends/passthrough.py
@@ -38,7 +38,6 @@ from nexus.core.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.core.permissions import OperationContext
-    from nexus.rebac.permissions_enhanced import EnhancedOperationContext
 
 logger = logging.getLogger(__name__)
 
@@ -490,7 +489,7 @@ class PassthroughBackend(Backend):
         path: str,
         parents: bool = False,
         exist_ok: bool = False,
-        context: OperationContext | EnhancedOperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> HandlerResponse[None]:
         """Create a directory in the pointers layer."""
         start_time = time.perf_counter()
@@ -541,7 +540,7 @@ class PassthroughBackend(Backend):
         self,
         path: str,
         recursive: bool = False,
-        context: OperationContext | EnhancedOperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> HandlerResponse[None]:
         """Remove a directory from the pointers layer."""
         import shutil

--- a/src/nexus/isolation/backend.py
+++ b/src/nexus/isolation/backend.py
@@ -26,7 +26,6 @@ from nexus.isolation.errors import (
 
 if TYPE_CHECKING:
     from nexus.core.permissions import OperationContext
-    from nexus.rebac.permissions_enhanced import EnhancedOperationContext
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +139,7 @@ class IsolatedBackend(Backend):
         path: str,
         parents: bool = False,
         exist_ok: bool = False,
-        context: OperationContext | EnhancedOperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> HandlerResponse[None]:
         return self._call("mkdir", path, parents=parents, exist_ok=exist_ok, context=context)
 
@@ -148,7 +147,7 @@ class IsolatedBackend(Backend):
         self,
         path: str,
         recursive: bool = False,
-        context: OperationContext | EnhancedOperationContext | None = None,
+        context: OperationContext | None = None,
     ) -> HandlerResponse[None]:
         return self._call("rmdir", path, recursive=recursive, context=context)
 

--- a/src/nexus/rebac/permissions_enhanced.py
+++ b/src/nexus/rebac/permissions_enhanced.py
@@ -22,9 +22,6 @@ from typing import Any
 # Import Permission and OperationContext from the original module (don't duplicate)
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
-from nexus.core.permissions import OperationContext
-from nexus.services.permissions.enforcer import PermissionEnforcer
-
 # ============================================================================
 # P0-4: Admin Capabilities and Audit System
 # ============================================================================
@@ -397,30 +394,3 @@ class AuditStore:
                 )
 
             return results
-
-
-# ============================================================================
-# Enhanced Operation Context with Admin Capabilities (P0-4)
-# ============================================================================
-# DEPRECATED: EnhancedOperationContext is now an alias for OperationContext.
-# OperationContext now includes all features (admin_capabilities, request_id).
-# Use OperationContext directly instead of EnhancedOperationContext.
-# ============================================================================
-
-
-# EnhancedOperationContext is now just an alias for OperationContext
-# This maintains backward compatibility while we migrate code to use OperationContext
-EnhancedOperationContext = OperationContext
-
-
-# ============================================================================
-# Enhanced Permission Enforcer with P0-4 Fix
-# ============================================================================
-# DEPRECATED: EnhancedPermissionEnforcer is now an alias for PermissionEnforcer.
-# PermissionEnforcer now includes all features (scoped bypass, audit logging, etc.).
-# Use PermissionEnforcer directly instead of EnhancedPermissionEnforcer.
-# ============================================================================
-
-# EnhancedPermissionEnforcer is now just an alias for PermissionEnforcer
-# This maintains backward compatibility while we migrate code to use PermissionEnforcer
-EnhancedPermissionEnforcer = PermissionEnforcer

--- a/src/nexus/services/permissions/permissions_enhanced.py
+++ b/src/nexus/services/permissions/permissions_enhanced.py
@@ -7,14 +7,10 @@ from nexus.rebac.permissions_enhanced import (
     AdminCapability,
     AuditLogEntry,
     AuditStore,
-    EnhancedOperationContext,
-    EnhancedPermissionEnforcer,
 )
 
 __all__ = [
     "AdminCapability",
     "AuditLogEntry",
     "AuditStore",
-    "EnhancedOperationContext",
-    "EnhancedPermissionEnforcer",
 ]


### PR DESCRIPTION
## Summary
- Delete deprecated `EnhancedOperationContext` alias (was just `OperationContext`)
- Delete deprecated `EnhancedPermissionEnforcer` alias (was just `PermissionEnforcer`)
- Update all 5 backend consumers to use `OperationContext` directly
- Clean up re-export shim in `services/permissions/permissions_enhanced.py`

Supersedes #1921 (clean branch from develop, no conflicts)

## Test plan
- [x] No remaining references to `EnhancedOperationContext` or `EnhancedPermissionEnforcer`
- [x] All pre-commit hooks pass (ruff, trailing-whitespace, etc.)
- [ ] CI mypy passes on Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)