### PR TITLE
Consolidate mutable state under ~/.nexus, separate store configs

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -44,12 +44,12 @@ first accessed. This reduces import time from ~10s to ~1s for simple use cases.
 from __future__ import annotations
 
 import logging
+import os as _os
+from typing import TYPE_CHECKING, Any, cast
 
 __version__ = "0.7.2.dev0"  # bump to trigger CI quality checks
 __author__ = "Nexi Lab Team"
 __license__ = "Apache-2.0"
-
-from typing import TYPE_CHECKING, Any, cast
 
 # =============================================================================
 # LAZY IMPORTS for performance optimization
@@ -104,6 +104,9 @@ from nexus.core.exceptions import (
     NexusFileNotFoundError,
     NexusPermissionError,
 )
+
+# All mutable state (data, metastore, record store, etc.) lives under this directory.
+NEXUS_STATE_DIR = _os.path.expanduser("~/.nexus")
 
 logger = logging.getLogger(__name__)
 
@@ -282,11 +285,16 @@ def connect(
             project_id=cfg.gcs_project_id,
             credentials_path=cfg.gcs_credentials_path,
         )
-        metadata_path = cfg.db_path or str(Path("./nexus-gcs-metadata"))
+        nexus_root = NEXUS_STATE_DIR
+        data_dir = str(Path(nexus_root) / "data")
     else:
-        data_dir = cfg.data_dir if cfg.data_dir is not None else "./nexus-data"
+        data_dir = cfg.data_dir if cfg.data_dir is not None else str(Path(NEXUS_STATE_DIR) / "data")
+        nexus_root = str(Path(data_dir).parent)
         backend = LocalBackend(root_path=Path(data_dir).resolve())
-        metadata_path = cfg.db_path or str(Path(data_dir) / "metadata")
+
+    # Resolve paths — new fields take precedence, db_path is legacy fallback
+    metadata_path = cfg.metastore_path or cfg.db_path or str(Path(nexus_root) / "metastore")
+    record_store_path = cfg.record_store_path or None
 
     # Create metadata store based on mode
     metadata_store: MetastoreABC
@@ -344,14 +352,14 @@ def connect(
     enable_tiger_cache_env = os.getenv("NEXUS_ENABLE_TIGER_CACHE", "true").lower()
     enable_tiger_cache = enable_tiger_cache_env in ("true", "1", "yes")
 
-    # RecordStore (Four Pillars) — optional; only created when db_path is
-    # explicitly set.  Passing None gives a bare kernel (storage-only) where
-    # all service-layer features (audit log, versioning, ReBAC, etc.) are
-    # skipped.  The factory handles record_store=None gracefully.
-    if cfg.db_path:
+    # RecordStore (Four Pillars) — optional; only created when record_store_path
+    # is set.  Passing None gives a bare kernel (storage-only) where all
+    # service-layer features (audit log, versioning, ReBAC, etc.) are skipped.
+    # The factory handles record_store=None gracefully.
+    if record_store_path:
         from nexus.storage.record_store import SQLAlchemyRecordStore
 
-        record_store = SQLAlchemyRecordStore(db_path=cfg.db_path)
+        record_store = SQLAlchemyRecordStore(db_path=record_store_path)
     else:
         record_store = None
 

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -29,7 +29,7 @@ BACKEND_OPTION = click.option(
 DATA_DIR_OPTION = click.option(
     "--data-dir",
     type=click.Path(),
-    default=lambda: os.getenv("NEXUS_DATA_DIR", "./nexus-data"),
+    default=lambda: os.getenv("NEXUS_DATA_DIR", str(Path(nexus.NEXUS_STATE_DIR) / "data")),
     help="Path to Nexus data directory (for local backend and metadata DB). Can also be set via NEXUS_DATA_DIR environment variable.",
     show_default=True,
 )
@@ -122,7 +122,7 @@ class BackendConfig:
     def __init__(
         self,
         backend: str = "local",
-        data_dir: str = "./nexus-data",
+        data_dir: str = str(Path(nexus.NEXUS_STATE_DIR) / "data"),
         config_path: str | None = None,
         gcs_bucket: str | None = None,
         gcs_project: str | None = None,

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -134,7 +134,7 @@ class NexusConfig(BaseModel):
 
     # Local backend settings
     data_dir: str | None = Field(
-        default="./nexus-data", description="Data directory for local backend"
+        default=None, description="Data directory for local backend (default: ~/.nexus/data)"
     )
 
     # GCS backend settings
@@ -155,7 +155,16 @@ class NexusConfig(BaseModel):
     enable_vector_search: bool = Field(default=True, description="Enable vector search")
     enable_llm_cache: bool = Field(default=True, description="Enable LLM KV cache")
     db_path: str | None = Field(
-        default=None, description="SQLite database path (auto-generated if None)"
+        default=None,
+        description="(Deprecated) Legacy alias — sets metastore_path when unset.",
+    )
+    metastore_path: str | None = Field(
+        default=None,
+        description="Path for the redb metadata store (auto-derived from data_dir if None)",
+    )
+    record_store_path: str | None = Field(
+        default=None,
+        description="Path for the SQLAlchemy record store (SQLite). None = no record store (bare kernel).",
     )
 
     # In-memory metadata caching settings
@@ -479,6 +488,8 @@ def _load_from_environment() -> NexusConfig:
         "NEXUS_ENABLE_VECTOR_SEARCH": "enable_vector_search",
         "NEXUS_ENABLE_LLM_CACHE": "enable_llm_cache",
         "NEXUS_DB_PATH": "db_path",
+        "NEXUS_METASTORE_PATH": "metastore_path",
+        "NEXUS_RECORD_STORE_PATH": "record_store_path",
         "NEXUS_ENABLE_METADATA_CACHE": "enable_metadata_cache",
         "NEXUS_CACHE_PATH_SIZE": "cache_path_size",
         "NEXUS_CACHE_LIST_SIZE": "cache_list_size",


### PR DESCRIPTION
## Summary
- Add `NEXUS_STATE_DIR` constant (`~/.nexus`) — single root for all mutable state
- Split the overloaded `db_path` config into two independent fields:
  - `metastore_path` / `NEXUS_METASTORE_PATH` → redb metadata store
  - `record_store_path` / `NEXUS_RECORD_STORE_PATH` → SQLAlchemy/SQLite record store
- RecordStore defaults to `None` (bare kernel — no audit log, versioning, or ReBAC)
- Default layout: `~/.nexus/data`, `~/.nexus/metastore`
- Fix cache warmer import path (`nexus.cache.warmer` → `nexus.server.cache_warmer`)

## Test plan
- [x] `nexus serve` starts cleanly from empty `~/.nexus/`
- [x] Basic file ops (write, read, exists, list, mkdir, delete) all pass
- [x] `NEXUS_RECORD_STORE_PATH` creates RecordStore with all tables when set
- [x] Without `record_store_path`, no SQLAlchemy loaded (bare kernel)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)