### PR TITLE
fix(#964): replace ALL hardcoded zone_id="root" with ROOT_ZONE_ID (43 files)

### DIFF
--- a/src/nexus/bricks/rebac/directory/expander.py
+++ b/src/nexus/bricks/rebac/directory/expander.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy.exc import OperationalError
 
 from nexus.bricks.rebac.consistency.revision import get_zone_revision_for_grant
+from nexus.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -317,7 +318,7 @@ class DirectoryExpander:
                 FilePathModel.deleted_at.is_(None),
                 or_(
                     FilePathModel.zone_id == zone_id,
-                    FilePathModel.zone_id == "root",
+                    FilePathModel.zone_id == ROOT_ZONE_ID,
                     FilePathModel.zone_id.is_(None),
                 ),
             )

--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -19,6 +19,8 @@ from dataclasses import asdict, dataclass, field
 from enum import IntFlag, StrEnum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from nexus.constants import ROOT_ZONE_ID
+
 if TYPE_CHECKING:
     from nexus.storage.read_set import ReadSet
 
@@ -206,7 +208,7 @@ class ContextIdentity:
 
     Replaces the pattern::
 
-        zone_id = getattr(context, "zone_id", None) or "root"
+        zone_id = getattr(context, "zone_id", None) or ROOT_ZONE_ID
         user_id = getattr(context, "user_id", None) or "anonymous"
         is_admin = getattr(context, "is_admin", False)
 
@@ -230,9 +232,9 @@ def extract_context_identity(context: OperationContext | None) -> ContextIdentit
         Frozen ContextIdentity with zone_id, user_id, is_admin.
     """
     if context is None:
-        return ContextIdentity(zone_id="root", user_id="anonymous", is_admin=False)
+        return ContextIdentity(zone_id=ROOT_ZONE_ID, user_id="anonymous", is_admin=False)
     return ContextIdentity(
-        zone_id=getattr(context, "zone_id", None) or "root",
+        zone_id=getattr(context, "zone_id", None) or ROOT_ZONE_ID,
         user_id=(
             getattr(context, "user_id", None) or getattr(context, "subject_id", None) or "anonymous"
         ),

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -321,7 +321,7 @@ class NexusFS(  # type: ignore[misc]
             self._tiger_cache_manager = TigerCacheManager(
                 rebac_manager=self._rebac_manager,
                 metadata_store=self.metadata,
-                default_zone_id=self._default_context.zone_id or "root",
+                default_zone_id=self._default_context.zone_id or ROOT_ZONE_ID,
                 process_queue_fn=getattr(self, "process_tiger_cache_queue", None),
                 warm_cache_fn=getattr(self, "warm_tiger_cache", None),
             )
@@ -893,7 +893,7 @@ class NexusFS(  # type: ignore[misc]
             modified_at=now,
             version=1,
             created_by=self._get_created_by(context),  # Track who created this directory
-            zone_id=ctx.zone_id or "root",  # P0 SECURITY: Set zone_id
+            zone_id=ctx.zone_id or ROOT_ZONE_ID,  # P0 SECURITY: Set zone_id
         )
 
         self.metadata.put(metadata)
@@ -987,7 +987,7 @@ class NexusFS(  # type: ignore[misc]
                             f"mkdir: Creating parent tuples for intermediate dir: {parent_dir}"
                         )
                         self._hierarchy_manager.ensure_parent_tuples(
-                            parent_dir, zone_id=ctx.zone_id or "root"
+                            parent_dir, zone_id=ctx.zone_id or ROOT_ZONE_ID
                         )
                     except Exception as e:
                         # Don't fail mkdir if parent tuple creation fails
@@ -1014,7 +1014,7 @@ class NexusFS(  # type: ignore[misc]
                     f"mkdir: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or 'default'}"
                 )
                 created_count = self._hierarchy_manager.ensure_parent_tuples(
-                    path, zone_id=ctx.zone_id or "root"
+                    path, zone_id=ctx.zone_id or ROOT_ZONE_ID
                 )
                 logger.debug(f"mkdir: Created {created_count} parent tuples for {path}")
                 if created_count > 0:
@@ -1039,7 +1039,7 @@ class NexusFS(  # type: ignore[misc]
                     subject=("user", ctx.user_id),
                     relation="direct_owner",
                     object=("file", path),
-                    zone_id=ctx.zone_id or "root",
+                    zone_id=ctx.zone_id or ROOT_ZONE_ID,
                 )
                 logger.debug(f"mkdir: Granted direct_owner permission to {ctx.user_id} for {path}")
             except Exception as e:
@@ -1062,7 +1062,7 @@ class NexusFS(  # type: ignore[misc]
             MutationEvent(
                 operation=MutationOp.MKDIR,
                 path=path,
-                zone_id=ctx.zone_id or "root",
+                zone_id=ctx.zone_id or ROOT_ZONE_ID,
                 revision=new_revision,
                 agent_id=ctx.agent_id,
                 user_id=ctx.user_id,
@@ -1228,7 +1228,7 @@ class NexusFS(  # type: ignore[misc]
             MutationEvent(
                 operation=MutationOp.RMDIR,
                 path=path,
-                zone_id=ctx.zone_id or "root",
+                zone_id=ctx.zone_id or ROOT_ZONE_ID,
                 revision=new_revision,
                 agent_id=ctx.agent_id,
                 user_id=ctx.user_id,

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -168,7 +168,7 @@ class NexusFSCoreMixin:
             event = FileEvent(
                 type=file_event_type,
                 path=path,
-                zone_id=zone_id or "root",
+                zone_id=zone_id or ROOT_ZONE_ID,
                 size=size,
                 etag=etag,
                 agent_id=agent_id,
@@ -486,7 +486,7 @@ class NexusFSCoreMixin:
         if cache_observer is None or metadata is None:
             return
 
-        zone_id = getattr(self, "zone_id", None) or "root"
+        zone_id = getattr(self, "zone_id", None) or ROOT_ZONE_ID
         revision = self._get_zone_revision()
         cache_observer.on_read(path, metadata, revision, zone_id, resource_type)
 
@@ -1685,7 +1685,8 @@ class NexusFSCoreMixin:
             created_at=meta.created_at if meta else now,
             modified_at=now,
             created_by=self._get_created_by(context),
-            zone_id=zone_id or "root",  # Issue #904, #773: Store zone_id for PREWHERE filtering
+            zone_id=zone_id
+            or ROOT_ZONE_ID,  # Issue #904, #773: Store zone_id for PREWHERE filtering
         )
 
         self.metadata.put(new_meta)
@@ -1935,7 +1936,8 @@ class NexusFSCoreMixin:
             modified_at=now,
             version=new_version,
             created_by=self._get_created_by(context),  # Track who created/modified this version
-            zone_id=zone_id or "root",  # Issue #904, #773: Store zone_id for PREWHERE filtering
+            zone_id=zone_id
+            or ROOT_ZONE_ID,  # Issue #904, #773: Store zone_id for PREWHERE filtering
             owner_id=owner_id,  # Issue #920: O(1) owner permission checks
         )
 
@@ -1947,7 +1949,7 @@ class NexusFSCoreMixin:
         # Issue #1169: Precise cache invalidation via cache observer
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_write(path, new_revision, zone_id or "root")
+            cache_observer.on_write(path, new_revision, zone_id or ROOT_ZONE_ID)
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         from nexus.contracts.vfs_hooks import MutationEvent
@@ -1976,7 +1978,7 @@ class NexusFSCoreMixin:
                 if tiger_cache:
                     added_count = tiger_cache.add_file_to_ancestor_grants(
                         file_path=path,
-                        zone_id=zone_id or "root",
+                        zone_id=zone_id or ROOT_ZONE_ID,
                     )
                     if added_count > 0:
                         logger.debug(
@@ -2009,9 +2011,11 @@ class NexusFSCoreMixin:
             # DEFERRED PATH: Queue permission operations for background batch processing
             # Owner can still access file immediately via owner_id fast-path
             try:
-                deferred_buffer.queue_hierarchy(path, ctx.zone_id or "root")
+                deferred_buffer.queue_hierarchy(path, ctx.zone_id or ROOT_ZONE_ID)
                 if meta is None and ctx.user_id and not ctx.is_system:
-                    deferred_buffer.queue_owner_grant(ctx.user_id, path, ctx.zone_id or "root")
+                    deferred_buffer.queue_owner_grant(
+                        ctx.user_id, path, ctx.zone_id or ROOT_ZONE_ID
+                    )
             except Exception as e:
                 logger.warning(f"write: Failed to queue deferred permissions for {path}: {e}")
         else:
@@ -2022,7 +2026,7 @@ class NexusFSCoreMixin:
                         f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or 'default'}"
                     )
                     created_count = self._hierarchy_manager.ensure_parent_tuples(
-                        path, zone_id=ctx.zone_id or "root"
+                        path, zone_id=ctx.zone_id or ROOT_ZONE_ID
                     )
                     logger.info(f"write: Created {created_count} parent tuples for {path}")
                 except Exception as e:
@@ -2041,7 +2045,7 @@ class NexusFSCoreMixin:
                             subject=("user", ctx.user_id),
                             relation="direct_owner",
                             object=("file", path),
-                            zone_id=ctx.zone_id or "root",
+                            zone_id=ctx.zone_id or ROOT_ZONE_ID,
                         )
                         logger.debug(
                             f"write: Granted direct_owner permission to {ctx.user_id} for {path}"
@@ -2090,7 +2094,7 @@ class NexusFSCoreMixin:
                 "size": len(content),
                 "etag": content_hash,
                 "version": new_version,
-                "zone_id": zone_id or "root",
+                "zone_id": zone_id or ROOT_ZONE_ID,
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "created": is_new_file,
@@ -2635,7 +2639,8 @@ class NexusFSCoreMixin:
                 version=new_version,
                 created_by=getattr(self, "agent_id", None)
                 or getattr(self, "user_id", None),  # Track who created/modified this version
-                zone_id=zone_id or "root",  # Issue #904, #773: Store zone_id for PREWHERE filtering
+                zone_id=zone_id
+                or ROOT_ZONE_ID,  # Issue #904, #773: Store zone_id for PREWHERE filtering
             )
             metadata_list.append(metadata)
 
@@ -2686,7 +2691,7 @@ class NexusFSCoreMixin:
         # This ensures agents can read files they create (via user inheritance)
         # PERF OPTIMIZATION: Use batch operations instead of individual calls (20x faster)
         ctx = context if context is not None else self._default_context
-        zone_id_for_perms = ctx.zone_id or "root"
+        zone_id_for_perms = ctx.zone_id or ROOT_ZONE_ID
 
         # PERF: Batch hierarchy tuple creation (single transaction instead of N)
         _hierarchy_start = time.perf_counter()
@@ -2985,7 +2990,7 @@ class NexusFSCoreMixin:
         # Issue #1169: Precise cache invalidation via cache observer
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_delete(path, new_revision, zone_id or "root")
+            cache_observer.on_delete(path, new_revision, zone_id or ROOT_ZONE_ID)
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         from nexus.contracts.vfs_hooks import MutationEvent
@@ -3009,7 +3014,7 @@ class NexusFSCoreMixin:
                 "file_path": path,
                 "size": meta.size,
                 "etag": meta.etag,
-                "zone_id": zone_id or "root",
+                "zone_id": zone_id or ROOT_ZONE_ID,
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "timestamp": datetime.now(UTC).isoformat(),
@@ -3167,7 +3172,7 @@ class NexusFSCoreMixin:
         new_revision = self._increment_zone_revision()
         cache_observer = getattr(self, "_cache_observer", None)
         if cache_observer is not None:
-            cache_observer.on_rename(old_path, new_path, new_revision, zone_id or "root")
+            cache_observer.on_rename(old_path, new_path, new_revision, zone_id or ROOT_ZONE_ID)
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         from nexus.contracts.vfs_hooks import MutationEvent
@@ -3239,7 +3244,7 @@ class NexusFSCoreMixin:
                 "new_path": new_path,
                 "size": meta.size if meta else 0,
                 "etag": meta.etag if meta else None,
-                "zone_id": zone_id or "root",
+                "zone_id": zone_id or ROOT_ZONE_ID,
                 "agent_id": agent_id,
                 "user_id": context.user_id if context and hasattr(context, "user_id") else None,
                 "timestamp": datetime.now(UTC).isoformat(),

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -21,6 +21,7 @@ import time
 from collections.abc import Callable
 from typing import Any, cast
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.factory._boot_context import _BootContext
 from nexus.factory._helpers import _make_gate
 
@@ -435,7 +436,7 @@ def _boot_system_services(
         tiger_cache_manager = TigerCacheManager(
             rebac_manager=rebac_manager,
             metadata_store=ctx.metadata_store,
-            default_zone_id=ctx.zone_id or "root",
+            default_zone_id=ctx.zone_id or ROOT_ZONE_ID,
         )
         tiger_cache_manager.initialize()
         logger.debug("[BOOT:SYSTEM] TigerCacheManager created")

--- a/src/nexus/raft/federation.py
+++ b/src/nexus/raft/federation.py
@@ -20,6 +20,8 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from nexus.constants import ROOT_ZONE_ID
+
 logger = logging.getLogger(__name__)
 
 
@@ -100,7 +102,7 @@ class NexusFederation:
         Returns:
             The new zone's ID.
         """
-        root_zone = self._mgr.root_zone_id or "root"
+        root_zone = self._mgr.root_zone_id or ROOT_ZONE_ID
 
         # Step 1: Create zone + copy subtree + DT_MOUNT in parent
         new_zone_id: str = self._mgr.share_subtree(
@@ -163,14 +165,14 @@ class NexusFederation:
             ValueError: If remote_path is not a DT_MOUNT on peer.
             RuntimeError: If zone discovery or join fails.
         """
-        root_zone = self._mgr.root_zone_id or "root"
+        root_zone = self._mgr.root_zone_id or ROOT_ZONE_ID
 
         # Step 1: Discover zone via peer's DT_MOUNT
         client = self._client_factory(peer_addr)
         try:
             metadata = await client.get_metadata(
                 path=remote_path,
-                zone_id="root",
+                zone_id=ROOT_ZONE_ID,
             )
 
             if metadata is None:

--- a/src/nexus/remote/base_client.py
+++ b/src/nexus/remote/base_client.py
@@ -14,6 +14,7 @@ import base64
 import logging
 from typing import Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
@@ -65,7 +66,7 @@ class BaseRemoteNexusFS:
 
     def _negative_cache_key(self, path: str) -> str:
         """Generate cache key with zone isolation."""
-        return f"{self._zone_id or 'root'}:{path}"
+        return f"{self._zone_id or ROOT_ZONE_ID}:{path}"
 
     def _negative_cache_check(self, path: str) -> bool:
         """Check if path is known to not exist (in negative cache).

--- a/src/nexus/server/api/v2/dependencies.py
+++ b/src/nexus/server/api/v2/dependencies.py
@@ -77,7 +77,7 @@ def _get_ace_context(nexus_fs: Any, auth_result: dict[str, Any]) -> ACEContext:
         backend=nexus_fs.memory.backend,
         user_id=context.user_id or "anonymous",
         agent_id=getattr(context, "agent_id", None),
-        zone_id=context.zone_id or "root",
+        zone_id=context.zone_id or ROOT_ZONE_ID,
         context=context,
     )
 

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
@@ -165,7 +166,7 @@ def create_async_files_router(
             return OperationContext(
                 user_id="anonymous",
                 groups=[],
-                zone_id="root",
+                zone_id=ROOT_ZONE_ID,
             )
         return get_operation_context(auth_result)
 

--- a/src/nexus/server/api/v2/routers/batch.py
+++ b/src/nexus/server/api/v2/routers/batch.py
@@ -20,6 +20,7 @@ from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.types import OperationContext
 from nexus.server.batch_executor import BatchExecutor, BatchRequest, BatchResponse
 
@@ -80,7 +81,7 @@ def create_batch_router(
             if auth_result is None or not auth_result.get("authenticated"):
                 from nexus.contracts.types import OperationContext as OC
 
-                return OC(user_id="anonymous", groups=[], zone_id="root")
+                return OC(user_id="anonymous", groups=[], zone_id=ROOT_ZONE_ID)
             return cast("OperationContext", _real_get_operation_context(auth_result))
 
     @router.post("/batch", response_model=BatchResponse)

--- a/src/nexus/server/api/v2/routers/governance.py
+++ b/src/nexus/server/api/v2/routers/governance.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_admin
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ class AddConstraintRequest(BaseModel):
 
     from_agent: str = Field(..., description="Source agent ID")
     to_agent: str = Field(..., description="Target agent ID")
-    zone_id: str = Field(default="root", description="Zone ID")
+    zone_id: str = Field(default=ROOT_ZONE_ID, description="Zone ID")
     constraint_type: str = Field(default="block", description="block, require_approval, rate_limit")
     reason: str = Field(default="", description="Reason for constraint")
 
@@ -43,7 +44,7 @@ class SuspendAgentRequest(BaseModel):
     """Request to suspend an agent."""
 
     agent_id: str = Field(..., description="Agent to suspend")
-    zone_id: str = Field(default="root", description="Zone ID")
+    zone_id: str = Field(default=ROOT_ZONE_ID, description="Zone ID")
     reason: str = Field(..., description="Reason for suspension")
     duration_hours: float = Field(default=24.0, description="Suspension duration in hours")
     severity: str = Field(default="high", description="Severity level")
@@ -109,7 +110,7 @@ def _get_response_service(request: Request) -> Any:
 @router.get("/alerts")
 async def list_alerts(
     request: Request,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
     severity: str | None = Query(default=None),
     resolved: bool | None = Query(default=None),
 ) -> JSONResponse:
@@ -146,7 +147,7 @@ async def resolve_alert(
     request: Request,
     alert_id: str,
     body: ResolveAlertRequest,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
     auth_result: dict = Depends(require_admin),
 ) -> JSONResponse:
     """Resolve an anomaly alert."""
@@ -176,7 +177,7 @@ async def resolve_alert(
 @router.get("/fraud-scores")
 async def list_fraud_scores(
     request: Request,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
 ) -> JSONResponse:
     """List stored fraud scores for all agents in a zone.
 
@@ -206,7 +207,7 @@ async def list_fraud_scores(
 @router.post("/fraud-scores/compute")
 async def compute_fraud_scores(
     request: Request,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
     auth_result: dict = Depends(require_admin),
 ) -> JSONResponse:
     """Recompute and persist fraud scores for all agents in a zone."""
@@ -235,7 +236,7 @@ async def compute_fraud_scores(
 async def get_fraud_score(
     request: Request,
     agent_id: str,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
 ) -> JSONResponse:
     """Get fraud score for a specific agent."""
     service = _get_collusion_service(request)
@@ -258,7 +259,7 @@ async def get_fraud_score(
 @router.get("/rings")
 async def list_fraud_rings(
     request: Request,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
 ) -> JSONResponse:
     """List detected fraud rings in a zone."""
     service = _get_collusion_service(request)
@@ -330,7 +331,7 @@ async def add_constraint(
 @router.get("/constraints")
 async def list_constraints(
     request: Request,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
     agent_id: str | None = Query(default=None),
 ) -> JSONResponse:
     """List governance constraints."""
@@ -359,7 +360,7 @@ async def list_constraints(
 async def remove_constraint(
     request: Request,
     edge_id: str,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
 ) -> JSONResponse:
     """Remove a governance constraint."""
     service = _get_graph_service(request)
@@ -376,7 +377,7 @@ async def check_constraint(
     request: Request,
     from_agent: str,
     to_agent: str,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
 ) -> JSONResponse:
     """Check governance constraint between two agents."""
     service = _get_graph_service(request)
@@ -442,7 +443,7 @@ async def suspend_agent(
 @router.get("/suspensions")
 async def list_suspensions(
     request: Request,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
     agent_id: str | None = Query(default=None),
 ) -> JSONResponse:
     """List suspensions."""
@@ -474,7 +475,7 @@ async def appeal_suspension(
     request: Request,
     suspension_id: str,
     body: AppealRequest,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
 ) -> JSONResponse:
     """Appeal a suspension."""
     service = _get_response_service(request)
@@ -506,7 +507,7 @@ async def decide_appeal(
     request: Request,
     suspension_id: str,
     body: DecideAppealRequest,
-    zone_id: str = Query(default="root"),
+    zone_id: str = Query(default=ROOT_ZONE_ID),
     auth_result: dict = Depends(require_admin),
 ) -> JSONResponse:
     """Decide on a suspension appeal."""

--- a/src/nexus/server/api/v2/routers/graph.py
+++ b/src/nexus/server/api/v2/routers/graph.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_auth
 
 logger = logging.getLogger(__name__)
@@ -90,7 +91,7 @@ async def _graph_session(
 
 def _zone_id_from(nexus_fs: Any) -> str:
     """Extract zone_id from a NexusFS instance, defaulting to "root"."""
-    return getattr(nexus_fs, "zone_id", None) or "root"
+    return getattr(nexus_fs, "zone_id", None) or ROOT_ZONE_ID
 
 
 # =============================================================================

--- a/src/nexus/server/api/v2/routers/locks.py
+++ b/src/nexus/server/api/v2/routers/locks.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.api.v2.models.locks import (
     LockAcquireRequest,
     LockExtendRequest,
@@ -110,7 +111,7 @@ async def acquire_lock(
     Supports both mutex (max_holders=1) and semaphore (max_holders>1) modes.
     Use blocking=false for non-blocking acquisition (returns immediately).
     """
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     path = _normalize_path(request.path)
     timeout = request.timeout if request.blocking else 0.0
 
@@ -162,7 +163,7 @@ async def list_locks(
     lock_manager: Any = Depends(_get_lock_manager),
 ) -> LockListResponse:
     """List active locks for the current zone."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     lock_infos = await lock_manager.list_locks(zone_id, pattern=pattern, limit=limit)
 
     locks: list[LockInfoMutex | LockInfoSemaphore] = [
@@ -178,7 +179,7 @@ async def get_lock_status(
     lock_manager: Any = Depends(_get_lock_manager),
 ) -> LockStatusResponse:
     """Get lock status for a specific path."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     path = _normalize_path(path)
 
     lock_info = await lock_manager.get_lock_info(zone_id, path)
@@ -201,7 +202,7 @@ async def release_lock(
     The lock_id must match the ID returned during acquisition.
     Use force=true for admin recovery of stuck locks (requires admin role).
     """
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     path = _normalize_path(path)
 
     if force:
@@ -234,7 +235,7 @@ async def extend_lock(
     Call this periodically (e.g., every TTL/2) to keep long-running
     operations alive. The lock must be owned by the caller (lock_id match).
     """
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     path = _normalize_path(path)
 
     extended = await lock_manager.extend(request.lock_id, zone_id, path, ttl=request.ttl)

--- a/src/nexus/server/api/v2/routers/subscriptions.py
+++ b/src/nexus/server/api/v2/routers/subscriptions.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_auth
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ async def create_subscription(
 
     body = await request.json()
     data = SubscriptionCreate(**body)
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     created_by = auth_result.get("subject_id")
 
     subscription = subscription_manager.create(
@@ -77,7 +78,7 @@ async def list_subscriptions(
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """List webhook subscriptions for the current zone."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     subscriptions = subscription_manager.list_subscriptions(
         zone_id=zone_id,
         enabled_only=enabled_only,
@@ -96,7 +97,7 @@ async def get_subscription(
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Get a webhook subscription by ID."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     subscription = subscription_manager.get(subscription_id, zone_id)
     if subscription is None:
         raise HTTPException(status_code=404, detail="Subscription not found")
@@ -115,7 +116,7 @@ async def update_subscription(
 
     body = await request.json()
     data = SubscriptionUpdate(**body)
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
 
     subscription = subscription_manager.update(
         subscription_id=subscription_id,
@@ -134,7 +135,7 @@ async def delete_subscription(
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Delete a webhook subscription."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     deleted = subscription_manager.delete(subscription_id, zone_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Subscription not found")
@@ -148,6 +149,6 @@ async def test_subscription(
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Send a test event to a webhook subscription."""
-    zone_id = auth_result.get("zone_id") or "root"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     result = await subscription_manager.test(subscription_id, zone_id)
     return JSONResponse(content=result)

--- a/src/nexus/services/event_subsystem/bus/nats.py
+++ b/src/nexus/services/event_subsystem/bus/nats.py
@@ -36,7 +36,7 @@ from nats.js.api import (
 )
 from nats.js.errors import NotFoundError
 
-from nexus.constants import DEFAULT_NATS_URL
+from nexus.constants import DEFAULT_NATS_URL, ROOT_ZONE_ID
 from nexus.services.event_subsystem.bus.base import EventBusBase
 from nexus.services.event_subsystem.bus.decorators import requires_started
 from nexus.services.event_subsystem.bus.protocol import AckableEvent
@@ -177,7 +177,7 @@ class NatsEventBus(EventBusBase):
         if self._js is None:
             raise RuntimeError("NatsEventBus JetStream not initialized.")
 
-        zone_id = event.zone_id or "root"
+        zone_id = event.zone_id or ROOT_ZONE_ID
         event_type = event.type.value if isinstance(event.type, FileEventType) else event.type
         subject = self._subject(zone_id, event_type)
 
@@ -217,7 +217,7 @@ class NatsEventBus(EventBusBase):
 
         results = []
         for event in events:
-            zone_id = event.zone_id or "root"
+            zone_id = event.zone_id or ROOT_ZONE_ID
             event_type = event.type.value if isinstance(event.type, FileEventType) else event.type
             subject = self._subject(zone_id, event_type)
 

--- a/src/nexus/services/event_subsystem/bus/redis.py
+++ b/src/nexus/services/event_subsystem/bus/redis.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from cachetools import TTLCache
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.services.event_subsystem.bus.base import EventBusBase
 from nexus.services.event_subsystem.bus.decorators import requires_started
 from nexus.services.event_subsystem.bus.protocol import AckableEvent, PubSubClientProtocol
@@ -115,7 +116,7 @@ class RedisEventBus(EventBusBase):
             except Exception as e:
                 logger.error(f"Event log append failed (event still published): {e}")
 
-        zone_id = event.zone_id or "root"
+        zone_id = event.zone_id or ROOT_ZONE_ID
         channel = self._channel_name(zone_id)
 
         # Explicit serialization error handling
@@ -176,7 +177,7 @@ class RedisEventBus(EventBusBase):
         pipeline = self._redis.client.pipeline()
 
         for event in unique_events:
-            zone_id = event.zone_id or "root"
+            zone_id = event.zone_id or ROOT_ZONE_ID
             channel = self._channel_name(zone_id)
 
             try:

--- a/src/nexus/services/event_subsystem/log/delivery.py
+++ b/src/nexus/services/event_subsystem/log/delivery.py
@@ -24,6 +24,7 @@ import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.operation_types import OperationType
 from nexus.services.event_subsystem.types import FileEvent, FileEventType
 
@@ -274,7 +275,7 @@ class EventDeliveryWorker:
                             "size": event.size,
                             "timestamp": event.timestamp,
                         },
-                        zone_id=event.zone_id or "root",
+                        zone_id=event.zone_id or ROOT_ZONE_ID,
                     )
 
                 _run_async(_broadcast(), self._event_loop)
@@ -368,7 +369,7 @@ class EventDeliveryWorker:
         return FileEvent(
             type=event_type,
             path=record.path,
-            zone_id=record.zone_id or "root",
+            zone_id=record.zone_id or ROOT_ZONE_ID,
             timestamp=record.created_at.isoformat() if record.created_at else "",
             old_path=record.new_path,  # new_path stores old_path for renames
             agent_id=record.agent_id,

--- a/src/nexus/storage/models/a2a.py
+++ b/src/nexus/storage/models/a2a.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid
 
 
@@ -24,7 +25,7 @@ class A2ATaskModel(Base):
     context_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
 
     # Multi-tenant isolation
-    zone_id: Mapped[str] = mapped_column(String(128), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(128), nullable=False, default=ROOT_ZONE_ID)
     agent_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     # Task state (TaskState enum value)

--- a/src/nexus/storage/models/access_manifest.py
+++ b/src/nexus/storage/models/access_manifest.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid
 
 
@@ -38,7 +39,7 @@ class AccessManifestModel(Base):
     zone_id: Mapped[str] = mapped_column(
         String(255),
         nullable=False,
-        default="root",
+        default=ROOT_ZONE_ID,
     )
 
     name: Mapped[str] = mapped_column(

--- a/src/nexus/storage/models/ace.py
+++ b/src/nexus/storage/models/ace.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, uuid_pk
 
@@ -35,7 +36,7 @@ class TrajectoryModel(Base):
 
     user_id: Mapped[str] = mapped_column(String(255), nullable=False)
     agent_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     task_description: Mapped[str] = mapped_column(Text, nullable=False)
     task_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
@@ -157,7 +158,7 @@ class PlaybookModel(Base):
 
     user_id: Mapped[str] = mapped_column(String(255), nullable=False)
     agent_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/nexus/storage/models/auth.py
+++ b/src/nexus/storage/models/auth.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, uuid_pk
 
@@ -139,7 +140,9 @@ class APIKeyModel(Base):
     user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     subject_type: Mapped[str | None] = mapped_column(String(50), nullable=True, default="user")
     subject_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root", index=True)
+    zone_id: Mapped[str] = mapped_column(
+        String(255), nullable=False, default=ROOT_ZONE_ID, index=True
+    )
     is_admin: Mapped[int] = mapped_column(Integer, default=0)
 
     inherit_permissions: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
@@ -196,7 +199,7 @@ class OAuthCredentialModel(Base):
 
     user_email: Mapped[str] = mapped_column(String(255), nullable=False)
     user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     encrypted_access_token: Mapped[str] = mapped_column(Text, nullable=False)
     encrypted_refresh_token: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/nexus/storage/models/context_branch.py
+++ b/src/nexus/storage/models/context_branch.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from sqlalchemy import Boolean, DateTime, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, uuid_pk
 
 
@@ -31,7 +32,7 @@ class ContextBranchModel(Base):
 
     id: Mapped[str] = uuid_pk()
 
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     workspace_path: Mapped[str] = mapped_column(Text, nullable=False)
     branch_name: Mapped[str] = mapped_column(String(255), nullable=False)
 

--- a/src/nexus/storage/models/dispute.py
+++ b/src/nexus/storage/models/dispute.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 from sqlalchemy import Boolean, DateTime, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 
@@ -38,7 +39,7 @@ class DisputeModel(Base):
 
     # Exchange + zone
     exchange_id: Mapped[str] = mapped_column(String(36), nullable=False)
-    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default=ROOT_ZONE_ID)
 
     # Parties
     complainant_agent_id: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/src/nexus/storage/models/exchange_audit_log.py
+++ b/src/nexus/storage/models/exchange_audit_log.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, Index, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 
@@ -58,7 +59,7 @@ class ExchangeAuditLogModel(Base):
     currency: Mapped[str] = mapped_column(String(10), nullable=False, default="credits")
 
     # Context
-    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default=ROOT_ZONE_ID)
     trace_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     metadata_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     transfer_id: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/src/nexus/storage/models/file_path.py
+++ b/src/nexus/storage/models/file_path.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import BigInteger, DateTime, Index, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 if TYPE_CHECKING:
@@ -32,7 +33,7 @@ class FilePathModel(Base):
     )
 
     # P0 SECURITY: Defense-in-depth zone isolation
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     # Path information
     virtual_path: Mapped[str] = mapped_column(Text, nullable=False)

--- a/src/nexus/storage/models/filesystem.py
+++ b/src/nexus/storage/models/filesystem.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, uuid_pk
 
@@ -35,7 +36,7 @@ class DirectoryEntryModel(Base):
     __tablename__ = "directory_entries"
 
     zone_id: Mapped[str] = mapped_column(
-        String(255), primary_key=True, nullable=False, default="root"
+        String(255), primary_key=True, nullable=False, default=ROOT_ZONE_ID
     )
     parent_path: Mapped[str] = mapped_column(String(4096), primary_key=True, nullable=False)
     entry_name: Mapped[str] = mapped_column(String(255), primary_key=True, nullable=False)

--- a/src/nexus/storage/models/infrastructure.py
+++ b/src/nexus/storage/models/infrastructure.py
@@ -10,6 +10,7 @@ from typing import Any
 from sqlalchemy import DateTime, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, ResourceConfigMixin, TimestampMixin, uuid_pk
 
@@ -98,7 +99,7 @@ class MountConfigModel(TimestampMixin, Base):
     backend_config: Mapped[str] = mapped_column(Text, nullable=False)
 
     owner_user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     conflict_strategy: Mapped[str | None] = mapped_column(String(50), nullable=True, default=None)
@@ -308,7 +309,7 @@ class UserSessionModel(Base):
 
     user_id: Mapped[str] = mapped_column(String(255), nullable=False)
     agent_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)

--- a/src/nexus/storage/models/memory.py
+++ b/src/nexus/storage/models/memory.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, ResourceConfigMixin, uuid_pk
 
@@ -36,7 +37,7 @@ class MemoryModel(Base):
 
     content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
 
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     agent_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
@@ -259,7 +260,7 @@ class EntityModel(Base):
 
     entity_id: Mapped[str] = uuid_pk()
 
-    zone_id: Mapped[str] = mapped_column(String(64), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(64), nullable=False, default=ROOT_ZONE_ID)
 
     canonical_name: Mapped[str] = mapped_column(String(512), nullable=False)
     entity_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
@@ -353,7 +354,7 @@ class RelationshipModel(Base):
 
     relationship_id: Mapped[str] = uuid_pk()
 
-    zone_id: Mapped[str] = mapped_column(String(64), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(64), nullable=False, default=ROOT_ZONE_ID)
 
     source_entity_id: Mapped[str] = mapped_column(
         String(36),

--- a/src/nexus/storage/models/operation_log.py
+++ b/src/nexus/storage/models/operation_log.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from sqlalchemy import BigInteger, Boolean, DateTime, Index, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 
@@ -32,7 +33,7 @@ class OperationLogModel(Base):
     operation_type: Mapped[str] = mapped_column(String(50), nullable=False)
 
     # Context
-    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default=ROOT_ZONE_ID)
     agent_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Affected paths

--- a/src/nexus/storage/models/payments.py
+++ b/src/nexus/storage/models/payments.py
@@ -10,6 +10,7 @@ from typing import Any
 from sqlalchemy import BigInteger, Boolean, DateTime, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, uuid_pk
 
 
@@ -22,7 +23,7 @@ class AgentWalletMeta(Base):
     __tablename__ = "agent_wallet_meta"
 
     agent_id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     tigerbeetle_account_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
     x402_address: Mapped[str | None] = mapped_column(String(64), nullable=True)
     x402_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
@@ -48,7 +49,7 @@ class PaymentTransactionMeta(Base):
     __tablename__ = "payment_transaction_meta"
 
     id: Mapped[str] = uuid_pk()
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     tigerbeetle_transfer_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
     from_agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
     to_agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
@@ -79,7 +80,7 @@ class CreditReservationMeta(Base):
     __tablename__ = "credit_reservation_meta"
 
     id: Mapped[str] = uuid_pk()
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     tigerbeetle_transfer_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
     agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
     amount: Mapped[int] = mapped_column(BigInteger, nullable=False)
@@ -106,7 +107,7 @@ class UsageEvent(Base):
     __tablename__ = "usage_events"
 
     id: Mapped[str] = uuid_pk()
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
     event_type: Mapped[str] = mapped_column(String(50), nullable=False)
     amount: Mapped[int] = mapped_column(BigInteger, nullable=False)

--- a/src/nexus/storage/models/permissions.py
+++ b/src/nexus/storage/models/permissions.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base
 
 
@@ -33,9 +34,9 @@ class ReBACTupleModel(Base):
 
     tuple_id: Mapped[str] = mapped_column(String(36), primary_key=True)
 
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
-    subject_zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
-    object_zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
+    subject_zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
+    object_zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     subject_type: Mapped[str] = mapped_column(String(50), nullable=False)
     subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -210,7 +211,9 @@ class ReBACChangelogModel(Base):
     object_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
     object_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root", index=True)
+    zone_id: Mapped[str] = mapped_column(
+        String(255), nullable=False, default=ROOT_ZONE_ID, index=True
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False, index=True
@@ -252,7 +255,7 @@ class ReBACCheckCacheModel(Base):
 
     cache_id: Mapped[str] = mapped_column(String(36), primary_key=True)
 
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     subject_type: Mapped[str] = mapped_column(String(50), nullable=False)
     subject_id: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/src/nexus/storage/models/persistent_namespace_view.py
+++ b/src/nexus/storage/models/persistent_namespace_view.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid
 
 
@@ -39,7 +40,7 @@ class PersistentNamespaceViewModel(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_generate_uuid)
     subject_type: Mapped[str] = mapped_column(String(50), nullable=False)
     subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     mount_paths_json: Mapped[str] = mapped_column(Text, nullable=False)
     grants_hash: Mapped[str] = mapped_column(String(16), nullable=False)
     revision_bucket: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/src/nexus/storage/models/refresh_token_history.py
+++ b/src/nexus/storage/models/refresh_token_history.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 
@@ -38,7 +39,7 @@ class RefreshTokenHistoryModel(Base):
     credential_id: Mapped[str] = mapped_column(String(36), nullable=False)
     refresh_token_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     rotation_counter: Mapped[int] = mapped_column(Integer, nullable=False)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     rotated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/nexus/storage/models/reputation_event.py
+++ b/src/nexus/storage/models/reputation_event.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, Float, Index, String
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 
@@ -48,7 +49,7 @@ class ReputationEventModel(Base):
     rater_agent_id: Mapped[str] = mapped_column(String(255), nullable=False)
     rated_agent_id: Mapped[str] = mapped_column(String(255), nullable=False)
     exchange_id: Mapped[str] = mapped_column(String(36), nullable=False)
-    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default=ROOT_ZONE_ID)
 
     # Event classification
     event_type: Mapped[str] = mapped_column(String(30), nullable=False)

--- a/src/nexus/storage/models/reputation_score.py
+++ b/src/nexus/storage/models/reputation_score.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, Float, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base
 
 
@@ -61,7 +62,7 @@ class ReputationScoreModel(Base):
     global_trust_score: Mapped[float | None] = mapped_column(Float, nullable=True)
 
     # Zone scope
-    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default=ROOT_ZONE_ID)
 
     # Last update timestamp
     updated_at: Mapped[datetime] = mapped_column(

--- a/src/nexus/storage/models/scheduler.py
+++ b/src/nexus/storage/models/scheduler.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 from sqlalchemy import DateTime, Index, Numeric, SmallInteger, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, uuid_pk
 
 
@@ -40,7 +41,7 @@ class ScheduledTaskModel(Base):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
     idempotency_key: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     __table_args__ = (

--- a/src/nexus/storage/models/secrets_audit_log.py
+++ b/src/nexus/storage/models/secrets_audit_log.py
@@ -12,6 +12,7 @@ from enum import StrEnum
 from sqlalchemy import DateTime, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 
@@ -67,7 +68,7 @@ class SecretsAuditLogModel(Base):
     token_family_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
 
     # Context
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
 
     # Additional details (JSON text — must NEVER contain secrets)

--- a/src/nexus/storage/models/sharing.py
+++ b/src/nexus/storage/models/sharing.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, uuid_pk
 
 
@@ -31,7 +32,9 @@ class ShareLinkModel(Base):
 
     permission_level: Mapped[str] = mapped_column(String(20), nullable=False, default="viewer")
 
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root", index=True)
+    zone_id: Mapped[str] = mapped_column(
+        String(255), nullable=False, default=ROOT_ZONE_ID, index=True
+    )
 
     created_by: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 

--- a/src/nexus/storage/models/sync.py
+++ b/src/nexus/storage/models/sync.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from sqlalchemy import BigInteger, DateTime, Float, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import ValidationError
 from nexus.storage.models._base import Base, uuid_pk
 
@@ -92,7 +93,7 @@ class BackendChangeLogModel(Base):
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )
 
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     __table_args__ = (
         UniqueConstraint("path", "backend_name", "zone_id", name="uq_backend_change_log"),
@@ -127,7 +128,7 @@ class SyncBacklogModel(Base):
 
     path: Mapped[str] = mapped_column(String(4096), nullable=False)
     backend_name: Mapped[str] = mapped_column(String(255), nullable=False)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     operation_type: Mapped[str] = mapped_column(String(50), nullable=False)
     content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
@@ -176,7 +177,7 @@ class ConflictLogModel(Base):
 
     path: Mapped[str] = mapped_column(String(4096), nullable=False)
     backend_name: Mapped[str] = mapped_column(String(255), nullable=False)
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
 
     strategy: Mapped[str] = mapped_column(String(50), nullable=False)
     outcome: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/src/nexus/storage/models/transaction_snapshot.py
+++ b/src/nexus/storage/models/transaction_snapshot.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from sqlalchemy import DateTime, Index, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 
@@ -29,7 +30,7 @@ class TransactionSnapshotModel(Base):
         default=_generate_uuid,
         server_default=_get_uuid_server_default(),
     )
-    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default=ROOT_ZONE_ID)
     agent_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/nexus/storage/models/upload_session.py
+++ b/src/nexus/storage/models/upload_session.py
@@ -10,6 +10,7 @@ from typing import Any
 from sqlalchemy import DateTime, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
 
@@ -39,7 +40,7 @@ class UploadSessionModel(Base):
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="created")
 
     # Identity
-    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
     user_id: Mapped[str] = mapped_column(String(255), nullable=False, default="anonymous")
 
     # tus metadata (JSON-encoded)


### PR DESCRIPTION
## Summary
- Comprehensive sweep replacing **every** hardcoded `"root"` zone ID string with `ROOT_ZONE_ID` constant from `nexus.constants` across **43 files**
- Covers: server routers, bricks, contracts, core kernel, factory, raft, remote, services, and 24 storage model column defaults
- Only docstring/comment examples remain as string literals (acceptable)
- Replaces closed PR #2525

## Files changed
- **Server**: batch.py, async_files.py, snapshots.py, locks.py, subscriptions.py, graph.py, governance.py, dependencies.py
- **Bricks**: rebac bulk_checker, expander
- **Contracts**: types.py
- **Core**: nexus_fs.py, nexus_fs_core.py
- **Factory**: _system.py
- **Raft**: federation.py
- **Remote**: base_client.py
- **Services**: event_subsystem (nats, redis, delivery)
- **Storage models**: 24 files (a2a, ace, auth, context_branch, dispute, exchange_audit_log, file_path, filesystem, infrastructure, memory, operation_log, payments, permissions, persistent_namespace_view, refresh_token_history, reputation_event, reputation_score, scheduler, secrets_audit_log, sharing, sync, transaction_snapshot, upload_session, access_manifest)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, ruff format, etc.)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)