### PR TITLE
fix(#568): add SkillRegistryProtocol + SkillManagerProtocol

### DIFF
--- a/src/nexus/cli/commands/skills.py
+++ b/src/nexus/cli/commands/skills.py
@@ -784,7 +784,7 @@ def skills_export(
 
         nx = get_filesystem(backend_config, enforce_permissions=False)
         registry = SkillRegistry(nx)
-        exporter = SkillExporter(registry)
+        exporter = SkillExporter(registry, filesystem=nx)
 
         async def export_skill_async() -> None:
             await registry.discover()
@@ -841,7 +841,7 @@ def skills_validate(
 
         nx = get_filesystem(backend_config, enforce_permissions=False)
         registry = SkillRegistry(nx)
-        exporter = SkillExporter(registry)
+        exporter = SkillExporter(registry, filesystem=nx)
 
         async def validate_skill_async() -> None:
             await registry.discover()
@@ -903,7 +903,7 @@ def skills_size(
 
         nx = get_filesystem(backend_config, enforce_permissions=False)
         registry = SkillRegistry(nx)
-        exporter = SkillExporter(registry)
+        exporter = SkillExporter(registry, filesystem=nx)
 
         async def calculate_size_async() -> None:
             await registry.discover()
@@ -1307,7 +1307,7 @@ def skills_diff(
             # Reconstruct SKILL.md content for both
             from nexus.skills.exporter import SkillExporter
 
-            exporter = SkillExporter(registry)
+            exporter = SkillExporter(registry, filesystem=nx)
 
             content1 = exporter._reconstruct_skill_md(skill_obj1)
             content2 = exporter._reconstruct_skill_md(skill_obj2)

--- a/src/nexus/connectors/base.py
+++ b/src/nexus/connectors/base.py
@@ -25,7 +25,7 @@ from nexus.core.exceptions import ValidationError as CoreValidationError
 if TYPE_CHECKING:
     from nexus.connectors.error_formatter import SkillErrorFormatter
     from nexus.connectors.schema_generator import SkillDocGenerator
-    from nexus.skills.registry import SkillRegistry
+    from nexus.skills.protocols import SkillRegistryProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +207,7 @@ class SkillDocMixin:
     NESTED_EXAMPLES: dict[str, list[str]] = {}  # Nested field examples for SKILL.md
     FIELD_EXAMPLES: dict[str, str] = {}  # Field-specific examples for SKILL.md
 
-    _skill_registry: SkillRegistry | None = None
+    _skill_registry: SkillRegistryProtocol | None = None
     _mount_path: str | None = None  # Set during mount
     _cached_doc_generator: SkillDocGenerator | None = None
     _cached_error_formatter: SkillErrorFormatter | None = None
@@ -219,7 +219,7 @@ class SkillDocMixin:
             return posixpath.join(self._mount_path.rstrip("/"), self.SKILL_DIR, "SKILL.md")
         return "/.skill/SKILL.md"  # Default fallback
 
-    def set_skill_registry(self, registry: SkillRegistry) -> None:
+    def set_skill_registry(self, registry: SkillRegistryProtocol) -> None:
         """Set the skill registry for this connector."""
         self._skill_registry = registry
 

--- a/src/nexus/skills/__init__.py
+++ b/src/nexus/skills/__init__.py
@@ -80,6 +80,8 @@ _LAZY_IMPORTS: dict[str, str] = {
     "SkillExportError": "nexus.skills.exporter",
     # Protocols
     "NexusFilesystem": "nexus.skills.protocols",
+    "SkillRegistryProtocol": "nexus.skills.protocols",
+    "SkillManagerProtocol": "nexus.skills.protocols",
     # Templates
     "get_template": "nexus.skills.templates",
     "list_templates": "nexus.skills.templates",
@@ -104,7 +106,11 @@ if TYPE_CHECKING:
         SkillApproval,
         SkillGovernance,
     )
-    from nexus.skills.protocols import NexusFilesystem
+    from nexus.skills.protocols import (
+        NexusFilesystem,
+        SkillManagerProtocol,
+        SkillRegistryProtocol,
+    )
     from nexus.skills.templates import (
         TemplateError,
         get_template,
@@ -158,4 +164,6 @@ __all__ = [
     "AuditAction",
     # Protocols
     "NexusFilesystem",
+    "SkillRegistryProtocol",
+    "SkillManagerProtocol",
 ]

--- a/src/nexus/skills/exporter.py
+++ b/src/nexus/skills/exporter.py
@@ -10,7 +10,8 @@ from typing import Any, BinaryIO
 
 from nexus.skills.exceptions import SkillExportError
 from nexus.skills.models import Skill
-from nexus.skills.registry import SkillNotFoundError, SkillRegistry
+from nexus.skills.protocols import NexusFilesystem, SkillRegistryProtocol
+from nexus.skills.registry import SkillNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -29,13 +30,22 @@ class SkillExporter:
         ... )
     """
 
-    def __init__(self, registry: SkillRegistry):
+    def __init__(
+        self,
+        registry: SkillRegistryProtocol,
+        filesystem: NexusFilesystem | None = None,
+    ):
         """Initialize skill exporter.
 
         Args:
-            registry: SkillRegistry instance
+            registry: Skill registry (any SkillRegistryProtocol implementation).
+            filesystem: Optional filesystem for reading skill files.
+                        If not provided, falls back to registry._filesystem (if available).
         """
         self._registry = registry
+        self._filesystem: NexusFilesystem | None = filesystem or getattr(
+            registry, "_filesystem", None
+        )
 
     async def export_skill(
         self,
@@ -171,10 +181,10 @@ class SkillExporter:
         logger.debug(f"Exporting skill '{skill_name}' from directory: {skill_dir_path}")
 
         # Get filesystem from registry
-        if not self._registry._filesystem:
+        if not self._filesystem:
             raise SkillExportError(f"Cannot export skill '{skill_name}': filesystem not available")
 
-        filesystem = self._registry._filesystem
+        filesystem = self._filesystem
 
         # List all files in skill directory recursively
         try:
@@ -460,12 +470,12 @@ class SkillExporter:
         skill_dir_path = str(Path(skill.metadata.file_path).parent)
 
         # Get filesystem from registry
-        if not self._registry._filesystem:
+        if not self._filesystem:
             # Fallback to SKILL.md only if filesystem not available
             content = self._reconstruct_skill_md(skill)
             return len(content.encode("utf-8"))
 
-        filesystem = self._registry._filesystem
+        filesystem = self._filesystem
 
         # List all files in skill directory recursively
         try:

--- a/src/nexus/skills/importer.py
+++ b/src/nexus/skills/importer.py
@@ -15,8 +15,7 @@ from nexus.skills.exceptions import (
     SkillPermissionDeniedError,
 )
 from nexus.skills.parser import SkillParseError, SkillParser
-from nexus.skills.protocols import NexusFilesystem
-from nexus.skills.registry import SkillRegistry
+from nexus.skills.protocols import NexusFilesystem, SkillRegistryProtocol
 
 if TYPE_CHECKING:
     from nexus.core.permissions import OperationContext
@@ -58,7 +57,7 @@ class SkillImporter:
     def __init__(
         self,
         filesystem: NexusFilesystem,
-        registry: SkillRegistry | None = None,
+        registry: SkillRegistryProtocol | None = None,
     ):
         """Initialize skill importer.
 
@@ -67,7 +66,12 @@ class SkillImporter:
             registry: Optional skill registry for conflict checking
         """
         self._filesystem = filesystem
-        self._registry = registry or SkillRegistry(filesystem)
+        if registry is not None:
+            self._registry = registry
+        else:
+            from nexus.skills.registry import SkillRegistry
+
+            self._registry = SkillRegistry(filesystem)
         self._parser = SkillParser()
 
     async def import_from_zip(

--- a/src/nexus/skills/manager.py
+++ b/src/nexus/skills/manager.py
@@ -14,7 +14,7 @@ from nexus.skills.exceptions import (
 )
 from nexus.skills.models import SkillMetadata
 from nexus.skills.parser import SkillParser
-from nexus.skills.protocols import NexusFilesystem
+from nexus.skills.protocols import NexusFilesystem, SkillRegistryProtocol
 from nexus.skills.registry import SkillNotFoundError, SkillRegistry
 
 if TYPE_CHECKING:
@@ -64,7 +64,7 @@ class SkillManager:
     def __init__(
         self,
         filesystem: NexusFilesystem | None = None,
-        registry: SkillRegistry | None = None,
+        registry: SkillRegistryProtocol | None = None,
         rebac_manager: ReBACManager | None = None,
         governance: SkillGovernance | None = None,
     ):
@@ -77,7 +77,7 @@ class SkillManager:
             governance: Optional governance system for approval checks
         """
         self._filesystem = filesystem
-        self._registry = registry or SkillRegistry(filesystem)
+        self._registry: SkillRegistryProtocol = registry or SkillRegistry(filesystem)
         self._parser = SkillParser()
         self._rebac = rebac_manager
         self._governance = governance
@@ -851,7 +851,7 @@ class SkillManager:
             >>> results = await manager.search_skills("data processing", tier="zone")
         """
         # Ensure registry has discovered skills
-        if not self._registry._metadata_index:
+        if not self._registry.list_skills():
             await self._registry.discover()
 
         query_lower = query.lower()

--- a/src/nexus/skills/protocols.py
+++ b/src/nexus/skills/protocols.py
@@ -1,10 +1,13 @@
-"""Narrow filesystem protocol for skills module.
+"""Protocols for the skills module.
 
-This defines only the filesystem methods that the skills module actually uses,
-rather than mirroring the full NexusFilesystem ABC (1,000+ LOC).
+Defines narrow interfaces that the skills module depends on:
 
-Any object implementing these 7 methods can serve as a filesystem for skills:
-read, write, list, exists, mkdir, delete, is_directory.
+- ``NexusFilesystem``: 7-method filesystem protocol (read/write/list/…)
+- ``SkillRegistryProtocol``: skill discovery, lookup, and dependency resolution
+- ``SkillManagerProtocol``: skill lifecycle (create, fork, publish, search)
+
+Callers should type-hint against Protocols, not concrete classes.
+Concrete implementations: ``SkillRegistry``, ``SkillManager``.
 
 Verification:
 - Run: pytest tests/unit/skills/test_protocol_compatibility.py
@@ -13,7 +16,11 @@ Verification:
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from nexus.core.permissions import OperationContext
+    from nexus.skills.models import Skill, SkillMetadata
 
 
 @runtime_checkable
@@ -129,5 +136,176 @@ class NexusFilesystem(Protocol):
 
         Returns:
             True if path is a directory
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# SkillRegistryProtocol — discovery, lookup, dependency resolution
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SkillRegistryProtocol(Protocol):
+    """Protocol for skill registry operations.
+
+    Concrete implementation: ``nexus.skills.registry.SkillRegistry``.
+    """
+
+    async def discover(
+        self,
+        context: OperationContext | None = None,
+        tiers: list[str] | None = None,
+    ) -> int:
+        """Discover skills from filesystem (metadata only).
+
+        Returns:
+            Number of skills discovered.
+        """
+        ...
+
+    async def get_skill(
+        self,
+        name: str,
+        context: OperationContext | None = None,
+        load_dependencies: bool = False,
+    ) -> Skill:
+        """Get a skill by name (loads full content on-demand).
+
+        Raises:
+            SkillNotFoundError: If skill not found.
+            SkillPermissionDeniedError: If subject lacks read permission.
+        """
+        ...
+
+    async def resolve_dependencies(self, name: str) -> list[str]:
+        """Resolve all dependencies for a skill (DAG order).
+
+        Raises:
+            SkillNotFoundError: If skill or dependency not found.
+            SkillDependencyError: If circular dependency detected.
+        """
+        ...
+
+    def list_skills(
+        self,
+        tier: str | None = None,
+        include_metadata: bool = False,
+    ) -> list[str] | list[SkillMetadata]:
+        """List available skills from the discovered index."""
+        ...
+
+    def get_metadata(self, name: str) -> SkillMetadata:
+        """Get skill metadata without loading full content.
+
+        Raises:
+            SkillNotFoundError: If skill not found.
+        """
+        ...
+
+    def clear_cache(self) -> None:
+        """Clear the loaded-skill cache (metadata index preserved)."""
+        ...
+
+    def clear(self) -> None:
+        """Clear all registered skills and caches."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# SkillManagerProtocol — lifecycle (create, fork, publish, search)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SkillManagerProtocol(Protocol):
+    """Protocol for skill lifecycle management.
+
+    Concrete implementation: ``nexus.skills.manager.SkillManager``.
+    """
+
+    async def create_skill(
+        self,
+        name: str,
+        description: str,
+        template: str = "basic",
+        tier: str = "user",
+        author: str | None = None,
+        version: str = "1.0.0",
+        creator_id: str | None = None,
+        creator_type: str = "agent",
+        zone_id: str | None = None,
+        context: OperationContext | None = None,
+        **kwargs: str,
+    ) -> str:
+        """Create a new skill from a template.
+
+        Returns:
+            Path to created SKILL.md file.
+        """
+        ...
+
+    async def create_skill_from_content(
+        self,
+        name: str,
+        description: str,
+        content: str,
+        tier: str = "user",
+        author: str | None = None,
+        version: str = "1.0.0",
+        source_url: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        context: OperationContext | None = None,
+    ) -> str:
+        """Create a new skill from raw content.
+
+        Returns:
+            Path to created SKILL.md file.
+        """
+        ...
+
+    async def fork_skill(
+        self,
+        source_name: str,
+        target_name: str,
+        tier: str = "user",
+        author: str | None = None,
+        creator_id: str | None = None,
+        creator_type: str = "user",
+        zone_id: str | None = None,
+    ) -> str:
+        """Fork an existing skill with lineage tracking.
+
+        Returns:
+            Path to forked SKILL.md file.
+        """
+        ...
+
+    async def publish_skill(
+        self,
+        name: str,
+        source_tier: str = "agent",
+        target_tier: str = "zone",
+        publisher_id: str | None = None,
+        publisher_type: str = "agent",
+        zone_id: str | None = None,
+    ) -> str:
+        """Publish a skill to a wider audience.
+
+        Returns:
+            Path to published SKILL.md file.
+        """
+        ...
+
+    async def search_skills(
+        self,
+        query: str,
+        tier: str | None = None,
+        limit: int | None = 10,
+    ) -> list[tuple[str, float]]:
+        """Search skills by description using text matching.
+
+        Returns:
+            List of (skill_name, score) tuples sorted by relevance.
         """
         ...


### PR DESCRIPTION
## Summary
- Cherry-pick of #2159 (rebased onto `develop` to avoid stale-base conflicts)
- Define `SkillRegistryProtocol` (7 methods) and `SkillManagerProtocol` (5 methods) as `typing.Protocol` interfaces in `skills/protocols.py`
- Update callers (`manager.py`, `exporter.py`, `importer.py`, `connectors/base.py`) to type-hint against Protocols instead of concrete classes
- Add `filesystem` DI parameter to `SkillExporter` to eliminate private-attribute access on registry
- Replace `_metadata_index` private-attribute check in `manager.search_skills()` with `list_skills()` (a Protocol method)
- Export new Protocols from `skills/__init__.py` via lazy imports
- Update CLI callers to pass `filesystem` explicitly

Closes #2159

## Test plan
- [ ] All pre-commit hooks pass (ruff, format, file size, brick zero-core-imports)
- [ ] Existing skill tests still pass (structural conformance, no inheritance needed)
- [ ] Verify `SkillRegistry` and `SkillManager` structurally satisfy their Protocols

🤖 Generated with [Claude Code](https://claude.com/claude-code)