### PR TITLE
fix(ci): skip Pages deploy on non-main branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- The `Deploy to GitHub Pages` job in the Documentation workflow fails on `develop` branch pushes because the `github-pages` environment restricts deployments to `main` only
- Added `if: github.ref == 'refs/heads/main'` to the deploy job so it only runs on main, while the build job still validates docs on both branches

## Test plan
- [ ] Push to `develop` — build job succeeds, deploy job is skipped (not failed)
- [ ] Push to `main` — both build and deploy jobs run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)