### PR TITLE
fix(#725): add zone_id filter to APIKeyModel lookups in auth_routes.py

### DIFF
--- a/src/nexus/server/auth/auth_routes.py
+++ b/src/nexus/server/auth/auth_routes.py
@@ -388,7 +388,13 @@ async def login(
                 for oauth_key in oauth_api_keys:
                     try:
                         # Verify the key still exists in api_keys and hasn't expired or been revoked
-                        api_key_model = session.get(APIKeyModel, oauth_key.key_id)
+                        # Zone-scoped query (replaces session.get for zone isolation)
+                        key_query = select(APIKeyModel).where(
+                            APIKeyModel.key_id == oauth_key.key_id
+                        )
+                        if user.zone_id is not None:
+                            key_query = key_query.where(APIKeyModel.zone_id == user.zone_id)
+                        api_key_model = session.scalar(key_query)
                         if api_key_model and not api_key_model.revoked:
                             # Check expiration
                             is_expired = False
@@ -1004,7 +1010,13 @@ async def oauth_check(
                 for oauth_key in oauth_api_keys:
                     try:
                         # Verify the key still exists in api_keys and hasn't expired or been revoked
-                        api_key_model = session.get(APIKeyModel, oauth_key.key_id)
+                        # Zone-scoped query (replaces session.get for zone isolation)
+                        key_query = select(APIKeyModel).where(
+                            APIKeyModel.key_id == oauth_key.key_id
+                        )
+                        if user.zone_id is not None:
+                            key_query = key_query.where(APIKeyModel.zone_id == user.zone_id)
+                        api_key_model = session.scalar(key_query)
                         if api_key_model and not api_key_model.revoked:
                             # Check expiration - handle both timezone-aware and naive datetimes
                             is_expired = False


### PR DESCRIPTION
## Summary
- Replaced `session.get(APIKeyModel, key_id)` with zone-scoped `select` queries in login endpoint (line 391) and OAuth callback (line 1007)
- Both now filter by `user.zone_id` when the user has a zone association, preventing cross-zone API key access

## Violation
`session.get()` fetches by PK only, bypassing zone isolation. `APIKeyModel` has a `zone_id` column (non-nullable, default "root") that must be included in queries per the data-storage-matrix.

## Test plan
- [ ] Login endpoint still returns valid API keys for authenticated users
- [ ] OAuth callback still retrieves encrypted API keys correctly
- [ ] Users with zone_id=None (global admins) still work correctly