### PR TITLE
fix(#2195): review fixes for EventLog + Scheduler wiring (stream3)

### DIFF
--- a/src/nexus/core/db_utils.py
+++ b/src/nexus/core/db_utils.py
@@ -3,8 +3,6 @@
 Issue #2195: Extracted from lifespan for testability and DRY.
 """
 
-from __future__ import annotations
-
 
 def sqlalchemy_url_to_asyncpg_dsn(url: str) -> str:
     """Convert a SQLAlchemy database URL to an asyncpg-compatible DSN.

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -478,8 +478,8 @@ def _boot_system_services(
     event_log: Any = None
     if _on("eventlog"):
         try:
-            import os as _el_os
-            from pathlib import Path as _ElPath
+            import os
+            from pathlib import Path
             from typing import Literal
 
             from nexus.services.event_subsystem.log import EventLogConfig, create_event_log
@@ -487,19 +487,19 @@ def _boot_system_services(
             _wal_dir: str = (
                 ctx.wal_dir
                 if ctx.wal_dir is not None
-                else _el_os.getenv("NEXUS_WAL_DIR", ".nexus-data/wal")
+                else os.getenv("NEXUS_WAL_DIR", ".nexus-data/wal")
             )
             _sync_mode: str = (
                 ctx.wal_sync_mode
                 if ctx.wal_sync_mode is not None
-                else _el_os.getenv("NEXUS_WAL_SYNC_MODE", "every")
+                else os.getenv("NEXUS_WAL_SYNC_MODE", "every")
             )
             _seg_size = ctx.wal_segment_size or int(
-                _el_os.getenv("NEXUS_WAL_SEGMENT_SIZE", str(4 * 1024 * 1024))
+                os.getenv("NEXUS_WAL_SEGMENT_SIZE", str(4 * 1024 * 1024))
             )
 
             _el_config = EventLogConfig(
-                wal_dir=_ElPath(_wal_dir),
+                wal_dir=Path(_wal_dir),
                 segment_size_bytes=_seg_size,
                 sync_mode=cast(Literal["every", "none"], _sync_mode),
             )

--- a/src/nexus/rlm/tools.py
+++ b/src/nexus/rlm/tools.py
@@ -51,7 +51,7 @@ def nexus_read(
             timeout=30,
         )
         resp.raise_for_status()
-        content = resp.text
+        content: str = resp.text
         if len(content) > _MAX_OUTPUT_CHARS:
             return content[:_MAX_OUTPUT_CHARS] + f"\n... [truncated, {len(content)} total chars]"
         return content

--- a/src/nexus/server/lifespan/realtime.py
+++ b/src/nexus/server/lifespan/realtime.py
@@ -111,11 +111,10 @@ def _startup_event_log(app: FastAPI, svc: LifespanServices) -> None:
     """Wire factory-created EventLog into app.state (Issue #2195).
 
     Construction moved to ``factory._boot_system_services``.
-    Lifespan only reads the pre-built instance from SystemServices.
+    Lifespan reads the pre-built instance from LifespanServices (extracted
+    once in ``from_app()``).
     """
-    _nx = svc.nexus_fs
-    _sys = getattr(_nx, "_system_services", None) if _nx else None
-    app.state.event_log = getattr(_sys, "event_log", None) if _sys else None
+    app.state.event_log = svc.event_log
     if app.state.event_log:
         logger.info("Event log wired from factory (WAL)")
 

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -517,9 +517,7 @@ async def _startup_scheduler(app: FastAPI, svc: LifespanServices) -> None:
     with ``db_pool=None`` (sync). This lifespan function completes the
     two-phase init: creates the asyncpg pool and calls ``scheduler.initialize(pool)``.
     """
-    _nx = svc.nexus_fs
-    _sys = getattr(_nx, "_system_services", None) if _nx else None
-    scheduler = getattr(_sys, "scheduler_service", None) if _sys else None
+    scheduler = svc.scheduler_service
 
     if scheduler is None or not svc.database_url:
         return
@@ -530,9 +528,17 @@ async def _startup_scheduler(app: FastAPI, svc: LifespanServices) -> None:
         from nexus.core.db_utils import sqlalchemy_url_to_asyncpg_dsn
 
         pg_dsn = sqlalchemy_url_to_asyncpg_dsn(svc.database_url)
-        _pool_tuning = svc.profile_tuning
-        _min_size = getattr(getattr(_pool_tuning, "pool", None), "asyncpg_min_size", 2)
-        _max_size = getattr(getattr(_pool_tuning, "pool", None), "asyncpg_max_size", 5)
+        try:
+            _min_size = svc.profile_tuning.pool.asyncpg_min_size
+            _max_size = svc.profile_tuning.pool.asyncpg_max_size
+        except AttributeError:
+            _min_size, _max_size = 2, 5
+            logger.warning(
+                "Pool tuning config missing asyncpg size attrs, "
+                "falling back to defaults (min=%d, max=%d)",
+                _min_size,
+                _max_size,
+            )
         pool = await asyncpg.create_pool(pg_dsn, min_size=_min_size, max_size=_max_size)
         app.state._scheduler_pool = pool
 

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -56,6 +56,10 @@ class LifespanServices:
     write_observer: Any = None
     zone_lifecycle: Any = None
 
+    # --- Issue #2195: EventLog + Scheduler (from SystemServices) ----------
+    event_log: Any = None
+    scheduler_service: Any = None
+
     # --- Brick services container ----------------------------------------
     brick_services: Any = None  # The whole BrickServices dataclass
 
@@ -112,6 +116,9 @@ class LifespanServices:
             scoped_hook_engine=(getattr(_sys, "scoped_hook_engine", None) if _sys else None),
             write_observer=getattr(nx, "_write_observer", None) if nx else None,
             zone_lifecycle=(getattr(_sys, "zone_lifecycle", None) if _sys else None),
+            # Issue #2195: EventLog + Scheduler
+            event_log=(getattr(_sys, "event_log", None) if _sys else None),
+            scheduler_service=(getattr(_sys, "scheduler_service", None) if _sys else None),
             # Brick services
             brick_services=_brk,
             # NexusFS internals

--- a/tests/integration/core/test_factory_lifespan_wiring.py
+++ b/tests/integration/core/test_factory_lifespan_wiring.py
@@ -10,12 +10,13 @@ This is an integration test because it exercises the real factory boot path
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from nexus.contracts.deployment_profile import DeploymentProfile
 from nexus.core.config import SystemServices
-from nexus.core.deployment_profile import DeploymentProfile
 from nexus.factory import _boot_kernel_services, _boot_system_services, _BootContext
 
 
@@ -35,18 +36,17 @@ def _make_boot_context(**overrides: object) -> _BootContext:
     backend.on_write_callback = None
     backend.on_sync_callback = None
 
-    from nexus.core.performance_tuning import resolve_profile_tuning
+    from nexus.lib.performance_tuning import resolve_profile_tuning
 
     profile_tuning = resolve_profile_tuning(DeploymentProfile.FULL)
 
-    defaults: dict[str, object] = {
+    defaults: dict[str, Any] = {
         "record_store": record_store,
         "metadata_store": MagicMock(),
         "backend": backend,
         "router": MagicMock(),
         "engine": record_store.engine,
         "read_engine": record_store.read_engine,
-        "session_factory": record_store.session_factory,
         "perm": MagicMock(
             enforce=False,
             enable_deferred=False,
@@ -82,12 +82,12 @@ class TestEventLogFactoryToLifespan:
 
         # Build system services with a mocked EventLog
         ctx = _make_boot_context()
-        kernel = _boot_kernel_services(ctx)
+        _boot_kernel_services(ctx)
         with patch(
-            "nexus.services.event_log.create_event_log",
+            "nexus.services.event_subsystem.log.create_event_log",
             return_value=sentinel_event_log,
         ):
-            system_dict = _boot_system_services(ctx, kernel)
+            system_dict = _boot_system_services(ctx)
 
         assert system_dict["event_log"] is sentinel_event_log
 
@@ -107,8 +107,8 @@ class TestSchedulerFactoryToLifespan:
     def test_factory_scheduler_arrives_in_system_services(self) -> None:
         """SchedulerService from factory boot lands in SystemServices."""
         ctx = _make_boot_context(db_url="postgresql://localhost/test")
-        kernel = _boot_kernel_services(ctx)
-        system_dict = _boot_system_services(ctx, kernel)
+        _boot_kernel_services(ctx)
+        system_dict = _boot_system_services(ctx)
 
         scheduler = system_dict["scheduler_service"]
         assert scheduler is not None
@@ -126,8 +126,8 @@ class TestSchedulerFactoryToLifespan:
     async def test_scheduler_two_phase_init_via_lifespan(self) -> None:
         """SchedulerService can be initialized with a mock pool (two-phase)."""
         ctx = _make_boot_context(db_url="postgresql://localhost/test")
-        kernel = _boot_kernel_services(ctx)
-        system_dict = _boot_system_services(ctx, kernel)
+        _boot_kernel_services(ctx)
+        system_dict = _boot_system_services(ctx)
         scheduler = system_dict["scheduler_service"]
 
         # Simulate lifespan: create mock pool and initialize


### PR DESCRIPTION
## Summary

Post-merge review fixes for #2195 (EventLog + Scheduler wiring into system services boot tier).

**Stream: 3**

- **Architecture**: Add `event_log` + `scheduler_service` to `LifespanServices` DI container, eliminating fragile `getattr` chains in lifespan modules. Follows LEGO Architecture Part 4.2 (constructor injection pattern) and the existing `services_container.py` pattern from Issue #2135.
- **Code quality**: Remove `from __future__ import annotations` from `db_utils.py` (aligns with PEP 649 strategy per LEGO Architecture Part 6.1), clean up `_el_os`/`_ElPath` import aliasing in `_system.py`, annotate `rlm/tools.py` for mypy.
- **Performance**: Replace defensive `getattr` chains for asyncpg pool sizing with direct attribute access + try/except + warning log on misconfiguration (prevents silent pool undersizing).
- **Tests**: Fix broken integration test — 3 wrong import paths (`deployment_profile`, `performance_tuning`, `event_log` patch target), stale `session_factory` field, changed `_boot_system_services` function signature.

## LEGO Architecture Alignment

| Principle | Compliance |
|-----------|-----------|
| Minimal kernel, maximal bricks | EventLog + Scheduler correctly in System Services tier (Tier 1) |
| Standard interface | Services accessed via typed `LifespanServices` container |
| Bricks don't know about each other | No cross-brick imports introduced |
| Composition over inheritance | DI via constructor, factory.py wires |
| PEP 649 adoption | Removed `from __future__ import annotations` from new code |

## Test plan

- [x] 129/129 unit tests pass
- [x] 3/3 integration tests pass (were 0/3 before fix)
- [x] 900 e2e tests pass (8 pre-existing failures, 0 regressions)
- [x] Ruff lint + format: clean
- [x] Mypy: clean (0 errors in changed files)
- [x] All pre-commit hooks pass
- [x] Server boots cleanly with `NEXUS_ENABLE_PERMISSIONS=true`
- [x] Scheduler correctly returns 503 on SQLite (no PostgreSQL = expected)