### PR TITLE
ci: block merge commits in PR branches

### DIFF
--- a/.github/workflows/no-merge-commits.yml
+++ b/.github/workflows/no-merge-commits.yml
@@ -1,0 +1,57 @@
+name: No Merge Commits
+
+on:
+  pull_request:
+    branches: [main, develop]
+  merge_group:
+
+jobs:
+  check:
+    name: Block Merge Commits in PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject merge commits in PR branch
+        run: |
+          # Get the merge base between PR branch and target
+          BASE_SHA=${{ github.event.pull_request.base.sha || github.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+
+          # For merge_group events, skip (queue handles rebase)
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "✅ Merge queue event — skipping merge commit check"
+            exit 0
+          fi
+
+          echo "Checking commits between $BASE_SHA and $HEAD_SHA for merge commits..."
+
+          # Find any merge commits (commits with 2+ parents) in the PR
+          MERGE_COMMITS=$(git rev-list --merges "$BASE_SHA".."$HEAD_SHA" 2>/dev/null || true)
+
+          if [ -n "$MERGE_COMMITS" ]; then
+            echo ""
+            echo "❌ ERROR: PR branch contains merge commit(s)!"
+            echo ""
+            echo "Found merge commits:"
+            for mc in $MERGE_COMMITS; do
+              echo "  - $(git log --format='%h %s' -1 $mc)"
+            done
+            echo ""
+            echo "This is forbidden because merging the target branch into your"
+            echo "feature branch can silently revert other people's changes."
+            echo ""
+            echo "Fix: rebase your branch instead of merging:"
+            echo "  git rebase origin/develop"
+            echo ""
+            echo "If your branch has merge commits from 'git merge develop',"
+            echo "you can clean them up with:"
+            echo "  git rebase -i origin/develop"
+            echo ""
+            exit 1
+          fi
+
+          echo "✅ No merge commits found in PR branch"


### PR DESCRIPTION
## Summary
- Adds a CI check that rejects PRs containing merge commits (2+ parents)
- Prevents `git merge develop` on feature branches, which can silently revert changes via criss-cross merge
- Added as required status check on both `develop` and `main` rulesets

## Why
During our massive refactor, we discovered that merge commits in feature branches can cause silent file reverts that are extremely hard to detect. This CI check enforces rebase-only workflow.

## Test plan
- [x] PR with clean rebase history → check passes
- [x] PR with `git merge develop` in branch → check fails with clear error message
- [x] merge_group events (queue) → check skipped (queue handles rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)