### PR TITLE
fix(#2126): replace deprecated asyncio APIs and add _RenameDetector tests

### DIFF
--- a/src/nexus/services/watch/file_watcher.py
+++ b/src/nexus/services/watch/file_watcher.py
@@ -202,7 +202,7 @@ class FileWatcher:
         if self._started:
             return
 
-        self._loop = loop or asyncio.get_event_loop()
+        self._loop = loop or asyncio.get_running_loop()
         self._stop_event.clear()
         self._started = True
         logger.info("FileWatcher started")
@@ -258,9 +258,9 @@ class FileWatcher:
         # Determine the actual path to watch with watchfiles
         watch_path = path if path.is_dir() else path.parent
 
-        info.task = asyncio.ensure_future(
+        assert self._loop is not None  # guaranteed by _started check above
+        info.task = self._loop.create_task(
             self._watch_loop(watch_path, callback, recursive),
-            loop=self._loop,
         )
         self._watches[key] = info
         logger.debug("Added watch: %s (recursive=%s)", path, recursive)
@@ -352,7 +352,11 @@ class FileWatcher:
                     try:
                         callback(fc)
                     except Exception:
-                        logger.exception("Error in file change callback")
+                        logger.exception(
+                            "Error in file change callback for %s (type=%s)",
+                            fc.path,
+                            fc.type.value,
+                        )
         except asyncio.CancelledError:
             pass  # normal shutdown
         except Exception:

--- a/tests/unit/services/test_file_watcher.py
+++ b/tests/unit/services/test_file_watcher.py
@@ -13,8 +13,14 @@ import asyncio
 from unittest.mock import MagicMock
 
 import pytest
+from watchfiles import Change
 
-from nexus.services.watch.file_watcher import ChangeType, FileChange, FileWatcher
+from nexus.services.watch.file_watcher import (
+    ChangeType,
+    FileChange,
+    FileWatcher,
+    _RenameDetector,
+)
 
 # =============================================================================
 # FileWatcher Lifecycle Tests
@@ -422,6 +428,119 @@ class TestFileChangeDataclass:
         assert result["type"] == "renamed"
         assert result["path"] == "/test/new.txt"
         assert result["old_path"] == "/test/old.txt"
+
+
+# =============================================================================
+# _RenameDetector Tests
+# =============================================================================
+
+
+class TestRenameDetector:
+    """Tests for _RenameDetector rename correlation logic."""
+
+    def test_single_delete_and_add_same_dir_produces_rename(self):
+        """One delete + one add in same directory -> RENAMED."""
+        raw: set[tuple[Change, str]] = {
+            (Change.deleted, "/dir/old.txt"),
+            (Change.added, "/dir/new.txt"),
+        }
+        result = _RenameDetector.process(raw)
+
+        assert len(result) == 1
+        assert result[0].type == ChangeType.RENAMED
+        assert result[0].path == "/dir/new.txt"
+        assert result[0].old_path == "/dir/old.txt"
+
+    def test_delete_and_add_different_dirs_no_rename(self):
+        """Delete in dir_a + add in dir_b -> separate events, no rename."""
+        raw: set[tuple[Change, str]] = {
+            (Change.deleted, "/dir_a/old.txt"),
+            (Change.added, "/dir_b/new.txt"),
+        }
+        result = _RenameDetector.process(raw)
+
+        assert len(result) == 2
+        types = {r.type for r in result}
+        assert types == {ChangeType.DELETED, ChangeType.CREATED}
+
+    def test_multiple_deletes_no_rename(self):
+        """Two deletes + one add -> no rename (ambiguous)."""
+        raw: set[tuple[Change, str]] = {
+            (Change.deleted, "/dir/a.txt"),
+            (Change.deleted, "/dir/b.txt"),
+            (Change.added, "/dir/c.txt"),
+        }
+        result = _RenameDetector.process(raw)
+
+        # Should have 3 separate events, no rename
+        types = [r.type for r in result]
+        assert ChangeType.RENAMED not in types
+        assert len(result) == 3
+
+    def test_hidden_files_filtered_for_rename_detection(self):
+        """Hidden files (.DS_Store) excluded from rename pairing."""
+        raw: set[tuple[Change, str]] = {
+            (Change.deleted, "/dir/old.txt"),
+            (Change.added, "/dir/new.txt"),
+            (Change.added, "/dir/.DS_Store"),
+        }
+        result = _RenameDetector.process(raw)
+
+        # Rename detected for visible pair; hidden file emitted separately
+        rename_events = [r for r in result if r.type == ChangeType.RENAMED]
+        created_events = [r for r in result if r.type == ChangeType.CREATED]
+
+        assert len(rename_events) == 1
+        assert rename_events[0].path == "/dir/new.txt"
+        assert rename_events[0].old_path == "/dir/old.txt"
+        assert len(created_events) == 1
+        assert ".DS_Store" in created_events[0].path
+
+    def test_empty_batch_returns_empty(self):
+        """Empty raw set -> empty result."""
+        raw: set[tuple[Change, str]] = set()
+        result = _RenameDetector.process(raw)
+        assert result == []
+
+    def test_modified_events_pass_through(self):
+        """Modified events pass through unchanged."""
+        raw: set[tuple[Change, str]] = {
+            (Change.modified, "/dir/file.txt"),
+        }
+        result = _RenameDetector.process(raw)
+
+        assert len(result) == 1
+        assert result[0].type == ChangeType.MODIFIED
+        assert result[0].path == "/dir/file.txt"
+
+    def test_only_hidden_files_no_rename(self):
+        """All hidden files -> individual events, no rename."""
+        raw: set[tuple[Change, str]] = {
+            (Change.deleted, "/dir/.hidden_old"),
+            (Change.added, "/dir/.hidden_new"),
+        }
+        result = _RenameDetector.process(raw)
+
+        # No visible files -> no rename detected
+        types = [r.type for r in result]
+        assert ChangeType.RENAMED not in types
+        assert len(result) == 2
+
+    def test_mixed_events_with_rename(self):
+        """Rename pair + modify in same batch -> both emitted."""
+        raw: set[tuple[Change, str]] = {
+            (Change.deleted, "/dir/old.txt"),
+            (Change.added, "/dir/new.txt"),
+            (Change.modified, "/dir/other.txt"),
+        }
+        result = _RenameDetector.process(raw)
+
+        rename_events = [r for r in result if r.type == ChangeType.RENAMED]
+        modified_events = [r for r in result if r.type == ChangeType.MODIFIED]
+
+        assert len(rename_events) == 1
+        assert len(modified_events) == 1
+        assert modified_events[0].path == "/dir/other.txt"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Replace `asyncio.get_event_loop()` with `get_running_loop()` (deprecated since Python 3.10)
- Replace `asyncio.ensure_future(loop=)` with `loop.create_task()` (deprecated since Python 3.10)
- Add type narrowing `assert self._loop is not None` before `create_task()`
- Improve error logging with path/type context in `_watch_loop` callback handler
- Add 8 `_RenameDetector` unit tests covering: rename detection, cross-directory no-rename, ambiguous multi-delete, hidden file filtering (.DS_Store), empty batch, modified pass-through, hidden-only files, mixed rename+modify

**Stream #11**

## LEGO Architecture Compliance

- `FileWatcher` has **zero** `nexus.*` imports — pure service isolation (Services tier)
- `EventsService` only imports protocols/constants — no upward tier violations
- Factory wiring uses two-phase DI boot, no circular dependencies
- Brick Zero-Core-Imports pre-commit hook passes

## Test plan

- [x] 30/30 unit tests pass (including 8 new `_RenameDetector` tests)
- [x] 32/33 e2e self-contained tests pass (1 pre-existing macOS FSEvents race)
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] mypy clean (no issues)
- [x] All pre-commit hooks pass
- [x] Server boots with `NEXUS_ENFORCE_PERMISSIONS=true` — no errors, 21/22 bricks