### PR TITLE
fix(#397): remove ContentCache concrete import from core/async_nexus_fs.py

### DIFF
--- a/src/nexus/core/async_nexus_fs.py
+++ b/src/nexus/core/async_nexus_fs.py
@@ -32,11 +32,11 @@ from nexus.core.metadata import (
     FileMetadata,
 )
 from nexus.core.metastore import AsyncMetastoreWrapper
-from nexus.storage.content_cache import ContentCache
 
 if TYPE_CHECKING:
     from nexus.core.metastore import MetastoreABC
     from nexus.rebac.async_permissions import AsyncPermissionEnforcer
+    from nexus.storage.content_cache import ContentCache
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +54,9 @@ class AsyncNexusFS:
 
     Example:
         ```python
-        from nexus.storage.raft_metadata_store import RaftMetadataStore
-
-        metadata_store = RaftMetadataStore.embedded("./raft")
         fs = AsyncNexusFS(
             backend_root=Path("./data"),
-            metadata_store=metadata_store,
+            metadata_store=metadata_store,  # any MetastoreABC implementation
         )
         await fs.initialize()
 
@@ -73,33 +70,27 @@ class AsyncNexusFS:
         backend_root: str | Path,
         metadata_store: MetastoreABC,
         tenant_id: str | None = None,
-        enable_content_cache: bool = True,
-        content_cache_size_mb: int = 256,
         enforce_permissions: bool = False,
         permission_enforcer: AsyncPermissionEnforcer | None = None,
+        content_cache: ContentCache | None = None,
     ):
         """
         Initialize async filesystem.
 
         Args:
             backend_root: Root directory for content storage
-            metadata_store: MetastoreABC instance (e.g. RaftMetadataStore)
+            metadata_store: MetastoreABC instance for metadata storage
             tenant_id: Default tenant ID for operations
-            enable_content_cache: Enable in-memory content caching (default: True)
-            content_cache_size_mb: Content cache size in MB (default: 256)
             enforce_permissions: If True, check permissions on operations (default: False)
             permission_enforcer: AsyncPermissionEnforcer instance for permission checks
+            content_cache: Pre-built ContentCache instance for read caching (default: None)
         """
         self._backend_root = Path(backend_root)
         self._metadata_store = metadata_store
         self._tenant_id = tenant_id
         self._enforce_permissions = enforce_permissions
         self._permission_enforcer = permission_enforcer
-
-        # Create content cache if enabled
-        self._content_cache: ContentCache | None = None
-        if enable_content_cache:
-            self._content_cache = ContentCache(max_size_mb=content_cache_size_mb)
+        self._content_cache = content_cache
 
         # Components (initialized in initialize())
         self._backend: AsyncLocalBackend | None = None

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -349,12 +349,15 @@ async def lifespan(_app: FastAPI) -> Any:
                 )
 
                 # Create AsyncNexusFS using the same RaftMetadataStore as sync NexusFS
+                from nexus.storage.content_cache import ContentCache as _ContentCache
+
                 _app.state.async_nexus_fs = AsyncNexusFS(
                     backend_root=backend_root,
                     metadata_store=_app.state.nexus_fs.metadata,
                     tenant_id=tenant_id,
                     enforce_permissions=enforce_permissions,
                     permission_enforcer=permission_enforcer,
+                    content_cache=_ContentCache(max_size_mb=256),
                 )
                 await _app.state.async_nexus_fs.initialize()
                 logger.info(

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -117,12 +117,15 @@ async def _startup_async_rebac(app: FastAPI) -> None:
             )
 
             # Create AsyncNexusFS using the same RaftMetadataStore as sync NexusFS
+            from nexus.storage.content_cache import ContentCache as _ContentCache
+
             app.state.async_nexus_fs = AsyncNexusFS(
                 backend_root=backend_root,
                 metadata_store=app.state.nexus_fs.metadata,
                 tenant_id=tenant_id,
                 enforce_permissions=enforce_permissions,
                 permission_enforcer=permission_enforcer,
+                content_cache=_ContentCache(max_size_mb=256),
             )
             await app.state.async_nexus_fs.initialize()
             logger.info(


### PR DESCRIPTION
## Summary
- Move `ContentCache` import from runtime to `TYPE_CHECKING` in `core/async_nexus_fs.py`, eliminating a kernel → storage concrete class dependency
- Replace `enable_content_cache` + `content_cache_size_mb` constructor params with injectable `content_cache: ContentCache | None = None`
- Server callers now explicitly construct and inject ContentCache (keeping the concrete dependency where it belongs — server layer)
- Fix docstring example to use generic `MetastoreABC` instead of concrete `RaftMetadataStore`

## Test plan
- [x] `tests/unit/core/test_async_nexus_fs.py` — 35 tests pass
- [x] `tests/unit/core/test_async_nexus_fs_permissions.py` — 25 tests pass
- [x] mypy clean on `src/nexus/core/async_nexus_fs.py`
- [x] All pre-commit hooks pass (ruff, ruff format, mypy, Brick Zero-Core-Imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)