### PR TITLE
fix(#950): replace stale AsyncNexusFS refs in tests

### DIFF
--- a/tests/e2e/server/test_async_files_permissions_e2e.py
+++ b/tests/e2e/server/test_async_files_permissions_e2e.py
@@ -3,8 +3,8 @@
 Starts a real `nexus serve` process (uvicorn + FastAPI) and makes real HTTP
 requests to verify all 9 /api/v2/files/* endpoints work through the full
 server stack, including:
-- Real FastAPI lifespan (AsyncNexusFS initialized via lifespan)
-- Real PostgreSQL database (shared between sync NexusFS and AsyncNexusFS)
+- Real FastAPI lifespan (NexusFS initialized via lifespan)
+- Real PostgreSQL database (shared between sync NexusFS and NexusFS)
 - Real HTTP network I/O (not ASGI test transport)
 - User context via X-Nexus-Subject and X-Nexus-Zone-ID headers
 
@@ -99,7 +99,7 @@ def server():
         "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
         # PostgreSQL: used by BOTH sync NexusFS and async lifespan
         "NEXUS_DATABASE_URL": database_url,
-        # AsyncNexusFS settings
+        # NexusFS settings
         "NEXUS_BACKEND_ROOT": backend_root,
         "NEXUS_TENANT_ID": "e2e-test",
         # Permissions disabled for happy-path E2E (no ReBAC setup needed)

--- a/tests/e2e/server/test_namespace_dcache_database_e2e.py
+++ b/tests/e2e/server/test_namespace_dcache_database_e2e.py
@@ -140,7 +140,7 @@ def _wait_for_health(base_url: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> 
 
 
 def _wait_for_ready(base_url: str, admin_key: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> None:
-    """Wait for AsyncNexusFS to be initialized (not just health check).
+    """Wait for NexusFS to be initialized (not just health check).
 
     Polls a v2 endpoint until it responds without 500 (503 = not ready yet).
     """
@@ -154,14 +154,14 @@ def _wait_for_ready(base_url: str, admin_key: str, timeout: float = SERVER_START
                     params={"path": "/__readiness_probe__"},
                     headers=headers,
                 )
-                # Any status other than 500 means AsyncNexusFS is initialized
+                # Any status other than 500 means NexusFS is initialized
                 # (404 = not found = server is ready, just file doesn't exist)
                 if resp.status_code != 500:
                     return
             except httpx.ConnectError:
                 pass
             time.sleep(0.5)
-    raise TimeoutError(f"AsyncNexusFS not ready within {timeout}s")
+    raise TimeoutError(f"NexusFS not ready within {timeout}s")
 
 
 def _check_postgres() -> bool:
@@ -303,7 +303,7 @@ def server():
         # PostgreSQL for database auth + async operations
         "NEXUS_DATABASE_URL": POSTGRES_URL,
         "NEXUS_JWT_SECRET": "dcache-e2e-jwt-secret-key-12345",
-        # AsyncNexusFS settings
+        # NexusFS settings
         "NEXUS_BACKEND_ROOT": backend_root,
         "NEXUS_TENANT_ID": "dcache-e2e-test",
         # CRITICAL: Permissions ENABLED for namespace + dcache testing

--- a/tests/e2e/server/test_namespace_fuse_e2e.py
+++ b/tests/e2e/server/test_namespace_fuse_e2e.py
@@ -50,7 +50,7 @@ def _make_client() -> httpx.Client:
 
 
 def _wait_for_health(base_url: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> None:
-    """Poll /health AND verify AsyncNexusFS is ready before returning."""
+    """Poll /health AND verify NexusFS is ready before returning."""
     deadline = time.monotonic() + timeout
     health_ok = False
     with _make_client() as client:
@@ -60,7 +60,7 @@ def _wait_for_health(base_url: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> 
                     resp = client.get(f"{base_url}/health")
                     if resp.status_code == 200:
                         health_ok = True
-                        # Health is up, but AsyncNexusFS may still be initializing.
+                        # Health is up, but NexusFS may still be initializing.
                         # Probe a real API endpoint to confirm readiness.
                 if health_ok:
                     resp = client.get(
@@ -68,7 +68,7 @@ def _wait_for_health(base_url: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> 
                         params={"path": "/"},
                         headers={"X-Nexus-Subject": "user:admin", "X-Nexus-Require-Admin": "true"},
                     )
-                    # Server wraps AsyncNexusFS errors as 500 (not 503).
+                    # Server wraps NexusFS errors as 500 (not 503).
                     # Only consider ready when we get a non-5xx response.
                     if resp.status_code < 500:
                         return  # Server fully ready
@@ -105,7 +105,7 @@ def server():
         "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
         "NEXUS_BACKEND_ROOT": backend_root,
         "NEXUS_TENANT_ID": "fuse-ns-e2e-test",
-        # SQLite database for AsyncNexusFS initialization (required by lifespan)
+        # SQLite database for NexusFS initialization (required by lifespan)
         "NEXUS_DATABASE_URL": f"sqlite:///{db_path}",
         # CRITICAL: Permissions ENABLED for namespace testing
         "NEXUS_ENFORCE_PERMISSIONS": "true",

--- a/tests/e2e/server/test_namespace_permissions_e2e.py
+++ b/tests/e2e/server/test_namespace_permissions_e2e.py
@@ -158,7 +158,7 @@ def server():
         "NO_PROXY": "*",
         # Source code on PYTHONPATH
         "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
-        # AsyncNexusFS settings
+        # NexusFS settings
         "NEXUS_DATABASE_URL": f"sqlite:///{os.path.join(data_dir, 'nexus.db')}",
         "NEXUS_BACKEND_ROOT": backend_root,
         "NEXUS_TENANT_ID": "ns-e2e-test",

--- a/tests/e2e/server/test_persistent_views_e2e.py
+++ b/tests/e2e/server/test_persistent_views_e2e.py
@@ -6,7 +6,7 @@ Verifies that:
 3. L3 doesn't break the existing namespace isolation behavior
 
 Uses multi-key StaticAPIKeyAuth for proper per-user identity, and the sync
-RPC endpoint (/api/nfs/) which doesn't require AsyncNexusFS (database_url).
+RPC endpoint (/api/nfs/) which doesn't require NexusFS (database_url).
 """
 
 import base64

--- a/tests/e2e/server/test_write_back_permissions_e2e.py
+++ b/tests/e2e/server/test_write_back_permissions_e2e.py
@@ -161,7 +161,7 @@ def server():
 
     base_url = f"http://127.0.0.1:{port}"
 
-    # SQLite database for async engine (required by AsyncNexusFS)
+    # SQLite database for async engine (required by NexusFS)
     db_path = os.path.join(data_dir, "nexus_e2e.db")
 
     env = {
@@ -174,9 +174,9 @@ def server():
         "NO_PROXY": "*",
         # Source code on PYTHONPATH
         "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
-        # Database URL for async engine (AsyncNexusFS requires this)
+        # Database URL for async engine (NexusFS requires this)
         "NEXUS_DATABASE_URL": f"sqlite:///{db_path}",
-        # AsyncNexusFS settings
+        # NexusFS settings
         "NEXUS_BACKEND_ROOT": backend_root,
         "NEXUS_TENANT_ID": "wb-perm-e2e",
         # CRITICAL: Permissions ENABLED

--- a/tests/unit/server/api/v2/routers/test_batch_router.py
+++ b/tests/unit/server/api/v2/routers/test_batch_router.py
@@ -1,6 +1,6 @@
 """Integration tests for batch router (Issue #1242).
 
-Tests the full FastAPI router with a mock AsyncNexusFS via TestClient.
+Tests the full FastAPI router with a mock NexusFS via TestClient.
 """
 
 from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
- Replaced all 17 stale `AsyncNexusFS` references with `NexusFS` across 7 test files
- `AsyncNexusFS` was deleted; these docstrings/comments still referenced it

## Files changed
- `tests/e2e/server/test_async_files_permissions_e2e.py` (3 refs)
- `tests/e2e/server/test_namespace_dcache_database_e2e.py` (4 refs)
- `tests/e2e/server/test_namespace_fuse_e2e.py` (4 refs)
- `tests/e2e/server/test_namespace_permissions_e2e.py` (1 ref)
- `tests/e2e/server/test_persistent_views_e2e.py` (1 ref)
- `tests/e2e/server/test_write_back_permissions_e2e.py` (3 refs)
- `tests/unit/server/api/v2/routers/test_batch_router.py` (1 ref)

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff format, mypy)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)