### PR TITLE
fix: gRPC REMOTE profile bugs breaking permissions demo

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1684,6 +1684,8 @@ class NexusFS(  # type: ignore[misc]
             >>> content = nx.sys_read("/memory/by-user/alice/facts")  # Same memory!
         """
         path = self._validate_path(path)
+        # Normalize context dict to OperationContext dataclass (CLI passes dicts)
+        context = self._parse_context(context)
 
         # PRE-DISPATCH: virtual path resolvers (Issue #889)
         # Memory paths → MemoryIOHandler, virtual views → VirtualViewResolver
@@ -2609,6 +2611,9 @@ class NexusFS(  # type: ignore[misc]
         This method contains the actual write logic, extracted to support
         both locked and non-locked write paths without code duplication.
         """
+        # Normalize context dict to OperationContext dataclass (CLI passes dicts)
+        context = self._parse_context(context)
+
         # Route to backend with write access check FIRST (to check zone/agent isolation)
         # This must happen before permission check so AccessDeniedError is raised before PermissionError
         zone_id, agent_id, is_admin = self._get_routing_params(context)
@@ -3756,6 +3761,8 @@ class NexusFS(  # type: ignore[misc]
         """
         old_path = self._validate_path(old_path)
         new_path = self._validate_path(new_path)
+        # Normalize context dict to OperationContext dataclass (CLI passes dicts)
+        context = self._parse_context(context)
         self._check_zone_writable(context)  # Issue #2061: write-gating
 
         # Route both paths

--- a/src/nexus/grpc/servicer.py
+++ b/src/nexus/grpc/servicer.py
@@ -22,6 +22,7 @@ Issue #1249: Port consolidation — single gRPC server.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import time
 from collections.abc import AsyncIterator
@@ -123,7 +124,7 @@ class VFSServicer(vfs_pb2_grpc.NexusVFSServiceServicer):
         if self._auth_provider:
             result = await self._auth_provider.authenticate(token)
             if result:
-                return dict(result)
+                return dataclasses.asdict(result)
 
         return {}
 

--- a/src/nexus/remote/rpc_proxy.py
+++ b/src/nexus/remote/rpc_proxy.py
@@ -61,19 +61,34 @@ class RPCProxyBase:
 
     @classmethod
     def _get_param_names(cls, method_name: str) -> list[str]:
-        """Get parameter names for a method from the NexusFilesystemABC ABC.
+        """Get parameter names for a method from known service classes.
 
         Uses inspect.signature to extract parameter names, caching results
-        for performance. Falls back to empty list for non-ABC methods.
+        for performance. Falls back to empty list for unknown methods.
         """
         if method_name not in cls._param_name_cache:
             # Lazy import to avoid circular dependency
             from nexus.contracts.filesystem.filesystem_abc import NexusFilesystemABC
 
-            abc_method = getattr(NexusFilesystemABC, method_name, None)
-            if abc_method and callable(abc_method):
+            # Try NexusFilesystemABC first, then NexusFS, then RPC params
+            method = getattr(NexusFilesystemABC, method_name, None)
+            if method is None:
                 try:
-                    sig = inspect.signature(abc_method)
+                    import dataclasses as _dc
+
+                    from nexus.server._rpc_params_generated import METHOD_PARAMS
+
+                    params_cls = METHOD_PARAMS.get(method_name)
+                    if params_cls and _dc.is_dataclass(params_cls):
+                        names = [f.name for f in _dc.fields(params_cls)]
+                        cls._param_name_cache[method_name] = names
+                        return names
+                except (ImportError, AttributeError):
+                    pass
+
+            if method and callable(method):
+                try:
+                    sig = inspect.signature(method)
                     names = [p for p in sig.parameters if p != "self"]
                     cls._param_name_cache[method_name] = names
                 except (ValueError, TypeError):

--- a/src/nexus/remote/rpc_transport.py
+++ b/src/nexus/remote/rpc_transport.py
@@ -157,6 +157,9 @@ class RPCTransport:
             self._error_handler._handle_rpc_error(error_dict)
 
         result = decode_rpc_message(response.payload)
+        # Unwrap server envelope: gRPC servicer wraps as {"result": actual_result}
+        if isinstance(result, dict) and "result" in result:
+            result = result["result"]
         logger.debug("RPCTransport.call_rpc OK: %s", method)
         return result
 

--- a/src/nexus/remote/service_proxy.py
+++ b/src/nexus/remote/service_proxy.py
@@ -66,8 +66,13 @@ class RemoteServiceProxy:
         from nexus.remote.rpc_proxy import RPCProxyBase
 
         def rpc_forwarder(*args: Any, **kwargs: Any) -> Any:
-            # Map positional args to keyword args using ABC signature
+            # Server exposes async @rpc_expose methods; client-side sync
+            # wrappers append "_sync" — strip suffix for RPC dispatch.
             rpc_name = name
+            if rpc_name.endswith("_sync"):
+                rpc_name = rpc_name[:-5]
+
+            # Map positional args to keyword args using ABC signature
             if args:
                 param_names = RPCProxyBase._get_param_names(rpc_name)
                 for i, val in enumerate(args):
@@ -77,11 +82,6 @@ class RemoteServiceProxy:
             # Strip context params (handled server-side via auth headers)
             kwargs.pop("context", None)
             kwargs.pop("_context", None)
-
-            # Server exposes async @rpc_expose methods; client-side sync
-            # wrappers append "_sync" — strip suffix for RPC dispatch.
-            if rpc_name.endswith("_sync"):
-                rpc_name = rpc_name[:-5]
 
             return self._call_rpc(rpc_name, kwargs or None)
 

--- a/src/nexus/storage/remote_metastore.py
+++ b/src/nexus/storage/remote_metastore.py
@@ -147,5 +147,16 @@ class RemoteMetastore(MetastoreABC):
                 )
         return metadata_list
 
+    def rename_path(self, old_path: str, new_path: str) -> None:
+        """Rename a file path in metadata via server RPC."""
+        self._call_rpc("sys_rename", {"old_path": old_path, "new_path": new_path})
+
+    def is_implicit_directory(self, path: str) -> bool:
+        """Check if path is an implicit directory (has children but no explicit metadata)."""
+        result = self._call_rpc("sys_is_directory", {"path": path})
+        if isinstance(result, dict):
+            return bool(result.get("is_directory", False))
+        return bool(result)
+
     def close(self) -> None:
         """No-op — transport lifecycle managed by factory."""


### PR DESCRIPTION
## Summary

- Fix 6 bugs in the gRPC-based REMOTE profile that caused `permissions_demo_enhanced.sh` to fail end-to-end
- **AuthResult serialization** (`servicer.py`): `dict(AuthResult)` fails on frozen dataclass → use `dataclasses.asdict()`
- **Response envelope unwrapping** (`rpc_transport.py`): gRPC servicer wraps in `{"result": ...}` but client never unwrapped it
- **Context normalization** (`nexus_fs.py`): CLI passes dict contexts but `dataclasses.replace()` requires dataclass → add `_parse_context()` in `sys_read`, `_write_internal`, `sys_rename`
- **Missing RemoteMetastore methods** (`remote_metastore.py`): Add `rename_path` and `is_implicit_directory` for REMOTE mode rename support
- **Positional arg mapping** (`service_proxy.py`): Strip `_sync` suffix before param lookup so `rebac_delete(tuple_id)` works
- **Param name resolution** (`rpc_proxy.py`): Also check `METHOD_PARAMS` for service methods not in `NexusFilesystemABC`

## Test plan

- [x] Run `permissions_demo_enhanced.sh` end-to-end — all 9 sections pass with exit code 0
- [ ] Verify no regression on existing gRPC unit tests
- [ ] Verify no regression on REMOTE profile integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)