### PR TITLE
fix(#959): move AuditConfig from core/config.py to contracts/types.py

### DIFF
--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -343,3 +343,31 @@ class SnapshotId:
     """Opaque identifier for a transactional snapshot."""
 
     id: str
+
+
+# ---------------------------------------------------------------------------
+# Audit configuration (moved from nexus.core.config, Issue #959)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuditConfig:
+    """Audit trail error-policy configuration (Issue #2152).
+
+    Controls what happens when audit logging (RecordStore sync) fails
+    during write operations. This is a P0 compliance concern — separate
+    from permission enforcement (PermissionConfig).
+
+    P0 COMPLIANCE: SOX, HIPAA, GDPR, PCI DSS require complete audit
+    trails. ``strict_mode=True`` (default) ensures writes fail if audit
+    logging fails, preventing silent audit gaps.
+
+    Note on buffered observers: ``strict_mode`` is enforced by the
+    synchronous ``RecordStoreWriteObserver``. The async
+    ``BufferedRecordStoreWriteObserver`` enqueues events into a
+    ``WriteBuffer`` where the enqueue path cannot fail; actual error
+    handling (retry + drop) is managed by the ``WriteBuffer`` background
+    flush thread, not by ``strict_mode``.
+    """
+
+    strict_mode: bool = True

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -77,29 +77,6 @@ class PermissionConfig:
 
 
 @dataclass(frozen=True)
-class AuditConfig:
-    """Audit trail error-policy configuration (Issue #2152).
-
-    Controls what happens when audit logging (RecordStore sync) fails
-    during write operations. This is a P0 compliance concern — separate
-    from permission enforcement (PermissionConfig).
-
-    P0 COMPLIANCE: SOX, HIPAA, GDPR, PCI DSS require complete audit
-    trails. ``strict_mode=True`` (default) ensures writes fail if audit
-    logging fails, preventing silent audit gaps.
-
-    Note on buffered observers: ``strict_mode`` is enforced by the
-    synchronous ``RecordStoreWriteObserver``. The async
-    ``BufferedRecordStoreWriteObserver`` enqueues events into a
-    ``WriteBuffer`` where the enqueue path cannot fail; actual error
-    handling (retry + drop) is managed by the ``WriteBuffer`` background
-    flush thread, not by ``strict_mode``.
-    """
-
-    strict_mode: bool = True
-
-
-@dataclass(frozen=True)
 class DistributedConfig:
     """Distributed coordination configuration.
 

--- a/src/nexus/factory/_boot_context.py
+++ b/src/nexus/factory/_boot_context.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from nexus.backends.backend import Backend
-    from nexus.core.config import AuditConfig, DistributedConfig, PermissionConfig
+    from nexus.contracts.types import AuditConfig
+    from nexus.core.config import DistributedConfig, PermissionConfig
     from nexus.core.metastore import MetastoreABC
     from nexus.core.router import PathRouter
     from nexus.lib.performance_tuning import ProfileTuning

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from nexus.backends.backend import Backend
     from nexus.bricks.workflows.protocol import WorkflowProtocol
+    from nexus.contracts.types import AuditConfig
     from nexus.core.config import (
-        AuditConfig,
         BrickServices,
         CacheConfig,
         DistributedConfig,
@@ -79,7 +79,7 @@ def create_nexus_services(
     """
     # --- Profile-based brick gating (Issue #1389) ---
     from nexus.contracts.deployment_profile import DeploymentProfile
-    from nexus.core.config import AuditConfig as _AuditConfig
+    from nexus.contracts.types import AuditConfig as _AuditConfig
     from nexus.core.config import BrickServices as _BrickServices
     from nexus.core.config import CacheConfig as _CacheConfig
     from nexus.core.config import DistributedConfig as _DistributedConfig

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -18,8 +18,8 @@ import pytest
 
 from nexus.contracts.deployment_profile import DeploymentProfile
 from nexus.contracts.exceptions import BootError
+from nexus.contracts.types import AuditConfig
 from nexus.core.config import (
-    AuditConfig,
     BrickServices,
     DistributedConfig,
     KernelServices,


### PR DESCRIPTION
## Summary
- Move `AuditConfig` dataclass from `nexus.core.config` to `nexus.contracts.types`
- Per KERNEL-ARCHITECTURE, config types consumed by multiple layers should live in contracts
- Update all 4 importers: `orchestrator.py`, `_boot_context.py`, `test_factory_boot.py`
- No backward-compat shim — clean delete from core

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, ruff format)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)