### PR TITLE
fix(#853): migrate 15 e2e test files off core/exceptions.py shim

### DIFF
--- a/tests/e2e/postgres/test_db_resilience.py
+++ b/tests/e2e/postgres/test_db_resilience.py
@@ -55,7 +55,7 @@ class TestCircuitBreakerResilience:
 
     async def test_circuit_breaker_opens_during_outage(self):
         """Circuit breaker opens after repeated failures via call()."""
-        from nexus.core.exceptions import CircuitOpenError
+        from nexus.contracts.exceptions import CircuitOpenError
         from nexus.rebac.circuit_breaker import (
             AsyncCircuitBreaker,
             CircuitBreakerConfig,

--- a/tests/e2e/redis/test_multi_instance_workflows.py
+++ b/tests/e2e/redis/test_multi_instance_workflows.py
@@ -515,7 +515,7 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_read_nonexistent_file_after_wait(self, nexus_fs):
         """Wait returns event but file doesn't exist -> graceful error."""
-        from nexus.core.exceptions import NexusFileNotFoundError
+        from nexus.contracts.exceptions import NexusFileNotFoundError
 
         with pytest.raises(NexusFileNotFoundError):
             nexus_fs.read("/nonexistent/file.txt")

--- a/tests/e2e/redis/test_nexusfs_distributed_lock.py
+++ b/tests/e2e/redis/test_nexusfs_distributed_lock.py
@@ -185,7 +185,7 @@ class TestLockTimeoutException:
 
     def test_lock_timeout_exception_attributes(self):
         """Test LockTimeout has correct attributes."""
-        from nexus.core.exceptions import LockTimeout
+        from nexus.contracts.exceptions import LockTimeout
 
         exc = LockTimeout(path="/test.txt", timeout=5.0)
 
@@ -196,7 +196,7 @@ class TestLockTimeoutException:
 
     def test_lock_timeout_custom_message(self):
         """Test LockTimeout with custom message."""
-        from nexus.core.exceptions import LockTimeout
+        from nexus.contracts.exceptions import LockTimeout
 
         exc = LockTimeout(path="/test.txt", timeout=10.0, message="Custom lock error")
 
@@ -247,7 +247,7 @@ class TestLockedContextManager:
     @pytest.mark.asyncio
     async def test_locked_timeout_raises_lock_timeout(self, nx_pair_with_lock):
         """Test that locked() raises LockTimeout when lock unavailable."""
-        from nexus.core.exceptions import LockTimeout
+        from nexus.contracts.exceptions import LockTimeout
 
         nx1, nx2 = nx_pair_with_lock
         nx1.write("/shared.txt", b"content")
@@ -327,7 +327,7 @@ class TestWriteWithLock:
         """Test that write(lock=True, lock_timeout=0.1) raises LockTimeout when contended."""
         import threading
 
-        from nexus.core.exceptions import LockTimeout
+        from nexus.contracts.exceptions import LockTimeout
 
         # First, acquire a lock on the file manually so write(lock=True) will contend
         nx_sync_with_lock.write("/contended.txt", b"initial")
@@ -371,7 +371,7 @@ class TestWriteWithLock:
         assert nx_sync_with_lock.read("/occ.txt") == b"v2"
 
         # Write with stale etag + lock should fail with ConflictError
-        from nexus.core.exceptions import ConflictError
+        from nexus.contracts.exceptions import ConflictError
 
         with pytest.raises(ConflictError):
             nx_sync_with_lock.write("/occ.txt", b"v3", lock=True, if_match=etag)
@@ -531,7 +531,7 @@ class TestAtomicUpdate:
     @pytest.mark.asyncio
     async def test_atomic_update_file_not_found(self, nx_with_lock: NexusFS):
         """Test atomic_update on non-existent file raises error."""
-        from nexus.core.exceptions import NexusFileNotFoundError
+        from nexus.contracts.exceptions import NexusFileNotFoundError
 
         with pytest.raises(NexusFileNotFoundError):
             await nx_with_lock.atomic_update(
@@ -566,7 +566,7 @@ class TestCombinedScenarios:
     @pytest.mark.asyncio
     async def test_locked_prevents_write_with_lock(self, nx_pair_with_lock):
         """Test that locked() prevents write(lock=True) from another agent."""
-        from nexus.core.exceptions import LockTimeout
+        from nexus.contracts.exceptions import LockTimeout
 
         nx1, nx2 = nx_pair_with_lock
         nx1.write("/shared.txt", b"initial")
@@ -596,7 +596,7 @@ class TestCombinedScenarios:
     @pytest.mark.asyncio
     async def test_atomic_update_vs_write_lock(self, nx_pair_with_lock):
         """Test atomic_update blocking write(lock=True)."""
-        from nexus.core.exceptions import LockTimeout
+        from nexus.contracts.exceptions import LockTimeout
 
         nx1, nx2 = nx_pair_with_lock
         nx1.write("/shared.txt", b"initial")

--- a/tests/e2e/self_contained/test_batch_self_contained.py
+++ b/tests/e2e/self_contained/test_batch_self_contained.py
@@ -137,7 +137,7 @@ class TestBatchSelfContainedE2E:
 
     def test_stop_on_error_cascading(self, client: TestClient, mock_fs: AsyncMock) -> None:
         """stop_on_error cascades 424 to all remaining operations."""
-        from nexus.core.exceptions import NexusFileNotFoundError
+        from nexus.contracts.exceptions import NexusFileNotFoundError
 
         mock_fs.read.side_effect = NexusFileNotFoundError(path="/missing.txt")
 
@@ -162,7 +162,7 @@ class TestBatchSelfContainedE2E:
 
     def test_partial_failure_continues(self, client: TestClient, mock_fs: AsyncMock) -> None:
         """Partial failure without stop_on_error continues processing."""
-        from nexus.core.exceptions import NexusPermissionError
+        from nexus.contracts.exceptions import NexusPermissionError
 
         call_count = 0
 

--- a/tests/e2e/self_contained/test_client_integration.py
+++ b/tests/e2e/self_contained/test_client_integration.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import httpx
 import pytest
 
-from nexus.core.exceptions import NexusError, NexusFileNotFoundError, NexusPermissionError
+from nexus.contracts.exceptions import NexusError, NexusFileNotFoundError, NexusPermissionError
 from nexus.remote.client import RemoteNexusFS
 from nexus.server.protocol import RPCErrorCode
 

--- a/tests/e2e/self_contained/test_context_branch_lifecycle.py
+++ b/tests/e2e/self_contained/test_context_branch_lifecycle.py
@@ -370,7 +370,7 @@ class TestFinishExploreValidation:
             service.finish_explore("/ws", "branch", outcome="rebase")
 
     def test_finish_nonexistent_branch_raises(self, service):
-        from nexus.core.exceptions import BranchNotFoundError
+        from nexus.contracts.exceptions import BranchNotFoundError
 
         with pytest.raises(BranchNotFoundError):
             service.finish_explore("/ws", "ghost", outcome="merge")

--- a/tests/e2e/self_contained/test_local_connector.py
+++ b/tests/e2e/self_contained/test_local_connector.py
@@ -20,8 +20,8 @@ import pytest
 
 from nexus.backends.local_connector import LocalConnectorBackend
 from nexus.backends.registry import create_connector
+from nexus.contracts.exceptions import BackendError
 from nexus.contracts.types import OperationContext
-from nexus.core.exceptions import BackendError
 
 # ============================================================================
 # FIXTURES

--- a/tests/e2e/self_contained/test_namespace_integration.py
+++ b/tests/e2e/self_contained/test_namespace_integration.py
@@ -17,8 +17,8 @@ from typing import TYPE_CHECKING
 import pytest
 from sqlalchemy import create_engine
 
+from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.contracts.types import OperationContext, Permission
-from nexus.core.exceptions import NexusFileNotFoundError
 from nexus.rebac.enforcer import PermissionEnforcer
 from nexus.rebac.manager import EnhancedReBACManager
 from nexus.rebac.namespace_manager import NamespaceManager

--- a/tests/e2e/self_contained/test_object_store_integration.py
+++ b/tests/e2e/self_contained/test_object_store_integration.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pytest
 
 from nexus.backends.local import LocalBackend
-from nexus.core.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import BackendObjectStore, ObjectStoreABC
 
 

--- a/tests/e2e/self_contained/test_overlay_nexusfs.py
+++ b/tests/e2e/self_contained/test_overlay_nexusfs.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 
 from nexus.backends.local import LocalBackend
-from nexus.core.exceptions import NexusFileNotFoundError
+from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.core.metadata import FileMetadata
 from nexus.core.metastore import MetastoreABC
 from nexus.core.workspace_manifest import ManifestEntry, WorkspaceManifest

--- a/tests/e2e/server/test_auth_security_e2e.py
+++ b/tests/e2e/server/test_auth_security_e2e.py
@@ -571,8 +571,8 @@ class TestStaleSessionDetection:
 
     def test_stale_jwt_rejected_by_permission_enforcer(self, nexus_fs_enforced: NexusFS):
         """Agent JWT with outdated generation is rejected during permission check."""
+        from nexus.contracts.exceptions import StaleSessionError
         from nexus.contracts.types import OperationContext
-        from nexus.core.exceptions import StaleSessionError
 
         nx = nexus_fs_enforced
 
@@ -675,8 +675,8 @@ class TestStaleSessionDetection:
 
     def test_deleted_agent_jwt_rejected(self, nexus_fs_enforced: NexusFS):
         """Agent deleted from registry but JWT still valid should be rejected."""
+        from nexus.contracts.exceptions import StaleSessionError
         from nexus.contracts.types import OperationContext
-        from nexus.core.exceptions import StaleSessionError
 
         nx = nexus_fs_enforced
 

--- a/tests/e2e/server/test_caching_wrapper_e2e.py
+++ b/tests/e2e/server/test_caching_wrapper_e2e.py
@@ -466,7 +466,7 @@ class TestCachingPermissions:
         nx.delete("/test/delete_me.txt", context=admin)
 
         # Should raise FileNotFoundError — NOT serve stale cached data
-        from nexus.core.exceptions import NexusFileNotFoundError
+        from nexus.contracts.exceptions import NexusFileNotFoundError
 
         with pytest.raises((NexusFileNotFoundError, FileNotFoundError)):
             nx.read("/test/delete_me.txt", context=admin)

--- a/tests/e2e/server/test_oauth_rotation_e2e.py
+++ b/tests/e2e/server/test_oauth_rotation_e2e.py
@@ -22,7 +22,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from nexus.cache.inmemory import InMemoryCacheStore
-from nexus.core.exceptions import AuthenticationError
+from nexus.contracts.exceptions import AuthenticationError
 from nexus.server.auth.oauth_provider import OAuthCredential
 from nexus.server.auth.token_manager import TokenManager, _hash_token
 from nexus.storage.models._base import Base

--- a/tests/e2e/server/test_rpc_proxy_e2e.py
+++ b/tests/e2e/server/test_rpc_proxy_e2e.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from nexus.core.exceptions import RemoteFilesystemError
+from nexus.contracts.exceptions import RemoteFilesystemError
 from nexus.remote.client import RemoteNexusFS
 
 # Clear proxy env vars so localhost connections work
@@ -494,21 +494,21 @@ class TestPermissionEnforcement:
 
     def test_non_admin_denied_write(self, non_admin_client: RemoteNexusFS) -> None:
         """Non-admin user without permissions should be denied write."""
-        from nexus.core.exceptions import NexusError
+        from nexus.contracts.exceptions import NexusError
 
         with pytest.raises((NexusError, RemoteFilesystemError)):
             non_admin_client.write("/workspace/unauthorized.txt", b"should fail")
 
     def test_non_admin_denied_read(self, non_admin_client: RemoteNexusFS) -> None:
         """Non-admin user without permissions should be denied read."""
-        from nexus.core.exceptions import NexusError
+        from nexus.contracts.exceptions import NexusError
 
         with pytest.raises((NexusError, RemoteFilesystemError)):
             non_admin_client.read("/workspace/proxy-test.txt")
 
     def test_non_admin_list_filtered(self, non_admin_client: RemoteNexusFS) -> None:
         """Non-admin list is filtered by permissions (empty or error)."""
-        from nexus.core.exceptions import NexusError
+        from nexus.contracts.exceptions import NexusError
 
         try:
             files = non_admin_client.list("/workspace")
@@ -520,7 +520,7 @@ class TestPermissionEnforcement:
 
     def test_non_admin_denied_delete(self, non_admin_client: RemoteNexusFS) -> None:
         """Non-admin user without permissions should be denied delete."""
-        from nexus.core.exceptions import NexusError
+        from nexus.contracts.exceptions import NexusError
 
         with pytest.raises((NexusError, RemoteFilesystemError)):
             non_admin_client.delete("/workspace/proxy-test.txt")

--- a/tests/e2e/test_context_branch_e2e.py
+++ b/tests/e2e/test_context_branch_e2e.py
@@ -19,7 +19,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from nexus.core.exceptions import (
+from nexus.contracts.exceptions import (
     BranchConflictError,
     BranchProtectedError,
     BranchStateError,


### PR DESCRIPTION
## Summary
- Migrates all 15 `tests/e2e/` files from `nexus.core.exceptions` to `nexus.contracts.exceptions`
- Part of the `core/exceptions.py` re-export shim elimination (batch 8 — final test batch)
- Pure import path changes — no logic changes

## Test plan
- [ ] CI passes (ruff, mypy, e2e tests)
- [ ] All 15 test files still import correctly from `nexus.contracts.exceptions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)