### PR TITLE
fix(#960): fix broken nexus.core.cache_store imports in nexus_fs.py and orchestrator.py

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -19,8 +19,8 @@ from nexus.core.hash_fast import hash_content
 if TYPE_CHECKING:
     from nexus.rebac.entity_registry import EntityRegistry
     from nexus.services.memory.memory_api import Memory
+from nexus.contracts.cache_store import CacheStoreABC, NullCacheStore
 from nexus.contracts.metadata import FileMetadata
-from nexus.core.cache_store import CacheStoreABC, NullCacheStore
 from nexus.core.config import (
     BrickServices,
     CacheConfig,

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -312,7 +312,7 @@ def create_nexus_fs(
     # KERNEL-ARCHITECTURE §2: No CacheStore → EventBus disabled.
     _has_real_cache = cache_store is not None
     if _has_real_cache:
-        from nexus.core.cache_store import NullCacheStore as _NullCacheStore
+        from nexus.contracts.cache_store import NullCacheStore as _NullCacheStore
 
         if isinstance(cache_store, _NullCacheStore):
             _has_real_cache = False


### PR DESCRIPTION
## Summary
- Fix `ModuleNotFoundError` caused by importing from deleted `nexus.core.cache_store`
- Update `nexus_fs.py` and `orchestrator.py` to import from canonical `nexus.contracts.cache_store`
- Critical bug: NexusFS could not be imported at runtime due to this broken import

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, ruff format)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)