### PR TITLE
fix(rebac): unscope zone-prefixed paths in enforcer and filter chain

### DIFF
--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -419,8 +419,8 @@ class BulkPermissionChecker:
             if self._enforce_zone_isolation:
                 stmt = text("""
                     WITH entity_list AS (
-                        SELECT unnest(:entity_types::text[]) AS entity_type,
-                               unnest(:entity_ids::text[]) AS entity_id
+                        SELECT unnest(CAST(:entity_types AS text[])) AS entity_type,
+                               unnest(CAST(:entity_ids AS text[])) AS entity_id
                     )
                     SELECT DISTINCT
                         t.subject_type, t.subject_id, t.subject_relation,
@@ -442,8 +442,8 @@ class BulkPermissionChecker:
             else:
                 stmt = text("""
                     WITH entity_list AS (
-                        SELECT unnest(:entity_types::text[]) AS entity_type,
-                               unnest(:entity_ids::text[]) AS entity_id
+                        SELECT unnest(CAST(:entity_types AS text[])) AS entity_type,
+                               unnest(CAST(:entity_ids AS text[])) AS entity_id
                     )
                     SELECT DISTINCT
                         t.subject_type, t.subject_id, t.subject_relation,
@@ -536,14 +536,14 @@ class BulkPermissionChecker:
         if is_postgresql:
             stmt = text("""
                 WITH subject_list AS (
-                    SELECT unnest(:subject_types::text[]) AS subject_type,
-                           unnest(:subject_ids::text[]) AS subject_id
+                    SELECT unnest(CAST(:subject_types AS text[])) AS subject_type,
+                           unnest(CAST(:subject_ids AS text[])) AS subject_id
                 )
                 SELECT DISTINCT
                     t.subject_type, t.subject_id, t.subject_relation,
                     t.relation, t.object_type, t.object_id, t.conditions, t.expires_at
                 FROM rebac_tuples t
-                WHERE t.relation = ANY(:relations::text[])
+                WHERE t.relation = ANY(CAST(:relations AS text[]))
                   AND (t.expires_at IS NULL OR t.expires_at >= :now_iso)
                   AND EXISTS (
                       SELECT 1 FROM subject_list s

--- a/src/nexus/bricks/rebac/enforcer.py
+++ b/src/nexus/bricks/rebac/enforcer.py
@@ -518,7 +518,11 @@ class PermissionEnforcer:
         # Get backend-specific object type for ReBAC check
         # This allows different backends (Postgres, Redis, etc.) to have different permission models
         object_type = "file"  # Default
-        object_id = path  # Default - use virtual path for permission checks
+        # Unscope zone-prefixed paths so object_id matches how ReBAC tuples
+        # are created (non-prefixed path + zone_id field for isolation).
+        from nexus.server.path_utils import unscope_internal_path
+
+        object_id = unscope_internal_path(path)  # Strip /zone/{id}/ prefix
 
         if self.router:
             try:
@@ -533,8 +537,13 @@ class PermissionEnforcer:
 
                 mapper = ObjectTypeMapper()
                 object_type = mapper.get_object_type(route.backend, route.backend_path)
-                object_id = mapper.get_object_id(
-                    route.backend, route.backend_path, virtual_path=path, object_type=object_type
+                object_id = unscope_internal_path(
+                    mapper.get_object_id(
+                        route.backend,
+                        route.backend_path,
+                        virtual_path=path,
+                        object_type=object_type,
+                    )
                 )
             except (KeyError, ValueError, AttributeError, LookupError, RuntimeError) as e:
                 # If routing fails, fall back to default "file" type with virtual path

--- a/src/nexus/bricks/rebac/permission_filter_chain.py
+++ b/src/nexus/bricks/rebac/permission_filter_chain.py
@@ -17,6 +17,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
+from nexus.server.path_utils import unscope_internal_path
+
 if TYPE_CHECKING:
     from nexus.bricks.rebac.manager import ReBACManager
     from nexus.bricks.rebac.permission_cache import PermissionCacheCoordinator
@@ -69,8 +71,12 @@ class TigerBitmapStrategy:
         allowed, still_remaining = result
         logger.debug(f"[TIGER-BITMAP] {len(allowed)} allowed, {len(still_remaining)} remaining")
 
-        # Check bitmap completeness — if complete, skip fallback
-        if still_remaining and ctx.cache.is_bitmap_complete(ctx.subject, ctx.zone_id):
+        # Check bitmap completeness — if complete, skip fallback.
+        # Only short-circuit when the bitmap found SOME allowed paths.
+        # If allowed is empty, the bitmap may be stale/incomplete (e.g.,
+        # zone-prefixed vs non-prefixed path mismatch) — fall through to
+        # the full ReBAC check to avoid false denials.
+        if still_remaining and allowed and ctx.cache.is_bitmap_complete(ctx.subject, ctx.zone_id):
             logger.info(f"[BITMAP-COMPLETE] Skipped {len(still_remaining)} fallback checks")
             return FilterResult(allowed=allowed, remaining=[], short_circuit=True)
 
@@ -135,7 +141,9 @@ class HierarchyPreFilterStrategy:
                 return FilterResult(allowed=[], remaining=[], short_circuit=True)
 
         # Batch check unique parent directories
-        parent_checks = [(subject, "read", ("file", parent)) for parent in unique_parents]
+        parent_checks = [
+            (subject, "read", ("file", unscope_internal_path(parent))) for parent in unique_parents
+        ]
         parent_results = ctx.rebac_manager.rebac_check_bulk(parent_checks, zone_id=ctx.zone_id)
 
         accessible_parents = {
@@ -185,7 +193,9 @@ class HierarchyPreFilterStrategy:
             if parts and parts[0]:
                 top_level_dirs.add("/" + parts[0])
 
-        top_level_checks = [(subject, "read", ("file", d)) for d in top_level_dirs]
+        top_level_checks = [
+            (subject, "read", ("file", unscope_internal_path(d))) for d in top_level_dirs
+        ]
         top_level_results = ctx.rebac_manager.rebac_check_bulk(
             top_level_checks, zone_id=ctx.zone_id
         )
@@ -271,7 +281,7 @@ class BulkReBACStrategy:
                         obj_type = route.mount_point.strip("/").split("/")[0]
                 except (KeyError, ValueError, AttributeError, LookupError) as e:
                     logger.debug("Route resolution failed for path %s: %s", path, e)
-            checks.append((subject, "read", (obj_type, path)))
+            checks.append((subject, "read", (obj_type, unscope_internal_path(path))))
 
         # Retry-once on transient I/O failures only
         try:

--- a/src/nexus/bricks/rebac/rebac_service.py
+++ b/src/nexus/bricks/rebac/rebac_service.py
@@ -171,6 +171,7 @@ class ReBACService(ReBACShareMixin):
         zone_id: str | None = None,
         context: Any = None,
         column_config: dict[str, Any] | None = None,
+        conditions: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Create a ReBAC relationship tuple (Issue #1081).
 
@@ -254,7 +255,7 @@ class ReBACService(ReBACShareMixin):
             self._check_share_permission(resource=object, context=context)
 
             # Validate column_config for dynamic_viewer relation
-            conditions = None
+            effective_conditions = conditions
             if relation == "dynamic_viewer":
                 # Check if object is a CSV file
                 if object[0] == "file" and not object[1].lower().endswith(".csv"):
@@ -335,7 +336,7 @@ class ReBACService(ReBACShareMixin):
                         )
 
                 # Store column_config as conditions
-                conditions = {"type": "dynamic_viewer", "column_config": column_config}
+                effective_conditions = {"type": "dynamic_viewer", "column_config": column_config}
             elif column_config is not None:
                 # column_config provided but relation is not dynamic_viewer
                 raise ValueError(
@@ -350,7 +351,7 @@ class ReBACService(ReBACShareMixin):
                 object=object,
                 expires_at=expires_at,
                 zone_id=effective_zone_id,
-                conditions=conditions,
+                conditions=effective_conditions,
             )
 
             # NOTE: Tiger Cache queue update is handled in ReBACManager.rebac_write()
@@ -509,7 +510,7 @@ class ReBACService(ReBACShareMixin):
         self,
         permission: str,
         object: tuple[str, str],
-        _zone_id: str | None = None,
+        zone_id: str | None = None,
         _limit: int = 100,
     ) -> list[tuple[str, str]]:
         """Find all subjects that have a permission on an object.
@@ -552,9 +553,10 @@ class ReBACService(ReBACShareMixin):
 
             # Expand permission (manager guaranteed by _run_in_thread)
             assert self._rebac_manager is not None
-            expanded: list[tuple[str, str]] = self._rebac_manager.rebac_expand(
-                permission=permission, object=object
-            )
+            kwargs: dict[str, Any] = {"permission": permission, "object": object}
+            if zone_id is not None:
+                kwargs["zone_id"] = zone_id
+            expanded: list[tuple[str, str]] = self._rebac_manager.rebac_expand(**kwargs)
             return expanded
 
         return await self._run_in_thread(_expand_sync)
@@ -643,7 +645,7 @@ class ReBACService(ReBACShareMixin):
     async def rebac_check_batch(
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
-        _zone_id: str | None = None,
+        zone_id: str | None = None,
     ) -> list[bool]:
         """Check multiple permissions in a single call for efficiency.
 
@@ -690,10 +692,25 @@ class ReBACService(ReBACShareMixin):
                 if not isinstance(obj, tuple) or len(obj) != 2:
                     raise ValueError(f"Check {i}: object must be (type, id) tuple, got {obj}")
 
-            # Perform batch check with Rust acceleration (manager guaranteed by _run_in_thread)
             assert self._rebac_manager is not None
-            batch_results: list[bool] = self._rebac_manager.rebac_check_batch_fast(checks=checks)
-            return batch_results
+
+            # When zone_id is available, use individual rebac_check calls which
+            # properly scope tuple lookups to the zone. rebac_check_batch_fast
+            # does not support zone_id and would query with zone_id IS NULL.
+            if zone_id is not None:
+                batch_results: list[bool] = []
+                for subj, perm, obj in checks:
+                    result: bool = self._rebac_manager.rebac_check(
+                        subject=subj,
+                        permission=perm,
+                        object=obj,
+                        zone_id=zone_id,
+                    )
+                    batch_results.append(result)
+                return batch_results
+
+            # No zone_id: use optimized batch path (Rust acceleration)
+            return self._rebac_manager.rebac_check_batch_fast(checks=checks)
 
         # Issue #702: Wrap batch check in a summary span
         import time as _time
@@ -849,6 +866,57 @@ class ReBACService(ReBACShareMixin):
             return tuples
 
         return await self._run_in_thread(_list_tuples_sync)
+
+    @rpc_expose(description="List objects a subject has a specific relation to")
+    async def rebac_list_objects(
+        self,
+        relation: str,
+        subject: tuple[str, str],
+        zone_id: str | None = None,
+    ) -> list[list[str]]:
+        """List objects that a subject has a given relation to.
+
+        This is useful for queries like "show all files user X can view" filtered
+        by a specific relation (e.g., direct_viewer, direct_editor).
+
+        Args:
+            relation: The relation to filter by (e.g., "direct_viewer", "direct_editor")
+            subject: (subject_type, subject_id) tuple, e.g., ("user", "alice")
+            zone_id: Optional zone ID for multi-zone isolation
+
+        Returns:
+            List of [object_type, object_id] pairs matching the relation
+
+        Examples:
+            # List all files a user has direct_viewer on
+            objects = await rebac.rebac_list_objects(
+                relation="direct_viewer",
+                subject=("user", "alice"),
+                zone_id="corp",
+            )
+        """
+
+        def _list_objects_sync() -> list[list[str]]:
+            assert self._rebac_manager is not None
+            tuples: list[dict[str, Any]] = self._rebac_manager.list_tuples(
+                subject=subject,
+                relation=relation,
+            )
+            seen: set[tuple[str, str]] = set()
+            result: list[list[str]] = []
+            for t in tuples:
+                # Filter by zone_id if specified
+                if zone_id is not None and t.get("zone_id") != zone_id:
+                    continue
+                obj_type = t.get("object_type", "file")
+                obj_id = t.get("object_id", "")
+                key = (obj_type, obj_id)
+                if key not in seen:
+                    seen.add(key)
+                    result.append([obj_type, obj_id])
+            return result
+
+        return await self._run_in_thread(_list_objects_sync)
 
     # =========================================================================
     # Public API: Configuration & Namespaces

--- a/src/nexus/server/_rpc_params_generated.py
+++ b/src/nexus/server/_rpc_params_generated.py
@@ -907,6 +907,7 @@ class RebacCreateParams:
     zone_id: str | None = None
     context: Any = None
     column_config: dict[str, Any] | None = None
+    conditions: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         """Convert lists to tuples (JSON deserializes tuples as lists)."""
@@ -924,11 +925,63 @@ class RebacDeleteParams:
 
 
 @dataclass
+class RebacCheckBatchParams:
+    """Parameters for rebac_check_batch(): Batch permission checks."""
+
+    checks: list[Any]
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert list-of-dicts to list-of-tuples for service compatibility."""
+        normalized: list[Any] = []
+        extracted_zone_id: str | None = self.zone_id
+        for check in self.checks:
+            if isinstance(check, dict):
+                subj = (
+                    tuple(check["subject"])
+                    if isinstance(check.get("subject"), list)
+                    else check.get("subject")
+                )
+                perm = check.get("permission", "")
+                obj = (
+                    tuple(check["object"])
+                    if isinstance(check.get("object"), list)
+                    else check.get("object")
+                )
+                # Extract zone_id from the first check dict if not set at top level
+                if extracted_zone_id is None and "zone_id" in check:
+                    extracted_zone_id = check["zone_id"]
+                normalized.append((subj, perm, obj))
+            elif isinstance(check, (list, tuple)):
+                normalized.append(tuple(tuple(c) if isinstance(c, list) else c for c in check))
+            else:
+                normalized.append(check)
+        object.__setattr__(self, "checks", normalized)
+        if extracted_zone_id is not None:
+            object.__setattr__(self, "zone_id", extracted_zone_id)
+
+
+@dataclass
+class RebacListObjectsParams:
+    """Parameters for rebac_list_objects(): List objects a subject has a relation to."""
+
+    relation: str
+    subject: tuple[str, str]
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.subject, list):
+            object.__setattr__(self, "subject", tuple(self.subject))
+
+
+@dataclass
 class RebacExpandParams:
     """Parameters for rebac_expand(): Find all subjects that have a permission on an object."""
 
     permission: str
     object: tuple[str, str]
+    zone_id: str | None = None
 
     def __post_init__(self) -> None:
         """Convert lists to tuples (JSON deserializes tuples as lists)."""
@@ -1568,10 +1621,12 @@ METHOD_PARAMS: dict[str, type] = {
     "provision_user": ProvisionUserParams,
     "read_bulk": ReadBulkParams,
     "rebac_check": RebacCheckParams,
+    "rebac_check_batch": RebacCheckBatchParams,
     "rebac_create": RebacCreateParams,
     "rebac_delete": RebacDeleteParams,
     "rebac_expand": RebacExpandParams,
     "rebac_explain": RebacExplainParams,
+    "rebac_list_objects": RebacListObjectsParams,
     "rebac_list_tuples": RebacListTuplesParams,
     "register_agent": RegisterAgentParams,
     "register_memory": RegisterMemoryParams,

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -323,6 +323,7 @@ def create_app(
         "mount_service",
         "version_service",
         "share_link_service",
+        "rebac_service",
     ):
         _brick_svc = getattr(nexus_fs, _attr_name, None)
         if _brick_svc is not None:

--- a/src/nexus/services/search/search_service.py
+++ b/src/nexus/services/search/search_service.py
@@ -426,6 +426,13 @@ class SearchService(SemanticSearchMixin):
             path = path + "/"
         list_prefix = path if path != "/" else ""
 
+        # Zone-scope the list prefix when called from internal methods (e.g., glob)
+        # that bypass the RPC layer's _scope_params_for_zone path prefixing.
+        if list_zone_id and list_zone_id != ROOT_ZONE_ID:
+            zone_scope = f"/zone/{list_zone_id}"
+            if list_prefix and not list_prefix.startswith(zone_scope):
+                list_prefix = f"{zone_scope}{list_prefix}"
+
         # OPTIMIZATION: For non-recursive, try sparse directory index + Tiger bitmap
         _use_fast_path = False
         _revision_before: int | None = None
@@ -950,7 +957,8 @@ class SearchService(SemanticSearchMixin):
                 all_files = [
                     f
                     for f in all_files
-                    if tiger_cache.get_or_create_int_id("file", f.path) in _accessible_int_ids
+                    if tiger_cache._resource_map.get_or_create_int_id("file", f.path)
+                    in _accessible_int_ids
                 ]
                 logger.info(
                     f"[PREDICATE-PUSHDOWN] Service-layer filter: "
@@ -1499,7 +1507,10 @@ class SearchService(SemanticSearchMixin):
                 full_pattern = "**/" + full_pattern
         else:
             base_path = path[1:] if path.startswith("/") else path
-            full_pattern = base_path + pattern
+            # Strip leading "/" from pattern to avoid double-slash when
+            # base_path already ends with "/" (e.g., zone-scoped paths).
+            pattern_part = pattern.lstrip("/") if pattern.startswith("/") else pattern
+            full_pattern = base_path + pattern_part
 
         # Phase 4: Execute strategy-specific matching
         match_start = time.time()

--- a/src/nexus/storage/raft_metadata_store.py
+++ b/src/nexus/storage/raft_metadata_store.py
@@ -514,10 +514,11 @@ class RaftMetadataStore(MetastoreABC):
         # zone_id parameter accepted for API consistency but filtering is inherent.
         # RaftMetadataStore is zone-local. Non-zoned stores serve the "root" zone,
         # so zone_id="root" is always allowed. Only assert on specific zone_ids.
+        # When prefix is already zone-scoped (e.g. /zone/corp/...), zone_id is
+        # redundant — path prefix already constrains to the zone namespace.
         if zone_id is not None and zone_id != ROOT_ZONE_ID:
-            assert self._zone_id is not None, (
-                f"zone_id filter '{zone_id}' passed to a non-zone-scoped store"
-            )
+            if self._zone_id is None and not prefix.startswith(f"/zone/{zone_id}"):
+                raise ValueError(f"zone_id filter '{zone_id}' passed to a non-zone-scoped store")
         if self._has_engine:
             return self._list_engine(prefix, recursive)
         else:
@@ -578,12 +579,10 @@ class RaftMetadataStore(MetastoreABC):
         Memory usage is O(limit) instead of O(total).
         """
         # RaftMetadataStore is zone-local: zone_id accepted for API consistency.
-        # RaftMetadataStore is zone-local. Non-zoned stores serve the "root" zone,
-        # so zone_id="root" is always allowed. Only assert on specific zone_ids.
+        # When prefix is already zone-scoped, zone_id is redundant.
         if zone_id is not None and zone_id != ROOT_ZONE_ID:
-            assert self._zone_id is not None, (
-                f"zone_id filter '{zone_id}' passed to a non-zone-scoped store"
-            )
+            if self._zone_id is None and not prefix.startswith(f"/zone/{zone_id}"):
+                raise ValueError(f"zone_id filter '{zone_id}' passed to a non-zone-scoped store")
         from itertools import islice
 
         # Decode cursor if it's base64-encoded
@@ -1139,12 +1138,10 @@ class RaftMetadataStore(MetastoreABC):
             List of file metadata
         """
         # RaftMetadataStore is zone-local: zone_id accepted for API consistency.
-        # RaftMetadataStore is zone-local. Non-zoned stores serve the "root" zone,
-        # so zone_id="root" is always allowed. Only assert on specific zone_ids.
+        # When prefix is already zone-scoped, zone_id is redundant.
         if zone_id is not None and zone_id != ROOT_ZONE_ID:
-            assert self._zone_id is not None, (
-                f"zone_id filter '{zone_id}' passed to a non-zone-scoped store"
-            )
+            if self._zone_id is None and not prefix.startswith(f"/zone/{zone_id}"):
+                raise ValueError(f"zone_id filter '{zone_id}' passed to a non-zone-scoped store")
         if self._has_engine:
             return self._list_engine(prefix, recursive)
         else:


### PR DESCRIPTION
## Summary
- Fix false permission denials for non-admin users caused by zone-prefixed storage paths (`/zone/corp/file.txt`) not matching ReBAC tuples (stored with non-prefixed paths + `zone_id` field)
- Add `unscope_internal_path()` to enforcer, HierarchyPreFilter, TopLevelPrune, and BulkReBAC strategies before ReBAC object_id lookups
- Fix TigerBitmapStrategy short-circuit: only skip fallback when bitmap found **some** allowed paths (prevents false denials from stale/mismatched bitmaps)
- Fix double-slash bug in glob pattern construction when zone-scoping paths
- Fix `raft_metadata_store` zone_id assertion when prefix is already zone-scoped
- Fix SQL `CAST` syntax in `bulk_checker.py` for PostgreSQL compatibility
- Register `rebac_service` as brick source for RPC method auto-discovery
- Add `rebac_check_batch` and `rebac_list_objects` RPC endpoints with param classes
- Support `conditions` param on `rebac_create` and `zone_id` on `rebac_expand`

## Test plan
- [x] All 23 ReBAC E2E tests pass (0 failures, 0 skips) with `NEXUS_ENFORCE_PERMISSIONS=true`
- [x] Tiger Cache write-through verified (226 grants, 184 revokes in logs)
- [x] Leopard directory expansion active for folder-level grants
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [ ] CI pipeline on develop