### PR TITLE
feat(#567): add keys_by_pattern to CacheStoreABC — close enumeration gap

### DIFF
--- a/src/nexus/cache/dragonfly.py
+++ b/src/nexus/cache/dragonfly.py
@@ -342,6 +342,13 @@ class DragonflyCacheStore(CacheStoreABC):
             deleted += sum(1 for r in results if r)
         return deleted
 
+    async def keys_by_pattern(self, pattern: str) -> list[str]:
+        """Return keys matching pattern using SCAN cursor."""
+        result: list[str] = []
+        async for key in self._client.client.scan_iter(match=pattern, count=1000):
+            result.append(key.decode() if isinstance(key, bytes) else key)
+        return result
+
     # --- Batch KV operations (Decision #13) ---
 
     async def get_many(self, keys: list[str]) -> dict[str, bytes | None]:

--- a/src/nexus/cache/inmemory.py
+++ b/src/nexus/cache/inmemory.py
@@ -108,6 +108,15 @@ class InMemoryCacheStore(CacheStoreABC):
                 del self._store[k]
             return len(to_delete)
 
+    async def keys_by_pattern(self, pattern: str) -> list[str]:
+        now = time.monotonic()
+        with self._lock:
+            return [
+                k
+                for k, (_, expire_at) in self._store.items()
+                if fnmatch(k, pattern) and (expire_at is None or now <= expire_at)
+            ]
+
     # --- PubSub operations ---
 
     async def publish(self, channel: str, message: bytes) -> int:

--- a/src/nexus/core/cache_store.py
+++ b/src/nexus/core/cache_store.py
@@ -90,6 +90,25 @@ class CacheStoreABC(ABC):
         """
         ...
 
+    @abstractmethod
+    async def keys_by_pattern(self, pattern: str) -> list[str]:
+        """Return all keys matching a glob pattern.
+
+        Supports ``*`` as wildcard. Examples:
+        - ``a2a:task:zone1:*`` — all zone1 task keys
+        - ``perm:*:user:alice:*`` — permission keys for alice across zones
+
+        Companion to ``delete_by_pattern`` — same pattern syntax, but returns
+        the matching key names instead of deleting them.  Enables enumeration
+        of cached entries for listing/filtering operations.
+
+        Drivers:
+        - InMemoryCacheStore: ``fnmatch`` over dict keys (same as delete_by_pattern)
+        - DragonflyCacheStore: ``SCAN`` cursor (same as delete_by_pattern)
+        - NullCacheStore: always returns ``[]``
+        """
+        ...
+
     # --- Batch KV operations ---
 
     async def get_many(self, keys: list[str]) -> dict[str, bytes | None]:
@@ -175,6 +194,9 @@ class NullCacheStore(CacheStoreABC):
 
     async def delete_by_pattern(self, pattern: str) -> int:
         return 0
+
+    async def keys_by_pattern(self, pattern: str) -> list[str]:
+        return []
 
     async def publish(self, channel: str, message: bytes) -> int:
         return 0


### PR DESCRIPTION
## Summary
- Adds `keys_by_pattern(pattern: str) -> list[str]` abstract method to `CacheStoreABC`
- Implements in all 3 drivers: `InMemoryCacheStore` (fnmatch + TTL), `DragonflyCacheStore` (SCAN cursor), `NullCacheStore` (returns `[]`)
- Closes the enumeration gap: CacheStoreABC had `delete_by_pattern` (SCAN+DELETE) but no way to enumerate matching keys without deleting them
- This is a prerequisite for replacing A2A's `InMemoryTaskStore` with a CacheStoreABC-backed implementation (needs key enumeration for `list_tasks` filtering/pagination)

## Test plan
- [ ] Verify existing cache tests still pass
- [ ] Verify `keys_by_pattern` returns correct results for InMemoryCacheStore
- [ ] Verify NullCacheStore returns empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)