### PR TITLE
feat(#826): migrate 27 service-layer files from core.permissions to contracts.types

### DIFF
--- a/src/nexus/auth/oauth/user_auth.py
+++ b/src/nexus/auth/oauth/user_auth.py
@@ -354,7 +354,7 @@ class OAuthUserAuth:
         email: str,
         display_name: str | None,
     ) -> None:
-        from nexus.core.permissions import OperationContext
+        from nexus.contracts.types import OperationContext
         from nexus.server.auth.auth_routes import get_nexus_instance
 
         nx = get_nexus_instance()

--- a/src/nexus/isolation/backend.py
+++ b/src/nexus/isolation/backend.py
@@ -25,7 +25,7 @@ from nexus.isolation.errors import (
 )
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/mcp/mount.py
+++ b/src/nexus/mcp/mount.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.mcp.models import MCPMount, MCPToolConfig, MCPToolDefinition
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.skills.protocols import NexusFilesystem
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/portability/import_service.py
+++ b/src/nexus/portability/import_service.py
@@ -30,8 +30,8 @@ from nexus.portability.models import (
 )
 
 if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
     from nexus.core.nexus_fs import NexusFS
-    from nexus.core.permissions import OperationContext
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ def _create_import_context() -> OperationContext:
 
     Import is a privileged system operation that bypasses normal permission checks.
     """
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
 
     return OperationContext(
         user_id="system",

--- a/src/nexus/server/api/v1/routers/share.py
+++ b/src/nexus/server/api/v1/routers/share.py
@@ -17,8 +17,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from starlette.responses import Response, StreamingResponse
 
+from nexus.contracts.types import OperationContext
 from nexus.core.exceptions import NexusFileNotFoundError
-from nexus.core.permissions import OperationContext
 from nexus.server.api.v1.dependencies import get_nexus_fs
 from nexus.server.dependencies import get_auth_result, get_operation_context
 from nexus.server.fastapi_server import to_thread_with_timeout

--- a/src/nexus/services/events_service.py
+++ b/src/nexus/services/events_service.py
@@ -29,8 +29,8 @@ from nexus.services.dedup_work_queue import DedupWorkQueue, ShutdownError
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
     from nexus.core.distributed_lock import LockManagerBase
-    from nexus.core.permissions import OperationContext
     from nexus.core.protocols.connector import ConnectorProtocol
     from nexus.services.event_bus.base import EventBusBase
     from nexus.services.watch.file_watcher import FileWatcher

--- a/src/nexus/services/mcp_service.py
+++ b/src/nexus/services/mcp_service.py
@@ -20,7 +20,7 @@ from nexus.core.rpc_decorator import rpc_expose
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
 
 
 class MCPService:

--- a/src/nexus/services/memory/memory_api.py
+++ b/src/nexus/services/memory/memory_api.py
@@ -17,7 +17,7 @@ from typing import Any, Literal
 
 from sqlalchemy.orm import Session
 
-from nexus.core.permissions import OperationContext, Permission
+from nexus.contracts.types import OperationContext, Permission
 from nexus.core.temporal import parse_datetime, validate_temporal_params
 from nexus.rebac.entity_registry import EntityRegistry
 from nexus.rebac.memory_permission_enforcer import MemoryPermissionEnforcer

--- a/src/nexus/services/memory/state.py
+++ b/src/nexus/services/memory/state.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
-from nexus.core.permissions import OperationContext, Permission
+from nexus.contracts.types import OperationContext, Permission
 from nexus.core.temporal import parse_datetime
 from nexus.rebac.memory_permission_enforcer import MemoryPermissionEnforcer
 from nexus.services.memory.memory_router import MemoryViewRouter

--- a/src/nexus/services/memory/versioning.py
+++ b/src/nexus/services/memory/versioning.py
@@ -21,7 +21,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from nexus.core.permissions import OperationContext, Permission
+from nexus.contracts.types import OperationContext, Permission
 from nexus.rebac.memory_permission_enforcer import MemoryPermissionEnforcer
 from nexus.services.memory.memory_router import MemoryViewRouter
 

--- a/src/nexus/services/mount_core_service.py
+++ b/src/nexus/services/mount_core_service.py
@@ -33,7 +33,7 @@ from nexus.core.context_utils import get_user_identity, get_zone_id
 from nexus.services.permission_utils import check_permission
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.services.gateway import NexusFSGateway
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/services/mount_persist_service.py
+++ b/src/nexus/services/mount_persist_service.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.core.context_utils import get_user_identity, get_zone_id
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.services.mount_core_service import MountCoreService
     from nexus.services.mount_manager import MountManager
     from nexus.services.sync_service import SyncService
@@ -355,7 +355,7 @@ class MountPersistService:
             return None
 
         try:
-            from nexus.core.permissions import OperationContext
+            from nexus.contracts.types import OperationContext
 
             owner_parts = mount["owner_user_id"].split(":", 1)
             if len(owner_parts) == 2:

--- a/src/nexus/services/mount_service.py
+++ b/src/nexus/services/mount_service.py
@@ -46,8 +46,8 @@ def _needs_token_manager_db(backend_type: str, config: dict[str, Any]) -> bool:
 ProgressCallback = Callable[[int, str], None]
 
 if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
     from nexus.core.nexus_fs import NexusFilesystem
-    from nexus.core.permissions import OperationContext
     from nexus.core.router import PathRouter
     from nexus.services.mount_manager import MountManager
 

--- a/src/nexus/services/oauth_service.py
+++ b/src/nexus/services/oauth_service.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from nexus.contracts.cache_store import CacheStoreABC
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
 
 
 class PKCEStateStore:

--- a/src/nexus/services/permissions/permission_filter_chain.py
+++ b/src/nexus/services/permissions/permission_filter_chain.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.rebac.manager import ReBACManager
     from nexus.services.permissions.permission_cache import PermissionCacheCoordinator
 

--- a/src/nexus/services/rebac_service.py
+++ b/src/nexus/services/rebac_service.py
@@ -1605,7 +1605,7 @@ class ReBACService(ReBACShareMixin):
         if not context:
             return
 
-        from nexus.core.permissions import OperationContext, Permission
+        from nexus.contracts.types import OperationContext, Permission
 
         # Extract OperationContext from context parameter
         op_context: OperationContext | None = None

--- a/src/nexus/services/search_listing_mixin.py
+++ b/src/nexus/services/search_listing_mixin.py
@@ -19,8 +19,8 @@ import time
 from concurrent.futures import as_completed
 from typing import TYPE_CHECKING, Any
 
+from nexus.contracts.types import Permission
 from nexus.core.exceptions import PermissionDeniedError
-from nexus.core.permissions import Permission
 from nexus.core.rpc_decorator import rpc_expose
 from nexus.raft.zone_manager import ROOT_ZONE_ID
 
@@ -427,7 +427,7 @@ class SearchListingMixin:
         if context:
             list_context = replace(context, backend_path=route.backend_path)
         else:
-            from nexus.core.permissions import OperationContext
+            from nexus.contracts.types import OperationContext
 
             list_context = OperationContext(
                 user_id="anonymous", groups=[], backend_path=route.backend_path
@@ -444,7 +444,7 @@ class SearchListingMixin:
 
         # Permission filtering
         if self._enforce_permissions and context:
-            from nexus.core.permissions import OperationContext
+            from nexus.contracts.types import OperationContext
 
             filter_ctx = context if isinstance(context, OperationContext) else self._default_context
             assert filter_ctx is not None  # guaranteed by isinstance or _default_context
@@ -718,7 +718,7 @@ class SearchListingMixin:
         if not self._enforce_permissions:
             return allowed_set, backend_dirs
 
-        from nexus.core.permissions import OperationContext
+        from nexus.contracts.types import OperationContext
 
         perm_start = time.time()
         ctx_raw = context or self._default_context

--- a/src/nexus/services/search_service.py
+++ b/src/nexus/services/search_service.py
@@ -24,9 +24,9 @@ from typing import TYPE_CHECKING, Any, cast
 
 from cachetools import TTLCache
 
+from nexus.contracts.types import Permission
 from nexus.core import glob_fast, grep_fast, trigram_fast
 from nexus.core.exceptions import PermissionDeniedError
-from nexus.core.permissions import Permission
 from nexus.core.rpc_decorator import rpc_expose
 from nexus.search.strategies import (
     GLOB_RUST_THRESHOLD,
@@ -116,8 +116,8 @@ def _filter_ignored_paths(
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
     from nexus.core.metastore import MetastoreABC
-    from nexus.core.permissions import OperationContext
     from nexus.core.router import PathRouter
     from nexus.rebac.enforcer import PermissionEnforcer
     from nexus.rebac.manager import EnhancedReBACManager
@@ -679,7 +679,7 @@ class SearchService(SemanticSearchMixin):
         if context:
             list_context = replace(context, backend_path=route.backend_path)
         else:
-            from nexus.core.permissions import OperationContext
+            from nexus.contracts.types import OperationContext
 
             list_context = OperationContext(
                 user_id="anonymous", groups=[], backend_path=route.backend_path
@@ -696,7 +696,7 @@ class SearchService(SemanticSearchMixin):
 
         # Permission filtering
         if self._enforce_permissions and context:
-            from nexus.core.permissions import OperationContext
+            from nexus.contracts.types import OperationContext
 
             filter_ctx = context if isinstance(context, OperationContext) else self._default_context
             assert filter_ctx is not None  # guaranteed by isinstance or _default_context
@@ -973,7 +973,7 @@ class SearchService(SemanticSearchMixin):
 
         import time
 
-        from nexus.core.permissions import OperationContext
+        from nexus.contracts.types import OperationContext
 
         perm_start = time.time()
         ctx_raw = context or self._default_context
@@ -2216,7 +2216,7 @@ class SearchService(SemanticSearchMixin):
         Raises:
             PermissionDeniedError: If permission denied
         """
-        from nexus.core.permissions import OperationContext
+        from nexus.contracts.types import OperationContext
 
         if not self._enforce_permissions or not self._permission_enforcer:
             return

--- a/src/nexus/services/share_link_service.py
+++ b/src/nexus/services/share_link_service.py
@@ -28,7 +28,7 @@ from nexus.core.rpc_decorator import rpc_expose
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.services.gateway import NexusFSGateway
 
 

--- a/src/nexus/services/skill_service.py
+++ b/src/nexus/services/skill_service.py
@@ -32,7 +32,7 @@ from nexus.skills.types import PromptContext, SkillContent, SkillInfo
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.services.gateway import NexusFSGateway
 
 
@@ -1055,7 +1055,7 @@ class SkillService:
             if is_public:
                 try:
                     # Create a system context for reading public skill metadata
-                    from nexus.core.permissions import OperationContext as OpCtx
+                    from nexus.contracts.types import OperationContext as OpCtx
 
                     system_ctx = OpCtx(
                         user_id="system",

--- a/src/nexus/services/sync_service.py
+++ b/src/nexus/services/sync_service.py
@@ -35,7 +35,7 @@ from nexus.services.permission_utils import check_permission
 
 if TYPE_CHECKING:
     from nexus.backends.backend import FileInfo
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.services.gateway import NexusFSGateway
 
 logger = logging.getLogger(__name__)
@@ -1130,7 +1130,7 @@ class SyncService:
         """
         try:
             if hasattr(backend, "get_content_size"):
-                from nexus.core.permissions import OperationContext
+                from nexus.contracts.types import OperationContext
 
                 size_context = OperationContext(
                     user_id="system",

--- a/src/nexus/services/version_service.py
+++ b/src/nexus/services/version_service.py
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from nexus.contracts.types import OperationContext
     from nexus.core.metastore import MetastoreABC
-    from nexus.core.permissions import OperationContext
     from nexus.core.router import PathRouter
     from nexus.rebac.async_permissions import AsyncPermissionEnforcer
     from nexus.rebac.manager import EnhancedReBACManager
@@ -483,7 +483,7 @@ class VersionService:
         Raises:
             PermissionError: If permission denied
         """
-        from nexus.core.permissions import Permission
+        from nexus.contracts.types import Permission
 
         # Skip permission checks if not enforcing or no enforcer configured
         if not self._enforce_permissions or self._permission_enforcer is None:
@@ -515,7 +515,7 @@ class VersionService:
         Raises:
             PermissionError: If permission denied
         """
-        from nexus.core.permissions import Permission
+        from nexus.contracts.types import Permission
 
         # Skip permission checks if not enforcing or no enforcer configured
         if not self._enforce_permissions or self._permission_enforcer is None:

--- a/src/nexus/services/workspace/workspace_registry.py
+++ b/src/nexus/services/workspace/workspace_registry.py
@@ -219,7 +219,7 @@ class WorkspaceRegistry:
             ... )
 
             >>> # v0.5.0: Session-scoped workspace (temporary)
-            >>> from nexus.core.permissions import OperationContext
+            >>> from nexus.contracts.types import OperationContext
             >>> from datetime import timedelta
             >>> ctx = OperationContext(user_id="alice", groups=[])
             >>> registry.register_workspace(
@@ -497,7 +497,7 @@ class WorkspaceRegistry:
             ... )
 
             >>> # v0.5.0: Session-scoped memory (temporary)
-            >>> from nexus.core.permissions import OperationContext
+            >>> from nexus.contracts.types import OperationContext
             >>> from datetime import timedelta
             >>> ctx = OperationContext(user_id="alice", groups=[])
             >>> registry.register_memory(

--- a/src/nexus/services/write_back_service.py
+++ b/src/nexus/services/write_back_service.py
@@ -22,8 +22,8 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from nexus.contracts.types import OperationContext
 from nexus.core.event_bus import FileEvent, FileEventType
-from nexus.core.permissions import OperationContext
 from nexus.services.conflict_resolution import (
     ConflictAbortError,
     ConflictContext,

--- a/src/nexus/skills/importer.py
+++ b/src/nexus/skills/importer.py
@@ -19,7 +19,7 @@ from nexus.skills.protocols import NexusFilesystem
 from nexus.skills.registry import SkillRegistry
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/skills/manager.py
+++ b/src/nexus/skills/manager.py
@@ -18,7 +18,7 @@ from nexus.skills.protocols import NexusFilesystem
 from nexus.skills.registry import SkillNotFoundError, SkillRegistry
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.rebac.manager import ReBACManager
     from nexus.skills.governance import SkillGovernance
 

--- a/src/nexus/skills/registry.py
+++ b/src/nexus/skills/registry.py
@@ -17,7 +17,7 @@ from nexus.skills.parser import SkillParseError, SkillParser
 from nexus.skills.protocols import NexusFilesystem
 
 if TYPE_CHECKING:
-    from nexus.core.permissions import OperationContext
+    from nexus.contracts.types import OperationContext
     from nexus.rebac.manager import ReBACManager
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Batch 1 of `core/permissions.py` shim deletion (27 of 42 files)
- All `services/`, `skills/`, `auth/`, `mcp/`, `portability/`, `isolation/`, `server/` callers now import `OperationContext` and `Permission` directly from `nexus.contracts.types`
- No behavioral changes — purely import path migration
- Shim file kept alive for batch 2 (core/, rebac/, cache/, ipc/ + tests/)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, ruff format)
- [x] Zero remaining `from nexus.core.permissions import` in the 7 target directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)