### PR TITLE
fix: deduplicate 7 InMemoryMetadataStore copies in e2e tests

### DIFF
--- a/tests/e2e/postgres/test_memory_paging_postgres.py
+++ b/tests/e2e/postgres/test_memory_paging_postgres.py
@@ -16,7 +16,6 @@ Run:
 
 import shutil
 import tempfile
-from typing import Any
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -120,45 +119,12 @@ def app(tmp_path, pg_engine, pg_session_factory, api_keys):
     tmpdir = tempfile.mkdtemp(prefix="nexus-pg-paging-")
     backend = LocalBackend(root_path=tmpdir)
 
-    # In-memory metadata store (same stub as in fastapi e2e test)
-    from collections.abc import Sequence
-
-    from nexus.contracts.metadata import FileMetadata
-    from nexus.core.metastore import MetastoreABC
-
-    class InMemoryMetadataStore(MetastoreABC):
-        def __init__(self) -> None:
-            self._store: dict[str, FileMetadata] = {}
-
-        def get(self, path: str) -> FileMetadata | None:
-            return self._store.get(path)
-
-        def put(self, metadata: FileMetadata) -> None:
-            self._store[metadata.path] = metadata
-
-        def delete(self, path: str) -> dict[str, Any] | None:
-            removed = self._store.pop(path, None)
-            return {"path": path} if removed else None
-
-        def exists(self, path: str) -> bool:
-            return path in self._store
-
-        def list(
-            self, prefix: str = "", recursive: bool = True, **kwargs: Any
-        ) -> list[FileMetadata]:
-            return [m for p, m in self._store.items() if p.startswith(prefix)]
-
-        def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
-            return {p: self._store.get(p) for p in paths}
-
-        def close(self) -> None:
-            self._store.clear()
-
     from nexus.storage.record_store import SQLAlchemyRecordStore
+    from tests.helpers.dict_metastore import DictMetastore
 
     record_db_path = tmp_path / "pg_records.db"
     record_store = SQLAlchemyRecordStore(db_path=str(record_db_path))
-    metadata_store = InMemoryMetadataStore()
+    metadata_store = DictMetastore()
 
     nx = NexusFS(
         backend=backend,

--- a/tests/e2e/self_contained/test_ipc_signing_e2e.py
+++ b/tests/e2e/self_contained/test_ipc_signing_e2e.py
@@ -17,7 +17,6 @@ import shutil
 import tempfile
 import time
 import uuid
-from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -29,48 +28,11 @@ from nexus.bricks.ipc.delivery import MessageProcessor, MessageSender
 from nexus.bricks.ipc.envelope import MessageEnvelope, MessageType
 from nexus.bricks.ipc.provisioning import AgentProvisioner
 from nexus.bricks.ipc.signing import MessageSigner, MessageVerifier, SigningMode
-from nexus.contracts.metadata import FileMetadata
 from nexus.core.config import ParseConfig, PermissionConfig
-from nexus.core.metastore import MetastoreABC
 from nexus.storage.models import Base
 from nexus.storage.zone_settings import ZoneSettings
+from tests.helpers.dict_metastore import DictMetastore
 from tests.unit.bricks.ipc.fakes import InMemoryStorageDriver
-
-# ---------------------------------------------------------------------------
-# In-memory metadata store (same pattern as test_identity_e2e.py)
-# ---------------------------------------------------------------------------
-
-
-class InMemoryMetadataStore(MetastoreABC):
-    def __init__(self) -> None:
-        self._store: dict[str, FileMetadata] = {}
-
-    def get(self, path: str) -> FileMetadata | None:
-        return self._store.get(path)
-
-    def put(self, metadata: FileMetadata) -> None:
-        self._store[metadata.path] = metadata
-
-    def delete(self, path: str) -> dict[str, Any] | None:
-        removed = self._store.pop(path, None)
-        return {"path": path} if removed else None
-
-    def exists(self, path: str) -> bool:
-        return path in self._store
-
-    def list(self, prefix: str = "", recursive: bool = True, **kwargs: Any) -> list[FileMetadata]:
-        return [m for p, m in self._store.items() if p.startswith(prefix)]
-
-    def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
-        return {p: self._store.get(p) for p in paths}
-
-    def is_implicit_directory(self, path: str) -> bool:
-        prefix = path.rstrip("/") + "/"
-        return any(p.startswith(prefix) for p in self._store)
-
-    def close(self) -> None:
-        self._store.clear()
-
 
 # ---------------------------------------------------------------------------
 # Fernet-compatible encryptor for IdentityCrypto
@@ -166,7 +128,7 @@ def app(tmp_path: Any, db_path: Any, record_store: Any) -> Any:
 
     tmpdir = tempfile.mkdtemp(prefix="nexus-signing-e2e-")
     backend = LocalBackend(root_path=tmpdir)
-    metadata_store = InMemoryMetadataStore()
+    metadata_store = DictMetastore()
 
     nx = create_nexus_fs(
         backend=backend,

--- a/tests/e2e/server/test_credentials_e2e.py
+++ b/tests/e2e/server/test_credentials_e2e.py
@@ -16,51 +16,13 @@ Run: pytest tests/e2e/server/test_credentials_e2e.py -v
 import shutil
 import tempfile
 import uuid
-from collections.abc import Sequence
 from typing import Any
 
 import pytest
 
-from nexus.contracts.metadata import FileMetadata
 from nexus.core.config import ParseConfig, PermissionConfig
-from nexus.core.metastore import MetastoreABC
 from nexus.storage.models import Base
-
-# ---------------------------------------------------------------------------
-# In-memory metadata store (same pattern as test_identity_e2e.py)
-# ---------------------------------------------------------------------------
-
-
-class InMemoryMetadataStore(MetastoreABC):
-    def __init__(self) -> None:
-        self._store: dict[str, FileMetadata] = {}
-
-    def get(self, path: str) -> FileMetadata | None:
-        return self._store.get(path)
-
-    def put(self, metadata: FileMetadata) -> None:
-        self._store[metadata.path] = metadata
-
-    def delete(self, path: str) -> dict[str, Any] | None:
-        removed = self._store.pop(path, None)
-        return {"path": path} if removed else None
-
-    def exists(self, path: str) -> bool:
-        return path in self._store
-
-    def list(self, prefix: str = "", recursive: bool = True, **kwargs: Any) -> list[FileMetadata]:
-        return [m for p, m in self._store.items() if p.startswith(prefix)]
-
-    def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
-        return {p: self._store.get(p) for p in paths}
-
-    def is_implicit_directory(self, path: str) -> bool:
-        prefix = path.rstrip("/") + "/"
-        return any(p.startswith(prefix) for p in self._store)
-
-    def close(self) -> None:
-        self._store.clear()
-
+from tests.helpers.dict_metastore import DictMetastore
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -137,7 +99,7 @@ def app(tmp_path: Any, db_path: Any, session_factory: Any, api_keys: Any) -> Any
 
     tmpdir = tempfile.mkdtemp(prefix="nexus-cred-e2e-")
     backend = LocalBackend(root_path=tmpdir)
-    metadata_store = InMemoryMetadataStore()
+    metadata_store = DictMetastore()
     record_store = SQLAlchemyRecordStore(db_url=f"sqlite:///{db_path}")
 
     nx = NexusFS(

--- a/tests/e2e/server/test_identity_e2e.py
+++ b/tests/e2e/server/test_identity_e2e.py
@@ -14,52 +14,13 @@ import base64
 import shutil
 import tempfile
 import uuid
-from collections.abc import Sequence
 from typing import Any
 
 import pytest
 
-from nexus.contracts.metadata import FileMetadata
 from nexus.core.config import ParseConfig, PermissionConfig
-from nexus.core.metastore import MetastoreABC
 from nexus.storage.models import Base
-
-# ---------------------------------------------------------------------------
-# In-memory metadata store (same pattern as test_memory_paging_postgres.py)
-# ---------------------------------------------------------------------------
-
-
-class InMemoryMetadataStore(MetastoreABC):
-    def __init__(self) -> None:
-        self._store: dict[str, FileMetadata] = {}
-
-    def get(self, path: str) -> FileMetadata | None:
-        return self._store.get(path)
-
-    def put(self, metadata: FileMetadata) -> None:
-        self._store[metadata.path] = metadata
-
-    def delete(self, path: str) -> dict[str, Any] | None:
-        removed = self._store.pop(path, None)
-        return {"path": path} if removed else None
-
-    def exists(self, path: str) -> bool:
-        return path in self._store
-
-    def list(self, prefix: str = "", recursive: bool = True, **kwargs: Any) -> list[FileMetadata]:
-        return [m for p, m in self._store.items() if p.startswith(prefix)]
-
-    def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
-        return {p: self._store.get(p) for p in paths}
-
-    def is_implicit_directory(self, path: str) -> bool:
-        """Check if path is an implicit dir (children exist without explicit dir metadata)."""
-        prefix = path.rstrip("/") + "/"
-        return any(p.startswith(prefix) for p in self._store)
-
-    def close(self) -> None:
-        self._store.clear()
-
+from tests.helpers.dict_metastore import DictMetastore
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -141,7 +102,7 @@ def app(tmp_path: Any, db_path: Any, session_factory: Any, api_keys: Any) -> Any
 
     tmpdir = tempfile.mkdtemp(prefix="nexus-identity-e2e-")
     backend = LocalBackend(root_path=tmpdir)
-    metadata_store = InMemoryMetadataStore()
+    metadata_store = DictMetastore()
     record_store = SQLAlchemyRecordStore(db_url=f"sqlite:///{db_path}")
 
     nx = NexusFS(

--- a/tests/e2e/server/test_memory_classification_e2e.py
+++ b/tests/e2e/server/test_memory_classification_e2e.py
@@ -11,8 +11,6 @@ Run with: python -m pytest tests/e2e/test_memory_classification_e2e.py -v
 
 import shutil
 import tempfile
-from collections.abc import Sequence
-from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -21,48 +19,9 @@ from sqlalchemy.orm import sessionmaker
 
 from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
 from nexus.bricks.auth.providers.discriminator import DiscriminatingAuthProvider
-from nexus.contracts.metadata import FileMetadata
 from nexus.core.config import PermissionConfig
-from nexus.core.metastore import MetastoreABC
 from nexus.storage.models import Base
-
-# ==============================================================================
-# In-memory metadata store stub (avoids LocalRaft dependency)
-# ==============================================================================
-
-
-class InMemoryMetadataStore(MetastoreABC):
-    """Minimal in-memory metadata store for tests that don't need file ops."""
-
-    def __init__(self) -> None:
-        self._store: dict[str, FileMetadata] = {}
-
-    def get(self, path: str) -> FileMetadata | None:
-        return self._store.get(path)
-
-    def put(self, metadata: FileMetadata) -> None:
-        self._store[metadata.path] = metadata
-
-    def delete(self, path: str) -> dict[str, Any] | None:
-        removed = self._store.pop(path, None)
-        if removed:
-            return {"path": path}
-        return None
-
-    def exists(self, path: str) -> bool:
-        return path in self._store
-
-    def list(  # noqa: A003
-        self, prefix: str = "", recursive: bool = True, **kwargs: Any
-    ) -> list[FileMetadata]:
-        return [m for p, m in self._store.items() if p.startswith(prefix)]
-
-    def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
-        return {p: self._store.get(p) for p in paths}
-
-    def close(self) -> None:
-        self._store.clear()
-
+from tests.helpers.dict_metastore import DictMetastore
 
 # ==============================================================================
 # Fixtures
@@ -130,7 +89,7 @@ def app_with_auth(tmp_path, db_session_factory, api_keys):
     tmpdir = tempfile.mkdtemp(prefix="nexus-classification-e2e-")
 
     backend = LocalBackend(root_path=tmpdir)
-    metadata_store = InMemoryMetadataStore()
+    metadata_store = DictMetastore()
 
     record_db_path = tmp_path / "records.db"
     record_store = SQLAlchemyRecordStore(db_path=str(record_db_path))

--- a/tests/e2e/server/test_memory_evolution_e2e.py
+++ b/tests/e2e/server/test_memory_evolution_e2e.py
@@ -13,7 +13,6 @@ import json
 import shutil
 import tempfile
 import time
-from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -23,48 +22,9 @@ from sqlalchemy.orm import sessionmaker
 
 from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
 from nexus.bricks.auth.providers.discriminator import DiscriminatingAuthProvider
-from nexus.contracts.metadata import FileMetadata
 from nexus.core.config import PermissionConfig
-from nexus.core.metastore import MetastoreABC
 from nexus.storage.models import Base
-
-# ==============================================================================
-# In-memory metadata store stub (avoids LocalRaft dependency)
-# ==============================================================================
-
-
-class InMemoryMetadataStore(MetastoreABC):
-    """Minimal in-memory metadata store for tests that don't need file ops."""
-
-    def __init__(self) -> None:
-        self._store: dict[str, FileMetadata] = {}
-
-    def get(self, path: str) -> FileMetadata | None:
-        return self._store.get(path)
-
-    def put(self, metadata: FileMetadata) -> None:
-        self._store[metadata.path] = metadata
-
-    def delete(self, path: str) -> dict[str, Any] | None:
-        removed = self._store.pop(path, None)
-        if removed:
-            return {"path": path}
-        return None
-
-    def exists(self, path: str) -> bool:
-        return path in self._store
-
-    def list(  # noqa: A003
-        self, prefix: str = "", recursive: bool = True, **kwargs: Any
-    ) -> list[FileMetadata]:
-        return [m for p, m in self._store.items() if p.startswith(prefix)]
-
-    def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
-        return {p: self._store.get(p) for p in paths}
-
-    def close(self) -> None:
-        self._store.clear()
-
+from tests.helpers.dict_metastore import DictMetastore
 
 # ==============================================================================
 # Fixtures
@@ -153,7 +113,7 @@ def app_with_auth(tmp_path, db_session_factory, api_keys):
     tmpdir = tempfile.mkdtemp(prefix="nexus-evolution-e2e-")
 
     backend = LocalBackend(root_path=tmpdir)
-    metadata_store = InMemoryMetadataStore()
+    metadata_store = DictMetastore()
 
     record_db_path = tmp_path / "records.db"
     record_store = SQLAlchemyRecordStore(db_path=str(record_db_path))

--- a/tests/e2e/server/test_memory_paging_fastapi_e2e.py
+++ b/tests/e2e/server/test_memory_paging_fastapi_e2e.py
@@ -13,8 +13,6 @@ Run with: python -m pytest tests/e2e/test_memory_paging_fastapi_e2e.py -v
 
 import shutil
 import tempfile
-from collections.abc import Sequence
-from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -23,48 +21,9 @@ from sqlalchemy.orm import sessionmaker
 
 from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
 from nexus.bricks.auth.providers.discriminator import DiscriminatingAuthProvider
-from nexus.contracts.metadata import FileMetadata
 from nexus.core.config import MemoryConfig, PermissionConfig
-from nexus.core.metastore import MetastoreABC
 from nexus.storage.models import Base
-
-# ==============================================================================
-# In-memory metadata store stub (avoids LocalRaft dependency)
-# ==============================================================================
-
-
-class InMemoryMetadataStore(MetastoreABC):
-    """Minimal in-memory metadata store for tests that don't need file ops."""
-
-    def __init__(self) -> None:
-        self._store: dict[str, FileMetadata] = {}
-
-    def get(self, path: str) -> FileMetadata | None:
-        return self._store.get(path)
-
-    def put(self, metadata: FileMetadata) -> None:
-        self._store[metadata.path] = metadata
-
-    def delete(self, path: str) -> dict[str, Any] | None:
-        removed = self._store.pop(path, None)
-        if removed:
-            return {"path": path}
-        return None
-
-    def exists(self, path: str) -> bool:
-        return path in self._store
-
-    def list(  # noqa: A003
-        self, prefix: str = "", recursive: bool = True, **kwargs: Any
-    ) -> list[FileMetadata]:
-        return [m for p, m in self._store.items() if p.startswith(prefix)]
-
-    def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
-        return {p: self._store.get(p) for p in paths}
-
-    def close(self) -> None:
-        self._store.clear()
-
+from tests.helpers.dict_metastore import DictMetastore
 
 # ==============================================================================
 # Fixtures
@@ -151,7 +110,7 @@ def app_with_db_auth(tmp_path, db_session_factory, api_keys):
     tmpdir = tempfile.mkdtemp(prefix="nexus-paging-auth-e2e-")
 
     backend = LocalBackend(root_path=tmpdir)
-    metadata_store = InMemoryMetadataStore()
+    metadata_store = DictMetastore()
 
     # Use file-backed SQLite for RecordStore to avoid in-memory connection isolation
     record_db_path = tmp_path / "records.db"


### PR DESCRIPTION
## Summary

- Replace 7 identical `InMemoryMetadataStore` class definitions across e2e test files with the centralized `DictMetastore` from `tests/helpers/dict_metastore.py`
- Removes ~285 lines of duplicate code that would confuse future AI and human readers
- `DictMetastore` is a strict superset (has all the same methods plus batch ops, rename, file_metadata)

Found during federation CRUD audit (issue D1).

### Files changed
- `tests/e2e/server/test_identity_e2e.py`
- `tests/e2e/server/test_memory_classification_e2e.py`
- `tests/e2e/server/test_credentials_e2e.py`
- `tests/e2e/server/test_memory_evolution_e2e.py`
- `tests/e2e/server/test_memory_paging_fastapi_e2e.py`
- `tests/e2e/self_contained/test_ipc_signing_e2e.py`
- `tests/e2e/postgres/test_memory_paging_postgres.py`

## Test plan

- [x] Zero `InMemoryMetadataStore` references remain in codebase
- [x] Ruff lint + format pass on all 7 files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)