### PR TITLE
feat(#2286): add brick import boundary lint to CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -122,7 +122,7 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   brick-imports-check:
-    name: Brick Zero-Core-Imports Check
+    name: Brick Import Boundary Check (regex)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -139,7 +139,39 @@ jobs:
       - name: Report violations
         if: failure()
         run: |
-          echo "::error::Bricks must not import from nexus.core or nexus.services internals. See NEXUS-LEGO-ARCHITECTURE.md §1.2."
+          echo "::error::Brick import boundary violations detected. See NEXUS-LEGO-ARCHITECTURE.md §1.2."
+
+  import-linter:
+    name: Architecture Boundary Check (import-linter)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install import-linter
+
+      - name: Cache import graph
+        uses: actions/cache@v4
+        with:
+          path: .import-linter-cache
+          key: import-linter-${{ runner.os }}-${{ hashFiles('src/**/*.py') }}
+          restore-keys: |
+            import-linter-${{ runner.os }}-
+
+      - name: Run import-linter
+        run: |
+          lint-imports --cache-dir .import-linter-cache
+
+      - name: Report violations
+        if: failure()
+        run: |
+          echo "::error::Architecture boundary violations detected. See NEXUS-LEGO-ARCHITECTURE.md."
 
   type-ignore-baseline:
     name: Track Type Ignore Baseline

--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
-Pre-commit hook and CI check to enforce zero-core-imports in bricks/.
+Pre-commit hook and CI check to enforce brick import boundaries.
 
 LEGO Architecture Principle 3: "Bricks don't know about each other"
 and bricks must never import from nexus.core (the kernel).
 
 Bricks communicate with the kernel exclusively through protocols defined
 in core/protocols/ and services/protocols/. Direct imports from nexus.core
-or nexus.services internals are architectural violations.
+or nexus.services internals are architectural violations. Cross-brick
+imports (bricks/<X>/ importing from nexus.bricks.<Y>) are also forbidden.
 
 Reference: docs/design/NEXUS-LEGO-ARCHITECTURE.md §1.2, Principle 3
 """
@@ -27,7 +28,7 @@ BRICKS_RELATIVE_PATH = Path("src") / "nexus" / "bricks"
 #   - nexus.services.protocols.*  (system service protocol interfaces)
 #   - nexus.storage.*           (storage pillar ABCs + RecordStoreABC)
 #   - Third-party packages
-#   - Other bricks' public APIs (through protocols, not direct imports)
+#   - Same brick (nexus.bricks.<own_brick>.*)
 #
 # Note: TYPE_CHECKING imports are also flagged intentionally — bricks should
 # not even type-reference kernel internals (use protocols for type annotations).
@@ -48,6 +49,21 @@ FORBIDDEN_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^\s*import\s+nexus\.services(?!\.protocols\b)"), "nexus.services"),
 ]
 
+# Regex to extract the target brick name from a brick import line
+CROSS_BRICK_IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+nexus\.bricks\.(\w+)")
+
+# Known cross-brick exceptions — temporary allowlist for imports that require
+# DI refactoring to fix properly. Each entry maps (source_brick, target_brick)
+# to a list of importing modules. Remove entries as fixes land.
+# TODO(#2286): Fix memory->search via DI refactoring.
+KNOWN_CROSS_BRICK_EXCEPTIONS: dict[tuple[str, str], list[str]] = {
+    ("memory", "search"): [
+        "nexus.bricks.memory.enrichment",
+        "nexus.bricks.memory.memory_with_paging",
+        "nexus.bricks.memory.service",
+    ],
+}
+
 # Lines matching these patterns are not actual imports (comments, strings, etc.)
 SKIP_PATTERNS = [
     re.compile(r"^\s*#"),  # Comments
@@ -61,9 +77,57 @@ def is_import_line(line: str) -> bool:
     return not any(p.match(line) for p in SKIP_PATTERNS)
 
 
-def check_file(file_path: Path) -> list[tuple[int, str, str]]:
+def extract_brick_name(file_path: Path) -> str | None:
+    """Extract brick name from file path.
+
+    Example: .../bricks/memory/service.py -> 'memory'
     """
-    Check a single file for forbidden imports.
+    parts = file_path.parts
+    try:
+        idx = parts.index("bricks")
+        if idx + 1 < len(parts):
+            return parts[idx + 1]
+    except ValueError:
+        pass
+    return None
+
+
+def _module_name_from_path(file_path: Path) -> str | None:
+    """Derive dotted module name from file path (best-effort).
+
+    Example: .../src/nexus/bricks/memory/service.py -> 'nexus.bricks.memory.service'
+    """
+    parts = file_path.parts
+    try:
+        idx = parts.index("nexus")
+    except ValueError:
+        return None
+    mod_parts = list(parts[idx:])
+    # Strip .py from last part
+    if mod_parts[-1].endswith(".py"):
+        mod_parts[-1] = mod_parts[-1][:-3]
+    # Strip __init__
+    if mod_parts[-1] == "__init__":
+        mod_parts = mod_parts[:-1]
+    return ".".join(mod_parts)
+
+
+def _is_cross_brick_exception(source_brick: str, target_brick: str, file_path: Path) -> bool:
+    """Check if a cross-brick import is in the known exceptions allowlist."""
+    allowed_modules = KNOWN_CROSS_BRICK_EXCEPTIONS.get((source_brick, target_brick))
+    if allowed_modules is None:
+        return False
+    module_name = _module_name_from_path(file_path)
+    return module_name in allowed_modules if module_name else False
+
+
+def check_file(file_path: Path, brick_name: str | None = None) -> list[tuple[int, str, str]]:
+    """Check a single file for forbidden imports.
+
+    Args:
+        file_path: Path to the Python file to check.
+        brick_name: Name of the brick this file belongs to (for cross-brick checks).
+            If None, cross-brick checks are skipped.
 
     Returns:
         List of (line_number, line_content, matched_pattern_description) tuples.
@@ -74,10 +138,33 @@ def check_file(file_path: Path) -> list[tuple[int, str, str]]:
             for line_num, line in enumerate(f, start=1):
                 if not is_import_line(line):
                     continue
+
+                # Check static forbidden patterns (core/services internals)
+                found = False
                 for pattern, desc in FORBIDDEN_PATTERNS:
                     if pattern.search(line):
                         violations.append((line_num, line.rstrip(), desc))
+                        found = True
                         break  # One violation per line is enough
+
+                if found:
+                    continue
+
+                # Check cross-brick imports
+                if brick_name:
+                    m = CROSS_BRICK_IMPORT_RE.match(line)
+                    if m:
+                        target_brick = m.group(1)
+                        if target_brick != brick_name and not _is_cross_brick_exception(
+                            brick_name, target_brick, file_path
+                        ):
+                            violations.append(
+                                (
+                                    line_num,
+                                    line.rstrip(),
+                                    f"nexus.bricks.{target_brick} (cross-brick import)",
+                                )
+                            )
     except Exception as e:
         print(f"Warning: Could not read {file_path}: {e}")
 
@@ -120,30 +207,34 @@ def main() -> int:
     all_violations: list[tuple[Path, list[tuple[int, str, str]]]] = []
 
     for file_path in files:
-        violations = check_file(file_path)
+        brick_name = extract_brick_name(file_path)
+        violations = check_file(file_path, brick_name=brick_name)
         if violations:
             all_violations.append((file_path, violations))
 
     if all_violations:
-        print("\n❌ Brick import check failed!")
-        print("\n🧱 Bricks must not import from kernel internals:\n")
+        print("\n" + "=" * 72)
+        print("Brick import boundary check FAILED")
+        print("=" * 72)
+        print()
 
         for file_path, violations in all_violations:
             print(f"  {file_path}:")
             for line_num, line_content, desc in violations:
                 print(f"    Line {line_num}: {line_content}")
-                print(f"             ↳ Forbidden: direct import from {desc}")
+                print(f"             -> Forbidden: direct import from {desc}")
             print()
 
-        print("📋 LEGO Architecture Principle 3: Bricks don't know about the kernel")
-        print("🎯 Bricks may only import from:")
+        print("LEGO Architecture Principle 3: Bricks don't know about the kernel")
+        print("or each other. Bricks may only import from:")
         print("     nexus.core.protocols.*      (kernel protocol interfaces)")
-        print("     nexus.core.cache_store      (CacheStoreABC — storage pillar)")
-        print("     nexus.core.object_store     (ObjectStoreABC — storage pillar)")
+        print("     nexus.core.cache_store      (CacheStoreABC -- storage pillar)")
+        print("     nexus.core.object_store     (ObjectStoreABC -- storage pillar)")
         print("     nexus.services.protocols.*   (system service protocol interfaces)")
         print("     nexus.storage.*              (RecordStoreABC + storage utilities)")
+        print("     nexus.bricks.<own_brick>.*   (same-brick internal imports)")
         print()
-        print("💡 See docs/design/NEXUS-LEGO-ARCHITECTURE.md §1.2")
+        print("See docs/design/NEXUS-LEGO-ARCHITECTURE.md")
         print()
 
         return 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ dev = [
     "ruff>=0.14.0",
     "mypy>=1.8.0",
     "pre-commit>=3.6.0",
+    "import-linter>=2.0",  # Architecture boundary enforcement (Issue #2286)
 
     # Documentation
     "mkdocs>=1.5.3",
@@ -765,6 +766,175 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+# =============================================================================
+# Import Linter — Architecture boundary enforcement (Issue #2286)
+# Reference: docs/design/NEXUS-LEGO-ARCHITECTURE.md §1.2, §3.3
+# =============================================================================
+
+[tool.importlinter]
+root_packages = ["nexus"]
+# TYPE_CHECKING imports are violations too (strict mode)
+include_external_packages = false
+
+# Contract 1: Bricks are independent — zero cross-brick imports
+[[tool.importlinter.contracts]]
+id = "brick-independence"
+name = "Bricks must not import from each other (LEGO Principle 3)"
+type = "independence"
+modules = [
+    "nexus.bricks.a2a",
+    "nexus.bricks.cache",
+    "nexus.bricks.context_manifest",
+    "nexus.bricks.delegation",
+    "nexus.bricks.discovery",
+    "nexus.bricks.governance",
+    "nexus.bricks.memory",
+    "nexus.bricks.pay",
+    "nexus.bricks.reputation",
+    "nexus.bricks.sandbox",
+    "nexus.bricks.search",
+    "nexus.bricks.skills",
+    "nexus.bricks.snapshot",
+    "nexus.bricks.workflows",
+]
+# Known violations — ratchet baseline. Remove entries as fixes land.
+ignore_imports = [
+    # memory -> search: direct lazy imports (TODO: fix via DI refactoring)
+    "nexus.bricks.memory.enrichment -> nexus.bricks.search.embeddings",
+    "nexus.bricks.memory.memory_with_paging -> nexus.bricks.search.vector_db",
+    "nexus.bricks.memory.service -> nexus.bricks.search.graph_store",
+    "nexus.bricks.memory.service -> nexus.bricks.search.embeddings",
+    # nexus.cache shim re-exports nexus.bricks.cache (deprecated, Issue #1524)
+    "nexus.cache -> nexus.bricks.cache",
+    "nexus.cache.base -> nexus.bricks.cache.base",
+    "nexus.cache.domain -> nexus.bricks.cache.domain",
+    "nexus.cache.dragonfly -> nexus.bricks.cache.dragonfly",
+    "nexus.cache.inmemory -> nexus.bricks.cache.inmemory",
+    # skills -> search: transitive via nexus.backends (TODO: fix backends)
+    "nexus.backends.sync_pipeline -> nexus.bricks.search.zoekt_client",
+]
+unmatched_ignore_imports_alerting = "warn"
+
+# Contract 2: Four-tier layered architecture
+# tier-neutral (lib, contracts) < kernel (core) < services < bricks
+[[tool.importlinter.contracts]]
+id = "four-tier-layers"
+name = "Four-tier architecture: tier-neutral < kernel < services < bricks"
+type = "layers"
+layers = [
+    "nexus.bricks",
+    "nexus.services",
+    "nexus.core",
+    "nexus.contracts | nexus.lib",
+]
+# Ratchet baseline — 94 known violations. Remove entries as fixes land.
+# Run: lint-imports --contract four-tier-layers to check.
+ignore_imports = [
+    # --- tier-neutral (contracts/lib) importing upward ---
+    "nexus.contracts -> nexus.lib.validators",
+    "nexus.contracts.deployment_profile -> nexus.core.performance_tuning",
+    "nexus.contracts.types -> nexus.core.read_set",
+    "nexus.contracts.write_observer -> nexus.core.metadata",
+    "nexus.lib.context_utils -> nexus.contracts.types",
+    "nexus.lib.response -> nexus.contracts.exceptions",
+    # --- kernel (core) importing services ---
+    "nexus.core.config -> nexus.services.protocols.namespace_manager",
+    "nexus.core.nexus_fs -> nexus.services.agents.agent_rpc_service",
+    "nexus.core.nexus_fs -> nexus.services.memory.memory_api",
+    "nexus.core.nexus_fs -> nexus.services.tiger_cache_manager",
+    "nexus.core.service_wiring -> nexus.services.ace_rpc_service",
+    "nexus.core.service_wiring -> nexus.services.agents.agent_rpc_service",
+    "nexus.core.service_wiring -> nexus.services.descendant_access",
+    "nexus.core.service_wiring -> nexus.services.events_service",
+    "nexus.core.service_wiring -> nexus.services.gateway",
+    "nexus.core.service_wiring -> nexus.services.llm_service",
+    "nexus.core.service_wiring -> nexus.services.mcp_service",
+    "nexus.core.service_wiring -> nexus.services.memory_provider",
+    "nexus.core.service_wiring -> nexus.services.mount_core_service",
+    "nexus.core.service_wiring -> nexus.services.mount_persist_service",
+    "nexus.core.service_wiring -> nexus.services.mount_service",
+    "nexus.core.service_wiring -> nexus.services.oauth_service",
+    "nexus.core.service_wiring -> nexus.services.rebac_service",
+    "nexus.core.service_wiring -> nexus.services.search_service",
+    "nexus.core.service_wiring -> nexus.services.share_link_service",
+    "nexus.core.service_wiring -> nexus.services.skill_service",
+    "nexus.core.service_wiring -> nexus.services.subsystems.llm_subsystem",
+    "nexus.core.service_wiring -> nexus.services.sync_job_service",
+    "nexus.core.service_wiring -> nexus.services.sync_service",
+    "nexus.core.service_wiring -> nexus.services.user_provisioning",
+    "nexus.core.service_wiring -> nexus.services.workspace_rpc_service",
+    # --- kernel (core) importing bricks ---
+    "nexus.core.config -> nexus.bricks.workflows.protocol",
+    "nexus.core.nexus_fs_core -> nexus.bricks.memory.router",
+    # --- kernel (core) importing non-layer modules (rebac) ---
+    "nexus.core.async_bridge -> nexus.rebac.manager",
+    "nexus.core.async_nexus_fs -> nexus.rebac.async_permissions",
+    "nexus.core.nexus_fs_core -> nexus.rebac.enforcer",
+    # --- services importing bricks ---
+    "nexus.services.ace.consolidation -> nexus.bricks.search.embeddings",
+    "nexus.services.delegation -> nexus.bricks.delegation.derivation",
+    "nexus.services.delegation -> nexus.bricks.delegation.errors",
+    "nexus.services.delegation -> nexus.bricks.delegation.models",
+    "nexus.services.delegation -> nexus.bricks.delegation.service",
+    "nexus.services.governance -> nexus.bricks.governance",
+    "nexus.services.governance.anomaly_math -> nexus.bricks.governance.anomaly_math",
+    "nexus.services.governance.anomaly_service -> nexus.bricks.governance.anomaly_service",
+    "nexus.services.governance.approval -> nexus.bricks.governance.approval",
+    "nexus.services.governance.approval.state_machine -> nexus.bricks.governance.approval.state_machine",
+    "nexus.services.governance.approval.types -> nexus.bricks.governance.approval.types",
+    "nexus.services.governance.approval.workflow -> nexus.bricks.governance.approval.workflow",
+    "nexus.services.governance.collusion_service -> nexus.bricks.governance.collusion_service",
+    "nexus.services.governance.db_models -> nexus.bricks.governance.db_models",
+    "nexus.services.governance.governance_graph_service -> nexus.bricks.governance.governance_graph_service",
+    "nexus.services.governance.governance_wrapper -> nexus.bricks.governance.governance_wrapper",
+    "nexus.services.governance.models -> nexus.bricks.governance.models",
+    "nexus.services.governance.protocols -> nexus.bricks.governance.protocols",
+    "nexus.services.governance.response_service -> nexus.bricks.governance.response_service",
+    "nexus.services.governance.trust_math -> nexus.bricks.governance.trust_math",
+    "nexus.services.graph_search_service -> nexus.bricks.search.graph_retrieval",
+    "nexus.services.graph_search_service -> nexus.bricks.search.graph_store",
+    "nexus.services.graph_search_service -> nexus.bricks.search.results",
+    "nexus.services.llm_document_reader -> nexus.bricks.search.protocols",
+    "nexus.services.memory -> nexus.bricks.memory",
+    "nexus.services.memory.enrichment -> nexus.bricks.search.embeddings",
+    "nexus.services.memory.memory_api -> nexus.bricks.search.embeddings",
+    "nexus.services.memory.memory_api -> nexus.bricks.search.graph_store",
+    "nexus.services.memory.memory_with_paging -> nexus.bricks.search.vector_db",
+    "nexus.services.memory_service -> nexus.bricks.search.embeddings",
+    "nexus.services.protocols -> nexus.bricks.governance.protocols",
+    "nexus.services.protocols.governance -> nexus.bricks.governance.models",
+    "nexus.services.protocols.sandbox -> nexus.bricks.sandbox.sandbox_provider",
+    "nexus.services.scheduler.service -> nexus.bricks.pay.credits",
+    "nexus.services.search_grep_mixin -> nexus.bricks.search.zoekt_client",
+    "nexus.services.search_listing_mixin -> nexus.bricks.memory.router",
+    "nexus.services.search_semantic -> nexus.bricks.search.chunking",
+    "nexus.services.search_semantic -> nexus.bricks.search.embeddings",
+    "nexus.services.search_semantic -> nexus.bricks.search.indexing",
+    "nexus.services.search_semantic -> nexus.bricks.search.indexing_service",
+    "nexus.services.search_semantic -> nexus.bricks.search.query_service",
+    "nexus.services.search_semantic -> nexus.bricks.search.vector_db",
+    "nexus.services.search_service -> nexus.bricks.memory.router",
+    "nexus.services.search_service -> nexus.bricks.search.zoekt_client",
+    "nexus.services.skill_service -> nexus.bricks.skills.package_service",
+    # --- services importing non-layer modules ---
+    "nexus.services.memory.memory_api -> nexus.rebac.memory_permission_enforcer",
+    "nexus.services.permissions.cache.tiger.bitmap_cache -> nexus.cache.base",
+    "nexus.services.search_semantic -> nexus.factory",
+    "nexus.services.sync_service -> nexus.backends.cache_mixin",
+    # --- non-layer module chain hops ---
+    "nexus.backends.cache_mixin -> nexus.backends.sync_pipeline",
+    "nexus.backends.sync_pipeline -> nexus.bricks.search.zoekt_client",
+    "nexus.cache.base -> nexus.bricks.cache.base",
+    "nexus.factory -> nexus.factory.orchestrator",
+    "nexus.factory.orchestrator -> nexus.bricks.cache.brick",
+    "nexus.rebac.async_permissions -> nexus.rebac.enforcer",
+    "nexus.rebac.cache.tiger -> nexus.services.permissions.cache.tiger.bitmap_cache",
+    "nexus.rebac.enforcer -> nexus.services.permissions.namespace_manager",
+    "nexus.rebac.manager -> nexus.rebac.consistency.zone_manager",
+    "nexus.rebac.memory_permission_enforcer -> nexus.bricks.memory.router",
+]
+unmatched_ignore_imports_alerting = "warn"
 
 [dependency-groups]
 dev = [

--- a/src/nexus/bricks/governance/governance_wrapper.py
+++ b/src/nexus/bricks/governance/governance_wrapper.py
@@ -18,8 +18,11 @@ from nexus.utils.async_helpers import fire_and_forget
 
 if TYPE_CHECKING:
     from nexus.bricks.governance.protocols import AnomalyServiceProtocol, GovernanceGraphProtocol
-    from nexus.bricks.pay.protocol import ProtocolTransferRequest, ProtocolTransferResult
-    from nexus.services.protocols.payment import PaymentProtocol
+    from nexus.services.protocols.payment import (
+        PaymentProtocol,
+        ProtocolTransferRequest,
+        ProtocolTransferResult,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/bricks/pay/protocol.py
+++ b/src/nexus/bricks/pay/protocol.py
@@ -18,13 +18,15 @@ Detection chain order:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.pay.audit_types import TransactionProtocol
 from nexus.constants import ROOT_ZONE_ID
+from nexus.services.protocols.payment import (
+    ProtocolTransferRequest,
+    ProtocolTransferResult,
+)
 
 if TYPE_CHECKING:
     from nexus.bricks.pay.x402 import X402Client
@@ -56,37 +58,6 @@ class ProtocolNotFoundError(ProtocolError):
 
 class ProtocolDetectionError(ProtocolError):
     """Raised when no protocol matches the destination."""
-
-
-# =============================================================================
-# Data Classes
-# =============================================================================
-
-
-@dataclass(frozen=True)
-class ProtocolTransferRequest:
-    """Immutable request for a protocol transfer."""
-
-    from_agent: str
-    to: str
-    amount: Decimal
-    memo: str = ""
-    idempotency_key: str | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
-class ProtocolTransferResult:
-    """Immutable result from a protocol transfer."""
-
-    protocol: TransactionProtocol
-    tx_id: str
-    amount: Decimal
-    from_agent: str
-    to: str
-    tx_hash: str | None = None
-    timestamp: datetime | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 # =============================================================================

--- a/src/nexus/services/protocols/payment.py
+++ b/src/nexus/services/protocols/payment.py
@@ -1,6 +1,8 @@
 """Payment service protocol (Issue #1357).
 
-Defines the contract for payment protocol implementations.
+Defines the contract for payment protocol implementations, including
+the transfer request/result data classes used across the protocol boundary.
+
 Concrete implementations live in ``nexus.bricks.pay.protocol``.
 
 Storage Affinity: **RecordStore** — transaction records + audit trail.
@@ -9,15 +11,54 @@ References:
     - docs/architecture/KERNEL-ARCHITECTURE.md §3
     - docs/architecture/data-storage-matrix.md (Four Pillars)
     - Issue #1357: Extensible protocol dispatch for agent commerce
+    - Issue #2286: Protocol types moved here from bricks/pay/protocol.py
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from nexus.bricks.pay.audit_types import TransactionProtocol
-    from nexus.bricks.pay.protocol import ProtocolTransferRequest, ProtocolTransferResult
+    from nexus.contracts.types import TransactionProtocol
+
+
+# =============================================================================
+# Protocol Data Classes
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class ProtocolTransferRequest:
+    """Immutable request for a protocol transfer."""
+
+    from_agent: str
+    to: str
+    amount: Decimal
+    memo: str = ""
+    idempotency_key: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProtocolTransferResult:
+    """Immutable result from a protocol transfer."""
+
+    protocol: TransactionProtocol
+    tx_id: str
+    amount: Decimal
+    from_agent: str
+    to: str
+    tx_hash: str | None = None
+    timestamp: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# =============================================================================
+# Protocol Interface
+# =============================================================================
 
 
 @runtime_checkable
@@ -36,3 +77,10 @@ class PaymentProtocol(Protocol):
     def can_handle(self, to: str, metadata: dict[str, Any] | None = None) -> bool: ...
 
     async def transfer(self, request: ProtocolTransferRequest) -> ProtocolTransferResult: ...
+
+
+__all__ = [
+    "PaymentProtocol",
+    "ProtocolTransferRequest",
+    "ProtocolTransferResult",
+]

--- a/tests/unit/scripts/test_check_brick_imports.py
+++ b/tests/unit/scripts/test_check_brick_imports.py
@@ -17,6 +17,7 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 
 check_file = _mod.check_file
+extract_brick_name = _mod.extract_brick_name
 find_brick_files = _mod.find_brick_files
 is_import_line = _mod.is_import_line
 main = _mod.main
@@ -247,3 +248,141 @@ class TestIsImportLine:
 
     def test_indented_comment(self):
         assert is_import_line("    # from nexus.core import foo") is False
+
+
+class TestExtractBrickName:
+    """Tests for extract_brick_name()."""
+
+    def test_extracts_brick_from_path(self):
+        p = Path("src/nexus/bricks/memory/service.py")
+        assert extract_brick_name(p) == "memory"
+
+    def test_extracts_brick_from_nested_path(self):
+        p = Path("src/nexus/bricks/governance/approval/workflow.py")
+        assert extract_brick_name(p) == "governance"
+
+    def test_returns_none_for_non_brick_path(self):
+        p = Path("src/nexus/core/nexus_fs.py")
+        assert extract_brick_name(p) is None
+
+    def test_returns_none_for_path_ending_at_bricks(self):
+        p = Path("src/nexus/bricks")
+        assert extract_brick_name(p) is None
+
+
+class TestCrossBrickImports:
+    """Tests for cross-brick import detection (Issue #2286)."""
+
+    @pytest.fixture()
+    def memory_brick_file(self, tmp_path: Path):
+        """Create a file simulating a module inside bricks/memory/."""
+
+        def _make(content: str) -> Path:
+            brick_dir = tmp_path / "src" / "nexus" / "bricks" / "memory"
+            brick_dir.mkdir(parents=True, exist_ok=True)
+            f = brick_dir / "service.py"
+            f.write_text(textwrap.dedent(content))
+            return f
+
+        return _make
+
+    def test_detects_cross_brick_from_import(self, memory_brick_file):
+        path = memory_brick_file("""\
+            from nexus.bricks.pay.credits import CreditsService
+        """)
+        violations = check_file(path, brick_name="memory")
+        assert len(violations) == 1
+        assert "cross-brick import" in violations[0][2]
+        assert "nexus.bricks.pay" in violations[0][2]
+
+    def test_detects_cross_brick_import_statement(self, memory_brick_file):
+        path = memory_brick_file("""\
+            import nexus.bricks.pay.credits
+        """)
+        violations = check_file(path, brick_name="memory")
+        assert len(violations) == 1
+        assert "cross-brick import" in violations[0][2]
+
+    def test_allows_same_brick_import(self, memory_brick_file):
+        path = memory_brick_file("""\
+            from nexus.bricks.memory.router import MemoryRouter
+            import nexus.bricks.memory.enrichment
+        """)
+        violations = check_file(path, brick_name="memory")
+        assert violations == []
+
+    def test_detects_type_checking_cross_brick(self, memory_brick_file):
+        """TYPE_CHECKING cross-brick imports are also violations."""
+        path = memory_brick_file("""\
+            from typing import TYPE_CHECKING
+            if TYPE_CHECKING:
+                from nexus.bricks.pay.protocol import ProtocolTransferRequest
+        """)
+        violations = check_file(path, brick_name="memory")
+        assert len(violations) == 1
+        assert "nexus.bricks.pay" in violations[0][2]
+
+    def test_cross_brick_in_comment_is_skipped(self, memory_brick_file):
+        path = memory_brick_file("""\
+            # from nexus.bricks.pay.credits import CreditsService
+        """)
+        violations = check_file(path, brick_name="memory")
+        assert violations == []
+
+    def test_cross_brick_without_brick_name_not_checked(self, tmp_path: Path):
+        """Files not identified as brick modules skip cross-brick checks."""
+        f = tmp_path / "module.py"
+        f.write_text("from nexus.bricks.search.embeddings import foo\n")
+        violations = check_file(f)  # No brick_name
+        assert violations == []
+
+    def test_multiple_cross_brick_violations(self, memory_brick_file):
+        path = memory_brick_file("""\
+            from nexus.bricks.governance.models import GovernanceModel
+            from nexus.bricks.pay.credits import CreditsService
+            from nexus.bricks.memory.router import MemoryRouter
+        """)
+        violations = check_file(path, brick_name="memory")
+        assert len(violations) == 2  # governance and pay, but not memory (same brick)
+        descs = [v[2] for v in violations]
+        assert any("nexus.bricks.governance" in d for d in descs)
+        assert any("nexus.bricks.pay" in d for d in descs)
+
+    def test_cross_brick_combined_with_core_violation(self, memory_brick_file):
+        """Both core and cross-brick violations are reported."""
+        path = memory_brick_file("""\
+            from nexus.core.nexus_fs import NexusFS
+            from nexus.bricks.pay.credits import foo
+        """)
+        violations = check_file(path, brick_name="memory")
+        assert len(violations) == 2
+        assert "nexus.core" in violations[0][2]
+        assert "cross-brick" in violations[1][2]
+
+    def test_allowlisted_cross_brick_not_reported(self, memory_brick_file):
+        """Memory->search imports in the allowlist should not be reported."""
+        path = memory_brick_file("""\
+            from nexus.bricks.search.embeddings import create_embedding_provider
+        """)
+        violations = check_file(path, brick_name="memory")
+        assert violations == []
+
+
+class TestCrossBrickMainIntegration:
+    """Integration tests for cross-brick detection via main()."""
+
+    def test_cross_brick_detected_in_ci_mode(self, monkeypatch, tmp_path: Path):
+        bricks = tmp_path / "src" / "nexus" / "bricks" / "memory"
+        bricks.mkdir(parents=True)
+        (bricks / "bad.py").write_text("from nexus.bricks.pay.credits import CreditsService\n")
+        monkeypatch.setattr("sys.argv", ["check_brick_imports.py"])
+        monkeypatch.chdir(tmp_path)
+        assert main() == 1
+
+    def test_same_brick_import_passes(self, monkeypatch, tmp_path: Path):
+        bricks = tmp_path / "src" / "nexus" / "bricks" / "memory"
+        bricks.mkdir(parents=True)
+        (bricks / "ok.py").write_text("from nexus.bricks.memory.router import MemoryRouter\n")
+        monkeypatch.setattr("sys.argv", ["check_brick_imports.py"])
+        monkeypatch.chdir(tmp_path)
+        assert main() == 0


### PR DESCRIPTION
## Summary

**Stream 3 | Issue #2286**

Adds comprehensive brick import boundary enforcement to CI, implementing LEGO Architecture Principle 3: "Bricks don't know about each other."

### What changed

- **Cross-brick detection in `check_brick_imports.py`**: Extended the fast regex pre-commit/CI check to detect `bricks/<X>/` importing from `nexus.bricks.<Y>` (where Y != X). Dynamic brick-name extraction, allowlist for memory->search pending DI refactoring.
- **`ProtocolTransferRequest`/`ProtocolTransferResult` moved to `services/protocols/payment.py`**: These are protocol interface types that belong at the services tier per the 4-tier architecture. `bricks/pay/protocol.py` re-imports them for backward compatibility.
- **Governance->pay cross-brick import fixed**: `governance_wrapper.py` TYPE_CHECKING import now sources from `services/protocols/payment` instead of `bricks/pay/protocol`.
- **`import-linter` added with two contracts**:
  - `brick-independence`: Enforces zero cross-brick imports (14 bricks, 11 allowlisted known violations)
  - `four-tier-layers`: Enforces `tier-neutral < kernel < services < bricks` (94 ratchet baseline entries)
- **CI job added**: New `import-linter` job in `code-quality.yml` with import graph caching.
- **15 new tests**: `TestExtractBrickName` (4), `TestCrossBrickImports` (9), `TestCrossBrickMainIntegration` (2) — 44 total in test file.

### Files modified

| File | Change |
|---|---|
| `.pre-commit-hooks/check_brick_imports.py` | Cross-brick detection, allowlist, `extract_brick_name()` |
| `pyproject.toml` | `import-linter` dep + independence/layers contracts |
| `.github/workflows/code-quality.yml` | New `import-linter` CI job |
| `src/nexus/services/protocols/payment.py` | Receives `ProtocolTransferRequest`/`Result` types |
| `src/nexus/bricks/pay/protocol.py` | Re-imports types from services/protocols |
| `src/nexus/bricks/governance/governance_wrapper.py` | Fix TYPE_CHECKING import source |
| `tests/unit/scripts/test_check_brick_imports.py` | 15 new cross-brick tests |

### LEGO Architecture Alignment

- Protocol interface types (`ProtocolTransferRequest`, `ProtocolTransferResult`) now live at the correct tier (`services/protocols/`)
- Cross-brick governance->pay dependency eliminated
- Type identity preserved across all import paths (verified at runtime)
- `import-linter` contracts enforce the full 4-tier model with ratchet baselines

## Test plan

- [x] `check_brick_imports.py` passes (exit 0, memory->search allowlisted)
- [x] `lint-imports` — both contracts KEPT (independence + layers)
- [x] 84/84 unit tests pass (44 brick import + 27 pay + 13 governance)
- [x] 23/23 NexusPay e2e tests pass
- [x] Runtime type identity verified (all 3 import paths -> same class)
- [x] No circular imports
- [x] ruff check + format clean
- [x] mypy clean on changed files
- [x] All pre-commit hooks pass
- [x] `lint-imports` performance: 0.5s total (68ms graph build)