### PR TITLE
fix(#417): sharpen lib/ vs contracts/ boundary

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -183,6 +183,52 @@ See `ops-scenario-matrix.md` §2–§3 for full enumeration and affinity matchin
 
 ---
 
+## 3.1. Tier-Neutral Layers (`contracts/`, `lib/`)
+
+Two packages sit **outside** the Kernel → Services → Drivers stack.
+Any layer may import from them; they must **not** import from `nexus.core`,
+`nexus.services`, `nexus.fuse`, `nexus.bricks`, or any other tier-specific package.
+
+| Package | Contains | Linux Analogue | Rule |
+|---------|----------|----------------|------|
+| **`contracts/`** | Types, enums, exceptions, constants | `include/linux/` (header files) | Declarations only — no implementation logic, no I/O |
+| **`lib/`** | Reusable helper functions, pure utilities | `lib/` (libc, libm) | Implementation allowed, but zero kernel deps |
+
+**Core distinction:** `contracts/` = **what** (shapes of data). `lib/` = **how** (behavior).
+When you see `from nexus.contracts import X` you know X is a lightweight type/exception
+with near-zero deps. `from nexus.lib import Y` means Y is a function that *does* something.
+
+### Placement Decision Tree
+
+```
+Is it used by a SINGLE layer?
+  → Yes: stays in that layer (e.g. fuse/filters.py)
+  → No (multi-layer):
+       Is it a type / ABC / exception / enum / constant?
+         → Yes: contracts/
+         → No (function / helper / I/O logic): lib/
+```
+
+### Import Rules
+
+`contracts/` and `lib/` may import from: each other, stdlib, third-party packages.
+They must **never** import from: `nexus.core`, `nexus.services`, `nexus.server`,
+`nexus.cli`, `nexus.fuse`, `nexus.bricks`, `nexus.rebac`.
+
+### What Goes Where — Examples
+
+| Module | Destination | Reason |
+|--------|-------------|--------|
+| `OperationContext`, `Permission` (type defs) | `contracts/types.py` | Type declarations |
+| `NexusError`, `BackendError` (exceptions) | `contracts/exceptions.py` | Exception hierarchy |
+| `Base`, `TimestampMixin` (ORM base/mixins) | `lib/db_base.py` | Schema helpers with implementation (uuid gen, server_default) |
+| `EmailList`, `ISODateTimeStr` (Pydantic Annotated) | `lib/validators.py` | Annotated types with validation logic |
+| `get_database_url()` (env var resolution) | `lib/env.py` | Implementation helper |
+| `path_matches_pattern()` (glob matching) | `lib/path_utils.py` | Pure utility function |
+| `is_os_metadata_file()` (OS file filter) | `fuse/filters.py` | Single-layer (FUSE only) |
+
+---
+
 ## 4. Zone
 
 A Zone is the **fundamental isolation and consensus unit** in NexusFS.

--- a/src/nexus/bricks/governance/db_models.py
+++ b/src/nexus/bricks/governance/db_models.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from sqlalchemy import Boolean, DateTime, Float, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
-from nexus.contracts.db_base import Base, TimestampMixin, ZoneIsolationMixin, uuid_pk
+from nexus.lib.db_base import Base, TimestampMixin, ZoneIsolationMixin, uuid_pk
 
 # =============================================================================
 # Phase 1: Anomaly Detection Tables

--- a/src/nexus/connectors/calendar/schemas.py
+++ b/src/nexus/connectors/calendar/schemas.py
@@ -31,7 +31,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, Field
 
-from nexus.contracts.validators import EmailAddress, ISODateTimeStr
+from nexus.lib.validators import EmailAddress, ISODateTimeStr
 
 
 class TimeSlot(BaseModel):

--- a/src/nexus/connectors/gmail/schemas.py
+++ b/src/nexus/connectors/gmail/schemas.py
@@ -30,7 +30,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from nexus.contracts.validators import EmailAddress, EmailList, EmailListRequired
+from nexus.lib.validators import EmailAddress, EmailList, EmailListRequired
 
 
 class Recipient(BaseModel):

--- a/src/nexus/contracts/__init__.py
+++ b/src/nexus/contracts/__init__.py
@@ -60,13 +60,13 @@ from nexus.contracts.types import (
     Permission,
     extract_context_identity,
 )
-from nexus.contracts.validators import (
+from nexus.contracts.write_observer import WriteObserverProtocol
+from nexus.lib.validators import (
     EmailAddress,
     EmailList,
     EmailListRequired,
     ISODateTimeStr,
 )
-from nexus.contracts.write_observer import WriteObserverProtocol
 
 __all__ = [
     # Constants (shared across bricks)

--- a/src/nexus/fuse/filters.py
+++ b/src/nexus/fuse/filters.py
@@ -1,10 +1,14 @@
-"""File filtering utilities for Nexus filesystem.
+"""File filtering utilities for the FUSE layer.
 
 This module provides utilities for filtering out OS-generated metadata files
-that should not be stored or displayed in Nexus.
+that should not be stored or displayed in Nexus.  Lives in ``nexus.fuse``
+because only FUSE handlers use it.
 """
 
-from nexus.core import glob_fast
+from __future__ import annotations
+
+import fnmatch
+from typing import Any
 
 # Try to import Rust acceleration
 try:
@@ -53,8 +57,8 @@ def is_os_metadata_file(path: str) -> bool:
     # Extract just the filename from the path
     filename = path.split("/")[-1] if "/" in path else path
 
-    # Check if filename matches any OS metadata pattern (uses Rust if available)
-    return glob_fast.glob_match(filename, OS_METADATA_PATTERNS)
+    # Check if filename matches any OS metadata pattern
+    return any(fnmatch.fnmatch(filename, pat) for pat in OS_METADATA_PATTERNS)
 
 
 def filter_os_metadata(files: list[str]) -> list[str]:
@@ -75,7 +79,8 @@ def filter_os_metadata(files: list[str]) -> list[str]:
     # Use Rust for bulk filtering if available (5-10x faster)
     if RUST_AVAILABLE and len(files) >= 10:
         try:
-            return nexus_fast.filter_paths(files, OS_METADATA_PATTERNS)  # type: ignore[no-any-return]
+            result: list[str] = nexus_fast.filter_paths(files, OS_METADATA_PATTERNS)
+            return result
         except (OSError, ValueError, RuntimeError):
             # Fall back to Python on error
             pass
@@ -84,7 +89,7 @@ def filter_os_metadata(files: list[str]) -> list[str]:
     return [f for f in files if not is_os_metadata_file(f)]
 
 
-def filter_os_metadata_dicts(files: list[dict[str, any]]) -> list[dict[str, any]]:  # type: ignore[valid-type]
+def filter_os_metadata_dicts(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Filter out OS metadata files from a list of file info dicts.
 
     Args:

--- a/src/nexus/fuse/ops/io_handler.py
+++ b/src/nexus/fuse/ops/io_handler.py
@@ -8,7 +8,7 @@ from typing import cast
 
 from fuse import FuseOSError
 
-from nexus.core.filters import is_os_metadata_file
+from nexus.fuse.filters import is_os_metadata_file
 from nexus.fuse.ops._shared import (
     FUSESharedContext,
     check_namespace_visible,

--- a/src/nexus/fuse/ops/metadata_handler.py
+++ b/src/nexus/fuse/ops/metadata_handler.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from fuse import FuseOSError
 
-from nexus.core.filters import is_os_metadata_file
 from nexus.core.virtual_views import should_add_virtual_views
+from nexus.fuse.filters import is_os_metadata_file
 from nexus.fuse.ops._shared import (
     FUSESharedContext,
     build_dir_attrs,

--- a/src/nexus/fuse/ops/mutation_handler.py
+++ b/src/nexus/fuse/ops/mutation_handler.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from fuse import FuseOSError
 
-from nexus.core.filters import is_os_metadata_file
+from nexus.fuse.filters import is_os_metadata_file
 from nexus.fuse.ops._shared import (
     FUSESharedContext,
     check_namespace_visible,

--- a/src/nexus/lib/db_base.py
+++ b/src/nexus/lib/db_base.py
@@ -1,18 +1,12 @@
 """Shared ORM base, mixins, and utilities for SQLAlchemy models.
 
 Canonical location for ``Base``, ``TimestampMixin``, ``ZoneIsolationMixin``,
-``ResourceConfigMixin``, and ``uuid_pk``.  This module lives in
-``nexus.contracts`` (tier-neutral) so that both kernel code and bricks can
-depend on it without pulling in storage internals.
+``ResourceConfigMixin``, and ``uuid_pk``.  Lives in ``nexus.lib`` (tier-neutral
+implementation helpers) so that both kernel code and bricks can depend on it
+without pulling in storage internals.
 
 History:
-    Originally in ``nexus.storage.models._base`` (Issue #1246 / #1286).
-    Moved here by Issue #2129 (governance brick extraction) to break the
-    storage ↔ brick import cycle.
-
-Backward compatibility:
-    ``from nexus.storage.models._base import Base`` still works via re-exports
-    in ``nexus/storage/models/_base.py``.
+    nexus.storage.models._base → nexus.contracts.db_base → nexus.lib.db_base
 """
 
 from __future__ import annotations

--- a/src/nexus/lib/validators.py
+++ b/src/nexus/lib/validators.py
@@ -4,7 +4,7 @@ Tier-neutral validation types used across connectors, services, and bricks.
 Zero imports from ``nexus.core`` or any other kernel module.
 
 Usage:
-    from nexus.contracts.validators import EmailAddress, EmailList, ISODateTimeStr
+    from nexus.lib.validators import EmailAddress, EmailList, ISODateTimeStr
 
     class MySchema(BaseModel):
         to: EmailList

--- a/src/nexus/storage/models/_base.py
+++ b/src/nexus/storage/models/_base.py
@@ -3,14 +3,14 @@
 Issue #1246 Phase 4: Extracted from monolithic models.py.
 Issue #1286: Added mixins (TimestampMixin, ZoneIsolationMixin, ResourceConfigMixin),
              uuid_pk() helper, and _get_uuid_server_default.
-Issue #2129: Canonical definitions moved to ``nexus.contracts.db_base``.
+Issue #2129: Canonical definitions moved to ``nexus.lib.db_base``.
              This module re-exports everything for backward compatibility.
 """
 
-from nexus.contracts.db_base import Base as Base
-from nexus.contracts.db_base import ResourceConfigMixin as ResourceConfigMixin
-from nexus.contracts.db_base import TimestampMixin as TimestampMixin
-from nexus.contracts.db_base import ZoneIsolationMixin as ZoneIsolationMixin
-from nexus.contracts.db_base import _generate_uuid as _generate_uuid
-from nexus.contracts.db_base import _get_uuid_server_default as _get_uuid_server_default
-from nexus.contracts.db_base import uuid_pk as uuid_pk
+from nexus.lib.db_base import Base as Base
+from nexus.lib.db_base import ResourceConfigMixin as ResourceConfigMixin
+from nexus.lib.db_base import TimestampMixin as TimestampMixin
+from nexus.lib.db_base import ZoneIsolationMixin as ZoneIsolationMixin
+from nexus.lib.db_base import _generate_uuid as _generate_uuid
+from nexus.lib.db_base import _get_uuid_server_default as _get_uuid_server_default
+from nexus.lib.db_base import uuid_pk as uuid_pk

--- a/tests/e2e/server/test_governance_e2e.py
+++ b/tests/e2e/server/test_governance_e2e.py
@@ -33,7 +33,7 @@ from nexus.bricks.governance.collusion_service import CollusionService
 from nexus.bricks.governance.governance_graph_service import GovernanceGraphService
 from nexus.bricks.governance.models import AgentBaseline
 from nexus.bricks.governance.response_service import ResponseService
-from nexus.contracts.db_base import Base
+from nexus.lib.db_base import Base
 from nexus.server.api.v2.routers.governance import router
 from nexus.server.dependencies import require_admin
 


### PR DESCRIPTION
## Summary
- Documents tier-neutral layer rules in KERNEL-ARCHITECTURE.md §3.1 (contracts/ = types/exceptions/constants like Linux `include/`, lib/ = implementation helpers like Linux `lib/`)
- Moves `db_base.py` and `validators.py` from `contracts/` → `lib/` since they contain implementation (ORM base classes, validation logic), not pure type definitions
- Moves `filters.py` from `core/` → `fuse/` since only FUSE handlers use it (single-layer code stays in its layer)
- Replaces `core.glob_fast` dependency with stdlib `fnmatch`, fixes `any` → `Any` type annotation, and removes `type:ignore[no-any-return]`
- Updates all 12 callers across bricks, connectors, contracts, fuse, storage, and tests

## Test plan
- [ ] CI passes (ruff, mypy, pre-commit hooks)
- [ ] All import paths resolve correctly — no `ModuleNotFoundError` at import time
- [ ] `filter_os_metadata` still correctly filters OS metadata files via `fnmatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)