### PR TITLE
fix: broken imports + hardcoded zone_id defaults post zombie cleanup

### DIFF
--- a/examples/mcp/verify_mcp_tools.py
+++ b/examples/mcp/verify_mcp_tools.py
@@ -5,7 +5,7 @@ can list all available tools.
 """
 
 from nexus import connect
-from nexus.mcp import create_mcp_server
+from nexus.bricks.mcp import create_mcp_server
 
 
 def main() -> None:

--- a/scripts/cleanup_os_metadata.py
+++ b/scripts/cleanup_os_metadata.py
@@ -24,7 +24,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from nexus import NexusFilesystem, connect
-from nexus.core.filters import is_os_metadata_file
+from nexus.fuse.filters import is_os_metadata_file
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/src/nexus/bricks/rebac/share_mixin.py
+++ b/src/nexus/bricks/rebac/share_mixin.py
@@ -14,6 +14,8 @@ import logging
 from datetime import datetime
 from typing import Any
 
+from nexus.contracts.constants import ROOT_ZONE_ID
+
 logger = logging.getLogger(__name__)
 
 
@@ -222,7 +224,7 @@ class ReBACShareMixin:
         limit: int = 100,
         offset: int = 0,
         cursor: str | None = None,
-        current_zone: str = "default",
+        current_zone: str = ROOT_ZONE_ID,
     ) -> dict[str, Any]:
         """List outgoing shares with iterator caching (sync)."""
         mgr = self._require_manager()
@@ -300,7 +302,7 @@ class ReBACShareMixin:
         limit: int = 100,
         offset: int = 0,
         cursor: str | None = None,
-        current_zone: str = "default",
+        current_zone: str = ROOT_ZONE_ID,
     ) -> dict[str, Any]:
         """List incoming shares with iterator caching (sync)."""
         mgr = self._require_manager()

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -25,6 +25,7 @@ from nexus.cli.utils import (
     REMOTE_URL_OPTION,
     console,
 )
+from nexus.contracts.constants import ROOT_ZONE_ID
 
 # Type alias for the RPC transport callable returned by get_admin_rpc().
 AdminRPC = Callable[[str, dict[str, Any] | None], Any]
@@ -102,7 +103,7 @@ def admin() -> None:
 @click.option("--email", help="User email (for documentation purposes)")
 @click.option("--is-admin", is_flag=True, help="Grant admin privileges")
 @click.option("--expires-days", type=int, help="API key expiry in days")
-@click.option("--zone-id", default="default", help="Zone ID (default: 'default')")
+@click.option("--zone-id", default=ROOT_ZONE_ID, help="Zone ID (default: root)")
 @click.option("--subject-type", default="user", help="Subject type: user or agent")
 @click.option("--json-output", is_flag=True, help="Output as JSON")
 @REMOTE_API_KEY_OPTION

--- a/src/nexus/cli/commands/cache.py
+++ b/src/nexus/cli/commands/cache.py
@@ -12,6 +12,7 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
+from nexus.contracts.constants import ROOT_ZONE_ID
 
 
 def register_commands(cli: click.Group) -> None:
@@ -42,7 +43,7 @@ def cache_group() -> None:
 @click.option(
     "--hours", type=int, default=24, help="Look back N hours for history-based warmup (default: 24)"
 )
-@click.option("-z", "--zone-id", type=str, default="default", help="Zone ID")
+@click.option("-z", "--zone-id", type=str, default=ROOT_ZONE_ID, help="Zone ID")
 @add_backend_options
 def warmup(
     path: str,
@@ -331,7 +332,7 @@ def clear(
 
 @cache_group.command(name="hot")
 @click.option("-n", "--limit", type=int, default=20, help="Number of hot files to show")
-@click.option("-z", "--zone-id", type=str, default="default", help="Zone ID")
+@click.option("-z", "--zone-id", type=str, default=ROOT_ZONE_ID, help="Zone ID")
 @click.option("-u", "--user", type=str, help="Filter by user")
 def hot(
     limit: int,

--- a/src/nexus/core/temporal_resolver.py
+++ b/src/nexus/core/temporal_resolver.py
@@ -220,7 +220,7 @@ Resolved:"""
         try:
             # Call LLM - handle different provider interfaces
             if hasattr(provider, "complete_async"):
-                from nexus.llm import Message, MessageRole
+                from nexus.contracts.llm_types import Message, MessageRole
 
                 messages = [Message(role=MessageRole.USER, content=prompt)]
                 response = await provider.complete_async(messages)
@@ -228,7 +228,7 @@ Resolved:"""
                 response = await provider.acomplete(prompt)
             elif hasattr(provider, "complete"):
                 if hasattr(provider, "config"):
-                    from nexus.llm import Message, MessageRole
+                    from nexus.contracts.llm_types import Message, MessageRole
 
                     messages = [Message(role=MessageRole.USER, content=prompt)]
                     response = provider.complete(messages)


### PR DESCRIPTION
## Summary
- Fix 3 broken imports left over from zombie cleanup (PR #2670)
- Replace 4 hardcoded `zone_id="default"` with `ROOT_ZONE_ID` constant

## Changes
| File | Fix | Task |
|------|-----|------|
| `examples/mcp/verify_mcp_tools.py` | `nexus.mcp` → `nexus.bricks.mcp` | #1272 |
| `scripts/cleanup_os_metadata.py` | `nexus.core.filters` → `nexus.fuse.filters` | #1275 |
| `core/temporal_resolver.py` | `nexus.llm` → `nexus.contracts.llm_types` (tier-neutral) | #1274 |
| `cli/commands/admin.py` | `default="default"` → `default=ROOT_ZONE_ID` | #1277 |
| `cli/commands/cache.py` (x2) | `default="default"` → `default=ROOT_ZONE_ID` | #1277 |
| `bricks/rebac/share_mixin.py` (x2) | `current_zone="default"` → `ROOT_ZONE_ID` | #1278 |

## Test plan
- [ ] Pre-commit hooks pass (ruff, mypy, brick boundary check)
- [ ] Import-linter four-tier-layers passes
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)