### PR TITLE
fix(#725): add zone_id filter to token rotation invalidate_family and prune_history

### DIFF
--- a/src/nexus/server/auth/token_manager.py
+++ b/src/nexus/server/auth/token_manager.py
@@ -354,7 +354,7 @@ class TokenManager:
                                 session, model.token_family_id, old_refresh_hash
                             ):
                                 count = self._rotation_store.invalidate_family(
-                                    session, model.token_family_id
+                                    session, model.token_family_id, zone_id=model.zone_id
                                 )
                                 session.commit()
                                 self._invalidate_cache(provider, user_email, zone_id)
@@ -413,6 +413,7 @@ class TokenManager:
                                 session,
                                 model.token_family_id,
                                 retention_days=_HISTORY_RETENTION_DAYS,
+                                zone_id=model.zone_id,
                             )
 
                         credential = new_credential
@@ -469,7 +470,7 @@ class TokenManager:
         with self.SessionLocal() as session:
             return self._rotation_store.detect_reuse(session, token_family_id, refresh_token_hash)
 
-    def invalidate_family(self, token_family_id: str) -> int:
+    def invalidate_family(self, token_family_id: str, zone_id: str | None = None) -> int:
         """Invalidate all credentials in a token family.
 
         Called when token reuse is detected.  Revokes all credentials
@@ -479,7 +480,9 @@ class TokenManager:
             Number of credentials revoked.
         """
         with self.SessionLocal() as session:
-            count = self._rotation_store.invalidate_family(session, token_family_id)
+            count = self._rotation_store.invalidate_family(
+                session, token_family_id, zone_id=zone_id
+            )
             session.commit()
 
             if count > 0:

--- a/src/nexus/storage/token_rotation_store.py
+++ b/src/nexus/storage/token_rotation_store.py
@@ -76,6 +76,7 @@ class TokenRotationStore:
         self,
         session: Any,
         token_family_id: str | None,
+        zone_id: str | None = None,
     ) -> int:
         """Revoke all credentials in a token family.
 
@@ -84,12 +85,14 @@ class TokenRotationStore:
         if not token_family_id:
             return 0
         now = datetime.now(UTC)
-        result = session.execute(
+        stmt = (
             update(OAuthCredentialModel)
             .where(OAuthCredentialModel.token_family_id == token_family_id)
             .where(OAuthCredentialModel.revoked == 0)
-            .values(revoked=1, revoked_at=now)
         )
+        if zone_id is not None:
+            stmt = stmt.where(OAuthCredentialModel.zone_id == zone_id)
+        result = session.execute(stmt.values(revoked=1, revoked_at=now))
         count = result.rowcount or 0
         if count > 0:
             logger.warning(
@@ -104,17 +107,19 @@ class TokenRotationStore:
         session: Any,
         token_family_id: str | None,
         retention_days: int = 30,
+        zone_id: str | None = None,
     ) -> None:
         """Delete history entries older than retention period."""
         if not token_family_id:
             return
         cutoff = datetime.now(UTC) - timedelta(days=retention_days)
         try:
-            session.execute(
-                delete(RefreshTokenHistoryModel).where(
-                    RefreshTokenHistoryModel.token_family_id == token_family_id,
-                    RefreshTokenHistoryModel.rotated_at < cutoff,
-                )
+            stmt = delete(RefreshTokenHistoryModel).where(
+                RefreshTokenHistoryModel.token_family_id == token_family_id,
+                RefreshTokenHistoryModel.rotated_at < cutoff,
             )
+            if zone_id is not None:
+                stmt = stmt.where(RefreshTokenHistoryModel.zone_id == zone_id)
+            session.execute(stmt)
         except Exception:
             logger.warning("Failed to prune token history", exc_info=True)


### PR DESCRIPTION
## Summary
- Added `zone_id` parameter to `TokenRotationStore.invalidate_family()` to scope credential revocation to the correct zone
- Added `zone_id` parameter to `TokenRotationStore.prune_history()` to scope history cleanup to the correct zone  
- Updated all callers in `token_manager.py` (both private refresh path and public `invalidate_family` wrapper) to pass `zone_id`

## Violation
`invalidate_family` used `update(OAuthCredentialModel).where(token_family_id == ...)` without zone_id filter, allowing cross-zone credential revocation. `prune_history` used `delete(RefreshTokenHistoryModel).where(token_family_id == ...)` without zone_id filter. Both `OAuthCredentialModel` and `RefreshTokenHistoryModel` have `zone_id` columns.

## Test plan
- [ ] Existing `test_family_invalidation` and E2E rotation tests still pass
- [ ] Zone-scoped invalidation only revokes credentials within the same zone