### PR TITLE
fix: search zone isolation leak and asyncpg startup crash

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -459,6 +459,7 @@ class SearchDaemon:
         alpha: float = 0.5,
         fusion_method: str = "rrf",
         adaptive_k: bool = False,
+        zone_id: str | None = None,
     ) -> list[SearchResult]:
         """Execute a search query with pre-warmed indexes.
 
@@ -493,11 +494,18 @@ class SearchDaemon:
 
         try:
             if search_type == "keyword":
-                results = await self._keyword_search(query, limit, path_filter)
+                results = await self._keyword_search(query, limit, path_filter, zone_id=zone_id)
             elif search_type == "semantic":
-                results = await self._semantic_search(query, limit, path_filter)
+                results = await self._semantic_search(query, limit, path_filter, zone_id=zone_id)
             else:  # hybrid
-                results = await self._hybrid_search(query, limit, path_filter, alpha, fusion_method)
+                results = await self._hybrid_search(
+                    query,
+                    limit,
+                    path_filter,
+                    alpha,
+                    fusion_method,
+                    zone_id=zone_id,
+                )
 
             # Track latency
             latency_ms = (time.perf_counter() - start) * 1000
@@ -514,6 +522,8 @@ class SearchDaemon:
         query: str,
         limit: int,
         path_filter: str | None,
+        *,
+        zone_id: str | None = None,
     ) -> list[SearchResult]:
         """Fast keyword search using BM25S or Zoekt."""
         results: list[SearchResult] = []
@@ -532,7 +542,7 @@ class SearchDaemon:
 
         # Final fallback: database FTS
         if self._async_engine:
-            return await self._search_fts(query, limit, path_filter)
+            return await self._search_fts(query, limit, path_filter, zone_id=zone_id)
 
         return results
 
@@ -541,6 +551,8 @@ class SearchDaemon:
         query: str,
         limit: int,
         path_filter: str | None,
+        *,
+        zone_id: str | None = None,
     ) -> list[SearchResult]:
         """Vector similarity search using pgvector."""
         if not self._async_engine or not self._async_session:
@@ -567,6 +579,7 @@ class SearchDaemon:
                     JOIN file_paths fp ON c.path_id = fp.path_id
                     WHERE c.embedding IS NOT NULL
                       AND (:path_filter IS NULL OR fp.virtual_path LIKE :path_pattern)
+                      AND (:zone_id IS NULL OR fp.zone_id = :zone_id)
                     ORDER BY c.embedding <=> CAST(:embedding AS halfvec)
                     LIMIT :limit
                 """)
@@ -578,6 +591,7 @@ class SearchDaemon:
                         "limit": limit,
                         "path_filter": path_filter,
                         "path_pattern": f"{path_filter}%" if path_filter else None,
+                        "zone_id": zone_id,
                     },
                 )
 
@@ -633,6 +647,8 @@ class SearchDaemon:
         path_filter: str | None,
         alpha: float,
         fusion_method: str,
+        *,
+        zone_id: str | None = None,
     ) -> list[SearchResult]:
         """Hybrid search combining keyword, semantic, and optionally SPLADE results.
 
@@ -662,8 +678,12 @@ class SearchDaemon:
 
         # Run all retrieval backends in parallel
         tasks: list[asyncio.Task] = [
-            asyncio.ensure_future(self._keyword_search(query, limit * 3, path_filter)),
-            asyncio.ensure_future(self._semantic_search(query, limit * 3, path_filter)),
+            asyncio.ensure_future(
+                self._keyword_search(query, limit * 3, path_filter, zone_id=zone_id)
+            ),
+            asyncio.ensure_future(
+                self._semantic_search(query, limit * 3, path_filter, zone_id=zone_id)
+            ),
         ]
         has_splade = self._splade is not None
         if has_splade:
@@ -813,6 +833,8 @@ class SearchDaemon:
         query: str,
         limit: int,
         path_filter: str | None,
+        *,
+        zone_id: str | None = None,
     ) -> list[SearchResult]:
         """Search using database FTS (fallback)."""
         if not self._async_engine or not self._async_session:
@@ -822,43 +844,28 @@ class SearchDaemon:
             from sqlalchemy import text
 
             async with self._async_session() as session:
-                # PostgreSQL FTS query - use explicit boolean for path filtering
-                if path_filter:
-                    sql = text("""
-                        SELECT
-                            c.chunk_index, c.chunk_text,
-                            c.start_offset, c.end_offset, c.line_start, c.line_end,
-                            fp.virtual_path,
-                            ts_rank(to_tsvector('english', c.chunk_text), plainto_tsquery('english', :query)) as score
-                        FROM document_chunks c
-                        JOIN file_paths fp ON c.path_id = fp.path_id
-                        WHERE to_tsvector('english', c.chunk_text) @@ plainto_tsquery('english', :query)
-                          AND fp.virtual_path LIKE :path_pattern
-                        ORDER BY score DESC
-                        LIMIT :limit
-                    """)
-                    params = {
-                        "query": query,
-                        "limit": limit,
-                        "path_pattern": f"{path_filter}%",
-                    }
-                else:
-                    sql = text("""
-                        SELECT
-                            c.chunk_index, c.chunk_text,
-                            c.start_offset, c.end_offset, c.line_start, c.line_end,
-                            fp.virtual_path,
-                            ts_rank(to_tsvector('english', c.chunk_text), plainto_tsquery('english', :query)) as score
-                        FROM document_chunks c
-                        JOIN file_paths fp ON c.path_id = fp.path_id
-                        WHERE to_tsvector('english', c.chunk_text) @@ plainto_tsquery('english', :query)
-                        ORDER BY score DESC
-                        LIMIT :limit
-                    """)
-                    params = {
-                        "query": query,
-                        "limit": limit,
-                    }
+                # PostgreSQL FTS query with zone isolation
+                sql = text("""
+                    SELECT
+                        c.chunk_index, c.chunk_text,
+                        c.start_offset, c.end_offset, c.line_start, c.line_end,
+                        fp.virtual_path,
+                        ts_rank(to_tsvector('english', c.chunk_text), plainto_tsquery('english', :query)) as score
+                    FROM document_chunks c
+                    JOIN file_paths fp ON c.path_id = fp.path_id
+                    WHERE to_tsvector('english', c.chunk_text) @@ plainto_tsquery('english', :query)
+                      AND (:path_filter IS NULL OR fp.virtual_path LIKE :path_pattern)
+                      AND (:zone_id IS NULL OR fp.zone_id = :zone_id)
+                    ORDER BY score DESC
+                    LIMIT :limit
+                """)
+                params = {
+                    "query": query,
+                    "limit": limit,
+                    "path_filter": path_filter,
+                    "path_pattern": f"{path_filter}%" if path_filter else None,
+                    "zone_id": zone_id,
+                }
 
                 result = await session.execute(sql, params)
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -108,15 +108,17 @@ async def search_query(
     graph_mode: str = Query(
         "none", description="Graph enhancement mode: none, low, high, dual, auto"
     ),
-    _auth_result: dict[str, Any] = Depends(require_auth),
+    auth_result: dict[str, Any] = Depends(require_auth),
     search_daemon: Any = Depends(_get_search_daemon),
     async_session_factory: Any = Depends(_get_async_read_session_factory),
     record_store: Any = Depends(_get_record_store),
 ) -> dict[str, Any]:
     """Execute a fast search query using the search daemon."""
     from nexus.bricks.search.query_router import QueryRouter
+    from nexus.contracts.constants import ROOT_ZONE_ID
 
     start_time = time.perf_counter()
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
 
     if not search_daemon.is_initialized:
         raise HTTPException(status_code=503, detail="Search daemon is still initializing")
@@ -170,6 +172,7 @@ async def search_query(
                 record_store=record_store,
                 async_session_factory=async_session_factory,
                 search_daemon=search_daemon,
+                zone_id=zone_id,
             )
             latency_ms = (time.perf_counter() - start_time) * 1000
 
@@ -207,6 +210,7 @@ async def search_query(
             alpha=alpha,
             fusion_method=fusion,
             adaptive_k=adaptive_k,
+            zone_id=zone_id,
         )
 
         latency_ms = (time.perf_counter() - start_time) * 1000

--- a/src/nexus/services/search/graph_search_service.py
+++ b/src/nexus/services/search/graph_search_service.py
@@ -16,9 +16,10 @@ logger = logging.getLogger(__name__)
 class DaemonSemanticSearchWrapper:
     """Wraps search daemon as SemanticSearch interface for GraphEnhancedRetriever."""
 
-    def __init__(self, daemon: Any) -> None:
+    def __init__(self, daemon: Any, *, zone_id: str | None = None) -> None:
         self.daemon = daemon
         self.embedding_provider = getattr(daemon, "_embedding_provider", None)
+        self._zone_id = zone_id
 
     async def search(
         self,
@@ -39,6 +40,7 @@ class DaemonSemanticSearchWrapper:
             limit=limit,
             path_filter=path if path != "/" else None,
             alpha=alpha,
+            zone_id=self._zone_id,
         )
         return [
             BaseSearchResult(
@@ -68,6 +70,7 @@ async def graph_enhanced_search(
     record_store: Any,
     async_session_factory: Any,
     search_daemon: Any,
+    zone_id: str | None = None,
 ) -> list[Any]:
     """Execute graph-enhanced search using GraphEnhancedRetriever (Issue #1040).
 
@@ -96,9 +99,9 @@ async def graph_enhanced_search(
     GraphStore = _il.import_module("nexus.bricks.search.graph_store").GraphStore
 
     async with async_session_factory() as session:
-        graph_store = GraphStore(record_store, session, zone_id=ROOT_ZONE_ID)
+        graph_store = GraphStore(record_store, session, zone_id=zone_id or ROOT_ZONE_ID)
 
-        semantic_wrapper = DaemonSemanticSearchWrapper(search_daemon)
+        semantic_wrapper = DaemonSemanticSearchWrapper(search_daemon, zone_id=zone_id)
         embedding_provider = getattr(search_daemon, "_embedding_provider", None)
 
         config = GraphRetrievalConfig(

--- a/src/nexus/storage/record_store.py
+++ b/src/nexus/storage/record_store.py
@@ -211,7 +211,13 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         from sqlalchemy.orm import sessionmaker
 
         # Resolve database URL
-        self.database_url = self._resolve_db_url(db_url, db_path)
+        _resolved = self._resolve_db_url(db_url, db_path)
+        # Auto-convert async driver URL to sync driver.  Many callers pass
+        # NEXUS_DATABASE_URL which uses ``postgresql+asyncpg://``, but this
+        # store uses a synchronous ``create_engine``.
+        self.database_url = (
+            _resolved.replace("postgresql+asyncpg://", "postgresql://") if _resolved else _resolved
+        )
 
         # Store creators for lazy async engine initialization
         self._async_creator = async_creator


### PR DESCRIPTION
## Summary
- **Search zone isolation**: Router extracted `zone_id` from auth but discarded it. Threaded `zone_id` through the entire search pipeline (router → daemon → keyword/semantic/hybrid/FTS SQL queries → graph search). All SQL queries now filter with `AND (:zone_id IS NULL OR fp.zone_id = :zone_id)`.
- **Server startup crash**: `SQLAlchemyRecordStore` uses sync `create_engine()` but callers pass `postgresql+asyncpg://` URLs causing greenlet_spawn errors. Auto-converts asyncpg URLs to plain `postgresql://` in `RecordStore.__init__`.
- Consolidated duplicate FTS SQL (with/without path_filter) into a single parameterized query.

## Files changed (4)
- `src/nexus/bricks/search/daemon.py` — zone_id param on search/keyword/semantic/hybrid/FTS + SQL filtering
- `src/nexus/server/api/v2/routers/search.py` — extract zone_id from auth_result, forward to daemon & graph search
- `src/nexus/services/search/graph_search_service.py` — zone_id on graph_enhanced_search + DaemonSemanticSearchWrapper
- `src/nexus/storage/record_store.py` — auto-convert asyncpg URL to sync driver in __init__

## Test plan
- [x] 12/12 zone isolation E2E tests pass (zone/001–zone/012), including zone/009 (search) which previously failed
- [x] ruff check — all passed
- [x] mypy — all passed
- [x] Server starts successfully with `NEXUS_DATABASE_URL=postgresql+asyncpg://...`