### PR TITLE
perf(#1568): avoid full-file read in FUSE getattr for virtual views

### DIFF
--- a/src/nexus/fuse/cache.py
+++ b/src/nexus/fuse/cache.py
@@ -185,6 +185,26 @@ class FUSECacheManager:
 
             return result
 
+    def get_parsed_size(self, path: str, view_type: str) -> int | None:
+        """Get the size of cached parsed content without returning the bytes.
+
+        Lightweight alternative to get_parsed() when only the size is needed
+        (e.g., for getattr st_size resolution). Avoids copying large byte arrays.
+
+        Args:
+            path: File path
+            view_type: View type (e.g., "txt", "md")
+
+        Returns:
+            Size in bytes of cached parsed content, or None if not cached
+        """
+        cache_key = f"{path}:{view_type}"
+        with self._parsed_lock:
+            result = self._parsed_cache.get(cache_key)
+            if result is not None:
+                return len(result)
+            return None
+
     def cache_parsed(self, path: str, view_type: str, content: bytes) -> None:
         """Cache parsed content.
 

--- a/src/nexus/fuse/ops/metadata_handler.py
+++ b/src/nexus/fuse/ops/metadata_handler.py
@@ -16,7 +16,6 @@ from nexus.fuse.ops._shared import (
     cache_file_attrs_from_list,
     check_namespace_visible,
     dir_cache_key,
-    get_file_content,
     get_metadata,
     parse_virtual_path_for_fuse,
     resolve_owner_group_to_uid_gid,
@@ -30,6 +29,10 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+# --- getattr size-estimation constants (Issue #1568) ---
+_VIRTUAL_VIEW_DEFAULT_SIZE = 10 * 1024 * 1024  # 10 MiB safe over-report
+_PARSED_SIZE_MULTIPLIER = 4  # Raw size × 4 estimates parsed output
 
 
 class MetadataHandler:
@@ -138,13 +141,54 @@ class MetadataHandler:
         }
 
     def _resolve_file_size(self, path: str, metadata: Any, view_type: str | None) -> int:
-        """Resolve file size from metadata, stat, or content fetch."""
+        """Resolve file size for getattr without reading the full file.
+
+        For virtual views (parsed .md/.txt), uses a 5-tier estimation strategy
+        that avoids the expensive full-file read + parse that previously happened
+        on every getattr call (Issue #1568).
+
+        Over-reporting st_size is safe: FUSE read() returns EOF naturally when
+        actual content is shorter than the reported size.
+
+        Tiers (virtual views only):
+            1. Parsed cache size — exact, O(1)
+            2. Raw content cache size × multiplier — estimate, O(1)
+            3. Metadata size × multiplier — estimate, O(1)
+            4. stat() RPC size × multiplier — lightweight RPC
+            5. Constant default (10 MiB) — no I/O at all
+        """
         ctx = self._ctx
 
         if view_type and view_type != "raw":
-            content = get_file_content(ctx, path, view_type)
-            return len(content)
+            # Tier 1: exact size from parsed cache
+            parsed_size = ctx.cache.get_parsed_size(path, view_type)
+            if parsed_size is not None:
+                return parsed_size
 
+            # Tier 2: estimate from raw content cache
+            raw_content = ctx.cache.get_content(path)
+            if raw_content is not None and len(raw_content) > 0:
+                return len(raw_content) * _PARSED_SIZE_MULTIPLIER
+
+            # Tier 3: estimate from metadata (already fetched by caller)
+            if metadata:
+                meta_size = (
+                    metadata.get("size")
+                    if isinstance(metadata, dict)
+                    else getattr(metadata, "size", 0)
+                )
+                if meta_size and meta_size > 0:
+                    return cast("int", meta_size) * _PARSED_SIZE_MULTIPLIER
+
+            # Tier 4: estimate from stat() RPC
+            stat_size = stat_size_fallback(ctx, path)
+            if stat_size > 0:
+                return stat_size * _PARSED_SIZE_MULTIPLIER
+
+            # Tier 5: safe constant default
+            return _VIRTUAL_VIEW_DEFAULT_SIZE
+
+        # Raw file path — use metadata or stat directly (no multiplier)
         if metadata:
             meta_size = (
                 metadata.get("size") if isinstance(metadata, dict) else getattr(metadata, "size", 0)

--- a/tests/unit/fuse/test_metadata_handler.py
+++ b/tests/unit/fuse/test_metadata_handler.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import errno
 import stat
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fuse import FuseOSError
+
+from nexus.fuse.cache import FUSECacheManager
+from nexus.fuse.ops.metadata_handler import (
+    _PARSED_SIZE_MULTIPLIER,
+    _VIRTUAL_VIEW_DEFAULT_SIZE,
+)
 
 
 class TestGetattr:
@@ -94,3 +100,171 @@ class TestReaddir:
         entries = fuse_ops.readdir("/cached")
         assert entries == [".", "..", "a.txt"]
         mock_nexus_fs.list.assert_not_called()
+
+
+class TestResolveFileSize:
+    """_resolve_file_size: tiered size estimation for getattr (Issue #1568)."""
+
+    def _make_handler(
+        self,
+        mock_nexus_fs: MagicMock,
+        mock_cache: MagicMock,
+    ) -> Any:
+        """Create a MetadataHandler with controlled dependencies."""
+        from nexus.fuse.ops.metadata_handler import MetadataHandler
+
+        ctx = MagicMock()
+        ctx.nexus_fs = mock_nexus_fs
+        ctx.cache = mock_cache
+        ctx.context = None
+        return MetadataHandler(ctx)
+
+    def test_raw_view_uses_metadata_size(
+        self, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """Raw files use metadata size directly (no multiplier)."""
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+        metadata = MagicMock()
+        metadata.size = 2048
+
+        result = handler._resolve_file_size("/data.bin", metadata, None)
+
+        assert result == 2048
+
+    def test_raw_view_type_uses_original_behavior(
+        self, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """/.raw/ paths (view_type='raw') use metadata directly like raw files."""
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+        metadata = MagicMock()
+        metadata.size = 5000
+
+        result = handler._resolve_file_size("/report.xlsx", metadata, "raw")
+
+        assert result == 5000
+
+    def test_virtual_view_tier1_parsed_cache_exact(
+        self, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """Tier 1: parsed cache returns exact size."""
+        mock_cache.get_parsed_size.return_value = 4200
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+
+        result = handler._resolve_file_size("/report.xlsx", None, "md")
+
+        assert result == 4200
+        mock_cache.get_parsed_size.assert_called_once_with("/report.xlsx", "md")
+
+    def test_virtual_view_tier2_raw_content_estimate(
+        self, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """Tier 2: raw content cache size * multiplier."""
+        mock_cache.get_parsed_size.return_value = None
+        mock_cache.get_content.return_value = b"x" * 1000
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+
+        result = handler._resolve_file_size("/report.xlsx", None, "md")
+
+        assert result == 1000 * _PARSED_SIZE_MULTIPLIER
+
+    def test_virtual_view_tier2_skips_zero_byte(
+        self, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """Tier 2: 0-byte raw content falls through to next tier."""
+        mock_cache.get_parsed_size.return_value = None
+        mock_cache.get_content.return_value = b""
+        metadata = MagicMock()
+        metadata.size = 500
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+
+        result = handler._resolve_file_size("/empty.xlsx", metadata, "md")
+
+        # Should fall through to tier 3 (metadata * multiplier)
+        assert result == 500 * _PARSED_SIZE_MULTIPLIER
+
+    def test_virtual_view_tier3_metadata_estimate(
+        self, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """Tier 3: metadata.size * multiplier."""
+        mock_cache.get_parsed_size.return_value = None
+        mock_cache.get_content.return_value = None
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+        metadata = MagicMock()
+        metadata.size = 2000
+
+        result = handler._resolve_file_size("/report.xlsx", metadata, "md")
+
+        assert result == 2000 * _PARSED_SIZE_MULTIPLIER
+
+    def test_virtual_view_tier4_stat_estimate(
+        self, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """Tier 4: stat() RPC size * multiplier."""
+        mock_cache.get_parsed_size.return_value = None
+        mock_cache.get_content.return_value = None
+        mock_nexus_fs.stat.return_value = {"st_size": 3000}
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+
+        result = handler._resolve_file_size("/report.xlsx", None, "md")
+
+        assert result == 3000 * _PARSED_SIZE_MULTIPLIER
+
+    def test_virtual_view_tier5_default_constant(
+        self, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        """Tier 5: 10 MiB default when nothing is available."""
+        mock_cache.get_parsed_size.return_value = None
+        mock_cache.get_content.return_value = None
+        mock_nexus_fs.stat.return_value = None
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+
+        result = handler._resolve_file_size("/report.xlsx", None, "md")
+
+        assert result == _VIRTUAL_VIEW_DEFAULT_SIZE
+
+    @patch("nexus.fuse.ops.metadata_handler.stat_size_fallback", return_value=0)
+    def test_virtual_view_no_full_read_triggered(
+        self,
+        _mock_stat: MagicMock,
+        mock_nexus_fs: MagicMock,
+        mock_cache: MagicMock,
+    ) -> None:
+        """nexus_fs.read() must NEVER be called during _resolve_file_size."""
+        mock_cache.get_parsed_size.return_value = None
+        mock_cache.get_content.return_value = None
+        handler = self._make_handler(mock_nexus_fs, mock_cache)
+
+        handler._resolve_file_size("/report.xlsx", None, "md")
+
+        mock_nexus_fs.read.assert_not_called()
+
+
+class TestCacheGetParsedSize:
+    """FUSECacheManager.get_parsed_size: lightweight size lookup."""
+
+    def test_returns_none_when_not_cached(self) -> None:
+        cache = FUSECacheManager()
+        assert cache.get_parsed_size("/file.xlsx", "md") is None
+
+    def test_returns_exact_size_when_cached(self) -> None:
+        cache = FUSECacheManager()
+        content = b"# Parsed markdown output\nSome data here."
+        cache.cache_parsed("/file.xlsx", "md", content)
+
+        assert cache.get_parsed_size("/file.xlsx", "md") == len(content)
+
+    def test_different_view_types_independent(self) -> None:
+        cache = FUSECacheManager()
+        cache.cache_parsed("/file.xlsx", "md", b"short")
+        cache.cache_parsed("/file.xlsx", "txt", b"a longer text output")
+
+        assert cache.get_parsed_size("/file.xlsx", "md") == 5
+        assert cache.get_parsed_size("/file.xlsx", "txt") == 20
+
+    def test_returns_none_after_invalidation(self) -> None:
+        cache = FUSECacheManager()
+        cache.cache_parsed("/file.xlsx", "md", b"cached data")
+        assert cache.get_parsed_size("/file.xlsx", "md") is not None
+
+        cache.invalidate_path("/file.xlsx")
+        assert cache.get_parsed_size("/file.xlsx", "md") is None


### PR DESCRIPTION
## Summary

- **Remove full-file read from `getattr`**: Replace the expensive `get_file_content()` call in `_resolve_file_size()` with a 5-tier size estimation strategy that never reads the full file during `getattr`. The OS kernel calls `getattr` before every `open()`, `read()`, `stat()`, and during `ls -la`, so 50 parsed views in a directory previously triggered 50 full file reads + CPU-intensive parses just to list it.
- **Add `get_parsed_size()` to `FUSECacheManager`**: O(1) size lookup from parsed cache without copying byte arrays.
- **12 new tests**: Cover all 5 tiers, raw view behavior, zero-byte guard, and the critical no-full-read invariant.

## 5-Tier Size Resolution (virtual views only)

| Tier | Source | Cost | Accuracy |
|------|--------|------|----------|
| 1 | Parsed cache (`get_parsed_size`) | O(1) | Exact |
| 2 | Raw content cache × 4 | O(1) | Estimate |
| 3 | Metadata size × 4 | O(1) | Estimate |
| 4 | stat() RPC × 4 | Lightweight RPC | Estimate |
| 5 | 10 MiB constant | No I/O | Safe over-report |

Over-reporting `st_size` is safe: FUSE `read()` returns EOF naturally when actual content is shorter.

## Files Changed (3)

| File | Change |
|------|--------|
| `src/nexus/fuse/cache.py` | Add `get_parsed_size()` method (+20 LOC) |
| `src/nexus/fuse/ops/metadata_handler.py` | Rewrite `_resolve_file_size()` with tiered strategy, remove `get_file_content` import (+54, -6 LOC) |
| `tests/unit/fuse/test_metadata_handler.py` | 12 new tests in `TestResolveFileSize` + `TestCacheGetParsedSize` (+176 LOC) |

## LEGO Architecture Alignment

- Cache layer (`cache.py`) is self-contained, thread-safe, no cross-tier imports
- `metadata_handler.py` depends only on cache interface + `stat_size_fallback` (lightweight RPC)
- `get_file_content` removed from metadata handler — only used in IO handler (read/write paths)
- No circular dependencies, proper layer separation
- Brick Zero-Core-Imports check: passed

## Test Plan

- [x] `uv run ruff check` — all 3 files clean
- [x] `uv run mypy` — our 2 source files clean (pre-existing yaml stubs issue in unrelated file)
- [x] `uv run pytest tests/unit/fuse/ -v` — 124/124 passed
- [x] Pre-commit hooks: ruff, ruff-format, debug-statements, brick-zero-core-imports all passed
- [ ] CI: ruff, mypy, unit tests, e2e

Stream: #11

Closes #1568