### PR TITLE
fix(raft): handle CasResult in command_result_to_proto

### DIFF
--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -271,6 +271,15 @@ fn command_result_to_proto(result: &CommandResult) -> RaftResponse {
                 })),
             }
         }
+        CommandResult::CasResult { success, .. } => RaftResponse {
+            success: *success,
+            error: if *success {
+                None
+            } else {
+                Some("CAS conflict".to_string())
+            },
+            result: None,
+        },
         CommandResult::Error(e) => RaftResponse {
             success: false,
             error: Some(e.clone()),


### PR DESCRIPTION
## Summary
- Add missing `CasResult` match arm in `command_result_to_proto` (transport/server.rs)
- The `CasResult` variant was added to `CommandResult` for the CAS feature but the exhaustive `match` in the gRPC transport layer was not updated, causing Docker builds to fail

## Test plan
- [x] Rust compilation succeeds (the only change is adding an exhaustive match arm)
- [ ] Docker build completes (`docker compose -f dockerfiles/docker-compose.demo.yml build nexus`)