### PR TITLE
fix(#660): replace 5 more hardcoded zone_id="default" with ROOT_ZONE_ID

### DIFF
--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -1648,7 +1648,7 @@ class NexusFSCoreMixin:
             if hasattr(self, "_hierarchy_manager"):
                 try:
                     logger.info(
-                        f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or 'default'}"
+                        f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or ROOT_ZONE_ID}"
                     )
                     created_count = self._hierarchy_manager.ensure_parent_tuples(
                         path, zone_id=ctx.zone_id or "root"

--- a/src/nexus/server/api/v2/routers/rlm.py
+++ b/src/nexus/server/api/v2/routers/rlm.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_auth
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ class RLMInferenceRequestModel(BaseModel):
         default_factory=list,
         description="Nexus VFS paths to relevant files",
     )
-    zone_id: str = Field(default="default", description="Zone ID for scoping")
+    zone_id: str = Field(default=ROOT_ZONE_ID, description="Zone ID for scoping")
     model: str = Field(
         default="claude-sonnet-4-20250514",
         description="LLM model to use for reasoning",

--- a/src/nexus/services/event_subsystem/log/exporters/kafka_exporter.py
+++ b/src/nexus/services/event_subsystem/log/exporters/kafka_exporter.py
@@ -13,6 +13,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.services.event_subsystem.types import FileEvent
 
 if TYPE_CHECKING:
@@ -62,7 +63,7 @@ class KafkaExporter:
     async def publish(self, event: FileEvent) -> None:
         """Publish a single event to Kafka."""
         producer = await self._ensure_producer()
-        topic = f"{self._config.topic_prefix}.{event.zone_id or 'default'}"
+        topic = f"{self._config.topic_prefix}.{event.zone_id or ROOT_ZONE_ID}"
         await producer.send_and_wait(
             topic,
             value=event.to_dict(),
@@ -78,7 +79,7 @@ class KafkaExporter:
         for i in range(0, len(events), chunk_size):
             chunk = events[i : i + chunk_size]
             for event in chunk:
-                topic = f"{self._config.topic_prefix}.{event.zone_id or 'default'}"
+                topic = f"{self._config.topic_prefix}.{event.zone_id or ROOT_ZONE_ID}"
                 try:
                     await producer.send_and_wait(
                         topic,

--- a/src/nexus/services/scheduler/migration.sql
+++ b/src/nexus/services/scheduler/migration.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS scheduled_tasks (
     idempotency_key TEXT UNIQUE,
 
     -- Multi-tenancy
-    zone_id TEXT NOT NULL DEFAULT 'default',
+    zone_id TEXT NOT NULL DEFAULT 'root',
 
     -- Error tracking
     error_message TEXT


### PR DESCRIPTION
## Summary
- Replace 5 more hardcoded `zone_id="default"` / `or 'default'` with `ROOT_ZONE_ID` in 4 files:
  - `server/api/v2/routers/rlm.py` — Pydantic Field default
  - `core/nexus_fs_core.py` — log message fallback
  - `services/event_subsystem/log/exporters/kafka_exporter.py` — 2x Kafka topic fallback
  - `services/scheduler/migration.sql` — SQL column default
- Canonical root zone is `"root"` not `"default"` per KERNEL-ARCHITECTURE.md

## Test plan
- [x] ruff check passes
- [x] mypy passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)