### PR TITLE
feat(#880): fix SQL injection in CLI, delete dead code

### DIFF
--- a/src/nexus/cli/commands/server.py
+++ b/src/nexus/cli/commands/server.py
@@ -1142,14 +1142,15 @@ def serve(
             console.print("  • All permissions and relationships")
             console.print()
 
-            from sqlalchemy import text
+            from sqlalchemy import table
 
             from nexus.storage.record_store import SQLAlchemyRecordStore
 
             _record_store = SQLAlchemyRecordStore(db_url=db_url)
             engine = _record_store.engine
 
-            # List of tables to clear (in dependency order)
+            # List of tables to clear (in dependency order).
+            # Uses SQLAlchemy table() construct — never f-string SQL.
             tables_to_clear = [
                 # Auth tables
                 "oauth_credentials",  # OAuth tokens (v0.7.0)
@@ -1183,19 +1184,18 @@ def serve(
             deleted_counts = {}
             console.print("[yellow]Clearing database tables...[/yellow]")
 
-            for table_name in tables_to_clear:
+            for name in tables_to_clear:
                 try:
+                    tbl = table(name)
                     with engine.connect() as conn:
                         trans = conn.begin()
                         try:
-                            cursor_result = conn.execute(text(f"DELETE FROM {table_name}"))
+                            cursor_result = conn.execute(tbl.delete())
                             count = cursor_result.rowcount
                             trans.commit()
-                            deleted_counts[table_name] = count
+                            deleted_counts[name] = count
                             if count > 0:
-                                console.print(
-                                    f"  [dim]Deleted {count} rows from {table_name}[/dim]"
-                                )
+                                console.print(f"  [dim]Deleted {count} rows from {name}[/dim]")
                         except Exception:
                             trans.rollback()
                             # Ignore table doesn't exist errors

--- a/src/nexus/cli/commands/skills.py
+++ b/src/nexus/cli/commands/skills.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import json
 import re
 import sys
-from typing import Any
 from urllib.parse import urlparse
 
 import click
@@ -28,64 +27,6 @@ from nexus.cli.utils import (
     handle_error,
 )
 from nexus.constants import ROOT_ZONE_ID
-
-
-class SQLAlchemyDatabaseConnection:
-    """Wrapper for SQLAlchemy session to match DatabaseConnection protocol."""
-
-    def __init__(self, session: Any) -> None:
-        self._session = session
-
-    def execute(self, query: str, params: dict | None = None) -> Any:
-        """Execute a query."""
-        from sqlalchemy import text
-
-        return self._session.execute(text(query), params or {})
-
-    def fetchall(self, query: str, params: dict | None = None) -> list[dict]:
-        """Fetch all results from a query."""
-        from sqlalchemy import text
-
-        result = self._session.execute(text(query), params or {})
-        return [dict(row._mapping) for row in result]
-
-    def fetchone(self, query: str, params: dict | None = None) -> dict | None:
-        """Fetch one result from a query."""
-        from sqlalchemy import text
-
-        result = self._session.execute(text(query), params or {})
-        row = result.fetchone()
-        return dict(row._mapping) if row else None
-
-    def commit(self) -> None:
-        """Commit the transaction."""
-        self._session.commit()
-
-
-def _get_database_connection() -> SQLAlchemyDatabaseConnection | None:
-    """Get database connection for skill governance.
-
-    Returns wrapped SQLAlchemy session using NEXUS_DATABASE_URL environment variable.
-    Returns None if not configured (falls back to in-memory storage).
-
-    Delegates to SQLAlchemyRecordStore for engine/session creation (Issue #622).
-    """
-    from nexus.lib.env import get_database_url
-
-    db_url = get_database_url()
-    if not db_url:
-        return None
-
-    from nexus.storage.record_store import SQLAlchemyRecordStore
-
-    try:
-        record_store = SQLAlchemyRecordStore(db_url=db_url)
-        session = record_store.session_factory()
-        return SQLAlchemyDatabaseConnection(session)
-    except Exception as e:
-        console.print(f"[yellow]Warning:[/yellow] Could not connect to database: {e}")
-        console.print("[dim]Falling back to in-memory governance storage[/dim]")
-        return None
 
 
 def register_commands(cli: click.Group) -> None:


### PR DESCRIPTION
## Summary
- **server.py**: Replace f-string SQL interpolation (`text(f"DELETE FROM {table_name}")`) with SQLAlchemy `table().delete()` construct — eliminates SQL injection vector in database reset command
- **skills.py**: Delete dead `SQLAlchemyDatabaseConnection` class and `_get_database_connection()` function (both never called anywhere in codebase), along with unused `Any` import

## Test plan
- [ ] CI passes (ruff, mypy, hooks)
- [ ] `nexus serve --reset` still clears database tables (uses SQLAlchemy table construct instead of raw SQL)
- [ ] No behavior change in skills commands (deleted code was dead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)