### PR TITLE
fix(cli): extract undo business logic to OperationUndoService (S24)

### DIFF
--- a/docs/architecture/ops-scenario-matrix.md
+++ b/docs/architecture/ops-scenario-matrix.md
@@ -764,7 +764,7 @@ In Linux, `vfsmount` (kernel) has two layers: `lookup_slow()` is the hot-path re
 | S21 Agent Memory | Yes — `services/memory/` (5 modules, 15+ API routes) | **MISSING PROTOCOL** — `MemoryAPI` exists as concrete class, no Protocol ABC |
 | S22 ACE | Yes — `services/ace/` (9 modules, 10+ RPC methods) | **MISSING PROTOCOL** — ACE operations go through NexusFS directly |
 | S23 Agent Delegation | Yes — `services/delegation/` (5 modules) | **MISSING PROTOCOL** — `DelegationService` is concrete, no Protocol ABC |
-| S24 Operations Undo | Yes — `storage/operation_logger.py` | **MISSING PROTOCOL** — `OperationLogger` is concrete, no Protocol ABC |
+| S24 Operations Undo | Yes — `storage/operation_logger.py`, `services/operation_undo_service.py` | `OperationLogProtocol` exists (`services/protocols/operation_log.py`). `OperationUndoService` extracted from CLI — handles undo orchestration via router + kernel primitives. |
 | S25 Governance | Partial — `AnomalyDetectorProtocol` (1 method) covers anomaly only | **INCOMPLETE** — Collusion, trust, suspension, approval workflow have no protocol |
 | S26 Reputation | Yes — `services/reputation/` (4 modules) | **MISSING PROTOCOL** — `ReputationService` is concrete, no Protocol ABC |
 | S27 Plugins | Yes — `plugins/` (7 modules) | **MISSING PROTOCOL** — `PluginRegistry` is concrete, no Protocol ABC |
@@ -793,7 +793,7 @@ In Linux, `vfsmount` (kernel) has two layers: `lookup_slow()` is the hot-path re
 | MED | S23 Agent Delegation | `DelegationProtocol` |
 | MED | S25 Governance (full) | `GovernanceProtocol` (extend beyond AnomalyDetector) |
 | MED | S26 Reputation | `ReputationProtocol` |
-| LOW | S24 Operations Undo | `OperationLogProtocol` |
+| ~~LOW~~ | ~~S24 Operations Undo~~ | ~~`OperationLogProtocol`~~ ✓ Done — `OperationLogProtocol` + `OperationUndoService` |
 | LOW | S27 Plugins | `PluginProtocol` |
 | LOW | S28 Workflows | `WorkflowProtocol` |
 
@@ -835,7 +835,7 @@ Map each surviving scenario (S1-S28) to its canonical Ops ABC (existing or propo
 | **S21** Agent Memory | *(new)* **MemoryProtocol** | MISSING | Service | — | Needs: store/get/edit/delete/search/invalidate/revalidate/history/lineage |
 | **S22** ACE | *(new)* **TrajectoryProtocol** | MISSING | Service | — | Needs: start/log_step/complete/feedback/score/playbook CRUD/reflect/curate |
 | **S23** Agent Delegation | *(new)* **DelegationProtocol** | MISSING | Service | — | Needs: delegate/revoke/list |
-| **S24** Operations Undo | *(new)* **OperationLogProtocol** | MISSING | Service | — | Needs: log/list/undo |
+| **S24** Operations Undo | **OperationLogProtocol** + **OperationUndoService** | EXISTS | Service | EXACT | `OperationLogProtocol` (`services/protocols/operation_log.py`) covers log/list/query. `OperationUndoService` (`services/operation_undo_service.py`) covers undo orchestration. |
 | **S25** Governance | *(extend P20)* **GovernanceProtocol** | INCOMPLETE | Service | — | Extend AnomalyDetector → add collusion/trust/suspension/approval |
 | **S26** Reputation | *(new)* **ReputationProtocol** | MISSING | Service | — | Needs: get_score/leaderboard/feedback/dispute/resolve |
 | **S27** Plugins | *(new)* **PluginProtocol** | MISSING | Service | — | Needs: install/uninstall/list/scaffold |
@@ -847,17 +847,17 @@ Map each surviving scenario (S1-S28) to its canonical Ops ABC (existing or propo
                     Existing Protocol?
                     YES (exact)     NEEDS WORK      MISSING
 Kernel tier:       S1,S19,S20      —               —
-Service tier:      S2,S4-S7,       S8,S9 (split)   S3,S14,S21-S28
-                   S10-S13,        S25 (extend)
-                   S15-S18
+Service tier:      S2,S4-S7,       S8,S9 (split)   S3,S14,S21-S23,
+                   S10-S13,        S25 (extend)    S26-S28
+                   S15-S18,S24
 ```
 
 | Status | Count | Scenarios |
 |--------|-------|-----------|
-| **EXACT match** | 17 | S1, S2, S4, S5, S6, S7, S10, S11, S12, S13, S15, S16, S17, S18, S19, S20 |
+| **EXACT match** | 18 | S1, S2, S4, S5, S6, S7, S10, S11, S12, S13, S15, S16, S17, S18, S19, S20, S24 |
 | **Needs split** | 2 | S8 (Watch), S9 (Lock) — from P9 EventsProtocol |
 | **Needs extension** | 1 | S25 (Governance) — extend P20 AnomalyDetector |
-| **Missing Protocol** | 8 | S3, S14, S21, S22, S23, S24, S26, S27, S28 |
+| **Missing Protocol** | 7 | S3, S14, S21, S22, S23, S26, S27, S28 |
 | **TOTAL** | 28 | |
 
 ### 3.3 Tier Assignment
@@ -897,8 +897,9 @@ Tier assignment per KERNEL-ARCHITECTURE.md (three swap tiers):
    - Rationale: 1-method Protocol is insufficient for 13 API routes spanning 6 sub-domains
    - Priority: MED
 
-6. **Create remaining Protocols** (S23 Delegation, S24 Undo, S26 Reputation, S27 Plugins, S28 Workflows)
+6. **Create remaining Protocols** (S23 Delegation, S26 Reputation, S27 Plugins, S28 Workflows)
    - Priority: LOW-MED — these can be extracted incrementally as concrete classes stabilize
+   - S24 Undo: ✓ Done — `OperationLogProtocol` + `OperationUndoService` (`services/operation_undo_service.py`)
 
 **Non-Actions:**
 - P22 (ContextManifestProtocol): keep as convenience interface but do NOT count as Ops ABC — it's orchestration

--- a/src/nexus/cli/commands/operations.py
+++ b/src/nexus/cli/commands/operations.py
@@ -326,8 +326,26 @@ def undo(agent: str | None, yes: bool, backend_config: BackendConfig) -> None:
                     nx.close()
                     return
 
-            # Perform undo based on operation type
-            _undo_operation(nx, logger, last_op)
+            # Perform undo via service layer (S24: Operations Undo)
+            from nexus.services.operation_undo_service import OperationUndoService
+
+            # Bind to Any — undo needs concrete NexusFS attrs (router, backend)
+            # not on the NexusFilesystem protocol.
+            _nx: Any = nx
+            undo_service = OperationUndoService(
+                router=_nx.router,
+                write_fn=nx.write,
+                delete_fn=nx.delete,
+                rename_fn=nx.rename,
+                exists_fn=nx.exists,
+                fallback_backend=getattr(nx, "backend", None),
+            )
+            result = undo_service.undo_operation(last_op)
+
+            if result.success:
+                console.print(f"  {result.message}")
+            else:
+                console.print(f"  [yellow]Warning: {result.message}[/yellow]")
 
             console.print(f"\n[green]✓[/green] Undid operation: {last_op.operation_type}")
 
@@ -335,88 +353,3 @@ def undo(agent: str | None, yes: bool, backend_config: BackendConfig) -> None:
 
     except Exception as e:
         handle_error(e)
-
-
-def _undo_operation(nx: Any, logger: Any, operation: Any) -> None:
-    """Undo a specific operation.
-
-    Args:
-        nx: NexusFS instance
-        logger: OperationLogger instance
-        operation: OperationLogModel to undo
-    """
-    if operation.operation_type == "write":
-        # Restore previous version if exists, otherwise delete
-        if operation.snapshot_hash:
-            # Read old content from correct backend (route to find backend for this path)
-            try:
-                route = nx.router.route(operation.path)
-                old_content = route.backend.read_content(operation.snapshot_hash).unwrap()
-            except Exception:
-                # Fallback: try default backend (for backward compatibility)
-                old_content = nx.backend.read_content(operation.snapshot_hash).unwrap()
-            nx.write(operation.path, old_content)
-            console.print(f"  Restored previous version of {operation.path}")
-        else:
-            # File didn't exist before, so delete it
-            nx.delete(operation.path)
-            console.print(f"  Deleted {operation.path} (was newly created)")
-
-    elif operation.operation_type == "delete":
-        # Restore deleted file from snapshot
-        if operation.snapshot_hash:
-            # Read content from correct backend (route to find backend for this path)
-            try:
-                route = nx.router.route(operation.path)
-                content = route.backend.read_content(operation.snapshot_hash).unwrap()
-            except Exception:
-                # Fallback: try default backend (for backward compatibility)
-                content = nx.backend.read_content(operation.snapshot_hash).unwrap()
-            nx.write(operation.path, content)
-
-            # Restore metadata if available
-            if operation.metadata_snapshot:
-                metadata = logger.get_metadata_snapshot(operation)
-                if metadata and (
-                    metadata.get("owner") or metadata.get("group") or metadata.get("mode")
-                ):
-                    # Restore permissions
-                    from nexus.core.permissions import OperationContext
-
-                    context = OperationContext(
-                        user_id=nx._default_context.agent_id or "system",
-                        groups=[],
-                        is_admin=True,
-                        is_system=True,
-                    )
-                    if metadata.get("owner"):
-                        nx.chown(operation.path, metadata["owner"], context=context)
-                    if metadata.get("group"):
-                        nx.chgrp(operation.path, metadata["group"], context=context)
-                    if metadata.get("mode") is not None:
-                        nx.chmod(operation.path, metadata["mode"], context=context)
-
-            console.print(f"  Restored deleted file: {operation.path}")
-        else:
-            console.print(
-                f"  [yellow]Warning: Cannot restore {operation.path} (no snapshot)[/yellow]"
-            )
-
-    elif operation.operation_type == "rename":
-        # Rename back to original path
-        if operation.new_path:
-            # Check if new path still exists
-            if nx.exists(operation.new_path):
-                nx.rename(operation.new_path, operation.path)
-                console.print(f"  Renamed {operation.new_path} back to {operation.path}")
-            else:
-                console.print(
-                    f"  [yellow]Warning: Cannot undo rename - {operation.new_path} no longer exists[/yellow]"
-                )
-        else:
-            console.print("  [yellow]Warning: Cannot undo rename - missing new_path[/yellow]")
-
-    else:
-        console.print(
-            f"  [yellow]Warning: Undo not implemented for {operation.operation_type}[/yellow]"
-        )

--- a/src/nexus/services/operation_undo_service.py
+++ b/src/nexus/services/operation_undo_service.py
@@ -1,0 +1,187 @@
+"""Operation undo service — extracted from CLI layer (S24).
+
+Orchestrates reversal of filesystem operations logged by OperationLogger.
+Uses router for CAS content retrieval and kernel primitives for state mutation.
+
+References:
+    - docs/architecture/ops-scenario-matrix.md  (S24: Operations Undo)
+    - services/protocols/operation_log.py        (OperationLogProtocol)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UndoResult:
+    """Result of an undo operation."""
+
+    success: bool
+    message: str
+    operation_type: str
+    path: str
+
+
+class OperationUndoService:
+    """Undo filesystem operations recorded in the operation log.
+
+    Extracted from ``cli/commands/operations.py::_undo_operation`` so that the
+    CLI remains a thin presentation layer (KERNEL-ARCHITECTURE.md).
+
+    Dependencies are injected as callables to avoid coupling to a concrete
+    NexusFS class.
+    """
+
+    def __init__(
+        self,
+        *,
+        router: Any,
+        write_fn: Any,
+        delete_fn: Any,
+        rename_fn: Any,
+        exists_fn: Any,
+        fallback_backend: Any | None = None,
+    ) -> None:
+        """Initialise the undo service.
+
+        Args:
+            router: PathRouter for resolving paths to backends.
+            write_fn: ``(path, content) -> None`` kernel write primitive.
+            delete_fn: ``(path) -> None`` kernel delete primitive.
+            rename_fn: ``(old, new) -> None`` kernel rename primitive.
+            exists_fn: ``(path) -> bool`` kernel existence check.
+            fallback_backend: Optional legacy backend for CAS reads.
+        """
+        self._router = router
+        self._write = write_fn
+        self._delete = delete_fn
+        self._rename = rename_fn
+        self._exists = exists_fn
+        self._fallback_backend = fallback_backend
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def undo_operation(self, operation: Any) -> UndoResult:
+        """Undo a single operation log entry.
+
+        Args:
+            operation: ``OperationLogModel`` to undo.
+
+        Returns:
+            ``UndoResult`` describing whether the undo succeeded and what
+            action was taken.
+        """
+        op_type = operation.operation_type
+
+        if op_type == "write":
+            return self._undo_write(operation)
+        if op_type == "delete":
+            return self._undo_delete(operation)
+        if op_type == "rename":
+            return self._undo_rename(operation)
+
+        return UndoResult(
+            success=False,
+            message=f"Undo not implemented for {op_type}",
+            operation_type=op_type,
+            path=operation.path,
+        )
+
+    # ------------------------------------------------------------------
+    # Per-type undo strategies
+    # ------------------------------------------------------------------
+
+    def _undo_write(self, operation: Any) -> UndoResult:
+        """Undo a write: restore previous content or delete new file."""
+        if operation.snapshot_hash:
+            old_content = self._read_content_from_cas(operation.path, operation.snapshot_hash)
+            self._write(operation.path, old_content)
+            return UndoResult(
+                success=True,
+                message=f"Restored previous version of {operation.path}",
+                operation_type="write",
+                path=operation.path,
+            )
+
+        # File did not exist before — remove it.
+        self._delete(operation.path)
+        return UndoResult(
+            success=True,
+            message=f"Deleted {operation.path} (was newly created)",
+            operation_type="write",
+            path=operation.path,
+        )
+
+    def _undo_delete(self, operation: Any) -> UndoResult:
+        """Undo a delete: restore content from CAS snapshot."""
+        if not operation.snapshot_hash:
+            return UndoResult(
+                success=False,
+                message=f"Cannot restore {operation.path} (no snapshot)",
+                operation_type="delete",
+                path=operation.path,
+            )
+
+        content = self._read_content_from_cas(operation.path, operation.snapshot_hash)
+        self._write(operation.path, content)
+
+        # NOTE: metadata restoration (chown/chgrp/chmod) is intentionally
+        # omitted.  The original CLI code called nx.chown/chgrp/chmod which
+        # do not exist on the NexusFS kernel — only on the FUSE layer.
+        # A future task should add metadata restoration via MetastoreABC.
+
+        return UndoResult(
+            success=True,
+            message=f"Restored deleted file: {operation.path}",
+            operation_type="delete",
+            path=operation.path,
+        )
+
+    def _undo_rename(self, operation: Any) -> UndoResult:
+        """Undo a rename: move file back to original path."""
+        if not operation.new_path:
+            return UndoResult(
+                success=False,
+                message="Cannot undo rename - missing new_path",
+                operation_type="rename",
+                path=operation.path,
+            )
+
+        if not self._exists(operation.new_path):
+            return UndoResult(
+                success=False,
+                message=(f"Cannot undo rename - {operation.new_path} no longer exists"),
+                operation_type="rename",
+                path=operation.path,
+            )
+
+        self._rename(operation.new_path, operation.path)
+        return UndoResult(
+            success=True,
+            message=f"Renamed {operation.new_path} back to {operation.path}",
+            operation_type="rename",
+            path=operation.path,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _read_content_from_cas(self, path: str, content_hash: str) -> bytes:
+        """Read content from CAS via router, with optional fallback."""
+        try:
+            route = self._router.route(path)
+            result: bytes = route.backend.read_content(content_hash).unwrap()
+            return result
+        except Exception:
+            if self._fallback_backend is not None:
+                fallback_result: bytes = self._fallback_backend.read_content(content_hash).unwrap()
+                return fallback_result
+            raise

--- a/tests/unit/services/test_operation_undo_service.py
+++ b/tests/unit/services/test_operation_undo_service.py
@@ -1,0 +1,224 @@
+"""Tests for OperationUndoService (S24: Operations Undo)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.services.operation_undo_service import OperationUndoService, UndoResult
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_route(content: bytes) -> MagicMock:
+    """Return a mock Route whose backend.read_content(hash).unwrap() → content."""
+    route = MagicMock()
+    route.backend.read_content.return_value.unwrap.return_value = content
+    return route
+
+
+def _make_router(content: bytes) -> MagicMock:
+    router = MagicMock()
+    router.route.return_value = _make_route(content)
+    return router
+
+
+def _make_service(
+    content: bytes = b"old-content",
+    fallback_backend: MagicMock | None = None,
+) -> tuple[OperationUndoService, MagicMock, MagicMock, MagicMock, MagicMock]:
+    """Create a service with mocked kernel primitives.
+
+    Returns (service, write_fn, delete_fn, rename_fn, exists_fn).
+    """
+    router = _make_router(content)
+    write_fn = MagicMock()
+    delete_fn = MagicMock()
+    rename_fn = MagicMock()
+    exists_fn = MagicMock(return_value=True)
+    svc = OperationUndoService(
+        router=router,
+        write_fn=write_fn,
+        delete_fn=delete_fn,
+        rename_fn=rename_fn,
+        exists_fn=exists_fn,
+        fallback_backend=fallback_backend,
+    )
+    return svc, write_fn, delete_fn, rename_fn, exists_fn
+
+
+def _op(op_type: str, **kwargs: object) -> SimpleNamespace:
+    """Build a fake OperationLogModel-like object."""
+    defaults = {
+        "operation_type": op_type,
+        "path": "/workspace/test.txt",
+        "new_path": None,
+        "snapshot_hash": None,
+        "metadata_snapshot": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Write undo
+# ---------------------------------------------------------------------------
+
+
+class TestUndoWrite:
+    def test_restore_previous_version(self) -> None:
+        svc, write_fn, delete_fn, *_ = _make_service(content=b"previous")
+        op = _op("write", snapshot_hash="abc123")
+
+        result = svc.undo_operation(op)
+
+        assert result == UndoResult(
+            success=True,
+            message="Restored previous version of /workspace/test.txt",
+            operation_type="write",
+            path="/workspace/test.txt",
+        )
+        write_fn.assert_called_once_with("/workspace/test.txt", b"previous")
+        delete_fn.assert_not_called()
+
+    def test_delete_newly_created_file(self) -> None:
+        svc, write_fn, delete_fn, *_ = _make_service()
+        op = _op("write")  # no snapshot_hash → file was new
+
+        result = svc.undo_operation(op)
+
+        assert result.success is True
+        assert "newly created" in result.message
+        delete_fn.assert_called_once_with("/workspace/test.txt")
+        write_fn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Delete undo
+# ---------------------------------------------------------------------------
+
+
+class TestUndoDelete:
+    def test_restore_deleted_file(self) -> None:
+        svc, write_fn, *_ = _make_service(content=b"restored")
+        op = _op("delete", snapshot_hash="hash456")
+
+        result = svc.undo_operation(op)
+
+        assert result.success is True
+        assert "Restored deleted file" in result.message
+        write_fn.assert_called_once_with("/workspace/test.txt", b"restored")
+
+    def test_no_snapshot_returns_failure(self) -> None:
+        svc, write_fn, *_ = _make_service()
+        op = _op("delete")  # no snapshot_hash
+
+        result = svc.undo_operation(op)
+
+        assert result.success is False
+        assert "no snapshot" in result.message
+        write_fn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Rename undo
+# ---------------------------------------------------------------------------
+
+
+class TestUndoRename:
+    def test_rename_back(self) -> None:
+        svc, _, _, rename_fn, exists_fn = _make_service()
+        exists_fn.return_value = True
+        op = _op("rename", new_path="/workspace/moved.txt")
+
+        result = svc.undo_operation(op)
+
+        assert result.success is True
+        rename_fn.assert_called_once_with("/workspace/moved.txt", "/workspace/test.txt")
+
+    def test_new_path_missing(self) -> None:
+        svc, _, _, rename_fn, _ = _make_service()
+        op = _op("rename")  # no new_path
+
+        result = svc.undo_operation(op)
+
+        assert result.success is False
+        assert "missing new_path" in result.message
+        rename_fn.assert_not_called()
+
+    def test_new_path_no_longer_exists(self) -> None:
+        svc, _, _, rename_fn, exists_fn = _make_service()
+        exists_fn.return_value = False
+        op = _op("rename", new_path="/workspace/moved.txt")
+
+        result = svc.undo_operation(op)
+
+        assert result.success is False
+        assert "no longer exists" in result.message
+        rename_fn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Unknown operation type
+# ---------------------------------------------------------------------------
+
+
+class TestUndoUnknown:
+    def test_unknown_op_type(self) -> None:
+        svc, *_ = _make_service()
+        op = _op("chmod")
+
+        result = svc.undo_operation(op)
+
+        assert result.success is False
+        assert "not implemented" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Fallback backend
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackBackend:
+    def test_uses_fallback_when_router_fails(self) -> None:
+        fallback = MagicMock()
+        fallback.read_content.return_value.unwrap.return_value = b"fallback-data"
+
+        router = MagicMock()
+        router.route.side_effect = RuntimeError("route failed")
+
+        svc = OperationUndoService(
+            router=router,
+            write_fn=MagicMock(),
+            delete_fn=MagicMock(),
+            rename_fn=MagicMock(),
+            exists_fn=MagicMock(),
+            fallback_backend=fallback,
+        )
+        op = _op("write", snapshot_hash="hash789")
+
+        result = svc.undo_operation(op)
+
+        assert result.success is True
+        fallback.read_content.assert_called_once_with("hash789")
+        svc._write.assert_called_once_with("/workspace/test.txt", b"fallback-data")
+
+    def test_raises_when_no_fallback_and_router_fails(self) -> None:
+        router = MagicMock()
+        router.route.side_effect = RuntimeError("route failed")
+
+        svc = OperationUndoService(
+            router=router,
+            write_fn=MagicMock(),
+            delete_fn=MagicMock(),
+            rename_fn=MagicMock(),
+            exists_fn=MagicMock(),
+        )
+        op = _op("write", snapshot_hash="hash789")
+
+        with pytest.raises(RuntimeError, match="route failed"):
+            svc.undo_operation(op)


### PR DESCRIPTION
## Summary
- Extracted `_undo_operation()` from `cli/commands/operations.py` to a new `services/operation_undo_service.py` per KERNEL-ARCHITECTURE.md (CLI should be thin presentation layer)
- `OperationUndoService` takes router + kernel callables (write, delete, rename, exists) via DI — no coupling to concrete NexusFS
- Returns `UndoResult` dataclass instead of printing to console directly
- Omitted broken `chown/chgrp/chmod` calls that never existed on the NexusFS kernel (pre-existing bug in CLI code)
- Updated `docs/architecture/ops-scenario-matrix.md` to reflect S24 Operations Undo now has implementation (coverage 17→18 exact matches)

## Test plan
- [x] 10 unit tests covering all undo paths (write restore, write delete-new, delete restore, delete no-snapshot, rename back, rename missing new_path, rename target gone, unknown op type, fallback backend, no-fallback raises)
- [x] All pre-commit hooks pass (ruff, mypy, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)