### PR TITLE
refactor(#844): eliminate HandlerResponse from connectors + tests

### DIFF
--- a/src/nexus/backends/backend.py
+++ b/src/nexus/backends/backend.py
@@ -14,7 +14,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 from nexus.core.object_store import ObjectStoreABC, WriteResult
-from nexus.lib.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
@@ -629,41 +628,23 @@ class Backend(ObjectStoreABC):
 
     # === Delta Sync Support (Issue #1127) ===
 
-    def get_file_info(
-        self, path: str, context: "OperationContext | None" = None
-    ) -> "HandlerResponse[FileInfo]":
-        """
-        Get file metadata for delta sync change detection (Issue #1127).
+    def get_file_info(self, path: str, context: "OperationContext | None" = None) -> "FileInfo":
+        """Get file metadata for delta sync change detection (Issue #1127).
 
         Returns file size, modification time, and backend-specific version
         identifier for efficient change detection during incremental sync.
-
-        Change Detection Strategy (rsync-inspired):
-        1. Quick check: Compare size + mtime first (fastest, no I/O)
-        2. Backend version: Compare GCS generation or S3 version ID
-        3. Content hash: Fallback if above not available
 
         Args:
             path: File path relative to backend root
             context: Operation context for authentication (optional)
 
         Returns:
-            HandlerResponse with FileInfo containing:
-            - size: File size in bytes
-            - mtime: Last modification time
-            - backend_version: Backend-specific version (GCS generation, S3 version ID)
-            - content_hash: Optional content hash if readily available
+            FileInfo with size, mtime, backend_version, content_hash.
 
-        Note:
-            Default implementation raises NotImplementedError.
-            Backends should override to provide efficient metadata retrieval
-            without reading file content.
-
-        Example:
-            >>> info = backend.get_file_info("data/file.txt").unwrap()
-            >>> if info.backend_version != cached_version:
-            ...     # File changed, needs sync
-            ...     sync_file(path)
+        Raises:
+            NotImplementedError: If backend doesn't support delta sync.
+            NexusFileNotFoundError: If file not found.
+            BackendError: If metadata retrieval fails.
         """
         raise NotImplementedError(
             f"Backend '{self.name}' does not support get_file_info for delta sync"

--- a/src/nexus/backends/base_blob_connector.py
+++ b/src/nexus/backends/base_blob_connector.py
@@ -19,7 +19,6 @@ Backend-specific implementations:
 
 import logging
 import mimetypes
-import time
 from abc import abstractmethod
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
@@ -27,15 +26,11 @@ from typing import TYPE_CHECKING
 from nexus.backends.backend import Backend
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
+from nexus.core.object_store import WriteResult
 from nexus.core.protocols.capabilities import BLOB_CONNECTOR_CAPABILITIES
-from nexus.lib.response import HandlerResponse
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
-
-logger = logging.getLogger(__name__)
-
-logger = logging.getLogger(__name__)
 
 logger = logging.getLogger(__name__)
 
@@ -159,9 +154,7 @@ class BaseBlobStorageConnector(Backend):
                 return self.prefix
         return backend_path
 
-    def get_ref_count(
-        self, content_hash: str, context: "OperationContext | None" = None
-    ) -> HandlerResponse[int]:
+    def get_ref_count(self, content_hash: str, context: "OperationContext | None" = None) -> int:
         """
         Get reference count (always 1 for connector backends).
 
@@ -173,10 +166,10 @@ class BaseBlobStorageConnector(Backend):
             context: Operation context
 
         Returns:
-            HandlerResponse with 1 (no reference counting)
+            1 (no reference counting)
         """
         # No deduplication - each file is unique
-        return HandlerResponse.ok(data=1, backend_name=self.name, path=content_hash)
+        return 1
 
     # === Abstract Methods (Must Implement in Subclasses) ===
 
@@ -434,7 +427,7 @@ class BaseBlobStorageConnector(Backend):
 
     def write_content(
         self, content: bytes, context: "OperationContext | None" = None
-    ) -> HandlerResponse[str]:
+    ) -> WriteResult:
         """
         Write content to blob storage at actual path (not CAS path).
 
@@ -445,48 +438,30 @@ class BaseBlobStorageConnector(Backend):
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with version ID (if versioning) or content hash in data field
-        """
-        start_time = time.perf_counter()
+            WriteResult with content_hash and size
 
+        Raises:
+            BackendError: If backend_path is missing from context or upload fails
+        """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
-                message=f"{self.name} connector requires backend_path in OperationContext. "
+            raise BackendError(
+                f"{self.name} connector requires backend_path in OperationContext. "
                 "This backend stores files at actual paths, not CAS hashes.",
-                code=400,
-                is_expected=True,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
+                backend=self.name,
             )
 
         # Get actual blob path from backend_path
         blob_path = self._get_blob_path(context.backend_path)
 
-        try:
-            # Detect appropriate Content-Type with charset for proper encoding
-            content_type = self._detect_content_type(context.backend_path, content)
+        # Detect appropriate Content-Type with charset for proper encoding
+        content_type = self._detect_content_type(context.backend_path, content)
 
-            # Upload blob (subclass implements cloud-specific upload)
-            result = self._upload_blob(blob_path, content, content_type)
+        # Upload blob (subclass implements cloud-specific upload)
+        result = self._upload_blob(blob_path, content, content_type)
 
-            return HandlerResponse.ok(
-                data=result,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
+        return WriteResult(content_hash=result, size=len(content))
 
-        except Exception as e:
-            return HandlerResponse.from_exception(
-                e,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
-
-    def read_content(
-        self, content_hash: str, context: "OperationContext | None" = None
-    ) -> HandlerResponse[bytes]:
+    def read_content(self, content_hash: str, context: "OperationContext | None" = None) -> bytes:
         """
         Read content from blob storage using backend_path.
 
@@ -503,46 +478,30 @@ class BaseBlobStorageConnector(Backend):
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with file content as bytes in data field
-        """
-        start_time = time.perf_counter()
+            File content as bytes
 
+        Raises:
+            BackendError: If backend_path is missing from context or download fails
+        """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
-                message=f"{self.name} connector requires backend_path in OperationContext. "
+            raise BackendError(
+                f"{self.name} connector requires backend_path in OperationContext. "
                 "This backend reads files from actual paths, not CAS hashes.",
-                code=400,
-                is_expected=True,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
+                backend=self.name,
             )
 
         # Get actual blob path from backend_path
         blob_path = self._get_blob_path(context.backend_path)
 
-        try:
-            # Determine if we should use version ID
-            version_id = None
-            if self.versioning_enabled and content_hash and self._is_version_id(content_hash):
-                version_id = content_hash
+        # Determine if we should use version ID
+        version_id = None
+        if self.versioning_enabled and content_hash and self._is_version_id(content_hash):
+            version_id = content_hash
 
-            # Download blob (subclass implements cloud-specific download)
-            content, _version_id = self._download_blob(blob_path, version_id)
+        # Download blob (subclass implements cloud-specific download)
+        content, _version_id = self._download_blob(blob_path, version_id)
 
-            return HandlerResponse.ok(
-                data=content,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
-
-        except Exception as e:
-            return HandlerResponse.from_exception(
-                e,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
+        return content
 
     def stream_content(
         self,
@@ -656,9 +615,7 @@ class BaseBlobStorageConnector(Backend):
                 pass
         return True  # Likely a version ID
 
-    def delete_content(
-        self, content_hash: str, context: "OperationContext | None" = None
-    ) -> HandlerResponse[None]:
+    def delete_content(self, content_hash: str, context: "OperationContext | None" = None) -> None:
         """
         Delete content from blob storage using backend_path.
 
@@ -668,44 +625,21 @@ class BaseBlobStorageConnector(Backend):
             content_hash: Content hash (ignored, kept for interface compatibility)
             context: Operation context with backend_path
 
-        Returns:
-            HandlerResponse indicating success or failure
+        Raises:
+            BackendError: If backend_path is missing from context or delete fails
         """
-        start_time = time.perf_counter()
-
         if not context or not context.backend_path:
-            return HandlerResponse.error(
-                message=f"{self.name} connector requires backend_path in OperationContext",
-                code=400,
-                is_expected=True,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
+            raise BackendError(
+                f"{self.name} connector requires backend_path in OperationContext",
+                backend=self.name,
             )
 
         blob_path = self._get_blob_path(context.backend_path)
 
-        try:
-            # Delete blob (subclass implements cloud-specific delete)
-            self._delete_blob(blob_path)
+        # Delete blob (subclass implements cloud-specific delete)
+        self._delete_blob(blob_path)
 
-            return HandlerResponse.ok(
-                data=None,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
-
-        except Exception as e:
-            return HandlerResponse.from_exception(
-                e,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
-
-    def content_exists(
-        self, content_hash: str, context: "OperationContext | None" = None
-    ) -> HandlerResponse[bool]:
+    def content_exists(self, content_hash: str, context: "OperationContext | None" = None) -> bool:
         """
         Check if content exists at backend_path.
 
@@ -714,37 +648,19 @@ class BaseBlobStorageConnector(Backend):
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with True if file exists, False otherwise in data field
+            True if file exists, False otherwise
         """
-        start_time = time.perf_counter()
-
         if not context or not context.backend_path:
-            return HandlerResponse.ok(
-                data=False,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-            )
+            return False
 
         try:
             blob_path = self._get_blob_path(context.backend_path)
             exists = self._blob_exists(blob_path)
+            return exists
+        except Exception:
+            return False
 
-            return HandlerResponse.ok(
-                data=exists,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
-        except Exception as e:
-            return HandlerResponse.from_exception(
-                e,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-            )
-
-    def get_content_size(
-        self, content_hash: str, context: "OperationContext | None" = None
-    ) -> HandlerResponse[int]:
+    def get_content_size(self, content_hash: str, context: "OperationContext | None" = None) -> int:
         """
         Get content size using backend_path (cache-first, efficient).
 
@@ -756,17 +672,15 @@ class BaseBlobStorageConnector(Backend):
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with content size in bytes in data field
-        """
-        start_time = time.perf_counter()
+            Content size in bytes
 
+        Raises:
+            BackendError: If backend_path is missing from context or operation fails
+        """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
-                message=f"{self.name} connector requires backend_path in OperationContext",
-                code=400,
-                is_expected=True,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
+            raise BackendError(
+                f"{self.name} connector requires backend_path in OperationContext",
+                backend=self.name,
             )
 
         # OPTIMIZATION: Check cache first (efficient - no API call)
@@ -780,33 +694,15 @@ class BaseBlobStorageConnector(Backend):
             cached_size = self._get_size_from_cache(context.virtual_path)
             if cached_size is not None:
                 assert isinstance(cached_size, int), "Cache size must be int"
-                return HandlerResponse.ok(
-                    data=cached_size,
-                    execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                    backend_name=self.name,
-                )
+                return cached_size
 
         # Fallback: Get size from cloud storage API
         # This only happens when file is not cached
         blob_path = self._get_blob_path(context.backend_path)
 
-        try:
-            size = self._get_blob_size(blob_path)
+        size = self._get_blob_size(blob_path)
 
-            return HandlerResponse.ok(
-                data=size,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
-
-        except Exception as e:
-            return HandlerResponse.from_exception(
-                e,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=blob_path,
-            )
+        return size
 
     # === Batch Operations (Parallel) ===
 
@@ -834,14 +730,20 @@ class BaseBlobStorageConnector(Backend):
 
         if len(content_hashes) == 1:
             # Single item — no thread pool overhead needed
-            response = self.read_content(content_hashes[0], context=context)
-            return {content_hashes[0]: response.data if response.success else None}
+            try:
+                data = self.read_content(content_hashes[0], context=context)
+            except Exception:
+                data = None
+            return {content_hashes[0]: data}
 
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
         def _read_one(content_hash: str) -> tuple[str, bytes | None]:
-            response = self.read_content(content_hash, context=context)
-            return (content_hash, response.data if response.success else None)
+            try:
+                data = self.read_content(content_hash, context=context)
+                return (content_hash, data)
+            except Exception:
+                return (content_hash, None)
 
         max_workers = min(8, len(content_hashes))
         result: dict[str, bytes | None] = {}
@@ -861,7 +763,7 @@ class BaseBlobStorageConnector(Backend):
         parents: bool = False,
         exist_ok: bool = False,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[None]:
+    ) -> None:
         """
         Create directory marker in blob storage.
 
@@ -874,81 +776,47 @@ class BaseBlobStorageConnector(Backend):
             exist_ok: Don't raise error if directory exists
             context: Operation context (not used for directory creation)
 
-        Returns:
-            HandlerResponse indicating success or failure
+        Raises:
+            BackendError: If directory already exists (without exist_ok) or creation fails
+            NexusFileNotFoundError: If parent directory doesn't exist
         """
-        start_time = time.perf_counter()
-
         # Normalize path
         path = path.strip("/")
         if not path:
             # Root always exists
-            return HandlerResponse.ok(
-                data=None,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path="/",
-            )
+            return
 
         # Directory paths end with trailing slash
         blob_path = self._get_blob_path(path) + "/"
 
-        try:
-            # Check if directory marker already exists
-            if self._blob_exists(blob_path):
-                if not exist_ok:
-                    return HandlerResponse.error(
-                        message=f"Directory already exists: {path}",
-                        code=409,
-                        is_expected=True,
-                        execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                        backend_name=self.name,
-                        path=path,
-                    )
-                return HandlerResponse.ok(
-                    data=None,
-                    execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                    backend_name=self.name,
+        # Check if directory marker already exists
+        if self._blob_exists(blob_path):
+            if not exist_ok:
+                raise BackendError(
+                    f"Directory already exists: {path}",
+                    backend=self.name,
                     path=path,
                 )
+            return
 
-            if not parents:
-                # Check if parent exists
-                parent = "/".join(path.split("/")[:-1])
-                if parent:
-                    parent_response = self.is_directory(parent)
-                    if not parent_response.success or not parent_response.data:
-                        return HandlerResponse.not_found(
-                            path=parent,
-                            message=f"Parent directory not found: {parent}",
-                            execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                            backend_name=self.name,
-                        )
+        if not parents:
+            # Check if parent exists
+            parent = "/".join(path.split("/")[:-1])
+            if parent and not self.is_directory(parent):
+                raise NexusFileNotFoundError(
+                    path=parent,
+                    message=f"Parent directory not found: {parent}",
+                )
 
-            # Create directory marker (subclass implements cloud-specific creation)
-            self._create_directory_marker(blob_path)
-
-            return HandlerResponse.ok(
-                data=None,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=path,
-            )
-
-        except Exception as e:
-            return HandlerResponse.from_exception(
-                e,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=path,
-            )
+        # Create directory marker (subclass implements cloud-specific creation)
+        self._create_directory_marker(blob_path)
 
     def rmdir(
         self,
         path: str,
         recursive: bool = False,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[None]:
+    ) -> None:
         """
         Remove directory from blob storage.
 
@@ -957,80 +825,53 @@ class BaseBlobStorageConnector(Backend):
             recursive: Remove non-empty directory
             context: Operation context (not used for directory removal)
 
-        Returns:
-            HandlerResponse indicating success or failure
+        Raises:
+            BackendError: If removing root directory or directory not empty
+            NexusFileNotFoundError: If directory doesn't exist
         """
-        start_time = time.perf_counter()
-
         path = path.strip("/")
         if not path:
-            return HandlerResponse.error(
-                message="Cannot remove root directory",
-                code=400,
-                is_expected=True,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
+            raise BackendError(
+                "Cannot remove root directory",
+                backend=self.name,
                 path="/",
             )
 
         blob_path = self._get_blob_path(path) + "/"
 
-        try:
-            # Check if directory marker exists
-            if not self._blob_exists(blob_path):
-                return HandlerResponse.not_found(
+        # Check if directory marker exists
+        if not self._blob_exists(blob_path):
+            raise NexusFileNotFoundError(
+                path=path,
+                message=f"Directory not found: {path}",
+            )
+
+        if not recursive:
+            # Check if directory is empty
+            blobs, prefixes = self._list_blobs(prefix=blob_path, delimiter="/")
+            # Directory marker itself will be in the list, so check for more than 1
+            if len(blobs) > 1 or prefixes:
+                raise BackendError(
+                    f"Directory not empty: {path}",
+                    backend=self.name,
                     path=path,
-                    message=f"Directory not found: {path}",
-                    execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                    backend_name=self.name,
                 )
 
-            if not recursive:
-                # Check if directory is empty
-                blobs, prefixes = self._list_blobs(prefix=blob_path, delimiter="/")
-                # Directory marker itself will be in the list, so check for more than 1
-                if len(blobs) > 1 or prefixes:
-                    return HandlerResponse.error(
-                        message=f"Directory not empty: {path}",
-                        code=400,
-                        is_expected=True,
-                        execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                        backend_name=self.name,
-                        path=path,
-                    )
+        # Delete directory marker
+        self._delete_blob(blob_path)
 
-            # Delete directory marker
-            self._delete_blob(blob_path)
+        if recursive:
+            # Delete all objects with this prefix
+            blobs, _ = self._list_blobs(prefix=blob_path, delimiter="")
+            for blob_key in blobs:
+                if blob_key != blob_path:  # Don't delete marker twice
+                    try:
+                        # Continue deleting other blobs even if one fails
+                        self._delete_blob(blob_key)
+                    except Exception as e:
+                        logger.debug("Failed to delete blob during recursive rmdir: %s", e)
 
-            if recursive:
-                # Delete all objects with this prefix
-                blobs, _ = self._list_blobs(prefix=blob_path, delimiter="")
-                for blob_key in blobs:
-                    if blob_key != blob_path:  # Don't delete marker twice
-                        try:
-                            # Continue deleting other blobs even if one fails
-                            self._delete_blob(blob_key)
-                        except Exception as e:
-                            logger.debug("Failed to delete blob during recursive rmdir: %s", e)
-
-            return HandlerResponse.ok(
-                data=None,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=path,
-            )
-
-        except Exception as e:
-            return HandlerResponse.from_exception(
-                e,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=path,
-            )
-
-    def is_directory(
-        self, path: str, context: "OperationContext | None" = None
-    ) -> HandlerResponse[bool]:
+    def is_directory(self, path: str, context: "OperationContext | None" = None) -> bool:
         """
         Check if path is a directory.
 
@@ -1043,50 +884,28 @@ class BaseBlobStorageConnector(Backend):
             context: Operation context (not used for directory check)
 
         Returns:
-            HandlerResponse with True if path is a directory, False otherwise in data field
+            True if path is a directory, False otherwise
         """
-        start_time = time.perf_counter()
-
         try:
             path = path.strip("/")
             if not path:
                 # Root is always a directory
-                return HandlerResponse.ok(
-                    data=True,
-                    execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                    backend_name=self.name,
-                    path="/",
-                )
+                return True
 
             blob_path = self._get_blob_path(path)
 
             # Check 1: Explicit directory marker blob
             if self._blob_exists(blob_path + "/"):
-                return HandlerResponse.ok(
-                    data=True,
-                    execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                    backend_name=self.name,
-                    path=path,
-                )
+                return True
 
             # Check 2: Virtual directory (has any blobs under this prefix)
             blobs, prefixes = self._list_blobs(prefix=blob_path + "/", delimiter="/")
             is_dir = len(blobs) > 0 or len(prefixes) > 0
 
-            return HandlerResponse.ok(
-                data=is_dir,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=path,
-            )
+            return is_dir
 
-        except Exception as e:
-            return HandlerResponse.from_exception(
-                e,
-                execution_time_ms=(time.perf_counter() - start_time) * 1000,
-                backend_name=self.name,
-                path=path,
-            )
+        except Exception:
+            return False
 
     def list_dir(self, path: str, context: "OperationContext | None" = None) -> list[str]:
         """
@@ -1107,10 +926,8 @@ class BaseBlobStorageConnector(Backend):
             path = path.strip("/")
 
             # Check if directory exists (except root)
-            if path:
-                is_dir_response = self.is_directory(path)
-                if not is_dir_response.success or not is_dir_response.data:
-                    raise FileNotFoundError(f"Directory not found: {path}")
+            if path and not self.is_directory(path):
+                raise FileNotFoundError(f"Directory not found: {path}")
 
             # Build prefix for this directory
             blob_base_path = self._get_blob_path(path)

--- a/src/nexus/backends/gcs_connector.py
+++ b/src/nexus/backends/gcs_connector.py
@@ -43,13 +43,13 @@ from google.api_core import retry
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
 
-from nexus.backends.backend import HandlerStatusResponse
+from nexus.backends.backend import FileInfo, HandlerStatusResponse
 from nexus.backends.base_blob_connector import BaseBlobStorageConnector
 from nexus.backends.cache_mixin import CacheConnectorMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+from nexus.core.object_store import WriteResult
 from nexus.core.protocols.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorCapability
-from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
@@ -818,12 +818,11 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
         except Exception:
             return None
 
-    @timed_response
     def get_file_info(
         self,
         path: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse:
+    ) -> "FileInfo":
         """
         Get file metadata for delta sync change detection (Issue #1127).
 
@@ -835,13 +834,14 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
             context: Operation context with optional backend_path
 
         Returns:
-            HandlerResponse with FileInfo containing:
+            FileInfo containing:
             - size: Object size in bytes
             - mtime: Last modified time (updated time in GCS)
             - backend_version: GCS generation number (monotonically increasing)
-        """
-        from nexus.backends.backend import FileInfo
 
+        Raises:
+            NexusFileNotFoundError: If the blob does not exist
+        """
         # Get backend path
         if context and context.backend_path:
             backend_path = context.backend_path
@@ -851,8 +851,11 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
         blob_path = self._get_blob_path(backend_path)
         blob = self.bucket.blob(blob_path)
 
-        # Fetch metadata in a single API call (reload handles NotFound)
-        blob.reload()  # Raises NotFound if blob doesn't exist
+        # Fetch metadata in a single API call (reload raises NotFound if missing)
+        try:
+            blob.reload()
+        except NotFound as e:
+            raise NexusFileNotFoundError(path) from e
 
         # Extract metadata
         size = blob.size or 0
@@ -869,7 +872,7 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
             content_hash=None,  # Not computed to avoid content download
         )
 
-        return HandlerResponse.ok(file_info, backend_name=self.name, path=path)
+        return file_info
 
     def generate_signed_url(
         self,
@@ -941,12 +944,11 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
 
     # === Override Content Operations with Caching ===
 
-    @timed_response
     def read_content(
         self,
         content_hash: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[bytes]:
+    ) -> bytes:
         """
         Read content from GCS with caching support.
 
@@ -960,15 +962,16 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with file content as bytes in data field
+            File content as bytes
+
+        Raises:
+            BackendError: If backend_path is missing from context
         """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
+            raise BackendError(
                 message="GCS connector requires backend_path in OperationContext. "
                 "This backend reads files from actual paths, not CAS hashes.",
-                code=400,
-                is_expected=True,
-                backend_name=self.name,
+                backend="gcs_connector",
             )
 
         # Get cache path (prefers virtual_path over backend_path)
@@ -986,11 +989,7 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
                 cached = self._read_from_cache(cache_path, original=True)
                 if cached and not cached.stale and cached.content_binary:
                     logger.info(f"[GCS] Cache hit (TTL-based) for {cache_path}")
-                    return HandlerResponse.ok(
-                        data=cached.content_binary,
-                        backend_name=self.name,
-                        path=blob_path,
-                    )
+                    return cached.content_binary
             except Exception as e:
                 logger.debug("[CACHE] Cache read failed for %s: %s", cache_path, e)
 
@@ -1018,18 +1017,13 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
             except Exception as e:
                 logger.debug("[CACHE] Cache write failed for %s: %s", cache_path, e)
 
-        return HandlerResponse.ok(
-            data=content,
-            backend_name=self.name,
-            path=blob_path,
-        )
+        return content
 
-    @timed_response
     def write_content(
         self,
         content: bytes,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[str]:
+    ) -> WriteResult:
         """
         Write content to GCS and update cache.
 
@@ -1042,15 +1036,16 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with version ID (GCS generation or content hash) in data field
+            WriteResult with content_hash (version ID) and size
+
+        Raises:
+            BackendError: If backend_path is missing from context
         """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
+            raise BackendError(
                 message="GCS connector requires backend_path in OperationContext. "
                 "This backend stores files at actual paths, not CAS hashes.",
-                code=400,
-                is_expected=True,
-                backend_name=self.name,
+                backend="gcs_connector",
             )
 
         # Get virtual path for cache operations
@@ -1081,19 +1076,14 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
             except Exception as e:
                 logger.debug("[CACHE] Cache write failed for %s: %s", virtual_path, e)
 
-        return HandlerResponse.ok(
-            data=new_version,
-            backend_name=self.name,
-            path=blob_path,
-        )
+        return WriteResult(content_hash=new_version, size=len(content))
 
-    @timed_response
     def write_content_with_version_check(
         self,
         content: bytes,
         context: "OperationContext | None" = None,
         expected_version: str | None = None,
-    ) -> HandlerResponse[str]:
+    ) -> WriteResult:
         """
         Write content with optimistic locking via version check.
 
@@ -1103,15 +1093,16 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
             expected_version: Expected GCS generation for optimistic locking
 
         Returns:
-            HandlerResponse with new version ID (GCS generation or content hash) in data field
+            WriteResult with content_hash (new version ID) and size
+
+        Raises:
+            BackendError: If backend_path is missing from context
         """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
+            raise BackendError(
                 message="GCS connector requires backend_path in OperationContext. "
                 "This backend stores files at actual paths, not CAS hashes.",
-                code=400,
-                is_expected=True,
-                backend_name=self.name,
+                backend="gcs_connector",
             )
 
         # Get virtual path for version check
@@ -1123,5 +1114,5 @@ class GCSConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin):
         if expected_version is not None:
             self._check_version(virtual_path, expected_version, context)
 
-        # Perform the write (returns HandlerResponse)
+        # Perform the write (returns WriteResult)
         return self.write_content(content, context)

--- a/src/nexus/backends/local_connector.py
+++ b/src/nexus/backends/local_connector.py
@@ -24,15 +24,16 @@ from datetime import UTC
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from nexus.backends.backend import Backend
+from nexus.backends.backend import Backend, FileInfo
 from nexus.backends.cache_mixin import CacheConnectorMixin
 from nexus.backends.registry import (
     ArgType,
     ConnectionArg,
     register_connector,
 )
-from nexus.contracts.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
+from nexus.core.object_store import WriteResult
 from nexus.core.protocols.capabilities import ConnectorCapability
 from nexus.lib.response import HandlerResponse, timed_response
 
@@ -41,13 +42,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Type alias for casting error responses
-_BytesResponse = HandlerResponse[bytes]
-_StrResponse = HandlerResponse[str]
+# Type alias for casting error responses (service methods only)
 _ListDictResponse = HandlerResponse[list[dict[str, Any]]]
 _DictResponse = HandlerResponse[dict[str, Any]]
 _ListStrResponse = HandlerResponse[list[str]]
-_IntResponse = HandlerResponse[int]
 
 
 @register_connector(
@@ -234,12 +232,11 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
         """
         return self.local_path
 
-    @timed_response
     def get_file_info(
         self,
         path: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse:
+    ) -> "FileInfo":
         """
         Get file metadata for delta sync change detection (Issue #1127).
 
@@ -251,14 +248,13 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             context: Operation context with optional backend_path
 
         Returns:
-            HandlerResponse with FileInfo containing:
-            - size: File size in bytes
-            - mtime: Last modification time
-            - backend_version: inode:mtime_ns string (changes on content/metadata change)
+            FileInfo containing size, mtime, backend_version
+
+        Raises:
+            NexusFileNotFoundError: If file does not exist
+            BackendError: On permission or OS errors
         """
         from datetime import datetime
-
-        from nexus.backends.backend import FileInfo
 
         try:
             # Get backend path
@@ -270,7 +266,7 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             physical = self._to_physical(backend_path)
 
             if not physical.exists():
-                return HandlerResponse.not_found(path, backend_name=self.name)
+                raise NexusFileNotFoundError(path)
 
             # Get file stats
             stat = physical.stat(follow_symlinks=self.follow_symlinks)
@@ -282,32 +278,31 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             # This combination detects both content changes (mtime) and file replacement (inode)
             backend_version = f"{stat.st_ino}:{stat.st_mtime_ns}"
 
-            file_info = FileInfo(
+            return FileInfo(
                 size=size,
                 mtime=mtime,
                 backend_version=backend_version,
                 content_hash=None,  # Not computed to avoid reading file content
             )
 
-            return HandlerResponse.ok(file_info, backend_name=self.name, path=path)
-
-        except FileNotFoundError:
-            return HandlerResponse.not_found(path, backend_name=self.name)
+        except NexusFileNotFoundError:
+            raise
+        except FileNotFoundError as e:
+            raise NexusFileNotFoundError(path) from e
         except PermissionError as e:
-            return HandlerResponse.error(f"Permission denied: {path} - {e}", backend_name=self.name)
+            raise BackendError(f"Permission denied: {path} - {e}") from e
         except OSError as e:
-            return HandlerResponse.error(f"Failed to get file info: {e}", backend_name=self.name)
+            raise BackendError(f"Failed to get file info: {e}") from e
 
     # =========================================================================
     # Content Operations (with L1 Caching)
     # =========================================================================
 
-    @timed_response
     def read_content(
         self,
         content_hash: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[bytes]:
+    ) -> bytes:
         """Read file content with L1 caching.
 
         For LocalConnectorBackend, content_hash is ignored - we use context.backend_path.
@@ -322,13 +317,14 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with file bytes on success, error message on failure
+            File content as bytes
+
+        Raises:
+            BackendError: If context/backend_path missing, permission denied, or OS error
+            NexusFileNotFoundError: If file does not exist
         """
         if context is None or not context.backend_path:
-            return cast(
-                _BytesResponse,
-                HandlerResponse.error("LocalConnectorBackend requires context with backend_path"),
-            )
+            raise BackendError("LocalConnectorBackend requires context with backend_path")
 
         path = context.backend_path
         cache_path = context.virtual_path if context.virtual_path else path
@@ -339,11 +335,7 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
                 cached = self._read_from_cache(cache_path, original=True)
                 if cached and not cached.stale and cached.content_binary:
                     logger.info(f"[LocalConnectorBackend] L1 cache hit: {cache_path}")
-                    return HandlerResponse.ok(
-                        data=cached.content_binary,
-                        backend_name=self.name,
-                        path=path,
-                    )
+                    return cached.content_binary
             except Exception as e:
                 logger.debug("[CACHE] Cache read failed for %s: %s", cache_path, e)
 
@@ -352,22 +344,16 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
         physical = self._to_physical(path)
 
         if not physical.exists():
-            return cast(
-                _BytesResponse,
-                HandlerResponse.not_found(
-                    path=path,
-                    message=f"File not found: {path}",
-                ),
-            )
+            raise NexusFileNotFoundError(path)
         if not physical.is_file():
-            return cast(_BytesResponse, HandlerResponse.error(f"Not a file: {path}"))
+            raise BackendError(f"Not a file: {path}")
 
         try:
             content = physical.read_bytes()
         except PermissionError as e:
-            return cast(_BytesResponse, HandlerResponse.error(f"Permission denied: {path} - {e}"))
+            raise BackendError(f"Permission denied: {path} - {e}") from e
         except OSError as e:
-            return cast(_BytesResponse, HandlerResponse.error(f"Read error: {e}"))
+            raise BackendError(f"Read error: {e}") from e
 
         # Step 3: Populate L1 cache for future reads
         if self._has_caching():
@@ -381,22 +367,17 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             except Exception as e:
                 logger.debug("[CACHE] Cache write failed for %s: %s", cache_path, e)
 
-        return HandlerResponse.ok(
-            data=content,
-            backend_name=self.name,
-            path=path,
-        )
+        return content
 
-    @timed_response
     def write_content(
         self,
         content: bytes,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[str]:
+    ) -> WriteResult:
         """Write content directly to local path.
 
         Unlike CAS-based backends, this writes directly to the file.
-        Returns content hash for consistency with other backends.
+        Returns WriteResult with content hash and size.
         Invalidates L1 cache after write.
 
         Args:
@@ -404,19 +385,19 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with content hash (SHA-256) on success
+            WriteResult with content_hash (SHA-256) and size
+
+        Raises:
+            BackendError: If read-only, missing path, permission denied, or OS error
         """
         if self.readonly:
-            return cast(_StrResponse, HandlerResponse.error("Backend is read-only"))
+            raise BackendError("Backend is read-only")
 
         # Get path from context
         write_path = context.backend_path if context else None
 
         if write_path is None:
-            return cast(
-                _StrResponse,
-                HandlerResponse.error("Path required for local_connector backend"),
-            )
+            raise BackendError("Path required for local_connector backend")
 
         physical = self._to_physical(write_path)
 
@@ -437,15 +418,13 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
                 except Exception as e:
                     logger.debug("[CACHE] Cache write failed for %s: %s", cache_path, e)
 
-            # Return content hash for consistency
+            # Return content hash and size for consistency
             content_hash = hash_content(content)
-            return HandlerResponse.ok(data=content_hash)
+            return WriteResult(content_hash=content_hash, size=len(content))
         except PermissionError as e:
-            return cast(
-                _StrResponse, HandlerResponse.error(f"Permission denied: {write_path} - {e}")
-            )
+            raise BackendError(f"Permission denied: {write_path} - {e}") from e
         except OSError as e:
-            return cast(_StrResponse, HandlerResponse.error(f"Write error: {e}"))
+            raise BackendError(f"Write error: {e}") from e
 
     # =========================================================================
     # Directory Operations
@@ -601,59 +580,58 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
     # Backend Interface Methods (for Backend abstract base class)
     # =========================================================================
 
-    @timed_response
     def delete_content(
         self,
         content_hash: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[None]:
+    ) -> None:
         """Delete content by hash - not supported for local_connector.
 
         LocalConnectorBackend uses path-based access, not content-hash based.
         This method exists for Backend interface compatibility.
+
+        Raises:
+            BackendError: Always (hash-based deletion not supported)
         """
-        return HandlerResponse.error(
+        raise BackendError(
             "delete_content by hash not supported for local_connector. Use delete(path) instead."
         )
 
-    @timed_response
     def content_exists(
         self,
         content_hash: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[bool]:
+    ) -> bool:
         """Check if content exists by hash - not supported for local_connector."""
-        return HandlerResponse.ok(data=False)
+        return False
 
-    @timed_response
     def get_content_size(
         self,
         content_hash: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[int]:
-        """Get content size by hash - not supported for local_connector."""
-        return cast(
-            _IntResponse,
-            HandlerResponse.error("get_content_size by hash not supported for local_connector"),
-        )
+    ) -> int:
+        """Get content size by hash - not supported for local_connector.
 
-    @timed_response
+        Raises:
+            BackendError: Always (hash-based size lookup not supported)
+        """
+        raise BackendError("get_content_size by hash not supported for local_connector")
+
     def get_ref_count(
         self,
         content_hash: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[int]:
+    ) -> int:
         """Get reference count by hash - not supported for local_connector."""
-        return HandlerResponse.ok(data=0)
+        return 0
 
-    @timed_response
     def mkdir(
         self,
         path: str,
         parents: bool = False,
         exist_ok: bool = False,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[None]:
+    ) -> None:
         """Create a directory.
 
         Args:
@@ -662,30 +640,28 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             exist_ok: Don't error if directory exists (always True for local_connector)
             context: Operation context (unused)
 
-        Returns:
-            HandlerResponse with None on success
+        Raises:
+            BackendError: If read-only, permission denied, or OS error
         """
         if self.readonly:
-            return HandlerResponse.error("Backend is read-only")
+            raise BackendError("Backend is read-only")
 
         physical = self._to_physical(path)
 
         try:
             # Always use parents=True, exist_ok=True for simplicity
             physical.mkdir(parents=True, exist_ok=True)
-            return HandlerResponse.ok(data=None)
         except PermissionError as e:
-            return HandlerResponse.error(f"Permission denied: {path} - {e}")
+            raise BackendError(f"Permission denied: {path} - {e}") from e
         except OSError as e:
-            return HandlerResponse.error(f"Mkdir error: {e}")
+            raise BackendError(f"Mkdir error: {e}") from e
 
-    @timed_response
     def rmdir(
         self,
         path: str,
         recursive: bool = False,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[None]:
+    ) -> None:
         """Remove a directory.
 
         Args:
@@ -693,21 +669,38 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             recursive: If True, remove directory and contents (not supported)
             context: Operation context (unused)
 
-        Returns:
-            HandlerResponse with None on success
+        Raises:
+            BackendError: If recursive, read-only, permission denied, not a directory, or OS error
+            NexusFileNotFoundError: If directory does not exist
         """
         if recursive:
-            return HandlerResponse.error("Recursive rmdir not supported for safety")
-        return self.delete(path, context)
+            raise BackendError("Recursive rmdir not supported for safety")
+        if self.readonly:
+            raise BackendError("Backend is read-only")
 
-    @timed_response
+        physical = self._to_physical(path)
+
+        try:
+            if physical.is_dir():
+                physical.rmdir()
+            else:
+                raise BackendError(f"Not a directory: {path}")
+        except FileNotFoundError as e:
+            raise NexusFileNotFoundError(path) from e
+        except PermissionError as e:
+            raise BackendError(f"Permission denied: {path} - {e}") from e
+        except BackendError:
+            raise
+        except OSError as e:
+            raise BackendError(f"Rmdir error: {e}") from e
+
     def is_directory(
         self,
         path: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[bool]:
+    ) -> bool:
         """Check if path is a directory."""
-        return HandlerResponse.ok(data=self.is_dir(path, context))
+        return self.is_dir(path, context)
 
     @timed_response
     def rename(

--- a/src/nexus/backends/s3_connector.py
+++ b/src/nexus/backends/s3_connector.py
@@ -36,14 +36,14 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-from nexus.backends.backend import HandlerStatusResponse
+from nexus.backends.backend import FileInfo, HandlerStatusResponse
 from nexus.backends.base_blob_connector import BaseBlobStorageConnector
 from nexus.backends.cache_mixin import CacheConnectorMixin
 from nexus.backends.multipart_upload_mixin import MultipartUploadMixin
 from nexus.backends.registry import ArgType, ConnectionArg, register_connector
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+from nexus.core.object_store import WriteResult
 from nexus.core.protocols.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorCapability
-from nexus.lib.response import HandlerResponse, timed_response
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
@@ -399,12 +399,11 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
         except Exception:
             return None
 
-    @timed_response
     def get_file_info(
         self,
         path: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse:
+    ) -> FileInfo:
         """
         Get file metadata for delta sync change detection (Issue #1127).
 
@@ -416,13 +415,15 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
             context: Operation context with optional backend_path
 
         Returns:
-            HandlerResponse with FileInfo containing:
+            FileInfo containing:
             - size: Object size in bytes
             - mtime: Last modified time
             - backend_version: S3 version ID (if versioning enabled)
-        """
-        from nexus.backends.backend import FileInfo
 
+        Raises:
+            NexusFileNotFoundError: If file does not exist in S3
+            BackendError: If S3 returns an unexpected error
+        """
         try:
             # Get backend path
             if context and context.backend_path:
@@ -456,13 +457,13 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
                 content_hash=None,  # Not computed to avoid content download
             )
 
-            return HandlerResponse.ok(file_info, backend_name=self.name, path=path)
+            return file_info
 
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "")
             if error_code == "404" or error_code == "NoSuchKey":
-                return HandlerResponse.not_found(path, backend_name=self.name)
-            return HandlerResponse.error(f"S3 error: {error_code}", backend_name=self.name)
+                raise NexusFileNotFoundError(path) from e
+            raise BackendError(f"S3 error: {error_code}") from e
 
     def generate_presigned_url(
         self,
@@ -1008,12 +1009,11 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
 
     # === Override Content Operations with Caching ===
 
-    @timed_response
     def read_content(
         self,
         content_hash: str,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[bytes]:
+    ) -> bytes:
         """
         Read content from S3 with caching support.
 
@@ -1027,15 +1027,16 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with file content as bytes in data field
+            File content as bytes.
+
+        Raises:
+            BackendError: If backend_path is missing from context or S3 operation fails.
+            NexusFileNotFoundError: If the file does not exist in S3.
         """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
+            raise BackendError(
                 message="S3 connector requires backend_path in OperationContext. "
                 "This backend reads files from actual paths, not CAS hashes.",
-                code=400,
-                is_expected=True,
-                backend_name=self.name,
             )
 
         # Get cache path (prefers virtual_path over backend_path)
@@ -1053,11 +1054,7 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
                 cached = self._read_from_cache(cache_path, original=True)
                 if cached and not cached.stale and cached.content_binary:
                     logger.info(f"[S3] Cache hit (TTL-based) for {cache_path}")
-                    return HandlerResponse.ok(
-                        data=cached.content_binary,
-                        backend_name=self.name,
-                        path=blob_path,
-                    )
+                    return cached.content_binary
             except Exception as e:
                 logger.debug("[CACHE] Cache read failed for %s: %s", cache_path, e)
 
@@ -1085,11 +1082,7 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
             except Exception as e:
                 logger.debug("[CACHE] Cache write failed for %s: %s", cache_path, e)
 
-        return HandlerResponse.ok(
-            data=content,
-            backend_name=self.name,
-            path=blob_path,
-        )
+        return content
 
     @property
     def batch_read_workers(self) -> int:
@@ -1131,9 +1124,12 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
 
         # Single file — skip thread pool overhead
         if len(content_hashes) == 1:
-            ctx = contexts.get(content_hashes[0], context) if contexts else context
-            response = self.read_content(content_hashes[0], context=ctx)
-            return {content_hashes[0]: response.data if response.success else None}
+            try:
+                ctx = contexts.get(content_hashes[0], context) if contexts else context
+                content = self.read_content(content_hashes[0], context=ctx)
+                return {content_hashes[0]: content}
+            except Exception:
+                return {content_hashes[0]: None}
 
         # Parallel downloads via ThreadPoolExecutor
         from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -1144,8 +1140,8 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
             """Read a single S3 object with per-hash context."""
             try:
                 ctx = contexts.get(content_hash, context) if contexts else context
-                response = self.read_content(content_hash, context=ctx)
-                return (content_hash, response.data if response.success else None)
+                content = self.read_content(content_hash, context=ctx)
+                return (content_hash, content)
             except Exception as e:
                 logger.warning(f"[S3] batch_read_content failed for {content_hash}: {e}")
                 return (content_hash, None)
@@ -1163,12 +1159,11 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
 
         return result
 
-    @timed_response
     def write_content(
         self,
         content: bytes,
         context: "OperationContext | None" = None,
-    ) -> HandlerResponse[str]:
+    ) -> WriteResult:
         """
         Write content to S3 and update cache.
 
@@ -1181,15 +1176,15 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
             context: Operation context with backend_path
 
         Returns:
-            HandlerResponse with version ID (S3 version or content hash) in data field
+            WriteResult with content_hash (version ID or content hash) and size.
+
+        Raises:
+            BackendError: If backend_path is missing from context or S3 operation fails.
         """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
+            raise BackendError(
                 message="S3 connector requires backend_path in OperationContext. "
                 "This backend stores files at actual paths, not CAS hashes.",
-                code=400,
-                is_expected=True,
-                backend_name=self.name,
             )
 
         # Get cache path (prefers virtual_path over backend_path)
@@ -1218,19 +1213,14 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
             except Exception as e:
                 logger.debug("[CACHE] Cache write failed for %s: %s", cache_path, e)
 
-        return HandlerResponse.ok(
-            data=new_version,
-            backend_name=self.name,
-            path=blob_path,
-        )
+        return WriteResult(content_hash=new_version, size=len(content))
 
-    @timed_response
     def write_content_with_version_check(
         self,
         content: bytes,
         context: "OperationContext | None" = None,
         expected_version: str | None = None,
-    ) -> HandlerResponse[str]:
+    ) -> WriteResult:
         """
         Write content with optimistic locking via version check.
 
@@ -1240,15 +1230,15 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
             expected_version: Expected S3 version for optimistic locking
 
         Returns:
-            HandlerResponse with new version ID (S3 version or content hash) in data field
+            WriteResult with content_hash (version ID or content hash) and size.
+
+        Raises:
+            BackendError: If backend_path is missing from context or S3 operation fails.
         """
         if not context or not context.backend_path:
-            return HandlerResponse.error(
+            raise BackendError(
                 message="S3 connector requires backend_path in OperationContext. "
                 "This backend stores files at actual paths, not CAS hashes.",
-                code=400,
-                is_expected=True,
-                backend_name=self.name,
             )
 
         # Get cache path (prefers virtual_path over backend_path)
@@ -1258,7 +1248,7 @@ class S3ConnectorBackend(BaseBlobStorageConnector, CacheConnectorMixin, Multipar
         if expected_version is not None:
             self._check_version(cache_path, expected_version, context)
 
-        # Perform the write (returns HandlerResponse)
+        # Perform the write (returns WriteResult)
         return self.write_content(content, context)
 
     # === Multipart Upload Operations (Issue #788) ===

--- a/src/nexus/bricks/rebac/cache/tiger/write_hook.py
+++ b/src/nexus/bricks/rebac/cache/tiger/write_hook.py
@@ -15,7 +15,7 @@ Issue #2133: Extracted from NexusFSCoreMixin inline code (Leopard-style grants).
 import logging
 from typing import Any
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.vfs_hooks import WriteHookContext
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -45,7 +45,7 @@ def _scope_params_for_zone(params: Any, zone_id: str) -> None:
     The reverse operation (stripping the prefix from results) is handled
     by ``unscope_internal_path`` in ``path_utils.py``.
     """
-    from nexus.constants import ROOT_ZONE_ID
+    from nexus.contracts.constants import ROOT_ZONE_ID
 
     if zone_id == ROOT_ZONE_ID:
         return

--- a/src/nexus/services/agents/agent_provisioning.py
+++ b/src/nexus/services/agents/agent_provisioning.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
-# Kernel-local defaults — avoids importing nexus.constants (service-level module)
+# Kernel-local defaults — avoids importing nexus.contracts.constants (service-level module)
 _DEFAULT_NEXUS_URL = "http://localhost:2026"
 _DEFAULT_LANGGRAPH_URL = "http://localhost:2024"
 

--- a/src/nexus/services/event_log/exporters/kafka_exporter.py
+++ b/src/nexus/services/event_log/exporters/kafka_exporter.py
@@ -13,7 +13,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:

--- a/src/nexus/services/event_log/exporters/nats_exporter.py
+++ b/src/nexus/services/event_log/exporters/nats_exporter.py
@@ -15,7 +15,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:

--- a/src/nexus/services/event_log/exporters/pubsub_exporter.py
+++ b/src/nexus/services/event_log/exporters/pubsub_exporter.py
@@ -13,7 +13,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:

--- a/src/nexus/services/protocols/write_back.py
+++ b/src/nexus/services/protocols/write_back.py
@@ -13,7 +13,7 @@ References:
 
 from typing import Any, Protocol, runtime_checkable
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 
 
 @runtime_checkable

--- a/src/nexus/system_services/sync/write_back_service.py
+++ b/src/nexus/system_services/sync/write_back_service.py
@@ -308,12 +308,7 @@ class WriteBackService:
         backend_file_info = None
         if hasattr(backend, "get_file_info"):
             try:
-                result = await asyncio.to_thread(backend.get_file_info, backend_path)
-                # Unwrap HandlerResponse if needed
-                if hasattr(result, "data") and hasattr(result, "success"):
-                    backend_file_info = result.data if result.success else None
-                else:
-                    backend_file_info = result
+                backend_file_info = await asyncio.to_thread(backend.get_file_info, backend_path)
             except FileNotFoundError:
                 pass  # File doesn't exist on backend yet — no conflict
             except Exception as exc:
@@ -360,11 +355,10 @@ class WriteBackService:
 
         op_ctx = dataclasses.replace(self._system_ctx, backend_path=backend_path)
         result = await asyncio.to_thread(backend.write_content, content, op_ctx)
-        if hasattr(result, "success") and not result.success:
-            raise RuntimeError(f"Backend write failed: {getattr(result, 'error', 'unknown')}")
+        # write_content now returns WriteResult directly, raises on error
 
         # Step 3: Update change log with new backend state
-        new_hash = getattr(result, "data", None) if hasattr(result, "data") else None
+        new_hash = result.content_hash
         self._change_log_store.upsert_change_log(
             path=entry.path,
             backend_name=entry.backend_name,
@@ -519,23 +513,19 @@ class WriteBackService:
         ctx = dataclasses.replace(self._system_ctx, backend_path=backend_path)
         if hasattr(backend, "delete"):
             result = await asyncio.to_thread(backend.delete, backend_path, ctx)
-        elif hasattr(backend, "delete_content"):
-            result = await asyncio.to_thread(backend.delete_content, backend_path, ctx)
+            # delete() is a service method that may still return HandlerResponse
+            if hasattr(result, "success") and not result.success:
+                raise RuntimeError(f"Backend delete failed: {getattr(result, 'error', 'unknown')}")
         else:
-            raise RuntimeError(
-                f"Backend {type(backend).__name__} supports neither delete nor delete_content"
-            )
-        if hasattr(result, "success") and not result.success:
-            raise RuntimeError(f"Backend delete failed: {getattr(result, 'error', 'unknown')}")
+            # delete_content raises on error, returns None on success
+            await asyncio.to_thread(backend.delete_content, backend_path, ctx)
 
     async def _handle_mkdir(self, backend: Any, backend_path: str) -> None:
         """Handle directory creation on the backend."""
         if not hasattr(backend, "mkdir"):
             raise RuntimeError(f"Backend {type(backend).__name__} does not support mkdir")
         ctx = dataclasses.replace(self._system_ctx, backend_path=backend_path)
-        result = await asyncio.to_thread(backend.mkdir, backend_path, context=ctx)
-        if hasattr(result, "success") and not result.success:
-            raise RuntimeError(f"Backend mkdir failed: {getattr(result, 'error', 'unknown')}")
+        await asyncio.to_thread(backend.mkdir, backend_path, context=ctx)
 
     def _read_nexus_content(self, path: str) -> bytes | None:
         """Read file content from NexusFS.

--- a/tests/unit/backends/test_chunked_storage.py
+++ b/tests/unit/backends/test_chunked_storage.py
@@ -163,17 +163,13 @@ class TestLocalBackendChunkedWriteRead:
     def test_small_file_not_chunked(self, backend: LocalBackend) -> None:
         """Test that small files use single-blob storage."""
         small_content = b"This is a small file that should not be chunked."
-        result = backend.write_content(small_content)
-        assert result.success
-        content_hash = result.unwrap()
+        content_hash = backend.write_content(small_content).content_hash
 
         # Verify not chunked
         assert not backend._is_chunked_content(content_hash)
 
         # Read back
-        read_result = backend.read_content(content_hash)
-        assert read_result.success
-        assert read_result.unwrap() == small_content
+        assert backend.read_content(content_hash) == small_content
 
     def test_large_file_chunked_write_read(self, backend: LocalBackend) -> None:
         """Test that large files are chunked and can be read back."""
@@ -181,25 +177,19 @@ class TestLocalBackendChunkedWriteRead:
         large_content = os.urandom(CDC_THRESHOLD_BYTES + 1024 * 1024)  # ~17MB
 
         # Write
-        result = backend.write_content(large_content)
-        assert result.success
-        content_hash = result.unwrap()
+        content_hash = backend.write_content(large_content).content_hash
 
         # Verify chunked
         assert backend._is_chunked_content(content_hash)
 
         # Read back
-        read_result = backend.read_content(content_hash)
-        assert read_result.success
-        assert read_result.unwrap() == large_content
+        assert backend.read_content(content_hash) == large_content
 
     def test_large_file_chunks_exist(self, backend: LocalBackend) -> None:
         """Test that individual chunks are created in CAS."""
         large_content = os.urandom(CDC_THRESHOLD_BYTES + 1024 * 1024)
 
-        result = backend.write_content(large_content)
-        assert result.success
-        content_hash = result.unwrap()
+        content_hash = backend.write_content(large_content).content_hash
 
         # Read manifest
         manifest_path = backend._hash_to_path(content_hash)
@@ -222,12 +212,8 @@ class TestLocalBackendChunkedWriteRead:
         content2 = prefix + suffix2
 
         # Write both
-        result1 = backend.write_content(content1)
-        result2 = backend.write_content(content2)
-        assert result1.success and result2.success
-
-        hash1 = result1.unwrap()
-        hash2 = result2.unwrap()
+        hash1 = backend.write_content(content1).content_hash
+        hash2 = backend.write_content(content2).content_hash
 
         # Read manifests
         manifest1 = ChunkedReference.from_json(backend._hash_to_path(hash1).read_bytes())
@@ -247,8 +233,7 @@ class TestLocalBackendChunkedWriteRead:
         large_content = os.urandom(CDC_THRESHOLD_BYTES + 1024 * 1024)
 
         # Write
-        result = backend.write_content(large_content)
-        content_hash = result.unwrap()
+        content_hash = backend.write_content(large_content).content_hash
 
         # Get chunk hashes
         manifest = ChunkedReference.from_json(backend._hash_to_path(content_hash).read_bytes())
@@ -259,8 +244,7 @@ class TestLocalBackendChunkedWriteRead:
             assert backend._hash_to_path(ch).exists()
 
         # Delete
-        delete_result = backend.delete_content(content_hash)
-        assert delete_result.success
+        backend.delete_content(content_hash)
 
         # Manifest should be deleted
         assert not backend._hash_to_path(content_hash).exists()
@@ -275,11 +259,8 @@ class TestLocalBackendChunkedWriteRead:
         large_content = os.urandom(CDC_THRESHOLD_BYTES + 1024 * 1024)
 
         # Write twice (same content = same chunks)
-        result1 = backend.write_content(large_content)
-        result2 = backend.write_content(large_content)
-
-        hash1 = result1.unwrap()
-        hash2 = result2.unwrap()
+        hash1 = backend.write_content(large_content).content_hash
+        hash2 = backend.write_content(large_content).content_hash
 
         # Both should have same manifest hash (same content)
         assert hash1 == hash2
@@ -292,42 +273,32 @@ class TestLocalBackendChunkedWriteRead:
         backend.delete_content(hash1)
 
         # Should still be readable (ref_count was 2, now 1)
-        read_result = backend.read_content(hash2)
-        assert read_result.success
-        assert read_result.unwrap() == large_content
+        assert backend.read_content(hash2) == large_content
 
     def test_get_content_size_chunked(self, backend: LocalBackend) -> None:
         """Test that get_content_size returns original size for chunked content."""
         large_content = os.urandom(CDC_THRESHOLD_BYTES + 500_000)
         original_size = len(large_content)
 
-        result = backend.write_content(large_content)
-        content_hash = result.unwrap()
+        content_hash = backend.write_content(large_content).content_hash
 
         # Get size
-        size_result = backend.get_content_size(content_hash)
-        assert size_result.success
-        assert size_result.unwrap() == original_size
+        assert backend.get_content_size(content_hash) == original_size
 
     def test_content_exists_chunked(self, backend: LocalBackend) -> None:
         """Test that content_exists works for chunked content."""
         large_content = os.urandom(CDC_THRESHOLD_BYTES + 100_000)
 
-        result = backend.write_content(large_content)
-        content_hash = result.unwrap()
+        content_hash = backend.write_content(large_content).content_hash
 
         # Should exist
-        exists_result = backend.content_exists(content_hash)
-        assert exists_result.success
-        assert exists_result.unwrap() is True
+        assert backend.content_exists(content_hash) is True
 
         # Delete
         backend.delete_content(content_hash)
 
         # Should not exist
-        exists_result2 = backend.content_exists(content_hash)
-        assert exists_result2.success
-        assert exists_result2.unwrap() is False
+        assert backend.content_exists(content_hash) is False
 
 
 class TestBackwardCompatibility:
@@ -354,9 +325,7 @@ class TestBackwardCompatibility:
         assert not backend._is_chunked_content(content_hash)
 
         # Should be readable
-        result = backend.read_content(content_hash)
-        assert result.success
-        assert result.unwrap() == content
+        assert backend.read_content(content_hash) == content
 
     def test_mixed_storage_operations(self, backend: LocalBackend) -> None:
         """Test that mixed chunked and single-blob operations work together."""
@@ -364,24 +333,24 @@ class TestBackwardCompatibility:
         large_content = os.urandom(CDC_THRESHOLD_BYTES + 100_000)
 
         # Write both
-        small_hash = backend.write_content(small_content).unwrap()
-        large_hash = backend.write_content(large_content).unwrap()
+        small_hash = backend.write_content(small_content).content_hash
+        large_hash = backend.write_content(large_content).content_hash
 
         # Verify types
         assert not backend._is_chunked_content(small_hash)
         assert backend._is_chunked_content(large_hash)
 
         # Read both
-        assert backend.read_content(small_hash).unwrap() == small_content
-        assert backend.read_content(large_hash).unwrap() == large_content
+        assert backend.read_content(small_hash) == small_content
+        assert backend.read_content(large_hash) == large_content
 
         # Delete both
         backend.delete_content(small_hash)
         backend.delete_content(large_hash)
 
         # Verify deleted
-        assert not backend.content_exists(small_hash).unwrap()
-        assert not backend.content_exists(large_hash).unwrap()
+        assert not backend.content_exists(small_hash)
+        assert not backend.content_exists(large_hash)
 
 
 class TestCDCChunking:
@@ -397,8 +366,7 @@ class TestCDCChunking:
         # Create content with some patterns that CDC should detect
         large_content = os.urandom(CDC_THRESHOLD_BYTES * 2)
 
-        result = backend.write_content(large_content)
-        content_hash = result.unwrap()
+        content_hash = backend.write_content(large_content).content_hash
 
         manifest = ChunkedReference.from_json(backend._hash_to_path(content_hash).read_bytes())
 
@@ -421,8 +389,7 @@ class TestCDCChunking:
         """Test that CDC chunk offsets are contiguous (no gaps/overlaps)."""
         large_content = os.urandom(CDC_THRESHOLD_BYTES + 1024 * 1024)
 
-        result = backend.write_content(large_content)
-        content_hash = result.unwrap()
+        content_hash = backend.write_content(large_content).content_hash
 
         manifest = ChunkedReference.from_json(backend._hash_to_path(content_hash).read_bytes())
 

--- a/tests/unit/backends/test_compressed_wrapper.py
+++ b/tests/unit/backends/test_compressed_wrapper.py
@@ -26,7 +26,7 @@ from unittest.mock import patch
 import pytest
 
 from nexus.contracts.describable import Describable
-from nexus.lib.response import HandlerResponse
+from nexus.core.object_store import WriteResult
 from tests.unit.backends.wrapper_test_helpers import make_leaf, make_storage_mock
 
 # ---------------------------------------------------------------------------
@@ -80,11 +80,10 @@ class TestCompressedRoundtrip:
 
         plaintext = b"hello world " * 100  # Compressible content
         write_resp = wrapper.write_content(plaintext)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == plaintext
 
     def test_binary_roundtrip(self) -> None:
         from nexus.backends.compressed_wrapper import CompressedStorage, CompressedStorageConfig
@@ -95,11 +94,10 @@ class TestCompressedRoundtrip:
 
         plaintext = bytes(range(256)) * 100
         write_resp = wrapper.write_content(plaintext)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == plaintext
 
     def test_large_content_roundtrip(self) -> None:
         from nexus.backends.compressed_wrapper import CompressedStorage, CompressedStorageConfig
@@ -110,11 +108,10 @@ class TestCompressedRoundtrip:
 
         plaintext = b"A" * (1024 * 1024)  # 1MB highly compressible
         write_resp = wrapper.write_content(plaintext)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == plaintext
 
 
 # ---------------------------------------------------------------------------
@@ -133,8 +130,8 @@ class TestCompressedCASDedup:
         wrapper = CompressedStorage(inner=mock, config=config)
 
         content = b"deterministic content " * 100
-        hash1 = wrapper.write_content(content).data
-        hash2 = wrapper.write_content(content).data
+        hash1 = wrapper.write_content(content).content_hash
+        hash2 = wrapper.write_content(content).content_hash
         assert hash1 == hash2, "zstd should produce identical output for identical input"
 
 
@@ -155,12 +152,11 @@ class TestCompressedThreshold:
 
         small_content = b"tiny"  # 4 bytes, below 1024 threshold
         write_resp = wrapper.write_content(small_content)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
         # Read should return original content
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == small_content
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == small_content
 
     def test_above_threshold_compressed(self) -> None:
         from nexus.backends.compressed_wrapper import CompressedStorage, CompressedStorageConfig
@@ -172,16 +168,15 @@ class TestCompressedThreshold:
         # Content above threshold — should be compressed
         large_content = b"compressible " * 100  # 1300 bytes
         write_resp = wrapper.write_content(large_content)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
         # The stored content should be smaller than original
-        stored = storage[write_resp.data]
+        stored = storage[write_resp.content_hash]
         assert len(stored) < len(large_content)
 
         # Read should return original
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == large_content
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == large_content
 
 
 # ---------------------------------------------------------------------------
@@ -204,12 +199,11 @@ class TestCompressedNegativeRatio:
         # Random data won't compress well
         random_data = os.urandom(1024)
         write_resp = wrapper.write_content(random_data)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
         # Read should return original regardless of whether compression was skipped
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == random_data
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == random_data
 
 
 # ---------------------------------------------------------------------------
@@ -228,11 +222,10 @@ class TestCompressedEmptyContent:
         wrapper = CompressedStorage(inner=mock, config=config)
 
         write_resp = wrapper.write_content(b"")
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == b""
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == b""
 
 
 # ---------------------------------------------------------------------------
@@ -247,25 +240,25 @@ class TestCompressedDelegation:
         from nexus.backends.compressed_wrapper import CompressedStorage, CompressedStorageConfig
 
         leaf = make_leaf("local")
-        leaf.mkdir.return_value = HandlerResponse.ok(data=None)
+        leaf.mkdir.return_value = None
         config = CompressedStorageConfig(metrics_enabled=False)
         wrapper = CompressedStorage(inner=leaf, config=config)
 
         result = wrapper.mkdir("/test", parents=True)
         leaf.mkdir.assert_called_once()
-        assert result.success
+        assert result is None
 
     def test_delete_delegates(self) -> None:
         from nexus.backends.compressed_wrapper import CompressedStorage, CompressedStorageConfig
 
         leaf = make_leaf("local")
-        leaf.delete_content.return_value = HandlerResponse.ok(data=None)
+        leaf.delete_content.return_value = None
         config = CompressedStorageConfig(metrics_enabled=False)
         wrapper = CompressedStorage(inner=leaf, config=config)
 
         result = wrapper.delete_content("hash123")
         leaf.delete_content.assert_called_once()
-        assert result.success
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -320,9 +313,9 @@ class TestCompressedBatch:
         content_b = b"beta " * 100
         content_c = b"gamma " * 100
 
-        h1 = wrapper.write_content(content_a).data
-        h2 = wrapper.write_content(content_b).data
-        h3 = wrapper.write_content(content_c).data
+        h1 = wrapper.write_content(content_a).content_hash
+        h2 = wrapper.write_content(content_b).content_hash
+        h3 = wrapper.write_content(content_c).content_hash
 
         # Batch read
         results = wrapper.batch_read_content([h1, h2, h3])
@@ -337,7 +330,7 @@ class TestCompressedBatch:
         config = CompressedStorageConfig(min_size=0, metrics_enabled=False)
         wrapper = CompressedStorage(inner=mock, config=config)
 
-        h1 = wrapper.write_content(b"exists " * 100).data
+        h1 = wrapper.write_content(b"exists " * 100).content_hash
         results = wrapper.batch_read_content([h1, "nonexistent"])
         assert results[h1] == b"exists " * 100
         assert results["nonexistent"] is None
@@ -371,11 +364,10 @@ class TestCompressedFailureFallback:
             write_resp = wrapper.write_content(content)
 
         # Write should succeed with uncompressed content
-        assert write_resp.success
-        stored = storage[write_resp.data]
+        assert isinstance(write_resp, WriteResult)
+        stored = storage[write_resp.content_hash]
         assert stored == content  # Stored raw, no NEXZ header
 
         # Read should return original
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == content
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == content

--- a/tests/unit/backends/test_delegating.py
+++ b/tests/unit/backends/test_delegating.py
@@ -21,7 +21,8 @@ import pytest
 
 from nexus.backends.backend import HandlerStatusResponse
 from nexus.backends.delegating import DelegatingBackend
-from nexus.lib.response import HandlerResponse
+from nexus.contracts.exceptions import NexusFileNotFoundError
+from nexus.core.object_store import WriteResult
 from tests.unit.backends.wrapper_test_helpers import make_leaf, make_storage_mock
 
 # ---------------------------------------------------------------------------
@@ -100,7 +101,7 @@ class TestDefaultHooks:
 
     def test_passthrough_write_delegates_to_inner(self) -> None:
         leaf = make_leaf()
-        expected = HandlerResponse.ok(data="hash123")
+        expected = WriteResult(content_hash="hash123")
         leaf.write_content.return_value = expected
         wrapper = DelegatingBackend(leaf)
 
@@ -110,15 +111,13 @@ class TestDefaultHooks:
 
     def test_passthrough_read_delegates_to_inner(self) -> None:
         leaf = make_leaf()
-        expected = HandlerResponse.ok(data=b"content")
+        expected = b"content"
         leaf.read_content.return_value = expected
         wrapper = DelegatingBackend(leaf)
 
         result = wrapper.read_content("hash123")
         leaf.read_content.assert_called_once_with("hash123", context=None)
-        # For identity transform, data is re-wrapped by DelegatingBackend
-        assert result.success
-        assert result.data == b"content"
+        assert result == b"content"
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +133,7 @@ class TestTransformOnWrite:
         wrapper = FakeTransformBackend(mock)
 
         resp = wrapper.write_content(b"hello")
-        assert resp.success
+        assert isinstance(resp, WriteResult)
 
         # Inner should receive transformed content
         call_args = mock.write_content.call_args
@@ -145,10 +144,8 @@ class TestTransformOnWrite:
         leaf = make_leaf()
         wrapper = FailingWriteBackend(leaf)
 
-        resp = wrapper.write_content(b"hello")
-        assert not resp.success
-        assert resp.error_message is not None
-        assert "transform" in resp.error_message.lower()
+        with pytest.raises(RuntimeError, match="write transform broken"):
+            wrapper.write_content(b"hello")
         # Inner should NOT have been called
         leaf.write_content.assert_not_called()
 
@@ -162,31 +159,27 @@ class TestTransformOnRead:
 
         # Write through wrapper (stores "TX:hello")
         write_resp = wrapper.write_content(b"hello")
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
         # Read through wrapper (strips "TX:" prefix)
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == b"hello"
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == b"hello"
 
     def test_error_response_propagated_from_inner(self) -> None:
         leaf = make_leaf()
-        leaf.read_content.return_value = HandlerResponse.error(message="not found")
+        leaf.read_content.side_effect = NexusFileNotFoundError("nonexistent")
         wrapper = FakeTransformBackend(leaf)
 
-        resp = wrapper.read_content("nonexistent")
-        assert not resp.success
-        assert "not found" in resp.error_message
+        with pytest.raises(NexusFileNotFoundError):
+            wrapper.read_content("nonexistent")
 
     def test_error_on_transform_failure(self) -> None:
         leaf = make_leaf()
-        leaf.read_content.return_value = HandlerResponse.ok(data=b"no-prefix")
+        leaf.read_content.return_value = b"no-prefix"
         wrapper = FakeTransformBackend(leaf)
 
-        resp = wrapper.read_content("some-hash")
-        assert not resp.success
-        assert resp.error_message is not None
-        assert "transform" in resp.error_message.lower()
+        with pytest.raises(ValueError, match="Missing TX: prefix"):
+            wrapper.read_content("some-hash")
 
 
 # ---------------------------------------------------------------------------
@@ -201,8 +194,8 @@ class TestBatchReadWithTransform:
         mock, storage = make_storage_mock()
         wrapper = FakeTransformBackend(mock)
 
-        h1 = wrapper.write_content(b"alpha").data
-        h2 = wrapper.write_content(b"beta").data
+        h1 = wrapper.write_content(b"alpha").content_hash
+        h2 = wrapper.write_content(b"beta").content_hash
 
         results = wrapper.batch_read_content([h1, h2])
         assert results[h1] == b"alpha"
@@ -212,7 +205,7 @@ class TestBatchReadWithTransform:
         mock, storage = make_storage_mock()
         wrapper = FakeTransformBackend(mock)
 
-        h1 = wrapper.write_content(b"exists").data
+        h1 = wrapper.write_content(b"exists").content_hash
         results = wrapper.batch_read_content([h1, "missing"])
         assert results[h1] == b"exists"
         assert results["missing"] is None

--- a/tests/unit/backends/test_encrypted_wrapper.py
+++ b/tests/unit/backends/test_encrypted_wrapper.py
@@ -22,7 +22,8 @@ Design reference:
 import pytest
 
 from nexus.contracts.describable import Describable
-from nexus.lib.response import HandlerResponse
+from nexus.contracts.exceptions import NexusFileNotFoundError
+from nexus.core.object_store import WriteResult
 from tests.unit.backends.wrapper_test_helpers import make_leaf, make_storage_mock
 
 # ---------------------------------------------------------------------------
@@ -88,12 +89,11 @@ class TestEncryptedRoundtrip:
 
         plaintext = b"hello world"
         write_resp = wrapper.write_content(plaintext)
-        assert write_resp.success
-        content_hash = write_resp.data
+        assert isinstance(write_resp, WriteResult)
+        content_hash = write_resp.content_hash
 
         read_resp = wrapper.read_content(content_hash)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        assert read_resp == plaintext
 
     def test_binary_roundtrip(self) -> None:
         from nexus.backends.encrypted_wrapper import EncryptedStorage, EncryptedStorageConfig
@@ -104,11 +104,10 @@ class TestEncryptedRoundtrip:
 
         plaintext = bytes(range(256))  # All byte values
         write_resp = wrapper.write_content(plaintext)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == plaintext
 
     def test_large_content_roundtrip(self) -> None:
         from nexus.backends.encrypted_wrapper import EncryptedStorage, EncryptedStorageConfig
@@ -119,11 +118,10 @@ class TestEncryptedRoundtrip:
 
         plaintext = b"A" * (1024 * 1024)  # 1MB
         write_resp = wrapper.write_content(plaintext)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == plaintext
 
 
 # ---------------------------------------------------------------------------
@@ -143,8 +141,8 @@ class TestEncryptedCASDedup:
         wrapper = EncryptedStorage(inner=mock, config=config)
 
         plaintext = b"deterministic content"
-        hash1 = wrapper.write_content(plaintext).data
-        hash2 = wrapper.write_content(plaintext).data
+        hash1 = wrapper.write_content(plaintext).content_hash
+        hash2 = wrapper.write_content(plaintext).content_hash
         assert hash1 == hash2, "GCM-SIV should produce identical ciphertext for identical plaintext"
 
     def test_different_plaintext_different_hash(self) -> None:
@@ -154,8 +152,8 @@ class TestEncryptedCASDedup:
         config = EncryptedStorageConfig(key=_generate_key(), metrics_enabled=False)
         wrapper = EncryptedStorage(inner=mock, config=config)
 
-        hash1 = wrapper.write_content(b"content A").data
-        hash2 = wrapper.write_content(b"content B").data
+        hash1 = wrapper.write_content(b"content A").content_hash
+        hash2 = wrapper.write_content(b"content B").content_hash
         assert hash1 != hash2
 
 
@@ -176,21 +174,15 @@ class TestEncryptedErrors:
 
         # Write valid content
         write_resp = wrapper.write_content(b"valid data")
-        content_hash = write_resp.data
+        content_hash = write_resp.content_hash
 
         # Corrupt the stored ciphertext
         stored = storage[content_hash]
         storage[content_hash] = stored[:10] + b"\xff" * 10 + stored[20:]
 
-        # Read should fail with error response, not raise
-        read_resp = wrapper.read_content(content_hash)
-        assert not read_resp.success
-        assert read_resp.error_message is not None
-        assert (
-            "decrypt" in read_resp.error_message.lower()
-            or "transform" in read_resp.error_message.lower()
-            or "error" in read_resp.error_message.lower()
-        )
+        # Read should raise ValueError from failed decryption
+        with pytest.raises(ValueError):
+            wrapper.read_content(content_hash)
 
     def test_wrong_key_fails(self) -> None:
         from nexus.backends.encrypted_wrapper import EncryptedStorage, EncryptedStorageConfig
@@ -208,25 +200,22 @@ class TestEncryptedErrors:
 
         # Write with key1
         write_resp = wrapper1.write_content(b"secret data")
-        content_hash = write_resp.data
+        content_hash = write_resp.content_hash
 
-        # Read with key2 should fail
-        read_resp = wrapper2.read_content(content_hash)
-        assert not read_resp.success
-        assert read_resp.error_message is not None
+        # Read with key2 should raise ValueError
+        with pytest.raises(ValueError):
+            wrapper2.read_content(content_hash)
 
     def test_inner_read_error_propagated(self) -> None:
         from nexus.backends.encrypted_wrapper import EncryptedStorage, EncryptedStorageConfig
 
         leaf = make_leaf("local")
-        leaf.read_content.return_value = HandlerResponse.error(message="disk I/O error")
+        leaf.read_content.side_effect = NexusFileNotFoundError("disk I/O error")
         config = EncryptedStorageConfig(key=_generate_key(), metrics_enabled=False)
         wrapper = EncryptedStorage(inner=leaf, config=config)
 
-        read_resp = wrapper.read_content("some-hash")
-        assert not read_resp.success
-        assert read_resp.error_message is not None
-        assert "disk I/O error" in read_resp.error_message
+        with pytest.raises(NexusFileNotFoundError, match="disk I/O error"):
+            wrapper.read_content("some-hash")
 
 
 # ---------------------------------------------------------------------------
@@ -255,8 +244,7 @@ class TestEncryptedPassthrough:
 
         # With passthrough, should return raw content
         read_resp = wrapper.read_content(h)
-        assert read_resp.success
-        assert read_resp.data == raw
+        assert read_resp == raw
 
     def test_no_passthrough_rejects_unencrypted_content(self) -> None:
         from nexus.backends.encrypted_wrapper import EncryptedStorage, EncryptedStorageConfig
@@ -274,9 +262,9 @@ class TestEncryptedPassthrough:
         h = hashlib.sha256(raw).hexdigest()
         storage[h] = raw
 
-        # Without passthrough, should fail
-        read_resp = wrapper.read_content(h)
-        assert not read_resp.success
+        # Without passthrough, should raise ValueError
+        with pytest.raises(ValueError):
+            wrapper.read_content(h)
 
 
 # ---------------------------------------------------------------------------
@@ -295,11 +283,10 @@ class TestEncryptedEmptyContent:
         wrapper = EncryptedStorage(inner=mock, config=config)
 
         write_resp = wrapper.write_content(b"")
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
-        read_resp = wrapper.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == b""
+        read_resp = wrapper.read_content(write_resp.content_hash)
+        assert read_resp == b""
 
 
 # ---------------------------------------------------------------------------
@@ -314,25 +301,25 @@ class TestEncryptedDelegation:
         from nexus.backends.encrypted_wrapper import EncryptedStorage, EncryptedStorageConfig
 
         leaf = make_leaf("local")
-        leaf.mkdir.return_value = HandlerResponse.ok(data=None)
+        leaf.mkdir.return_value = None
         config = EncryptedStorageConfig(key=_generate_key(), metrics_enabled=False)
         wrapper = EncryptedStorage(inner=leaf, config=config)
 
         result = wrapper.mkdir("/test", parents=True)
         leaf.mkdir.assert_called_once()
-        assert result.success
+        assert result is None
 
     def test_rmdir_delegates(self) -> None:
         from nexus.backends.encrypted_wrapper import EncryptedStorage, EncryptedStorageConfig
 
         leaf = make_leaf("local")
-        leaf.rmdir.return_value = HandlerResponse.ok(data=None)
+        leaf.rmdir.return_value = None
         config = EncryptedStorageConfig(key=_generate_key(), metrics_enabled=False)
         wrapper = EncryptedStorage(inner=leaf, config=config)
 
         result = wrapper.rmdir("/test", recursive=True)
         leaf.rmdir.assert_called_once()
-        assert result.success
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -372,9 +359,9 @@ class TestEncryptedBatch:
         wrapper = EncryptedStorage(inner=mock, config=config)
 
         # Write 3 items
-        h1 = wrapper.write_content(b"alpha").data
-        h2 = wrapper.write_content(b"beta").data
-        h3 = wrapper.write_content(b"gamma").data
+        h1 = wrapper.write_content(b"alpha").content_hash
+        h2 = wrapper.write_content(b"beta").content_hash
+        h3 = wrapper.write_content(b"gamma").content_hash
 
         # Batch read
         results = wrapper.batch_read_content([h1, h2, h3])
@@ -389,7 +376,7 @@ class TestEncryptedBatch:
         config = EncryptedStorageConfig(key=_generate_key(), metrics_enabled=False)
         wrapper = EncryptedStorage(inner=mock, config=config)
 
-        h1 = wrapper.write_content(b"exists").data
+        h1 = wrapper.write_content(b"exists").content_hash
         results = wrapper.batch_read_content([h1, "nonexistent"])
         assert results[h1] == b"exists"
         assert results["nonexistent"] is None

--- a/tests/unit/backends/test_get_file_info.py
+++ b/tests/unit/backends/test_get_file_info.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nexus.backends.backend import FileInfo
+from nexus.contracts.exceptions import NexusFileNotFoundError
 
 # =============================================================================
 # LocalConnectorBackend.get_file_info()
@@ -33,10 +34,9 @@ class TestLocalConnectorGetFileInfo:
         test_file = tmp_path / "test.txt"
         test_file.write_text("hello world")
 
-        response = connector.get_file_info("test.txt")
+        info = connector.get_file_info("test.txt")
 
-        assert response.success is True
-        info: FileInfo = response.data
+        assert isinstance(info, FileInfo)
         assert info.size == 11  # len("hello world")
         assert info.mtime is not None
         assert info.backend_version is not None
@@ -47,19 +47,18 @@ class TestLocalConnectorGetFileInfo:
         assert parts[1].isdigit()  # mtime_ns
         assert info.content_hash is None
 
-    def test_returns_not_found_for_missing_file(self, connector):
-        """Should return not_found for nonexistent file."""
-        response = connector.get_file_info("nonexistent.txt")
-
-        assert response.success is False
+    def test_raises_not_found_for_missing_file(self, connector):
+        """Should raise NexusFileNotFoundError for nonexistent file."""
+        with pytest.raises(NexusFileNotFoundError):
+            connector.get_file_info("nonexistent.txt")
 
     def test_version_changes_on_content_change(self, connector, tmp_path: Path):
         """Should return different version when file content changes."""
         test_file = tmp_path / "mutable.txt"
         test_file.write_text("original")
 
-        response1 = connector.get_file_info("mutable.txt")
-        version1 = response1.data.backend_version
+        info1 = connector.get_file_info("mutable.txt")
+        version1 = info1.backend_version
 
         # Modify the file (ensure mtime changes)
         import time
@@ -67,8 +66,8 @@ class TestLocalConnectorGetFileInfo:
         time.sleep(0.01)
         test_file.write_text("modified content")
 
-        response2 = connector.get_file_info("mutable.txt")
-        version2 = response2.data.backend_version
+        info2 = connector.get_file_info("mutable.txt")
+        version2 = info2.backend_version
 
         # Version should change (mtime_ns differs)
         assert version1 != version2
@@ -82,19 +81,19 @@ class TestLocalConnectorGetFileInfo:
         ctx = MagicMock()
         ctx.backend_path = "sub/file.txt"
 
-        response = connector.get_file_info("ignored_path", context=ctx)
+        info = connector.get_file_info("ignored_path", context=ctx)
 
-        assert response.success is True
-        assert response.data.size == 4
+        assert isinstance(info, FileInfo)
+        assert info.size == 4
 
     def test_empty_file(self, connector, tmp_path: Path):
         """Should handle empty files correctly."""
         (tmp_path / "empty.txt").write_text("")
 
-        response = connector.get_file_info("empty.txt")
+        info = connector.get_file_info("empty.txt")
 
-        assert response.success is True
-        assert response.data.size == 0
+        assert isinstance(info, FileInfo)
+        assert info.size == 0
 
 
 # =============================================================================
@@ -132,26 +131,24 @@ class TestGCSConnectorGetFileInfo:
         blob.generation = 1234567890
         mock_bucket.blob.return_value = blob
 
-        response = connector.get_file_info("data/file.csv")
+        info = connector.get_file_info("data/file.csv")
 
-        assert response.success is True
-        info: FileInfo = response.data
+        assert isinstance(info, FileInfo)
         assert info.size == 2048
         assert info.mtime == datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
         assert info.backend_version == "1234567890"
         assert info.content_hash is None
 
-    def test_returns_not_found_for_missing_blob(self, connector, mock_bucket):
-        """Should return not_found when blob doesn't exist."""
+    def test_raises_not_found_for_missing_blob(self, connector, mock_bucket):
+        """Should raise NexusFileNotFoundError when blob doesn't exist."""
         from google.cloud.exceptions import NotFound
 
         blob = MagicMock()
         blob.reload.side_effect = NotFound("Blob not found")
         mock_bucket.blob.return_value = blob
 
-        response = connector.get_file_info("missing/file.txt")
-
-        assert response.success is False
+        with pytest.raises(NexusFileNotFoundError):
+            connector.get_file_info("missing/file.txt")
 
     def test_handles_none_generation(self, connector, mock_bucket):
         """Should handle None generation gracefully."""
@@ -161,10 +158,10 @@ class TestGCSConnectorGetFileInfo:
         blob.generation = None
         mock_bucket.blob.return_value = blob
 
-        response = connector.get_file_info("file.txt")
+        info = connector.get_file_info("file.txt")
 
-        assert response.success is True
-        assert response.data.backend_version is None
+        assert isinstance(info, FileInfo)
+        assert info.backend_version is None
 
     def test_handles_zero_size(self, connector, mock_bucket):
         """Should handle blob with zero size."""
@@ -174,11 +171,11 @@ class TestGCSConnectorGetFileInfo:
         blob.generation = 999
         mock_bucket.blob.return_value = blob
 
-        response = connector.get_file_info("empty.txt")
+        info = connector.get_file_info("empty.txt")
 
-        assert response.success is True
-        assert response.data.size == 0
-        assert response.data.backend_version == "999"
+        assert isinstance(info, FileInfo)
+        assert info.size == 0
+        assert info.backend_version == "999"
 
     def test_uses_context_backend_path(self, connector, mock_bucket):
         """Should use context.backend_path when available."""
@@ -231,10 +228,9 @@ class TestS3ConnectorGetFileInfo:
             "VersionId": "abc-123-def",
         }
 
-        response = connector.get_file_info("data/report.pdf")
+        info = connector.get_file_info("data/report.pdf")
 
-        assert response.success is True
-        info: FileInfo = response.data
+        assert isinstance(info, FileInfo)
         assert info.size == 4096
         assert info.mtime == datetime(2025, 7, 1, 10, 30, 0, tzinfo=UTC)
         assert info.backend_version == "abc-123-def"
@@ -249,10 +245,10 @@ class TestS3ConnectorGetFileInfo:
             "ETag": '"d41d8cd98f00b204e9800998ecf8427e"',
         }
 
-        response = connector.get_file_info("file.txt")
+        info = connector.get_file_info("file.txt")
 
-        assert response.success is True
-        assert response.data.backend_version == "etag:d41d8cd98f00b204e9800998ecf8427e"
+        assert isinstance(info, FileInfo)
+        assert info.backend_version == "etag:d41d8cd98f00b204e9800998ecf8427e"
 
     def test_falls_back_to_etag_when_version_id_missing(self, connector, mock_client):
         """Should use ETag when VersionId key is absent."""
@@ -262,13 +258,13 @@ class TestS3ConnectorGetFileInfo:
             "ETag": '"abc123"',
         }
 
-        response = connector.get_file_info("file.txt")
+        info = connector.get_file_info("file.txt")
 
-        assert response.success is True
-        assert response.data.backend_version == "etag:abc123"
+        assert isinstance(info, FileInfo)
+        assert info.backend_version == "etag:abc123"
 
-    def test_returns_not_found_for_missing_object(self, connector, mock_client):
-        """Should return not_found for 404 ClientError."""
+    def test_raises_not_found_for_missing_object(self, connector, mock_client):
+        """Should raise NexusFileNotFoundError for 404 ClientError."""
         from botocore.exceptions import ClientError
 
         mock_client.head_object.side_effect = ClientError(
@@ -276,12 +272,11 @@ class TestS3ConnectorGetFileInfo:
             "HeadObject",
         )
 
-        response = connector.get_file_info("missing.txt")
+        with pytest.raises(NexusFileNotFoundError):
+            connector.get_file_info("missing.txt")
 
-        assert response.success is False
-
-    def test_handles_no_such_key_error(self, connector, mock_client):
-        """Should handle NoSuchKey error code."""
+    def test_raises_not_found_for_no_such_key_error(self, connector, mock_client):
+        """Should raise NexusFileNotFoundError for NoSuchKey error code."""
         from botocore.exceptions import ClientError
 
         mock_client.head_object.side_effect = ClientError(
@@ -289,9 +284,8 @@ class TestS3ConnectorGetFileInfo:
             "HeadObject",
         )
 
-        response = connector.get_file_info("missing.txt")
-
-        assert response.success is False
+        with pytest.raises(NexusFileNotFoundError):
+            connector.get_file_info("missing.txt")
 
     def test_uses_context_backend_path(self, connector, mock_client):
         """Should use context.backend_path when available."""

--- a/tests/unit/backends/test_local_backend.py
+++ b/tests/unit/backends/test_local_backend.py
@@ -34,14 +34,15 @@ def test_backend_name(temp_backend):
 def test_write_and_read_content(temp_backend):
     """Test writing and reading content."""
     content = b"Hello, World!"
-    content_hash = temp_backend.write_content(content).unwrap()
+    result = temp_backend.write_content(content)
+    content_hash = result.content_hash
 
     # Verify hash is correct (using BLAKE3)
     expected_hash = hash_content(content)
     assert content_hash == expected_hash
 
     # Read content back
-    retrieved = temp_backend.read_content(content_hash).unwrap()
+    retrieved = temp_backend.read_content(content_hash)
     assert retrieved == content
 
 
@@ -49,13 +50,13 @@ def test_write_duplicate_content(temp_backend):
     """Test writing duplicate content returns same hash."""
     content = b"Duplicate test content"
 
-    hash1 = temp_backend.write_content(content).unwrap()
-    hash2 = temp_backend.write_content(content).unwrap()
+    hash1 = temp_backend.write_content(content).content_hash
+    hash2 = temp_backend.write_content(content).content_hash
 
     assert hash1 == hash2
 
     # Verify content can be read
-    retrieved = temp_backend.read_content(hash1).unwrap()
+    retrieved = temp_backend.read_content(hash1)
     assert retrieved == content
 
 
@@ -64,24 +65,24 @@ def test_read_nonexistent_content(temp_backend):
     fake_hash = "a" * 64
 
     with pytest.raises(NexusFileNotFoundError):
-        temp_backend.read_content(fake_hash).unwrap()
+        temp_backend.read_content(fake_hash)
 
 
 def test_delete_content(temp_backend):
     """Test deleting content."""
     content = b"Content to delete"
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
     # Verify content exists
-    retrieved = temp_backend.read_content(content_hash).unwrap()
+    retrieved = temp_backend.read_content(content_hash)
     assert retrieved == content
 
     # Delete content
-    temp_backend.delete_content(content_hash).unwrap()
+    temp_backend.delete_content(content_hash)
 
     # Verify content is deleted
     with pytest.raises(NexusFileNotFoundError):
-        temp_backend.read_content(content_hash).unwrap()
+        temp_backend.read_content(content_hash)
 
 
 def test_delete_nonexistent_content(temp_backend):
@@ -92,18 +93,18 @@ def test_delete_nonexistent_content(temp_backend):
 
     # Should raise or handle gracefully (implementation dependent)
     with suppress(NexusFileNotFoundError):  # Expected behavior
-        temp_backend.delete_content(fake_hash).unwrap()
+        temp_backend.delete_content(fake_hash)
 
 
 def test_exists_content(temp_backend):
     """Test checking if content exists."""
     content = b"Existence test"
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
-    assert temp_backend.content_exists(content_hash).unwrap() is True
+    assert temp_backend.content_exists(content_hash) is True
 
     fake_hash = "c" * 64
-    assert temp_backend.content_exists(fake_hash).unwrap() is False
+    assert temp_backend.content_exists(fake_hash) is False
 
 
 def test_hash_to_path(temp_backend):
@@ -136,14 +137,14 @@ def test_compute_hash(temp_backend):
 def test_write_empty_content(temp_backend):
     """Test writing empty content."""
     content = b""
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
     # Verify hash is correct for empty content (using BLAKE3)
     expected_hash = hash_content(b"")
     assert content_hash == expected_hash
 
     # Read it back
-    retrieved = temp_backend.read_content(content_hash).unwrap()
+    retrieved = temp_backend.read_content(content_hash)
     assert retrieved == b""
 
 
@@ -151,10 +152,10 @@ def test_write_large_content(temp_backend):
     """Test writing large content."""
     # 10 MB of data
     content = b"X" * (10 * 1024 * 1024)
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
     # Verify it can be read back
-    retrieved = temp_backend.read_content(content_hash).unwrap()
+    retrieved = temp_backend.read_content(content_hash)
     assert len(retrieved) == len(content)
     assert retrieved == content
 
@@ -162,9 +163,9 @@ def test_write_large_content(temp_backend):
 def test_get_content_size(temp_backend):
     """Test getting content size."""
     content = b"Test content for size"
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
-    size = temp_backend.get_content_size(content_hash).unwrap()
+    size = temp_backend.get_content_size(content_hash)
     assert size == len(content)
 
 
@@ -173,9 +174,9 @@ def test_content_deduplication(temp_backend):
     content = b"Deduplicate me!"
 
     # Write same content multiple times
-    hash1 = temp_backend.write_content(content).unwrap()
-    hash2 = temp_backend.write_content(content).unwrap()
-    hash3 = temp_backend.write_content(content).unwrap()
+    hash1 = temp_backend.write_content(content).content_hash
+    hash2 = temp_backend.write_content(content).content_hash
+    hash3 = temp_backend.write_content(content).content_hash
 
     # All hashes should be identical
     assert hash1 == hash2 == hash3
@@ -185,14 +186,14 @@ def test_content_deduplication(temp_backend):
     assert content_path.exists()
 
     # Read should still work
-    retrieved = temp_backend.read_content(hash1).unwrap()
+    retrieved = temp_backend.read_content(hash1)
     assert retrieved == content
 
 
 def test_directory_creation(temp_backend):
     """Test creating directories."""
     dir_path = "/test/nested/directory"
-    temp_backend.mkdir(dir_path, parents=True).unwrap()
+    temp_backend.mkdir(dir_path, parents=True)
 
     # Check that directory was created
     physical_path = temp_backend.dir_root / dir_path.lstrip("/")
@@ -203,18 +204,18 @@ def test_directory_creation(temp_backend):
 def test_directory_creation_existing(temp_backend):
     """Test creating directory that already exists."""
     dir_path = "/test/existing"
-    temp_backend.mkdir(dir_path, parents=True, exist_ok=True).unwrap()
+    temp_backend.mkdir(dir_path, parents=True, exist_ok=True)
 
     # Create again - should not raise
-    temp_backend.mkdir(dir_path, exist_ok=True).unwrap()
+    temp_backend.mkdir(dir_path, exist_ok=True)
 
 
 def test_is_directory(temp_backend):
     """Test checking if path is a directory."""
     dir_path = "/test/directory"
-    temp_backend.mkdir(dir_path, parents=True).unwrap()
+    temp_backend.mkdir(dir_path, parents=True)
 
-    assert temp_backend.is_directory(dir_path).unwrap() is True
+    assert temp_backend.is_directory(dir_path) is True
 
 
 def test_backend_error_on_invalid_root():
@@ -232,9 +233,9 @@ def test_binary_content(temp_backend):
     """Test handling of binary content."""
     # Binary data with all byte values
     content = bytes(range(256))
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
-    retrieved = temp_backend.read_content(content_hash).unwrap()
+    retrieved = temp_backend.read_content(content_hash)
     assert retrieved == content
 
 
@@ -243,7 +244,7 @@ def test_unicode_directory_names(temp_backend):
     dir_path = "/test/unicode_测试_тест"
 
     try:
-        temp_backend.mkdir(dir_path).unwrap()
+        temp_backend.mkdir(dir_path)
         physical_path = temp_backend.dir_root / dir_path.lstrip("/")
         assert physical_path.exists()
     except Exception:
@@ -260,19 +261,19 @@ def test_multiple_backends_same_root(tmp_path):
 
     # Write with first backend
     content = b"Shared content"
-    hash1 = backend1.write_content(content).unwrap()
+    hash1 = backend1.write_content(content).content_hash
 
     # Read with second backend
-    retrieved = backend2.read_content(hash1).unwrap()
+    retrieved = backend2.read_content(hash1)
     assert retrieved == content
 
 
 def test_list_directory(temp_backend):
     """Test listing directory contents."""
     # Create a directory structure
-    temp_backend.mkdir("/test", parents=True, exist_ok=True).unwrap()
-    temp_backend.mkdir("/test/sub1", exist_ok=True).unwrap()
-    temp_backend.mkdir("/test/sub2", exist_ok=True).unwrap()
+    temp_backend.mkdir("/test", parents=True, exist_ok=True)
+    temp_backend.mkdir("/test/sub1", exist_ok=True)
+    temp_backend.mkdir("/test/sub2", exist_ok=True)
 
     items = temp_backend.list_dir("/test")
 
@@ -288,9 +289,9 @@ def test_batch_read_content_basic(temp_backend):
     content2 = b"Content 2"
     content3 = b"Content 3"
 
-    hash1 = temp_backend.write_content(content1).unwrap()
-    hash2 = temp_backend.write_content(content2).unwrap()
-    hash3 = temp_backend.write_content(content3).unwrap()
+    hash1 = temp_backend.write_content(content1).content_hash
+    hash2 = temp_backend.write_content(content2).content_hash
+    hash3 = temp_backend.write_content(content3).content_hash
 
     # Batch read all content
     result = temp_backend.batch_read_content([hash1, hash2, hash3])
@@ -305,7 +306,7 @@ def test_batch_read_content_missing_hashes(temp_backend):
     """Test batch read with some missing content hashes."""
     # Write one content item
     content1 = b"Content 1"
-    hash1 = temp_backend.write_content(content1).unwrap()
+    hash1 = temp_backend.write_content(content1).content_hash
 
     # Create fake hashes that don't exist
     fake_hash1 = "0" * 64
@@ -329,7 +330,7 @@ def test_batch_read_content_empty_list(temp_backend):
 def test_batch_read_content_deduplication(temp_backend):
     """Test that batch read handles duplicate hashes correctly."""
     content = b"Duplicate content"
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
     # Request same hash multiple times
     result = temp_backend.batch_read_content([content_hash, content_hash, content_hash])
@@ -349,8 +350,8 @@ def test_batch_read_content_with_cache(tmp_path):
     # Write content
     content1 = b"Cached content 1"
     content2 = b"Cached content 2"
-    hash1 = backend.write_content(content1).unwrap()
-    hash2 = backend.write_content(content2).unwrap()
+    hash1 = backend.write_content(content1).content_hash
+    hash2 = backend.write_content(content2).content_hash
 
     # First batch read (populates cache)
     result1 = backend.batch_read_content([hash1, hash2])
@@ -381,7 +382,7 @@ def test_batch_read_content_parallel(tmp_path):
 
     # Write multiple files
     contents = [f"Content for file {i}".encode() for i in range(10)]
-    hashes = [backend.write_content(content).unwrap() for content in contents]
+    hashes = [backend.write_content(content).content_hash for content in contents]
 
     # Batch read all files (will use parallel reads since cache is disabled)
     result = backend.batch_read_content(hashes)
@@ -404,7 +405,7 @@ def test_batch_read_content_parallel_performance(tmp_path):
 
     # Write 20 files
     contents = [f"Content for performance test file {i}".encode() for i in range(20)]
-    hashes = [backend.write_content(content).unwrap() for content in contents]
+    hashes = [backend.write_content(content).content_hash for content in contents]
 
     # Time batch read (should be parallel)
     start = time.time()
@@ -427,7 +428,7 @@ def test_batch_read_content_single_file_no_threadpool(tmp_path):
     backend.content_cache = None
 
     content = b"Single file content"
-    content_hash = backend.write_content(content).unwrap()
+    content_hash = backend.write_content(content).content_hash
 
     # Batch read with single file
     result = backend.batch_read_content([content_hash])
@@ -459,7 +460,7 @@ def test_batch_read_respects_worker_limit(tmp_path):
 
     # Write 10 files
     contents = [f"Content {i}".encode() for i in range(10)]
-    hashes = [backend.write_content(c).unwrap() for c in contents]
+    hashes = [backend.write_content(c).content_hash for c in contents]
 
     # Batch read should work correctly even with limited workers
     result = backend.batch_read_content(hashes)
@@ -472,7 +473,7 @@ def test_batch_read_respects_worker_limit(tmp_path):
 def test_stream_content_small_file(temp_backend):
     """Test streaming a small file."""
     content = b"Small file content for streaming test"
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
     # Stream content
     chunks = list(temp_backend.stream_content(content_hash, chunk_size=10))
@@ -489,7 +490,7 @@ def test_stream_content_large_file(temp_backend):
     """Test streaming a large file in chunks."""
     # Create 1MB test file
     content = b"X" * (1024 * 1024)
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
     # Stream in 64KB chunks
     chunk_size = 64 * 1024
@@ -507,7 +508,7 @@ def test_stream_content_exact_chunk_boundary(temp_backend):
     """Test streaming when file size is exact multiple of chunk size."""
     chunk_size = 100
     content = b"A" * (chunk_size * 5)  # Exactly 5 chunks
-    content_hash = temp_backend.write_content(content).unwrap()
+    content_hash = temp_backend.write_content(content).content_hash
 
     chunks = list(temp_backend.stream_content(content_hash, chunk_size=chunk_size))
 
@@ -528,7 +529,7 @@ def test_stream_content_memory_efficient(temp_backend):
     """Test that streaming doesn't load entire file into memory."""
     # Create 10MB file
     large_content = b"X" * (10 * 1024 * 1024)
-    content_hash = temp_backend.write_content(large_content).unwrap()
+    content_hash = temp_backend.write_content(large_content).content_hash
 
     # Stream it - should not cause memory spike
     total_bytes = 0
@@ -557,7 +558,7 @@ class TestConcurrentSync:
         content = b"concurrent same content sync"
 
         def writer(_i: int) -> str:
-            return temp_backend.write_content(content).unwrap()
+            return temp_backend.write_content(content).content_hash
 
         with ThreadPoolExecutor(max_workers=NUM_THREADS) as pool:
             futures = [pool.submit(writer, i) for i in range(NUM_THREADS)]
@@ -568,7 +569,7 @@ class TestConcurrentSync:
         h = hashes[0]
 
         # Content must be readable
-        assert temp_backend.read_content(h).unwrap() == content
+        assert temp_backend.read_content(h) == content
 
         # ref_count must be exactly NUM_THREADS
         meta = temp_backend._cas.read_meta(h)
@@ -580,7 +581,7 @@ class TestConcurrentSync:
 
         def writer(i: int) -> str:
             content = f"unique sync content {i}".encode()
-            return temp_backend.write_content(content).unwrap()
+            return temp_backend.write_content(content).content_hash
 
         with ThreadPoolExecutor(max_workers=NUM_THREADS) as pool:
             futures = [pool.submit(writer, i) for i in range(NUM_THREADS)]
@@ -599,13 +600,13 @@ class TestConcurrentSync:
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
         content = b"read-write concurrent sync"
-        h = temp_backend.write_content(content).unwrap()
+        h = temp_backend.write_content(content).content_hash
 
         def worker(i: int) -> bytes | str:
             if i % 2 == 0:
-                return temp_backend.write_content(content).unwrap()
+                return temp_backend.write_content(content).content_hash
             else:
-                return temp_backend.read_content(h).unwrap()
+                return temp_backend.read_content(h)
 
         with ThreadPoolExecutor(max_workers=NUM_THREADS) as pool:
             futures = [pool.submit(worker, i) for i in range(NUM_THREADS)]
@@ -640,7 +641,7 @@ class TestChunkedCASIntegration:
         assert len(content) >= chunked_backend.cdc_threshold
 
         # Write
-        manifest_hash = chunked_backend.write_content(content).unwrap()
+        manifest_hash = chunked_backend.write_content(content).content_hash
 
         # Verify manifest is in CAS
         meta = chunked_backend._cas.read_meta(manifest_hash)
@@ -651,7 +652,7 @@ class TestChunkedCASIntegration:
         assert chunked_backend._is_chunked_content(manifest_hash)
 
         # Read back and verify content integrity
-        read_back = chunked_backend.read_content(manifest_hash).unwrap()
+        read_back = chunked_backend.read_content(manifest_hash)
         assert read_back == content
 
     def test_chunked_manifest_structure(self, chunked_backend):
@@ -659,7 +660,7 @@ class TestChunkedCASIntegration:
         from nexus.backends.chunked_storage import ChunkedReference
 
         content = b"X" * 2048  # 2KB, above threshold
-        manifest_hash = chunked_backend.write_content(content).unwrap()
+        manifest_hash = chunked_backend.write_content(content).content_hash
 
         # Read raw manifest
         manifest_bytes = chunked_backend._cas.read_blob(manifest_hash)
@@ -681,7 +682,7 @@ class TestChunkedCASIntegration:
         from nexus.backends.chunked_storage import ChunkedReference
 
         content = b"D" * 2048
-        manifest_hash = chunked_backend.write_content(content).unwrap()
+        manifest_hash = chunked_backend.write_content(content).content_hash
 
         # Read manifest to get chunk hashes
         manifest_bytes = chunked_backend._cas.read_blob(manifest_hash)
@@ -701,8 +702,8 @@ class TestChunkedCASIntegration:
     def test_chunked_deduplication(self, chunked_backend):
         """Writing same chunked content twice increments ref_count."""
         content = b"E" * 2048
-        h1 = chunked_backend.write_content(content).unwrap()
-        h2 = chunked_backend.write_content(content).unwrap()
+        h1 = chunked_backend.write_content(content).content_hash
+        h2 = chunked_backend.write_content(content).content_hash
 
         assert h1 == h2
         meta = chunked_backend._cas.read_meta(h1)
@@ -714,7 +715,7 @@ class TestChunkedCASIntegration:
 
         def writer(i: int) -> str:
             content = f"chunked content {i} ".encode() * 200  # ~3.6KB each
-            return chunked_backend.write_content(content).unwrap()
+            return chunked_backend.write_content(content).content_hash
 
         with ThreadPoolExecutor(max_workers=8) as pool:
             futures = [pool.submit(writer, i) for i in range(8)]

--- a/tests/unit/backends/test_local_connector.py
+++ b/tests/unit/backends/test_local_connector.py
@@ -14,7 +14,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nexus.backends.local_connector import LocalConnectorBackend
-from nexus.contracts.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+from nexus.core.object_store import WriteResult
 
 
 class TestLocalConnectorInit:
@@ -116,27 +117,24 @@ class TestReadContent:
         context.zone_id = None
 
         result = connector.read_content("", context)
-        assert result.success is True
-        assert result.data == b"hello world"
+        assert result == b"hello world"
 
     def test_read_nonexistent_file(self, tmp_path: Path):
-        """Should return not_found for nonexistent file."""
+        """Should raise NexusFileNotFoundError for nonexistent file."""
         connector = LocalConnectorBackend(tmp_path)
 
         context = MagicMock()
         context.backend_path = "nonexistent.txt"
         context.virtual_path = "/mnt/local/nonexistent.txt"
 
-        result = connector.read_content("", context)
-        assert result.success is False
-        assert "not found" in result.error_message.lower()
+        with pytest.raises(NexusFileNotFoundError):
+            connector.read_content("", context)
 
     def test_read_requires_context(self, tmp_path: Path):
-        """Should return error if context is missing."""
+        """Should raise BackendError if context is missing."""
         connector = LocalConnectorBackend(tmp_path)
-        result = connector.read_content("", None)
-        assert result.success is False
-        assert "requires context" in result.error_message
+        with pytest.raises(BackendError):
+            connector.read_content("", None)
 
     def test_read_uses_l1_cache(self, tmp_path: Path):
         """Should check L1 cache before reading from disk."""
@@ -160,7 +158,7 @@ class TestReadContent:
             result = connector.read_content("", context)
 
             # Should return cached content
-            assert result.data == b"cached content"
+            assert result == b"cached content"
             mock_cache.assert_called_once()
 
 
@@ -178,7 +176,7 @@ class TestWriteContent:
 
         result = connector.write_content(b"new content", context=context)
 
-        assert result.success is True
+        assert isinstance(result, WriteResult)
         assert (tmp_path / "new.txt").read_bytes() == b"new content"
 
     def test_write_creates_parent_dirs(self, tmp_path: Path):
@@ -192,20 +190,18 @@ class TestWriteContent:
 
         result = connector.write_content(b"nested content", context=context)
 
-        assert result.success is True
+        assert isinstance(result, WriteResult)
         assert (tmp_path / "subdir" / "nested" / "file.txt").exists()
 
     def test_write_readonly_rejected(self, tmp_path: Path):
-        """Should reject write in readonly mode."""
+        """Should raise BackendError in readonly mode."""
         connector = LocalConnectorBackend(tmp_path, readonly=True)
 
         context = MagicMock()
         context.backend_path = "file.txt"
 
-        result = connector.write_content(b"content", context=context)
-
-        assert result.success is False
-        assert "read-only" in result.error_message
+        with pytest.raises(BackendError):
+            connector.write_content(b"content", context=context)
 
 
 class TestDirectoryOperations:
@@ -249,7 +245,7 @@ class TestDirectoryOperations:
         connector = LocalConnectorBackend(tmp_path)
         result = connector.mkdir("newdir")
 
-        assert result.success is True
+        assert result is None
         assert (tmp_path / "newdir").is_dir()
 
     def test_delete_file(self, tmp_path: Path):
@@ -281,21 +277,18 @@ class TestBackendInterface:
         connector = LocalConnectorBackend(tmp_path)
 
         # These methods exist for interface compatibility but don't work with path-based connector
-        # They now return HandlerResponse for consistency with Backend interface
+        # They now return direct types or raise exceptions
         result = connector.content_exists("somehash")
-        assert result.success is True
-        assert result.data is False
+        assert result is False
 
-        result = connector.get_content_size("somehash")
-        assert result.success is False  # Error response
+        with pytest.raises(BackendError):
+            connector.get_content_size("somehash")
 
         result = connector.get_ref_count("somehash")
-        assert result.success is True
-        assert result.data == 0
+        assert result == 0
 
-        result = connector.delete_content("somehash")
-        assert result.success is False
-        assert "not supported" in result.error_message
+        with pytest.raises(BackendError):
+            connector.delete_content("somehash")
 
 
 class TestCacheConfiguration:

--- a/tests/unit/backends/test_logging_wrapper.py
+++ b/tests/unit/backends/test_logging_wrapper.py
@@ -23,7 +23,7 @@ import pytest
 
 from nexus.backends.backend import HandlerStatusResponse
 from nexus.backends.logging_wrapper import LoggingBackendWrapper
-from nexus.lib.response import HandlerResponse
+from nexus.core.object_store import WriteResult
 from tests.unit.backends.wrapper_test_helpers import make_leaf
 
 # ---------------------------------------------------------------------------
@@ -69,11 +69,10 @@ class TestContentOperationLogs:
     def test_read_content_logs(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        mock_inner.read_content.return_value = HandlerResponse.ok(data=b"content")
+        mock_inner.read_content.return_value = b"content"
         with caplog.at_level(logging.DEBUG, logger="nexus.backends.logging_wrapper"):
             result = logged.read_content("abcdef123456")
-        assert result.success
-        assert result.data == b"content"
+        assert result == b"content"
         assert len(caplog.records) == 1
         record = caplog.records[0]
         assert record.levelno == logging.DEBUG
@@ -85,10 +84,10 @@ class TestContentOperationLogs:
     def test_write_content_logs(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        mock_inner.write_content.return_value = HandlerResponse.ok(data="hash123456ab")
+        mock_inner.write_content.return_value = WriteResult(content_hash="hash123456ab", size=11)
         with caplog.at_level(logging.DEBUG, logger="nexus.backends.logging_wrapper"):
             result = logged.write_content(b"hello world")
-        assert result.success
+        assert isinstance(result, WriteResult)
         assert len(caplog.records) == 1
         record = caplog.records[0]
         assert "write_content" in record.message
@@ -98,7 +97,7 @@ class TestContentOperationLogs:
     def test_delete_content_logs(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        mock_inner.delete_content.return_value = HandlerResponse.ok(data=None)
+        mock_inner.delete_content.return_value = None
         with caplog.at_level(logging.DEBUG, logger="nexus.backends.logging_wrapper"):
             logged.delete_content("abcdef123456")
         assert len(caplog.records) == 1
@@ -107,10 +106,10 @@ class TestContentOperationLogs:
     def test_content_exists_logs(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        mock_inner.content_exists.return_value = HandlerResponse.ok(data=True)
+        mock_inner.content_exists.return_value = True
         with caplog.at_level(logging.DEBUG, logger="nexus.backends.logging_wrapper"):
             result = logged.content_exists("abcdef123456")
-        assert result.data is True
+        assert result is True
         assert len(caplog.records) == 1
         assert "content_exists" in caplog.records[0].message
         assert "exists=True" in caplog.records[0].message
@@ -153,7 +152,7 @@ class TestDirectoryOperationLogs:
     def test_mkdir_logs(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        mock_inner.mkdir.return_value = HandlerResponse.ok(data=None)
+        mock_inner.mkdir.return_value = None
         with caplog.at_level(logging.DEBUG, logger="nexus.backends.logging_wrapper"):
             logged.mkdir("/test/dir", parents=True)
         assert len(caplog.records) == 1
@@ -163,7 +162,7 @@ class TestDirectoryOperationLogs:
     def test_rmdir_logs(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        mock_inner.rmdir.return_value = HandlerResponse.ok(data=None)
+        mock_inner.rmdir.return_value = None
         with caplog.at_level(logging.DEBUG, logger="nexus.backends.logging_wrapper"):
             logged.rmdir("/test/dir", recursive=True)
         assert len(caplog.records) == 1
@@ -231,7 +230,7 @@ class TestDelegationCorrectness:
     def test_read_returns_inner_response(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock
     ) -> None:
-        expected = HandlerResponse.ok(data=b"exact-data")
+        expected = b"exact-data"
         mock_inner.read_content.return_value = expected
         result = logged.read_content("hash")
         assert result is expected
@@ -239,7 +238,7 @@ class TestDelegationCorrectness:
     def test_write_returns_inner_response(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock
     ) -> None:
-        expected = HandlerResponse.ok(data="hash-result")
+        expected = WriteResult(content_hash="hash-result")
         mock_inner.write_content.return_value = expected
         result = logged.write_content(b"data")
         assert result is expected
@@ -247,12 +246,17 @@ class TestDelegationCorrectness:
     def test_failure_response_logged(
         self, logged: LoggingBackendWrapper, mock_inner: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        failed = HandlerResponse.error(message="not found")
-        mock_inner.read_content.return_value = failed
-        with caplog.at_level(logging.DEBUG, logger="nexus.backends.logging_wrapper"):
-            result = logged.read_content("missing-hash")
-        assert not result.success
-        assert "success=False" in caplog.records[0].message
+        mock_inner.read_content.side_effect = RuntimeError("not found")
+        with (
+            caplog.at_level(logging.DEBUG, logger="nexus.backends.logging_wrapper"),
+            pytest.raises(RuntimeError, match="not found"),
+        ):
+            logged.read_content("missing-hash")
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert "read_content" in record.message
+        assert "error=" in record.message
+        assert "not found" in record.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/test_passthrough.py
+++ b/tests/unit/backends/test_passthrough.py
@@ -3,6 +3,7 @@
 import pytest
 
 from nexus.backends.passthrough import POINTER_PREFIX, PassthroughBackend
+from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 
 
@@ -38,54 +39,54 @@ class TestContentOperations:
     def test_write_and_read_content(self, temp_backend):
         """Test writing and reading content."""
         content = b"Hello, World!"
-        content_hash = temp_backend.write_content(content).unwrap()
+        result = temp_backend.write_content(content)
+        content_hash = result.content_hash
 
         # Verify hash is correct
         expected_hash = hash_content(content)
         assert content_hash == expected_hash
 
         # Read content back
-        retrieved = temp_backend.read_content(content_hash).unwrap()
+        retrieved = temp_backend.read_content(content_hash)
         assert retrieved == content
 
     def test_write_duplicate_content(self, temp_backend):
         """Test writing duplicate content returns same hash."""
         content = b"Duplicate test content"
 
-        hash1 = temp_backend.write_content(content).unwrap()
-        hash2 = temp_backend.write_content(content).unwrap()
+        hash1 = temp_backend.write_content(content).content_hash
+        hash2 = temp_backend.write_content(content).content_hash
 
         assert hash1 == hash2
 
     def test_read_nonexistent_content(self, temp_backend):
-        """Test reading non-existent content returns not_found."""
+        """Test reading non-existent content raises NexusFileNotFoundError."""
         fake_hash = "a" * 64
-        response = temp_backend.read_content(fake_hash)
-        assert not response.success
-        assert response.error_code == 404
+        with pytest.raises(NexusFileNotFoundError):
+            temp_backend.read_content(fake_hash)
 
     def test_content_exists(self, temp_backend):
         """Test checking if content exists."""
         content = b"Existence test"
-        content_hash = temp_backend.write_content(content).unwrap()
+        content_hash = temp_backend.write_content(content).content_hash
 
-        assert temp_backend.content_exists(content_hash).unwrap() is True
+        assert temp_backend.content_exists(content_hash) is True
 
         fake_hash = "b" * 64
-        assert temp_backend.content_exists(fake_hash).unwrap() is False
+        assert temp_backend.content_exists(fake_hash) is False
 
     def test_get_content_size(self, temp_backend):
         """Test getting content size."""
         content = b"Size test content"
-        content_hash = temp_backend.write_content(content).unwrap()
+        content_hash = temp_backend.write_content(content).content_hash
 
-        size = temp_backend.get_content_size(content_hash).unwrap()
+        size = temp_backend.get_content_size(content_hash)
         assert size == len(content)
 
     def test_cas_path_structure(self, temp_backend):
         """Test CAS uses two-level directory structure."""
         content = b"Path structure test"
-        content_hash = temp_backend.write_content(content).unwrap()
+        content_hash = temp_backend.write_content(content).content_hash
 
         cas_path = temp_backend._get_cas_path(content_hash)
         # Should be: cas/ab/cd/abcd...
@@ -129,7 +130,7 @@ class TestPointerOperations:
         content = b"Content with pointer"
         context = MockContext(virtual_path="/inbox/file.txt")
 
-        content_hash = temp_backend.write_content(content, context=context).unwrap()
+        content_hash = temp_backend.write_content(content, context=context).content_hash
 
         # Verify pointer was created
         pointer_path = temp_backend._get_pointer_path("/inbox/file.txt")
@@ -163,7 +164,7 @@ class TestDirectoryOperations:
 
     def test_mkdir(self, temp_backend):
         """Test creating directories."""
-        temp_backend.mkdir("/test/nested", parents=True).unwrap()
+        temp_backend.mkdir("/test/nested", parents=True)
 
         dir_path = temp_backend._get_pointer_path("/test/nested")
         assert dir_path.exists()
@@ -171,23 +172,23 @@ class TestDirectoryOperations:
 
     def test_rmdir(self, temp_backend):
         """Test removing directories."""
-        temp_backend.mkdir("/to_delete", parents=True).unwrap()
-        temp_backend.rmdir("/to_delete").unwrap()
+        temp_backend.mkdir("/to_delete", parents=True)
+        temp_backend.rmdir("/to_delete")
 
         dir_path = temp_backend._get_pointer_path("/to_delete")
         assert not dir_path.exists()
 
     def test_is_directory(self, temp_backend):
         """Test checking if path is directory."""
-        temp_backend.mkdir("/is_dir_test", parents=True).unwrap()
+        temp_backend.mkdir("/is_dir_test", parents=True)
 
-        assert temp_backend.is_directory("/is_dir_test").unwrap() is True
-        assert temp_backend.is_directory("/nonexistent").unwrap() is False
+        assert temp_backend.is_directory("/is_dir_test") is True
+        assert temp_backend.is_directory("/nonexistent") is False
 
     def test_list_dir(self, temp_backend):
         """Test listing directory contents."""
         # Create some files and directories
-        temp_backend.mkdir("/list_test/subdir", parents=True).unwrap()
+        temp_backend.mkdir("/list_test/subdir", parents=True)
         temp_backend._write_pointer("/list_test/file1.txt", "hash1" + "0" * 59)
         temp_backend._write_pointer("/list_test/file2.txt", "hash2" + "0" * 59)
 
@@ -199,7 +200,7 @@ class TestDirectoryOperations:
 
     def test_list_dir_excludes_tmp_files(self, temp_backend):
         """Test that list_dir excludes .tmp files."""
-        temp_backend.mkdir("/tmp_test", parents=True).unwrap()
+        temp_backend.mkdir("/tmp_test", parents=True)
 
         # Create a normal file and a temp file
         pointer_path = temp_backend._get_pointer_path("/tmp_test")
@@ -357,20 +358,20 @@ class TestEdgeCases:
     def test_empty_content(self, temp_backend):
         """Test writing empty content."""
         content = b""
-        content_hash = temp_backend.write_content(content).unwrap()
+        content_hash = temp_backend.write_content(content).content_hash
 
         expected_hash = hash_content(b"")
         assert content_hash == expected_hash
 
-        retrieved = temp_backend.read_content(content_hash).unwrap()
+        retrieved = temp_backend.read_content(content_hash)
         assert retrieved == b""
 
     def test_large_content(self, temp_backend):
         """Test writing large content."""
         content = b"X" * (1024 * 1024)  # 1 MB
-        content_hash = temp_backend.write_content(content).unwrap()
+        content_hash = temp_backend.write_content(content).content_hash
 
-        retrieved = temp_backend.read_content(content_hash).unwrap()
+        retrieved = temp_backend.read_content(content_hash)
         assert len(retrieved) == len(content)
         assert retrieved == content
 
@@ -390,7 +391,7 @@ class TestEdgeCases:
         content = b"Nested content"
         context = MockContext(virtual_path="/a/b/c/d/e/f/file.txt")
 
-        content_hash = temp_backend.write_content(content, context=context).unwrap()
+        content_hash = temp_backend.write_content(content, context=context).content_hash
 
         # Verify pointer exists
         read_hash = temp_backend._read_pointer("/a/b/c/d/e/f/file.txt")

--- a/tests/unit/backends/test_protocol_conformance.py
+++ b/tests/unit/backends/test_protocol_conformance.py
@@ -17,6 +17,8 @@ from typing import Any
 import pytest
 
 from nexus.backends.backend import Backend
+from nexus.contracts.exceptions import NexusFileNotFoundError
+from nexus.core.object_store import WriteResult
 from nexus.core.protocols.connector import (
     BatchContentProtocol,
     ConnectorProtocol,
@@ -27,7 +29,6 @@ from nexus.core.protocols.connector import (
     PassthroughProtocol,
     StreamingProtocol,
 )
-from nexus.lib.response import HandlerResponse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -49,60 +50,49 @@ class _MockBackend(Backend):
     def _hash(self, content: bytes) -> str:
         return hashlib.sha256(content).hexdigest()
 
-    def write_content(self, content: bytes, context: Any = None) -> HandlerResponse[str]:
+    def write_content(self, content: bytes, context: Any = None) -> WriteResult:
         h = self._hash(content)
         if h in self._content:
             self._ref_counts[h] += 1
         else:
             self._content[h] = content
             self._ref_counts[h] = 1
-        return HandlerResponse.ok(data=h, backend_name="mock")
+        return WriteResult(content_hash=h, size=len(content))
 
-    def read_content(self, content_hash: str, context: Any = None) -> HandlerResponse[bytes]:
+    def read_content(self, content_hash: str, context: Any = None) -> bytes:
         if content_hash not in self._content:
-            return HandlerResponse.not_found(
-                path=content_hash, message="Not found", backend_name="mock"
-            )
-        return HandlerResponse.ok(data=self._content[content_hash], backend_name="mock")
+            raise NexusFileNotFoundError(content_hash)
+        return self._content[content_hash]
 
-    def delete_content(self, content_hash: str, context: Any = None) -> HandlerResponse[None]:
+    def delete_content(self, content_hash: str, context: Any = None) -> None:
         if content_hash not in self._content:
-            return HandlerResponse.not_found(
-                path=content_hash, message="Not found", backend_name="mock"
-            )
+            raise NexusFileNotFoundError(content_hash)
         self._ref_counts[content_hash] -= 1
         if self._ref_counts[content_hash] <= 0:
             del self._content[content_hash]
             del self._ref_counts[content_hash]
-        return HandlerResponse.ok(data=None, backend_name="mock")
 
-    def content_exists(self, content_hash: str, context: Any = None) -> HandlerResponse[bool]:
-        return HandlerResponse.ok(data=content_hash in self._content, backend_name="mock")
+    def content_exists(self, content_hash: str, context: Any = None) -> bool:
+        return content_hash in self._content
 
-    def get_content_size(self, content_hash: str, context: Any = None) -> HandlerResponse[int]:
+    def get_content_size(self, content_hash: str, context: Any = None) -> int:
         if content_hash not in self._content:
-            return HandlerResponse.not_found(
-                path=content_hash, message="Not found", backend_name="mock"
-            )
-        return HandlerResponse.ok(data=len(self._content[content_hash]), backend_name="mock")
+            raise NexusFileNotFoundError(content_hash)
+        return len(self._content[content_hash])
 
-    def get_ref_count(self, content_hash: str, context: Any = None) -> HandlerResponse[int]:
-        return HandlerResponse.ok(data=self._ref_counts.get(content_hash, 0), backend_name="mock")
+    def get_ref_count(self, content_hash: str, context: Any = None) -> int:
+        return self._ref_counts.get(content_hash, 0)
 
     def mkdir(
         self, path: str, parents: bool = False, exist_ok: bool = False, context: Any = None
-    ) -> HandlerResponse[None]:
+    ) -> None:
         self._dirs.add(path)
-        return HandlerResponse.ok(data=None, backend_name="mock")
 
-    def rmdir(
-        self, path: str, recursive: bool = False, context: Any = None
-    ) -> HandlerResponse[None]:
+    def rmdir(self, path: str, recursive: bool = False, context: Any = None) -> None:
         self._dirs.discard(path)
-        return HandlerResponse.ok(data=None, backend_name="mock")
 
-    def is_directory(self, path: str, context: Any = None) -> HandlerResponse[bool]:
-        return HandlerResponse.ok(data=path in self._dirs, backend_name="mock")
+    def is_directory(self, path: str, context: Any = None) -> bool:
+        return path in self._dirs
 
 
 class _IncompleteClass:

--- a/tests/unit/backends/test_stream_range.py
+++ b/tests/unit/backends/test_stream_range.py
@@ -24,8 +24,8 @@ def _create_local_backend(tmp_path: Path) -> LocalBackend:
 
 
 def _write_content(backend: LocalBackend, data: bytes) -> str:
-    resp = backend.write_content(data)
-    return resp.unwrap()
+    result = backend.write_content(data)
+    return result.content_hash
 
 
 # =============================================================================

--- a/tests/unit/backends/test_wrapper_chain.py
+++ b/tests/unit/backends/test_wrapper_chain.py
@@ -15,6 +15,7 @@ Design reference:
 
 import time
 
+from nexus.core.object_store import WriteResult
 from tests.unit.backends.wrapper_test_helpers import make_storage_mock
 
 # ---------------------------------------------------------------------------
@@ -67,16 +68,15 @@ class TestCompressEncryptChain:
         # Write plaintext through entire chain
         plaintext = b"hello world from the full chain! " * 100
         write_resp = compressed.write_content(plaintext)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
         # Verify stored content is neither plaintext nor just compressed
-        stored = storage[write_resp.data]
+        stored = storage[write_resp.content_hash]
         assert stored != plaintext, "Stored content should be encrypted"
 
         # Read back through chain
-        read_resp = compressed.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        read_back = compressed.read_content(write_resp.content_hash)
+        assert read_back == plaintext
 
     def test_chain_dedup(self) -> None:
         """Same content through same chain should produce same hash."""
@@ -98,8 +98,8 @@ class TestCompressEncryptChain:
         )
 
         content = b"deduplicate me " * 100
-        h1 = compressed.write_content(content).data
-        h2 = compressed.write_content(content).data
+        h1 = compressed.write_content(content).content_hash
+        h2 = compressed.write_content(content).content_hash
         assert h1 == h2
 
     def test_chain_batch_read(self) -> None:
@@ -122,7 +122,7 @@ class TestCompressEncryptChain:
         )
 
         items = [b"item_a " * 50, b"item_b " * 50, b"item_c " * 50]
-        hashes = [compressed.write_content(item).data for item in items]
+        hashes = [compressed.write_content(item).content_hash for item in items]
 
         results = compressed.batch_read_content(hashes)
         for h, expected in zip(hashes, items):
@@ -173,11 +173,10 @@ class TestEncryptCompressChain:
 
         plaintext = b"reversed chain data " * 100
         write_resp = encrypted.write_content(plaintext)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
-        read_resp = encrypted.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        read_back = encrypted.read_content(write_resp.content_hash)
+        assert read_back == plaintext
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +212,7 @@ class TestWrapperChainPerformance:
         content = b"performance test data " * 100
 
         # Warm up
-        h = compressed.write_content(content).data
+        h = compressed.write_content(content).content_hash
         compressed.read_content(h)
 
         # Time writes
@@ -269,17 +268,15 @@ class TestCacheWrapperChain:
 
         plaintext = b"cache chain test data " * 100
         write_resp = cached.write_content(plaintext)
-        assert write_resp.success
+        assert isinstance(write_resp, WriteResult)
 
         # First read populates L1
-        read_resp = cached.read_content(write_resp.data)
-        assert read_resp.success
-        assert read_resp.data == plaintext
+        read_back = cached.read_content(write_resp.content_hash)
+        assert read_back == plaintext
 
         # Second read should hit L1 cache
-        read_resp2 = cached.read_content(write_resp.data)
-        assert read_resp2.success
-        assert read_resp2.data == plaintext
+        read_back2 = cached.read_content(write_resp.content_hash)
+        assert read_back2 == plaintext
 
     def test_cache_only_chain(self) -> None:
         """cache → leaf: verify cache hit skips inner."""
@@ -294,16 +291,15 @@ class TestCacheWrapperChain:
 
         # Write and first read
         write_resp = cached.write_content(b"hello")
-        content_hash = write_resp.data
+        content_hash = write_resp.content_hash
         cached.read_content(content_hash)
 
         # Reset mock call count
         mock.read_content.reset_mock()
 
         # Second read should hit L1, not call inner
-        resp = cached.read_content(content_hash)
-        assert resp.success
-        assert resp.data == b"hello"
+        read_back = cached.read_content(content_hash)
+        assert read_back == b"hello"
         mock.read_content.assert_not_called()
 
     def test_cache_chain_describe(self) -> None:
@@ -385,7 +381,7 @@ class TestPerformanceRegression:
         content = b"full chain perf data " * 100
 
         # Warm up
-        h = cached.write_content(content).data
+        h = cached.write_content(content).content_hash
         cached.read_content(h)
 
         # Time reads (includes L1 cache hit path)

--- a/tests/unit/cache/test_caching_backend_wrapper.py
+++ b/tests/unit/cache/test_caching_backend_wrapper.py
@@ -14,7 +14,7 @@ from nexus.backends.caching_backend_wrapper import (
     CacheWrapperConfig,
     CachingBackendWrapper,
 )
-from nexus.lib.response import HandlerResponse
+from nexus.core.object_store import WriteResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -27,11 +27,6 @@ def _make_mock_backend(name: str = "mock") -> MagicMock:
     backend.name = name
     backend.describe.return_value = name
     return backend
-
-
-def _ok_response(data: object) -> HandlerResponse:
-    """Build a HandlerResponse.ok for testing."""
-    return HandlerResponse.ok(data=data, backend_name="mock")
 
 
 # ---------------------------------------------------------------------------
@@ -81,18 +76,17 @@ class TestL1CacheHitMiss:
     def test_l1_cache_miss_delegates_to_inner(self) -> None:
         """First read_content delegates to inner backend (L1 miss)."""
         inner = _make_mock_backend()
-        inner.read_content.return_value = _ok_response(b"file-data")
+        inner.read_content.return_value = b"file-data"
         wrapper = CachingBackendWrapper(inner=inner)
 
         response = wrapper.read_content("hash123")
-        assert response.success
-        assert response.data == b"file-data"
+        assert response == b"file-data"
         inner.read_content.assert_called_once()
 
     def test_l1_cache_hit_avoids_inner(self) -> None:
         """Second read_content with same hash returns from L1 (no inner call)."""
         inner = _make_mock_backend()
-        inner.read_content.return_value = _ok_response(b"file-data")
+        inner.read_content.return_value = b"file-data"
         wrapper = CachingBackendWrapper(inner=inner)
 
         # First read — populates L1
@@ -101,14 +95,13 @@ class TestL1CacheHitMiss:
 
         # Second read — should hit L1
         response = wrapper.read_content("hash123")
-        assert response.success
-        assert response.data == b"file-data"
+        assert response == b"file-data"
         inner.read_content.assert_not_called()
 
     def test_l1_miss_increments_miss_counter(self) -> None:
         """L1 miss is tracked in stats."""
         inner = _make_mock_backend()
-        inner.read_content.return_value = _ok_response(b"data")
+        inner.read_content.return_value = b"data"
         wrapper = CachingBackendWrapper(inner=inner)
 
         wrapper.read_content("hash_a")
@@ -118,7 +111,7 @@ class TestL1CacheHitMiss:
     def test_l1_hit_increments_hit_counter(self) -> None:
         """L1 hit is tracked in stats."""
         inner = _make_mock_backend()
-        inner.read_content.return_value = _ok_response(b"data")
+        inner.read_content.return_value = b"data"
         wrapper = CachingBackendWrapper(inner=inner)
 
         wrapper.read_content("hash_b")
@@ -138,8 +131,8 @@ class TestCacheInvalidation:
     def test_write_around_invalidates_l1(self) -> None:
         """After write_content, cached content for that hash is evicted."""
         inner = _make_mock_backend()
-        inner.read_content.return_value = _ok_response(b"original")
-        inner.write_content.return_value = _ok_response("hash_x")
+        inner.read_content.return_value = b"original"
+        inner.write_content.return_value = WriteResult(content_hash="hash_x")
 
         config = CacheWrapperConfig(strategy=CacheStrategy.WRITE_AROUND)
         wrapper = CachingBackendWrapper(inner=inner, config=config)
@@ -152,15 +145,15 @@ class TestCacheInvalidation:
         wrapper.write_content(b"new-data")
 
         # Next read should go to inner (L1 was invalidated)
-        inner.read_content.return_value = _ok_response(b"new-data")
+        inner.read_content.return_value = b"new-data"
         response = wrapper.read_content("hash_x")
         inner.read_content.assert_called_once()
-        assert response.data == b"new-data"
+        assert response == b"new-data"
 
     def test_write_through_populates_l1(self) -> None:
         """WRITE_THROUGH strategy populates L1 on write."""
         inner = _make_mock_backend()
-        inner.write_content.return_value = _ok_response("hash_y")
+        inner.write_content.return_value = WriteResult(content_hash="hash_y")
 
         config = CacheWrapperConfig(strategy=CacheStrategy.WRITE_THROUGH)
         wrapper = CachingBackendWrapper(inner=inner, config=config)
@@ -169,8 +162,7 @@ class TestCacheInvalidation:
 
         # L1 should have the content now; read should not call inner
         response = wrapper.read_content("hash_y")
-        assert response.success
-        assert response.data == b"content-data"
+        assert response == b"content-data"
         inner.read_content.assert_not_called()
 
 
@@ -283,7 +275,7 @@ class TestL2WritePopulateOnly:
     def test_clear_cache_resets_all_counters(self) -> None:
         """clear_cache() resets WrapperMetrics counters."""
         inner = _make_mock_backend()
-        inner.read_content.return_value = _ok_response(b"data")
+        inner.read_content.return_value = b"data"
         wrapper = CachingBackendWrapper(inner=inner)
 
         wrapper.read_content("hash_z")

--- a/tests/unit/core/test_object_store.py
+++ b/tests/unit/core/test_object_store.py
@@ -1,14 +1,14 @@
 """Conformance test suite for ObjectStoreABC Protocol.
 
 Tests:
-- ObjectStoreABC conformance (write/read/delete/exists/size/batch_read)
-- BackendObjectStore adapter error handling
+- ObjectStoreABC conformance (write_content/read_content/delete_content/get_content_size/batch_read_content)
+- Error handling on direct backend calls
 - Protocol isinstance checks
 - Deduplication behavior
 - Edge cases (empty, binary, large content)
 - Hash validation
-- Context propagation
-- Repr and debuggability
+- Context propagation (direct method parameter)
+- Backend call overhead
 
 Parametrized across LocalBackend and MockBackend.
 """
@@ -22,8 +22,7 @@ import pytest
 from nexus.backends.backend import Backend
 from nexus.backends.local import LocalBackend
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
-from nexus.core.object_store import BackendObjectStore, ObjectStoreABC, _validate_hash
-from nexus.lib.response import HandlerResponse
+from nexus.core.object_store import ObjectStoreABC, WriteResult, _validate_hash
 
 
 class MockBackend(Backend):
@@ -38,7 +37,7 @@ class MockBackend(Backend):
     def name(self) -> str:
         return "mock"
 
-    def write_content(self, content, context=None) -> HandlerResponse[str]:
+    def write_content(self, content, context=None) -> WriteResult:
         self._last_context = context
         h = hashlib.sha256(content).hexdigest()
         if h in self._content:
@@ -46,15 +45,13 @@ class MockBackend(Backend):
         else:
             self._content[h] = content
             self._ref_counts[h] = 1
-        return HandlerResponse.ok(data=h, backend_name="mock")
+        return WriteResult(content_hash=h, size=len(content))
 
-    def read_content(self, content_hash, context=None) -> HandlerResponse[bytes]:
+    def read_content(self, content_hash, context=None) -> bytes:
         self._last_context = context
         if content_hash not in self._content:
-            return HandlerResponse.not_found(
-                path=content_hash, message="Content not found", backend_name="mock"
-            )
-        return HandlerResponse.ok(data=self._content[content_hash], backend_name="mock")
+            raise NexusFileNotFoundError(path=content_hash, message="Content not found")
+        return self._content[content_hash]
 
     def batch_read_content(
         self, content_hashes, context=None, *, contexts=None
@@ -62,47 +59,45 @@ class MockBackend(Backend):
         self._last_context = context
         return {h: self._content.get(h) for h in content_hashes}
 
-    def delete_content(self, content_hash, context=None) -> HandlerResponse[None]:
+    def delete_content(self, content_hash, context=None) -> None:
         self._last_context = context
         if content_hash not in self._content:
-            return HandlerResponse.not_found(path=content_hash, backend_name="mock")
+            raise NexusFileNotFoundError(path=content_hash, message="Content not found")
         self._ref_counts[content_hash] -= 1
         if self._ref_counts[content_hash] <= 0:
             del self._content[content_hash]
             del self._ref_counts[content_hash]
-        return HandlerResponse.ok(data=None, backend_name="mock")
 
-    def content_exists(self, content_hash, context=None) -> HandlerResponse[bool]:
+    def content_exists(self, content_hash, context=None) -> bool:
         self._last_context = context
-        return HandlerResponse.ok(data=content_hash in self._content, backend_name="mock")
+        return content_hash in self._content
 
-    def get_content_size(self, content_hash, context=None) -> HandlerResponse[int]:
+    def get_content_size(self, content_hash, context=None) -> int:
         self._last_context = context
         if content_hash not in self._content:
-            return HandlerResponse.not_found(path=content_hash, backend_name="mock")
-        return HandlerResponse.ok(data=len(self._content[content_hash]), backend_name="mock")
+            raise NexusFileNotFoundError(path=content_hash, message="Content not found")
+        return len(self._content[content_hash])
 
-    def get_ref_count(self, content_hash, context=None) -> HandlerResponse[int]:
-        return HandlerResponse.ok(data=self._ref_counts.get(content_hash, 0), backend_name="mock")
+    def get_ref_count(self, content_hash, context=None) -> int:
+        return self._ref_counts.get(content_hash, 0)
 
-    def mkdir(self, path, parents=False, exist_ok=False, context=None) -> HandlerResponse[None]:
-        return HandlerResponse.ok(data=None, backend_name="mock")
+    def mkdir(self, path, parents=False, exist_ok=False, context=None) -> None:
+        return None
 
-    def rmdir(self, path, recursive=False, context=None) -> HandlerResponse[None]:
-        return HandlerResponse.ok(data=None, backend_name="mock")
+    def rmdir(self, path, recursive=False, context=None) -> None:
+        return None
 
-    def is_directory(self, path, context=None) -> HandlerResponse[bool]:
-        return HandlerResponse.ok(data=False, backend_name="mock")
+    def is_directory(self, path, context=None) -> bool:
+        return False
 
 
 # === Fixtures ===
 
 
 @pytest.fixture
-def local_store(tmp_path) -> BackendObjectStore:
+def local_store(tmp_path) -> ObjectStoreABC:
     """ObjectStoreABC backed by LocalBackend with tmp_path."""
-    backend = LocalBackend(root_path=str(tmp_path))
-    return BackendObjectStore(backend)
+    return LocalBackend(root_path=str(tmp_path))
 
 
 @pytest.fixture
@@ -112,83 +107,79 @@ def mock_backend() -> MockBackend:
 
 
 @pytest.fixture
-def mock_store(mock_backend) -> BackendObjectStore:
-    """ObjectStoreABC backed by MockBackend."""
-    return BackendObjectStore(mock_backend)
+def mock_store() -> MockBackend:
+    """MockBackend as ObjectStoreABC (Backend IS ObjectStoreABC now)."""
+    return MockBackend()
 
 
 @pytest.fixture(params=["local", "mock"])
-def store(request, tmp_path) -> BackendObjectStore:
+def store(request, tmp_path) -> ObjectStoreABC:
     """Parametrized fixture for both local and mock stores."""
     if request.param == "local":
-        backend = LocalBackend(root_path=str(tmp_path))
-        return BackendObjectStore(backend)
+        return LocalBackend(root_path=str(tmp_path))
     else:
-        backend = MockBackend()
-        return BackendObjectStore(backend)
+        return MockBackend()
 
 
 # === Conformance Tests ===
 
 
 class TestObjectStoreConformance:
-    """Core conformance tests — must pass for all ObjectStoreABC implementations."""
+    """Core conformance tests -- must pass for all ObjectStoreABC implementations."""
 
-    def test_write_returns_hash(self, store: BackendObjectStore) -> None:
-        content_hash = store.write(b"hello world")
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 64  # SHA-256 hex
+    def test_write_returns_write_result(self, store: ObjectStoreABC) -> None:
+        result = store.write_content(b"hello world")
+        assert isinstance(result, WriteResult)
+        assert isinstance(result.content_hash, str)
+        assert result.size == len(b"hello world")
 
-    def test_read_roundtrip(self, store: BackendObjectStore) -> None:
+    def test_read_roundtrip(self, store: ObjectStoreABC) -> None:
         content = b"roundtrip test data"
-        content_hash = store.write(content)
-        result = store.read(content_hash)
-        assert result == content
+        result = store.write_content(content)
+        retrieved = store.read_content(result.content_hash)
+        assert retrieved == content
 
-    def test_read_nonexistent_raises(self, store: BackendObjectStore) -> None:
+    def test_read_nonexistent_raises(self, store: ObjectStoreABC) -> None:
         fake_hash = "a" * 64
         with pytest.raises((NexusFileNotFoundError, BackendError)):
-            store.read(fake_hash)
+            store.read_content(fake_hash)
 
-    def test_delete(self, store: BackendObjectStore) -> None:
-        content_hash = store.write(b"delete me")
-        assert store.exists(content_hash)
-        store.delete(content_hash)
-        assert not store.exists(content_hash)
+    def test_delete(self, store: ObjectStoreABC) -> None:
+        result = store.write_content(b"delete me")
+        content_hash = result.content_hash
+        # Verify content exists via read
+        store.read_content(content_hash)
+        # Delete it
+        store.delete_content(content_hash)
+        # Verify it's gone
+        with pytest.raises((NexusFileNotFoundError, BackendError)):
+            store.read_content(content_hash)
 
-    def test_exists_true(self, store: BackendObjectStore) -> None:
-        content_hash = store.write(b"I exist")
-        assert store.exists(content_hash) is True
-
-    def test_exists_false(self, store: BackendObjectStore) -> None:
-        fake_hash = "b" * 64
-        assert store.exists(fake_hash) is False
-
-    def test_size(self, store: BackendObjectStore) -> None:
+    def test_get_content_size(self, store: ObjectStoreABC) -> None:
         content = b"size check"
-        content_hash = store.write(content)
-        assert store.size(content_hash) == len(content)
+        result = store.write_content(content)
+        assert store.get_content_size(result.content_hash) == len(content)
 
-    def test_batch_read(self, store: BackendObjectStore) -> None:
-        h1 = store.write(b"item1")
-        h2 = store.write(b"item2")
-        h3 = store.write(b"item3")
-        result = store.batch_read([h1, h2, h3])
+    def test_batch_read_content(self, store: ObjectStoreABC) -> None:
+        h1 = store.write_content(b"item1").content_hash
+        h2 = store.write_content(b"item2").content_hash
+        h3 = store.write_content(b"item3").content_hash
+        result = store.batch_read_content([h1, h2, h3])
         assert result[h1] == b"item1"
         assert result[h2] == b"item2"
         assert result[h3] == b"item3"
 
-    def test_batch_read_partial(self, store: BackendObjectStore) -> None:
-        h1 = store.write(b"exists")
+    def test_batch_read_content_partial(self, store: ObjectStoreABC) -> None:
+        h1 = store.write_content(b"exists").content_hash
         fake_hash = "c" * 64
-        result = store.batch_read([h1, fake_hash])
+        result = store.batch_read_content([h1, fake_hash])
         assert result[h1] == b"exists"
         assert result[fake_hash] is None
 
-    def test_deduplication(self, store: BackendObjectStore) -> None:
+    def test_deduplication(self, store: ObjectStoreABC) -> None:
         content = b"same content twice"
-        h1 = store.write(content)
-        h2 = store.write(content)
+        h1 = store.write_content(content).content_hash
+        h2 = store.write_content(content).content_hash
         assert h1 == h2
 
 
@@ -196,106 +187,105 @@ class TestObjectStoreConformance:
 
 
 class TestEdgeCases:
-    """Edge cases that validate adapter boundary behavior."""
+    """Edge cases that validate boundary behavior."""
 
-    def test_empty_content(self, store: BackendObjectStore) -> None:
+    def test_empty_content(self, store: ObjectStoreABC) -> None:
         """Empty content (0 bytes) should hash consistently and roundtrip."""
         content = b""
-        content_hash = store.write(content)
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 64
-        retrieved = store.read(content_hash)
+        result = store.write_content(content)
+        assert isinstance(result.content_hash, str)
+        retrieved = store.read_content(result.content_hash)
         assert retrieved == b""
-        assert store.size(content_hash) == 0
+        assert store.get_content_size(result.content_hash) == 0
 
-    def test_binary_content_all_bytes(self, store: BackendObjectStore) -> None:
+    def test_binary_content_all_bytes(self, store: ObjectStoreABC) -> None:
         """Binary content with all 256 byte values should preserve exactly."""
         content = bytes(range(256))
-        content_hash = store.write(content)
-        retrieved = store.read(content_hash)
+        result = store.write_content(content)
+        retrieved = store.read_content(result.content_hash)
         assert retrieved == content
-        assert store.size(content_hash) == 256
+        assert store.get_content_size(result.content_hash) == 256
 
-    def test_large_content(self, store: BackendObjectStore) -> None:
+    def test_large_content(self, store: ObjectStoreABC) -> None:
         """Large content (1MB) should handle without memory issues."""
         content = b"X" * (1024 * 1024)
-        content_hash = store.write(content)
-        retrieved = store.read(content_hash)
+        result = store.write_content(content)
+        retrieved = store.read_content(result.content_hash)
         assert len(retrieved) == len(content)
-        assert store.size(content_hash) == 1024 * 1024
+        assert store.get_content_size(result.content_hash) == 1024 * 1024
 
-    def test_batch_read_empty_list(self, store: BackendObjectStore) -> None:
-        """batch_read([]) returns empty dict."""
-        result = store.batch_read([])
+    def test_batch_read_content_empty_list(self, store: ObjectStoreABC) -> None:
+        """batch_read_content([]) returns empty dict."""
+        result = store.batch_read_content([])
         assert result == {}
 
-    def test_batch_read_single_item(self, store: BackendObjectStore) -> None:
-        """batch_read([hash]) works like read()."""
+    def test_batch_read_content_single_item(self, store: ObjectStoreABC) -> None:
+        """batch_read_content([hash]) works like read_content()."""
         content = b"single"
-        content_hash = store.write(content)
-        result = store.batch_read([content_hash])
+        content_hash = store.write_content(content).content_hash
+        result = store.batch_read_content([content_hash])
         assert len(result) == 1
         assert result[content_hash] == content
 
-    def test_batch_read_all_missing(self, store: BackendObjectStore) -> None:
-        """batch_read with all missing hashes returns all None."""
-        result = store.batch_read(["a" * 64, "b" * 64, "c" * 64])
+    def test_batch_read_content_all_missing(self, store: ObjectStoreABC) -> None:
+        """batch_read_content with all missing hashes returns all None."""
+        result = store.batch_read_content(["a" * 64, "b" * 64, "c" * 64])
         assert len(result) == 3
         assert all(v is None for v in result.values())
 
-    def test_size_consistency_roundtrip(self, store: BackendObjectStore) -> None:
-        """size() matches len(read()) immediately after write()."""
+    def test_size_consistency_roundtrip(self, store: ObjectStoreABC) -> None:
+        """get_content_size() matches len(read_content()) immediately after write_content()."""
         content = b"consistency check content"
-        content_hash = store.write(content)
-        assert store.size(content_hash) == len(content)
-        retrieved = store.read(content_hash)
-        assert len(retrieved) == store.size(content_hash)
+        content_hash = store.write_content(content).content_hash
+        assert store.get_content_size(content_hash) == len(content)
+        retrieved = store.read_content(content_hash)
+        assert len(retrieved) == store.get_content_size(content_hash)
 
 
 # === Protocol isinstance Tests ===
 
 
 class TestProtocolConformance:
-    def test_backend_object_store_isinstance(self, mock_store: BackendObjectStore) -> None:
+    def test_mock_backend_isinstance(self, mock_store: MockBackend) -> None:
         assert isinstance(mock_store, ObjectStoreABC)
 
-    def test_name_property(self, mock_store: BackendObjectStore) -> None:
+    def test_mock_backend_name(self, mock_store: MockBackend) -> None:
         assert mock_store.name == "mock"
 
-    def test_local_store_isinstance(self, local_store: BackendObjectStore) -> None:
+    def test_local_store_isinstance(self, local_store: ObjectStoreABC) -> None:
         assert isinstance(local_store, ObjectStoreABC)
 
-    def test_local_store_name(self, local_store: BackendObjectStore) -> None:
+    def test_local_store_name(self, local_store: ObjectStoreABC) -> None:
         assert local_store.name == "local"
 
 
-# === Adapter Error Handling Tests (Issue 10A) ===
+# === Error Handling Tests (Issue 10A) ===
 
 
-class TestAdapterErrorHandling:
-    def test_read_nonexistent_raises(self, mock_store: BackendObjectStore) -> None:
+class TestErrorHandling:
+    def test_read_nonexistent_raises(self, mock_store: MockBackend) -> None:
         with pytest.raises((NexusFileNotFoundError, BackendError)):
-            mock_store.read("0" * 64)
+            mock_store.read_content("0" * 64)
 
-    def test_delete_nonexistent_raises(self, mock_store: BackendObjectStore) -> None:
+    def test_delete_nonexistent_raises(self, mock_store: MockBackend) -> None:
         with pytest.raises((NexusFileNotFoundError, BackendError)):
-            mock_store.delete("0" * 64)
+            mock_store.delete_content("0" * 64)
 
-    def test_size_nonexistent_raises(self, mock_store: BackendObjectStore) -> None:
+    def test_size_nonexistent_raises(self, mock_store: MockBackend) -> None:
         with pytest.raises((NexusFileNotFoundError, BackendError)):
-            mock_store.size("0" * 64)
+            mock_store.get_content_size("0" * 64)
 
-    def test_error_message_preserved(self, mock_store: BackendObjectStore) -> None:
+    def test_error_message_preserved(self, mock_store: MockBackend) -> None:
         try:
-            mock_store.read("0" * 64)
+            mock_store.read_content("0" * 64)
             pytest.fail("Expected exception")
         except (NexusFileNotFoundError, BackendError) as e:
             assert "not found" in str(e).lower() or "Content not found" in str(e)
 
-    def test_write_returns_consistent_hash(self, mock_store: BackendObjectStore) -> None:
+    def test_write_returns_consistent_hash(self, mock_store: MockBackend) -> None:
         content = b"deterministic"
-        h1 = mock_store.write(content)
-        h2 = mock_store.write(content)
+        h1 = mock_store.write_content(content).content_hash
+        h2 = mock_store.write_content(content).content_hash
         assert h1 == h2
 
 
@@ -303,7 +293,7 @@ class TestAdapterErrorHandling:
 
 
 class TestHashValidation:
-    """Validates _validate_hash rejects malformed hashes at adapter boundary."""
+    """Validates _validate_hash rejects malformed hashes."""
 
     def test_validate_hash_accepts_valid(self) -> None:
         _validate_hash("a" * 64)
@@ -329,122 +319,63 @@ class TestHashValidation:
         with pytest.raises(ValueError, match="Invalid SHA-256"):
             _validate_hash("a" * 65)
 
-    def test_read_rejects_invalid_hash(self, mock_store: BackendObjectStore) -> None:
-        with pytest.raises(ValueError, match="Invalid SHA-256"):
-            mock_store.read("not-a-hash")
-
-    def test_delete_rejects_invalid_hash(self, mock_store: BackendObjectStore) -> None:
-        with pytest.raises(ValueError, match="Invalid SHA-256"):
-            mock_store.delete("xyz")
-
-    def test_exists_rejects_invalid_hash(self, mock_store: BackendObjectStore) -> None:
-        with pytest.raises(ValueError, match="Invalid SHA-256"):
-            mock_store.exists("")
-
-    def test_size_rejects_invalid_hash(self, mock_store: BackendObjectStore) -> None:
-        with pytest.raises(ValueError, match="Invalid SHA-256"):
-            mock_store.size("A" * 64)
-
-    def test_batch_read_rejects_invalid_hash(self, mock_store: BackendObjectStore) -> None:
-        valid = "a" * 64
-        invalid = "ZZZZ"
-        with pytest.raises(ValueError, match="Invalid SHA-256"):
-            mock_store.batch_read([valid, invalid])
-
 
 # === Context Propagation Tests (Issue 11A) ===
 
 
 class TestContextPropagation:
-    """Verify OperationContext flows from adapter to backend."""
+    """Verify OperationContext flows through direct backend method calls."""
 
     def test_context_none_by_default(self, mock_backend: MockBackend) -> None:
-        store = BackendObjectStore(mock_backend)
-        store.write(b"test")
+        mock_backend.write_content(b"test")
         assert mock_backend._last_context is None
 
     def test_context_propagated_to_write(self, mock_backend: MockBackend) -> None:
         ctx = MagicMock()
-        store = BackendObjectStore(mock_backend, context=ctx)
-        store.write(b"test")
+        mock_backend.write_content(b"test", context=ctx)
         assert mock_backend._last_context is ctx
 
     def test_context_propagated_to_read(self, mock_backend: MockBackend) -> None:
         ctx = MagicMock()
-        store_no_ctx = BackendObjectStore(mock_backend)
-        content_hash = store_no_ctx.write(b"ctx read test")
-
-        store = BackendObjectStore(mock_backend, context=ctx)
-        store.read(content_hash)
+        result = mock_backend.write_content(b"ctx read test")
+        mock_backend.read_content(result.content_hash, context=ctx)
         assert mock_backend._last_context is ctx
 
-    def test_context_propagated_to_exists(self, mock_backend: MockBackend) -> None:
+    def test_context_propagated_to_content_exists(self, mock_backend: MockBackend) -> None:
         ctx = MagicMock()
-        store = BackendObjectStore(mock_backend, context=ctx)
-        store.exists("a" * 64)
+        mock_backend.content_exists("a" * 64, context=ctx)
         assert mock_backend._last_context is ctx
 
     def test_context_propagated_to_delete(self, mock_backend: MockBackend) -> None:
         ctx = MagicMock()
-        store_no_ctx = BackendObjectStore(mock_backend)
-        content_hash = store_no_ctx.write(b"ctx delete test")
-
-        store = BackendObjectStore(mock_backend, context=ctx)
-        store.delete(content_hash)
+        result = mock_backend.write_content(b"ctx delete test")
+        mock_backend.delete_content(result.content_hash, context=ctx)
         assert mock_backend._last_context is ctx
 
     def test_context_propagated_to_batch_read(self, mock_backend: MockBackend) -> None:
         ctx = MagicMock()
-        store = BackendObjectStore(mock_backend, context=ctx)
-        store.batch_read(["a" * 64])
+        mock_backend.batch_read_content(["a" * 64], context=ctx)
         assert mock_backend._last_context is ctx
-
-
-# === Repr and Debuggability Tests (Issue 6A) ===
-
-
-class TestReprAndDebug:
-    """Verify __repr__ and read-only properties work correctly."""
-
-    def test_repr_without_context(self, mock_store: BackendObjectStore) -> None:
-        r = repr(mock_store)
-        assert "BackendObjectStore" in r
-        assert "mock" in r
-        assert "context" not in r
-
-    def test_repr_with_context(self, mock_backend: MockBackend) -> None:
-        ctx = MagicMock()
-        store = BackendObjectStore(mock_backend, context=ctx)
-        r = repr(store)
-        assert "BackendObjectStore" in r
-        assert "mock" in r
-        assert "context=" in r
-
-    def test_backend_property_readonly(self, mock_backend: MockBackend) -> None:
-        store = BackendObjectStore(mock_backend)
-        assert store.backend is mock_backend
-
-    def test_backend_property_returns_backend_type(self, local_store: BackendObjectStore) -> None:
-        assert isinstance(local_store.backend, LocalBackend)
 
 
 # === Benchmark Tests ===
 
 
-class TestAdapterOverhead:
-    def test_adapter_overhead_under_50us(self, mock_store: BackendObjectStore) -> None:
-        """Measure adapter call overhead — should be minimal."""
-        content_hash = mock_store.write(b"benchmark data")
+class TestBackendOverhead:
+    def test_direct_call_overhead_under_50us(self, mock_store: MockBackend) -> None:
+        """Measure direct backend call overhead -- should be minimal."""
+        result = mock_store.write_content(b"benchmark data")
+        content_hash = result.content_hash
 
         # Warmup
         for _ in range(100):
-            mock_store.exists(content_hash)
+            mock_store.read_content(content_hash)
 
         iterations = 10_000
         start = time.perf_counter()
         for _ in range(iterations):
-            mock_store.exists(content_hash)
+            mock_store.read_content(content_hash)
         elapsed_us = (time.perf_counter() - start) * 1_000_000 / iterations
 
-        # Adapter overhead should be minimal (under 50μs including MockBackend + validation)
-        assert elapsed_us < 50, f"Adapter call took {elapsed_us:.2f}μs per call"
+        # Direct backend call should be minimal (under 50us including MockBackend)
+        assert elapsed_us < 50, f"Backend call took {elapsed_us:.2f}us per call"


### PR DESCRIPTION
## Summary

- **Migrate 5 backend connectors** (base_blob_connector, local_connector, gcs_connector, s3_connector, backend.py) from `HandlerResponse` wrapping to direct return types (`WriteResult`, `bytes`, `None`, `int`, `bool`) + exception-based errors (`BackendError`, `NexusFileNotFoundError`)
- **Update write_back_service** to remove defensive `.unwrap()` patterns now that backends return direct types
- **Fix `nexus.constants` → `nexus.contracts.constants`** imports across 7 files (module was already migrated in a prior PR)
- **Update 14 test files** to match new direct-return contract: remove `.unwrap()`, `.success`, `.data` patterns; use `isinstance(WriteResult)` and `pytest.raises` for error cases
- **Rewrite `test_object_store.py`** — remove deleted `BackendObjectStore` adapter references

## Details

### Source changes (14 files)
| File | Change |
|---|---|
| `backend.py` | `get_file_info()` → returns `FileInfo` directly (not `HandlerResponse[FileInfo]`) |
| `base_blob_connector.py` | All 9 kernel methods migrated (-564/+435 lines), removed `time.perf_counter()` timing |
| `local_connector.py` | 10 kernel methods → direct types; service methods (list_dir_detailed, delete, rename, stat, glob) keep `HandlerResponse` |
| `gcs_connector.py` | read_content, write_content, write_content_with_version_check, get_file_info → direct types |
| `s3_connector.py` | Same as gcs_connector + batch_read_content internal error handling |
| `write_back_service.py` | Remove `.unwrap()` in _handle_write, _handle_delete, _handle_mkdir |
| 7 files | `nexus.constants` → `nexus.contracts.constants` |

### Test changes (14 files)
All test files updated to match exception-based contract: `WriteResult` assertions, `pytest.raises` for errors, no more `.unwrap()`/`.success`/`.data`.

**Note**: AsyncLocalBackend tests keep `.unwrap()` — async migration is deferred per plan.

### Test results
**884 passed, 1 skipped, 0 failed** across all backend + cache + core/object_store tests.

## Test plan
- [x] `uv run pytest tests/unit/backends/ -v` — 832 passed
- [x] `uv run pytest tests/unit/cache/ -v` — all passed
- [x] `uv run pytest tests/unit/core/test_object_store.py -v` — 52 passed
- [x] Pre-commit hooks (ruff, ruff-format, mypy) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)