### PR TITLE
fix(#943): replace remaining hardcoded root zone IDs with ROOT_ZONE_ID

### DIFF
--- a/src/nexus/bricks/governance/governance_wrapper.py
+++ b/src/nexus/bricks/governance/governance_wrapper.py
@@ -10,11 +10,9 @@ Wrapper chain: GovernanceEnforcedPayment -> PolicyEnforcedPayment -> CreditsPaym
 import logging
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.types import TransactionProtocol
 from nexus.utils.async_helpers import fire_and_forget
-
-# Inlined to avoid cross-brick import to nexus.constants (brick isolation rule)
-_ROOT_ZONE_ID = "root"
 
 if TYPE_CHECKING:
     from nexus.bricks.governance.protocols import AnomalyServiceProtocol, GovernanceGraphProtocol
@@ -82,7 +80,7 @@ class GovernanceEnforcedPayment:
         Post-analysis: fire-and-forget anomaly detection.
         """
         zone_id = (
-            request.metadata.get("zone_id", _ROOT_ZONE_ID) if request.metadata else _ROOT_ZONE_ID
+            request.metadata.get("zone_id", ROOT_ZONE_ID) if request.metadata else ROOT_ZONE_ID
         )
 
         # 1. Pre-check: governance constraints

--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import OperationalError
 
 from nexus.bricks.rebac.domain import Entity
 from nexus.bricks.rebac.types import ConsistencyLevel
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.rebac_types import CROSS_ZONE_ALLOWED_RELATIONS
 
 if TYPE_CHECKING:
@@ -147,7 +148,7 @@ class BulkPermissionChecker:
                 raise ValueError("zone_id is required for bulk permission checks in production")
             else:
                 logger.warning("rebac_check_bulk called without zone_id, defaulting to 'root'")
-                zone_id = "root"
+                zone_id = ROOT_ZONE_ID
 
         results: dict[tuple[tuple[str, str], str, tuple[str, str]], bool] = {}
         cache_misses: list[tuple[tuple[str, str], str, tuple[str, str]]] = []

--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.rebac.domain import RELATION_TO_PERMISSIONS
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from collections.abc import Callable, MutableMapping
@@ -39,9 +40,6 @@ if TYPE_CHECKING:
     from nexus.bricks.rebac.domain import Entity
 
 logger = logging.getLogger(__name__)
-
-# Default zone when none specified
-_ROOT_ZONE_ID = "root"
 
 # Canonical mapping from domain.py — local alias for backward compat.
 _RELATION_TO_PERMISSIONS = RELATION_TO_PERMISSIONS
@@ -363,7 +361,7 @@ class CacheCoordinator:
             expires_at: Optional expiration time (disables eager recomputation)
             conn: Optional database connection to reuse
         """
-        effective_zone_id = zone_id if zone_id is not None else _ROOT_ZONE_ID
+        effective_zone_id = zone_id if zone_id is not None else ROOT_ZONE_ID
 
         # Track write for adaptive TTL (Phase 4)
         if self._l1_cache:
@@ -725,7 +723,7 @@ class CacheCoordinator:
                         relation,
                         object_type,
                         object_id,
-                        zone_id or _ROOT_ZONE_ID,
+                        zone_id or ROOT_ZONE_ID,
                         datetime.now(UTC).isoformat(),
                     ),
                 )

--- a/src/nexus/server/api/v2/routers/snapshots.py
+++ b/src/nexus/server/api/v2/routers/snapshots.py
@@ -99,7 +99,7 @@ async def get_snapshot_context(request: Request) -> tuple[Any, str, str | None]:
     if snapshot_service is None:
         raise HTTPException(status_code=503, detail="Snapshot service not available")
 
-    zone_id = "root"
+    zone_id = ROOT_ZONE_ID
     agent_id = None
 
     # Lazy import to avoid circular dependencies


### PR DESCRIPTION
## Summary
- Replace `zone_id = "root"` assignments in `bulk_checker.py` and `snapshots.py` with `ROOT_ZONE_ID` constant
- Replace private `_ROOT_ZONE_ID = "root"` constants in `governance_wrapper.py` and `coordinator.py` with import from `nexus.constants`
- Delete stale "brick isolation rule" comment — `nexus.constants` is a shared top-level module, 20+ brick files already import from it

## Test plan
- [ ] Pre-commit hooks pass (ruff, mypy, brick zero-core-imports check)
- [ ] No behavioral change — same string value, just using the canonical constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)