### PR TITLE
fix: replace hardcoded zone_id 'default' with ROOT_ZONE_ID in event exporters and core logging

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -768,7 +768,7 @@ class NexusFS(  # type: ignore[misc]
         if hasattr(self, "_hierarchy_manager"):
             try:
                 logger.debug(
-                    f"mkdir: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or 'default'}"
+                    f"mkdir: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or ROOT_ZONE_ID}"
                 )
                 created_count = self._hierarchy_manager.ensure_parent_tuples(
                     path, zone_id=ctx.zone_id or ROOT_ZONE_ID

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -1843,7 +1843,7 @@ class NexusFSCoreMixin:
             if hasattr(self, "_hierarchy_manager"):
                 try:
                     logger.info(
-                        f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or 'default'}"
+                        f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or ROOT_ZONE_ID}"
                     )
                     created_count = self._hierarchy_manager.ensure_parent_tuples(
                         path, zone_id=ctx.zone_id or "root"

--- a/src/nexus/services/event_log/exporters/kafka_exporter.py
+++ b/src/nexus/services/event_log/exporters/kafka_exporter.py
@@ -13,6 +13,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:
@@ -62,7 +63,7 @@ class KafkaExporter:
     async def publish(self, event: FileEvent) -> None:
         """Publish a single event to Kafka."""
         producer = await self._ensure_producer()
-        topic = f"{self._config.topic_prefix}.{event.zone_id or 'default'}"
+        topic = f"{self._config.topic_prefix}.{event.zone_id or ROOT_ZONE_ID}"
         await producer.send_and_wait(
             topic,
             value=event.to_dict(),
@@ -78,7 +79,7 @@ class KafkaExporter:
         for i in range(0, len(events), chunk_size):
             chunk = events[i : i + chunk_size]
             for event in chunk:
-                topic = f"{self._config.topic_prefix}.{event.zone_id or 'default'}"
+                topic = f"{self._config.topic_prefix}.{event.zone_id or ROOT_ZONE_ID}"
                 try:
                     await producer.send_and_wait(
                         topic,

--- a/src/nexus/services/event_log/exporters/nats_exporter.py
+++ b/src/nexus/services/event_log/exporters/nats_exporter.py
@@ -15,6 +15,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:
@@ -71,7 +72,7 @@ class NatsExporter:
 
     def _subject(self, event: FileEvent) -> str:
         """Build the NATS subject for an event."""
-        zone = event.zone_id or "default"
+        zone = event.zone_id or ROOT_ZONE_ID
         event_type = event.type.value if hasattr(event.type, "value") else str(event.type)
         return f"{self._config.subject_prefix}.{zone}.{event_type}"
 

--- a/src/nexus/services/event_log/exporters/pubsub_exporter.py
+++ b/src/nexus/services/event_log/exporters/pubsub_exporter.py
@@ -13,6 +13,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from nexus.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:
@@ -55,7 +56,7 @@ class PubSubExporter:
     async def publish(self, event: FileEvent) -> None:
         """Publish a single event to Pub/Sub."""
         publisher = await self._ensure_publisher()
-        zone = event.zone_id or "default"
+        zone = event.zone_id or ROOT_ZONE_ID
         topic = self._topic_path(zone)
         data = json.dumps(event.to_dict()).encode("utf-8")
 
@@ -77,7 +78,7 @@ class PubSubExporter:
         # Group events by zone for efficient batching
         by_zone: dict[str, list[FileEvent]] = {}
         for event in events:
-            zone = event.zone_id or "default"
+            zone = event.zone_id or ROOT_ZONE_ID
             by_zone.setdefault(zone, []).append(event)
 
         for zone, zone_events in by_zone.items():


### PR DESCRIPTION
## Summary
- Replace hardcoded `"default"` zone_id fallback with `ROOT_ZONE_ID` (`"root"`) in 3 event log exporters (Kafka, Pub/Sub, NATS) and 2 core kernel debug log statements
- Per KERNEL-ARCHITECTURE.md, canonical root zone is `"root"` not `"default"` — using wrong zone_id breaks zone isolation

## Files changed (5)
- `src/nexus/services/event_log/exporters/kafka_exporter.py` — 2 occurrences
- `src/nexus/services/event_log/exporters/pubsub_exporter.py` — 2 occurrences
- `src/nexus/services/event_log/exporters/nats_exporter.py` — 1 occurrence
- `src/nexus/core/nexus_fs.py` — 1 occurrence (debug log in mkdir)
- `src/nexus/core/nexus_fs_core.py` — 1 occurrence (info log in write)

## Test plan
- [x] `ruff check` passes on all modified files
- [x] `mypy` passes (pre-commit hook)
- [x] `pytest tests/unit/services/event_log/` passes
- [x] Brick Zero-Core-Imports Check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)