### PR TITLE
feat(#994): clean up stale brick boundary exceptions

### DIFF
--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -69,7 +69,6 @@ KNOWN_CROSS_BRICK_EXCEPTIONS: dict[tuple[str, str], list[str]] = {
     # TODO(#2429): Fix a2a->ipc via DI refactoring.
     ("a2a", "ipc"): [
         "nexus.bricks.a2a.messaging_adapters",
-        "nexus.bricks.a2a.stores.vfs",
     ],
     # TODO(#2429): Fix mcp->rebac/discovery via DI refactoring.
     ("mcp", "rebac"): [
@@ -88,10 +87,6 @@ KNOWN_CROSS_BRICK_EXCEPTIONS: dict[tuple[str, str], list[str]] = {
     ("memory", "llm"): [
         "nexus.bricks.memory.coref_resolver",
         "nexus.bricks.memory.relationship_extractor",
-    ],
-    # TODO: Fix scheduler->pay via DI refactoring (CreditsService).
-    ("scheduler", "pay"): [
-        "nexus.bricks.scheduler.service",
     ],
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -873,7 +873,6 @@ ignore_imports = [
     "nexus.server.telemetry -> nexus.bricks.rebac.rebac_tracing",
     # a2a -> ipc: TYPE_CHECKING imports only (runtime imports now use importlib)
     "nexus.bricks.a2a.messaging_adapters -> nexus.bricks.ipc.envelope",
-    "nexus.bricks.a2a.stores.vfs -> nexus.bricks.ipc.storage.protocol",
     # mcp -> rebac: TYPE_CHECKING imports for middleware/profiles (Issue #2429)
     "nexus.bricks.mcp.middleware -> nexus.bricks.rebac.manager",
     "nexus.bricks.mcp.profiles -> nexus.bricks.rebac.manager",


### PR DESCRIPTION
## Summary
- Remove dead `scheduler->pay` exception from `check_brick_imports.py` (bricks/scheduler/ deleted in 84df74f2e)
- Remove stale `a2a.stores.vfs -> ipc.storage.protocol` from import-linter config (ipc.storage deleted in PR #2617)
- Remove `a2a.stores.vfs` from `check_brick_imports.py` a2a->ipc exception list (import replaced with importlib in PR #2617)

## Test plan
- [ ] Brick Zero-Core-Imports Check pre-commit hook passes
- [ ] Architecture Boundary Check (import-linter) CI — stale "No matches for ignored import" warning gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)