### PR TITLE
fix: remote stat returns empty path/size via gRPC

### DIFF
--- a/examples/tutorials/deployment-profiles/test_profiles_sdk.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_sdk.py
@@ -113,10 +113,17 @@ def test_profile(profile: str) -> dict[str, str]:
     print("  STAT")
     try:
         info = nx.sys_stat("/project/src/main.py")
-        path_v = info.get("path", "?") if isinstance(info, dict) else getattr(info, "path", "?")
-        size_v = info.get("size", "?") if isinstance(info, dict) else getattr(info, "size", "?")
-        print(f"    OK   /project/src/main.py => path={path_v}, size={size_v}")
-        row["stat"] = "OK"
+        size_v = info.get("size", None) if isinstance(info, dict) else getattr(info, "size", None)
+        expected_size = len(FILES["/project/src/main.py"])
+        if size_v is not None and int(size_v) == expected_size:
+            print(f"    OK   /project/src/main.py => size={size_v} (correct)")
+            row["stat"] = "OK"
+        elif size_v is not None:
+            print(f"    FAIL /project/src/main.py => size={size_v}, expected {expected_size}")
+            row["stat"] = "FAIL"
+        else:
+            print(f"    WARN /project/src/main.py => size not in stat, raw: {info}")
+            row["stat"] = "OK"  # stat worked, just no size field
     except Exception as e:
         print(f"    FAIL: {e}")
         row["stat"] = "FAIL"
@@ -126,8 +133,15 @@ def test_profile(profile: str) -> dict[str, str]:
     try:
         entries = nx.sys_readdir("/project/src")
         names = sorted(entries) if isinstance(entries, list) else entries
-        print(f"    OK   /project/src => {names}")
-        row["list"] = "OK"
+        # Verify main.py and utils.py are listed
+        found = {str(e) for e in (names if isinstance(names, list) else [])}
+        expected_names = {"main.py", "utils.py", "/project/src/main.py", "/project/src/utils.py"}
+        if found & expected_names:
+            print(f"    OK   /project/src => {names}")
+            row["list"] = "OK"
+        else:
+            print(f"    FAIL /project/src => {names} (missing expected files)")
+            row["list"] = "FAIL"
     except Exception as e:
         print(f"    FAIL: {e}")
         row["list"] = "FAIL"
@@ -135,10 +149,21 @@ def test_profile(profile: str) -> dict[str, str]:
     # --- GLOB ---
     print("  GLOB")
     try:
-        matches = nx.glob("**/*.py")
-        paths = sorted(matches) if isinstance(matches, list) else matches
-        print(f"    OK   **/*.py => {paths}")
-        row["glob"] = "OK"
+        result = nx.glob("**/*.py")
+        # Handle both list and dict return types
+        if isinstance(result, dict) and "matches" in result:
+            paths = sorted(result["matches"])
+        elif isinstance(result, list):
+            paths = sorted(result)
+        else:
+            paths = []
+        py_paths = [p for p in paths if ".py" in str(p)]
+        if len(py_paths) >= 3:  # main.py, utils.py, test_utils.py
+            print(f"    OK   **/*.py => {py_paths}")
+            row["glob"] = "OK"
+        else:
+            print(f"    FAIL **/*.py => {paths} (expected >= 3 .py files)")
+            row["glob"] = "FAIL"
     except Exception as e:
         print(f"    FAIL: {e}")
         row["glob"] = "FAIL"
@@ -146,10 +171,23 @@ def test_profile(profile: str) -> dict[str, str]:
     # --- GREP ---
     print("  GREP")
     try:
-        matches = nx.grep("TODO")
+        result = nx.grep("TODO")
+        # Handle list, dict with 'matches', or dict with 'results'
+        if isinstance(result, dict) and "results" in result:
+            matches = result["results"]
+        elif isinstance(result, dict) and "matches" in result:
+            matches = result["matches"]
+        elif isinstance(result, list):
+            matches = result
+        else:
+            matches = result
         count = len(matches) if isinstance(matches, list) else "?"
-        print(f"    OK   'TODO' => {count} match(es)")
-        row["grep"] = "OK"
+        if isinstance(matches, list) and len(matches) >= 2:
+            print(f"    OK   'TODO' => {count} match(es)")
+            row["grep"] = "OK"
+        else:
+            print(f"    FAIL 'TODO' => {count} match(es), expected >= 2")
+            row["grep"] = "FAIL"
     except Exception as e:
         print(f"    FAIL: {e}")
         row["grep"] = "FAIL"

--- a/examples/tutorials/deployment-profiles/test_remote_client.py
+++ b/examples/tutorials/deployment-profiles/test_remote_client.py
@@ -3,7 +3,8 @@
 Test remote client mode: gRPC proxy from client SDK to a running server.
 
 Starts a minimal server with gRPC enabled, then connects a remote client
-and verifies write/read/list/stat/delete operations work through the proxy.
+and verifies write/read/list/stat/glob/grep/delete operations work through
+the proxy.
 
 Prerequisites:
     pip install -e .
@@ -108,7 +109,8 @@ def main() -> int:
     print("\nWRITE")
     files = {
         "/hello.txt": b"Hello from remote client!",
-        "/project/main.py": b'print("Hello, Nexus!")\n',
+        "/project/main.py": b'# TODO: implement argument parsing\nprint("Hello, Nexus!")\n',
+        "/project/utils.py": b'# TODO: add logging\ndef greet(name):\n    return f"Hello, {name}!"\n',
         "/project/config.json": b'{"version": "1.0"}\n',
     }
     for path, content in files.items():
@@ -137,7 +139,22 @@ def main() -> int:
     print("LIST")
     try:
         entries = nx.sys_readdir("/")
-        print(f"  OK   / => {sorted(entries)}")
+        names = sorted(entries) if isinstance(entries, list) else entries
+        print(f"  raw  / => {names}")
+        # Verify expected paths are present
+        expected_paths = {
+            "/hello.txt",
+            "/project/main.py",
+            "/project/utils.py",
+            "/project/config.json",
+        }
+        found = {str(e) for e in (names if isinstance(names, list) else [])}
+        missing = expected_paths - found
+        if missing:
+            print(f"  FAIL missing entries: {missing}")
+            ok = False
+        else:
+            print(f"  OK   all {len(expected_paths)} expected entries found")
     except Exception as e:
         print(f"  FAIL: {e}")
         ok = False
@@ -146,8 +163,64 @@ def main() -> int:
     print("STAT")
     try:
         info = nx.sys_stat("/hello.txt")
-        path_v = info.get("path", "?") if isinstance(info, dict) else getattr(info, "path", "?")
-        print(f"  OK   /hello.txt => path={path_v}")
+        print(f"  raw  /hello.txt => {info}")
+        # Verify size matches what we wrote (25 bytes)
+        size_v = info.get("size", None) if isinstance(info, dict) else getattr(info, "size", None)
+        if size_v is not None and int(size_v) == len(files["/hello.txt"]):
+            print(f"  OK   /hello.txt => size={size_v} (correct)")
+        elif size_v is not None:
+            print(f"  FAIL /hello.txt => size={size_v}, expected {len(files['/hello.txt'])}")
+            ok = False
+        else:
+            print("  WARN /hello.txt => size not in stat result")
+    except Exception as e:
+        print(f"  FAIL: {e}")
+        ok = False
+
+    # --- GLOB ---
+    print("GLOB")
+    try:
+        result = nx.glob("**/*.py")
+        print(f"  raw  **/*.py => {result}")
+        # Handle both list and dict return types
+        if isinstance(result, dict) and "matches" in result:
+            paths = sorted(result["matches"])
+        elif isinstance(result, list):
+            paths = sorted(result)
+        else:
+            paths = []
+        expected_py = {"/project/main.py", "/project/utils.py"}
+        found_py = set(paths)
+        if expected_py <= found_py:
+            print(f"  OK   found {len(paths)} .py file(s): {paths}")
+        else:
+            print(f"  FAIL expected {expected_py}, got {found_py}")
+            ok = False
+    except Exception as e:
+        print(f"  FAIL: {e}")
+        ok = False
+
+    # --- GREP ---
+    print("GREP")
+    try:
+        result = nx.grep("TODO")
+        print(f"  raw  'TODO' => {result}")
+        # Handle list, dict with 'matches', or dict with 'results'
+        if isinstance(result, dict) and "results" in result:
+            matches = result["results"]
+        elif isinstance(result, dict) and "matches" in result:
+            matches = result["matches"]
+        elif isinstance(result, list):
+            matches = result
+        else:
+            matches = result
+        # We expect at least 2 matches (main.py and utils.py both have TODO)
+        count = len(matches) if isinstance(matches, list) else "?"
+        if isinstance(matches, list) and len(matches) >= 2:
+            print(f"  OK   {count} match(es)")
+        else:
+            print(f"  FAIL expected >= 2 matches, got {count}")
+            ok = False
     except Exception as e:
         print(f"  FAIL: {e}")
         ok = False

--- a/src/nexus/storage/remote_metastore.py
+++ b/src/nexus/storage/remote_metastore.py
@@ -84,6 +84,9 @@ class RemoteMetastore(MetastoreABC):
         if result is None:
             return None
         if isinstance(result, dict):
+            # Server wraps stat result in {"metadata": ...}
+            if "metadata" in result and isinstance(result["metadata"], dict):
+                result = result["metadata"]
             return _dict_to_file_metadata(result)
         return None
 


### PR DESCRIPTION
## Summary
- **Bug fix**: `RemoteMetastore.get()` wasn't unwrapping the `{"metadata": ...}` envelope from the gRPC server's `handle_get_metadata()` response, causing `sys_stat()` to return `path=""` and `size=0` for all files in remote mode.
- **Test improvements**: Adds glob/grep coverage to the remote client tutorial test, and strengthens all tutorial tests to verify actual content (stat size, list entries, glob file matches, grep result counts) instead of just checking for no exception.

## Test plan
- [x] `test_remote_client.py` passes — all 8 operations (write/read/list/stat/glob/grep/delete/verify) verified
- [x] `test_profiles_sdk.py` passes — all 42 operations (6 ops × 7 profiles) verified with content checks
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)