### PR TITLE
fix(#2194): kernel-mode list/glob/grep crash — always create SearchService

### DIFF
--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -222,27 +222,28 @@ def _boot_wired_services(
         except Exception:
             pass  # Optional, may not be importable
 
-    # --- SearchService: Search operations ---
+    # --- SearchService: list/glob/grep are kernel-level VFS operations (Issue #2194) ---
+    # Always create SearchService regardless of "search" brick — basic directory
+    # listing, glob matching, and grep must work even in KERNEL-only mode.
+    # The "search" brick gates advanced features (semantic search, indexing),
+    # not core filesystem enumeration.
     search_service: Any = None
-    if _on("search"):
-        try:
-            from nexus.services.search.search_service import SearchService
+    try:
+        from nexus.services.search.search_service import SearchService
 
-            search_service = SearchService(
-                metadata_store=nx.metadata,
-                permission_enforcer=getattr(nx, "_permission_enforcer", None),
-                router=kernel_services.router,
-                rebac_manager=system_services.rebac_manager,
-                enforce_permissions=getattr(nx, "_enforce_permissions", True),
-                default_context=getattr(nx, "_default_context", None),
-                record_store=getattr(nx, "_record_store", None),
-                gateway=gateway,
-            )
-            logger.debug("[BOOT:WIRED] SearchService created")
-        except Exception as exc:
-            logger.debug("[BOOT:WIRED] SearchService unavailable: %s", exc)
-    else:
-        logger.debug("[BOOT:WIRED] SearchService disabled by profile")
+        search_service = SearchService(
+            metadata_store=nx.metadata,
+            permission_enforcer=getattr(nx, "_permission_enforcer", None),
+            router=kernel_services.router,
+            rebac_manager=system_services.rebac_manager,
+            enforce_permissions=getattr(nx, "_enforce_permissions", True),
+            default_context=getattr(nx, "_default_context", None),
+            record_store=getattr(nx, "_record_store", None),
+            gateway=gateway,
+        )
+        logger.debug("[BOOT:WIRED] SearchService created (kernel-level)")
+    except Exception as exc:
+        logger.debug("[BOOT:WIRED] SearchService unavailable: %s", exc)
 
     # --- ShareLinkService: Share link operations ---
     share_link_service: Any = None


### PR DESCRIPTION
## Summary

- **Always create `SearchService`** in `_boot_wired_services()` regardless of the "search" brick being enabled
- `list()`, `glob()`, and `grep()` are **kernel-level VFS operations** that must work in all profiles including KERNEL-only mode
- Previously, `SearchService` creation was gated on `_on("search")`, causing `AttributeError: 'NoneType' object has no attribute 'list'` when calling `nx.list()` in kernel mode
- The "search" brick should only gate advanced features (semantic search, indexing), not core filesystem enumeration

## Root Cause

In the factory boot path (`_boot_wired_services`), `SearchService` was only created when the "search" brick was enabled. In KERNEL profile, only "storage" is enabled, so `search_service` remained `None`. The factory then called `_bind_wired_services()` which overwrote the `SearchService` that `_wire_services()` had already created in `NexusFS.__init__`.

## Stream 14

## Test plan

- [x] All 39 kernel boot mode unit tests pass
- [x] All 126 kernel/factory/profile tests pass (zero regressions)
- [x] E2E kernel-mode boot test: write/read/exists/list/glob/delete all pass
- [x] Ruff, ruff format, mypy, pre-commit hooks all pass
- [x] 2000 core unit tests pass (failures are pre-existing Rust/zone tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)