### PR TITLE
fix(#960): remove 2 stale import-linter ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -941,9 +941,6 @@ ignore_imports = [
     "nexus.core.nexus_fs_core -> nexus.bricks.memory.router",
     "nexus.core.async_bridge -> nexus.rebac.manager",
     # --- services importing bricks ---
-    # filesystem backward-compat re-exports from bricks/ (Issue #2424)
-    "nexus.services.filesystem -> nexus.bricks.filesystem._scoped_base",
-    "nexus.services.filesystem -> nexus.bricks.filesystem.scoped_filesystem",
     "nexus.services.ace.consolidation -> nexus.bricks.search.embeddings",
     "nexus.services.oauth.oauth_service -> nexus.bricks.auth.oauth.credential_service",
     "nexus.services.oauth_service -> nexus.bricks.auth.oauth.token_manager",


### PR DESCRIPTION
## Summary
- Remove 2 stale `brick-independence` import-linter ignore rules for `nexus.services.filesystem`
- The module was deleted in #998 (PR #2560) but these ignore rules were left behind

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI green (no code changes, only pyproject.toml linter config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)