### PR TITLE
fix(#936): replace hardcoded zone_id == "root" with ROOT_ZONE_ID in rebac expander

### DIFF
--- a/src/nexus/bricks/rebac/directory/expander.py
+++ b/src/nexus/bricks/rebac/directory/expander.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy.exc import OperationalError
 
 from nexus.bricks.rebac.consistency.revision import get_zone_revision_for_grant
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -317,7 +318,7 @@ class DirectoryExpander:
                 FilePathModel.deleted_at.is_(None),
                 or_(
                     FilePathModel.zone_id == zone_id,
-                    FilePathModel.zone_id == "root",
+                    FilePathModel.zone_id == ROOT_ZONE_ID,
                     FilePathModel.zone_id.is_(None),
                 ),
             )


### PR DESCRIPTION
## Summary
- Replaced `FilePathModel.zone_id == "root"` with `ROOT_ZONE_ID` constant
- Single occurrence in `bricks/rebac/directory/expander.py:320`

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, ruff format)
- [x] No runtime behavior change — constant value is identical `"root"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)