### PR TITLE
fix(#417): replace type: ignore with cast() in scoped_filesystem.py

### DIFF
--- a/src/nexus/core/scoped_filesystem.py
+++ b/src/nexus/core/scoped_filesystem.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import builtins
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
@@ -231,8 +231,11 @@ class ScopedFilesystem:
         """List files in a directory."""
         result = self._fs.list(self._scope_path(path), recursive, details, show_parsed, context)
         if details:
-            return [self._unscope_dict(r, ["path", "virtual_path"]) for r in result]  # type: ignore
-        return self._unscope_paths(result)  # type: ignore
+            return [
+                self._unscope_dict(r, ["path", "virtual_path"])
+                for r in cast(builtins.list[dict[str, Any]], result)
+            ]
+        return self._unscope_paths(cast(builtins.list[str], result))
 
     def glob(self, pattern: str, path: str = "/", context: Any = None) -> builtins.list[str]:
         """Find files matching a glob pattern."""


### PR DESCRIPTION
## Summary
- Replace 2 bare `# type: ignore` comments with proper `cast()` calls in `ScopedFilesystem.list()`
- The `list()` method returns `list[str] | list[dict]` union and mypy cannot narrow based on the `details` parameter — `cast()` is the correct fix
- Part of task #417: reduce type-safety debt in core/ (only 2 fixable type-ignores remained; filters.py and virtual_views.py were already resolved)

## Test plan
- [x] ruff lint + format passes
- [x] mypy passes (0 issues found)
- [x] All pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)