### PR TITLE
fix(#920): delete dead search primitives compat shim from core/__init__

### DIFF
--- a/src/nexus/core/__init__.py
+++ b/src/nexus/core/__init__.py
@@ -81,10 +81,7 @@ _LAZY_IMPORTS = {
 
 
 def __getattr__(name: str) -> Any:
-    """Lazy import for heavy dependencies.
-
-    Also provides backward compatibility for search primitives (Issue #2123).
-    """
+    """Lazy import for heavy dependencies."""
     # Check cache first
     if name in _lazy_imports_cache:
         return _lazy_imports_cache[name]
@@ -96,24 +93,6 @@ def __getattr__(name: str) -> Any:
 
         module = importlib.import_module(module_path)
         value = getattr(module, attr_name)
-        _lazy_imports_cache[name] = value
-        return value
-
-    # Backward compatibility for search primitives (Issue #2123)
-    # Deprecated: moved from nexus.core.* to nexus.bricks.search.primitives.*
-    if name in ("grep_fast", "glob_fast", "trigram_fast"):
-        import warnings
-
-        warnings.warn(
-            f"Importing {name} from nexus.core is deprecated. "
-            f"Use: from nexus.bricks.search.primitives import {name}",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        import importlib
-
-        module = importlib.import_module("nexus.bricks.search.primitives")
-        value = getattr(module, name)
         _lazy_imports_cache[name] = value
         return value
 


### PR DESCRIPTION
## Summary
- Delete dead backward-compatibility shim in `core/__init__.py` for `grep_fast`/`glob_fast`/`trigram_fast` (Issue #2123)
- Zero callers exist in the entire codebase — all imports use the canonical path `nexus.bricks.search.primitives` directly
- Removes 22 lines of dead code (DeprecationWarning + lazy import logic)

## Test plan
- [x] Verified zero callers via `rg` across `src/` and `tests/`
- [x] All pre-commit hooks pass (ruff, mypy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)