### PR TITLE
fix(#1401): move A2A FastAPI router from brick to server layer

### DIFF
--- a/src/nexus/bricks/a2a/__init__.py
+++ b/src/nexus/bricks/a2a/__init__.py
@@ -1,77 +1,14 @@
-"""Google A2A (Agent-to-Agent) protocol endpoint for Nexus.
+"""Google A2A (Agent-to-Agent) protocol brick for Nexus.
 
 This module implements the A2A protocol specification, enabling Nexus to
 participate in the agent interoperability ecosystem as one of three protocol
 surfaces (alongside VFS and MCP).
 
+The FastAPI router lives in ``nexus.server.api.v2.routers.a2a`` (server
+layer), while business logic (handlers, streaming, task management) lives
+here in the brick.
+
 See: https://a2a-protocol.org/latest/specification/
 """
 
 from __future__ import annotations
-
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from fastapi import APIRouter
-
-    from nexus.bricks.a2a.task_manager import TaskManager
-
-
-__all__ = ["create_a2a_router"]
-
-
-def create_a2a_router(
-    *,
-    nexus_fs: Any = None,
-    config: Any = None,
-    base_url: str | None = None,
-    auth_required: bool = False,
-    auth_fn: Any = None,
-    data_dir: str | None = None,
-    hook_engine: Any = None,
-) -> tuple[APIRouter, TaskManager]:
-    """Create the A2A protocol FastAPI router.
-
-    Args:
-        nexus_fs: NexusFS instance for backend operations.
-        config: NexusConfig instance for Agent Card generation.
-        base_url: Base URL for the Agent Card endpoint URL field.
-            If None, defaults to "http://localhost:2026".
-        auth_required: When True, all A2A operational endpoints
-            require a valid Authorization header.
-        auth_fn: Optional async callback ``(Request) -> dict | None``
-            for authentication.  Injected by the server layer.
-        data_dir: Server data directory.  When provided, A2A tasks
-            are persisted as MessageEnvelope JSON files under
-            ``{data_dir}/agents/{agent_id}/tasks/`` (§17.6 convergence).
-            When None, tasks are stored in-memory only.
-        hook_engine: Optional HookEngineProtocol instance for artifact
-            indexing hooks (Issue #1861).
-
-    Returns:
-        Tuple of (configured FastAPI APIRouter, TaskManager instance).
-    """
-    from nexus.bricks.a2a.router import build_router
-    from nexus.bricks.a2a.task_manager import TaskManager as _TaskManager
-
-    task_manager: _TaskManager | None = None
-    if data_dir is not None:
-        from nexus.bricks.a2a.stores.local_driver import LocalStorageDriver
-        from nexus.bricks.a2a.stores.vfs import VFSTaskStore
-
-        storage = LocalStorageDriver(root=data_dir)
-        store = VFSTaskStore(storage=storage)
-        task_manager = _TaskManager(store=store, hook_engine=hook_engine)
-
-    if task_manager is None:
-        task_manager = _TaskManager(hook_engine=hook_engine)
-
-    router = build_router(
-        _nexus_fs=nexus_fs,
-        config=config,
-        base_url=base_url,
-        task_manager=task_manager,
-        auth_required=auth_required,
-        auth_fn=auth_fn,
-    )
-    return router, task_manager

--- a/src/nexus/server/api/v2/routers/a2a.py
+++ b/src/nexus/server/api/v2/routers/a2a.py
@@ -7,8 +7,8 @@ Implements:
   and ``subscribeToTask``
 
 This module handles only HTTP concerns (auth, body parsing, error
-wrapping).  Business logic lives in ``handlers.py`` and
-``streaming.py``.
+wrapping).  Business logic lives in ``nexus.bricks.a2a.handlers`` and
+``nexus.bricks.a2a.streaming``.
 """
 
 from __future__ import annotations
@@ -260,3 +260,62 @@ def _extract_agent_id(auth_result: dict[str, Any] | None) -> str | None:
     if auth_result:
         return auth_result.get("x_agent_id") or auth_result.get("subject_id")
     return None
+
+
+# ======================================================================
+# High-level factory (moved from nexus.bricks.a2a.__init__)
+# ======================================================================
+
+
+def create_a2a_router(
+    *,
+    nexus_fs: Any = None,
+    config: Any = None,
+    base_url: str | None = None,
+    auth_required: bool = False,
+    auth_fn: Any = None,
+    data_dir: str | None = None,
+    hook_engine: Any = None,
+) -> tuple[APIRouter, TaskManager]:
+    """Create the A2A protocol FastAPI router.
+
+    Args:
+        nexus_fs: NexusFS instance for backend operations.
+        config: NexusConfig instance for Agent Card generation.
+        base_url: Base URL for the Agent Card endpoint URL field.
+            If None, defaults to "http://localhost:2026".
+        auth_required: When True, all A2A operational endpoints
+            require a valid Authorization header.
+        auth_fn: Optional async callback ``(Request) -> dict | None``
+            for authentication.  Injected by the server layer.
+        data_dir: Server data directory.  When provided, A2A tasks
+            are persisted as MessageEnvelope JSON files under
+            ``{data_dir}/agents/{agent_id}/tasks/`` (§17.6 convergence).
+            When None, tasks are stored in-memory only.
+        hook_engine: Optional HookEngineProtocol instance for artifact
+            indexing hooks (Issue #1861).
+
+    Returns:
+        Tuple of (configured FastAPI APIRouter, TaskManager instance).
+    """
+    task_manager: TaskManager | None = None
+    if data_dir is not None:
+        from nexus.bricks.a2a.stores.local_driver import LocalStorageDriver
+        from nexus.bricks.a2a.stores.vfs import VFSTaskStore
+
+        storage = LocalStorageDriver(root=data_dir)
+        store = VFSTaskStore(storage=storage)
+        task_manager = TaskManager(store=store, hook_engine=hook_engine)
+
+    if task_manager is None:
+        task_manager = TaskManager(hook_engine=hook_engine)
+
+    router = build_router(
+        _nexus_fs=nexus_fs,
+        config=config,
+        base_url=base_url,
+        task_manager=task_manager,
+        auth_required=auth_required,
+        auth_fn=auth_fn,
+    )
+    return router, task_manager

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -620,7 +620,7 @@ def _register_routes(app: FastAPI) -> None:
 
     # A2A Protocol Endpoint (Issue #1256, brick-extracted #1401)
     try:
-        from nexus.bricks.a2a import create_a2a_router
+        from nexus.server.api.v2.routers.a2a import create_a2a_router
 
         a2a_base_url = os.environ.get("NEXUS_A2A_BASE_URL", DEFAULT_NEXUS_URL)
         a2a_auth_required = bool(

--- a/tests/e2e/self_contained/test_a2a_auth.py
+++ b/tests/e2e/self_contained/test_a2a_auth.py
@@ -15,7 +15,7 @@ import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
-from nexus.bricks.a2a.router import build_router
+from nexus.server.api.v2.routers.a2a import build_router
 
 # ======================================================================
 # Fixtures

--- a/tests/e2e/self_contained/test_a2a_endpoints.py
+++ b/tests/e2e/self_contained/test_a2a_endpoints.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from nexus.bricks.a2a.router import build_router
+from nexus.server.api.v2.routers.a2a import build_router
 
 # ======================================================================
 # Fixtures
@@ -317,7 +317,9 @@ class TestNarrowedExceptionHandlers:
             {"message": {"role": "user", "parts": [{"type": "text", "text": "hi"}]}},
         )
         # Mock dispatch to raise an unexpected exception
-        with patch("nexus.bricks.a2a.router.dispatch", new_callable=AsyncMock) as mock_dispatch:
+        with patch(
+            "nexus.server.api.v2.routers.a2a.dispatch", new_callable=AsyncMock
+        ) as mock_dispatch:
             mock_dispatch.side_effect = RuntimeError("unexpected crash")
             resp = client.post("/a2a", json=body)
 

--- a/tests/e2e/self_contained/test_a2a_streaming.py
+++ b/tests/e2e/self_contained/test_a2a_streaming.py
@@ -19,8 +19,8 @@ import httpx
 import pytest
 from fastapi import FastAPI
 
-from nexus.bricks.a2a.router import build_router
 from nexus.bricks.a2a.task_manager import TaskManager
+from nexus.server.api.v2.routers.a2a import build_router
 
 # ======================================================================
 # Fixtures


### PR DESCRIPTION
## Summary
- Move `router.py` (A2A FastAPI endpoints) from `nexus.bricks.a2a` to `nexus.server.api.v2.routers.a2a`
- Move `create_a2a_router()` factory to the server router module
- Per LEGO architecture: API routers belong in the server layer, bricks provide business logic only
- Business logic (`handlers.py`, `streaming.py`, `task_manager.py`) stays in the brick
- Update all consumer imports: `fastapi_server.py`, 3 e2e test files, 1 mock patch target
- a2a brick `__init__.py` is now clean — no FastAPI imports

Stream: #14

## Test plan
- [x] All 236 A2A tests pass (unit + e2e endpoints + auth + streaming)
- [x] ruff check + format clean
- [x] No remaining references to `nexus.bricks.a2a.router`
- [x] Pre-commit hooks pass (ruff, format, brick-zero-core-imports)