### PR TITLE
fix(#826): delete dead permissions shim stub __init__.py files

### DIFF
--- a/src/nexus/services/permissions/batch/__init__.py
+++ b/src/nexus/services/permissions/batch/__init__.py
@@ -1,1 +1,0 @@
-"""Backward-compat shim — canonical: nexus.bricks.rebac.batch."""

--- a/src/nexus/services/permissions/cache/__init__.py
+++ b/src/nexus/services/permissions/cache/__init__.py
@@ -1,1 +1,0 @@
-"""Backward-compat shim — canonical: ``nexus.bricks.rebac.cache`` (Issue #2179)."""

--- a/src/nexus/services/permissions/cache/tiger/__init__.py
+++ b/src/nexus/services/permissions/cache/tiger/__init__.py
@@ -1,1 +1,0 @@
-"""Backward-compat shim — canonical: ``nexus.bricks.rebac.cache.tiger`` (Issue #2179)."""

--- a/src/nexus/services/permissions/consistency/__init__.py
+++ b/src/nexus/services/permissions/consistency/__init__.py
@@ -1,1 +1,0 @@
-"""Backward-compat shim — canonical: ``nexus.bricks.rebac.consistency`` (Issue #2179)."""

--- a/src/nexus/services/permissions/directory/__init__.py
+++ b/src/nexus/services/permissions/directory/__init__.py
@@ -1,1 +1,0 @@
-"""Backward-compat shim — canonical: ``nexus.bricks.rebac.directory`` (Issue #2179)."""

--- a/src/nexus/services/permissions/graph/__init__.py
+++ b/src/nexus/services/permissions/graph/__init__.py
@@ -1,1 +1,0 @@
-"""Backward-compat shim — canonical: nexus.bricks.rebac.graph."""

--- a/src/nexus/services/permissions/tuples/__init__.py
+++ b/src/nexus/services/permissions/tuples/__init__.py
@@ -1,1 +1,0 @@
-"""Backward-compat shim — canonical: nexus.bricks.rebac.tuples."""

--- a/src/nexus/services/permissions/utils/__init__.py
+++ b/src/nexus/services/permissions/utils/__init__.py
@@ -1,1 +1,0 @@
-"""Backward-compat shim — canonical: nexus.bricks.rebac.utils."""


### PR DESCRIPTION
## Summary
- Delete 8 dead `__init__.py` stubs in `services/permissions/` sub-packages
- These files are docstring-only or empty stubs made unnecessary by the MetaPath redirector in the parent `__init__.py`
- The MetaPath redirector intercepts all `nexus.services.permissions.*` imports and transparently redirects to `nexus.bricks.rebac.*`
- Zero code imports these stub files directly — all imports target specific submodules (e.g., `consistency.zone_manager`)

Deleted sub-packages: `batch/`, `cache/`, `cache/tiger/`, `consistency/`, `directory/`, `graph/`, `tuples/`, `utils/`

Kept: root `__init__.py` (MetaPath redirector) and `checker.py` (production service code)

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)