### PR TITLE
fix(rebac): bidirectional tupleToUserset, Tiger Cache consistency bypass, get_stats

### DIFF
--- a/rust/nexus_core/src/rebac/graph.rs
+++ b/rust/nexus_core/src/rebac/graph.rs
@@ -10,6 +10,9 @@ use crate::types::*;
 pub struct InternedGraph {
     pub tuple_index: AHashSet<InternedTupleKey>,
     pub adjacency_list: AHashMap<InternedAdjacencyKey, Vec<InternedEntity>>,
+    /// Reverse adjacency: (object_type, object_id, relation) → [subjects].
+    /// Enables tupleToUserset resolution which needs "find subjects with relation on object".
+    pub reverse_adjacency: AHashMap<InternedAdjacencyKey, Vec<InternedEntity>>,
     pub userset_index: AHashMap<InternedUsersetKey, Vec<InternedUsersetEntry>>,
     /// Wildcard subject (*:*) symbol.
     pub wildcard_subject: Option<InternedEntity>,
@@ -27,6 +30,8 @@ impl InternedGraph {
 
         let mut tuple_index = AHashSet::new();
         let mut adjacency_list: AHashMap<InternedAdjacencyKey, Vec<InternedEntity>> =
+            AHashMap::new();
+        let mut reverse_adjacency: AHashMap<InternedAdjacencyKey, Vec<InternedEntity>> =
             AHashMap::new();
         let mut userset_index: AHashMap<InternedUsersetKey, Vec<InternedUsersetEntry>> =
             AHashMap::new();
@@ -53,6 +58,7 @@ impl InternedGraph {
                 tuple_index.insert(tuple_key);
             }
 
+            // Forward adjacency: subject → objects
             let adj_key = (tuple.subject_type, tuple.subject_id, tuple.relation);
             adjacency_list
                 .entry(adj_key)
@@ -61,11 +67,23 @@ impl InternedGraph {
                     entity_type: tuple.object_type,
                     entity_id: tuple.object_id,
                 });
+
+            // Reverse adjacency: object → subjects
+            // Required for tupleToUserset which needs "find subjects with relation on object"
+            let rev_key = (tuple.object_type, tuple.object_id, tuple.relation);
+            reverse_adjacency
+                .entry(rev_key)
+                .or_default()
+                .push(InternedEntity {
+                    entity_type: tuple.subject_type,
+                    entity_id: tuple.subject_id,
+                });
         }
 
         InternedGraph {
             tuple_index,
             adjacency_list,
+            reverse_adjacency,
             userset_index,
             wildcard_subject,
         }
@@ -106,15 +124,29 @@ impl InternedGraph {
         false
     }
 
-    /// Find related objects via adjacency list.
+    /// Find objects that a subject has a relation on (forward: subject → objects).
     pub fn find_related_objects(
+        &self,
+        subject: InternedEntity,
+        relation: Sym,
+    ) -> Vec<InternedEntity> {
+        let adj_key = (subject.entity_type, subject.entity_id, relation);
+        self.adjacency_list
+            .get(&adj_key)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Find subjects that have a relation on an object (reverse: object → subjects).
+    /// Required for tupleToUserset: "find who has `tupleset` relation on this object".
+    pub fn find_subjects_for_object(
         &self,
         object: InternedEntity,
         relation: Sym,
     ) -> Vec<InternedEntity> {
-        let adj_key = (object.entity_type, object.entity_id, relation);
-        self.adjacency_list
-            .get(&adj_key)
+        let rev_key = (object.entity_type, object.entity_id, relation);
+        self.reverse_adjacency
+            .get(&rev_key)
             .cloned()
             .unwrap_or_default()
     }
@@ -221,13 +253,24 @@ pub fn compute_permission_interned(
                 tupleset,
                 computed_userset,
             } => {
-                let related_objects = graph.find_related_objects(object, *tupleset);
+                // tupleToUserset checks BOTH directions:
+                //
+                // Forward (parent pattern): object acts as subject with tupleset relation
+                //   parent_viewer = {tupleset: "parent", computedUserset: "viewer"}
+                //   file:doc → parent → folder:docs, then check viewer on folder:docs
+                //
+                // Reverse (group pattern): others have tupleset relation ON object
+                //   group_viewer = {tupleset: "direct_viewer", computedUserset: "member"}
+                //   group:team → direct_viewer → file:/path, then check member on group:team
                 let mut allowed = false;
-                for related_obj in related_objects {
+
+                // Forward: object as subject → find objects it points to
+                let forward_targets = graph.find_related_objects(object, *tupleset);
+                for target in &forward_targets {
                     if compute_permission_interned(
                         subject,
                         *computed_userset,
-                        related_obj,
+                        *target,
                         graph,
                         namespaces,
                         memo_cache,
@@ -238,6 +281,27 @@ pub fn compute_permission_interned(
                         break;
                     }
                 }
+
+                // Reverse: find subjects that have tupleset relation ON object
+                if !allowed {
+                    let reverse_targets = graph.find_subjects_for_object(object, *tupleset);
+                    for target in &reverse_targets {
+                        if compute_permission_interned(
+                            subject,
+                            *computed_userset,
+                            *target,
+                            graph,
+                            namespaces,
+                            memo_cache,
+                            visited,
+                            depth + 1,
+                        ) {
+                            allowed = true;
+                            break;
+                        }
+                    }
+                }
+
                 allowed
             }
         }

--- a/rust/nexus_core/src/rebac/mod.rs
+++ b/rust/nexus_core/src/rebac/mod.rs
@@ -22,6 +22,9 @@ pub const MAX_DEPTH: u32 = 50;
 pub struct ReBACGraph {
     pub tuple_index: AHashSet<TupleKey>,
     pub adjacency_list: AHashMap<AdjacencyKey, Vec<Entity>>,
+    /// Reverse adjacency: (object_type, object_id, relation) → [subjects].
+    /// Enables tupleToUserset resolution which needs "find subjects with relation on object".
+    pub reverse_adjacency: AHashMap<AdjacencyKey, Vec<Entity>>,
     pub userset_index: AHashMap<UsersetKey, Vec<UsersetEntry>>,
 }
 
@@ -30,6 +33,7 @@ impl ReBACGraph {
     pub fn from_tuples(tuples: &[ReBACTuple]) -> Self {
         let mut tuple_index = AHashSet::new();
         let mut adjacency_list: AHashMap<AdjacencyKey, Vec<Entity>> = AHashMap::new();
+        let mut reverse_adjacency: AHashMap<AdjacencyKey, Vec<Entity>> = AHashMap::new();
         let mut userset_index: AHashMap<UsersetKey, Vec<UsersetEntry>> = AHashMap::new();
 
         for tuple in tuples {
@@ -58,6 +62,7 @@ impl ReBACGraph {
                 tuple_index.insert(tuple_key);
             }
 
+            // Forward adjacency: subject → objects
             let adj_key = (
                 tuple.subject_type.clone(),
                 tuple.subject_id.clone(),
@@ -67,11 +72,23 @@ impl ReBACGraph {
                 entity_type: tuple.object_type.clone(),
                 entity_id: tuple.object_id.clone(),
             });
+
+            // Reverse adjacency: object → subjects
+            let rev_key = (
+                tuple.object_type.clone(),
+                tuple.object_id.clone(),
+                tuple.relation.clone(),
+            );
+            reverse_adjacency.entry(rev_key).or_default().push(Entity {
+                entity_type: tuple.subject_type.clone(),
+                entity_id: tuple.subject_id.clone(),
+            });
         }
 
         ReBACGraph {
             tuple_index,
             adjacency_list,
+            reverse_adjacency,
             userset_index,
         }
     }
@@ -100,15 +117,29 @@ impl ReBACGraph {
         self.tuple_index.contains(&wildcard_key)
     }
 
-    /// Find related objects in O(1) time using adjacency list.
-    pub fn find_related_objects(&self, object: &Entity, relation: &str) -> Vec<Entity> {
+    /// Find objects that a subject has a relation on (forward: subject → objects).
+    pub fn find_related_objects(&self, subject: &Entity, relation: &str) -> Vec<Entity> {
         let adj_key = (
-            object.entity_type.clone(),
-            object.entity_id.clone(),
+            subject.entity_type.clone(),
+            subject.entity_id.clone(),
             relation.to_string(),
         );
         self.adjacency_list
             .get(&adj_key)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Find subjects that have a relation on an object (reverse: object → subjects).
+    /// Required for tupleToUserset: "find who has `tupleset` relation on this object".
+    pub fn find_subjects_for_object(&self, object: &Entity, relation: &str) -> Vec<Entity> {
+        let rev_key = (
+            object.entity_type.clone(),
+            object.entity_id.clone(),
+            relation.to_string(),
+        );
+        self.reverse_adjacency
+            .get(&rev_key)
             .cloned()
             .unwrap_or_default()
     }
@@ -216,14 +247,25 @@ pub fn compute_permission(
                 allowed
             }
             RelationConfig::TupleToUserset { tuple_to_userset } => {
-                let related_objects =
-                    graph.find_related_objects(object, &tuple_to_userset.tupleset);
+                // tupleToUserset checks BOTH directions:
+                //
+                // Forward (parent pattern): object acts as subject with tupleset relation
+                //   parent_viewer = {tupleset: "parent", computedUserset: "viewer"}
+                //   file:doc → parent → folder:docs, then check viewer on folder:docs
+                //
+                // Reverse (group pattern): others have tupleset relation ON object
+                //   group_viewer = {tupleset: "direct_viewer", computedUserset: "member"}
+                //   group:team → direct_viewer → file:/path, then check member on group:team
                 let mut allowed = false;
-                for related_obj in related_objects {
+
+                // Forward: object as subject → find objects it points to
+                let forward_targets =
+                    graph.find_related_objects(object, &tuple_to_userset.tupleset);
+                for target in &forward_targets {
                     if compute_permission(
                         subject,
                         &tuple_to_userset.computed_userset,
-                        &related_obj,
+                        target,
                         graph,
                         namespaces,
                         memo_cache,
@@ -234,6 +276,28 @@ pub fn compute_permission(
                         break;
                     }
                 }
+
+                // Reverse: find subjects that have tupleset relation ON object
+                if !allowed {
+                    let reverse_targets =
+                        graph.find_subjects_for_object(object, &tuple_to_userset.tupleset);
+                    for target in &reverse_targets {
+                        if compute_permission(
+                            subject,
+                            &tuple_to_userset.computed_userset,
+                            target,
+                            graph,
+                            namespaces,
+                            memo_cache,
+                            &mut visited.clone(),
+                            depth + 1,
+                        ) {
+                            allowed = true;
+                            break;
+                        }
+                    }
+                }
+
                 // Also check direct relations — Zanzibar: direct tuples always apply
                 if !allowed {
                     allowed = check_relation_with_usersets(
@@ -358,12 +422,28 @@ pub fn expand_permission(
                 }
             }
             RelationConfig::TupleToUserset { tuple_to_userset } => {
-                let related_objects =
+                // Forward: object as subject → find objects it points to
+                let forward_targets =
                     graph.find_related_objects(object, &tuple_to_userset.tupleset);
-                for related_obj in related_objects {
+                for target in &forward_targets {
                     expand_permission(
                         &tuple_to_userset.computed_userset,
-                        &related_obj,
+                        target,
+                        graph,
+                        namespaces,
+                        subjects,
+                        &mut visited.clone(),
+                        depth + 1,
+                    );
+                }
+
+                // Reverse: find subjects that have tupleset relation ON object
+                let reverse_targets =
+                    graph.find_subjects_for_object(object, &tuple_to_userset.tupleset);
+                for target in &reverse_targets {
+                    expand_permission(
+                        &tuple_to_userset.computed_userset,
+                        target,
                         graph,
                         namespaces,
                         subjects,

--- a/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
+++ b/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
@@ -122,6 +122,12 @@ class TigerCache:
         self._cache_max_size = 100_000  # Increased from 10k per Issue #979
         self._lock = threading.RLock()
 
+        # Stats counters for observability
+        self._stats_hits = 0
+        self._stats_misses = 0
+        self._stats_sets = 0
+        self._stats_invalidations = 0
+
         # Persistent thread pool for L2 operations (avoid per-operation creation)
         self._l2_executor: Any | None = None
         self._l2_max_workers = l2_max_workers
@@ -356,6 +362,7 @@ class TigerCache:
                 bitmap, revision, cached_at = self._cache[key]
                 if time.time() - cached_at < self._cache_ttl:
                     result = int_id in bitmap
+                    self._stats_hits += 1
                     logger.debug(
                         f"Tiger Cache MEMORY HIT: {subject_type}:{subject_id} -> {permission} -> {resource_type}:{resource_id} = {result}"
                     )
@@ -368,12 +375,14 @@ class TigerCache:
         bitmap = self._load_from_db(key, conn)
         if bitmap is not None:
             result = int_id in bitmap
+            self._stats_hits += 1
             logger.debug(
                 f"Tiger Cache DB HIT: {subject_type}:{subject_id} -> {permission} -> {resource_type}:{resource_id} = {result}"
             )
             return result
 
         # Not in cache
+        self._stats_misses += 1
         logger.debug(
             f"Tiger Cache MISS: {subject_type}:{subject_id} -> {permission} -> {resource_type}:{resource_id}"
         )
@@ -891,6 +900,7 @@ class TigerCache:
         with self._lock:
             self._evict_if_needed()
             self._cache[key] = (bitmap, revision, time.time())
+            self._stats_sets += 1
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"[TIGER] Updated cache for {key}, {len(resource_int_ids)} resources")
@@ -987,6 +997,7 @@ class TigerCache:
             for key in keys_to_remove:
                 del self._cache[key]
 
+        self._stats_invalidations += count + dragonfly_count + len(keys_to_remove)
         logger.debug(
             f"[TIGER] Invalidated {count} L3 + {dragonfly_count} L2 + {len(keys_to_remove)} L1 entries"
         )
@@ -1009,6 +1020,25 @@ class TigerCache:
         """Clear in-memory cache."""
         with self._lock:
             self._cache.clear()
+
+    def get_stats(self) -> dict[str, Any]:
+        """Return cache statistics for observability.
+
+        Returns a dict with hit/miss/set/invalidation counts and L1 cache size.
+        Exposed via the /cache/stats endpoint.
+        """
+        with self._lock:
+            l1_size = len(self._cache)
+        return {
+            "hits": self._stats_hits,
+            "misses": self._stats_misses,
+            "sets": self._stats_sets,
+            "invalidations": self._stats_invalidations,
+            "l1_size": l1_size,
+            "l1_max_size": self._cache_max_size,
+            "l1_ttl_seconds": self._cache_ttl,
+            "l2_enabled": self._dragonfly is not None,
+        }
 
     def add_to_bitmap(
         self,

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -471,10 +471,12 @@ class ReBACManager:
 
         # OPTIMIZATION 1: Boundary Cache (Issue #922) - O(1) inheritance shortcut
         # For file permissions, check if we have a cached boundary (nearest ancestor with grant)
+        # Skip when consistency_level is STRONG — caches must be bypassed for strong reads
         if (
             object_type == "file"
             and permission in ("read", "write", "execute")
             and self._boundary_cache
+            and consistency_level != ConsistencyLevel.STRONG
         ):
             boundary = self._boundary_cache.get_boundary(
                 effective_zone, subject_type, subject_id, permission, object_id
@@ -499,7 +501,8 @@ class ReBACManager:
 
         # OPTIMIZATION 2: Try Tiger Cache (O(1) bitmap lookup)
         # Tiger Cache stores pre-materialized permissions as Roaring Bitmaps
-        if self._tiger_cache and zone_id:
+        # Skip when consistency_level is STRONG — caches must be bypassed for strong reads
+        if self._tiger_cache and zone_id and consistency_level != ConsistencyLevel.STRONG:
             tiger_result = self.tiger_check_access(
                 subject=subject,
                 permission=permission,
@@ -1780,6 +1783,18 @@ class ReBACManager:
                     tuple_info["object_id"],
                     effective_zone,
                 )
+
+            # Boundary Cache: Invalidate cached boundaries for affected subject+object
+            if self._boundary_cache:
+                effective_zone_bc = normalize_zone_id(zone_id)
+                for perm in RELATION_TO_PERMISSIONS.get(tuple_info["relation"], []):
+                    self._boundary_cache.invalidate_permission_change(
+                        effective_zone_bc,
+                        tuple_info["subject_type"],
+                        tuple_info["subject_id"],
+                        perm,
+                        tuple_info["object_id"],
+                    )
 
             # Issue #919: Notify directory visibility cache invalidators
             object_tuple = (tuple_info["object_type"], tuple_info["object_id"])


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during ReBAC E2E test implementation (issue #5):

- **Bug 1 — Tiger Cache ignores consistency_level**: `_rebac_check_inner` checked Tiger Cache and Boundary Cache unconditionally. `STRONG` reads now bypass both caches. Also adds missing Boundary Cache invalidation in `rebac_delete`.
- **Bug 2 — Rust engine missing reverse tupleToUserset**: Only forward adjacency was used (`file → parent → folder`), missing reverse direction needed for group patterns (`group → direct_viewer → file`). Adds `reverse_adjacency` index and bidirectional lookup to both `InternedGraph` and `ReBACGraph`.
- **Bug 3 — TigerCache missing `get_stats()`**: The `/api/v2/cache/stats` endpoint couldn't report Tiger Cache metrics. Adds hit/miss/set/invalidation counters and `get_stats()` method.

## Changed files
- `rust/nexus_core/src/rebac/graph.rs` — reverse adjacency + bidirectional tupleToUserset (InternedGraph)
- `rust/nexus_core/src/rebac/mod.rs` — bidirectional tupleToUserset (ReBACGraph string-keyed)
- `src/nexus/bricks/rebac/manager.py` — consistency bypass + Boundary Cache invalidation
- `src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py` — counters + `get_stats()`

## Test plan
- [x] All 21 Rust unit tests pass (`cargo test`)
- [x] All 14 ReBAC E2E tests pass (see nexus-test PR)
- [ ] Review: forward tupleToUserset (parent inheritance) works
- [ ] Review: reverse tupleToUserset (group membership) works
- [ ] Review: `fully_consistent` bypasses Tiger + Boundary caches
- [ ] Review: `get_stats()` reports correct counters