### PR TITLE
fix(raft): skip bootstrap for joiners + snapshot-based catch-up

### DIFF
--- a/rust/nexus_raft/src/raft/node.rs
+++ b/rust/nexus_raft/src/raft/node.rs
@@ -50,7 +50,7 @@ use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use raft::eraftpb::{ConfChange, ConfChangeType, ConfState, Entry, EntryType, Message};
+use raft::eraftpb::{ConfChange, ConfChangeType, ConfState, Entry, EntryType, Message, Snapshot};
 use raft::{Config, RawNode, Storage};
 use slog::{o, Logger};
 use tokio::sync::{mpsc, oneshot, RwLock};
@@ -91,6 +91,13 @@ pub struct RaftConfig {
 
     /// Tick interval (how often to call tick()).
     pub tick_interval: Duration,
+
+    /// Skip ConfState bootstrap for joining nodes.
+    ///
+    /// When true, the node starts with an empty ConfState and waits for
+    /// the leader to send a snapshot with the correct voter set.
+    /// Per raft contract: joining nodes must NOT bootstrap themselves.
+    pub skip_bootstrap: bool,
 }
 
 impl Default for RaftConfig {
@@ -104,6 +111,7 @@ impl Default for RaftConfig {
             max_inflight_msgs: 256,
             is_witness: false,
             tick_interval: Duration::from_millis(10),
+            skip_bootstrap: false,
         }
     }
 }
@@ -351,7 +359,11 @@ impl<S: StateMachine + 'static> ZoneConsensus<S> {
             .initial_state()
             .map_err(|e| RaftError::Storage(e.to_string()))?;
 
-        if initial_state.conf_state.voters.is_empty() {
+        if initial_state.conf_state.voters.is_empty() && !config.skip_bootstrap {
+            // Bootstrap: create initial voter set for a NEW cluster.
+            // Joining nodes (skip_bootstrap=true) must NOT bootstrap — they
+            // start uninitialized and receive the correct ConfState via
+            // snapshot from the leader (per raft contract).
             let mut voters = vec![config.id];
             voters.extend(config.peers.iter());
             let cs = ConfState {
@@ -720,6 +732,10 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         .raw_node
                         .campaign()
                         .map_err(|e| RaftError::Raft(e.to_string()));
+                    // Sync cached role so handle.is_leader() reflects the
+                    // post-campaign state before the next advance() cycle.
+                    // For single-node: campaign() grants self-vote → Leader.
+                    self.update_cached_status();
                     let _ = tx.send(result);
                 }
             }
@@ -768,13 +784,26 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
             self.apply_entries(committed).await?;
         }
 
-        // Handle snapshot
+        // Handle snapshot (received from leader during catch-up / join)
         if !ready.snapshot().is_empty() {
             let snapshot = ready.snapshot();
+            tracing::info!(
+                index = snapshot.get_metadata().index,
+                term = snapshot.get_metadata().term,
+                voters = ?snapshot.get_metadata().get_conf_state().voters,
+                "Applying snapshot from leader"
+            );
             self.raw_node
                 .mut_store()
                 .apply_snapshot(snapshot)
                 .map_err(|e| RaftError::Storage(e.to_string()))?;
+            // Restore state machine from snapshot data (raft contract:
+            // application must restore its state from the snapshot).
+            if !snapshot.data.is_empty() {
+                let mut sm = self.state_machine.write().await;
+                sm.restore_snapshot(&snapshot.data)
+                    .map_err(|e| RaftError::Storage(format!("restore snapshot: {e}")))?;
+            }
         }
 
         // Persist entries and hard state
@@ -905,6 +934,53 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         voters = ?cs.voters,
                         "raft.conf_change.applied",
                     );
+
+                    // After AddNode: create snapshot and compact log so raft-rs
+                    // sends snapshot (not AppendEntries) to the new follower.
+                    // Per raft contract: the initial ConfState is only in the
+                    // snapshot — new followers MUST receive a snapshot to learn
+                    // about all voters. Without this, the joiner would only see
+                    // voters added via ConfChange entries, missing the bootstrap
+                    // voters.
+                    if matches!(
+                        cc.get_change_type(),
+                        ConfChangeType::AddNode | ConfChangeType::AddLearnerNode
+                    ) {
+                        let sm_data = sm.snapshot().map_err(|e| {
+                            RaftError::Storage(format!("snapshot for new voter: {e}"))
+                        })?;
+                        let mut snapshot = Snapshot::new();
+                        {
+                            let meta = snapshot.mut_metadata();
+                            meta.index = entry.index;
+                            meta.term = entry.term;
+                            *meta.mut_conf_state() = cs.clone();
+                        }
+                        snapshot.data = sm_data.into();
+
+                        // Store snapshot WITHOUT clearing entries (we are the
+                        // leader and need entries for other followers).
+                        self.raw_node
+                            .mut_store()
+                            .store_snapshot(&snapshot)
+                            .map_err(|e| RaftError::Storage(format!("store snapshot: {e}")))?;
+                        // Compact log up to this entry so raft-rs detects
+                        // Compacted when probing the new follower and falls
+                        // back to sending the snapshot.
+                        self.raw_node
+                            .mut_store()
+                            .compact(entry.index)
+                            .map_err(|e| {
+                                RaftError::Storage(format!("compact after AddNode: {e}"))
+                            })?;
+
+                        tracing::info!(
+                            index = entry.index,
+                            node_id = cc.node_id,
+                            voters = ?cs.voters,
+                            "Created snapshot and compacted log for new voter catch-up"
+                        );
+                    }
 
                     // Notify waiting JoinZone caller (if any)
                     if let Some(tx) = self.pending_conf_changes.remove(&cc.node_id) {
@@ -1252,5 +1328,56 @@ mod tests {
             matches!(result.unwrap_err(), RaftError::NotLeader { .. }),
             "Should be NotLeader error"
         );
+    }
+
+    /// Regression test: after campaign() on a single-node cluster,
+    /// is_leader() must return true IMMEDIATELY — without needing advance().
+    ///
+    /// Previously, update_cached_status() was only called inside advance(),
+    /// so the cached role stayed Follower until the next transport loop tick.
+    /// Callers (PyO3 set_metadata) that checked is_leader() right after
+    /// create_zone() would get "not leader" errors.
+    #[tokio::test]
+    async fn test_single_node_is_leader_after_campaign_without_advance() {
+        let dir = TempDir::new().unwrap();
+        let storage = RaftStorage::open(dir.path()).unwrap();
+        let store = RedbStore::open(dir.path().join("sm")).unwrap();
+        let state_machine = FullStateMachine::new(&store).unwrap();
+
+        let config = RaftConfig {
+            id: 1,
+            peers: vec![],
+            ..Default::default()
+        };
+
+        let (handle, mut driver) =
+            ZoneConsensus::new(config, storage, state_machine, None).unwrap();
+
+        // Before campaign: should be Follower
+        assert_eq!(handle.role(), NodeRole::Follower);
+        assert!(!handle.is_leader());
+
+        // Spawn campaign on a separate task (it blocks waiting for driver response).
+        // Then drive process_messages() to dequeue and process the Campaign msg.
+        let campaign_handle = handle.clone();
+        let campaign_task = tokio::spawn(async move { campaign_handle.campaign().await });
+
+        // Yield to let the campaign task send the message
+        tokio::task::yield_now().await;
+
+        // Process the Campaign message in the driver (no advance!)
+        driver.process_messages();
+
+        // Wait for campaign to complete
+        campaign_task.await.unwrap().unwrap();
+
+        // is_leader() must be true now — the cached status was synced
+        // inside the campaign handler, not deferred to advance().
+        assert!(
+            handle.is_leader(),
+            "is_leader() must be true after campaign() + process_messages(), without advance()"
+        );
+        assert_eq!(handle.role(), NodeRole::Leader);
+        assert_eq!(handle.leader_id(), Some(1));
     }
 }

--- a/rust/nexus_raft/src/raft/storage.rs
+++ b/rust/nexus_raft/src/raft/storage.rs
@@ -152,7 +152,20 @@ impl RaftStorage {
         Ok(())
     }
 
-    /// Apply a snapshot.
+    /// Store a snapshot without clearing existing entries.
+    ///
+    /// Used by the leader after ConfChange(AddNode) to prepare a snapshot
+    /// that raft-rs sends to lagging followers via `Storage::snapshot()`.
+    /// Unlike [`apply_snapshot`], this preserves existing log entries
+    /// (the leader still needs them for other followers).
+    pub fn store_snapshot(&self, snapshot: &Snapshot) -> Result<()> {
+        let value = protobuf::Message::write_to_bytes(snapshot)
+            .map_err(|e| RaftError::Serialization(e.to_string()))?;
+        self.state.set(KEY_SNAPSHOT, &value)?;
+        Ok(())
+    }
+
+    /// Apply a snapshot (receiver side — clears log and updates state).
     pub fn apply_snapshot(&self, snapshot: &Snapshot) -> Result<()> {
         let meta = snapshot.get_metadata();
 

--- a/rust/nexus_raft/src/raft/zone_registry.rs
+++ b/rust/nexus_raft/src/raft/zone_registry.rs
@@ -129,10 +129,13 @@ impl ZoneRaftRegistry {
         peers: Vec<NodeAddress>,
         runtime_handle: &tokio::runtime::Handle,
     ) -> Result<ZoneConsensus<FullStateMachine>, TransportError> {
-        // Empty peers in config → no ConfState bootstrap. Snapshot overwrites.
+        // Per raft contract: joining nodes start uninitialized (empty ConfState).
+        // The leader will send a snapshot with the correct voter set after
+        // the ConfChange(AddNode) is committed.
         let config = RaftConfig {
             id: self.node_id,
             peers: vec![],
+            skip_bootstrap: true,
             ..Default::default()
         };
 


### PR DESCRIPTION
## Summary

- **Fixes** `raft_log.rs:292: to_commit N is out of range [last_index 0]` panic when a new node joins via `join_zone()`
- **Root cause**: Two gaps in the raft contract implementation:
  1. `join_zone()` intended to skip ConfState bootstrap (comment said so) but `ZoneConsensus::new()` bootstrapped unconditionally — joiner got `voters=[self.id]` instead of staying uninitialized
  2. Leader never created snapshots, so `Storage::snapshot()` returned empty data — raft-rs couldn't send snapshot to new followers

- **Fix** (aligned with raft-rs `five_mem_node` example + etcd/tikv pattern):
  - Add `skip_bootstrap` flag to `RaftConfig`; set it in `join_zone()` — joiner starts with empty ConfState (per raft contract: joining nodes must be uninitialized)
  - After `ConfChange(AddNode)`, leader creates snapshot with correct ConfState + state machine data, then compacts log — forces raft-rs to use `Storage::snapshot()` when probing the new follower (`StorageError::Compacted` triggers snapshot fallback)
  - Add `store_snapshot()` to `RaftStorage` (stores snapshot without clearing entries — leader needs entries for other followers)
  - In `advance()`, restore state machine from received snapshot data

## Verification

- All 61 unit tests pass (`cargo test --features consensus,grpc`)
- `test_three_node_grpc_cluster` integration test passes
- JoinZone RPC tested successfully on running federation server

## Test plan

- [x] `cargo test -p nexus_raft --features consensus,grpc` — all pass
- [x] Manual JoinZone RPC test against running federation server
- [ ] End-to-end federation test: Windows node 1 + macOS node 2 over WireGuard

🤖 Generated with [Claude Code](https://claude.com/claude-code)