### PR TITLE
fix(#353): replace raw create_engine with RecordStore in startup callers

### DIFF
--- a/src/nexus/rebac/async_manager.py
+++ b/src/nexus/rebac/async_manager.py
@@ -243,26 +243,3 @@ class AsyncReBACManager:
     def enforce_zone_isolation(self) -> bool:
         """Delegate to sync manager's zone isolation setting."""
         return self._sync.enforce_zone_isolation  # type: ignore[no-any-return]
-
-
-# ── Utility ─────────────────────────────────────────────────────────
-
-
-def create_async_engine_from_url(database_url: str) -> Any:
-    """Create async SQLAlchemy engine from database URL via RecordStoreABC.
-
-    Delegates to SQLAlchemyRecordStore which handles URL conversion and pool
-    settings internally (Issue #592).
-
-    Args:
-        database_url: Standard database URL
-
-    Returns:
-        AsyncEngine instance
-    """
-    from nexus.storage.record_store import SQLAlchemyRecordStore
-
-    store = SQLAlchemyRecordStore(db_url=database_url)
-    # Trigger lazy async engine creation and return it
-    _ = store.async_session_factory
-    return store._async_engine

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -296,15 +296,14 @@ async def lifespan(_app: FastAPI) -> Any:
                 _app.state.async_rebac_manager = AsyncReBACManager(sync_rebac)
                 logger.info("Async ReBAC manager initialized (wrapping sync manager)")
             else:
-                # Fallback: create a fresh sync manager for async wrapper
-                from sqlalchemy import create_engine as _create_engine
-
+                # Fallback: create a fresh sync manager via RecordStore
                 from nexus.rebac.manager import ReBACManager
+                from nexus.storage.record_store import SQLAlchemyRecordStore
 
-                _sync_engine = _create_engine(_app.state.database_url)
-                _sync_mgr = ReBACManager(engine=_sync_engine)
+                _store = SQLAlchemyRecordStore(db_url=_app.state.database_url)
+                _sync_mgr = ReBACManager(engine=_store.engine)
                 _app.state.async_rebac_manager = AsyncReBACManager(_sync_mgr)
-                logger.info("Async ReBAC manager initialized (fresh sync manager)")
+                logger.info("Async ReBAC manager initialized (fresh sync manager via RecordStore)")
 
             # Issue #940: Initialize AsyncNexusFS with permission enforcement
             try:

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -51,11 +51,24 @@ async def _startup_async_rebac(app: FastAPI) -> None:
         return
 
     try:
-        from nexus.rebac.async_manager import AsyncReBACManager, create_async_engine_from_url
+        from nexus.rebac.async_manager import AsyncReBACManager
 
-        engine = create_async_engine_from_url(app.state.database_url)
-        app.state.async_rebac_manager = AsyncReBACManager(engine)
-        logger.info("Async ReBAC manager initialized")
+        # Reuse the sync ReBACManager from NexusFS (avoids creating standalone engine)
+        sync_rebac = (
+            getattr(app.state.nexus_fs, "_rebac_manager", None) if app.state.nexus_fs else None
+        )
+        if sync_rebac:
+            app.state.async_rebac_manager = AsyncReBACManager(sync_rebac)
+            logger.info("Async ReBAC manager initialized (wrapping sync manager)")
+        else:
+            # Fallback: create fresh sync manager using RecordStore engine
+            from nexus.rebac.manager import ReBACManager
+            from nexus.storage.record_store import SQLAlchemyRecordStore
+
+            _store = SQLAlchemyRecordStore(db_url=app.state.database_url)
+            _sync_mgr = ReBACManager(engine=_store.engine)
+            app.state.async_rebac_manager = AsyncReBACManager(_sync_mgr)
+            logger.info("Async ReBAC manager initialized (fresh sync manager via RecordStore)")
 
         # Issue #940: Initialize AsyncNexusFS with permission enforcement
         try:


### PR DESCRIPTION
## Summary
- Rewrites fallback paths in `fastapi_server.py` and `permissions.py` to create engines via `SQLAlchemyRecordStore(db_url=...)` instead of raw `create_engine()` / `create_async_engine_from_url()`
- Fixes a bug in `permissions.py` where a raw engine was passed to `AsyncReBACManager()` (expects `sync_manager`)
- Deletes the now-callerless `create_async_engine_from_url()` utility from `rebac/async_manager.py`

Part 1 of Task #353 (14 classes take raw Engine). This PR fixes the startup caller sites; future sub-tasks will address class constructors.

## Test plan
- [ ] CI passes (ruff, mypy, existing tests)
- [ ] Server startup with `NEXUS_DATABASE_URL` set still initializes async ReBAC manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)