### PR TITLE
fix(#690): move sync_bridge from core/ to lib/

### DIFF
--- a/src/nexus/backends/gcalendar_connector.py
+++ b/src/nexus/backends/gcalendar_connector.py
@@ -345,7 +345,7 @@ send_notifications: true
             )
 
         # Get valid access token from TokenManager
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         try:
             zone_id = (

--- a/src/nexus/backends/gdrive_connector.py
+++ b/src/nexus/backends/gdrive_connector.py
@@ -275,7 +275,7 @@ class GoogleDriveConnectorBackend(Backend):
 
         try:
             # Check if we have a valid token
-            from nexus.core.sync_bridge import run_sync
+            from nexus.lib.sync_bridge import run_sync
 
             zone_id = (
                 context.zone_id
@@ -396,7 +396,7 @@ class GoogleDriveConnectorBackend(Backend):
             )
 
         # Get valid access token from TokenManager (auto-refreshes if expired)
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         try:
             # Default to 'root' zone if not specified to match mount configurations

--- a/src/nexus/backends/gmail_connector.py
+++ b/src/nexus/backends/gmail_connector.py
@@ -390,7 +390,7 @@ class GmailConnectorBackend(
             )
 
         # Get valid access token from TokenManager (auto-refreshes if expired)
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         try:
             # Default to 'default' zone if not specified to match mount configurations

--- a/src/nexus/backends/hn_connector.py
+++ b/src/nexus/backends/hn_connector.py
@@ -455,7 +455,7 @@ class HNConnectorBackend(Backend, CacheConnectorMixin, SkillDocMixin):
             finally:
                 await self._close_client()
 
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         content = run_sync(_fetch())
 
@@ -768,7 +768,7 @@ class HNConnectorBackend(Backend, CacheConnectorMixin, SkillDocMixin):
 
             await self._close_client()
 
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         run_sync(_sync_feeds())
         return result

--- a/src/nexus/backends/slack_connector.py
+++ b/src/nexus/backends/slack_connector.py
@@ -230,7 +230,7 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
             )
 
         # Get valid access token from TokenManager
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         try:
             # Default to 'root' zone if not specified

--- a/src/nexus/backends/x_connector.py
+++ b/src/nexus/backends/x_connector.py
@@ -251,7 +251,7 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
         Raises:
             BackendError: If authentication fails
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(self._get_api_client_async(context))
 
@@ -680,7 +680,7 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
             )
 
         # Fetch from API
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         content = run_sync(self._read_content_async(context, endpoint_type, params))
         return HandlerResponse.ok(
@@ -771,7 +771,7 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
             finally:
                 await client.close()
 
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         tweet_id = run_sync(_post_tweet())
         return HandlerResponse.ok(
@@ -850,7 +850,7 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
                     await client.close()
 
             try:
-                from nexus.core.sync_bridge import run_sync
+                from nexus.lib.sync_bridge import run_sync
 
                 run_sync(_delete_tweet())
             except BackendError as e:
@@ -1350,7 +1350,7 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
             return results
 
         try:
-            from nexus.core.sync_bridge import run_sync
+            from nexus.lib.sync_bridge import run_sync
 
             return run_sync(_search_user_tweets())
         except Exception as e:
@@ -1400,7 +1400,7 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
             return results
 
         try:
-            from nexus.core.sync_bridge import run_sync
+            from nexus.lib.sync_bridge import run_sync
 
             return run_sync(_search_global())
         except Exception as e:

--- a/src/nexus/bricks/memory/_sync.py
+++ b/src/nexus/bricks/memory/_sync.py
@@ -1,7 +1,7 @@
 """Minimal sync-to-async bridge for Memory brick.
 
 Brick-local copy of the essential run_sync() function (Issue #2177).
-Avoids importing nexus.core.sync_bridge which is a kernel internal.
+Avoids importing nexus.lib.sync_bridge for brick isolation.
 """
 
 from __future__ import annotations

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -26,7 +26,7 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
-from nexus.core.sync_bridge import run_sync
+from nexus.lib.sync_bridge import run_sync
 
 
 @click.group(name="mounts")

--- a/src/nexus/cli/commands/server.py
+++ b/src/nexus/cli/commands/server.py
@@ -24,8 +24,8 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
-from nexus.core.sync_bridge import run_sync
 from nexus.lib.env import get_database_url
+from nexus.lib.sync_bridge import run_sync
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ def start_background_mount_sync(nx: NexusFilesystem) -> None:
         """Background thread worker that performs the actual sync."""
         import time
 
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         time.sleep(2)  # Wait for server to be fully ready
         console.print("[cyan]🔄 Starting background sync for connector mounts...[/cyan]")

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -5722,7 +5722,7 @@ class NexusFS(  # type: ignore[misc]
         Returns:
             Result of the coroutine
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(coro)
 

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -211,7 +211,7 @@ class NexusFSCoreMixin:
             )
 
             # Fire event asynchronously (fire-and-forget via sync bridge)
-            from nexus.core.sync_bridge import fire_and_forget
+            from nexus.lib.sync_bridge import fire_and_forget
 
             # Ensure event bus is started (lazy init for NATS JetStream)
             if not getattr(self._event_bus, "_started", False):
@@ -616,7 +616,7 @@ class NexusFSCoreMixin:
                 timeout=timeout,
             )
 
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         lock_id = run_sync(acquire_lock())
 
@@ -649,7 +649,7 @@ class NexusFSCoreMixin:
         async def release_lock() -> None:
             await self._lock_manager.release(lock_id, zone_id, path)
 
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         try:
             run_sync(release_lock())
@@ -838,7 +838,7 @@ class NexusFSCoreMixin:
                 return future.result()
         except RuntimeError:
             # No running loop - use sync bridge
-            from nexus.core.sync_bridge import run_sync
+            from nexus.lib.sync_bridge import run_sync
 
             return run_sync(self._get_parsed_content_async(path, content))
 
@@ -2865,7 +2865,7 @@ class NexusFSCoreMixin:
         """
         try:
             # Run async parse via sync bridge (thread-safe)
-            from nexus.core.sync_bridge import run_sync
+            from nexus.lib.sync_bridge import run_sync
 
             run_sync(self.parse(path, store_result=True))
         except Exception as e:

--- a/src/nexus/fuse/ops/_shared.py
+++ b/src/nexus/fuse/ops/_shared.py
@@ -569,7 +569,7 @@ def resolve_io_profile(ctx: FUSESharedContext, path: str) -> str:
         ctx._io_profile_loaded = True  # type: ignore[attr-defined]
         try:
             mount_svc = cast(Any, ctx.nexus_fs).mount_service
-            from nexus.core.sync_bridge import run_sync as _run_sync
+            from nexus.lib.sync_bridge import run_sync as _run_sync
 
             mounts = _run_sync(mount_svc.list_mounts())
             ctx._io_profile_mounts = sorted(  # type: ignore[attr-defined]

--- a/src/nexus/lib/sync_bridge.py
+++ b/src/nexus/lib/sync_bridge.py
@@ -15,7 +15,7 @@ cleanly shut down via ``shutdown_sync_bridge()``.
 
 Usage::
 
-    from nexus.core.sync_bridge import run_sync
+    from nexus.lib.sync_bridge import run_sync
 
     # Works from ANY context (sync, async, thread pool worker)
     result = run_sync(some_async_function(arg1, arg2))

--- a/src/nexus/mcp/server.py
+++ b/src/nexus/mcp/server.py
@@ -795,7 +795,7 @@ def create_mcp_server(
             )
 
         try:
-            from nexus.core.sync_bridge import run_sync
+            from nexus.lib.sync_bridge import run_sync
 
             fetch_limit = offset + limit * 2
             all_results = run_sync(nx_instance.semantic_search(query, path="/", limit=fetch_limit))

--- a/src/nexus/services/ace/consolidation.py
+++ b/src/nexus/services/ace/consolidation.py
@@ -50,7 +50,7 @@ def _run_coroutine(coro: Any) -> Any:
     Returns:
         The coroutine's return value.
     """
-    from nexus.core.sync_bridge import run_sync
+    from nexus.lib.sync_bridge import run_sync
 
     return run_sync(coro)
 

--- a/src/nexus/services/ace/learning_loop.py
+++ b/src/nexus/services/ace/learning_loop.py
@@ -215,7 +215,7 @@ class LearningLoop:
         Returns:
             Execution results
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(
             self.execute_with_learning_async(
@@ -287,7 +287,7 @@ class LearningLoop:
         Returns:
             List of re-learning results
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(self.process_relearning_queue_async(limit))
 

--- a/src/nexus/services/ace/memory_hierarchy.py
+++ b/src/nexus/services/ace/memory_hierarchy.py
@@ -595,7 +595,7 @@ def build_hierarchy(
     Returns:
         HierarchyResult with hierarchy data
     """
-    from nexus.core.sync_bridge import run_sync
+    from nexus.lib.sync_bridge import run_sync
 
     manager = HierarchicalMemoryManager(consolidation_engine, session, zone_id)
     return run_sync(

--- a/src/nexus/services/ace/reflection.py
+++ b/src/nexus/services/ace/reflection.py
@@ -439,6 +439,6 @@ Provide your analysis as valid JSON only, no additional commentary.
         Returns:
             Reflection results
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(self.reflect_async(trajectory_id, context, reflection_prompt))

--- a/src/nexus/services/memory/coref_resolver.py
+++ b/src/nexus/services/memory/coref_resolver.py
@@ -170,7 +170,7 @@ Resolved text:"""
         Returns:
             CorefResult with resolved text.
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         result: CorefResult = run_sync(self.resolve_async(text, context, entity_hints))
         return result

--- a/src/nexus/services/memory/enrichment.py
+++ b/src/nexus/services/memory/enrichment.py
@@ -202,7 +202,7 @@ class EnrichmentPipeline:
             return
 
         try:
-            from nexus.core.sync_bridge import run_sync
+            from nexus.lib.sync_bridge import run_sync
 
             embedding_vec = run_sync(provider.embed_text(text))
             result.embedding_json = json.dumps(embedding_vec)

--- a/src/nexus/services/memory/memory_api.py
+++ b/src/nexus/services/memory/memory_api.py
@@ -542,10 +542,9 @@ class Memory:
         """
         import json
 
-        from nexus.core.sync_bridge import run_sync
-
         # Get database URL from session's engine
         from nexus.lib.env import get_database_url
+        from nexus.lib.sync_bridge import run_sync
         from nexus.search.graph_store import GraphStore
         from nexus.storage.record_store import SQLAlchemyRecordStore
 
@@ -930,7 +929,7 @@ class Memory:
         """
         import json
 
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         # #1023: Validate and normalize temporal parameters
         after_dt, before_dt = validate_temporal_params(after, before, during)
@@ -1659,7 +1658,7 @@ class Memory:
 
     def reflect(self, trajectory_id: str, context: str | None = None) -> dict[str, Any]:
         """Reflect on a single trajectory (sync). Delegates to ACE Reflector."""
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(self.reflect_async(trajectory_id, context))
 
@@ -1818,7 +1817,7 @@ class Memory:
         task_type: str | None = None,
     ) -> dict[str, Any]:
         """Batch reflection across multiple trajectories (sync)."""
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(self.batch_reflect_async(agent_id, since, min_trajectories, task_type))
 
@@ -1911,7 +1910,7 @@ class Memory:
         importance_threshold: float = 0.8,
     ) -> dict[str, Any]:
         """Consolidate memories (sync). Delegates to ACE ConsolidationEngine."""
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(
             self.consolidate_async(
@@ -1963,7 +1962,7 @@ class Memory:
         **task_kwargs: Any,
     ) -> tuple[Any, str]:
         """Execute with automatic learning loop (sync). Delegates to ACE LearningLoop."""
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(
             self.execute_with_learning_async(
@@ -2137,7 +2136,7 @@ class Memory:
             >>> result = memory.index_memories()
             >>> print(f"Indexed {result['success_count']} memories")
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(
             self.index_memories_async(embedding_provider, batch_size, memory_type, scope)

--- a/src/nexus/services/memory/relationship_extractor.py
+++ b/src/nexus/services/memory/relationship_extractor.py
@@ -274,7 +274,7 @@ Output:"""
         Returns:
             RelationshipExtractionResult with extracted relationships.
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(self.extract_async(text, entities, relationship_types))
 

--- a/src/nexus/services/memory/temporal_resolver.py
+++ b/src/nexus/services/memory/temporal_resolver.py
@@ -159,7 +159,7 @@ Resolved:"""
         Returns:
             TemporalResult with resolved text.
         """
-        from nexus.core.sync_bridge import run_sync
+        from nexus.lib.sync_bridge import run_sync
 
         return run_sync(self.resolve_async(text, reference_time, context))
 

--- a/src/nexus/services/mount_core_service.py
+++ b/src/nexus/services/mount_core_service.py
@@ -581,8 +581,8 @@ class MountCoreService:
                 )
             elif self._token_manager_fn is not None:
                 try:
-                    from nexus.core.sync_bridge import run_sync
                     from nexus.lib.context_utils import get_zone_id
+                    from nexus.lib.sync_bridge import run_sync
 
                     zone_id = get_zone_id(context)
                     token_manager = self._token_manager_fn()

--- a/src/nexus/services/workflow_dispatch_service.py
+++ b/src/nexus/services/workflow_dispatch_service.py
@@ -122,12 +122,12 @@ class WorkflowDispatchService:
                 logger.warning("Workflow pipe full, dropping event: %s", label)
         else:
             # Fallback: fire-and-forget (CLI mode or pre-startup, no pipe yet)
-            from nexus.core.sync_bridge import fire_and_forget
+            from nexus.lib.sync_bridge import fire_and_forget
 
             fire_and_forget(self._workflow_engine.fire_event(trigger_type, event_context))
 
         if self._subscription_manager:
-            from nexus.core.sync_bridge import fire_and_forget
+            from nexus.lib.sync_bridge import fire_and_forget
 
             event_type = label.split(":")[0] if ":" in label else label
             fire_and_forget(

--- a/src/nexus/utils/async_helpers.py
+++ b/src/nexus/utils/async_helpers.py
@@ -1,7 +1,7 @@
 """Async utility helpers (Issue #2129).
 
-Re-exports ``fire_and_forget`` from ``nexus.core.sync_bridge`` so that
-bricks can use it without importing from ``nexus.core``.
+Re-exports ``fire_and_forget`` from ``nexus.lib.sync_bridge`` so that
+bricks can use it without importing from ``nexus.lib`` directly.
 """
 
-from nexus.core.sync_bridge import fire_and_forget as fire_and_forget
+from nexus.lib.sync_bridge import fire_and_forget as fire_and_forget

--- a/tests/e2e/self_contained/test_sync_bridge_e2e.py
+++ b/tests/e2e/self_contained/test_sync_bridge_e2e.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pytest
 
 from nexus.backends.async_local import AsyncLocalBackend
-from nexus.core.sync_bridge import (
+from nexus.lib.sync_bridge import (
     fire_and_forget,
     run_sync,
     shutdown_sync_bridge,

--- a/tests/e2e/server/test_sync_bridge_fastapi_e2e.py
+++ b/tests/e2e/server/test_sync_bridge_fastapi_e2e.py
@@ -22,7 +22,7 @@ import httpx
 import pytest
 
 from nexus.backends.local import LocalBackend
-from nexus.core.sync_bridge import shutdown_sync_bridge
+from nexus.lib.sync_bridge import shutdown_sync_bridge
 from nexus.storage.record_store import SQLAlchemyRecordStore
 
 

--- a/tests/e2e/server/test_validation_e2e.py
+++ b/tests/e2e/server/test_validation_e2e.py
@@ -75,7 +75,7 @@ def _run_async(coro):
 @pytest.fixture
 def test_app(tmp_path):
     """Create test FastAPI app without permission enforcement."""
-    from nexus.core.sync_bridge import shutdown_sync_bridge
+    from nexus.lib.sync_bridge import shutdown_sync_bridge
 
     app, api_key, nx = _create_test_app(tmp_path, enforce_permissions=False)
     yield app, api_key, nx
@@ -85,7 +85,7 @@ def test_app(tmp_path):
 @pytest.fixture
 def test_app_with_perms(tmp_path):
     """Create test FastAPI app with permission enforcement."""
-    from nexus.core.sync_bridge import shutdown_sync_bridge
+    from nexus.lib.sync_bridge import shutdown_sync_bridge
 
     app, api_key, nx = _create_test_app(tmp_path, enforce_permissions=True)
     yield app, api_key, nx

--- a/tests/unit/core/test_sync_bridge.py
+++ b/tests/unit/core/test_sync_bridge.py
@@ -1,4 +1,4 @@
-"""Tests for nexus.core.sync_bridge — unified sync-to-async bridge.
+"""Tests for nexus.lib.sync_bridge — unified sync-to-async bridge.
 
 Tests cover:
   - run_sync() from sync context (no running loop)
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nexus.core.sync_bridge import (
+from nexus.lib.sync_bridge import (
     _ensure_background_loop,
     fire_and_forget,
     run_sync,
@@ -237,7 +237,7 @@ class TestFireAndForget:
 
     def test_error_is_logged_not_raised(self) -> None:
         """Errors in fire_and_forget coroutines are logged, not raised."""
-        with patch("nexus.core.sync_bridge.logger") as mock_logger:
+        with patch("nexus.lib.sync_bridge.logger") as mock_logger:
             fire_and_forget(_fail())
             # Give background loop time to process.
             time.sleep(0.1)

--- a/tests/unit/services/test_workflow_dispatch.py
+++ b/tests/unit/services/test_workflow_dispatch.py
@@ -106,7 +106,7 @@ class TestFire:
             enable_workflows=True,
         )
 
-        with patch("nexus.core.sync_bridge.fire_and_forget") as mock_ff:
+        with patch("nexus.lib.sync_bridge.fire_and_forget") as mock_ff:
             svc.fire("file_delete", {"path": "/x"}, "file_delete:/x")
             mock_ff.assert_called_once()
 
@@ -114,7 +114,7 @@ class TestFire:
         """Pipe manager exists but start() not called yet."""
         svc, _ = _make_service()
 
-        with patch("nexus.core.sync_bridge.fire_and_forget") as mock_ff:
+        with patch("nexus.lib.sync_bridge.fire_and_forget") as mock_ff:
             svc.fire("file_write", {"path": "/y"}, "file_write:/y")
             mock_ff.assert_called_once()
 


### PR DESCRIPTION
## Summary
- Moved `sync_bridge.py` from `nexus.core` to `nexus.lib` — it's a pure stdlib utility (asyncio, threading, logging) with zero nexus dependencies, so it belongs in the tier-neutral `lib/` package
- Updated all 50 import sites across backends, services, cli, fuse, mcp, and tests
- Updated string references (docstrings, mock patch paths) in async_helpers, memory brick, and test files

## Test plan
- [x] All 18 sync_bridge unit tests pass
- [x] ruff lint + format clean
- [x] mypy clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)