### PR TITLE
fix(#850): migrate server/ off core/exceptions.py shim

### DIFF
--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -12,7 +12,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, Response
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     ConflictError,
     ConnectorError,
     DatabaseError,

--- a/src/nexus/server/api/core/streaming.py
+++ b/src/nexus/server/api/core/streaming.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import Response, StreamingResponse
 
 from nexus.constants import ROOT_ZONE_ID
-from nexus.core.exceptions import NexusFileNotFoundError, NexusPermissionError
+from nexus.contracts.exceptions import NexusFileNotFoundError, NexusPermissionError
 from nexus.server.streaming import _verify_stream_token
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/server/api/v1/routers/events.py
+++ b/src/nexus/server/api/v1/routers/events.py
@@ -31,7 +31,7 @@ from fastapi import (
 from fastapi import status as http_status
 
 from nexus.constants import ROOT_ZONE_ID
-from nexus.core.exceptions import NexusFileNotFoundError, NexusPermissionError
+from nexus.contracts.exceptions import NexusFileNotFoundError, NexusPermissionError
 from nexus.server.api.v1.dependencies import get_nexus_fs
 from nexus.server.dependencies import get_auth_result, get_operation_context, resolve_auth
 

--- a/src/nexus/server/api/v1/routers/share.py
+++ b/src/nexus/server/api/v1/routers/share.py
@@ -18,8 +18,8 @@ from fastapi.responses import JSONResponse
 from starlette.responses import Response, StreamingResponse
 
 from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.contracts.types import OperationContext
-from nexus.core.exceptions import NexusFileNotFoundError
 from nexus.server.api.v1.dependencies import get_nexus_fs
 from nexus.server.dependencies import get_auth_result, get_operation_context
 from nexus.server.fastapi_server import to_thread_with_timeout

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -25,7 +25,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
     NexusFileNotFoundError,

--- a/src/nexus/server/api/v2/routers/tus_uploads.py
+++ b/src/nexus/server/api/v2/routers/tus_uploads.py
@@ -128,7 +128,7 @@ def create_tus_uploads_router(
         _tus_resumable: str = Depends(_validate_tus_resumable),
     ) -> Response:
         """Create a new upload session (tus creation extension)."""
-        from nexus.core.exceptions import ValidationError
+        from nexus.contracts.exceptions import ValidationError
 
         service = _get_service()
 
@@ -187,7 +187,7 @@ def create_tus_uploads_router(
         _tus_resumable: str = Depends(_validate_tus_resumable),
     ) -> Response:
         """Upload a chunk of data (tus core protocol)."""
-        from nexus.core.exceptions import (
+        from nexus.contracts.exceptions import (
             UploadChecksumMismatchError,
             UploadExpiredError,
             UploadNotFoundError,
@@ -264,7 +264,7 @@ def create_tus_uploads_router(
         _tus_resumable: str = Depends(_validate_tus_resumable),
     ) -> Response:
         """Get the current offset of an upload (for resumption)."""
-        from nexus.core.exceptions import UploadExpiredError, UploadNotFoundError
+        from nexus.contracts.exceptions import UploadExpiredError, UploadNotFoundError
 
         service = _get_service()
 
@@ -294,7 +294,7 @@ def create_tus_uploads_router(
         _tus_resumable: str = Depends(_validate_tus_resumable),
     ) -> Response:
         """Terminate an upload and release resources (tus termination extension)."""
-        from nexus.core.exceptions import UploadNotFoundError
+        from nexus.contracts.exceptions import UploadNotFoundError
 
         service = _get_service()
 

--- a/src/nexus/server/auth/token_manager.py
+++ b/src/nexus/server/auth/token_manager.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 from nexus.auth.oauth.crypto import OAuthCrypto
 from nexus.constants import ROOT_ZONE_ID
-from nexus.core.exceptions import AuthenticationError
+from nexus.contracts.exceptions import AuthenticationError
 from nexus.storage.models import OAuthCredentialModel
 from nexus.storage.token_rotation_store import TokenRotationStore
 

--- a/src/nexus/server/batch_executor.py
+++ b/src/nexus/server/batch_executor.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from pydantic import BaseModel, Discriminator, Field, Tag, model_validator
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
     NexusFileNotFoundError,

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -51,7 +51,7 @@ from slowapi.errors import RateLimitExceeded
 from starlette.middleware.gzip import GZipMiddleware
 
 from nexus.constants import DEFAULT_GOOGLE_REDIRECT_URI, DEFAULT_NEXUS_URL, ROOT_ZONE_ID
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
     NexusError,
@@ -1479,7 +1479,7 @@ def create_app(
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
     # Register Nexus exception handlers for error classification
-    from nexus.core.exceptions import NexusError
+    from nexus.contracts.exceptions import NexusError
 
     app.add_exception_handler(NexusError, _nexus_error_handler)
 
@@ -3360,7 +3360,7 @@ def _handle_delta_write(params: Any, context: Any) -> dict[str, Any]:
 
 def _require_admin(context: Any) -> None:
     """Require admin privileges for admin operations."""
-    from nexus.core.exceptions import NexusPermissionError
+    from nexus.contracts.exceptions import NexusPermissionError
 
     if not context or not getattr(context, "is_admin", False):
         raise NexusPermissionError("Admin privileges required for this operation")
@@ -3501,7 +3501,7 @@ def _handle_admin_get_key(params: Any, context: Any) -> dict[str, Any]:
     """Handle admin_get_key method."""
     from sqlalchemy import select
 
-    from nexus.core.exceptions import NexusFileNotFoundError
+    from nexus.contracts.exceptions import NexusFileNotFoundError
     from nexus.storage.models import APIKeyModel
 
     _require_admin(context)
@@ -3536,7 +3536,7 @@ def _handle_admin_get_key(params: Any, context: Any) -> dict[str, Any]:
 def _handle_admin_revoke_key(params: Any, context: Any) -> dict[str, Any]:
     """Handle admin_revoke_key method."""
     from nexus.auth.providers.database_key import DatabaseAPIKeyAuth
-    from nexus.core.exceptions import NexusFileNotFoundError
+    from nexus.contracts.exceptions import NexusFileNotFoundError
 
     _require_admin(context)
 
@@ -3559,7 +3559,7 @@ def _handle_admin_update_key(params: Any, context: Any) -> dict[str, Any]:
 
     from sqlalchemy import select
 
-    from nexus.core.exceptions import NexusFileNotFoundError
+    from nexus.contracts.exceptions import NexusFileNotFoundError
     from nexus.storage.models import APIKeyModel
 
     _require_admin(context)

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def require_admin(context: Any) -> None:
     """Require admin privileges for admin operations."""
-    from nexus.core.exceptions import NexusPermissionError
+    from nexus.contracts.exceptions import NexusPermissionError
 
     if not context or not getattr(context, "is_admin", False):
         raise NexusPermissionError("Admin privileges required for this operation")
@@ -27,7 +27,7 @@ def require_database_auth(auth_provider: Any) -> None:
     Raises:
         ConfigurationError: If auth_provider is missing or lacks session_factory.
     """
-    from nexus.core.exceptions import ConfigurationError
+    from nexus.contracts.exceptions import ConfigurationError
 
     if not auth_provider or not hasattr(auth_provider, "session_factory"):
         raise ConfigurationError(
@@ -165,7 +165,7 @@ def handle_admin_get_key(auth_provider: Any, params: Any, context: Any) -> dict[
     """Handle admin_get_key method."""
     from sqlalchemy import select
 
-    from nexus.core.exceptions import NexusFileNotFoundError
+    from nexus.contracts.exceptions import NexusFileNotFoundError
     from nexus.storage.models import APIKeyModel
 
     require_admin(context)
@@ -186,7 +186,7 @@ def handle_admin_get_key(auth_provider: Any, params: Any, context: Any) -> dict[
 def handle_admin_revoke_key(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
     """Handle admin_revoke_key method."""
     from nexus.auth.providers.database_key import DatabaseAPIKeyAuth
-    from nexus.core.exceptions import NexusFileNotFoundError
+    from nexus.contracts.exceptions import NexusFileNotFoundError
 
     require_admin(context)
     require_database_auth(auth_provider)
@@ -206,7 +206,7 @@ def handle_admin_update_key(auth_provider: Any, params: Any, context: Any) -> di
 
     from sqlalchemy import select
 
-    from nexus.core.exceptions import NexusFileNotFoundError, ValidationError
+    from nexus.contracts.exceptions import NexusFileNotFoundError, ValidationError
     from nexus.storage.models import APIKeyModel
 
     require_admin(context)


### PR DESCRIPTION
## Summary
- Batch 5 of `core/exceptions.py` re-export shim elimination
- Updated 10 `server/` files (21 import sites) to import from `nexus.contracts.exceptions` directly
- Files: fastapi_server.py (5 sites), rpc/handlers/admin.py (5 sites), api/v2/routers/tus_uploads.py (4 sites), api/core/{rpc,streaming}.py, batch_executor.py, auth/token_manager.py, api/v1/routers/{events,share}.py, api/v2/routers/async_files.py

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Verify no remaining `from nexus.core.exceptions import` in server/

🤖 Generated with [Claude Code](https://claude.com/claude-code)