### PR TITLE
fix(#2048,#2136): add auth to unprotected v2 endpoints + RPC method whitelisting

### DIFF
--- a/src/nexus/server/api/v2/routers/bricks.py
+++ b/src/nexus/server/api/v2/routers/bricks.py
@@ -18,9 +18,15 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
+from nexus.server.dependencies import require_admin
+
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v2/bricks", tags=["bricks"])
+# Public router for K8s probes — no auth required
+health_router = APIRouter(prefix="/api/v2/bricks", tags=["bricks"])
+
+# Admin router for lifecycle management — requires admin auth
+router = APIRouter(prefix="/api/v2/bricks", tags=["bricks"], dependencies=[Depends(require_admin)])
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +90,7 @@ def _get_lifecycle_manager(request: Request) -> Any:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/health", response_model=BrickHealthResponse)
+@health_router.get("/health", response_model=BrickHealthResponse)
 async def brick_health(
     manager: Any = Depends(_get_lifecycle_manager),
 ) -> BrickHealthResponse:

--- a/src/nexus/server/api/v2/routers/governance.py
+++ b/src/nexus/server/api/v2/routers/governance.py
@@ -14,13 +14,17 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from nexus.server.dependencies import require_admin
+
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v2/governance", tags=["governance"])
+router = APIRouter(
+    prefix="/api/v2/governance", tags=["governance"], dependencies=[Depends(require_admin)]
+)
 
 
 # =============================================================================
@@ -145,8 +149,10 @@ async def resolve_alert(
     request: Request,
     alert_id: str,
     body: ResolveAlertRequest,
+    auth_result: dict = Depends(require_admin),
 ) -> JSONResponse:
     """Resolve an anomaly alert."""
+    logger.info("resolve_alert by subject=%s", auth_result.get("subject_id"))
     service = _get_anomaly_service(request)
     alert = await service.resolve_alert(alert_id=alert_id, resolved_by=body.resolved_by)
 
@@ -254,8 +260,10 @@ async def list_fraud_rings(
 async def add_constraint(
     request: Request,
     body: AddConstraintRequest,
+    auth_result: dict = Depends(require_admin),
 ) -> JSONResponse:
     """Add a governance constraint between two agents."""
+    logger.info("add_constraint by subject=%s", auth_result.get("subject_id"))
     service = _get_graph_service(request)
 
     from nexus.services.governance.models import ConstraintType
@@ -364,8 +372,10 @@ async def check_constraint(
 async def suspend_agent(
     request: Request,
     body: SuspendAgentRequest,
+    auth_result: dict = Depends(require_admin),
 ) -> JSONResponse:
     """Suspend an agent."""
+    logger.info("suspend_agent by subject=%s", auth_result.get("subject_id"))
     service = _get_response_service(request)
 
     from nexus.services.governance.models import AnomalySeverity
@@ -461,8 +471,10 @@ async def decide_appeal(
     request: Request,
     suspension_id: str,
     body: DecideAppealRequest,
+    auth_result: dict = Depends(require_admin),
 ) -> JSONResponse:
     """Decide on a suspension appeal."""
+    logger.info("decide_appeal by subject=%s", auth_result.get("subject_id"))
     service = _get_response_service(request)
 
     try:

--- a/src/nexus/server/api/v2/routers/mobile_search.py
+++ b/src/nexus/server/api/v2/routers/mobile_search.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from nexus.search.mobile_config import (
@@ -21,10 +21,11 @@ from nexus.search.mobile_config import (
     detect_device_tier,
     get_config_for_tier,
 )
+from nexus.server.dependencies import require_auth
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v2/mobile", tags=["mobile"])
+router = APIRouter(prefix="/api/v2/mobile", tags=["mobile"], dependencies=[Depends(require_auth)])
 
 
 # =============================================================================

--- a/src/nexus/server/api/v2/routers/rlm.py
+++ b/src/nexus/server/api/v2/routers/rlm.py
@@ -18,13 +18,15 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from nexus.server.dependencies import require_auth
+
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v2/rlm", tags=["rlm"])
+router = APIRouter(prefix="/api/v2/rlm", tags=["rlm"], dependencies=[Depends(require_auth)])
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/server/api/v2/routers/tus_uploads.py
+++ b/src/nexus/server/api/v2/routers/tus_uploads.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
 
+from nexus.server.dependencies import require_auth
+
 if TYPE_CHECKING:
     from nexus.services.chunked_upload_service import ChunkedUploadService
 
@@ -72,17 +74,20 @@ def _parse_upload_metadata(raw: str | None) -> dict[str, str]:
 
 def create_tus_uploads_router(
     get_upload_service: object,
-) -> APIRouter:
-    """Factory function to create the tus uploads router.
+) -> tuple[APIRouter, APIRouter]:
+    """Factory function to create the tus uploads routers.
 
     Args:
         get_upload_service: Callable that returns the ChunkedUploadService.
             Follows the same factory pattern as create_async_files_router().
 
     Returns:
-        Configured APIRouter for tus endpoints.
+        Tuple of (public_router, auth_router). The public router contains
+        only the OPTIONS endpoint (for CORS preflight). The auth router
+        contains all other endpoints requiring authentication.
     """
-    router = APIRouter(tags=["uploads"])
+    public_router = APIRouter(tags=["uploads"])
+    router = APIRouter(tags=["uploads"], dependencies=[Depends(require_auth)])
 
     def _get_service() -> ChunkedUploadService:
         svc: ChunkedUploadService | None = get_upload_service()  # type: ignore[operator]
@@ -90,9 +95,9 @@ def create_tus_uploads_router(
             raise HTTPException(status_code=503, detail="Upload service not available")
         return svc
 
-    # --- OPTIONS: Server capabilities ---
+    # --- OPTIONS: Server capabilities (public — no auth required) ---
 
-    @router.options("")
+    @public_router.options("")
     async def tus_options() -> Response:
         """Return tus server capabilities."""
         service = _get_service()
@@ -303,4 +308,4 @@ def create_tus_uploads_router(
             headers={"Tus-Resumable": TUS_RESUMABLE},
         )
 
-    return router
+    return public_router, router

--- a/src/nexus/server/api/v2/routers/x402.py
+++ b/src/nexus/server/api/v2/routers/x402.py
@@ -17,12 +17,18 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from nexus.server.dependencies import require_auth
+
 if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/x402", tags=["x402"])
+# Public router for webhook (called by external x402 facilitator)
+webhook_router = APIRouter(prefix="/x402", tags=["x402"])
+
+# Auth'd router for topup/config (called by authenticated agents)
+router = APIRouter(prefix="/x402", tags=["x402"], dependencies=[Depends(require_auth)])
 
 
 # =============================================================================
@@ -115,7 +121,7 @@ def get_credits_service(request: Request) -> Any:
 # =============================================================================
 
 
-@router.post("/webhook", response_model=WebhookResponse)
+@webhook_router.post("/webhook", response_model=WebhookResponse)
 async def x402_webhook(
     payload: WebhookPayload,
     x402_client: Any = Depends(get_x402_client),
@@ -236,4 +242,4 @@ async def get_x402_config(
 # Module Exports
 # =============================================================================
 
-__all__ = ["router"]
+__all__ = ["router", "webhook_router"]

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -182,15 +182,24 @@ def build_v2_registry(
         try:
             from nexus.server.api.v2.routers.tus_uploads import create_tus_uploads_router
 
-            tus_router = create_tus_uploads_router(
+            tus_public_router, tus_auth_router = create_tus_uploads_router(
                 get_upload_service=chunked_upload_service_getter,
+            )
+            # OPTIONS endpoint is public (CORS preflight); all others require auth
+            registry.add(
+                RouterEntry(
+                    router=tus_public_router,
+                    name="tus_uploads_public",
+                    prefix="/api/v2/uploads",
+                    endpoint_count=1,
+                )
             )
             registry.add(
                 RouterEntry(
-                    router=tus_router,
+                    router=tus_auth_router,
                     name="tus_uploads",
                     prefix="/api/v2/uploads",
-                    endpoint_count=5,
+                    endpoint_count=4,
                 )
             )
         except ImportError as e:
@@ -238,9 +247,14 @@ def build_v2_registry(
 
     # ---- Bricks lifecycle router (Issue #1704) ----
     try:
+        from nexus.server.api.v2.routers.bricks import health_router as bricks_health_router
         from nexus.server.api.v2.routers.bricks import router as bricks_router
 
-        registry.add(RouterEntry(router=bricks_router, name="bricks", endpoint_count=4))
+        # Health endpoint is public (K8s probes); admin endpoints require auth
+        registry.add(
+            RouterEntry(router=bricks_health_router, name="bricks_health", endpoint_count=1)
+        )
+        registry.add(RouterEntry(router=bricks_router, name="bricks", endpoint_count=3))
     except ImportError as e:
         logger.warning("Failed to import Bricks routes: %s", e)
 
@@ -259,6 +273,25 @@ def build_v2_registry(
         )
     except ImportError as e:
         logger.warning("Failed to import Batch routes: %s", e)
+
+    # ---- Governance router (Issue #1359) — admin auth required ----
+    try:
+        from nexus.server.api.v2.routers.governance import router as governance_router
+
+        registry.add(RouterEntry(router=governance_router, name="governance", endpoint_count=14))
+    except ImportError as e:
+        logger.warning("Failed to import Governance routes: %s", e)
+
+    # ---- x402 protocol router (Issue #1206) ----
+    try:
+        from nexus.server.api.v2.routers.x402 import router as x402_router
+        from nexus.server.api.v2.routers.x402 import webhook_router as x402_webhook_router
+
+        # Webhook is public (called by external facilitator); topup/config require auth
+        registry.add(RouterEntry(router=x402_webhook_router, name="x402_webhook", endpoint_count=1))
+        registry.add(RouterEntry(router=x402_router, name="x402", endpoint_count=2))
+    except ImportError as e:
+        logger.warning("Failed to import x402 routes: %s", e)
 
     return registry
 

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -1616,6 +1616,12 @@ def _discover_exposed_methods(nexus_fs: NexusFS) -> dict[str, Any]:
             attr = getattr(nexus_fs, name)
             if callable(attr) and hasattr(attr, "_rpc_exposed"):
                 method_name = getattr(attr, "_rpc_name", name)
+                # Issue #2136: Block rpc_name bypass — skip private method names
+                if method_name.startswith("_"):
+                    logger.warning(
+                        "Skipping RPC method with private rpc_name: %s -> %s", name, method_name
+                    )
+                    continue
                 exposed[method_name] = attr
                 logger.debug(f"Discovered RPC method: {method_name}")
         except Exception:

--- a/src/nexus/server/rpc/dispatch.py
+++ b/src/nexus/server/rpc/dispatch.py
@@ -209,6 +209,11 @@ async def dispatch_method(
     if nexus_fs is None:
         raise RuntimeError("NexusFS not initialized")
 
+    # Issue #2136: Block private/malformed method names at dispatch time
+    if not method or method.startswith("_") or "." in method:
+        logger.warning("[RPC-SECURITY] Blocked method call: %r", method)
+        raise ValueError("Method not found")
+
     # Lazy-init on first call
     if not _DISPATCH_TABLE:
         _DISPATCH_TABLE = build_dispatch_table()
@@ -266,7 +271,8 @@ async def dispatch_method(
     if method in exposed_methods:
         return await _auto_dispatch(method, params, context, exposed_methods=exposed_methods)
 
-    raise ValueError(f"Unknown method: {method}")
+    logger.warning("[RPC] Unknown method requested: %r", method)
+    raise ValueError("Method not found")
 
 
 async def _auto_dispatch(

--- a/tests/e2e/self_contained/pay/test_x402_integration.py
+++ b/tests/e2e/self_contained/pay/test_x402_integration.py
@@ -19,6 +19,8 @@ from fastapi.testclient import TestClient
 
 from nexus.pay.x402 import X402Client, X402PaymentVerification
 from nexus.server.api.v2.routers.x402 import router as x402_router
+from nexus.server.api.v2.routers.x402 import webhook_router as x402_webhook_router
+from nexus.server.dependencies import require_auth
 from nexus.server.middleware.x402 import X402PaymentMiddleware
 
 # =============================================================================
@@ -52,8 +54,13 @@ def app(x402_client, mock_credits_service):
     """Create full FastAPI app with x402 integration."""
     app = FastAPI(title="Nexus x402 Integration Test")
 
-    # Add x402 router
+    # Add x402 routers (public webhook + auth'd topup/config)
+    app.include_router(x402_webhook_router, prefix="/api/v2")
     app.include_router(x402_router, prefix="/api/v2")
+
+    # Override require_auth for functional tests (simulate authenticated user)
+    _auth_result = {"authenticated": True, "is_admin": False, "subject_id": "test-user"}
+    app.dependency_overrides[require_auth] = lambda: _auth_result
 
     # Add middleware for protected endpoints
     app.add_middleware(
@@ -426,3 +433,63 @@ class TestErrorHandling:
         )
 
         assert response.status_code == 422
+
+
+# =============================================================================
+# Auth Enforcement Tests (Issue #2048)
+# =============================================================================
+
+
+class TestAuthRequired:
+    """Verify auth enforcement on x402 endpoints."""
+
+    @pytest.fixture
+    def auth_app(self, x402_client, mock_credits_service):
+        """App with real auth (api_key set, no auth override)."""
+        app = FastAPI(title="Nexus x402 Auth Test")
+        app.include_router(x402_webhook_router, prefix="/api/v2")
+        app.include_router(x402_router, prefix="/api/v2")
+        app.state.x402_client = x402_client
+        app.state.credits_service = mock_credits_service
+        # Set api_key to trigger real auth checks
+        app.state.api_key = "test-secret-key"
+        app.state.auth_provider = None
+        return app
+
+    @pytest.fixture
+    def unauthed_client(self, auth_app):
+        return TestClient(auth_app)
+
+    def test_topup_requires_auth(self, unauthed_client):
+        """Topup endpoint should return 401 without auth."""
+        resp = unauthed_client.post(
+            "/api/v2/x402/topup",
+            json={"agent_id": "test", "amount": "10.00"},
+        )
+        assert resp.status_code == 401
+
+    def test_config_requires_auth(self, unauthed_client):
+        """Config endpoint should return 401 without auth."""
+        resp = unauthed_client.get("/api/v2/x402/config")
+        assert resp.status_code == 401
+
+    def test_webhook_remains_public(self, unauthed_client, x402_client):
+        """Webhook endpoint should NOT require auth (external facilitator calls it)."""
+        x402_client._verify_webhook_signature = MagicMock(return_value=True)
+        resp = unauthed_client.post(
+            "/api/v2/x402/webhook",
+            json={
+                "event": "payment.confirmed",
+                "tx_hash": "0x" + "ab" * 32,
+                "network": "eip155:8453",
+                "amount": "1000000",
+                "currency": "USDC",
+                "from": "0x" + "ab" * 20,
+                "to": "0x" + "cd" * 20,
+                "timestamp": "2025-01-15T12:00:00Z",
+                "metadata": {"agent_id": "test-agent"},
+                "signature": "valid",
+            },
+        )
+        # Should NOT be 401 — webhook is public
+        assert resp.status_code != 401

--- a/tests/e2e/self_contained/test_auth_enforcement_e2e.py
+++ b/tests/e2e/self_contained/test_auth_enforcement_e2e.py
@@ -1,0 +1,314 @@
+"""E2E auth enforcement tests for Issues #2048 + #2136.
+
+Validates that ALL newly-protected endpoints reject unauthenticated requests
+when api_key is configured. Uses create_app() with static API key (no database
+auth needed) to exercise the full auth middleware chain.
+
+Covers:
+- governance (require_admin) → 401 without auth
+- bricks (require_admin) → 401 without auth, health stays public
+- rlm (require_auth) → 401 without auth
+- mobile_search (require_auth) → 401 without auth
+- tus_uploads (require_auth) → 401 for PATCH/POST/DELETE, OPTIONS stays public
+- x402 topup/config (require_auth) → 401, webhook stays public
+- RPC dispatch method name validation (#2136)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers import bricks, governance, mobile_search, rlm
+from nexus.server.api.v2.routers.tus_uploads import create_tus_uploads_router
+from nexus.server.api.v2.routers.x402 import router as x402_router
+from nexus.server.api.v2.routers.x402 import webhook_router as x402_webhook_router
+
+# ---------------------------------------------------------------------------
+# Fixture: app with static API key auth (no auth overrides!)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def secured_app() -> FastAPI:
+    """FastAPI app with api_key set — triggers real auth checks."""
+    app = FastAPI()
+
+    # Register all routers we protect
+    app.include_router(governance.router)
+    app.include_router(bricks.health_router)
+    app.include_router(bricks.router)
+    app.include_router(rlm.router)
+    app.include_router(mobile_search.router)
+
+    tus_public, tus_auth = create_tus_uploads_router(get_upload_service=lambda: MagicMock())
+    app.include_router(tus_public, prefix="/api/v2/uploads")
+    app.include_router(tus_auth, prefix="/api/v2/uploads")
+
+    app.include_router(x402_webhook_router, prefix="/api/v2")
+    app.include_router(x402_router, prefix="/api/v2")
+
+    # Critical: set api_key to trigger real auth checks
+    app.state.api_key = "test-secret-key-e2e"
+    app.state.auth_provider = None
+
+    # Stubs for endpoints that check app.state
+    app.state.nexus_fs = MagicMock()
+    app.state.rlm_service = MagicMock()
+    app.state.x402_client = MagicMock()
+    app.state.credits_service = MagicMock()
+    app.state.brick_container = MagicMock()
+
+    return app
+
+
+@pytest.fixture
+def unauthed(secured_app: FastAPI) -> TestClient:
+    """Client without auth headers."""
+    return TestClient(secured_app)
+
+
+@pytest.fixture
+def authed(secured_app: FastAPI) -> TestClient:
+    """Client with valid API key (no server exception propagation)."""
+    return TestClient(
+        secured_app,
+        headers={"Authorization": "Bearer test-secret-key-e2e"},
+        raise_server_exceptions=False,
+    )
+
+
+# ===========================================================================
+# Governance — require_admin
+# ===========================================================================
+
+
+class TestGovernanceAuthEnforcement:
+    """governance endpoints must reject unauthenticated requests."""
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("GET", "/api/v2/governance/alerts"),
+            ("GET", "/api/v2/governance/constraints"),
+            ("GET", "/api/v2/governance/fraud-scores"),
+            ("POST", "/api/v2/governance/alerts/fake-id/resolve"),
+            ("POST", "/api/v2/governance/constraints"),
+            ("POST", "/api/v2/governance/suspensions"),
+            ("POST", "/api/v2/governance/suspensions/fake-id/decide"),
+        ],
+    )
+    def test_unauthenticated_returns_401(
+        self, unauthed: TestClient, method: str, path: str
+    ) -> None:
+        resp = getattr(unauthed, method.lower())(path)
+        assert resp.status_code == 401, f"{method} {path} returned {resp.status_code}"
+
+
+# ===========================================================================
+# Bricks — require_admin (health is public)
+# ===========================================================================
+
+
+class TestBricksAuthEnforcement:
+    """bricks admin endpoints must reject unauthenticated; health stays open."""
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("GET", "/api/v2/bricks/somebrick"),
+            ("POST", "/api/v2/bricks/somebrick/mount"),
+            ("POST", "/api/v2/bricks/somebrick/unmount"),
+        ],
+    )
+    def test_unauthenticated_returns_401(
+        self, unauthed: TestClient, method: str, path: str
+    ) -> None:
+        resp = getattr(unauthed, method.lower())(path)
+        assert resp.status_code == 401, f"{method} {path} returned {resp.status_code}"
+
+    def test_health_endpoint_stays_public(self, unauthed: TestClient) -> None:
+        resp = unauthed.get("/api/v2/bricks/health")
+        assert resp.status_code != 401, "health should not require auth"
+
+
+# ===========================================================================
+# RLM — require_auth
+# ===========================================================================
+
+
+class TestRLMAuthEnforcement:
+    """rlm endpoint must reject unauthenticated requests."""
+
+    def test_infer_returns_401(self, unauthed: TestClient) -> None:
+        resp = unauthed.post(
+            "/api/v2/rlm/infer",
+            json={"query": "test"},
+        )
+        assert resp.status_code == 401
+
+
+# ===========================================================================
+# Mobile Search — require_auth
+# ===========================================================================
+
+
+class TestMobileSearchAuthEnforcement:
+    """mobile_search endpoints must reject unauthenticated requests."""
+
+    def test_detect_returns_401(self, unauthed: TestClient) -> None:
+        resp = unauthed.get("/api/v2/mobile/detect")
+        assert resp.status_code == 401
+
+    def test_download_returns_401(self, unauthed: TestClient) -> None:
+        resp = unauthed.post(
+            "/api/v2/mobile/download",
+            json={"model_name": "test"},
+        )
+        assert resp.status_code == 401
+
+
+# ===========================================================================
+# TUS Uploads — require_auth (OPTIONS is public)
+# ===========================================================================
+
+
+class TestTusUploadsAuthEnforcement:
+    """tus upload endpoints must reject unauthenticated; OPTIONS stays open."""
+
+    def test_create_upload_returns_401(self, unauthed: TestClient) -> None:
+        resp = unauthed.post(
+            "/api/v2/uploads",
+            headers={"Tus-Resumable": "1.0.0", "Upload-Length": "100"},
+        )
+        assert resp.status_code == 401
+
+    def test_options_stays_public(self, unauthed: TestClient) -> None:
+        resp = unauthed.options("/api/v2/uploads")
+        assert resp.status_code != 401, "OPTIONS should not require auth"
+
+
+# ===========================================================================
+# x402 — require_auth for topup/config, webhook stays public
+# ===========================================================================
+
+
+class TestX402AuthEnforcement:
+    """x402 topup/config require auth; webhook is public."""
+
+    def test_topup_returns_401(self, unauthed: TestClient) -> None:
+        resp = unauthed.post(
+            "/api/v2/x402/topup",
+            json={"agent_id": "test", "amount": "10.00"},
+        )
+        assert resp.status_code == 401
+
+    def test_config_returns_401(self, unauthed: TestClient) -> None:
+        resp = unauthed.get("/api/v2/x402/config")
+        assert resp.status_code == 401
+
+    def test_webhook_stays_public(self, unauthed: TestClient) -> None:
+        resp = unauthed.post(
+            "/api/v2/x402/webhook",
+            json={"event": "test"},
+        )
+        # Should NOT be 401 (webhook is public; may be 400/422 for bad payload)
+        assert resp.status_code != 401, "webhook should not require auth"
+
+
+# ===========================================================================
+# Authenticated requests should pass auth checks
+# ===========================================================================
+
+
+class TestAuthenticatedRequestsPass:
+    """Verify that authenticated requests are not blocked by auth."""
+
+    def test_governance_with_auth_passes(self, authed: TestClient) -> None:
+        resp = authed.get("/api/v2/governance/alerts")
+        # May fail later (500 due to mock), but NOT 401
+        assert resp.status_code != 401
+
+    def test_bricks_with_auth_passes(self, authed: TestClient) -> None:
+        resp = authed.get("/api/v2/bricks/somebrick")
+        assert resp.status_code != 401
+
+    def test_rlm_with_auth_passes(self, authed: TestClient) -> None:
+        resp = authed.post("/api/v2/rlm/infer", json={"query": "test"})
+        assert resp.status_code != 401
+
+    def test_x402_config_with_auth_passes(self, authed: TestClient) -> None:
+        resp = authed.get("/api/v2/x402/config")
+        assert resp.status_code != 401
+
+    def test_tus_create_with_auth_passes(self, authed: TestClient) -> None:
+        resp = authed.post(
+            "/api/v2/uploads",
+            headers={"Tus-Resumable": "1.0.0", "Upload-Length": "100"},
+        )
+        assert resp.status_code != 401
+
+
+# ===========================================================================
+# RPC dispatch method name validation (#2136)
+# ===========================================================================
+
+
+class TestRPCDispatchSecurity:
+    """Verify dispatch_method() blocks private/malformed method names."""
+
+    @pytest.mark.asyncio
+    async def test_private_method_blocked(self) -> None:
+        from nexus.server.rpc.dispatch import dispatch_method
+
+        with pytest.raises(ValueError, match="Method not found"):
+            await dispatch_method(
+                "_private",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=MagicMock(),
+                exposed_methods={"read": MagicMock()},
+            )
+
+    @pytest.mark.asyncio
+    async def test_dot_method_blocked(self) -> None:
+        from nexus.server.rpc.dispatch import dispatch_method
+
+        with pytest.raises(ValueError, match="Method not found"):
+            await dispatch_method(
+                "os.system",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=MagicMock(),
+                exposed_methods={"read": MagicMock()},
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_method_blocked(self) -> None:
+        from nexus.server.rpc.dispatch import dispatch_method
+
+        with pytest.raises(ValueError, match="Method not found"):
+            await dispatch_method(
+                "",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=MagicMock(),
+                exposed_methods={"read": MagicMock()},
+            )
+
+    @pytest.mark.asyncio
+    async def test_error_does_not_echo_method_name(self) -> None:
+        from nexus.server.rpc.dispatch import dispatch_method
+
+        with pytest.raises(ValueError) as exc_info:
+            await dispatch_method(
+                "_secret_internal",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=MagicMock(),
+                exposed_methods={"read": MagicMock()},
+            )
+        assert "_secret_internal" not in str(exc_info.value)

--- a/tests/e2e/self_contained/test_tus_protocol.py
+++ b/tests/e2e/self_contained/test_tus_protocol.py
@@ -16,6 +16,7 @@ from httpx import ASGITransport, AsyncClient
 
 from nexus.backends.local import LocalBackend
 from nexus.server.api.v2.routers.tus_uploads import create_tus_uploads_router
+from nexus.server.dependencies import require_auth
 from nexus.services.chunked_upload_service import (
     ChunkedUploadConfig,
     ChunkedUploadService,
@@ -67,8 +68,14 @@ def upload_service(tmp_path: Path, tmp_backend: LocalBackend) -> ChunkedUploadSe
 def app(upload_service: ChunkedUploadService) -> FastAPI:
     """Create a FastAPI app with the tus router."""
     _app = FastAPI()
-    router = create_tus_uploads_router(get_upload_service=lambda: upload_service)
-    _app.include_router(router, prefix="/api/v2/uploads")
+    public_router, auth_router = create_tus_uploads_router(
+        get_upload_service=lambda: upload_service
+    )
+    _app.include_router(public_router, prefix="/api/v2/uploads")
+    _app.include_router(auth_router, prefix="/api/v2/uploads")
+    # Override require_auth for functional tests
+    _auth_result = {"authenticated": True, "is_admin": False, "subject_id": "test-user"}
+    _app.dependency_overrides[require_auth] = lambda: _auth_result
     return _app
 
 

--- a/tests/e2e/server/test_governance_e2e.py
+++ b/tests/e2e/server/test_governance_e2e.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.ext.asyncio import async_sessionmaker as AsyncSessionMaker
 
 from nexus.server.api.v2.routers.governance import router
+from nexus.server.dependencies import require_admin
 from nexus.services.governance.anomaly_service import AnomalyService, StatisticalAnomalyDetector
 from nexus.services.governance.collusion_service import CollusionService
 from nexus.services.governance.governance_graph_service import GovernanceGraphService
@@ -92,6 +93,10 @@ def governance_app(session_factory, detector) -> FastAPI:
     app = FastAPI()
     app.include_router(router)
 
+    # Override require_admin for functional tests (simulate authenticated admin)
+    _admin_result = {"authenticated": True, "is_admin": True, "subject_id": "test-admin"}
+    app.dependency_overrides[require_admin] = lambda: _admin_result
+
     # Wire real services (no mocks)
     anomaly_service = AnomalyService(session_factory=session_factory, detector=detector)
     collusion_service = CollusionService(session_factory=session_factory)
@@ -127,6 +132,9 @@ def unwired_app() -> FastAPI:
     """FastAPI app WITHOUT governance services (for 503 tests)."""
     app = FastAPI()
     app.include_router(router)
+    # Override require_admin so 503 tests still reach the handlers
+    _admin_result = {"authenticated": True, "is_admin": True, "subject_id": "test-admin"}
+    app.dependency_overrides[require_admin] = lambda: _admin_result
     return app
 
 
@@ -709,3 +717,63 @@ class TestCrossServiceIntegration:
         resp = await client.get("/api/v2/governance/alerts?zone_id=default")
         assert resp.status_code == 200
         assert resp.json()["count"] >= 1
+
+
+# =============================================================================
+# Auth enforcement (Issue #2048)
+# =============================================================================
+
+
+class TestAuthRequired:
+    """Verify governance endpoints reject unauthenticated requests."""
+
+    @pytest.fixture
+    def auth_app(self) -> FastAPI:
+        """App with real auth (api_key set, no admin override)."""
+        app = FastAPI()
+        app.include_router(router)
+        app.state.api_key = "test-secret-key"
+        app.state.auth_provider = None
+        return app
+
+    @pytest.fixture
+    async def unauthed_client(self, auth_app: FastAPI):
+        async with AsyncClient(
+            transport=ASGITransport(app=auth_app),
+            base_url="http://test",
+        ) as c:
+            yield c
+
+    @pytest.mark.asyncio
+    async def test_alerts_requires_auth(self, unauthed_client: AsyncClient) -> None:
+        resp = await unauthed_client.get("/api/v2/governance/alerts")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_constraints_requires_auth(self, unauthed_client: AsyncClient) -> None:
+        resp = await unauthed_client.get("/api/v2/governance/constraints")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_suspensions_requires_auth(self, unauthed_client: AsyncClient) -> None:
+        resp = await unauthed_client.get("/api/v2/governance/suspensions")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_fraud_scores_requires_auth(self, unauthed_client: AsyncClient) -> None:
+        resp = await unauthed_client.get("/api/v2/governance/fraud-scores")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_write_endpoints_require_auth(self, unauthed_client: AsyncClient) -> None:
+        resp = await unauthed_client.post(
+            "/api/v2/governance/suspensions",
+            json={"agent_id": "a", "reason": "test"},
+        )
+        assert resp.status_code == 401
+
+        resp = await unauthed_client.post(
+            "/api/v2/governance/constraints",
+            json={"from_agent": "a", "to_agent": "b"},
+        )
+        assert resp.status_code == 401

--- a/tests/integration/test_rlm_e2e.py
+++ b/tests/integration/test_rlm_e2e.py
@@ -20,10 +20,14 @@ from fastapi.testclient import TestClient
 from nexus.rlm.types import RLMInferenceResult, RLMStatus, SSEEvent, SSEEventType
 from nexus.server.api.v2.routers.rlm import router
 from nexus.server.api.v2.versioning import VersionHeaderMiddleware
+from nexus.server.dependencies import require_auth
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+_auth_result = {"authenticated": True, "is_admin": False, "subject_id": "test-user"}
 
 
 @pytest.fixture
@@ -33,6 +37,7 @@ def app_no_rlm() -> FastAPI:
     app.state.rlm_service = None
     app.include_router(router)
     app.add_middleware(VersionHeaderMiddleware)
+    app.dependency_overrides[require_auth] = lambda: _auth_result
     return app
 
 
@@ -76,6 +81,7 @@ def app_with_rlm() -> FastAPI:
     app.state.rlm_service = mock_service
     app.include_router(router)
     app.add_middleware(VersionHeaderMiddleware)
+    app.dependency_overrides[require_auth] = lambda: _auth_result
     return app
 
 
@@ -208,3 +214,28 @@ class TestRLMRequestValidation:
             },
         )
         assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests: Auth enforcement (Issue #2048)
+# ---------------------------------------------------------------------------
+
+
+class TestRLMAuthRequired:
+    """Verify RLM endpoint rejects unauthenticated requests."""
+
+    def test_infer_requires_auth(self) -> None:
+        """POST /api/v2/rlm/infer returns 401 without auth."""
+        app = FastAPI()
+        app.include_router(router)
+        app.state.rlm_service = MagicMock()
+        # Set api_key to trigger real auth checks
+        app.state.api_key = "test-secret-key"
+        app.state.auth_provider = None
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/v2/rlm/infer",
+            json={"query": "test"},
+        )
+        assert response.status_code == 401

--- a/tests/unit/server/api/v2/routers/test_bricks_router.py
+++ b/tests/unit/server/api/v2/routers/test_bricks_router.py
@@ -14,8 +14,10 @@ from fastapi.testclient import TestClient
 
 from nexus.server.api.v2.routers.bricks import (
     _get_lifecycle_manager,
+    health_router,
     router,
 )
+from nexus.server.dependencies import require_admin
 from nexus.services.protocols.brick_lifecycle import (
     BrickHealthReport,
     BrickState,
@@ -27,6 +29,7 @@ from nexus.services.protocols.brick_lifecycle import (
 # ---------------------------------------------------------------------------
 
 _test_app = FastAPI()
+_test_app.include_router(health_router)
 _test_app.include_router(router)
 
 
@@ -53,6 +56,10 @@ def _override_manager() -> MagicMock:
 
 
 _test_app.dependency_overrides[_get_lifecycle_manager] = _override_manager
+
+# Override require_admin for existing functional tests (simulates authenticated admin)
+_admin_result = {"authenticated": True, "is_admin": True, "subject_id": "test-admin"}
+_test_app.dependency_overrides[require_admin] = lambda: _admin_result
 
 client = TestClient(_test_app)
 
@@ -276,9 +283,45 @@ class TestManagerUnavailable:
 
     def test_health_without_manager(self) -> None:
         app = FastAPI()
-        app.include_router(router)
+        app.include_router(health_router)
         # No dependency override — _get_lifecycle_manager will fail
         # We need to mock the app state
         c = TestClient(app)
         resp = c.get("/api/v2/bricks/health")
         assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Auth enforcement (Issue #2048)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthRequired:
+    """Verify admin endpoints reject unauthenticated requests."""
+
+    def _make_auth_app(self) -> tuple[FastAPI, TestClient]:
+        """Create an app with real auth (api_key set, so open-access is off)."""
+        app = FastAPI()
+        app.include_router(health_router)
+        app.include_router(router)
+        app.dependency_overrides[_get_lifecycle_manager] = _override_manager
+        # Set api_key so open-access mode is off (triggers real auth)
+        app.state.api_key = "test-secret-key"
+        app.state.auth_provider = None
+        return app, TestClient(app)
+
+    def test_unauthenticated_returns_401(self) -> None:
+        """Admin endpoints without auth should return 401."""
+        _, c = self._make_auth_app()
+
+        # Admin endpoints should return 401
+        assert c.get("/api/v2/bricks/test_brick").status_code == 401
+        assert c.post("/api/v2/bricks/test_brick/mount").status_code == 401
+        assert c.post("/api/v2/bricks/test_brick/unmount").status_code == 401
+
+    def test_health_endpoint_remains_public(self) -> None:
+        """Health endpoint does not require auth (K8s probes)."""
+        _, c = self._make_auth_app()
+
+        resp = c.get("/api/v2/bricks/health")
+        assert resp.status_code == 200

--- a/tests/unit/server/test_rpc_method_security.py
+++ b/tests/unit/server/test_rpc_method_security.py
@@ -1,0 +1,165 @@
+"""Tests for RPC method name validation security (Issue #2136).
+
+Ensures that:
+- Private/malformed method names are blocked at dispatch time
+- Discovery filter rejects rpc_name bypass attempts
+- Valid method names still dispatch correctly
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.server.rpc.dispatch import dispatch_method
+
+# =============================================================================
+# dispatch_method() — runtime method name validation
+# =============================================================================
+
+
+class TestRPCMethodNameValidation:
+    """Verify dispatch_method() rejects private/malformed method names."""
+
+    @pytest.fixture
+    def mock_nexus_fs(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def exposed_methods(self) -> dict:
+        return {"read": MagicMock(), "write": MagicMock()}
+
+    @pytest.mark.asyncio
+    async def test_underscore_method_rejected(
+        self, mock_nexus_fs: MagicMock, exposed_methods: dict
+    ) -> None:
+        """Methods starting with '_' must be blocked."""
+        with pytest.raises(ValueError, match="Method not found"):
+            await dispatch_method(
+                "_private_method",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=mock_nexus_fs,
+                exposed_methods=exposed_methods,
+            )
+
+    @pytest.mark.asyncio
+    async def test_dot_method_rejected(
+        self, mock_nexus_fs: MagicMock, exposed_methods: dict
+    ) -> None:
+        """Methods containing '.' must be blocked."""
+        with pytest.raises(ValueError, match="Method not found"):
+            await dispatch_method(
+                "os.system",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=mock_nexus_fs,
+                exposed_methods=exposed_methods,
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_method_rejected(
+        self, mock_nexus_fs: MagicMock, exposed_methods: dict
+    ) -> None:
+        """Empty method name must be blocked."""
+        with pytest.raises(ValueError, match="Method not found"):
+            await dispatch_method(
+                "",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=mock_nexus_fs,
+                exposed_methods=exposed_methods,
+            )
+
+    @pytest.mark.asyncio
+    async def test_dunder_method_rejected(
+        self, mock_nexus_fs: MagicMock, exposed_methods: dict
+    ) -> None:
+        """Dunder methods must be blocked."""
+        with pytest.raises(ValueError, match="Method not found"):
+            await dispatch_method(
+                "__init__",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=mock_nexus_fs,
+                exposed_methods=exposed_methods,
+            )
+
+    @pytest.mark.asyncio
+    async def test_unknown_valid_method_raises_not_found(
+        self, mock_nexus_fs: MagicMock, exposed_methods: dict
+    ) -> None:
+        """Unknown but validly-named methods raise generic 'Method not found'."""
+        with pytest.raises(ValueError, match="Method not found"):
+            await dispatch_method(
+                "nonexistent_method",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=mock_nexus_fs,
+                exposed_methods=exposed_methods,
+            )
+
+    @pytest.mark.asyncio
+    async def test_error_message_does_not_echo_method_name(
+        self, mock_nexus_fs: MagicMock, exposed_methods: dict
+    ) -> None:
+        """Error messages must not echo the method name (security)."""
+        with pytest.raises(ValueError) as exc_info:
+            await dispatch_method(
+                "_secret_internal",
+                params=MagicMock(),
+                context=MagicMock(),
+                nexus_fs=mock_nexus_fs,
+                exposed_methods=exposed_methods,
+            )
+        assert "_secret_internal" not in str(exc_info.value)
+
+
+# =============================================================================
+# _discover_exposed_methods() — rpc_name bypass prevention
+# =============================================================================
+
+
+class TestDiscoveryFilterRpcName:
+    """Verify _discover_exposed_methods() filters out private rpc_name aliases."""
+
+    def test_rpc_name_underscore_filtered(self) -> None:
+        """Methods with rpc_name starting with '_' must be excluded from discovery."""
+        from nexus.server.fastapi_server import _discover_exposed_methods
+
+        def private_method():
+            pass
+
+        private_method._rpc_exposed = True  # type: ignore[attr-defined]
+        private_method._rpc_name = "_hidden"  # type: ignore[attr-defined]
+
+        def normal_method():
+            pass
+
+        normal_method._rpc_exposed = True  # type: ignore[attr-defined]
+        normal_method._rpc_name = "visible"  # type: ignore[attr-defined]
+
+        class FakeFS:
+            good_method = staticmethod(normal_method)
+            bad_method = staticmethod(private_method)
+
+        exposed = _discover_exposed_methods(FakeFS())  # type: ignore[arg-type]
+        assert "visible" in exposed
+        assert "_hidden" not in exposed
+
+    def test_rpc_name_normal_passes(self) -> None:
+        """Methods with normal rpc_name are included in discovery."""
+        from nexus.server.fastapi_server import _discover_exposed_methods
+
+        def method():
+            pass
+
+        method._rpc_exposed = True  # type: ignore[attr-defined]
+        method._rpc_name = "safe_method"  # type: ignore[attr-defined]
+
+        class FakeFS:
+            my_method = staticmethod(method)
+
+        exposed = _discover_exposed_methods(FakeFS())  # type: ignore[arg-type]
+        assert "safe_method" in exposed

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -373,6 +373,17 @@ def test_all_public_methods_are_exposed_or_excluded():
     print("  - 0 missing (enforcement passed!)")
 
 
+def test_no_exposed_method_starts_with_underscore():
+    """Issue #2136: No exposed method name should start with '_'.
+
+    This ensures that even if a method has _rpc_name set to something
+    starting with '_', it won't bypass the discovery filter.
+    """
+    exposed_methods = get_rpc_exposed_methods(NexusFS)
+    private_methods = [name for name in exposed_methods if name.startswith("_")]
+    assert not private_methods, f"Exposed methods must not start with '_': {private_methods}"
+
+
 def test_list_all_exposed_methods():
     """List all @rpc_expose methods for documentation purposes."""
     exposed_methods = get_rpc_exposed_methods(NexusFS)


### PR DESCRIPTION
## Summary

- **#2048**: Add authentication to 26 unprotected API v2 endpoints across 6 routers (governance, bricks, rlm, mobile_search, tus_uploads, x402)
- **#2136**: Add RPC dispatch runtime method name validation to prevent private method invocation via bypass

### Router Auth Strategy
| Router | Auth Level | Public Endpoints |
|--------|-----------|-----------------|
| governance | `require_admin` | none |
| bricks | `require_admin` | `/health` (K8s probes) |
| rlm | `require_auth` | none |
| mobile_search | `require_auth` | none |
| tus_uploads | `require_auth` | `OPTIONS` (tus spec) |
| x402 | `require_auth` | `/webhook` (external facilitator) |

### RPC Security
- Runtime validation in `dispatch_method()` blocks `_`-prefixed, `.`-containing, and empty method names
- Discovery filter rejects `rpc_name` bypass attempts
- Generic "Method not found" error prevents internal name leakage

## Stream Numbers
- Stream #2048 — Unprotected API v2 endpoints
- Stream #2136 — RPC method name validation security

## Files Changed (17)
**Production (9):**
- `src/nexus/server/rpc/dispatch.py` — runtime method validation
- `src/nexus/server/fastapi_server.py` — discovery filter for rpc_name
- `src/nexus/server/api/v2/routers/governance.py` — require_admin
- `src/nexus/server/api/v2/routers/bricks.py` — split health (public) + admin router
- `src/nexus/server/api/v2/routers/rlm.py` — require_auth
- `src/nexus/server/api/v2/routers/mobile_search.py` — require_auth
- `src/nexus/server/api/v2/routers/tus_uploads.py` — split OPTIONS (public) + auth router
- `src/nexus/server/api/v2/routers/x402.py` — split webhook (public) + auth router
- `src/nexus/server/api/v2/versioning.py` — register split routers

**Tests (8):**
- `tests/unit/server/test_rpc_method_security.py` — **NEW** (8 tests)
- `tests/e2e/self_contained/test_auth_enforcement_e2e.py` — **NEW** (28 tests)
- `tests/unit/server/test_rpc_parity.py` — extended
- `tests/unit/server/api/v2/routers/test_bricks_router.py` — auth tests
- `tests/e2e/server/test_governance_e2e.py` — auth tests
- `tests/integration/test_rlm_e2e.py` — auth tests
- `tests/e2e/self_contained/pay/test_x402_integration.py` — auth tests
- `tests/e2e/self_contained/test_tus_protocol.py` — auth tests

## Test plan
- [x] 981 tests pass (unit/server + e2e + integration)
- [x] Ruff lint: clean
- [x] Ruff format: clean
- [x] Mypy: clean (8 source files, 0 errors)
- [ ] CI pipeline green
- [ ] Verify unauthenticated requests return 401 on all newly-protected endpoints
- [ ] Verify public endpoints (health, OPTIONS, webhook) remain accessible
- [ ] Verify authenticated requests pass through auth gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)