### PR TITLE
fix(#660): replace runtime dialect sniffing with config-time flags

### DIFF
--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -632,6 +632,7 @@ def _boot_system_services(ctx: _BootContext, kernel: dict[str, Any]) -> dict[str
                 session_factory=ctx.session_factory,
                 poll_interval_ms=200,
                 batch_size=50,
+                use_row_locking=True,
             )
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] EventDeliveryWorker unavailable: %s", exc)

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -478,15 +478,16 @@ async def lifespan(_app: FastAPI) -> Any:
 
             # ConflictLogStore is always available for the REST API,
             # even if the full write-back pipeline can't start (no event bus).
-            conflict_log_store = ConflictLogStore(gw.session_factory)
+            _is_pg = gw.is_postgresql
+            conflict_log_store = ConflictLogStore(gw.session_factory, is_postgresql=_is_pg)
             _app.state.conflict_log_store = conflict_log_store
 
             wb_event_bus = None
             if hasattr(_app.state.nexus_fs, "_event_bus"):
                 wb_event_bus = _app.state.nexus_fs._event_bus
             if wb_event_bus:
-                backlog_store = SyncBacklogStore(gw.session_factory)
-                change_log_store = ChangeLogStore(gw.session_factory)
+                backlog_store = SyncBacklogStore(gw.session_factory, is_postgresql=_is_pg)
+                change_log_store = ChangeLogStore(gw.session_factory, is_postgresql=_is_pg)
 
                 # Map env var to ConflictStrategy (backward compat)
                 _policy_map = {

--- a/src/nexus/server/lifespan/realtime.py
+++ b/src/nexus/server/lifespan/realtime.py
@@ -199,15 +199,16 @@ async def _startup_writeback(app: FastAPI) -> None:
         gw = NexusFSGateway(app.state.nexus_fs)
 
         # ConflictLogStore is always available for the REST API
-        conflict_log_store = ConflictLogStore(gw.session_factory)
+        _is_pg = gw.is_postgresql
+        conflict_log_store = ConflictLogStore(gw.session_factory, is_postgresql=_is_pg)
         app.state.conflict_log_store = conflict_log_store
 
         wb_event_bus = None
         if hasattr(app.state.nexus_fs, "_event_bus"):
             wb_event_bus = app.state.nexus_fs._event_bus
         if wb_event_bus:
-            backlog_store = SyncBacklogStore(gw.session_factory)
-            change_log_store = ChangeLogStore(gw.session_factory)
+            backlog_store = SyncBacklogStore(gw.session_factory, is_postgresql=_is_pg)
+            change_log_store = ChangeLogStore(gw.session_factory, is_postgresql=_is_pg)
 
             # Map env var to ConflictStrategy (backward compat)
             _policy_map = {

--- a/src/nexus/services/change_log_store.py
+++ b/src/nexus/services/change_log_store.py
@@ -45,13 +45,19 @@ class ChangeLogStore(SyncStoreBase):
     Inherits from SyncStoreBase for session management and dialect detection.
     """
 
-    def __init__(self, session_factory: Callable[..., Any] | None) -> None:
+    def __init__(
+        self,
+        session_factory: Callable[..., Any] | None,
+        *,
+        is_postgresql: bool = False,
+    ) -> None:
         """Initialize change log store.
 
         Args:
             session_factory: SQLAlchemy session factory callable.
+            is_postgresql: Whether the database is PostgreSQL (config-time flag).
         """
-        super().__init__(session_factory)
+        super().__init__(session_factory, is_postgresql=is_postgresql)
 
     def get_change_log(
         self, path: str, backend_name: str, zone_id: str = "root"
@@ -241,7 +247,7 @@ class ChangeLogStore(SyncStoreBase):
         try:
             with self._with_session() as session:
                 now = datetime.now(UTC)
-                is_pg = self._detect_dialect()
+                is_pg = self._is_postgres
 
                 # Build all value dicts upfront
                 all_values = [

--- a/src/nexus/services/event_log/delivery_worker.py
+++ b/src/nexus/services/event_log/delivery_worker.py
@@ -96,6 +96,7 @@ class EventDeliveryWorker:
         batch_size: int = 50,
         max_retries: int = 3,
         max_backoff_ms: int = 5000,
+        use_row_locking: bool = False,
     ) -> None:
         self._session_factory = session_factory
         self._event_bus = event_bus
@@ -105,6 +106,7 @@ class EventDeliveryWorker:
         self._batch_size = batch_size
         self._max_retries = max_retries
         self._max_backoff_s = max_backoff_ms / 1000.0
+        self._use_row_locking = use_row_locking
 
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
@@ -210,9 +212,8 @@ class EventDeliveryWorker:
                 .limit(self._batch_size)
             )
 
-            # PostgreSQL: row-level locking for concurrent workers
-            dialect_name = session.bind.dialect.name if session.bind else ""
-            if dialect_name == "postgresql":
+            # Row-level locking for concurrent workers (PostgreSQL)
+            if self._use_row_locking:
                 stmt = stmt.with_for_update(skip_locked=True)
 
             rows = list(session.execute(stmt).scalars())

--- a/src/nexus/services/gateway.py
+++ b/src/nexus/services/gateway.py
@@ -462,6 +462,15 @@ class NexusFSGateway:
     # Database URL
     # =========================================================================
 
+    @property
+    def is_postgresql(self) -> bool:
+        """Check if the database is PostgreSQL (config-time detection)."""
+        try:
+            url = self.get_database_url()
+            return url.startswith(("postgres", "postgresql"))
+        except Exception:
+            return False
+
     def get_database_url(self) -> str:
         """Get database URL for OAuth backends.
 

--- a/src/nexus/services/sync_backlog_store.py
+++ b/src/nexus/services/sync_backlog_store.py
@@ -47,8 +47,13 @@ class SyncBacklogStore(SyncStoreBase):
     Supports upsert coalescing, FIFO fetch, status transitions, and TTL expiry.
     """
 
-    def __init__(self, session_factory: Callable[..., Any] | None) -> None:
-        super().__init__(session_factory)
+    def __init__(
+        self,
+        session_factory: Callable[..., Any] | None,
+        *,
+        is_postgresql: bool = False,
+    ) -> None:
+        super().__init__(session_factory, is_postgresql=is_postgresql)
 
     def enqueue(
         self,

--- a/src/nexus/services/sync_service.py
+++ b/src/nexus/services/sync_service.py
@@ -122,7 +122,9 @@ class SyncService:
         """
         self._gw = gateway
         # Issue #1127: Initialize change log store for delta sync
-        self._change_log = ChangeLogStore(gateway.session_factory)
+        self._change_log = ChangeLogStore(
+            gateway.session_factory, is_postgresql=gateway.is_postgresql
+        )
         # Issue #1127: Per-mount sync locks to prevent concurrent races
         self._mount_locks: dict[str, threading.Lock] = {}
         self._lock_guard = threading.Lock()

--- a/src/nexus/storage/sync_store_base.py
+++ b/src/nexus/storage/sync_store_base.py
@@ -1,6 +1,6 @@
 """Base class for sync-related database stores.
 
-Provides shared session management and dialect detection for
+Provides shared session management and dialect-aware helpers for
 ChangeLogStore, SyncBacklogStore, and future sync stores.
 
 Extracted from ChangeLogStore (Issue #1127) during Phase 0 refactoring
@@ -10,7 +10,6 @@ for Issue #1129 (Bidirectional Sync).
 from __future__ import annotations
 
 import logging
-import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from typing import Any
@@ -19,53 +18,35 @@ logger = logging.getLogger(__name__)
 
 
 class SyncStoreBase:
-    """Base class providing session management and dialect detection.
+    """Base class providing session management and dialect-aware helpers.
 
     Subclasses (ChangeLogStore, SyncBacklogStore) inherit:
     - _with_session(): Context manager for DB sessions (commit/rollback/close)
-    - _detect_dialect(): Cached, thread-safe PostgreSQL detection
+    - _dialect_insert(): Dialect-appropriate INSERT statement
+    - _dialect_upsert(): Dialect-aware INSERT ON CONFLICT DO UPDATE
     """
 
-    def __init__(self, session_factory: Callable[..., Any] | None) -> None:
+    def __init__(
+        self,
+        session_factory: Callable[..., Any] | None,
+        *,
+        is_postgresql: bool = False,
+    ) -> None:
         """Initialize with a session factory for database access.
 
         Args:
             session_factory: SQLAlchemy session factory callable.
+            is_postgresql: Whether the database is PostgreSQL (config-time flag).
+                Determines dialect-specific INSERT/UPSERT behaviour.
         """
         self._session_factory = session_factory
-        self._is_postgres: bool | None = None
-        self._dialect_lock = threading.Lock()
+        self._is_postgres: bool = is_postgresql
 
     def _get_session(self) -> Any:
         """Get a database session from the session factory."""
         if self._session_factory is not None:
             return self._session_factory()
         return None
-
-    def _detect_dialect(self) -> bool:
-        """Detect if the database is PostgreSQL. Result is cached after first call.
-
-        Thread-safe: uses double-checked locking to avoid races.
-
-        Returns:
-            True if PostgreSQL, False for SQLite or unknown
-        """
-        if self._is_postgres is not None:
-            return self._is_postgres
-        with self._dialect_lock:
-            if self._is_postgres is not None:
-                return self._is_postgres
-            session = self._get_session()
-            if session is not None:
-                try:
-                    self._is_postgres = session.bind.dialect.name == "postgresql"
-                except Exception:
-                    self._is_postgres = False
-                finally:
-                    session.close()
-            else:
-                self._is_postgres = False
-            return self._is_postgres
 
     def _dialect_insert(self, model: type) -> Any:
         """Return dialect-appropriate INSERT statement for the given model.
@@ -78,7 +59,7 @@ class SyncStoreBase:
         Returns:
             Dialect-appropriate insert statement (pg_insert or sqlite_insert)
         """
-        if self._detect_dialect():
+        if self._is_postgres:
             from sqlalchemy.dialects.postgresql import insert as pg_insert
 
             return pg_insert(model)
@@ -109,7 +90,7 @@ class SyncStoreBase:
             update_set: Columns to update on conflict
         """
         stmt = self._dialect_insert(model).values(**values)
-        if self._detect_dialect():
+        if self._is_postgres:
             stmt = stmt.on_conflict_do_update(constraint=pg_constraint, set_=update_set)
         else:
             stmt = stmt.on_conflict_do_update(index_elements=sqlite_index_elements, set_=update_set)

--- a/tests/e2e/postgres/test_delta_sync_postgres.py
+++ b/tests/e2e/postgres/test_delta_sync_postgres.py
@@ -85,7 +85,7 @@ def pg_session_factory(pg_engine):
 @pytest.fixture()
 def store(pg_session_factory):
     """Create a ChangeLogStore backed by real PostgreSQL."""
-    return ChangeLogStore(pg_session_factory)
+    return ChangeLogStore(pg_session_factory, is_postgresql=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/storage/test_sync_store_base.py
+++ b/tests/unit/storage/test_sync_store_base.py
@@ -1,9 +1,8 @@
 """Unit tests for SyncStoreBase shared session/dialect logic.
 
 Tests cover:
-- __init__: session_factory assignment, initial state
+- __init__: session_factory assignment, is_postgresql config-time flag
 - _get_session: session factory present/absent
-- _detect_dialect: PostgreSQL detection, SQLite fallback, caching, thread safety
 - _dialect_insert: correct dialect-specific INSERT statement
 - _dialect_upsert: correct dialect-specific ON CONFLICT handling
 - _with_session: commit on success, rollback on error, close always, no factory
@@ -23,25 +22,18 @@ from nexus.storage.sync_store_base import SyncStoreBase
 # ---------------------------------------------------------------------------
 
 
-def _make_session(dialect_name: str = "sqlite") -> MagicMock:
-    """Build a mock SQLAlchemy session."""
-    session = MagicMock()
-    session.bind.dialect.name = dialect_name
-    return session
-
-
 @pytest.fixture
 def sqlite_store() -> SyncStoreBase:
-    """SyncStoreBase backed by a SQLite session."""
-    session = _make_session("sqlite")
-    return SyncStoreBase(lambda: session)
+    """SyncStoreBase configured for SQLite."""
+    session = MagicMock()
+    return SyncStoreBase(lambda: session, is_postgresql=False)
 
 
 @pytest.fixture
 def pg_store() -> SyncStoreBase:
-    """SyncStoreBase backed by a PostgreSQL session."""
-    session = _make_session("postgresql")
-    return SyncStoreBase(lambda: session)
+    """SyncStoreBase configured for PostgreSQL."""
+    session = MagicMock()
+    return SyncStoreBase(lambda: session, is_postgresql=True)
 
 
 @pytest.fixture
@@ -63,9 +55,13 @@ class TestInit:
         store = SyncStoreBase(factory)
         assert store._session_factory is factory
 
-    def test_initial_dialect_is_none(self):
+    def test_default_dialect_is_sqlite(self):
         store = SyncStoreBase(MagicMock())
-        assert store._is_postgres is None
+        assert store._is_postgres is False
+
+    def test_is_postgresql_flag(self):
+        store = SyncStoreBase(MagicMock(), is_postgresql=True)
+        assert store._is_postgres is True
 
 
 # ===========================================================================
@@ -82,48 +78,6 @@ class TestGetSession:
 
     def test_returns_none_without_factory(self, no_session_store):
         assert no_session_store._get_session() is None
-
-
-# ===========================================================================
-# _detect_dialect
-# ===========================================================================
-
-
-class TestDetectDialect:
-    """Tests for _detect_dialect."""
-
-    def test_detects_postgresql(self, pg_store):
-        assert pg_store._detect_dialect() is True
-
-    def test_detects_sqlite(self, sqlite_store):
-        assert sqlite_store._detect_dialect() is False
-
-    def test_caches_result(self, pg_store):
-        """Second call should return cached value without opening a new session."""
-        result1 = pg_store._detect_dialect()
-        result2 = pg_store._detect_dialect()
-        assert result1 is result2
-        assert pg_store._is_postgres is True
-
-    def test_no_session_returns_false(self, no_session_store):
-        assert no_session_store._detect_dialect() is False
-
-    def test_exception_during_detection_returns_false(self):
-        """Exception reading dialect should fall back to False."""
-        session = MagicMock()
-        session.bind.dialect.name = property(lambda s: (_ for _ in ()).throw(RuntimeError("boom")))
-        # Simpler: make the attribute access raise
-        type(session.bind.dialect).name = property(lambda self: (_ for _ in ()).throw(RuntimeError))
-
-        store = SyncStoreBase(lambda: session)
-        assert store._detect_dialect() is False
-
-    def test_session_closed_after_detection(self):
-        """Session should be closed after dialect detection."""
-        session = _make_session("postgresql")
-        store = SyncStoreBase(lambda: session)
-        store._detect_dialect()
-        session.close.assert_called_once()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Cherry-pick of #2163 (rebased onto `develop` to avoid 522-commit stale base)
- `SyncStoreBase`: remove `_detect_dialect()` and threading lock, accept `is_postgresql` bool at construction time
- All subclass callers (`ChangeLogStore`, `SyncBacklogStore`, `ConflictLogStore`) and server wiring (`fastapi_server`, `lifespan/realtime`, `sync_service`) now pass the flag from `NexusFSGateway.is_postgresql`
- `EventDeliveryWorker`: replace `session.bind.dialect.name` check with `use_row_locking` bool injected at construction; `factory.py` passes `True` when PostgreSQL is already known
- Per KERNEL-ARCHITECTURE.md §7: "Driver selection is config-time"

Closes #2163

## Test plan
- [ ] All pre-commit hooks pass (ruff, format, file size, brick zero-core-imports)
- [ ] Unit tests for `SyncStoreBase` updated (no more dialect detection mocking)
- [ ] E2E PostgreSQL delta sync test updated with `is_postgresql=True`
- [ ] Existing CI passes (lint, type check, unit tests, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)