### PR TITLE
feat(#888): move async_bridge.py from core/ to rebac/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -924,8 +924,6 @@ ignore_imports = [
     "nexus.core.config -> nexus.bricks.workflows.protocol",
     "nexus.core.nexus_fs_core -> nexus.bricks.memory.router",
     # --- kernel (core) importing bricks (rebac, Issue #2179) ---
-    "nexus.core.async_bridge -> nexus.bricks.rebac.async_manager",
-    "nexus.core.async_bridge -> nexus.bricks.rebac.manager",
     "nexus.core.async_nexus_fs -> nexus.bricks.rebac.async_permissions",
     "nexus.core.nexus_fs -> nexus.bricks.rebac.entity_registry",
     "nexus.core.nexus_fs_core -> nexus.bricks.rebac.entity_registry",

--- a/src/nexus/rebac/async_bridge.py
+++ b/src/nexus/rebac/async_bridge.py
@@ -8,7 +8,7 @@ allowing the sync server to benefit from async database pooling and
 non-blocking I/O.
 
 Usage:
-    from nexus.core.async_bridge import AsyncReBACBridge
+    from nexus.rebac.async_bridge import AsyncReBACBridge
 
     # Initialize once at server startup (prefer injecting engine via DI)
     bridge = AsyncReBACBridge(database_url, engine=record_store.engine)

--- a/tests/unit/core/test_async_bridge.py
+++ b/tests/unit/core/test_async_bridge.py
@@ -5,7 +5,7 @@ These tests verify the async-to-sync bridge functionality for ReBAC operations.
 
 import pytest
 
-from nexus.core.async_bridge import (
+from nexus.rebac.async_bridge import (
     AsyncReBACBridge,
     get_async_rebac_bridge,
     shutdown_async_rebac_bridge,

--- a/tests/unit/core/test_import_boundaries.py
+++ b/tests/unit/core/test_import_boundaries.py
@@ -106,7 +106,6 @@ class TestKernelTopLevelImports:
 
     # Pre-existing violations that are tracked for cleanup (Issue #1519)
     KNOWN_CORE_SERVICES_IMPORTS = {
-        "core/async_bridge.py",  # async_rebac_manager (TYPE_CHECKING)
         "core/async_nexus_fs.py",  # async_permissions (TYPE_CHECKING)
         "core/config.py",  # NamespaceManagerProtocol, namespace_manager (TYPE_CHECKING)
         "core/nexus_fs.py",  # memory_api, entity_registry (TYPE_CHECKING)

--- a/tests/unit/core/test_import_smoke.py
+++ b/tests/unit/core/test_import_smoke.py
@@ -13,7 +13,7 @@ import pytest
 _CORE_MODULES = [
     "nexus.core.config",
     "nexus.core.nexus_fs",
-    "nexus.core.async_bridge",
+    "nexus.rebac.async_bridge",
     "nexus.core.protocols",
     "nexus.core.protocols.vfs_router",
     "nexus.core.protocols.vfs_core",


### PR DESCRIPTION
## Summary
- Move `core/async_bridge.py` → `rebac/async_bridge.py` — the bridge depends on rebac managers and storage at runtime, so it belongs in the rebac layer, not the kernel
- Update all imports in tests and source code
- Remove the now-unnecessary import boundary exceptions in `pyproject.toml` and `test_import_boundaries.py`

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, Brick Zero-Core-Imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)