### PR TITLE
feat(#917): replace hardcoded root zone_id with ROOT_ZONE_ID in core/

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -303,7 +303,7 @@ class NexusFS(  # type: ignore[misc]
             self._tiger_cache_manager = TigerCacheManager(
                 rebac_manager=self._rebac_manager,
                 metadata_store=self.metadata,
-                default_zone_id=self._default_context.zone_id or "root",
+                default_zone_id=self._default_context.zone_id or ROOT_ZONE_ID,
                 process_queue_fn=getattr(self, "process_tiger_cache_queue", None),
                 warm_cache_fn=getattr(self, "warm_tiger_cache", None),
             )
@@ -887,7 +887,7 @@ class NexusFS(  # type: ignore[misc]
             modified_at=now,
             version=1,
             created_by=self._get_created_by(context),  # Track who created this directory
-            zone_id=ctx.zone_id or "root",  # P0 SECURITY: Set zone_id
+            zone_id=ctx.zone_id or ROOT_ZONE_ID,  # P0 SECURITY: Set zone_id
         )
 
         self.metadata.put(metadata)
@@ -981,7 +981,7 @@ class NexusFS(  # type: ignore[misc]
                             f"mkdir: Creating parent tuples for intermediate dir: {parent_dir}"
                         )
                         self._hierarchy_manager.ensure_parent_tuples(
-                            parent_dir, zone_id=ctx.zone_id or "root"
+                            parent_dir, zone_id=ctx.zone_id or ROOT_ZONE_ID
                         )
                     except Exception as e:
                         # Don't fail mkdir if parent tuple creation fails
@@ -1008,7 +1008,7 @@ class NexusFS(  # type: ignore[misc]
                     f"mkdir: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or ROOT_ZONE_ID}"
                 )
                 created_count = self._hierarchy_manager.ensure_parent_tuples(
-                    path, zone_id=ctx.zone_id or "root"
+                    path, zone_id=ctx.zone_id or ROOT_ZONE_ID
                 )
                 logger.debug(f"mkdir: Created {created_count} parent tuples for {path}")
                 if created_count > 0:
@@ -1033,7 +1033,7 @@ class NexusFS(  # type: ignore[misc]
                     subject=("user", ctx.user_id),
                     relation="direct_owner",
                     object=("file", path),
-                    zone_id=ctx.zone_id or "root",
+                    zone_id=ctx.zone_id or ROOT_ZONE_ID,
                 )
                 logger.debug(f"mkdir: Granted direct_owner permission to {ctx.user_id} for {path}")
             except Exception as e:
@@ -1051,7 +1051,7 @@ class NexusFS(  # type: ignore[misc]
         self._fire_post_mutation_hooks(
             MutationOp.MKDIR,
             path,
-            ctx.zone_id or "root",
+            ctx.zone_id or ROOT_ZONE_ID,
             new_revision,
             agent_id=ctx.agent_id,
             user_id=ctx.user_id,
@@ -1214,7 +1214,7 @@ class NexusFS(  # type: ignore[misc]
         self._fire_post_mutation_hooks(
             MutationOp.RMDIR,
             path,
-            ctx.zone_id or "root",
+            ctx.zone_id or ROOT_ZONE_ID,
             new_revision,
             agent_id=ctx.agent_id,
             user_id=ctx.user_id,

--- a/src/nexus/core/nexus_fs_bulk.py
+++ b/src/nexus/core/nexus_fs_bulk.py
@@ -626,7 +626,7 @@ class NexusFSBulkMixin:
                 modified_at=now,
                 version=new_version,
                 created_by=getattr(self, "agent_id", None) or getattr(self, "user_id", None),
-                zone_id=zone_id or "root",
+                zone_id=zone_id or ROOT_ZONE_ID,
             )
             metadata_list.append(metadata)
 
@@ -713,7 +713,7 @@ class NexusFSBulkMixin:
 
         # Create parent tuples and grant direct_owner for new files
         ctx = context if context is not None else self._default_context
-        zone_id_for_perms = ctx.zone_id or "root"
+        zone_id_for_perms = ctx.zone_id or ROOT_ZONE_ID
 
         # Batch hierarchy tuple creation
         _hierarchy_start = time.perf_counter()

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -159,7 +159,7 @@ class NexusFSCoreMixin:
             event = FileEvent(
                 type=event_type,
                 path=path,
-                zone_id=zone_id or "root",
+                zone_id=zone_id or ROOT_ZONE_ID,
                 size=size,
                 etag=etag,
                 agent_id=agent_id,
@@ -521,7 +521,7 @@ class NexusFSCoreMixin:
         if cache_observer is None or metadata is None:
             return
 
-        zone_id = getattr(self, "zone_id", None) or "root"
+        zone_id = getattr(self, "zone_id", None) or ROOT_ZONE_ID
         revision = self._get_zone_revision()
         cache_observer.on_read(path, metadata, revision, zone_id, resource_type)
 
@@ -1276,7 +1276,8 @@ class NexusFSCoreMixin:
             created_at=meta.created_at if meta else now,
             modified_at=now,
             created_by=self._get_created_by(context),
-            zone_id=zone_id or "root",  # Issue #904, #773: Store zone_id for PREWHERE filtering
+            zone_id=zone_id
+            or ROOT_ZONE_ID,  # Issue #904, #773: Store zone_id for PREWHERE filtering
         )
 
         self.metadata.put(new_meta)
@@ -1538,7 +1539,8 @@ class NexusFSCoreMixin:
             modified_at=now,
             version=new_version,
             created_by=self._get_created_by(context),  # Track who created/modified this version
-            zone_id=zone_id or "root",  # Issue #904, #773: Store zone_id for PREWHERE filtering
+            zone_id=zone_id
+            or ROOT_ZONE_ID,  # Issue #904, #773: Store zone_id for PREWHERE filtering
             owner_id=owner_id,  # Issue #920: O(1) owner permission checks
         )
 
@@ -1567,7 +1569,7 @@ class NexusFSCoreMixin:
         # Issue #1169: Precise cache invalidation via cache observer
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_write(path, new_revision, zone_id or "root")
+            cache_observer.on_write(path, new_revision, zone_id or ROOT_ZONE_ID)
 
         # Issue #625: Fire post-mutation hooks for single-file write
         self._fire_post_mutation_hooks(
@@ -1592,7 +1594,7 @@ class NexusFSCoreMixin:
                 if tiger_cache:
                     added_count = tiger_cache.add_file_to_ancestor_grants(
                         file_path=path,
-                        zone_id=zone_id or "root",
+                        zone_id=zone_id or ROOT_ZONE_ID,
                     )
                     if added_count > 0:
                         logger.debug(
@@ -1625,9 +1627,11 @@ class NexusFSCoreMixin:
             # DEFERRED PATH: Queue permission operations for background batch processing
             # Owner can still access file immediately via owner_id fast-path
             try:
-                deferred_buffer.queue_hierarchy(path, ctx.zone_id or "root")
+                deferred_buffer.queue_hierarchy(path, ctx.zone_id or ROOT_ZONE_ID)
                 if meta is None and ctx.user_id and not ctx.is_system:
-                    deferred_buffer.queue_owner_grant(ctx.user_id, path, ctx.zone_id or "root")
+                    deferred_buffer.queue_owner_grant(
+                        ctx.user_id, path, ctx.zone_id or ROOT_ZONE_ID
+                    )
             except Exception as e:
                 logger.warning(f"write: Failed to queue deferred permissions for {path}: {e}")
         else:
@@ -1638,7 +1642,7 @@ class NexusFSCoreMixin:
                         f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or ROOT_ZONE_ID}"
                     )
                     created_count = self._hierarchy_manager.ensure_parent_tuples(
-                        path, zone_id=ctx.zone_id or "root"
+                        path, zone_id=ctx.zone_id or ROOT_ZONE_ID
                     )
                     logger.info(f"write: Created {created_count} parent tuples for {path}")
                 except Exception as e:
@@ -1657,7 +1661,7 @@ class NexusFSCoreMixin:
                             subject=("user", ctx.user_id),
                             relation="direct_owner",
                             object=("file", path),
-                            zone_id=ctx.zone_id or "root",
+                            zone_id=ctx.zone_id or ROOT_ZONE_ID,
                         )
                         logger.debug(
                             f"write: Granted direct_owner permission to {ctx.user_id} for {path}"
@@ -1722,7 +1726,7 @@ class NexusFSCoreMixin:
                 "size": len(content),
                 "etag": content_hash,
                 "version": new_version,
-                "zone_id": zone_id or "root",
+                "zone_id": zone_id or ROOT_ZONE_ID,
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "created": is_new_file,
@@ -2292,7 +2296,7 @@ class NexusFSCoreMixin:
         # Issue #1169: Precise cache invalidation via cache observer
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_delete(path, new_revision, zone_id or "root")
+            cache_observer.on_delete(path, new_revision, zone_id or ROOT_ZONE_ID)
 
         # Issue #625: Fire post-mutation hooks for delete
         self._fire_post_mutation_hooks(
@@ -2312,7 +2316,7 @@ class NexusFSCoreMixin:
                 "file_path": path,
                 "size": meta.size,
                 "etag": meta.etag,
-                "zone_id": zone_id or "root",
+                "zone_id": zone_id or ROOT_ZONE_ID,
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "timestamp": datetime.now(UTC).isoformat(),
@@ -2493,7 +2497,7 @@ class NexusFSCoreMixin:
         new_revision = self._increment_zone_revision()
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_rename(old_path, new_path, new_revision, zone_id or "root")
+            cache_observer.on_rename(old_path, new_path, new_revision, zone_id or ROOT_ZONE_ID)
 
         # Issue #625: Fire post-mutation hooks for rename
         self._fire_post_mutation_hooks(
@@ -2577,7 +2581,7 @@ class NexusFSCoreMixin:
                 "new_path": new_path,
                 "size": meta.size if meta else 0,
                 "etag": meta.etag if meta else None,
-                "zone_id": zone_id or "root",
+                "zone_id": zone_id or ROOT_ZONE_ID,
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "timestamp": datetime.now(UTC).isoformat(),

--- a/src/nexus/core/vfs_hook_impls.py
+++ b/src/nexus/core/vfs_hook_impls.py
@@ -11,6 +11,7 @@ import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.core.vfs_hooks import ReadHookContext, RenameHookContext, WriteHookContext
 
 if TYPE_CHECKING:
@@ -239,7 +240,7 @@ class TigerCacheRenameHook:
         if self._tiger_cache is None:
             return
 
-        zone_id = ctx.zone_id or "root"
+        zone_id = ctx.zone_id or ROOT_ZONE_ID
         old_grants = self._tiger_cache.get_directory_grants_for_path(ctx.old_path, zone_id)
         new_grants = self._tiger_cache.get_directory_grants_for_path(ctx.new_path, zone_id)
 


### PR DESCRIPTION
## Summary
- Replace ~25 instances of hardcoded `or "root"` with `or ROOT_ZONE_ID` constant in 4 kernel files
- All files already imported `ROOT_ZONE_ID` from `nexus.constants` but inconsistently used the string literal
- `vfs_hook_impls.py` needed the import added (1 instance)

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, Brick Zero-Core-Imports Check)
- [x] Pure mechanical string replacement — no behavioral change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)