### PR TITLE
feat(#808): replace _workflow_queue with DT_PIPE kernel IPC

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -294,6 +294,11 @@ class NexusFS(  # type: ignore[misc]
         self._snapshot_service = brk_svc.snapshot_service
         self._api_key_creator = brk_svc.api_key_creator
 
+        # DT_PIPE: Kernel pipe manager for IPC ring buffers (Task #808)
+        from nexus.core.pipe_manager import PipeManager
+
+        self._pipe_manager = PipeManager(self.metadata, zone_id=ROOT_ZONE_ID)
+
         # Initialize OAuth token manager (lazy initialization in mixin)
         self._token_manager = None
 
@@ -10848,6 +10853,10 @@ class NexusFS(  # type: ignore[misc]
                 self._memory_api.session.close()
             except Exception as e:
                 logger.debug("Failed to close memory API session: %s", e)
+
+        # Close all kernel pipes (DT_PIPE cleanup, Task #808)
+        if hasattr(self, "_pipe_manager"):
+            self._pipe_manager.close_all()
 
         # Close metadata store after all parsers have finished
         self.metadata.close()

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -70,6 +70,9 @@ class NexusFSCoreMixin:
         _overlay_resolver: Any  # Issue #1264: OverlayResolver service
         _workspace_registry: Any  # Workspace registry for overlay config lookup
         _write_observer: WriteObserverProtocol | None  # Issue #55
+        _pipe_manager: Any  # PipeManager (set by NexusFS.__init__)
+        _workflow_pipe_ready: bool
+        _workflow_consumer_task: asyncio.Task[None] | None
 
         @property
         def zone_id(self) -> str | None: ...
@@ -226,6 +229,10 @@ class NexusFSCoreMixin:
         except Exception as e:
             logger.warning(f"Failed to create {event_type} event: {e}")
 
+    # DT_PIPE workflow event pipe path and capacity (Task #808)
+    _WORKFLOW_PIPE_PATH = "/nexus/pipes/workflow-events"
+    _WORKFLOW_PIPE_CAPACITY = 65_536  # 64KB
+
     def _fire_workflow_event(
         self,
         trigger_type: str,
@@ -237,6 +244,9 @@ class NexusFSCoreMixin:
         Consolidates the repeated async-or-thread pattern from write/delete/rename.
         Does nothing if workflows are not enabled.
 
+        DT_PIPE path (Task #808): writes to PipeManager by VFS path.
+        User-space code never touches the RingBuffer directly.
+
         Args:
             trigger_type: String trigger type (e.g. "file_write", "file_delete").
             event_context: Event payload dict.
@@ -245,15 +255,20 @@ class NexusFSCoreMixin:
         if not (self.enable_workflows and self.workflow_engine):  # type: ignore[attr-defined]
             return
 
-        # Bounded queue: try to enqueue, drop on overflow
-        queue = getattr(self, "_workflow_queue", None)
-        if queue is not None:
+        # DT_PIPE: write workflow event to kernel pipe via PipeManager (#808)
+        import json
+
+        from nexus.core.pipe import PipeFullError
+
+        pipe_mgr = getattr(self, "_pipe_manager", None)
+        if pipe_mgr is not None and getattr(self, "_workflow_pipe_ready", False):
             try:
-                queue.put_nowait((trigger_type, event_context))
-            except Exception:
-                logger.warning("Workflow event queue full, dropping event: %s", label)
+                data = json.dumps({"type": trigger_type, "ctx": event_context}).encode()
+                pipe_mgr.pipe_write_nowait(self._WORKFLOW_PIPE_PATH, data)
+            except PipeFullError:
+                logger.warning("Workflow pipe full, dropping event: %s", label)
         else:
-            # Fallback: fire-and-forget (no queue — CLI or pre-startup)
+            # Fallback: fire-and-forget (CLI mode or pre-startup, no pipe yet)
             from nexus.core.sync_bridge import fire_and_forget
 
             fire_and_forget(
@@ -273,25 +288,54 @@ class NexusFSCoreMixin:
             )
 
     async def _start_workflow_consumer(self) -> None:
-        """Background consumer for bounded workflow event queue (#1522)."""
-        queue = self._workflow_queue  # type: ignore[attr-defined]
+        """Background consumer for workflow events via DT_PIPE (#808).
+
+        Reads from PipeManager by VFS path (user-space API).
+        Deserializes JSON messages and fires workflow engine events.
+        """
+        import json
+
+        from nexus.core.pipe import PipeClosedError, PipeNotFoundError
+
+        pipe_mgr = self._pipe_manager
         engine = self.workflow_engine  # type: ignore[attr-defined]
         while True:
-            trigger_type, event_context = await queue.get()
             try:
-                await engine.fire_event(trigger_type, event_context)
+                data = await pipe_mgr.pipe_read(self._WORKFLOW_PIPE_PATH)
+            except (PipeClosedError, PipeNotFoundError):
+                # PipeClosedError: buffer exists but closed (concurrent shutdown)
+                # PipeNotFoundError: buffer removed (close_all during shutdown)
+                logger.debug("Workflow pipe closed, consumer exiting")
+                break
+            try:
+                msg = json.loads(data)
+                await engine.fire_event(msg["type"], msg["ctx"])
             except Exception as e:
                 logger.error("Workflow event processing failed: %s", e)
-            finally:
-                queue.task_done()
 
     def ensure_workflow_consumer(self) -> None:
-        """Start the workflow consumer task if not already running."""
-        if (
-            getattr(self, "_workflow_queue", None) is None
-            or getattr(self, "_workflow_consumer_task", None) is not None
-        ):
+        """Create workflow pipe via PipeManager and start consumer task (#808)."""
+        if getattr(self, "_workflow_pipe_ready", False):
             return
+
+        pipe_mgr = getattr(self, "_pipe_manager", None)
+        if pipe_mgr is None:
+            return  # CLI mode — no pipe manager
+
+        from nexus.core.pipe import PipeError
+
+        try:
+            pipe_mgr.create(
+                self._WORKFLOW_PIPE_PATH,
+                capacity=self._WORKFLOW_PIPE_CAPACITY,
+                owner_id="kernel",
+            )
+        except PipeError:
+            # Pipe already exists (e.g., restart recovery) — open it
+            pipe_mgr.open(self._WORKFLOW_PIPE_PATH, capacity=self._WORKFLOW_PIPE_CAPACITY)
+
+        self._workflow_pipe_ready = True
+
         try:
             loop = asyncio.get_running_loop()
             self._workflow_consumer_task = loop.create_task(  # type: ignore[attr-defined]

--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -1,4 +1,4 @@
-"""DT_PIPE kernel IPC primitive — SPSC message-oriented ring buffer.
+"""DT_PIPE kernel IPC primitive — SPSC message-oriented ring buffer (kfifo).
 
 Implements the Kernel messaging tier from KERNEL-ARCHITECTURE.md §6:
 
@@ -6,10 +6,11 @@ Implements the Kernel messaging tier from KERNEL-ARCHITECTURE.md §6:
     |------------|------------------|------------------------------------|---------|
     | **Kernel** | kfifo ring buffer| Nexus Native Pipe (DT_PIPE)        | ~5μs    |
 
-Two layers, mirroring Linux:
+This file contains the kernel-internal ring buffer (kfifo equivalent).
+For VFS-visible named pipes (mkfifo/fs/pipe.c equivalent), see pipe_manager.py.
 
-    RingBuffer  = kfifo equivalent (kernel-internal, no VFS path, any code can use directly)
-    PipeManager = mkfifo equivalent (VFS-visible named pipe, inode in MetastoreABC)
+    pipe.py         = kfifo     (include/linux/kfifo.h + lib/kfifo.c)
+    pipe_manager.py = fs/pipe.c (VFS named pipe with per-pipe lock for MPMC)
 
 Storage model (KERNEL-ARCHITECTURE.md line 228):
     - Pipe **inode** (FileMetadata, entry_type=DT_PIPE) → MetastoreABC
@@ -29,10 +30,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import deque
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from nexus.core.metastore import MetastoreABC
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +70,8 @@ class RingBuffer:
     visibility. Any kernel code or in-process service can instantiate one
     directly for fast async signaling.
 
-    For VFS-visible named pipes (mkfifo equivalent), use PipeManager.
+    For VFS-visible named pipes (mkfifo equivalent), use PipeManager
+    from pipe_manager.py.
 
     Design choices:
       - Message-oriented (deque of discrete bytes), not byte-stream.
@@ -189,6 +187,65 @@ class RingBuffer:
 
         return msg
 
+    def write_nowait(self, data: bytes) -> int:
+        """Synchronous non-blocking write. Raises PipeFullError if full.
+
+        Same logic as write(blocking=False) but callable from sync code.
+        Used by PipeManager.pipe_write_nowait() for sync producers.
+        """
+        if self._closed:
+            raise PipeClosedError("write to closed pipe")
+        if not data:
+            return 0
+        msg_len = len(data)
+        if msg_len > self._capacity:
+            raise ValueError(f"message size {msg_len} exceeds buffer capacity {self._capacity}")
+        if self._size + msg_len > self._capacity:
+            raise PipeFullError(f"buffer full ({self._size}/{self._capacity} bytes)")
+        self._buf.append(data)
+        self._size += msg_len
+        self._not_empty.set()
+        if self._size >= self._capacity:
+            self._not_full.clear()
+        return msg_len
+
+    def read_nowait(self) -> bytes:
+        """Synchronous non-blocking read. Raises PipeEmptyError if empty.
+
+        Same logic as read(blocking=False) but callable from sync code.
+        Used by PipeManager.pipe_read() under lock for MPMC safety.
+        """
+        if not self._buf:
+            if self._closed:
+                raise PipeClosedError("read from closed empty pipe")
+            raise PipeEmptyError("buffer empty")
+        msg = self._buf.popleft()
+        self._size -= len(msg)
+        self._not_full.set()
+        if not self._buf:
+            self._not_empty.clear()
+        return msg
+
+    async def wait_writable(self) -> None:
+        """Wait until buffer has space or is closed.
+
+        Public interface to internal Event state. Used by PipeManager
+        for lock→try→unlock→wait→retry pattern (avoids exposing _not_full).
+        """
+        while self._size >= self._capacity and not self._closed:
+            self._not_full.clear()
+            await self._not_full.wait()
+
+    async def wait_readable(self) -> None:
+        """Wait until buffer has data or is closed.
+
+        Public interface to internal Event state. Used by PipeManager
+        for lock→try→unlock→wait→retry pattern (avoids exposing _not_empty).
+        """
+        while not self._buf and not self._closed:
+            self._not_empty.clear()
+            await self._not_empty.wait()
+
     def peek(self) -> bytes | None:
         """Non-consuming peek at the next message. Returns None if empty."""
         return self._buf[0] if self._buf else None
@@ -221,184 +278,3 @@ class RingBuffer:
             "msg_count": len(self._buf),
             "closed": self._closed,
         }
-
-
-# ---------------------------------------------------------------------------
-# PipeManager — mkfifo equivalent (VFS-visible named pipes)
-# ---------------------------------------------------------------------------
-
-
-class PipeManager:
-    """Manages DT_PIPE lifecycle and buffer registry.
-
-    Analogous to mkfifo: creates named pipes visible in the VFS namespace.
-    Each pipe has a FileMetadata inode in MetastoreABC (entry_type=DT_PIPE)
-    and a RingBuffer in process memory.
-
-    The inode provides:
-      - VFS path (/nexus/pipes/{name}) for agent access via FUSE/MCP
-      - ReBAC access control (owner_id, permission checks)
-      - Observability (list all pipes, inspect stats)
-
-    The ring buffer data is NOT in any storage pillar — it's process heap
-    memory, like Linux kfifo data in kmalloc'd kernel heap.
-    """
-
-    def __init__(self, metastore: MetastoreABC, zone_id: str = "root") -> None:
-        self._metastore = metastore
-        self._zone_id = zone_id
-        self._buffers: dict[str, RingBuffer] = {}
-
-    def create(
-        self,
-        path: str,
-        *,
-        capacity: int = 65_536,
-        owner_id: str | None = None,
-    ) -> RingBuffer:
-        """Create a new named pipe at the given VFS path.
-
-        Creates a DT_PIPE inode in MetastoreABC and a RingBuffer in memory.
-
-        Args:
-            path: VFS path (e.g., "/nexus/pipes/my-pipe"). Must start with "/".
-            capacity: Ring buffer byte capacity. Default 64KB.
-            owner_id: Owner for ReBAC permission checks.
-
-        Returns:
-            The created RingBuffer.
-
-        Raises:
-            PipeError: Pipe already exists at this path.
-        """
-        from nexus.core.metadata import DT_PIPE, FileMetadata
-
-        if path in self._buffers:
-            raise PipeError(f"pipe already exists: {path}")
-
-        # Check if inode already exists in metastore
-        existing = self._metastore.get(path)
-        if existing is not None:
-            raise PipeError(f"path already exists: {path}")
-
-        # Create DT_PIPE inode in MetastoreABC
-        metadata = FileMetadata(
-            path=path,
-            backend_name="pipe",
-            physical_path="mem://",
-            size=capacity,
-            entry_type=DT_PIPE,
-            zone_id=self._zone_id,
-            owner_id=owner_id,
-        )
-        self._metastore.put(metadata)
-
-        # Create in-memory ring buffer
-        buf = RingBuffer(capacity=capacity)
-        self._buffers[path] = buf
-
-        logger.debug("pipe created: %s (capacity=%d)", path, capacity)
-        return buf
-
-    def open(self, path: str, *, capacity: int = 65_536) -> RingBuffer:
-        """Open an existing pipe, or recover its buffer after restart.
-
-        If the buffer is already in memory, returns it. If a DT_PIPE inode
-        exists but the buffer was lost (process restart), creates a new
-        buffer for the existing inode.
-
-        Args:
-            path: VFS path of the pipe.
-            capacity: Buffer capacity (used only if recreating after restart).
-
-        Returns:
-            The RingBuffer for this pipe.
-
-        Raises:
-            PipeNotFoundError: No pipe inode at this path.
-        """
-        from nexus.core.metadata import DT_PIPE
-
-        # Return existing buffer if available
-        if path in self._buffers and not self._buffers[path].closed:
-            return self._buffers[path]
-
-        # Check metastore for inode
-        metadata = self._metastore.get(path)
-        if metadata is None or metadata.entry_type != DT_PIPE:
-            raise PipeNotFoundError(f"no pipe at: {path}")
-
-        # Recreate buffer (restart recovery)
-        buf = RingBuffer(capacity=capacity)
-        self._buffers[path] = buf
-
-        logger.debug("pipe opened (recovered): %s", path)
-        return buf
-
-    def close(self, path: str) -> None:
-        """Close a pipe's buffer. Inode stays in MetastoreABC.
-
-        Readers can still drain remaining messages. The inode persists
-        so the pipe can be reopened later.
-
-        Raises:
-            PipeNotFoundError: No buffer at this path.
-        """
-        buf = self._buffers.pop(path, None)
-        if buf is None:
-            raise PipeNotFoundError(f"no pipe at: {path}")
-        buf.close()
-        logger.debug("pipe closed: %s", path)
-
-    def destroy(self, path: str) -> None:
-        """Close buffer AND delete inode from MetastoreABC.
-
-        Raises:
-            PipeNotFoundError: No pipe at this path.
-        """
-        buf = self._buffers.pop(path, None)
-        if buf is not None:
-            buf.close()
-
-        metadata = self._metastore.get(path)
-        if metadata is None:
-            if buf is None:
-                raise PipeNotFoundError(f"no pipe at: {path}")
-            return
-
-        self._metastore.delete(path)
-        logger.debug("pipe destroyed: %s", path)
-
-    def _get_buffer(self, path: str) -> RingBuffer:
-        """Get buffer or raise PipeNotFoundError."""
-        buf = self._buffers.get(path)
-        if buf is None:
-            raise PipeNotFoundError(f"no pipe at: {path}")
-        return buf
-
-    async def pipe_write(self, path: str, data: bytes, *, blocking: bool = True) -> int:
-        """Write to a named pipe."""
-        return await self._get_buffer(path).write(data, blocking=blocking)
-
-    async def pipe_read(self, path: str, *, blocking: bool = True) -> bytes:
-        """Read from a named pipe."""
-        return await self._get_buffer(path).read(blocking=blocking)
-
-    def pipe_peek(self, path: str) -> bytes | None:
-        """Peek at next message in a named pipe."""
-        return self._get_buffer(path).peek()
-
-    def pipe_peek_all(self, path: str) -> list[bytes]:
-        """Peek at all messages in a named pipe."""
-        return self._get_buffer(path).peek_all()
-
-    def list_pipes(self) -> dict[str, dict]:
-        """List all active pipes with their stats."""
-        return {path: buf.stats for path, buf in self._buffers.items()}
-
-    def close_all(self) -> None:
-        """Close all pipe buffers. Called on kernel shutdown."""
-        for path, buf in self._buffers.items():
-            buf.close()
-            logger.debug("pipe closed (shutdown): %s", path)
-        self._buffers.clear()

--- a/src/nexus/core/pipe_manager.py
+++ b/src/nexus/core/pipe_manager.py
@@ -1,0 +1,283 @@
+"""PipeManager — VFS named pipe manager (fs/pipe.c equivalent).
+
+Manages DT_PIPE lifecycle and buffer registry with per-pipe locking for MPMC.
+
+    pipe.py         = kfifo     (include/linux/kfifo.h + lib/kfifo.c)
+    pipe_manager.py = fs/pipe.c (VFS named pipe with per-pipe lock for MPMC)
+
+Concurrency model (aligned with Linux pipe(7)):
+  - RingBuffer (kfifo) is SPSC, no internal lock.
+  - PipeManager (mkfifo) adds per-pipe asyncio.Lock for MPMC safety.
+    Async methods use Linux-style lock→try_nowait→unlock→wait→retry
+    to avoid holding the lock during blocking waits (deadlock-free).
+  - Sync methods (pipe_write_nowait) are atomic under asyncio event loop
+    (no await points), safe for MPSC without lock.
+
+See: pipe.py for RingBuffer, federation-memo.md §7j
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from nexus.core.pipe import (
+    PipeClosedError,
+    PipeEmptyError,
+    PipeError,
+    PipeFullError,
+    PipeNotFoundError,
+    RingBuffer,
+)
+
+if TYPE_CHECKING:
+    from nexus.core.metastore import MetastoreABC
+
+logger = logging.getLogger(__name__)
+
+# Re-export exceptions so callers can import from either module
+__all__ = [
+    "PipeManager",
+    "PipeError",
+    "PipeFullError",
+    "PipeEmptyError",
+    "PipeClosedError",
+    "PipeNotFoundError",
+]
+
+
+class PipeManager:
+    """Manages DT_PIPE lifecycle and buffer registry.
+
+    Analogous to Linux fs/pipe.c: creates named pipes visible in the VFS
+    namespace. Each pipe has a FileMetadata inode in MetastoreABC
+    (entry_type=DT_PIPE) and a RingBuffer in process memory.
+
+    The inode provides:
+      - VFS path (/nexus/pipes/{name}) for agent access via FUSE/MCP
+      - ReBAC access control (owner_id, permission checks)
+      - Observability (list all pipes, inspect stats)
+
+    The ring buffer data is NOT in any storage pillar — it's process heap
+    memory, like Linux kfifo data in kmalloc'd kernel heap.
+    """
+
+    def __init__(self, metastore: MetastoreABC, zone_id: str = "root") -> None:
+        self._metastore = metastore
+        self._zone_id = zone_id
+        self._buffers: dict[str, RingBuffer] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def create(
+        self,
+        path: str,
+        *,
+        capacity: int = 65_536,
+        owner_id: str | None = None,
+    ) -> RingBuffer:
+        """Create a new named pipe at the given VFS path.
+
+        Creates a DT_PIPE inode in MetastoreABC and a RingBuffer in memory.
+
+        Args:
+            path: VFS path (e.g., "/nexus/pipes/my-pipe"). Must start with "/".
+            capacity: Ring buffer byte capacity. Default 64KB.
+            owner_id: Owner for ReBAC permission checks.
+
+        Returns:
+            The created RingBuffer.
+
+        Raises:
+            PipeError: Pipe already exists at this path.
+        """
+        from nexus.core.metadata import DT_PIPE, FileMetadata
+
+        if path in self._buffers:
+            raise PipeError(f"pipe already exists: {path}")
+
+        # Check if inode already exists in metastore
+        existing = self._metastore.get(path)
+        if existing is not None:
+            raise PipeError(f"path already exists: {path}")
+
+        # Create DT_PIPE inode in MetastoreABC
+        metadata = FileMetadata(
+            path=path,
+            backend_name="pipe",
+            physical_path="mem://",
+            size=capacity,
+            entry_type=DT_PIPE,
+            zone_id=self._zone_id,
+            owner_id=owner_id,
+        )
+        self._metastore.put(metadata)
+
+        # Create in-memory ring buffer
+        buf = RingBuffer(capacity=capacity)
+        self._buffers[path] = buf
+
+        logger.debug("pipe created: %s (capacity=%d)", path, capacity)
+        return buf
+
+    def open(self, path: str, *, capacity: int = 65_536) -> RingBuffer:
+        """Open an existing pipe, or recover its buffer after restart.
+
+        If the buffer is already in memory, returns it. If a DT_PIPE inode
+        exists but the buffer was lost (process restart), creates a new
+        buffer for the existing inode.
+
+        Args:
+            path: VFS path of the pipe.
+            capacity: Buffer capacity (used only if recreating after restart).
+
+        Returns:
+            The RingBuffer for this pipe.
+
+        Raises:
+            PipeNotFoundError: No pipe inode at this path.
+        """
+        from nexus.core.metadata import DT_PIPE
+
+        # Return existing buffer if available
+        if path in self._buffers and not self._buffers[path].closed:
+            return self._buffers[path]
+
+        # Check metastore for inode
+        metadata = self._metastore.get(path)
+        if metadata is None or metadata.entry_type != DT_PIPE:
+            raise PipeNotFoundError(f"no pipe at: {path}")
+
+        # Recreate buffer (restart recovery)
+        buf = RingBuffer(capacity=capacity)
+        self._buffers[path] = buf
+
+        logger.debug("pipe opened (recovered): %s", path)
+        return buf
+
+    def close(self, path: str) -> None:
+        """Close a pipe's buffer. Inode stays in MetastoreABC.
+
+        Readers can still drain remaining messages. The inode persists
+        so the pipe can be reopened later.
+
+        Raises:
+            PipeNotFoundError: No buffer at this path.
+        """
+        buf = self._buffers.pop(path, None)
+        if buf is None:
+            raise PipeNotFoundError(f"no pipe at: {path}")
+        buf.close()
+        self._locks.pop(path, None)
+        logger.debug("pipe closed: %s", path)
+
+    def destroy(self, path: str) -> None:
+        """Close buffer AND delete inode from MetastoreABC.
+
+        Raises:
+            PipeNotFoundError: No pipe at this path.
+        """
+        buf = self._buffers.pop(path, None)
+        if buf is not None:
+            buf.close()
+        self._locks.pop(path, None)
+
+        metadata = self._metastore.get(path)
+        if metadata is None:
+            if buf is None:
+                raise PipeNotFoundError(f"no pipe at: {path}")
+            return
+
+        self._metastore.delete(path)
+        logger.debug("pipe destroyed: %s", path)
+
+    def _get_buffer(self, path: str) -> RingBuffer:
+        """Get buffer or raise PipeNotFoundError."""
+        buf = self._buffers.get(path)
+        if buf is None:
+            raise PipeNotFoundError(f"no pipe at: {path}")
+        return buf
+
+    def _get_lock(self, path: str) -> asyncio.Lock:
+        """Get or create per-pipe lock for MPMC safety."""
+        lock = self._locks.get(path)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[path] = lock
+        return lock
+
+    # ------------------------------------------------------------------
+    # Data path — MPMC-safe read/write
+    # ------------------------------------------------------------------
+
+    async def pipe_write(self, path: str, data: bytes, *, blocking: bool = True) -> int:
+        """Write to a named pipe. MPMC-safe (per-pipe asyncio.Lock).
+
+        Uses Linux pipe_write pattern: lock → try_nowait → unlock → wait → retry.
+        Lock is never held during blocking waits (deadlock-free).
+        """
+        buf = self._get_buffer(path)
+        lock = self._get_lock(path)
+        while True:
+            async with lock:
+                try:
+                    return buf.write_nowait(data)
+                except PipeFullError:
+                    if not blocking:
+                        raise
+            # Full and blocking: wait for space without holding lock
+            await buf.wait_writable()
+
+    async def pipe_read(self, path: str, *, blocking: bool = True) -> bytes:
+        """Read from a named pipe. MPMC-safe (per-pipe asyncio.Lock).
+
+        Uses Linux pipe_read pattern: lock → try_nowait → unlock → wait → retry.
+        Lock is never held during blocking waits (deadlock-free).
+        """
+        buf = self._get_buffer(path)
+        lock = self._get_lock(path)
+        while True:
+            async with lock:
+                try:
+                    return buf.read_nowait()
+                except PipeEmptyError:
+                    if not blocking:
+                        raise
+            # Empty and blocking: wait for data without holding lock
+            await buf.wait_readable()
+
+    def pipe_write_nowait(self, path: str, data: bytes) -> int:
+        """Synchronous non-blocking write to a named pipe.
+
+        Atomic under asyncio event loop (no await points = no preemption).
+        Safe for MPSC without lock. Used by sync producers (e.g. VFS write/delete/rename).
+        """
+        return self._get_buffer(path).write_nowait(data)
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    def pipe_peek(self, path: str) -> bytes | None:
+        """Peek at next message in a named pipe."""
+        return self._get_buffer(path).peek()
+
+    def pipe_peek_all(self, path: str) -> list[bytes]:
+        """Peek at all messages in a named pipe."""
+        return self._get_buffer(path).peek_all()
+
+    def list_pipes(self) -> dict[str, dict]:
+        """List all active pipes with their stats."""
+        return {path: buf.stats for path, buf in self._buffers.items()}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close_all(self) -> None:
+        """Close all pipe buffers. Called on kernel shutdown."""
+        for path, buf in self._buffers.items():
+            buf.close()
+            logger.debug("pipe closed (shutdown): %s", path)
+        self._buffers.clear()
+        self._locks.clear()

--- a/tests/unit/core/test_pipe.py
+++ b/tests/unit/core/test_pipe.py
@@ -16,10 +16,10 @@ from nexus.core.pipe import (
     PipeEmptyError,
     PipeError,
     PipeFullError,
-    PipeManager,
     PipeNotFoundError,
     RingBuffer,
 )
+from nexus.core.pipe_manager import PipeManager
 
 # ======================================================================
 # RingBuffer — basic operations
@@ -442,6 +442,251 @@ class TestPipeManager:
         mgr, _ = self._make_manager()
         with pytest.raises(PipeNotFoundError):
             await mgr.pipe_read("/nexus/pipes/ghost")
+
+    def test_pipe_write_nowait_basic(self) -> None:
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/sync", capacity=1024)
+        written = mgr.pipe_write_nowait("/nexus/pipes/sync", b"hello")
+        assert written == 5
+
+    def test_pipe_write_nowait_nonexistent_raises(self) -> None:
+        mgr, _ = self._make_manager()
+        with pytest.raises(PipeNotFoundError):
+            mgr.pipe_write_nowait("/nexus/pipes/ghost", b"data")
+
+    @pytest.mark.asyncio
+    async def test_pipe_write_nowait_then_async_read(self) -> None:
+        """Sync write + async read roundtrip (workflow queue pattern)."""
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/mixed", capacity=1024)
+        mgr.pipe_write_nowait("/nexus/pipes/mixed", b"event-1")
+        mgr.pipe_write_nowait("/nexus/pipes/mixed", b"event-2")
+        assert await mgr.pipe_read("/nexus/pipes/mixed") == b"event-1"
+        assert await mgr.pipe_read("/nexus/pipes/mixed") == b"event-2"
+
+    def test_close_all_clears_locks(self) -> None:
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/a")
+        mgr._get_lock("/nexus/pipes/a")  # force lock creation
+        assert len(mgr._locks) == 1
+        mgr.close_all()
+        assert len(mgr._locks) == 0
+
+    def test_close_clears_lock(self) -> None:
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/a")
+        mgr._get_lock("/nexus/pipes/a")
+        mgr.close("/nexus/pipes/a")
+        assert "/nexus/pipes/a" not in mgr._locks
+
+    def test_destroy_clears_lock(self) -> None:
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/a")
+        mgr._get_lock("/nexus/pipes/a")
+        mgr.destroy("/nexus/pipes/a")
+        assert "/nexus/pipes/a" not in mgr._locks
+
+
+# ======================================================================
+# RingBuffer — write_nowait / read_nowait
+# ======================================================================
+
+
+class TestRingBufferSyncOps:
+    def test_write_nowait_basic(self) -> None:
+        buf = RingBuffer(capacity=1024)
+        written = buf.write_nowait(b"hello")
+        assert written == 5
+        assert buf.stats["size"] == 5
+        assert buf.stats["msg_count"] == 1
+
+    def test_write_nowait_empty_is_noop(self) -> None:
+        buf = RingBuffer(capacity=1024)
+        assert buf.write_nowait(b"") == 0
+        assert buf.stats["msg_count"] == 0
+
+    def test_write_nowait_full_raises(self) -> None:
+        buf = RingBuffer(capacity=10)
+        buf.write_nowait(b"x" * 10)
+        with pytest.raises(PipeFullError, match="buffer full"):
+            buf.write_nowait(b"y")
+
+    def test_write_nowait_oversized_raises(self) -> None:
+        buf = RingBuffer(capacity=10)
+        with pytest.raises(ValueError, match="exceeds buffer capacity"):
+            buf.write_nowait(b"x" * 11)
+
+    def test_write_nowait_closed_raises(self) -> None:
+        buf = RingBuffer(capacity=1024)
+        buf.close()
+        with pytest.raises(PipeClosedError, match="write to closed pipe"):
+            buf.write_nowait(b"data")
+
+    def test_read_nowait_basic(self) -> None:
+        buf = RingBuffer(capacity=1024)
+        buf.write_nowait(b"msg")
+        assert buf.read_nowait() == b"msg"
+        assert buf.stats["size"] == 0
+
+    def test_read_nowait_empty_raises(self) -> None:
+        buf = RingBuffer(capacity=1024)
+        with pytest.raises(PipeEmptyError, match="buffer empty"):
+            buf.read_nowait()
+
+    def test_read_nowait_closed_empty_raises(self) -> None:
+        buf = RingBuffer(capacity=1024)
+        buf.close()
+        with pytest.raises(PipeClosedError, match="read from closed empty pipe"):
+            buf.read_nowait()
+
+    def test_read_nowait_drains_before_closed_error(self) -> None:
+        buf = RingBuffer(capacity=1024)
+        buf.write_nowait(b"last")
+        buf.close()
+        assert buf.read_nowait() == b"last"
+        with pytest.raises(PipeClosedError):
+            buf.read_nowait()
+
+    @pytest.mark.asyncio
+    async def test_write_nowait_wakes_async_reader(self) -> None:
+        """Sync write should wake a blocked async reader."""
+        buf = RingBuffer(capacity=1024)
+        result = None
+
+        async def reader() -> None:
+            nonlocal result
+            result = await buf.read()
+
+        async def writer() -> None:
+            await asyncio.sleep(0.01)
+            buf.write_nowait(b"wakeup")
+
+        await asyncio.gather(reader(), writer())
+        assert result == b"wakeup"
+
+    @pytest.mark.asyncio
+    async def test_wait_writable(self) -> None:
+        buf = RingBuffer(capacity=10)
+        buf.write_nowait(b"x" * 10)
+
+        unblocked = False
+
+        async def waiter() -> None:
+            nonlocal unblocked
+            await buf.wait_writable()
+            unblocked = True
+
+        async def reader() -> None:
+            await asyncio.sleep(0.01)
+            await buf.read()
+
+        await asyncio.gather(waiter(), reader())
+        assert unblocked is True
+
+    @pytest.mark.asyncio
+    async def test_wait_readable(self) -> None:
+        buf = RingBuffer(capacity=1024)
+
+        unblocked = False
+
+        async def waiter() -> None:
+            nonlocal unblocked
+            await buf.wait_readable()
+            unblocked = True
+
+        async def writer() -> None:
+            await asyncio.sleep(0.01)
+            buf.write_nowait(b"data")
+
+        await asyncio.gather(waiter(), writer())
+        assert unblocked is True
+
+
+# ======================================================================
+# PipeManager — MPMC locking
+# ======================================================================
+
+
+class TestPipeManagerMPMC:
+    def _make_manager(self) -> tuple[PipeManager, MockMetastore]:
+        ms = MockMetastore()
+        return PipeManager(ms, zone_id="test-zone"), ms
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writers(self) -> None:
+        """Multiple async writers should not lose messages."""
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/mpmc", capacity=65_536)
+        n_writers = 5
+        msgs_per_writer = 20
+
+        async def writer(writer_id: int) -> None:
+            for i in range(msgs_per_writer):
+                await mgr.pipe_write("/nexus/pipes/mpmc", f"w{writer_id}-{i}".encode())
+
+        await asyncio.gather(*(writer(w) for w in range(n_writers)))
+
+        received: list[bytes] = []
+        for _ in range(n_writers * msgs_per_writer):
+            msg = await mgr.pipe_read("/nexus/pipes/mpmc", blocking=False)
+            received.append(msg)
+
+        assert len(received) == n_writers * msgs_per_writer
+
+    @pytest.mark.asyncio
+    async def test_blocking_write_waits_for_space(self) -> None:
+        """Blocking pipe_write should wait (release lock) then succeed."""
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/block", capacity=10)
+        await mgr.pipe_write("/nexus/pipes/block", b"x" * 10)
+
+        written = False
+
+        async def writer() -> None:
+            nonlocal written
+            await mgr.pipe_write("/nexus/pipes/block", b"y" * 5)
+            written = True
+
+        async def reader() -> None:
+            await asyncio.sleep(0.01)
+            await mgr.pipe_read("/nexus/pipes/block")
+
+        await asyncio.gather(writer(), reader())
+        assert written is True
+
+    @pytest.mark.asyncio
+    async def test_blocking_read_waits_for_data(self) -> None:
+        """Blocking pipe_read should wait then succeed when data arrives."""
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/block-read", capacity=1024)
+
+        result = None
+
+        async def reader() -> None:
+            nonlocal result
+            result = await mgr.pipe_read("/nexus/pipes/block-read")
+
+        async def writer() -> None:
+            await asyncio.sleep(0.01)
+            await mgr.pipe_write("/nexus/pipes/block-read", b"hello")
+
+        await asyncio.gather(reader(), writer())
+        assert result == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_nonblocking_write_full_raises(self) -> None:
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/nb", capacity=10)
+        await mgr.pipe_write("/nexus/pipes/nb", b"x" * 10)
+        with pytest.raises(PipeFullError):
+            await mgr.pipe_write("/nexus/pipes/nb", b"y", blocking=False)
+
+    @pytest.mark.asyncio
+    async def test_nonblocking_read_empty_raises(self) -> None:
+        mgr, _ = self._make_manager()
+        mgr.create("/nexus/pipes/nb-read", capacity=1024)
+        with pytest.raises(PipeEmptyError):
+            await mgr.pipe_read("/nexus/pipes/nb-read", blocking=False)
 
 
 # ======================================================================

--- a/tests/unit/core/test_workflow_pipe.py
+++ b/tests/unit/core/test_workflow_pipe.py
@@ -1,0 +1,230 @@
+"""Unit tests for workflow event pipe (DT_PIPE replacing asyncio.Queue, Task #808).
+
+Tests the integration between NexusFSCoreMixin._fire_workflow_event,
+_start_workflow_consumer, ensure_workflow_consumer, and PipeManager.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nexus.core.metadata import FileMetadata
+from nexus.core.pipe_manager import PipeManager
+
+# ======================================================================
+# Fixtures
+# ======================================================================
+
+
+class MockMetastore:
+    """Minimal MetastoreABC mock."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, FileMetadata] = {}
+
+    def get(self, path: str) -> FileMetadata | None:
+        return self._store.get(path)
+
+    def put(self, metadata: FileMetadata, *, consistency: str = "sc") -> None:
+        if metadata.path:
+            self._store[metadata.path] = metadata
+
+    def delete(self, path: str, *, consistency: str = "sc") -> dict | None:
+        return {"path": path} if self._store.pop(path, None) else None
+
+    def exists(self, path: str) -> bool:
+        return path in self._store
+
+    def list(self, prefix: str = "", recursive: bool = True, **kwargs) -> list:  # noqa: ARG002
+        return [m for p, m in self._store.items() if p.startswith(prefix)]
+
+    def close(self) -> None:
+        pass
+
+
+class FakeCoreMixin:
+    """Mimics NexusFSCoreMixin attributes for testing."""
+
+    _WORKFLOW_PIPE_PATH = "/nexus/pipes/workflow-events"
+    _WORKFLOW_PIPE_CAPACITY = 65_536
+
+    def __init__(self, *, enable_workflows: bool = True) -> None:
+        self.enable_workflows = enable_workflows
+        self.workflow_engine = AsyncMock()
+        self.subscription_manager = None
+        self._pipe_manager: PipeManager | None = PipeManager(MockMetastore(), zone_id="test")
+        self._workflow_pipe_ready = False
+        self._workflow_consumer_task = None
+
+    # Import the real methods from NexusFSCoreMixin
+    from nexus.core.nexus_fs_core import NexusFSCoreMixin
+
+    _fire_workflow_event = NexusFSCoreMixin._fire_workflow_event
+    _start_workflow_consumer = NexusFSCoreMixin._start_workflow_consumer
+    ensure_workflow_consumer = NexusFSCoreMixin.ensure_workflow_consumer
+
+
+# ======================================================================
+# _fire_workflow_event
+# ======================================================================
+
+
+class TestFireWorkflowEvent:
+    def test_writes_to_pipe(self) -> None:
+        """Event should be serialized and written to PipeManager."""
+        obj = FakeCoreMixin()
+        obj.ensure_workflow_consumer()
+
+        obj._fire_workflow_event("file_write", {"path": "/foo.txt"}, "file_write:/foo.txt")
+
+        # Verify data in pipe via peek
+        data = obj._pipe_manager.pipe_peek(obj._WORKFLOW_PIPE_PATH)
+        assert data is not None
+        msg = json.loads(data)
+        assert msg["type"] == "file_write"
+        assert msg["ctx"]["path"] == "/foo.txt"
+
+    def test_drops_on_full(self) -> None:
+        """Overflow should log warning, not raise."""
+        obj = FakeCoreMixin()
+        # Create pipe with enough capacity for one message but not two
+        obj._pipe_manager.create(obj._WORKFLOW_PIPE_PATH, capacity=256, owner_id="kernel")
+        obj._workflow_pipe_ready = True
+
+        # Fill the pipe with enough data to overflow
+        obj._pipe_manager.pipe_write_nowait(obj._WORKFLOW_PIPE_PATH, b"x" * 256)
+
+        # Should not raise — drops on overflow
+        obj._fire_workflow_event("file_write", {"path": "/big.txt"}, "file_write:/big.txt")
+
+    def test_fallback_without_pipe_manager(self) -> None:
+        """No pipe manager → fire-and-forget fallback."""
+        obj = FakeCoreMixin()
+        obj._pipe_manager = None
+        obj._workflow_pipe_ready = False
+
+        with patch("nexus.core.sync_bridge.fire_and_forget") as mock_ff:
+            obj._fire_workflow_event("file_delete", {"path": "/x"}, "file_delete:/x")
+            mock_ff.assert_called_once()
+
+    def test_fallback_before_ensure(self) -> None:
+        """Pipe manager exists but ensure_workflow_consumer not called yet."""
+        obj = FakeCoreMixin()
+        # _workflow_pipe_ready is False, so should use fallback
+
+        with patch("nexus.core.sync_bridge.fire_and_forget") as mock_ff:
+            obj._fire_workflow_event("file_write", {"path": "/y"}, "file_write:/y")
+            mock_ff.assert_called_once()
+
+    def test_noop_when_workflows_disabled(self) -> None:
+        """Should do nothing when workflows are disabled."""
+        obj = FakeCoreMixin(enable_workflows=False)
+        obj.ensure_workflow_consumer()
+        obj._fire_workflow_event("file_write", {"path": "/z"}, "file_write:/z")
+        # Pipe should be empty (event was not written)
+        assert obj._pipe_manager.pipe_peek(obj._WORKFLOW_PIPE_PATH) is None
+
+
+# ======================================================================
+# _start_workflow_consumer
+# ======================================================================
+
+
+class TestWorkflowConsumer:
+    @pytest.mark.asyncio
+    async def test_consumer_reads_and_fires(self) -> None:
+        """Consumer should deserialize messages and call engine.fire_event."""
+        obj = FakeCoreMixin()
+        obj.ensure_workflow_consumer()
+
+        # Write events
+        for i in range(3):
+            obj._fire_workflow_event("file_write", {"idx": i}, f"file_write:{i}")
+
+        # Start consumer as concurrent task
+        task = asyncio.create_task(obj._start_workflow_consumer())
+
+        # Wait for consumer to drain all messages
+        await asyncio.sleep(0.05)
+
+        # Now shut down — close_all closes buffers then removes from registry
+        obj._pipe_manager.close_all()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert obj.workflow_engine.fire_event.call_count == 3
+        calls = obj.workflow_engine.fire_event.call_args_list
+        assert calls[0].args == ("file_write", {"idx": 0})
+        assert calls[1].args == ("file_write", {"idx": 1})
+        assert calls[2].args == ("file_write", {"idx": 2})
+
+    @pytest.mark.asyncio
+    async def test_consumer_exits_on_close(self) -> None:
+        """Consumer should exit cleanly when pipe is closed."""
+        obj = FakeCoreMixin()
+        obj.ensure_workflow_consumer()
+
+        # Start consumer, then close pipe
+        task = asyncio.create_task(obj._start_workflow_consumer())
+        await asyncio.sleep(0.01)
+        obj._pipe_manager.close_all()
+
+        # Should not hang
+        await asyncio.wait_for(task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_consumer_survives_engine_error(self) -> None:
+        """Consumer should continue processing after engine error."""
+        obj = FakeCoreMixin()
+        obj.ensure_workflow_consumer()
+
+        # Make engine fail on first call, succeed on second
+        obj.workflow_engine.fire_event.side_effect = [
+            RuntimeError("boom"),
+            None,
+        ]
+
+        obj._fire_workflow_event("file_write", {"x": 1}, "w:1")
+        obj._fire_workflow_event("file_write", {"x": 2}, "w:2")
+
+        # Start consumer concurrently
+        task = asyncio.create_task(obj._start_workflow_consumer())
+        await asyncio.sleep(0.05)
+        obj._pipe_manager.close_all()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        # Both were attempted
+        assert obj.workflow_engine.fire_event.call_count == 2
+
+
+# ======================================================================
+# ensure_workflow_consumer
+# ======================================================================
+
+
+class TestEnsureWorkflowConsumer:
+    def test_creates_pipe(self) -> None:
+        """Should create pipe at the correct path with correct capacity."""
+        obj = FakeCoreMixin()
+        obj.ensure_workflow_consumer()
+
+        assert obj._workflow_pipe_ready is True
+        pipes = obj._pipe_manager.list_pipes()
+        assert obj._WORKFLOW_PIPE_PATH in pipes
+        assert pipes[obj._WORKFLOW_PIPE_PATH]["capacity"] == obj._WORKFLOW_PIPE_CAPACITY
+
+    def test_idempotent(self) -> None:
+        """Calling twice should not raise."""
+        obj = FakeCoreMixin()
+        obj.ensure_workflow_consumer()
+        obj.ensure_workflow_consumer()  # should not raise
+
+    def test_noop_without_pipe_manager(self) -> None:
+        """No pipe manager (CLI mode) → no-op."""
+        obj = FakeCoreMixin()
+        obj._pipe_manager = None
+        obj.ensure_workflow_consumer()
+        assert obj._workflow_pipe_ready is False


### PR DESCRIPTION
## Summary
- **Replace dead `_workflow_queue`** (asyncio.Queue that was never instantiated) in `NexusFSCoreMixin` with a live DT_PIPE — the first real consumer of the DT_PIPE primitive from Task #6
- **Split `pipe.py`** into `pipe.py` (RingBuffer/kfifo, SPSC) + `pipe_manager.py` (fs/pipe.c, MPMC with per-pipe `asyncio.Lock`), aligned with Linux kernel file organization
- **Add sync data path**: `write_nowait()` / `read_nowait()` on RingBuffer + `pipe_write_nowait()` on PipeManager for sync producers (VFS write/delete/rename)
- **Wire PipeManager** into `NexusFS.__init__` and `close()` for lifecycle management

Cherry-picked from #2157, conflict-resolved against #2158 (audit error policy move).

Related: #808

## Test plan
- [x] 65 pipe tests (RingBuffer + PipeManager MPMC)
- [x] 11 workflow pipe integration tests (fire, consume, fallback, lifecycle)
- [x] All pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)