### PR TITLE
fix: value-based enum comparison in delegation derivation

### DIFF
--- a/src/nexus/bricks/delegation/derivation.py
+++ b/src/nexus/bricks/delegation/derivation.py
@@ -109,11 +109,14 @@ def derive_grants(
         if existing is None or _relation_rank(relation) > _relation_rank(existing):
             parent_map[object_id] = relation
 
-    if mode == DelegationMode.COPY:
+    # Compare by value to handle pytest-xdist module double-loading where
+    # enum identity (==) fails across separately-loaded module instances.
+    mode_value = mode.value if isinstance(mode, DelegationMode) else mode
+    if mode_value == DelegationMode.COPY.value:
         result = _derive_copy(parent_map, remove_set, readonly_set, scope_prefix)
-    elif mode == DelegationMode.CLEAN:
+    elif mode_value == DelegationMode.CLEAN.value:
         result = _derive_clean(parent_map, add_set, scope_prefix)
-    elif mode == DelegationMode.SHARED:
+    elif mode_value == DelegationMode.SHARED.value:
         result = _derive_shared(parent_map, scope_prefix)
     else:
         raise InvalidDelegationModeError(f"Unknown delegation mode: {mode}")


### PR DESCRIPTION
## Summary
- Fix flaky delegation test failures on macOS and Ubuntu CI caused by pytest-xdist module double-loading
- Python enum `==` uses identity comparison (same as `is`), which fails when the same module is loaded twice creating separate `DelegationMode` class objects
- Changed to compare by `.value` (string) which works across module instances
- Fixes delegation test failures affecting PRs #2491, #2494, #2495, #2497

## Test plan
- [ ] macOS CI delegation tests pass consistently
- [ ] Ubuntu CI delegation tests pass consistently
- [ ] All existing delegation tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)