### PR TITLE
fix(#848): migrate storage/ off core/exceptions.py shim

### DIFF
--- a/src/nexus/storage/models/ace.py
+++ b/src/nexus/storage/models/ace.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from nexus.core.exceptions import ValidationError
+from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, uuid_pk
 
 

--- a/src/nexus/storage/models/auth.py
+++ b/src/nexus/storage/models/auth.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from nexus.core.exceptions import ValidationError
+from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, uuid_pk
 
 if TYPE_CHECKING:

--- a/src/nexus/storage/models/file_path.py
+++ b/src/nexus/storage/models/file_path.py
@@ -107,7 +107,7 @@ class FilePathModel(Base):
 
     def validate(self) -> None:
         """Validate file path model before database operations."""
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
 
         if not self.virtual_path:
             raise ValidationError("virtual_path is required")

--- a/src/nexus/storage/models/filesystem.py
+++ b/src/nexus/storage/models/filesystem.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from nexus.core.exceptions import ValidationError
+from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, uuid_pk
 
 if TYPE_CHECKING:

--- a/src/nexus/storage/models/infrastructure.py
+++ b/src/nexus/storage/models/infrastructure.py
@@ -12,7 +12,7 @@ from typing import Any
 from sqlalchemy import DateTime, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
-from nexus.core.exceptions import ValidationError
+from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, ResourceConfigMixin, TimestampMixin, uuid_pk
 
 

--- a/src/nexus/storage/models/memory.py
+++ b/src/nexus/storage/models/memory.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from nexus.core.exceptions import ValidationError
+from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, ResourceConfigMixin, uuid_pk
 
 if TYPE_CHECKING:

--- a/src/nexus/storage/models/operation_log.py
+++ b/src/nexus/storage/models/operation_log.py
@@ -116,7 +116,7 @@ class OperationLogModel(Base):
 
     def validate(self) -> None:
         """Validate operation log model before database operations."""
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
         from nexus.core.operation_types import OperationType
 
         valid_types = [t.value for t in OperationType]

--- a/src/nexus/storage/models/sync.py
+++ b/src/nexus/storage/models/sync.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from sqlalchemy import BigInteger, DateTime, Float, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
-from nexus.core.exceptions import ValidationError
+from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, uuid_pk
 
 

--- a/src/nexus/storage/models/version_history.py
+++ b/src/nexus/storage/models/version_history.py
@@ -95,7 +95,7 @@ class VersionHistoryModel(Base):
 
     def validate(self) -> None:
         """Validate version history model before database operations."""
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
 
         valid_types = ["file", "memory", "skill"]
         if self.resource_type not in valid_types:

--- a/src/nexus/storage/models/workflows.py
+++ b/src/nexus/storage/models/workflows.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from nexus.core.exceptions import ValidationError
+from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, TimestampMixin, uuid_pk
 
 

--- a/src/nexus/storage/query_builder.py
+++ b/src/nexus/storage/query_builder.py
@@ -17,7 +17,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from nexus.core.exceptions import MetadataError
+from nexus.contracts.exceptions import MetadataError
 
 
 class WorkQueryBuilder:

--- a/src/nexus/storage/session_scope.py
+++ b/src/nexus/storage/session_scope.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import OperationalError as SAOperationalError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     DatabaseConnectionError,
     DatabaseError,
     DatabaseIntegrityError,

--- a/src/nexus/storage/time_travel.py
+++ b/src/nexus/storage/time_travel.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import and_, or_, select
 
-from nexus.core.exceptions import NexusFileNotFoundError
+from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.storage.models import FilePathModel, OperationLogModel
 
 if TYPE_CHECKING:

--- a/src/nexus/storage/version_manager.py
+++ b/src/nexus/storage/version_manager.py
@@ -17,7 +17,7 @@ from typing import Any
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
-from nexus.core.exceptions import MetadataError
+from nexus.contracts.exceptions import MetadataError
 from nexus.core.metadata import FileMetadata
 from nexus.storage.models import FilePathModel, VersionHistoryModel
 


### PR DESCRIPTION
## Summary
- Batch 3 of `core/exceptions.py` re-export shim elimination
- Updated 14 `storage/` files to import from `nexus.contracts.exceptions` directly instead of the `nexus.core.exceptions` shim
- Files: session_scope.py, query_builder.py, version_manager.py, time_travel.py, models/{ace,operation_log,file_path,auth,workflows,sync,filesystem,infrastructure,version_history,memory}.py

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Verify no remaining `from nexus.core.exceptions import` in storage/

🤖 Generated with [Claude Code](https://claude.com/claude-code)