### PR TITLE
fix(#409): remove dead open() fallback in read_dynamic_viewer_file

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -9397,31 +9397,22 @@ class NexusFS(  # type: ignore[misc]
 
         # Read the file content WITHOUT dynamic_viewer filtering
         # We need the raw content to apply filtering here
-        if (
-            hasattr(self, "metadata")
-            and hasattr(self, "router")
-            and hasattr(self, "_get_routing_params")
-        ):
-            zone_id, _agent_id, is_admin = self._get_routing_params(context)
-            route = self.router.route(
-                file_path,
-                zone_id=zone_id,
-                is_admin=is_admin,
-                check_write=False,
-            )
-            meta = self.metadata.get(file_path)
-            if meta is None or meta.etag is None:
-                raise RuntimeError(f"File not found: {file_path}")
+        zone_id, _agent_id, is_admin = self._get_routing_params(context)
+        route = self.router.route(
+            file_path,
+            zone_id=zone_id,
+            is_admin=is_admin,
+            check_write=False,
+        )
+        meta = self.metadata.get(file_path)
+        if meta is None or meta.etag is None:
+            raise RuntimeError(f"File not found: {file_path}")
 
-            # Read raw content from backend
-            content_bytes = route.backend.read_content(meta.etag, context=context).unwrap()
-            content = (
-                content_bytes.decode("utf-8") if isinstance(content_bytes, bytes) else content_bytes
-            )
-        else:
-            # Fallback: read from filesystem
-            with open(file_path, encoding="utf-8") as f:
-                content = f.read()
+        # Read raw content from backend
+        content_bytes = route.backend.read_content(meta.etag, context=context).unwrap()
+        content = (
+            content_bytes.decode("utf-8") if isinstance(content_bytes, bytes) else content_bytes
+        )
 
         # If no dynamic viewer config, return full content
         if not column_config:


### PR DESCRIPTION
## Summary
- Remove dead `else: open(file_path)` fallback in `read_dynamic_viewer_file`
- The `hasattr(self, "metadata/router/_get_routing_params")` guard was always True on NexusFS — these are core kernel attributes
- The else branch bypassed the VFS backend read path by reading directly from host filesystem
- Remaining `open()` calls (export/import, skills) are legitimate host-filesystem I/O, not VFS bypasses

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Existing tests pass (no behavior change — dead code removal only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)