### PR TITLE
fix(#392): delete dead global singletons from path_interner and read_set

### DIFF
--- a/src/nexus/core/__init__.py
+++ b/src/nexus/core/__init__.py
@@ -28,8 +28,6 @@ from nexus.core.path_interner import (
     PathInterner,
     SegmentedPathInterner,
     get_path_interner,
-    get_segmented_interner,
-    reset_global_interners,
 )
 
 
@@ -151,6 +149,4 @@ __all__ = [
     "SegmentedPathInterner",
     "CompactFileMetadata",
     "get_path_interner",
-    "get_segmented_interner",
-    "reset_global_interners",
 ]

--- a/src/nexus/core/path_interner.py
+++ b/src/nexus/core/path_interner.py
@@ -343,7 +343,6 @@ class SegmentedPathInterner:
 # Use module-level instances for sharing across the application
 
 _global_path_interner: PathInterner | None = None
-_global_segmented_interner: SegmentedPathInterner | None = None
 _interner_lock = threading.Lock()
 
 
@@ -359,36 +358,6 @@ def get_path_interner() -> PathInterner:
             if _global_path_interner is None:
                 _global_path_interner = PathInterner()
     return _global_path_interner
-
-
-def get_segmented_interner() -> SegmentedPathInterner:
-    """Get the global SegmentedPathInterner instance (thread-safe singleton).
-
-    Returns:
-        The global SegmentedPathInterner instance
-    """
-    global _global_segmented_interner
-    if _global_segmented_interner is None:
-        with _interner_lock:
-            if _global_segmented_interner is None:
-                _global_segmented_interner = SegmentedPathInterner()
-    return _global_segmented_interner
-
-
-def reset_global_interners() -> None:
-    """Reset global interners (primarily for testing).
-
-    Warning: This should only be called in tests or during shutdown.
-    Existing path IDs will become invalid.
-    """
-    global _global_path_interner, _global_segmented_interner
-    with _interner_lock:
-        if _global_path_interner is not None:
-            _global_path_interner.clear()
-            _global_path_interner = None
-        if _global_segmented_interner is not None:
-            _global_segmented_interner.clear()
-            _global_segmented_interner = None
 
 
 @dataclass(slots=True)

--- a/src/nexus/core/read_set.py
+++ b/src/nexus/core/read_set.py
@@ -701,36 +701,6 @@ class ReadSetRegistry:
             return len(self._read_sets)
 
 
-# Module-level singleton for global access
-_global_registry: ReadSetRegistry | None = None
-_registry_lock = threading.Lock()
-
-
-def get_global_registry() -> ReadSetRegistry:
-    """Get or create the global ReadSetRegistry singleton.
-
-    Returns:
-        The global ReadSetRegistry instance
-    """
-    global _global_registry
-    if _global_registry is None:
-        with _registry_lock:
-            if _global_registry is None:
-                _global_registry = ReadSetRegistry()
-    return _global_registry
-
-
-def set_global_registry(registry: ReadSetRegistry | None) -> None:
-    """Set the global ReadSetRegistry (for testing).
-
-    Args:
-        registry: Registry to set, or None to clear
-    """
-    global _global_registry
-    with _registry_lock:
-        _global_registry = registry
-
-
 def enable_read_tracking(ctx: OperationContext, zone_id: str | None = None) -> None:
     """Enable read tracking and initialize read set on an OperationContext.
 

--- a/tests/unit/core/test_read_set.py
+++ b/tests/unit/core/test_read_set.py
@@ -12,8 +12,6 @@ from nexus.core.read_set import (
     ReadSetEntry,
     ReadSetRegistry,
     ResourceType,
-    get_global_registry,
-    set_global_registry,
 )
 
 
@@ -396,36 +394,6 @@ class TestReadSetRegistry:
         assert stats["directories_indexed"] == 1
         assert stats["registers"] == 1
         assert stats["lookups"] == 2
-
-
-class TestGlobalRegistry:
-    """Tests for global registry singleton."""
-
-    def teardown_method(self):
-        """Clear global registry after each test."""
-        set_global_registry(None)
-
-    def test_get_global_registry_creates_singleton(self):
-        """Test that get_global_registry creates a singleton."""
-        registry1 = get_global_registry()
-        registry2 = get_global_registry()
-        assert registry1 is registry2
-
-    def test_set_global_registry(self):
-        """Test setting the global registry."""
-        custom_registry = ReadSetRegistry()
-        set_global_registry(custom_registry)
-
-        assert get_global_registry() is custom_registry
-
-    def test_set_global_registry_to_none(self):
-        """Test clearing the global registry."""
-        get_global_registry()  # Create the singleton
-        set_global_registry(None)
-
-        # Should create a new one
-        new_registry = get_global_registry()
-        assert new_registry is not None
 
 
 class TestRWLockConcurrency:


### PR DESCRIPTION
## Summary
- Delete unused `get_segmented_interner()`, `reset_global_interners()`, and `_global_segmented_interner` from `path_interner.py` (zero callers in src/ and tests/)
- Delete unused `get_global_registry()`, `set_global_registry()`, `_global_registry`, `_registry_lock` from `read_set.py` (zero callers in src/)
- Remove dead re-exports from `core/__init__.py`
- Remove `TestGlobalRegistry` tests for the deleted functions

## Test plan
- [x] Verified zero callers via codebase-wide grep (src/ and tests/)
- [x] `get_path_interner()` kept — still used as default param in `CompactFileMetadata` methods
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)