### PR TITLE
chore: sync main → develop (resolve 6-commit divergence)

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 
 import logging
 
-__version__ = "0.7.2.dev0"
+__version__ = "0.7.2.dev0"  # bump to trigger CI quality checks
 __author__ = "Nexi Lab Team"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Merges `main` back into `develop` to eliminate the "6 commits ahead" divergence caused by:
  - 5 old commits that were pushed directly to `main` before branch protection was set up
  - 1 squash merge commit from PR #2109 (develop → main sync)
- Removes `CLAUDE.md` that was re-introduced by the merge (develop already deleted it in PR #2107)
- After this merge, `main` will be 0 commits ahead of `develop` (purely behind, as expected)

## Test plan
- [ ] CI passes (no code changes, only git history fix)
- [ ] After merge, GitHub shows main is 0 ahead of develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)