### PR TITLE
fix(#725): add zone_id isolation to admin API key operations

### DIFF
--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -91,12 +91,18 @@ def handle_admin_list_keys(auth_provider: Any, params: Any, context: Any) -> dic
     if not auth_provider or not hasattr(auth_provider, "session_factory"):
         raise RuntimeError("Database auth provider not configured")
 
+    # Zone isolation: use context.zone_id if caller is zone-scoped,
+    # otherwise fall back to explicit params.zone_id filter
+    caller_zone_id = getattr(context, "zone_id", None)
+
     with auth_provider.session_factory() as session:
         stmt = select(APIKeyModel)
 
         if params.user_id:
             stmt = stmt.where(APIKeyModel.user_id == params.user_id)
-        if params.zone_id:
+        if caller_zone_id is not None:
+            stmt = stmt.where(APIKeyModel.zone_id == caller_zone_id)
+        elif params.zone_id:
             stmt = stmt.where(APIKeyModel.zone_id == params.zone_id)
         if params.is_admin is not None:
             stmt = stmt.where(APIKeyModel.is_admin == int(params.is_admin))
@@ -153,8 +159,13 @@ def handle_admin_get_key(auth_provider: Any, params: Any, context: Any) -> dict[
     if not auth_provider or not hasattr(auth_provider, "session_factory"):
         raise RuntimeError("Database auth provider not configured")
 
+    # Zone-scoped query: use context.zone_id to enforce zone isolation
+    caller_zone_id = getattr(context, "zone_id", None)
+
     with auth_provider.session_factory() as session:
         stmt = select(APIKeyModel).where(APIKeyModel.key_id == params.key_id)
+        if caller_zone_id is not None:
+            stmt = stmt.where(APIKeyModel.zone_id == caller_zone_id)
         api_key = session.scalar(stmt)
 
         if not api_key:
@@ -186,8 +197,10 @@ def handle_admin_revoke_key(auth_provider: Any, params: Any, context: Any) -> di
     if not auth_provider or not hasattr(auth_provider, "session_factory"):
         raise RuntimeError("Database auth provider not configured")
 
+    caller_zone_id = getattr(context, "zone_id", None)
+
     with auth_provider.session_factory() as session:
-        success = DatabaseAPIKeyAuth.revoke_key(session, params.key_id)
+        success = DatabaseAPIKeyAuth.revoke_key(session, params.key_id, zone_id=caller_zone_id)
         if not success:
             raise NexusFileNotFoundError(f"API key not found: {params.key_id}")
 
@@ -209,8 +222,12 @@ def handle_admin_update_key(auth_provider: Any, params: Any, context: Any) -> di
     if not auth_provider or not hasattr(auth_provider, "session_factory"):
         raise RuntimeError("Database auth provider not configured")
 
+    caller_zone_id = getattr(context, "zone_id", None)
+
     with auth_provider.session_factory() as session:
         stmt = select(APIKeyModel).where(APIKeyModel.key_id == params.key_id)
+        if caller_zone_id is not None:
+            stmt = stmt.where(APIKeyModel.zone_id == caller_zone_id)
         api_key = session.scalar(stmt)
 
         if not api_key:

--- a/src/nexus/server/rpc_server.py
+++ b/src/nexus/server/rpc_server.py
@@ -553,6 +553,10 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         if not self.auth_provider or not hasattr(self.auth_provider, "session_factory"):
             raise RuntimeError("Database auth provider not configured")
 
+        # Zone isolation: use caller's zone_id from auth context
+        context = self._get_operation_context()
+        caller_zone_id = getattr(context, "zone_id", None) if context else None
+
         with self.auth_provider.session_factory() as session:
             # Build query with filters
             stmt = select(APIKeyModel)
@@ -560,7 +564,10 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
             if params.user_id:
                 stmt = stmt.where(APIKeyModel.user_id == params.user_id)
 
-            if params.zone_id:
+            # Zone isolation: caller's zone_id takes priority
+            if caller_zone_id is not None:
+                stmt = stmt.where(APIKeyModel.zone_id == caller_zone_id)
+            elif params.zone_id:
                 stmt = stmt.where(APIKeyModel.zone_id == params.zone_id)
 
             if params.is_admin is not None:
@@ -628,8 +635,14 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         if not self.auth_provider or not hasattr(self.auth_provider, "session_factory"):
             raise RuntimeError("Database auth provider not configured")
 
+        # Zone isolation: use caller's zone_id from auth context
+        context = self._get_operation_context()
+        caller_zone_id = getattr(context, "zone_id", None) if context else None
+
         with self.auth_provider.session_factory() as session:
             stmt = select(APIKeyModel).where(APIKeyModel.key_id == params.key_id)
+            if caller_zone_id is not None:
+                stmt = stmt.where(APIKeyModel.zone_id == caller_zone_id)
             api_key = session.scalar(stmt)
 
             if not api_key:
@@ -665,8 +678,12 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         if not self.auth_provider or not hasattr(self.auth_provider, "session_factory"):
             raise RuntimeError("Database auth provider not configured")
 
+        # Zone isolation: use caller's zone_id from auth context
+        context = self._get_operation_context()
+        caller_zone_id = getattr(context, "zone_id", None) if context else None
+
         with self.auth_provider.session_factory() as session:
-            success = DatabaseAPIKeyAuth.revoke_key(session, params.key_id)
+            success = DatabaseAPIKeyAuth.revoke_key(session, params.key_id, zone_id=caller_zone_id)
             if not success:
                 raise NexusFileNotFoundError(f"API key not found: {params.key_id}")
 
@@ -691,8 +708,14 @@ class RPCRequestHandler(BaseHTTPRequestHandler):
         if not self.auth_provider or not hasattr(self.auth_provider, "session_factory"):
             raise RuntimeError("Database auth provider not configured")
 
+        # Zone isolation: use caller's zone_id from auth context
+        context = self._get_operation_context()
+        caller_zone_id = getattr(context, "zone_id", None) if context else None
+
         with self.auth_provider.session_factory() as session:
             stmt = select(APIKeyModel).where(APIKeyModel.key_id == params.key_id)
+            if caller_zone_id is not None:
+                stmt = stmt.where(APIKeyModel.zone_id == caller_zone_id)
             api_key = session.scalar(stmt)
 
             if not api_key:


### PR DESCRIPTION
## Summary
- Adds zone_id isolation to all admin API key operations (list, get, revoke, update) in both `rpc_server.py` and `rpc/handlers/admin.py`
- Extracts caller's zone_id from auth context via `_get_operation_context()` / `getattr(context, "zone_id", None)`
- Applies mandatory zone_id filter on all APIKeyModel queries to prevent cross-zone data access
- For list operations, caller's zone_id takes priority over `params.zone_id` (global admins can still filter by zone)

## Test plan
- [ ] Verify admin_list_keys returns only keys from caller's zone
- [ ] Verify admin_get_key returns 404 for keys in other zones
- [ ] Verify admin_revoke_key cannot revoke keys in other zones
- [ ] Verify admin_update_key cannot modify keys in other zones
- [ ] Verify global admin (no zone_id) can still access all keys