### PR TITLE
fix(#933): replace hardcoded zone_id="root" with ROOT_ZONE_ID

### DIFF
--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -147,7 +147,9 @@ class BulkPermissionChecker:
             if is_production:
                 raise ValueError("zone_id is required for bulk permission checks in production")
             else:
-                logger.warning("rebac_check_bulk called without zone_id, defaulting to 'root'")
+                logger.warning(
+                    "rebac_check_bulk called without zone_id, defaulting to ROOT_ZONE_ID"
+                )
                 zone_id = ROOT_ZONE_ID
 
         results: dict[tuple[tuple[str, str], str, tuple[str, str]], bool] = {}

--- a/src/nexus/raft/federation.py
+++ b/src/nexus/raft/federation.py
@@ -20,6 +20,8 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from nexus.constants import ROOT_ZONE_ID
+
 logger = logging.getLogger(__name__)
 
 
@@ -100,7 +102,7 @@ class NexusFederation:
         Returns:
             The new zone's ID.
         """
-        root_zone = self._mgr.root_zone_id or "root"
+        root_zone = self._mgr.root_zone_id or ROOT_ZONE_ID
 
         # Step 1: Create zone + copy subtree + DT_MOUNT in parent
         new_zone_id: str = self._mgr.share_subtree(
@@ -163,14 +165,14 @@ class NexusFederation:
             ValueError: If remote_path is not a DT_MOUNT on peer.
             RuntimeError: If zone discovery or join fails.
         """
-        root_zone = self._mgr.root_zone_id or "root"
+        root_zone = self._mgr.root_zone_id or ROOT_ZONE_ID
 
         # Step 1: Discover zone via peer's DT_MOUNT
         client = self._client_factory(peer_addr)
         try:
             metadata = await client.get_metadata(
                 path=remote_path,
-                zone_id="root",
+                zone_id=ROOT_ZONE_ID,
             )
 
             if metadata is None:

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
@@ -165,7 +166,7 @@ def create_async_files_router(
             return OperationContext(
                 user_id="anonymous",
                 groups=[],
-                zone_id="root",
+                zone_id=ROOT_ZONE_ID,
             )
         return get_operation_context(auth_result)
 

--- a/src/nexus/server/api/v2/routers/batch.py
+++ b/src/nexus/server/api/v2/routers/batch.py
@@ -20,6 +20,7 @@ from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.types import OperationContext
 from nexus.server.batch_executor import BatchExecutor, BatchRequest, BatchResponse
 
@@ -80,7 +81,7 @@ def create_batch_router(
             if auth_result is None or not auth_result.get("authenticated"):
                 from nexus.contracts.types import OperationContext as OC
 
-                return OC(user_id="anonymous", groups=[], zone_id="root")
+                return OC(user_id="anonymous", groups=[], zone_id=ROOT_ZONE_ID)
             return cast("OperationContext", _real_get_operation_context(auth_result))
 
     @router.post("/batch", response_model=BatchResponse)


### PR DESCRIPTION
## Summary
- Replaces 7 hardcoded `zone_id="root"` strings with `ROOT_ZONE_ID` constant from `nexus.constants`
- Files: bulk_checker.py, federation.py, async_files.py, batch.py, snapshots.py
- Skipped `contracts/types.py` (has zero nexus.* runtime imports policy)
- Follows up on #917 which fixed core/ directory

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, ruff format)
- [x] No runtime behavior change — constant value is identical `"root"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)