### PR TITLE
fix: update stale nexus.constants imports to nexus.contracts.constants

### DIFF
--- a/src/nexus/bricks/rebac/cache/tiger/write_hook.py
+++ b/src/nexus/bricks/rebac/cache/tiger/write_hook.py
@@ -15,7 +15,7 @@ Issue #2133: Extracted from NexusFSCoreMixin inline code (Leopard-style grants).
 import logging
 from typing import Any
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.vfs_hooks import WriteHookContext
 
 logger = logging.getLogger(__name__)

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -45,7 +45,7 @@ def _scope_params_for_zone(params: Any, zone_id: str) -> None:
     The reverse operation (stripping the prefix from results) is handled
     by ``unscope_internal_path`` in ``path_utils.py``.
     """
-    from nexus.constants import ROOT_ZONE_ID
+    from nexus.contracts.constants import ROOT_ZONE_ID
 
     if zone_id == ROOT_ZONE_ID:
         return

--- a/src/nexus/services/event_log/exporters/kafka_exporter.py
+++ b/src/nexus/services/event_log/exporters/kafka_exporter.py
@@ -13,7 +13,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:

--- a/src/nexus/services/event_log/exporters/nats_exporter.py
+++ b/src/nexus/services/event_log/exporters/nats_exporter.py
@@ -15,7 +15,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:

--- a/src/nexus/services/event_log/exporters/pubsub_exporter.py
+++ b/src/nexus/services/event_log/exporters/pubsub_exporter.py
@@ -13,7 +13,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:

--- a/src/nexus/services/protocols/write_back.py
+++ b/src/nexus/services/protocols/write_back.py
@@ -13,7 +13,7 @@ References:
 
 from typing import Any, Protocol, runtime_checkable
 
-from nexus.constants import ROOT_ZONE_ID
+from nexus.contracts.constants import ROOT_ZONE_ID
 
 
 @runtime_checkable


### PR DESCRIPTION
## Summary
- 6 files still imported `ROOT_ZONE_ID` from the old `nexus.constants` module after it was merged into `nexus.contracts.constants` in #1024
- This broke `nexus serve` on startup: `No module named 'nexus.constants'`

## Files fixed
- `bricks/rebac/cache/tiger/write_hook.py`
- `server/api/core/rpc.py`
- `services/event_log/exporters/kafka_exporter.py`
- `services/event_log/exporters/nats_exporter.py`
- `services/event_log/exporters/pubsub_exporter.py`
- `services/protocols/write_back.py`

## Test plan
- [x] `grep -r 'from nexus.constants import' src/` returns zero matches
- [x] `nexus serve` starts successfully after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)