### PR TITLE
fix: remove per-process fence token counter from RaftLockManager

### DIFF
--- a/src/nexus/raft/lock_manager.py
+++ b/src/nexus/raft/lock_manager.py
@@ -28,16 +28,6 @@ from nexus.core.distributed_lock import (
 
 logger = logging.getLogger(__name__)
 
-# Monotonically increasing fence token counter (per-process)
-_fence_token_counter: int = 0
-
-
-def _next_fence_token() -> int:
-    """Generate the next monotonically increasing fence token."""
-    global _fence_token_counter  # noqa: PLW0603
-    _fence_token_counter += 1
-    return _fence_token_counter
-
 
 class RaftLockManager(LockManagerBase):
     """Raft-based distributed locking with strong consistency.
@@ -52,7 +42,12 @@ class RaftLockManager(LockManagerBase):
     - Ownership verification on release/extend
     - TTL-based auto-expiry (default: 30s)
     - Supports mutex (max_holders=1) and semaphore (max_holders>1)
-    - Advisory fencing tokens for stale-lock protection
+
+    Note:
+        Fence tokens are set to 0 (not yet provided by the store layer).
+        When the Rust engine exposes per-lock monotonic counters (e.g. from
+        the Raft log index), ``_store_info_to_lock_info`` should read
+        ``store_info["fence_token"]`` instead.
 
     Example:
         >>> from nexus.storage.raft_metadata_store import RaftMetadataStore
@@ -108,7 +103,7 @@ class RaftLockManager(LockManagerBase):
             mode="mutex" if max_holders == 1 else "semaphore",
             max_holders=max_holders,
             holders=holders,
-            fence_token=_next_fence_token(),
+            fence_token=store_info.get("fence_token", 0),
         )
 
     async def acquire(


### PR DESCRIPTION
## Summary
- Removed the `_fence_token_counter` global and `_next_fence_token()` function from `raft/lock_manager.py`
- The per-process counter generated a new value on every `get_lock_info`/`list_locks` call — meaningless in multi-node federation where each node has its own counter starting at 0
- Replaced with `store_info.get("fence_token", 0)` so the store can provide real fence tokens (e.g. from Raft log index) when the Rust engine adds support

## Test plan
- [ ] Existing lock manager integration tests pass (fence_token field still present, just defaults to 0)
- [ ] Lock REST API e2e tests pass (fence_token field exists in response)
- [ ] No behavioral change — fence tokens were never relied upon for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)