### PR TITLE
feat(#908): VFSSemaphore kernel primitive — Rust + Python fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -642,6 +648,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "getset"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,13 +732,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -836,6 +864,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +887,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -914,6 +950,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1089,6 +1131,7 @@ dependencies = [
  "simdutf8",
  "simsimd",
  "string-interner",
+ "uuid",
 ]
 
 [[package]]
@@ -1829,6 +1872,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,6 +2422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2438,17 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -2442,7 +2508,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2488,6 +2563,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -2676,6 +2785,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -25,6 +25,7 @@ bloomfilter = "3.0"
 memmap2 = "0.9.9"
 dashmap = "6.1"
 parking_lot = "0.12"
+uuid = { version = "1", features = ["v4"] }
 lru = "0.16"
 simdutf8 = "0.1"
 simsimd = "6"

--- a/rust/nexus_pyo3/src/lib.rs
+++ b/rust/nexus_pyo3/src/lib.rs
@@ -8,6 +8,7 @@ mod hash;
 mod io;
 mod lock;
 mod prefix;
+mod semaphore;
 mod rebac;
 mod search;
 mod simd;
@@ -78,5 +79,6 @@ fn nexus_fast(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<bloom::BloomFilter>()?;
     m.add_class::<cache::L1MetadataCache>()?;
     m.add_class::<lock::VFSLockManager>()?;
+    m.add_class::<semaphore::VFSSemaphore>()?;
     Ok(())
 }

--- a/rust/nexus_pyo3/src/semaphore.rs
+++ b/rust/nexus_pyo3/src/semaphore.rs
@@ -1,0 +1,659 @@
+//! VFS Counting Semaphore — Rust-accelerated (Issue #908).
+//!
+//! Name-addressed counting semaphore with holder tracking, SSOT max_holders
+//! enforcement, TTL expiry, and UUID holder IDs.  Local counterpart to
+//! `RaftLockManager.acquire(max_holders=N)` (~200ns vs ~5-10ms Raft).
+//!
+//! Semantics mirror the Raft semaphore:
+//!   - holder IDs are UUID4 strings
+//!   - first acquirer sets `max_holders` (SSOT); mismatch → ValueError
+//!   - TTL: lazy expiry on acquire
+//!   - acquire() returns Option<String> (holder_id or None)
+
+use parking_lot::{Condvar, Mutex};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct HolderEntry {
+    holder_id: String,
+    acquired_at_ns: u64,
+    expires_at_ns: u64,
+}
+
+#[derive(Debug, Clone)]
+struct SemaphoreEntry {
+    max_holders: u32,
+    holders: HashMap<String, HolderEntry>,
+}
+
+impl SemaphoreEntry {
+    fn new(max_holders: u32) -> Self {
+        Self {
+            max_holders,
+            holders: HashMap::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.holders.is_empty()
+    }
+
+    /// Remove holders whose TTL has expired.
+    fn evict_expired(&mut self, now_ns: u64) {
+        self.holders.retain(|_, entry| entry.expires_at_ns > now_ns);
+    }
+}
+
+/// Protected state: all semaphore mutations go through this Mutex.
+#[derive(Debug)]
+struct SemaphoreState {
+    semaphores: HashMap<String, SemaphoreEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Monotonic clock helper
+// ---------------------------------------------------------------------------
+
+/// Return a monotonic timestamp in nanoseconds (relative to process start).
+fn monotonic_ns() -> u64 {
+    // Use a lazily-initialized epoch so values are small and readable.
+    use std::sync::OnceLock;
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    let epoch = EPOCH.get_or_init(Instant::now);
+    epoch.elapsed().as_nanos() as u64
+}
+
+// ---------------------------------------------------------------------------
+// VFSSemaphore
+// ---------------------------------------------------------------------------
+
+/// Rust-accelerated VFS counting semaphore.
+///
+/// All mutations are serialized through a `parking_lot::Mutex`.
+/// A `Condvar` wakes blocked threads on release.
+#[pyclass]
+pub struct VFSSemaphore {
+    state: Mutex<SemaphoreState>,
+    notify: Condvar,
+
+    // Metrics (relaxed atomics)
+    acquire_count: AtomicU64,
+    release_count: AtomicU64,
+    timeout_count: AtomicU64,
+}
+
+impl VFSSemaphore {
+    /// Single non-blocking acquire attempt under the lock.
+    /// Returns `Ok(Some(holder_id))` on success, `Ok(None)` if full,
+    /// `Err(msg)` on SSOT mismatch.
+    fn try_acquire_locked(
+        state: &mut SemaphoreState,
+        name: &str,
+        max_holders: u32,
+        ttl_ms: u64,
+    ) -> Result<Option<String>, String> {
+        let now_ns = monotonic_ns();
+        let expires_at_ns = now_ns + ttl_ms * 1_000_000;
+
+        let entry = state.semaphores.get_mut(name);
+
+        if let Some(entry) = entry {
+            // SSOT check
+            if entry.max_holders != max_holders {
+                return Err(format!(
+                    "Semaphore {:?}: max_holders mismatch — existing={}, requested={}",
+                    name, entry.max_holders, max_holders
+                ));
+            }
+
+            // Lazy TTL expiry
+            entry.evict_expired(now_ns);
+
+            // If empty after eviction, remove and re-create below
+            if entry.is_empty() {
+                state.semaphores.remove(name);
+            } else {
+                // Capacity check
+                if entry.holders.len() as u32 >= entry.max_holders {
+                    return Ok(None);
+                }
+
+                let holder_id = Uuid::new_v4().to_string();
+                entry.holders.insert(
+                    holder_id.clone(),
+                    HolderEntry {
+                        holder_id: holder_id.clone(),
+                        acquired_at_ns: now_ns,
+                        expires_at_ns,
+                    },
+                );
+                return Ok(Some(holder_id));
+            }
+        }
+
+        // Create new entry (either first time, or emptied after eviction)
+        let holder_id = Uuid::new_v4().to_string();
+        let mut new_entry = SemaphoreEntry::new(max_holders);
+        new_entry.holders.insert(
+            holder_id.clone(),
+            HolderEntry {
+                holder_id: holder_id.clone(),
+                acquired_at_ns: now_ns,
+                expires_at_ns,
+            },
+        );
+        state.semaphores.insert(name.to_string(), new_entry);
+        Ok(Some(holder_id))
+    }
+}
+
+#[pymethods]
+impl VFSSemaphore {
+    #[new]
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(SemaphoreState {
+                semaphores: HashMap::new(),
+            }),
+            notify: Condvar::new(),
+            acquire_count: AtomicU64::new(0),
+            release_count: AtomicU64::new(0),
+            timeout_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Acquire a semaphore slot.
+    ///
+    /// * `name` – semaphore name
+    /// * `max_holders` – maximum concurrent holders (SSOT)
+    /// * `timeout_ms` – 0 = non-blocking; >0 blocks up to that many ms
+    /// * `ttl_ms` – holder auto-expires after this many ms
+    ///
+    /// Returns holder_id (UUID string) on success, None on timeout.
+    #[pyo3(signature = (name, max_holders, timeout_ms=0, ttl_ms=30000))]
+    fn acquire(
+        &self,
+        py: Python<'_>,
+        name: &str,
+        max_holders: u32,
+        timeout_ms: u64,
+        ttl_ms: u64,
+    ) -> PyResult<Option<String>> {
+        if max_holders < 1 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "max_holders must be >= 1, got {max_holders}"
+            )));
+        }
+
+        let name = name.to_string();
+
+        // Release the GIL for the (potentially blocking) acquire loop.
+        let result = py.detach(|| -> Result<Option<String>, String> {
+            // Fast path: non-blocking try under mutex.
+            {
+                let mut state = self.state.lock();
+                match Self::try_acquire_locked(&mut state, &name, max_holders, ttl_ms) {
+                    Ok(Some(holder_id)) => {
+                        self.acquire_count.fetch_add(1, Ordering::Relaxed);
+                        return Ok(Some(holder_id));
+                    }
+                    Ok(None) => {} // full, continue to blocking path
+                    Err(msg) => return Err(msg),
+                }
+            }
+
+            // Non-blocking: return immediately
+            if timeout_ms == 0 {
+                self.timeout_count.fetch_add(1, Ordering::Relaxed);
+                return Ok(None);
+            }
+
+            // Blocking wait with Condvar
+            let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+
+            loop {
+                let mut state = self.state.lock();
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    self.timeout_count.fetch_add(1, Ordering::Relaxed);
+                    return Ok(None);
+                }
+
+                let wait_result = self.notify.wait_for(&mut state, remaining);
+
+                match Self::try_acquire_locked(&mut state, &name, max_holders, ttl_ms) {
+                    Ok(Some(holder_id)) => {
+                        self.acquire_count.fetch_add(1, Ordering::Relaxed);
+                        return Ok(Some(holder_id));
+                    }
+                    Ok(None) => {} // still full
+                    Err(msg) => return Err(msg),
+                }
+
+                if wait_result.timed_out() {
+                    self.timeout_count.fetch_add(1, Ordering::Relaxed);
+                    return Ok(None);
+                }
+            }
+        });
+
+        match result {
+            Ok(holder_id) => Ok(holder_id),
+            Err(msg) => Err(pyo3::exceptions::PyValueError::new_err(msg)),
+        }
+    }
+
+    /// Release a semaphore slot by holder_id.
+    fn release(&self, name: &str, holder_id: &str) -> bool {
+        let released = {
+            let mut state = self.state.lock();
+
+            let entry = match state.semaphores.get_mut(name) {
+                Some(e) => e,
+                None => return false,
+            };
+
+            if entry.holders.remove(holder_id).is_none() {
+                return false;
+            }
+
+            if entry.is_empty() {
+                state.semaphores.remove(name);
+            }
+
+            true
+        };
+
+        if released {
+            self.notify.notify_all();
+            self.release_count.fetch_add(1, Ordering::Relaxed);
+        }
+
+        released
+    }
+
+    /// Extend TTL for a holder.
+    #[pyo3(signature = (name, holder_id, ttl_ms=30000))]
+    fn extend(&self, name: &str, holder_id: &str, ttl_ms: u64) -> bool {
+        let now_ns = monotonic_ns();
+        let mut state = self.state.lock();
+
+        let entry = match state.semaphores.get_mut(name) {
+            Some(e) => e,
+            None => return false,
+        };
+
+        match entry.holders.get_mut(holder_id) {
+            Some(holder) => {
+                holder.expires_at_ns = now_ns + ttl_ms * 1_000_000;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Return info about a semaphore, or None if it doesn't exist / is empty.
+    fn info(&self, py: Python<'_>, name: &str) -> PyResult<Option<Py<PyAny>>> {
+        let now_ns = monotonic_ns();
+        let mut state = self.state.lock();
+
+        let entry = match state.semaphores.get_mut(name) {
+            Some(e) => e,
+            None => return Ok(None),
+        };
+
+        // Evict expired before reporting
+        entry.evict_expired(now_ns);
+        if entry.is_empty() {
+            state.semaphores.remove(name);
+            return Ok(None);
+        }
+
+        let dict = PyDict::new(py);
+        dict.set_item("name", name)?;
+        dict.set_item("max_holders", entry.max_holders)?;
+        dict.set_item("active_count", entry.holders.len())?;
+
+        let holders_list = PyList::empty(py);
+        for holder in entry.holders.values() {
+            let h = PyDict::new(py);
+            h.set_item("holder_id", &holder.holder_id)?;
+            h.set_item("acquired_at_ns", holder.acquired_at_ns)?;
+            h.set_item("expires_at_ns", holder.expires_at_ns)?;
+            holders_list.append(h)?;
+        }
+        dict.set_item("holders", holders_list)?;
+
+        Ok(Some(dict.into()))
+    }
+
+    /// Force-release all holders for a semaphore.
+    fn force_release(&self, name: &str) -> bool {
+        let released = {
+            let mut state = self.state.lock();
+
+            let entry = match state.semaphores.remove(name) {
+                Some(e) => e,
+                None => return false,
+            };
+
+            let count = entry.holders.len() as u64;
+            self.release_count.fetch_add(count, Ordering::Relaxed);
+            true
+        };
+
+        if released {
+            self.notify.notify_all();
+        }
+
+        released
+    }
+
+    /// Return aggregate metrics.
+    fn stats(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let state = self.state.lock();
+        let active_semaphores = state.semaphores.len();
+        let active_holders: usize = state.semaphores.values().map(|e| e.holders.len()).sum();
+        drop(state);
+
+        let dict = PyDict::new(py);
+        dict.set_item("acquire_count", self.acquire_count.load(Ordering::Relaxed))?;
+        dict.set_item("release_count", self.release_count.load(Ordering::Relaxed))?;
+        dict.set_item("timeout_count", self.timeout_count.load(Ordering::Relaxed))?;
+        dict.set_item("active_semaphores", active_semaphores)?;
+        dict.set_item("active_holders", active_holders)?;
+        Ok(dict.into())
+    }
+
+    /// Number of active semaphores.
+    #[getter]
+    fn active_semaphores(&self) -> usize {
+        self.state.lock().semaphores.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make() -> VFSSemaphore {
+        VFSSemaphore::new()
+    }
+
+    /// Helper: acquire directly through the mutex (bypasses PyO3 / GIL).
+    fn acquire(sem: &VFSSemaphore, name: &str, max_holders: u32, ttl_ms: u64) -> Option<String> {
+        let mut state = sem.state.lock();
+        match VFSSemaphore::try_acquire_locked(&mut state, name, max_holders, ttl_ms) {
+            Ok(opt) => opt,
+            Err(msg) => panic!("acquire error: {msg}"),
+        }
+    }
+
+    /// Helper: acquire expecting a ValueError (SSOT mismatch).
+    fn acquire_err(sem: &VFSSemaphore, name: &str, max_holders: u32, ttl_ms: u64) -> String {
+        let mut state = sem.state.lock();
+        match VFSSemaphore::try_acquire_locked(&mut state, name, max_holders, ttl_ms) {
+            Err(msg) => msg,
+            Ok(_) => panic!("expected error, got success"),
+        }
+    }
+
+    // -- basic acquire / release -------------------------------------------
+
+    #[test]
+    fn test_basic_acquire_release() {
+        let sem = make();
+        let hid = acquire(&sem, "test", 1, 30_000).unwrap();
+        assert!(!hid.is_empty());
+        assert!(sem.release("test", &hid));
+    }
+
+    #[test]
+    fn test_acquire_returns_uuid() {
+        let sem = make();
+        let hid = acquire(&sem, "test", 1, 30_000).unwrap();
+        // UUID4 format: 8-4-4-4-12
+        assert_eq!(hid.len(), 36);
+        assert_eq!(hid.chars().filter(|c| *c == '-').count(), 4);
+        sem.release("test", &hid);
+    }
+
+    #[test]
+    fn test_release_returns_false_for_unknown() {
+        let sem = make();
+        assert!(!sem.release("nonexistent", "fake-id"));
+    }
+
+    #[test]
+    fn test_double_release_returns_false() {
+        let sem = make();
+        let hid = acquire(&sem, "test", 1, 30_000).unwrap();
+        assert!(sem.release("test", &hid));
+        assert!(!sem.release("test", &hid));
+    }
+
+    #[test]
+    fn test_release_wrong_name() {
+        let sem = make();
+        let hid = acquire(&sem, "test", 1, 30_000).unwrap();
+        assert!(!sem.release("other", &hid));
+        sem.release("test", &hid);
+    }
+
+    // -- multiple holders --------------------------------------------------
+
+    #[test]
+    fn test_multiple_holders() {
+        let sem = make();
+        let h1 = acquire(&sem, "test", 3, 30_000).unwrap();
+        let h2 = acquire(&sem, "test", 3, 30_000).unwrap();
+        let h3 = acquire(&sem, "test", 3, 30_000).unwrap();
+        assert_ne!(h1, h2);
+        assert_ne!(h2, h3);
+
+        // 4th should fail
+        assert!(acquire(&sem, "test", 3, 30_000).is_none());
+
+        // Release one, then 4th should succeed
+        sem.release("test", &h1);
+        let h4 = acquire(&sem, "test", 3, 30_000).unwrap();
+        assert!(!h4.is_empty());
+
+        sem.release("test", &h2);
+        sem.release("test", &h3);
+        sem.release("test", &h4);
+    }
+
+    #[test]
+    fn test_max_holders_one_is_mutex() {
+        let sem = make();
+        let h1 = acquire(&sem, "mutex", 1, 30_000).unwrap();
+        assert!(acquire(&sem, "mutex", 1, 30_000).is_none());
+        sem.release("mutex", &h1);
+        let h2 = acquire(&sem, "mutex", 1, 30_000).unwrap();
+        assert!(!h2.is_empty());
+        sem.release("mutex", &h2);
+    }
+
+    // -- SSOT enforcement --------------------------------------------------
+
+    #[test]
+    fn test_ssot_mismatch() {
+        let sem = make();
+        let _h = acquire(&sem, "test", 3, 30_000).unwrap();
+        let err = acquire_err(&sem, "test", 5, 30_000);
+        assert!(err.contains("max_holders mismatch"));
+        assert!(err.contains("existing=3"));
+        assert!(err.contains("requested=5"));
+    }
+
+    #[test]
+    fn test_ssot_after_full_release() {
+        let sem = make();
+        let h = acquire(&sem, "test", 3, 30_000).unwrap();
+        sem.release("test", &h);
+        // After full release, entry is cleaned up → new max_holders is OK
+        let h2 = acquire(&sem, "test", 5, 30_000).unwrap();
+        assert!(!h2.is_empty());
+        sem.release("test", &h2);
+    }
+
+    // -- TTL expiry --------------------------------------------------------
+
+    #[test]
+    fn test_ttl_expiry() {
+        let sem = make();
+        // Acquire with 1ms TTL
+        let h = acquire(&sem, "test", 1, 1).unwrap();
+        assert!(!h.is_empty());
+
+        // Wait for expiry
+        std::thread::sleep(Duration::from_millis(5));
+
+        // Should succeed (expired holder evicted)
+        let h2 = acquire(&sem, "test", 1, 30_000).unwrap();
+        assert!(!h2.is_empty());
+        sem.release("test", &h2);
+    }
+
+    // -- extend ------------------------------------------------------------
+
+    #[test]
+    fn test_extend() {
+        let sem = make();
+        let h = acquire(&sem, "test", 1, 10).unwrap(); // 10ms TTL
+        assert!(sem.extend("test", &h, 30_000)); // extend to 30s
+        std::thread::sleep(Duration::from_millis(15));
+        // Should still be held (extended past 10ms)
+        assert!(acquire(&sem, "test", 1, 30_000).is_none());
+        sem.release("test", &h);
+    }
+
+    #[test]
+    fn test_extend_unknown_returns_false() {
+        let sem = make();
+        assert!(!sem.extend("nonexistent", "fake-id", 30_000));
+    }
+
+    #[test]
+    fn test_extend_wrong_holder() {
+        let sem = make();
+        let _h = acquire(&sem, "test", 1, 30_000).unwrap();
+        assert!(!sem.extend("test", "wrong-id", 30_000));
+    }
+
+    // -- force_release -----------------------------------------------------
+
+    #[test]
+    fn test_force_release() {
+        let sem = make();
+        let _h1 = acquire(&sem, "test", 3, 30_000).unwrap();
+        let _h2 = acquire(&sem, "test", 3, 30_000).unwrap();
+        assert!(sem.force_release("test"));
+        assert_eq!(sem.active_semaphores(), 0);
+    }
+
+    #[test]
+    fn test_force_release_nonexistent() {
+        let sem = make();
+        assert!(!sem.force_release("nonexistent"));
+    }
+
+    // -- stats -------------------------------------------------------------
+
+    #[test]
+    fn test_stats_counters() {
+        let sem = make();
+        let h = acquire(&sem, "test", 1, 30_000).unwrap();
+        sem.release("test", &h);
+        assert_eq!(sem.release_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_active_semaphores() {
+        let sem = make();
+        assert_eq!(sem.active_semaphores(), 0);
+        let h1 = acquire(&sem, "a", 1, 30_000).unwrap();
+        let h2 = acquire(&sem, "b", 1, 30_000).unwrap();
+        assert_eq!(sem.active_semaphores(), 2);
+        sem.release("a", &h1);
+        assert_eq!(sem.active_semaphores(), 1);
+        sem.release("b", &h2);
+        assert_eq!(sem.active_semaphores(), 0);
+    }
+
+    // -- concurrent --------------------------------------------------------
+
+    #[test]
+    fn test_concurrent_acquire() {
+        use rayon::prelude::*;
+        use std::sync::atomic::AtomicU32;
+
+        let sem = make();
+        let success_count = AtomicU32::new(0);
+
+        (0..100).into_par_iter().for_each(|_| {
+            if acquire(&sem, "shared", 5, 30_000).is_some() {
+                success_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        // Exactly 5 should succeed (max_holders=5)
+        assert_eq!(success_count.load(Ordering::Relaxed), 5);
+    }
+
+    #[test]
+    fn test_concurrent_mutex() {
+        use rayon::prelude::*;
+        use std::sync::atomic::AtomicU32;
+
+        let sem = make();
+        let success_count = AtomicU32::new(0);
+
+        (0..100).into_par_iter().for_each(|_| {
+            if acquire(&sem, "exclusive", 1, 30_000).is_some() {
+                success_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        assert_eq!(success_count.load(Ordering::Relaxed), 1);
+    }
+
+    // -- empty cleanup -----------------------------------------------------
+
+    #[test]
+    fn test_empty_cleanup_on_release() {
+        let sem = make();
+        let h = acquire(&sem, "temp", 1, 30_000).unwrap();
+        assert_eq!(sem.active_semaphores(), 1);
+        sem.release("temp", &h);
+        assert_eq!(sem.active_semaphores(), 0);
+    }
+
+    #[test]
+    fn test_empty_cleanup_on_ttl_expiry() {
+        let sem = make();
+        let _h = acquire(&sem, "temp", 1, 1).unwrap(); // 1ms TTL
+        assert_eq!(sem.active_semaphores(), 1);
+
+        std::thread::sleep(Duration::from_millis(5));
+
+        // Next acquire triggers eviction + cleanup
+        let h2 = acquire(&sem, "temp", 1, 30_000).unwrap();
+        assert!(!h2.is_empty());
+        sem.release("temp", &h2);
+    }
+}

--- a/src/nexus/core/semaphore.py
+++ b/src/nexus/core/semaphore.py
@@ -1,0 +1,331 @@
+"""VFS Counting Semaphore with Rust acceleration (Issue #908).
+
+Provides name-addressed counting semaphore with holder tracking, SSOT
+max_holders enforcement, TTL expiry, and UUID holder IDs.  This is the
+**local, in-process** counterpart to ``RaftLockManager.acquire(max_holders=N)``
+(~200ns vs ~5-10ms Raft round-trip).
+
+Semantics mirror the Raft semaphore exactly:
+    - holder IDs are UUID4 strings
+    - first acquirer sets ``max_holders`` (SSOT); mismatch → ``ValueError``
+    - TTL: lazy expiry on acquire (evict expired before capacity check)
+    - acquire() returns ``str | None`` (holder_id or None on timeout)
+
+Fallback chain:
+    1. Rust ``VFSSemaphore`` (via ``nexus_fast``) — ~200ns per acquire
+    2. Python ``PythonVFSSemaphore`` (threading-based) — ~500ns-1us
+
+References:
+    - docs/architecture/lock-architecture.md §3.2
+    - src/nexus/raft/lock_manager.py  (Raft semaphore to match)
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from typing import Any, Protocol, cast, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class VFSSemaphoreProtocol(Protocol):
+    """Structural interface shared by Rust and Python implementations."""
+
+    def acquire(
+        self,
+        name: str,
+        max_holders: int,
+        timeout_ms: int = 0,
+        ttl_ms: int = 30_000,
+    ) -> str | None: ...
+
+    def release(self, name: str, holder_id: str) -> bool: ...
+
+    def extend(self, name: str, holder_id: str, ttl_ms: int = 30_000) -> bool: ...
+
+    def info(self, name: str) -> dict | None: ...
+
+    def force_release(self, name: str) -> bool: ...
+
+    def stats(self) -> dict: ...
+
+    @property
+    def active_semaphores(self) -> int: ...
+
+
+# ---------------------------------------------------------------------------
+# Internal data classes
+# ---------------------------------------------------------------------------
+
+
+class _HolderEntry:
+    __slots__ = ("holder_id", "acquired_at_ns", "expires_at_ns")
+
+    def __init__(self, holder_id: str, acquired_at_ns: int, expires_at_ns: int) -> None:
+        self.holder_id = holder_id
+        self.acquired_at_ns = acquired_at_ns
+        self.expires_at_ns = expires_at_ns
+
+
+class _SemaphoreState:
+    __slots__ = ("max_holders", "holders")
+
+    def __init__(self, max_holders: int) -> None:
+        self.max_holders = max_holders
+        self.holders: dict[str, _HolderEntry] = {}
+
+    def is_empty(self) -> bool:
+        return len(self.holders) == 0
+
+
+# ---------------------------------------------------------------------------
+# Python fallback
+# ---------------------------------------------------------------------------
+
+
+class PythonVFSSemaphore:
+    """Pure-Python counting semaphore using ``threading.RLock`` + dict."""
+
+    def __init__(self) -> None:
+        self._mu = threading.RLock()
+        self._semaphores: dict[str, _SemaphoreState] = {}
+
+        # Metrics
+        self._acquire_count = 0
+        self._release_count = 0
+        self._timeout_count = 0
+
+    # -- helpers -----------------------------------------------------------
+
+    def _evict_expired(self, state: _SemaphoreState, now_ns: int) -> None:
+        """Remove holders whose TTL has expired (lazy expiry)."""
+        expired = [hid for hid, entry in state.holders.items() if entry.expires_at_ns <= now_ns]
+        for hid in expired:
+            del state.holders[hid]
+
+    def _try_acquire_once(self, name: str, max_holders: int, ttl_ms: int) -> str | None:
+        """Non-blocking single attempt.  Returns holder_id or None."""
+        now_ns = time.monotonic_ns()
+
+        with self._mu:
+            state = self._semaphores.get(name)
+
+            if state is not None:
+                # SSOT: max_holders must match
+                if state.max_holders != max_holders:
+                    raise ValueError(
+                        f"Semaphore {name!r}: max_holders mismatch — "
+                        f"existing={state.max_holders}, requested={max_holders}"
+                    )
+                # Lazy TTL expiry
+                self._evict_expired(state, now_ns)
+                # Clean up empty
+                if state.is_empty():
+                    del self._semaphores[name]
+                    state = None
+
+            if state is None:
+                state = _SemaphoreState(max_holders)
+                self._semaphores[name] = state
+
+            # Capacity check
+            if len(state.holders) >= state.max_holders:
+                return None
+
+            holder_id = str(uuid.uuid4())
+            expires_at_ns = now_ns + ttl_ms * 1_000_000
+            state.holders[holder_id] = _HolderEntry(holder_id, now_ns, expires_at_ns)
+            return holder_id
+
+    # -- public API --------------------------------------------------------
+
+    def acquire(
+        self,
+        name: str,
+        max_holders: int,
+        timeout_ms: int = 0,
+        ttl_ms: int = 30_000,
+    ) -> str | None:
+        if max_holders < 1:
+            raise ValueError(f"max_holders must be >= 1, got {max_holders}")
+
+        holder_id = self._try_acquire_once(name, max_holders, ttl_ms)
+        if holder_id is not None:
+            self._acquire_count += 1
+            return holder_id
+
+        if timeout_ms == 0:
+            self._timeout_count += 1
+            return None
+
+        deadline = time.monotonic() + timeout_ms / 1000.0
+        backoff_s = 0.00005  # 50us
+
+        while True:
+            time.sleep(backoff_s)
+
+            holder_id = self._try_acquire_once(name, max_holders, ttl_ms)
+            if holder_id is not None:
+                self._acquire_count += 1
+                return holder_id
+
+            if time.monotonic() >= deadline:
+                self._timeout_count += 1
+                return None
+
+            backoff_s = min(backoff_s * 2, 0.005)  # cap at 5ms
+
+    def release(self, name: str, holder_id: str) -> bool:
+        with self._mu:
+            state = self._semaphores.get(name)
+            if state is None:
+                return False
+
+            if holder_id not in state.holders:
+                return False
+
+            del state.holders[holder_id]
+
+            # Clean up empty
+            if state.is_empty():
+                del self._semaphores[name]
+
+            self._release_count += 1
+            return True
+
+    def extend(self, name: str, holder_id: str, ttl_ms: int = 30_000) -> bool:
+        now_ns = time.monotonic_ns()
+        with self._mu:
+            state = self._semaphores.get(name)
+            if state is None:
+                return False
+
+            entry = state.holders.get(holder_id)
+            if entry is None:
+                return False
+
+            entry.expires_at_ns = now_ns + ttl_ms * 1_000_000
+            return True
+
+    def info(self, name: str) -> dict | None:
+        now_ns = time.monotonic_ns()
+        with self._mu:
+            state = self._semaphores.get(name)
+            if state is None:
+                return None
+
+            self._evict_expired(state, now_ns)
+            if state.is_empty():
+                del self._semaphores[name]
+                return None
+
+            return {
+                "name": name,
+                "max_holders": state.max_holders,
+                "active_count": len(state.holders),
+                "holders": [
+                    {
+                        "holder_id": e.holder_id,
+                        "acquired_at_ns": e.acquired_at_ns,
+                        "expires_at_ns": e.expires_at_ns,
+                    }
+                    for e in state.holders.values()
+                ],
+            }
+
+    def force_release(self, name: str) -> bool:
+        with self._mu:
+            state = self._semaphores.get(name)
+            if state is None:
+                return False
+
+            count = len(state.holders)
+            del self._semaphores[name]
+            self._release_count += count
+            return True
+
+    def stats(self) -> dict:
+        with self._mu:
+            active_semaphores = len(self._semaphores)
+            active_holders = sum(len(s.holders) for s in self._semaphores.values())
+        return {
+            "acquire_count": self._acquire_count,
+            "release_count": self._release_count,
+            "timeout_count": self._timeout_count,
+            "active_semaphores": active_semaphores,
+            "active_holders": active_holders,
+        }
+
+    @property
+    def active_semaphores(self) -> int:
+        with self._mu:
+            return len(self._semaphores)
+
+
+# ---------------------------------------------------------------------------
+# Rust wrapper
+# ---------------------------------------------------------------------------
+
+
+class RustVFSSemaphore:
+    """Thin wrapper around ``nexus_fast.VFSSemaphore``."""
+
+    def __init__(self) -> None:
+        from nexus_fast import VFSSemaphore
+
+        self._inner: Any = VFSSemaphore()
+
+    def acquire(
+        self,
+        name: str,
+        max_holders: int,
+        timeout_ms: int = 0,
+        ttl_ms: int = 30_000,
+    ) -> str | None:
+        return cast("str | None", self._inner.acquire(name, max_holders, timeout_ms, ttl_ms))
+
+    def release(self, name: str, holder_id: str) -> bool:
+        return cast(bool, self._inner.release(name, holder_id))
+
+    def extend(self, name: str, holder_id: str, ttl_ms: int = 30_000) -> bool:
+        return cast(bool, self._inner.extend(name, holder_id, ttl_ms))
+
+    def info(self, name: str) -> dict | None:
+        return cast("dict | None", self._inner.info(name))
+
+    def force_release(self, name: str) -> bool:
+        return cast(bool, self._inner.force_release(name))
+
+    def stats(self) -> dict:
+        return cast(dict, self._inner.stats())
+
+    @property
+    def active_semaphores(self) -> int:
+        return cast(int, self._inner.active_semaphores)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_vfs_semaphore() -> VFSSemaphoreProtocol:
+    """Return the best available VFS semaphore.
+
+    Prefers the Rust implementation; falls back to pure Python.
+    """
+    try:
+        sem = RustVFSSemaphore()
+        logger.debug("VFS semaphore: Rust (nexus_fast)")
+        return sem
+    except (ImportError, Exception) as exc:
+        logger.debug("Rust VFS semaphore unavailable (%s), using Python fallback", exc)
+        return PythonVFSSemaphore()

--- a/tests/unit/core/test_vfs_semaphore.py
+++ b/tests/unit/core/test_vfs_semaphore.py
@@ -1,0 +1,481 @@
+"""Unit tests for VFS Counting Semaphore (Issue #908).
+
+Tests both the Rust-accelerated and pure-Python implementations to verify
+identical semantics.
+"""
+
+import threading
+import time
+
+import pytest
+
+from nexus.core.semaphore import (
+    PythonVFSSemaphore,
+    VFSSemaphoreProtocol,
+    create_vfs_semaphore,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — parametrize over both implementations
+# ---------------------------------------------------------------------------
+
+_IMPLEMENTATIONS: list[type] = [PythonVFSSemaphore]
+
+try:
+    from nexus.core.semaphore import RustVFSSemaphore
+
+    _IMPLEMENTATIONS.append(RustVFSSemaphore)
+except (ImportError, Exception):
+    pass
+
+
+@pytest.fixture(params=_IMPLEMENTATIONS, ids=lambda cls: cls.__name__)
+def sem(request: pytest.FixtureRequest) -> VFSSemaphoreProtocol:
+    return request.param()
+
+
+# ---------------------------------------------------------------------------
+# Basic acquire / release
+# ---------------------------------------------------------------------------
+
+
+class TestBasicAcquireRelease:
+    def test_acquire_returns_uuid_string(self, sem: VFSSemaphoreProtocol) -> None:
+        hid = sem.acquire("test", max_holders=1)
+        assert hid is not None
+        assert isinstance(hid, str)
+        assert len(hid) == 36  # UUID4: 8-4-4-4-12
+        assert hid.count("-") == 4
+        sem.release("test", hid)
+
+    def test_release_returns_true(self, sem: VFSSemaphoreProtocol) -> None:
+        hid = sem.acquire("test", max_holders=1)
+        assert hid is not None
+        assert sem.release("test", hid)
+
+    def test_double_release_returns_false(self, sem: VFSSemaphoreProtocol) -> None:
+        hid = sem.acquire("test", max_holders=1)
+        assert hid is not None
+        assert sem.release("test", hid)
+        assert not sem.release("test", hid)
+
+    def test_release_unknown_name(self, sem: VFSSemaphoreProtocol) -> None:
+        hid = sem.acquire("test", max_holders=1)
+        assert hid is not None
+        assert not sem.release("other", hid)
+        sem.release("test", hid)
+
+    def test_release_unknown_holder_id(self, sem: VFSSemaphoreProtocol) -> None:
+        hid = sem.acquire("test", max_holders=1)
+        assert hid is not None
+        assert not sem.release("test", "nonexistent-id")
+        sem.release("test", hid)
+
+
+# ---------------------------------------------------------------------------
+# Multiple holders
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleHolders:
+    def test_n_holders_up_to_max(self, sem: VFSSemaphoreProtocol) -> None:
+        h1 = sem.acquire("test", max_holders=3)
+        h2 = sem.acquire("test", max_holders=3)
+        h3 = sem.acquire("test", max_holders=3)
+        assert h1 is not None
+        assert h2 is not None
+        assert h3 is not None
+        assert len({h1, h2, h3}) == 3  # all unique
+        sem.release("test", h1)
+        sem.release("test", h2)
+        sem.release("test", h3)
+
+    def test_n_plus_1_blocked(self, sem: VFSSemaphoreProtocol) -> None:
+        holders = []
+        for _ in range(3):
+            h = sem.acquire("test", max_holders=3)
+            assert h is not None
+            holders.append(h)
+
+        # 4th should fail (non-blocking)
+        assert sem.acquire("test", max_holders=3, timeout_ms=0) is None
+
+        for h in holders:
+            sem.release("test", h)
+
+    def test_release_one_then_acquire_succeeds(self, sem: VFSSemaphoreProtocol) -> None:
+        h1 = sem.acquire("test", max_holders=2)
+        h2 = sem.acquire("test", max_holders=2)
+        assert h1 is not None
+        assert h2 is not None
+
+        # Full
+        assert sem.acquire("test", max_holders=2) is None
+
+        # Release one
+        sem.release("test", h1)
+
+        # Now should succeed
+        h3 = sem.acquire("test", max_holders=2)
+        assert h3 is not None
+
+        sem.release("test", h2)
+        sem.release("test", h3)
+
+
+# ---------------------------------------------------------------------------
+# SSOT enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestSSOT:
+    def test_mismatch_raises_value_error(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=3)
+        assert h is not None
+        with pytest.raises(ValueError, match="max_holders mismatch"):
+            sem.acquire("test", max_holders=5)
+        sem.release("test", h)
+
+    def test_same_max_holders_ok(self, sem: VFSSemaphoreProtocol) -> None:
+        h1 = sem.acquire("test", max_holders=3)
+        h2 = sem.acquire("test", max_holders=3)
+        assert h1 is not None
+        assert h2 is not None
+        sem.release("test", h1)
+        sem.release("test", h2)
+
+    def test_after_full_release_new_max_holders_ok(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=3)
+        assert h is not None
+        sem.release("test", h)
+
+        # Entry cleaned up → new max_holders accepted
+        h2 = sem.acquire("test", max_holders=5)
+        assert h2 is not None
+        sem.release("test", h2)
+
+    def test_max_holders_less_than_1_raises(self, sem: VFSSemaphoreProtocol) -> None:
+        with pytest.raises(ValueError):
+            sem.acquire("test", max_holders=0)
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry
+# ---------------------------------------------------------------------------
+
+
+class TestTTLExpiry:
+    def test_expired_holder_evicted_on_acquire(self, sem: VFSSemaphoreProtocol) -> None:
+        # Acquire with very short TTL
+        h = sem.acquire("test", max_holders=1, ttl_ms=5)
+        assert h is not None
+
+        # Wait for expiry
+        time.sleep(0.02)
+
+        # Should succeed (expired holder evicted lazily)
+        h2 = sem.acquire("test", max_holders=1, ttl_ms=30_000)
+        assert h2 is not None
+        sem.release("test", h2)
+
+    def test_non_expired_holder_blocks(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1, ttl_ms=30_000)
+        assert h is not None
+        # Should fail immediately (holder has 30s TTL)
+        assert sem.acquire("test", max_holders=1, timeout_ms=0) is None
+        sem.release("test", h)
+
+
+# ---------------------------------------------------------------------------
+# Extend
+# ---------------------------------------------------------------------------
+
+
+class TestExtend:
+    def test_extend_keeps_holder_alive(self, sem: VFSSemaphoreProtocol) -> None:
+        # Acquire with short TTL
+        h = sem.acquire("test", max_holders=1, ttl_ms=10)
+        assert h is not None
+
+        # Extend to much longer
+        assert sem.extend("test", h, ttl_ms=30_000)
+
+        # Wait past original TTL
+        time.sleep(0.02)
+
+        # Should still be held (was extended)
+        assert sem.acquire("test", max_holders=1, timeout_ms=0) is None
+        sem.release("test", h)
+
+    def test_extend_unknown_name(self, sem: VFSSemaphoreProtocol) -> None:
+        assert not sem.extend("nonexistent", "fake-id")
+
+    def test_extend_wrong_holder_id(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1)
+        assert h is not None
+        assert not sem.extend("test", "wrong-id")
+        sem.release("test", h)
+
+
+# ---------------------------------------------------------------------------
+# Force release
+# ---------------------------------------------------------------------------
+
+
+class TestForceRelease:
+    def test_force_release_clears_all(self, sem: VFSSemaphoreProtocol) -> None:
+        h1 = sem.acquire("test", max_holders=3)
+        h2 = sem.acquire("test", max_holders=3)
+        assert h1 is not None
+        assert h2 is not None
+        assert sem.active_semaphores == 1
+
+        assert sem.force_release("test")
+        assert sem.active_semaphores == 0
+
+        # Can acquire again
+        h3 = sem.acquire("test", max_holders=3)
+        assert h3 is not None
+        sem.release("test", h3)
+
+    def test_force_release_nonexistent(self, sem: VFSSemaphoreProtocol) -> None:
+        assert not sem.force_release("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Info
+# ---------------------------------------------------------------------------
+
+
+class TestInfo:
+    def test_info_none_when_no_semaphore(self, sem: VFSSemaphoreProtocol) -> None:
+        assert sem.info("nonexistent") is None
+
+    def test_info_structure(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=3, ttl_ms=30_000)
+        assert h is not None
+
+        info = sem.info("test")
+        assert info is not None
+        assert info["name"] == "test"
+        assert info["max_holders"] == 3
+        assert info["active_count"] == 1
+        assert isinstance(info["holders"], list)
+        assert len(info["holders"]) == 1
+
+        holder = info["holders"][0]
+        assert holder["holder_id"] == h
+        assert "acquired_at_ns" in holder
+        assert "expires_at_ns" in holder
+
+        sem.release("test", h)
+
+    def test_info_none_after_release(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1)
+        assert h is not None
+        sem.release("test", h)
+        assert sem.info("test") is None
+
+    def test_info_evicts_expired(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1, ttl_ms=5)
+        assert h is not None
+        time.sleep(0.02)
+        # info() should evict and return None
+        assert sem.info("test") is None
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+
+class TestStats:
+    def test_stats_keys(self, sem: VFSSemaphoreProtocol) -> None:
+        s = sem.stats()
+        expected_keys = {
+            "acquire_count",
+            "release_count",
+            "timeout_count",
+            "active_semaphores",
+            "active_holders",
+        }
+        assert expected_keys.issubset(set(s.keys()))
+
+    def test_stats_after_operations(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1)
+        assert h is not None
+        sem.release("test", h)
+
+        s = sem.stats()
+        assert s["acquire_count"] >= 1
+        assert s["release_count"] >= 1
+
+    def test_stats_timeout_count(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1)
+        assert h is not None
+        # This should timeout
+        sem.acquire("test", max_holders=1, timeout_ms=0)
+
+        s = sem.stats()
+        assert s["timeout_count"] >= 1
+        sem.release("test", h)
+
+    def test_stats_active_holders(self, sem: VFSSemaphoreProtocol) -> None:
+        h1 = sem.acquire("a", max_holders=2)
+        h2 = sem.acquire("a", max_holders=2)
+        h3 = sem.acquire("b", max_holders=1)
+        assert h1 is not None
+        assert h2 is not None
+        assert h3 is not None
+
+        s = sem.stats()
+        assert s["active_semaphores"] == 2
+        assert s["active_holders"] == 3
+
+        sem.release("a", h1)
+        sem.release("a", h2)
+        sem.release("b", h3)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_concurrent_acquire_respects_max(self, sem: VFSSemaphoreProtocol) -> None:
+        """20 threads try to acquire semaphore with max_holders=5."""
+        results: list[str | None] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            hid = sem.acquire("shared", max_holders=5, timeout_ms=0)
+            with lock:
+                results.append(hid)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        successes = [r for r in results if r is not None]
+        assert len(successes) == 5
+        assert len(set(successes)) == 5  # all unique UUIDs
+
+        for hid in successes:
+            sem.release("shared", hid)
+
+    def test_concurrent_mutex(self, sem: VFSSemaphoreProtocol) -> None:
+        """20 threads try to acquire max_holders=1 — exactly one succeeds."""
+        results: list[str | None] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            hid = sem.acquire("mutex", max_holders=1, timeout_ms=0)
+            with lock:
+                results.append(hid)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        successes = [r for r in results if r is not None]
+        assert len(successes) == 1
+
+        sem.release("mutex", successes[0])
+
+
+# ---------------------------------------------------------------------------
+# Timeout behavior
+# ---------------------------------------------------------------------------
+
+
+class TestTimeout:
+    def test_nonblocking_returns_none(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1)
+        assert h is not None
+        result = sem.acquire("test", max_holders=1, timeout_ms=0)
+        assert result is None
+        sem.release("test", h)
+
+    def test_blocking_timeout_returns_none(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1)
+        assert h is not None
+        start = time.monotonic()
+        result = sem.acquire("test", max_holders=1, timeout_ms=50)
+        elapsed_ms = (time.monotonic() - start) * 1000
+        assert result is None
+        assert elapsed_ms >= 40  # allow slack
+        sem.release("test", h)
+
+    def test_blocking_succeeds_when_released(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("test", max_holders=1)
+        assert h is not None
+        result_holder: list[str | None] = []
+
+        def release_later() -> None:
+            time.sleep(0.02)
+            sem.release("test", h)
+
+        t = threading.Thread(target=release_later)
+        t.start()
+
+        hid = sem.acquire("test", max_holders=1, timeout_ms=500)
+        result_holder.append(hid)
+        t.join()
+
+        assert result_holder[0] is not None
+        sem.release("test", result_holder[0])
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_max_holders_one_acts_as_mutex(self, sem: VFSSemaphoreProtocol) -> None:
+        h1 = sem.acquire("mutex", max_holders=1)
+        assert h1 is not None
+        assert sem.acquire("mutex", max_holders=1, timeout_ms=0) is None
+        sem.release("mutex", h1)
+
+        h2 = sem.acquire("mutex", max_holders=1)
+        assert h2 is not None
+        sem.release("mutex", h2)
+
+    def test_multiple_independent_semaphores(self, sem: VFSSemaphoreProtocol) -> None:
+        ha = sem.acquire("a", max_holders=1)
+        hb = sem.acquire("b", max_holders=1)
+        assert ha is not None
+        assert hb is not None
+        assert sem.active_semaphores == 2
+        sem.release("a", ha)
+        sem.release("b", hb)
+
+    def test_empty_cleanup(self, sem: VFSSemaphoreProtocol) -> None:
+        h = sem.acquire("temp", max_holders=1)
+        assert h is not None
+        assert sem.active_semaphores == 1
+        sem.release("temp", h)
+        assert sem.active_semaphores == 0
+
+
+# ---------------------------------------------------------------------------
+# Factory function
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_create_returns_protocol(self) -> None:
+        s = create_vfs_semaphore()
+        assert isinstance(s, VFSSemaphoreProtocol)
+
+    def test_factory_functional(self) -> None:
+        s = create_vfs_semaphore()
+        h = s.acquire("test", max_holders=1)
+        assert h is not None
+        assert s.release("test", h)


### PR DESCRIPTION
## Summary
- Add `VFSSemaphore` as local kernel counting semaphore — Phase 1 of `lock-architecture.md`
- Rust PyO3 implementation (~200ns) with Python fallback (~500ns), matching `VFSLockManager` pattern
- Semantics identical to `RaftLockManager.acquire(max_holders=N)`: SSOT max_holders, UUID holder IDs, TTL expiry, ownership verification

## Files
| File | Action |
|------|--------|
| `src/nexus/core/semaphore.py` | **New** — VFSSemaphoreProtocol + PythonVFSSemaphore + RustVFSSemaphore + factory |
| `rust/nexus_pyo3/src/semaphore.rs` | **New** — Rust implementation (21 unit tests) |
| `rust/nexus_pyo3/src/lib.rs` | **Edit** — `mod semaphore` + class registration |
| `rust/nexus_pyo3/Cargo.toml` | **Edit** — added `uuid` crate |
| `tests/unit/core/test_vfs_semaphore.py` | **New** — 36 parametrized tests (Python + Rust) |

## Design Decisions
- **Location: `core/`** not `lib/` — kernel primitive used by kernel itself; services use `contracts/protocols/` 
- **Returns `str | None`** — matches Raft semaphore (UUID holder_id), not int handle
- **No hierarchical path awareness** — semaphores are name-addressed, not path-addressed
- **SSOT enforcement** — first acquirer sets max_holders; mismatch → ValueError
- **Lazy TTL expiry** — expired holders evicted on next acquire (same as Raft)

## Test plan
- [x] Rust unit tests: `cargo test -- semaphore` (21 passed)
- [x] Python parametrized tests: `pytest test_vfs_semaphore.py` (72 passed — 36×2 impls)
- [x] Existing lock tests: `pytest test_vfs_lock_manager.py` (62 passed, no regression)
- [x] Ruff lint + mypy: all passed
- [x] Pre-commit hooks: all passed

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)