### PR TITLE
fix(#2360): scheduler review fixes — DI, DRY, typing, perf, tests

### DIFF
--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -16,6 +16,7 @@ Two severity classes:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
 from collections.abc import Callable
@@ -247,6 +248,13 @@ def _boot_system_services(
     # ORIGINAL SYSTEM SERVICES (all degradable)
     # =====================================================================
 
+    # --- AgentStateEmitter (Issue #2360: created early for DI into AsyncAgentRegistry) ---
+    state_emitter: Any = None
+    with contextlib.suppress(Exception):
+        from nexus.services.scheduler.events import AgentStateEmitter
+
+        state_emitter = AgentStateEmitter()
+
     # --- Agent Registry (Issue #1502) ---
     agent_registry: Any = None
     async_agent_registry: Any = None
@@ -260,7 +268,7 @@ def _boot_system_services(
                 entity_registry=entity_registry,
                 flush_interval=ctx.profile_tuning.background_task.heartbeat_flush_interval,
             )
-            async_agent_registry = AsyncAgentRegistry(agent_registry)
+            async_agent_registry = AsyncAgentRegistry(agent_registry, state_emitter=state_emitter)
             logger.debug("[BOOT:SYSTEM] AgentRegistry + AsyncAgentRegistry created")
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] AgentRegistry unavailable: %s", exc)
@@ -511,15 +519,13 @@ def _boot_system_services(
         logger.debug("[BOOT:SYSTEM] EventLog disabled by profile")
 
     # --- Scheduler Service (Issue #2195, #2360: promoted to always-started) ---
+    # state_emitter already created above (before AgentRegistry) for DI.
     scheduler_service: Any = None
-    state_emitter: Any = None
     try:
-        from nexus.services.scheduler.events import AgentStateEmitter
         from nexus.services.scheduler.policies.fair_share import FairShareCounter
         from nexus.services.scheduler.queue import TaskQueue
         from nexus.services.scheduler.service import SchedulerService
 
-        state_emitter = AgentStateEmitter()
         scheduler_service = SchedulerService(
             queue=TaskQueue(),
             db_pool=None,
@@ -541,13 +547,6 @@ def _boot_system_services(
         except Exception:
             # nexus.services namespace unavailable (e.g., nats not installed)
             pass
-
-    # Wire state_emitter into async_agent_registry if both are available
-    import contextlib
-
-    with contextlib.suppress(Exception):
-        if state_emitter is not None and async_agent_registry is not None:
-            async_agent_registry._state_emitter = state_emitter
 
     # =====================================================================
     # Assemble result

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -74,23 +74,14 @@ async def shutdown_services(app: FastAPI, svc: LifespanServices) -> None:
             logger.warning("Error shutting down Task Queue runner: %s", e, exc_info=True)
 
     # Shutdown scheduler (Issue #1212, #2360)
+    # Both SchedulerService and InMemoryScheduler implement shutdown().
     scheduler_svc = getattr(app.state, "scheduler_service", None)
-    if scheduler_svc is not None and hasattr(scheduler_svc, "shutdown"):
+    if scheduler_svc is not None:
         try:
             await scheduler_svc.shutdown()
             logger.info("Scheduler service shut down")
         except Exception as e:
             logger.warning("Error shutting down scheduler: %s", e, exc_info=True)
-    else:
-        # Legacy fallback: close pool directly
-        scheduler_pool = getattr(app.state, "_scheduler_pool", None)
-        if scheduler_pool:
-            try:
-                await scheduler_pool.close()
-                logger.info("Scheduler pool closed")
-            except Exception as e:
-                logger.warning("Error closing scheduler pool: %s", e, exc_info=True)
-            app.state._scheduler_pool = None
 
     # Cancel agent background tasks and final flush (Issue #1240, #2170)
     heartbeat_task = getattr(app.state, "_heartbeat_task", None)
@@ -585,19 +576,22 @@ async def _startup_scheduler(app: FastAPI, svc: LifespanServices) -> None:
                 _min_size,
                 _max_size,
             )
+        # Design decision: scheduler uses its own asyncpg pool for isolation.
+        # Scheduler queries don't compete with application queries.
+        # 2-5 extra connections is negligible cost for the isolation benefit.
         pool = await asyncpg.create_pool(pg_dsn, min_size=_min_size, max_size=_max_size)
         app.state._scheduler_pool = pool
 
-        await scheduler.initialize(pool)
+        # At this point scheduler is SchedulerService (InMemoryScheduler
+        # returned early above), which has .initialize() outside the Protocol.
+        if hasattr(scheduler, "initialize"):
+            await scheduler.initialize(pool)
 
-        # Wire emitter into AsyncAgentRegistry if available
+        # Wire hook cleanup handler into state emitter (Issue #1257)
+        # Note: state_emitter is constructor-injected into AsyncAgentRegistry
+        # by factory._boot_system_services() — no post-construction wiring needed.
         state_emitter = getattr(scheduler, "_state_emitter", None)
         if state_emitter is not None:
-            async_reg = getattr(app.state, "async_agent_registry", None)
-            if async_reg is not None:
-                async_reg._state_emitter = state_emitter
-
-            # Wire hook cleanup handler into state emitter (Issue #1257)
             scoped_hook_engine = svc.scoped_hook_engine
             if scoped_hook_engine is not None:
                 from nexus.system_services.lifecycle.hook_engine import create_agent_cleanup_handler

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.services.protocols.scheduler import SchedulerProtocol
+
 
 @dataclass(slots=True)
 class LifespanServices:
@@ -56,9 +58,9 @@ class LifespanServices:
     write_observer: Any = None
     zone_lifecycle: Any = None
 
-    # --- Issue #2195: EventLog + Scheduler (from SystemServices) ----------
+    # --- Issue #2195, #2360: EventLog + Scheduler (from SystemServices) ----
     event_log: Any = None
-    scheduler_service: Any = None
+    scheduler_service: SchedulerProtocol | None = None
 
     # --- Brick services container ----------------------------------------
     brick_services: Any = None  # The whole BrickServices dataclass

--- a/src/nexus/services/protocols/scheduler.py
+++ b/src/nexus/services/protocols/scheduler.py
@@ -8,6 +8,10 @@ Also defines ``CreditsReservationProtocol`` — the narrow interface
 the scheduler uses for credit-based priority boosting, decoupling
 the system service tier from the pay brick (LEGO §3.3).
 
+``classify_agent_request()`` is the single source of truth for
+AgentRequest → PriorityClass conversion, shared by both
+SchedulerService and InMemoryScheduler (DRY).
+
 Storage Affinity: **CacheStore** — ephemeral work queue (Dragonfly sorted set).
 
 References:
@@ -28,6 +32,10 @@ from decimal import Decimal
 from typing import Any, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+# Maximum completed tasks retained by InMemoryScheduler to prevent
+# unbounded memory growth in long-running edge deployments.
+_MAX_COMPLETED = 10_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,6 +95,37 @@ class SchedulerProtocol(Protocol):
     async def classify(self, request: AgentRequest) -> str: ...
 
     async def metrics(self, *, zone_id: str | None = None) -> dict[str, Any]: ...
+
+
+# ---------------------------------------------------------------------------
+# classify_agent_request — shared classification helper (DRY)
+# ---------------------------------------------------------------------------
+
+
+def classify_agent_request(request: AgentRequest) -> str:
+    """Classify an AgentRequest into a PriorityClass string.
+
+    Single source of truth for AgentRequest → PriorityClass conversion.
+    Delegates to ``classify_request()`` from the scheduler policies module,
+    handling AgentRequest field parsing (tier, request_state) in one place.
+
+    Used by both ``InMemoryScheduler.classify()`` and
+    ``SchedulerService.classify()`` to avoid duplicated logic.
+    """
+    from nexus.services.scheduler.constants import PriorityTier, RequestState
+    from nexus.services.scheduler.policies.classifier import classify_request
+
+    try:
+        tier = PriorityTier(request.priority)
+    except ValueError:
+        tier = PriorityTier.NORMAL
+
+    try:
+        req_state = RequestState(request.request_state)
+    except ValueError:
+        req_state = RequestState.PENDING
+
+    return classify_request(tier, req_state)
 
 
 # ---------------------------------------------------------------------------
@@ -169,9 +208,6 @@ class InMemoryScheduler:
         self._seq: int = 0
         self._completed: dict[str, dict[str, Any]] = {}
         self._task_map: dict[str, AgentRequest] = {}
-        logger.warning(
-            "[SCHEDULER] Using InMemoryScheduler fallback — tasks will NOT persist across restarts"
-        )
 
     async def submit(self, request: AgentRequest) -> str:
         import heapq
@@ -228,27 +264,13 @@ class InMemoryScheduler:
         }
         self._task_map.pop(task_id, None)
 
+        # Evict oldest entries to prevent unbounded memory growth
+        if len(self._completed) > _MAX_COMPLETED:
+            oldest = next(iter(self._completed))
+            del self._completed[oldest]
+
     async def classify(self, request: AgentRequest) -> str:
-        from nexus.contracts.constants import PriorityTier
-
-        # Tier→class mapping (uses shared PriorityTier from contracts, not implementation).
-        _TIER_TO_CLASS = {
-            PriorityTier.CRITICAL: "interactive",
-            PriorityTier.HIGH: "interactive",
-            PriorityTier.NORMAL: "batch",
-            PriorityTier.LOW: "background",
-            PriorityTier.BEST_EFFORT: "background",
-        }
-        try:
-            tier = PriorityTier(request.priority)
-        except ValueError:
-            tier = PriorityTier.NORMAL
-        base_class = _TIER_TO_CLASS[tier]
-
-        # IO promotion: BACKGROUND → BATCH if IO_WAIT
-        if base_class == "background" and request.request_state == "io_wait":
-            return "batch"
-        return base_class
+        return classify_agent_request(request)
 
     async def metrics(self, *, zone_id: str | None = None) -> dict[str, Any]:
         count = await self.pending_count(zone_id=zone_id)

--- a/src/nexus/services/scheduler/queue.py
+++ b/src/nexus/services/scheduler/queue.py
@@ -224,6 +224,18 @@ WHERE status = 'queued'
 RETURNING id
 """
 
+_SQL_COUNT_PENDING = """
+SELECT count(*) AS cnt
+FROM scheduled_tasks
+WHERE status = 'queued'
+"""
+
+_SQL_COUNT_PENDING_BY_ZONE = """
+SELECT count(*) AS cnt
+FROM scheduled_tasks
+WHERE status = 'queued' AND zone_id = $1
+"""
+
 _SQL_PENDING_METRICS = """
 SELECT
     priority_class,
@@ -440,6 +452,18 @@ class TaskQueue:
         """Promote BACKGROUND tasks that have waited longer than threshold to BATCH."""
         rows = await conn.fetch(_SQL_STARVATION_PROMOTE, threshold_seconds)
         return len(rows)
+
+    async def count_pending(self, conn: Any, *, zone_id: str | None = None) -> int:
+        """Count pending (queued) tasks via a direct COUNT(*).
+
+        More efficient than ``get_queue_metrics()`` when only the total
+        count is needed (avoids GROUP BY aggregation).
+        """
+        if zone_id is not None:
+            row = await conn.fetchrow(_SQL_COUNT_PENDING_BY_ZONE, zone_id)
+        else:
+            row = await conn.fetchrow(_SQL_COUNT_PENDING)
+        return row["cnt"] if row else 0
 
     async def get_queue_metrics(
         self, conn: Any, *, zone_id: str | None = None

--- a/src/nexus/services/scheduler/service.py
+++ b/src/nexus/services/scheduler/service.py
@@ -269,17 +269,9 @@ class SchedulerService:
 
     async def classify(self, request: AgentRequest) -> str:
         """Classify an AgentRequest into a PriorityClass."""
-        try:
-            tier = PriorityTier(request.priority)
-        except ValueError:
-            tier = PriorityTier.NORMAL
+        from nexus.services.protocols.scheduler import classify_agent_request
 
-        try:
-            req_state = RequestState(request.request_state)
-        except ValueError:
-            req_state = RequestState.PENDING
-
-        return classify_request(tier, req_state)
+        return classify_agent_request(request)
 
     async def metrics(self, *, zone_id: str | None = None) -> dict[str, Any]:
         """Get scheduler metrics including queue stats and fair-share."""
@@ -300,9 +292,12 @@ class SchedulerService:
         }
 
     async def pending_count(self, *, zone_id: str | None = None) -> int:
-        """Count pending tasks. Placeholder for protocol conformance."""
-        m = await self.metrics(zone_id=zone_id)
-        return sum(row.get("cnt", 0) for row in m.get("queue_by_class", []))
+        """Count pending tasks via a direct COUNT(*) query.
+
+        More efficient than metrics() which aggregates by priority_class.
+        """
+        async with self.pool.acquire() as conn:
+            return await self._queue.count_pending(conn, zone_id=zone_id)
 
     async def cancel(self, agent_id: str) -> int:
         """Cancel all queued tasks for an agent. Returns count cancelled."""

--- a/tests/unit/core/test_architectural_tier_placement.py
+++ b/tests/unit/core/test_architectural_tier_placement.py
@@ -31,6 +31,7 @@ class TestSchedulerTierPlacement:
         assert hasattr(mod, "InMemoryScheduler")
         assert hasattr(mod, "CreditsReservationProtocol")
         assert hasattr(mod, "NullCreditsReservation")
+        assert hasattr(mod, "classify_agent_request")
 
     def test_scheduler_service_in_services(self) -> None:
         mod = importlib.import_module("nexus.services.scheduler.service")

--- a/tests/unit/services/protocols/test_scheduler.py
+++ b/tests/unit/services/protocols/test_scheduler.py
@@ -1,5 +1,5 @@
 """Tests for SchedulerProtocol, AgentRequest, InMemoryScheduler,
-and CreditsReservationProtocol (Issues #1383, #2360)."""
+CreditsReservationProtocol, and classify_agent_request (Issues #1383, #2360)."""
 
 from __future__ import annotations
 
@@ -9,11 +9,13 @@ from decimal import Decimal
 import pytest
 
 from nexus.services.protocols.scheduler import (
+    _MAX_COMPLETED,
     AgentRequest,
     CreditsReservationProtocol,
     InMemoryScheduler,
     NullCreditsReservation,
     SchedulerProtocol,
+    classify_agent_request,
 )
 
 # ---------------------------------------------------------------------------
@@ -295,3 +297,100 @@ class TestNullCreditsReservation:
     async def test_release_reservation_is_noop(self) -> None:
         null = NullCreditsReservation()
         await null.release_reservation("any-id")  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# classify_agent_request tests (Issue #2360 — DRY fix)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyAgentRequest:
+    """Verify classify_agent_request shared helper."""
+
+    def test_normal_priority_maps_to_batch(self) -> None:
+        """PriorityTier.NORMAL (2) → 'batch'."""
+        req = AgentRequest(agent_id="a1", zone_id=None, priority=2)
+        assert classify_agent_request(req) == "batch"
+
+    def test_critical_priority_maps_to_interactive(self) -> None:
+        """PriorityTier.CRITICAL (0) → 'interactive'."""
+        req = AgentRequest(agent_id="a1", zone_id=None, priority=0)
+        assert classify_agent_request(req) == "interactive"
+
+    def test_low_priority_maps_to_background(self) -> None:
+        """PriorityTier.LOW (3) → 'background'."""
+        req = AgentRequest(agent_id="a1", zone_id=None, priority=3)
+        assert classify_agent_request(req) == "background"
+
+    def test_io_wait_promotes_background_to_batch(self) -> None:
+        """BACKGROUND + IO_WAIT → 'batch' (IO promotion)."""
+        req = AgentRequest(agent_id="a1", zone_id=None, priority=3, request_state="io_wait")
+        assert classify_agent_request(req) == "batch"
+
+    def test_invalid_priority_defaults_to_normal(self) -> None:
+        """Unknown priority value → NORMAL → 'batch'."""
+        req = AgentRequest(agent_id="a1", zone_id=None, priority=999)
+        assert classify_agent_request(req) == "batch"
+
+    def test_invalid_request_state_defaults_to_pending(self) -> None:
+        """Unknown request_state → PENDING (no promotion)."""
+        req = AgentRequest(agent_id="a1", zone_id=None, priority=3, request_state="unknown_state")
+        assert classify_agent_request(req) == "background"
+
+
+@pytest.mark.asyncio
+class TestClassifyParity:
+    """InMemoryScheduler.classify() must agree with classify_agent_request."""
+
+    @pytest.mark.parametrize(
+        "priority,request_state",
+        [
+            (0, "pending"),  # CRITICAL
+            (1, "pending"),  # HIGH
+            (2, "pending"),  # NORMAL
+            (3, "pending"),  # LOW
+            (4, "pending"),  # BEST_EFFORT
+            (3, "io_wait"),  # IO promotion
+            (0, "io_wait"),  # No promotion (already interactive)
+            (999, "pending"),  # Invalid priority
+            (2, "unknown"),  # Invalid state
+        ],
+    )
+    async def test_classify_matches_shared_function(
+        self, priority: int, request_state: str
+    ) -> None:
+        req = AgentRequest(
+            agent_id="a1", zone_id=None, priority=priority, request_state=request_state
+        )
+        scheduler = InMemoryScheduler()
+        scheduler_result = await scheduler.classify(req)
+        shared_result = classify_agent_request(req)
+        assert scheduler_result == shared_result, (
+            f"Divergence for priority={priority}, state={request_state}: "
+            f"scheduler={scheduler_result!r}, shared={shared_result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bounded completed dict tests (Issue #2360 — performance)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestInMemorySchedulerCompletedBound:
+    """Verify _completed dict is bounded to _MAX_COMPLETED entries."""
+
+    async def test_completed_eviction(self) -> None:
+        scheduler = InMemoryScheduler()
+        # Submit and complete _MAX_COMPLETED + 50 tasks
+        task_ids = []
+        for _ in range(_MAX_COMPLETED + 50):
+            tid = await scheduler.submit(AgentRequest(agent_id="a1", zone_id="z1"))
+            task_ids.append(tid)
+            await scheduler.next()  # Dequeue to allow completion
+            await scheduler.complete(tid)
+
+        # Dict should be bounded
+        assert len(scheduler._completed) <= _MAX_COMPLETED
+        # Most recent tasks should still be present
+        assert await scheduler.get_status(task_ids[-1]) is not None


### PR DESCRIPTION
## Summary

Post-merge review fixes for the scheduler promotion (#2360). Addresses 16 review items across architecture, code quality, performance, and test coverage.

- **Architecture**: Constructor-inject `AgentStateEmitter` into `AsyncAgentRegistry` (LEGO §4.2 DI pattern), type `scheduler_service` as `SchedulerProtocol` in `LifespanServices`, move `contextlib` import to module level
- **Code quality**: Extract `classify_agent_request()` shared helper eliminating 3-way DRY violation, remove duplicate emitter wiring in lifespan, remove legacy shutdown fallback dead code, remove noisy constructor log
- **Performance**: Add `TaskQueue.count_pending()` with direct `COUNT(*)` query (avoids full `GROUP BY` aggregation), bound `InMemoryScheduler._completed` dict to 10k entries to prevent unbounded memory growth
- **Tests**: 16 new test cases — `TestClassifyAgentRequest` (6), `TestClassifyParity` (9 parametrized), `TestInMemorySchedulerCompletedBound` (1), architecture tier placement assertion

## Test plan

- [x] 47/47 scheduler protocol + architecture tier tests pass
- [x] 99/99 factory/boot tests pass
- [x] 7/7 scheduler e2e integration tests pass
- [x] 432/432 self-contained e2e tests pass (2 pre-existing failures excluded: `test_ipc_signing_e2e`, `test_adaptive_retrieval`)
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, brick-imports)