### PR TITLE
fix(#698): move scheduled_tasks DDL to Alembic migration

### DIFF
--- a/alembic/versions/add_scheduled_tasks_table.py
+++ b/alembic/versions/add_scheduled_tasks_table.py
@@ -1,0 +1,137 @@
+"""fix(#698): Add scheduled_tasks table via Alembic migration
+
+Revision ID: add_scheduled_tasks_tbl
+Revises: merge_agent_spec_zone_phase
+Create Date: 2026-02-21
+
+Replaces runtime DDL in server/lifespan/services.py with a proper
+Alembic migration. Includes all Astraea columns (Issue #1274) and
+fixes zone_id default from 'default' to 'root' (ROOT_ZONE_ID).
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_scheduled_tasks_tbl"
+down_revision: Union[str, Sequence[str], None] = "merge_agent_spec_zone_phase"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create table only if it doesn't already exist (idempotent for deployments
+    # that used the old runtime DDL).
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "scheduled_tasks" not in inspector.get_table_names():
+        op.create_table(
+            "scheduled_tasks",
+            sa.Column(
+                "id", sa.Text(), server_default=sa.text("gen_random_uuid()::text"), nullable=False
+            ),
+            sa.Column("agent_id", sa.Text(), nullable=False),
+            sa.Column("executor_id", sa.Text(), nullable=False),
+            sa.Column("task_type", sa.Text(), nullable=False),
+            sa.Column(
+                "payload",
+                postgresql.JSONB(astext_type=sa.Text()),
+                server_default="{}",
+                nullable=False,
+            ),
+            sa.Column("priority_tier", sa.SmallInteger(), nullable=False, server_default="2"),
+            sa.Column("effective_tier", sa.SmallInteger(), nullable=False, server_default="2"),
+            sa.Column(
+                "enqueued_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column("deadline", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "boost_amount",
+                sa.Numeric(precision=12, scale=6),
+                nullable=False,
+                server_default="0",
+            ),
+            sa.Column("boost_tiers", sa.SmallInteger(), nullable=False, server_default="0"),
+            sa.Column("boost_reservation_id", sa.Text(), nullable=True),
+            sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="queued"),
+            sa.Column("idempotency_key", sa.Text(), nullable=True, unique=True),
+            sa.Column("zone_id", sa.String(length=255), nullable=False, server_default="root"),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            # Astraea columns (Issue #1274)
+            sa.Column("request_state", sa.Text(), nullable=False, server_default="pending"),
+            sa.Column("priority_class", sa.Text(), nullable=False, server_default="batch"),
+            sa.Column("executor_state", sa.Text(), nullable=False, server_default="UNKNOWN"),
+            sa.Column("estimated_service_time", sa.Float(), nullable=False, server_default="30.0"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+        # Indexes
+        op.create_index(
+            "idx_scheduled_tasks_dequeue",
+            "scheduled_tasks",
+            ["effective_tier", "enqueued_at"],
+            postgresql_where=sa.text("status = 'queued'"),
+        )
+        op.create_index(
+            "idx_sched_astraea_dequeue",
+            "scheduled_tasks",
+            ["priority_class", "enqueued_at"],
+            postgresql_where=sa.text("status = 'queued'"),
+        )
+        op.create_index("idx_scheduled_tasks_status", "scheduled_tasks", ["status"])
+        op.create_index("idx_scheduled_tasks_zone", "scheduled_tasks", ["zone_id"])
+    else:
+        # Table exists from runtime DDL — ensure Astraea columns + correct defaults.
+        existing_cols = {c["name"] for c in inspector.get_columns("scheduled_tasks")}
+
+        astraea_cols = [
+            ("request_state", sa.Text(), "pending"),
+            ("priority_class", sa.Text(), "batch"),
+            ("executor_state", sa.Text(), "UNKNOWN"),
+            ("estimated_service_time", sa.Float(), "30.0"),
+        ]
+        for col_name, col_type, default in astraea_cols:
+            if col_name not in existing_cols:
+                op.add_column(
+                    "scheduled_tasks",
+                    sa.Column(col_name, col_type, nullable=False, server_default=default),
+                )
+
+        # Fix zone_id default from 'default' to 'root' (ROOT_ZONE_ID)
+        op.alter_column(
+            "scheduled_tasks",
+            "zone_id",
+            server_default="root",
+        )
+
+        # Ensure HRRN index exists
+        existing_indexes = {idx["name"] for idx in inspector.get_indexes("scheduled_tasks")}
+        if "idx_sched_astraea_dequeue" not in existing_indexes:
+            op.create_index(
+                "idx_sched_astraea_dequeue",
+                "scheduled_tasks",
+                ["priority_class", "enqueued_at"],
+                postgresql_where=sa.text("status = 'queued'"),
+            )
+        if "idx_scheduled_tasks_status" not in existing_indexes:
+            op.create_index("idx_scheduled_tasks_status", "scheduled_tasks", ["status"])
+        if "idx_scheduled_tasks_zone" not in existing_indexes:
+            op.create_index("idx_scheduled_tasks_zone", "scheduled_tasks", ["zone_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_scheduled_tasks_zone", table_name="scheduled_tasks")
+    op.drop_index("idx_scheduled_tasks_status", table_name="scheduled_tasks")
+    op.drop_index("idx_sched_astraea_dequeue", table_name="scheduled_tasks")
+    op.drop_index("idx_scheduled_tasks_dequeue", table_name="scheduled_tasks")
+    op.drop_table("scheduled_tasks")

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -536,50 +536,10 @@ async def _startup_scheduler(app: FastAPI) -> None:
         )
         app.state._scheduler_pool = pool
 
-        # Create scheduled_tasks table if it doesn't exist
-        async with pool.acquire() as conn:
-            await conn.execute("""
-                CREATE TABLE IF NOT EXISTS scheduled_tasks (
-                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                    agent_id TEXT NOT NULL,
-                    executor_id TEXT NOT NULL,
-                    task_type TEXT NOT NULL,
-                    payload JSONB NOT NULL DEFAULT '{}',
-                    priority_tier SMALLINT NOT NULL DEFAULT 2,
-                    deadline TIMESTAMPTZ,
-                    boost_amount NUMERIC(12,6) NOT NULL DEFAULT 0,
-                    boost_tiers SMALLINT NOT NULL DEFAULT 0,
-                    effective_tier SMALLINT NOT NULL DEFAULT 2,
-                    enqueued_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                    started_at TIMESTAMPTZ,
-                    completed_at TIMESTAMPTZ,
-                    status TEXT NOT NULL DEFAULT 'queued',
-                    boost_reservation_id TEXT,
-                    idempotency_key TEXT UNIQUE,
-                    zone_id TEXT NOT NULL DEFAULT 'default',
-                    error_message TEXT
-                )
-            """)
-            await conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_scheduled_tasks_dequeue
-                ON scheduled_tasks (effective_tier, enqueued_at)
-                WHERE status = 'queued'
-            """)
-
-            # Astraea columns (Issue #1274) — idempotent ALTER TABLE
-            for col_sql in (
-                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS request_state TEXT NOT NULL DEFAULT 'pending'",
-                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS priority_class TEXT NOT NULL DEFAULT 'batch'",
-                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS executor_state TEXT NOT NULL DEFAULT 'UNKNOWN'",
-                "ALTER TABLE scheduled_tasks ADD COLUMN IF NOT EXISTS estimated_service_time REAL NOT NULL DEFAULT 30.0",
-            ):
-                await conn.execute(col_sql)
-
-            await conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_sched_astraea_dequeue
-                ON scheduled_tasks (priority_class, enqueued_at)
-                WHERE status = 'queued'
-            """)
+        # NOTE: scheduled_tasks table is now managed by Alembic migration
+        # (alembic/versions/add_scheduled_tasks_table.py). Run `alembic upgrade head`
+        # to create/update the schema. The runtime DDL that was previously here has
+        # been removed per Issue #698.
 
         # Astraea: state emitter + fair-share (Issue #1274)
         state_emitter = AgentStateEmitter()

--- a/src/nexus/storage/models/scheduler.py
+++ b/src/nexus/storage/models/scheduler.py
@@ -3,7 +3,7 @@
 Replaces runtime DDL in server/lifespan/services.py and raw asyncpg SQL
 in scheduler/queue.py with a proper ORM model.
 
-Related: Issue #1212
+Related: Issue #1212, #1274
 """
 
 from __future__ import annotations
@@ -11,8 +11,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 
-from sqlalchemy import DateTime, Index, Numeric, SmallInteger, String, Text
+from sqlalchemy import DateTime, Float, Index, Numeric, SmallInteger, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
 
 from nexus.storage.models._base import Base, uuid_pk
 
@@ -26,7 +28,12 @@ class ScheduledTaskModel(Base):
     agent_id: Mapped[str] = mapped_column(Text, nullable=False)
     executor_id: Mapped[str] = mapped_column(Text, nullable=False)
     task_type: Mapped[str] = mapped_column(Text, nullable=False)
-    payload: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    payload: Mapped[dict] = mapped_column(
+        JSON().with_variant(JSONB, "postgresql"),
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
     priority_tier: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=2)
     effective_tier: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=2)
     enqueued_at: Mapped[datetime] = mapped_column(
@@ -45,10 +52,30 @@ class ScheduledTaskModel(Base):
     zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Astraea columns (Issue #1274)
+    request_state: Mapped[str] = mapped_column(
+        Text, nullable=False, default="pending", server_default="pending"
+    )
+    priority_class: Mapped[str] = mapped_column(
+        Text, nullable=False, default="batch", server_default="batch"
+    )
+    executor_state: Mapped[str] = mapped_column(
+        Text, nullable=False, default="UNKNOWN", server_default="UNKNOWN"
+    )
+    estimated_service_time: Mapped[float] = mapped_column(
+        Float, nullable=False, default=30.0, server_default="30.0"
+    )
+
     __table_args__ = (
         Index(
             "idx_scheduled_tasks_dequeue",
             "effective_tier",
+            "enqueued_at",
+            postgresql_where="status = 'queued'",
+        ),
+        Index(
+            "idx_sched_astraea_dequeue",
+            "priority_class",
             "enqueued_at",
             postgresql_where="status = 'queued'",
         ),


### PR DESCRIPTION
## Summary
- Replace runtime `CREATE TABLE` / `ALTER TABLE` / `CREATE INDEX` in `server/lifespan/services.py` with a proper Alembic migration
- Add missing Astraea columns (`request_state`, `priority_class`, `executor_state`, `estimated_service_time`) to `ScheduledTaskModel`
- Fix `payload` column type from `Text` to `JSONB` (matching actual PostgreSQL column type)
- Fix `zone_id` default from `'default'` to `'root'` (`ROOT_ZONE_ID`)
- Migration is idempotent: if table exists from old runtime DDL, it adds missing columns and fixes defaults

## Test plan
- [x] All 29 scheduler unit tests pass
- [x] ruff lint + format clean
- [x] mypy clean
- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)