### PR TITLE
fix(#690): move rpc_decorator and context_utils from core/ to lib/

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -43,7 +43,7 @@ from nexus.core.metadata import FileMetadata
 from nexus.core.metastore import MetastoreABC
 from nexus.core.nexus_fs_core import NexusFSCoreMixin
 from nexus.core.router import NamespaceConfig, PathRouter
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 if TYPE_CHECKING:
     from nexus.parsers.registry import ParserRegistry

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -27,7 +27,7 @@ from nexus.contracts.types import Permission
 from nexus.core.hash_fast import hash_content
 from nexus.core.metadata import FileMetadata
 from nexus.core.mutation_hooks import MutationOp
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/lib/__init__.py
+++ b/src/nexus/lib/__init__.py
@@ -1,11 +1,13 @@
 """Tier-neutral library utilities — shared across all layers.
 
 Contains reusable, zero-kernel-dependency modules that were previously
-in ``nexus.contracts`` but are purely implementation helpers rather than
-formal Protocol/ABC contracts.
+in ``nexus.contracts`` or ``nexus.core`` but are purely implementation
+helpers rather than formal Protocol/ABC contracts or kernel logic.
 
 Modules:
+    context_utils: Context extraction helpers (zone_id, user identity, db URL)
     path_utils: Cached glob/pattern matching (path_matches_pattern)
     registry: Generic BaseRegistry[T] + BrickRegistry
     rpc_codec: JSON-RPC encode/decode with special-type handling
+    rpc_decorator: @rpc_expose decorator for marking RPC-exposed methods
 """

--- a/src/nexus/lib/context_utils.py
+++ b/src/nexus/lib/context_utils.py
@@ -1,13 +1,11 @@
-"""
-Utility functions for extracting and resolving context information.
+"""Utility functions for extracting and resolving context information.
 
-This module provides centralized helpers for:
+Tier-neutral utility (``nexus.lib``) — zero kernel dependency.
+
+Provides centralized helpers for:
 - Extracting zone_id from context with defaults
 - Extracting user identity (type, id) from context
 - Resolving database URLs with environment variable priority
-
-These utilities eliminate code duplication across nexus_fs_mounts, nexus_fs_oauth,
-and workspace_registry modules.
 """
 
 import logging

--- a/src/nexus/lib/rpc_decorator.py
+++ b/src/nexus/lib/rpc_decorator.py
@@ -1,9 +1,7 @@
 """RPC exposure decorator for marking methods to be exposed via RPC.
 
-This module is separate to avoid circular imports between core and server modules.
-
-The decorator is also re-exported from ``nexus.services.protocols.rpc``
-so that bricks can import it without depending on nexus.core (Issue #2035).
+Tier-neutral utility (``nexus.lib``) — zero kernel dependency.
+Also re-exported from ``nexus.services.protocols.rpc`` for convenience.
 """
 
 from __future__ import annotations
@@ -39,11 +37,12 @@ def rpc_expose(
     """
 
     def decorator(fn: F) -> F:
-        fn._rpc_exposed = True  # type: ignore[attr-defined]
-        fn._rpc_name = name or fn.__name__  # type: ignore[attr-defined]
-        fn._rpc_description = description or fn.__doc__  # type: ignore[attr-defined]
-        fn._rpc_version = version  # type: ignore[attr-defined]
-        fn._rpc_admin_only = admin_only  # type: ignore[attr-defined]
+        _fn: Any = fn
+        _fn._rpc_exposed = True
+        _fn._rpc_name = name or fn.__name__
+        _fn._rpc_description = description or fn.__doc__
+        _fn._rpc_version = version
+        _fn._rpc_admin_only = admin_only
         return fn
 
     return decorator

--- a/src/nexus/services/events_service.py
+++ b/src/nexus/services/events_service.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.constants import ROOT_ZONE_ID
 from nexus.core.path_utils import validate_path
 from nexus.core.protocols.connector import PassthroughProtocol
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 from nexus.services.dedup_work_queue import DedupWorkQueue, ShutdownError
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/services/gateway.py
+++ b/src/nexus/services/gateway.py
@@ -480,7 +480,7 @@ class NexusFSGateway:
         Raises:
             RuntimeError: If database URL cannot be determined
         """
-        from nexus.core.context_utils import get_database_url
+        from nexus.lib.context_utils import get_database_url
 
         return get_database_url(self._fs)
 

--- a/src/nexus/services/llm_service.py
+++ b/src/nexus/services/llm_service.py
@@ -16,7 +16,7 @@ import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/services/mcp_service.py
+++ b/src/nexus/services/mcp_service.py
@@ -15,7 +15,7 @@ import builtins
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 from nexus.services.protocols.filesystem import NexusFilesystem
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/services/memory_service.py
+++ b/src/nexus/services/memory_service.py
@@ -18,7 +18,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 from nexus.contracts.types import OperationContext
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/src/nexus/services/mount_core_service.py
+++ b/src/nexus/services/mount_core_service.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.core.context_utils import get_user_identity, get_zone_id
+from nexus.lib.context_utils import get_user_identity, get_zone_id
 from nexus.services.permission_utils import check_permission
 
 if TYPE_CHECKING:
@@ -581,8 +581,8 @@ class MountCoreService:
                 )
             elif self._token_manager_fn is not None:
                 try:
-                    from nexus.core.context_utils import get_zone_id
                     from nexus.core.sync_bridge import run_sync
+                    from nexus.lib.context_utils import get_zone_id
 
                     zone_id = get_zone_id(context)
                     token_manager = self._token_manager_fn()

--- a/src/nexus/services/mount_persist_service.py
+++ b/src/nexus/services/mount_persist_service.py
@@ -32,7 +32,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from nexus.constants import ROOT_ZONE_ID
-from nexus.core.context_utils import get_user_identity, get_zone_id
+from nexus.lib.context_utils import get_user_identity, get_zone_id
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/services/mount_service.py
+++ b/src/nexus/services/mount_service.py
@@ -15,8 +15,8 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
-from nexus.core.context_utils import get_database_url, get_user_identity, get_zone_id
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.context_utils import get_database_url, get_user_identity, get_zone_id
+from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/services/oauth_service.py
+++ b/src/nexus/services/oauth_service.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from nexus.constants import DEFAULT_OAUTH_REDIRECT_URI
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 from nexus.services.protocols.filesystem import NexusFilesystem
 
 logger = logging.getLogger(__name__)
@@ -364,7 +364,7 @@ class OAuthService:
             - If user_email not provided, service attempts to fetch it from provider
             - Credentials are stored per-zone for isolation
         """
-        from nexus.core.context_utils import get_zone_id
+        from nexus.lib.context_utils import get_zone_id
 
         logger.info(
             f"Exchanging OAuth code for provider={provider}, user_email={'provided' if user_email else 'will fetch'}"
@@ -502,7 +502,7 @@ class OAuthService:
             - Admins see all credentials in their zone
             - Credentials from other zones are never visible
         """
-        from nexus.core.context_utils import get_zone_id
+        from nexus.lib.context_utils import get_zone_id
 
         token_manager = self._get_token_manager()
         zone_id = get_zone_id(context)
@@ -589,7 +589,7 @@ class OAuthService:
             - Admins can revoke any credential in their zone
             - Revoked credentials cannot be unrevoked (create new credential instead)
         """
-        from nexus.core.context_utils import get_zone_id
+        from nexus.lib.context_utils import get_zone_id
 
         token_manager = self._get_token_manager()
         zone_id = get_zone_id(context)
@@ -670,7 +670,7 @@ class OAuthService:
             - Returns detailed error if credential cannot be refreshed
             - Does not revoke invalid credentials (use oauth_revoke_credential)
         """
-        from nexus.core.context_utils import get_zone_id
+        from nexus.lib.context_utils import get_zone_id
 
         token_manager = self._get_token_manager()
         zone_id = get_zone_id(context)

--- a/src/nexus/services/permission_utils.py
+++ b/src/nexus/services/permission_utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from nexus.core.context_utils import get_user_identity, get_zone_id
+from nexus.lib.context_utils import get_user_identity, get_zone_id
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/services/protocols/rpc.py
+++ b/src/nexus/services/protocols/rpc.py
@@ -1,15 +1,15 @@
 """RPC exposure decorator — services/protocols re-export (Issue #2035).
 
-Canonical implementation lives in ``nexus.core.rpc_decorator``.
+Canonical implementation lives in ``nexus.lib.rpc_decorator``.
 This re-export allows bricks to import ``rpc_expose`` from
-``nexus.services.protocols.rpc`` without depending on nexus.core.
+``nexus.services.protocols.rpc`` without depending on nexus.lib directly.
 
 Both import paths are equivalent::
 
-    from nexus.core.rpc_decorator import rpc_expose      # original
-    from nexus.services.protocols.rpc import rpc_expose   # brick-safe
+    from nexus.lib.rpc_decorator import rpc_expose       # canonical
+    from nexus.services.protocols.rpc import rpc_expose   # brick-safe alias
 """
 
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 __all__ = ["rpc_expose"]

--- a/src/nexus/services/rebac_service.py
+++ b/src/nexus/services/rebac_service.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from nexus.contracts.exceptions import CircuitOpenError
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 from nexus.services.rebac_share_mixin import ReBACShareMixin
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/services/search_grep_mixin.py
+++ b/src/nexus/services/search_grep_mixin.py
@@ -24,7 +24,7 @@ from nexus.contracts.search_types import (
     SearchStrategy,
 )
 from nexus.core import glob_fast, grep_fast, trigram_fast
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/services/search_listing_mixin.py
+++ b/src/nexus/services/search_listing_mixin.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import PermissionDeniedError
 from nexus.contracts.types import Permission
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 # Constants duplicated from search_service to avoid circular import
 LIST_PARALLEL_MAX_DEPTH = 100

--- a/src/nexus/services/search_semantic.py
+++ b/src/nexus/services/search_semantic.py
@@ -17,7 +17,7 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/services/search_service.py
+++ b/src/nexus/services/search_service.py
@@ -39,7 +39,7 @@ from nexus.contracts.search_types import (
 )
 from nexus.contracts.types import Permission
 from nexus.core import glob_fast, grep_fast, trigram_fast
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 from nexus.services.gateway import NexusFSGateway
 from nexus.services.search_semantic import SemanticSearchMixin
 

--- a/src/nexus/services/share_link_service.py
+++ b/src/nexus/services/share_link_service.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 from nexus.constants import ROOT_ZONE_ID
 from nexus.core.path_utils import validate_path
 from nexus.core.response import HandlerResponse
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/services/sync_service.py
+++ b/src/nexus/services/sync_service.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.types import SyncContext, SyncResult
-from nexus.core.context_utils import get_zone_id
+from nexus.lib.context_utils import get_zone_id
 from nexus.services.change_log_store import ChangeLogEntry, ChangeLogStore
 from nexus.services.permission_utils import check_permission
 

--- a/src/nexus/services/task_queue_service.py
+++ b/src/nexus/services/task_queue_service.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 if TYPE_CHECKING:
     from _nexus_tasks import TaskEngine

--- a/src/nexus/services/version_service.py
+++ b/src/nexus/services/version_service.py
@@ -18,7 +18,7 @@ import difflib
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/core/test_context_utils.py
+++ b/tests/unit/core/test_context_utils.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from nexus.core.context_utils import (
+from nexus.lib.context_utils import (
     get_database_url,
     get_user_identity,
     get_zone_id,

--- a/tests/unit/server/test_rpc_admin_only.py
+++ b/tests/unit/server/test_rpc_admin_only.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nexus.core.rpc_decorator import rpc_expose
+from nexus.lib.rpc_decorator import rpc_expose
 
 # ============================================================================
 # Test 1: Decorator sets _rpc_admin_only flag

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -378,7 +378,7 @@ def test_all_public_methods_are_exposed_or_excluded():
                 "",
                 "1. Add @rpc_expose decorator to the method (RECOMMENDED):",
                 "   ```python",
-                "   from nexus.core.rpc_decorator import rpc_expose",
+                "   from nexus.lib.rpc_decorator import rpc_expose",
                 "",
                 "   @rpc_expose(description='Your description')",
                 "   def your_method(self, ...):",


### PR DESCRIPTION
## Summary
- Move `rpc_decorator.py` and `context_utils.py` from `core/` to `lib/` (tier-neutral package)
- Both modules have zero kernel dependencies — pure utility code that doesn't belong in the kernel
- All 28 import sites updated across services, core, and tests
- Fixes 5 pre-existing `# type: ignore[attr-defined]` in rpc_decorator (uses `Any` cast pattern)

## Test plan
- [x] All 38 unit tests pass (test_context_utils.py, test_rpc_admin_only.py)
- [x] ruff lint + format clean
- [x] mypy clean
- [x] All pre-commit hooks pass (including Block New Type Ignores, Brick Zero-Core-Imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)