### PR TITLE
fix(#846): migrate core/ off core/exceptions.py shim

### DIFF
--- a/src/nexus/core/__init__.py
+++ b/src/nexus/core/__init__.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 # =============================================================================
 # Lightweight imports (always loaded) - these are fast
 # =============================================================================
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     AccessDeniedError,
     BackendError,
     InvalidPathError,

--- a/src/nexus/core/async_nexus_fs.py
+++ b/src/nexus/core/async_nexus_fs.py
@@ -19,13 +19,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from nexus.backends.async_local import AsyncLocalBackend
-from nexus.contracts.types import OperationContext, Permission
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
     NexusFileNotFoundError,
     NexusPermissionError,
 )
+from nexus.contracts.types import OperationContext, Permission
 from nexus.core.metadata import (
     DT_DIR,
     DT_REG,

--- a/src/nexus/core/metadata.py
+++ b/src/nexus/core/metadata.py
@@ -107,7 +107,7 @@ class FileMetadata:
         Raises:
             ValidationError: If validation fails with clear message.
         """
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
 
         if not self.path:
             raise ValidationError("path is required")

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from nexus.backends.backend import Backend
 from nexus.constants import ROOT_ZONE_ID
-from nexus.core.exceptions import InvalidPathError, NexusFileNotFoundError
+from nexus.contracts.exceptions import InvalidPathError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.mutation_hooks import MutationOp
 

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -21,8 +21,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import BackendError, ConflictError, NexusFileNotFoundError
 from nexus.contracts.types import Permission
-from nexus.core.exceptions import BackendError, ConflictError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.metadata import FileMetadata
 from nexus.core.mutation_hooks import MutationOp
@@ -593,7 +593,7 @@ class NexusFSCoreMixin:
                 "Ensure NexusFS is initialized with enable_distributed_locks=True."
             )
 
-        from nexus.core.exceptions import LockTimeout
+        from nexus.contracts.exceptions import LockTimeout
 
         # Run async lock in sync context
         # Check if we're in an async context - if so, user should use locked() instead
@@ -2317,7 +2317,7 @@ class NexusFSCoreMixin:
             if if_match is not None and not force:
                 current_etag = result.get("etag")
                 if current_etag != if_match:
-                    from nexus.core.exceptions import ConflictError
+                    from nexus.contracts.exceptions import ConflictError
 
                     raise ConflictError(
                         path=path,
@@ -2327,7 +2327,7 @@ class NexusFSCoreMixin:
         except Exception as e:
             # If file doesn't exist, treat as empty (will create new file)
             # Permission errors on non-existent files are OK - write() will check parent permissions
-            from nexus.core.exceptions import NexusFileNotFoundError
+            from nexus.contracts.exceptions import NexusFileNotFoundError
 
             if not isinstance(e, (NexusFileNotFoundError, PermissionError)):
                 # Re-raise unexpected errors

--- a/src/nexus/core/path_utils.py
+++ b/src/nexus/core/path_utils.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import re
 
-from nexus.core.exceptions import InvalidPathError
+from nexus.contracts.exceptions import InvalidPathError
 
 # Pre-compiled regex for normalizing consecutive slashes
 _MULTI_SLASH = re.compile(r"/+")

--- a/src/nexus/core/response.py
+++ b/src/nexus/core/response.py
@@ -232,7 +232,7 @@ class HandlerResponse(Generic[T]):
             HandlerResponse with appropriate status
         """
         # Import here to avoid circular imports
-        from nexus.core.exceptions import ConflictError, NexusFileNotFoundError
+        from nexus.contracts.exceptions import ConflictError, NexusFileNotFoundError
 
         # Get path from exception if not provided
         exc_path = path or getattr(e, "path", None)
@@ -292,7 +292,7 @@ class HandlerResponse(Generic[T]):
             return self.data  # type: ignore[return-value]
 
         # Import here to avoid circular imports
-        from nexus.core.exceptions import BackendError, ConflictError, NexusFileNotFoundError
+        from nexus.contracts.exceptions import BackendError, ConflictError, NexusFileNotFoundError
 
         if self.resp_type == ResponseType.NOT_FOUND:
             raise NexusFileNotFoundError(

--- a/src/nexus/core/router.py
+++ b/src/nexus/core/router.py
@@ -4,7 +4,7 @@ import posixpath
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from nexus.core.exceptions import AccessDeniedError, InvalidPathError, PathNotMountedError
+from nexus.contracts.exceptions import AccessDeniedError, InvalidPathError, PathNotMountedError
 
 if TYPE_CHECKING:
     from nexus.core.protocols.connector import ConnectorProtocol


### PR DESCRIPTION
## Summary
- Batch 1 of `core/exceptions.py` re-export shim elimination (130 total callers)
- Updates all 8 `core/` files (12 import sites) to import directly from `nexus.contracts.exceptions`
- No behavior change — pure import path cleanup
- The `core/exceptions.py` shim remains for the ~120 non-core callers (future batches)

## Test plan
- [ ] CI passes (ruff, mypy, pre-commit hooks)
- [ ] All imports resolve correctly — no `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)