### PR TITLE
fix(#965): move cache_invalidation.py from core/ to storage/

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -292,7 +292,7 @@ class NexusFS(  # type: ignore[misc]
         self._read_set_cache = None
         metadata_cache = getattr(self.metadata, "_cache", None)
         if metadata_cache is not None and self._cache_config.enable_metadata_cache:
-            from nexus.core.read_set import ReadSetRegistry
+            from nexus.storage.read_set import ReadSetRegistry
             from nexus.storage.read_set_cache import ReadSetAwareCache
 
             self._read_set_registry = ReadSetRegistry()
@@ -306,7 +306,7 @@ class NexusFS(  # type: ignore[misc]
         # (Removed from KernelServices — NexusFS owns the cache observer lifecycle.)
         self._cache_observer = None
         if self._read_set_cache is not None:
-            from nexus.core.cache_invalidation import ReadSetCacheObserver
+            from nexus.storage.cache_invalidation import ReadSetCacheObserver
 
             self._cache_observer = ReadSetCacheObserver(self._read_set_cache)
 

--- a/src/nexus/storage/cache_invalidation.py
+++ b/src/nexus/storage/cache_invalidation.py
@@ -78,7 +78,7 @@ class ReadSetCacheObserver:
         if metadata is None:
             return
 
-        from nexus.core.read_set import ReadSet
+        from nexus.storage.read_set import ReadSet
 
         rs = ReadSet(query_id=f"cache:{path}", zone_id=zone_id)
         rs.record_read(resource_type, path, revision=revision)


### PR DESCRIPTION
## Summary
- Move `cache_invalidation.py` from `core/` to `storage/` — it's a cache/storage concern, not kernel logic
- Fix broken `from nexus.core.read_set import ReadSetRegistry` in `nexus_fs.py` (read_set.py was moved to storage/ earlier but this import was missed)
- Fix internal `from nexus.core.read_set import ReadSet` inside the moved file → `from nexus.storage.read_set`
- No backward compat shim — old file deleted completely

## Test plan
- [ ] Pre-commit hooks pass (ruff, mypy, import boundary checks)
- [ ] CI green
- [ ] No remaining references to `nexus.core.cache_invalidation` or `nexus.core.read_set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)