### PR TITLE
fix(#826): delete dead aliases and unused re-exports

### DIFF
--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -41,8 +41,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Canonical mapping from domain.py — local alias for backward compat.
-_RELATION_TO_PERMISSIONS = RELATION_TO_PERMISSIONS
 
 
 class CacheCoordinator:
@@ -853,7 +851,7 @@ class CacheCoordinator:
             return
 
         # Map relation to permissions
-        permissions = _RELATION_TO_PERMISSIONS.get(relation, [relation])
+        permissions = RELATION_TO_PERMISSIONS.get(relation, [relation])
 
         self._boundary_invalidations += 1
 

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -96,10 +96,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Canonical mapping imported from domain.py — see RELATION_TO_PERMISSIONS.
-# Local alias kept for backward compat with code referencing the old name.
-_RELATION_TO_PERMISSIONS = RELATION_TO_PERMISSIONS
-
 # ============================================================================
 # Flattened ReBAC Manager (Issue #1385)
 # ============================================================================
@@ -1083,7 +1079,7 @@ class ReBACManager:
 
         # Map relation to permission(s) for invalidation
         # This maps relation names to permissions they grant
-        permissions = _RELATION_TO_PERMISSIONS.get(relation, [])
+        permissions = RELATION_TO_PERMISSIONS.get(relation, [])
         if not permissions:
             return
 
@@ -1298,7 +1294,7 @@ class ReBACManager:
             object_id = object[1]
 
             # Get permissions for this relation (fail-closed: unknown → [])
-            permissions = _RELATION_TO_PERMISSIONS.get(relation, [])
+            permissions = RELATION_TO_PERMISSIONS.get(relation, [])
 
             # Persist each permission grant immediately
             for permission in permissions:
@@ -1411,7 +1407,7 @@ class ReBACManager:
 
                     # Get permissions for this relation
                     # FIX: Default to empty list for unknown relations
-                    permissions = _RELATION_TO_PERMISSIONS.get(relation, [])
+                    permissions = RELATION_TO_PERMISSIONS.get(relation, [])
 
                     # Persist each permission grant immediately
                     for permission in permissions:
@@ -1758,7 +1754,7 @@ class ReBACManager:
                 object_id = tuple_info["object_id"]
 
                 if subject_type and subject_id and object_type and object_id:
-                    permissions = _RELATION_TO_PERMISSIONS.get(relation, [])
+                    permissions = RELATION_TO_PERMISSIONS.get(relation, [])
 
                     # Revoke each permission immediately
                     for permission in permissions:
@@ -4193,8 +4189,6 @@ class ReBACManager:
         """
         pass
 
-
-ZoneAwareReBACManager = ReBACManager
 
 # Backward-compat alias — many tests and call-sites still reference the old name.
 EnhancedReBACManager = ReBACManager

--- a/src/nexus/bricks/rebac/utils/zone.py
+++ b/src/nexus/bricks/rebac/utils/zone.py
@@ -8,7 +8,7 @@ Provides:
 
 from typing import Any
 
-from nexus.lib.zone import DEFAULT_ZONE, normalize_zone_id  # noqa: F401
+from nexus.lib.zone import normalize_zone_id  # noqa: F401
 
 # ==============================================================================
 # ReBAC Group Naming Helpers

--- a/src/nexus/server/auth/factory.py
+++ b/src/nexus/server/auth/factory.py
@@ -6,7 +6,6 @@ This module now delegates to nexus.auth brick providers (Issue #1399).
 import logging
 from typing import Any
 
-from nexus.bricks.auth.constants import API_KEY_PREFIX  # noqa: F401
 from nexus.bricks.auth.providers.base import AuthProvider
 from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
 from nexus.bricks.auth.providers.discriminator import DiscriminatingAuthProvider  # noqa: F401


### PR DESCRIPTION
## Summary
- Remove unused `API_KEY_PREFIX` re-export from `server/auth/factory.py` (noqa:F401, zero callers)
- Remove unused `DEFAULT_ZONE` re-export from `bricks/rebac/utils/zone.py` (noqa:F401, zero callers)
- Delete dead `ZoneAwareReBACManager = ReBACManager` alias (zero usages in src/ or tests/)
- Replace `_RELATION_TO_PERMISSIONS` aliases with direct `RELATION_TO_PERMISSIONS` in `manager.py` (4 sites) and `cache/coordinator.py` (1 site) — unnecessary indirection marked "backward compat" but only used file-locally

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, brick-zero-core-imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)