### PR TITLE
refactor(#2072): polish observability subsystem — DRY registry, relocate thread pool

### DIFF
--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -156,6 +156,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await startup_observability(app, svc)
     # Re-extract observability_registry after startup_observability writes it
     svc.observability_registry = getattr(app.state, "observability_registry", None)
+
+    # Configure thread pool size (Issue #932) — server infra, not observability
+    from anyio import to_thread
+
+    limiter = to_thread.current_default_thread_limiter()
+    limiter.total_tokens = svc.thread_pool_size
+    logger.info("Thread pool size set to %d", limiter.total_tokens)
+
     _done(StartupPhase.OBSERVABILITY)
 
     _compute_features_info(app, svc)

--- a/src/nexus/server/lifespan/observability.py
+++ b/src/nexus/server/lifespan/observability.py
@@ -6,8 +6,10 @@ Replaces 6 inline _startup_* / 3 shutdown_* calls with a single registry.
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from nexus.server.observability.registry import ObservabilityRegistry
@@ -18,6 +20,35 @@ if TYPE_CHECKING:
     from nexus.server.lifespan.services_container import LifespanServices
 
 logger = logging.getLogger(__name__)
+
+# Declarative registration table: (name, module_path, setup_function, shutdown_function)
+_OBSERVABILITY_PROVIDERS: list[tuple[str, str, str, str]] = [
+    ("logging", "nexus.server.logging_config", "configure_logging", "shutdown_logging"),
+    ("otel-tracing", "nexus.server.telemetry", "setup_telemetry", "shutdown_telemetry"),
+    ("sentry", "nexus.server.sentry", "setup_sentry", "shutdown_sentry"),
+    ("pyroscope", "nexus.server.profiling", "setup_profiling", "shutdown_profiling"),
+    ("prometheus", "nexus.server.metrics", "setup_prometheus", "shutdown_prometheus"),
+]
+
+
+def _make_start(mod: str, fn: str) -> Callable[..., None]:
+    """Factory for lazy-import start functions (avoids closure-over-loop-variable bugs)."""
+
+    def _start(**kwargs: Any) -> None:
+        module = importlib.import_module(mod)
+        getattr(module, fn)(**kwargs)
+
+    return _start
+
+
+def _make_stop(mod: str, fn: str) -> Callable[[], None]:
+    """Factory for lazy-import stop functions (avoids closure-over-loop-variable bugs)."""
+
+    def _stop() -> None:
+        module = importlib.import_module(mod)
+        getattr(module, fn)()
+
+    return _stop
 
 
 def create_registry(*, write_observer: Any = None) -> ObservabilityRegistry:
@@ -31,93 +62,20 @@ def create_registry(*, write_observer: Any = None) -> ObservabilityRegistry:
     from nexus.server.observability.components import FunctionPairComponent, WriteBufferComponent
 
     registry = ObservabilityRegistry()
-
-    # Logging — lazy import start/stop functions
     env = os.environ.get("NEXUS_ENV", "dev")
 
-    def _start_logging() -> None:
-        from nexus.server.logging_config import configure_logging
-
-        configure_logging(env=env)
-
-    def _stop_logging() -> None:
-        from nexus.server.logging_config import shutdown_logging
-
-        shutdown_logging()
-
-    registry.register(
-        "logging",
-        FunctionPairComponent("logging", start_fn=_start_logging, stop_fn=_stop_logging),
-        required=False,
-    )
-
-    # OTel Tracing
-    def _start_otel() -> None:
-        from nexus.server.telemetry import setup_telemetry
-
-        setup_telemetry()
-
-    def _stop_otel() -> None:
-        from nexus.server.telemetry import shutdown_telemetry
-
-        shutdown_telemetry()
-
-    registry.register(
-        "otel-tracing",
-        FunctionPairComponent("otel-tracing", start_fn=_start_otel, stop_fn=_stop_otel),
-        required=False,
-    )
-
-    # Sentry
-    def _start_sentry() -> None:
-        from nexus.server.sentry import setup_sentry
-
-        setup_sentry()
-
-    def _stop_sentry() -> None:
-        from nexus.server.sentry import shutdown_sentry
-
-        shutdown_sentry()
-
-    registry.register(
-        "sentry",
-        FunctionPairComponent("sentry", start_fn=_start_sentry, stop_fn=_stop_sentry),
-        required=False,
-    )
-
-    # Pyroscope
-    def _start_pyroscope() -> None:
-        from nexus.server.profiling import setup_profiling
-
-        setup_profiling()
-
-    def _stop_pyroscope() -> None:
-        from nexus.server.profiling import shutdown_profiling
-
-        shutdown_profiling()
-
-    registry.register(
-        "pyroscope",
-        FunctionPairComponent("pyroscope", start_fn=_start_pyroscope, stop_fn=_stop_pyroscope),
-        required=False,
-    )
-
-    # Prometheus
-    def _start_prometheus() -> None:
-        from nexus.server.metrics import setup_prometheus
-
-        setup_prometheus()
-
-    def _stop_prometheus() -> None:
-        from nexus.server.metrics import shutdown_prometheus
-
-        shutdown_prometheus()
-
-    registry.register(
-        "prometheus",
-        FunctionPairComponent("prometheus", start_fn=_start_prometheus, stop_fn=_stop_prometheus),
-        required=False,
-    )
+    for comp_name, module_path, setup_fn_name, shutdown_fn_name in _OBSERVABILITY_PROVIDERS:
+        start_kwargs: dict[str, Any] = {"env": env} if comp_name == "logging" else {}
+        registry.register(
+            comp_name,
+            FunctionPairComponent(
+                comp_name,
+                start_fn=_make_start(module_path, setup_fn_name),
+                stop_fn=_make_stop(module_path, shutdown_fn_name),
+                start_kwargs=start_kwargs,
+            ),
+            required=False,
+        )
 
     # WriteBuffer (Issue #1370) — managed shutdown, started by factory
     if write_observer is not None:
@@ -144,7 +102,6 @@ async def startup_observability(app: FastAPI, svc: LifespanServices) -> None:
         logger.info("Observability components skipped: %s", ", ".join(failed))
 
     logger.info("Starting FastAPI Nexus server...")
-    _startup_thread_pool(svc)
 
 
 async def shutdown_observability(app: FastAPI, _svc: LifespanServices) -> None:
@@ -153,12 +110,3 @@ async def shutdown_observability(app: FastAPI, _svc: LifespanServices) -> None:
     if registry:
         await registry.shutdown_all()
         app.state.observability_registry = None
-
-
-def _startup_thread_pool(svc: LifespanServices) -> None:
-    """Configure thread pool size (Issue #932)."""
-    from anyio import to_thread
-
-    limiter = to_thread.current_default_thread_limiter()
-    limiter.total_tokens = svc.thread_pool_size
-    logger.info("Thread pool size set to %d", limiter.total_tokens)

--- a/tests/unit/server/test_observability_registry.py
+++ b/tests/unit/server/test_observability_registry.py
@@ -382,3 +382,81 @@ class TestWriteBufferComponent:
         comp = WriteBufferComponent(write_observer=wo)
         await comp.shutdown()
         wo.stop.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create_registry() wiring tests (Issue #2072)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRegistry:
+    """Tests for create_registry() wiring (Issue #2072)."""
+
+    def test_registers_all_providers(self) -> None:
+        """create_registry() should register 5 observability providers."""
+        from nexus.server.lifespan.observability import create_registry
+
+        registry = create_registry()
+        names = [name for name, _, _ in registry._components]
+        assert "logging" in names
+        assert "otel-tracing" in names
+        assert "sentry" in names
+        assert "pyroscope" in names
+        assert "prometheus" in names
+        assert len(names) == 5  # No write-buffer when write_observer=None
+
+    def test_registers_write_buffer_when_observer_provided(self) -> None:
+        from unittest.mock import MagicMock
+
+        from nexus.server.lifespan.observability import create_registry
+
+        registry = create_registry(write_observer=MagicMock())
+        names = [name for name, _, _ in registry._components]
+        assert "write-buffer" in names
+        assert len(names) == 6
+
+    def test_registration_order_matches_dependency_order(self) -> None:
+        from nexus.server.lifespan.observability import create_registry
+
+        registry = create_registry()
+        names = [name for name, _, _ in registry._components]
+        # Logging must be first (other components may log during startup)
+        assert names[0] == "logging"
+
+    @pytest.mark.asyncio
+    async def test_start_all_does_not_raise_on_missing_deps(self) -> None:
+        """start_all() should gracefully handle missing optional deps."""
+        from nexus.server.lifespan.observability import create_registry
+
+        registry = create_registry()
+        # All components are optional (required=False), so even if
+        # otel/sentry/pyroscope aren't installed, start should succeed
+        statuses = await registry.start_all()
+        # At minimum logging should start
+        assert any(s.started for s in statuses)
+        await registry.shutdown_all()
+
+
+# ---------------------------------------------------------------------------
+# Registry performance benchmark (Issue #2072)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryPerformance:
+    """Benchmark registry overhead (Issue #2072)."""
+
+    @pytest.mark.asyncio
+    async def test_start_shutdown_overhead_under_100ms(self) -> None:
+        """Registry with 10 mock components should start+shutdown in <100ms."""
+        import time
+
+        registry = ObservabilityRegistry()
+        for i in range(10):
+            registry.register(f"mock-{i}", FakeComponent(f"mock-{i}"))
+
+        start = time.perf_counter()
+        await registry.start_all()
+        await registry.shutdown_all()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert elapsed_ms < 100, f"Registry overhead: {elapsed_ms:.1f}ms"


### PR DESCRIPTION
## Summary

**Stream 5** | Issue #2072 — Consolidate Observability Subsystem (polish pass)

- **DRY up `create_registry()`**: Replace 5 near-identical closure pairs (~80 LOC) with a declarative `_OBSERVABILITY_PROVIDERS` table + `_make_start`/`_make_stop` factory functions (~20 LOC). Eliminates closure-over-loop-variable risk.
- **Relocate `_startup_thread_pool()`**: Move thread pool config from `observability.py` to `lifespan/__init__.py` — thread pool sizing is server infrastructure, not observability. Aligns with the Lego architecture tier separation (kernel/services/bricks).
- **Add `TestCreateRegistry` (4 tests)**: Validates 5 providers registered, write-buffer wiring, logging-first ordering, graceful start with missing optional deps.
- **Add `TestRegistryPerformance` (1 test)**: Benchmarks 10-component start+shutdown under 100ms.

## Architecture Alignment (Lego/Brick)

Per `NEXUS-LEGO-ARCHITECTURE.md` and `KERNEL-ARCHITECTURE.md`:
- Observability is a **service** (not kernel) — stays in `lifespan/observability.py`
- Registry follows OTel Collector `component.Component` protocol pattern
- Declarative table matches brick composition pattern (constructor injection)
- Thread pool is server infra, now lives in `lifespan/__init__.py` (correct tier)
- All components use `LifecycleComponent` protocol (duck-typed, no ABC inheritance)

## Files Changed

| File | Change |
|------|--------|
| `src/nexus/server/lifespan/observability.py` | DRY registration table, remove `_startup_thread_pool()` |
| `src/nexus/server/lifespan/__init__.py` | Add thread pool config inline (3 lines) |
| `tests/unit/server/test_observability_registry.py` | Add `TestCreateRegistry` (4) + `TestRegistryPerformance` (1) |

## Test Plan

- [x] 28/28 unit tests pass (`test_observability_registry.py`)
- [x] 11/11 E2E tests pass (`test_observability_pipeline.py`)
- [x] Full lifespan E2E: `/health` 200, `/metrics` 200, `/api/v2/features` 200
- [x] Registry starts all 6 components in correct order (logging first)
- [x] Shutdown in reverse LIFO order confirmed
- [x] Thread pool set to 200 (logged from `lifespan/__init__.py`)
- [x] Performance: registry overhead ~5ms for all components
- [x] `ruff check` — all passed
- [x] `ruff format` — all formatted
- [x] `mypy` — no issues found