### PR TITLE
fix: replace PL/pgSQL functions with inline SQL in scheduler

### DIFF
--- a/src/nexus/scheduler/migration_v2.sql
+++ b/src/nexus/scheduler/migration_v2.sql
@@ -11,34 +11,13 @@ ALTER TABLE scheduled_tasks
 ALTER TABLE scheduled_tasks
   ADD COLUMN IF NOT EXISTS estimated_service_time REAL NOT NULL DEFAULT 30.0;
 
--- HRRN SQL function for ORDER BY at dequeue time
-CREATE OR REPLACE FUNCTION hrrn_score(
-  enqueued_at TIMESTAMPTZ, est_svc REAL, now_ts TIMESTAMPTZ DEFAULT now()
-) RETURNS REAL AS $$
-BEGIN
-  RETURN (EXTRACT(EPOCH FROM (now_ts - enqueued_at)) + est_svc)
-         / GREATEST(est_svc, 0.001);
-END; $$ LANGUAGE plpgsql IMMUTABLE;
+-- NOTE: hrrn_score() and compute_effective_tier() PL/pgSQL functions removed.
+-- HRRN scoring is now inlined in SQL queries (queue.py).
+-- Effective tier computation uses Python (scheduler/priority.py).
 
--- Unified priority function (replaces Python duplicate)
-CREATE OR REPLACE FUNCTION compute_effective_tier(
-  base_tier SMALLINT, boost_tiers SMALLINT, enqueued_at TIMESTAMPTZ,
-  aging_secs INT DEFAULT 120, max_wait INT DEFAULT 600,
-  now_ts TIMESTAMPTZ DEFAULT now()
-) RETURNS SMALLINT AS $$
-DECLARE
-  wait_secs REAL;
-  aging_boost INT;
-  effective INT;
-BEGIN
-  wait_secs := EXTRACT(EPOCH FROM (now_ts - enqueued_at));
-  aging_boost := FLOOR(wait_secs / aging_secs)::INT;
-  effective := base_tier - boost_tiers - aging_boost;
-  IF wait_secs > max_wait THEN
-    effective := LEAST(effective, 1);  -- Escalate to HIGH
-  END IF;
-  RETURN GREATEST(0, effective)::SMALLINT;
-END; $$ LANGUAGE plpgsql IMMUTABLE;
+-- Drop legacy PL/pgSQL functions if they exist
+DROP FUNCTION IF EXISTS hrrn_score(TIMESTAMPTZ, REAL, TIMESTAMPTZ);
+DROP FUNCTION IF EXISTS compute_effective_tier(SMALLINT, SMALLINT, TIMESTAMPTZ, INT, INT, TIMESTAMPTZ);
 
 -- Indexes for Astraea dequeue pattern
 CREATE INDEX IF NOT EXISTS idx_sched_astraea_dequeue

--- a/src/nexus/scheduler/queue.py
+++ b/src/nexus/scheduler/queue.py
@@ -5,7 +5,7 @@ Tasks are ordered by (effective_tier ASC, enqueued_at ASC) for
 strict priority ordering with FIFO within each tier.
 
 HRRN dequeue (Issue #1274) orders by priority_class ASC,
-hrrn_score() DESC, enqueued_at ASC for Astraea-style scheduling.
+inline HRRN score DESC, enqueued_at ASC for Astraea-style scheduling.
 
 Related: Issue #1212, #1274
 """
@@ -91,7 +91,8 @@ WHERE id = (
       AND executor_state IN ('CONNECTED', 'IDLE', 'UNKNOWN')
     ORDER BY
         priority_class ASC,
-        hrrn_score(enqueued_at, estimated_service_time) DESC,
+        (EXTRACT(EPOCH FROM (now() - enqueued_at)) + estimated_service_time)
+            / GREATEST(estimated_service_time, 0.001) DESC,
         enqueued_at ASC
     FOR UPDATE SKIP LOCKED
     LIMIT 1
@@ -115,7 +116,8 @@ WHERE id = (
       AND executor_state IN ('CONNECTED', 'IDLE', 'UNKNOWN')
     ORDER BY
         priority_class ASC,
-        hrrn_score(enqueued_at, estimated_service_time) DESC,
+        (EXTRACT(EPOCH FROM (now() - enqueued_at)) + estimated_service_time)
+            / GREATEST(estimated_service_time, 0.001) DESC,
         enqueued_at ASC
     FOR UPDATE SKIP LOCKED
     LIMIT 1
@@ -370,7 +372,7 @@ class TaskQueue:
     ) -> ScheduledTask | None:
         """Dequeue using HRRN scoring within priority classes (Astraea).
 
-        Orders by: priority_class ASC, hrrn_score DESC, enqueued_at ASC.
+        Orders by: priority_class ASC, HRRN score DESC, enqueued_at ASC.
         Filters out tasks whose executor is SUSPENDED.
 
         Args:


### PR DESCRIPTION
## Summary
- Replace `hrrn_score()` PL/pgSQL function calls in `queue.py` with inline SQL expressions
- Remove `hrrn_score()` and `compute_effective_tier()` PL/pgSQL function definitions from `migration_v2.sql`
- Add `DROP FUNCTION IF EXISTS` for clean migration from existing databases
- Python implementations in `policies/hrrn.py` and `priority.py` already exist and are unaffected

## Test plan
- [ ] CI passes
- [ ] Scheduler dequeue ordering works correctly with inline HRRN expression
- [ ] No PL/pgSQL functions remain in migration files

🤖 Generated with [Claude Code](https://claude.com/claude-code)