### PR TITLE
feat(#690): move response.py from core/ to lib/

### DIFF
--- a/src/nexus/backends/async_local.py
+++ b/src/nexus/backends/async_local.py
@@ -18,7 +18,7 @@ from nexus.backends.backend import AsyncBackend
 from nexus.backends.cas_blob_store import CASBlobStore
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 from nexus.storage.content_cache import ContentCache
 
 if TYPE_CHECKING:

--- a/src/nexus/backends/backend.py
+++ b/src/nexus/backends/backend.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/backends/base_blob_connector.py
+++ b/src/nexus/backends/base_blob_connector.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 from nexus.backends.backend import Backend
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/backends/caching_backend_wrapper.py
+++ b/src/nexus/backends/caching_backend_wrapper.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.backends.backend import Backend
 from nexus.backends.delegating import DelegatingBackend
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 from nexus.storage.content_cache import ContentCache
 
 if TYPE_CHECKING:

--- a/src/nexus/backends/delegating.py
+++ b/src/nexus/backends/delegating.py
@@ -25,7 +25,7 @@ from nexus.backends.backend import Backend
 if TYPE_CHECKING:
     from nexus.backends.backend import HandlerStatusResponse
     from nexus.contracts.types import OperationContext
-    from nexus.core.response import HandlerResponse
+    from nexus.lib.response import HandlerResponse
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +141,7 @@ class DelegatingBackend(Backend):
 
         If ``_transform_on_write`` raises, returns an error response.
         """
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         try:
             transformed = self._transform_on_write(content)
@@ -156,7 +156,7 @@ class DelegatingBackend(Backend):
         self, content_hash: str, context: OperationContext | None = None
     ) -> HandlerResponse[bytes]:
         """Read from inner, then transform via ``_transform_on_read``."""
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         response = self._inner.read_content(content_hash, context=context)
         if not response.success or response.data is None:

--- a/src/nexus/backends/gcalendar_connector.py
+++ b/src/nexus/backends/gcalendar_connector.py
@@ -58,7 +58,7 @@ from nexus.connectors.calendar.schemas import (
     UpdateEventSchema,
 )
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 # Suppress annoying googleapiclient discovery cache warnings
 logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)

--- a/src/nexus/backends/gcs_connector.py
+++ b/src/nexus/backends/gcs_connector.py
@@ -48,7 +48,7 @@ from nexus.backends.base_blob_connector import BaseBlobStorageConnector
 from nexus.backends.cache_mixin import CacheConnectorMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/backends/gdrive_connector.py
+++ b/src/nexus/backends/gdrive_connector.py
@@ -40,7 +40,7 @@ from nexus.backends.backend import Backend, HandlerStatusResponse
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.contracts.exceptions import BackendError
 from nexus.core.hash_fast import hash_content
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from googleapiclient.discovery import Resource

--- a/src/nexus/backends/gmail_connector.py
+++ b/src/nexus/backends/gmail_connector.py
@@ -56,7 +56,7 @@ from nexus.connectors.base import (
 )
 from nexus.connectors.gmail.errors import ERROR_REGISTRY
 from nexus.contracts.exceptions import BackendError
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 try:
     import yaml

--- a/src/nexus/backends/hn_connector.py
+++ b/src/nexus/backends/hn_connector.py
@@ -48,7 +48,7 @@ from nexus.backends.cache_mixin import CacheConnectorMixin, SyncResult
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.connectors.base import SkillDocMixin
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/backends/local.py
+++ b/src/nexus/backends/local.py
@@ -16,7 +16,7 @@ from nexus.backends.multipart_upload_mixin import MultipartUploadMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 from nexus.storage.content_cache import ContentCache
 
 if TYPE_CHECKING:

--- a/src/nexus/backends/local_connector.py
+++ b/src/nexus/backends/local_connector.py
@@ -35,7 +35,7 @@ from nexus.backends.registry import (
 )
 from nexus.contracts.exceptions import BackendError
 from nexus.core.hash_fast import hash_content
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.core.context import OperationContext

--- a/src/nexus/backends/logging_wrapper.py
+++ b/src/nexus/backends/logging_wrapper.py
@@ -37,7 +37,7 @@ from nexus.backends.delegating import DelegatingBackend
 if TYPE_CHECKING:
     from nexus.backends.backend import Backend, HandlerStatusResponse
     from nexus.contracts.types import OperationContext
-    from nexus.core.response import HandlerResponse
+    from nexus.lib.response import HandlerResponse
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/backends/passthrough.py
+++ b/src/nexus/backends/passthrough.py
@@ -34,7 +34,7 @@ from nexus.backends.backend import Backend
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.contracts.exceptions import BackendError
 from nexus.core.hash_fast import hash_content
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/backends/s3_connector.py
+++ b/src/nexus/backends/s3_connector.py
@@ -42,7 +42,7 @@ from nexus.backends.cache_mixin import CacheConnectorMixin
 from nexus.backends.multipart_upload_mixin import MultipartUploadMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/backends/slack_connector.py
+++ b/src/nexus/backends/slack_connector.py
@@ -52,7 +52,7 @@ from nexus.backends.slack_connector_utils import (
     list_messages_from_channel,
 )
 from nexus.contracts.exceptions import BackendError
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/backends/x_connector.py
+++ b/src/nexus/backends/x_connector.py
@@ -52,7 +52,7 @@ from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import BackendError
 from nexus.core import glob_fast
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/core/protocols/connector.py
+++ b/src/nexus/core/protocols/connector.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
     from nexus.backends.backend import FileInfo, HandlerStatusResponse
     from nexus.contracts.types import OperationContext
-    from nexus.core.response import HandlerResponse
+    from nexus.lib.response import HandlerResponse
 
 
 @runtime_checkable

--- a/src/nexus/ipc/driver.py
+++ b/src/nexus/ipc/driver.py
@@ -25,7 +25,7 @@ import threading
 from typing import TYPE_CHECKING, Any
 
 from nexus.backends.backend import HandlerStatusResponse
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/isolation/backend.py
+++ b/src/nexus/isolation/backend.py
@@ -15,7 +15,6 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, cast
 
 from nexus.backends.backend import Backend, HandlerStatusResponse
-from nexus.core.response import HandlerResponse
 from nexus.isolation._pool import IsolatedPool
 from nexus.isolation.config import IsolationConfig
 from nexus.isolation.errors import (
@@ -23,6 +22,7 @@ from nexus.isolation.errors import (
     IsolationError,
     IsolationTimeoutError,
 )
+from nexus.lib.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext

--- a/src/nexus/lib/response.py
+++ b/src/nexus/lib/response.py
@@ -28,7 +28,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, cast
 
 if TYPE_CHECKING:
     pass  # Exceptions imported at runtime to avoid circular imports
@@ -289,7 +289,7 @@ class HandlerResponse(Generic[T]):
             BackendError: For other error types
         """
         if self.success:
-            return self.data  # type: ignore[return-value]
+            return cast(T, self.data)
 
         # Import here to avoid circular imports
         from nexus.contracts.exceptions import BackendError, ConflictError, NexusFileNotFoundError
@@ -323,7 +323,7 @@ class HandlerResponse(Generic[T]):
             The response data if successful, otherwise the default value
         """
         if self.success:
-            return self.data  # type: ignore[return-value]
+            return cast(T, self.data)
         return default
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/nexus/services/share_link_service.py
+++ b/src/nexus/services/share_link_service.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 
 from nexus.constants import ROOT_ZONE_ID
 from nexus.core.path_utils import validate_path
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)

--- a/tests/benchmarks/bench_isolation.py
+++ b/tests/benchmarks/bench_isolation.py
@@ -54,7 +54,7 @@ class BenchMockBackend:
         return HandlerStatusResponse(success=True)
 
     def write_content(self, content: bytes, context: Any = None) -> Any:  # noqa: ARG002
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         h = hashlib.sha256(content).hexdigest()
         self._store[h] = content
@@ -62,32 +62,32 @@ class BenchMockBackend:
         return HandlerResponse.ok(data=h, backend_name=self.name)
 
     def read_content(self, content_hash: str, context: Any = None) -> Any:  # noqa: ARG002
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         if content_hash not in self._store:
             return HandlerResponse.not_found(path=content_hash, backend_name=self.name)
         return HandlerResponse.ok(data=self._store[content_hash], backend_name=self.name)
 
     def delete_content(self, content_hash: str, context: Any = None) -> Any:  # noqa: ARG002
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         self._store.pop(content_hash, None)
         self._refs.pop(content_hash, None)
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def content_exists(self, content_hash: str, context: Any = None) -> Any:  # noqa: ARG002
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=content_hash in self._store, backend_name=self.name)
 
     def get_content_size(self, content_hash: str, context: Any = None) -> Any:  # noqa: ARG002
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         size = len(self._store.get(content_hash, b""))
         return HandlerResponse.ok(data=size, backend_name=self.name)
 
     def get_ref_count(self, content_hash: str, context: Any = None) -> Any:  # noqa: ARG002
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=self._refs.get(content_hash, 0), backend_name=self.name)
 
@@ -98,19 +98,19 @@ class BenchMockBackend:
         exist_ok: bool = False,  # noqa: ARG002
         context: Any = None,  # noqa: ARG002
     ) -> Any:
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         self._dirs.add(path)
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def rmdir(self, path: str, recursive: bool = False, context: Any = None) -> Any:  # noqa: ARG002
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         self._dirs.discard(path)
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def is_directory(self, path: str, context: Any = None) -> Any:  # noqa: ARG002
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=path in self._dirs, backend_name=self.name)
 

--- a/tests/benchmarks/test_adapter_overhead.py
+++ b/tests/benchmarks/test_adapter_overhead.py
@@ -14,7 +14,7 @@ import pytest
 
 from nexus.backends.backend import Backend
 from nexus.core.object_store import BackendObjectStore, ObjectStoreABC
-from nexus.core.response import HandlerResponse, timed_response
+from nexus.lib.response import HandlerResponse, timed_response
 
 
 class _BenchBackend(Backend):

--- a/tests/e2e/self_contained/isolation_helpers.py
+++ b/tests/e2e/self_contained/isolation_helpers.py
@@ -65,40 +65,40 @@ class MockBackend:
     # ── content ops ──
 
     def write_content(self, content, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         h = hashlib.sha256(content).hexdigest()
         (self._content_dir / h).write_bytes(content)
         return HandlerResponse.ok(data=h, backend_name=self.name)
 
     def read_content(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         p = self._content_dir / h
         data = p.read_bytes() if p.exists() else b""
         return HandlerResponse.ok(data=data, backend_name=self.name)
 
     def delete_content(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         p = self._content_dir / h
         p.unlink(missing_ok=True)
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def content_exists(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=(self._content_dir / h).exists(), backend_name=self.name)
 
     def get_content_size(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         p = self._content_dir / h
         size = p.stat().st_size if p.exists() else 0
         return HandlerResponse.ok(data=size, backend_name=self.name)
 
     def get_ref_count(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(
             data=1 if (self._content_dir / h).exists() else 0, backend_name=self.name
@@ -107,7 +107,7 @@ class MockBackend:
     # ── directory ops ──
 
     def mkdir(self, path, parents=False, exist_ok=False, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         dirs = self._load_dirs()
         dirs.add(path)
@@ -115,7 +115,7 @@ class MockBackend:
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def rmdir(self, path, recursive=False, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         dirs = self._load_dirs()
         dirs.discard(path)
@@ -123,11 +123,11 @@ class MockBackend:
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def is_directory(self, path, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=(path in self._load_dirs()), backend_name=self.name)
 
     def list_dir(self, path, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=[], backend_name=self.name)

--- a/tests/e2e/self_contained/test_context_branch_lifecycle.py
+++ b/tests/e2e/self_contained/test_context_branch_lifecycle.py
@@ -20,7 +20,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from nexus.contracts.workspace_manifest import ManifestEntry, WorkspaceManifest
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from nexus.services.context_branch import ContextBranchService
 from nexus.storage.models._base import Base
 from nexus.storage.models.filesystem import WorkspaceSnapshotModel

--- a/tests/e2e/self_contained/test_isolation_boundary.py
+++ b/tests/e2e/self_contained/test_isolation_boundary.py
@@ -59,47 +59,47 @@ class SysModulesMutator:
 
     # Stubs for abstract methods (unused in boundary tests)
     def write_content(self, content, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data="hash", backend_name=self.name)
 
     def read_content(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=b"", backend_name=self.name)
 
     def delete_content(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def content_exists(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=False, backend_name=self.name)
 
     def get_content_size(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=0, backend_name=self.name)
 
     def get_ref_count(self, h, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=0, backend_name=self.name)
 
     def mkdir(self, path, parents=False, exist_ok=False, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def rmdir(self, path, recursive=False, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=None, backend_name=self.name)
 
     def is_directory(self, path, context=None):
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         return HandlerResponse.ok(data=False, backend_name=self.name)
 

--- a/tests/e2e/test_context_branch_e2e.py
+++ b/tests/e2e/test_context_branch_e2e.py
@@ -27,7 +27,7 @@ from nexus.contracts.exceptions import (
     NexusPermissionError,
 )
 from nexus.contracts.workspace_manifest import ManifestEntry, WorkspaceManifest
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from nexus.services.context_branch import ContextBranchService
 from nexus.storage.models._base import Base
 from nexus.storage.models.filesystem import WorkspaceSnapshotModel

--- a/tests/unit/backends/test_backend_contract.py
+++ b/tests/unit/backends/test_backend_contract.py
@@ -13,7 +13,7 @@ from nexus.core.protocols.connector import (
     ContentStoreProtocol,
     DirectoryOpsProtocol,
 )
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 
 class _MockBackend(Backend):

--- a/tests/unit/backends/test_batch_operations.py
+++ b/tests/unit/backends/test_batch_operations.py
@@ -15,7 +15,7 @@ from nexus.backends.backend import Backend
 from nexus.backends.base_blob_connector import BaseBlobStorageConnector
 from nexus.backends.cache_mixin import CacheConnectorMixin
 from nexus.contracts.types import OperationContext
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 
 class MockBlobConnector(BaseBlobStorageConnector, CacheConnectorMixin):

--- a/tests/unit/backends/test_compressed_wrapper.py
+++ b/tests/unit/backends/test_compressed_wrapper.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 import pytest
 
 from nexus.core.protocols.describable import Describable
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from tests.unit.backends.wrapper_test_helpers import make_leaf, make_storage_mock
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/test_delegating.py
+++ b/tests/unit/backends/test_delegating.py
@@ -23,7 +23,7 @@ import pytest
 
 from nexus.backends.backend import HandlerStatusResponse
 from nexus.backends.delegating import DelegatingBackend
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from tests.unit.backends.wrapper_test_helpers import make_leaf, make_storage_mock
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/test_delegating_backend.py
+++ b/tests/unit/backends/test_delegating_backend.py
@@ -15,7 +15,7 @@ import pytest
 
 from nexus.backends.backend import Backend
 from nexus.backends.delegating import DelegatingBackend
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/backends/test_encrypted_wrapper.py
+++ b/tests/unit/backends/test_encrypted_wrapper.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import pytest
 
 from nexus.core.protocols.describable import Describable
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from tests.unit.backends.wrapper_test_helpers import make_leaf, make_storage_mock
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/test_logging_wrapper.py
+++ b/tests/unit/backends/test_logging_wrapper.py
@@ -25,7 +25,7 @@ import pytest
 
 from nexus.backends.backend import HandlerStatusResponse
 from nexus.backends.logging_wrapper import LoggingBackendWrapper
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from tests.unit.backends.wrapper_test_helpers import make_leaf
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/test_protocol_conformance.py
+++ b/tests/unit/backends/test_protocol_conformance.py
@@ -26,7 +26,7 @@ from nexus.core.protocols.connector import (
     PassthroughProtocol,
     StreamingProtocol,
 )
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/backends/test_streaming.py
+++ b/tests/unit/backends/test_streaming.py
@@ -23,7 +23,7 @@ class TestBackendWriteStreamDefault:
 
     def test_default_write_stream_collects_chunks(self) -> None:
         """Test that default implementation collects chunks and calls write_content."""
-        from nexus.core.response import HandlerResponse
+        from nexus.lib.response import HandlerResponse
 
         class TestBackend(Backend):
             """Minimal test backend."""

--- a/tests/unit/backends/wrapper_test_helpers.py
+++ b/tests/unit/backends/wrapper_test_helpers.py
@@ -11,7 +11,7 @@ import hashlib
 from unittest.mock import MagicMock, PropertyMock
 
 from nexus.backends.backend import Backend
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 
 def make_leaf(name: str = "local") -> MagicMock:

--- a/tests/unit/cache/test_caching_backend_wrapper.py
+++ b/tests/unit/cache/test_caching_backend_wrapper.py
@@ -16,7 +16,7 @@ from nexus.backends.caching_backend_wrapper import (
     CacheWrapperConfig,
     CachingBackendWrapper,
 )
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/core/test_object_store.py
+++ b/tests/unit/core/test_object_store.py
@@ -25,7 +25,7 @@ from nexus.backends.backend import Backend
 from nexus.backends.local import LocalBackend
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import BackendObjectStore, ObjectStoreABC, _validate_hash
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 
 
 class MockBackend(Backend):

--- a/tests/unit/core/test_response.py
+++ b/tests/unit/core/test_response.py
@@ -6,7 +6,7 @@ Tests the standardized response wrapper for backend operations.
 import pytest
 
 from nexus.contracts.exceptions import BackendError, ConflictError, NexusFileNotFoundError
-from nexus.core.response import HandlerResponse, ResponseType, timed_response
+from nexus.lib.response import HandlerResponse, ResponseType, timed_response
 
 
 class TestResponseType:

--- a/tests/unit/core/test_timed_response.py
+++ b/tests/unit/core/test_timed_response.py
@@ -15,7 +15,7 @@ import time
 import pytest
 
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
-from nexus.core.response import HandlerResponse, ResponseType, timed_response
+from nexus.lib.response import HandlerResponse, ResponseType, timed_response
 
 # === Fixtures ===
 

--- a/tests/unit/core/test_workspace_manager_permissions.py
+++ b/tests/unit/core/test_workspace_manager_permissions.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.contracts.exceptions import NexusPermissionError
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from nexus.services.workspace_manager import WorkspaceManager
 from nexus.storage.models import WorkspaceSnapshotModel
 

--- a/tests/unit/services/test_context_branch_merge.py
+++ b/tests/unit/services/test_context_branch_merge.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import sessionmaker
 
 from nexus.contracts.exceptions import BranchConflictError, BranchStateError
 from nexus.contracts.workspace_manifest import ManifestEntry, WorkspaceManifest
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from nexus.services.context_branch import ContextBranchService
 from nexus.storage.models._base import Base
 from nexus.storage.models.context_branch import ContextBranchModel

--- a/tests/unit/services/test_share_link_service.py
+++ b/tests/unit/services/test_share_link_service.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.contracts.types import OperationContext
-from nexus.core.response import HandlerResponse
+from nexus.lib.response import HandlerResponse
 from nexus.services.share_link_service import ShareLinkService
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Move `response.py` (generic HandlerResponse wrapper) from `core/` to `lib/` — it's a tier-neutral utility, not kernel infrastructure
- Fix 2x `# type: ignore[return-value]` with `typing.cast()` (Block New Type Ignores hook)
- 45 files changed (22 src + 23 test importers updated)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, Block New Type Ignores, Brick Zero-Core-Imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)