### PR TITLE
fix(#414): replace runtime dialect sniffing with config-time is_postgresql flag

### DIFF
--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -386,6 +386,9 @@ def _boot_kernel_services(ctx: _BootContext) -> dict[str, Any]:
 
     t0 = time.perf_counter()
     try:
+        # Config-time dialect flag (KERNEL-ARCHITECTURE §7)
+        _is_pg = not ctx.db_url.startswith("sqlite")
+
         # --- ReBAC Manager ---
         from nexus.rebac.manager import EnhancedReBACManager
 
@@ -397,6 +400,7 @@ def _boot_kernel_services(ctx: _BootContext) -> dict[str, Any]:
             enable_graph_limits=True,
             enable_tiger_cache=ctx.perm.enable_tiger_cache,
             read_engine=ctx.read_engine,
+            is_postgresql=_is_pg,
         )
 
         # --- Circuit Breaker for ReBAC DB Resilience (Issue #726) ---
@@ -430,7 +434,7 @@ def _boot_kernel_services(ctx: _BootContext) -> dict[str, Any]:
         # --- Audit Store ---
         from nexus.rebac.permissions_enhanced import AuditStore
 
-        audit_store = AuditStore(engine=ctx.engine)
+        audit_store = AuditStore(engine=ctx.engine, is_postgresql=_is_pg)
 
         # --- Entity Registry ---
         from nexus.rebac.entity_registry import EntityRegistry

--- a/src/nexus/rebac/manager.py
+++ b/src/nexus/rebac/manager.py
@@ -126,6 +126,7 @@ class ReBACManager:
         enable_leopard: bool = True,
         enable_tiger_cache: bool = True,
         read_engine: Engine | None = None,
+        is_postgresql: bool = False,
     ):
         """Initialize ReBAC manager.
 
@@ -139,9 +140,11 @@ class ReBACManager:
             enable_tiger_cache: Enable Tiger Cache for materialized permissions (default: True)
             read_engine: Optional separate engine for read-only operations (Issue #725).
                         Defaults to ``engine`` when not provided.
+            is_postgresql: Whether the database is PostgreSQL (config-time flag).
         """
         # ── Base initialization (formerly in ReBACManager.__init__) ──
         self.engine = engine
+        self._is_postgresql = is_postgresql
         self.cache_ttl_seconds = cache_ttl_seconds
         self.max_depth = max_depth
         self._last_cleanup_time: datetime | None = None
@@ -207,7 +210,7 @@ class ReBACManager:
         # Only enable on PostgreSQL - SQLite has lock contention issues
         self._tiger_cache: TigerCache | None = None
         self._tiger_updater: TigerCacheUpdater | None = None
-        if enable_tiger_cache and engine.dialect.name == "postgresql":
+        if enable_tiger_cache and is_postgresql:
             from nexus.rebac.cache.tiger import (
                 TigerCache,
                 TigerCacheUpdater,
@@ -2481,9 +2484,8 @@ class ReBACManager:
         visited: set[tuple[str, str]] = set()
         queue: list[tuple[str, str]] = [(subject_type, subject_id)]
 
-        # Determine SQL NOW function based on database type
-        is_postgresql = "postgresql" in str(self.engine.url)
-        now_sql = "NOW()" if is_postgresql else "datetime('now')"
+        # Determine SQL NOW function based on database type (config-time flag)
+        now_sql = "NOW()" if self._is_postgresql else "datetime('now')"
 
         with self.engine.connect() as conn:
             while queue:
@@ -3526,7 +3528,7 @@ class ReBACManager:
             cursor = self._create_cursor(conn)
 
             # Check if rebac_namespaces table exists
-            if self.engine.dialect.name == "sqlite":
+            if not self._is_postgresql:
                 cursor.execute(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name='rebac_namespaces'"
                 )
@@ -4226,7 +4228,7 @@ class ReBACManager:
             # PostgreSQL: Use DELETE...RETURNING to get deleted row in single query
             # This eliminates the SELECT+DELETE round-trip for better performance
             # Note: DELETE only has one row version, so no need for OLD prefix
-            if self.engine.dialect.name == "postgresql":
+            if self._is_postgresql:
                 cursor.execute(
                     self._fix_sql_placeholders(
                         """

--- a/src/nexus/rebac/permissions_enhanced.py
+++ b/src/nexus/rebac/permissions_enhanced.py
@@ -113,13 +113,15 @@ class AuditStore:
     Provides append-only audit trail for all bypass attempts.
     """
 
-    def __init__(self, engine: Any):
+    def __init__(self, engine: Any, *, is_postgresql: bool = False):
         """Initialize audit store.
 
         Args:
             engine: SQLAlchemy database engine
+            is_postgresql: Whether the database is PostgreSQL (config-time flag).
         """
         self.engine = engine
+        self._is_postgresql = is_postgresql
         self._ensure_tables()
 
     def _ensure_tables(self) -> None:
@@ -130,7 +132,7 @@ class AuditStore:
         try:
             with self.engine.connect() as conn:
                 # Check if table exists
-                if self.engine.dialect.name == "sqlite":
+                if not self._is_postgresql:
                     result = conn.execute(
                         text(
                             "SELECT name FROM sqlite_master WHERE type='table' AND name='admin_bypass_audit'"
@@ -171,7 +173,7 @@ class AuditStore:
                             )
                         )
                         conn.commit()
-                elif self.engine.dialect.name == "postgresql":
+                else:
                     result = conn.execute(
                         text(
                             "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = 'admin_bypass_audit'"
@@ -238,8 +240,7 @@ class AuditStore:
 
     def _fix_sql_placeholders(self, sql: str) -> str:
         """Convert SQLite ? placeholders to PostgreSQL %s if needed."""
-        dialect_name = self.engine.dialect.name
-        if dialect_name == "postgresql":
+        if self._is_postgresql:
             return sql.replace("?", "%s")
         return sql
 

--- a/src/nexus/server/background_tasks.py
+++ b/src/nexus/server/background_tasks.py
@@ -164,6 +164,8 @@ async def tiger_cache_queue_task(
 async def version_gc_task(
     session_factory: Any,
     config: VersionGCSettings | None = None,
+    *,
+    is_postgresql: bool = False,
 ) -> None:
     """Background task: Garbage collect old version history (Issue #974).
 
@@ -176,6 +178,7 @@ async def version_gc_task(
     Args:
         session_factory: SQLAlchemy session factory
         config: GC configuration (uses VersionGCSettings.from_env() if None)
+        is_postgresql: Whether the database is PostgreSQL (config-time flag).
 
     Examples:
         >>> # Start version GC task in server
@@ -193,7 +196,7 @@ async def version_gc_task(
     # Wait for server to fully start
     await asyncio.sleep(10)
 
-    gc = VersionHistoryGC(session_factory)
+    gc = VersionHistoryGC(session_factory, is_postgresql=is_postgresql)
 
     while True:
         if config.enabled:
@@ -338,6 +341,8 @@ def start_background_tasks(
     session_factory: Any,
     sandbox_manager: Any | None = None,
     agent_registry: Any | None = None,
+    *,
+    is_postgresql: bool = False,
 ) -> list:
     """Start all background tasks.
 
@@ -345,6 +350,7 @@ def start_background_tasks(
         session_factory: SQLAlchemy session factory
         sandbox_manager: Optional SandboxManager for sandbox cleanup (Issue #372)
         agent_registry: Optional AgentRegistry for heartbeat flush (Issue #1240)
+        is_postgresql: Whether the database is PostgreSQL (config-time flag).
 
     Returns:
         List of asyncio tasks
@@ -368,7 +374,11 @@ def start_background_tasks(
     # Add version history GC (Issue #974)
     gc_config = VersionGCSettings.from_env()
     if gc_config.enabled:
-        tasks.append(asyncio.create_task(version_gc_task(session_factory, gc_config)))
+        tasks.append(
+            asyncio.create_task(
+                version_gc_task(session_factory, gc_config, is_postgresql=is_postgresql)
+            )
+        )
 
     # Add agent heartbeat flush and stale detection (Issue #1240)
     if agent_registry is not None:

--- a/src/nexus/storage/version_gc.py
+++ b/src/nexus/storage/version_gc.py
@@ -130,13 +130,15 @@ class VersionHistoryGC:
         >>> print(f"Deleted {stats.total_deleted} versions")
     """
 
-    def __init__(self, session_factory: Any) -> None:
+    def __init__(self, session_factory: Any, *, is_postgresql: bool = False) -> None:
         """Initialize garbage collector.
 
         Args:
             session_factory: SQLAlchemy session factory
+            is_postgresql: Whether the database is PostgreSQL (config-time flag).
         """
         self._session_factory = session_factory
+        self._is_postgresql = is_postgresql
 
     def run_gc(
         self,
@@ -235,12 +237,9 @@ class VersionHistoryGC:
         stats.duration_seconds = (datetime.now(UTC) - start_time).total_seconds()
         return stats
 
-    def _is_sqlite(self, session: Session) -> bool:
-        """Check if the database is SQLite."""
-        if session.bind is None:
-            return False
-        bind_url = getattr(session.bind, "url", None)
-        return "sqlite" in str(bind_url) if bind_url else False
+    def _is_sqlite(self) -> bool:
+        """Check if the database is SQLite (config-time, not runtime)."""
+        return not self._is_postgresql
 
     def _delete_old_versions(
         self,
@@ -257,7 +256,7 @@ class VersionHistoryGC:
             Tuple of (deleted_count, bytes_reclaimed)
         """
         cutoff_date = datetime.now(UTC) - timedelta(days=retention_days)
-        is_sqlite = self._is_sqlite(session)
+        is_sqlite = self._is_sqlite()
 
         # SQLite-compatible query to find latest version per resource
         # Uses a subquery with GROUP BY instead of DISTINCT ON
@@ -352,7 +351,7 @@ class VersionHistoryGC:
     ) -> tuple[int, int]:
         """Async version that yields between batches."""
         cutoff_date = datetime.now(UTC) - timedelta(days=retention_days)
-        is_sqlite = self._is_sqlite(session)
+        is_sqlite = self._is_sqlite()
 
         # SQLite-compatible query to find latest version per resource
         if is_sqlite:
@@ -446,7 +445,7 @@ class VersionHistoryGC:
         Returns:
             Tuple of (deleted_count, bytes_reclaimed)
         """
-        _is_sqlite = self._is_sqlite(session)  # noqa: F841
+        _is_sqlite = self._is_sqlite()  # noqa: F841
 
         # SQLite doesn't support window functions in all contexts the same way,
         # but ROW_NUMBER() is supported in modern SQLite (3.25+)


### PR DESCRIPTION
## Summary
- Replace `engine.dialect.name` / `engine.url` runtime checks in `ReBACManager`, `AuditStore`, and `VersionHistoryGC` with a config-time `is_postgresql: bool` injected at construction time (KERNEL-ARCHITECTURE §7: driver selection is config-time)
- Wire the flag through `factory.py` (derives from `ctx.db_url`) and `background_tasks.py` callers
- Also fixes 3 additional runtime dialect checks in `ReBACManager` (tiger cache init, NOW() function, DELETE...RETURNING)

## Files Changed
- `src/nexus/rebac/manager.py` — add `is_postgresql` kwarg, replace 4 runtime dialect checks
- `src/nexus/rebac/permissions_enhanced.py` — add `is_postgresql` kwarg, replace 3 runtime dialect checks
- `src/nexus/storage/version_gc.py` — add `is_postgresql` kwarg, simplify `_is_sqlite()` to config-time
- `src/nexus/factory.py` — derive `_is_pg` from `ctx.db_url`, pass to `EnhancedReBACManager` and `AuditStore`
- `src/nexus/server/background_tasks.py` — thread `is_postgresql` through `version_gc_task` and `start_background_tasks`

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [x] All existing callers default to `is_postgresql=False` (SQLite) so test suites are unaffected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)