### PR TITLE
chore: remove .claude/settings.json from repo, add to .gitignore

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,0 @@
-{
-  "env": {
-    "CLAUDE_CODE_TASK_LIST_ID": "nexus-project"
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,7 @@ aws-config
 aws-credentials
 
 # Claude Code local settings
+.claude/settings.json
 .claude/settings.local.json
 CLAUDE.md
 .claude/CLAUDE.md


### PR DESCRIPTION
## Summary
- Remove `.claude/settings.json` from version control — contains local Claude Code task-list config (`CLAUDE_CODE_TASK_LIST_ID`) that should not be in the repo
- Add `.claude/settings.json` to `.gitignore`

Recreated from closed PR #2041 (stale branch with 553 files diff).

## Test plan
- [x] Verify `.claude/settings.json` is deleted from tracked files
- [x] Verify `.gitignore` includes `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)