### PR TITLE
fix: add external_content capability to RemoteBackend for remote reads

### DIFF
--- a/src/nexus/backends/remote.py
+++ b/src/nexus/backends/remote.py
@@ -61,6 +61,11 @@ class RemoteBackend(ObjectStoreABC):
         connect_timeout: Connection timeout in seconds.
     """
 
+    # Expose EXTERNAL_CONTENT so the client-side kernel takes the dynamic
+    # connector path in sys_read (bypassing local metadata/CAS lookup).
+    # The server knows the actual backend type and handles reads correctly.
+    capabilities: frozenset[str] = frozenset({"external_content"})
+
     def __init__(
         self,
         server_url: str,


### PR DESCRIPTION
## Summary
- Add `capabilities: frozenset[str] = frozenset({"external_content"})` class attribute to `RemoteBackend`
- Without this, path-based connector backends (e.g. `local_connector`) fail with "File not found" in remote mode because the client-side kernel falls to CAS lookup with a null content hash
- The kernel checks `route.backend.capabilities` for `"external_content"` to decide the read path, but `RemoteBackend` had no `capabilities` attribute, so `getattr()` always returned an empty frozenset

## Test plan
- [ ] Verify `RemoteBackend().capabilities` returns `frozenset({"external_content"})`
- [ ] Verify remote-mode reads for `local_connector`-backed mounts no longer raise "File not found"
- [ ] Existing `test_remote_backend.py` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)