### PR TITLE
feat(#2067): expectations tracker for safe async convergence

### DIFF
--- a/src/nexus/system_services/lifecycle/__init__.py
+++ b/src/nexus/system_services/lifecycle/__init__.py
@@ -6,6 +6,7 @@ Canonical location for runtime lifecycle services.
 from nexus.system_services.lifecycle.brick_lifecycle import BrickLifecycleManager
 from nexus.system_services.lifecycle.brick_reconciler import BrickReconciler
 from nexus.system_services.lifecycle.events_service import EventsService
+from nexus.system_services.lifecycle.expectations import Expectations
 from nexus.system_services.lifecycle.hook_engine import ScopedHookEngine
 from nexus.system_services.lifecycle.task_queue_service import TaskQueueService
 
@@ -13,6 +14,7 @@ __all__ = [
     "BrickLifecycleManager",
     "BrickReconciler",
     "EventsService",
+    "Expectations",
     "ScopedHookEngine",
     "TaskQueueService",
 ]

--- a/src/nexus/system_services/lifecycle/brick_reconciler.py
+++ b/src/nexus/system_services/lifecycle/brick_reconciler.py
@@ -34,6 +34,7 @@ from nexus.services.protocols.brick_lifecycle import (
     DriftReport,
     ReconcileResult,
 )
+from nexus.system_services.lifecycle.expectations import Expectations
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,8 @@ class BrickReconciler:
         self._next_retry_after: dict[str, float] = {}
         # Zone-aware filtering (Issue #2061)
         self._terminating_zone_bricks: dict[str, set[str]] = {}  # zone_id → brick_names
+        # Expectations tracker — prevents duplicate actions (Issue #2067)
+        self._expectations = Expectations()
 
     # ------------------------------------------------------------------
     # Public read-only accessors
@@ -360,6 +363,38 @@ class BrickReconciler:
         self._next_retry_after.pop(name, None)
 
     # ------------------------------------------------------------------
+    # Expectations auto-observation (Issue #2067)
+    # ------------------------------------------------------------------
+
+    def _observe_completed_operations(
+        self, brick_list: list[tuple[str, BrickSpec, BrickState, int, Any]]
+    ) -> None:
+        """Auto-observe completed operations by diffing expectations against snapshot.
+
+        O(k) scan of pending expectations only — not full brick list.
+        """
+        pending = self._expectations.pending_keys
+        if not pending:
+            return
+
+        # Build lookup for current brick states (only for pending keys)
+        state_map: dict[str, BrickState] = {}
+        for name, _spec, state, _retry, _inst in brick_list:
+            if name in pending:
+                state_map[name] = state
+
+        for key in pending:
+            brick_state = state_map.get(key)
+            if brick_state is None:
+                continue
+            if brick_state == BrickState.ACTIVE:
+                self._expectations.mount_observed(key)
+                logger.debug("[RECONCILER] Auto-observed mount for %r", key)
+            elif brick_state in (BrickState.UNREGISTERED, BrickState.STOPPING):
+                self._expectations.unmount_observed(key)
+                logger.debug("[RECONCILER] Auto-observed unmount for %r", key)
+
+    # ------------------------------------------------------------------
     # Corrective actions
     # ------------------------------------------------------------------
 
@@ -395,6 +430,7 @@ class BrickReconciler:
             if not self._should_retry(name):
                 return False
 
+            self._expectations.expect_mount(name)
             new_retry = self._manager.reset_for_retry(name)
             await self._manager.mount(name)
 
@@ -405,9 +441,13 @@ class BrickReconciler:
                 self._clear_backoff(name)
                 logger.info("[RECONCILER] Self-healed brick %r", name)
             else:
+                # Mount failed — clear expectation so next pass can retry
+                self._expectations.mount_observed(name)
                 self._set_backoff(name, new_retry)
             return True
         except Exception as exc:
+            # Clear expectation on error so brick isn't permanently gated
+            self._expectations.mount_observed(name)
             retry_count = self._manager.get_retry_count(name)
             self._set_backoff(name, retry_count)
             logger.warning(
@@ -422,20 +462,24 @@ class BrickReconciler:
     async def _action_mount(self, name: str) -> bool:
         """Mount a REGISTERED brick."""
         try:
+            self._expectations.expect_mount(name)
             await self._manager.mount(name)
             logger.info("[RECONCILER] Mounted drifted brick %r", name)
             return True
         except Exception as exc:
+            self._expectations.mount_observed(name)
             logger.warning("[RECONCILER] Failed to mount %r: %s", name, exc)
             return True
 
     async def _action_unmount(self, name: str) -> bool:
         """Unmount a disabled brick."""
         try:
+            self._expectations.expect_unmount(name)
             await self._manager.unmount(name)
             logger.info("[RECONCILER] Unmounted disabled brick %r", name)
             return True
         except Exception as exc:
+            self._expectations.unmount_observed(name)
             logger.warning("[RECONCILER] Failed to unmount %r: %s", name, exc)
             return True
 
@@ -469,6 +513,9 @@ class BrickReconciler:
         try:
             # Snapshot via public API
             brick_list = self._manager.iter_bricks()
+
+            # Auto-observe completed operations (Issue #2067)
+            self._observe_completed_operations(brick_list)
 
             # Track bricks that just failed health check — don't auto-heal same pass
             health_failed: set[str] = set()
@@ -520,6 +567,11 @@ class BrickReconciler:
             brick_list = self._manager.iter_bricks()
             for name, spec, state, retry_count, _instance in brick_list:
                 if name in health_failed:
+                    continue
+
+                # Gate: skip bricks with unsatisfied expectations (Issue #2067)
+                if not self._expectations.satisfied(name):
+                    logger.debug("[RECONCILER] Expectations pending for %r, skipping", name)
                     continue
 
                 drift = self._compute_drift(spec, state, retry_count)

--- a/src/nexus/system_services/lifecycle/expectations.py
+++ b/src/nexus/system_services/lifecycle/expectations.py
@@ -1,0 +1,165 @@
+"""Expectations tracker for safe async convergence (Issue #2067).
+
+Kubernetes-inspired ``ControllerExpectations`` pattern: atomic counters + TTL
+expiration to prevent duplicate mount/unmount operations during the race window
+between "action requested" and "action observed in next snapshot."
+
+Tier: TIER 3 System Services (internal utility for reconciler).
+
+References:
+    - Issue #2067: Agent warm-up phase / expectations tracker
+    - kubernetes/kubernetes pkg/controller/controller_utils.go
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, replace
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectationEntry:
+    """Immutable snapshot of pending expectations for a single brick.
+
+    Attributes:
+        key: Brick name (registry key).
+        pending_mounts: Number of expected but unobserved mount operations.
+        pending_unmounts: Number of expected but unobserved unmount operations.
+        created_at: Monotonic timestamp when this entry was created/updated.
+    """
+
+    key: str
+    pending_mounts: int = 0
+    pending_unmounts: int = 0
+    created_at: float = 0.0
+
+
+class Expectations:
+    """Thread-safe expectations tracker with lazy TTL expiration.
+
+    Prevents duplicate reconciler actions by tracking pending operations
+    and gating per-brick processing until expectations are satisfied
+    (all observed) or expired (TTL).
+
+    Thread safety: single ``threading.Lock`` guards all mutations.
+    Safe for both sync and async callers (PEP 703 future-proof).
+    """
+
+    _DEFAULT_TTL: float = 300.0  # 5 minutes
+
+    def __init__(self, *, ttl: float = _DEFAULT_TTL) -> None:
+        self._store: dict[str, ExpectationEntry] = {}
+        self._lock = threading.Lock()
+        self._ttl = ttl
+
+    # ------------------------------------------------------------------
+    # Expect operations
+    # ------------------------------------------------------------------
+
+    def expect_mount(self, key: str) -> None:
+        """Record that a mount operation has been requested for *key*."""
+        with self._lock:
+            self._store[key] = ExpectationEntry(
+                key=key,
+                pending_mounts=1,
+                pending_unmounts=0,
+                created_at=time.monotonic(),
+            )
+
+    def expect_unmount(self, key: str) -> None:
+        """Record that an unmount operation has been requested for *key*."""
+        with self._lock:
+            self._store[key] = ExpectationEntry(
+                key=key,
+                pending_mounts=0,
+                pending_unmounts=1,
+                created_at=time.monotonic(),
+            )
+
+    # ------------------------------------------------------------------
+    # Observe operations
+    # ------------------------------------------------------------------
+
+    def mount_observed(self, key: str) -> None:
+        """Record that a previously expected mount has completed for *key*."""
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return  # No expectation — noop
+            new_mounts = max(0, entry.pending_mounts - 1)
+            if new_mounts == 0 and entry.pending_unmounts <= 0:
+                del self._store[key]
+            else:
+                self._store[key] = replace(entry, pending_mounts=new_mounts)
+
+    def unmount_observed(self, key: str) -> None:
+        """Record that a previously expected unmount has completed for *key*."""
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return  # No expectation — noop
+            new_unmounts = max(0, entry.pending_unmounts - 1)
+            if entry.pending_mounts <= 0 and new_unmounts == 0:
+                del self._store[key]
+            else:
+                self._store[key] = replace(entry, pending_unmounts=new_unmounts)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def satisfied(self, key: str) -> bool:
+        """Check whether expectations for *key* are satisfied.
+
+        Returns ``True`` if:
+        - No expectations exist for *key*, OR
+        - All pending counts are <= 0, OR
+        - The entry has expired (TTL exceeded) — logs a warning.
+        """
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return True
+            if entry.pending_mounts <= 0 and entry.pending_unmounts <= 0:
+                return True
+            # Lazy TTL check
+            if time.monotonic() - entry.created_at > self._ttl:
+                logger.warning(
+                    "[EXPECTATIONS] TTL expired for %r (pending_mounts=%d, pending_unmounts=%d)",
+                    key,
+                    entry.pending_mounts,
+                    entry.pending_unmounts,
+                )
+                del self._store[key]
+                return True
+            return False
+
+    # ------------------------------------------------------------------
+    # Maintenance
+    # ------------------------------------------------------------------
+
+    def expire_stale(self) -> int:
+        """Remove all expired entries. Returns count removed."""
+        now = time.monotonic()
+        removed = 0
+        with self._lock:
+            stale_keys = [k for k, v in self._store.items() if now - v.created_at > self._ttl]
+            for k in stale_keys:
+                del self._store[k]
+                removed += 1
+        return removed
+
+    @property
+    def pending_keys(self) -> frozenset[str]:
+        """Return snapshot of keys with pending expectations (for observation scan)."""
+        with self._lock:
+            return frozenset(self._store)
+
+    def __len__(self) -> int:
+        """Number of tracked entries."""
+        with self._lock:
+            return len(self._store)

--- a/tests/unit/services/test_expectations.py
+++ b/tests/unit/services/test_expectations.py
@@ -1,0 +1,295 @@
+"""Tests for Expectations tracker — safe async convergence (Issue #2067).
+
+TDD: Tests written FIRST, implementation follows.
+Full 18-test matrix covering operations, satisfied, TTL, edge cases,
+and integration with BrickReconciler.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from nexus.services.brick_lifecycle import BrickLifecycleManager
+from nexus.services.brick_reconciler import BrickReconciler
+from nexus.services.protocols.brick_lifecycle import BrickState
+from nexus.system_services.lifecycle.expectations import (
+    ExpectationEntry,
+    Expectations,
+)
+from tests.unit.services.conftest import (
+    make_lifecycle_brick as _make_lifecycle_brick,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def expectations() -> Expectations:
+    """Default expectations tracker with standard TTL."""
+    return Expectations()
+
+
+@pytest.fixture
+def short_ttl_expectations() -> Expectations:
+    """Expectations tracker with very short TTL for expiration tests."""
+    return Expectations(ttl=0.05)
+
+
+@pytest.fixture
+def manager() -> BrickLifecycleManager:
+    return BrickLifecycleManager()
+
+
+@pytest.fixture
+def reconciler(manager: BrickLifecycleManager) -> BrickReconciler:
+    return BrickReconciler(
+        lifecycle_manager=manager,
+        reconcile_interval=30.0,
+        health_check_timeout=2.0,
+        max_retries=3,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestExpectationOperations (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestExpectationOperations:
+    """Test basic expect/observe operations."""
+
+    def test_expect_mount_creates_entry(self, expectations: Expectations) -> None:
+        """expect_mount creates an entry with pending_mounts=1."""
+        expectations.expect_mount("brick-a")
+        assert len(expectations) == 1
+        assert not expectations.satisfied("brick-a")
+
+    def test_expect_unmount_creates_entry(self, expectations: Expectations) -> None:
+        """expect_unmount creates an entry with pending_unmounts=1."""
+        expectations.expect_unmount("brick-b")
+        assert len(expectations) == 1
+        assert not expectations.satisfied("brick-b")
+
+    def test_mount_observed_decrements(self, expectations: Expectations) -> None:
+        """mount_observed decrements pending_mounts and cleans up when zero."""
+        expectations.expect_mount("brick-a")
+        assert not expectations.satisfied("brick-a")
+        expectations.mount_observed("brick-a")
+        assert expectations.satisfied("brick-a")
+        assert len(expectations) == 0
+
+    def test_unmount_observed_decrements(self, expectations: Expectations) -> None:
+        """unmount_observed decrements pending_unmounts and cleans up when zero."""
+        expectations.expect_unmount("brick-b")
+        assert not expectations.satisfied("brick-b")
+        expectations.unmount_observed("brick-b")
+        assert expectations.satisfied("brick-b")
+        assert len(expectations) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestSatisfied (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestSatisfied:
+    """Test satisfied() predicate."""
+
+    def test_satisfied_when_no_expectations(self, expectations: Expectations) -> None:
+        """Key with no expectations is satisfied."""
+        assert expectations.satisfied("unknown")
+
+    def test_satisfied_when_all_observed(self, expectations: Expectations) -> None:
+        """After all pending observed, key is satisfied."""
+        expectations.expect_mount("brick-a")
+        expectations.mount_observed("brick-a")
+        assert expectations.satisfied("brick-a")
+
+    def test_not_satisfied_with_pending_mount(self, expectations: Expectations) -> None:
+        """Key with pending mount is not satisfied."""
+        expectations.expect_mount("brick-a")
+        assert not expectations.satisfied("brick-a")
+
+    def test_not_satisfied_with_pending_unmount(self, expectations: Expectations) -> None:
+        """Key with pending unmount is not satisfied."""
+        expectations.expect_unmount("brick-a")
+        assert not expectations.satisfied("brick-a")
+
+
+# ---------------------------------------------------------------------------
+# TestTTLExpiration (3 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestTTLExpiration:
+    """Test TTL expiration behavior."""
+
+    def test_expired_expectation_returns_satisfied(
+        self, short_ttl_expectations: Expectations
+    ) -> None:
+        """After TTL expires, satisfied() returns True (K8s pattern)."""
+        short_ttl_expectations.expect_mount("brick-a")
+        assert not short_ttl_expectations.satisfied("brick-a")
+        time.sleep(0.06)  # Wait for TTL to expire
+        assert short_ttl_expectations.satisfied("brick-a")
+
+    def test_non_expired_returns_not_satisfied(self, short_ttl_expectations: Expectations) -> None:
+        """Before TTL, satisfied() returns False for pending entry."""
+        short_ttl_expectations.expect_mount("brick-a")
+        assert not short_ttl_expectations.satisfied("brick-a")
+
+    def test_expire_stale_returns_removed_count(self, short_ttl_expectations: Expectations) -> None:
+        """expire_stale() removes expired entries and returns count."""
+        short_ttl_expectations.expect_mount("brick-a")
+        short_ttl_expectations.expect_unmount("brick-b")
+        assert len(short_ttl_expectations) == 2
+        time.sleep(0.06)
+        removed = short_ttl_expectations.expire_stale()
+        assert removed == 2
+        assert len(short_ttl_expectations) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and safety."""
+
+    def test_observe_without_expect_is_noop(self, expectations: Expectations) -> None:
+        """Observing a key that was never expected is a harmless noop."""
+        expectations.mount_observed("ghost")
+        expectations.unmount_observed("ghost")
+        assert len(expectations) == 0
+        assert expectations.satisfied("ghost")
+
+    def test_double_expect_overwrites(self, expectations: Expectations) -> None:
+        """Second expect_mount overwrites the first entry."""
+        expectations.expect_mount("brick-a")
+        expectations.expect_mount("brick-a")
+        assert len(expectations) == 1
+        # Single observe should satisfy
+        expectations.mount_observed("brick-a")
+        assert expectations.satisfied("brick-a")
+
+    def test_observe_past_zero_no_negative(self, expectations: Expectations) -> None:
+        """Observing more than expected does not go negative."""
+        expectations.expect_mount("brick-a")
+        expectations.mount_observed("brick-a")
+        expectations.mount_observed("brick-a")  # Extra observe
+        assert expectations.satisfied("brick-a")
+        assert len(expectations) == 0
+
+    def test_concurrent_lock_safety(self, expectations: Expectations) -> None:
+        """Concurrent expect/observe from multiple threads does not corrupt state."""
+        errors: list[Exception] = []
+
+        def _worker(i: int) -> None:
+            try:
+                key = f"brick-{i % 5}"
+                expectations.expect_mount(key)
+                expectations.mount_observed(key)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_worker, args=(i,)) for i in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        # All should be satisfied after observe
+        for i in range(5):
+            assert expectations.satisfied(f"brick-{i}")
+
+
+# ---------------------------------------------------------------------------
+# TestExpectationEntry (1 test — data model)
+# ---------------------------------------------------------------------------
+
+
+class TestExpectationEntry:
+    """Test the frozen dataclass model."""
+
+    def test_entry_is_frozen(self) -> None:
+        """ExpectationEntry is immutable."""
+        entry = ExpectationEntry(key="a", pending_mounts=1, created_at=1.0)
+        with pytest.raises(AttributeError):
+            entry.key = "b"
+
+
+# ---------------------------------------------------------------------------
+# TestExpectationsIntegration (3 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestExpectationsIntegration:
+    """Integration tests with BrickReconciler."""
+
+    @pytest.mark.asyncio
+    async def test_reconciler_skips_brick_with_pending_expectation(
+        self, manager: BrickLifecycleManager, reconciler: BrickReconciler
+    ) -> None:
+        """Reconciler skips a brick that has unsatisfied expectations."""
+        manager.register("a", _make_lifecycle_brick("a"), protocol_name="AP")
+        # Don't mount — stays REGISTERED → would normally trigger MOUNT action
+
+        # Manually set an expectation on the reconciler's tracker
+        reconciler._expectations.expect_mount("a")
+
+        result = await reconciler.reconcile()
+        # Brick "a" should be skipped due to pending expectation
+        a_drifts = [d for d in result.drifts if d.brick_name == "a"]
+        assert len(a_drifts) == 0
+
+    @pytest.mark.asyncio
+    async def test_reconciler_auto_observes_from_snapshot(
+        self, manager: BrickLifecycleManager, reconciler: BrickReconciler
+    ) -> None:
+        """Reconciler auto-observes completed mount operations from snapshot."""
+        brick = _make_lifecycle_brick("a")
+        manager.register("a", brick, protocol_name="AP")
+        await manager.mount("a")
+        status = manager.get_status("a")
+        assert status is not None
+        assert status.state == BrickState.ACTIVE
+
+        # Set a mount expectation — brick is already ACTIVE
+        reconciler._expectations.expect_mount("a")
+        assert not reconciler._expectations.satisfied("a")
+
+        # Reconcile should auto-observe the mount
+        await reconciler.reconcile()
+        assert reconciler._expectations.satisfied("a")
+
+    @pytest.mark.asyncio
+    async def test_full_cycle_expect_reconcile_observe(
+        self, manager: BrickLifecycleManager, reconciler: BrickReconciler
+    ) -> None:
+        """Full lifecycle: expect → reconcile (skip) → observe → reconcile (act)."""
+        manager.register("a", _make_lifecycle_brick("a"), protocol_name="AP")
+        # Brick is REGISTERED, spec.enabled=True → normally would mount
+
+        # Step 1: Set expectation — reconciler should skip
+        reconciler._expectations.expect_mount("a")
+        result1 = await reconciler.reconcile()
+        a_drifts1 = [d for d in result1.drifts if d.brick_name == "a"]
+        assert len(a_drifts1) == 0  # Skipped
+
+        # Step 2: Clear expectation manually (simulating observation)
+        reconciler._expectations.mount_observed("a")
+        assert reconciler._expectations.satisfied("a")
+
+        # Step 3: Next reconcile should detect drift and mount
+        result2 = await reconciler.reconcile()
+        status = manager.get_status("a")
+        assert status is not None
+        assert status.state == BrickState.ACTIVE
+        assert result2.actions_taken >= 1


### PR DESCRIPTION
## Summary

Kubernetes-inspired `ControllerExpectations` pattern to prevent duplicate mount/unmount operations during the race window between "action requested" and "action observed in next `iter_bricks()` snapshot."

- Add `Expectations` class with thread-safe `expect_mount`/`expect_unmount`/`mount_observed`/`unmount_observed`/`satisfied` API
- Frozen `ExpectationEntry` dataclass with lazy TTL expiration (5min default, K8s pattern)
- Auto-observe completed operations from snapshot diff at reconcile start (O(k) pending scan)
- Gate per-brick processing on unsatisfied expectations in reconcile loop
- Clear expectations on failed actions to prevent permanent gating

**Stream:** 1

## Architecture Alignment (LEGO)

| Rule | Status |
|------|--------|
| Tier placement (TIER 3 System Services) | PASS — lives in `system_services/lifecycle/` |
| Storage affinity (ephemeral in-memory) | PASS — Python dict with TTL, no persistence |
| Brick boundaries (no kernel deps) | PASS — `expectations.py` has zero Nexus imports |
| Immutability (frozen dataclass + replace) | PASS — `frozen=True, slots=True` |
| Federation (process-local, not Raft) | PASS — reconciler-local state only |

## Files Changed

| Action | File | LOC |
|--------|------|-----|
| CREATE | `src/nexus/system_services/lifecycle/expectations.py` | ~165 |
| CREATE | `tests/unit/services/test_expectations.py` | ~295 |
| MODIFY | `src/nexus/system_services/lifecycle/brick_reconciler.py` | +52 |
| MODIFY | `src/nexus/system_services/lifecycle/__init__.py` | +2 |

## Test plan

- [x] 19 new unit tests (operations, satisfied, TTL, edge cases, integration)
- [x] 27 existing reconciler tests still pass (49 total)
- [x] ruff check — all passed
- [x] mypy — no issues
- [x] Pre-commit hooks (ruff, ruff-format, mypy, type-ignore check) — all passed
- [ ] CI pipeline green