### PR TITLE
fix(#938): replace or "root" fallbacks with ROOT_ZONE_ID in storage + factory

### DIFF
--- a/src/nexus/factory/_bricks.py
+++ b/src/nexus/factory/_bricks.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.factory._boot_context import _BootContext
 from nexus.factory._helpers import _make_gate, _resolve_tasks_db_path, _safe_create
 
@@ -422,7 +423,7 @@ def _boot_independent_bricks(
                 record_store=ctx.record_store,
             )
 
-            _ipc_zone = ctx.zone_id or "root"
+            _ipc_zone = ctx.zone_id or ROOT_ZONE_ID
             ipc_vfs_driver = IPCVFSDriver(
                 storage=ipc_storage_driver,
                 zone_id=_ipc_zone,
@@ -626,7 +627,7 @@ def _boot_dependent_bricks(
             from nexus.bricks.search.graph_store import GraphStore
 
             _record_store = ctx.record_store
-            _zone_id = ctx.zone_id or "root"
+            _zone_id = ctx.zone_id or ROOT_ZONE_ID
 
             def _make_graph_store(session: Any) -> Any:
                 return GraphStore(

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from nexus.contracts.write_observer import WriteObserverProtocol
     from nexus.services.protocols.rebac import ReBACBrickProtocol
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.factory._boot_context import _BootContext
 from nexus.factory._helpers import _make_gate
 
@@ -494,7 +495,7 @@ def _boot_system_services(
         tiger_cache_manager = TigerCacheManager(
             rebac_manager=rebac_manager,
             metadata_store=ctx.metadata_store,
-            default_zone_id=ctx.zone_id or "root",
+            default_zone_id=ctx.zone_id or ROOT_ZONE_ID,
         )
         tiger_cache_manager.initialize()
         logger.debug("[BOOT:SYSTEM] TigerCacheManager created")

--- a/src/nexus/storage/auth_stores/sqlalchemy_api_key_store.py
+++ b/src/nexus/storage/auth_stores/sqlalchemy_api_key_store.py
@@ -11,6 +11,7 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.orm import Session
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.auth_store_types import APIKeyDTO
 from nexus.storage.models import APIKeyModel
 
@@ -60,7 +61,7 @@ class SQLAlchemyAPIKeyStore:
             name=name,
             subject_type=subject_type,
             subject_id=subject_id or user_id,
-            zone_id=zone_id or "root",
+            zone_id=zone_id or ROOT_ZONE_ID,
             is_admin=int(is_admin),
             expires_at=expires_at,
             inherit_permissions=int(inherit_permissions),

--- a/src/nexus/storage/write_buffer.py
+++ b/src/nexus/storage/write_buffer.py
@@ -36,6 +36,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
+
 if TYPE_CHECKING:
     from nexus.storage.record_store import RecordStoreABC
 
@@ -372,7 +374,7 @@ class WriteBuffer:
                 recorder = VersionRecorder(session)
 
                 for event in events:
-                    zone = event.zone_id or "root"
+                    zone = event.zone_id or ROOT_ZONE_ID
 
                     if event.event_type == EventType.WRITE:
                         op_logger.log_operation(


### PR DESCRIPTION
## Summary
- Replace 5 hardcoded `or "root"` zone ID fallbacks with `or ROOT_ZONE_ID` constant
- Files: `write_buffer.py`, `sqlalchemy_api_key_store.py`, `_system.py`, `_bricks.py`
- Adds `from nexus.constants import ROOT_ZONE_ID` import to each file

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, brick-zero-core-imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)