### PR TITLE
fix(#826): fix stale AsyncNexusFS references in docstrings

### DIFF
--- a/src/nexus/server/api/v2/routers/batch.py
+++ b/src/nexus/server/api/v2/routers/batch.py
@@ -6,7 +6,7 @@ of VFS operations, reducing HTTP round-trips for chatty agent workloads.
 Design decisions:
     - Presentation layer only (not a brick) per §5.5
     - Factory pattern for DI (same as async_files.py)
-    - Direct VFS dispatch via AsyncNexusFS
+    - Direct VFS dispatch via NexusFS
     - Batch-specific rate limit (separate from per-endpoint limits)
 
 References:

--- a/src/nexus/server/batch_executor.py
+++ b/src/nexus/server/batch_executor.py
@@ -4,7 +4,7 @@ Executes multiple VFS operations in a single request, reducing HTTP round-trips.
 Operations execute sequentially; each produces its own status code.
 
 Design decisions (from architecture review):
-    - Direct VFS dispatch via AsyncNexusFS (no ASGI loopback)
+    - Direct VFS dispatch via NexusFS (no ASGI loopback)
     - VFS operations only: read, write, delete, stat, exists, list, mkdir
     - Per-operation timeout via asyncio.wait_for (30s default)
     - Strict validation: 1-50 ops, max 10MB total payload
@@ -194,7 +194,7 @@ def _map_exception(exc: Exception) -> tuple[int, str]:
 
 
 class BatchExecutor:
-    """Executes a batch of VFS operations sequentially against AsyncNexusFS.
+    """Executes a batch of VFS operations sequentially against NexusFS.
 
     Follows the io_uring pattern: operations submitted as a batch,
     results returned with per-operation status codes.
@@ -258,7 +258,7 @@ class BatchExecutor:
         op: ReadOp | WriteOp | DeleteOp | StatOp | ExistsOp | ListOp | MkdirOp,
         context: "OperationContext",
     ) -> OperationResult:
-        """Dispatch a single operation to the appropriate AsyncNexusFS method."""
+        """Dispatch a single operation to the appropriate NexusFS method."""
         if isinstance(op, ReadOp):
             return await self._exec_read(op, context)
         if isinstance(op, WriteOp):

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -20,7 +20,7 @@ async def startup_permissions(app: "FastAPI", svc: "LifespanServices") -> list[a
     """Initialize permission infrastructure and return background tasks.
 
     Covers:
-    - Async ReBAC manager + AsyncNexusFS (Issue #940)
+    - ReBAC manager + NexusFS (Issue #940)
     - Cache factory + Tiger Cache L2 wiring (Issue #1075, #1106)
     - Tiger Cache queue processor + warm-up (Issue #935, #979)
     - DirectoryGrantExpander worker


### PR DESCRIPTION
## Summary
- Update 5 stale docstring/comment references to deleted `AsyncNexusFS` class
- `batch_executor.py` (3 references) -> `NexusFS`
- `batch.py` (1 reference) -> `NexusFS`
- `permissions.py` (1 reference) -> `NexusFS`

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)