### PR TITLE
refactor(#1631): migrate WriteObserver from getattr() to Protocol dispatch

### DIFF
--- a/src/nexus/contracts/write_observer.py
+++ b/src/nexus/contracts/write_observer.py
@@ -1,18 +1,15 @@
 """WriteObserverProtocol — kernel write-mutation observer interface.
 
 Defines the contract for write observers injected into NexusFS kernel.
-The kernel calls on_write()/on_delete()/on_rename()/on_write_batch()/
-on_mkdir()/on_rmdir() after Metastore mutations. Observers handle
-side-effects (audit trail, version recording, etc.) and own their
-own error policy.
+The kernel calls observer methods directly via typed Protocol dispatch.
+Observers own their error policy (#55). The kernel has a defensive
+safety net (_handle_observer_error) for any errors that escape.
 
 Current implementations:
 - RecordStoreWriteObserver: synchronous audit trail + versioning (strict_mode)
 - BufferedRecordStoreWriteObserver: async via WriteBuffer (fire-and-forget)
 
-The kernel is a pure caller — it never catches observer exceptions.
-Each implementation decides its own failure handling strategy.
-
+Migrated from getattr() dispatch in #1631.
 Tracked by: #55 (Move _audit_strict_mode from kernel to observer)
 """
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1040,13 +1040,17 @@ class NexusFS(  # type: ignore[misc]
                 logger.warning(f"Failed to grant direct_owner permission for {path}: {e}")
 
         # Issue #625: Observer + hook coverage for mkdir
+        # Issue #1631: Direct typed dispatch with error handling.
         new_revision = self._increment_zone_revision()
-        if self._write_observer:
-            self._write_observer.on_mkdir(
-                path=path,
-                zone_id=ctx.zone_id,
-                agent_id=ctx.agent_id,
-            )
+        if (obs := self._write_observer) is not None:
+            try:
+                obs.on_mkdir(
+                    path=path,
+                    zone_id=ctx.zone_id,
+                    agent_id=ctx.agent_id,
+                )
+            except Exception as e:
+                self._handle_observer_error("mkdir", path, e)
         self._fire_post_mutation_hooks(
             MutationOp.MKDIR,
             path,
@@ -1198,14 +1202,18 @@ class NexusFS(  # type: ignore[misc]
                 logger.debug("Failed to clean up directory index for %s: %s", path, e)
 
         # Issue #625: Observer + hook coverage for rmdir
+        # Issue #1631: Direct typed dispatch with error handling.
         new_revision = self._increment_zone_revision()
-        if self._write_observer:
-            self._write_observer.on_rmdir(
-                path=path,
-                zone_id=ctx.zone_id,
-                agent_id=ctx.agent_id,
-                recursive=recursive,
-            )
+        if (obs := self._write_observer) is not None:
+            try:
+                obs.on_rmdir(
+                    path=path,
+                    zone_id=ctx.zone_id,
+                    agent_id=ctx.agent_id,
+                    recursive=recursive,
+                )
+            except Exception as e:
+                self._handle_observer_error("rmdir", path, e)
         self._fire_post_mutation_hooks(
             MutationOp.RMDIR,
             path,

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from nexus.backends.backend import Backend
     from nexus.contracts.types import OperationContext
+    from nexus.contracts.write_observer import WriteObserverProtocol
     from nexus.core.router import PathRouter
     from nexus.parsers.registry import ParserRegistry
 
@@ -66,7 +67,7 @@ class NexusFSCoreMixin:
         _event_tasks: set[asyncio.Task[Any]]  # Issue #913: Tracked async event tasks
         _overlay_resolver: Any  # Issue #1264: OverlayResolver service
         _workspace_registry: Any  # Workspace registry for overlay config lookup
-        _write_observer: Any  # Duck-typed: on_write()/on_delete()
+        _write_observer: WriteObserverProtocol | None
         _audit_strict_mode: bool
 
         @property
@@ -1740,15 +1741,17 @@ class NexusFSCoreMixin:
         self.metadata.put(new_meta)
 
         # Sync to RecordStore via write_observer (closes gap: write_stream was missing this)
-        self._notify_observer(
-            "write",
-            path,
-            metadata=new_meta,
-            is_new=(meta is None),
-            path=path,
-            zone_id=zone_id,
-            agent_id=agent_id,
-        )
+        if (obs := self._write_observer) is not None:
+            try:
+                obs.on_write(
+                    metadata=new_meta,
+                    is_new=(meta is None),
+                    path=path,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                )
+            except Exception as e:
+                self._handle_observer_error("write", path, e)
 
         return {
             "etag": content_hash,
@@ -2129,18 +2132,20 @@ class NexusFSCoreMixin:
 
         # Task #45: Sync to RecordStore via write_observer (audit trail + version history)
         # Observer is optional — injected by factory.py, not created by kernel.
-        # Issue #1246: Unified error handling via _notify_observer.
-        self._notify_observer(
-            "write",
-            path,
-            metadata=metadata,
-            is_new=(meta is None),
-            path=path,
-            zone_id=zone_id,
-            agent_id=agent_id,
-            snapshot_hash=snapshot_hash,
-            metadata_snapshot=metadata_snapshot,
-        )
+        # Issue #1631: Direct typed dispatch (replaces getattr-based _notify_observer).
+        if (obs := self._write_observer) is not None:
+            try:
+                obs.on_write(
+                    metadata=metadata,
+                    is_new=(meta is None),
+                    path=path,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    snapshot_hash=snapshot_hash,
+                    metadata_snapshot=metadata_snapshot,
+                )
+            except Exception as e:
+                self._handle_observer_error("write", path, e)
 
         # v0.7.0: Fire workflow event for automatic trigger execution
         is_new_file = meta is None or meta.etag is None
@@ -2714,17 +2719,19 @@ class NexusFSCoreMixin:
         self.metadata.put_batch(metadata_list)
 
         # Task #45: Sync batch to RecordStore (audit trail + version history)
-        # Issue #1246: Unified error handling — no longer silently suppressed.
+        # Issue #1631: Direct typed dispatch (replaces getattr-based _notify_observer).
         items = [
             (metadata, existing_metadata.get(metadata.path) is None) for metadata in metadata_list
         ]
-        self._notify_observer(
-            "write_batch",
-            f"batch({len(metadata_list)} files)",
-            items=items,
-            zone_id=zone_id,
-            agent_id=agent_id,
-        )
+        if (obs := self._write_observer) is not None:
+            try:
+                obs.on_write_batch(
+                    items=items,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                )
+            except Exception as e:
+                self._handle_observer_error("write_batch", f"batch({len(metadata_list)} files)", e)
 
         # Issue #625: Fire post-mutation hooks for each file in the batch
         new_revision = self._increment_zone_revision()
@@ -2853,45 +2860,40 @@ class NexusFSCoreMixin:
 
         return results
 
-    def _notify_observer(self, operation: str, op_path: str, **kwargs: Any) -> None:
-        """Notify the write observer of a mutation, with unified error policy.
+    def _handle_observer_error(self, operation: str, op_path: str, error: Exception) -> None:
+        """Defensive safety net for observer errors (see Issue #55).
 
-        Replaces the inconsistent error handling where single writes used
-        audit_strict_mode but batch/delete/rename silently suppressed errors.
-
-        Issue #1246: All observer calls now follow the same policy:
-        - audit_strict_mode=True: raise AuditLogError on failure
-        - audit_strict_mode=False: log critical warning, continue
+        Per WriteObserverProtocol contract, observers own their error policy.
+        This catches any errors that escape the observer implementation.
 
         Args:
-            operation: One of 'write', 'write_batch', 'delete', 'rename'.
+            operation: The mutation operation name (e.g. 'write', 'delete').
             op_path: Primary path affected (for error messages only).
-            **kwargs: Passed directly to the observer method.
+            error: The exception that escaped the observer.
         """
-        if not self._write_observer:
-            return
+        from nexus.contracts.exceptions import AuditLogError
 
-        try:
-            method = getattr(self._write_observer, f"on_{operation}")
-            method(**kwargs)
-        except Exception as e:
-            from nexus.contracts.exceptions import AuditLogError
-
-            if self._audit_strict_mode:
-                logger.error(
-                    f"AUDIT LOG FAILURE: {operation} on '{op_path}' ABORTED. "
-                    f"Error: {e}. Set audit_strict_mode=False to allow writes without audit logs."
-                )
-                raise AuditLogError(
-                    f"Operation aborted: audit logging failed for {operation}: {e}",
-                    path=op_path,
-                    original_error=e,
-                ) from e
-            else:
-                logger.critical(
-                    f"AUDIT LOG FAILURE: {operation} on '{op_path}' SUCCEEDED but audit log FAILED. "
-                    f"Error: {e}. This creates an audit trail gap!"
-                )
+        if self._audit_strict_mode:
+            logger.error(
+                "AUDIT LOG FAILURE: %s on '%s' ABORTED. "
+                "Error: %s. Set audit_strict_mode=False to allow writes without audit logs.",
+                operation,
+                op_path,
+                error,
+            )
+            raise AuditLogError(
+                f"Operation aborted: audit logging failed for {operation}: {error}",
+                path=op_path,
+                original_error=error,
+            ) from error
+        else:
+            logger.critical(
+                "AUDIT LOG FAILURE: %s on '%s' SUCCEEDED but audit log FAILED. "
+                "Error: %s. This creates an audit trail gap!",
+                operation,
+                op_path,
+                error,
+            )
 
     def _auto_parse_file(self, path: str) -> None:
         """Auto-parse a file in the background (fire-and-forget).
@@ -3056,16 +3058,18 @@ class NexusFSCoreMixin:
                 self._snapshot_service.track_delete(_txn_id, path, snapshot_hash, metadata_snapshot)
 
         # Task #45: Sync to RecordStore BEFORE deleting CAS content
-        # Issue #1246: Unified error handling via _notify_observer.
-        self._notify_observer(
-            "delete",
-            path,
-            path=path,
-            zone_id=zone_id,
-            agent_id=agent_id,
-            snapshot_hash=snapshot_hash,
-            metadata_snapshot=metadata_snapshot,
-        )
+        # Issue #1631: Direct typed dispatch (replaces getattr-based _notify_observer).
+        if (obs := self._write_observer) is not None:
+            try:
+                obs.on_delete(
+                    path=path,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    snapshot_hash=snapshot_hash,
+                    metadata_snapshot=metadata_snapshot,
+                )
+            except Exception as e:
+                self._handle_observer_error("delete", path, e)
 
         # Delete from routed backend CAS (decrements ref count)
         # Content is only physically deleted when ref_count reaches 0
@@ -3367,17 +3371,19 @@ class NexusFSCoreMixin:
             _pipeline.run_post_rename(_rename_ctx)
 
         # Task #45: Sync to RecordStore (audit trail)
-        # Issue #1246: Unified error handling via _notify_observer.
-        self._notify_observer(
-            "rename",
-            old_path,
-            old_path=old_path,
-            new_path=new_path,
-            zone_id=zone_id,
-            agent_id=agent_id,
-            snapshot_hash=snapshot_hash,
-            metadata_snapshot=metadata_snapshot,
-        )
+        # Issue #1631: Direct typed dispatch (replaces getattr-based _notify_observer).
+        if (obs := self._write_observer) is not None:
+            try:
+                obs.on_rename(
+                    old_path=old_path,
+                    new_path=new_path,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    snapshot_hash=snapshot_hash,
+                    metadata_snapshot=metadata_snapshot,
+                )
+            except Exception as e:
+                self._handle_observer_error("rename", old_path, e)
 
         # v0.7.0: Fire workflow event for automatic trigger execution
         self._fire_workflow_event(

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from nexus.contracts.write_observer import WriteObserverProtocol
 
 from nexus.factory._boot_context import _BootContext
 from nexus.factory._helpers import _make_gate
@@ -106,7 +109,7 @@ def _boot_system_services(
         # --- RecordStore Syncer (constructed, NOT started) ---
         import os
 
-        write_observer: Any = None
+        write_observer: WriteObserverProtocol | None = None
         use_buffer = ctx.enable_write_buffer
         if use_buffer is None:
             env_val = os.environ.get("NEXUS_ENABLE_WRITE_BUFFER", "").lower()

--- a/tests/unit/core/test_write_observer_calls.py
+++ b/tests/unit/core/test_write_observer_calls.py
@@ -10,6 +10,7 @@ Coverage matrix (all gaps closed in Issue #625):
 - rmdir()       -> on_rmdir()       YES  (Issue #625)
 
 Phase 1.3 of #1246/#1330 consolidation plan.
+Issue #1631: Error handling tests for _handle_observer_error (strict + non-strict).
 """
 
 from __future__ import annotations
@@ -294,3 +295,98 @@ class TestPostMutationHookCoverage:
         event = hook.on_mutation.call_args.args[0]
         assert event.operation.value == "rmdir"
         assert event.path == "/mydir"
+
+
+# =========================================================================
+# Observer error handling (Issue #1631)
+# =========================================================================
+
+
+def _make_failing_observer() -> MagicMock:
+    """Create a mock observer where every method raises RuntimeError."""
+    obs = MagicMock()
+    err = RuntimeError("observer boom")
+    obs.on_write.side_effect = err
+    obs.on_write_batch.side_effect = err
+    obs.on_delete.side_effect = err
+    obs.on_rename.side_effect = err
+    obs.on_mkdir.side_effect = err
+    obs.on_rmdir.side_effect = err
+    return obs
+
+
+class TestObserverErrorHandlingStrict:
+    """audit_strict_mode=True + failing observer → AuditLogError."""
+
+    @pytest.fixture
+    def failing_observer(self) -> MagicMock:
+        return _make_failing_observer()
+
+    @pytest.fixture
+    def nx_strict(
+        self, temp_dir: Path, failing_observer: MagicMock
+    ) -> Generator[NexusFS, None, None]:
+        nx = NexusFS(
+            backend=LocalBackend(str(temp_dir / "data")),
+            metadata_store=InMemoryMetastore(),
+            permissions=PermissionConfig(enforce=False, audit_strict_mode=True),
+            parsing=ParseConfig(auto_parse=False),
+            system_services=SystemServices(write_observer=failing_observer),
+        )
+        yield nx
+        nx.close()
+
+    def test_write_raises_audit_log_error_on_observer_failure(self, nx_strict: NexusFS) -> None:
+        from nexus.contracts.exceptions import AuditLogError
+
+        with pytest.raises(AuditLogError, match="audit logging failed"):
+            nx_strict.write("/test.txt", b"hello")
+
+    def test_mkdir_raises_audit_log_error_on_observer_failure(self, nx_strict: NexusFS) -> None:
+        from nexus.contracts.exceptions import AuditLogError
+
+        with pytest.raises(AuditLogError, match="audit logging failed"):
+            nx_strict.mkdir("/testdir")
+
+    def test_rmdir_raises_audit_log_error_on_observer_failure(
+        self, nx_strict: NexusFS, failing_observer: MagicMock
+    ) -> None:
+        from nexus.contracts.exceptions import AuditLogError
+
+        # Create dir with a non-failing observer first, then switch
+        failing_observer.on_mkdir.side_effect = None
+        nx_strict.mkdir("/testdir")
+        failing_observer.on_rmdir.side_effect = RuntimeError("observer boom")
+
+        with pytest.raises(AuditLogError, match="audit logging failed"):
+            nx_strict.rmdir("/testdir")
+
+
+class TestObserverErrorHandlingNonStrict:
+    """audit_strict_mode=False + failing observer → operation succeeds."""
+
+    @pytest.fixture
+    def failing_observer(self) -> MagicMock:
+        return _make_failing_observer()
+
+    @pytest.fixture
+    def nx_nonstrict(
+        self, temp_dir: Path, failing_observer: MagicMock
+    ) -> Generator[NexusFS, None, None]:
+        nx = NexusFS(
+            backend=LocalBackend(str(temp_dir / "data")),
+            metadata_store=InMemoryMetastore(),
+            permissions=PermissionConfig(enforce=False, audit_strict_mode=False),
+            parsing=ParseConfig(auto_parse=False),
+            system_services=SystemServices(write_observer=failing_observer),
+        )
+        yield nx
+        nx.close()
+
+    def test_write_succeeds_despite_observer_failure(self, nx_nonstrict: NexusFS) -> None:
+        result = nx_nonstrict.write("/test.txt", b"hello")
+        assert result["etag"] is not None
+
+    def test_mkdir_succeeds_despite_observer_failure(self, nx_nonstrict: NexusFS) -> None:
+        # Should not raise — observer failure is logged but swallowed
+        nx_nonstrict.mkdir("/testdir")


### PR DESCRIPTION
## Summary

- Replace duck-typed `_notify_observer()` (getattr + `**kwargs`) with direct typed calls via `WriteObserverProtocol`
- Fix `_write_observer` type annotation: `Any` → `WriteObserverProtocol | None` (3 locations: nexus_fs_core.py, factory/_system.py, config.py)
- Add `_handle_observer_error()` defensive safety net (strict mode raises `AuditLogError`, non-strict logs critical)
- Replace all 5 `_notify_observer()` call sites with direct `obs.on_X()` dispatch (write, write_batch, delete, rename, write_stream)
- Fix `mkdir()`/`rmdir()` in nexus_fs.py: add missing error handling (previously had no try/except)
- Delete `_notify_observer()` method entirely
- Add 5 error handling tests (strict raises AuditLogError, non-strict logs and continues)

**Stream 2** | Issue #1631

## Architecture alignment (LEGO kernel)

- `WriteObserverProtocol` uses `@runtime_checkable` Protocol per KERNEL-ARCHITECTURE.md §3
- Wiring: `factory/_system.py` → `SystemServices` → `NexusFS._write_observer` → 7 direct dispatch sites
- Direct typed calls give mypy full visibility into method names and argument types
- No backward-compat shims needed — `_notify_observer` was private, zero external refs

## Files changed (5 files, +217 −107)

| File | Change |
|------|--------|
| `src/nexus/core/nexus_fs_core.py` | Type fix, `_handle_observer_error()`, replace 5 call sites, delete `_notify_observer()` |
| `src/nexus/core/nexus_fs.py` | Fix mkdir/rmdir — add error handling with same pattern |
| `src/nexus/contracts/write_observer.py` | Update docstring to reflect typed dispatch |
| `src/nexus/factory/_system.py` | `write_observer: Any` → `WriteObserverProtocol \| None` |
| `tests/unit/core/test_write_observer_calls.py` | Add 5 error handling tests (strict + non-strict) |

## Test plan

- [x] 24/24 `test_write_observer_calls.py` pass (19 existing + 5 new)
- [x] 137/137 observer/audit/syncer tests pass
- [x] 10/10 dual write consistency E2E pass
- [x] 9/9 WriteBuffer metrics E2E pass (FastAPI in-process, performance <50ms)
- [x] 6/6 write-back E2E pass (live server subprocess)
- [x] ruff lint: all checks passed
- [x] ruff format: all files formatted
- [x] mypy: 0 issues on 4 source files
- [x] Pre-commit hooks: all passed