### PR TITLE
feat(#690): move resiliency.py from core/ to lib/

### DIFF
--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -360,7 +360,7 @@ def _boot_system_services(
         logger.debug("[BOOT:SYSTEM] ResiliencyManager disabled by profile")
     else:
         try:
-            from nexus.core.resiliency import (
+            from nexus.lib.resiliency import (
                 ResiliencyConfig,
                 ResiliencyManager,
                 set_default_manager,

--- a/src/nexus/lib/resiliency.py
+++ b/src/nexus/lib/resiliency.py
@@ -8,7 +8,7 @@ Composition order (outer → inner): CircuitBreaker → Retry → Timeout
 
 Usage::
 
-    from nexus.core.resiliency import with_resiliency
+    from nexus.lib.resiliency import with_resiliency
 
     @with_resiliency(target="gcs")
     async def upload_file(data: bytes) -> str:
@@ -28,7 +28,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import wraps
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 logger = logging.getLogger(__name__)
 
@@ -508,7 +508,7 @@ def with_resiliency(
 
                 return await _inner()
 
-        return wrapper  # type: ignore[return-value]
+        return cast(F, wrapper)
 
     return decorator
 

--- a/tests/e2e/self_contained/test_resiliency_integration.py
+++ b/tests/e2e/self_contained/test_resiliency_integration.py
@@ -10,7 +10,7 @@ import asyncio
 
 import pytest
 
-from nexus.core.resiliency import (
+from nexus.lib.resiliency import (
     CircuitBreakerOpenError,
     CircuitBreakerPolicy,
     CircuitState,

--- a/tests/unit/core/test_resiliency_config.py
+++ b/tests/unit/core/test_resiliency_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from nexus.core.resiliency import (
+from nexus.lib.resiliency import (
     CircuitBreakerPolicy,
     ResiliencyConfig,
     TargetBinding,


### PR DESCRIPTION
## Summary
- Move `resiliency.py` (circuit breaker, retry, timeout) from `core/` to `lib/` — not mentioned in any of the 4 design docs (KERNEL-ARCHITECTURE, ops-scenario-matrix, data-storage-matrix, federation-memo)
- Fix 1x `# type: ignore[return-value]` with `cast(F, wrapper)`
- Update docstring self-reference path

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, Block New Type Ignores, Brick Zero-Core-Imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)