### PR TITLE
fix(#690): move SYSTEM_PATH_PREFIX from core to contracts/constants

### DIFF
--- a/src/nexus/contracts/constants.py
+++ b/src/nexus/contracts/constants.py
@@ -38,3 +38,9 @@ TIER_ALIASES: dict[str, PriorityTier] = {
     "low": PriorityTier.LOW,
     "best_effort": PriorityTier.BEST_EFFORT,
 }
+
+# Kernel-reserved path prefix for internal system entries (zone revisions, etc.).
+# These entries are stored in MetastoreABC but filtered from user-visible operations.
+# Originally in ``nexus.core.nexus_fs_core``; moved to contracts because both
+# core and services depend on it.
+SYSTEM_PATH_PREFIX = "/__sys__/"

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -2331,7 +2331,7 @@ class NexusFS(  # type: ignore[misc]
             filter.path_prefix = prefix
 
         # Get all files matching prefix (exclude internal system entries)
-        from nexus.core.nexus_fs_core import SYSTEM_PATH_PREFIX
+        from nexus.contracts.constants import SYSTEM_PATH_PREFIX
 
         all_files = [
             m

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -21,6 +21,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import SYSTEM_PATH_PREFIX
 from nexus.contracts.exceptions import BackendError, ConflictError, NexusFileNotFoundError
 from nexus.contracts.types import Permission
 from nexus.core.hash_fast import hash_content
@@ -29,10 +30,6 @@ from nexus.core.mutation_hooks import MutationOp
 from nexus.core.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
-
-# Kernel-reserved path prefix for internal system entries (zone revisions, etc.)
-# These entries are stored in MetastoreABC but filtered from user-visible operations.
-SYSTEM_PATH_PREFIX = "/__sys__/"
 
 if TYPE_CHECKING:
     from nexus.backends.backend import Backend

--- a/src/nexus/services/search_listing_mixin.py
+++ b/src/nexus/services/search_listing_mixin.py
@@ -207,7 +207,7 @@ class SearchListingMixin:
                             logger.debug("Skipping deleted cross-zone path: %s", ct_path)
 
         # Filter out internal system entries
-        from nexus.core.nexus_fs_core import SYSTEM_PATH_PREFIX
+        from nexus.contracts.constants import SYSTEM_PATH_PREFIX
 
         all_files = [m for m in all_files if not m.path.startswith(SYSTEM_PATH_PREFIX)]
 
@@ -1003,7 +1003,7 @@ class SearchListingMixin:
                 zone_id=list_zone_id,
             )
 
-            from nexus.core.nexus_fs_core import SYSTEM_PATH_PREFIX
+            from nexus.contracts.constants import SYSTEM_PATH_PREFIX
 
             batch.items = [
                 item for item in batch.items if not item.path.startswith(SYSTEM_PATH_PREFIX)

--- a/src/nexus/services/search_service.py
+++ b/src/nexus/services/search_service.py
@@ -468,7 +468,7 @@ class SearchService(SemanticSearchMixin):
                             logger.debug("Skipping deleted cross-zone path: %s", ct_path)
 
         # Filter out internal system entries
-        from nexus.core.nexus_fs_core import SYSTEM_PATH_PREFIX
+        from nexus.contracts.constants import SYSTEM_PATH_PREFIX
 
         all_files = [m for m in all_files if not m.path.startswith(SYSTEM_PATH_PREFIX)]
 
@@ -1267,7 +1267,7 @@ class SearchService(SemanticSearchMixin):
                 zone_id=list_zone_id,
             )
 
-            from nexus.core.nexus_fs_core import SYSTEM_PATH_PREFIX
+            from nexus.contracts.constants import SYSTEM_PATH_PREFIX
 
             batch.items = [
                 item for item in batch.items if not item.path.startswith(SYSTEM_PATH_PREFIX)


### PR DESCRIPTION
## Summary
- Moved `SYSTEM_PATH_PREFIX` constant from `core/nexus_fs_core.py` to `contracts/constants.py`
- Updated all 5 import sites (core/nexus_fs_core.py, core/nexus_fs.py, services/search_service.py x2, services/search_listing_mixin.py x2) to import from the new canonical location
- Fixes layering violation where services imported a constant from core internals

## Test plan
- [x] ruff lint passes
- [x] ruff format passes
- [x] mypy passes
- [x] All pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)