### PR TITLE
feat(#2366): move pipe_manager.py from core/ to system_services/

### DIFF
--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -7,10 +7,11 @@ Implements the Kernel messaging tier from KERNEL-ARCHITECTURE.md §6:
     | **Kernel** | kfifo ring buffer| Nexus Native Pipe (DT_PIPE)        | ~5μs    |
 
 This file contains the kernel-internal ring buffer (kfifo equivalent).
-For VFS-visible named pipes (mkfifo/fs/pipe.c equivalent), see pipe_manager.py.
+For VFS-visible named pipes (mkfifo/fs/pipe.c equivalent), see
+system_services/pipe_manager.py (moved from core/ per Issue #2366).
 
     pipe.py         = kfifo     (include/linux/kfifo.h + lib/kfifo.c)
-    pipe_manager.py = fs/pipe.c (VFS named pipe with per-pipe lock for MPMC)
+    system_services/pipe_manager.py = fs/pipe.c (VFS named pipe, system service tier)
 
 Storage model (KERNEL-ARCHITECTURE.md line 228):
     - Pipe **inode** (FileMetadata, entry_type=DT_PIPE) → MetastoreABC
@@ -69,7 +70,7 @@ class RingBuffer:
     directly for fast async signaling.
 
     For VFS-visible named pipes (mkfifo equivalent), use PipeManager
-    from pipe_manager.py.
+    from system_services/pipe_manager.py.
 
     Design choices:
       - Message-oriented (deque of discrete bytes), not byte-stream.

--- a/src/nexus/system_services/lifecycle/workflow_dispatch_service.py
+++ b/src/nexus/system_services/lifecycle/workflow_dispatch_service.py
@@ -24,8 +24,8 @@ from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.bricks.workflows.protocol import WorkflowProtocol
-    from nexus.core.pipe_manager import PipeManager
     from nexus.lib.mutation_hooks import MutationEvent
+    from nexus.system_services.pipe_manager import PipeManager
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/system_services/pipe_manager.py
+++ b/src/nexus/system_services/pipe_manager.py
@@ -1,9 +1,14 @@
 """PipeManager — VFS named pipe manager (fs/pipe.c equivalent).
 
-Manages DT_PIPE lifecycle and buffer registry with per-pipe locking for MPMC.
+System service (Tier 1) managing DT_PIPE lifecycle and buffer registry
+with per-pipe locking for MPMC.
 
-    pipe.py         = kfifo     (include/linux/kfifo.h + lib/kfifo.c)
-    pipe_manager.py = fs/pipe.c (VFS named pipe with per-pipe lock for MPMC)
+    core/pipe.py    = kfifo     (include/linux/kfifo.h + lib/kfifo.c)  [kernel]
+    pipe_manager.py = fs/pipe.c (VFS named pipe with per-pipe lock)    [system service]
+
+Moved from core/ to system_services/ per NEXUS-LEGO-ARCHITECTURE.md — the kernel
+contains only VFSRouter + MetastoreABC + ConnectorProtocol. PipeManager builds on
+the kernel (uses MetastoreABC, RingBuffer) but is a system-tier service (#2366).
 
 Concurrency model (aligned with Linux pipe(7)):
   - RingBuffer (kfifo) is SPSC, no internal lock.
@@ -13,7 +18,7 @@ Concurrency model (aligned with Linux pipe(7)):
   - Sync methods (pipe_write_nowait) are atomic under asyncio event loop
     (no await points), safe for MPSC without lock.
 
-See: pipe.py for RingBuffer, federation-memo.md §7j
+See: core/pipe.py for RingBuffer, federation-memo.md §7j
 """
 
 import asyncio

--- a/tests/unit/core/test_architectural_tier_placement.py
+++ b/tests/unit/core/test_architectural_tier_placement.py
@@ -8,16 +8,22 @@ refactor accidentally moves a file, these tests will catch it.
 import importlib
 
 
-class TestPipeManagerTierPlacement:
-    """pipe.py is a kernel VFS primitive — MUST stay in core/ (Issue #2366).
+class TestPipeTierPlacement:
+    """pipe.py (RingBuffer/kfifo) is a kernel VFS primitive — stays in core/.
+    pipe_manager.py (PipeManager/fs/pipe.c) is a system service — lives in system_services/.
 
-    Rationale: KERNEL-ARCHITECTURE.md §6.2 classifies PipeManager as kernel-tier
-    IPC (equivalent to Linux fs/pipe.c). It manages DT_PIPE inodes via MetastoreABC.
+    Issue #2366: PipeManager moved from core/ to system_services/ because the kernel
+    should contain only VFSRouter + MetastoreABC + ConnectorProtocol per
+    NEXUS-LEGO-ARCHITECTURE.md. RingBuffer stays as a kernel primitive.
     """
 
-    def test_pipe_module_in_core(self) -> None:
+    def test_ring_buffer_in_core(self) -> None:
         mod = importlib.import_module("nexus.core.pipe")
         assert hasattr(mod, "RingBuffer")
+
+    def test_pipe_manager_in_system_services(self) -> None:
+        mod = importlib.import_module("nexus.system_services.pipe_manager")
+        assert hasattr(mod, "PipeManager")
 
 
 class TestSchedulerTierPlacement:

--- a/tests/unit/core/test_pipe.py
+++ b/tests/unit/core/test_pipe.py
@@ -1,7 +1,9 @@
 """Unit tests for DT_PIPE kernel IPC primitive.
 
-Tests RingBuffer (kfifo equivalent) and PipeManager (mkfifo equivalent).
-See: src/nexus/core/pipe.py, KERNEL-ARCHITECTURE.md §6.
+Tests RingBuffer (kfifo equivalent, kernel tier) and PipeManager
+(mkfifo equivalent, system service tier).
+See: src/nexus/core/pipe.py, src/nexus/system_services/pipe_manager.py,
+     KERNEL-ARCHITECTURE.md §6.
 """
 
 import asyncio
@@ -17,7 +19,7 @@ from nexus.core.pipe import (
     PipeNotFoundError,
     RingBuffer,
 )
-from nexus.core.pipe_manager import PipeManager
+from nexus.system_services.pipe_manager import PipeManager
 
 # ======================================================================
 # RingBuffer — basic operations

--- a/tests/unit/services/test_workflow_dispatch.py
+++ b/tests/unit/services/test_workflow_dispatch.py
@@ -11,9 +11,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from nexus.core.metadata import FileMetadata
-from nexus.core.pipe_manager import PipeManager
 from nexus.lib.mutation_hooks import MutationEvent, MutationOp
 from nexus.system_services.lifecycle.workflow_dispatch_service import WorkflowDispatchService
+from nexus.system_services.pipe_manager import PipeManager
 
 # ======================================================================
 # Fixtures


### PR DESCRIPTION
## Summary

Move `PipeManager` (fs/pipe.c analogue) from `core/` to `system_services/` per NEXUS-LEGO-ARCHITECTURE.md tier placement rules.

**Stream:** stream4

**Target merge branch:** `develop`

### LEGO Architecture Alignment

Per NEXUS-LEGO-ARCHITECTURE.md, the kernel (`core/`) should contain **only**:
- `VFSRouterProtocol` — virtual filesystem routing
- `MetastoreABC` — metadata storage
- `ConnectorProtocol` — backend connector interface

`PipeManager` builds **on top of** the kernel (uses `MetastoreABC` + `RingBuffer`) but is itself a **system-tier service** managing DT_PIPE lifecycle, buffer registry, and per-pipe MPMC locking. This is the `fs/pipe.c` equivalent — a system service, not a kernel primitive.

`RingBuffer` (kfifo analogue) in `core/pipe.py` remains in `core/` as it **is** a kernel primitive.

### Changes

- **Moved** `src/nexus/core/pipe_manager.py` → `src/nexus/system_services/pipe_manager.py`
- **Updated** docstrings in `core/pipe.py` to reference new location
- **Updated** import in `workflow_dispatch_service.py` (only consumer)
- **Updated** `test_architectural_tier_placement.py` — renamed test class, added system_services assertion
- **Updated** test imports in `test_pipe.py` and `test_workflow_dispatch.py`
- **Deleted** old `src/nexus/core/pipe_manager.py`

### Verification

- ruff check + format: clean
- mypy: clean
- All pre-commit hooks pass (including Brick Zero-Core-Imports Check)
- import-linter: no pipe_manager violations
- 84 unit tests pass
- 970 e2e self-contained tests pass (6 failures all pre-existing)

## Test plan

- [x] Unit tests for PipeManager import from new location
- [x] Unit tests for WorkflowDispatchService (only consumer)
- [x] Architectural tier placement regression tests updated
- [x] ruff check + ruff format clean
- [x] mypy clean
- [x] import-linter contracts satisfied
- [x] E2E tests pass (no regressions)