### PR TITLE
fix(rebac): zone graph cache invalidation, expand permission resolution, CLI zone support

### DIFF
--- a/.pre-commit-hooks/check_file_size.py
+++ b/.pre-commit-hooks/check_file_size.py
@@ -32,6 +32,7 @@ EXCEPTIONS = [
     "src/nexus/services/permissions/tiger_cache.py",  # 2,896 lines - Leopard-style directory grants
     "src/nexus/services/permissions/nexus_fs_rebac.py",  # 2,192 lines - NexusFS mixin
     "src/nexus/services/rebac_service.py",  # 2,400 lines - sync + async methods for ReBAC delegation
+    "src/nexus/bricks/rebac/rebac_service.py",  # 2,356 lines - sync + async methods for ReBAC delegation
     "src/nexus/services/search_service.py",  # 2,290 lines - Issue #954 trigram index additions
     "src/nexus/services/search/search_service.py",  # 2,001 lines - Issue #2188 DI param added
     "src/nexus/remote/client.py",  # 5,000 lines - Phase 4 splitting

--- a/examples/cli/permissions_demo_enhanced.sh
+++ b/examples/cli/permissions_demo_enhanced.sh
@@ -200,12 +200,10 @@ nexus rebac create user admin direct_owner file $DEMO_BASE
 print_success "Admin has ownership of $DEMO_BASE"
 
 print_subsection "1.1 Understanding Permission Roles"
-echo "  NOTE: In this ReBAC implementation:"
-echo "    OWNER:  read ✗  write ✓  execute ✓  (can write & manage, but not read!)"
+echo "  NOTE: In this ReBAC implementation (Zanzibar-style):"
+echo "    OWNER:  read ✓  write ✓  execute ✓  (full access including manage)"
 echo "    EDITOR: read ✓  write ✓  execute ✗  (can read & write, but can't manage)"
 echo "    VIEWER: read ✓  write ✗  execute ✗  (read-only)"
-echo ""
-echo "  This is the actual behavior - owners need editor/viewer role for read!"
 echo ""
 
 # Create test users
@@ -221,15 +219,11 @@ nexus rebac create user alice direct_owner file $DEMO_BASE/test-file.txt
 nexus rebac create user bob direct_editor file $DEMO_BASE/test-file.txt
 nexus rebac create user charlie direct_viewer file $DEMO_BASE/test-file.txt
 
-print_test "Verify alice (owner) has write+execute (but NOT read in this model)"
-if nexus rebac check user alice write file $DEMO_BASE/test-file.txt 2>&1 | grep -q "GRANTED" && \
+print_test "Verify alice (owner) has read+write+execute"
+if nexus rebac check user alice read file $DEMO_BASE/test-file.txt 2>&1 | grep -q "GRANTED" && \
+   nexus rebac check user alice write file $DEMO_BASE/test-file.txt 2>&1 | grep -q "GRANTED" && \
    nexus rebac check user alice execute file $DEMO_BASE/test-file.txt 2>&1 | grep -q "GRANTED"; then
-    print_success "✅ Owner has write + execute (as expected in this ReBAC model)"
-
-    # Verify owner does NOT have read (unless explicitly granted)
-    if nexus rebac check user alice read file $DEMO_BASE/test-file.txt 2>&1 | grep -q "DENIED"; then
-        print_info "Note: Owner does NOT have read (needs editor/viewer role for that)"
-    fi
+    print_success "Owner has read + write + execute"
 else
     print_error "Owner permissions incorrect!"
 fi
@@ -359,9 +353,9 @@ sys.path.insert(0, 'src')
 import nexus
 nx = nexus.connect(config={"mode": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')})
 base = os.getenv('DEMO_BASE')
-nx.rebac_create(("file", f"{base}/project1/docs"), "parent", ("file", f"{base}/project1"))
-nx.rebac_create(("file", f"{base}/project1/docs/guides"), "parent", ("file", f"{base}/project1/docs"))
-nx.rebac_create(("file", f"{base}/project1/docs/guides/advanced"), "parent", ("file", f"{base}/project1/docs/guides"))
+nx.rebac_create(subject=("file", f"{base}/project1/docs"), relation="parent", object=("file", f"{base}/project1"))
+nx.rebac_create(subject=("file", f"{base}/project1/docs/guides"), relation="parent", object=("file", f"{base}/project1/docs"))
+nx.rebac_create(subject=("file", f"{base}/project1/docs/guides/advanced"), relation="parent", object=("file", f"{base}/project1/docs/guides"))
 print("✓ Parent relations created")
 nx.close()
 PYTHON_PARENTS
@@ -439,9 +433,9 @@ print_section "5. Audit & List Permissions"
 print_subsection "5.1 List all users with access to a resource"
 print_info "Finding all users with 'write' permission on $DEMO_BASE/test-file.txt"
 
-# BUGFIX: More robust regex for usernames (digits, underscores, dashes)
+# Parse user names from rich table output (│ user │ alice │)
 WRITERS=$(nexus rebac expand write file $DEMO_BASE/test-file.txt 2>/dev/null \
-    | grep -oE "user:[A-Za-z0-9._-]+" | cut -d: -f2 | sort -u)
+    | grep "│.*user.*│" | awk -F'│' '{gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3}' | sort -u)
 
 print_test "Expected writers: alice (owner), bob (editor)"
 if echo "$WRITERS" | grep -q "alice" && echo "$WRITERS" | grep -q "bob"; then
@@ -487,8 +481,8 @@ import nexus
 nx = nexus.connect(config={"mode": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')})
 base = os.getenv('DEMO_BASE')
 try:
-    nx.rebac_create(("file", f"{base}/cycleA"), "parent", ("file", f"{base}/cycleB"))
-    nx.rebac_create(("file", f"{base}/cycleB"), "parent", ("file", f"{base}/cycleA"))
+    nx.rebac_create(subject=("file", f"{base}/cycleA"), relation="parent", object=("file", f"{base}/cycleB"))
+    nx.rebac_create(subject=("file", f"{base}/cycleB"), relation="parent", object=("file", f"{base}/cycleA"))
     print("❌ Cycle was allowed (should be prevented!)")
 except Exception as e:
     # BUGFIX: Backend might not include "cycle" in error text

--- a/scripts/create-api-key.py
+++ b/scripts/create-api-key.py
@@ -10,6 +10,7 @@ import argparse
 import os
 import sys
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -48,7 +49,12 @@ def main() -> None:
         expires_at = datetime.now(UTC) + timedelta(days=args.days)
 
     # Register user in entity registry (for agent permission inheritance)
-    entity_registry = EntityRegistry(SessionFactory)
+    # EntityRegistry expects an object with .session_factory attribute
+    class _SessionFactoryWrapper:
+        def __init__(self, sf: Any) -> None:
+            self.session_factory = sf
+
+    entity_registry = EntityRegistry(_SessionFactoryWrapper(SessionFactory))
     entity_registry.register_entity(
         entity_type="user",
         entity_id=args.user_id,

--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -360,6 +360,9 @@ class CacheCoordinator:
         """
         effective_zone_id = zone_id if zone_id is not None else ROOT_ZONE_ID
 
+        # Zone graph cache must be invalidated so fresh computes see the new tuples
+        self._invalidate_zone_graph(effective_zone_id)
+
         # Track write for adaptive TTL (Phase 4)
         if self._l1_cache:
             self._l1_cache.track_write(obj.entity_id)

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -1524,6 +1524,15 @@ class ReBACManager:
             return
         visited.add(visit_key)
 
+        # Resolve computed permissions (e.g. "write" -> ["editor", "owner"])
+        # These live in the "permissions" section, not "relations"
+        if namespace.has_permission(permission):
+            for userset_rel in namespace.get_permission_usersets(permission):
+                self._expand_permission_zone_aware(
+                    userset_rel, obj, namespace, zone_id, subjects, visited.copy(), depth + 1
+                )
+            return
+
         rel_config = namespace.get_relation_config(permission)
         if not rel_config:
             direct_subjects = self._get_direct_subjects_zone_aware(permission, obj, zone_id)

--- a/src/nexus/bricks/rebac/rebac_service.py
+++ b/src/nexus/bricks/rebac/rebac_service.py
@@ -158,6 +158,86 @@ class ReBACService(ReBACShareMixin):
         return cast(T, await asyncio.to_thread(fn_with_ctx, *args, **kwargs))
 
     # =========================================================================
+    # Internal: Zone Resolution Helper
+    # =========================================================================
+
+    def _resolve_zone_for_subject(self, subject: tuple[str, ...]) -> str | None:
+        """Look up zone_id from entity_registry for a subject.
+
+        For user subjects: look up the user's zone directly.
+        For group userset subjects (group, id, relation): find a member of the
+        group and use their zone, so the tuple lands in the same zone as the
+        users who will be checked against it.
+        """
+        if not self._rebac_manager:
+            return None
+        try:
+            with self._rebac_manager._connection() as conn:
+                cursor = self._rebac_manager._create_cursor(conn)
+                if subject[0] == "user":
+                    sql = self._rebac_manager._fix_sql_placeholders(
+                        "SELECT parent_id FROM entity_registry "
+                        "WHERE entity_type = 'user' AND entity_id = ? "
+                        "AND parent_type = 'zone' LIMIT 1"
+                    )
+                    cursor.execute(sql, (subject[1],))
+                elif subject[0] == "group" and len(subject) >= 3:
+                    # Userset-as-subject: find a member's zone via rebac_tuples
+                    # e.g. subject=("group","editors","member") → find a user
+                    # who has relation "member" on group:editors
+                    sql = self._rebac_manager._fix_sql_placeholders(
+                        "SELECT er.parent_id FROM rebac_tuples rt "
+                        "JOIN entity_registry er "
+                        "  ON er.entity_type = 'user' AND er.entity_id = rt.subject_id "
+                        "  AND er.parent_type = 'zone' "
+                        "WHERE rt.object_type = 'group' AND rt.object_id = ? "
+                        "  AND rt.relation = ? AND rt.subject_type = 'user' "
+                        "LIMIT 1"
+                    )
+                    cursor.execute(sql, (subject[1], subject[2]))
+                else:
+                    return None
+                row = cursor.fetchone()
+                if row:
+                    return row["parent_id"] if isinstance(row, dict) else row[0]
+        except Exception:
+            pass  # Table may not exist; fall through to context zone
+        return None
+
+    def _resolve_zone_for_object(self, object: tuple[str, str]) -> str | None:
+        """Look up zone_id from existing rebac_tuples for an object.
+
+        Used by rebac_expand (which has no subject) to auto-detect the zone
+        where tuples for this object live.  Prefers non-root zones since
+        user-created tuples typically live in a named zone.
+        """
+        if not self._rebac_manager:
+            return None
+        try:
+            with self._rebac_manager._connection() as conn:
+                cursor = self._rebac_manager._create_cursor(conn)
+                sql = self._rebac_manager._fix_sql_placeholders(
+                    "SELECT zone_id, COUNT(*) as cnt FROM rebac_tuples "
+                    "WHERE object_type = ? AND object_id = ? "
+                    "AND zone_id IS NOT NULL "
+                    "GROUP BY zone_id ORDER BY cnt DESC"
+                )
+                cursor.execute(sql, (object[0], object[1]))
+                rows = cursor.fetchall()
+                if not rows:
+                    return None
+                # Prefer non-root zone (user-created tuples)
+                for row in rows:
+                    zid = row["zone_id"] if isinstance(row, dict) else row[0]
+                    if zid != "root":
+                        return zid
+                # Fall back to root
+                return rows[0]["zone_id"] if isinstance(rows[0], dict) else rows[0][0]
+        except Exception:
+            pass
+        return None
+
+    # =========================================================================
     # Public API: Core ReBAC Operations
     # =========================================================================
 
@@ -243,12 +323,15 @@ class ReBACService(ReBACShareMixin):
 
             # Use zone_id from context if not explicitly provided
             effective_zone_id = zone_id
-            if effective_zone_id is None and context:
-                # Handle both dict and OperationContext
-                if isinstance(context, dict):
-                    effective_zone_id = context.get("zone")
-                elif hasattr(context, "zone_id"):
-                    effective_zone_id = context.zone_id
+            if effective_zone_id is None:
+                # Auto-detect zone from subject's entity registry
+                effective_zone_id = self._resolve_zone_for_subject(subject)
+                # Fall back to context zone
+                if effective_zone_id is None and context:
+                    if isinstance(context, dict):
+                        effective_zone_id = context.get("zone")
+                    elif hasattr(context, "zone_id"):
+                        effective_zone_id = context.zone_id
 
             # SECURITY: Check execute permission before allowing permission management
             # Only owners (those with execute permission) can grant/manage permissions on resources
@@ -450,12 +533,15 @@ class ReBACService(ReBACShareMixin):
 
             # Use zone_id from context if not explicitly provided
             effective_zone_id = zone_id
-            if effective_zone_id is None and context:
-                # Handle both dict and OperationContext
-                if isinstance(context, dict):
-                    effective_zone_id = context.get("zone")
-                elif hasattr(context, "zone_id"):
-                    effective_zone_id = context.zone_id
+            if effective_zone_id is None:
+                # Auto-detect zone from subject's entity registry
+                effective_zone_id = self._resolve_zone_for_subject(subject)
+                # Fall back to context zone
+                if effective_zone_id is None and context:
+                    if isinstance(context, dict):
+                        effective_zone_id = context.get("zone")
+                    elif hasattr(context, "zone_id"):
+                        effective_zone_id = context.zone_id
 
             # Issue #1081: Build consistency requirement from API params
             consistency = None
@@ -556,6 +642,11 @@ class ReBACService(ReBACShareMixin):
             kwargs: dict[str, Any] = {"permission": permission, "object": object}
             if zone_id is not None:
                 kwargs["zone_id"] = zone_id
+            else:
+                # Auto-detect zone from existing tuples for this object
+                detected_zone = self._resolve_zone_for_object(object)
+                if detected_zone is not None:
+                    kwargs["zone_id"] = detected_zone
             expanded: list[tuple[str, str]] = self._rebac_manager.rebac_expand(**kwargs)
             return expanded
 
@@ -622,12 +713,15 @@ class ReBACService(ReBACShareMixin):
 
             # Use zone_id from context if not explicitly provided
             effective_zone_id = zone_id
-            if effective_zone_id is None and context:
-                # Handle both dict and OperationContext
-                if isinstance(context, dict):
-                    effective_zone_id = context.get("zone")
-                elif hasattr(context, "zone_id"):
-                    effective_zone_id = context.zone_id
+            if effective_zone_id is None:
+                # Auto-detect zone from subject's entity registry
+                effective_zone_id = self._resolve_zone_for_subject(subject)
+                # Fall back to context zone
+                if effective_zone_id is None and context:
+                    if isinstance(context, dict):
+                        effective_zone_id = context.get("zone")
+                    elif hasattr(context, "zone_id"):
+                        effective_zone_id = context.zone_id
 
             # Get explanation from manager (manager guaranteed by _run_in_thread)
             assert self._rebac_manager is not None
@@ -1814,11 +1908,15 @@ class ReBACService(ReBACShareMixin):
 
         # Use zone_id from context if not explicitly provided
         effective_zone_id = zone_id
-        if effective_zone_id is None and context:
-            if isinstance(context, dict):
-                effective_zone_id = context.get("zone")
-            elif hasattr(context, "zone_id"):
-                effective_zone_id = context.zone_id
+        if effective_zone_id is None:
+            # Auto-detect zone from subject's entity registry
+            effective_zone_id = self._resolve_zone_for_subject(subject)
+            # Fall back to context zone
+            if effective_zone_id is None and context:
+                if isinstance(context, dict):
+                    effective_zone_id = context.get("zone")
+                elif hasattr(context, "zone_id"):
+                    effective_zone_id = context.zone_id
 
         # SECURITY: Check execute permission before allowing permission management
         self._check_share_permission(resource=object, context=context)

--- a/src/nexus/cli/commands/rebac.py
+++ b/src/nexus/cli/commands/rebac.py
@@ -360,6 +360,7 @@ def rebac_delete_cmd(
 @click.argument("object_type", type=str)
 @click.argument("object_id", type=str)
 @add_backend_options
+@add_context_options
 def rebac_check_cmd(
     subject_type: str,
     subject_id: str,
@@ -367,10 +368,12 @@ def rebac_check_cmd(
     object_type: str,
     object_id: str,
     backend_config: BackendConfig,
+    operation_context: dict[str, Any],
 ) -> None:
     """Check if subject has permission on object.
 
     Uses graph traversal and caching to determine if permission is granted.
+    Supports multi-zone isolation via --zone-id or NEXUS_ZONE_ID env var.
 
     Examples:
         # Does alice have read permission on file123?
@@ -385,11 +388,15 @@ def rebac_check_cmd(
     try:
         nx = get_filesystem(backend_config)
 
+        # Get zone_id from operation_context (set by @add_context_options)
+        zone = operation_context.get("zone")
+
         # Check permission
         granted = nx.rebac_service.rebac_check_sync(  # type: ignore[attr-defined]
             subject=(subject_type, subject_id),
             permission=permission,
             object=(object_type, object_id),
+            zone_id=zone,
         )
 
         nx.close()
@@ -415,15 +422,18 @@ def rebac_check_cmd(
 @click.argument("object_type", type=str)
 @click.argument("object_id", type=str)
 @add_backend_options
+@add_context_options
 def rebac_expand_cmd(
     permission: str,
     object_type: str,
     object_id: str,
     backend_config: BackendConfig,
+    operation_context: dict[str, Any],
 ) -> None:
     """Find all subjects with a given permission on an object.
 
     Uses recursive graph traversal to find all subjects.
+    Supports multi-zone isolation via --zone-id or NEXUS_ZONE_ID env var.
 
     Examples:
         # Who has read permission on file123?
@@ -438,10 +448,14 @@ def rebac_expand_cmd(
     try:
         nx = get_filesystem(backend_config)
 
+        # Get zone_id from operation_context (set by @add_context_options)
+        zone = operation_context.get("zone")
+
         # Expand permission
         subjects = nx.rebac_service.rebac_expand_sync(  # type: ignore[attr-defined]
             permission=permission,
             object=(object_type, object_id),
+            zone_id=zone,
         )
 
         nx.close()

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -797,6 +797,20 @@ class NexusFSCoreMixin:
             if overlay_config:
                 meta = self._overlay_resolver.resolve_read(path, overlay_config)
 
+        # Zone fallback: if zone-scoped path not found, try unscoped (root-zone) path.
+        # Admin-created files live at unscoped paths; zone-scoped users should still
+        # be able to read them (ReBAC permission check already passed above).
+        if (meta is None or meta.etag is None) and path.startswith("/zone/"):
+            from nexus.server.path_utils import unscope_internal_path
+
+            unscoped = unscope_internal_path(path)
+            if unscoped != path:
+                fallback_meta = self.metadata.get(unscoped)
+                if fallback_meta is not None and fallback_meta.etag is not None:
+                    meta = fallback_meta
+                    route = self.router.route(unscoped, is_admin=is_admin, check_write=False)
+                    path = unscoped
+
         if meta is None or meta.etag is None:
             raise NexusFileNotFoundError(path)
 


### PR DESCRIPTION
## Summary

- **Zone graph cache invalidation**: `CacheCoordinator.invalidate_for_tuple_change()` now invalidates the ZoneGraphLoader cache. Previously PathUpdater renames updated DB tuples but left the zone graph cache stale, causing fresh computes to return wrong results after file rename (demo section 4.3).
- **Expand permission resolution**: `_expand_permission_zone_aware()` now resolves computed permissions (e.g. `write` → `["editor", "owner"]`) from the namespace `permissions` config before falling through to relation lookup. Previously `rebac_expand("write")` returned empty (demo section 5.1).
- **Zone auto-detection**: `ReBACService` auto-detects `zone_id` from entity_registry (subjects) and existing tuples (objects) when not explicitly provided. CLI `rebac check` and `rebac expand` now support `--zone-id`.

## Files changed

| File | Change |
|------|--------|
| `cache/coordinator.py` | +3 lines: add `_invalidate_zone_graph()` to `invalidate_for_tuple_change()` |
| `manager.py` | +9 lines: resolve computed permissions in `_expand_permission_zone_aware()` |
| `rebac_service.py` | Zone auto-detection helpers (`_resolve_zone_for_subject`, `_resolve_zone_for_object`) |
| `cli/commands/rebac.py` | Add `@add_context_options` to check/expand, use RPC client methods |
| `nexus_fs_core.py` | Zone fallback: try unscoped path for zone-scoped reads |
| `permissions_demo_enhanced.sh` | Fix owner permission docs, table output parsing, keyword args |
| `create-api-key.py` | Fix `EntityRegistry` constructor wrapper |
| `check_file_size.py` | Add `bricks/rebac/rebac_service.py` to exceptions |

## Test plan

- [x] Full `permissions_demo_enhanced.sh` passes all sections (20+ green checks)
- [x] Section 4.3 (rename cache invalidation): permission removed from old path, follows to new path
- [x] Section 5.1 (expand audit): finds alice (owner) and bob (editor) with write permission
- [x] All pre-commit hooks pass (ruff, ruff-format, file-size, type-ignores, brick-imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)