### PR TITLE
feat(#883): plugins use NexusFilesystem Protocol instead of concrete ABC

### DIFF
--- a/src/nexus/plugins/base.py
+++ b/src/nexus/plugins/base.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from nexus.core.filesystem import NexusFilesystem
+from nexus.services.protocols.filesystem import NexusFilesystem
 
 
 @dataclass

--- a/src/nexus/plugins/registry.py
+++ b/src/nexus/plugins/registry.py
@@ -8,10 +8,10 @@ from typing import Any, cast
 
 import yaml
 
-from nexus.core.filesystem import NexusFilesystem
 from nexus.lib.registry import BaseRegistry
 from nexus.plugins.base import NexusPlugin, PluginMetadata
 from nexus.plugins.hooks import HookType, PluginHooks
+from nexus.services.protocols.filesystem import NexusFilesystem
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Change `plugins/base.py` and `plugins/registry.py` to import `NexusFilesystem` from `services/protocols/filesystem` (the narrow 7-method Protocol) instead of `core/filesystem` (the concrete ABC)
- Plugins should depend on the Protocol, not the concrete kernel implementation

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, Brick Zero-Core-Imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)