### PR TITLE
fix(e2e): drain stale mkdir event before wait_timeout_no_write assertion

### DIFF
--- a/tests/e2e/redis/test_multi_instance_workflows.py
+++ b/tests/e2e/redis/test_multi_instance_workflows.py
@@ -237,6 +237,9 @@ class TestWaitThenRead:
         """Agent A waits but no file written -> timeout returns None."""
         nexus_fs.mkdir("/empty", parents=True)
 
+        # Drain any stale events from mkdir before subscribing
+        await asyncio.sleep(0.3)
+
         change = await nexus_fs.events_service.wait_for_changes("/empty/", timeout=0.5)
 
         assert change is None


### PR DESCRIPTION
## Summary
- Fixes flaky `test_wait_timeout_no_write` in Redis E2E tests by adding a short `asyncio.sleep(0.3)` drain between `mkdir("/empty")` and `wait_for_changes()` to prevent a stale `dir_create` event from satisfying the wait before the actual timeout assertion kicks in.

## Test plan
- [ ] Redis E2E `test_wait_timeout_no_write` should pass consistently without flaky failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)