### PR TITLE
fix: delete 4 dead services/permissions/ shim files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -981,8 +981,6 @@ ignore_imports = [
     "nexus.services.permissions.namespace_manager -> nexus.rebac.manager",
     "nexus.services.permissions.permission_cache -> nexus.rebac.manager",
     "nexus.services.permissions.permission_filter_chain -> nexus.rebac.manager",
-    "nexus.services.permissions.rebac_manager -> nexus.rebac.manager",
-    "nexus.services.permissions.rebac_manager_enhanced -> nexus.rebac.manager",
     # --- non-layer module chain hops (transitively reaching bricks) ---
     "nexus.rebac.manager -> nexus.rebac.rebac_tracing",
     "nexus.rebac.rebac_tracing -> nexus.server.telemetry",

--- a/src/nexus/services/permissions/enforcer.py
+++ b/src/nexus/services/permissions/enforcer.py
@@ -1,3 +1,0 @@
-"""Backward-compat shim — canonical: nexus.rebac.enforcer."""
-
-from nexus.rebac.enforcer import PermissionEnforcer  # noqa: F401

--- a/src/nexus/services/permissions/permissions_enhanced.py
+++ b/src/nexus/services/permissions/permissions_enhanced.py
@@ -1,7 +1,0 @@
-"""Backward-compat shim — canonical: nexus.rebac.permissions_enhanced."""
-
-from nexus.rebac.permissions_enhanced import (  # noqa: F401
-    AdminCapability,
-    AuditLogEntry,
-    AuditStore,
-)

--- a/src/nexus/services/permissions/rebac_manager.py
+++ b/src/nexus/services/permissions/rebac_manager.py
@@ -1,3 +1,0 @@
-"""Backward-compat shim — canonical: nexus.rebac.manager."""
-
-from nexus.rebac.manager import ReBACManager  # noqa: F401

--- a/src/nexus/services/permissions/rebac_manager_enhanced.py
+++ b/src/nexus/services/permissions/rebac_manager_enhanced.py
@@ -1,3 +1,0 @@
-"""Backward-compat shim — canonical: nexus.rebac.manager."""
-
-from nexus.rebac.manager import EnhancedReBACManager, ReBACManager  # noqa: F401


### PR DESCRIPTION
## Summary
- Delete 4 dead backward-compat shim files in `services/permissions/` with zero external callers:
  - `enforcer.py` (3 lines) — re-exports from `nexus.rebac.enforcer`
  - `rebac_manager.py` (3 lines) — re-exports from `nexus.rebac.manager`
  - `rebac_manager_enhanced.py` (3 lines) — re-exports from `nexus.rebac.manager`
  - `permissions_enhanced.py` (7 lines) — re-exports from `nexus.rebac.permissions_enhanced`
- Clean 2 import-linter exceptions in `pyproject.toml`

## Verification
- `__init__.py` already has `_PermissionsRedirector` that dynamically maps `nexus.services.permissions.X` → `nexus.bricks.rebac.X` — individual shims are completely redundant
- Grep confirmed zero external imports for all 4 files (only `docs/` and the old `nexus.rebac.enforcer` reference them)
- Production code (`checker.py`, `namespace_manager.py`, `permission_cache.py`, `permission_filter_chain.py`, `object_type_mapper.py`) is kept — these are real implementations

## Test plan
- [ ] CI passes (ruff, mypy, pytest)
- [ ] No import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)