### PR TITLE
fix(#820): integrate GraphStore with RecordStoreABC — eliminate runtime dialect sniffing

### DIFF
--- a/docs/architecture/data-storage-matrix.md
+++ b/docs/architecture/data-storage-matrix.md
@@ -133,6 +133,22 @@ Map **data requiring properties** ↔ **storage providing properties**.
 
 ---
 
+## PART 4b: KNOWLEDGE GRAPH (GraphRAG)
+
+| Data Type | Read | Write | Consistency | Query | Size | Card | Dur | Scope | Why Exists | Current Storage | Optimal Storage | Action |
+|-----------|------|-------|-------------|-------|------|------|-----|-------|------------|----------------|-----------------|--------|
+| **EntityModel** | Med | Med | EC | Relational + Vector (embedding similarity, name lookup, batch fetch) | Medium | High | Persistent | Zone | Knowledge graph entities with embeddings for entity resolution (pgvector HNSW) | SQLAlchemy with vector index | **Keep RecordStore** (relational + vector) | ✅ KEEP |
+| **RelationshipModel** | Med | Med | EC | Relational (FK to entities, recursive CTE for N-hop traversal) | Small | Very High | Persistent | Zone | Directed typed relationships between entities for graph traversal | SQLAlchemy with composite indexes | **Keep RecordStore** (relational FK + recursive CTE) | ✅ KEEP |
+| **EntityMentionModel** | Low | Med | EC | Relational (FK to entity + memory, JOIN for provenance) | Tiny | High | Persistent | Zone | Links entities to source memories for provenance tracking | SQLAlchemy | **Keep RecordStore** (relational FK) | ✅ KEEP |
+
+**Analysis:**
+- **EntityModel**: ✅ KEEP RecordStore — uses pgvector for embedding similarity search (same pattern as MemoryModel). Composite indexes on `(zone_id, canonical_name)`.
+- **RelationshipModel**: ✅ KEEP RecordStore — recursive CTEs for N-hop neighbor traversal require SQL. FK to EntityModel.
+- **EntityMentionModel**: ✅ KEEP RecordStore — FK to both EntityModel and MemoryModel for provenance tracking.
+- **GraphStore** is a RecordStore consumer (receives `RecordStoreABC` + session). Dialect selection is config-time via `RecordStoreABC._is_postgresql`.
+
+---
+
 ## PART 5: ACCESS CONTROL (ReBAC)
 
 | Data Type | Read | Write | Consistency | Query | Size | Card | Dur | Scope | Why Exists | Current Storage | Optimal Storage | Action |

--- a/src/nexus/search/graph_store.py
+++ b/src/nexus/search/graph_store.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -46,6 +45,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from nexus.search.embeddings import EmbeddingProvider
+    from nexus.storage.record_store import RecordStoreABC
 
 
 # =============================================================================
@@ -260,7 +260,9 @@ class GraphStore:
 
     def __init__(
         self,
+        record_store: RecordStoreABC,
         session: AsyncSession,
+        *,
         zone_id: str = "root",
         embedding_provider: EmbeddingProvider | None = None,
         merge_threshold: float = 0.85,
@@ -268,35 +270,28 @@ class GraphStore:
     ):
         """Initialize GraphStore.
 
+        GraphStore is a RecordStore consumer — it receives its session and
+        dialect flag from the injected ``RecordStoreABC``.
+
         Args:
-            session: SQLAlchemy async session
-            zone_id: Zone ID for multi-zone isolation
-            embedding_provider: Provider for generating entity embeddings
-            merge_threshold: Similarity threshold for entity merging (0.0-1.0)
-            confidence_threshold: Minimum confidence for relationships
+            record_store: RecordStoreABC that owns the database connection.
+            session: SQLAlchemy async session (from record_store.async_session_factory).
+            zone_id: Zone ID for multi-zone isolation.
+            embedding_provider: Provider for generating entity embeddings.
+            merge_threshold: Similarity threshold for entity merging (0.0-1.0).
+            confidence_threshold: Minimum confidence for relationships.
         """
+        self._record_store = record_store
         self.session = session
         self.zone_id = zone_id
         self.embedding_provider = embedding_provider
         self.merge_threshold = merge_threshold
         self.confidence_threshold = confidence_threshold
+        self._is_postgresql: bool = getattr(record_store, "_is_postgresql", False)
 
     def _is_postgres(self) -> bool:
-        """Check if the database is PostgreSQL (vs SQLite).
-
-        Uses the session's engine URL to determine the database type.
-        """
-        bind = self.session.get_bind()
-        if bind is None:
-            # Fallback to environment variable
-            db_url = os.environ.get("NEXUS_DATABASE_URL", "")
-            return db_url.startswith(("postgres", "postgresql"))
-        # Handle both Engine and Connection types
-        url = getattr(bind, "url", None)
-        if url is None:
-            return False
-        db_url = str(url)
-        return db_url.startswith(("postgres", "postgresql"))
+        """Check if the database is PostgreSQL (vs SQLite)."""
+        return self._is_postgresql
 
     # =========================================================================
     # Entity CRUD Operations

--- a/src/nexus/server/api/v1/dependencies.py
+++ b/src/nexus/server/api/v1/dependencies.py
@@ -103,6 +103,17 @@ def get_async_read_session_factory(request: Request) -> Any:
     return get_async_session_factory(request)
 
 
+def get_record_store(request: Request) -> Any:
+    """Get RecordStoreABC from app.state, raising 503 if not available."""
+    store = getattr(request.app.state, "record_store", None)
+    if store is None:
+        raise HTTPException(
+            status_code=503,
+            detail="RecordStore not available",
+        )
+    return store
+
+
 # =============================================================================
 # Optional service dependencies (return None instead of 503)
 # =============================================================================

--- a/src/nexus/server/api/v1/routers/graph.py
+++ b/src/nexus/server/api/v1/routers/graph.py
@@ -18,7 +18,11 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
-from nexus.server.api.v1.dependencies import get_async_read_session_factory, get_nexus_fs
+from nexus.server.api.v1.dependencies import (
+    get_async_read_session_factory,
+    get_nexus_fs,
+    get_record_store,
+)
 from nexus.server.dependencies import require_auth
 
 logger = logging.getLogger(__name__)
@@ -32,7 +36,9 @@ router = APIRouter(tags=["graph"])
 
 
 @asynccontextmanager
-async def _graph_session(async_session_factory: Any, zone_id: str) -> AsyncIterator[Any]:
+async def _graph_session(
+    record_store: Any, async_session_factory: Any, zone_id: str
+) -> AsyncIterator[Any]:
     """Create a GraphStore from the RecordStoreABC async session factory.
 
     Uses the shared async_session_factory from RecordStoreABC rather than
@@ -44,7 +50,7 @@ async def _graph_session(async_session_factory: Any, zone_id: str) -> AsyncItera
     from nexus.search.graph_store import GraphStore
 
     async with async_session_factory() as session:
-        yield GraphStore(session, zone_id=zone_id)
+        yield GraphStore(record_store, session, zone_id=zone_id)
 
 
 def _zone_id_from(nexus_fs: Any) -> str:
@@ -62,6 +68,7 @@ async def get_graph_entity(
     entity_id: str,
     _auth_result: dict[str, Any] = Depends(require_auth),
     nexus_fs: Any = Depends(get_nexus_fs),
+    record_store: Any = Depends(get_record_store),
     async_sf: Any = Depends(get_async_read_session_factory),
 ) -> dict[str, Any]:
     """Get an entity by ID from the knowledge graph.
@@ -74,7 +81,7 @@ async def get_graph_entity(
     """
     try:
         zone_id = _zone_id_from(nexus_fs)
-        async with _graph_session(async_sf, zone_id) as graph_store:
+        async with _graph_session(record_store, async_sf, zone_id) as graph_store:
             entity = await graph_store.get_entity(entity_id)
             return {"entity": entity.to_dict() if entity else None}
     except Exception as e:
@@ -89,6 +96,7 @@ async def get_graph_neighbors(
     direction: str = Query("both", description="Direction: outgoing, incoming, both"),
     _auth_result: dict[str, Any] = Depends(require_auth),
     nexus_fs: Any = Depends(get_nexus_fs),
+    record_store: Any = Depends(get_record_store),
     async_sf: Any = Depends(get_async_read_session_factory),
 ) -> dict[str, Any]:
     """Get N-hop neighbors of an entity.
@@ -103,7 +111,7 @@ async def get_graph_neighbors(
     """
     try:
         zone_id = _zone_id_from(nexus_fs)
-        async with _graph_session(async_sf, zone_id) as graph_store:
+        async with _graph_session(record_store, async_sf, zone_id) as graph_store:
             neighbors = await graph_store.get_neighbors(entity_id, hops=hops, direction=direction)
             return {
                 "neighbors": [
@@ -125,6 +133,7 @@ async def get_graph_subgraph(
     request: Request,
     _auth_result: dict[str, Any] = Depends(require_auth),
     nexus_fs: Any = Depends(get_nexus_fs),
+    record_store: Any = Depends(get_record_store),
     async_sf: Any = Depends(get_async_read_session_factory),
 ) -> dict[str, Any]:
     """Extract a subgraph for GraphRAG context building.
@@ -144,7 +153,7 @@ async def get_graph_subgraph(
         max_hops = body.get("max_hops", 2)
 
         zone_id = _zone_id_from(nexus_fs)
-        async with _graph_session(async_sf, zone_id) as graph_store:
+        async with _graph_session(record_store, async_sf, zone_id) as graph_store:
             subgraph = await graph_store.get_subgraph(entity_ids, max_hops=max_hops)
             result: dict[str, Any] = subgraph.to_dict()
             return result
@@ -160,6 +169,7 @@ async def search_graph_entities(
     fuzzy: bool = Query(False, description="Search in aliases as well"),
     _auth_result: dict[str, Any] = Depends(require_auth),
     nexus_fs: Any = Depends(get_nexus_fs),
+    record_store: Any = Depends(get_record_store),
     async_sf: Any = Depends(get_async_read_session_factory),
 ) -> dict[str, Any]:
     """Search for entities by name.
@@ -174,7 +184,7 @@ async def search_graph_entities(
     """
     try:
         zone_id = _zone_id_from(nexus_fs)
-        async with _graph_session(async_sf, zone_id) as graph_store:
+        async with _graph_session(record_store, async_sf, zone_id) as graph_store:
             entity = await graph_store.find_entity(name=name, entity_type=entity_type, fuzzy=fuzzy)
             return {"entity": entity.to_dict() if entity else None}
     except Exception as e:

--- a/src/nexus/server/api/v1/routers/search.py
+++ b/src/nexus/server/api/v1/routers/search.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from nexus.server.api.v1.dependencies import (
     get_async_read_session_factory,
     get_optional_search_daemon,
+    get_record_store,
     get_search_daemon,
 )
 from nexus.server.dependencies import require_auth
@@ -87,6 +88,7 @@ async def search_query(
     ),
     _auth_result: dict[str, Any] = Depends(require_auth),
     search_daemon: Any = Depends(get_search_daemon),
+    record_store: Any = Depends(get_record_store),
     async_session_factory: Any = Depends(get_async_read_session_factory),
 ) -> dict[str, Any]:
     """Execute a fast search query using the search daemon.
@@ -173,6 +175,7 @@ async def search_query(
                 path_filter=path,
                 alpha=alpha,
                 graph_mode=effective_graph_mode,
+                record_store=record_store,
                 async_session_factory=async_session_factory,
                 search_daemon=search_daemon,
             )

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -1290,10 +1290,11 @@ def create_app(
     # Performance tuning (Issue #2071): resolve per-profile thresholds
     app.state.profile_tuning = _profile.tuning()
 
-    # Expose async_session_factory from RecordStoreABC (if available).
+    # Expose RecordStoreABC and its session factories on app.state (if available).
     # This is the canonical way for async endpoints to get database sessions
     # without bypassing the RecordStore abstraction with raw URLs.
     _record_store = getattr(nexus_fs, "_record_store", None)
+    app.state.record_store = _record_store
     if _record_store is not None:
         try:
             app.state.async_session_factory = _record_store.async_session_factory

--- a/src/nexus/services/graph_search_service.py
+++ b/src/nexus/services/graph_search_service.py
@@ -63,6 +63,7 @@ async def graph_enhanced_search(
     alpha: float,
     graph_mode: str,
     *,
+    record_store: Any,
     async_session_factory: Any,
     search_daemon: Any,
 ) -> list[Any]:
@@ -78,6 +79,7 @@ async def graph_enhanced_search(
         path_filter: Optional path prefix filter
         alpha: Semantic vs keyword weight
         graph_mode: Graph enhancement mode (low, high, dual)
+        record_store: RecordStoreABC instance (injected via app.state)
         async_session_factory: Async session factory from RecordStoreABC (injected via app.state)
         search_daemon: SearchDaemon instance (injected)
 
@@ -91,7 +93,7 @@ async def graph_enhanced_search(
     from nexus.search.graph_store import GraphStore
 
     async with async_session_factory() as session:
-        graph_store = GraphStore(session, zone_id="root")
+        graph_store = GraphStore(record_store, session, zone_id="root")
 
         semantic_wrapper = DaemonSemanticSearchWrapper(search_daemon)
         embedding_provider = getattr(search_daemon, "_embedding_provider", None)

--- a/src/nexus/services/memory/memory_api.py
+++ b/src/nexus/services/memory/memory_api.py
@@ -548,7 +548,7 @@ class Memory:
             _store = SQLAlchemyRecordStore(db_url=db_url)
             try:
                 async with _store.async_session_factory() as session:
-                    graph_store = GraphStore(session, zone_id=effective_zone_id)
+                    graph_store = GraphStore(_store, session, zone_id=effective_zone_id)
 
                     # Store entities
                     entity_id_map: dict[str, str] = {}  # name -> entity_id

--- a/tests/e2e/self_contained/test_graph_store.py
+++ b/tests/e2e/self_contained/test_graph_store.py
@@ -24,10 +24,9 @@ import json
 import logging
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from nexus.search.graph_store import GraphStore
-from nexus.storage.models import Base
+from nexus.storage.record_store import SQLAlchemyRecordStore
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
@@ -35,36 +34,32 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-async def async_engine(tmp_path):
-    """Create async database engine with file-based SQLite."""
-    # Use file-based SQLite for testing
+async def record_store(tmp_path):
+    """Create a RecordStore backed by file-based SQLite."""
     db_path = tmp_path / "test_graph.db"
-    async_url = f"sqlite+aiosqlite:///{db_path}"
-
-    engine = create_async_engine(async_url, echo=False)
-
-    # Create all tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-    await engine.dispose()
+    store = SQLAlchemyRecordStore(db_url=f"sqlite:///{db_path}", create_tables=True)
+    yield store
+    store.close()
 
 
 @pytest.fixture
-async def session(async_engine):
-    """Create async database session."""
-    async_session_factory = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
-    async with async_session_factory() as session:
+async def async_engine(record_store):
+    """Get async engine from record_store (delegates to RecordStoreABC)."""
+    # Access the underlying engine for table creation verification
+    yield record_store.engine
+
+
+@pytest.fixture
+async def session(record_store):
+    """Create async database session from RecordStoreABC."""
+    async with record_store.async_session_factory() as session:
         yield session
 
 
 @pytest.fixture
-async def graph_store(session):
+async def graph_store(record_store, session):
     """Create GraphStore instance."""
-    return GraphStore(session, zone_id="test-zone")
+    return GraphStore(record_store, session, zone_id="test-zone")
 
 
 class TestGraphStoreE2E:


### PR DESCRIPTION
## Summary
- **GraphStore** now receives `RecordStoreABC` as its first constructor parameter instead of sniffing `engine.dialect.name` / `os.environ` at runtime, aligning with KERNEL-ARCHITECTURE §7 ("driver selection is config-time")
- Threads `record_store` through FastAPI `app.state` → dependency → routers → services → `GraphStore`
- Documents EntityModel, RelationshipModel, EntityMentionModel in `data-storage-matrix.md` PART 4b as RecordStore data

## Changes
- `graph_store.py`: Constructor takes `(record_store, session, ...)`, removes 15-line runtime `_is_postgres()` + `os` import
- `fastapi_server.py`: Exposes `app.state.record_store`
- `dependencies.py`: Adds `get_record_store()` FastAPI dependency
- `graph.py`: All 4 routes thread `record_store` through `_graph_session`
- `search.py`: Passes `record_store` to `graph_enhanced_search`
- `graph_search_service.py`: Accepts and forwards `record_store`
- `memory_api.py`: Passes ad-hoc `SQLAlchemyRecordStore` to `GraphStore`
- `test_graph_store.py`: Creates `SQLAlchemyRecordStore` fixture
- `data-storage-matrix.md`: PART 4b — knowledge graph models cataloged

## Test plan
- [ ] Existing e2e test `test_graph_store.py` passes with updated fixtures
- [ ] CI passes (ruff, mypy, all hooks green)
- [ ] No runtime dialect sniffing remains in GraphStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)