### PR TITLE
feat(#963): rename kernel _zone_revision to _vfs_revision

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1046,7 +1046,7 @@ class NexusFS(  # type: ignore[misc]
                 logger.warning(f"Failed to grant direct_owner permission for {path}: {e}")
 
         # Issue #900: Unified two-phase dispatch for mkdir
-        new_revision = self._increment_zone_revision()
+        new_revision = self._increment_vfs_revision()
 
         from nexus.contracts.vfs_hooks import MkdirHookContext, MutationEvent
 
@@ -1211,7 +1211,7 @@ class NexusFS(  # type: ignore[misc]
                 logger.debug("Failed to clean up directory index for %s: %s", path, e)
 
         # Issue #900: Unified two-phase dispatch for rmdir
-        new_revision = self._increment_zone_revision()
+        new_revision = self._increment_vfs_revision()
 
         from nexus.contracts.vfs_hooks import MutationEvent, RmdirHookContext
 

--- a/src/nexus/core/nexus_fs_bulk.py
+++ b/src/nexus/core/nexus_fs_bulk.py
@@ -53,7 +53,7 @@ class NexusFSBulkMixin:
         - _permission_checker: object with .check() method
         - auto_parse: bool
         - Various methods: _validate_path, _get_routing_params, _check_zone_writable,
-          _fire_post_mutation_hooks, _increment_zone_revision,
+          _fire_post_mutation_hooks, _increment_vfs_revision,
           _check_permission, _get_zone_id, exists, delete, rename, is_directory,
           _has_descendant_access, _rmdir_internal
     """
@@ -113,7 +113,7 @@ class NexusFSBulkMixin:
             is_new: bool = False,
             new_path: str | None = None,
         ) -> None: ...
-        def _increment_zone_revision(self) -> int: ...
+        def _increment_vfs_revision(self) -> int: ...
         # _handle_observer_error → removed (Issue #2152)
         @staticmethod
         def _resolve_write_urgency(io_profile: str) -> str | None: ...
@@ -659,7 +659,7 @@ class NexusFSBulkMixin:
             )
 
         # Fire post-mutation hooks for each file in the batch
-        new_revision = self._increment_zone_revision()
+        new_revision = self._increment_vfs_revision()
         for metadata in metadata_list:
             is_new = existing_metadata.get(metadata.path) is None
             self._fire_post_mutation_hooks(

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -42,10 +42,10 @@ class NexusFSCoreMixin:
 
     _revision_notifier: ClassVar[Any] = None
 
-    # Issue #1169: Defaults for per-instance zone revision state.
-    # Actual instances override these in _init_zone_revision().
-    _zone_revision: int = 0
-    _zone_revision_lock: threading.Lock | None = None
+    # Issue #1169: Defaults for per-instance VFS revision state.
+    # Actual instances override these in _init_vfs_revision().
+    _vfs_revision: int = 0
+    _vfs_revision_lock: threading.Lock | None = None
     _read_tracking_enabled: bool = False
 
     # Type hints for attributes/methods that will be provided by NexusFS parent class
@@ -373,20 +373,20 @@ class NexusFSCoreMixin:
         return notifier.wait_for_revision(zone_id, min_revision, timeout_ms)
 
     # =========================================================================
-    # Zone Revision Counter - Issue #1169
+    # VFS Revision Counter - Issue #1169
     # =========================================================================
 
-    def _init_zone_revision(self) -> None:
-        """Initialize per-instance zone revision state.
+    def _init_vfs_revision(self) -> None:
+        """Initialize per-instance VFS revision state.
 
         Must be called during NexusFS.__init__ to ensure each instance
         has its own lock and counter (not shared via class-level defaults).
         """
-        self._zone_revision = 0
-        self._zone_revision_lock = threading.Lock()
+        self._vfs_revision = 0
+        self._vfs_revision_lock = threading.Lock()
 
-    def _increment_zone_revision(self) -> int:
-        """Atomically increment and return the new zone revision.
+    def _increment_vfs_revision(self) -> int:
+        """Atomically increment and return the new VFS revision.
 
         Called after every write/delete to advance the monotonic counter.
         Thread-safe via per-instance lock.
@@ -394,26 +394,26 @@ class NexusFSCoreMixin:
         Returns:
             The new revision number (always > previous).
         """
-        lock = self._zone_revision_lock
+        lock = self._vfs_revision_lock
         if lock is None:
             # Fallback: not yet initialized (shouldn't happen in production)
-            self._zone_revision += 1
-            return self._zone_revision
+            self._vfs_revision += 1
+            return self._vfs_revision
         with lock:
-            self._zone_revision += 1
-            return self._zone_revision
+            self._vfs_revision += 1
+            return self._vfs_revision
 
-    def _get_zone_revision(self) -> int:
-        """Return the current zone revision (read-only, thread-safe).
+    def _get_vfs_revision(self) -> int:
+        """Return the current VFS revision (read-only, thread-safe).
 
         Returns:
             Current monotonic revision counter value.
         """
-        lock = self._zone_revision_lock
+        lock = self._vfs_revision_lock
         if lock is None:
-            return self._zone_revision
+            return self._vfs_revision
         with lock:
-            return self._zone_revision
+            return self._vfs_revision
 
     # =========================================================================
     # Read Set Tracking - Issue #1166 / #1169
@@ -431,7 +431,7 @@ class NexusFSCoreMixin:
         This is called automatically by read(), stat(), and list() operations
         when the context has read tracking enabled.
 
-        Issue #1169: Uses per-zone monotonic counter instead of hardcoded 0.
+        Issue #1169: Uses per-VFS monotonic counter instead of hardcoded 0.
                      Gated by instance-level _read_tracking_enabled flag.
 
         Args:
@@ -449,8 +449,8 @@ class NexusFSCoreMixin:
         if context.read_set is None:
             return
 
-        # Issue #1169: Use per-zone monotonic counter for meaningful revisions
-        revision = self._get_zone_revision()
+        # Issue #1169: Use per-VFS monotonic counter for meaningful revisions
+        revision = self._get_vfs_revision()
 
         # Record the read
         context.record_read(
@@ -486,8 +486,8 @@ class NexusFSCoreMixin:
         if cache_observer is None or metadata is None:
             return
 
-        zone_id = getattr(self, "zone_id", None) or "root"
-        revision = self._get_zone_revision()
+        zone_id = getattr(self, "zone_id", None) or ROOT_ZONE_ID
+        revision = self._get_vfs_revision()
         cache_observer.on_read(path, metadata, revision, zone_id, resource_type)
 
     # =========================================================================
@@ -1941,8 +1941,8 @@ class NexusFSCoreMixin:
 
         self.metadata.put(metadata)
 
-        # Issue #1169: Advance zone revision counter after mutation
-        new_revision = self._increment_zone_revision()
+        # Issue #1169: Advance VFS revision counter after mutation
+        new_revision = self._increment_vfs_revision()
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         from nexus.contracts.vfs_hooks import MutationEvent
@@ -2660,7 +2660,7 @@ class NexusFSCoreMixin:
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         from nexus.contracts.vfs_hooks import MutationEvent
 
-        new_revision = self._increment_zone_revision()
+        new_revision = self._increment_vfs_revision()
         for metadata in metadata_list:
             is_new = existing_metadata.get(metadata.path) is None
             self._dispatch.notify(
@@ -2974,8 +2974,8 @@ class NexusFSCoreMixin:
         # Remove from metadata
         self.metadata.delete(path)
 
-        # Issue #1169: Advance zone revision counter after delete
-        new_revision = self._increment_zone_revision()
+        # Issue #1169: Advance VFS revision counter after delete
+        new_revision = self._increment_vfs_revision()
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         from nexus.contracts.vfs_hooks import MutationEvent
@@ -3153,7 +3153,7 @@ class NexusFSCoreMixin:
         # For connector backends: metadata follows the file we just moved
         self.metadata.rename_path(old_path, new_path)
 
-        new_revision = self._increment_zone_revision()
+        new_revision = self._increment_vfs_revision()
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         from nexus.contracts.vfs_hooks import MutationEvent

--- a/tests/unit/storage/test_read_set_cache.py
+++ b/tests/unit/storage/test_read_set_cache.py
@@ -318,28 +318,28 @@ class TestZoneRevisionCounter:
         from nexus.core.nexus_fs_core import NexusFSCoreMixin
 
         mixin = NexusFSCoreMixin()
-        mixin._init_zone_revision()
+        mixin._init_vfs_revision()
 
-        values = [mixin._increment_zone_revision() for _ in range(100)]
+        values = [mixin._increment_vfs_revision() for _ in range(100)]
         assert values == list(range(1, 101))
 
     def test_get_returns_current(self):
-        """get_zone_revision returns the latest value."""
+        """get_vfs_revision returns the latest value."""
         from nexus.core.nexus_fs_core import NexusFSCoreMixin
 
         mixin = NexusFSCoreMixin()
-        mixin._init_zone_revision()
+        mixin._init_vfs_revision()
 
-        assert mixin._get_zone_revision() == 0
-        mixin._increment_zone_revision()
-        assert mixin._get_zone_revision() == 1
+        assert mixin._get_vfs_revision() == 0
+        mixin._increment_vfs_revision()
+        assert mixin._get_vfs_revision() == 1
 
     def test_concurrent_increments_no_lost_updates(self):
         """50 threads * 100 increments = 5000 total, no lost updates."""
         from nexus.core.nexus_fs_core import NexusFSCoreMixin
 
         mixin = NexusFSCoreMixin()
-        mixin._init_zone_revision()
+        mixin._init_vfs_revision()
 
         n_threads = 50
         n_per_thread = 100
@@ -348,7 +348,7 @@ class TestZoneRevisionCounter:
         def worker():
             barrier.wait()  # Ensure all threads start simultaneously
             for _ in range(n_per_thread):
-                mixin._increment_zone_revision()
+                mixin._increment_vfs_revision()
 
         threads = [threading.Thread(target=worker) for _ in range(n_threads)]
         for t in threads:
@@ -356,14 +356,14 @@ class TestZoneRevisionCounter:
         for t in threads:
             t.join()
 
-        assert mixin._get_zone_revision() == n_threads * n_per_thread
+        assert mixin._get_vfs_revision() == n_threads * n_per_thread
 
     def test_concurrent_no_duplicate_values(self):
         """Each increment returns a unique value (no duplicates)."""
         from nexus.core.nexus_fs_core import NexusFSCoreMixin
 
         mixin = NexusFSCoreMixin()
-        mixin._init_zone_revision()
+        mixin._init_vfs_revision()
 
         n_threads = 20
         n_per_thread = 50
@@ -373,7 +373,7 @@ class TestZoneRevisionCounter:
         def worker(idx):
             barrier.wait()
             for _ in range(n_per_thread):
-                results[idx].append(mixin._increment_zone_revision())
+                results[idx].append(mixin._increment_vfs_revision())
 
         threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
         for t in threads:


### PR DESCRIPTION
## Summary
- Renames the kernel's internal monotonic VFS revision counter from `_zone_revision` to `_vfs_revision` (like Linux `i_version`)
- "Zone" is a federation concept — the kernel counter is VFS-scoped, not zone-scoped
- Renames: `_zone_revision`, `_zone_revision_lock`, `_init_zone_revision()`, `_increment_zone_revision()`, `_get_zone_revision()` → `_vfs_revision` equivalents
- Only affects 3 kernel files (`nexus_fs_core.py`, `nexus_fs.py`, `nexus_fs_bulk.py`) + 1 test
- ReBac `zone_revision` (genuinely per-zone) is intentionally NOT renamed

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [x] No stale `_zone_revision` references remain in `core/`
- [x] Test file `test_read_set_cache.py` updated to match new names
- [x] ReBac zone_revision references untouched (correct scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)