### PR TITLE
fix: correct wal_backend → wal import in event log factory

### DIFF
--- a/src/nexus/system_services/event_subsystem/log/factory.py
+++ b/src/nexus/system_services/event_subsystem/log/factory.py
@@ -34,7 +34,7 @@ def create_event_log(
     """
     # Prefer Rust WAL
     try:
-        from nexus.system_services.event_subsystem.log.wal_backend import WALEventLog, is_available
+        from nexus.system_services.event_subsystem.log.wal import WALEventLog, is_available
 
         if is_available():
             log: EventLogProtocol = WALEventLog(config)


### PR DESCRIPTION
## Summary
- Fix broken import in `event_subsystem/log/factory.py`: `wal_backend` → `wal`
- The event_subsystem consolidation (`3471cab9d`) renamed `wal_backend.py` to `wal.py` but `factory.py` still imported the old name
- The `try/except` silently caught the `ModuleNotFoundError`, permanently disabling the Rust WAL backend even when the extension is installed

## Root cause
The refactor moved files from `services/event_log/` (which had `wal_backend.py`) into `system_services/event_subsystem/log/` (where the canonical copy was already named `wal.py`). The factory was copied from the old path without updating the import.

## Test plan
- [ ] CI passes (lint, mypy, tests, benchmarks)
- [ ] Rust WAL backend is correctly loaded when available (verified by log message "Event log: Rust WAL backend")

🤖 Generated with [Claude Code](https://claude.com/claude-code)