### PR TITLE
feat(#2172): agent warmup phase — structured initialization before accepting work

### DIFF
--- a/src/nexus/contracts/agent_warmup_types.py
+++ b/src/nexus/contracts/agent_warmup_types.py
@@ -1,0 +1,110 @@
+"""Agent warmup phase types (Issue #2172).
+
+Pure value objects for structured agent initialization before accepting work.
+Zero runtime dependencies — only stdlib imports.
+
+WarmupStep defines a named initialization step with timeout and required/optional
+semantics. WarmupResult captures the outcome of a warmup attempt. WarmupContext
+provides typed dependency injection for step functions.
+
+Design:
+    - Server-orchestrated: warmup runs on the server side
+    - Sequential execution: steps run in order with per-step timeouts
+    - Required steps gate transition to CONNECTED
+    - Optional steps log failures but continue
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class WarmupStep:
+    """A single initialization step in the agent warmup sequence.
+
+    Attributes:
+        name: Step identifier (e.g. "load_credentials", "mount_namespace").
+        timeout: Maximum time allowed for this step. Exceeding triggers
+            asyncio.TimeoutError.
+        required: If True, step failure aborts warmup and agent stays
+            in UNKNOWN state. If False, failure is logged and warmup
+            continues to the next step.
+    """
+
+    name: str
+    timeout: timedelta = field(default_factory=lambda: timedelta(seconds=30))
+    required: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class WarmupResult:
+    """Outcome of an agent warmup attempt.
+
+    Immutable snapshot capturing exactly what happened during warmup:
+    which steps completed, which were skipped (optional failures),
+    which step caused failure (if any), and total duration.
+
+    Attributes:
+        success: True if all required steps passed and agent transitioned
+            to CONNECTED.
+        agent_id: The agent that was warmed up.
+        steps_completed: Names of steps that completed successfully, in order.
+        steps_skipped: Names of optional steps that failed (logged, not fatal).
+        failed_step: Name of the required step that failed, or None on success.
+        error: Human-readable error message if warmup failed.
+        duration_ms: Total wallclock time of the warmup in milliseconds.
+    """
+
+    success: bool
+    agent_id: str
+    steps_completed: tuple[str, ...] = ()
+    steps_skipped: tuple[str, ...] = ()
+    failed_step: str | None = None
+    error: str | None = None
+    duration_ms: float = 0.0
+
+
+@dataclass(frozen=True)
+class WarmupContext:
+    """Typed dependency bag for warmup step functions.
+
+    Each step function receives this context and accesses only the
+    dependencies it needs. Optional dependencies are None when the
+    corresponding service is not available.
+
+    Follows the LifespanServices pattern from server/lifespan/services_container.py.
+
+    Attributes:
+        agent_id: The agent being warmed up.
+        agent_record: Immutable snapshot of the agent at warmup start.
+        agent_registry: AgentRegistry for state queries.
+        namespace_manager: NamespaceManager for mount resolution (optional).
+        enabled_bricks: Set of brick names enabled in this deployment.
+        cache_store: CacheStoreABC for cache warming (optional).
+        mcp_config: MCP server configuration (optional).
+    """
+
+    agent_id: str
+    agent_record: Any  # AgentRecord (TYPE_CHECKING import avoided for zero-dep)
+    agent_registry: Any  # AgentRegistry
+    namespace_manager: Any | None = None
+    enabled_bricks: frozenset[str] = field(default_factory=frozenset)
+    cache_store: Any | None = None
+    mcp_config: dict[str, Any] | None = None
+
+
+# Type alias for warmup step functions is defined in the service module
+# to avoid importing async types into a pure-data contracts module.
+
+# Standard warmup sequence for common agent types (Issue #2172).
+STANDARD_WARMUP: tuple[WarmupStep, ...] = (
+    WarmupStep("load_credentials", timeout=timedelta(seconds=5)),
+    WarmupStep("mount_namespace", timeout=timedelta(seconds=10)),
+    WarmupStep("verify_bricks", timeout=timedelta(seconds=10)),
+    WarmupStep("warm_caches", timeout=timedelta(seconds=15), required=False),
+    WarmupStep("connect_mcp", timeout=timedelta(seconds=10), required=False),
+    WarmupStep("load_context", timeout=timedelta(seconds=20)),
+)

--- a/src/nexus/server/api/v2/routers/agent_status.py
+++ b/src/nexus/server/api/v2/routers/agent_status.py
@@ -1,9 +1,10 @@
-"""Agent spec/status REST API endpoints (Issue #2169).
+"""Agent spec/status/warmup REST API endpoints (Issues #2169, #2172).
 
 Provides:
 - GET  /api/v2/agents/{agent_id}/status  - Computed agent status
 - PUT  /api/v2/agents/{agent_id}/spec    - Set agent spec
 - GET  /api/v2/agents/{agent_id}/spec    - Get agent spec
+- POST /api/v2/agents/{agent_id}/warmup  - Trigger agent warmup
 
 All endpoints are authenticated via existing auth middleware.
 
@@ -91,6 +92,63 @@ class AgentStatusResponse(BaseModel):
     last_activity: str | None
     inbox_depth: int
     context_usage_pct: float
+
+
+class WarmupStepModel(BaseModel):
+    """A single warmup step in the request body (Issue #2172)."""
+
+    name: str
+    timeout_seconds: float = 30.0
+    required: bool = True
+
+
+class WarmupRequest(BaseModel):
+    """Request body for POST /warmup (Issue #2172)."""
+
+    steps: list[WarmupStepModel] | None = None
+
+
+class WarmupResponse(BaseModel):
+    """Response body for POST /warmup (Issue #2172)."""
+
+    success: bool
+    agent_id: str
+    steps_completed: list[str] = []
+    steps_skipped: list[str] = []
+    failed_step: str | None = None
+    error: str | None = None
+    duration_ms: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers (DRY fix — Issue #2172)
+# ---------------------------------------------------------------------------
+
+
+def _spec_to_response(stored: Any) -> AgentSpecResponse:
+    """Convert an AgentSpec domain object to AgentSpecResponse.
+
+    Eliminates duplication across set_agent_spec and get_agent_spec endpoints.
+    """
+    return AgentSpecResponse(
+        agent_type=stored.agent_type,
+        capabilities=sorted(stored.capabilities),
+        resource_requests=AgentResourcesModel(
+            token_budget=stored.resource_requests.token_budget,
+            token_request=stored.resource_requests.token_request,
+            storage_limit_mb=stored.resource_requests.storage_limit_mb,
+            context_limit=stored.resource_requests.context_limit,
+        ),
+        resource_limits=AgentResourcesModel(
+            token_budget=stored.resource_limits.token_budget,
+            token_request=stored.resource_limits.token_request,
+            storage_limit_mb=stored.resource_limits.storage_limit_mb,
+            context_limit=stored.resource_limits.context_limit,
+        ),
+        qos_class=str(stored.qos_class),
+        zone_affinity=stored.zone_affinity,
+        spec_generation=stored.spec_generation,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -208,25 +266,7 @@ async def set_agent_spec(
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-    return AgentSpecResponse(
-        agent_type=stored.agent_type,
-        capabilities=sorted(stored.capabilities),
-        resource_requests=AgentResourcesModel(
-            token_budget=stored.resource_requests.token_budget,
-            token_request=stored.resource_requests.token_request,
-            storage_limit_mb=stored.resource_requests.storage_limit_mb,
-            context_limit=stored.resource_requests.context_limit,
-        ),
-        resource_limits=AgentResourcesModel(
-            token_budget=stored.resource_limits.token_budget,
-            token_request=stored.resource_limits.token_request,
-            storage_limit_mb=stored.resource_limits.storage_limit_mb,
-            context_limit=stored.resource_limits.context_limit,
-        ),
-        qos_class=str(stored.qos_class),
-        zone_affinity=stored.zone_affinity,
-        spec_generation=stored.spec_generation,
-    )
+    return _spec_to_response(stored)
 
 
 @router.get(
@@ -245,22 +285,63 @@ async def get_agent_spec(
     if stored is None:
         raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' has no spec")
 
-    return AgentSpecResponse(
-        agent_type=stored.agent_type,
-        capabilities=sorted(stored.capabilities),
-        resource_requests=AgentResourcesModel(
-            token_budget=stored.resource_requests.token_budget,
-            token_request=stored.resource_requests.token_request,
-            storage_limit_mb=stored.resource_requests.storage_limit_mb,
-            context_limit=stored.resource_requests.context_limit,
-        ),
-        resource_limits=AgentResourcesModel(
-            token_budget=stored.resource_limits.token_budget,
-            token_request=stored.resource_limits.token_request,
-            storage_limit_mb=stored.resource_limits.storage_limit_mb,
-            context_limit=stored.resource_limits.context_limit,
-        ),
-        qos_class=str(stored.qos_class),
-        zone_affinity=stored.zone_affinity,
-        spec_generation=stored.spec_generation,
+    return _spec_to_response(stored)
+
+
+# ---------------------------------------------------------------------------
+# Warmup endpoint (Issue #2172)
+# ---------------------------------------------------------------------------
+
+
+async def _get_warmup_service(request: Request) -> Any:
+    """Get AgentWarmupService from app state."""
+    service = getattr(request.app.state, "agent_warmup_service", None)
+    if service is None:
+        raise HTTPException(status_code=503, detail="Agent warmup service not available")
+    return service
+
+
+@router.post(
+    "/api/v2/agents/{agent_id}/warmup",
+    response_model=WarmupResponse,
+    summary="Trigger agent warmup (Issue #2172)",
+    description=(
+        "Execute structured warmup steps for an agent before it accepts work. "
+        "Steps run sequentially with per-step timeouts. Required steps must "
+        "pass for the agent to transition from UNKNOWN to CONNECTED."
+    ),
+)
+async def warmup_agent(
+    agent_id: str,
+    body: WarmupRequest | None = None,
+    _auth: dict = Depends(_get_require_auth()),
+    warmup_service: Any = Depends(_get_warmup_service),
+) -> WarmupResponse:
+    """Trigger agent warmup."""
+    from datetime import timedelta
+
+    from nexus.contracts.agent_warmup_types import WarmupStep
+
+    # Convert request body steps to domain objects (or use defaults)
+    steps: list[WarmupStep] | None = None
+    if body is not None and body.steps is not None:
+        steps = [
+            WarmupStep(
+                name=s.name,
+                timeout=timedelta(seconds=s.timeout_seconds),
+                required=s.required,
+            )
+            for s in body.steps
+        ]
+
+    result = await warmup_service.warmup(agent_id, steps=steps)
+
+    return WarmupResponse(
+        success=result.success,
+        agent_id=result.agent_id,
+        steps_completed=list(result.steps_completed),
+        steps_skipped=list(result.steps_skipped),
+        failed_step=result.failed_step,
+        error=result.error,
+        duration_ms=result.duration_ms,
     )

--- a/src/nexus/server/app_state.py
+++ b/src/nexus/server/app_state.py
@@ -76,6 +76,7 @@ class NexusAppState:
 
     # === Services (initialized to None, set during lifespan) ===
     agent_registry: Any = None
+    agent_warmup_service: Any = None
     async_agent_registry: Any = None
     async_rebac_manager: Any = None
     async_nexus_fs: Any = None

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -185,6 +185,26 @@ def _startup_agent_registry(app: FastAPI, svc: LifespanServices) -> None:
 
             app.state.async_agent_registry = AsyncAgentRegistry(app.state.agent_registry)
 
+            # Issue #2172: Create AgentWarmupService with step registry
+            try:
+                from nexus.services.agents.agent_warmup import AgentWarmupService
+                from nexus.services.agents.warmup_steps import register_standard_steps
+
+                app.state.agent_warmup_service = AgentWarmupService(
+                    agent_registry=app.state.agent_registry,
+                    namespace_manager=svc.namespace_manager,
+                    enabled_bricks=getattr(app.state, "enabled_bricks", frozenset()),
+                    cache_store=getattr(app.state, "cache_brick", None),
+                    mcp_config=None,
+                )
+                register_standard_steps(app.state.agent_warmup_service)
+                logger.info("[WARMUP] AgentWarmupService initialized with standard steps")
+            except Exception as e:
+                logger.warning(
+                    "[WARMUP] Failed to initialize AgentWarmupService: %s", e, exc_info=True
+                )
+                app.state.agent_warmup_service = None
+
             logger.info("[AGENT-REG] AgentRegistry initialized and wired")
         except Exception as e:
             logger.warning("[AGENT-REG] Failed to initialize AgentRegistry: %s", e, exc_info=True)

--- a/src/nexus/services/agents/agent_warmup.py
+++ b/src/nexus/services/agents/agent_warmup.py
@@ -1,0 +1,295 @@
+"""Agent warmup service — structured initialization before accepting work (Issue #2172).
+
+Server-orchestrated warmup that runs a sequence of steps for an agent,
+gating the UNKNOWN → CONNECTED transition on required step success.
+
+Design decisions (from review):
+    - 1A: Server-orchestrated (server runs all steps)
+    - 2C: UNKNOWN→CONNECTED gate (no new AgentState)
+    - 3A: Step registry + callables (ParserRegistry pattern)
+    - 13A: Sequential execution with per-step timeouts
+    - 14A: Session-per-operation (existing DB pattern)
+    - 16A: New warmup_and_connect() method (transition() unchanged)
+
+Edge cases handled:
+    - Re-warmup on already-CONNECTED agent → skip (idempotent)
+    - Required step timeout → WarmupResult with failed_step
+    - Required step exception → WarmupResult with error
+    - All optional steps fail → still transitions CONNECTED
+    - Agent unregistered during warmup → clean failure
+    - Concurrent warmup → optimistic locking via expected_generation
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.agent_types import AgentState
+from nexus.contracts.agent_warmup_types import (
+    STANDARD_WARMUP,
+    WarmupContext,
+    WarmupResult,
+    WarmupStep,
+)
+
+if TYPE_CHECKING:
+    from nexus.services.agents.agent_registry import AgentRegistry
+
+logger = logging.getLogger(__name__)
+
+# Type alias for warmup step functions.
+WarmupStepFn = Callable[[WarmupContext], Awaitable[bool]]
+
+
+class AgentWarmupService:
+    """Server-orchestrated agent warmup with step registry.
+
+    Follows the ParserRegistry pattern: step names map to async callables.
+    New steps are registered via ``register_step()``, and the executor
+    iterates the step list calling the registry.
+
+    Args:
+        agent_registry: AgentRegistry for state queries and transitions.
+        namespace_manager: Optional NamespaceManager for mount resolution.
+        enabled_bricks: Set of brick names enabled in this deployment.
+        cache_store: Optional CacheStoreABC for cache warming.
+        mcp_config: Optional MCP server configuration.
+    """
+
+    def __init__(
+        self,
+        agent_registry: AgentRegistry,
+        namespace_manager: Any | None = None,
+        enabled_bricks: frozenset[str] | None = None,
+        cache_store: Any | None = None,
+        mcp_config: dict[str, Any] | None = None,
+    ) -> None:
+        self._registry = agent_registry
+        self._namespace_manager = namespace_manager
+        self._enabled_bricks = enabled_bricks or frozenset()
+        self._cache_store = cache_store
+        self._mcp_config = mcp_config
+        self._step_registry: dict[str, WarmupStepFn] = {}
+
+    def register_step(self, name: str, fn: WarmupStepFn) -> None:
+        """Register a warmup step function.
+
+        Args:
+            name: Step name (must match WarmupStep.name).
+            fn: Async callable that receives WarmupContext and returns bool.
+
+        Raises:
+            ValueError: If a step with this name is already registered.
+        """
+        if name in self._step_registry:
+            raise ValueError(f"Warmup step '{name}' is already registered")
+        self._step_registry[name] = fn
+
+    def get_step(self, name: str) -> WarmupStepFn | None:
+        """Look up a registered step function by name.
+
+        Args:
+            name: Step name.
+
+        Returns:
+            The step function, or None if not registered.
+        """
+        return self._step_registry.get(name)
+
+    async def warmup(
+        self,
+        agent_id: str,
+        steps: list[WarmupStep] | None = None,
+    ) -> WarmupResult:
+        """Execute warmup steps for an agent.
+
+        Runs each step sequentially with per-step timeouts. Required steps
+        that fail abort warmup. Optional steps that fail are logged and
+        skipped. On success, transitions agent from UNKNOWN → CONNECTED.
+
+        Args:
+            agent_id: The agent to warm up.
+            steps: Warmup steps to execute. If None, uses STANDARD_WARMUP.
+
+        Returns:
+            WarmupResult with success status and step-level detail.
+        """
+        if steps is None:
+            steps = list(STANDARD_WARMUP)
+
+        start = time.monotonic()
+
+        # Edge case 1: Verify agent exists
+        record = self._registry.get(agent_id)
+        if record is None:
+            return WarmupResult(
+                success=False,
+                agent_id=agent_id,
+                error=f"Agent '{agent_id}' not found",
+                duration_ms=_elapsed_ms(start),
+            )
+
+        # Edge case 2: Already CONNECTED → skip (idempotent)
+        if record.state is AgentState.CONNECTED:
+            logger.info("[WARMUP] Agent %s already CONNECTED, skipping warmup", agent_id)
+            return WarmupResult(
+                success=True,
+                agent_id=agent_id,
+                duration_ms=_elapsed_ms(start),
+            )
+
+        # Edge case 5: Empty step list → immediate transition
+        if not steps:
+            return await self._transition_connected(agent_id, record.generation, start, (), ())
+
+        # Build context for step functions
+        ctx = WarmupContext(
+            agent_id=agent_id,
+            agent_record=record,
+            agent_registry=self._registry,
+            namespace_manager=self._namespace_manager,
+            enabled_bricks=self._enabled_bricks,
+            cache_store=self._cache_store,
+            mcp_config=self._mcp_config,
+        )
+
+        completed: list[str] = []
+        skipped: list[str] = []
+
+        for step in steps:
+            step_fn = self._step_registry.get(step.name)
+            if step_fn is None:
+                # Unregistered step: skip if optional, fail if required
+                if step.required:
+                    logger.error(
+                        "[WARMUP] Required step '%s' not registered for agent %s",
+                        step.name,
+                        agent_id,
+                    )
+                    return WarmupResult(
+                        success=False,
+                        agent_id=agent_id,
+                        steps_completed=tuple(completed),
+                        steps_skipped=tuple(skipped),
+                        failed_step=step.name,
+                        error=f"Required step '{step.name}' is not registered",
+                        duration_ms=_elapsed_ms(start),
+                    )
+                logger.debug("[WARMUP] Optional step '%s' not registered, skipping", step.name)
+                skipped.append(step.name)
+                continue
+
+            # Execute step with timeout
+            success = await self._execute_step(step, step_fn, ctx)
+
+            if success:
+                completed.append(step.name)
+            elif step.required:
+                # Required step failed → abort
+                return WarmupResult(
+                    success=False,
+                    agent_id=agent_id,
+                    steps_completed=tuple(completed),
+                    steps_skipped=tuple(skipped),
+                    failed_step=step.name,
+                    error=f"Required step '{step.name}' failed",
+                    duration_ms=_elapsed_ms(start),
+                )
+            else:
+                # Optional step failed → skip and continue
+                skipped.append(step.name)
+
+        # All required steps passed → transition to CONNECTED
+        return await self._transition_connected(
+            agent_id, record.generation, start, tuple(completed), tuple(skipped)
+        )
+
+    async def _execute_step(
+        self,
+        step: WarmupStep,
+        step_fn: WarmupStepFn,
+        ctx: WarmupContext,
+    ) -> bool:
+        """Execute a single warmup step with timeout.
+
+        Returns True on success, False on failure (timeout or exception).
+        """
+        timeout_secs = step.timeout.total_seconds()
+        try:
+            result = await asyncio.wait_for(step_fn(ctx), timeout=timeout_secs)
+            if result:
+                logger.debug("[WARMUP] Step '%s' completed for agent %s", step.name, ctx.agent_id)
+            else:
+                logger.warning(
+                    "[WARMUP] Step '%s' returned False for agent %s", step.name, ctx.agent_id
+                )
+            return bool(result)
+        except TimeoutError:
+            logger.warning(
+                "[WARMUP] Step '%s' timed out after %.1fs for agent %s",
+                step.name,
+                timeout_secs,
+                ctx.agent_id,
+            )
+            return False
+        except Exception:
+            logger.exception(
+                "[WARMUP] Step '%s' raised exception for agent %s", step.name, ctx.agent_id
+            )
+            return False
+
+    async def _transition_connected(
+        self,
+        agent_id: str,
+        expected_generation: int,
+        start: float,
+        completed: tuple[str, ...],
+        skipped: tuple[str, ...],
+    ) -> WarmupResult:
+        """Transition agent to CONNECTED after successful warmup.
+
+        Handles edge cases:
+        - Agent unregistered during warmup (ValueError)
+        - Concurrent warmup (StaleAgentError / InvalidTransitionError)
+        """
+        from nexus.services.agents.agent_registry import InvalidTransitionError, StaleAgentError
+
+        try:
+            self._registry.transition(
+                agent_id, AgentState.CONNECTED, expected_generation=expected_generation
+            )
+        except (ValueError, InvalidTransitionError, StaleAgentError) as exc:
+            logger.warning("[WARMUP] Failed to transition agent %s to CONNECTED: %s", agent_id, exc)
+            return WarmupResult(
+                success=False,
+                agent_id=agent_id,
+                steps_completed=completed,
+                steps_skipped=skipped,
+                error=str(exc),
+                duration_ms=_elapsed_ms(start),
+            )
+
+        elapsed = _elapsed_ms(start)
+        logger.info(
+            "[WARMUP] Agent %s warmed up in %.1fms (%d completed, %d skipped)",
+            agent_id,
+            elapsed,
+            len(completed),
+            len(skipped),
+        )
+        return WarmupResult(
+            success=True,
+            agent_id=agent_id,
+            steps_completed=completed,
+            steps_skipped=skipped,
+            duration_ms=elapsed,
+        )
+
+
+def _elapsed_ms(start: float) -> float:
+    """Compute elapsed milliseconds since start (monotonic)."""
+    return (time.monotonic() - start) * 1000.0

--- a/src/nexus/services/agents/warmup_steps.py
+++ b/src/nexus/services/agents/warmup_steps.py
@@ -1,0 +1,214 @@
+"""Standard warmup step implementations (Issue #2172).
+
+Each function receives a ``WarmupContext`` and returns True on success,
+False on failure. Functions are registered into the ``AgentWarmupService``
+step registry by ``register_standard_steps()``.
+
+Steps:
+    load_credentials   — Verify agent has valid credentials/API key
+    mount_namespace    — Resolve agent's namespace mount table
+    verify_bricks      — Check required bricks are enabled
+    warm_caches        — Pre-populate cache for agent's zone (optional)
+    connect_mcp        — Validate MCP server configuration (optional)
+    load_context       — Pre-load context manifest sources
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.contracts.agent_warmup_types import WarmupContext
+    from nexus.services.agents.agent_warmup import AgentWarmupService
+
+logger = logging.getLogger(__name__)
+
+
+async def load_credentials(ctx: WarmupContext) -> bool:
+    """Verify agent has valid credentials in the registry.
+
+    Checks that the agent record has a non-empty owner_id and is in a
+    state eligible for connection (UNKNOWN, IDLE, or SUSPENDED).
+    """
+    record = ctx.agent_record
+    if not record.owner_id:
+        logger.warning("[WARMUP:credentials] Agent %s has no owner_id", ctx.agent_id)
+        return False
+
+    from nexus.contracts.agent_types import AgentState
+
+    eligible = {AgentState.UNKNOWN, AgentState.IDLE, AgentState.SUSPENDED}
+    if record.state not in eligible:
+        logger.warning(
+            "[WARMUP:credentials] Agent %s in non-eligible state %s",
+            ctx.agent_id,
+            record.state.value,
+        )
+        return False
+
+    logger.debug("[WARMUP:credentials] Agent %s credentials verified", ctx.agent_id)
+    return True
+
+
+async def mount_namespace(ctx: WarmupContext) -> bool:
+    """Resolve the agent's namespace mount table.
+
+    Validates that the namespace manager can resolve mounts for this agent.
+    Skips gracefully if namespace_manager is not available.
+    """
+    ns_mgr = ctx.namespace_manager
+    if ns_mgr is None:
+        logger.debug("[WARMUP:namespace] No namespace_manager, skipping mount resolution")
+        return True  # Not a failure — just not configured
+
+    try:
+        # Attempt to resolve mounts for the agent's zone
+        zone_id = ctx.agent_record.zone_id
+        if zone_id is not None:
+            subject = ("agent", ctx.agent_id)
+            mounts = ns_mgr.get_mount_entries(subject, zone_id=zone_id)
+            logger.debug(
+                "[WARMUP:namespace] Resolved %d mounts for agent %s in zone %s",
+                len(mounts),
+                ctx.agent_id,
+                zone_id,
+            )
+        return True
+    except Exception:
+        logger.exception(
+            "[WARMUP:namespace] Failed to resolve namespace for agent %s", ctx.agent_id
+        )
+        return False
+
+
+async def verify_bricks(ctx: WarmupContext) -> bool:
+    """Check that the deployment has enabled bricks.
+
+    Validates that the enabled_bricks set is non-empty. If the agent
+    has declared required capabilities in metadata, checks that matching
+    bricks are available.
+    """
+    if not ctx.enabled_bricks:
+        logger.debug("[WARMUP:bricks] No enabled_bricks configured, skipping verification")
+        return True  # Not a failure — might be embedded deployment
+
+    # Check agent capabilities against enabled bricks
+    capabilities = ctx.agent_record.capabilities
+    if capabilities:
+        missing = [cap for cap in capabilities if cap not in ctx.enabled_bricks]
+        if missing:
+            logger.warning(
+                "[WARMUP:bricks] Agent %s requires bricks %s but they are not enabled",
+                ctx.agent_id,
+                missing,
+            )
+            # Don't fail — capabilities are advisory, not mandatory
+            # The agent can still function with degraded features
+
+    logger.debug(
+        "[WARMUP:bricks] %d bricks available for agent %s",
+        len(ctx.enabled_bricks),
+        ctx.agent_id,
+    )
+    return True
+
+
+async def warm_caches(ctx: WarmupContext) -> bool:
+    """Pre-populate cache for the agent's zone (optional step).
+
+    If a cache store is available and the agent has a zone_id, attempts
+    to warm frequently-accessed cache keys.
+    """
+    cache = ctx.cache_store
+    if cache is None:
+        logger.debug("[WARMUP:caches] No cache_store, skipping cache warmup")
+        return True
+
+    try:
+        zone_id = ctx.agent_record.zone_id
+        if zone_id is not None:
+            # Touch the cache to verify it's accessible
+            # Actual cache warming strategy depends on deployment
+            logger.debug("[WARMUP:caches] Cache store accessible for zone %s", zone_id)
+        return True
+    except Exception:
+        logger.exception("[WARMUP:caches] Cache warmup failed for agent %s", ctx.agent_id)
+        return False
+
+
+async def connect_mcp(ctx: WarmupContext) -> bool:
+    """Validate MCP server configuration (optional step).
+
+    Checks that MCP configuration is syntactically valid if provided.
+    Does not establish actual connections (that happens at request time).
+    """
+    mcp_cfg = ctx.mcp_config
+    if mcp_cfg is None:
+        logger.debug("[WARMUP:mcp] No MCP configuration, skipping")
+        return True
+
+    try:
+        # Validate configuration structure
+        servers = mcp_cfg.get("servers", [])
+        if not isinstance(servers, list):
+            logger.warning("[WARMUP:mcp] Invalid MCP servers config (not a list)")
+            return False
+
+        logger.debug("[WARMUP:mcp] %d MCP servers configured", len(servers))
+        return True
+    except Exception:
+        logger.exception("[WARMUP:mcp] MCP config validation failed for agent %s", ctx.agent_id)
+        return False
+
+
+async def load_context(ctx: WarmupContext) -> bool:
+    """Pre-load context manifest sources.
+
+    Validates that the agent's context_manifest (if any) references
+    sources that can be resolved. Does not fully load content — just
+    verifies manifest structure.
+    """
+    manifest = ctx.agent_record.context_manifest
+    if not manifest:
+        logger.debug("[WARMUP:context] No context manifest, skipping")
+        return True
+
+    try:
+        # Validate manifest entries are well-formed dicts
+        for i, entry in enumerate(manifest):
+            if not isinstance(entry, dict):
+                logger.warning(
+                    "[WARMUP:context] Manifest entry %d is not a dict for agent %s",
+                    i,
+                    ctx.agent_id,
+                )
+                return False
+
+        logger.debug(
+            "[WARMUP:context] Validated %d manifest entries for agent %s",
+            len(manifest),
+            ctx.agent_id,
+        )
+        return True
+    except Exception:
+        logger.exception(
+            "[WARMUP:context] Context manifest validation failed for agent %s", ctx.agent_id
+        )
+        return False
+
+
+def register_standard_steps(service: AgentWarmupService) -> None:
+    """Register all standard warmup steps into the service's step registry.
+
+    Called during service initialization (e.g., in factory.py or lifespan setup).
+
+    Args:
+        service: The AgentWarmupService to register steps into.
+    """
+    service.register_step("load_credentials", load_credentials)
+    service.register_step("mount_namespace", mount_namespace)
+    service.register_step("verify_bricks", verify_bricks)
+    service.register_step("warm_caches", warm_caches)
+    service.register_step("connect_mcp", connect_mcp)
+    service.register_step("load_context", load_context)

--- a/src/nexus/services/protocols/agent_warmup.py
+++ b/src/nexus/services/protocols/agent_warmup.py
@@ -1,0 +1,55 @@
+"""Agent warmup service protocol (Issue #2172).
+
+Defines the contract for structured agent initialization before accepting work.
+The warmup service runs a sequence of steps (credentials, namespace, bricks,
+caches, MCP, context) and gates the UNKNOWN → CONNECTED transition on
+required step success.
+
+Tier: System Service (TIER 3) — agent lifecycle infrastructure.
+
+References:
+    - docs/design/NEXUS-LEGO-ARCHITECTURE.md §2.4 (System Services)
+    - Issue #2172: Agent warmup phase
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from nexus.contracts.agent_warmup_types import WarmupResult, WarmupStep
+
+
+@runtime_checkable
+class AgentWarmupProtocol(Protocol):
+    """Service contract for structured agent warmup.
+
+    Implementations execute a sequence of warmup steps for an agent,
+    gating the transition to CONNECTED on required step success.
+
+    The warmup service is server-orchestrated: the server runs all steps
+    on behalf of the agent. Steps run sequentially with per-step timeouts.
+
+    Methods:
+        warmup: Execute warmup steps for an agent.
+    """
+
+    async def warmup(
+        self,
+        agent_id: str,
+        steps: list[WarmupStep] | None = None,
+    ) -> WarmupResult:
+        """Execute warmup steps for an agent.
+
+        Runs each step sequentially. Required steps that fail abort warmup
+        and leave the agent in UNKNOWN state. Optional steps that fail are
+        logged and skipped. On success, transitions the agent to CONNECTED.
+
+        Args:
+            agent_id: The agent to warm up.
+            steps: Warmup steps to execute. If None, uses STANDARD_WARMUP.
+
+        Returns:
+            WarmupResult with success status and step-level detail.
+        """
+        ...

--- a/tests/e2e/server/test_agent_warmup_e2e.py
+++ b/tests/e2e/server/test_agent_warmup_e2e.py
@@ -1,0 +1,282 @@
+"""E2E tests for agent warmup endpoint (Issue #2172).
+
+Tests the full pipeline: HTTP → REST endpoint → AgentWarmupService → AgentRegistry.
+Verifies the POST /api/v2/agents/{agent_id}/warmup endpoint works end-to-end
+with permissions enabled, exercises warmup step execution, and validates
+timing/performance.
+
+Uses httpx ASGITransport for in-process testing (no subprocess).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+def _create_test_app(tmp_path: Path, enforce_permissions: bool = False):
+    """Create a FastAPI app with real NexusFS + AgentWarmupService."""
+    from nexus.backends.local import LocalBackend
+    from nexus.core.config import PermissionConfig
+    from nexus.factory import create_nexus_fs
+    from nexus.server.fastapi_server import create_app
+    from tests.helpers.in_memory_metadata_store import InMemoryMetastore
+
+    os.environ.setdefault("NEXUS_JWT_SECRET", "test-secret-warmup-e2e")
+
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir(exist_ok=True)
+    backend = LocalBackend(root_path=str(storage_dir))
+    metadata_store = InMemoryMetastore()
+
+    db_url = f"sqlite:///{tmp_path / 'records.db'}"
+
+    nx = create_nexus_fs(
+        backend=backend,
+        metadata_store=metadata_store,
+        record_store=None,
+        permissions=PermissionConfig(
+            enforce=enforce_permissions,
+            allow_admin_bypass=True,
+            enforce_zone_isolation=False,
+            enable_tiger_cache=False,
+            enable_deferred=False,
+        ),
+        is_admin=True,
+    )
+
+    api_key = "test-api-key-warmup-e2e"
+    app = create_app(nexus_fs=nx, api_key=api_key, database_url=db_url)
+    return app, api_key
+
+
+def _run_async(coro):
+    """Run a coroutine in a fresh event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def test_app_with_warmup(tmp_path):
+    """Create test FastAPI app with warmup service and permissions."""
+    from nexus.lib.sync_bridge import shutdown_sync_bridge
+
+    app, api_key = _create_test_app(tmp_path, enforce_permissions=True)
+
+    # Wire AgentWarmupService onto app.state for the warmup endpoint
+    from nexus.services.agents.agent_registry import AgentRegistry
+    from nexus.services.agents.agent_warmup import AgentWarmupService
+    from nexus.services.agents.warmup_steps import register_standard_steps
+
+    # Create a fresh AgentRegistry for this test
+    from tests.helpers.in_memory_record_store import InMemoryRecordStore
+
+    record_store = InMemoryRecordStore()
+    registry = AgentRegistry(record_store=record_store, flush_interval=60)
+    app.state.agent_registry = registry
+
+    warmup_service = AgentWarmupService(
+        agent_registry=registry,
+        enabled_bricks=frozenset({"search", "pay", "auth"}),
+    )
+    register_standard_steps(warmup_service)
+    app.state.agent_warmup_service = warmup_service
+
+    yield app, api_key, registry, record_store
+
+    record_store.close()
+    shutdown_sync_bridge()
+
+
+class TestWarmupEndpointE2E:
+    """E2E: POST /api/v2/agents/{agent_id}/warmup through FastAPI."""
+
+    def test_warmup_service_not_available_returns_503(self, tmp_path):
+        """When warmup service is not wired, endpoint returns 503."""
+        from nexus.lib.sync_bridge import shutdown_sync_bridge
+
+        app, api_key = _create_test_app(tmp_path, enforce_permissions=False)
+        # Explicitly set warmup service to None
+        app.state.agent_warmup_service = None
+
+        async def _test():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v2/agents/agent-999/warmup",
+                    json={"steps": []},
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                assert resp.status_code == 503
+                assert "warmup" in resp.json()["detail"].lower()
+
+        _run_async(_test())
+        shutdown_sync_bridge()
+
+    def test_warmup_nonexistent_agent(self, test_app_with_warmup):
+        """Warmup on nonexistent agent → success=False with error."""
+        app, api_key, _registry, _rs = test_app_with_warmup
+
+        async def _test():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v2/agents/nonexistent-agent/warmup",
+                    json={"steps": [{"name": "load_credentials"}]},
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["success"] is False
+                assert "not found" in data["error"]
+                assert data["agent_id"] == "nonexistent-agent"
+
+        _run_async(_test())
+
+    def test_warmup_registered_agent_empty_steps(self, test_app_with_warmup):
+        """Warmup with empty steps → immediate CONNECTED."""
+        app, api_key, registry, _rs = test_app_with_warmup
+
+        # Register an agent
+        registry.register("e2e-agent-1", "alice")
+
+        async def _test():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v2/agents/e2e-agent-1/warmup",
+                    json={"steps": []},
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["success"] is True
+                assert data["agent_id"] == "e2e-agent-1"
+                assert data["duration_ms"] >= 0
+
+        _run_async(_test())
+
+        # Verify agent transitioned to CONNECTED
+        from nexus.contracts.agent_types import AgentState
+
+        record = registry.get("e2e-agent-1")
+        assert record.state is AgentState.CONNECTED
+
+    def test_warmup_with_custom_steps(self, test_app_with_warmup):
+        """Warmup with custom steps including optional + required."""
+        app, api_key, registry, _rs = test_app_with_warmup
+
+        registry.register("e2e-agent-2", "bob")
+
+        async def _test():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v2/agents/e2e-agent-2/warmup",
+                    json={
+                        "steps": [
+                            {"name": "load_credentials", "timeout_seconds": 5, "required": True},
+                            {"name": "verify_bricks", "timeout_seconds": 5, "required": True},
+                            {"name": "warm_caches", "timeout_seconds": 5, "required": False},
+                            {"name": "connect_mcp", "timeout_seconds": 5, "required": False},
+                        ]
+                    },
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["success"] is True
+                assert data["agent_id"] == "e2e-agent-2"
+                assert "load_credentials" in data["steps_completed"]
+                assert "verify_bricks" in data["steps_completed"]
+                assert data["duration_ms"] > 0
+
+        _run_async(_test())
+
+    def test_warmup_idempotent_on_connected_agent(self, test_app_with_warmup):
+        """Second warmup on already-CONNECTED agent → idempotent success."""
+        app, api_key, registry, _rs = test_app_with_warmup
+
+        registry.register("e2e-agent-3", "carol")
+
+        async def _test():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                headers = {"Authorization": f"Bearer {api_key}"}
+
+                # First warmup
+                resp1 = await client.post(
+                    "/api/v2/agents/e2e-agent-3/warmup",
+                    json={"steps": []},
+                    headers=headers,
+                )
+                assert resp1.status_code == 200
+                assert resp1.json()["success"] is True
+
+                # Second warmup (already CONNECTED)
+                resp2 = await client.post(
+                    "/api/v2/agents/e2e-agent-3/warmup",
+                    json={"steps": [{"name": "load_credentials"}]},
+                    headers=headers,
+                )
+                assert resp2.status_code == 200
+                assert resp2.json()["success"] is True
+
+        _run_async(_test())
+
+    def test_warmup_performance_under_100ms(self, test_app_with_warmup):
+        """Warmup with standard steps completes in under 100ms (no I/O)."""
+        app, api_key, registry, _rs = test_app_with_warmup
+
+        registry.register("e2e-agent-perf", "perf-user")
+
+        async def _test():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v2/agents/e2e-agent-perf/warmup",
+                    json={
+                        "steps": [
+                            {"name": "load_credentials", "timeout_seconds": 5},
+                            {"name": "verify_bricks", "timeout_seconds": 5},
+                            {"name": "load_context", "timeout_seconds": 5},
+                        ]
+                    },
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["success"] is True
+                # Performance: warmup should complete in < 100ms for in-memory steps
+                assert data["duration_ms"] < 100, (
+                    f"Warmup took {data['duration_ms']:.1f}ms, expected < 100ms"
+                )
+
+        _run_async(_test())
+
+    def test_warmup_no_body_uses_standard_steps(self, test_app_with_warmup):
+        """POST with no body uses STANDARD_WARMUP steps."""
+        app, api_key, registry, _rs = test_app_with_warmup
+
+        registry.register("e2e-agent-default", "default-user")
+
+        async def _test():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v2/agents/e2e-agent-default/warmup",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["success"] is True
+                assert data["agent_id"] == "e2e-agent-default"
+
+        _run_async(_test())

--- a/tests/unit/contracts/test_agent_warmup_types.py
+++ b/tests/unit/contracts/test_agent_warmup_types.py
@@ -1,0 +1,190 @@
+"""Tests for agent warmup types (Issue #2172).
+
+Verifies:
+1. WarmupStep frozen dataclass with defaults
+2. WarmupResult frozen dataclass with all fields
+3. WarmupContext frozen dataclass
+4. STANDARD_WARMUP sequence structure
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import timedelta
+
+import pytest
+
+from nexus.contracts.agent_warmup_types import (
+    STANDARD_WARMUP,
+    WarmupContext,
+    WarmupResult,
+    WarmupStep,
+)
+
+# ---------------------------------------------------------------------------
+# WarmupStep
+# ---------------------------------------------------------------------------
+
+
+class TestWarmupStep:
+    def test_defaults(self) -> None:
+        step = WarmupStep(name="test_step")
+        assert step.name == "test_step"
+        assert step.timeout == timedelta(seconds=30)
+        assert step.required is True
+
+    def test_custom_values(self) -> None:
+        step = WarmupStep(name="slow_step", timeout=timedelta(seconds=60), required=False)
+        assert step.name == "slow_step"
+        assert step.timeout == timedelta(seconds=60)
+        assert step.required is False
+
+    def test_frozen(self) -> None:
+        step = WarmupStep(name="immutable")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            step.name = "mutated"
+
+    def test_equality(self) -> None:
+        a = WarmupStep(name="x", timeout=timedelta(seconds=5))
+        b = WarmupStep(name="x", timeout=timedelta(seconds=5))
+        assert a == b
+
+    def test_inequality(self) -> None:
+        a = WarmupStep(name="x", required=True)
+        b = WarmupStep(name="x", required=False)
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# WarmupResult
+# ---------------------------------------------------------------------------
+
+
+class TestWarmupResult:
+    def test_success_result(self) -> None:
+        result = WarmupResult(
+            success=True,
+            agent_id="agent-1",
+            steps_completed=("load_credentials", "mount_namespace"),
+            duration_ms=42.5,
+        )
+        assert result.success is True
+        assert result.agent_id == "agent-1"
+        assert result.steps_completed == ("load_credentials", "mount_namespace")
+        assert result.steps_skipped == ()
+        assert result.failed_step is None
+        assert result.error is None
+        assert result.duration_ms == 42.5
+
+    def test_failure_result(self) -> None:
+        result = WarmupResult(
+            success=False,
+            agent_id="agent-2",
+            steps_completed=("load_credentials",),
+            steps_skipped=("warm_caches",),
+            failed_step="mount_namespace",
+            error="Required step 'mount_namespace' failed",
+            duration_ms=100.0,
+        )
+        assert result.success is False
+        assert result.failed_step == "mount_namespace"
+        assert result.error is not None
+        assert "mount_namespace" in result.error
+
+    def test_frozen(self) -> None:
+        result = WarmupResult(success=True, agent_id="agent-1")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            result.success = False
+
+    def test_defaults(self) -> None:
+        result = WarmupResult(success=True, agent_id="agent-1")
+        assert result.steps_completed == ()
+        assert result.steps_skipped == ()
+        assert result.failed_step is None
+        assert result.error is None
+        assert result.duration_ms == 0.0
+
+
+# ---------------------------------------------------------------------------
+# WarmupContext
+# ---------------------------------------------------------------------------
+
+
+class TestWarmupContext:
+    def test_minimal(self) -> None:
+        ctx = WarmupContext(
+            agent_id="agent-1",
+            agent_record={"fake": "record"},
+            agent_registry={"fake": "registry"},
+        )
+        assert ctx.agent_id == "agent-1"
+        assert ctx.namespace_manager is None
+        assert ctx.enabled_bricks == frozenset()
+        assert ctx.cache_store is None
+        assert ctx.mcp_config is None
+
+    def test_with_all_fields(self) -> None:
+        ctx = WarmupContext(
+            agent_id="agent-1",
+            agent_record={"fake": "record"},
+            agent_registry={"fake": "registry"},
+            namespace_manager="ns_mgr",
+            enabled_bricks=frozenset({"search", "pay"}),
+            cache_store="cache",
+            mcp_config={"servers": []},
+        )
+        assert ctx.namespace_manager == "ns_mgr"
+        assert "search" in ctx.enabled_bricks
+        assert ctx.cache_store == "cache"
+        assert ctx.mcp_config == {"servers": []}
+
+    def test_frozen(self) -> None:
+        ctx = WarmupContext(
+            agent_id="agent-1",
+            agent_record={"fake": "record"},
+            agent_registry={"fake": "registry"},
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ctx.agent_id = "mutated"
+
+
+# ---------------------------------------------------------------------------
+# STANDARD_WARMUP
+# ---------------------------------------------------------------------------
+
+
+class TestStandardWarmup:
+    def test_is_tuple(self) -> None:
+        assert isinstance(STANDARD_WARMUP, tuple)
+
+    def test_has_six_steps(self) -> None:
+        assert len(STANDARD_WARMUP) == 6
+
+    def test_step_names(self) -> None:
+        names = [s.name for s in STANDARD_WARMUP]
+        assert names == [
+            "load_credentials",
+            "mount_namespace",
+            "verify_bricks",
+            "warm_caches",
+            "connect_mcp",
+            "load_context",
+        ]
+
+    def test_optional_steps(self) -> None:
+        optional = [s.name for s in STANDARD_WARMUP if not s.required]
+        assert set(optional) == {"warm_caches", "connect_mcp"}
+
+    def test_required_steps(self) -> None:
+        required = [s.name for s in STANDARD_WARMUP if s.required]
+        assert set(required) == {
+            "load_credentials",
+            "mount_namespace",
+            "verify_bricks",
+            "load_context",
+        }
+
+    def test_all_steps_are_frozen(self) -> None:
+        for step in STANDARD_WARMUP:
+            with pytest.raises(dataclasses.FrozenInstanceError):
+                step.name = "mutated"

--- a/tests/unit/services/test_agent_warmup.py
+++ b/tests/unit/services/test_agent_warmup.py
@@ -1,0 +1,403 @@
+"""Tests for AgentWarmupService (Issue #2172).
+
+Covers:
+- Happy path: all required steps pass → CONNECTED
+- Mixed required + optional steps
+- Required step failures (exception, timeout, returns False)
+- Optional step failures → still CONNECTED
+- Edge cases: re-warmup, nonexistent agent, empty steps, concurrent, unregister-during
+- Step registry operations
+- Integration: warmup → status phase check
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+
+import pytest
+
+from nexus.contracts.agent_types import AgentState
+from nexus.contracts.agent_warmup_types import WarmupContext, WarmupStep
+from nexus.services.agents.agent_registry import AgentRegistry
+from nexus.services.agents.agent_warmup import AgentWarmupService
+from tests.helpers.in_memory_record_store import InMemoryRecordStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def record_store():
+    store = InMemoryRecordStore()
+    yield store
+    store.close()
+
+
+@pytest.fixture
+def registry(record_store):
+    return AgentRegistry(record_store=record_store, flush_interval=60)
+
+
+@pytest.fixture
+def warmup_service(registry):
+    service = AgentWarmupService(
+        agent_registry=registry,
+        enabled_bricks=frozenset({"search", "pay", "auth"}),
+    )
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Helper step functions
+# ---------------------------------------------------------------------------
+
+
+async def _always_pass(_ctx: WarmupContext) -> bool:
+    return True
+
+
+async def _always_fail(_ctx: WarmupContext) -> bool:
+    return False
+
+
+async def _raise_error(_ctx: WarmupContext) -> bool:
+    raise RuntimeError("step exploded")
+
+
+async def _slow_step(_ctx: WarmupContext) -> bool:
+    await asyncio.sleep(10)  # Will be cancelled by timeout
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Step registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestStepRegistry:
+    def test_register_and_get(self, warmup_service):
+        warmup_service.register_step("test_step", _always_pass)
+        fn = warmup_service.get_step("test_step")
+        assert fn is _always_pass
+
+    def test_unregistered_returns_none(self, warmup_service):
+        assert warmup_service.get_step("nonexistent") is None
+
+    def test_duplicate_registration_raises(self, warmup_service):
+        warmup_service.register_step("dup", _always_pass)
+        with pytest.raises(ValueError, match="already registered"):
+            warmup_service.register_step("dup", _always_fail)
+
+
+# ---------------------------------------------------------------------------
+# Happy path tests
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_all_required_steps_pass(self, warmup_service, registry):
+        """All required steps pass → agent transitions to CONNECTED."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("step_a", _always_pass)
+        warmup_service.register_step("step_b", _always_pass)
+
+        steps = [
+            WarmupStep("step_a", timeout=timedelta(seconds=5)),
+            WarmupStep("step_b", timeout=timedelta(seconds=5)),
+        ]
+
+        result = await warmup_service.warmup("agent-1", steps=steps)
+        assert result.success is True
+        assert result.agent_id == "agent-1"
+        assert result.steps_completed == ("step_a", "step_b")
+        assert result.steps_skipped == ()
+        assert result.failed_step is None
+        assert result.error is None
+        assert result.duration_ms > 0
+
+        # Verify agent is now CONNECTED
+        record = registry.get("agent-1")
+        assert record.state is AgentState.CONNECTED
+        assert record.generation == 1
+
+    @pytest.mark.asyncio
+    async def test_mixed_required_and_optional(self, warmup_service, registry):
+        """Required passes, optional fails → still CONNECTED."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("required_step", _always_pass)
+        warmup_service.register_step("optional_step", _always_fail)
+
+        steps = [
+            WarmupStep("required_step", timeout=timedelta(seconds=5), required=True),
+            WarmupStep("optional_step", timeout=timedelta(seconds=5), required=False),
+        ]
+
+        result = await warmup_service.warmup("agent-1", steps=steps)
+        assert result.success is True
+        assert "required_step" in result.steps_completed
+        assert "optional_step" in result.steps_skipped
+
+    @pytest.mark.asyncio
+    async def test_standard_warmup_runs_in_order(self, warmup_service, registry):
+        """Steps execute in order — verified by step_completed ordering."""
+        registry.register("agent-1", "alice")
+
+        order: list[str] = []
+
+        async def _tracking_step(name: str):
+            async def _inner(_ctx: WarmupContext) -> bool:
+                order.append(name)
+                return True
+
+            return _inner
+
+        for name in ["a", "b", "c"]:
+            warmup_service.register_step(name, await _tracking_step(name))
+
+        steps = [
+            WarmupStep("a", timeout=timedelta(seconds=5)),
+            WarmupStep("b", timeout=timedelta(seconds=5)),
+            WarmupStep("c", timeout=timedelta(seconds=5)),
+        ]
+
+        result = await warmup_service.warmup("agent-1", steps=steps)
+        assert result.success is True
+        assert order == ["a", "b", "c"]
+        assert result.steps_completed == ("a", "b", "c")
+
+
+# ---------------------------------------------------------------------------
+# Required step failure tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredStepFailure:
+    @pytest.mark.asyncio
+    async def test_required_step_exception(self, warmup_service, registry):
+        """Required step that raises → warmup fails, agent stays UNKNOWN."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("boom", _raise_error)
+
+        steps = [WarmupStep("boom", timeout=timedelta(seconds=5))]
+        result = await warmup_service.warmup("agent-1", steps=steps)
+
+        assert result.success is False
+        assert result.failed_step == "boom"
+        assert result.error is not None
+
+        record = registry.get("agent-1")
+        assert record.state is AgentState.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_required_step_timeout(self, warmup_service, registry):
+        """Required step that times out → warmup fails."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("slow", _slow_step)
+
+        steps = [WarmupStep("slow", timeout=timedelta(milliseconds=50))]
+        result = await warmup_service.warmup("agent-1", steps=steps)
+
+        assert result.success is False
+        assert result.failed_step == "slow"
+
+        record = registry.get("agent-1")
+        assert record.state is AgentState.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_required_step_returns_false(self, warmup_service, registry):
+        """Required step returns False → warmup fails."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("nope", _always_fail)
+
+        steps = [WarmupStep("nope", timeout=timedelta(seconds=5))]
+        result = await warmup_service.warmup("agent-1", steps=steps)
+
+        assert result.success is False
+        assert result.failed_step == "nope"
+
+        record = registry.get("agent-1")
+        assert record.state is AgentState.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_unregistered_required_step(self, warmup_service, registry):
+        """Required step not in registry → warmup fails."""
+        registry.register("agent-1", "alice")
+
+        steps = [WarmupStep("missing_step", timeout=timedelta(seconds=5), required=True)]
+        result = await warmup_service.warmup("agent-1", steps=steps)
+
+        assert result.success is False
+        assert result.failed_step == "missing_step"
+        assert "not registered" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Optional step failure tests
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalStepFailure:
+    @pytest.mark.asyncio
+    async def test_optional_step_fails_continues(self, warmup_service, registry):
+        """Optional step failure → logged and skipped, warmup continues."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("opt_fail", _always_fail)
+        warmup_service.register_step("required_ok", _always_pass)
+
+        steps = [
+            WarmupStep("opt_fail", timeout=timedelta(seconds=5), required=False),
+            WarmupStep("required_ok", timeout=timedelta(seconds=5), required=True),
+        ]
+
+        result = await warmup_service.warmup("agent-1", steps=steps)
+        assert result.success is True
+        assert "opt_fail" in result.steps_skipped
+        assert "required_ok" in result.steps_completed
+
+    @pytest.mark.asyncio
+    async def test_optional_step_timeout(self, warmup_service, registry):
+        """Optional step timeout → skipped, warmup continues."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("slow_opt", _slow_step)
+        warmup_service.register_step("fast_req", _always_pass)
+
+        steps = [
+            WarmupStep("slow_opt", timeout=timedelta(milliseconds=50), required=False),
+            WarmupStep("fast_req", timeout=timedelta(seconds=5), required=True),
+        ]
+
+        result = await warmup_service.warmup("agent-1", steps=steps)
+        assert result.success is True
+        assert "slow_opt" in result.steps_skipped
+
+    @pytest.mark.asyncio
+    async def test_all_optional_steps_fail(self, warmup_service, registry):
+        """ALL optional steps fail → still CONNECTED."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("opt1", _always_fail)
+        warmup_service.register_step("opt2", _raise_error)
+
+        steps = [
+            WarmupStep("opt1", timeout=timedelta(seconds=5), required=False),
+            WarmupStep("opt2", timeout=timedelta(seconds=5), required=False),
+        ]
+
+        result = await warmup_service.warmup("agent-1", steps=steps)
+        assert result.success is True
+        assert result.steps_skipped == ("opt1", "opt2")
+        assert result.steps_completed == ()
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_warmup_already_connected(self, warmup_service, registry):
+        """Warmup on already-CONNECTED agent → skipped (idempotent)."""
+        registry.register("agent-1", "alice")
+        registry.transition("agent-1", AgentState.CONNECTED, expected_generation=0)
+
+        result = await warmup_service.warmup("agent-1", steps=[])
+        assert result.success is True
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_warmup_nonexistent_agent(self, warmup_service):
+        """Warmup on nonexistent agent → error result."""
+        result = await warmup_service.warmup("no-such-agent", steps=[])
+        assert result.success is False
+        assert "not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_empty_step_list(self, warmup_service, registry):
+        """Empty step list → immediate CONNECTED."""
+        registry.register("agent-1", "alice")
+
+        result = await warmup_service.warmup("agent-1", steps=[])
+        assert result.success is True
+
+        record = registry.get("agent-1")
+        assert record.state is AgentState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_agent_unregistered_during_warmup(self, warmup_service, registry):
+        """Agent unregistered between warmup start and transition → clean failure."""
+        registry.register("agent-1", "alice")
+
+        async def _unregister_and_pass(ctx: WarmupContext) -> bool:
+            # Simulate agent being unregistered during warmup
+            registry.unregister(ctx.agent_id)
+            return True
+
+        warmup_service.register_step("sneaky", _unregister_and_pass)
+
+        steps = [WarmupStep("sneaky", timeout=timedelta(seconds=5))]
+        result = await warmup_service.warmup("agent-1", steps=steps)
+
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_warmup_same_agent(self, warmup_service, registry):
+        """Concurrent warmup for same agent → one wins via optimistic locking."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("pass", _always_pass)
+
+        steps = [WarmupStep("pass", timeout=timedelta(seconds=5))]
+
+        # First warmup succeeds
+        result1 = await warmup_service.warmup("agent-1", steps=steps)
+        assert result1.success is True
+
+        # Second warmup on now-CONNECTED agent → idempotent skip
+        result2 = await warmup_service.warmup("agent-1", steps=steps)
+        assert result2.success is True
+
+    @pytest.mark.asyncio
+    async def test_unregistered_optional_step_skipped(self, warmup_service, registry):
+        """Optional step not in registry → skipped, not failed."""
+        registry.register("agent-1", "alice")
+
+        steps = [WarmupStep("nonexistent_opt", timeout=timedelta(seconds=5), required=False)]
+        result = await warmup_service.warmup("agent-1", steps=steps)
+
+        assert result.success is True
+        assert "nonexistent_opt" in result.steps_skipped
+
+
+# ---------------------------------------------------------------------------
+# Integration: warmup → status phase
+# ---------------------------------------------------------------------------
+
+
+class TestWarmupStatusIntegration:
+    @pytest.mark.asyncio
+    async def test_warmup_changes_status_phase(self, warmup_service, registry):
+        """After warmup, get_status returns phase=active (CONNECTED → ACTIVE)."""
+        registry.register("agent-1", "alice")
+
+        warmup_service.register_step("pass", _always_pass)
+        steps = [WarmupStep("pass", timeout=timedelta(seconds=5))]
+
+        result = await warmup_service.warmup("agent-1", steps=steps)
+        assert result.success is True
+
+        # Check status via registry
+        status = registry.get_status("agent-1")
+        assert status is not None
+        assert str(status.phase) == "active"


### PR DESCRIPTION
## Summary
- Server-orchestrated agent warmup with step registry, gating UNKNOWN → CONNECTED transition on required step success
- 6 standard warmup steps: load_credentials, mount_namespace, verify_bricks, warm_caches (optional), connect_mcp (optional), load_context
- DRY fix in agent_status.py (extracted `_spec_to_response()` helper)
- REST endpoint: `POST /api/v2/agents/{agent_id}/warmup`
- Lifespan wiring: AgentWarmupService initialized during service startup

## Design Decisions
| # | Decision | Choice |
|---|----------|--------|
| 1A | Execution model | Server-orchestrated |
| 2C | State gate | UNKNOWN→CONNECTED (no new state) |
| 3A | Step design | Registry + callables (ParserRegistry pattern) |
| 13A | Execution order | Sequential with per-step timeouts |
| 14A | DB pattern | Session-per-operation |
| 16A | Integration | New warmup() method, transition() unchanged |

## Files Changed
**New (7 files):**
- `src/nexus/contracts/agent_warmup_types.py` — WarmupStep, WarmupResult, WarmupContext, STANDARD_WARMUP
- `src/nexus/services/protocols/agent_warmup.py` — AgentWarmupProtocol
- `src/nexus/services/agents/agent_warmup.py` — AgentWarmupService with step registry
- `src/nexus/services/agents/warmup_steps.py` — 6 step implementations + register_standard_steps()
- `tests/unit/contracts/test_agent_warmup_types.py` — 18 sync tests
- `tests/unit/services/test_agent_warmup.py` — 20 async tests
- `tests/e2e/server/test_agent_warmup_e2e.py` — 7 e2e tests

**Modified (3 files):**
- `src/nexus/server/api/v2/routers/agent_status.py` — DRY fix + warmup endpoint
- `src/nexus/server/app_state.py` — agent_warmup_service field
- `src/nexus/server/lifespan/services.py` — Wire warmup service at startup

## Test plan
- [x] 18 unit tests for contracts (frozen, defaults, equality, STANDARD_WARMUP)
- [x] 20 unit tests for service (registry, happy path, failures, edge cases, integration)
- [x] 7 e2e tests with FastAPI + permissions (503, nonexistent, empty steps, custom steps, idempotent, performance <100ms, default steps)
- [x] All 45 tests passing in ~5.4s
- [x] ruff, mypy, ruff-format clean
- [x] All pre-commit hooks passing
- [x] Performance validated: warmup completes in <100ms for in-memory steps