### PR TITLE
fix(#942): replace default zone_id="root" params with ROOT_ZONE_ID constant

### DIFF
--- a/src/nexus/bricks/access_manifest/service.py
+++ b/src/nexus/bricks/access_manifest/service.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select, update
 
 from nexus.bricks.access_manifest.evaluator import ManifestEvaluator
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.access_manifest_types import (
     AccessManifest,
     ManifestEntry,
@@ -151,7 +152,7 @@ class AccessManifestService:
         agent_id: str,
         name: str,
         entries: tuple[ManifestEntry, ...],
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         created_by: str = "",
         valid_hours: int = 720,
         credential_id: str | None = None,
@@ -234,7 +235,9 @@ class AccessManifestService:
             credential_id=credential_id,
         )
 
-    def evaluate(self, agent_id: str, tool_name: str, zone_id: str = "root") -> ToolPermission:
+    def evaluate(
+        self, agent_id: str, tool_name: str, zone_id: str = ROOT_ZONE_ID
+    ) -> ToolPermission:
         """Evaluate a tool access request for an agent.
 
         Uses cache first, falls back to DB lookup.
@@ -253,7 +256,7 @@ class AccessManifestService:
         return self._evaluator.evaluate(entries, tool_name)
 
     def filter_tools(
-        self, agent_id: str, tool_names: frozenset[str], zone_id: str = "root"
+        self, agent_id: str, tool_names: frozenset[str], zone_id: str = ROOT_ZONE_ID
     ) -> frozenset[str]:
         """Batch filter tools for an agent.
 

--- a/src/nexus/bricks/ipc/discovery.py
+++ b/src/nexus/bricks/ipc/discovery.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.ipc.conventions import AGENTS_ROOT, agent_card_path
 from nexus.bricks.ipc.storage.protocol import IPCStorageDriver
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from nexus.contracts.cache_store import CacheStoreABC
@@ -61,7 +62,7 @@ class AgentDiscovery:
     def __init__(
         self,
         storage: IPCStorageDriver,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         cache_ttl_seconds: float = 10.0,
         cache_store: "CacheStoreABC | None" = None,
     ) -> None:

--- a/src/nexus/bricks/ipc/provisioning.py
+++ b/src/nexus/bricks/ipc/provisioning.py
@@ -20,6 +20,7 @@ from nexus.bricks.ipc.conventions import (
     inbox_path,
 )
 from nexus.bricks.ipc.storage.protocol import IPCStorageDriver
+from nexus.constants import ROOT_ZONE_ID
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class AgentProvisioner:
         zone_id: Zone ID for multi-zone isolation.
     """
 
-    def __init__(self, storage: IPCStorageDriver, zone_id: str = "root") -> None:
+    def __init__(self, storage: IPCStorageDriver, zone_id: str = ROOT_ZONE_ID) -> None:
         self._storage = storage
         self._zone_id = zone_id
 

--- a/src/nexus/bricks/ipc/sweep.py
+++ b/src/nexus/bricks/ipc/sweep.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from nexus.bricks.ipc.conventions import AGENTS_ROOT, dead_letter_path, inbox_path
 from nexus.bricks.ipc.envelope import MessageEnvelope
 from nexus.bricks.ipc.storage.protocol import IPCStorageDriver
+from nexus.constants import ROOT_ZONE_ID
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ class TTLSweeper:
     def __init__(
         self,
         storage: IPCStorageDriver,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         interval: float = DEFAULT_SWEEP_INTERVAL,
     ) -> None:
         self._storage = storage

--- a/src/nexus/bricks/memory/memory_paging/archival_store.py
+++ b/src/nexus/bricks/memory/memory_paging/archival_store.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.memory.memory_paging.namespace_util import strip_tier_prefix
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -42,7 +43,7 @@ class ArchivalStore:
     def __init__(
         self,
         session_factory: "Callable[[], Session]",
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         namespace: str = "archival",
         vector_db: Any = None,
     ):

--- a/src/nexus/bricks/memory/memory_paging/pager.py
+++ b/src/nexus/bricks/memory/memory_paging/pager.py
@@ -17,6 +17,7 @@ from nexus.bricks.memory.memory_paging.archival_store import ArchivalStore
 from nexus.bricks.memory.memory_paging.context_manager import ContextManager
 from nexus.bricks.memory.memory_paging.namespace_util import strip_tier_prefix
 from nexus.bricks.memory.memory_paging.recall_store import RecallStore
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -59,7 +60,7 @@ class MemoryPager:
     def __init__(
         self,
         session_factory: "Callable[[], Session]",
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         main_capacity: int = 100,
         recall_max_age_hours: float = 24.0,
         warm_up: bool = True,

--- a/src/nexus/bricks/memory/memory_paging/recall_store.py
+++ b/src/nexus/bricks/memory/memory_paging/recall_store.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from nexus.bricks.memory.memory_paging.namespace_util import strip_tier_prefix
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -38,7 +39,7 @@ class RecallStore:
     def __init__(
         self,
         session_factory: "Callable[[], Session]",
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         namespace: str = "recall",
     ):
         """Initialize recall store.

--- a/src/nexus/bricks/search/graph_store.py
+++ b/src/nexus/bricks/search/graph_store.py
@@ -30,6 +30,7 @@ from nexus.bricks.search.models import (
     EntityModel,
     RelationshipModel,
 )
+from nexus.constants import ROOT_ZONE_ID
 
 
 def _utcnow_naive() -> datetime:
@@ -260,7 +261,7 @@ class GraphStore:
         record_store: "RecordStoreABC",
         session: "AsyncSession",
         *,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         embedding_provider: "EmbeddingProvider | None" = None,
         merge_threshold: float = 0.85,
         confidence_threshold: float = 0.75,

--- a/src/nexus/remote/domain/admin.py
+++ b/src/nexus/remote/domain/admin.py
@@ -6,6 +6,8 @@ Issue #1603: Decompose remote/client.py into domain clients.
 import builtins
 from typing import Any
 
+from nexus.constants import ROOT_ZONE_ID
+
 
 class AsyncAdminClient:
     """Async Admin API client for managing API keys."""
@@ -17,7 +19,7 @@ class AsyncAdminClient:
         self,
         user_id: str,
         name: str,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         is_admin: bool = False,
         expires_days: int | None = None,
         subject_type: str | None = None,

--- a/src/nexus/services/workspace_rpc_service.py
+++ b/src/nexus/services/workspace_rpc_service.py
@@ -9,6 +9,7 @@ import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.contracts.rpc import rpc_expose
 from nexus.contracts.types import OperationContext, parse_operation_context
@@ -197,7 +198,7 @@ class WorkspaceRPCService:
         self,
         paths: list[str],
         agent_id: str | None = None,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         context: OperationContext | None = None,
     ) -> dict[str, Any]:
         """Begin a transactional snapshot for the specified paths."""

--- a/src/nexus/storage/exchange_audit_logger.py
+++ b/src/nexus/storage/exchange_audit_logger.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import desc, event, func, select
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models.exchange_audit_log import ExchangeAuditLogModel
 
 if TYPE_CHECKING:
@@ -164,7 +165,7 @@ class ExchangeAuditLogger:
         currency: str = "credits",
         status: str,
         application: str,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         trace_id: str | None = None,
         metadata: dict[str, Any] | None = None,
         transfer_id: str | None = None,

--- a/src/nexus/storage/secrets_audit_logger.py
+++ b/src/nexus/storage/secrets_audit_logger.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import event, select
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models.secrets_audit_log import SecretsAuditLogModel
 
 if TYPE_CHECKING:
@@ -118,7 +119,7 @@ class SecretsAuditLogger:
         provider: str | None = None,
         credential_id: str | None = None,
         token_family_id: str | None = None,
-        zone_id: str = "root",
+        zone_id: str = ROOT_ZONE_ID,
         ip_address: str | None = None,
         details: dict[str, Any] | None = None,
     ) -> str:


### PR DESCRIPTION
## Summary
- Replace 14 hardcoded `zone_id: str = "root"` default parameter values with `zone_id: str = ROOT_ZONE_ID`
- 12 files across remote, storage, services, bricks layers
- Adds `from nexus.constants import ROOT_ZONE_ID` import to each file

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, brick-zero-core-imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)