### PR TITLE
chore: gitignore entire .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,11 +205,9 @@ secret-manager-sa-key.json
 aws-config
 aws-credentials
 
-# Claude Code local settings
-.claude/settings.json
-.claude/settings.local.json
+# Claude Code
+.claude/
 CLAUDE.md
-.claude/CLAUDE.md
 docs/plans/
 
 # Cargo local config (Windows MSVC linker path is dev-machine specific)


### PR DESCRIPTION
## Summary
- Replace 4 specific `.claude/*` gitignore entries with a single `.claude/` wildcard
- Prevents any Claude Code local config (settings, skills, memory) from being accidentally committed

## Test plan
- [x] Verify `.claude/` directory contents are untracked after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)