### PR TITLE
fix: move mount restoration I/O from factory to application layer

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -43,6 +43,8 @@ first accessed. This reduces import time from ~10s to ~1s for simple use cases.
 
 from __future__ import annotations
 
+import logging
+
 __version__ = "0.7.2.dev0"
 __author__ = "Nexi Lab Team"
 __license__ = "Apache-2.0"
@@ -102,6 +104,8 @@ from nexus.core.exceptions import (
     NexusFileNotFoundError,
     NexusPermissionError,
 )
+
+logger = logging.getLogger(__name__)
 
 # Module-level cache for lazy imports
 _lazy_imports_cache: dict[str, Any] = {}
@@ -407,7 +411,45 @@ def connect(
     if cfg.mode == "federation":
         nx_fs._zone_mgr = zone_mgr
 
+    # Restore saved mounts (application-layer startup I/O)
+    _restore_mounts(nx_fs)
+
     return nx_fs
+
+
+def _restore_mounts(nx_fs: NexusFS) -> None:
+    """Restore saved mounts from database at application startup.
+
+    This is application-layer I/O that runs after NexusFS construction.
+    The factory itself never performs I/O — callers decide when to
+    restore mounts.
+    """
+    import os
+
+    try:
+        auto_sync = os.getenv("NEXUS_AUTO_SYNC_MOUNTS", "false").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+        mount_result = nx_fs.load_all_saved_mounts(auto_sync=auto_sync)
+        if mount_result["loaded"] > 0 or mount_result["failed"] > 0:
+            sync_msg = f", {mount_result['synced']} synced" if mount_result["synced"] > 0 else ""
+            logger.info(
+                "Mount restoration: %d loaded%s, %d failed",
+                mount_result["loaded"],
+                sync_msg,
+                mount_result["failed"],
+            )
+            if not auto_sync and mount_result["loaded"] > 0:
+                logger.info(
+                    "Auto-sync disabled for fast startup. "
+                    "Use sync_mount() or set NEXUS_AUTO_SYNC_MOUNTS=true"
+                )
+            for error in mount_result.get("errors", []):
+                logger.error("  Mount error: %s", error)
+    except Exception as e:
+        logger.warning("Failed to load saved mounts during initialization: %s", e)
 
 
 __all__ = [

--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -1255,44 +1255,6 @@ def _create_provider_registry(parsing: Any) -> Any:
     return registry
 
 
-def _post_init(nx: NexusFS) -> None:
-    """Post-construction steps: mount restoration.
-
-    Called after NexusFS is constructed to perform I/O that requires
-    a fully-wired kernel instance.
-    """
-    import os
-
-    # Load all saved mounts from database and activate them
-    try:
-        if hasattr(nx, "load_all_saved_mounts"):
-            auto_sync = os.getenv("NEXUS_AUTO_SYNC_MOUNTS", "false").lower() in (
-                "true",
-                "1",
-                "yes",
-            )
-            mount_result = nx.load_all_saved_mounts(auto_sync=auto_sync)
-            if mount_result["loaded"] > 0 or mount_result["failed"] > 0:
-                sync_msg = (
-                    f", {mount_result['synced']} synced" if mount_result["synced"] > 0 else ""
-                )
-                logger.info(
-                    "Mount restoration: %d loaded%s, %d failed",
-                    mount_result["loaded"],
-                    sync_msg,
-                    mount_result["failed"],
-                )
-                if not auto_sync and mount_result["loaded"] > 0:
-                    logger.info(
-                        "Auto-sync disabled for fast startup. "
-                        "Use sync_mount() or set NEXUS_AUTO_SYNC_MOUNTS=true"
-                    )
-                for error in mount_result.get("errors", []):
-                    logger.error("  Mount error: %s", error)
-    except Exception as e:
-        logger.warning("Failed to load saved mounts during initialization: %s", e)
-
-
 def create_nexus_fs(
     backend: Backend,
     metadata_store: MetastoreABC,
@@ -1451,8 +1413,5 @@ def create_nexus_fs(
 
     # Attach CacheBrick to NexusFS for server layer access (Issue #1524)
     nx._cache_brick = _cache_brick  # type: ignore[attr-defined]
-
-    # Post-construction I/O (mount restoration, etc.)
-    _post_init(nx)
 
     return nx


### PR DESCRIPTION
## Summary
- Delete `_post_init()` from `factory.py` — it violated KERNEL-ARCHITECTURE.md §3 by performing I/O (os.getenv, load_all_saved_mounts) inside the factory layer
- Move mount restoration logic to `_restore_mounts()` in `__init__.py` (application layer), where callers decide when to restore
- Remove unnecessary `hasattr()` runtime guard (NexusFS always has `load_all_saved_mounts`)
- Add `import logging` and `logger` to `__init__.py` for mount restoration logs

## Test plan
- [ ] CI passes (unit tests, e2e)
- [ ] Mount restoration still works at startup (logs show "Mount restoration: X loaded")
- [ ] Factory no longer performs post-construction I/O

🤖 Generated with [Claude Code](https://claude.com/claude-code)