### PR TITLE
fix(#851): migrate remaining src/ off core/exceptions.py shim

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
     from nexus.backends.gcs import GCSBackend
     from nexus.backends.local import LocalBackend
     from nexus.config import NexusConfig, load_config
-    from nexus.core.exceptions import (
+    from nexus.contracts.exceptions import (
         BackendError,
         InvalidPathError,
         MetadataError,
@@ -96,7 +96,7 @@ if TYPE_CHECKING:
 # =============================================================================
 # Lightweight imports (always loaded) - these are fast
 # =============================================================================
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     BackendError,
     InvalidPathError,
     MetadataError,

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -13,7 +13,7 @@ from rich.console import Console
 import nexus
 from nexus import NexusFilesystem
 from nexus.config import load_config
-from nexus.core.exceptions import NexusError, NexusFileNotFoundError, ValidationError
+from nexus.contracts.exceptions import NexusError, NexusFileNotFoundError, ValidationError
 
 console = Console()
 
@@ -549,7 +549,7 @@ def handle_error(e: Exception) -> None:
     - 3: Permission denied
     """
     # Import exception types here to avoid circular imports
-    from nexus.core.exceptions import AccessDeniedError, NexusPermissionError
+    from nexus.contracts.exceptions import AccessDeniedError, NexusPermissionError
 
     if isinstance(e, (PermissionError, AccessDeniedError, NexusPermissionError)):
         console.print(f"[red]Permission Denied:[/red] {e}")

--- a/src/nexus/connectors/base.py
+++ b/src/nexus/connectors/base.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
-from nexus.core.exceptions import ValidationError as CoreValidationError
+from nexus.contracts.exceptions import ValidationError as CoreValidationError
 
 if TYPE_CHECKING:
     from nexus.connectors.error_formatter import SkillErrorFormatter

--- a/src/nexus/factory.py
+++ b/src/nexus/factory.py
@@ -475,7 +475,7 @@ def _boot_kernel_services(ctx: _BootContext) -> dict[str, Any]:
     Returns:
         Dict with 13 kernel service entries.
     """
-    from nexus.core.exceptions import BootError
+    from nexus.contracts.exceptions import BootError
 
     t0 = time.perf_counter()
     try:

--- a/src/nexus/fuse/ops/_shared.py
+++ b/src/nexus/fuse/ops/_shared.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 from cachetools import TTLCache as _TTLCache
 from fuse import FuseOSError
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     NexusFileNotFoundError,
     NexusPermissionError,
     RemoteConnectionError,

--- a/src/nexus/rebac/async_permissions.py
+++ b/src/nexus/rebac/async_permissions.py
@@ -97,7 +97,7 @@ class AsyncPermissionEnforcer:
         if self.namespace_manager is not None:
             subject = context.get_subject()
             if not self.namespace_manager.is_visible(subject, path, context.zone_id):
-                from nexus.core.exceptions import NexusFileNotFoundError
+                from nexus.contracts.exceptions import NexusFileNotFoundError
 
                 raise NexusFileNotFoundError(
                     path=path,

--- a/src/nexus/rebac/circuit_breaker.py
+++ b/src/nexus/rebac/circuit_breaker.py
@@ -28,7 +28,7 @@ from typing import Any, TypeVar
 
 from sqlalchemy.exc import InterfaceError, OperationalError
 
-from nexus.core.exceptions import CircuitOpenError
+from nexus.contracts.exceptions import CircuitOpenError
 
 T = TypeVar("T")
 

--- a/src/nexus/rebac/enforcer.py
+++ b/src/nexus/rebac/enforcer.py
@@ -48,7 +48,7 @@ def check_stale_session(agent_registry: Any, context: OperationContext) -> None:
 
     current_record = agent_registry.get(agent_id)
 
-    from nexus.core.exceptions import StaleSessionError
+    from nexus.contracts.exceptions import StaleSessionError
 
     # Issue #1445: Agent deleted but JWT still valid → stale session
     if current_record is None:
@@ -467,7 +467,7 @@ class PermissionEnforcer:
         if self.namespace_manager is not None:
             subject = context.get_subject()
             if not self.namespace_manager.is_visible(subject, path, context.zone_id):
-                from nexus.core.exceptions import NexusFileNotFoundError
+                from nexus.contracts.exceptions import NexusFileNotFoundError
 
                 raise NexusFileNotFoundError(
                     path=path,

--- a/src/nexus/remote/__init__.py
+++ b/src/nexus/remote/__init__.py
@@ -31,7 +31,7 @@ Example (async):
     ...     await nx.skills.create("my-skill", "A skill", template="basic")
 """
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     RemoteConnectionError,
     RemoteFilesystemError,
     RemoteTimeoutError,

--- a/src/nexus/remote/async_client.py
+++ b/src/nexus/remote/async_client.py
@@ -53,7 +53,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     NexusFileNotFoundError,
     RemoteConnectionError,
     RemoteFilesystemError,

--- a/src/nexus/remote/base_client.py
+++ b/src/nexus/remote/base_client.py
@@ -16,7 +16,7 @@ import base64
 import logging
 from typing import Any
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
     NexusError,

--- a/src/nexus/remote/client.py
+++ b/src/nexus/remote/client.py
@@ -51,7 +51,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     NexusFileNotFoundError,
     RemoteConnectionError,
     RemoteFilesystemError,

--- a/src/nexus/sdk/__init__.py
+++ b/src/nexus/sdk/__init__.py
@@ -114,20 +114,20 @@ from nexus.backends.gcs import GCSBackend
 from nexus.backends.local import LocalBackend
 from nexus.config import NexusConfig as Config
 from nexus.config import load_config
-from nexus.contracts.types import OperationContext
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     BackendError,
     InvalidPathError,
     MetadataError,
     NexusError,
     ValidationError,
 )
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     NexusFileNotFoundError as FileNotFoundError,
 )
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     NexusPermissionError as PermissionError,
 )
+from nexus.contracts.types import OperationContext
 from nexus.core.filesystem import NexusFilesystem as Filesystem
 from nexus.core.nexus_fs import NexusFS
 from nexus.core.router import NamespaceConfig


### PR DESCRIPTION
## Summary
- Batch 6 (final src/) of `core/exceptions.py` re-export shim elimination
- Updated 13 files across 8 layers: fuse/, remote/, rebac/, connectors/, sdk/, cli/, factory.py, __init__.py
- ~20 import sites migrated to `nexus.contracts.exceptions`
- **With batches 1-6, all non-core src/ callers are migrated** (only tests/ remain)

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Verify all non-core, non-test layers have zero `from nexus.core.exceptions import` occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)