### PR TITLE
fix(#932): remove 11 dead TYPE_CHECKING pass blocks

### DIFF
--- a/src/nexus/bricks/context_manifest/executors/snapshot_lookup_db.py
+++ b/src/nexus/bricks/context_manifest/executors/snapshot_lookup_db.py
@@ -12,10 +12,7 @@ Re-exported here for backward compatibility.
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    pass
+from typing import Any, Protocol, runtime_checkable
 
 from nexus.storage.repositories.snapshot_lookup import DatabaseSnapshotLookup
 

--- a/src/nexus/bricks/rebac/cache/boundary.py
+++ b/src/nexus/bricks/rebac/cache/boundary.py
@@ -32,14 +32,11 @@ Example:
 import logging
 import os
 import threading
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from cachetools import TTLCache
 
 from nexus.constants import ROOT_ZONE_ID
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/core/vfs_hook_impls.py
+++ b/src/nexus/core/vfs_hook_impls.py
@@ -9,12 +9,9 @@ Phase 4 of Issue #2033 (Strangler Fig decomposition):
 import logging
 import threading
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from nexus.core.vfs_hooks import ReadHookContext, RenameHookContext, WriteHookContext
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/fuse/ops/metadata_handler.py
+++ b/src/nexus/fuse/ops/metadata_handler.py
@@ -3,7 +3,7 @@
 import logging
 import stat
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from fuse import FuseOSError
 
@@ -22,9 +22,6 @@ from nexus.fuse.ops._shared import (
     try_rust,
 )
 from nexus.lib.virtual_views import should_add_virtual_views
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/lib/response.py
+++ b/src/nexus/lib/response.py
@@ -26,10 +26,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, cast
-
-if TYPE_CHECKING:
-    pass  # Exceptions imported at runtime to avoid circular imports
+from typing import Any, Generic, ParamSpec, TypeVar, cast
 
 T = TypeVar("T")
 

--- a/src/nexus/server/api/v2/routers/pay.py
+++ b/src/nexus/server/api/v2/routers/pay.py
@@ -15,16 +15,13 @@ Related: Issue #1209
 
 import logging
 from decimal import Decimal, InvalidOperation
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 
 from nexus.constants import ROOT_ZONE_ID
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/server/api/v2/routers/x402.py
+++ b/src/nexus/server/api/v2/routers/x402.py
@@ -10,15 +10,12 @@ Related: Issue #1206 (x402 protocol integration)
 
 import logging
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from nexus.server.dependencies import require_auth
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/services/ace/affinity.py
+++ b/src/nexus/services/ace/affinity.py
@@ -16,16 +16,12 @@ https://arxiv.org/html/2601.02553
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
 
 # sklearn is imported lazily inside cluster_by_affinity() to avoid
 # making it a hard dependency for other ACE components that don't need clustering.
-
-if TYPE_CHECKING:
-    pass
 
 
 @dataclass

--- a/src/nexus/services/rpc_transport.py
+++ b/src/nexus/services/rpc_transport.py
@@ -7,14 +7,9 @@ This is a low-level utility, not a user-facing API. Used internally by:
 
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import httpx
-
-# Lazy imports to avoid circular dependency.
-# Protocol types are imported inside methods that use them.
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/storage/models/memory.py
+++ b/src/nexus/storage/models/memory.py
@@ -4,7 +4,6 @@ Issue #1286: Extracted from monolithic __init__.py.
 """
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     Boolean,
@@ -22,9 +21,6 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, ResourceConfigMixin, uuid_pk
-
-if TYPE_CHECKING:
-    pass
 
 
 class MemoryModel(Base):

--- a/src/nexus/utils/edit_engine.py
+++ b/src/nexus/utils/edit_engine.py
@@ -27,7 +27,7 @@ References:
 import difflib
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 # Try to use rapidfuzz for 10-100x faster fuzzy matching (Rust-backed)
 # Falls back to difflib if not available
@@ -37,9 +37,6 @@ try:
     RAPIDFUZZ_AVAILABLE = True
 except ImportError:
     RAPIDFUZZ_AVAILABLE = False
-
-if TYPE_CHECKING:
-    pass
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- Removed 11 dead `if TYPE_CHECKING: pass` blocks across `src/nexus/`
- Cleaned up unused `TYPE_CHECKING` imports from typing in all 11 files
- Files: edit_engine, metadata_handler, affinity, vfs_hook_impls, response, x402, snapshot_lookup_db, pay, rpc_transport, memory models, boundary cache

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, ruff format)
- [x] No runtime behavior change — dead code removal only

🤖 Generated with [Claude Code](https://claude.com/claude-code)