### PR TITLE
refactor(#2152): move audit error policy from kernel to WriteObserverProtocol

### DIFF
--- a/src/nexus/contracts/__init__.py
+++ b/src/nexus/contracts/__init__.py
@@ -68,6 +68,7 @@ from nexus.contracts.validators import (
     EmailListRequired,
     ISODateTimeStr,
 )
+from nexus.contracts.write_observer import WriteObserverProtocol
 
 __all__ = [
     # Constants (shared across bricks)
@@ -133,4 +134,6 @@ __all__ = [
     "UploadNotFoundError",
     "UploadOffsetMismatchError",
     "ValidationError",
+    # Protocols
+    "WriteObserverProtocol",
 ]

--- a/src/nexus/contracts/write_observer.py
+++ b/src/nexus/contracts/write_observer.py
@@ -1,0 +1,86 @@
+"""WriteObserverProtocol — kernel write-mutation observer interface.
+
+Defines the contract for write observers injected into NexusFS kernel.
+The kernel calls on_write()/on_delete()/on_rename()/on_write_batch()
+after Metastore mutations. Observers handle side-effects (audit trail,
+version recording, etc.) and own their own error policy.
+
+Current implementations:
+- RecordStoreWriteObserver: synchronous audit trail + versioning (strict_mode)
+- BufferedRecordStoreWriteObserver: async via WriteBuffer (fire-and-forget)
+
+The kernel is a pure caller — it never catches observer exceptions.
+Each implementation decides its own failure handling strategy.
+
+Tracked by: #55 (Move _audit_strict_mode from kernel to observer)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from nexus.core.metadata import FileMetadata
+
+
+@runtime_checkable
+class WriteObserverProtocol(Protocol):
+    """Protocol for kernel write-mutation observers.
+
+    Duck-typed interface injected into NexusFS as write_observer.
+    Implementations handle RecordStore side-effects (audit log,
+    version history) and own their error policy.
+    """
+
+    def on_write(
+        self,
+        metadata: FileMetadata,
+        *,
+        is_new: bool,
+        path: str,
+        zone_id: str | None = ...,
+        agent_id: str | None = ...,
+        snapshot_hash: str | None = ...,
+        metadata_snapshot: dict[str, Any] | None = ...,
+    ) -> None:
+        """Called after a single file write completes in Metastore."""
+        ...
+
+    def on_write_batch(
+        self,
+        items: list[tuple[FileMetadata, bool]],
+        *,
+        zone_id: str | None = ...,
+        agent_id: str | None = ...,
+    ) -> None:
+        """Called after a batch write completes in Metastore.
+
+        Args:
+            items: List of (metadata, is_new) tuples.
+        """
+        ...
+
+    def on_rename(
+        self,
+        old_path: str,
+        new_path: str,
+        *,
+        zone_id: str | None = ...,
+        agent_id: str | None = ...,
+        snapshot_hash: str | None = ...,
+        metadata_snapshot: dict[str, Any] | None = ...,
+    ) -> None:
+        """Called after a file rename completes in Metastore."""
+        ...
+
+    def on_delete(
+        self,
+        path: str,
+        *,
+        zone_id: str | None = ...,
+        agent_id: str | None = ...,
+        snapshot_hash: str | None = ...,
+        metadata_snapshot: dict[str, Any] | None = ...,
+    ) -> None:
+        """Called after a file delete completes in Metastore."""
+        ...

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -24,6 +24,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+if TYPE_CHECKING:
+    from nexus.contracts.write_observer import WriteObserverProtocol
+
 from nexus.constants import DEFAULT_NATS_URL
 
 if TYPE_CHECKING:
@@ -150,7 +153,7 @@ class KernelServices:
     workspace_manager: Any = None
 
     # Sync / versioning
-    write_observer: Any = None
+    write_observer: WriteObserverProtocol | None = None
     version_service: Any = None
     overlay_resolver: Any = None
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -175,7 +175,8 @@ class NexusFS(  # type: ignore[misc]
         self._memory_recall_max_age_hours = memory.recall_max_age_hours
         self._enforce_permissions = permissions.enforce
         self._enforce_zone_isolation = permissions.enforce_zone_isolation
-        self._audit_strict_mode = permissions.audit_strict_mode
+        # _audit_strict_mode removed (Issue #55) — error policy now owned by
+        # WriteObserverProtocol implementations (e.g. RecordStoreWriteObserver).
         self.allow_admin_bypass = permissions.allow_admin_bypass
         self.auto_parse = parsing.auto_parse
         self.is_admin = is_admin

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -52,6 +52,7 @@ class NexusFSCoreMixin:
 
     # Type hints for attributes/methods that will be provided by NexusFS parent class
     if TYPE_CHECKING:
+        from nexus.contracts.write_observer import WriteObserverProtocol
         from nexus.core.metastore import MetastoreABC
         from nexus.rebac.enforcer import PermissionEnforcer
 
@@ -68,8 +69,7 @@ class NexusFSCoreMixin:
         _event_tasks: set[asyncio.Task[Any]]  # Issue #913: Tracked async event tasks
         _overlay_resolver: Any  # Issue #1264: OverlayResolver service
         _workspace_registry: Any  # Workspace registry for overlay config lookup
-        _write_observer: Any  # Duck-typed: on_write()/on_delete()
-        _audit_strict_mode: bool
+        _write_observer: WriteObserverProtocol | None  # Issue #55
 
         @property
         def zone_id(self) -> str | None: ...
@@ -1765,7 +1765,6 @@ class NexusFSCoreMixin:
         # Sync to RecordStore via write_observer (closes gap: write_stream was missing this)
         self._notify_observer(
             "write",
-            path,
             metadata=new_meta,
             is_new=(meta is None),
             path=path,
@@ -2131,7 +2130,6 @@ class NexusFSCoreMixin:
         # Issue #1246: Unified error handling via _notify_observer.
         self._notify_observer(
             "write",
-            path,
             metadata=metadata,
             is_new=(meta is None),
             path=path,
@@ -2715,7 +2713,6 @@ class NexusFSCoreMixin:
         ]
         self._notify_observer(
             "write_batch",
-            f"batch({len(metadata_list)} files)",
             items=items,
             zone_id=zone_id,
             agent_id=agent_id,
@@ -2836,45 +2833,21 @@ class NexusFSCoreMixin:
 
         return results
 
-    def _notify_observer(self, operation: str, op_path: str, **kwargs: Any) -> None:
-        """Notify the write observer of a mutation, with unified error policy.
+    def _notify_observer(self, operation: str, **kwargs: Any) -> None:
+        """Notify the write observer of a mutation.
 
-        Replaces the inconsistent error handling where single writes used
-        audit_strict_mode but batch/delete/rename silently suppressed errors.
-
-        Issue #1246: All observer calls now follow the same policy:
-        - audit_strict_mode=True: raise AuditLogError on failure
-        - audit_strict_mode=False: log critical warning, continue
+        Pure caller — the observer owns its own error policy (Issue #55).
+        If the observer raises, the exception propagates to the caller.
 
         Args:
             operation: One of 'write', 'write_batch', 'delete', 'rename'.
-            op_path: Primary path affected (for error messages only).
             **kwargs: Passed directly to the observer method.
         """
         if not self._write_observer:
             return
 
-        try:
-            method = getattr(self._write_observer, f"on_{operation}")
-            method(**kwargs)
-        except Exception as e:
-            from nexus.core.exceptions import AuditLogError
-
-            if self._audit_strict_mode:
-                logger.error(
-                    f"AUDIT LOG FAILURE: {operation} on '{op_path}' ABORTED. "
-                    f"Error: {e}. Set audit_strict_mode=False to allow writes without audit logs."
-                )
-                raise AuditLogError(
-                    f"Operation aborted: audit logging failed for {operation}: {e}",
-                    path=op_path,
-                    original_error=e,
-                ) from e
-            else:
-                logger.critical(
-                    f"AUDIT LOG FAILURE: {operation} on '{op_path}' SUCCEEDED but audit log FAILED. "
-                    f"Error: {e}. This creates an audit trail gap!"
-                )
+        method = getattr(self._write_observer, f"on_{operation}")
+        method(**kwargs)
 
     def _auto_parse_file(self, path: str) -> None:
         """Auto-parse a file in the background (fire-and-forget).
@@ -3041,7 +3014,6 @@ class NexusFSCoreMixin:
         # Issue #1246: Unified error handling via _notify_observer.
         self._notify_observer(
             "delete",
-            path,
             path=path,
             zone_id=zone_id,
             agent_id=agent_id,
@@ -3304,7 +3276,6 @@ class NexusFSCoreMixin:
         # Issue #1246: Unified error handling via _notify_observer.
         self._notify_observer(
             "rename",
-            old_path,
             old_path=old_path,
             new_path=new_path,
             zone_id=zone_id,

--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -511,18 +511,22 @@ def _boot_kernel_services(ctx: _BootContext) -> dict[str, Any]:
                 use_buffer = ctx.db_url.startswith(("postgres", "postgresql"))
 
         if use_buffer:
-            from nexus.storage.record_store_syncer import BufferedRecordStoreSyncer
+            from nexus.storage.record_store_syncer import BufferedRecordStoreWriteObserver
 
             _st = ctx.profile_tuning.storage
-            write_observer = BufferedRecordStoreSyncer(
+            write_observer = BufferedRecordStoreWriteObserver(
                 ctx.session_factory,
+                strict_mode=ctx.perm.audit_strict_mode,
                 flush_interval_ms=_st.write_buffer_flush_ms,
                 max_buffer_size=_st.write_buffer_max_size,
             )
         else:
-            from nexus.storage.record_store_syncer import RecordStoreSyncer
+            from nexus.storage.record_store_syncer import RecordStoreWriteObserver
 
-            write_observer = RecordStoreSyncer(ctx.session_factory)
+            write_observer = RecordStoreWriteObserver(
+                ctx.session_factory,
+                strict_mode=ctx.perm.audit_strict_mode,
+            )
 
         # --- VersionService (Task #45) ---
         from nexus.services.version_service import VersionService
@@ -1018,14 +1022,14 @@ def _start_background_services(kernel: dict[str, Any], system: dict[str, Any]) -
         dpb.start()
         logger.debug("[BOOT:BG] DeferredPermissionBuffer started")
 
-    # Write Observer — only BufferedRecordStoreSyncer needs .start()
+    # Write Observer — only BufferedRecordStoreWriteObserver needs .start()
     wo = kernel.get("write_observer")
     if wo is not None and hasattr(wo, "start"):
-        from nexus.storage.record_store_syncer import BufferedRecordStoreSyncer
+        from nexus.storage.record_store_syncer import BufferedRecordStoreWriteObserver
 
-        if isinstance(wo, BufferedRecordStoreSyncer):
+        if isinstance(wo, BufferedRecordStoreWriteObserver):
             wo.start()
-            logger.debug("[BOOT:BG] BufferedRecordStoreSyncer started")
+            logger.debug("[BOOT:BG] BufferedRecordStoreWriteObserver started")
 
     # Event Delivery Worker (system tier)
     dw = system.get("delivery_worker")

--- a/src/nexus/storage/record_store_syncer.py
+++ b/src/nexus/storage/record_store_syncer.py
@@ -1,21 +1,21 @@
-"""RecordStore write-through syncer.
+"""RecordStore write observers — WriteObserverProtocol implementations.
 
 Bundles OperationLogger + VersionRecorder into a single injectable observer.
 Created by factory.py, injected into NexusFS kernel as write_observer.
 
 The kernel calls on_write()/on_delete() after Metastore mutations.
-This syncer handles all RecordStore side-effects in a single transaction.
+These observers handle all RecordStore side-effects in a single transaction.
 
 Two implementations:
-    RecordStoreSyncer         — synchronous, blocks hot path (~2-10ms per write)
-    BufferedRecordStoreSyncer — async via WriteBuffer (~0.1ms amortized)
+    RecordStoreWriteObserver         — synchronous, blocks hot path (~2-10ms)
+    BufferedRecordStoreWriteObserver — async via WriteBuffer (~0.1ms amortized)
 
 Architecture:
     Kernel → write_observer.on_write() → [OperationLogger + VersionRecorder]
     Kernel → write_observer.on_delete() → [OperationLogger + VersionRecorder]
-    Error policy owned by kernel (audit_strict_mode). Syncer just raises on failure.
+    Error policy owned by observer (strict_mode). Kernel is a pure caller.
 
-Issue #1246: BufferedRecordStoreSyncer implements Decision 13A (write-behind buffer).
+Issue #1246: BufferedRecordStoreWriteObserver implements Decision 13A (write-behind buffer).
 """
 
 from __future__ import annotations
@@ -31,15 +31,51 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class RecordStoreSyncer:
+class RecordStoreWriteObserver:
     """Syncs Metastore writes to RecordStore (OperationLog + VersionHistory).
 
-    Duck-typed write observer — kernel calls on_write/on_delete without
-    knowing or importing this class.
+    Implements WriteObserverProtocol. Kernel calls on_write/on_delete
+    without knowing or importing this class.
+
+    Error policy:
+        strict_mode=True  → raise AuditLogError on failure (P0 compliance)
+        strict_mode=False → log CRITICAL warning, continue (high-availability)
     """
 
-    def __init__(self, session_factory: Callable[..., Any]) -> None:
+    def __init__(
+        self,
+        session_factory: Callable[..., Any],
+        *,
+        strict_mode: bool = True,
+    ) -> None:
         self._session_factory = session_factory
+        self._strict_mode = strict_mode
+
+    def _handle_error(self, operation: str, path: str, error: Exception) -> None:
+        """Apply audit error policy: raise or log depending on strict_mode."""
+        from nexus.contracts.exceptions import AuditLogError
+
+        if self._strict_mode:
+            logger.error(
+                "AUDIT LOG FAILURE: %s on '%s' ABORTED. "
+                "Error: %s. Set audit_strict_mode=False to allow writes without audit logs.",
+                operation,
+                path,
+                error,
+            )
+            raise AuditLogError(
+                f"Operation aborted: audit logging failed for {operation}: {error}",
+                path=path,
+                original_error=error,
+            ) from error
+        else:
+            logger.critical(
+                "AUDIT LOG FAILURE: %s on '%s' SUCCEEDED but audit log FAILED. "
+                "Error: %s. This creates an audit trail gap!",
+                operation,
+                path,
+                error,
+            )
 
     def on_write(
         self,
@@ -52,25 +88,25 @@ class RecordStoreSyncer:
         snapshot_hash: str | None = None,
         metadata_snapshot: dict[str, Any] | None = None,
     ) -> None:
-        """Sync a write operation to RecordStore.
-
-        Raises on failure — caller (kernel) decides error policy.
-        """
+        """Sync a write operation to RecordStore."""
         from nexus.storage.operation_logger import OperationLogger
         from nexus.storage.version_recorder import VersionRecorder
 
-        with self._session_factory() as session:
-            OperationLogger(session).log_operation(
-                operation_type="write",
-                path=path,
-                zone_id=zone_id,
-                agent_id=agent_id,
-                snapshot_hash=snapshot_hash,
-                metadata_snapshot=metadata_snapshot,
-                status="success",
-            )
-            VersionRecorder(session).record_write(metadata, is_new=is_new)
-            session.commit()
+        try:
+            with self._session_factory() as session:
+                OperationLogger(session).log_operation(
+                    operation_type="write",
+                    path=path,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    snapshot_hash=snapshot_hash,
+                    metadata_snapshot=metadata_snapshot,
+                    status="success",
+                )
+                VersionRecorder(session).record_write(metadata, is_new=is_new)
+                session.commit()
+        except Exception as e:
+            self._handle_error("write", path, e)
 
     def on_write_batch(
         self,
@@ -87,22 +123,26 @@ class RecordStoreSyncer:
         from nexus.storage.operation_logger import OperationLogger
         from nexus.storage.version_recorder import VersionRecorder
 
-        with self._session_factory() as session:
-            op_logger = OperationLogger(session)
-            recorder = VersionRecorder(session)
-            for metadata, is_new in items:
-                op_logger.log_operation(
-                    operation_type="write",
-                    path=metadata.path,
-                    zone_id=zone_id,
-                    agent_id=agent_id,
-                    snapshot_hash=metadata.etag,
-                    metadata_snapshot=None,
-                    status="success",
-                    flush=False,  # Defer flush — commit handles it
-                )
-                recorder.record_write(metadata, is_new=is_new)
-            session.commit()
+        try:
+            with self._session_factory() as session:
+                op_logger = OperationLogger(session)
+                recorder = VersionRecorder(session)
+                for metadata, is_new in items:
+                    op_logger.log_operation(
+                        operation_type="write",
+                        path=metadata.path,
+                        zone_id=zone_id,
+                        agent_id=agent_id,
+                        snapshot_hash=metadata.etag,
+                        metadata_snapshot=None,
+                        status="success",
+                        flush=False,  # Defer flush — commit handles it
+                    )
+                    recorder.record_write(metadata, is_new=is_new)
+                session.commit()
+        except Exception as e:
+            first_path = items[0][0].path if items else "<batch>"
+            self._handle_error("write_batch", first_path, e)
 
     def on_rename(
         self,
@@ -114,24 +154,24 @@ class RecordStoreSyncer:
         snapshot_hash: str | None = None,
         metadata_snapshot: dict[str, Any] | None = None,
     ) -> None:
-        """Sync a rename operation to RecordStore.
-
-        Raises on failure — caller (kernel) decides error policy.
-        """
+        """Sync a rename operation to RecordStore."""
         from nexus.storage.operation_logger import OperationLogger
 
-        with self._session_factory() as session:
-            OperationLogger(session).log_operation(
-                operation_type="rename",
-                path=old_path,
-                new_path=new_path,
-                zone_id=zone_id,
-                agent_id=agent_id,
-                snapshot_hash=snapshot_hash,
-                metadata_snapshot=metadata_snapshot,
-                status="success",
-            )
-            session.commit()
+        try:
+            with self._session_factory() as session:
+                OperationLogger(session).log_operation(
+                    operation_type="rename",
+                    path=old_path,
+                    new_path=new_path,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    snapshot_hash=snapshot_hash,
+                    metadata_snapshot=metadata_snapshot,
+                    status="success",
+                )
+                session.commit()
+        except Exception as e:
+            self._handle_error("rename", old_path, e)
 
     def on_delete(
         self,
@@ -142,33 +182,37 @@ class RecordStoreSyncer:
         snapshot_hash: str | None = None,
         metadata_snapshot: dict[str, Any] | None = None,
     ) -> None:
-        """Sync a delete operation to RecordStore.
-
-        Raises on failure — caller (kernel) decides error policy.
-        """
+        """Sync a delete operation to RecordStore."""
         from nexus.storage.operation_logger import OperationLogger
         from nexus.storage.version_recorder import VersionRecorder
 
-        with self._session_factory() as session:
-            OperationLogger(session).log_operation(
-                operation_type="delete",
-                path=path,
-                zone_id=zone_id,
-                agent_id=agent_id,
-                snapshot_hash=snapshot_hash,
-                metadata_snapshot=metadata_snapshot,
-                status="success",
-            )
-            VersionRecorder(session).record_delete(path)
-            session.commit()
+        try:
+            with self._session_factory() as session:
+                OperationLogger(session).log_operation(
+                    operation_type="delete",
+                    path=path,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    snapshot_hash=snapshot_hash,
+                    metadata_snapshot=metadata_snapshot,
+                    status="success",
+                )
+                VersionRecorder(session).record_delete(path)
+                session.commit()
+        except Exception as e:
+            self._handle_error("delete", path, e)
 
 
-class BufferedRecordStoreSyncer:
+class BufferedRecordStoreWriteObserver:
     """Async write observer backed by WriteBuffer (Issue #1246, Decision 13A).
 
-    Same duck-typed interface as RecordStoreSyncer, but enqueues events
-    into a WriteBuffer instead of writing synchronously. Hot path returns
-    immediately (~0.1ms amortized vs ~2-10ms synchronous).
+    Same WriteObserverProtocol interface as RecordStoreWriteObserver, but
+    enqueues events into a WriteBuffer instead of writing synchronously.
+    Hot path returns immediately (~0.1ms amortized vs ~2-10ms synchronous).
+
+    Error policy: strict_mode is stored for API consistency. Since enqueue
+    never fails, the error policy applies only to background flush failures
+    handled by WriteBuffer (retry + drop with logging).
 
     Must call start() before use and stop() on shutdown.
     """
@@ -177,12 +221,14 @@ class BufferedRecordStoreSyncer:
         self,
         session_factory: Callable[..., Any],
         *,
+        strict_mode: bool = True,
         flush_interval_ms: int = 100,
         max_buffer_size: int = 100,
         max_retries: int = 3,
     ) -> None:
         from nexus.storage.write_buffer import WriteBuffer
 
+        self._strict_mode = strict_mode
         self._buffer = WriteBuffer(
             session_factory,
             flush_interval_ms=flush_interval_ms,

--- a/tests/benchmarks/bench_write_buffer_pg.py
+++ b/tests/benchmarks/bench_write_buffer_pg.py
@@ -1,4 +1,4 @@
-"""Benchmark: WriteBuffer vs sync RecordStoreSyncer on real PostgreSQL.
+"""Benchmark: WriteBuffer vs sync RecordStoreWriteObserver on real PostgreSQL.
 
 Issue #1246 — Verify that the WriteBuffer actually delivers latency savings
 when writing to PostgreSQL (network I/O is the bottleneck, not SQLite).
@@ -84,14 +84,14 @@ class FakeMetadata:
         self.owner_id = None
 
 
-# ── Benchmark: Synchronous RecordStoreSyncer ────────────────────────────
+# ── Benchmark: Synchronous RecordStoreWriteObserver ──────────────────────
 
 
 def bench_sync(engine, session_factory, n: int) -> dict:
     """Benchmark sync writes (one DB round-trip per write)."""
-    from nexus.storage.record_store_syncer import RecordStoreSyncer
+    from nexus.storage.record_store_syncer import RecordStoreWriteObserver
 
-    syncer = RecordStoreSyncer(session_factory)
+    syncer = RecordStoreWriteObserver(session_factory)
 
     latencies = []
     for i in range(n):
@@ -129,9 +129,9 @@ def bench_buffered(
     engine, session_factory, n: int, flush_interval_ms: int = 50, max_buffer_size: int = 50
 ) -> dict:
     """Benchmark buffered writes (hot path = enqueue only, flush in background)."""
-    from nexus.storage.record_store_syncer import BufferedRecordStoreSyncer
+    from nexus.storage.record_store_syncer import BufferedRecordStoreWriteObserver
 
-    syncer = BufferedRecordStoreSyncer(
+    syncer = BufferedRecordStoreWriteObserver(
         session_factory,
         flush_interval_ms=flush_interval_ms,
         max_buffer_size=max_buffer_size,

--- a/tests/e2e/nats/test_nats_event_bus_e2e.py
+++ b/tests/e2e/nats/test_nats_event_bus_e2e.py
@@ -163,10 +163,6 @@ def server_app():
 
     assert isinstance(nexus_fs, NexusFS)
 
-    # Disable audit strict mode — SQLite embedded mode lacks operation_log table.
-    # We're testing the NATS event bus, not audit logging.
-    nexus_fs._audit_strict_mode = False
-
     # Verify event bus is NATS
     from nexus.services.event_bus.nats import NatsEventBus
 

--- a/tests/e2e/self_contained/test_dual_write_consistency.py
+++ b/tests/e2e/self_contained/test_dual_write_consistency.py
@@ -58,11 +58,11 @@ def nx(temp_dir: Path, record_store: SQLAlchemyRecordStore) -> Generator[NexusFS
     raft_store = _try_create_raft_store(str(temp_dir / "raft-metadata"))
     if raft_store is None:
         # Fallback to InMemoryMetastore with factory-style wiring
-        from nexus.storage.record_store_syncer import RecordStoreSyncer
+        from nexus.storage.record_store_syncer import RecordStoreWriteObserver
         from tests.helpers.in_memory_metadata_store import InMemoryMetastore
 
         metadata_store = InMemoryMetastore()
-        write_observer = RecordStoreSyncer(record_store.session_factory)
+        write_observer = RecordStoreWriteObserver(record_store.session_factory)
 
         nx = NexusFS(
             backend=LocalBackend(str(temp_dir / "data")),

--- a/tests/e2e/self_contained/test_transactional_event_log.py
+++ b/tests/e2e/self_contained/test_transactional_event_log.py
@@ -1,7 +1,7 @@
 """Integration test for Transactional Event Log (Issue #1241).
 
 End-to-end flow:
-1. Write file via RecordStoreSyncer → verify operation_log has delivered=FALSE
+1. Write file via RecordStoreWriteObserver → verify operation_log has delivered=FALSE
 2. Run EventDeliveryWorker → verify event dispatched to mock EventBus
 3. Verify delivered=TRUE after dispatch
 4. Verify retry on dispatch failure
@@ -22,7 +22,7 @@ from nexus.core.event_bus import FileEventType
 from nexus.core.metadata import FileMetadata
 from nexus.storage.models import OperationLogModel
 from nexus.storage.record_store import SQLAlchemyRecordStore
-from nexus.storage.record_store_syncer import RecordStoreSyncer
+from nexus.storage.record_store_syncer import RecordStoreWriteObserver
 
 
 @pytest.fixture
@@ -39,8 +39,8 @@ def record_store(temp_dir: Path) -> Generator[SQLAlchemyRecordStore, None, None]
 
 
 @pytest.fixture
-def syncer(record_store: SQLAlchemyRecordStore) -> RecordStoreSyncer:
-    return RecordStoreSyncer(record_store.session_factory)
+def syncer(record_store: SQLAlchemyRecordStore) -> RecordStoreWriteObserver:
+    return RecordStoreWriteObserver(record_store.session_factory)
 
 
 def _make_metadata(
@@ -71,7 +71,7 @@ class TestTransactionalOutboxIntegration:
 
     def test_write_creates_undelivered_then_worker_delivers(
         self,
-        syncer: RecordStoreSyncer,
+        syncer: RecordStoreWriteObserver,
         record_store: SQLAlchemyRecordStore,
     ) -> None:
         """Write via syncer → start worker → verify delivery."""
@@ -126,7 +126,7 @@ class TestTransactionalOutboxIntegration:
 
     def test_multiple_operations_delivered_in_order(
         self,
-        syncer: RecordStoreSyncer,
+        syncer: RecordStoreWriteObserver,
         record_store: SQLAlchemyRecordStore,
     ) -> None:
         """Multiple writes + delete → all delivered in created_at order."""
@@ -187,7 +187,7 @@ class TestTransactionalOutboxIntegration:
 
     def test_crash_recovery_retries_undelivered(
         self,
-        syncer: RecordStoreSyncer,
+        syncer: RecordStoreWriteObserver,
         record_store: SQLAlchemyRecordStore,
     ) -> None:
         """Simulate crash: dispatch fails → restart → events retried."""
@@ -225,7 +225,7 @@ class TestTransactionalOutboxIntegration:
 
     def test_worker_background_delivery(
         self,
-        syncer: RecordStoreSyncer,
+        syncer: RecordStoreWriteObserver,
         record_store: SQLAlchemyRecordStore,
     ) -> None:
         """Worker running in background picks up events automatically."""

--- a/tests/unit/storage/test_record_store_syncer.py
+++ b/tests/unit/storage/test_record_store_syncer.py
@@ -1,4 +1,4 @@
-"""Unit tests for RecordStoreSyncer — the bridge between Metastore and RecordStore.
+"""Unit tests for RecordStoreWriteObserver — the bridge between Metastore and RecordStore.
 
 Tests happy paths, SQL failure injection, partial failures, and session exhaustion.
 Phase 1.1 of #1246/#1330 consolidation plan.
@@ -18,7 +18,7 @@ from sqlalchemy.exc import OperationalError
 from nexus.core.metadata import FileMetadata
 from nexus.storage.models import FilePathModel, OperationLogModel, VersionHistoryModel
 from nexus.storage.record_store import SQLAlchemyRecordStore
-from nexus.storage.record_store_syncer import RecordStoreSyncer
+from nexus.storage.record_store_syncer import RecordStoreWriteObserver
 
 
 @pytest.fixture
@@ -35,8 +35,8 @@ def record_store(temp_dir: Path) -> Generator[SQLAlchemyRecordStore, None, None]
 
 
 @pytest.fixture
-def syncer(record_store: SQLAlchemyRecordStore) -> RecordStoreSyncer:
-    return RecordStoreSyncer(record_store.session_factory)
+def syncer(record_store: SQLAlchemyRecordStore) -> RecordStoreWriteObserver:
+    return RecordStoreWriteObserver(record_store.session_factory)
 
 
 def _make_metadata(
@@ -74,7 +74,7 @@ class TestOnWriteHappyPath:
     """Test on_write() creates OperationLog + FilePathModel + VersionHistory."""
 
     def test_new_file_creates_all_records(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         metadata = _make_metadata("/new.txt", etag="hash1")
         syncer.on_write(metadata, is_new=True, path="/new.txt", zone_id="root")
@@ -97,7 +97,7 @@ class TestOnWriteHappyPath:
             assert vhs[0].content_hash == "hash1"
 
     def test_update_file_increments_version(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         # Create initial file
         m1 = _make_metadata("/file.txt", etag="v1hash")
@@ -138,7 +138,7 @@ class TestOnDeleteHappyPath:
     """Test on_delete() soft-deletes FilePathModel."""
 
     def test_delete_soft_deletes(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         # Create file first
         m = _make_metadata("/del.txt", etag="delhash")
@@ -169,7 +169,7 @@ class TestOnDeleteHappyPath:
             assert len(ops) == 1
 
     def test_delete_nonexistent_is_noop(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         """Deleting a file that doesn't exist in RecordStore should not raise."""
         syncer.on_delete(path="/nonexistent.txt", zone_id="root")
@@ -189,7 +189,7 @@ class TestOnRenameHappyPath:
     """Test on_rename() logs the rename operation."""
 
     def test_rename_logged(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         syncer.on_rename(
             old_path="/old.txt",
@@ -210,7 +210,7 @@ class TestOnWriteBatchHappyPath:
     """Test on_write_batch() handles multiple items in one transaction."""
 
     def test_batch_creates_all_records(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         items = [
             (_make_metadata("/a.txt", etag="ha"), True),
@@ -246,11 +246,11 @@ class TestSQLFailure:
         def failing_session_factory():
             return mock_session
 
-        # RecordStoreSyncer uses context manager protocol
+        # RecordStoreWriteObserver uses context manager protocol
         mock_session.__enter__ = MagicMock(return_value=mock_session)
         mock_session.__exit__ = MagicMock(return_value=False)
 
-        syncer = RecordStoreSyncer(failing_session_factory)
+        syncer = RecordStoreWriteObserver(failing_session_factory)
         metadata = _make_metadata()
 
         with pytest.raises(OperationalError):
@@ -262,7 +262,7 @@ class TestSQLFailure:
         mock_session.__enter__ = MagicMock(return_value=mock_session)
         mock_session.__exit__ = MagicMock(return_value=False)
 
-        syncer = RecordStoreSyncer(lambda: mock_session)
+        syncer = RecordStoreWriteObserver(lambda: mock_session)
 
         with pytest.raises(OperationalError):
             syncer.on_delete(path="/test.txt")
@@ -275,7 +275,7 @@ class TestPartialFailure:
         self, record_store: SQLAlchemyRecordStore
     ) -> None:
         """If VersionRecorder raises, the entire transaction should fail."""
-        syncer = RecordStoreSyncer(record_store.session_factory)
+        syncer = RecordStoreWriteObserver(record_store.session_factory)
         metadata = _make_metadata()
 
         with (
@@ -299,7 +299,7 @@ class TestPartialFailure:
         self, record_store: SQLAlchemyRecordStore
     ) -> None:
         """If OperationLogger raises, nothing should be committed."""
-        syncer = RecordStoreSyncer(record_store.session_factory)
+        syncer = RecordStoreWriteObserver(record_store.session_factory)
         metadata = _make_metadata()
 
         with (
@@ -328,7 +328,7 @@ class TestSessionFactoryFailure:
         def failing_factory():
             raise ConnectionError("database unavailable")
 
-        syncer = RecordStoreSyncer(failing_factory)
+        syncer = RecordStoreWriteObserver(failing_factory)
         metadata = _make_metadata()
 
         with pytest.raises(ConnectionError, match="database unavailable"):
@@ -340,7 +340,7 @@ class TestBatchPartialFailure:
 
     def test_batch_failure_rolls_back_all(self, record_store: SQLAlchemyRecordStore) -> None:
         """If batch write fails partway through, no items should be committed."""
-        syncer = RecordStoreSyncer(record_store.session_factory)
+        syncer = RecordStoreWriteObserver(record_store.session_factory)
 
         items = [
             (_make_metadata("/a.txt", etag="ha"), True),
@@ -382,7 +382,7 @@ class TestDeliveredColumn:
     """Verify that all syncer operations create records with delivered=FALSE."""
 
     def test_on_write_sets_delivered_false(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         """on_write() should create operation_log with delivered=FALSE."""
         metadata = _make_metadata("/outbox.txt", etag="ohash")
@@ -394,7 +394,7 @@ class TestDeliveredColumn:
             assert ops[0].delivered is False
 
     def test_on_delete_sets_delivered_false(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         """on_delete() should create operation_log with delivered=FALSE."""
         syncer.on_delete(path="/del-outbox.txt", zone_id="root")
@@ -409,7 +409,7 @@ class TestDeliveredColumn:
             assert ops[0].delivered is False
 
     def test_on_rename_sets_delivered_false(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         """on_rename() should create operation_log with delivered=FALSE."""
         syncer.on_rename(old_path="/old.txt", new_path="/new.txt", zone_id="root")
@@ -420,7 +420,7 @@ class TestDeliveredColumn:
             assert ops[0].delivered is False
 
     def test_on_write_batch_sets_delivered_false(
-        self, syncer: RecordStoreSyncer, record_store: SQLAlchemyRecordStore
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
     ) -> None:
         """on_write_batch() should create all records with delivered=FALSE."""
         items = [

--- a/tests/unit/storage/test_write_path_failures.py
+++ b/tests/unit/storage/test_write_path_failures.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import sessionmaker
 
 from nexus.core.metadata import DT_DIR, DT_REG, FileMetadata
 from nexus.storage.models import Base, FilePathModel
-from nexus.storage.record_store_syncer import RecordStoreSyncer
+from nexus.storage.record_store_syncer import RecordStoreWriteObserver
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -77,16 +77,16 @@ def session_factory(engine):
 
 
 # ---------------------------------------------------------------------------
-# Test: RecordStoreSyncer raises on failure (caller decides policy)
+# Test: RecordStoreWriteObserver raises on failure (caller decides policy)
 # ---------------------------------------------------------------------------
 
 
 class TestSyncerRaisesOnFailure:
-    """RecordStoreSyncer should raise exceptions — caller (kernel) decides policy."""
+    """RecordStoreWriteObserver should raise exceptions — caller (kernel) decides policy."""
 
     def test_on_write_propagates_db_error(self, session_factory) -> None:
         """Database errors in on_write should propagate to caller."""
-        syncer = RecordStoreSyncer(session_factory=session_factory)
+        syncer = RecordStoreWriteObserver(session_factory=session_factory)
 
         with (
             patch(
@@ -103,7 +103,7 @@ class TestSyncerRaisesOnFailure:
 
     def test_on_write_propagates_version_recorder_error(self, session_factory) -> None:
         """VersionRecorder errors in on_write should propagate to caller."""
-        syncer = RecordStoreSyncer(session_factory=session_factory)
+        syncer = RecordStoreWriteObserver(session_factory=session_factory)
 
         with (
             patch(
@@ -120,7 +120,7 @@ class TestSyncerRaisesOnFailure:
 
     def test_on_delete_propagates_error(self, session_factory) -> None:
         """Errors in on_delete should propagate to caller."""
-        syncer = RecordStoreSyncer(session_factory=session_factory)
+        syncer = RecordStoreWriteObserver(session_factory=session_factory)
 
         with (
             patch(

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -151,8 +151,8 @@ class TestBootKernelServices:
         ctx = _make_mock_ctx(enable_write_buffer=False)
         result = _boot_kernel_services(ctx)
         wo = result["write_observer"]
-        # RecordStoreSyncer doesn't have .start() called in kernel boot
-        # (only BufferedRecordStoreSyncer does, and only in _start_background_services)
+        # RecordStoreWriteObserver doesn't have .start() called in kernel boot
+        # (only BufferedRecordStoreWriteObserver does, and only in _start_background_services)
         assert wo is not None
 
     def test_deferred_buffer_created_when_enabled(self) -> None:
@@ -313,9 +313,9 @@ class TestStartBackgroundServices:
 
     def test_buffered_syncer_started(self) -> None:
         from nexus.factory import _start_background_services
-        from nexus.storage.record_store_syncer import BufferedRecordStoreSyncer
+        from nexus.storage.record_store_syncer import BufferedRecordStoreWriteObserver
 
-        wo = MagicMock(spec=BufferedRecordStoreSyncer)
+        wo = MagicMock(spec=BufferedRecordStoreWriteObserver)
         kernel = {"deferred_permission_buffer": None, "write_observer": wo}
         system = {"delivery_worker": None}
         _start_background_services(kernel, system)


### PR DESCRIPTION
## Summary
- Define `WriteObserverProtocol` in `contracts/write_observer.py` — shared interface for all write observers
- Move `_audit_strict_mode` error policy from kernel's `_notify_observer()` into the observer implementations (`RecordStoreWriteObserver` / `BufferedRecordStoreWriteObserver`)
- Rename `RecordStoreSyncer` → `RecordStoreWriteObserver`, `BufferedRecordStoreSyncer` → `BufferedRecordStoreWriteObserver`
- Kernel's `_notify_observer()` simplified to a pure dispatch method — no more try/catch or error policy logic

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, ruff format, end-of-file-fixer)
- [ ] Unit tests updated for new class names
- [ ] E2E tests updated (removed stale `_audit_strict_mode` assignments)
- [ ] CI green

Related: #2152

🤖 Generated with [Claude Code](https://claude.com/claude-code)