### PR TITLE
refactor(#2135): replace lifespan getattr() reflection with LifespanServices container

### DIFF
--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -5,7 +5,7 @@ domain-specific initializers during startup and shuts them down in reverse
 order during shutdown.
 
 Each initializer function:
-- Accepts ``app: FastAPI`` (reads/writes ``app.state``)
+- Accepts ``app: FastAPI`` and ``svc: LifespanServices``
 - Returns a list of ``asyncio.Task`` references that must be cancelled on shutdown
 """
 
@@ -17,13 +17,15 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING
 
+from nexus.server.lifespan.services_container import LifespanServices
+
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
 logger = logging.getLogger(__name__)
 
 
-def _compute_features_info(app: FastAPI) -> None:
+def _compute_features_info(app: FastAPI, svc: LifespanServices) -> None:
     """Compute and store features_info on app.state (Issue #1389).
 
     Called once at startup. The result is immutable and served by
@@ -32,21 +34,18 @@ def _compute_features_info(app: FastAPI) -> None:
     from nexus.contracts.deployment_profile import ALL_BRICK_NAMES, DeploymentProfile
     from nexus.server.api.core.features import FeaturesResponse, PerformanceTuningInfo
 
-    # Read profile from app state (set during server init).
-    # Use getattr() for resilience — e2e tests may create apps without init_app_state().
-    profile_str: str = getattr(app.state, "deployment_profile", "full")
+    # Read profile from svc (set during server init).
+    profile_str: str = svc.deployment_profile
     try:
         profile = DeploymentProfile(profile_str)
     except ValueError:
         logger.warning("Unknown deployment profile '%s', defaulting to 'full'", profile_str)
         profile = DeploymentProfile.FULL
 
-    # Read enabled_bricks from app state (set during factory wiring)
-    enabled: frozenset[str] = (
-        getattr(app.state, "enabled_bricks", frozenset()) or profile.default_bricks()
-    )
+    # Read enabled_bricks from svc (set during factory wiring)
+    enabled: frozenset[str] = svc.enabled_bricks or profile.default_bricks()
 
-    mode: str = getattr(app.state, "deployment_mode", "standalone")
+    mode: str = svc.deployment_mode
 
     # Get version
     version: str | None = None
@@ -60,7 +59,7 @@ def _compute_features_info(app: FastAPI) -> None:
     disabled = sorted(ALL_BRICK_NAMES - enabled)
 
     # Issue #2071: include performance tuning summary
-    _pt = getattr(app.state, "profile_tuning", None)
+    _pt = svc.profile_tuning
     _perf_info = None
     if _pt is not None:
         _perf_info = PerformanceTuningInfo(
@@ -95,16 +94,16 @@ def _compute_features_info(app: FastAPI) -> None:
     )
 
 
-def _wire_query_observer(app: FastAPI) -> None:
+def _wire_query_observer(_app: FastAPI, svc: LifespanServices) -> None:
     """Register QueryObserverComponent into the observability registry.
 
     Called after startup_services so observability_subsystem is available.
     """
-    registry = app.state.observability_registry
+    registry = svc.observability_registry
     if registry is None:
         return
 
-    obs_subsystem = app.state.observability_subsystem
+    obs_subsystem = svc.observability_subsystem
     if obs_subsystem is None:
         return
 
@@ -140,8 +139,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Collect all background tasks for clean shutdown
     bg_tasks: list[asyncio.Task] = []
 
+    # Extract typed service container once
+    svc = LifespanServices.from_app(app)
+
     # Issue #2168: startup tracker for health probes
-    from nexus.server.health import StartupPhase
+    from nexus.server.health.startup_tracker import StartupPhase
 
     tracker = getattr(app.state, "startup_tracker", None)
 
@@ -151,38 +153,40 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # --- Startup (order matters: observability first, then core, then services) ---
 
-    await startup_observability(app)
+    await startup_observability(app, svc)
+    # Re-extract observability_registry after startup_observability writes it
+    svc.observability_registry = getattr(app.state, "observability_registry", None)
     _done(StartupPhase.OBSERVABILITY)
 
-    _compute_features_info(app)
+    _compute_features_info(app, svc)
     _done(StartupPhase.FEATURES)
 
-    bg_tasks.extend(await startup_permissions(app))
+    bg_tasks.extend(await startup_permissions(app, svc))
     _done(StartupPhase.PERMISSIONS)
 
-    bg_tasks.extend(await startup_realtime(app))
+    bg_tasks.extend(await startup_realtime(app, svc))
     _done(StartupPhase.REALTIME)
 
-    bg_tasks.extend(await startup_search(app))
+    bg_tasks.extend(await startup_search(app, svc))
     _done(StartupPhase.SEARCH)
 
-    bg_tasks.extend(await startup_services(app))
+    bg_tasks.extend(await startup_services(app, svc))
     _done(StartupPhase.SERVICES)
 
-    bg_tasks.extend(await startup_bricks(app))
+    bg_tasks.extend(await startup_bricks(app, svc))
     _done(StartupPhase.BRICKS)
 
-    bg_tasks.extend(await startup_uploads(app))
+    bg_tasks.extend(await startup_uploads(app, svc))
     _done(StartupPhase.UPLOADS)
 
-    bg_tasks.extend(await startup_ipc(app))
+    bg_tasks.extend(await startup_ipc(app, svc))
     _done(StartupPhase.IPC)
 
-    bg_tasks.extend(await startup_a2a_grpc(app))
+    bg_tasks.extend(await startup_a2a_grpc(app, svc))
     _done(StartupPhase.A2A_GRPC)
 
     # Wire QueryObserverComponent into registry after services start (Issue #2072)
-    _wire_query_observer(app)
+    _wire_query_observer(app, svc)
 
     yield
 
@@ -198,11 +202,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             await asyncio.gather(*[t for t in bg_tasks if t], return_exceptions=True)
         logger.debug("Cancelled %d background tasks", len(bg_tasks))
 
-    await shutdown_a2a_grpc(app)
-    await shutdown_ipc(app)
-    await shutdown_bricks(app)
-    await shutdown_services(app)
-    await shutdown_realtime(app)
+    await shutdown_a2a_grpc(app, svc)
+    await shutdown_ipc(app, svc)
+    await shutdown_bricks(app, svc)
+    await shutdown_services(app, svc)
+    await shutdown_realtime(app, svc)
 
     # Close NexusFS kernel
     # (WriteBuffer shutdown is now handled by ObservabilityRegistry via WriteBufferComponent)
@@ -217,4 +221,4 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         except Exception as e:
             logger.warning("Error shutting down CacheBrick: %s", e, exc_info=True)
 
-    await shutdown_observability(app)
+    await shutdown_observability(app, svc)

--- a/src/nexus/server/lifespan/a2a_grpc.py
+++ b/src/nexus/server/lifespan/a2a_grpc.py
@@ -15,16 +15,18 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
-async def startup_a2a_grpc(app: FastAPI) -> list[asyncio.Task]:
+async def startup_a2a_grpc(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Start the A2A gRPC server if configured."""
     port = int(os.environ.get("NEXUS_A2A_GRPC_PORT", "0"))
     if not port:
         return []
 
-    task_manager = app.state.a2a_task_manager
+    task_manager = svc.a2a_task_manager
     if task_manager is None:
         logger.warning("A2A gRPC disabled: no task manager on app.state")
         return []
@@ -38,7 +40,7 @@ async def startup_a2a_grpc(app: FastAPI) -> list[asyncio.Task]:
     return []
 
 
-async def shutdown_a2a_grpc(app: FastAPI) -> None:
+async def shutdown_a2a_grpc(app: FastAPI, _svc: LifespanServices) -> None:
     """Stop the A2A gRPC server if running."""
     server = app.state.a2a_grpc_server
     if server is not None:

--- a/src/nexus/server/lifespan/bricks.py
+++ b/src/nexus/server/lifespan/bricks.py
@@ -15,15 +15,17 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
-async def startup_bricks(app: FastAPI) -> list[asyncio.Task[None]]:
+async def startup_bricks(_app: FastAPI, svc: LifespanServices) -> list[asyncio.Task[None]]:
     """Mount all registered bricks via BrickLifecycleManager."""
-    if app.state.nexus_fs is None:
+    if svc.nexus_fs is None:
         return []
 
-    manager = app.state.brick_lifecycle_manager
+    manager = svc.brick_lifecycle_manager
     if manager is None:
         return []
 
@@ -42,7 +44,7 @@ async def startup_bricks(app: FastAPI) -> list[asyncio.Task[None]]:
         logger.error("[LIFECYCLE] mount_all failed: %s", exc)
 
     # Start brick reconciler (Issue #2060)
-    reconciler = app.state.brick_reconciler
+    reconciler = svc.brick_reconciler
     if reconciler is not None:
         try:
             await reconciler.start()
@@ -52,17 +54,17 @@ async def startup_bricks(app: FastAPI) -> list[asyncio.Task[None]]:
     return []
 
 
-async def shutdown_bricks(app: FastAPI) -> None:
+async def shutdown_bricks(_app: FastAPI, svc: LifespanServices) -> None:
     """Unmount all active bricks in reverse-DAG order."""
-    if app.state.nexus_fs is None:
+    if svc.nexus_fs is None:
         return
 
-    manager = app.state.brick_lifecycle_manager
+    manager = svc.brick_lifecycle_manager
     if manager is None:
         return
 
     # Stop brick reconciler before unmounting (Issue #2060)
-    reconciler = app.state.brick_reconciler
+    reconciler = svc.brick_reconciler
     if reconciler is not None:
         try:
             await reconciler.stop()

--- a/src/nexus/server/lifespan/ipc.py
+++ b/src/nexus/server/lifespan/ipc.py
@@ -14,24 +14,26 @@ from nexus.constants import ROOT_ZONE_ID
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
-async def startup_ipc(app: FastAPI) -> list[asyncio.Task]:
+async def startup_ipc(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Start IPC background tasks (TTLSweeper).
 
     Reads ``ipc_storage_driver`` and ``ipc_provisioner`` from
-    ``app.state.brick_services`` and exposes them on ``app.state``
+    ``svc.brick_services`` and exposes them on ``app.state``
     for the IPC REST router.
 
     Returns list of background tasks to cancel on shutdown.
     """
     bg_tasks: list[asyncio.Task] = []
 
-    if app.state.nexus_fs is None:
+    if svc.nexus_fs is None:
         return bg_tasks
 
-    brk = app.state.brick_services
+    brk = svc.brick_services
     if brk is None:
         return bg_tasks
 
@@ -46,7 +48,7 @@ async def startup_ipc(app: FastAPI) -> list[asyncio.Task]:
     app.state.ipc_storage_driver = ipc_storage
     app.state.ipc_provisioner = ipc_provisioner
 
-    zone_id = getattr(app.state, "zone_id", None) or ROOT_ZONE_ID
+    zone_id = svc.zone_id or ROOT_ZONE_ID
 
     # Start TTLSweeper background task
     try:
@@ -67,7 +69,7 @@ async def startup_ipc(app: FastAPI) -> list[asyncio.Task]:
     return bg_tasks
 
 
-async def shutdown_ipc(app: FastAPI) -> None:
+async def shutdown_ipc(app: FastAPI, svc: LifespanServices) -> None:
     """Stop IPC background tasks."""
     sweeper = app.state.ipc_sweeper
     if sweeper is not None and hasattr(sweeper, "stop"):
@@ -78,7 +80,7 @@ async def shutdown_ipc(app: FastAPI) -> None:
             logger.warning("[IPC] Error stopping TTLSweeper: %s", exc)
 
     # Close IPCVFSDriver's background event loop
-    brk = app.state.brick_services
+    brk = svc.brick_services
     vfs_driver = getattr(brk, "ipc_vfs_driver", None) if brk else None
     if vfs_driver is not None and hasattr(vfs_driver, "close"):
         try:

--- a/src/nexus/server/lifespan/observability.py
+++ b/src/nexus/server/lifespan/observability.py
@@ -15,6 +15,8 @@ from nexus.server.observability.registry import ObservabilityRegistry
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
@@ -126,9 +128,9 @@ def create_registry(*, write_observer: Any = None) -> ObservabilityRegistry:
     return registry
 
 
-async def startup_observability(app: FastAPI) -> None:
+async def startup_observability(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize all observability subsystems via the registry."""
-    write_observer = app.state.write_observer
+    write_observer = svc.write_observer
     registry = create_registry(write_observer=write_observer)
     statuses = await registry.start_all()
     app.state.observability_registry = registry
@@ -142,10 +144,10 @@ async def startup_observability(app: FastAPI) -> None:
         logger.info("Observability components skipped: %s", ", ".join(failed))
 
     logger.info("Starting FastAPI Nexus server...")
-    _startup_thread_pool(app)
+    _startup_thread_pool(svc)
 
 
-async def shutdown_observability(app: FastAPI) -> None:
+async def shutdown_observability(app: FastAPI, _svc: LifespanServices) -> None:
     """Shutdown all observability components via the registry."""
     registry = app.state.observability_registry
     if registry:
@@ -153,10 +155,10 @@ async def shutdown_observability(app: FastAPI) -> None:
         app.state.observability_registry = None
 
 
-def _startup_thread_pool(app: FastAPI) -> None:
+def _startup_thread_pool(svc: LifespanServices) -> None:
     """Configure thread pool size (Issue #932)."""
     from anyio import to_thread
 
     limiter = to_thread.current_default_thread_limiter()
-    limiter.total_tokens = app.state.thread_pool_size
+    limiter.total_tokens = svc.thread_pool_size
     logger.info("Thread pool size set to %d", limiter.total_tokens)

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -13,10 +13,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
-async def startup_permissions(app: FastAPI) -> list[asyncio.Task]:
+async def startup_permissions(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Initialize permission infrastructure and return background tasks.
 
     Covers:
@@ -30,12 +32,12 @@ async def startup_permissions(app: FastAPI) -> list[asyncio.Task]:
     """
     bg_tasks: list[asyncio.Task] = []
 
-    await _startup_async_rebac(app)
-    await _startup_cache_brick(app)
-    bg_tasks.extend(_startup_tiger_cache(app))
-    bg_tasks.extend(_startup_backfill(app))
-    _startup_cache_warmup(app)
-    _startup_circuit_breaker(app)
+    await _startup_async_rebac(app, svc)
+    await _startup_cache_brick(app, svc)
+    bg_tasks.extend(_startup_tiger_cache(app, svc))
+    bg_tasks.extend(_startup_backfill(app, svc))
+    _startup_cache_warmup(app, svc)
+    _startup_circuit_breaker(app, svc)
 
     return bg_tasks
 
@@ -45,16 +47,16 @@ async def startup_permissions(app: FastAPI) -> list[asyncio.Task]:
 # ---------------------------------------------------------------------------
 
 
-async def _startup_async_rebac(app: FastAPI) -> None:
+async def _startup_async_rebac(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize async ReBAC manager and AsyncNexusFS."""
-    if not app.state.database_url:
+    if not svc.database_url:
         return
 
     try:
         from nexus.rebac.async_manager import AsyncReBACManager
 
         # Reuse the sync ReBACManager from NexusFS (avoids creating standalone engine)
-        sync_rebac = app.state.rebac_manager
+        sync_rebac = svc.rebac_manager
         if sync_rebac:
             app.state.async_rebac_manager = AsyncReBACManager(sync_rebac)
             logger.info("Async ReBAC manager initialized (wrapping sync manager)")
@@ -63,7 +65,7 @@ async def _startup_async_rebac(app: FastAPI) -> None:
             from nexus.rebac.manager import ReBACManager
             from nexus.storage.record_store import SQLAlchemyRecordStore
 
-            _store = SQLAlchemyRecordStore(db_url=app.state.database_url)
+            _store = SQLAlchemyRecordStore(db_url=svc.database_url)
             _sync_mgr = ReBACManager(engine=_store.engine)
             app.state.async_rebac_manager = AsyncReBACManager(_sync_mgr)
             logger.info("Async ReBAC manager initialized (fresh sync manager via RecordStore)")
@@ -84,14 +86,14 @@ async def _startup_async_rebac(app: FastAPI) -> None:
             # Issue #1239: Create namespace manager for per-subject visibility
             # Issue #1265: Factory function handles L3 persistent store wiring
             namespace_manager = None
-            if enforce_permissions and app.state.nexus_fs is not None:
-                sync_rebac = app.state.rebac_manager
+            if enforce_permissions and svc.nexus_fs is not None:
+                sync_rebac = svc.rebac_manager
                 if sync_rebac:
                     from nexus.rebac.namespace_factory import (
                         create_namespace_manager,
                     )
 
-                    ns_record_store = app.state.record_store
+                    ns_record_store = svc.record_store
                     namespace_manager = create_namespace_manager(
                         rebac_manager=sync_rebac,
                         record_store=ns_record_store,
@@ -119,7 +121,7 @@ async def _startup_async_rebac(app: FastAPI) -> None:
 
             app.state.async_nexus_fs = AsyncNexusFS(
                 backend_root=backend_root,
-                metadata_store=app.state.nexus_fs.metadata,
+                metadata_store=svc.nexus_fs.metadata,
                 tenant_id=tenant_id,
                 enforce_permissions=enforce_permissions,
                 permission_enforcer=permission_enforcer,
@@ -139,7 +141,7 @@ async def _startup_async_rebac(app: FastAPI) -> None:
         logger.warning("Failed to initialize async ReBAC manager: %s", e, exc_info=True)
 
 
-async def _startup_cache_brick(app: FastAPI) -> None:
+async def _startup_cache_brick(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize cache for Dragonfly/Redis or NullCacheStore fallback (Issue #1075, #1251, #1524).
 
     Prefers CacheBrick from BrickServices (injected by factory). Falls back to
@@ -149,7 +151,7 @@ async def _startup_cache_brick(app: FastAPI) -> None:
         # Prefer CacheBrick already in BrickServices (set by create_nexus_fs → lifespan)
         cache_brick = app.state.cache_brick
         if cache_brick is None:
-            brk = app.state.brick_services
+            brk = svc.brick_services
             cache_brick = getattr(brk, "cache_brick", None) if brk else None
 
         if cache_brick is None:
@@ -158,8 +160,8 @@ async def _startup_cache_brick(app: FastAPI) -> None:
             from nexus.bricks.cache.settings import CacheSettings
 
             cache_settings = CacheSettings.from_env()
-            record_store = app.state.record_store
-            cache_store = getattr(app.state.nexus_fs, "_cache_store", None)
+            record_store = svc.record_store
+            cache_store = getattr(svc.nexus_fs, "_cache_store", None)
             cache_brick = CacheBrick(
                 cache_store=cache_store,
                 settings=cache_settings,
@@ -172,7 +174,7 @@ async def _startup_cache_brick(app: FastAPI) -> None:
 
         # Wire up CacheStoreABC L2 cache to TigerCache (Issue #1106)
         if cache_brick.has_cache_store:
-            rebac = app.state.rebac_manager
+            rebac = svc.rebac_manager
             tiger_cache = getattr(rebac, "_tiger_cache", None) if rebac is not None else None
             if tiger_cache:
                 dragonfly_tiger = cache_brick.get_tiger_cache()
@@ -185,12 +187,12 @@ async def _startup_cache_brick(app: FastAPI) -> None:
         logger.warning("Failed to initialize cache: %s", e, exc_info=True)
 
 
-def _startup_tiger_cache(app: FastAPI) -> list[asyncio.Task]:
+def _startup_tiger_cache(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Start Tiger Cache worker, warm-up, and DirectoryGrantExpander."""
     bg_tasks: list[asyncio.Task] = []
 
     # Tiger Cache queue processor (Issue #935)
-    if app.state.nexus_fs and os.getenv("NEXUS_ENABLE_TIGER_WORKER", "false").lower() in (
+    if svc.nexus_fs and os.getenv("NEXUS_ENABLE_TIGER_WORKER", "false").lower() in (
         "true",
         "1",
         "yes",
@@ -198,7 +200,7 @@ def _startup_tiger_cache(app: FastAPI) -> list[asyncio.Task]:
         try:
             from nexus.server.background_tasks import tiger_cache_queue_task
 
-            _rebac_mgr = app.state.rebac_manager
+            _rebac_mgr = svc.rebac_manager
             if _rebac_mgr is not None:
                 task = asyncio.create_task(
                     tiger_cache_queue_task(_rebac_mgr, interval_seconds=60, batch_size=1)
@@ -213,9 +215,9 @@ def _startup_tiger_cache(app: FastAPI) -> list[asyncio.Task]:
         logger.debug("Tiger Cache queue processor disabled (write-through handles grants)")
 
     # Tiger Cache warm-up on startup (Issue #979)
-    if app.state.nexus_fs:
+    if svc.nexus_fs:
         try:
-            _rebac = app.state.rebac_manager
+            _rebac = svc.rebac_manager
             tiger_cache = getattr(_rebac, "_tiger_cache", None) if _rebac is not None else None
             if tiger_cache:
                 warm_limit = int(os.getenv("NEXUS_TIGER_CACHE_WARM_LIMIT", "500"))
@@ -242,7 +244,7 @@ def _startup_tiger_cache(app: FastAPI) -> list[asyncio.Task]:
                     expander = DirectoryGrantExpander(
                         engine=_rebac_engine,
                         tiger_cache=tiger_cache,
-                        metadata_store=app.state.nexus_fs.metadata,
+                        metadata_store=svc.nexus_fs.metadata,
                     )
                     app.state.directory_grant_expander = expander
 
@@ -260,13 +262,13 @@ def _startup_tiger_cache(app: FastAPI) -> list[asyncio.Task]:
     return bg_tasks
 
 
-def _startup_backfill(app: FastAPI) -> list[asyncio.Task]:
+def _startup_backfill(_app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Auto-backfill sparse directory index for system paths (Issue #perf19)."""
     bg_tasks: list[asyncio.Task] = []
 
-    if app.state.nexus_fs and hasattr(app.state.nexus_fs, "metadata"):
+    if svc.nexus_fs and hasattr(svc.nexus_fs, "metadata"):
         try:
-            _nexus_fs = app.state.nexus_fs  # Capture for closure
+            _nexus_fs = svc.nexus_fs  # Capture for closure
 
             async def _backfill_system_paths() -> None:
                 for prefix in ["/skills", "/sessions"]:
@@ -289,15 +291,15 @@ def _startup_backfill(app: FastAPI) -> list[asyncio.Task]:
     return bg_tasks
 
 
-def _startup_cache_warmup(app: FastAPI) -> None:
+def _startup_cache_warmup(_app: FastAPI, svc: LifespanServices) -> None:
     """File cache warmup on server startup (Issue #1076)."""
-    if not app.state.nexus_fs:
+    if not svc.nexus_fs:
         return
 
     try:
         warmup_max_files = int(os.getenv("NEXUS_CACHE_WARMUP_MAX_FILES", "1000"))
         warmup_depth = int(os.getenv("NEXUS_CACHE_WARMUP_DEPTH", "2"))
-        _nexus_fs_warmup = app.state.nexus_fs  # Capture for closure
+        _nexus_fs_warmup = svc.nexus_fs  # Capture for closure
 
         async def _warmup_file_cache() -> None:
             from nexus.server.cache_warmer import CacheWarmer, WarmupConfig
@@ -330,9 +332,9 @@ def _startup_cache_warmup(app: FastAPI) -> None:
         logger.debug("[WARMUP] Server startup warmup skipped: %s", e)
 
 
-def _startup_circuit_breaker(app: FastAPI) -> None:
+def _startup_circuit_breaker(app: FastAPI, svc: LifespanServices) -> None:
     """Wire circuit breaker and manifest resolver from factory (Issue #726, #2130)."""
-    if app.state.nexus_fs:
-        brk = app.state.brick_services
+    if svc.nexus_fs:
+        brk = svc.brick_services
         app.state.rebac_circuit_breaker = getattr(brk, "rebac_circuit_breaker", None)
         app.state.manifest_resolver = getattr(brk, "manifest_resolver", None) if brk else None

--- a/src/nexus/server/lifespan/realtime.py
+++ b/src/nexus/server/lifespan/realtime.py
@@ -14,10 +14,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
-async def startup_realtime(app: FastAPI) -> list[asyncio.Task]:
+async def startup_realtime(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Initialize realtime infrastructure and return background tasks.
 
     Covers:
@@ -30,27 +32,26 @@ async def startup_realtime(app: FastAPI) -> list[asyncio.Task]:
     """
     bg_tasks: list[asyncio.Task] = []
 
-    _startup_event_log(app)
-    await _startup_event_bus(app)
-    _startup_exporter_registry(app)
-    await _startup_websocket(app)
-    await _startup_writeback(app)
-    await _startup_lock_manager(app)
+    _startup_event_log(app, svc)
+    await _startup_event_bus(app, svc)
+    _startup_exporter_registry(app, svc)
+    await _startup_websocket(app, svc)
+    await _startup_writeback(app, svc)
+    await _startup_lock_manager(app, svc)
 
     return bg_tasks
 
 
-async def shutdown_realtime(app: FastAPI) -> None:
+async def shutdown_realtime(app: FastAPI, svc: LifespanServices) -> None:
     """Shutdown realtime infrastructure in reverse order."""
     # Disconnect Lock Manager coordination client (Issue #1186)
-    if app.state.nexus_fs and hasattr(app.state.nexus_fs, "_coordination_client"):
-        coord_client = app.state.nexus_fs._coordination_client
-        if coord_client is not None:
-            try:
-                await coord_client.disconnect()
-                logger.info("Lock manager coordination client disconnected")
-            except Exception as e:
-                logger.warning("Error disconnecting coordination client: %s", e, exc_info=True)
+    coord_client = svc.coordination_client
+    if svc.nexus_fs and coord_client is not None:
+        try:
+            await coord_client.disconnect()
+            logger.info("Lock manager coordination client disconnected")
+        except Exception as e:
+            logger.warning("Error disconnecting coordination client: %s", e, exc_info=True)
 
     # Shutdown WebSocket manager (Issue #1116)
     if app.state.websocket_manager:
@@ -69,7 +70,7 @@ async def shutdown_realtime(app: FastAPI) -> None:
             logger.warning("Error shutting down WriteBack service: %s", e, exc_info=True)
 
     # Stop event bus (Issue #1331)
-    _ebus = app.state.event_bus
+    _ebus = svc.event_bus
     if _ebus is not None:
         try:
             await _ebus.stop()
@@ -107,7 +108,7 @@ async def shutdown_realtime(app: FastAPI) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _startup_event_log(app: FastAPI) -> None:
+def _startup_event_log(app: FastAPI, _svc: LifespanServices) -> None:
     """Event Log WAL for durable event persistence (Issue #1397)."""
     app.state.event_log = None
     try:
@@ -129,12 +130,12 @@ def _startup_event_log(app: FastAPI) -> None:
         logger.warning("Failed to initialize event log: %s", e)
 
 
-async def _startup_event_bus(app: FastAPI) -> None:
+async def _startup_event_bus(app: FastAPI, svc: LifespanServices) -> None:
     """Start event bus and wire event log for WAL-first persistence (Issue #1397)."""
-    if not app.state.nexus_fs:
+    if not svc.nexus_fs:
         return
 
-    event_bus_ref = app.state.event_bus
+    event_bus_ref = svc.event_bus
     if event_bus_ref is None:
         return
 
@@ -155,7 +156,7 @@ async def _startup_event_bus(app: FastAPI) -> None:
             logger.warning("Failed to start event bus: %s", e)
 
     # Issue #1331: Store main event loop ref for cross-thread event publishing
-    app.state.nexus_fs._main_event_loop = asyncio.get_running_loop()
+    svc.nexus_fs._main_event_loop = asyncio.get_running_loop()
 
     # Wire event_log into EventBus for WAL-first durability (Issue #1397)
     if app.state.event_log is not None and hasattr(event_bus_ref, "set_event_log"):
@@ -163,12 +164,12 @@ async def _startup_event_bus(app: FastAPI) -> None:
         logger.info("Event log wired into EventBus (WAL-first before pub/sub)")
 
 
-async def _startup_websocket(app: FastAPI) -> None:
+async def _startup_websocket(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize WebSocket Manager for real-time events (Issue #1116)."""
     try:
         from nexus.server.websocket import WebSocketManager
 
-        event_bus = app.state.event_bus
+        event_bus = svc.event_bus
 
         app.state.websocket_manager = WebSocketManager(
             event_bus=event_bus,
@@ -180,10 +181,10 @@ async def _startup_websocket(app: FastAPI) -> None:
         logger.warning("Failed to start WebSocket manager: %s", e)
 
 
-async def _startup_writeback(app: FastAPI) -> None:
+async def _startup_writeback(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize WriteBack Service for bidirectional sync (Issue #1129/#1130)."""
     write_back_enabled = os.getenv("NEXUS_WRITE_BACK", "").lower() in ("true", "1", "yes")
-    if not (write_back_enabled and app.state.nexus_fs):
+    if not (write_back_enabled and svc.nexus_fs):
         return
 
     try:
@@ -194,7 +195,7 @@ async def _startup_writeback(app: FastAPI) -> None:
         from nexus.system_services.sync.sync_backlog_store import SyncBacklogStore
         from nexus.system_services.sync.write_back_service import WriteBackService
 
-        _nfs = app.state.nexus_fs
+        _nfs = svc.nexus_fs
         gw = NexusFSGateway(
             _nfs,
             hierarchy_manager=getattr(_nfs, "_hierarchy_manager", None),
@@ -209,7 +210,7 @@ async def _startup_writeback(app: FastAPI) -> None:
         conflict_log_store = ConflictLogStore(record_store=gw.record_store, is_postgresql=_is_pg)
         app.state.conflict_log_store = conflict_log_store
 
-        wb_event_bus = app.state.event_bus
+        wb_event_bus = svc.event_bus
         if wb_event_bus:
             backlog_store = SyncBacklogStore(record_store=gw.record_store, is_postgresql=_is_pg)
             change_log_store = ChangeLogStore(record_store=gw.record_store, is_postgresql=_is_pg)
@@ -241,12 +242,12 @@ async def _startup_writeback(app: FastAPI) -> None:
         logger.warning("Failed to start WriteBack service: %s", e)
 
 
-async def _startup_lock_manager(app: FastAPI) -> None:
+async def _startup_lock_manager(_app: FastAPI, svc: LifespanServices) -> None:
     """Connect Lock Manager coordination client (Issue #1186)."""
-    if not (app.state.nexus_fs and hasattr(app.state.nexus_fs, "_coordination_client")):
+    if not svc.nexus_fs:
         return
 
-    coord_client = app.state.nexus_fs._coordination_client
+    coord_client = svc.coordination_client
     if coord_client is not None:
         try:
             await coord_client.connect()
@@ -255,7 +256,7 @@ async def _startup_lock_manager(app: FastAPI) -> None:
             logger.warning("Failed to connect lock manager coordination client: %s", e)
 
 
-def _startup_exporter_registry(app: FastAPI) -> None:
+def _startup_exporter_registry(app: FastAPI, _svc: LifespanServices) -> None:
     """Initialize ExporterRegistry and configured exporters (Issue #1138)."""
     app.state.exporter_registry = None
 

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -14,10 +14,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
-async def startup_search(app: FastAPI) -> list[asyncio.Task]:
+async def startup_search(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Initialize search daemon and return background tasks."""
     search_daemon_enabled = os.getenv("NEXUS_SEARCH_DAEMON", "").lower() in (
         "true",
@@ -26,7 +28,7 @@ async def startup_search(app: FastAPI) -> list[asyncio.Task]:
     ) or (
         # Auto-enable if not explicitly disabled and database URL is set
         os.getenv("NEXUS_SEARCH_DAEMON", "").lower() not in ("false", "0", "no")
-        and app.state.database_url
+        and svc.database_url
     )
 
     if not search_daemon_enabled:
@@ -37,11 +39,11 @@ async def startup_search(app: FastAPI) -> list[asyncio.Task]:
         from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
 
         # Issue #2071: source max_indexing_concurrency from profile tuning
-        _search_tuning = app.state.profile_tuning
+        _search_tuning = svc.profile_tuning
         _max_indexing = _search_tuning.search.search_max_concurrency if _search_tuning else None
 
         _daemon_kwargs: dict = {
-            "database_url": app.state.database_url,
+            "database_url": svc.database_url,
             "bm25s_index_dir": os.getenv("NEXUS_BM25S_INDEX_DIR", ".nexus-data/bm25s"),
             "db_pool_min_size": int(os.getenv("NEXUS_SEARCH_POOL_MIN", "10")),
             "db_pool_max_size": int(os.getenv("NEXUS_SEARCH_POOL_MAX", "50")),
@@ -59,7 +61,7 @@ async def startup_search(app: FastAPI) -> list[asyncio.Task]:
         config = DaemonConfig(**_daemon_kwargs)
 
         # Inject async_session_factory from RecordStoreABC when available
-        _record_store = app.state.record_store
+        _record_store = svc.record_store
         _async_sf = None
         if _record_store is not None:
             with contextlib.suppress(Exception):
@@ -90,7 +92,7 @@ async def startup_search(app: FastAPI) -> list[asyncio.Task]:
         # Issue #1520: Set FileReaderProtocol for index refresh (replaces _nexus_fs)
         from nexus.factory import _NexusFSFileReader
 
-        app.state.search_daemon._file_reader = _NexusFSFileReader(app.state.nexus_fs)
+        app.state.search_daemon._file_reader = _NexusFSFileReader(svc.nexus_fs)
 
         # Issue #2036: Inject AdaptiveKProtocol (LEGO compliance)
         with contextlib.suppress(Exception):
@@ -99,7 +101,7 @@ async def startup_search(app: FastAPI) -> list[asyncio.Task]:
             app.state.search_daemon._adaptive_k_provider = ContextBuilder()
 
         # Issue #2036: Register with BrickLifecycleManager
-        _blm = app.state.brick_lifecycle_manager
+        _blm = svc.brick_lifecycle_manager
         if _blm is not None:
             with contextlib.suppress(Exception):
                 from nexus.bricks.search.lifecycle_adapter import (

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -14,10 +14,12 @@ from typing import TYPE_CHECKING, cast
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
-async def startup_services(app: FastAPI) -> list[asyncio.Task]:
+async def startup_services(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Initialize application services and return background tasks.
 
     Covers:
@@ -29,29 +31,29 @@ async def startup_services(app: FastAPI) -> list[asyncio.Task]:
     """
     bg_tasks: list[asyncio.Task] = []
 
-    _startup_agent_registry(app)
-    _startup_key_service(app)
-    _startup_reputation_delegation_from_bricks(app)
-    _startup_governance(app)
-    _startup_sandbox_auth(app)
-    _startup_transactional_snapshot(app)
-    _startup_rlm_service(app)
+    _startup_agent_registry(app, svc)
+    _startup_key_service(app, svc)
+    _startup_reputation_delegation_from_bricks(app, svc)
+    _startup_governance(app, svc)
+    _startup_sandbox_auth(app, svc)
+    _startup_transactional_snapshot(app, svc)
+    _startup_rlm_service(app, svc)
 
     # Agent background tasks depend on agent_registry
-    agent_tasks = _startup_agent_tasks(app)
+    agent_tasks = _startup_agent_tasks(app, svc)
     bg_tasks.extend(agent_tasks)
 
-    await _startup_scheduler(app)
-    task_runner_task = _startup_task_queue(app)
+    await _startup_scheduler(app, svc)
+    task_runner_task = _startup_task_queue(app, svc)
     if task_runner_task:
         bg_tasks.append(task_runner_task)
 
-    await _startup_workflow_engine(app)
+    await _startup_workflow_engine(app, svc)
 
     return bg_tasks
 
 
-async def shutdown_services(app: FastAPI) -> None:
+async def shutdown_services(app: FastAPI, svc: LifespanServices) -> None:
     """Shutdown services in reverse order."""
     # Issue #625: Stop workflow dispatch consumer
     wds = app.state.workflow_dispatch
@@ -143,8 +145,8 @@ async def shutdown_services(app: FastAPI) -> None:
             logger.warning("Error stopping DirectoryGrantExpander: %s", e, exc_info=True)
 
     # Cancel pending event tasks in NexusFS (Issue #913)
-    if app.state.nexus_fs and hasattr(app.state.nexus_fs, "_event_tasks"):
-        event_tasks = app.state.nexus_fs._event_tasks.copy()
+    if svc.nexus_fs and hasattr(svc.nexus_fs, "_event_tasks"):
+        event_tasks = svc.nexus_fs._event_tasks.copy()
         for task in event_tasks:
             task.cancel()
         if event_tasks:
@@ -158,23 +160,23 @@ async def shutdown_services(app: FastAPI) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _startup_agent_registry(app: FastAPI) -> None:
+def _startup_agent_registry(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize AgentRegistry for agent lifecycle tracking (Issue #1240)."""
-    if app.state.nexus_fs and getattr(app.state.nexus_fs, "SessionLocal", None):
+    if svc.nexus_fs and svc.session_factory:
         try:
             from nexus.services.agents.agent_registry import AgentRegistry
 
-            _bg = getattr(app.state.profile_tuning, "background_task", None)
+            _bg = getattr(svc.profile_tuning, "background_task", None)
             app.state.agent_registry = AgentRegistry(
-                record_store=app.state.record_store,
-                entity_registry=app.state.entity_registry,
+                record_store=svc.record_store,
+                entity_registry=svc.entity_registry,
                 flush_interval=_bg.heartbeat_flush_interval if _bg else 60,
             )
             # Inject into NexusFS for RPC methods
-            app.state.nexus_fs._agent_registry = app.state.agent_registry
+            svc.nexus_fs._agent_registry = app.state.agent_registry
 
             # Wire into sync PermissionEnforcer
-            perm_enforcer = app.state.permission_enforcer
+            perm_enforcer = svc.permission_enforcer
             if perm_enforcer is not None:
                 perm_enforcer.agent_registry = app.state.agent_registry
 
@@ -193,9 +195,9 @@ def _startup_agent_registry(app: FastAPI) -> None:
         app.state.async_agent_registry = None
 
 
-def _startup_key_service(app: FastAPI) -> None:
+def _startup_key_service(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize KeyService for agent identity (Issue #1355)."""
-    if app.state.nexus_fs and getattr(app.state.nexus_fs, "SessionLocal", None):
+    if svc.nexus_fs and svc.session_factory:
         try:
             from nexus.auth.oauth.crypto import OAuthCrypto
             from nexus.identity.crypto import IdentityCrypto
@@ -203,7 +205,7 @@ def _startup_key_service(app: FastAPI) -> None:
             from nexus.storage.models.identity import AgentKeyModel
 
             # Ensure agent_keys table exists
-            _nx_engine = getattr(app.state.nexus_fs, "_sql_engine", None)
+            _nx_engine = svc.sql_engine
             if _nx_engine is not None:
                 from sqlalchemy import Table
 
@@ -211,18 +213,18 @@ def _startup_key_service(app: FastAPI) -> None:
 
             # Reuse OAuthCrypto for Fernet encryption of private keys
             _enc_key = os.environ.get("NEXUS_OAUTH_ENCRYPTION_KEY", "").strip() or None
-            _identity_record_store = app.state.record_store
+            _identity_record_store = svc.record_store
             _identity_oauth_crypto = OAuthCrypto(
                 encryption_key=_enc_key, record_store=_identity_record_store
             )
             _identity_crypto = IdentityCrypto(oauth_crypto=_identity_oauth_crypto)
 
             app.state.key_service = KeyService(
-                record_store=app.state.record_store,
+                record_store=svc.record_store,
                 crypto=_identity_crypto,
             )
             # Inject into NexusFS for register_agent integration
-            app.state.nexus_fs._key_service = app.state.key_service
+            svc.nexus_fs._key_service = app.state.key_service
 
             logger.info("[KYA] KeyService initialized and wired")
         except Exception as e:
@@ -232,21 +234,20 @@ def _startup_key_service(app: FastAPI) -> None:
         app.state.key_service = None
 
 
-def _startup_reputation_delegation_from_bricks(app: FastAPI) -> None:
+def _startup_reputation_delegation_from_bricks(app: FastAPI, svc: LifespanServices) -> None:
     """Expose ReputationService and DelegationService from factory brick_dict (Issue #2131).
 
     These services are now created in ``factory._boot_brick_services()`` and
     stored in ``BrickServices``. This function wires them onto ``app.state``
     for backward-compatible access by routers and dependencies.
     """
-    nx = app.state.nexus_fs
-    if nx is None:
+    if svc.nexus_fs is None:
         app.state.reputation_service = None
         app.state.delegation_service = None
         return
 
     # Get from BrickServices (created by factory)
-    brk = app.state.brick_services
+    brk = svc.brick_services
     app.state.reputation_service = getattr(brk, "reputation_service", None) if brk else None
     app.state.delegation_service = getattr(brk, "delegation_service", None) if brk else None
 
@@ -256,24 +257,23 @@ def _startup_reputation_delegation_from_bricks(app: FastAPI) -> None:
         # Wire system-tier dependencies that weren't available during factory boot
         deleg = app.state.delegation_service
         if getattr(deleg, "_namespace_manager", None) is None:
-            deleg._namespace_manager = app.state.namespace_manager
+            deleg._namespace_manager = svc.namespace_manager
         if getattr(deleg, "_agent_registry", None) is None:
             deleg._agent_registry = app.state.agent_registry
         logger.info("[DELEGATION] DelegationService wired from brick_dict")
 
 
-def _startup_governance(app: FastAPI) -> None:
+def _startup_governance(app: FastAPI, svc: LifespanServices) -> None:
     """Expose governance brick services from factory BrickServices (Issue #2129).
 
     Governance services are created in ``factory._boot_brick_services()`` and
     stored in ``BrickServices``. This function wires them onto ``app.state``
     for backward-compatible access by the governance router.
     """
-    nx = app.state.nexus_fs
-    if nx is None:
+    if svc.nexus_fs is None:
         return
 
-    brk = getattr(nx, "_brick_services", None)
+    brk = svc.brick_services
     app.state.governance_anomaly_service = (
         getattr(brk, "governance_anomaly_service", None) if brk else None
     )
@@ -291,13 +291,13 @@ def _startup_governance(app: FastAPI) -> None:
         logger.info("[GOV] Governance services wired from brick_dict")
 
 
-def _startup_sandbox_auth(app: FastAPI) -> None:
+def _startup_sandbox_auth(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize SandboxAuthService for authenticated sandbox creation (Issue #1307)."""
-    if app.state.nexus_fs and not app.state.agent_registry:
+    if svc.nexus_fs and not app.state.agent_registry:
         logger.info(
             "[SANDBOX-AUTH] AgentRegistry not available, SandboxAuthService will not be initialized"
         )
-    if not (app.state.nexus_fs and app.state.agent_registry):
+    if not (svc.nexus_fs and app.state.agent_registry):
         return
 
     try:
@@ -307,13 +307,13 @@ def _startup_sandbox_auth(app: FastAPI) -> None:
             SQLAlchemyAgentEventLog as AgentEventLog,
         )
 
-        _sandbox_rs = app.state.record_store
-        session_factory = getattr(app.state.nexus_fs, "SessionLocal", None)
+        _sandbox_rs = svc.record_store
+        session_factory = svc.session_factory
         if not (_sandbox_rs and session_factory and callable(session_factory)):
             return
 
         # Get AgentEventLog from factory (preferred) or create fallback
-        brk = app.state.brick_services
+        brk = svc.brick_services
         _factory_event_log = getattr(brk, "agent_event_log", None) if brk else None
         if _factory_event_log is not None:
             app.state.agent_event_log = _factory_event_log
@@ -321,7 +321,7 @@ def _startup_sandbox_auth(app: FastAPI) -> None:
             app.state.agent_event_log = AgentEventLog(record_store=_sandbox_rs)
 
         # Create SandboxManager
-        sandbox_config = getattr(app.state.nexus_fs, "config", None)
+        sandbox_config = svc.nexus_config
         sandbox_mgr = SandboxManager(
             record_store=_sandbox_rs,
             e2b_api_key=os.getenv("E2B_API_KEY"),
@@ -335,14 +335,14 @@ def _startup_sandbox_auth(app: FastAPI) -> None:
 
         # Get NamespaceManager if available (best-effort)
         namespace_manager = None
-        sync_rebac = app.state.rebac_manager
+        sync_rebac = svc.rebac_manager
         if sync_rebac:
             try:
                 from nexus.rebac.namespace_factory import (
                     create_namespace_manager,
                 )
 
-                ns_record_store = app.state.record_store
+                ns_record_store = svc.record_store
                 namespace_manager = create_namespace_manager(
                     rebac_manager=sync_rebac,
                     record_store=ns_record_store,
@@ -373,17 +373,17 @@ def _startup_sandbox_auth(app: FastAPI) -> None:
         )
 
 
-def _startup_transactional_snapshot(app: FastAPI) -> None:
+def _startup_transactional_snapshot(app: FastAPI, svc: LifespanServices) -> None:
     """Expose TransactionalSnapshotService on app.state for REST API (Issue #1752)."""
-    svc = getattr(app.state.nexus_fs, "_snapshot_service", None) if app.state.nexus_fs else None
-    app.state.transactional_snapshot_service = svc
-    if svc is not None:
+    snap_svc = svc.snapshot_service
+    app.state.transactional_snapshot_service = snap_svc
+    if snap_svc is not None:
         logger.info("[SNAPSHOT] TransactionalSnapshotService wired to app.state")
     else:
         logger.debug("[SNAPSHOT] TransactionalSnapshotService not available")
 
 
-def _startup_rlm_service(app: FastAPI) -> None:
+def _startup_rlm_service(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize RLM inference service (Issue #1306).
 
     Requires SandboxAuthService (for SandboxManager) and an LLM provider.
@@ -400,7 +400,7 @@ def _startup_rlm_service(app: FastAPI) -> None:
         logger.debug("[RLM] SandboxManager not available, RLM service skipped")
         return
 
-    llm_provider = getattr(app.state.nexus_fs, "_llm_provider", None)
+    llm_provider = svc.llm_provider
 
     try:
         from nexus.rlm.service import RLMInferenceService
@@ -419,7 +419,7 @@ def _startup_rlm_service(app: FastAPI) -> None:
         logger.warning("[RLM] Failed to initialize RLMInferenceService: %s", e, exc_info=True)
 
 
-def _startup_agent_tasks(app: FastAPI) -> list[asyncio.Task]:
+def _startup_agent_tasks(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Start agent heartbeat and stale detection background tasks (Issue #1240)."""
     if not app.state.agent_registry:
         return []
@@ -429,7 +429,7 @@ def _startup_agent_tasks(app: FastAPI) -> list[asyncio.Task]:
         stale_agent_detection_task,
     )
 
-    _bg_tuning = app.state.profile_tuning.background_task
+    _bg_tuning = svc.profile_tuning.background_task
     app.state._heartbeat_task = asyncio.create_task(
         heartbeat_flush_task(
             app.state.agent_registry,
@@ -451,8 +451,8 @@ def _startup_agent_tasks(app: FastAPI) -> list[asyncio.Task]:
     # Use factory-constructed EvictionManager (DRY — avoid duplicate construction)
     app.state._eviction_task = None
     app.state._checkpoint_cleanup_task = None
-    _factory_em = app.state.eviction_manager
-    _eviction_tuning = getattr(app.state.profile_tuning, "eviction", None)
+    _factory_em = svc.eviction_manager
+    _eviction_tuning = getattr(svc.profile_tuning, "eviction", None)
     if _factory_em is not None and _eviction_tuning is not None:
         try:
             from nexus.server.background_tasks import (
@@ -510,9 +510,9 @@ def _startup_agent_tasks(app: FastAPI) -> list[asyncio.Task]:
     return tasks
 
 
-async def _startup_scheduler(app: FastAPI) -> None:
+async def _startup_scheduler(app: FastAPI, svc: LifespanServices) -> None:
     """Initialize SchedulerService if PostgreSQL database is available (Issue #1212)."""
-    if not (app.state.database_url and "postgresql" in app.state.database_url):
+    if not (svc.database_url and "postgresql" in svc.database_url):
         return
 
     try:
@@ -525,8 +525,8 @@ async def _startup_scheduler(app: FastAPI) -> None:
         from nexus.services.scheduler.service import SchedulerService
 
         # Convert SQLAlchemy URL to asyncpg DSN
-        pg_dsn = app.state.database_url.replace("+asyncpg", "").replace("+psycopg2", "")
-        _pool_tuning = app.state.profile_tuning.pool
+        pg_dsn = svc.database_url.replace("+asyncpg", "").replace("+psycopg2", "")
+        _pool_tuning = svc.profile_tuning.pool
         pool = await asyncpg.create_pool(
             pg_dsn,
             min_size=_pool_tuning.asyncpg_min_size,
@@ -559,7 +559,7 @@ async def _startup_scheduler(app: FastAPI) -> None:
             async_reg._state_emitter = state_emitter
 
         # Wire hook cleanup handler into state emitter (Issue #1257)
-        scoped_hook_engine = app.state.scoped_hook_engine
+        scoped_hook_engine = svc.scoped_hook_engine
         if scoped_hook_engine is not None:
             from nexus.system_services.lifecycle.hook_engine import create_agent_cleanup_handler
 
@@ -576,21 +576,21 @@ async def _startup_scheduler(app: FastAPI) -> None:
         logger.warning("Failed to initialize Scheduler service: %s", e, exc_info=True)
 
 
-def _startup_task_queue(app: FastAPI) -> asyncio.Task | None:
+def _startup_task_queue(app: FastAPI, svc: LifespanServices) -> asyncio.Task | None:
     """Start Task Queue Engine background worker (Issue #574)."""
-    if not app.state.nexus_fs:
+    if not svc.nexus_fs:
         return None
 
     try:
         from nexus.tasks import is_available
 
         if is_available():
-            service = app.state.nexus_fs.task_queue_service
+            service = svc.nexus_fs.task_queue_service
             engine = service.get_engine()
 
             from nexus.tasks.runner import AsyncTaskRunner
 
-            _task_workers = app.state.profile_tuning.concurrency.task_runner_workers
+            _task_workers = svc.profile_tuning.concurrency.task_runner_workers
             runner = AsyncTaskRunner(engine=engine, max_workers=_task_workers)
             service.set_runner(runner)
             app.state.task_runner = runner
@@ -605,12 +605,12 @@ def _startup_task_queue(app: FastAPI) -> asyncio.Task | None:
     return None
 
 
-async def _startup_workflow_engine(app: FastAPI) -> None:
+async def _startup_workflow_engine(app: FastAPI, svc: LifespanServices) -> None:
     """Load workflows from persistent storage (Issue #1522)."""
-    if not app.state.nexus_fs:
+    if not svc.nexus_fs:
         return
 
-    engine = getattr(app.state.nexus_fs, "workflow_engine", None)
+    engine = svc.workflow_engine
     if engine and hasattr(engine, "startup"):
         try:
             await engine.startup()

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -1,0 +1,136 @@
+"""Typed service container for lifespan modules (Issue #2135).
+
+Replaces untyped ``getattr()`` / ``hasattr()`` reflection in lifespan
+startup/shutdown with a single frozen extraction performed once at
+server startup.  All ``from_app()`` extraction logic lives here —
+lifespan modules consume typed attributes instead of probing
+``app.state`` and NexusFS internals.
+
+Design decisions:
+    - Fields are ``Any | None`` to avoid circular imports.
+    - ``from_app()`` centralises every ``getattr()`` call so no lifespan
+      module ever touches NexusFS private attributes directly.
+    - The container is **not** frozen because some startup modules
+      may need to cache additional references after extraction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+@dataclass(slots=True)
+class LifespanServices:
+    """Typed snapshot of factory-produced services for lifespan modules.
+
+    Populated once via ``from_app()`` at the beginning of the lifespan
+    context manager.  Lifespan sub-modules receive this object instead
+    of reaching into ``app.state`` / NexusFS internals with reflection.
+
+    Writes to ``app.state`` (for router access) still use ``app``
+    directly — this container is read-only by convention.
+    """
+
+    # --- Core / kernel ---------------------------------------------------
+    nexus_fs: Any = None
+    database_url: str | None = None
+    record_store: Any = None
+    zone_id: str | None = None
+
+    # --- Configuration ---------------------------------------------------
+    deployment_profile: str = "full"
+    deployment_mode: str = "standalone"
+    enabled_bricks: frozenset[str] = field(default_factory=frozenset)
+    profile_tuning: Any = None
+    thread_pool_size: int = 40
+
+    # --- System services (from nexus_fs._system_services) ----------------
+    brick_lifecycle_manager: Any = None
+    brick_reconciler: Any = None
+    eviction_manager: Any = None
+    scoped_hook_engine: Any = None
+    write_observer: Any = None
+    zone_lifecycle: Any = None
+
+    # --- Brick services container ----------------------------------------
+    brick_services: Any = None  # The whole BrickServices dataclass
+
+    # --- NexusFS internals (extracted once, never re-probed) --------------
+    session_factory: Any = None  # NexusFS.SessionLocal
+    sql_engine: Any = None
+    entity_registry: Any = None
+    permission_enforcer: Any = None
+    rebac_manager: Any = None
+    event_bus: Any = None
+    coordination_client: Any = None
+    llm_provider: Any = None
+    workflow_engine: Any = None
+    snapshot_service: Any = None
+    namespace_manager: Any = None
+    nexus_config: Any = None
+    observability_subsystem: Any = None
+
+    # --- From app.state (set by server init, not factory) ----------------
+    a2a_task_manager: Any = None
+    observability_registry: Any = None
+
+    @classmethod
+    def from_app(cls, app: FastAPI) -> LifespanServices:
+        """Extract all factory-produced services into a typed container.
+
+        This method is the **single place** where ``getattr()`` is used to
+        reach into ``app.state`` and NexusFS internals.  After this call,
+        lifespan modules access services via typed attributes.
+        """
+        nx = getattr(app.state, "nexus_fs", None)
+        _sys = getattr(nx, "_system_services", None) if nx else None
+        _brk = getattr(nx, "_brick_services", None) if nx else None
+        _extras = getattr(nx, "_service_extras", None) if nx else None
+
+        return cls(
+            # Core / kernel
+            nexus_fs=nx,
+            database_url=getattr(app.state, "database_url", None),
+            record_store=getattr(app.state, "record_store", None),
+            zone_id=getattr(app.state, "zone_id", None),
+            # Configuration
+            deployment_profile=getattr(app.state, "deployment_profile", "full"),
+            deployment_mode=getattr(app.state, "deployment_mode", "standalone"),
+            enabled_bricks=getattr(app.state, "enabled_bricks", frozenset()),
+            profile_tuning=getattr(app.state, "profile_tuning", None),
+            thread_pool_size=getattr(app.state, "thread_pool_size", 40),
+            # System services
+            brick_lifecycle_manager=(
+                getattr(_sys, "brick_lifecycle_manager", None) if _sys else None
+            ),
+            brick_reconciler=(getattr(_sys, "brick_reconciler", None) if _sys else None),
+            eviction_manager=(getattr(_sys, "eviction_manager", None) if _sys else None),
+            scoped_hook_engine=(getattr(_sys, "scoped_hook_engine", None) if _sys else None),
+            write_observer=getattr(nx, "_write_observer", None) if nx else None,
+            zone_lifecycle=(getattr(_sys, "zone_lifecycle", None) if _sys else None),
+            # Brick services
+            brick_services=_brk,
+            # NexusFS internals
+            session_factory=getattr(nx, "SessionLocal", None) if nx else None,
+            sql_engine=getattr(nx, "_sql_engine", None) if nx else None,
+            entity_registry=(getattr(nx, "_entity_registry", None) if nx else None),
+            permission_enforcer=(getattr(nx, "_permission_enforcer", None) if nx else None),
+            rebac_manager=(getattr(nx, "_rebac_manager", None) if nx else None),
+            event_bus=getattr(nx, "_event_bus", None) if nx else None,
+            coordination_client=(getattr(nx, "_coordination_client", None) if nx else None),
+            llm_provider=(getattr(nx, "_llm_provider", None) if nx else None),
+            workflow_engine=(getattr(nx, "workflow_engine", None) if nx else None),
+            snapshot_service=(getattr(nx, "_snapshot_service", None) if nx else None),
+            namespace_manager=(getattr(nx, "_namespace_manager", None) if nx else None),
+            nexus_config=getattr(nx, "config", None) if nx else None,
+            observability_subsystem=(
+                _extras.get("observability_subsystem") if isinstance(_extras, dict) else None
+            ),
+            # From app.state (set by server init)
+            a2a_task_manager=getattr(app.state, "a2a_task_manager", None),
+            observability_registry=getattr(app.state, "observability_registry", None),
+        )

--- a/src/nexus/server/lifespan/uploads.py
+++ b/src/nexus/server/lifespan/uploads.py
@@ -12,15 +12,17 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.server.lifespan.services_container import LifespanServices
+
 logger = logging.getLogger(__name__)
 
 
-async def startup_uploads(app: FastAPI) -> list[asyncio.Task]:
+async def startup_uploads(app: FastAPI, svc: LifespanServices) -> list[asyncio.Task]:
     """Initialize chunked upload service and return background tasks."""
     bg_tasks: list[asyncio.Task] = []
 
     # Get the pre-configured service from factory (reads NEXUS_UPLOAD_* env vars)
-    brk = app.state.brick_services
+    brk = svc.brick_services
     _factory_upload_svc = getattr(brk, "chunked_upload_service", None) if brk else None
 
     if _factory_upload_svc is not None:
@@ -28,7 +30,7 @@ async def startup_uploads(app: FastAPI) -> list[asyncio.Task]:
         cleanup_task = asyncio.create_task(app.state.chunked_upload_service.start_cleanup_loop())
         bg_tasks.append(cleanup_task)
         logger.info("[TUS] ChunkedUploadService initialized from factory with background cleanup")
-    elif app.state.nexus_fs and app.state.record_store is not None:
+    elif svc.nexus_fs and svc.record_store is not None:
         # Fallback: create from env vars when factory didn't provide the service
         try:
             from nexus.services.chunked_upload_service import (
@@ -36,8 +38,8 @@ async def startup_uploads(app: FastAPI) -> list[asyncio.Task]:
                 ChunkedUploadService,
             )
 
-            _backend = getattr(app.state.nexus_fs, "backend", None)
-            _upload_rs = app.state.record_store
+            _backend = getattr(svc.nexus_fs, "backend", None)
+            _upload_rs = svc.record_store
             if _backend and _upload_rs:
                 import os as _os
 
@@ -57,7 +59,7 @@ async def startup_uploads(app: FastAPI) -> list[asyncio.Task]:
                 app.state.chunked_upload_service = ChunkedUploadService(
                     record_store=_upload_rs,
                     backend=_backend,
-                    metadata_store=getattr(app.state.nexus_fs, "metadata", None),
+                    metadata_store=getattr(svc.nexus_fs, "metadata", None),
                     config=ChunkedUploadConfig(**_upload_kwargs),
                 )
                 cleanup_task = asyncio.create_task(

--- a/tests/unit/server/lifespan/test_bricks_lifespan.py
+++ b/tests/unit/server/lifespan/test_bricks_lifespan.py
@@ -2,28 +2,27 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from nexus.server.lifespan.bricks import shutdown_bricks, startup_bricks
+from nexus.server.lifespan.services_container import LifespanServices
 from nexus.services.protocols.brick_lifecycle import BrickHealthReport
 
 
-def _make_app(
+def _make_svc(
     *,
     nexus_fs: object | None = None,
     brick_lifecycle_manager: object | None = None,
     brick_reconciler: object | None = None,
-) -> MagicMock:
-    """Create a minimal FastAPI-like app stub with state."""
-    app = MagicMock()
-    app.state = SimpleNamespace()
-    app.state.nexus_fs = nexus_fs
-    app.state.brick_lifecycle_manager = brick_lifecycle_manager
-    app.state.brick_reconciler = brick_reconciler
-    return app
+) -> LifespanServices:
+    """Create a minimal LifespanServices stub with given fields."""
+    return LifespanServices(
+        nexus_fs=nexus_fs,
+        brick_lifecycle_manager=brick_lifecycle_manager,
+        brick_reconciler=brick_reconciler,
+    )
 
 
 def _make_health_report(total: int = 3, active: int = 3, failed: int = 0) -> BrickHealthReport:
@@ -39,8 +38,9 @@ class TestStartupBricks:
         manager = MagicMock()
         manager.mount_all = AsyncMock(return_value=_make_health_report())
 
-        app = _make_app(nexus_fs=MagicMock(), brick_lifecycle_manager=manager)
-        result = await startup_bricks(app)
+        app = MagicMock()
+        svc = _make_svc(nexus_fs=MagicMock(), brick_lifecycle_manager=manager)
+        result = await startup_bricks(app, svc)
 
         manager.mount_all.assert_awaited_once()
         assert result == []
@@ -48,15 +48,17 @@ class TestStartupBricks:
     @pytest.mark.asyncio
     async def test_no_nexus_fs_is_safe(self) -> None:
         """startup_bricks should no-op when nexus_fs is not set."""
-        app = _make_app()
-        result = await startup_bricks(app)
+        app = MagicMock()
+        svc = _make_svc()
+        result = await startup_bricks(app, svc)
         assert result == []
 
     @pytest.mark.asyncio
     async def test_no_manager_is_safe(self) -> None:
         """startup_bricks should no-op when lifecycle manager is None."""
-        app = _make_app(nexus_fs=MagicMock(), brick_lifecycle_manager=None)
-        result = await startup_bricks(app)
+        app = MagicMock()
+        svc = _make_svc(nexus_fs=MagicMock(), brick_lifecycle_manager=None)
+        result = await startup_bricks(app, svc)
         assert result == []
 
     @pytest.mark.asyncio
@@ -67,12 +69,13 @@ class TestStartupBricks:
         reconciler = MagicMock()
         reconciler.start = AsyncMock()
 
-        app = _make_app(
+        app = MagicMock()
+        svc = _make_svc(
             nexus_fs=MagicMock(),
             brick_lifecycle_manager=manager,
             brick_reconciler=reconciler,
         )
-        await startup_bricks(app)
+        await startup_bricks(app, svc)
         reconciler.start.assert_awaited_once()
 
 
@@ -85,22 +88,25 @@ class TestShutdownBricks:
         manager = MagicMock()
         manager.unmount_all = AsyncMock(return_value=_make_health_report(active=0))
 
-        app = _make_app(nexus_fs=MagicMock(), brick_lifecycle_manager=manager)
-        await shutdown_bricks(app)
+        app = MagicMock()
+        svc = _make_svc(nexus_fs=MagicMock(), brick_lifecycle_manager=manager)
+        await shutdown_bricks(app, svc)
 
         manager.unmount_all.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_no_nexus_fs_is_safe(self) -> None:
         """shutdown_bricks should no-op when nexus_fs is not set."""
-        app = _make_app()
-        await shutdown_bricks(app)  # Should not raise
+        app = MagicMock()
+        svc = _make_svc()
+        await shutdown_bricks(app, svc)  # Should not raise
 
     @pytest.mark.asyncio
     async def test_no_manager_is_safe(self) -> None:
         """shutdown_bricks should no-op when lifecycle manager is None."""
-        app = _make_app(nexus_fs=MagicMock(), brick_lifecycle_manager=None)
-        await shutdown_bricks(app)  # Should not raise
+        app = MagicMock()
+        svc = _make_svc(nexus_fs=MagicMock(), brick_lifecycle_manager=None)
+        await shutdown_bricks(app, svc)  # Should not raise
 
     @pytest.mark.asyncio
     async def test_stops_reconciler_before_unmount(self) -> None:
@@ -113,11 +119,12 @@ class TestShutdownBricks:
         reconciler = MagicMock()
         reconciler.stop = AsyncMock(side_effect=lambda: call_order.append("stop"))
 
-        app = _make_app(
+        app = MagicMock()
+        svc = _make_svc(
             nexus_fs=MagicMock(),
             brick_lifecycle_manager=manager,
             brick_reconciler=reconciler,
         )
-        await shutdown_bricks(app)
+        await shutdown_bricks(app, svc)
 
         assert call_order == ["stop", "unmount"]

--- a/tests/unit/server/lifespan/test_lifespan_services.py
+++ b/tests/unit/server/lifespan/test_lifespan_services.py
@@ -1,0 +1,253 @@
+"""Tests for LifespanServices.from_app() extraction (Issue #2135).
+
+Validates that the typed container correctly extracts all factory-produced
+services from app.state and NexusFS internals, and handles missing/None
+values gracefully.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from nexus.server.lifespan.services_container import LifespanServices
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(**state_attrs) -> MagicMock:
+    """Create a minimal FastAPI-like app stub with given state attributes."""
+    app = MagicMock()
+    app.state = SimpleNamespace(**state_attrs)
+    return app
+
+
+def _make_nexus_fs(**attrs) -> SimpleNamespace:
+    """Create a NexusFS stub with given attributes."""
+    defaults = {
+        "_system_services": None,
+        "_brick_services": None,
+        "_service_extras": {},
+        "SessionLocal": None,
+        "_sql_engine": None,
+        "_entity_registry": None,
+        "_permission_enforcer": None,
+        "_rebac_manager": None,
+        "_event_bus": None,
+        "_coordination_client": None,
+        "_llm_provider": None,
+        "workflow_engine": None,
+        "_snapshot_service": None,
+        "_namespace_manager": None,
+        "_write_observer": None,
+        "config": None,
+    }
+    defaults.update(attrs)
+    return SimpleNamespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# from_app() — core extraction
+# ---------------------------------------------------------------------------
+
+
+class TestFromAppExtraction:
+    """Test that from_app() extracts all factory services."""
+
+    def test_bare_app_produces_all_none(self) -> None:
+        """App with no nexus_fs yields container with all None."""
+        app = _make_app()
+        svc = LifespanServices.from_app(app)
+
+        assert svc.nexus_fs is None
+        assert svc.database_url is None
+        assert svc.record_store is None
+        assert svc.brick_lifecycle_manager is None
+        assert svc.brick_reconciler is None
+        assert svc.event_bus is None
+        assert svc.rebac_manager is None
+
+    def test_extracts_top_level_state(self) -> None:
+        """Top-level app.state attributes are extracted."""
+        app = _make_app(
+            nexus_fs=None,
+            database_url="postgresql://localhost/test",
+            record_store="fake_rs",
+            zone_id="zone-42",
+            deployment_profile="lite",
+            deployment_mode="federated",
+            profile_tuning="fake_tuning",
+            thread_pool_size=80,
+        )
+        svc = LifespanServices.from_app(app)
+
+        assert svc.database_url == "postgresql://localhost/test"
+        assert svc.record_store == "fake_rs"
+        assert svc.zone_id == "zone-42"
+        assert svc.deployment_profile == "lite"
+        assert svc.deployment_mode == "federated"
+        assert svc.profile_tuning == "fake_tuning"
+        assert svc.thread_pool_size == 80
+
+    def test_extracts_nexus_fs_internals(self) -> None:
+        """NexusFS private attributes are extracted."""
+        nx = _make_nexus_fs(
+            SessionLocal="session_factory",
+            _sql_engine="sql_engine",
+            _entity_registry="entity_reg",
+            _permission_enforcer="perm_enf",
+            _rebac_manager="rebac_mgr",
+            _event_bus="event_bus",
+            _coordination_client="coord_client",
+            _llm_provider="llm_prov",
+            workflow_engine="wf_engine",
+            _snapshot_service="snap_svc",
+            _namespace_manager="ns_mgr",
+            _write_observer="write_obs",
+            config="nexus_cfg",
+        )
+        app = _make_app(nexus_fs=nx)
+        svc = LifespanServices.from_app(app)
+
+        assert svc.nexus_fs is nx
+        assert svc.session_factory == "session_factory"
+        assert svc.sql_engine == "sql_engine"
+        assert svc.entity_registry == "entity_reg"
+        assert svc.permission_enforcer == "perm_enf"
+        assert svc.rebac_manager == "rebac_mgr"
+        assert svc.event_bus == "event_bus"
+        assert svc.coordination_client == "coord_client"
+        assert svc.llm_provider == "llm_prov"
+        assert svc.workflow_engine == "wf_engine"
+        assert svc.snapshot_service == "snap_svc"
+        assert svc.namespace_manager == "ns_mgr"
+        assert svc.write_observer == "write_obs"
+        assert svc.nexus_config == "nexus_cfg"
+
+
+class TestFromAppSystemServices:
+    """Test extraction from nexus_fs._system_services."""
+
+    def test_extracts_system_services(self) -> None:
+        """System services (brick_lifecycle_manager, etc.) are extracted."""
+        sys_svc = SimpleNamespace(
+            brick_lifecycle_manager="blm",
+            brick_reconciler="br",
+            eviction_manager="em",
+            scoped_hook_engine="she",
+            zone_lifecycle="zl",
+        )
+        nx = _make_nexus_fs(_system_services=sys_svc)
+        app = _make_app(nexus_fs=nx)
+        svc = LifespanServices.from_app(app)
+
+        assert svc.brick_lifecycle_manager == "blm"
+        assert svc.brick_reconciler == "br"
+        assert svc.eviction_manager == "em"
+        assert svc.scoped_hook_engine == "she"
+        assert svc.zone_lifecycle == "zl"
+
+    def test_missing_system_services_yields_none(self) -> None:
+        """When _system_services is None, all system service fields are None."""
+        nx = _make_nexus_fs(_system_services=None)
+        app = _make_app(nexus_fs=nx)
+        svc = LifespanServices.from_app(app)
+
+        assert svc.brick_lifecycle_manager is None
+        assert svc.brick_reconciler is None
+        assert svc.eviction_manager is None
+
+
+class TestFromAppBrickServices:
+    """Test extraction from nexus_fs._brick_services."""
+
+    def test_extracts_brick_services_container(self) -> None:
+        """The entire BrickServices object is captured."""
+        brk = SimpleNamespace(cache_brick="cb", ipc_storage_driver="ipc")
+        nx = _make_nexus_fs(_brick_services=brk)
+        app = _make_app(nexus_fs=nx)
+        svc = LifespanServices.from_app(app)
+
+        assert svc.brick_services is brk
+
+    def test_missing_brick_services_is_none(self) -> None:
+        """When _brick_services is None, field is None."""
+        nx = _make_nexus_fs(_brick_services=None)
+        app = _make_app(nexus_fs=nx)
+        svc = LifespanServices.from_app(app)
+
+        assert svc.brick_services is None
+
+
+class TestFromAppObservability:
+    """Test extraction from _service_extras."""
+
+    def test_extracts_observability_subsystem(self) -> None:
+        """observability_subsystem extracted from _service_extras dict."""
+        nx = _make_nexus_fs(_service_extras={"observability_subsystem": "obs_sub"})
+        app = _make_app(nexus_fs=nx)
+        svc = LifespanServices.from_app(app)
+
+        assert svc.observability_subsystem == "obs_sub"
+
+    def test_non_dict_service_extras_yields_none(self) -> None:
+        """Non-dict _service_extras produces None observability_subsystem."""
+        nx = _make_nexus_fs(_service_extras=None)
+        app = _make_app(nexus_fs=nx)
+        svc = LifespanServices.from_app(app)
+
+        assert svc.observability_subsystem is None
+
+
+class TestFromAppDefaults:
+    """Test default values when attributes are absent from app.state."""
+
+    def test_deployment_profile_defaults_to_full(self) -> None:
+        app = _make_app()
+        svc = LifespanServices.from_app(app)
+        assert svc.deployment_profile == "full"
+
+    def test_deployment_mode_defaults_to_standalone(self) -> None:
+        app = _make_app()
+        svc = LifespanServices.from_app(app)
+        assert svc.deployment_mode == "standalone"
+
+    def test_thread_pool_size_defaults_to_40(self) -> None:
+        app = _make_app()
+        svc = LifespanServices.from_app(app)
+        assert svc.thread_pool_size == 40
+
+    def test_enabled_bricks_defaults_to_empty_frozenset(self) -> None:
+        app = _make_app()
+        svc = LifespanServices.from_app(app)
+        assert svc.enabled_bricks == frozenset()
+
+
+class TestFromAppEdgeCases:
+    """Edge cases for from_app() robustness."""
+
+    def test_nexus_fs_without_optional_attributes(self) -> None:
+        """NexusFS missing some private attrs doesn't crash."""
+        # Use a SimpleNamespace with only _system_services
+        nx = SimpleNamespace(_system_services=None, _brick_services=None, _service_extras={})
+        app = _make_app(nexus_fs=nx)
+
+        # Should not raise even though nx has no _write_observer, etc.
+        svc = LifespanServices.from_app(app)
+        assert svc.nexus_fs is nx
+        assert svc.write_observer is None  # getattr with default
+        assert svc.rebac_manager is None
+
+    def test_a2a_task_manager_extracted(self) -> None:
+        """a2a_task_manager from app.state is extracted."""
+        app = _make_app(a2a_task_manager="atm")
+        svc = LifespanServices.from_app(app)
+        assert svc.a2a_task_manager == "atm"
+
+    def test_observability_registry_extracted(self) -> None:
+        """observability_registry from app.state is extracted."""
+        app = _make_app(observability_registry="obs_reg")
+        svc = LifespanServices.from_app(app)
+        assert svc.observability_registry == "obs_reg"


### PR DESCRIPTION
## Summary

- **New `services_container.py`**: `LifespanServices` dataclass with `from_app()` classmethod centralizing all `getattr()` extraction into a single pass (24+ service fields)
- **Updated 9 lifespan sub-modules** (`bricks`, `services`, `permissions`, `realtime`, `search`, `uploads`, `ipc`, `a2a_grpc`, `observability`) to accept typed `(app, svc: LifespanServices)` parameters instead of probing `app.state` / NexusFS internals with reflection
- **New test file** `test_lifespan_services.py` (16 tests) covering extraction, defaults, and edge cases; updated `test_bricks_lifespan.py` (7 tests)

### Design alignment (NEXUS-LEGO-ARCHITECTURE Principle #2)

> "Standard interface — Protocol classes define every boundary"

`LifespanServices` acts as the typed boundary between the factory (Composition Root) and lifespan consumers. The `from_app()` classmethod is the **single extraction point** — after this call, no lifespan module ever touches `app.state` or NexusFS private attributes via reflection. Writes to `app.state` (for router access) still use `app` directly.

### What changed

| Before | After |
|--------|-------|
| Each lifespan module did `getattr(app.state.nexus_fs, "_rebac_manager", None)` | `svc.rebac_manager` |
| `getattr(getattr(nx, "_system_services"), "brick_lifecycle_manager")` chains | `svc.brick_lifecycle_manager` |
| `hasattr(app.state.nexus_fs, "_coordination_client")` | `svc.coordination_client is not None` |
| Different fallback defaults scattered across modules | Centralized defaults in dataclass fields |

## Test plan

- [x] 23/23 lifespan unit tests pass (16 extraction + 7 bricks)
- [x] 1002/1002 server unit tests pass (zero regressions)
- [x] All 14 startup/shutdown function signatures verified: `(app, svc)`
- [x] E2E extraction validated: all 24 service fields correctly extracted through real `create_app()`
- [x] Ruff lint + format clean
- [x] mypy pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)