### PR TITLE
fix(raft): add missing connect() in federation join script

### DIFF
--- a/scripts/federation_join.py
+++ b/scripts/federation_join.py
@@ -38,6 +38,7 @@ print("  gRPC: 0.0.0.0:2126")
 # Step 2: Ask leader to add us as Voter
 async def request_join():
     client = RaftClient(address=LEADER_ADDR)
+    await client.connect()
     try:
         result = await client.join_zone(
             zone_id=ROOT_ZONE_ID,


### PR DESCRIPTION
## Summary
- `scripts/federation_join.py` was missing `await client.connect()` before calling `client.join_zone()`, causing `RuntimeError: RaftClient not connected`
- Discovered during live cross-machine federation testing (WireGuard VPN, Windows→macOS)

## Test plan
- [x] Verified fix by successfully joining 2-node federation (voters: [1, 2])

🤖 Generated with [Claude Code](https://claude.com/claude-code)