### PR TITLE
fix(#847): migrate backends/ off core/exceptions.py shim

### DIFF
--- a/src/nexus/backends/async_local.py
+++ b/src/nexus/backends/async_local.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.backends.backend import AsyncBackend
 from nexus.backends.cas_blob_store import CASBlobStore
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.response import HandlerResponse, timed_response
 from nexus.storage.content_cache import ContentCache

--- a/src/nexus/backends/base_blob_connector.py
+++ b/src/nexus/backends/base_blob_connector.py
@@ -25,7 +25,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 from nexus.backends.backend import Backend
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.response import HandlerResponse
 

--- a/src/nexus/backends/cache_service.py
+++ b/src/nexus/backends/cache_service.py
@@ -29,8 +29,8 @@ from nexus.backends.cache_models import (
     CacheEntry,
 )
 from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import ConflictError
 from nexus.contracts.types import OperationContext
-from nexus.core.exceptions import ConflictError
 from nexus.core.hash_fast import hash_content
 from nexus.storage.file_cache import FileContentCache
 from nexus.storage.models import FilePathModel

--- a/src/nexus/backends/cas_blob_store.py
+++ b/src/nexus/backends/cas_blob_store.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeVar
 
-from nexus.core.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError
 
 _T = TypeVar("_T")
 

--- a/src/nexus/backends/gcalendar_connector.py
+++ b/src/nexus/backends/gcalendar_connector.py
@@ -57,7 +57,7 @@ from nexus.connectors.calendar.schemas import (
     DeleteEventSchema,
     UpdateEventSchema,
 )
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.response import HandlerResponse, timed_response
 
 # Suppress annoying googleapiclient discovery cache warnings

--- a/src/nexus/backends/gcs.py
+++ b/src/nexus/backends/gcs.py
@@ -22,7 +22,7 @@ from google.cloud.exceptions import NotFound
 
 from nexus.backends.backend import Backend
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 
 if TYPE_CHECKING:

--- a/src/nexus/backends/gcs_connector.py
+++ b/src/nexus/backends/gcs_connector.py
@@ -47,7 +47,7 @@ from nexus.backends.backend import HandlerStatusResponse
 from nexus.backends.base_blob_connector import BaseBlobStorageConnector
 from nexus.backends.cache_mixin import CacheConnectorMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:

--- a/src/nexus/backends/gdrive_connector.py
+++ b/src/nexus/backends/gdrive_connector.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.backends.backend import Backend, HandlerStatusResponse
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
-from nexus.core.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError
 from nexus.core.hash_fast import hash_content
 from nexus.core.response import HandlerResponse, timed_response
 

--- a/src/nexus/backends/gmail_connector.py
+++ b/src/nexus/backends/gmail_connector.py
@@ -55,7 +55,7 @@ from nexus.connectors.base import (
     ValidatedMixin,
 )
 from nexus.connectors.gmail.errors import ERROR_REGISTRY
-from nexus.core.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError
 from nexus.core.response import HandlerResponse, timed_response
 
 try:

--- a/src/nexus/backends/hn_connector.py
+++ b/src/nexus/backends/hn_connector.py
@@ -47,7 +47,7 @@ from nexus.backends.backend import Backend
 from nexus.backends.cache_mixin import CacheConnectorMixin, SyncResult
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.connectors.base import SkillDocMixin
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:

--- a/src/nexus/backends/local.py
+++ b/src/nexus/backends/local.py
@@ -14,7 +14,7 @@ from nexus.backends.cas_blob_store import CASBlobStore
 from nexus.backends.chunked_storage import ChunkedStorageMixin
 from nexus.backends.multipart_upload_mixin import MultipartUploadMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.response import HandlerResponse, timed_response
 from nexus.storage.content_cache import ContentCache

--- a/src/nexus/backends/local_connector.py
+++ b/src/nexus/backends/local_connector.py
@@ -33,7 +33,7 @@ from nexus.backends.registry import (
     ConnectionArg,
     register_connector,
 )
-from nexus.core.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError
 from nexus.core.hash_fast import hash_content
 from nexus.core.response import HandlerResponse, timed_response
 

--- a/src/nexus/backends/passthrough.py
+++ b/src/nexus/backends/passthrough.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 
 from nexus.backends.backend import Backend
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
-from nexus.core.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError
 from nexus.core.hash_fast import hash_content
 from nexus.core.response import HandlerResponse
 

--- a/src/nexus/backends/s3_connector.py
+++ b/src/nexus/backends/s3_connector.py
@@ -41,7 +41,7 @@ from nexus.backends.base_blob_connector import BaseBlobStorageConnector
 from nexus.backends.cache_mixin import CacheConnectorMixin
 from nexus.backends.multipart_upload_mixin import MultipartUploadMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:

--- a/src/nexus/backends/slack_connector.py
+++ b/src/nexus/backends/slack_connector.py
@@ -51,7 +51,7 @@ from nexus.backends.slack_connector_utils import (
     list_channels,
     list_messages_from_channel,
 )
-from nexus.core.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError
 from nexus.core.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:

--- a/src/nexus/backends/x_api_client.py
+++ b/src/nexus/backends/x_api_client.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import httpx
 
-from nexus.core.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/backends/x_connector.py
+++ b/src/nexus/backends/x_connector.py
@@ -50,8 +50,8 @@ from nexus.backends.backend import Backend
 from nexus.backends.oauth_mixin import OAuthConnectorMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import BackendError
 from nexus.core import glob_fast
-from nexus.core.exceptions import BackendError
 from nexus.core.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary
- Batch 2 of `core/exceptions.py` re-export shim elimination
- Updates all 17 `backends/` files to import directly from `nexus.contracts.exceptions`
- No behavior change — pure import path cleanup

## Test plan
- [ ] CI passes (ruff, mypy, pre-commit hooks)
- [ ] All imports resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)