### PR TITLE
fix(#934): remove stale service_wiring.py references from comments

### DIFF
--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -388,7 +388,7 @@ class WiredServices:
     time_travel_service: Any = None
     operations_service: Any = None
 
-    # RPC services (Issue #2133: migrated from service_wiring.py)
+    # RPC services (Issue #2133)
     workspace_rpc_service: Any = None
     agent_rpc_service: Any = None
     user_provisioning_service: Any = None

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -289,7 +289,7 @@ def _boot_wired_services(
     else:
         logger.debug("[BOOT:WIRED] EventsService disabled by profile")
 
-    # --- RPC / helper services (Issue #2133: migrated from service_wiring.py) ---
+    # --- RPC / helper services (Issue #2133) ---
     # Pre-extract optional NexusFS attrs to avoid mypy getattr+None inference issues
     _nx_default_context: Any = getattr(nx, "_default_context", None)
     _nx_session_factory: Any = getattr(nx, "SessionLocal", None)


### PR DESCRIPTION
## Summary
- Removed stale "migrated from service_wiring.py" suffix from 2 comments
- `core/config.py` and `factory/_wired.py` still referenced the deleted module
- Issue reference (#2133) preserved for traceability

## Test plan
- [x] All pre-commit hooks pass
- [x] Comment-only change, zero runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)