### PR TITLE
fix: expose generate_embedding in memory v2 API

### DIFF
--- a/src/nexus/server/api/v2/models/memories.py
+++ b/src/nexus/server/api/v2/models/memories.py
@@ -29,6 +29,7 @@ class MemoryStoreRequest(ApiModel):
     valid_at: str | None = Field(None, description="When fact became valid (ISO-8601)")
     classify_stability: bool = Field(True, description="Auto-classify temporal stability")
     detect_evolution: bool = Field(False, description="Detect evolution relationships (#1190)")
+    generate_embedding: bool = Field(True, description="Generate embedding for semantic search")
     metadata: dict[str, Any] | None = Field(None, description="Additional metadata")
 
 

--- a/src/nexus/server/api/v2/routers/memories.py
+++ b/src/nexus/server/api/v2/routers/memories.py
@@ -102,6 +102,7 @@ async def store_memory(
             valid_at=request.valid_at,
             classify_stability=request.classify_stability,
             detect_evolution=request.detect_evolution,
+            generate_embedding=request.generate_embedding,
             _metadata=request.metadata,
             context=context,
         )
@@ -268,11 +269,13 @@ async def revalidate_memory(
 @router.post("/search", response_model=dict[str, Any])
 async def search_memories(
     request: MemorySearchRequest,
-    _auth_result: dict[str, Any] = Depends(_get_require_auth()),
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),
     memory_api: Any = Depends(get_memory_api),
 ) -> dict[str, Any]:
     """Search memories with semantic/keyword/hybrid search."""
     try:
+        context = _get_operation_context(auth_result)
+
         results = memory_api.search(
             query=request.query,
             scope=request.scope,
@@ -282,6 +285,7 @@ async def search_memories(
             after=request.after,
             before=request.before,
             during=request.during,
+            context=context,
         )
 
         return {
@@ -387,7 +391,10 @@ async def batch_store_memories(
                     extract_temporal=mem_request.extract_temporal,
                     extract_relationships=mem_request.extract_relationships,
                     store_to_graph=mem_request.store_to_graph,
+                    valid_at=mem_request.valid_at,
                     classify_stability=mem_request.classify_stability,
+                    detect_evolution=mem_request.detect_evolution,
+                    generate_embedding=mem_request.generate_embedding,
                     _metadata=mem_request.metadata,
                     context=context,
                 )


### PR DESCRIPTION
## Summary
- Add `generate_embedding` bool field to `MemoryStoreRequest` (default `True`) so callers can skip embedding generation for write-perf benchmarks or bulk ingestion where embeddings are computed separately
- Pass `generate_embedding` through to `memory_api.store()` in both single and batch store endpoints
- Fix batch store parameter drift: `valid_at` and `detect_evolution` were on `MemoryStoreRequest` but missing from the batch endpoint code path
- Pass auth context to memory search endpoint for proper zone-scoped isolation

## Test plan
- [x] Verified single store with `generate_embedding: false` returns 201 and skips embedding
- [x] All 33 memory E2E tests pass (nexus-test suite)
- [x] Write perf test now measures pure DB+enrichment latency (p50=31ms, p95<100ms)
- [x] Existing API calls without the field default to `True` (backward compatible)