### PR TITLE
Make RecordStore optional for bare kernel mode

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -226,7 +226,6 @@ def connect(
     from nexus.core.router import NamespaceConfig
     from nexus.remote import RemoteNexusFS
     from nexus.storage.raft_metadata_store import RaftMetadataStore
-    from nexus.storage.record_store import SQLAlchemyRecordStore
 
     # Load configuration
     cfg = load_config(config)
@@ -345,8 +344,16 @@ def connect(
     enable_tiger_cache_env = os.getenv("NEXUS_ENABLE_TIGER_CACHE", "true").lower()
     enable_tiger_cache = enable_tiger_cache_env in ("true", "1", "yes")
 
-    # RecordStore (Four Pillars)
-    record_store = SQLAlchemyRecordStore(db_path=cfg.db_path)
+    # RecordStore (Four Pillars) — optional; only created when db_path is
+    # explicitly set.  Passing None gives a bare kernel (storage-only) where
+    # all service-layer features (audit log, versioning, ReBAC, etc.) are
+    # skipped.  The factory handles record_store=None gracefully.
+    if cfg.db_path:
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+
+        record_store = SQLAlchemyRecordStore(db_path=cfg.db_path)
+    else:
+        record_store = None
 
     # Build config objects from NexusConfig fields (Issue #1391)
     from nexus.core.config import (

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -695,7 +695,7 @@ async def lifespan(_app: FastAPI) -> Any:
             _nexus_fs_warmup = _app.state.nexus_fs  # Capture for closure
 
             async def _warmup_file_cache() -> None:
-                from nexus.cache.warmer import CacheWarmer, WarmupConfig
+                from nexus.server.cache_warmer import CacheWarmer, WarmupConfig
 
                 config = WarmupConfig(
                     max_files=warmup_max_files,


### PR DESCRIPTION
## Summary
- **RecordStore is now optional** in `connect()` — only created when `db_path` is explicitly set. Without it, the factory returns a bare storage-only kernel where core file operations (read/write/list/mkdir/delete) work without the service layer (audit log, versioning, ReBAC, sqlite-vec).
- **Fixes cache warmer import path** in `fastapi_server.py`: `nexus.cache.warmer` → `nexus.server.cache_warmer` (was causing `ModuleNotFoundError` on startup).

## Test plan
- [x] `nexus serve` starts without `enable_load_extension` or `operation_log` errors
- [x] Basic file operations (write, read, exists, list, mkdir, delete) all pass via `RemoteNexusFS`
- [x] Cache warmer runs without `ModuleNotFoundError`
- [ ] Verify `nexus serve` with explicit `--db-path` still creates RecordStore and enables service-layer features

🤖 Generated with [Claude Code](https://claude.com/claude-code)