### PR TITLE
fix(#961): replace hardcoded "root" with ROOT_ZONE_ID in isolated modules

### DIFF
--- a/src/nexus/lib/db_base.py
+++ b/src/nexus/lib/db_base.py
@@ -15,6 +15,8 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, String, Text, TextClause, text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
+
 
 def _generate_uuid() -> str:
     """Generate a UUID string (UUIDv4).
@@ -69,7 +71,7 @@ class TimestampMixin:
 class ZoneIsolationMixin:
     """Mixin providing a zone_id column for multi-zone isolation."""
 
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
 
 class ResourceConfigMixin:


### PR DESCRIPTION
## Summary
- Replace 3 hardcoded `"root"` zone ID strings in `raft/federation.py` with `ROOT_ZONE_ID` constant
- Replace 1 hardcoded `"root"` default in `lib/db_base.py` `ZoneIsolationMixin` with `ROOT_ZONE_ID` constant
- Both modules import from `nexus.constants` (tier-neutral, zero nexus dependencies)

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, ruff format)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)