### PR TITLE
feat(#690): move trigram_fast.py from core/ to lib/

### DIFF
--- a/src/nexus/lib/trigram_fast.py
+++ b/src/nexus/lib/trigram_fast.py
@@ -31,24 +31,21 @@ _trigram_index_stats: Callable[..., dict[str, Any]] | None = None
 _invalidate_trigram_cache: Callable[..., None] | None = None
 
 try:
-    from nexus_fast import (  # type: ignore[no-redef]
-        build_trigram_index as _build_trigram_index,
+    from nexus_fast import build_trigram_index as _imported_build_trigram_index
+    from nexus_fast import (
+        build_trigram_index_from_entries as _imported_build_trigram_index_from_entries,
     )
-    from nexus_fast import (  # type: ignore[no-redef]
-        build_trigram_index_from_entries as _build_trigram_index_from_entries,
-    )
-    from nexus_fast import (  # type: ignore[no-redef]
-        invalidate_trigram_cache as _invalidate_trigram_cache,
-    )
-    from nexus_fast import (  # type: ignore[no-redef]
-        trigram_grep as _trigram_grep,
-    )
-    from nexus_fast import (  # type: ignore[no-redef]
-        trigram_index_stats as _trigram_index_stats,
-    )
-    from nexus_fast import (  # type: ignore[no-redef]
-        trigram_search_candidates as _trigram_search_candidates,
-    )
+    from nexus_fast import invalidate_trigram_cache as _imported_invalidate_trigram_cache
+    from nexus_fast import trigram_grep as _imported_trigram_grep
+    from nexus_fast import trigram_index_stats as _imported_trigram_index_stats
+    from nexus_fast import trigram_search_candidates as _imported_trigram_search_candidates
+
+    _build_trigram_index = _imported_build_trigram_index
+    _build_trigram_index_from_entries = _imported_build_trigram_index_from_entries
+    _invalidate_trigram_cache = _imported_invalidate_trigram_cache
+    _trigram_grep = _imported_trigram_grep
+    _trigram_index_stats = _imported_trigram_index_stats
+    _trigram_search_candidates = _imported_trigram_search_candidates
 
     TRIGRAM_AVAILABLE = True
 except ImportError:

--- a/src/nexus/search/manifest.py
+++ b/src/nexus/search/manifest.py
@@ -67,7 +67,7 @@ def verify_imports() -> dict[str, bool]:
         "nexus.search.bm25s_search",
         "nexus.search.zoekt_client",
         "nexus.search.graph_store",
-        "nexus.core.trigram_fast",
+        "nexus.lib.trigram_fast",
     ]:
         try:
             importlib.import_module(mod)

--- a/tests/benchmarks/test_search_benchmarks.py
+++ b/tests/benchmarks/test_search_benchmarks.py
@@ -708,7 +708,7 @@ class TestTrigramBenchmarks:
 
     def test_trigram_build_1k_files(self, benchmark):
         """Benchmark building trigram index from 1K files."""
-        from nexus.core import trigram_fast
+        from nexus.lib import trigram_fast
 
         if not trigram_fast.is_available():
             pytest.skip("Trigram index not available")
@@ -730,7 +730,7 @@ class TestTrigramBenchmarks:
 
     def test_trigram_search_literal(self, benchmark):
         """Benchmark trigram search for literal pattern."""
-        from nexus.core import trigram_fast
+        from nexus.lib import trigram_fast
 
         if not trigram_fast.is_available():
             pytest.skip("Trigram index not available")
@@ -747,7 +747,7 @@ class TestTrigramBenchmarks:
 
     def test_trigram_search_regex(self, benchmark):
         """Benchmark trigram search for regex pattern."""
-        from nexus.core import trigram_fast
+        from nexus.lib import trigram_fast
 
         if not trigram_fast.is_available():
             pytest.skip("Trigram index not available")
@@ -764,7 +764,7 @@ class TestTrigramBenchmarks:
 
     def test_trigram_search_no_match(self, benchmark):
         """Benchmark trigram search for non-matching pattern."""
-        from nexus.core import trigram_fast
+        from nexus.lib import trigram_fast
 
         if not trigram_fast.is_available():
             pytest.skip("Trigram index not available")
@@ -782,7 +782,7 @@ class TestTrigramBenchmarks:
 
     def test_trigram_vs_mmap_grep(self, benchmark):
         """Compare trigram index search vs mmap grep."""
-        from nexus.core import trigram_fast
+        from nexus.lib import trigram_fast
 
         if not trigram_fast.is_available():
             pytest.skip("Trigram index not available")

--- a/tests/e2e/self_contained/test_trigram_search_integration.py
+++ b/tests/e2e/self_contained/test_trigram_search_integration.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nexus.core import trigram_fast
+from nexus.lib import trigram_fast
 from nexus.search.strategies import (
     GREP_TRIGRAM_THRESHOLD,
     SearchStrategy,


### PR DESCRIPTION
## Summary
- Move `trigram_fast.py` (Rust extension wrapper) from `core/` to `lib/` — completes the `*_fast` module set already in lib/
- Fix 6x `# type: ignore[no-redef]` with `_imported_*` intermediate variable pattern
- core/ should not import from external `nexus_fast` — `lib/` is the correct tier

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, Block New Type Ignores, Brick Zero-Core-Imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)