### PR TITLE
fix(#660): replace hardcoded zone_id "default" with ROOT_ZONE_ID in scripts

### DIFF
--- a/scripts/provision_namespace.py
+++ b/scripts/provision_namespace.py
@@ -24,6 +24,7 @@ from _core.constants import (
 )
 
 import nexus
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.types import OperationContext
 
 
@@ -77,7 +78,7 @@ def provision_system_resources(nx: Any) -> None:
     context = OperationContext(
         user_id="system",
         groups=[],
-        zone_id="default",
+        zone_id=ROOT_ZONE_ID,
         is_admin=True,
         is_system=False,  # Set to False as is_system may not be fully supported
     )
@@ -95,7 +96,7 @@ def provision_system_resources(nx: Any) -> None:
             subject=("system", "admin"),
             relation="owner-of",
             object=("file", template_path),
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
             context=context,
         )
         print(f"  ✓ Created {template_path} with ownership")
@@ -113,7 +114,7 @@ def provision_system_resources(nx: Any) -> None:
             subject=("system", "admin"),
             relation="owner-of",
             object=("file", skill_path),
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
             context=context,
         )
         print(f"  ✓ Created {skill_path} with ownership")
@@ -508,7 +509,7 @@ def load_env_file(env_file: str = ".env") -> dict:
     return env_vars
 
 
-def ensure_admin_api_key(zone_id: str = "default", env_file: str = ".env") -> str | None:
+def ensure_admin_api_key(zone_id: str = ROOT_ZONE_ID, env_file: str = ".env") -> str | None:
     """Ensure admin API key exists, loading from .env or creating if needed.
 
     Returns:

--- a/scripts/test_gcalendar_e2e.py
+++ b/scripts/test_gcalendar_e2e.py
@@ -380,6 +380,7 @@ def main():
 
     # Import after path setup
     from nexus.backends.gcalendar_connector import GoogleCalendarConnectorBackend
+    from nexus.constants import ROOT_ZONE_ID
     from nexus.contracts.types import OperationContext
 
     # Create backend
@@ -394,7 +395,7 @@ def main():
     context = OperationContext(
         user_id=user_email,
         groups=[],
-        zone_id="default",
+        zone_id=ROOT_ZONE_ID,
     )
 
     # Create temp directory for output

--- a/scripts/test_gmail_e2e.py
+++ b/scripts/test_gmail_e2e.py
@@ -606,6 +606,7 @@ def main():
 
     # Import after path setup
     from nexus.backends.gmail_connector import GmailConnectorBackend
+    from nexus.constants import ROOT_ZONE_ID
     from nexus.contracts.types import OperationContext
 
     # Create backend
@@ -619,7 +620,7 @@ def main():
     context = OperationContext(
         user_id=user_email,
         groups=[],
-        zone_id="default",
+        zone_id=ROOT_ZONE_ID,
     )
 
     # Create temp directory for output

--- a/scripts/test_gmail_real_api.py
+++ b/scripts/test_gmail_real_api.py
@@ -90,6 +90,7 @@ def get_db_url_from_docker():
 def test_gmail_multipart_parsing(user_email: str, max_messages: int = 5):
     """Test Gmail connector with real API calls."""
     from nexus.backends.gmail_connector import GmailConnectorBackend
+    from nexus.constants import ROOT_ZONE_ID
     from nexus.contracts.types import OperationContext
 
     try:
@@ -110,7 +111,7 @@ def test_gmail_multipart_parsing(user_email: str, max_messages: int = 5):
 
         # Create operation context
         context = OperationContext(
-            user_id=user_email, groups=[], zone_id="default", backend_path=""
+            user_id=user_email, groups=[], zone_id=ROOT_ZONE_ID, backend_path=""
         )
 
         # Get Gmail service


### PR DESCRIPTION
## Summary
- Replace 7 hardcoded `zone_id="default"` with `ROOT_ZONE_ID` constant in 4 script files
- Canonical root zone is `"root"` per federation-memo.md
- Files: `test_gmail_e2e.py`, `test_gcalendar_e2e.py`, `test_gmail_real_api.py`, `provision_namespace.py`

## Test plan
- [x] ruff clean
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)