### PR TITLE
fix(#2124): update edit_engine import path broken by refactor

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3061,8 +3061,8 @@ class NexusFS(  # type: ignore[misc]
             ...     {"old_str": "def foo():", "new_str": "def bar():", "hint_line": 42}
             ... ], fuzzy_threshold=0.8)
         """
-        from nexus.core.edit_engine import EditEngine
-        from nexus.core.edit_engine import EditOperation as EditOp
+        from nexus.utils.edit_engine import EditEngine
+        from nexus.utils.edit_engine import EditOperation as EditOp
 
         path = self._validate_path(path)
 


### PR DESCRIPTION
## Summary
- Fix broken `edit()` RPC endpoint — `ModuleNotFoundError: No module named 'nexus.core.edit_engine'`
- Refactor #2124 moved `edit_engine.py` from `core/` to `utils/` but missed updating the lazy import inside `NexusFS.edit()` (line 3064)

## Test plan
- [x] Verified `edit()` RPC calls succeed after fix (13 E2E tests in nexus-test kernel/028-040)
- [x] All pre-commit hooks pass (mypy, ruff, brick zero-core-imports)