### PR TITLE
fix(#937): replace or "root" fallbacks with ROOT_ZONE_ID in server routers

### DIFF
--- a/src/nexus/server/api/v2/dependencies.py
+++ b/src/nexus/server/api/v2/dependencies.py
@@ -77,7 +77,7 @@ def _get_ace_context(nexus_fs: Any, auth_result: dict[str, Any]) -> ACEContext:
         backend=nexus_fs.memory.backend,
         user_id=context.user_id or "anonymous",
         agent_id=getattr(context, "agent_id", None),
-        zone_id=context.zone_id or "root",
+        zone_id=context.zone_id or ROOT_ZONE_ID,
         context=context,
     )
 

--- a/src/nexus/server/api/v2/routers/graph.py
+++ b/src/nexus/server/api/v2/routers/graph.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_auth
 
 logger = logging.getLogger(__name__)
@@ -90,7 +91,7 @@ async def _graph_session(
 
 def _zone_id_from(nexus_fs: Any) -> str:
     """Extract zone_id from a NexusFS instance, defaulting to "root"."""
-    return getattr(nexus_fs, "zone_id", None) or "root"
+    return getattr(nexus_fs, "zone_id", None) or ROOT_ZONE_ID
 
 
 # =============================================================================

--- a/src/nexus/server/api/v2/routers/locks.py
+++ b/src/nexus/server/api/v2/routers/locks.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.api.v2.models.locks import (
     LockAcquireRequest,
     LockExtendRequest,
@@ -110,7 +111,7 @@ async def acquire_lock(
     Supports both mutex (max_holders=1) and semaphore (max_holders>1) modes.
     Use blocking=false for non-blocking acquisition (returns immediately).
     """
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     path = _normalize_path(request.path)
     timeout = request.timeout if request.blocking else 0.0
 
@@ -162,7 +163,7 @@ async def list_locks(
     lock_manager: Any = Depends(_get_lock_manager),
 ) -> LockListResponse:
     """List active locks for the current zone."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     lock_infos = await lock_manager.list_locks(zone_id, pattern=pattern, limit=limit)
 
     locks: list[LockInfoMutex | LockInfoSemaphore] = [
@@ -178,7 +179,7 @@ async def get_lock_status(
     lock_manager: Any = Depends(_get_lock_manager),
 ) -> LockStatusResponse:
     """Get lock status for a specific path."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     path = _normalize_path(path)
 
     lock_info = await lock_manager.get_lock_info(zone_id, path)
@@ -201,7 +202,7 @@ async def release_lock(
     The lock_id must match the ID returned during acquisition.
     Use force=true for admin recovery of stuck locks (requires admin role).
     """
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     path = _normalize_path(path)
 
     if force:
@@ -234,7 +235,7 @@ async def extend_lock(
     Call this periodically (e.g., every TTL/2) to keep long-running
     operations alive. The lock must be owned by the caller (lock_id match).
     """
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     path = _normalize_path(path)
 
     extended = await lock_manager.extend(request.lock_id, zone_id, path, ttl=request.ttl)

--- a/src/nexus/server/api/v2/routers/subscriptions.py
+++ b/src/nexus/server/api/v2/routers/subscriptions.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_auth
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ async def create_subscription(
 
     body = await request.json()
     data = SubscriptionCreate(**body)
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     created_by = auth_result.get("subject_id")
 
     subscription = subscription_manager.create(
@@ -77,7 +78,7 @@ async def list_subscriptions(
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """List webhook subscriptions for the current zone."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     subscriptions = subscription_manager.list_subscriptions(
         zone_id=zone_id,
         enabled_only=enabled_only,
@@ -96,7 +97,7 @@ async def get_subscription(
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Get a webhook subscription by ID."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     subscription = subscription_manager.get(subscription_id, zone_id)
     if subscription is None:
         raise HTTPException(status_code=404, detail="Subscription not found")
@@ -115,7 +116,7 @@ async def update_subscription(
 
     body = await request.json()
     data = SubscriptionUpdate(**body)
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
 
     subscription = subscription_manager.update(
         subscription_id=subscription_id,
@@ -134,7 +135,7 @@ async def delete_subscription(
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Delete a webhook subscription."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     deleted = subscription_manager.delete(subscription_id, zone_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Subscription not found")
@@ -148,6 +149,6 @@ async def test_subscription(
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Send a test event to a webhook subscription."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     result = await subscription_manager.test(subscription_id, zone_id)
     return JSONResponse(content=result)


### PR DESCRIPTION
## Summary
- Replace 13 hardcoded `or "root"` zone ID fallbacks with `or ROOT_ZONE_ID` constant in server API v2 layer
- Files: `dependencies.py`, `locks.py`, `subscriptions.py`, `graph.py`
- Adds `from nexus.constants import ROOT_ZONE_ID` import where missing

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, brick-zero-core-imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)