### PR TITLE
fix(#693): centralise NexusFS isinstance checks in CLI via is_standalone()

### DIFF
--- a/src/nexus/cli/commands/directory.py
+++ b/src/nexus/cli/commands/directory.py
@@ -14,6 +14,7 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    is_standalone,
 )
 
 
@@ -53,9 +54,6 @@ def list_files(
         # Time-travel: List files at historical operation point
         nexus ls /workspace --at-operation op_abc123
     """
-    # Import at function level - needed for both time-travel and regular long listing
-    from nexus.core.nexus_fs import NexusFS
-
     try:
         nx = get_filesystem(backend_config)
 
@@ -68,7 +66,7 @@ def list_files(
                 nx.close()
                 return
 
-            if not isinstance(nx, NexusFS):
+            if not is_standalone(nx):
                 console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
                 nx.close()
                 return
@@ -166,7 +164,7 @@ def list_files(
             table.add_column("Modified", style="yellow")
 
             # Get metadata with permissions
-            if isinstance(nx, NexusFS):
+            if is_standalone(nx):
                 for file in files:
                     # Use is_directory from metadata if available, otherwise check via API
                     is_dir = file.get("is_directory", False)

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -17,6 +17,7 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    is_standalone,
 )
 
 
@@ -117,14 +118,13 @@ def cat(
             # Time-travel: Read file at historical operation point
             # Import at function level to avoid scoping issues
             try:
-                from nexus.core.nexus_fs import NexusFS
                 from nexus.storage.time_travel import TimeTravelReader
             except ImportError as e:
                 console.print(f"[red]Error:[/red] Failed to import time-travel modules: {e}")
                 nx.close()
                 return
 
-            if not isinstance(nx, NexusFS):
+            if not is_standalone(nx):
                 console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
                 nx.close()
                 return

--- a/src/nexus/cli/commands/metadata.py
+++ b/src/nexus/cli/commands/metadata.py
@@ -18,6 +18,7 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    is_standalone,
 )
 
 
@@ -34,8 +35,6 @@ def info(
         nexus info /workspace/data.txt
     """
     try:
-        from nexus.core.nexus_fs import NexusFS
-
         nx = get_filesystem(backend_config)
 
         # Check if file exists first
@@ -46,7 +45,7 @@ def info(
 
         # Get file metadata from metadata store
         # Note: Only NexusFS mode has direct metadata access
-        if not isinstance(nx, NexusFS):
+        if not is_standalone(nx):
             console.print("[red]Error:[/red] File info is only available for NexusFS instances")
             nx.close()
             return
@@ -132,13 +131,12 @@ def export_metadata(
         nexus export zone.jsonl --zone-id acme-corp
     """
     try:
-        from nexus.core.nexus_fs import NexusFS
         from nexus.lib.export_import import ExportFilter
 
         nx = get_filesystem(backend_config)
 
         # Note: Only standalone mode supports metadata export
-        if not isinstance(nx, NexusFS):
+        if not is_standalone(nx):
             console.print("[red]Error:[/red] Metadata export is only available in standalone mode")
             nx.close()
             sys.exit(1)
@@ -230,13 +228,12 @@ def import_metadata(
         nexus import metadata-backup.jsonl --conflict-mode=remap
     """
     try:
-        from nexus.core.nexus_fs import NexusFS
         from nexus.lib.export_import import ImportOptions
 
         nx = get_filesystem(backend_config)
 
         # Note: Only standalone mode supports metadata import
-        if not isinstance(nx, NexusFS):
+        if not is_standalone(nx):
             console.print("[red]Error:[/red] Metadata import is only available in standalone mode")
             nx.close()
             sys.exit(1)

--- a/src/nexus/cli/commands/operations.py
+++ b/src/nexus/cli/commands/operations.py
@@ -17,6 +17,7 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    is_standalone,
 )
 
 
@@ -71,14 +72,13 @@ def ops_diff(
 
         # Import at function level to avoid scoping issues
         try:
-            from nexus.core.nexus_fs import NexusFS
             from nexus.storage.time_travel import TimeTravelReader
         except ImportError as e:
             console.print(f"[red]Error:[/red] Failed to import time-travel modules: {e}")
             nx.close()
             return
 
-        if not isinstance(nx, NexusFS):
+        if not is_standalone(nx):
             console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
             nx.close()
             return

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import click
+
+if TYPE_CHECKING:
+    from nexus.core.nexus_fs import NexusFS
 
 from nexus.cli.utils import (
     BackendConfig,
@@ -13,6 +16,7 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    is_standalone,
 )
 
 
@@ -252,12 +256,10 @@ def find_duplicates(path: str, json_output: bool, backend_config: BackendConfig)
         nexus find-duplicates --json
     """
     try:
-        from nexus.core.nexus_fs import NexusFS
-
         nx = get_filesystem(backend_config)
 
         # Only standalone mode supports batch_get_content_ids
-        if not isinstance(nx, NexusFS):
+        if not is_standalone(nx):
             console.print("[red]Error:[/red] find-duplicates is only available in standalone mode")
             nx.close()
             sys.exit(1)
@@ -417,8 +419,6 @@ def search_init(
     import asyncio
 
     try:
-        from nexus.core.nexus_fs import NexusFS
-
         nx = get_filesystem(backend_config)
 
         with console.status("[yellow]Initializing search engine...[/yellow]", spinner="dots"):
@@ -436,7 +436,7 @@ def search_init(
             asyncio.run(init_search())
 
         console.print("[green]✓ Search engine initialized successfully![/green]")
-        if isinstance(nx, NexusFS):
+        if is_standalone(nx):
             db_name = nx._record_store.engine.dialect.name if nx._record_store else "N/A"
             console.print(f"  Database: [cyan]{db_name}[/cyan]")
         else:
@@ -482,15 +482,13 @@ def search_index(
     import asyncio
 
     try:
-        from nexus.core.nexus_fs import NexusFS
-
         nx = get_filesystem(backend_config)
 
         with console.status(f"[yellow]Indexing {path}...[/yellow]", spinner="dots"):
 
             async def do_index() -> dict[str, int]:
                 # Auto-initialize semantic search if not already initialized (standalone mode)
-                if isinstance(nx, NexusFS) and (
+                if is_standalone(nx) and (
                     not hasattr(nx, "_semantic_search") or nx._semantic_search is None
                 ):
                     await nx.ainitialize_semantic_search()
@@ -577,15 +575,13 @@ def search_query(
     import asyncio
 
     try:
-        from nexus.core.nexus_fs import NexusFS
-
         nx = get_filesystem(backend_config)
 
         with console.status(f"[yellow]Searching for: {query}[/yellow]", spinner="dots"):
 
             async def do_search() -> list[dict[str, Any]]:
                 # Auto-initialize semantic search if not already initialized (standalone mode)
-                if isinstance(nx, NexusFS) and (
+                if is_standalone(nx) and (
                     not hasattr(nx, "_semantic_search") or nx._semantic_search is None
                 ):
                     await nx.ainitialize_semantic_search(
@@ -643,13 +639,11 @@ def search_stats(backend_config: BackendConfig) -> None:
     import asyncio
 
     try:
-        from nexus.core.nexus_fs import NexusFS
-
         nx = get_filesystem(backend_config)
 
         async def get_stats() -> dict[str, Any]:
             # Auto-initialize semantic search if not already initialized (standalone mode)
-            if isinstance(nx, NexusFS) and (
+            if is_standalone(nx) and (
                 not hasattr(nx, "_semantic_search") or nx._semantic_search is None
             ):
                 await nx.ainitialize_semantic_search()

--- a/src/nexus/cli/commands/server.py
+++ b/src/nexus/cli/commands/server.py
@@ -23,6 +23,7 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    is_standalone,
 )
 from nexus.lib.env import get_database_url
 from nexus.lib.sync_bridge import run_sync
@@ -821,16 +822,15 @@ def serve(
 
             from nexus.cli.utils import create_backend_from_config
             from nexus.config import load_config
-            from nexus.core.nexus_fs import NexusFS
 
             try:
                 cfg = load_config(PathlibPath(backend_config.config_path))
                 # Store config on NexusFS for OAuth factory and other components
-                if isinstance(nx, NexusFS):
+                if is_standalone(nx):
                     nx._config = cfg
                 if cfg.backends:
                     # Type check: backends can only be mounted on NexusFS, not RemoteNexusFS
-                    if not isinstance(nx, NexusFS):
+                    if not is_standalone(nx):
                         console.print(
                             "[yellow]⚠️  Warning: Multi-backend configuration is only supported for local NexusFS instances[/yellow]"
                         )

--- a/src/nexus/cli/commands/work.py
+++ b/src/nexus/cli/commands/work.py
@@ -13,6 +13,7 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    is_standalone,
 )
 
 
@@ -51,12 +52,10 @@ def work(
         nexus work ready --json
     """
     try:
-        from nexus.core.nexus_fs import NexusFS
-
         nx = get_filesystem(backend_config)
 
         # Only standalone mode has metadata store with work views
-        if not isinstance(nx, NexusFS):
+        if not is_standalone(nx):
             console.print("[red]Error:[/red] Work views are only available in standalone mode")
             nx.close()
             sys.exit(1)

--- a/src/nexus/cli/commands/zone.py
+++ b/src/nexus/cli/commands/zone.py
@@ -32,6 +32,7 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    is_standalone,
 )
 from nexus.constants import DEFAULT_GRPC_BIND_ADDR
 
@@ -460,7 +461,6 @@ def export_zone(
         nexus zone export acme-corp -o /backup/acme.nexus --after 2025-01-01T00:00:00
     """
     try:
-        from nexus.core.nexus_fs import NexusFS
         from nexus.portability import ZoneExportOptions, ZoneExportService
 
         # Parse after time if provided
@@ -477,7 +477,7 @@ def export_zone(
 
         # Get filesystem
         nx = get_filesystem(backend_config)
-        if not isinstance(nx, NexusFS):
+        if not is_standalone(nx):
             console.print("[red]Error:[/red] Zone export requires NexusFS instance")
             nx.close()
             sys.exit(1)
@@ -604,7 +604,6 @@ def import_zone(
         nexus zone import /backup/acme.nexus --dry-run
     """
     try:
-        from nexus.core.nexus_fs import NexusFS
         from nexus.portability import ConflictMode, ZoneImportOptions, ZoneImportService
 
         # Parse path remappings
@@ -619,7 +618,7 @@ def import_zone(
 
         # Get filesystem
         nx = get_filesystem(backend_config)
-        if not isinstance(nx, NexusFS):
+        if not is_standalone(nx):
             console.print("[red]Error:[/red] Zone import requires NexusFS instance")
             nx.close()
             sys.exit(1)

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, TypeGuard, cast
+
+if TYPE_CHECKING:
+    from nexus.core.nexus_fs import NexusFS
 
 import click
 from rich.console import Console
@@ -358,6 +361,19 @@ def get_default_filesystem() -> NexusFilesystem:
     except Exception as e:
         console.print(f"[red]Error connecting to Nexus:[/red] {e}")
         sys.exit(1)
+
+
+def is_standalone(nx: NexusFilesystem) -> TypeGuard[NexusFS]:
+    """Check whether *nx* is a local NexusFS instance (not a remote client).
+
+    Many CLI features (time-travel, metadata export, zone portability, etc.)
+    require direct access to the local metadata store and are unavailable
+    when connected to a remote server.  This helper centralises the runtime
+    check so individual commands don't need to import the concrete class.
+    """
+    from nexus.core.nexus_fs import NexusFS as _NexusFS
+
+    return isinstance(nx, _NexusFS)
 
 
 def get_subject_from_env() -> tuple[str, str] | None:


### PR DESCRIPTION
## Summary
- Add `is_standalone(nx) -> TypeGuard[NexusFS]` helper to `cli/utils.py` that centralises the runtime `isinstance(nx, NexusFS)` check
- Replace 15 scattered `from nexus.core.nexus_fs import NexusFS` runtime imports across 8 CLI command files (directory, file_ops, metadata, operations, search, server, work, zone) with calls to `is_standalone(nx)`
- Uses `TypeGuard` for mypy type narrowing so downstream attribute access (e.g. `nx.metadata`, `nx.SessionLocal`) continues to type-check
- Result: 1 centralised runtime import (in the helper) + 2 TYPE_CHECKING imports, down from 15 scattered runtime imports

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff format, mypy, end-of-file-fixer, Block New Type Ignores, Brick Zero-Core-Imports Check)
- [ ] CI passes
- [ ] CLI commands work in both standalone and remote modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)