### PR TITLE
fix(#830): replace "root" literals with ROOT_ZONE_ID in bricks/

### DIFF
--- a/src/nexus/bricks/a2a/grpc_server.py
+++ b/src/nexus/bricks/a2a/grpc_server.py
@@ -21,6 +21,7 @@ from nexus.bricks.a2a.proto_converter import (
     send_request_from_proto,
     task_to_proto,
 )
+from nexus.constants import ROOT_ZONE_ID
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class A2AServicer(a2a_pb2_grpc.A2AServiceServicer):
     HTTP+JSON-RPC and gRPC transports share the same task state.
     """
 
-    def __init__(self, task_manager: Any, zone_id: str = "root") -> None:
+    def __init__(self, task_manager: Any, zone_id: str = ROOT_ZONE_ID) -> None:
         self._tm = task_manager
         self._zone_id = zone_id
 
@@ -216,7 +217,7 @@ async def create_grpc_server(
     tls_cert_path: str | None = None,
     tls_key_path: str | None = None,
     tls_ca_path: str | None = None,
-    zone_id: str = "root",
+    zone_id: str = ROOT_ZONE_ID,
 ) -> grpc.aio.Server:
     """Create and configure a gRPC server for the A2A service.
 

--- a/src/nexus/bricks/a2a/task_manager.py
+++ b/src/nexus/bricks/a2a/task_manager.py
@@ -28,6 +28,7 @@ from nexus.bricks.a2a.models import (
     TaskStatusUpdateEvent,
     is_valid_transition,
 )
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     import asyncio
@@ -90,7 +91,7 @@ class TaskManager:
         self,
         message: Message,
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         agent_id: str | None = None,
         context_id: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -117,7 +118,7 @@ class TaskManager:
         self,
         task_id: str,
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         history_length: int | None = None,
     ) -> Task:
         """Retrieve a task by ID.
@@ -139,7 +140,7 @@ class TaskManager:
     async def list_tasks(
         self,
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         agent_id: str | None = None,
         state: TaskState | None = None,
         limit: int = 50,
@@ -158,7 +159,7 @@ class TaskManager:
         self,
         task_id: str,
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> Task:
         """Cancel a task.
 
@@ -184,7 +185,7 @@ class TaskManager:
         task_id: str,
         new_state: TaskState,
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         message: Message | None = None,
     ) -> Task:
         """Transition a task to a new state.
@@ -237,7 +238,7 @@ class TaskManager:
         task_id: str,
         artifact: Artifact,
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         append: bool = True,
     ) -> Task:
         """Add an artifact to a task.

--- a/src/nexus/bricks/cache/persistent_view_postgres.py
+++ b/src/nexus/bricks/cache/persistent_view_postgres.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import text
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.core.protocols import PersistentView
 
 if TYPE_CHECKING:
@@ -85,7 +86,7 @@ class PostgresPersistentViewStore:
         revision_bucket: int,
     ) -> None:
         """Persist a namespace view (upsert via DELETE + INSERT)."""
-        effective_zone = zone_id or "root"
+        effective_zone = zone_id or ROOT_ZONE_ID
         now = datetime.now(UTC)
         view_id = str(uuid.uuid4())
 
@@ -117,7 +118,7 @@ class PostgresPersistentViewStore:
         zone_id: str | None,
     ) -> PersistentView | None:
         """Load a persisted namespace view."""
-        effective_zone = zone_id or "root"
+        effective_zone = zone_id or ROOT_ZONE_ID
 
         with self._engine.connect() as conn:
             result = conn.execute(
@@ -147,7 +148,7 @@ class PostgresPersistentViewStore:
         return PersistentView(
             subject_type=row.subject_type,
             subject_id=row.subject_id,
-            zone_id=row.zone_id if row.zone_id != "root" else None,
+            zone_id=row.zone_id if row.zone_id != ROOT_ZONE_ID else None,
             mount_paths=mount_paths,
             grants_hash=row.grants_hash,
             revision_bucket=int(row.revision_bucket),

--- a/src/nexus/bricks/governance/governance_wrapper.py
+++ b/src/nexus/bricks/governance/governance_wrapper.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.types import TransactionProtocol
 from nexus.utils.async_helpers import fire_and_forget
 
@@ -77,7 +78,9 @@ class GovernanceEnforcedPayment:
         Pre-check: governance constraint check (~1ms).
         Post-analysis: fire-and-forget anomaly detection.
         """
-        zone_id = request.metadata.get("zone_id", "root") if request.metadata else "root"
+        zone_id = (
+            request.metadata.get("zone_id", ROOT_ZONE_ID) if request.metadata else ROOT_ZONE_ID
+        )
 
         # 1. Pre-check: governance constraints
         from nexus.bricks.governance.models import ConstraintType

--- a/src/nexus/bricks/pay/credits.py
+++ b/src/nexus/bricks/pay/credits.py
@@ -45,6 +45,7 @@ from nexus.bricks.pay.constants import (
     make_tb_account_id,
     micro_to_credits,
 )
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.storage.exchange_audit_logger import ExchangeAuditLogger
@@ -164,7 +165,7 @@ class CreditsService:
         currency: str = "credits",
         status: str,
         application: str = "gateway",
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         trace_id: str | None = None,
         transfer_id: str | None = None,
     ) -> None:
@@ -268,7 +269,7 @@ class CreditsService:
                 # Log but don't fail - system might still work
                 pass
 
-    def _to_tb_id(self, agent_id: str, zone_id: str = "root") -> int:
+    def _to_tb_id(self, agent_id: str, zone_id: str = ROOT_ZONE_ID) -> int:
         """Convert agent_id to TigerBeetle account ID."""
         return make_tb_account_id(zone_id, agent_id)
 
@@ -289,7 +290,7 @@ class CreditsService:
     # Balance Operations
     # =========================================================================
 
-    async def get_balance(self, agent_id: str, zone_id: str = "root") -> Decimal:
+    async def get_balance(self, agent_id: str, zone_id: str = ROOT_ZONE_ID) -> Decimal:
         """Get available balance (credits_posted - debits_posted).
 
         Args:
@@ -314,7 +315,7 @@ class CreditsService:
         return Decimal(str(micro_to_credits(micro_balance)))
 
     async def get_balance_with_reserved(
-        self, agent_id: str, zone_id: str = "root"
+        self, agent_id: str, zone_id: str = ROOT_ZONE_ID
     ) -> tuple[Decimal, Decimal]:
         """Get available balance and reserved (pending) amount.
 
@@ -352,7 +353,7 @@ class CreditsService:
         *,
         memo: str = "",  # noqa: ARG002 - stored in PostgreSQL, not TigerBeetle
         idempotency_key: str | None = None,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> str:
         """Execute atomic credit transfer between agents.
 
@@ -449,7 +450,7 @@ class CreditsService:
         source: str,  # noqa: ARG002 - stored in PostgreSQL metadata
         *,
         external_tx_id: str | None = None,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> str:
         """Add credits from external source (treasury -> agent).
 
@@ -515,7 +516,7 @@ class CreditsService:
         amount: Decimal,
         timeout_seconds: int = 300,
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> str:
         """Reserve credits for a pending operation.
 
@@ -706,7 +707,7 @@ class CreditsService:
         amount: Decimal,
         *,
         code: int = TRANSFER_CODE_API_USAGE,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> bool:
         """Fast credit deduction for API metering / rate limiting.
 
@@ -761,7 +762,7 @@ class CreditsService:
         self,
         transfers: list[TransferRequest],
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> list[str]:
         """Execute atomic batch transfer - all succeed or all fail.
 
@@ -837,7 +838,7 @@ class CreditsService:
     async def provision_wallet(
         self,
         agent_id: str,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> None:
         """Create TigerBeetle account for a new agent.
 
@@ -877,7 +878,7 @@ class CreditsService:
         agent_id: str,
         amount: Decimal,
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> bool:
         """Check if agent has sufficient balance for an amount.
 

--- a/src/nexus/bricks/pay/policy_wrapper.py
+++ b/src/nexus/bricks/pay/policy_wrapper.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.bricks.pay.audit_types import TransactionProtocol
 from nexus.bricks.pay.protocol import ProtocolTransferRequest, ProtocolTransferResult
 from nexus.bricks.pay.spending_policy import ApprovalRequiredError, PolicyDeniedError
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.bricks.pay.spending_policy_service import SpendingPolicyService
@@ -67,7 +68,9 @@ class PolicyEnforcedPayment:
             5. Delegate to inner protocol
             6. On success → fire-and-forget ledger update
         """
-        zone_id = request.metadata.get("zone_id", "root") if request.metadata else "root"
+        zone_id = (
+            request.metadata.get("zone_id", ROOT_ZONE_ID) if request.metadata else ROOT_ZONE_ID
+        )
         approval_id = request.metadata.get("approval_id") if request.metadata else None
 
         # 1. If approval_id provided, check it before evaluation

--- a/src/nexus/bricks/pay/protocol.py
+++ b/src/nexus/bricks/pay/protocol.py
@@ -24,6 +24,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.pay.audit_types import TransactionProtocol
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.bricks.pay.x402 import X402Client
@@ -254,7 +255,7 @@ class CreditsPaymentProtocol:
     Structurally satisfies ``PaymentProtocol``.
     """
 
-    def __init__(self, service: Any, zone_id: str = "root") -> None:
+    def __init__(self, service: Any, zone_id: str = ROOT_ZONE_ID) -> None:
         self._service = service
         self._zone_id = zone_id
 

--- a/src/nexus/bricks/pay/sdk.py
+++ b/src/nexus/bricks/pay/sdk.py
@@ -40,6 +40,7 @@ from nexus.bricks.pay.protocol import (
     get_protocol_method_name,
 )
 from nexus.bricks.pay.x402 import validate_wallet_address
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -201,7 +202,7 @@ class NexusPay:
         x402_client: X402Client | None = None,
         x402_enabled: bool = True,
         scheduler_service: Any | None = None,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
     ) -> None:
         match = _API_KEY_PATTERN.match(api_key)
         if not match:

--- a/src/nexus/bricks/pay/x402.py
+++ b/src/nexus/bricks/pay/x402.py
@@ -36,6 +36,8 @@ from typing import TYPE_CHECKING, Any
 from cachetools import TTLCache
 from starlette.responses import Response
 
+from nexus.constants import ROOT_ZONE_ID
+
 if TYPE_CHECKING:
     import httpx
 
@@ -581,7 +583,7 @@ class X402Client:
         # 2. Extract payment details
         metadata = webhook_payload.get("metadata", {})
         agent_id = metadata.get("agent_id")
-        zone_id = metadata.get("zone_id", "root")
+        zone_id = metadata.get("zone_id", ROOT_ZONE_ID)
 
         if not agent_id:
             raise X402Error("Missing agent_id in webhook metadata")

--- a/src/nexus/bricks/skills/importer.py
+++ b/src/nexus/bricks/skills/importer.py
@@ -17,6 +17,7 @@ from nexus.bricks.skills.exceptions import (
 from nexus.bricks.skills.parser import SkillParseError, SkillParser
 from nexus.bricks.skills.protocols import NexusFilesystem
 from nexus.bricks.skills.registry import SkillRegistry
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.bricks.skills.types import SkillOperationContext as OperationContext
@@ -376,7 +377,7 @@ class SkillImporter:
         if not context:
             raise ValueError("Context required for personal/zone tier skills")
 
-        zone_id = context.zone_id or "root"
+        zone_id = context.zone_id or ROOT_ZONE_ID
 
         if tier == "personal":
             # Personal: /zone/{tid}/user/{uid}/skill/{skill_name}/

--- a/src/nexus/bricks/skills/manager.py
+++ b/src/nexus/bricks/skills/manager.py
@@ -16,6 +16,7 @@ from nexus.bricks.skills.models import SkillMetadata
 from nexus.bricks.skills.parser import SkillParser
 from nexus.bricks.skills.protocols import NexusFilesystem
 from nexus.bricks.skills.registry import SkillNotFoundError, SkillRegistry
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.bricks.skills.governance import SkillGovernance
@@ -149,7 +150,7 @@ class SkillManager:
 
         try:
             # Get zone_id from context if not provided
-            effective_zone_id = zone_id or (context.zone_id if context else None) or "root"
+            effective_zone_id = zone_id or (context.zone_id if context else None) or ROOT_ZONE_ID
 
             # For user-level skills: Owner gets direct_owner on the skill directory
             # This allows them full control (read, write, delete)
@@ -182,7 +183,7 @@ class SkillManager:
                     subject=("role", "public"),
                     relation="viewer",
                     object=("file", skill_dir.rstrip("/")),
-                    zone_id="root",  # System skills use root zone
+                    zone_id=ROOT_ZONE_ID,  # System skills use root zone
                 )
                 logger.debug(f"Created public viewer permission on {skill_dir}")
 

--- a/src/nexus/bricks/skills/registry.py
+++ b/src/nexus/bricks/skills/registry.py
@@ -15,6 +15,7 @@ from nexus.bricks.skills.exceptions import (
 from nexus.bricks.skills.models import Skill, SkillMetadata
 from nexus.bricks.skills.parser import SkillParseError, SkillParser
 from nexus.bricks.skills.protocols import NexusFilesystem
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.bricks.skills.types import SkillOperationContext as OperationContext
@@ -85,7 +86,7 @@ class SkillRegistry:
         paths: dict[str, str] = {**cls.TIER_PATHS}
 
         if context:
-            zone_id = context.zone_id or "root"
+            zone_id = context.zone_id or ROOT_ZONE_ID
 
             # Zone-level skills: /zone/{tid}/skill/
             paths["zone"] = f"/zone/{zone_id}/skill/"


### PR DESCRIPTION
## Summary
- Mechanical sweep of 12 `bricks/` files replacing hardcoded `"root"` zone_id defaults with the canonical `ROOT_ZONE_ID` constant from `nexus.constants`
- Covers: `a2a/` (grpc_server, task_manager), `cache/` (persistent_view_postgres), `governance/` (governance_wrapper), `pay/` (credits, policy_wrapper, protocol, sdk, x402), `skills/` (importer, manager, registry)

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, ruff format)
- [ ] No behavioral change — `ROOT_ZONE_ID == "root"` at runtime
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)