### PR TITLE
fix(raft): block on campaign instead of fire-and-forget spawn

### DIFF
--- a/rust/nexus_raft/src/raft/zone_registry.rs
+++ b/rust/nexus_raft/src/raft/zone_registry.rs
@@ -207,13 +207,14 @@ impl ZoneRaftRegistry {
         let transport_handle = runtime_handle.spawn(transport_loop.run(shutdown_rx));
 
         if campaign {
-            let campaign_node = handle.clone();
-            runtime_handle.spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                if let Err(e) = campaign_node.campaign().await {
-                    tracing::error!("Zone campaign failed: {}", e);
-                }
-            });
+            // Block until campaign is processed by the driver.
+            // Per raft contract: for single-node, campaign() grants self-vote
+            // (quorum=1) and the node becomes leader immediately. For multi-node,
+            // campaign() sends MsgVote to peers and returns (election is async).
+            // This ensures the node is ready before returning to the caller.
+            runtime_handle
+                .block_on(async { handle.campaign().await })
+                .map_err(|e| TransportError::Connection(format!("Campaign failed: {}", e)))?;
         }
 
         tracing::info!(


### PR DESCRIPTION
## Summary
- Replace the 50ms-delayed `tokio::spawn` for raft campaign with synchronous `runtime_handle.block_on(campaign())`.
- Per raft contract: single-node campaign grants self-vote (quorum=1) and becomes leader immediately — no reason to fire-and-forget.
- Eliminates the need for Python-side `is_leader()` polling after `bootstrap()` — the node is guaranteed ready when `create_zone()` returns.

## Context
After PR #2623 fixed ConfState bootstrap for single-node clusters, the remaining issue was that `setup_zone()` used a fire-and-forget `tokio::spawn` with 50ms delay for campaign. This meant `create_zone()` returned to Python before the node became leader, requiring a polling wait in `__init__.py`. That polling was the wrong fix at the wrong layer.

## Test plan
- [x] `cargo check -p nexus_raft --features full` — compiles clean
- [x] `cargo test -p nexus_raft --features consensus` — 46/46 pass
- [x] Verified `block_on` is safe: `ZoneRegistry::create_zone()` is only called from PyO3 (Python thread, not inside tokio runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)