### PR TITLE
fix(#940): replace or "root" fallbacks with ROOT_ZONE_ID in bricks + services

### DIFF
--- a/src/nexus/bricks/delegation/service.py
+++ b/src/nexus/bricks/delegation/service.py
@@ -640,7 +640,7 @@ class DelegationService:
                     "subject": ("agent", worker_id),
                     "relation": grant.relation,
                     "object": (grant.object_type, grant.object_id),
-                    "zone_id": zone_id or "root",
+                    "zone_id": zone_id or ROOT_ZONE_ID,
                     "expires_at": expires_at,
                     "conditions": json.dumps({"delegated_by": coordinator_agent_id}),
                 }

--- a/src/nexus/bricks/memory/memory_with_paging.py
+++ b/src/nexus/bricks/memory/memory_with_paging.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.memory.memory_paging import MemoryPager
 from nexus.bricks.memory.service import Memory
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -108,7 +109,7 @@ class MemoryWithPaging(Memory):
         if enable_paging:
             self.pager = MemoryPager(
                 session_factory=session_factory,
-                zone_id=zone_id or "root",
+                zone_id=zone_id or ROOT_ZONE_ID,
                 main_capacity=main_capacity,
                 recall_max_age_hours=recall_max_age_hours,
                 warm_up=warm_up,

--- a/src/nexus/bricks/memory/service.py
+++ b/src/nexus/bricks/memory/service.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 
 from nexus.bricks.memory._temporal import parse_datetime, validate_temporal_params
 from nexus.bricks.memory.router import MemoryViewRouter
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.types import OperationContext, Permission
 
 logger = logging.getLogger(__name__)
@@ -567,7 +568,7 @@ class Memory:
             return
 
         # Use default zone if not provided
-        effective_zone_id = zone_id or "root"
+        effective_zone_id = zone_id or ROOT_ZONE_ID
 
         async def _do_store() -> None:
             _store = SQLAlchemyRecordStore(db_url=db_url)

--- a/src/nexus/bricks/portability/import_service.py
+++ b/src/nexus/bricks/portability/import_service.py
@@ -26,6 +26,7 @@ from nexus.bricks.portability.models import (
     PermissionRecord,
     ZoneImportOptions,
 )
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.contracts.portability_types import PortabilityFSProtocol
@@ -565,7 +566,7 @@ class ZoneImportService:
                     object_id = options.remap_path(object_id)
 
                 # Determine target zone
-                target_zone = options.target_zone_id or "root"
+                target_zone = options.target_zone_id or ROOT_ZONE_ID
 
                 # Write tuple to ReBAC
                 rebac_manager.rebac_write(

--- a/src/nexus/services/agents/agent_rpc_service.py
+++ b/src/nexus/services/agents/agent_rpc_service.py
@@ -13,6 +13,7 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.rpc import rpc_expose
 from nexus.contracts.types import VFSOperations, parse_operation_context
 
@@ -137,7 +138,7 @@ class AgentRPCService:
             self._write_agent_config(config_path, config_data, context)
 
             if self._rebac_manager:
-                zone_id = self._extract_zone_id(context) or "root"
+                zone_id = self._extract_zone_id(context) or ROOT_ZONE_ID
                 try:
                     self._rebac_manager.rebac_write(
                         subject=("agent", agent_id),
@@ -385,7 +386,7 @@ class AgentRPCService:
         user_id = self._extract_user_id(context)
         if not user_id:
             raise ValueError("user_id required in context to register agent")
-        zone_id = self._extract_zone_id(context) or "root"
+        zone_id = self._extract_zone_id(context) or ROOT_ZONE_ID
 
         agent_name_part = agent_id.split(",", 1)[1] if "," in agent_id else agent_id
         agent_dir = f"/zone/{zone_id}/user/{user_id}/agent/{agent_name_part}"
@@ -460,7 +461,7 @@ class AgentRPCService:
         user_id = self._extract_user_id(context)
         if not user_id:
             raise ValueError("user_id required in context to update agent")
-        zone_id = self._extract_zone_id(context) or "root"
+        zone_id = self._extract_zone_id(context) or ROOT_ZONE_ID
 
         agent_name_part = agent_id.split(",", 1)[1] if "," in agent_id else agent_id
         agent_dir = f"/zone/{zone_id}/user/{user_id}/agent/{agent_name_part}"
@@ -644,7 +645,7 @@ class AgentRPCService:
         try:
             if "," in agent_id:
                 user_id, agent_name_part = agent_id.split(",", 1)
-                zone_id = self._extract_zone_id(_context) or "root"
+                zone_id = self._extract_zone_id(_context) or ROOT_ZONE_ID
                 agent_dir = f"/zone/{zone_id}/user/{user_id}/agent/{agent_name_part}"
 
                 # Delete directory
@@ -716,7 +717,7 @@ class AgentRPCService:
 
         # Wallet cleanup
         if self._wallet_provisioner is not None:
-            zone_id_for_wallet = self._extract_zone_id(_context) or "root"
+            zone_id_for_wallet = self._extract_zone_id(_context) or ROOT_ZONE_ID
             try:
                 cleanup_fn = getattr(self._wallet_provisioner, "cleanup", None)
                 if cleanup_fn is not None:
@@ -821,7 +822,7 @@ class AgentRPCService:
             if "," not in entity_id:
                 return None
             user_id, agent_name = entity_id.split(",", 1)
-            zone_id = self._extract_zone_id(context) or "root"
+            zone_id = self._extract_zone_id(context) or ROOT_ZONE_ID
             config_path = f"/zone/{zone_id}/user/{user_id}/agent/{agent_name}/config.yaml"
             ctx = parse_operation_context(context)
             content = self._vfs.read(config_path, context=ctx)
@@ -847,7 +848,7 @@ class AgentRPCService:
             if "," not in entity.entity_id:
                 return
             user_id, agent_name = entity.entity_id.split(",", 1)
-            zone_id = self._extract_zone_id(context) or "root"
+            zone_id = self._extract_zone_id(context) or ROOT_ZONE_ID
             config_path = f"/zone/{zone_id}/user/{user_id}/agent/{agent_name}/config.yaml"
             ctx = parse_operation_context(context)
             content = self._vfs.read(config_path, context=ctx)

--- a/src/nexus/services/descendant_access.py
+++ b/src/nexus/services/descendant_access.py
@@ -10,6 +10,8 @@ Extracted from ``nexus.core.nexus_fs._has_descendant_access`` and
 import logging
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
+
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext, Permission
 
@@ -113,7 +115,7 @@ class DescendantAccessChecker:
             Permission.TRAVERSE: "traverse",
         }
         rebac_permission = permission_map.get(permission, "read")
-        zone_id = context.zone_id or "root"
+        zone_id = context.zone_id or ROOT_ZONE_ID
 
         # =============================================================
         # Issue #919 OPTIMIZATION 1: Check DirectoryVisibilityCache (O(1))
@@ -240,7 +242,7 @@ class DescendantAccessChecker:
             try:
                 # Perform bulk permission check
                 results = self._rebac_manager.rebac_check_bulk(
-                    checks, zone_id=context.zone_id or "root"
+                    checks, zone_id=context.zone_id or ROOT_ZONE_ID
                 )
 
                 # OPTIMIZATION 5: Early exit on first accessible descendant
@@ -447,7 +449,7 @@ class DescendantAccessChecker:
         # PHASE 2: Perform ONE bulk permission check for everything
         try:
             results = self._rebac_manager.rebac_check_bulk(
-                all_checks, zone_id=context.zone_id or "root"
+                all_checks, zone_id=context.zone_id or ROOT_ZONE_ID
             )
         except Exception as e:
             logger.warning(f"has_access_bulk: Bulk check failed, falling back: {e}")


### PR DESCRIPTION
## Summary
- Replace 14 hardcoded `or "root"` zone ID fallbacks with `or ROOT_ZONE_ID` constant
- Bricks: `memory_with_paging.py`, `memory/service.py`, `delegation/service.py`, `import_service.py`
- Services: `descendant_access.py`, `agent_rpc_service.py`
- Adds `from nexus.constants import ROOT_ZONE_ID` import where missing

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, brick-zero-core-imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)