### PR TITLE
fix: strip 85 lines of dead backward-compat re-exports from server/auth/__init__.py

### DIFF
--- a/src/nexus/server/auth/__init__.py
+++ b/src/nexus/server/auth/__init__.py
@@ -1,95 +1,10 @@
 """Authentication providers for Nexus server.
 
-Backward-compatibility shim: OAuth components moved to nexus.auth.oauth brick.
-Auth providers live in nexus.auth brick.
+Server-layer auth modules:
+- auth_routes: FastAPI routes for authentication (register, login, OAuth callbacks)
+- zone_routes: FastAPI routes for zone management
+- factory: Auth provider factory (create_auth_provider)
+- oauth_init: OAuth provider initialization
+- oauth_provider: OAuthCredential, OAuthProvider, OAuthError interfaces
+- email_sender: Email verification sender
 """
-
-import warnings
-
-from nexus.auth_config import OAuthConfig, OAuthProviderConfig  # noqa: F401
-
-# OAuth components — now in nexus.auth.oauth brick (re-exported for backward compat)
-from nexus.bricks.auth.oauth.crypto import OAuthCrypto  # noqa: F401
-from nexus.bricks.auth.oauth.factory import OAuthProviderFactory  # noqa: F401
-from nexus.bricks.auth.oauth.providers.google import GoogleOAuthProvider  # noqa: F401
-from nexus.bricks.auth.oauth.providers.microsoft import MicrosoftOAuthProvider  # noqa: F401
-from nexus.bricks.auth.oauth.token_manager import TokenManager  # noqa: F401
-
-# Auth brick re-exports (moved to nexus.auth in Issue #1399)
-from nexus.bricks.auth.providers.base import AuthProvider, AuthResult  # noqa: F401
-from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth  # noqa: F401
-from nexus.bricks.auth.providers.database_local import DatabaseLocalAuth  # noqa: F401
-from nexus.bricks.auth.providers.discriminator import DiscriminatingAuthProvider  # noqa: F401
-from nexus.bricks.auth.providers.local import LocalAuth  # noqa: F401
-from nexus.bricks.auth.providers.oidc import MultiOIDCAuth, OIDCAuth  # noqa: F401
-from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth  # noqa: F401
-
-# Factory function — stays here but delegates to brick providers
-from nexus.server.auth.factory import create_auth_provider  # noqa: F401
-
-# Keep original OAuthCredential/OAuthProvider/OAuthError from server layer
-# (token_manager.py still uses mutable OAuthCredential)
-from nexus.server.auth.oauth_provider import (  # noqa: F401
-    OAuthCredential,
-    OAuthError,
-    OAuthProvider,
-)
-
-__all__ = [
-    # Auth brick (canonical: nexus.auth)
-    "AuthProvider",
-    "AuthResult",
-    "StaticAPIKeyAuth",
-    "DatabaseAPIKeyAuth",
-    "DatabaseLocalAuth",
-    "DiscriminatingAuthProvider",
-    "LocalAuth",
-    "OIDCAuth",
-    "MultiOIDCAuth",
-    "create_auth_provider",
-    # OAuth components (canonical: nexus.auth.oauth)
-    "OAuthProvider",
-    "OAuthCredential",
-    "OAuthError",
-    "OAuthCrypto",
-    "OAuthConfig",
-    "OAuthProviderConfig",
-    "OAuthProviderFactory",
-    "GoogleOAuthProvider",
-    "MicrosoftOAuthProvider",
-    "TokenManager",
-]
-
-
-def __getattr__(name: str) -> object:
-    """Emit deprecation warning for auth provider imports from server.auth."""
-    _auth_brick_names = {
-        "AuthProvider",
-        "AuthResult",
-        "StaticAPIKeyAuth",
-        "DatabaseAPIKeyAuth",
-        "DatabaseLocalAuth",
-        "DiscriminatingAuthProvider",
-        "LocalAuth",
-        "OIDCAuth",
-        "MultiOIDCAuth",
-    }
-    _oauth_brick_names = {
-        "OAuthCrypto",
-        "OAuthProviderFactory",
-        "GoogleOAuthProvider",
-        "MicrosoftOAuthProvider",
-    }
-    if name in _auth_brick_names:
-        warnings.warn(
-            f"Importing {name} from nexus.server.auth is deprecated. Use nexus.auth instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-    elif name in _oauth_brick_names:
-        warnings.warn(
-            f"Importing {name} from nexus.server.auth is deprecated. Use nexus.auth.oauth instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-    return globals()[name]


### PR DESCRIPTION
## Summary
- Stripped all backward-compat re-exports from `src/nexus/server/auth/__init__.py`
- Zero callers do `from nexus.server.auth import X` — all use specific submodules or canonical locations
- Removed: 14 dead imports, 23-line `__all__`, 32-line `__getattr__` deprecation handler, `warnings` import
- Kept: clean docstring listing available submodules

## Rationale
All callers import from specific submodules (`server.auth.factory`, `server.auth.auth_routes`, `server.auth.oauth_init`, etc.) or from canonical locations (`nexus.bricks.auth.*`). The `__init__.py` re-exports were dead code that nobody consumed.

## Test plan
- [x] All pre-commit hooks pass
- [x] Verified zero `from nexus.server.auth import` callers via grep across src/ and tests/
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)