### PR TITLE
fix(#643): migrate _wire_services() from kernel to factory.py

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -53,9 +53,11 @@ system (like systemd): creates selected services and injects them via
 `KernelServices` dataclass. Different distros select different service sets at
 startup — `nexus-server` loads all 22+, `nexus-embedded` loads zero.
 
-> *Implemented:* `factory.py` gates services via `DeploymentProfile` + `enabled_bricks`
-> frozenset. See §5.1 for profile details. Remaining gap: `_wire_services()` in
-> kernel still loads unconditionally (#643).
+> *Resolved (Issue #643):* `factory.py` gates all services via `DeploymentProfile` +
+> `enabled_bricks` frozenset (see §5.1). `_wire_services()` migrated to
+> `factory._boot_wired_services()` — NexusFS constructor no longer imports or creates
+> services. Two-phase init: `NexusFS(...)` → `_boot_wired_services(nx, ...)` →
+> `nx._bind_wired_services(dict)`.
 
 **Phase 2 — Runtime hot-swap (Linux LKM model).** A `ServiceRegistry` manages
 in-process service modules following the Loadable Kernel Module pattern:
@@ -159,8 +161,8 @@ constructor and never auto-creates services.
 
 > *Resolved:* Event mixins fully extracted — `NexusFSEventsMixin` removed (#573),
 > `FileWatcher` moved to `services/watch/` (#706), orphaned kernel attrs cleaned (#656).
-> Remaining: ~40 lazy service imports in `_wire_services()` (#194), replace
-> `KernelServices` dataclass with `ServiceRegistry`.
+> `_wire_services()` deleted — all service creation moved to `factory._boot_wired_services()` (#643).
+> Remaining: replace `KernelServices` dataclass with `ServiceRegistry`.
 
 ### Service Protocols (`nexus.services.protocols`)
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -98,14 +98,6 @@ class NexusFS(  # type: ignore[misc]
         parser_registry: ParserRegistry | None = None,
         provider_registry: Any | None = None,
         vfs_lock_manager: Any | None = None,
-        # Test injection params — "accept or build" services (Issue #2034)
-        rebac_service: Any | None = None,
-        search_service: Any | None = None,
-        events_service: Any | None = None,
-        mount_core_service: Any | None = None,
-        sync_service: Any | None = None,
-        sync_job_service: Any | None = None,
-        mount_persist_service: Any | None = None,
     ):
         """Initialize NexusFS kernel.
 
@@ -128,13 +120,10 @@ class NexusFS(  # type: ignore[misc]
                 for virtual views. Created by factory.py via ParsersBrick.create_parse_fn().
             parser_registry: Injected ParserRegistry from ParsersBrick (Issue #1523).
             provider_registry: Injected ProviderRegistry from ParsersBrick (Issue #1523).
-            rebac_service: Pre-built ReBACService (test injection).
-            search_service: Pre-built SearchService (test injection).
-            events_service: Pre-built EventsService (test injection).
-            mount_core_service: Pre-built MountCoreService (test injection).
-            sync_service: Pre-built SyncService (test injection).
-            sync_job_service: Pre-built SyncJobService (test injection).
-            mount_persist_service: Pre-built MountPersistService (test injection).
+
+        .. versionchanged:: Issue #643
+            Test injection params (rebac_service, search_service, etc.) removed.
+            Services are now created by factory.py and bound via _bind_wired_services().
         """
         # Apply defaults — config dataclasses are SSOT for default values
         cache = cache or CacheConfig()
@@ -157,15 +146,6 @@ class NexusFS(  # type: ignore[misc]
         self._kernel_services = ksvc
         self._system_services = sys_svc
         self._brick_services = brk_svc
-
-        # Store test injection params for _wire_services()
-        self._inject_rebac_service = rebac_service
-        self._inject_search_service = search_service
-        self._inject_events_service = events_service
-        self._inject_mount_core_service = mount_core_service
-        self._inject_sync_service = sync_service
-        self._inject_sync_job_service = sync_job_service
-        self._inject_mount_persist_service = mount_persist_service
 
         # Store config for OAuth factory and other components that need it
         self._config: Any | None = None
@@ -337,8 +317,27 @@ class NexusFS(  # type: ignore[misc]
             self._vfs_lock_manager = create_vfs_lock_manager()
         logger.info("VFS lock manager initialized (%s)", type(self._vfs_lock_manager).__name__)
 
-        # Wire self-dependent services (require self reference)
-        self._wire_services()
+        # Service attributes — set to None by default.
+        # Wired by factory.py two-phase init via _bind_wired_services().
+        # Issue #643: kernel no longer creates services.
+        self.version_service: Any = None
+        self.rebac_service: Any = None
+        self.mount_service: Any = None
+        self._gateway: Any = None
+        self._mount_core_service: Any = None
+        self._sync_service: Any = None
+        self._sync_job_service: Any = None
+        self._mount_persist_service: Any = None
+        self.mcp_service: Any = None
+        self.llm_service: Any = None
+        self._llm_subsystem: Any = None
+        self.oauth_service: Any = None
+        self.skill_service: Any = None
+        self.skill_package_service: Any = None
+        self.search_service: Any = None
+        self.share_link_service: Any = None
+        self.events_service: Any = None
+        self.task_queue_service: Any = None
 
         # Issue #1169: Read Set-Aware Cache for precise invalidation
         # Wraps the metadata cache with read-set-aware invalidation.
@@ -394,177 +393,35 @@ class NexusFS(  # type: ignore[misc]
         """
         self._post_mutation_hooks.append(hook)
 
-    def _wire_services(self) -> None:
-        """Wire services that require a reference to self (NexusFS).
+    def _bind_wired_services(self, wired: dict[str, Any]) -> None:
+        """Bind pre-built services from factory.py two-phase init.
 
-        Called at end of __init__. Services follow "accept or build" pattern:
-        if pre-built via constructor injection params, use that instance;
-        otherwise build internally. This enables test-time mock injection.
+        Called by ``create_nexus_fs()`` AFTER NexusFS construction.
+        All service creation lives in ``factory._boot_wired_services()``.
 
-        Issue #2034: Service sources are now the 3-tier containers
-        (KernelServices, SystemServices, BrickServices) + explicit constructor
-        params for "accept or build" services.
+        Issue #643: Kernel no longer imports or creates services.
+
+        Args:
+            wired: Dict of service_name -> instance (from _boot_wired_services).
         """
-        brk_svc = self._brick_services
-
-        # VersionService: injected by factory (Task #45) — from kernel tier
-        self.version_service = self._kernel_services.version_service
-
-        # Lazy-import services to avoid core/ → services/ top-level coupling (#1519)
-        from nexus.services.llm_service import LLMService
-        from nexus.services.mcp_service import MCPService
-        from nexus.services.mount_service import MountService
-        from nexus.services.oauth_service import OAuthService
-        from nexus.services.search_service import SearchService
-
-        # ReBACService: Permission and access control operations
-        if self._inject_rebac_service is not None:
-            self.rebac_service = self._inject_rebac_service
-        else:
-            from nexus.services.rebac_service import ReBACService
-
-            self.rebac_service = ReBACService(
-                rebac_manager=self._rebac_manager,
-                enforce_permissions=self._enforce_permissions,
-                enable_audit_logging=True,
-                circuit_breaker=brk_svc.rebac_circuit_breaker,
-            )
-
-        # MountService: Dynamic backend mounting operations
-        self.mount_service = MountService(
-            router=self.router,
-            mount_manager=self.mount_manager,
-            nexus_fs=self,
-        )
-
-        # MCPService: Model Context Protocol operations
-        self.mcp_service = MCPService(nexus_fs=self)
-
-        # LLMService: LLM integration operations
-        self.llm_service = LLMService(nexus_fs=self)
-        from nexus.services.subsystems.llm_subsystem import LLMSubsystem
-
-        self._llm_subsystem = LLMSubsystem(llm_service=self.llm_service)
-
-        # OAuthService: OAuth authentication operations
-        self.oauth_service = OAuthService(
-            oauth_factory=None,
-            token_manager=None,
-            nexus_fs=self,
-        )
-
-        # Shared gateway for all extracted services (Issue #1287)
-        from nexus.services.gateway import NexusFSGateway
-
-        self._gateway = NexusFSGateway(self)
-
-        # Mount/sync services: accept pre-built or create (Issue #655)
-        if self._inject_mount_core_service is not None:
-            self._mount_core_service = self._inject_mount_core_service
-        else:
-            from nexus.services.mount_core_service import MountCoreService
-
-            self._mount_core_service = MountCoreService(self._gateway)
-
-        if self._inject_sync_service is not None:
-            self._sync_service = self._inject_sync_service
-        else:
-            from nexus.services.sync_service import SyncService
-
-            self._sync_service = SyncService(self._gateway)
-
-        if self._inject_sync_job_service is not None:
-            self._sync_job_service = self._inject_sync_job_service
-        else:
-            from nexus.services.sync_job_service import SyncJobService
-
-            self._sync_job_service = SyncJobService(self._gateway, self._sync_service)
-
-        if self._inject_mount_persist_service is not None:
-            self._mount_persist_service = self._inject_mount_persist_service
-        else:
-            from nexus.services.mount_persist_service import MountPersistService
-
-            self._mount_persist_service = MountPersistService(
-                mount_manager=getattr(self, "mount_manager", None),
-                mount_service=self._mount_core_service,
-                sync_service=self._sync_service,
-            )
-
-        # TaskQueueService: from brick tier (Issue #655)
-        if brk_svc.task_queue_service is not None:
-            self.task_queue_service = brk_svc.task_queue_service
-
-        # SkillService: Skill management (Issue #2035 — prefer injected brick)
-        if brk_svc.skill_service is not None:
-            self.skill_service = brk_svc.skill_service
-        else:
-            from nexus.services.skill_service import SkillService as _SkillService
-
-            self.skill_service = _SkillService(gateway=self._gateway)
-
-        # SkillPackageService: Skill export/import/validate (Issue #2035)
-        if getattr(brk_svc, "skill_package_service", None) is not None:
-            self.skill_package_service = brk_svc.skill_package_service
-        else:
-            try:
-                from nexus.skills.package_service import (
-                    SkillPackageService as _SkillPkgSvc,
-                )
-
-                # Reuse same protocol deps as skill_service (gateway adapter)
-                self.skill_package_service = _SkillPkgSvc(
-                    fs=self.skill_service._fs,
-                    perms=self.skill_service._perms,
-                    skill_service=self.skill_service,
-                )
-            except Exception:
-                self.skill_package_service = None
-
-        # SearchService: Search operations
-        if self._inject_search_service is not None:
-            self.search_service = self._inject_search_service
-        else:
-            self.search_service = SearchService(
-                metadata_store=self.metadata,
-                permission_enforcer=self._permission_enforcer,
-                router=self.router,
-                rebac_manager=self._rebac_manager,
-                enforce_permissions=self._enforce_permissions,
-                default_context=self._default_context,
-                record_store=self._record_store,
-                gateway=self._gateway,
-            )
-
-        # ShareLinkService: Share link operations
-        from nexus.services.share_link_service import ShareLinkService
-
-        self.share_link_service = ShareLinkService(
-            gateway=self._gateway,
-            enforce_permissions=self._enforce_permissions,
-        )
-
-        # EventsService: File watching + advisory locking
-        if self._inject_events_service is not None:
-            self.events_service = self._inject_events_service
-        else:
-            from nexus.services.events_service import EventsService
-
-            metadata_cache = None
-            if hasattr(self.metadata, "_cache"):
-                metadata_cache = self.metadata._cache
-
-            self.events_service = EventsService(
-                backend=self.backend,
-                event_bus=self._event_bus,
-                lock_manager=self._lock_manager,
-                zone_id=None,
-                metadata_cache=metadata_cache,
-            )
-
-        # _workflow_dispatch REMOVED (#625 infra cleanup)
-        # Kernel no longer references BrickServices.workflow_dispatch.
-        # Userspace hooks register via register_mutation_hook() post-construction.
+        self.version_service = wired.get("version_service")
+        self.rebac_service = wired.get("rebac_service")
+        self.mount_service = wired.get("mount_service")
+        self._gateway = wired.get("gateway")
+        self._mount_core_service = wired.get("mount_core_service")
+        self._sync_service = wired.get("sync_service")
+        self._sync_job_service = wired.get("sync_job_service")
+        self._mount_persist_service = wired.get("mount_persist_service")
+        self.mcp_service = wired.get("mcp_service")
+        self.llm_service = wired.get("llm_service")
+        self._llm_subsystem = wired.get("llm_subsystem")
+        self.oauth_service = wired.get("oauth_service")
+        self.skill_service = wired.get("skill_service")
+        self.skill_package_service = wired.get("skill_package_service")
+        self.search_service = wired.get("search_service")
+        self.share_link_service = wired.get("share_link_service")
+        self.events_service = wired.get("events_service")
+        self.task_queue_service = wired.get("task_queue_service")
 
     @property
     def read_set_cache(self) -> Any | None:

--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -1235,6 +1235,290 @@ def _start_background_services(kernel: dict[str, Any], system: dict[str, Any]) -
         logger.debug("[BOOT:BG] EventDeliveryWorker started")
 
 
+def _boot_wired_services(
+    nx: Any,
+    kernel_services: Any,
+    brick_services: Any,
+    brick_on: Callable[[str], bool] | None = None,
+) -> dict[str, Any]:
+    """Boot Tier 2b (WIRED) — services needing NexusFS reference.
+
+    Two-phase init: called AFTER NexusFS construction in ``create_nexus_fs()``.
+    ``NexusFSGateway`` breaks the circular dependency between kernel and services.
+
+    Profile gating is applied via ``brick_on`` — same callback used by other tiers.
+    Services that fail to construct are set to None (degraded mode).
+
+    Issue #643: Migrated from ``NexusFS._wire_services()`` to factory.py
+    so the kernel never imports or creates services.
+
+    Args:
+        nx: The NexusFS instance (already constructed).
+        kernel_services: KernelServices container (Tier 0).
+        brick_services: BrickServices container (Tier 2).
+        brick_on: Callable ``(name: str) -> bool`` for profile-based gating.
+
+    Returns:
+        Dict of service name -> instance (some may be None).
+    """
+    t0 = time.perf_counter()
+
+    def _on(name: str) -> bool:
+        if brick_on is None:
+            return True
+        return brick_on(name)
+
+    # --- NexusFSGateway: adapter breaking circular dep (Issue #1287) ---
+    gateway: Any = None
+    try:
+        from nexus.services.gateway import NexusFSGateway
+
+        gateway = NexusFSGateway(nx)
+        logger.debug("[BOOT:WIRED] NexusFSGateway created")
+    except Exception as exc:
+        logger.warning("[BOOT:WIRED] NexusFSGateway unavailable: %s", exc)
+
+    # --- ReBACService: Permission and access control operations ---
+    rebac_service: Any = None
+    try:
+        from nexus.services.rebac_service import ReBACService
+
+        rebac_service = ReBACService(
+            rebac_manager=kernel_services.rebac_manager,
+            enforce_permissions=getattr(nx, "_enforce_permissions", True),
+            enable_audit_logging=True,
+            circuit_breaker=brick_services.rebac_circuit_breaker,
+        )
+        logger.debug("[BOOT:WIRED] ReBACService created")
+    except Exception as exc:
+        logger.warning("[BOOT:WIRED] ReBACService unavailable: %s", exc)
+
+    # --- MountService: Dynamic backend mounting operations ---
+    mount_service: Any = None
+    try:
+        from nexus.services.mount_service import MountService
+
+        mount_service = MountService(
+            router=kernel_services.router,
+            mount_manager=kernel_services.mount_manager,
+            nexus_fs=nx,
+        )
+        logger.debug("[BOOT:WIRED] MountService created")
+    except Exception as exc:
+        logger.warning("[BOOT:WIRED] MountService unavailable: %s", exc)
+
+    # --- MCPService: Model Context Protocol operations ---
+    mcp_service: Any = None
+    if _on("mcp"):
+        try:
+            from nexus.services.mcp_service import MCPService
+
+            mcp_service = MCPService(nexus_fs=nx)
+            logger.debug("[BOOT:WIRED] MCPService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] MCPService unavailable: %s", exc)
+    else:
+        logger.debug("[BOOT:WIRED] MCPService disabled by profile")
+
+    # --- LLMService + LLMSubsystem: LLM integration ---
+    llm_service: Any = None
+    llm_subsystem: Any = None
+    if _on("llm"):
+        try:
+            from nexus.services.llm_service import LLMService
+
+            llm_service = LLMService(nexus_fs=nx)
+
+            from nexus.services.subsystems.llm_subsystem import LLMSubsystem
+
+            llm_subsystem = LLMSubsystem(llm_service=llm_service)
+            logger.debug("[BOOT:WIRED] LLMService + LLMSubsystem created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] LLMService unavailable: %s", exc)
+    else:
+        logger.debug("[BOOT:WIRED] LLMService disabled by profile")
+
+    # --- OAuthService: OAuth authentication operations ---
+    oauth_service: Any = None
+    if _on("sandbox"):
+        try:
+            from nexus.services.oauth_service import OAuthService
+
+            oauth_service = OAuthService(
+                oauth_factory=None,
+                token_manager=None,
+                nexus_fs=nx,
+            )
+            logger.debug("[BOOT:WIRED] OAuthService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] OAuthService unavailable: %s", exc)
+    else:
+        logger.debug("[BOOT:WIRED] OAuthService disabled by profile")
+
+    # --- MountCoreService: Internal mount operations (gateway-dependent) ---
+    mount_core_service: Any = None
+    if gateway is not None:
+        try:
+            from nexus.services.mount_core_service import MountCoreService
+
+            mount_core_service = MountCoreService(gateway)
+            logger.debug("[BOOT:WIRED] MountCoreService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] MountCoreService unavailable: %s", exc)
+
+    # --- SyncService: Sync operations (gateway-dependent) ---
+    sync_service: Any = None
+    if gateway is not None:
+        try:
+            from nexus.services.sync_service import SyncService
+
+            sync_service = SyncService(gateway)
+            logger.debug("[BOOT:WIRED] SyncService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] SyncService unavailable: %s", exc)
+
+    # --- SyncJobService: Sync job management ---
+    sync_job_service: Any = None
+    if gateway is not None and sync_service is not None:
+        try:
+            from nexus.services.sync_job_service import SyncJobService
+
+            sync_job_service = SyncJobService(gateway, sync_service)
+            logger.debug("[BOOT:WIRED] SyncJobService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] SyncJobService unavailable: %s", exc)
+
+    # --- MountPersistService: Mount persistence ---
+    mount_persist_service: Any = None
+    if mount_core_service is not None:
+        try:
+            from nexus.services.mount_persist_service import MountPersistService
+
+            mount_persist_service = MountPersistService(
+                mount_manager=kernel_services.mount_manager,
+                mount_service=mount_core_service,
+                sync_service=sync_service,
+            )
+            logger.debug("[BOOT:WIRED] MountPersistService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] MountPersistService unavailable: %s", exc)
+
+    # --- SkillService: Skill management (Issue #2035) ---
+    skill_service: Any = brick_services.skill_service
+    if skill_service is None and _on("skills") and gateway is not None:
+        try:
+            from nexus.services.skill_service import SkillService as _SkillService
+
+            skill_service = _SkillService(gateway=gateway)
+            logger.debug("[BOOT:WIRED] SkillService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] SkillService unavailable: %s", exc)
+    elif not _on("skills"):
+        logger.debug("[BOOT:WIRED] SkillService disabled by profile")
+
+    # --- SkillPackageService: Skill export/import/validate (Issue #2035) ---
+    skill_package_service: Any = getattr(brick_services, "skill_package_service", None)
+    if skill_package_service is None and _on("skills") and skill_service is not None:
+        try:
+            from nexus.skills.package_service import SkillPackageService as _SkillPkgSvc
+
+            skill_package_service = _SkillPkgSvc(
+                fs=skill_service._fs,
+                perms=skill_service._perms,
+                skill_service=skill_service,
+            )
+            logger.debug("[BOOT:WIRED] SkillPackageService created")
+        except Exception:
+            pass  # Optional, may not be importable
+
+    # --- SearchService: Search operations ---
+    search_service: Any = None
+    if _on("search"):
+        try:
+            from nexus.services.search_service import SearchService
+
+            search_service = SearchService(
+                metadata_store=nx.metadata,
+                permission_enforcer=getattr(nx, "_permission_enforcer", None),
+                router=kernel_services.router,
+                rebac_manager=kernel_services.rebac_manager,
+                enforce_permissions=getattr(nx, "_enforce_permissions", True),
+                default_context=getattr(nx, "_default_context", None),
+                record_store=getattr(nx, "_record_store", None),
+                gateway=gateway,
+            )
+            logger.debug("[BOOT:WIRED] SearchService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] SearchService unavailable: %s", exc)
+    else:
+        logger.debug("[BOOT:WIRED] SearchService disabled by profile")
+
+    # --- ShareLinkService: Share link operations ---
+    share_link_service: Any = None
+    if _on("discovery"):
+        try:
+            from nexus.services.share_link_service import ShareLinkService
+
+            share_link_service = ShareLinkService(
+                gateway=gateway,
+                enforce_permissions=getattr(nx, "_enforce_permissions", True),
+            )
+            logger.debug("[BOOT:WIRED] ShareLinkService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] ShareLinkService unavailable: %s", exc)
+    else:
+        logger.debug("[BOOT:WIRED] ShareLinkService disabled by profile")
+
+    # --- EventsService: File watching + advisory locking ---
+    events_service: Any = None
+    if _on("ipc"):
+        try:
+            from nexus.services.events_service import EventsService
+
+            metadata_cache = None
+            if hasattr(nx.metadata, "_cache"):
+                metadata_cache = nx.metadata._cache
+
+            events_service = EventsService(
+                backend=nx.backend,
+                event_bus=brick_services.event_bus,
+                lock_manager=brick_services.lock_manager,
+                zone_id=None,
+                metadata_cache=metadata_cache,
+            )
+            logger.debug("[BOOT:WIRED] EventsService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] EventsService unavailable: %s", exc)
+    else:
+        logger.debug("[BOOT:WIRED] EventsService disabled by profile")
+
+    result = {
+        "version_service": kernel_services.version_service,
+        "rebac_service": rebac_service,
+        "mount_service": mount_service,
+        "gateway": gateway,
+        "mount_core_service": mount_core_service,
+        "sync_service": sync_service,
+        "sync_job_service": sync_job_service,
+        "mount_persist_service": mount_persist_service,
+        "mcp_service": mcp_service,
+        "llm_service": llm_service,
+        "llm_subsystem": llm_subsystem,
+        "oauth_service": oauth_service,
+        "skill_service": skill_service,
+        "skill_package_service": skill_package_service,
+        "search_service": search_service,
+        "share_link_service": share_link_service,
+        "events_service": events_service,
+        "task_queue_service": brick_services.task_queue_service,
+    }
+
+    elapsed = time.perf_counter() - t0
+    active = sum(1 for v in result.values() if v is not None)
+    logger.info("[BOOT:WIRED] %d/%d services ready (%.3fs)", active, len(result), elapsed)
+    return result
+
+
 def create_nexus_services(
     record_store: RecordStoreABC,
     metadata_store: MetastoreABC,
@@ -1729,6 +2013,20 @@ def create_nexus_fs(
         provider_registry=parsers_brick.provider_registry,
         vfs_lock_manager=_vfs_lock_manager,
     )
+
+    # --- Phase 2: Wire services needing NexusFS reference (Issue #643) ---
+    # Resolve enabled_bricks for brick gating (same pattern as create_nexus_services)
+    from nexus.core.deployment_profile import DeploymentProfile as _DP
+
+    _resolved_bricks = enabled_bricks
+    if _resolved_bricks is None:
+        _resolved_bricks = _DP.FULL.default_bricks()
+
+    def _brick_on(name: str) -> bool:
+        return name in _resolved_bricks
+
+    _wired = _boot_wired_services(nx, kernel_services, brick_services, _brick_on)
+    nx._bind_wired_services(_wired)
 
     # Register bricks created in create_nexus_fs with lifecycle manager (Issue #1704)
     _blm = getattr(system_services, "brick_lifecycle_manager", None)

--- a/tests/unit/core/test_mount_directory_creation.py
+++ b/tests/unit/core/test_mount_directory_creation.py
@@ -21,20 +21,16 @@ from nexus.storage.raft_metadata_store import RaftMetadataStore
 
 @pytest.fixture
 def nx_with_mount():
-    """Create NexusFS instance with mount manager support."""
-    from nexus import NexusFS
+    """Create NexusFS instance with mount manager support via factory."""
     from nexus.backends.local import LocalBackend
+    from nexus.factory import create_nexus_fs
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Create root backend
         root_backend = LocalBackend(root_path=tmpdir)
-
-        # Use unique SQLite database file to avoid parallel test conflicts
         db_file = Path(tmpdir) / "metadata.db"
-
-        # Create NexusFS with metadata store
         metadata_store = RaftMetadataStore.embedded(str(db_file).replace(".db", ""))
-        nx = NexusFS(
+
+        nx = create_nexus_fs(
             backend=root_backend,
             metadata_store=metadata_store,
             permissions=PermissionConfig(enforce=False),

--- a/tests/unit/core/test_nexus_fs_services.py
+++ b/tests/unit/core/test_nexus_fs_services.py
@@ -1,4 +1,8 @@
-"""Test NexusFS service composition (Phase 2)."""
+"""Test NexusFS service composition (Phase 2).
+
+Issue #643: Services are now created by factory._boot_wired_services(),
+not by NexusFS.__init__. Tests use create_nexus_fs() factory entry point.
+"""
 
 from __future__ import annotations
 
@@ -7,9 +11,8 @@ from pathlib import Path
 import pytest
 
 from nexus.backends.local import LocalBackend
-from nexus.core.config import KernelServices, PermissionConfig
+from nexus.core.config import PermissionConfig
 from nexus.core.nexus_fs import NexusFS
-from nexus.services.version_service import VersionService
 
 try:
     from nexus.storage.raft_metadata_store import RaftMetadataStore
@@ -23,24 +26,23 @@ pytestmark = pytest.mark.skipif(not _raft_available, reason="Raft metastore not 
 
 
 def _make_fs(tmp_path: Path, *, enforce_permissions: bool = True) -> NexusFS:
-    """Create NexusFS with VersionService injected (mimics factory)."""
+    """Create NexusFS via factory (includes two-phase wired services)."""
+    from nexus.factory import create_nexus_fs
+    from nexus.storage.record_store import SQLAlchemyRecordStore
+
     backend_path = tmp_path / "storage"
     backend_path.mkdir(exist_ok=True)
     db_path = tmp_path / "metadata"
 
     backend = LocalBackend(str(backend_path))
     metadata_store = RaftMetadataStore.embedded(str(db_path))
-    # VersionService is created by factory; for unit tests we inject it manually
-    version_service = VersionService(
-        metadata_store=metadata_store,
-        cas_store=backend,
-        enforce_permissions=False,
-    )
-    return NexusFS(
+    record_store = SQLAlchemyRecordStore(db_path=str(tmp_path / "nexus.db"))
+
+    return create_nexus_fs(
         backend=backend,
         metadata_store=metadata_store,
+        record_store=record_store,
         permissions=PermissionConfig(enforce=enforce_permissions),
-        kernel_services=KernelServices(version_service=version_service),
     )
 
 


### PR DESCRIPTION
## Summary
- Deleted `NexusFS._wire_services()` — all 15 service creations moved to `factory._boot_wired_services()` with `DeploymentProfile` + `brick_on` gating
- Two-phase init: `NexusFS(...)` → `_boot_wired_services(nx)` → `nx._bind_wired_services(dict)` — kernel never imports from `nexus.services.*`
- Removed 7 obsolete `_inject_*` constructor params from NexusFS (test injection pattern no longer needed)
- Updated test fixtures to use `create_nexus_fs()` factory entry point

## Test plan
- [x] All unit tests pass (only pre-existing `test_security_hardening` SSRF failure unrelated)
- [x] `test_factory.py` — 21 tests pass
- [x] `test_mount_directory_creation.py` — 8 tests pass (migrated to factory)
- [x] `test_nexus_fs_services.py` — service composition tests pass (migrated to factory)
- [x] ruff, mypy, brick-zero-core-imports hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)