### PR TITLE
refactor(#889): extract memory I/O via generic pre-dispatch resolver

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -145,7 +145,7 @@ See `ops-scenario-matrix.md` for full Ops-Scenario affinity proof.
 | `CacheStoreABC` | (no direct analogue) | Ephemeral KV + Pub/Sub primitives |
 | `VFSLockManagerProtocol` | per-inode `i_rwsem` | Path-level RW locking with hierarchy awareness |
 | `PipeManagerProtocol` | `pipe(2)` + `fs/pipe.c` | Named pipe lifecycle + MPMC data path (see §6 Kernel Tier) |
-| Notification dispatch | `security_hook_heads` + `fsnotify` | Two-phase callback lists at VFS operation points (see §3 Notification Dispatch) |
+| VFS dispatch | `file->f_op` + `security_hook_heads` + `fsnotify` | Three-phase dispatch at VFS operation points (see §3 VFS Dispatch) |
 
 `MetastoreABC` is kernel because it IS the inode layer — the typed contract
 between VFS and storage. Without it, the kernel cannot describe files.
@@ -190,9 +190,9 @@ LSM modules call `security_add_hooks()` to populate them.
 > `_wire_services()` deleted — all service creation moved to `factory._boot_wired_services()` (#643).
 > Remaining: replace `KernelServices` dataclass with `ServiceRegistry`.
 
-### Kernel Notification Dispatch
+### Kernel VFS Dispatch
 
-The kernel provides callback-based notification at VFS operation points (read,
+The kernel provides callback-based dispatch at VFS operation points (read,
 write, delete, rename, mkdir, rmdir). Like Linux's `security_hook_heads` and
 `fsnotify_group`, these are kernel-internal callback lists.
 
@@ -201,17 +201,25 @@ write, delete, rename, mkdir, rmdir). Like Linux's `security_hook_heads` and
 callbacks into kernel-owned dispatch at boot. Empty lists = no-op dispatch
 = kernel operates with zero services.
 
-Two-phase dispatch per VFS operation:
+Three-phase dispatch per VFS operation:
 
-| Phase | Semantics | Abort? | Modify? | Linux Analogue | Mechanism |
-|-------|-----------|--------|---------|----------------|-----------|
-| **INTERCEPT** | Synchronous, ordered | Yes (hook policy) | Yes (hooks) | LSM `call_void_hook()` | `KernelDispatch.intercept_post_*()` |
-| **OBSERVE** | Fire-and-forget | No | No | `fsnotify()` / `notifier_call_chain()` | `KernelDispatch.notify()` |
+| Phase | Semantics | Short-circuit? | Linux Analogue | Mechanism |
+|-------|-----------|----------------|----------------|-----------|
+| **PRE-DISPATCH** | First-match short-circuit | Yes (skips pipeline) | VFS `file->f_op` dispatch (procfs, sysfs) | `KernelDispatch.resolve_*()` |
+| **INTERCEPT** | Synchronous, ordered | Yes (hook policy) | LSM `call_void_hook()` | `KernelDispatch.intercept_post_*()` |
+| **OBSERVE** | Fire-and-forget | No | `fsnotify()` / `notifier_call_chain()` | `KernelDispatch.notify()` |
 
-**Implementation** (`core/kernel_dispatch.py`, Issue #900):
+**Implementation** (`core/kernel_dispatch.py`, Issues #900, #889):
 
-`KernelDispatch` is a single class that owns both phases. Each VFS operation
-(read/write/delete/rename/mkdir/rmdir) calls `intercept_post_*()` then `notify()`.
+`KernelDispatch` is a single class that owns all three phases.
+
+PRE-DISPATCH (Issue #889) resolves virtual path operations before the
+normal VFS pipeline runs. Registered `VFSPathResolver` instances are
+checked in order; the first whose `matches(path)` returns True handles
+the entire operation (read/write/delete). Each resolver owns its own
+permission semantics — like procfs has `proc_pid_permission` separate
+from ext4's `ext4_permission`. Current resolvers: `MemoryIOHandler`
+(memory virtual paths). Empty resolver chain = no-op = zero overhead.
 
 INTERCEPT phase dispatches registered interceptor hooks — per-operation
 hook lists (`register_intercept_read/write/delete/rename/mkdir/rmdir`).
@@ -229,12 +237,15 @@ Failures logged, never abort.
 
 **Contracts:**
 - `FileEvent`/`FileEventType` in `core/file_events.py` (kernel-defined data type).
+- `VFSPathResolver` — PRE-DISPATCH protocol for virtual path resolvers
+  (in `contracts/vfs_hooks.py`).
 - Hook protocols (`VFSReadHook`, `VFSWriteHook`, etc.), context dataclasses
   (`ReadHookContext`, `WriteHookContext`, etc.), `VFSObserver` — in
   `contracts/vfs_hooks.py` (tier-neutral, like `include/linux/notifier.h`).
 - Concrete implementations in `services/hooks/` (policy, like SELinux/AppArmor).
 
 **Registration API** (factory registers at boot):
+- `dispatch.register_resolver(resolver)` — PRE-DISPATCH resolvers (first-match)
 - `dispatch.register_intercept_read(hook)` — INTERCEPT hooks (per-operation)
 - `dispatch.register_observe(observer)` — OBSERVE observers (all mutations)
 

--- a/src/nexus/bricks/memory/io_handler.py
+++ b/src/nexus/bricks/memory/io_handler.py
@@ -1,0 +1,135 @@
+"""Memory I/O handler — VFSPathResolver for memory virtual paths (#889).
+
+Structurally satisfies the ``VFSPathResolver`` protocol so it can be
+registered in ``KernelDispatch`` as a PRE-DISPATCH resolver.  When a
+read/write/delete targets a memory path, this handler short-circuits
+the normal VFS pipeline and handles the operation directly.
+
+Linux analogue: procfs ``proc_reg_read()`` / ``proc_reg_write()`` —
+a virtual filesystem whose file_operations bypass the block layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nexus.contracts.exceptions import NexusFileNotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryIOHandler:
+    """PRE-DISPATCH resolver for memory virtual paths.
+
+    Satisfies ``VFSPathResolver`` protocol (structural typing):
+    - ``matches(path)`` — routing predicate
+    - ``read(path, ...)`` — memory read
+    - ``write(path, content)`` — memory write
+    - ``delete(path, ...)`` — memory delete
+
+    Dependencies injected via constructor (no kernel imports at runtime):
+    - memory_router: MemoryViewRouter (path resolution + metadata)
+    - memory_provider: MemoryProvider (lazy Memory API factory)
+    - path_router: PathRouter (CAS content routing)
+    """
+
+    __slots__ = ("_router", "_provider", "_path_router")
+
+    def __init__(
+        self,
+        memory_router: Any,
+        memory_provider: Any,
+        path_router: Any,
+    ) -> None:
+        self._router = memory_router
+        self._provider = memory_provider
+        self._path_router = path_router
+
+    # ------------------------------------------------------------------
+    # VFSPathResolver protocol
+    # ------------------------------------------------------------------
+
+    def matches(self, path: str) -> bool:
+        """Return True if *path* is a memory virtual path."""
+        return bool(self._router.is_memory_path(path))
+
+    def read(
+        self, path: str, *, return_metadata: bool = False, context: Any = None
+    ) -> bytes | dict[str, Any]:
+        """Read memory via virtual path.
+
+        Extracted from ``NexusFSCoreMixin._read_memory_path``.
+        """
+        memory = self._router.resolve(path)
+        if not memory:
+            raise NexusFileNotFoundError(f"Memory not found at path: {path}")
+
+        # Read content from CAS — route the memory path to find the backend
+        route = self._path_router.route(path, is_admin=True)
+        content: bytes = route.backend.read_content(memory.content_hash, context=context)
+
+        if return_metadata:
+            return {
+                "content": content,
+                "etag": memory.content_hash,
+                "version": 1,  # Memories don't version like files
+                "modified_at": memory.created_at,
+                "size": len(content),
+            }
+        return content
+
+    def write(self, path: str, content: bytes) -> dict[str, Any]:
+        """Write memory via virtual path.
+
+        Extracted from ``NexusFSCoreMixin._write_memory_path``.
+        """
+        memory_api = self._provider.get_or_create()
+        if memory_api is None:
+            raise RuntimeError("Memory API not initialized")
+
+        # Extract memory type from path if present
+        parts = [p for p in path.split("/") if p]
+        memory_type = None
+        if "memory" in parts:
+            idx = parts.index("memory")
+            if idx + 1 < len(parts):
+                memory_type = parts[idx + 1]
+
+        # Store memory with default scope='user'
+        memory_id = memory_api.store(
+            content=content.decode("utf-8") if isinstance(content, bytes) else content,
+            scope="user",
+            memory_type=memory_type,
+        )
+
+        # Get the created memory
+        mem = memory_api.get(memory_id)
+        if mem is None:
+            raise RuntimeError(
+                f"Failed to retrieve stored memory (id={memory_id}). "
+                "The memory API may not be properly configured or the memory was not persisted."
+            )
+
+        return {
+            "etag": mem["content_hash"],
+            "version": 1,
+            "modified_at": mem["created_at"],
+            "size": len(content),
+        }
+
+    def delete(self, path: str, *, context: Any = None) -> None:
+        """Delete memory via virtual path.
+
+        Extracted from ``NexusFSCoreMixin._delete_memory_path``.
+        """
+        memory = self._router.resolve(path)
+        if not memory:
+            raise NexusFileNotFoundError(f"Memory not found at path: {path}")
+
+        # Delete the memory
+        self._router.delete_memory(memory.memory_id)
+
+        # Also delete content from CAS (decrement ref count)
+        route = self._path_router.route(path, is_admin=True)
+        route.backend.delete_content(memory.content_hash, context=context)

--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -236,3 +236,29 @@ class VFSObserver(Protocol):
     """
 
     def on_mutation(self, event: Any) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# PRE-DISPATCH phase — virtual path resolver protocol (Issue #889)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class VFSPathResolver(Protocol):
+    """PRE-DISPATCH resolver for virtual paths (Issue #889).
+
+    Linux analogue: virtual filesystem dispatch (procfs, sysfs, devtmpfs).
+    When read()/write()/delete() is called on a path claimed by a resolver,
+    the resolver handles the entire operation — the normal VFS pipeline is
+    skipped.  Each resolver owns its own permission semantics.
+
+    Registered at boot via factory into KernelDispatch.  Empty resolver
+    chain = no-op = zero overhead when no resolvers registered.
+    """
+
+    def matches(self, path: str) -> bool: ...
+    def read(
+        self, path: str, *, return_metadata: bool = False, context: Any = None
+    ) -> bytes | dict: ...
+    def write(self, path: str, content: bytes) -> dict[str, Any]: ...
+    def delete(self, path: str, *, context: Any = None) -> None: ...

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -1,8 +1,14 @@
-"""KernelDispatch — unified two-phase VFS notification dispatch.
+"""KernelDispatch — unified three-phase VFS dispatch.
 
 Single dispatch point for all kernel VFS operation notifications.
 Every VFS operation (read/write/delete/rename/mkdir/rmdir) passes
-through two ordered phases:
+through three ordered phases:
+
+    PRE-DISPATCH  (first-match short-circuit)
+    └── Registered VFSPathResolver chain.
+        First resolver whose ``matches(path)`` returns True handles
+        the entire operation — normal VFS pipeline is skipped.
+        Each resolver owns its own permission semantics.
 
     INTERCEPT  (synchronous, ordered)
     └── Registered interceptor hooks (per-operation hook lists).
@@ -15,19 +21,22 @@ through two ordered phases:
         Failures are caught and logged.  Never abort.
 
 Linux kernel analogy:
-    INTERCEPT ≈ LSM ``call_void_hook()`` chain
-    OBSERVE   ≈ ``fsnotify()`` / ``notifier_call_chain()``
+    PRE-DISPATCH ≈ VFS ``file->f_op`` dispatch (procfs, sysfs, devtmpfs)
+    INTERCEPT    ≈ LSM ``call_void_hook()`` chain
+    OBSERVE      ≈ ``fsnotify()`` / ``notifier_call_chain()``
 
 Lifecycle:
     Kernel creates KernelDispatch with empty callback lists at init.
-    Factory registers interceptor hooks and observers at boot.
-    Kernel call sites invoke ``intercept_post_*()`` then ``notify()``.
-    Empty hook lists = no-op dispatch = zero overhead when no services.
+    Factory registers resolvers, interceptor hooks, and observers at boot.
+    Kernel call sites invoke ``resolve_*()`` then ``intercept_post_*()``
+    then ``notify()``.
+    Empty lists = no-op dispatch = zero overhead when no services.
 
-Issue #900.
+Issue #900, #889.
 """
 
 import logging
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.exceptions import AuditLogError
 from nexus.contracts.operation_result import OperationWarning
@@ -50,6 +59,9 @@ from nexus.contracts.vfs_hooks import (
 )
 from nexus.core.file_events import FileEvent
 
+if TYPE_CHECKING:
+    from nexus.contracts.vfs_hooks import VFSPathResolver
+
 logger = logging.getLogger(__name__)
 
 
@@ -70,6 +82,7 @@ class KernelDispatch:
     """
 
     __slots__ = (
+        "_resolvers",
         "_read_hooks",
         "_write_hooks",
         "_write_batch_hooks",
@@ -81,6 +94,9 @@ class KernelDispatch:
     )
 
     def __init__(self) -> None:
+        # PRE-DISPATCH: virtual path resolvers (Issue #889)
+        self._resolvers: list[VFSPathResolver] = []
+
         # INTERCEPT: per-operation hook lists
         self._read_hooks: list[VFSReadHook] = []
         self._write_hooks: list[VFSWriteHook] = []
@@ -92,6 +108,48 @@ class KernelDispatch:
 
         # OBSERVE: generic mutation observers
         self._observers: list[VFSObserver] = []
+
+    # ── PRE-DISPATCH: virtual path resolvers (Issue #889) ─────────────
+
+    def register_resolver(self, resolver: "VFSPathResolver") -> None:
+        """Register a PRE-DISPATCH virtual path resolver."""
+        self._resolvers.append(resolver)
+
+    def resolve_read(
+        self,
+        path: str,
+        *,
+        return_metadata: bool = False,
+        context: Any = None,
+    ) -> tuple[bool, Any]:
+        """PRE-DISPATCH: first-match resolver for read.
+
+        Returns (handled, result).  If handled is True the caller
+        must return result and skip the normal VFS pipeline.
+        """
+        for r in self._resolvers:
+            if r.matches(path):
+                return True, r.read(path, return_metadata=return_metadata, context=context)
+        return False, None
+
+    def resolve_write(self, path: str, content: bytes) -> tuple[bool, Any]:
+        """PRE-DISPATCH: first-match resolver for write."""
+        for r in self._resolvers:
+            if r.matches(path):
+                return True, r.write(path, content)
+        return False, None
+
+    def resolve_delete(self, path: str, *, context: Any = None) -> tuple[bool, Any]:
+        """PRE-DISPATCH: first-match resolver for delete."""
+        for r in self._resolvers:
+            if r.matches(path):
+                r.delete(path, context=context)
+                return True, {}
+        return False, None
+
+    @property
+    def resolver_count(self) -> int:
+        return len(self._resolvers)
 
     # ── register_intercept: per-operation INTERCEPT hooks ─────────────
 

--- a/src/nexus/core/nexus_fs_core.py
+++ b/src/nexus/core/nexus_fs_core.py
@@ -665,10 +665,12 @@ class NexusFSCoreMixin:
         """
         path = self._validate_path(path)
 
-        # Phase 2 Integration: Intercept memory paths
-        _mr = self._brick_services.memory_router
-        if _mr is not None and _mr.is_memory_path(path):
-            return self._read_memory_path(path, return_metadata, context=context)
+        # PRE-DISPATCH: virtual path resolvers (Issue #889)
+        _handled, _result = self._dispatch.resolve_read(
+            path, return_metadata=return_metadata, context=context
+        )
+        if _handled:
+            return _result
 
         # Check read permission (handles virtual views by checking original file)
         perm_check_start = time.time()
@@ -1596,10 +1598,10 @@ class NexusFSCoreMixin:
         path = self._validate_path(path)
         self._check_zone_writable(context)  # Issue #2061: write-gating
 
-        # Phase 2 Integration: Intercept memory paths
-        _mr = self._brick_services.memory_router
-        if _mr is not None and _mr.is_memory_path(path):
-            return self._write_memory_path(path, content)
+        # PRE-DISPATCH: virtual path resolvers (Issue #889)
+        _handled, _result = self._dispatch.resolve_write(path, content)
+        if _handled:
+            return _result
 
         # Issue #1106 Block 3: Acquire distributed lock if requested
         lock_id = None
@@ -2645,11 +2647,10 @@ class NexusFSCoreMixin:
         path = self._validate_path(path)
         self._check_zone_writable(context)  # Issue #2061: write-gating
 
-        # Phase 2 Integration: Intercept memory paths
-        _mr = self._brick_services.memory_router
-        if _mr is not None and _mr.is_memory_path(path):
-            self._delete_memory_path(path, context=context)
-            return {}
+        # PRE-DISPATCH: virtual path resolvers (Issue #889)
+        _handled, _result = self._dispatch.resolve_delete(path, context=context)
+        if _handled:
+            return _result
 
         # Route to backend with write access check FIRST (to check zone/agent isolation)
         # This must happen before permission check so AccessDeniedError is raised before PermissionError
@@ -3360,118 +3361,6 @@ class NexusFSCoreMixin:
                 results[path] = None
 
         return results
-
-    def _read_memory_path(
-        self, path: str, return_metadata: bool = False, context: OperationContext | None = None
-    ) -> bytes | dict[str, Any]:
-        """Read memory via virtual path (Phase 2 Integration).
-
-        Args:
-            path: Memory virtual path.
-            return_metadata: If True, return dict with content and metadata.
-
-        Returns:
-            Memory content as bytes, or dict with metadata if return_metadata=True.
-
-        Raises:
-            NexusFileNotFoundError: If memory doesn't exist.
-        """
-        router = self._brick_services.memory_router
-        if router is None:
-            raise RuntimeError("Memory brick not available — MemoryViewRouter not injected")
-
-        memory = router.resolve(path)
-
-        if not memory:
-            raise NexusFileNotFoundError(f"Memory not found at path: {path}")
-
-        # Read content from CAS — route the memory path to find the backend
-        route = self.router.route(path, is_admin=True)
-        content = route.backend.read_content(memory.content_hash, context=context)
-
-        if return_metadata:
-            return {
-                "content": content,
-                "etag": memory.content_hash,
-                "version": 1,  # Memories don't version like files
-                "modified_at": memory.created_at,
-                "size": len(content),
-            }
-
-        return content
-
-    def _write_memory_path(self, path: str, content: bytes) -> dict[str, Any]:
-        """Write memory via virtual path (Phase 2 Integration).
-
-        Args:
-            path: Memory virtual path.
-            content: Content to store.
-
-        Returns:
-            Dict with memory metadata.
-        """
-        # Delegate to Memory API
-        if not hasattr(self, "memory") or self.memory is None:
-            raise RuntimeError(
-                "Memory API not initialized. Use nx.memory for direct memory operations."
-            )
-
-        # Extract memory type from path if present
-        parts = [p for p in path.split("/") if p]
-        memory_type = None
-        if "memory" in parts:
-            idx = parts.index("memory")
-            if idx + 1 < len(parts):
-                memory_type = parts[idx + 1]
-
-        # Store memory with default scope='user'
-        memory_id = self.memory.store(
-            content=content.decode("utf-8") if isinstance(content, bytes) else content,
-            scope="user",
-            memory_type=memory_type,
-        )
-
-        # Get the created memory
-        mem = self.memory.get(memory_id)
-
-        # Handle case where memory.get() returns None
-        if mem is None:
-            raise RuntimeError(
-                f"Failed to retrieve stored memory (id={memory_id}). "
-                "The memory API may not be properly configured or the memory was not persisted."
-            )
-
-        return {
-            "etag": mem["content_hash"],
-            "version": 1,
-            "modified_at": mem["created_at"],
-            "size": len(content),
-        }
-
-    def _delete_memory_path(self, path: str, context: OperationContext | None = None) -> None:
-        """Delete memory via virtual path (Phase 2 Integration).
-
-        Args:
-            path: Memory virtual path.
-
-        Raises:
-            NexusFileNotFoundError: If memory doesn't exist.
-        """
-        router = self._brick_services.memory_router
-        if router is None:
-            raise RuntimeError("Memory brick not available — MemoryViewRouter not injected")
-
-        memory = router.resolve(path)
-
-        if not memory:
-            raise NexusFileNotFoundError(f"Memory not found at path: {path}")
-
-        # Delete the memory
-        router.delete_memory(memory.memory_id)
-
-        # Also delete content from CAS (decrement ref count)
-        route = self.router.route(path, is_admin=True)
-        route.backend.delete_content(memory.content_hash, context=context)
 
     @rpc_expose(description="Shutdown background parser threads")
     def shutdown_parser_threads(self, timeout: float = 10.0) -> dict[str, Any]:

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -547,6 +547,20 @@ def _register_vfs_hooks(nx: "NexusFS") -> None:
 
         dispatch.register_intercept_write(TigerCacheWriteHook(tiger_cache=tiger_cache))
 
+    # ── PRE-DISPATCH: Memory virtual path resolver (Issue #889) ────────
+    _mem_router = getattr(nx._brick_services, "memory_router", None)
+    _mem_provider = getattr(nx, "_memory_provider", None)
+    if _mem_router is not None and _mem_provider is not None:
+        from nexus.bricks.memory.io_handler import MemoryIOHandler
+
+        dispatch.register_resolver(
+            MemoryIOHandler(
+                memory_router=_mem_router,
+                memory_provider=_mem_provider,
+                path_router=nx.router,
+            )
+        )
+
     # ── OBSERVE observers (Issue #900, #922) ──────────────────────────
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).
     # Replaces _publish_file_event() direct calls — single dispatch exit point.


### PR DESCRIPTION
## Summary

- Introduce `VFSPathResolver` protocol and **PRE-DISPATCH** phase in `KernelDispatch` — the kernel now has **zero memory-specific code**
- `MemoryIOHandler` (bricks layer) is registered as a pre-dispatch resolver at boot; first match short-circuits the normal VFS pipeline
- Three-phase dispatch model: `PRE-DISPATCH → INTERCEPT → OBSERVE` (Linux: `procfs → LSM → fsnotify`)

### Changes

| File | Action |
|------|--------|
| `contracts/vfs_hooks.py` | +`VFSPathResolver` protocol |
| `core/kernel_dispatch.py` | +resolver chain, `resolve_read/write/delete()`, `resolver_count` |
| `bricks/memory/io_handler.py` | **NEW** — concrete `VFSPathResolver` for memory paths |
| `core/nexus_fs_core.py` | -112 lines (3 private methods + 3 early-exit blocks → 3 generic dispatch calls) |
| `factory/orchestrator.py` | Register `MemoryIOHandler` in `_register_vfs_hooks()` |
| `KERNEL-ARCHITECTURE.md` | Two-phase → three-phase dispatch documentation |

### Architecture

```
BEFORE (violation — memory-specific dispatch in kernel):
  nx.read("/workspace/alice/memory/facts")
    → kernel: if memory_router.is_memory_path(path)   ← brick-specific routing
    → kernel._read_memory_path()                       ← 37 lines of bricks logic

AFTER (generic pre-dispatch — zero memory code in kernel):
  nx.read("/workspace/alice/memory/facts")
    → kernel: handled, result = self._dispatch.resolve_read(path, ...)  ← generic
    → MemoryIOHandler.read()                           ← bricks layer
```

## Test plan

- [x] `ruff check` — all checks passed
- [x] `mypy` — passed (pre-commit hook)
- [x] Brick Zero-Core-Imports check — passed
- [x] Kernel unit tests (89) — all passed
- [x] Factory boot tests (19) — all passed
- [x] Factory tests (27) — all passed
- [x] Zero `memory_router`/`is_memory_path` references remain in kernel

🤖 Generated with [Claude Code](https://claude.com/claude-code)