### PR TITLE
fix(#849): migrate services/ off core/exceptions.py shim

### DIFF
--- a/src/nexus/services/change_log_store.py
+++ b/src/nexus/services/change_log_store.py
@@ -18,7 +18,7 @@ from typing import Any
 from sqlalchemy import delete, func, select
 
 from nexus.constants import ROOT_ZONE_ID
-from nexus.core.exceptions import DatabaseError
+from nexus.contracts.exceptions import DatabaseError
 from nexus.storage.sync_store_base import SyncStoreBase
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/services/chunked_upload_service.py
+++ b/src/nexus/services/chunked_upload_service.py
@@ -20,7 +20,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from nexus.constants import ROOT_ZONE_ID
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     BackendError,
     UploadChecksumMismatchError,
     UploadExpiredError,

--- a/src/nexus/services/context_branch.py
+++ b/src/nexus/services/context_branch.py
@@ -26,7 +26,7 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 
 from nexus.constants import ROOT_ZONE_ID
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     BranchConflictError,
     BranchExistsError,
     BranchNotFoundError,

--- a/src/nexus/services/events_service.py
+++ b/src/nexus/services/events_service.py
@@ -440,7 +440,7 @@ class EventsService:
         Raises:
             LockTimeout: If lock cannot be acquired within timeout
         """
-        from nexus.core.exceptions import LockTimeout
+        from nexus.contracts.exceptions import LockTimeout
 
         lock_id = await self.lock(path, timeout=timeout, ttl=ttl, _context=_context)
         if lock_id is None:

--- a/src/nexus/services/mcp_service.py
+++ b/src/nexus/services/mcp_service.py
@@ -192,7 +192,7 @@ class MCPService:
         import asyncio
         import json
 
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
 
         # Get MCP mount manager
         manager = self._get_mcp_mount_manager()
@@ -323,7 +323,7 @@ class MCPService:
             - Transport is auto-detected: stdio for command, sse for url
             - Tools are automatically synced after mounting
         """
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
         from nexus.mcp.models import MCPMount
 
         # Validate: need either command or url
@@ -410,7 +410,7 @@ class MCPService:
             for m in mounts:
                 service.mcp_unmount(m['name'], context=context)
         """
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
 
         manager = self._get_mcp_mount_manager()
 
@@ -463,7 +463,7 @@ class MCPService:
         """
         import asyncio
 
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
 
         manager = self._get_mcp_mount_manager()
 

--- a/src/nexus/services/rebac_service.py
+++ b/src/nexus/services/rebac_service.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from nexus.core.exceptions import CircuitOpenError
+from nexus.contracts.exceptions import CircuitOpenError
 from nexus.core.rpc_decorator import rpc_expose
 from nexus.services.rebac_share_mixin import ReBACShareMixin
 

--- a/src/nexus/services/search_listing_mixin.py
+++ b/src/nexus/services/search_listing_mixin.py
@@ -20,8 +20,8 @@ from concurrent.futures import as_completed
 from typing import TYPE_CHECKING, Any
 
 from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import PermissionDeniedError
 from nexus.contracts.types import Permission
-from nexus.core.exceptions import PermissionDeniedError
 from nexus.core.rpc_decorator import rpc_expose
 
 # Constants duplicated from search_service to avoid circular import

--- a/src/nexus/services/search_service.py
+++ b/src/nexus/services/search_service.py
@@ -25,9 +25,9 @@ from typing import TYPE_CHECKING, Any, cast
 from cachetools import TTLCache
 
 from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import PermissionDeniedError
 from nexus.contracts.types import Permission
 from nexus.core import glob_fast, grep_fast, trigram_fast
-from nexus.core.exceptions import PermissionDeniedError
 from nexus.core.rpc_decorator import rpc_expose
 from nexus.search.strategies import (
     GLOB_RUST_THRESHOLD,

--- a/src/nexus/services/version_service.py
+++ b/src/nexus/services/version_service.py
@@ -158,7 +158,7 @@ class VersionService:
                 context=context
             )
         """
-        from nexus.core.exceptions import NexusFileNotFoundError
+        from nexus.contracts.exceptions import NexusFileNotFoundError
 
         # Validate and normalize path
         path = self._validate_path(path)

--- a/src/nexus/services/workspace_manager.py
+++ b/src/nexus/services/workspace_manager.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import desc, select
 
-from nexus.core.exceptions import NexusFileNotFoundError
+from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.core.workspace_manifest import WorkspaceManifest
 from nexus.services.workspace_permissions import check_workspace_permission
 from nexus.storage.models import WorkspaceSnapshotModel

--- a/src/nexus/services/workspace_permissions.py
+++ b/src/nexus/services/workspace_permissions.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from nexus.core.exceptions import NexusPermissionError
+from nexus.contracts.exceptions import NexusPermissionError
 
 if TYPE_CHECKING:
     from nexus.rebac.manager import ReBACManager


### PR DESCRIPTION
## Summary
- Batch 4 of `core/exceptions.py` re-export shim elimination
- Updated 11 `services/` files (14 import sites) to import from `nexus.contracts.exceptions` directly
- Files: mcp_service.py (4 lazy imports), chunked_upload_service.py, workspace_permissions.py, rebac_service.py, context_branch.py, change_log_store.py, workspace_manager.py, search_listing_mixin.py, version_service.py, events_service.py, search_service.py

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Verify no remaining `from nexus.core.exceptions import` in services/

🤖 Generated with [Claude Code](https://claude.com/claude-code)