### PR TITLE
fix: align CLI --profile choices with DeploymentProfile enum

### DIFF
--- a/src/nexus/cli/commands/server.py
+++ b/src/nexus/cli/commands/server.py
@@ -496,10 +496,10 @@ def unmount(mount_point: str) -> None:
 @click.option("--port", default=2026, type=int, help="Server port (default: 2026)")
 @click.option(
     "--profile",
-    type=click.Choice(["kernel", "embedded", "lite", "full", "cloud"]),
+    type=click.Choice(["minimal", "embedded", "lite", "full", "cloud", "remote", "auto"]),
     default=None,
     envvar="NEXUS_PROFILE",
-    help="Deployment profile (kernel=bare VFS, embedded, lite, full, cloud)",
+    help="Deployment profile (minimal, embedded, lite, full, cloud, remote, auto)",
 )
 @click.option(
     "--api-key",


### PR DESCRIPTION
## Summary
- The CLI's `click.Choice` for `--profile` in `nexus serve` was out of sync with the `DeploymentProfile` enum and Pydantic config validator
- It listed `kernel` (not a valid profile) instead of `minimal`, and was missing `remote` and `auto`
- This caused `nexus serve --profile=minimal` to fail at the CLI and `nexus serve --profile=kernel` to fail at Pydantic validation

## Test plan
- [x] `nexus serve --profile=minimal` no longer rejected by CLI
- [x] `nexus serve --profile=kernel` now correctly rejected with clear error
- [x] `nexus serve --help` shows all valid profiles
- [x] All 68 deployment profile tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)