### PR TITLE
fix(#1036): delete 4 dead permission shim files

### DIFF
--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -173,7 +173,7 @@ tuples = nx.rebac_list_tuples(object=("file", "/file.txt"))
 
 ```python
 # ❌ DEPRECATED:
-from nexus.services.permissions.enforcer import PermissionEnforcer
+from nexus.rebac.enforcer import PermissionEnforcer
 
 enforcer = PermissionEnforcer(
     metadata_store=metadata,

--- a/docs/development/PERMISSION_ENFORCEMENT_GUIDE.md
+++ b/docs/development/PERMISSION_ENFORCEMENT_GUIDE.md
@@ -111,7 +111,7 @@ Multi-layer permission enforcement engine:
 
 ```python
 from nexus.contracts.types import Permission
-from nexus.services.permissions.enforcer import PermissionEnforcer
+from nexus.rebac.enforcer import PermissionEnforcer
 
 enforcer = PermissionEnforcer(
     metadata_store=metadata,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -981,8 +981,6 @@ ignore_imports = [
     "nexus.services.permissions.namespace_manager -> nexus.rebac.manager",
     "nexus.services.permissions.permission_cache -> nexus.rebac.manager",
     "nexus.services.permissions.permission_filter_chain -> nexus.rebac.manager",
-    "nexus.services.permissions.rebac_manager -> nexus.rebac.manager",
-    "nexus.services.permissions.rebac_manager_enhanced -> nexus.rebac.manager",
     # --- non-layer module chain hops (transitively reaching bricks) ---
     "nexus.rebac.manager -> nexus.rebac.rebac_tracing",
     "nexus.rebac.rebac_tracing -> nexus.server.telemetry",

--- a/src/nexus/rebac/enforcer.py
+++ b/src/nexus/rebac/enforcer.py
@@ -21,10 +21,10 @@ from nexus.contracts.types import OperationContext, Permission
 
 if TYPE_CHECKING:
     from nexus.rebac.manager import ReBACManager
+    from nexus.rebac.permissions_enhanced import AuditStore
     from nexus.services.permissions.hotspot_detector import HotspotDetector
     from nexus.services.permissions.namespace_manager import NamespaceManager
     from nexus.services.permissions.permission_boundary_cache import PermissionBoundaryCache
-    from nexus.services.permissions.permissions_enhanced import AuditStore
 
 logger = logging.getLogger(__name__)
 
@@ -357,7 +357,7 @@ class PermissionEnforcer:
                 return self._check_rebac(path, permission, context)
 
             # Import AdminCapability here to avoid circular imports
-            from nexus.services.permissions.permissions_enhanced import AdminCapability
+            from nexus.rebac.permissions_enhanced import AdminCapability
 
             # P0-4: Zone boundary check (security fix for issue #819)
             # Extract zone from path (format: /zone/{zone_id}/...)
@@ -765,7 +765,7 @@ class PermissionEnforcer:
 
         from datetime import UTC, datetime
 
-        from nexus.services.permissions.permissions_enhanced import AuditLogEntry
+        from nexus.rebac.permissions_enhanced import AuditLogEntry
 
         entry = AuditLogEntry(
             timestamp=datetime.now(UTC).isoformat(),
@@ -795,7 +795,7 @@ class PermissionEnforcer:
 
         from datetime import UTC, datetime
 
-        from nexus.services.permissions.permissions_enhanced import AuditLogEntry
+        from nexus.rebac.permissions_enhanced import AuditLogEntry
 
         entry = AuditLogEntry(
             timestamp=datetime.now(UTC).isoformat(),

--- a/src/nexus/services/permissions/enforcer.py
+++ b/src/nexus/services/permissions/enforcer.py
@@ -1,3 +1,0 @@
-"""Backward-compat shim — canonical: nexus.rebac.enforcer."""
-
-from nexus.rebac.enforcer import PermissionEnforcer  # noqa: F401

--- a/src/nexus/services/permissions/permissions_enhanced.py
+++ b/src/nexus/services/permissions/permissions_enhanced.py
@@ -1,7 +1,0 @@
-"""Backward-compat shim — canonical: nexus.rebac.permissions_enhanced."""
-
-from nexus.rebac.permissions_enhanced import (  # noqa: F401
-    AdminCapability,
-    AuditLogEntry,
-    AuditStore,
-)

--- a/src/nexus/services/permissions/rebac_manager.py
+++ b/src/nexus/services/permissions/rebac_manager.py
@@ -1,3 +1,0 @@
-"""Backward-compat shim — canonical: nexus.rebac.manager."""
-
-from nexus.rebac.manager import ReBACManager  # noqa: F401

--- a/src/nexus/services/permissions/rebac_manager_enhanced.py
+++ b/src/nexus/services/permissions/rebac_manager_enhanced.py
@@ -1,3 +1,0 @@
-"""Backward-compat shim — canonical: nexus.rebac.manager."""
-
-from nexus.rebac.manager import EnhancedReBACManager, ReBACManager  # noqa: F401


### PR DESCRIPTION
## Summary
- Delete 4 backward-compat shim files in `services/permissions/` that only re-export from `nexus.rebac` (canonical since Issue #2179)
- Fix 4 runtime imports in `rebac/enforcer.py` → direct `nexus.rebac.permissions_enhanced` path
- Remove 2 stale import-linter ignores for deleted shim modules
- Update 2 doc references to canonical import path

Files deleted:
- `services/permissions/enforcer.py` (3 lines — re-exports PermissionEnforcer)
- `services/permissions/rebac_manager.py` (3 lines — re-exports ReBACManager)
- `services/permissions/rebac_manager_enhanced.py` (3 lines — re-exports EnhancedReBACManager)
- `services/permissions/permissions_enhanced.py` (7 lines — re-exports AdminCapability, AuditLogEntry, AuditStore)

The `_PermissionsRedirector` MetaPathFinder in `services/permissions/__init__.py` remains — it handles broader redirects for the remaining real files.

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, brick zero-core-imports, import-linter)
- [ ] CI green on all unit/integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)