### PR TITLE
feat(#2062): DedupWorkQueue for EventBus cache invalidation

### DIFF
--- a/src/nexus/services/dedup_work_queue.py
+++ b/src/nexus/services/dedup_work_queue.py
@@ -1,0 +1,249 @@
+"""DedupWorkQueue — coalescing work queue for event processing (Issue #2062).
+
+Follows the Kubernetes controller-runtime workqueue pattern:
+  - 10 rapid writes to the same file → 10 events recorded (audit complete)
+    but only 1 processing run.
+  - Does NOT replace EventLog — dedup is for *processing*, not *recording*.
+
+Three invariants maintained by add/get/done:
+  1. An item in ``dirty`` but not ``processing`` has exactly one entry in ``queue``.
+  2. An item in ``processing`` has zero entries in ``queue``.
+  3. An item can be in both ``dirty`` and ``processing`` (re-added during
+     processing → will be re-queued on ``done()``).
+
+Architecture: Tier 3 System Service (NEXUS-LEGO-ARCHITECTURE.md §12.5).
+Consumer-side dedup: each subscriber opts in independently.
+
+References:
+  - https://github.com/kubernetes/client-go/blob/master/util/workqueue/queue.go
+  - NEXUS-LEGO-ARCHITECTURE.md §12.5
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class ShutdownError(Exception):
+    """Raised when get() is called on a shut-down queue."""
+
+
+class DedupWorkQueue(Generic[T]):
+    """Deduplicating async work queue.
+
+    Coalesces duplicate keys so that rapid additions of the same key
+    result in at most one processing run.
+
+    **Threading model:** This queue is designed for single-event-loop asyncio.
+    ``add()`` and ``get()`` are async and acquire a lock.  ``done()`` is
+    intentionally synchronous (for use in ``finally`` blocks) and is safe
+    ONLY when called from a coroutine on the **same** event loop as
+    ``add()``/``get()``.  Never call ``done()`` from a thread pool executor
+    or a different event loop.
+
+    Usage::
+
+        q: DedupWorkQueue[str] = DedupWorkQueue()
+
+        # Producer side — events coalesce by key
+        await q.add("/data/file.txt")
+        await q.add("/data/file.txt")  # coalesced
+
+        # Consumer side — processes each key once
+        key = await q.get()            # "/data/file.txt"
+        try:
+            await process(key)
+        finally:
+            q.done(key)
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[T] = asyncio.Queue()
+        self._dirty: set[T] = set()
+        self._processing: set[T] = set()
+        self._lock = asyncio.Lock()
+        self._shutting_down = False
+
+        # Metrics (monotonic counters)
+        self._adds = 0
+        self._coalesced = 0
+        self._gets = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def add(self, key: T) -> None:
+        """Enqueue a key for processing, coalescing duplicates.
+
+        If the key is already pending (in dirty set) and not currently
+        being processed, this is a no-op (coalesced).
+
+        If the key is currently being processed, it is added to the
+        dirty set so that ``done()`` will re-queue it.
+
+        Raises:
+            ShutdownError: If the queue has been shut down.
+        """
+        async with self._lock:
+            if self._shutting_down:
+                raise ShutdownError("DedupWorkQueue has been shut down")
+
+            self._adds += 1
+
+            if key in self._dirty:
+                # Already pending — coalesce
+                self._coalesced += 1
+                return
+
+            self._dirty.add(key)
+
+            if key in self._processing:
+                # Currently being processed — will re-queue on done()
+                return
+
+            # New work item — enqueue
+            self._queue.put_nowait(key)
+
+    async def get(self) -> T:
+        """Get the next key to process (blocks until available).
+
+        The caller MUST call ``done(key)`` when processing is complete,
+        even if processing fails.  Use a try/finally block.
+
+        Returns:
+            The next key to process.
+
+        Raises:
+            ShutdownError: If the queue is shut down while waiting.
+        """
+        while True:
+            if self._shutting_down and self._queue.empty():
+                raise ShutdownError("DedupWorkQueue has been shut down")
+
+            try:
+                key = await asyncio.wait_for(self._queue.get(), timeout=0.5)
+            except TimeoutError:
+                if self._shutting_down:
+                    raise ShutdownError("DedupWorkQueue has been shut down") from None
+                continue
+
+            async with self._lock:
+                self._gets += 1
+                self._dirty.discard(key)
+                self._processing.add(key)
+
+            return key
+
+    def done(self, key: T) -> None:
+        """Mark a key as done processing.
+
+        If the key was re-added while being processed (present in dirty),
+        it is re-queued for another processing run.
+
+        This method is intentionally synchronous so it can be called in
+        ``finally`` blocks without ``await``.  It is safe in single-event-loop
+        asyncio because it contains no suspension points — CPython's cooperative
+        scheduling guarantees atomic execution with respect to other coroutines.
+
+        **Do NOT call from a thread pool executor or different event loop.**
+
+        Args:
+            key: The key that was returned by ``get()``.
+        """
+        self._processing.discard(key)
+
+        if key in self._dirty:
+            # Re-added during processing — re-queue
+            self._queue.put_nowait(key)
+
+    async def shutdown(self) -> None:
+        """Shut down the queue gracefully.
+
+        After shutdown, ``add()`` raises ``ShutdownError`` and ``get()``
+        drains remaining items then raises ``ShutdownError``.
+        """
+        async with self._lock:
+            self._shutting_down = True
+
+        logger.info(
+            "DedupWorkQueue shutdown (adds=%d, coalesced=%d, gets=%d)",
+            self._adds,
+            self._coalesced,
+            self._gets,
+        )
+
+    @property
+    def is_shutting_down(self) -> bool:
+        """Whether the queue has been shut down."""
+        return self._shutting_down
+
+    def __len__(self) -> int:
+        """Number of items pending processing (in dirty set)."""
+        return len(self._dirty)
+
+    def __repr__(self) -> str:
+        return (
+            f"DedupWorkQueue(pending={len(self._dirty)}, "
+            f"processing={len(self._processing)}, "
+            f"shutting_down={self._shutting_down})"
+        )
+
+    @property
+    def processing_count(self) -> int:
+        """Number of items currently being processed."""
+        return len(self._processing)
+
+    @property
+    def metrics(self) -> dict[str, int]:
+        """Queue metrics for observability."""
+        return {
+            "adds": self._adds,
+            "coalesced": self._coalesced,
+            "gets": self._gets,
+            "pending": len(self._dirty),
+            "processing": len(self._processing),
+            "queue_depth": self._queue.qsize(),
+        }
+
+
+async def run_worker(
+    queue: DedupWorkQueue[T],
+    handler: Callable[[T], Awaitable[None]],
+    *,
+    name: str = "dedup-worker",
+) -> None:
+    """Run a worker loop that processes items from a DedupWorkQueue.
+
+    Convenience function for the common consumer pattern.
+
+    Args:
+        queue: The dedup work queue to consume from.
+        handler: Async callable that processes each key.
+        name: Worker name for logging.
+    """
+    logger.info("[%s] Worker started", name)
+    while True:
+        try:
+            key = await queue.get()
+        except ShutdownError:
+            logger.info("[%s] Worker stopped (queue shut down)", name)
+            return
+
+        t0 = time.monotonic()
+        try:
+            await handler(key)
+        except Exception:
+            logger.exception("[%s] Handler error for key=%s", name, key)
+        finally:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            queue.done(key)
+            logger.debug("[%s] Processed key=%s in %.1fms", name, key, elapsed_ms)

--- a/src/nexus/services/events_service.py
+++ b/src/nexus/services/events_service.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.core.path_utils import validate_path
 from nexus.core.protocols.connector import PassthroughProtocol
 from nexus.core.rpc_decorator import rpc_expose
+from nexus.services.dedup_work_queue import DedupWorkQueue, ShutdownError
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,7 @@ class EventsService:
         self._metadata_cache = metadata_cache
         self._cache_invalidation_started = False
         self._event_tasks: set[asyncio.Task[Any]] = set()
+        self._dedup_queue: DedupWorkQueue[str] | None = None
 
         logger.info("[EventsService] Initialized")
 
@@ -511,16 +513,43 @@ class EventsService:
         self._on_distributed_event(event)
 
     def _start_cache_invalidation(self) -> None:
-        """Start cache invalidation listeners for both Layer 1 and Layer 2."""
+        """Start cache invalidation listeners for both Layer 1 and Layer 2.
+
+        Layer 2 (distributed) uses a DedupWorkQueue (Issue #2062) to coalesce
+        rapid events for the same path.  10 writes to /data/file.txt → 10 events
+        recorded (audit intact) but only 1 cache invalidation run.
+        """
         if self._cache_invalidation_started:
             logger.debug("Cache invalidation already started, skipping")
             return
 
         self._cache_invalidation_started = True
 
-        # Layer 2: Distributed event bus
+        # Layer 2: Distributed event bus with dedup (Issue #2062)
         if self._has_distributed_events():
             zone_id = self._get_zone_id(None)
+            dedup_queue: DedupWorkQueue[str] = DedupWorkQueue()
+            self._dedup_queue = dedup_queue
+
+            async def _invalidation_worker() -> None:
+                """Worker that processes deduped paths for cache invalidation.
+
+                Captures ``dedup_queue`` as a local variable to avoid the
+                race where ``_stop_cache_invalidation`` nulls ``self._dedup_queue``
+                while the worker is between ``get()`` and ``done()``.
+                """
+                while True:
+                    try:
+                        path = await dedup_queue.get()
+                    except ShutdownError:
+                        logger.info("Cache invalidation worker stopped (dedup queue shut down)")
+                        return
+                    try:
+                        self._invalidate_cache_for_path(path)
+                    except Exception:
+                        logger.exception("Cache invalidation error for path: %s", path)
+                    finally:
+                        dedup_queue.done(path)
 
             async def _subscribe_loop() -> None:
                 try:
@@ -530,25 +559,37 @@ class EventsService:
                                 event_handler=self._async_handle_event,
                             )
                             if synced > 0:
-                                logger.info(f"Startup sync: processed {synced} missed events")
+                                logger.info("Startup sync: processed %d missed events", synced)
                         except Exception as e:
-                            logger.warning(f"Startup sync failed (continuing anyway): {e}")
+                            logger.warning("Startup sync failed (continuing anyway): %s", e)
 
-                    logger.info(f"Starting distributed cache invalidation for zone: {zone_id}")
-                    assert self._event_bus is not None
+                    logger.info("Starting distributed cache invalidation for zone: %s", zone_id)
+                    if self._event_bus is None:
+                        logger.error("Event bus became None before subscribe loop started")
+                        return
                     async for event in self._event_bus.subscribe(zone_id):
-                        self._on_distributed_event(event)
+                        # Enqueue path(s) for deduped invalidation instead of
+                        # invalidating directly.  Coalesces rapid writes to the
+                        # same path into a single invalidation.
+                        await dedup_queue.add(event.path)
+                        if event.old_path:
+                            await dedup_queue.add(event.old_path)
+                except ShutdownError:
+                    logger.info("Distributed cache invalidation stopped (dedup queue shut down)")
                 except asyncio.CancelledError:
                     logger.info("Distributed cache invalidation stopped")
                     raise
                 except Exception as e:
-                    logger.error(f"Distributed cache invalidation error: {e}")
+                    logger.error("Distributed cache invalidation error: %s", e)
 
             try:
                 loop = asyncio.get_running_loop()
-                task = loop.create_task(_subscribe_loop())
-                self._event_tasks.add(task)
-                task.add_done_callback(self._event_tasks.discard)
+                worker_task = loop.create_task(_invalidation_worker())
+                self._event_tasks.add(worker_task)
+                worker_task.add_done_callback(self._event_tasks.discard)
+                subscribe_task = loop.create_task(_subscribe_loop())
+                self._event_tasks.add(subscribe_task)
+                subscribe_task.add_done_callback(self._event_tasks.discard)
             except RuntimeError:
                 logger.debug("No running event loop, skipping distributed cache invalidation")
 
@@ -574,14 +615,56 @@ class EventsService:
             except Exception as e:
                 logger.warning(f"Could not start same-box cache invalidation: {e}")
 
-    def _stop_cache_invalidation(self) -> None:
-        """Stop all cache invalidation listeners."""
+    async def _stop_cache_invalidation_async(self) -> None:
+        """Stop all cache invalidation listeners (async version).
+
+        Shutdown order: cancel tasks first (stop new events), then shut down
+        the dedup queue (worker drains remaining items and exits).
+        """
+        # 1. Cancel tasks — stops subscribe loop (no new items) and worker
         for task in list(self._event_tasks):
             if not task.done():
                 task.cancel()
+        # Allow cancellations to propagate
+        if self._event_tasks:
+            await asyncio.gather(*self._event_tasks, return_exceptions=True)
+
+        # 2. Shut down dedup queue (worker already stopped via cancellation)
+        if self._dedup_queue is not None:
+            await self._dedup_queue.shutdown()
+            logger.debug("Dedup queue shut down: %s", self._dedup_queue.metrics)
 
         if self._file_watcher is not None:
             self._file_watcher.stop()
 
         self._cache_invalidation_started = False
+        self._dedup_queue = None
+        logger.debug("Cache invalidation stopped")
+
+    def _stop_cache_invalidation(self) -> None:
+        """Stop all cache invalidation listeners (sync version).
+
+        Cancels tasks first, then schedules dedup queue shutdown.
+        Does NOT null ``_dedup_queue`` immediately — the worker closure
+        captured it as a local variable, so it is safe to null here.
+        """
+        # 1. Cancel tasks first — stops subscribe loop and worker
+        for task in list(self._event_tasks):
+            if not task.done():
+                task.cancel()
+
+        # 2. Schedule dedup queue shutdown (tasks already cancelled)
+        if self._dedup_queue is not None:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._dedup_queue.shutdown())
+            except RuntimeError:
+                pass  # No event loop — queue will be GC'd
+
+        if self._file_watcher is not None:
+            self._file_watcher.stop()
+
+        self._cache_invalidation_started = False
+        # Safe to null: worker captured dedup_queue as local variable
+        self._dedup_queue = None
         logger.debug("Cache invalidation stopped")

--- a/tests/integration/services/test_dedup_work_queue_integration.py
+++ b/tests/integration/services/test_dedup_work_queue_integration.py
@@ -1,0 +1,225 @@
+"""Integration tests for DedupWorkQueue with EventsService (Issue #2062).
+
+Validates that the DedupWorkQueue correctly coalesces rapid events
+when wired into the EventsService cache invalidation pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.core.event_bus import FileEvent, FileEventType
+from nexus.services.dedup_work_queue import DedupWorkQueue
+from nexus.services.events_service import EventsService
+
+
+def _make_event(
+    path: str = "/data/file.txt",
+    event_type: FileEventType = FileEventType.FILE_WRITE,
+    zone_id: str = "root",
+    old_path: str | None = None,
+) -> FileEvent:
+    """Create a FileEvent for testing."""
+    return FileEvent(
+        type=event_type,
+        path=path,
+        zone_id=zone_id,
+        old_path=old_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Cache invalidation coalesces rapid writes to same path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidation_coalesces_writes() -> None:
+    """10 FILE_WRITE events to the same path → 1 cache invalidation.
+
+    This is the core scenario from Issue #2062 / NEXUS-LEGO-ARCHITECTURE §12.5:
+    '10 rapid writes to the same file → 10 events recorded (audit complete)
+    but only 1 processing run.'
+    """
+    # Setup: mock backend (non-passthrough) + mock event bus + mock cache
+    backend = MagicMock()
+    backend.is_passthrough = False
+
+    mock_cache = MagicMock()
+    mock_cache.invalidate_path = MagicMock()
+
+    # Create event bus that yields 10 FILE_WRITE events for the same path
+    events = [_make_event(path="/data/file.txt") for _ in range(10)]
+
+    async def mock_subscribe(zone_id: str):  # noqa: ANN202
+        for event in events:
+            yield event
+
+    event_bus = AsyncMock()
+    event_bus.subscribe = mock_subscribe
+    event_bus.start = AsyncMock()
+    event_bus._started = True
+
+    service = EventsService(
+        backend=backend,
+        event_bus=event_bus,
+        metadata_cache=mock_cache,
+    )
+
+    # Start cache invalidation (this creates the dedup queue + worker)
+    service._start_cache_invalidation()
+
+    # Wait for events to be processed through the dedup queue
+    # The subscribe loop yields all 10 events, but the dedup queue coalesces them
+    await asyncio.sleep(0.5)
+
+    # Assert: cache invalidation called at most twice (initial + possible re-queue)
+    # The key assertion is that it's significantly less than 10
+    invalidation_count = mock_cache.invalidate_path.call_count
+    assert invalidation_count <= 2, (
+        f"Expected at most 2 invalidations (dedup), got {invalidation_count}"
+    )
+    assert invalidation_count >= 1, "Expected at least 1 invalidation"
+
+    # Verify the dedup queue metrics
+    assert service._dedup_queue is not None
+    metrics = service._dedup_queue.metrics
+    assert metrics["coalesced"] >= 8, (
+        f"Expected at least 8 coalesced events, got {metrics['coalesced']}"
+    )
+
+    # Cleanup
+    service._stop_cache_invalidation()
+
+
+# ---------------------------------------------------------------------------
+# 2. Different paths are all invalidated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_different_paths_all_invalidated() -> None:
+    """Events for different paths are all processed (no false coalescing)."""
+    backend = MagicMock()
+    backend.is_passthrough = False
+
+    mock_cache = MagicMock()
+    mock_cache.invalidate_path = MagicMock()
+
+    paths = [f"/data/file-{i}.txt" for i in range(5)]
+    events = [_make_event(path=p) for p in paths]
+
+    async def mock_subscribe(zone_id: str):  # noqa: ANN202
+        for event in events:
+            yield event
+
+    event_bus = AsyncMock()
+    event_bus.subscribe = mock_subscribe
+    event_bus.start = AsyncMock()
+    event_bus._started = True
+
+    service = EventsService(
+        backend=backend,
+        event_bus=event_bus,
+        metadata_cache=mock_cache,
+    )
+
+    service._start_cache_invalidation()
+    await asyncio.sleep(0.5)
+
+    # All 5 different paths should be invalidated
+    assert mock_cache.invalidate_path.call_count == 5
+    invalidated_paths = sorted(c.args[0] for c in mock_cache.invalidate_path.call_args_list)
+    assert invalidated_paths == sorted(paths)
+
+    service._stop_cache_invalidation()
+
+
+# ---------------------------------------------------------------------------
+# 3. Rename events invalidate both old and new paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_event_invalidates_both_paths() -> None:
+    """FILE_RENAME event adds both old_path and new path to dedup queue."""
+    backend = MagicMock()
+    backend.is_passthrough = False
+
+    mock_cache = MagicMock()
+    mock_cache.invalidate_path = MagicMock()
+
+    events = [
+        _make_event(
+            path="/data/new-name.txt",
+            event_type=FileEventType.FILE_RENAME,
+            old_path="/data/old-name.txt",
+        ),
+    ]
+
+    async def mock_subscribe(zone_id: str):  # noqa: ANN202
+        for event in events:
+            yield event
+
+    event_bus = AsyncMock()
+    event_bus.subscribe = mock_subscribe
+    event_bus.start = AsyncMock()
+    event_bus._started = True
+
+    service = EventsService(
+        backend=backend,
+        event_bus=event_bus,
+        metadata_cache=mock_cache,
+    )
+
+    service._start_cache_invalidation()
+    await asyncio.sleep(0.5)
+
+    # Both old and new paths should be invalidated
+    assert mock_cache.invalidate_path.call_count == 2
+    invalidated_paths = sorted(c.args[0] for c in mock_cache.invalidate_path.call_args_list)
+    assert invalidated_paths == ["/data/new-name.txt", "/data/old-name.txt"]
+
+    service._stop_cache_invalidation()
+
+
+# ---------------------------------------------------------------------------
+# 4. Standalone DedupWorkQueue coalescing with concurrent add/process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_add_during_processing() -> None:
+    """Producer adds keys while consumer processes — coalescing still works."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+    processed: list[str] = []
+
+    async def consumer() -> None:
+        for _ in range(3):
+            key = await asyncio.wait_for(q.get(), timeout=2.0)
+            await asyncio.sleep(0.05)  # Simulate work
+            processed.append(key)
+            q.done(key)
+
+    async def producer() -> None:
+        # Burst 1: 5 adds for "a" (should coalesce to 1)
+        for _ in range(5):
+            await q.add("a")
+        await asyncio.sleep(0.15)  # Wait for consumer to process "a"
+
+        # Burst 2: 5 adds for "b" (should coalesce to 1)
+        for _ in range(5):
+            await q.add("b")
+        await asyncio.sleep(0.15)
+
+        # Burst 3: 5 adds for "c" (should coalesce to 1)
+        for _ in range(5):
+            await q.add("c")
+
+    await asyncio.gather(consumer(), producer())
+
+    assert processed == ["a", "b", "c"]
+    assert q.metrics["coalesced"] == 12  # 15 adds - 3 unique = 12 coalesced

--- a/tests/unit/services/test_dedup_work_queue.py
+++ b/tests/unit/services/test_dedup_work_queue.py
@@ -1,0 +1,353 @@
+"""Unit tests for DedupWorkQueue — coalescing work queue (Issue #2062).
+
+Tests cover:
+- Basic add/get/done lifecycle
+- Coalescing: same key added multiple times → processed once
+- Re-queue on done: key re-added during processing → re-queued
+- Concurrent producers: multiple add() coroutines racing
+- Concurrent consumers: multiple get() coroutines (one wins per key)
+- Shutdown: pending get() raises ShutdownError
+- Edge cases: done() without get(), add() after shutdown, len()
+- FIFO ordering: keys come out in insertion order
+- Benchmark: throughput under coalescing workload
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from nexus.services.dedup_work_queue import DedupWorkQueue, ShutdownError, run_worker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _drain(q: DedupWorkQueue[str], count: int) -> list[str]:
+    """Drain exactly `count` items, calling done() for each."""
+    results: list[str] = []
+    for _ in range(count):
+        key = await asyncio.wait_for(q.get(), timeout=2.0)
+        results.append(key)
+        q.done(key)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic add/get/done lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_basic_lifecycle() -> None:
+    """Single key: add → get → done works correctly."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    await q.add("a")
+    assert len(q) == 1
+
+    key = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert key == "a"
+    assert q.processing_count == 1
+    assert len(q) == 0
+
+    q.done(key)
+    assert q.processing_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Coalescing: same key added 10x → only 1 get()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coalescing_same_key() -> None:
+    """Adding the same key 10 times yields only 1 item from get()."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    for _ in range(10):
+        await q.add("file.txt")
+
+    assert len(q) == 1
+    assert q.metrics["coalesced"] == 9
+
+    key = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert key == "file.txt"
+    q.done(key)
+
+    # Queue should now be empty — no more items
+    assert len(q) == 0
+    assert q._queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# 3. Re-queue on done: add during processing → re-queued
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_requeue_on_done() -> None:
+    """Key re-added while processing gets re-queued after done()."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    # Add and start processing
+    await q.add("key1")
+    key = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert key == "key1"
+    assert q.processing_count == 1
+
+    # Re-add the same key while it's being processed
+    await q.add("key1")
+    assert len(q) == 1  # In dirty set
+
+    # Complete processing — should trigger re-queue
+    q.done(key)
+    assert q.processing_count == 0
+
+    # Key should be available again
+    key2 = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert key2 == "key1"
+    q.done(key2)
+
+    # Now truly empty
+    assert len(q) == 0
+    assert q._queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# 4. Concurrent producers: multiple add() coroutines racing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_producers() -> None:
+    """Many producers adding overlapping keys concurrently."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    keys = [f"key-{i % 5}" for i in range(50)]  # 50 adds, only 5 unique
+
+    await asyncio.gather(*(q.add(k) for k in keys))
+
+    assert len(q) == 5
+    assert q.metrics["coalesced"] == 45
+
+    results = await _drain(q, 5)
+    assert sorted(results) == ["key-0", "key-1", "key-2", "key-3", "key-4"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Concurrent consumers: multiple get() coroutines
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_consumers() -> None:
+    """Multiple consumers each get a distinct key."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    for i in range(3):
+        await q.add(f"item-{i}")
+
+    async def consume() -> str:
+        key = await asyncio.wait_for(q.get(), timeout=2.0)
+        await asyncio.sleep(0.01)  # Simulate work
+        q.done(key)
+        return key
+
+    results = await asyncio.gather(consume(), consume(), consume())
+    assert sorted(results) == ["item-0", "item-1", "item-2"]
+    assert len(q) == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Shutdown: pending get() raises ShutdownError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shutdown_unblocks_get() -> None:
+    """Shutdown causes pending get() to raise ShutdownError."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    async def delayed_shutdown() -> None:
+        await asyncio.sleep(0.1)
+        await q.shutdown()
+
+    shutdown_task = asyncio.create_task(delayed_shutdown())
+
+    with pytest.raises(ShutdownError):
+        await asyncio.wait_for(q.get(), timeout=2.0)
+
+    await shutdown_task
+
+
+@pytest.mark.asyncio
+async def test_add_after_shutdown_raises() -> None:
+    """add() after shutdown raises ShutdownError."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+    await q.shutdown()
+
+    with pytest.raises(ShutdownError):
+        await q.add("x")
+
+
+# ---------------------------------------------------------------------------
+# 7. Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_done_without_get_is_safe() -> None:
+    """Calling done() for a key not in processing is a no-op."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+    q.done("nonexistent")  # Should not raise
+    assert q.processing_count == 0
+
+
+@pytest.mark.asyncio
+async def test_len_empty_queue() -> None:
+    """Empty queue has len 0 and correct metrics."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+    assert len(q) == 0
+    assert q.processing_count == 0
+    assert q.metrics == {
+        "adds": 0,
+        "coalesced": 0,
+        "gets": 0,
+        "pending": 0,
+        "processing": 0,
+        "queue_depth": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_multiple_different_keys() -> None:
+    """Different keys are all enqueued independently."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    await q.add("a")
+    await q.add("b")
+    await q.add("c")
+    assert len(q) == 3
+
+    results = await _drain(q, 3)
+    assert results == ["a", "b", "c"]  # FIFO order
+
+
+# ---------------------------------------------------------------------------
+# 8. FIFO ordering: keys come out in insertion order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fifo_ordering() -> None:
+    """Keys are returned in FIFO (first-added) order."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    for i in range(10):
+        await q.add(f"item-{i}")
+
+    results: list[str] = []
+    for _ in range(10):
+        key = await asyncio.wait_for(q.get(), timeout=1.0)
+        results.append(key)
+        q.done(key)
+
+    assert results == [f"item-{i}" for i in range(10)]
+
+
+# ---------------------------------------------------------------------------
+# 9. run_worker convenience function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_worker() -> None:
+    """run_worker processes items and stops on shutdown."""
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+    processed: list[str] = []
+
+    async def handler(key: str) -> None:
+        processed.append(key)
+
+    for i in range(5):
+        await q.add(f"k{i}")
+
+    # Start worker, then shut down after items are processed
+    async def shutdown_after_drain() -> None:
+        while len(processed) < 5:
+            await asyncio.sleep(0.05)
+        await q.shutdown()
+
+    worker_task = asyncio.create_task(run_worker(q, handler, name="test-worker"))
+    shutdown_task = asyncio.create_task(shutdown_after_drain())
+
+    await asyncio.gather(worker_task, shutdown_task)
+    assert sorted(processed) == ["k0", "k1", "k2", "k3", "k4"]
+
+
+# ---------------------------------------------------------------------------
+# 10. Tuple keys (generic type test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tuple_keys() -> None:
+    """DedupWorkQueue works with tuple keys (zone_id, path)."""
+    q: DedupWorkQueue[tuple[str, str]] = DedupWorkQueue()
+
+    await q.add(("zone1", "/file.txt"))
+    await q.add(("zone1", "/file.txt"))  # Coalesced
+    await q.add(("zone2", "/file.txt"))  # Different zone — not coalesced
+
+    assert len(q) == 2
+    assert q.metrics["coalesced"] == 1
+
+    results: list[tuple[str, str]] = []
+    for _ in range(2):
+        key = await asyncio.wait_for(q.get(), timeout=2.0)
+        results.append(key)
+        q.done(key)
+    assert results == [("zone1", "/file.txt"), ("zone2", "/file.txt")]
+
+
+# ---------------------------------------------------------------------------
+# 11. Benchmark: throughput under coalescing workload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_benchmark_coalescing_throughput() -> None:
+    """Benchmark: 100K adds with high duplication + drain.
+
+    Validates that coalescing overhead is negligible.
+    Target: > 50K ops/sec (conservative for asyncio).
+    """
+    q: DedupWorkQueue[str] = DedupWorkQueue()
+
+    num_adds = 100_000
+    num_unique_keys = 100  # High duplication ratio
+
+    t0 = time.monotonic()
+    for i in range(num_adds):
+        await q.add(f"key-{i % num_unique_keys}")
+    add_elapsed = time.monotonic() - t0
+
+    assert len(q) == num_unique_keys
+    assert q.metrics["coalesced"] == num_adds - num_unique_keys
+
+    t1 = time.monotonic()
+    drained = await _drain(q, num_unique_keys)
+    drain_elapsed = time.monotonic() - t1
+
+    assert len(drained) == num_unique_keys
+
+    add_rate = num_adds / add_elapsed
+    drain_rate = num_unique_keys / drain_elapsed
+
+    # Conservative thresholds — asyncio overhead is real
+    assert add_rate > 50_000, f"add rate too low: {add_rate:.0f} ops/sec"
+    assert drain_rate > 10_000, f"drain rate too low: {drain_rate:.0f} ops/sec"


### PR DESCRIPTION
## Summary

Implements Issue #2062: DedupWorkQueue for EventBus — prevent duplicate event processing.

- Adds `DedupWorkQueue[T]` following the Kubernetes controller-runtime workqueue pattern (queue + dirty set + processing set) to coalesce rapid duplicate events
- Wires dedup queue into `EventsService` Layer 2 distributed cache invalidation path
- 10 rapid writes to the same file → 10 events recorded (audit intact) but only **1 cache invalidation run**
- Worker captures `dedup_queue` as local variable to prevent null-before-shutdown race
- Shutdown ordering: cancel tasks first, then shutdown queue (fixes race condition)

**Stream:** #2062

## Files Changed

| File | Change |
|------|--------|
| `src/nexus/services/dedup_work_queue.py` | **NEW** — Generic DedupWorkQueue[T] with add/get/done/shutdown API, run_worker helper |
| `src/nexus/services/events_service.py` | **MODIFIED** — Wire dedup queue into Layer 2 cache invalidation |
| `tests/unit/services/test_dedup_work_queue.py` | **NEW** — 14 unit tests (lifecycle, coalescing, concurrency, shutdown, benchmark) |
| `tests/integration/services/test_dedup_work_queue_integration.py` | **NEW** — 4 integration tests (EventsService wiring, rename paths, concurrent) |

## Test plan

- [x] 14 unit tests pass (basic lifecycle, coalescing 10→1, re-queue on done, concurrent producers/consumers, shutdown, FIFO ordering, run_worker, tuple keys, benchmark 100K ops)
- [x] 4 integration tests pass (cache invalidation coalesces writes, different paths all invalidated, rename invalidates both paths, concurrent add during processing)
- [x] 35 existing EventsService unit tests pass (zero regressions)
- [x] 18 edit e2e tests pass (real server file CRUD)
- [x] 31/32 API v2 e2e tests pass (1 pre-existing failure unrelated)
- [x] Custom e2e smoke test: 20 rapid writes + 50 burst writes on real server with permissions — avg 12-14ms latency
- [x] Benchmark: >50K add ops/sec, >10K drain ops/sec
- [x] ruff check + ruff format clean (1826 files)
- [x] mypy clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)