### PR TITLE
fix: replace direct storage logger imports with protocol abstractions in audit routers

### DIFF
--- a/src/nexus/server/api/v2/routers/audit.py
+++ b/src/nexus/server/api/v2/routers/audit.py
@@ -32,7 +32,7 @@ from nexus.server.api.v2.models import (
     AuditTransactionListResponse,
     AuditTransactionResponse,
 )
-from nexus.storage.exchange_audit_logger import ExchangeAuditLogger
+from nexus.services.protocols.exchange_audit_log import ExchangeAuditLogProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +118,7 @@ def list_transactions(
     limit: int = Query(100, ge=1, le=1000, description="Page size"),
     cursor: str | None = Query(None, description="Cursor from previous response"),
     include_total: bool = Query(False, description="Include total count"),
-    logger_and_zone: tuple[ExchangeAuditLogger, str] = Depends(get_exchange_audit_logger),
+    logger_and_zone: tuple[ExchangeAuditLogProtocol, str] = Depends(get_exchange_audit_logger),
 ) -> AuditTransactionListResponse:
     """List exchange audit transactions with cursor-based pagination."""
     audit_logger, zone_id = logger_and_zone
@@ -166,7 +166,7 @@ def list_transactions(
 def get_aggregations(
     since: datetime | None = Query(None, description="Start time (ISO-8601)"),
     until: datetime | None = Query(None, description="End time (ISO-8601)"),
-    logger_and_zone: tuple[ExchangeAuditLogger, str] = Depends(get_exchange_audit_logger),
+    logger_and_zone: tuple[ExchangeAuditLogProtocol, str] = Depends(get_exchange_audit_logger),
 ) -> AuditAggregationResponse:
     """Compute aggregations: total volume, count, top counterparties."""
     audit_logger, zone_id = logger_and_zone
@@ -194,7 +194,7 @@ def export_transactions(
     seller_agent_id: str | None = Query(None),
     status: str | None = Query(None),
     application: str | None = Query(None),
-    logger_and_zone: tuple[ExchangeAuditLogger, str] = Depends(get_exchange_audit_logger),
+    logger_and_zone: tuple[ExchangeAuditLogProtocol, str] = Depends(get_exchange_audit_logger),
 ) -> StreamingResponse:
     """Export transactions as CSV or JSON (streaming)."""
     audit_logger, zone_id = logger_and_zone
@@ -299,7 +299,7 @@ def _json_response(rows: list[dict[str, Any]]) -> StreamingResponse:
 @router.get("/transactions/{record_id}")
 def get_transaction(
     record_id: str,
-    logger_and_zone: tuple[ExchangeAuditLogger, str] = Depends(get_exchange_audit_logger),
+    logger_and_zone: tuple[ExchangeAuditLogProtocol, str] = Depends(get_exchange_audit_logger),
 ) -> AuditTransactionResponse:
     """Get a single audit transaction by ID."""
     audit_logger, zone_id = logger_and_zone
@@ -318,7 +318,7 @@ def get_transaction(
 @router.get("/integrity/{record_id}")
 def verify_integrity(
     record_id: str,
-    logger_and_zone: tuple[ExchangeAuditLogger, str] = Depends(get_exchange_audit_logger),
+    logger_and_zone: tuple[ExchangeAuditLogProtocol, str] = Depends(get_exchange_audit_logger),
 ) -> AuditIntegrityResponse:
     """Verify a record's hash matches its data (tamper detection)."""
     audit_logger, zone_id = logger_and_zone

--- a/src/nexus/server/api/v2/routers/secrets_audit.py
+++ b/src/nexus/server/api/v2/routers/secrets_audit.py
@@ -29,7 +29,7 @@ from nexus.server.api.v2.models.secrets_audit import (
     SecretsAuditEventResponse,
     SecretsAuditIntegrityResponse,
 )
-from nexus.storage.secrets_audit_logger import SecretsAuditLogger
+from nexus.services.protocols.secrets_audit_log import SecretsAuditLogProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ def _build_filters(
 # --------------------------------------------------------------------------
 
 
-def get_secrets_audit_logger() -> tuple[SecretsAuditLogger, str]:
+def get_secrets_audit_logger() -> tuple[SecretsAuditLogProtocol, str]:
     """Placeholder dependency — overridden by fastapi_server.py."""
     raise HTTPException(status_code=500, detail="Secrets audit not configured")
 
@@ -108,7 +108,7 @@ def list_events(
     limit: int = Query(100, ge=1, le=1000, description="Page size"),
     cursor: str | None = Query(None, description="Cursor from previous response"),
     include_total: bool = Query(False, description="Include total count"),
-    logger_and_zone: tuple[SecretsAuditLogger, str] = Depends(get_secrets_audit_logger),
+    logger_and_zone: tuple[SecretsAuditLogProtocol, str] = Depends(get_secrets_audit_logger),
 ) -> SecretsAuditEventListResponse:
     """List secrets audit events with cursor-based pagination."""
     audit_logger, zone_id = logger_and_zone
@@ -158,7 +158,7 @@ def export_events(
     actor_id: str | None = Query(None),
     provider: str | None = Query(None),
     limit: int = Query(10_000, ge=1, le=100_000, description="Max rows to export"),
-    logger_and_zone: tuple[SecretsAuditLogger, str] = Depends(get_secrets_audit_logger),
+    logger_and_zone: tuple[SecretsAuditLogProtocol, str] = Depends(get_secrets_audit_logger),
 ) -> StreamingResponse:
     """Export secrets audit events as CSV or JSON (streaming)."""
     audit_logger, zone_id = logger_and_zone
@@ -238,7 +238,7 @@ def _json_response(rows: list[dict[str, Any]]) -> StreamingResponse:
 @router.get("/events/{record_id}")
 def get_event(
     record_id: str,
-    logger_and_zone: tuple[SecretsAuditLogger, str] = Depends(get_secrets_audit_logger),
+    logger_and_zone: tuple[SecretsAuditLogProtocol, str] = Depends(get_secrets_audit_logger),
 ) -> SecretsAuditEventResponse:
     """Get a single secrets audit event by ID."""
     audit_logger, zone_id = logger_and_zone
@@ -257,7 +257,7 @@ def get_event(
 @router.get("/integrity/{record_id}")
 def verify_integrity(
     record_id: str,
-    logger_and_zone: tuple[SecretsAuditLogger, str] = Depends(get_secrets_audit_logger),
+    logger_and_zone: tuple[SecretsAuditLogProtocol, str] = Depends(get_secrets_audit_logger),
 ) -> SecretsAuditIntegrityResponse:
     """Verify a record's hash matches its data (tamper detection)."""
     audit_logger, zone_id = logger_and_zone

--- a/src/nexus/services/protocols/exchange_audit_log.py
+++ b/src/nexus/services/protocols/exchange_audit_log.py
@@ -1,0 +1,110 @@
+"""Exchange audit log service protocol.
+
+Defines the contract for exchange transaction audit logging — recording
+every exchange with cryptographic integrity (SHA-256 self-hash) and
+providing query/export capabilities.
+
+Storage Affinity: **RecordStore** (append-only audit log records with
+                  timestamps, zone scoping, and integrity hashes).
+
+References:
+    - docs/architecture/data-storage-matrix.md  (Four Pillars)
+    - Issue #1360: Exchange audit trail
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ExchangeAuditLogProtocol(Protocol):
+    """Service contract for exchange transaction audit logging.
+
+    Mirrors ``storage/exchange_audit_logger.ExchangeAuditLogger``.
+
+    Provides append-only, cryptographically immutable transaction records
+    with cursor-based pagination, aggregations, and integrity verification.
+    """
+
+    def record(
+        self,
+        *,
+        protocol: str,
+        buyer_agent_id: str,
+        seller_agent_id: str,
+        amount: Decimal,
+        currency: str = "credits",
+        status: str,
+        application: str,
+        zone_id: str = "root",
+        trace_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        transfer_id: str | None = None,
+    ) -> str:
+        """Record an exchange transaction (append-only).
+
+        Returns:
+            The record ID (UUID string).
+        """
+        ...
+
+    def get_transaction(self, record_id: str) -> Any | None:
+        """Get a single transaction by ID."""
+        ...
+
+    def list_transactions_cursor(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        limit: int = 100,
+        cursor: str | None = None,
+    ) -> tuple[list[Any], str | None]:
+        """Query transactions with cursor-based pagination."""
+        ...
+
+    def count_transactions(self, **filters: Any) -> int:
+        """Count matching transactions."""
+        ...
+
+    def get_aggregations(
+        self,
+        *,
+        zone_id: str,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Compute aggregations: total_volume, tx_count, top counterparties."""
+        ...
+
+    def verify_integrity(self, record_id: str) -> bool:
+        """Recompute a record's hash and compare to stored value."""
+        ...
+
+    def verify_integrity_from_row(self, row: Any) -> bool:
+        """Verify integrity using an already-fetched row."""
+        ...
+
+    def compute_merkle_root(self, first_id: str, last_id: str) -> str:
+        """Compute Merkle root over a range of records."""
+        ...
+
+    def iter_transactions(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        batch_size: int = 500,
+    ) -> list[Any]:
+        """Fetch all matching transactions for export."""
+        ...
+
+    def estimate_pages(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        page_size: int = 100,
+    ) -> int:
+        """Estimate total pages for a given filter set."""
+        ...

--- a/src/nexus/services/protocols/secrets_audit_log.py
+++ b/src/nexus/services/protocols/secrets_audit_log.py
@@ -1,0 +1,82 @@
+"""Secrets audit log service protocol.
+
+Defines the contract for secrets/credential audit logging — recording
+every OAuth credential and token lifecycle event with cryptographic
+integrity (SHA-256 self-hash).
+
+Storage Affinity: **RecordStore** (append-only audit log records with
+                  timestamps, zone scoping, and integrity hashes).
+
+References:
+    - docs/architecture/data-storage-matrix.md  (Four Pillars)
+    - Issue #997: Secrets audit trail
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SecretsAuditLogProtocol(Protocol):
+    """Service contract for secrets/credential audit logging.
+
+    Mirrors ``storage/secrets_audit_logger.SecretsAuditLogger``.
+
+    Provides append-only, cryptographically immutable event records
+    with cursor-based pagination and integrity verification.
+    """
+
+    def log_event(
+        self,
+        *,
+        event_type: str,
+        actor_id: str,
+        provider: str | None = None,
+        credential_id: str | None = None,
+        token_family_id: str | None = None,
+        zone_id: str = "root",
+        ip_address: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> str:
+        """Record a secrets audit event (append-only).
+
+        Returns:
+            The record ID (UUID string).
+        """
+        ...
+
+    def get_event(self, record_id: str) -> Any | None:
+        """Get a single audit event by ID."""
+        ...
+
+    def list_events_cursor(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        limit: int = 100,
+        cursor: str | None = None,
+    ) -> tuple[list[Any], str | None]:
+        """Query events with cursor-based pagination."""
+        ...
+
+    def count_events(self, **filters: Any) -> int:
+        """Count matching events."""
+        ...
+
+    def iter_events(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        limit: int = 10_000,
+    ) -> list[Any]:
+        """Fetch matching events for export."""
+        ...
+
+    def verify_integrity(self, record_id: str) -> bool:
+        """Verify a record's hash matches its data (tamper detection)."""
+        ...
+
+    def verify_integrity_from_row(self, row: Any) -> bool:
+        """Verify integrity from an already-loaded row."""
+        ...


### PR DESCRIPTION
## Summary
- Create `ExchangeAuditLogProtocol` and `SecretsAuditLogProtocol` in `services/protocols/`
- Update `audit.py` and `secrets_audit.py` routers to import from protocol abstractions instead of concrete `nexus.storage.*` classes
- DI wiring in `dependencies.py` and `fastapi_server.py` correctly remains using concrete classes (they are the construction point)
- Both concrete classes pass `isinstance()` check against their respective protocols (`@runtime_checkable`)

## Test plan
- [x] All 51 audit logger unit tests pass
- [x] Protocol imports verified working
- [x] Concrete classes verified satisfying protocols at runtime
- [x] Pre-commit hooks pass (ruff, format, brick zero-core-imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)