### PR TITLE
cleanup(#2076, #2428): remove stale DatabaseTaskStore config + empty bricks/scheduler/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -523,9 +523,8 @@ disable_error_code = ["attr-defined", "no-any-return"]
 [[tool.mypy.overrides]]
 module = [
     "nexus.core.exceptions",
-    "nexus.bricks.a2a.stores.database",
 ]
-# Pre-existing errors from develop merges (zone-id-default-root, a2a DI).
+# Pre-existing errors from develop merges (zone-id-default-root).
 # Suppressed to unblock mixin extraction PR.
 disable_error_code = ["misc", "assignment", "attr-defined"]
 


### PR DESCRIPTION
## Summary

- Remove `nexus.bricks.a2a.stores.database` from `pyproject.toml` mypy overrides — the `database.py` file was already deleted, only the config reference remained
- Delete empty `bricks/scheduler/` directory (only contained `__pycache__`) — scheduler is a Tier 1 System Service per NEXUS-LEGO-ARCHITECTURE.md §2.4, correctly lives in `services/scheduler/`

## Test plan

- [x] `ruff check` passes
- [x] Scheduler unit tests pass (5/5)
- [x] A2A brick lint passes
- [x] No imports reference `nexus.bricks.scheduler` or `nexus.bricks.a2a.stores.database`
- [x] Pre-commit hooks pass

Closes #2076
Closes #2428