### PR TITLE
refactor(#2134): move factory flat params into BrickServices container

### DIFF
--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -317,6 +317,13 @@ class BrickServices:
     memory_router: Any = None  # MemoryViewRouter singleton
     memory_permission: Any = None  # MemoryPermissionProtocol adapter
 
+    # --- Factory-created bricks (Issue #2134: moved from NexusFS flat params) ---
+    parse_fn: Any = None  # Callable for parsing files (ParsersBrick)
+    content_cache: Any = None  # ContentCache instance
+    parser_registry: Any = None  # ParserRegistry (file format detection)
+    provider_registry: Any = None  # ProviderRegistry (parsing providers)
+    vfs_lock_manager: Any = None  # VFS lock manager (fine-grained file locks)
+
 
 # ---------------------------------------------------------------------------
 # Observability (unchanged from before)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -36,10 +36,6 @@ from nexus.core.metastore import MetastoreABC
 from nexus.core.nexus_fs_core import NexusFSCoreMixin
 from nexus.core.router import NamespaceConfig, PathRouter
 from nexus.lib.rpc_decorator import rpc_expose
-
-if TYPE_CHECKING:
-    from nexus.parsers.registry import ParserRegistry
-
 from nexus.storage.record_store import RecordStoreABC
 
 logger = logging.getLogger(__name__)
@@ -82,11 +78,6 @@ class NexusFS(  # type: ignore[misc]
         kernel_services: KernelServices | None = None,
         system_services: SystemServices | None = None,
         brick_services: BrickServices | None = None,
-        parse_fn: Any | None = None,
-        content_cache: Any | None = None,
-        parser_registry: ParserRegistry | None = None,
-        provider_registry: Any | None = None,
-        vfs_lock_manager: Any | None = None,
     ):
         """Initialize NexusFS kernel."""
         # Config defaults
@@ -120,9 +111,9 @@ class NexusFS(  # type: ignore[misc]
         self.auto_parse = parsing.auto_parse
         self.is_admin = is_admin
 
-        # Content cache
-        if content_cache is not None:
-            backend.content_cache = content_cache
+        # Content cache (Issue #2134: from BrickServices)
+        if brk_svc.content_cache is not None:
+            backend.content_cache = brk_svc.content_cache
 
         # Four pillars: backend, metadata, record store, cache store
         self.backend = backend
@@ -151,24 +142,24 @@ class NexusFS(  # type: ignore[misc]
                     self.router.register_namespace(ns_config)
         self.router.add_mount("/", self.backend, priority=0)
 
-        # Parser registries (injected by ParsersBrick, fallback for tests)
-        if parser_registry is not None:
-            self.parser_registry = parser_registry
+        # Parser registries (Issue #2134: from BrickServices, fallback for tests)
+        if brk_svc.parser_registry is not None:
+            self.parser_registry = brk_svc.parser_registry
         else:
             from nexus.parsers.markitdown_parser import MarkItDownParser as _MkD
             from nexus.parsers.registry import ParserRegistry as _PR
 
             self.parser_registry = _PR()
             self.parser_registry.register(_MkD())
-        if provider_registry is not None:
-            self.provider_registry = provider_registry
+        if brk_svc.provider_registry is not None:
+            self.provider_registry = brk_svc.provider_registry
         else:
             from nexus.parsers.providers.registry import ProviderRegistry as _PvR
 
             self.provider_registry = _PvR()
             self.provider_registry.auto_discover()
 
-        self._virtual_view_parse_fn = parse_fn
+        self._virtual_view_parse_fn = brk_svc.parse_fn
         self._parser_threads: list[threading.Thread] = []
         self._parser_threads_lock = threading.Lock()
 
@@ -239,9 +230,9 @@ class NexusFS(  # type: ignore[misc]
         self._coordination_client: Any = None
         self._event_client: Any = None
 
-        # VFS lock manager
-        if vfs_lock_manager is not None:
-            self._vfs_lock_manager = vfs_lock_manager
+        # VFS lock manager (Issue #2134: from BrickServices)
+        if brk_svc.vfs_lock_manager is not None:
+            self._vfs_lock_manager = brk_svc.vfs_lock_manager
         else:
             from nexus.core.lock_fast import create_vfs_lock_manager
 

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -227,34 +227,6 @@ def create_nexus_services(
     return kernel_services, system_services, brick_services
 
 
-def _create_provider_registry(parsing: Any) -> Any:
-    """Create ProviderRegistry with auto-discovered providers (Issue #657)."""
-    from nexus.parsers.providers import ProviderRegistry
-    from nexus.parsers.providers.base import ProviderConfig
-
-    registry = ProviderRegistry()
-    if parsing is None:
-        registry.auto_discover()
-        return registry
-    parse_providers = [dict(p) for p in parsing.providers] if parsing.providers else None
-    if parse_providers:
-        configs = [
-            ProviderConfig(
-                name=p.get("name", "unknown"),
-                enabled=p.get("enabled", True),
-                priority=p.get("priority", 50),
-                api_key=p.get("api_key"),
-                api_url=p.get("api_url"),
-                supported_formats=p.get("supported_formats"),
-            )
-            for p in parse_providers
-        ]
-        registry.auto_discover(configs)
-    else:
-        registry.auto_discover()
-    return registry
-
-
 def create_nexus_fs(
     backend: Backend,
     metadata_store: MetastoreABC,
@@ -376,10 +348,6 @@ def create_nexus_fs(
 
     from dataclasses import replace as _dc_replace
 
-    # Inject workflow_engine override if provided directly (frozen — use replace)
-    if workflow_engine is not None:
-        brick_services = _dc_replace(brick_services, workflow_engine=workflow_engine)
-
     # Create ParsersBrick — owns both registries (Issue #1523)
     from nexus.parsers.brick import ParsersBrick
 
@@ -393,7 +361,6 @@ def create_nexus_fs(
         cache_store=cache_store,
         record_store=record_store,
     )
-    brick_services = _dc_replace(brick_services, cache_brick=_cache_brick)
 
     # Create content cache (Issue #657)
     _content_cache = None
@@ -413,6 +380,19 @@ def create_nexus_fs(
 
     _vfs_lock_manager = create_vfs_lock_manager()
 
+    # Pack factory-created bricks into BrickServices container (Issue #2134)
+    _brick_updates: dict[str, Any] = {
+        "cache_brick": _cache_brick,
+        "parse_fn": _parse_fn,
+        "content_cache": _content_cache,
+        "parser_registry": parsers_brick.parser_registry,
+        "provider_registry": parsers_brick.provider_registry,
+        "vfs_lock_manager": _vfs_lock_manager,
+    }
+    if workflow_engine is not None:
+        _brick_updates["workflow_engine"] = workflow_engine
+    brick_services = _dc_replace(brick_services, **_brick_updates)
+
     nx = NexusFS(
         backend=backend,
         metadata_store=metadata_store,
@@ -428,11 +408,6 @@ def create_nexus_fs(
         kernel_services=kernel_services,
         system_services=system_services,
         brick_services=brick_services,
-        parse_fn=_parse_fn,
-        content_cache=_content_cache,
-        parser_registry=parsers_brick.parser_registry,
-        provider_registry=parsers_brick.provider_registry,
-        vfs_lock_manager=_vfs_lock_manager,
     )
 
     # --- Phase 2: Wire services needing NexusFS reference (Issue #643) ---

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -33,6 +33,7 @@ from nexus.factory import (
     _boot_kernel_services,
     _boot_system_services,
     _BootContext,
+    create_nexus_fs,
     create_nexus_services,
 )
 
@@ -415,3 +416,97 @@ class TestCreateNexusServices:
 
         # Issue #2034: version_service moved to brick tier
         assert brick.version_service is not None
+
+
+class TestBrickServicesFieldCompleteness:
+    """Issue #2134: Factory-created bricks are packed into BrickServices container."""
+
+    def test_create_nexus_fs_packs_factory_bricks_into_brick_services(self) -> None:
+        """create_nexus_fs() packs parse_fn, content_cache, registries, lock manager
+        into BrickServices rather than passing as flat NexusFS params (Issue #2134).
+        """
+        record_store = MagicMock()
+        record_store.engine = MagicMock()
+        record_store.read_engine = MagicMock()
+        record_store.session_factory = MagicMock()
+        record_store.has_read_replica = False
+        record_store.database_url = "sqlite://"
+        record_store.async_session_factory = MagicMock()
+
+        metadata_store = MagicMock()
+
+        backend = MagicMock()
+        backend.root_path = "/tmp/test"
+        backend.has_root_path = True
+        backend.on_write_callback = None
+        backend.on_sync_callback = None
+
+        nx = create_nexus_fs(
+            backend=backend,
+            metadata_store=metadata_store,
+            record_store=record_store,
+            permissions=PermissionConfig(
+                enforce=False,
+                enable_deferred=False,
+                enable_tiger_cache=False,
+            ),
+            distributed=DistributedConfig(
+                enable_events=False,
+                enable_locks=False,
+                enable_workflows=False,
+            ),
+            enable_write_buffer=False,
+        )
+
+        brk = nx._brick_services
+
+        # Issue #2134: These fields now live in BrickServices, not as flat params
+        assert brk.parse_fn is not None, "parse_fn should be packed into BrickServices"
+        assert brk.parser_registry is not None, "parser_registry should be in BrickServices"
+        assert brk.provider_registry is not None, "provider_registry should be in BrickServices"
+        assert brk.vfs_lock_manager is not None, "vfs_lock_manager should be in BrickServices"
+        # backend.has_root_path=True + CacheConfig.enable_content_cache=True (default)
+        assert brk.content_cache is not None, (
+            "content_cache should be non-None when backend.has_root_path=True "
+            "and CacheConfig.enable_content_cache=True (defaults)"
+        )
+
+    def test_create_nexus_fs_workflow_engine_override_in_brick_services(self) -> None:
+        """workflow_engine param is packed into BrickServices (Issue #2134)."""
+        record_store = MagicMock()
+        record_store.engine = MagicMock()
+        record_store.read_engine = MagicMock()
+        record_store.session_factory = MagicMock()
+        record_store.has_read_replica = False
+        record_store.database_url = "sqlite://"
+        record_store.async_session_factory = MagicMock()
+
+        metadata_store = MagicMock()
+
+        backend = MagicMock()
+        backend.root_path = "/tmp/test"
+        backend.has_root_path = True
+        backend.on_write_callback = None
+        backend.on_sync_callback = None
+
+        sentinel_engine = MagicMock()
+
+        nx = create_nexus_fs(
+            backend=backend,
+            metadata_store=metadata_store,
+            record_store=record_store,
+            permissions=PermissionConfig(
+                enforce=False,
+                enable_deferred=False,
+                enable_tiger_cache=False,
+            ),
+            distributed=DistributedConfig(
+                enable_events=False,
+                enable_locks=False,
+                enable_workflows=False,
+            ),
+            enable_write_buffer=False,
+            workflow_engine=sentinel_engine,
+        )
+
+        assert nx._brick_services.workflow_engine is sentinel_engine

--- a/tests/unit/core/test_kernel_config.py
+++ b/tests/unit/core/test_kernel_config.py
@@ -419,6 +419,12 @@ class TestBrickServices:
             "version_service",
             "memory_router",
             "memory_permission",
+            # Factory-created bricks (Issue #2134)
+            "parse_fn",
+            "content_cache",
+            "parser_registry",
+            "provider_registry",
+            "vfs_lock_manager",
         }
         assert field_names == expected_fields, (
             f"Extra: {field_names - expected_fields}, Missing: {expected_fields - field_names}"


### PR DESCRIPTION
## Summary

- **Issue**: #2134 — Deprecate factory.py legacy flat parameters
- **Stream**: Stream 2 (Architecture Refactoring)
- **LEGO Architecture Alignment**: §2 Four-Tier Architecture, §5.6 factory.py as Composition Root

Moves 5 bypass parameters (`parse_fn`, `content_cache`, `parser_registry`, `provider_registry`, `vfs_lock_manager`) from `NexusFS.__init__` flat kwargs into the `BrickServices` frozen dataclass container. This enforces the 4-tier boundary: the kernel (`NexusFS`) now receives brick dependencies exclusively through the `BrickServices` container, not via flat constructor params that bypass the tier contract.

### Changes

- **`src/nexus/core/config.py`** (+7): Add 5 fields to `BrickServices` dataclass
- **`src/nexus/factory/orchestrator.py`** (-51/+51): Pack all brick params into `BrickServices` via single `dataclasses.replace()` call; consolidate `workflow_engine` override; delete dead `_create_provider_registry()` (26 LOC)
- **`src/nexus/core/nexus_fs.py`** (-33/+33): Remove 5 flat params from `__init__` signature; read from `self._brick_services`; remove unused `ParserRegistry` TYPE_CHECKING import
- **`tests/unit/core/test_factory_boot.py`** (+95): Add `TestBrickServicesFieldCompleteness` — 2 tests verifying container wiring
- **`tests/unit/core/test_kernel_config.py`** (+6): Update field enumeration test

### LEGO Architecture Compliance

Per NEXUS-LEGO-ARCHITECTURE.md §2:
- **Tier 0 KERNEL** receives only `KernelServices` (Storage Pillars)
- **Tier 1 SYSTEM** receives `SystemServices`
- **Tier 2 BRICK** receives `BrickServices` ← flat params now consolidated here

Before: `NexusFS(parse_fn=..., content_cache=..., parser_registry=..., ...)` bypassed the tier boundary.
After: `NexusFS(brick_services=BrickServices(parse_fn=..., content_cache=..., ...))` — clean 4-tier contract.

### Verification

- 89/89 factory+config unit tests pass
- 15/15 self-contained e2e tests pass
- 50/53 server e2e tests pass (3 pre-existing: OAuth config, feedback)
- Boot benchmark: no regression (~4.2ms full boot)
- Pre-commit: ruff ✓, ruff-format ✓, mypy ✓, brick-zero-core-imports ✓

## Test plan

- [x] `uv run ruff check` — all clean
- [x] `uv run ruff format --check` — all formatted
- [x] `uv run mypy` — no issues
- [x] Unit tests: `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py tests/unit/core/test_kernel_config.py` — 89 passed
- [x] E2E tests: `pytest tests/e2e/server/test_api_v2_e2e.py tests/e2e/self_contained/` — passed
- [x] Boot benchmark: no regression
- [ ] CI pipeline green