### PR TITLE
fix(#660): replace 32 hardcoded zone_id="default" with ROOT_ZONE_ID in tests

### DIFF
--- a/tests/e2e/server/test_delegation_full_e2e.py
+++ b/tests/e2e/server/test_delegation_full_e2e.py
@@ -20,6 +20,7 @@ import pytest
 
 from nexus.bricks.rebac.entity_registry import EntityRegistry
 from nexus.bricks.rebac.manager import EnhancedReBACManager
+from nexus.constants import ROOT_ZONE_ID
 from nexus.services.agents.agent_registry import AgentRegistry
 from nexus.services.delegation.errors import DelegationChainError, EscalationError
 from nexus.services.delegation.models import DelegationMode, DelegationStatus
@@ -370,7 +371,7 @@ class TestFullDelegationLifecycle:
             worker_id="worker_sub_b",
             worker_name="Sub Worker B",
             delegation_mode=DelegationMode.COPY,
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
             can_sub_delegate=True,
             intent="Coordinate sub-tasks",
         )
@@ -382,7 +383,7 @@ class TestFullDelegationLifecycle:
             worker_id="worker_sub_c",
             worker_name="Sub Worker C",
             delegation_mode=DelegationMode.COPY,
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
             intent="Execute specific task",
         )
 
@@ -510,7 +511,7 @@ class TestFullDelegationLifecycle:
             worker_id="worker_intent",
             worker_name="Intent Worker",
             delegation_mode=DelegationMode.COPY,
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
             intent="Run security scan on project files",
         )
 
@@ -535,7 +536,7 @@ class TestFullDelegationLifecycle:
                 worker_id=f"worker_page_{i}",
                 worker_name=f"Page Worker {i}",
                 delegation_mode=DelegationMode.COPY,
-                zone_id="default",
+                zone_id=ROOT_ZONE_ID,
             )
 
         # Get first page

--- a/tests/e2e/server/test_trust_routing_e2e.py
+++ b/tests/e2e/server/test_trust_routing_e2e.py
@@ -14,6 +14,7 @@ import pytest
 
 from nexus.bricks.rebac.entity_registry import EntityRegistry
 from nexus.bricks.rebac.manager import EnhancedReBACManager
+from nexus.constants import ROOT_ZONE_ID
 from nexus.services.agents.agent_registry import AgentRegistry
 from nexus.services.delegation.errors import InsufficientTrustError
 from nexus.services.delegation.models import (
@@ -143,7 +144,7 @@ class TestTrustRoutingE2E:
                 rater_agent_id=f"rater-{i}",
                 rated_agent_id="coordinator_agent",
                 exchange_id=f"exchange-{i}",
-                zone_id="default",
+                zone_id=ROOT_ZONE_ID,
                 outcome="positive",
                 reliability_score=1.0,
                 quality_score=0.9,
@@ -161,7 +162,7 @@ class TestTrustRoutingE2E:
             worker_id="worker-trust-ok",
             worker_name="Trusted Worker",
             delegation_mode=DelegationMode.COPY,
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
             min_trust_score=0.5,
         )
 
@@ -184,7 +185,7 @@ class TestTrustRoutingE2E:
                 rater_agent_id=f"rater-{i}",
                 rated_agent_id="coordinator_agent",
                 exchange_id=f"neg-exchange-{i}",
-                zone_id="default",
+                zone_id=ROOT_ZONE_ID,
                 outcome="negative",
                 reliability_score=0.0,
             )
@@ -197,7 +198,7 @@ class TestTrustRoutingE2E:
                 worker_id="worker-trust-fail",
                 worker_name="Untrusted Worker",
                 delegation_mode=DelegationMode.COPY,
-                zone_id="default",
+                zone_id=ROOT_ZONE_ID,
                 min_trust_score=0.7,
             )
 
@@ -220,7 +221,7 @@ class TestTrustRoutingE2E:
                 worker_id="worker-no-rep",
                 worker_name="Unknown Worker",
                 delegation_mode=DelegationMode.COPY,
-                zone_id="default",
+                zone_id=ROOT_ZONE_ID,
                 min_trust_score=0.5,
             )
 
@@ -243,7 +244,7 @@ class TestTrustRoutingE2E:
             worker_id="worker-complete",
             worker_name="Completable Worker",
             delegation_mode=DelegationMode.COPY,
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         # Complete the delegation with positive outcome
@@ -276,7 +277,7 @@ class TestTrustRoutingE2E:
             worker_id="worker-fail",
             worker_name="Failing Worker",
             delegation_mode=DelegationMode.COPY,
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         updated = delegation_service.complete_delegation(
@@ -306,7 +307,7 @@ class TestTrustRoutingE2E:
                 rater_agent_id=f"external-{i}",
                 rated_agent_id="coordinator_agent",
                 exchange_id=f"lifecycle-{i}",
-                zone_id="default",
+                zone_id=ROOT_ZONE_ID,
                 outcome="positive",
                 reliability_score=1.0,
                 quality_score=0.9,
@@ -324,7 +325,7 @@ class TestTrustRoutingE2E:
             worker_id="worker-lifecycle",
             worker_name="Lifecycle Worker",
             delegation_mode=DelegationMode.COPY,
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
             min_trust_score=0.5,
         )
 

--- a/tests/integration/server/api/v2/test_events_replay.py
+++ b/tests/integration/server/api/v2/test_events_replay.py
@@ -18,6 +18,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.api.v2.routers.events_replay import router
 from nexus.storage.models import OperationLogModel
 from nexus.storage.record_store import SQLAlchemyRecordStore
@@ -66,7 +67,7 @@ def _seed_events(session_factory: Any, count: int) -> list[str]:
                 operation_id=op_id,
                 operation_type="write" if i % 2 == 0 else "delete",
                 path=f"/workspace/file{i}.txt",
-                zone_id="default",
+                zone_id=ROOT_ZONE_ID,
                 agent_id=f"agent-{i % 3}",
                 status="success",
                 delivered=True,

--- a/tests/unit/core/test_nexus_fs_stream_range.py
+++ b/tests/unit/core/test_nexus_fs_stream_range.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.contracts.types import OperationContext
 
@@ -23,7 +24,7 @@ class _StubFS:
         self.metadata = metadata
         self.router = router
         self._enforce_permissions = False
-        self._default_context = OperationContext(user_id="test", groups=[], zone_id="default")
+        self._default_context = OperationContext(user_id="test", groups=[], zone_id=ROOT_ZONE_ID)
 
     def _validate_path(self, path):
         if not path.startswith("/"):

--- a/tests/unit/rlm/test_tools.py
+++ b/tests/unit/rlm/test_tools.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.rlm.tools import (
     build_tools_injection_code,
     nexus_list,
@@ -35,7 +36,7 @@ class TestNexusRead:
             "/workspace/doc.md",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         assert result == "File content here"
@@ -55,7 +56,7 @@ class TestNexusRead:
             "/workspace/doc.md",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         call_kwargs = mock_get.call_args.kwargs
@@ -74,7 +75,7 @@ class TestNexusRead:
             "/nonexistent/file.md",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         assert "error" in result.lower() or "Error" in result
@@ -87,7 +88,7 @@ class TestNexusRead:
             "/workspace/doc.md",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         assert "error" in result.lower() or "Error" in result
@@ -113,7 +114,7 @@ class TestNexusSearch:
             "quantum computing",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         assert isinstance(result, str)
@@ -131,7 +132,7 @@ class TestNexusSearch:
             "test query",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
             limit=5,
         )
 
@@ -148,7 +149,7 @@ class TestNexusSearch:
             "test",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         assert "error" in result.lower() or "Error" in result
@@ -174,7 +175,7 @@ class TestNexusList:
             "/workspace/",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         assert isinstance(result, str)
@@ -188,7 +189,7 @@ class TestNexusList:
             "/workspace/",
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         assert "error" in result.lower() or "Error" in result
@@ -201,7 +202,7 @@ class TestBuildToolsInjectionCode:
         code = build_tools_injection_code(
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
 
         assert isinstance(code, str)
@@ -212,7 +213,7 @@ class TestBuildToolsInjectionCode:
         code = build_tools_injection_code(
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
         assert "def nexus_read" in code
 
@@ -220,7 +221,7 @@ class TestBuildToolsInjectionCode:
         code = build_tools_injection_code(
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
         assert "def nexus_search" in code
 
@@ -228,7 +229,7 @@ class TestBuildToolsInjectionCode:
         code = build_tools_injection_code(
             api_url="http://localhost:2026",
             api_key="test-key",
-            zone_id="default",
+            zone_id=ROOT_ZONE_ID,
         )
         assert "FINAL" in code
 

--- a/tests/unit/services/event_log/test_exporter_registry.py
+++ b/tests/unit/services/event_log/test_exporter_registry.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.services.event_subsystem.log.exporter_registry import ExporterRegistry
 from nexus.services.event_subsystem.types import FileEvent, FileEventType
 
@@ -17,7 +18,7 @@ def _make_event(event_id: str = "evt-1", path: str = "/test.txt") -> FileEvent:
     return FileEvent(
         type=FileEventType.FILE_WRITE,
         path=path,
-        zone_id="default",
+        zone_id=ROOT_ZONE_ID,
         event_id=event_id,
     )
 

--- a/tests/unit/services/event_log/test_replay_hypothesis.py
+++ b/tests/unit/services/event_log/test_replay_hypothesis.py
@@ -19,6 +19,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.services.event_subsystem.log.replay import EventReplayService
 from nexus.storage.models import OperationLogModel
 from nexus.storage.record_store import SQLAlchemyRecordStore
@@ -47,7 +48,7 @@ def _seed_events(session_factory, count: int) -> list[str]:
                 operation_id=op_id,
                 operation_type="write",
                 path=f"/file{i}.txt",
-                zone_id="default",
+                zone_id=ROOT_ZONE_ID,
                 status="success",
                 delivered=True,
                 created_at=datetime.now(UTC),

--- a/tests/unit/skills/test_skill_importer.py
+++ b/tests/unit/skills/test_skill_importer.py
@@ -8,6 +8,7 @@ import pytest
 
 from nexus.bricks.skills.exceptions import SkillPermissionDeniedError
 from nexus.bricks.skills.importer import SkillImporter, SkillImportError
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.types import OperationContext
 
 # Mock SKILL.md content with valid YAML frontmatter
@@ -156,7 +157,7 @@ def admin_context():
         agent_id=None,
         subject_type="user",
         subject_id="admin",
-        zone_id="default",
+        zone_id=ROOT_ZONE_ID,
         groups=[],
         is_admin=True,
         is_system=False,
@@ -173,7 +174,7 @@ def user_context():
         agent_id=None,
         subject_type="user",
         subject_id="alice",
-        zone_id="default",
+        zone_id=ROOT_ZONE_ID,
         groups=[],
         is_admin=False,
         is_system=False,


### PR DESCRIPTION
## Summary
- Replace 32 hardcoded `zone_id="default"` with `ROOT_ZONE_ID` constant across 8 test files
- Canonical root zone is `"root"` not `"default"` per KERNEL-ARCHITECTURE.md
- Files: test_events_replay, test_nexus_fs_stream_range, test_tools, test_skill_importer, test_replay_hypothesis, test_exporter_registry, test_delegation_full_e2e, test_trust_routing_e2e

## Test plan
- [x] ruff check passes on all 8 files
- [x] ruff format passes
- [x] All pre-commit hooks pass
- [x] Zero remaining `zone_id="default"` in tests/

🤖 Generated with [Claude Code](https://claude.com/claude-code)