### PR TITLE
fix: add search_service to RPC discovery for remote ls

### DIFF
--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -321,6 +321,7 @@ def create_app(
         "llm_service",
         "oauth_service",
         "mount_service",
+        "search_service",
         "version_service",
         "share_link_service",
     ):


### PR DESCRIPTION
## Summary

- `SearchService.list()` has `@rpc_expose` but was not being discovered because `search_service` was missing from the discovery sources list in `fastapi_server.py`
- This caused "Method not found" errors when using `nexus ls` in remote mode (`NEXUS_URL` set)
- Added `"search_service"` to the `_attr_name` iteration tuple in `create_app()` so that `SearchService` methods decorated with `@rpc_expose` (list, glob, glob_batch, grep) are registered in the RPC dispatch table

## Test plan

- [ ] Verify `nexus ls` works in remote mode (with `NEXUS_URL` set) without "Method not found" errors
- [ ] Verify `SearchService.list()`, `SearchService.glob()`, `SearchService.grep()` are all discoverable via RPC
- [ ] CI passes (ruff, mypy, existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)