### PR TITLE
feat(#1708): DeviceCapabilities auto-detection + profile-based brick gating

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -396,6 +396,36 @@ def connect(
         providers=tuple(cfg.parse_providers) if cfg.parse_providers else None,
     )
 
+    # --- Profile resolution (Issue #1708) ---
+    from nexus.core.deployment_profile import DeploymentProfile, resolve_enabled_bricks
+
+    if cfg.profile == "auto":
+        from nexus.core.device_capabilities import detect_capabilities, suggest_profile
+
+        caps = detect_capabilities()
+        resolved_profile = suggest_profile(caps)
+        logger.info(
+            "Auto-detected profile: %s (RAM=%dMB, GPU=%s, cores=%d)",
+            resolved_profile,
+            caps.memory_mb,
+            caps.has_gpu,
+            caps.cpu_cores,
+        )
+    else:
+        resolved_profile = DeploymentProfile(cfg.profile)
+        # Warn if explicit profile may exceed device capabilities
+        from nexus.core.device_capabilities import (
+            detect_capabilities,
+            warn_if_profile_exceeds_device,
+        )
+
+        caps = detect_capabilities()
+        warn_if_profile_exceeds_device(resolved_profile, caps)
+
+    # Apply FeaturesConfig overrides (Issue #1389 — was unused in connect())
+    overrides = cfg.features.to_overrides() if cfg.features else {}
+    enabled_bricks = resolve_enabled_bricks(resolved_profile, overrides=overrides)
+
     # Create NexusFS via factory
     from nexus.factory import create_nexus_fs
 
@@ -409,6 +439,7 @@ def connect(
         permissions=perm_cfg,
         distributed=dist_cfg,
         parsing=parse_cfg,
+        enabled_bricks=enabled_bricks,
     )
 
     # Set memory config for Memory API

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -348,9 +348,9 @@ class NexusConfig(BaseModel):
     def validate_profile(cls, v: str) -> str:
         """Validate deployment profile.
 
-        Valid profiles: embedded, lite, full, cloud
+        Valid profiles: embedded, lite, full, cloud, auto
         """
-        allowed = ["embedded", "lite", "full", "cloud"]
+        allowed = ["embedded", "lite", "full", "cloud", "auto"]
         if v not in allowed:
             raise ValueError(f"profile must be one of {allowed}, got '{v}'")
         return v

--- a/src/nexus/core/device_capabilities.py
+++ b/src/nexus/core/device_capabilities.py
@@ -1,0 +1,313 @@
+"""Device capability detection and profile suggestion.
+
+Issue #1708: Auto-detect RAM, CPU cores, and GPU availability at startup
+to suggest the appropriate deployment profile (embedded/lite/full/cloud).
+
+Detection is performed once at startup via ``detect_capabilities()``.
+When ``NEXUS_PROFILE=auto``, the suggested profile drives brick gating.
+
+Environment variable overrides (for CI / containers):
+- ``NEXUS_HAS_GPU``: "true"/"false" — skip GPU probe
+- ``NEXUS_MEMORY_MB``: integer — override detected RAM
+- ``NEXUS_CPU_CORES``: integer — override detected CPU count
+
+Lego Architecture reference: Part 10 — Edge Deployment.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import platform
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.core.deployment_profile import DeploymentProfile
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# DeviceCapabilities — immutable snapshot of detected hardware
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeviceCapabilities:
+    """Frozen snapshot of device hardware capabilities.
+
+    Detected once at startup by ``detect_capabilities()``.
+    """
+
+    memory_mb: int
+    cpu_cores: int = 1
+    has_gpu: bool = False
+    has_network: bool = True
+    has_persistent_storage: bool = True
+
+
+# ---------------------------------------------------------------------------
+# BrickRequirement — minimum hardware for each optional brick
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BrickRequirement:
+    """Minimum device capabilities required to run a brick."""
+
+    min_memory_mb: int = 0
+    requires_gpu: bool = False
+    requires_network: bool = False
+
+
+BRICK_REQUIREMENTS: dict[str, BrickRequirement] = {
+    # Feature bricks (Tier 2) — gated by capabilities
+    "search": BrickRequirement(min_memory_mb=512),
+    "llm": BrickRequirement(min_memory_mb=1024),
+    "pay": BrickRequirement(min_memory_mb=128, requires_network=True),
+    "skills": BrickRequirement(min_memory_mb=256),
+    "sandbox": BrickRequirement(min_memory_mb=256),
+    "workflows": BrickRequirement(min_memory_mb=128),
+    "a2a": BrickRequirement(min_memory_mb=64),
+    "discovery": BrickRequirement(min_memory_mb=64),
+    "mcp": BrickRequirement(min_memory_mb=64),
+    "memory": BrickRequirement(min_memory_mb=128),
+    "federation": BrickRequirement(min_memory_mb=256, requires_network=True),
+    # Infrastructure bricks
+    "cache": BrickRequirement(min_memory_mb=64),
+    "ipc": BrickRequirement(min_memory_mb=64),
+    "observability": BrickRequirement(min_memory_mb=64),
+    "uploads": BrickRequirement(min_memory_mb=64),
+    "resiliency": BrickRequirement(min_memory_mb=32),
+    # System bricks (lightweight — always meet requirements in practice)
+    "eventlog": BrickRequirement(min_memory_mb=32),
+    "namespace": BrickRequirement(min_memory_mb=32),
+    "agent_registry": BrickRequirement(min_memory_mb=32),
+    "permissions": BrickRequirement(min_memory_mb=32),
+    "scheduler": BrickRequirement(min_memory_mb=32),
+    # Kernel (always on, listed for completeness)
+    "storage": BrickRequirement(min_memory_mb=0),
+}
+
+
+# ---------------------------------------------------------------------------
+# Detection functions
+# ---------------------------------------------------------------------------
+
+
+def get_system_memory_mb() -> int:
+    """Detect total system memory in megabytes.
+
+    Priority:
+    1. ``NEXUS_MEMORY_MB`` environment variable
+    2. ``psutil.virtual_memory().total``
+    3. Platform-specific fallback (macOS sysctl, Linux /proc/meminfo)
+    4. Conservative default: 4096 MB
+    """
+    env_override = os.environ.get("NEXUS_MEMORY_MB")
+    if env_override is not None:
+        try:
+            return int(env_override)
+        except ValueError:
+            logger.warning("Invalid NEXUS_MEMORY_MB='%s', falling back to detection", env_override)
+
+    try:
+        import psutil
+
+        return int(psutil.virtual_memory().total / (1024 * 1024))
+    except ImportError:
+        pass
+
+    import subprocess
+
+    try:
+        system = platform.system()
+        if system == "Darwin":
+            result = subprocess.run(
+                ["sysctl", "-n", "hw.memsize"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return int(int(result.stdout.strip()) / (1024 * 1024))
+        elif system == "Linux":
+            with open("/proc/meminfo") as f:
+                for line in f:
+                    if line.startswith("MemTotal:"):
+                        kb = int(line.split()[1])
+                        return int(kb / 1024)
+    except (OSError, ValueError, subprocess.TimeoutExpired) as exc:
+        logger.debug("Platform memory detection failed: %s", exc)
+
+    return 4096
+
+
+def get_available_memory_mb() -> int:
+    """Detect available (free) system memory in megabytes.
+
+    Priority:
+    1. ``psutil.virtual_memory().available``
+    2. Conservative default: 2048 MB
+    """
+    try:
+        import psutil
+
+        return int(psutil.virtual_memory().available / (1024 * 1024))
+    except ImportError:
+        pass
+
+    return 2048
+
+
+def get_cpu_cores() -> int:
+    """Detect number of CPU cores.
+
+    Priority:
+    1. ``NEXUS_CPU_CORES`` environment variable
+    2. ``os.cpu_count()``
+    3. Fallback: 1
+    """
+    env_override = os.environ.get("NEXUS_CPU_CORES")
+    if env_override is not None:
+        try:
+            return int(env_override)
+        except ValueError:
+            logger.warning("Invalid NEXUS_CPU_CORES='%s', falling back to detection", env_override)
+
+    count = os.cpu_count()
+    return count if count is not None else 1
+
+
+def has_gpu() -> bool:
+    """Detect whether a GPU is available.
+
+    Priority:
+    1. ``NEXUS_HAS_GPU`` environment variable ("true"/"false")
+    2. ``shutil.which("nvidia-smi")`` path check
+    3. ``nvidia-smi`` subprocess probe
+    4. Default: False
+    """
+    env_override = os.environ.get("NEXUS_HAS_GPU")
+    if env_override is not None:
+        return env_override.lower() in ("true", "1", "yes")
+
+    import shutil
+
+    if shutil.which("nvidia-smi") is None:
+        return False
+
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.returncode == 0 and bool(result.stdout.strip())
+    except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+        return False
+
+
+@functools.lru_cache(maxsize=1)
+def detect_capabilities() -> DeviceCapabilities:
+    """One-shot detection of device capabilities. Logs timing.
+
+    Cached after first call — hardware doesn't change during a process.
+    Called at startup when ``NEXUS_PROFILE=auto`` or when
+    ``warn_if_profile_exceeds_device()`` needs capabilities.
+    """
+    t0 = time.perf_counter()
+
+    caps = DeviceCapabilities(
+        memory_mb=get_system_memory_mb(),
+        cpu_cores=get_cpu_cores(),
+        has_gpu=has_gpu(),
+    )
+
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    logger.info(
+        "Device capabilities detected in %.1fms: RAM=%dMB, cores=%d, GPU=%s",
+        elapsed_ms,
+        caps.memory_mb,
+        caps.cpu_cores,
+        caps.has_gpu,
+    )
+    return caps
+
+
+# ---------------------------------------------------------------------------
+# Profile suggestion and brick filtering
+# ---------------------------------------------------------------------------
+
+# Profile tier indices for comparison
+_PROFILE_INDEX: dict[str, int] = {
+    "embedded": 0,
+    "lite": 1,
+    "full": 2,
+    "cloud": 3,
+}
+
+
+def suggest_profile(caps: DeviceCapabilities) -> DeploymentProfile:
+    """Map device capabilities to a suggested deployment profile.
+
+    Memory thresholds (conservative):
+    - <512 MB   → EMBEDDED
+    - 512–4095 MB → LITE
+    - 4096–32767 MB → FULL
+    - >=32768 MB  → CLOUD
+    """
+    from nexus.core.deployment_profile import DeploymentProfile
+
+    if caps.memory_mb < 512:
+        return DeploymentProfile.EMBEDDED
+    if caps.memory_mb < 4096:
+        return DeploymentProfile.LITE
+    if caps.memory_mb < 32768:
+        return DeploymentProfile.FULL
+    return DeploymentProfile.CLOUD
+
+
+def bricks_for_device(caps: DeviceCapabilities) -> frozenset[str]:
+    """Filter BRICK_REQUIREMENTS by device capabilities.
+
+    Returns the set of brick names whose requirements are met by *caps*.
+    """
+    result: set[str] = set()
+    for brick_name, req in BRICK_REQUIREMENTS.items():
+        if caps.memory_mb < req.min_memory_mb:
+            continue
+        if req.requires_gpu and not caps.has_gpu:
+            continue
+        if req.requires_network and not caps.has_network:
+            continue
+        result.add(brick_name)
+    return frozenset(result)
+
+
+def warn_if_profile_exceeds_device(
+    profile: DeploymentProfile,
+    caps: DeviceCapabilities,
+) -> None:
+    """Log WARNING if the explicit profile may exceed device capabilities.
+
+    Called from connect() and server when profile is explicitly set
+    (not auto) so users get early feedback about potential issues.
+    """
+    suggested = suggest_profile(caps)
+    profile_idx = _PROFILE_INDEX.get(profile.value, 2)
+    suggested_idx = _PROFILE_INDEX.get(suggested.value, 2)
+
+    if profile_idx > suggested_idx:
+        logger.warning(
+            "Profile '%s' may exceed device capabilities (detected: RAM=%dMB, suggested: '%s')",
+            profile,
+            caps.memory_mb,
+            suggested,
+        )

--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -767,146 +768,175 @@ def _resolve_tasks_db_path(backend: Any) -> str:
     return os.path.join(".nexus-data", "tasks-db")
 
 
-def _boot_brick_services(ctx: _BootContext, kernel: dict[str, Any]) -> dict[str, Any]:
+def _boot_brick_services(
+    ctx: _BootContext,
+    kernel: dict[str, Any],
+    brick_on: Callable[[str], bool] | None = None,
+) -> dict[str, Any]:
     """Boot Tier 2 (BRICK) — optional, silent on failure.
 
     Creates Search/Zoekt wiring, Wallet, Manifest, ToolNamespace,
     ChunkedUpload, Distributed infra, Workflow engine, API key creator.
     On failure: logs DEBUG, sets that service to None.
 
+    Args:
+        ctx: Boot context with shared dependencies.
+        kernel: Kernel services dict from Tier 0.
+        brick_on: Callable ``(name: str) -> bool`` for profile-based gating.
+            When None, all bricks are enabled (backward-compatible default).
+
     Returns:
-        Dict with 9 brick service entries (some may be None).
+        Dict with brick service entries (some may be None).
     """
     t0 = time.perf_counter()
 
+    def _on(name: str) -> bool:
+        if brick_on is None:
+            return True
+        return brick_on(name)
+
     # --- Search Brick Import Validation (Issue #1520) ---
-    try:
-        from nexus.search.manifest import verify_imports as _verify_search
+    if _on("search"):
+        try:
+            from nexus.search.manifest import verify_imports as _verify_search
 
-        _search_status = _verify_search()
-        logger.debug("[BOOT:BRICK] Search brick imports: %s", _search_status)
-    except ImportError:
-        logger.debug("[BOOT:BRICK] Search brick manifest not available")
+            _search_status = _verify_search()
+            logger.debug("[BOOT:BRICK] Search brick imports: %s", _search_status)
+        except ImportError:
+            logger.debug("[BOOT:BRICK] Search brick manifest not available")
 
-    # Wire zoekt callbacks into backends (Issue #1520)
-    try:
-        from nexus.search.zoekt_client import notify_zoekt_sync_complete, notify_zoekt_write
+        # Wire zoekt callbacks into backends (Issue #1520)
+        try:
+            from nexus.search.zoekt_client import notify_zoekt_sync_complete, notify_zoekt_write
 
-        if hasattr(ctx.backend, "on_write_callback") and ctx.backend.on_write_callback is None:
-            ctx.backend.on_write_callback = notify_zoekt_write
-        if hasattr(ctx.backend, "on_sync_callback") and ctx.backend.on_sync_callback is None:
-            ctx.backend.on_sync_callback = notify_zoekt_sync_complete
-    except ImportError:
-        logger.debug("[BOOT:BRICK] Zoekt not available, skipping callback wiring")
+            if hasattr(ctx.backend, "on_write_callback") and ctx.backend.on_write_callback is None:
+                ctx.backend.on_write_callback = notify_zoekt_write
+            if hasattr(ctx.backend, "on_sync_callback") and ctx.backend.on_sync_callback is None:
+                ctx.backend.on_sync_callback = notify_zoekt_sync_complete
+        except ImportError:
+            logger.debug("[BOOT:BRICK] Zoekt not available, skipping callback wiring")
+    else:
+        logger.debug("[BOOT:BRICK] Search brick disabled by profile")
 
     # --- Wallet Provisioner (Issue #1210) ---
-    wallet_provisioner = _create_wallet_provisioner()
+    if _on("pay"):
+        wallet_provisioner = _create_wallet_provisioner()
+    else:
+        wallet_provisioner = None
+        logger.debug("[BOOT:BRICK] Pay brick disabled by profile")
 
     # --- Manifest Resolver (Issue #1427, #1428) ---
     manifest_resolver: Any = None
     manifest_metrics: Any = None
-    try:
-        from nexus.bricks.context_manifest import ManifestResolver
-        from nexus.bricks.context_manifest.executors.file_glob import FileGlobExecutor
-        from nexus.bricks.context_manifest.metrics import (
-            ManifestMetricsConfig,
-            ManifestMetricsObserver,
-        )
-
-        executors: dict[str, Any] = {}
-        root_path = getattr(ctx.backend, "root_path", None)
-        if root_path is not None:
-            from pathlib import Path
-
-            try:
-                executors["file_glob"] = FileGlobExecutor(workspace_root=Path(root_path))
-            except TypeError:
-                logger.debug("Cannot create FileGlobExecutor: root_path=%r", root_path)
-
-        # WorkspaceSnapshotExecutor (Issue #1428)
+    if _on("mcp"):
         try:
-            from nexus.bricks.context_manifest.executors.snapshot_lookup_db import (
-                CASManifestReader,
-                DatabaseSnapshotLookup,
+            from nexus.bricks.context_manifest import ManifestResolver
+            from nexus.bricks.context_manifest.executors.file_glob import FileGlobExecutor
+            from nexus.bricks.context_manifest.metrics import (
+                ManifestMetricsConfig,
+                ManifestMetricsObserver,
             )
-            from nexus.bricks.context_manifest.executors.workspace_snapshot import (
-                WorkspaceSnapshotExecutor,
+
+            executors: dict[str, Any] = {}
+            root_path = getattr(ctx.backend, "root_path", None)
+            if root_path is not None:
+                from pathlib import Path
+
+                try:
+                    executors["file_glob"] = FileGlobExecutor(workspace_root=Path(root_path))
+                except TypeError:
+                    logger.debug("Cannot create FileGlobExecutor: root_path=%r", root_path)
+
+            # WorkspaceSnapshotExecutor (Issue #1428)
+            try:
+                from nexus.bricks.context_manifest.executors.snapshot_lookup_db import (
+                    CASManifestReader,
+                    DatabaseSnapshotLookup,
+                )
+                from nexus.bricks.context_manifest.executors.workspace_snapshot import (
+                    WorkspaceSnapshotExecutor,
+                )
+
+                snapshot_lookup = DatabaseSnapshotLookup(session_factory=ctx.session_factory)
+                cas_reader = CASManifestReader(backend=ctx.backend)
+                executors["workspace_snapshot"] = WorkspaceSnapshotExecutor(
+                    snapshot_lookup=snapshot_lookup,
+                    manifest_reader=cas_reader,
+                )
+            except ImportError as _snap_e:
+                logger.debug("WorkspaceSnapshotExecutor unavailable: %s", _snap_e)
+
+            import importlib.util
+
+            if importlib.util.find_spec("nexus.bricks.context_manifest.executors.memory_query"):
+                logger.debug("MemoryQueryExecutor available for per-agent wiring")
+            else:
+                logger.debug("MemoryQueryExecutor module not found")
+
+            manifest_metrics = ManifestMetricsObserver(ManifestMetricsConfig())
+
+            manifest_resolver = ManifestResolver(
+                executors=executors,
+                max_resolve_seconds=5.0,
+                metrics_observer=manifest_metrics,
             )
-
-            snapshot_lookup = DatabaseSnapshotLookup(session_factory=ctx.session_factory)
-            cas_reader = CASManifestReader(backend=ctx.backend)
-            executors["workspace_snapshot"] = WorkspaceSnapshotExecutor(
-                snapshot_lookup=snapshot_lookup,
-                manifest_reader=cas_reader,
-            )
-        except ImportError as _snap_e:
-            logger.debug("WorkspaceSnapshotExecutor unavailable: %s", _snap_e)
-
-        import importlib.util
-
-        if importlib.util.find_spec("nexus.bricks.context_manifest.executors.memory_query"):
-            logger.debug("MemoryQueryExecutor available for per-agent wiring")
-        else:
-            logger.debug("MemoryQueryExecutor module not found")
-
-        manifest_metrics = ManifestMetricsObserver(ManifestMetricsConfig())
-
-        manifest_resolver = ManifestResolver(
-            executors=executors,
-            max_resolve_seconds=5.0,
-            metrics_observer=manifest_metrics,
-        )
-        logger.debug("[BOOT:BRICK] ManifestResolver created with %d executors", len(executors))
-    except ImportError as _e:
-        logger.debug("[BOOT:BRICK] ManifestResolver unavailable: %s", _e)
+            logger.debug("[BOOT:BRICK] ManifestResolver created with %d executors", len(executors))
+        except ImportError as _e:
+            logger.debug("[BOOT:BRICK] ManifestResolver unavailable: %s", _e)
+    else:
+        logger.debug("[BOOT:BRICK] MCP/Manifest brick disabled by profile")
 
     # --- Tool Namespace Middleware (Issue #1272) ---
     tool_namespace_middleware = None
-    try:
-        from nexus.mcp.middleware import ToolNamespaceMiddleware
+    if _on("mcp"):
+        try:
+            from nexus.mcp.middleware import ToolNamespaceMiddleware
 
-        tool_namespace_middleware = ToolNamespaceMiddleware(
-            rebac_manager=kernel["rebac_manager"],
-            zone_id=ctx.zone_id,
-            cache_ttl=ctx.cache_ttl_seconds or 300,
-        )
-        logger.debug("[BOOT:BRICK] ToolNamespaceMiddleware created (zone_id=%s)", ctx.zone_id)
-    except ImportError as _e:
-        logger.debug("[BOOT:BRICK] ToolNamespaceMiddleware unavailable: %s", _e)
+            tool_namespace_middleware = ToolNamespaceMiddleware(
+                rebac_manager=kernel["rebac_manager"],
+                zone_id=ctx.zone_id,
+                cache_ttl=ctx.cache_ttl_seconds or 300,
+            )
+            logger.debug("[BOOT:BRICK] ToolNamespaceMiddleware created (zone_id=%s)", ctx.zone_id)
+        except ImportError as _e:
+            logger.debug("[BOOT:BRICK] ToolNamespaceMiddleware unavailable: %s", _e)
 
     # --- Chunked Upload Service (Issue #788) ---
     chunked_upload_service: Any = None
-    try:
-        import os as _os
+    if _on("uploads"):
+        try:
+            import os as _os
 
-        from nexus.services.chunked_upload_service import (
-            ChunkedUploadConfig,
-            ChunkedUploadService,
-        )
+            from nexus.services.chunked_upload_service import (
+                ChunkedUploadConfig,
+                ChunkedUploadService,
+            )
 
-        _upload_config_kwargs: dict[str, Any] = {}
-        _upload_env_mapping = {
-            "NEXUS_UPLOAD_MIN_CHUNK_SIZE": "min_chunk_size",
-            "NEXUS_UPLOAD_MAX_CHUNK_SIZE": "max_chunk_size",
-            "NEXUS_UPLOAD_DEFAULT_CHUNK_SIZE": "default_chunk_size",
-            "NEXUS_UPLOAD_MAX_CONCURRENT": "max_concurrent_uploads",
-            "NEXUS_UPLOAD_SESSION_TTL_HOURS": "session_ttl_hours",
-            "NEXUS_UPLOAD_CLEANUP_INTERVAL": "cleanup_interval_seconds",
-            "NEXUS_UPLOAD_MAX_SIZE": "max_upload_size",
-        }
-        for _env_var, _config_key in _upload_env_mapping.items():
-            _val = _os.getenv(_env_var)
-            if _val is not None:
-                _upload_config_kwargs[_config_key] = int(_val)
+            _upload_config_kwargs: dict[str, Any] = {}
+            _upload_env_mapping = {
+                "NEXUS_UPLOAD_MIN_CHUNK_SIZE": "min_chunk_size",
+                "NEXUS_UPLOAD_MAX_CHUNK_SIZE": "max_chunk_size",
+                "NEXUS_UPLOAD_DEFAULT_CHUNK_SIZE": "default_chunk_size",
+                "NEXUS_UPLOAD_MAX_CONCURRENT": "max_concurrent_uploads",
+                "NEXUS_UPLOAD_SESSION_TTL_HOURS": "session_ttl_hours",
+                "NEXUS_UPLOAD_CLEANUP_INTERVAL": "cleanup_interval_seconds",
+                "NEXUS_UPLOAD_MAX_SIZE": "max_upload_size",
+            }
+            for _env_var, _config_key in _upload_env_mapping.items():
+                _val = _os.getenv(_env_var)
+                if _val is not None:
+                    _upload_config_kwargs[_config_key] = int(_val)
 
-        chunked_upload_service = ChunkedUploadService(
-            session_factory=ctx.session_factory,
-            backend=ctx.backend,
-            metadata_store=ctx.metadata_store,
-            config=ChunkedUploadConfig(**_upload_config_kwargs),
-        )
-    except Exception as exc:
-        logger.debug("[BOOT:BRICK] ChunkedUploadService unavailable: %s", exc)
+            chunked_upload_service = ChunkedUploadService(
+                session_factory=ctx.session_factory,
+                backend=ctx.backend,
+                metadata_store=ctx.metadata_store,
+                config=ChunkedUploadConfig(**_upload_config_kwargs),
+            )
+        except Exception as exc:
+            logger.debug("[BOOT:BRICK] ChunkedUploadService unavailable: %s", exc)
+    else:
+        logger.debug("[BOOT:BRICK] Uploads brick disabled by profile")
 
     # --- Infrastructure: event bus + lock manager ---
     event_bus: Any = None
@@ -921,7 +951,7 @@ def _boot_brick_services(ctx: _BootContext, kernel: dict[str, Any]) -> dict[str,
 
     # --- Workflow engine ---
     workflow_engine: WorkflowProtocol | None = None
-    if ctx.dist.enable_workflows:
+    if _on("workflows") and ctx.dist.enable_workflows:
         # Try to get Rust glob_match for performance (falls back to fnmatch)
         _glob_match_fn: Any = None
         try:
@@ -931,6 +961,8 @@ def _boot_brick_services(ctx: _BootContext, kernel: dict[str, Any]) -> dict[str,
         except ImportError:
             pass
         workflow_engine = _create_workflow_engine(ctx.record_store, _glob_match_fn)
+    elif not _on("workflows"):
+        logger.debug("[BOOT:BRICK] Workflows brick disabled by profile")
 
     # --- API key creator (Issue #1519, 3A: inject server auth into kernel) ---
     api_key_creator: Any = None
@@ -969,7 +1001,9 @@ def _boot_brick_services(ctx: _BootContext, kernel: dict[str, Any]) -> dict[str,
     ipc_storage_driver: Any = None
     ipc_vfs_driver: Any = None
     ipc_provisioner: Any = None
-    if ctx.session_factory is not None:
+    if not _on("ipc"):
+        logger.debug("[BOOT:BRICK] IPC brick disabled by profile")
+    elif ctx.session_factory is not None:
         try:
             from nexus.ipc.driver import IPCVFSDriver
             from nexus.ipc.provisioning import AgentProvisioner
@@ -1133,10 +1167,12 @@ def create_nexus_services(
     def _brick_on(name: str) -> bool:
         return name in enabled_bricks
 
+    from nexus.core.deployment_profile import ALL_BRICK_NAMES as _ALL_BRICKS
+
     _factory_log.info(
         "Factory: enabled_bricks=%d/%d %s",
         len(enabled_bricks),
-        20,
+        len(_ALL_BRICKS),
         sorted(enabled_bricks),
     )
 
@@ -1146,10 +1182,14 @@ def create_nexus_services(
     from nexus.core.performance_tuning import resolve_profile_tuning
 
     _profile_str = os.environ.get("NEXUS_PROFILE", "full")
-    try:
-        _factory_profile = DeploymentProfile(_profile_str)
-    except ValueError:
+    if _profile_str == "auto":
+        # "auto" is config-only, not in enum — use FULL for tuning defaults
         _factory_profile = DeploymentProfile.FULL
+    else:
+        try:
+            _factory_profile = DeploymentProfile(_profile_str)
+        except ValueError:
+            _factory_profile = DeploymentProfile.FULL
     _profile_tuning = resolve_profile_tuning(_factory_profile)
 
     perm = permissions or _PermissionConfig()
@@ -1181,8 +1221,8 @@ def create_nexus_services(
     # --- Tier 1: SYSTEM (degraded on failure) ---
     system_dict = _boot_system_services(ctx, kernel_dict)
 
-    # --- Tier 2: BRICK (optional) ---
-    brick_dict = _boot_brick_services(ctx, kernel_dict)
+    # --- Tier 2: BRICK (optional, gated by profile) ---
+    brick_dict = _boot_brick_services(ctx, kernel_dict, _brick_on)
 
     # --- Start background threads post-construction ---
     _start_background_services(kernel_dict, system_dict)

--- a/src/nexus/search/mobile_config.py
+++ b/src/nexus/search/mobile_config.py
@@ -27,7 +27,6 @@ References:
 from __future__ import annotations
 
 import logging
-import platform
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
@@ -440,58 +439,29 @@ TIER_PRESETS: dict[DeviceTier, MobileSearchConfig] = {
 def get_system_memory_gb() -> float:
     """Get total system memory in gigabytes.
 
+    Delegates to ``nexus.core.device_capabilities.get_system_memory_mb()``
+    (Issue #1708: DRY extraction).
+
     Returns:
         Total RAM in GB, or 4.0 as fallback if detection fails
     """
-    try:
-        import psutil
+    from nexus.core.device_capabilities import get_system_memory_mb
 
-        return psutil.virtual_memory().total / (1024**3)  # type: ignore[no-any-return]
-    except ImportError:
-        logger.warning("psutil not available, using fallback memory detection")
-
-    # Fallback: try platform-specific methods
-    try:
-        system = platform.system()
-        if system == "Darwin":  # macOS
-            import subprocess
-
-            result = subprocess.run(
-                ["sysctl", "-n", "hw.memsize"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            return int(result.stdout.strip()) / (1024**3)
-        elif system == "Linux":
-            with open("/proc/meminfo") as f:
-                for line in f:
-                    if line.startswith("MemTotal:"):
-                        # Value is in KB
-                        kb = int(line.split()[1])
-                        return kb / (1024**2)
-    except Exception as e:
-        logger.warning(f"Failed to detect system memory: {e}")
-
-    # Conservative fallback
-    return 4.0
+    return get_system_memory_mb() / 1024
 
 
 def get_available_memory_gb() -> float:
     """Get available (free) system memory in gigabytes.
 
+    Delegates to ``nexus.core.device_capabilities.get_available_memory_mb()``
+    (Issue #1708: DRY extraction).
+
     Returns:
         Available RAM in GB, or 2.0 as fallback if detection fails
     """
-    try:
-        import psutil
+    from nexus.core.device_capabilities import get_available_memory_mb
 
-        return psutil.virtual_memory().available / (1024**3)  # type: ignore[no-any-return]
-    except ImportError:
-        pass
-
-    # Conservative fallback
-    return 2.0
+    return get_available_memory_mb() / 1024
 
 
 def detect_device_tier(

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -1275,17 +1275,47 @@ def create_app(
     app.state.database_url = database_url
     app.state.data_dir = data_dir  # Issue #1412: A2A task persistence
 
-    # Deployment profile (Issue #1389): resolve enabled bricks from NEXUS_PROFILE env
+    # Deployment profile (Issue #1389, #1708): resolve enabled bricks from NEXUS_PROFILE env
     from nexus.core.deployment_profile import DeploymentProfile, resolve_enabled_bricks
 
     _profile_str = os.environ.get("NEXUS_PROFILE", "full")
-    try:
-        _profile = DeploymentProfile(_profile_str)
-    except ValueError:
-        logger.warning("Unknown NEXUS_PROFILE '%s', defaulting to 'full'", _profile_str)
-        _profile = DeploymentProfile.FULL
+    if _profile_str == "auto":
+        from nexus.core.device_capabilities import detect_capabilities, suggest_profile
+
+        _caps = detect_capabilities()
+        _profile = suggest_profile(_caps)
+        logger.info(
+            "Auto-detected profile: %s (RAM=%dMB, GPU=%s, cores=%d)",
+            _profile,
+            _caps.memory_mb,
+            _caps.has_gpu,
+            _caps.cpu_cores,
+        )
+    else:
+        try:
+            _profile = DeploymentProfile(_profile_str)
+        except ValueError:
+            logger.warning("Unknown NEXUS_PROFILE '%s', defaulting to 'full'", _profile_str)
+            _profile = DeploymentProfile.FULL
+        # Warn if explicit profile may exceed device capabilities
+        from nexus.core.device_capabilities import (
+            detect_capabilities as _detect_caps,
+        )
+        from nexus.core.device_capabilities import (
+            warn_if_profile_exceeds_device,
+        )
+
+        _caps = _detect_caps()
+        warn_if_profile_exceeds_device(_profile, _caps)
+
+    # Apply FeaturesConfig overrides (Issue #1389 — was unused in server)
+    _features_overrides: dict[str, bool] = {}
+    _nx_config = getattr(nexus_fs, "_config", None)
+    if _nx_config is not None and hasattr(_nx_config, "features") and _nx_config.features:
+        _features_overrides = _nx_config.features.to_overrides()
+
     app.state.deployment_profile = _profile.value
-    app.state.enabled_bricks = resolve_enabled_bricks(_profile)
+    app.state.enabled_bricks = resolve_enabled_bricks(_profile, overrides=_features_overrides)
 
     # Performance tuning (Issue #2071): resolve per-profile thresholds
     app.state.profile_tuning = _profile.tuning()

--- a/tests/e2e/self_contained/test_device_capabilities_e2e.py
+++ b/tests/e2e/self_contained/test_device_capabilities_e2e.py
@@ -1,0 +1,170 @@
+"""E2E tests for device capability auto-detection and profile suggestion.
+
+Issue #1708: 'lite' deployment profile + DeviceCapabilities auto-detection.
+
+Tests:
+- Auto profile via features endpoint (mocked capabilities)
+- Explicit profile with mismatch warning
+- FeaturesConfig override with auto profile
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.core.deployment_profile import (
+    ALL_BRICK_NAMES,
+    DeploymentProfile,
+    resolve_enabled_bricks,
+)
+from nexus.core.device_capabilities import DeviceCapabilities
+from nexus.server.api.core.features import FeaturesResponse, router
+
+
+def _make_features_app(
+    profile: DeploymentProfile,
+    enabled_bricks: frozenset[str] | None = None,
+) -> FastAPI:
+    """Create a FastAPI app with features endpoint and pre-computed features_info."""
+    app = FastAPI()
+    bricks = enabled_bricks if enabled_bricks is not None else profile.default_bricks()
+    disabled = sorted(ALL_BRICK_NAMES - bricks)
+
+    app.state.features_info = FeaturesResponse(
+        profile=profile.value,
+        mode="standalone",
+        enabled_bricks=sorted(bricks),
+        disabled_bricks=disabled,
+        version="0.test.0",
+    )
+    app.state.limiter = MagicMock()
+    app.include_router(router)
+    return app
+
+
+class TestAutoProfileViaFeatures:
+    """Test auto-detected profile reflected in /api/v2/features."""
+
+    @pytest.mark.parametrize(
+        "memory_mb,expected_profile,expected_absent",
+        [
+            pytest.param(256, "embedded", {"search", "pay", "llm"}, id="256MB-embedded"),
+            pytest.param(2048, "lite", {"search", "pay", "llm"}, id="2048MB-lite"),
+            pytest.param(8192, "full", set(), id="8192MB-full"),
+            pytest.param(65536, "cloud", set(), id="65536MB-cloud"),
+        ],
+    )
+    def test_auto_detected_profile(
+        self,
+        memory_mb: int,
+        expected_profile: str,
+        expected_absent: set[str],
+    ) -> None:
+        from nexus.core.device_capabilities import suggest_profile
+
+        caps = DeviceCapabilities(memory_mb=memory_mb, cpu_cores=4, has_gpu=False)
+        profile = suggest_profile(caps)
+
+        assert profile.value == expected_profile
+
+        bricks = resolve_enabled_bricks(profile)
+        app = _make_features_app(profile, enabled_bricks=bricks)
+        client = TestClient(app)
+
+        data = client.get("/api/v2/features").json()
+        assert data["profile"] == expected_profile
+        for brick in expected_absent:
+            assert brick not in data["enabled_bricks"]
+
+
+class TestExplicitProfileWithMismatchWarning:
+    """Test that explicit profile with low RAM logs a warning."""
+
+    def test_mismatch_warning_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        from nexus.core.device_capabilities import warn_if_profile_exceeds_device
+
+        caps = DeviceCapabilities(memory_mb=256)  # suggested: embedded
+        with caplog.at_level(logging.WARNING, logger="nexus.core.device_capabilities"):
+            warn_if_profile_exceeds_device(DeploymentProfile.FULL, caps)
+
+        assert any("may exceed device capabilities" in r.message for r in caplog.records)
+        assert any("RAM=256MB" in r.message for r in caplog.records)
+
+    def test_no_warning_for_matching_profile(self, caplog: pytest.LogCaptureFixture) -> None:
+        from nexus.core.device_capabilities import warn_if_profile_exceeds_device
+
+        caps = DeviceCapabilities(memory_mb=8192)  # suggested: full
+        with caplog.at_level(logging.WARNING, logger="nexus.core.device_capabilities"):
+            warn_if_profile_exceeds_device(DeploymentProfile.FULL, caps)
+
+        assert not any("may exceed" in r.message for r in caplog.records)
+
+
+class TestFeaturesConfigOverrideWithAutoProfile:
+    """Test that FeaturesConfig overrides work with auto-detected profile."""
+
+    def test_auto_profile_with_search_override(self) -> None:
+        """Auto-detect lite profile, then force-enable search via override."""
+        from nexus.core.device_capabilities import suggest_profile
+
+        caps = DeviceCapabilities(memory_mb=2048)  # lite
+        profile = suggest_profile(caps)
+        assert profile == DeploymentProfile.LITE
+
+        # Force-enable search via FeaturesConfig override
+        bricks = resolve_enabled_bricks(profile, overrides={"search": True})
+        assert "search" in bricks
+
+        # Verify through features endpoint
+        app = _make_features_app(profile, enabled_bricks=bricks)
+        client = TestClient(app)
+
+        data = client.get("/api/v2/features").json()
+        assert data["profile"] == "lite"
+        assert "search" in data["enabled_bricks"]
+
+    def test_auto_profile_with_brick_disabled(self) -> None:
+        """Auto-detect full profile, then force-disable pay via override."""
+        from nexus.core.device_capabilities import suggest_profile
+
+        caps = DeviceCapabilities(memory_mb=8192)  # full
+        profile = suggest_profile(caps)
+        assert profile == DeploymentProfile.FULL
+
+        # Force-disable pay via override
+        bricks = resolve_enabled_bricks(profile, overrides={"pay": False})
+        assert "pay" not in bricks
+
+        app = _make_features_app(profile, enabled_bricks=bricks)
+        client = TestClient(app)
+
+        data = client.get("/api/v2/features").json()
+        assert data["profile"] == "full"
+        assert "pay" not in data["enabled_bricks"]
+        assert "pay" in data["disabled_bricks"]
+
+
+class TestComputeFeaturesInfoAutoProfile:
+    """Test _compute_features_info with auto-resolved bricks."""
+
+    def test_compute_with_lite_bricks(self) -> None:
+        from nexus.server.lifespan import _compute_features_info
+
+        app = FastAPI()
+        app.state.deployment_profile = "lite"
+        app.state.deployment_mode = "standalone"
+        app.state.enabled_bricks = resolve_enabled_bricks(DeploymentProfile.LITE)
+
+        _compute_features_info(app)
+
+        info: Any = app.state.features_info
+        assert info.profile == "lite"
+        assert "storage" in info.enabled_bricks
+        assert "search" not in info.enabled_bricks
+        assert "search" in info.disabled_bricks

--- a/tests/unit/core/test_device_capabilities.py
+++ b/tests/unit/core/test_device_capabilities.py
@@ -1,0 +1,458 @@
+"""Tests for device capability detection and profile suggestion.
+
+Issue #1708: DeviceCapabilities auto-detection + profile suggestion.
+
+Tests cover:
+- DeviceCapabilities dataclass (frozen, defaults)
+- get_system_memory_mb() detection with psutil + platform fallbacks
+- get_available_memory_mb() detection
+- get_cpu_cores() detection + fallback
+- has_gpu() detection with env override, shutil.which, subprocess
+- detect_capabilities() integration + timing log
+- BrickRequirement dataclass
+- BRICK_REQUIREMENTS completeness
+- bricks_for_device() — table-driven parametrized
+- suggest_profile() — table-driven parametrized
+- warn_if_profile_exceeds_device() — warning logged
+- Smoke test — unmocked detect_capabilities()
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.core.deployment_profile import DeploymentProfile
+from nexus.core.device_capabilities import (
+    BRICK_REQUIREMENTS,
+    BrickRequirement,
+    DeviceCapabilities,
+    bricks_for_device,
+    detect_capabilities,
+    get_available_memory_mb,
+    get_cpu_cores,
+    get_system_memory_mb,
+    has_gpu,
+    suggest_profile,
+    warn_if_profile_exceeds_device,
+)
+
+# ---------------------------------------------------------------------------
+# DeviceCapabilities dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceCapabilities:
+    """Tests for the DeviceCapabilities frozen dataclass."""
+
+    def test_frozen(self) -> None:
+        caps = DeviceCapabilities(memory_mb=2048, cpu_cores=4)
+        with pytest.raises(AttributeError):
+            caps.memory_mb = 4096  # type: ignore[misc]
+
+    def test_defaults(self) -> None:
+        caps = DeviceCapabilities(memory_mb=1024)
+        assert caps.cpu_cores == 1
+        assert caps.has_gpu is False
+        assert caps.has_network is True
+        assert caps.has_persistent_storage is True
+
+    def test_all_fields(self) -> None:
+        caps = DeviceCapabilities(
+            memory_mb=8192,
+            cpu_cores=8,
+            has_gpu=True,
+            has_network=False,
+            has_persistent_storage=False,
+        )
+        assert caps.memory_mb == 8192
+        assert caps.cpu_cores == 8
+        assert caps.has_gpu is True
+        assert caps.has_network is False
+        assert caps.has_persistent_storage is False
+
+
+# ---------------------------------------------------------------------------
+# get_system_memory_mb()
+# ---------------------------------------------------------------------------
+
+
+class TestGetSystemMemoryMb:
+    """Tests for get_system_memory_mb() detection."""
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_MEMORY_MB", "16384")
+        assert get_system_memory_mb() == 16384
+
+    def test_psutil_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_MEMORY_MB", raising=False)
+        mock_psutil = MagicMock()
+        mock_psutil.virtual_memory.return_value.total = 8 * 1024 * 1024 * 1024  # 8 GB
+        with patch.dict("sys.modules", {"psutil": mock_psutil}):
+            result = get_system_memory_mb()
+            assert result == 8192
+
+    def test_psutil_missing_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_MEMORY_MB", raising=False)
+
+        def _import_fail(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if name == "psutil":
+                raise ImportError("no psutil")
+            return original_import(name, *args, **kwargs)
+
+        import builtins
+
+        original_import = builtins.__import__
+
+        with (
+            patch("nexus.core.device_capabilities.platform.system", return_value="Darwin"),
+            patch("builtins.__import__", side_effect=_import_fail),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = str(4 * 1024 * 1024 * 1024)  # 4 GB in bytes
+            result = get_system_memory_mb()
+            assert result == 4096
+
+    def test_fallback_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_MEMORY_MB", raising=False)
+
+        def _import_fail(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if name == "psutil":
+                raise ImportError("no psutil")
+            return original_import(name, *args, **kwargs)
+
+        import builtins
+
+        original_import = builtins.__import__
+
+        with (
+            patch("builtins.__import__", side_effect=_import_fail),
+            patch(
+                "nexus.core.device_capabilities.platform.system",
+                side_effect=OSError("unknown platform"),
+            ),
+        ):
+            result = get_system_memory_mb()
+            assert result == 4096
+
+
+# ---------------------------------------------------------------------------
+# get_available_memory_mb()
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableMemoryMb:
+    """Tests for get_available_memory_mb() detection."""
+
+    def test_psutil_available(self) -> None:
+        mock_psutil = MagicMock()
+        mock_psutil.virtual_memory.return_value.available = 4 * 1024 * 1024 * 1024
+        with patch.dict("sys.modules", {"psutil": mock_psutil}):
+            result = get_available_memory_mb()
+            assert result == 4096
+
+    def test_fallback(self) -> None:
+        def _import_fail(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if name == "psutil":
+                raise ImportError("no psutil")
+            return original_import(name, *args, **kwargs)
+
+        import builtins
+
+        original_import = builtins.__import__
+
+        with patch("builtins.__import__", side_effect=_import_fail):
+            result = get_available_memory_mb()
+            assert result == 2048
+
+
+# ---------------------------------------------------------------------------
+# get_cpu_cores()
+# ---------------------------------------------------------------------------
+
+
+class TestGetCpuCores:
+    """Tests for get_cpu_cores() detection."""
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_CPU_CORES", "16")
+        assert get_cpu_cores() == 16
+
+    def test_os_cpu_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_CPU_CORES", raising=False)
+        with patch("os.cpu_count", return_value=8):
+            assert get_cpu_cores() == 8
+
+    def test_cpu_count_none_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_CPU_CORES", raising=False)
+        with patch("os.cpu_count", return_value=None):
+            assert get_cpu_cores() == 1
+
+
+# ---------------------------------------------------------------------------
+# has_gpu()
+# ---------------------------------------------------------------------------
+
+
+class TestHasGpu:
+    """Tests for has_gpu() detection."""
+
+    def test_env_override_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_HAS_GPU", "true")
+        assert has_gpu() is True
+
+    def test_env_override_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_HAS_GPU", "false")
+        assert has_gpu() is False
+
+    def test_no_nvidia_smi(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_HAS_GPU", raising=False)
+        with patch("shutil.which", return_value=None):
+            assert has_gpu() is False
+
+    def test_nvidia_smi_found_and_works(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_HAS_GPU", raising=False)
+        with (
+            patch("shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "NVIDIA GeForce RTX 3090"
+            assert has_gpu() is True
+
+    def test_nvidia_smi_found_but_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_HAS_GPU", raising=False)
+        with (
+            patch("shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stdout = ""
+            assert has_gpu() is False
+
+
+# ---------------------------------------------------------------------------
+# detect_capabilities()
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCapabilities:
+    """Tests for detect_capabilities() integration."""
+
+    def setup_method(self) -> None:
+        """Clear lru_cache before each test."""
+        detect_capabilities.cache_clear()
+
+    def test_integration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_MEMORY_MB", "2048")
+        monkeypatch.setenv("NEXUS_CPU_CORES", "4")
+        monkeypatch.setenv("NEXUS_HAS_GPU", "false")
+
+        caps = detect_capabilities()
+        assert caps.memory_mb == 2048
+        assert caps.cpu_cores == 4
+        assert caps.has_gpu is False
+        assert caps.has_network is True
+
+    def test_logs_timing(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("NEXUS_MEMORY_MB", "1024")
+        monkeypatch.setenv("NEXUS_CPU_CORES", "2")
+        monkeypatch.setenv("NEXUS_HAS_GPU", "false")
+
+        with caplog.at_level(logging.INFO, logger="nexus.core.device_capabilities"):
+            detect_capabilities()
+
+        assert any("detected in" in record.message for record in caplog.records)
+
+    def test_caching(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_MEMORY_MB", "2048")
+        monkeypatch.setenv("NEXUS_CPU_CORES", "4")
+        monkeypatch.setenv("NEXUS_HAS_GPU", "false")
+
+        caps1 = detect_capabilities()
+        caps2 = detect_capabilities()
+        assert caps1 is caps2  # same object from cache
+
+
+# ---------------------------------------------------------------------------
+# BrickRequirement + BRICK_REQUIREMENTS
+# ---------------------------------------------------------------------------
+
+
+class TestBrickRequirement:
+    """Tests for BrickRequirement dataclass and BRICK_REQUIREMENTS mapping."""
+
+    def test_frozen(self) -> None:
+        req = BrickRequirement(min_memory_mb=512)
+        with pytest.raises(AttributeError):
+            req.min_memory_mb = 1024  # type: ignore[misc]
+
+    def test_defaults(self) -> None:
+        req = BrickRequirement()
+        assert req.min_memory_mb == 0
+        assert req.requires_gpu is False
+        assert req.requires_network is False
+
+    def test_all_bricks_have_entries(self) -> None:
+        from nexus.core.deployment_profile import ALL_BRICK_NAMES
+
+        for brick_name in ALL_BRICK_NAMES:
+            assert brick_name in BRICK_REQUIREMENTS, f"Missing requirement for {brick_name}"
+
+    def test_values_reasonable(self) -> None:
+        for brick_name, req in BRICK_REQUIREMENTS.items():
+            assert req.min_memory_mb >= 0, f"{brick_name} has negative memory requirement"
+            assert req.min_memory_mb <= 4096, f"{brick_name} requires too much memory"
+
+
+# ---------------------------------------------------------------------------
+# bricks_for_device() — table-driven
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "memory_mb,has_gpu_flag,has_network_flag,expected_absent,expected_present",
+    [
+        pytest.param(
+            256,
+            False,
+            True,
+            {"search", "llm"},
+            {"storage", "eventlog", "skills", "pay", "sandbox", "workflows"},
+            id="256MB-no-gpu",
+        ),
+        pytest.param(
+            2048,
+            False,
+            True,
+            set(),
+            {"search", "llm", "skills", "sandbox", "workflows", "pay"},
+            id="2048MB-no-gpu-lite",
+        ),
+        pytest.param(
+            8192,
+            True,
+            True,
+            set(),
+            {"search", "llm", "skills", "sandbox", "pay", "workflows", "federation"},
+            id="8192MB-gpu-full",
+        ),
+        pytest.param(
+            32768,
+            True,
+            True,
+            set(),
+            {"search", "llm", "skills", "sandbox", "pay", "workflows", "federation"},
+            id="32768MB-gpu-cloud",
+        ),
+        pytest.param(
+            512,
+            False,
+            True,
+            {"llm"},
+            {"search", "skills", "sandbox"},
+            id="512MB-boundary",
+        ),
+        pytest.param(
+            1024,
+            False,
+            False,
+            {"pay", "federation"},
+            {"search", "skills", "sandbox", "llm"},
+            id="1024MB-no-network",
+        ),
+    ],
+)
+def test_bricks_for_device(
+    memory_mb: int,
+    has_gpu_flag: bool,
+    has_network_flag: bool,
+    expected_absent: set[str],
+    expected_present: set[str],
+) -> None:
+    caps = DeviceCapabilities(
+        memory_mb=memory_mb,
+        has_gpu=has_gpu_flag,
+        has_network=has_network_flag,
+    )
+    result = bricks_for_device(caps)
+    for brick in expected_present:
+        assert brick in result, f"{brick} should be present for {memory_mb}MB"
+    for brick in expected_absent:
+        assert brick not in result, f"{brick} should be absent for {memory_mb}MB"
+
+
+# ---------------------------------------------------------------------------
+# suggest_profile() — table-driven
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "memory_mb,expected_profile",
+    [
+        pytest.param(256, DeploymentProfile.EMBEDDED, id="256MB-embedded"),
+        pytest.param(511, DeploymentProfile.EMBEDDED, id="511MB-embedded-boundary"),
+        pytest.param(512, DeploymentProfile.LITE, id="512MB-lite"),
+        pytest.param(1024, DeploymentProfile.LITE, id="1024MB-lite"),
+        pytest.param(4095, DeploymentProfile.LITE, id="4095MB-lite-boundary"),
+        pytest.param(4096, DeploymentProfile.FULL, id="4096MB-full"),
+        pytest.param(8192, DeploymentProfile.FULL, id="8192MB-full"),
+        pytest.param(32767, DeploymentProfile.FULL, id="32767MB-full-boundary"),
+        pytest.param(32768, DeploymentProfile.CLOUD, id="32768MB-cloud"),
+        pytest.param(65536, DeploymentProfile.CLOUD, id="65536MB-cloud"),
+    ],
+)
+def test_suggest_profile(memory_mb: int, expected_profile: DeploymentProfile) -> None:
+    caps = DeviceCapabilities(memory_mb=memory_mb)
+    assert suggest_profile(caps) == expected_profile
+
+
+# ---------------------------------------------------------------------------
+# warn_if_profile_exceeds_device()
+# ---------------------------------------------------------------------------
+
+
+class TestWarnIfProfileExceedsDevice:
+    """Tests for profile mismatch warnings."""
+
+    def test_warns_when_profile_exceeds(self, caplog: pytest.LogCaptureFixture) -> None:
+        caps = DeviceCapabilities(memory_mb=256)  # → EMBEDDED
+        with caplog.at_level(logging.WARNING, logger="nexus.core.device_capabilities"):
+            warn_if_profile_exceeds_device(DeploymentProfile.FULL, caps)
+
+        assert any("may exceed device capabilities" in r.message for r in caplog.records)
+
+    def test_no_warning_when_appropriate(self, caplog: pytest.LogCaptureFixture) -> None:
+        caps = DeviceCapabilities(memory_mb=8192)  # → FULL
+        with caplog.at_level(logging.WARNING, logger="nexus.core.device_capabilities"):
+            warn_if_profile_exceeds_device(DeploymentProfile.LITE, caps)
+
+        assert not any("may exceed" in r.message for r in caplog.records)
+
+    def test_no_warning_when_exact_match(self, caplog: pytest.LogCaptureFixture) -> None:
+        caps = DeviceCapabilities(memory_mb=8192)  # → FULL
+        with caplog.at_level(logging.WARNING, logger="nexus.core.device_capabilities"):
+            warn_if_profile_exceeds_device(DeploymentProfile.FULL, caps)
+
+        assert not any("may exceed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Smoke test — unmocked
+# ---------------------------------------------------------------------------
+
+
+class TestSmokeTest:
+    """Smoke test: call detect_capabilities() without mocks."""
+
+    def test_real_detection(self) -> None:
+        detect_capabilities.cache_clear()
+        caps = detect_capabilities()
+        assert caps.memory_mb > 0
+        assert caps.cpu_cores > 0
+        assert isinstance(caps.has_gpu, bool)


### PR DESCRIPTION
## Summary

- **New**: `core/device_capabilities.py` — runtime detection of RAM, CPU cores, GPU via psutil/platform fallbacks with `lru_cache` (4-8ms first call, <0.002ms cached)
- **New**: `NEXUS_PROFILE=auto` support — auto-detects device hardware and maps to deployment profile (embedded/lite/full/cloud)
- **Wire**: Profile-based brick gating through full DI chain: config → `resolve_enabled_bricks()` → `create_nexus_fs()` → factory → `_boot_brick_services(brick_on=...)`
- **Wire**: `FeaturesConfig.to_overrides()` integrated into both `connect()` and `create_app()` (was dead code)
- **DRY**: Extract RAM detection from `search/mobile_config.py` to `core/device_capabilities.py`, delegate via import
- **Gate**: Tier 2 bricks (search, pay, mcp, uploads, workflows, ipc) gated by `_brick_on()` callback; Tier 0/1 always boot

## Stream

**Stream 12**

## LEGO Architecture Alignment

| Principle | Status |
|-----------|--------|
| 4-tier boot (Pillars → Kernel → System → Bricks) | PASS |
| Profile hierarchy (embedded ⊂ lite ⊂ full ⊆ cloud) | PASS |
| Brick gating only in Tier 2 | PASS |
| Tiers 0/1 always boot regardless of profile | PASS |
| DI flow: config → resolve → factory → boot | PASS |
| FeaturesConfig.to_overrides() wired | PASS |
| Immutable brick sets (frozenset) | PASS |

## Files Changed

| File | Action | Change |
|------|--------|--------|
| `src/nexus/core/device_capabilities.py` | **NEW** | +260 LOC — detection, profiling, brick requirements |
| `src/nexus/search/mobile_config.py` | Edit (DRY) | -50, +6 — delegate to core |
| `src/nexus/config.py` | Edit | +1 — add "auto" to allowed profiles |
| `src/nexus/__init__.py` | Edit | +31 — wire enabled_bricks in connect() |
| `src/nexus/server/fastapi_server.py` | Edit | +44 — wire enabled_bricks in create_app() |
| `src/nexus/factory.py` | Edit | +100 — brick gating in _boot_brick_services() |
| `tests/unit/core/test_device_capabilities.py` | **NEW** | 44 unit tests, table-driven |
| `tests/e2e/self_contained/test_device_capabilities_e2e.py` | **NEW** | 9 E2E tests with FastAPI TestClient |

## Test plan

- [x] `ruff check` — all 8 files pass (0 errors)
- [x] `ruff format` — all 8 files formatted
- [x] `mypy` — 6 source files, 0 errors
- [x] Unit tests: 44/44 pass (`test_device_capabilities.py`)
- [x] E2E tests: 9/9 pass (`test_device_capabilities_e2e.py`)
- [x] Regression: 99/99 pass (deployment_profile, features_endpoint, performance_tuning, mobile_search)
- [x] Live server: `NEXUS_PROFILE=lite` — 8 enabled, 14 disabled, 401 on unauthenticated
- [x] Live server: `NEXUS_PROFILE=auto` — auto-detects cloud (32GB), 22 bricks enabled
- [x] Performance: 4.7ms detection, <0.002ms cached, <5ms total startup overhead