### PR TITLE
fix: add external_content capability to RemoteBackend for remote reads

### DIFF
--- a/src/nexus/backends/remote.py
+++ b/src/nexus/backends/remote.py
@@ -61,6 +61,11 @@ class RemoteBackend(ObjectStoreABC):
         connect_timeout: Connection timeout in seconds.
     """
 
+    # Expose EXTERNAL_CONTENT so the client-side kernel takes the dynamic
+    # connector path in sys_read (bypassing local metadata/CAS lookup).
+    # The server knows the actual backend type and handles reads correctly.
+    capabilities: frozenset[str] = frozenset({"external_content"})
+
     def __init__(
         self,
         server_url: str,


### PR DESCRIPTION
## Summary
- In remote mode, the client-side kernel checks `route.backend.capabilities` for `"external_content"` to decide the read path. Without it, path-based connector backends (`local_connector`, etc.) fail with "File not found" because the client falls through to CAS lookup with a null content hash (`meta.etag` is `None`).
- `RemoteBackend` now declares `capabilities: frozenset[str] = frozenset({"external_content"})` so the kernel takes the dynamic connector path, which calls `read_content("", context=...)` — delegating to the server via RPC where the actual backend type handles reads correctly.
- Single-line class attribute addition on `RemoteBackend`; no behavioral change on the server side.

## Test plan
- [ ] Verify `nexus cat <file>` works in remote mode with a `local_connector` mount
- [ ] Verify existing CAS-backed reads (non-connector backends) are unaffected
- [ ] Verify `RemoteBackend.capabilities` contains `"external_content"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)