### PR TITLE
fix(#166): remove SandboxRouter wiring from kernel + clean dead override

### DIFF
--- a/src/nexus/core/filesystem.py
+++ b/src/nexus/core/filesystem.py
@@ -899,10 +899,6 @@ class NexusFilesystem(ABC):
         """
         ...
 
-    # NOTE: sandbox_validate() removed from kernel ABC — it's a service-level
-    # linting/validation pipeline, not a kernel primitive. The implementation
-    # remains on NexusFS via @rpc_expose for RPC dispatch.
-
     @abstractmethod
     def sandbox_pause(self, sandbox_id: str, context: dict | None = None) -> dict[Any, Any]:
         """Pause a running sandbox.

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -6296,7 +6296,7 @@ class NexusFS(  # type: ignore[misc]
         return result
 
     @rpc_expose(description="Validate code in sandbox")
-    async def sandbox_validate(  # type: ignore[override]
+    async def sandbox_validate(
         self,
         sandbox_id: str,
         workspace_path: str = "/workspace",


### PR DESCRIPTION
## Summary
- Replace inline `SandboxRouter` import+wiring in `_ensure_sandbox_manager()` with existing `SandboxManager.wire_router()` (removes bricks import from kernel, stops reaching into private `_router` attribute)
- Remove dead `# type: ignore[override]` on `sandbox_validate()` — ABC method was already removed
- Remove stale NOTE comment in `filesystem.py` ABC

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)