### PR TITLE
fix(#1311): use resolve_delete() prefetch hint in sys_unlink

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3646,8 +3646,9 @@ class NexusFS(  # type: ignore[misc]
         if route.readonly:
             raise PermissionError(f"Cannot delete from read-only path: {path}")
 
-        # Check if file exists in metadata
-        meta = self.metadata.get(path)
+        # Check if file exists in metadata.
+        # Use prefetched hint from resolve_delete() if available (#1311)
+        meta = _result if _result is not None else self.metadata.get(path)
 
         # Issue #1264: If file exists only in base layer, create whiteout instead of deleting
         if meta is None and getattr(self, "_overlay_resolver", None):


### PR DESCRIPTION
## Summary
- `resolve_delete()` returns `(False, metadata_hint)` when a resolver already fetched metadata but didn't handle the delete (e.g., FederationContentResolver returning local content metadata)
- `sys_unlink()` was ignoring this prefetched hint and redundantly calling `self.metadata.get(path)` again
- One-line fix: use the prefetched result when available, skip the redundant metastore lookup

## Test plan
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] 2208 unit tests pass (0 failures)

Closes #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)