### PR TITLE
feat(#909): LocalLockManager + two-lock architecture

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -143,8 +143,7 @@ See `ops-scenario-matrix.md` for full Ops-Scenario affinity proof.
 | `VFSRouterProtocol` | VFS `lookup_slow()` | Path resolution only — mount CRUD lives in Service `MountProtocol` |
 | `ObjectStoreABC` (= `Backend`) | `struct file_operations` | Blob I/O interface (read/write/delete/list) |
 | `CacheStoreABC` | (no direct analogue) | Ephemeral KV + Pub/Sub primitives |
-| `VFSLockManagerProtocol` | per-inode `i_rwsem` | Path-level RW lock — mandatory in sys_read/sys_write (see `lock-architecture.md`) |
-| `VFSSemaphoreProtocol` | `struct semaphore` | Holder-tracked counting semaphore — local counterpart to Raft semaphore |
+| `VFSLockManagerProtocol` | per-inode `i_rwsem` | Path-level RW lock — mandatory I/O serialization in sys_read/sys_write |
 | `PipeManagerProtocol` | `pipe(2)` + `fs/pipe.c` | Named pipe lifecycle + MPMC data path (see §6 Kernel Tier) |
 | VFS dispatch | `file->f_op` + `security_hook_heads` + `fsnotify` | Three-phase dispatch at VFS operation points (see §3 VFS Dispatch) |
 
@@ -154,12 +153,12 @@ between VFS and storage. Without it, the kernel cannot describe files.
 `VFSLockManager` (`core/lock_fast.py`) provides rwsem semantics with hierarchical
 ancestor/descendant conflict detection. Rust-accelerated (PyO3), Python fallback.
 Wired into sys_read (shared) / sys_write (exclusive) for mandatory I/O serialization.
-Distinct from service-layer advisory locking (LockProtocol / `ops-scenario-matrix.md` S9).
+~200ns, in-memory, process-scoped (crash → released). Metadata-invisible.
 
-`VFSSemaphore` (`core/semaphore.py`, satisfies `VFSSemaphoreProtocol`) provides
-holder-tracked counting semaphore with TTL expiry — local kernel counterpart to
-RaftLockManager's `max_holders > 1` mode. Both primitives are routed transparently
-via `lib/lock.py` (local or distributed). See `lock-architecture.md`.
+**Advisory locks** are a separate concern — user/service coordination (task queues,
+turn-taking). Advisory locks are *metadata* stored in MetastoreABC (redb), with TTL
+expiry, queryable via `LockManagerProtocol`. Factory injects `LocalLockManager`
+(standalone) or `RaftLockManager` (federation). See `lock-architecture.md` §4.
 
 ### NexusFS — Syscall Dispatch Layer
 

--- a/docs/architecture/lock-architecture.md
+++ b/docs/architecture/lock-architecture.md
@@ -166,90 +166,66 @@ under single mutex. Lazy TTL expiry on acquire.
 
 ---
 
-## 4. Routing: Kernel Primitive + Conditional Driver
+## 4. Two-Lock Architecture (revised)
 
-### 4.1 Linux VFS Lock Analogy
+Through architecture review, the original LockRouter plan was rejected.
+Key insight: advisory locks and I/O locks are **fundamentally different concerns**.
+
+### 4.1 Why No Router
+
+1. **Writes converge**: In all deployment modes (standalone, REMOTE, federation),
+   writes to the same path converge to a single process. VFSLockManager
+   (in-memory, ~200ns) is sufficient for I/O serialization.
+2. **Advisory locks ARE metadata**: Like HDFS leases in the NameNode's
+   FSImage+EditLog, advisory locks should live in the metastore — visible,
+   queryable, Raft-replicated in federation, persistent with TTL cleanup.
+3. **Factory DI suffices**: `factory.py` injects `LocalLockManager` (standalone)
+   or `RaftLockManager` (federation). Both implement `LockManagerProtocol`.
+   No runtime routing needed.
+
+### 4.2 Two Locks
 
 ```
-Linux:   flock(fd, LOCK_EX)  →  VFS (fs/locks.c)  →  ext4: local    / NFS: → lockd/NLM
-Nexus:   lib.lock.lock(path) →  _LockRouter        →  VFSLock: local / Raft: → consensus
-                                  (always present)     (always)         (conditional)
+┌──────────────────────────────────────┬──────────────────────────────────────┐
+│  I/O Lock (core/)                    │  Advisory Lock (metastore)           │
+├──────────────────────────────────────┼──────────────────────────────────────┤
+│  VFSLockManager — in-memory HashMap  │  MetastoreABC.acquire_lock() — redb │
+│  ~200ns, sync, handle-based          │  ~5μs standalone / ~ms Raft         │
+│  Process-scoped (crash → released)   │  TTL-based (expire → released)      │
+│  Kernel-internal (sys_read/write)    │  User/service-facing (coordination) │
+│  Metadata-invisible                  │  Metadata-visible, queryable        │
+└──────────────────────────────────────┴──────────────────────────────────────┘
 ```
 
-Key properties borrowed from Linux:
-- **User code is the same** regardless of backend — `lock("/path")` everywhere
-- **Distributed driver is conditionally loaded** — only when Raft service is installed
-  AND node has joined a zone (like lockd only when NFS is mounted)
-- **Never silent downgrade** — if caller expects distributed and it's unavailable,
-  error (like Linux `ENOLCK`), don't silently give local lock
+**Fingerprint**: Advisory locks require `ttl > 0` (mandatory, prevents orphans).
+I/O locks have no TTL (kernel manages lifecycle in try/finally).
 
-### 4.2 Routing Rules
-
-| Scenario | Behavior |
-|----------|----------|
-| `lock("/path")`, no Raft | Local. Caller made no distributed claim. |
-| `lock("/path")`, Raft available | Distributed. Best available consistency. |
-| `force_local=True` | Always local. Caller explicitly chose local scope. |
-| `force_distributed=True`, Raft available | Distributed. |
-| `force_distributed=True`, **no Raft** | **`ServiceUnavailableError`** (like `ENOLCK`). |
-
-**Never silent downgrade**: two nodes each holding "local exclusive lock" = no actual
-mutual exclusion. Worse than failing. Same code transparently upgrades when Raft is
-added later — user code unchanged.
+**Restart behavior**: Advisory locks survive in redb. Dead holders stop renewing →
+TTL expires → auto-released. No orphans.
 
 ### 4.3 DI Model
 
-Distributed path is **DI'd at boot by factory.py**, not user-managed:
-
 ```python
 # factory.py (pseudo-code)
-vfs_lock = create_vfs_lock_manager()         # always
-vfs_sem = VFSSemaphore()                      # always
-distributed = RaftLockManager(raft_store) if raft_store else None  # conditional
-configure_locks(local_lock=vfs_lock, local_sem=vfs_sem, distributed=distributed)
+if metastore.supports_locks:
+    if dist.enable_locks:
+        lock_manager = RaftLockManager(metadata_store)   # federation
+    else:
+        lock_manager = LocalLockManager(metadata_store)  # standalone
 ```
 
-Pattern: kernel primitives always present, distributed driver conditionally loaded via DI.
-Same pattern as all other Nexus subsystems (metastore, event bus, etc.).
+| Profile | Metastore | lock_manager → |
+|---------|-----------|----------------|
+| minimal / embedded | redb (supports_locks=True) | LocalLockManager |
+| lite / full | redb (supports_locks=True) | LocalLockManager |
+| cloud / federation | redb + Raft (supports_locks=True) | RaftLockManager |
+| remote | RemoteMetastore (supports_locks=False) | None (server-side) |
 
-### 4.4 Mode Matrix
-
-| Profile | Raft | lock() → | sem_acquire() → |
-|---------|------|----------|----------------|
-| kernel / embedded / lite | No | VFSLockManager | VFSSemaphore |
-| full | Optional | Auto-detect | Auto-detect |
-| cloud / federation | Yes | RaftLockManager | RaftLockManager |
-
-### 4.5 Unlock Routing Registry
-
-`_registry[lock_id] = "local" | "distributed"` — set on acquire, looked up on release,
-cleaned up on release. Prevents cross-backend confusion. Leaked entries: distributed
-expire via TTL; local are process-scoped (lost on crash anyway).
-
-### 4.6 Semaphore → Raft Mapping
-
-Semaphore names map to reserved VFS namespace for Raft:
-`sem_acquire("upload_slots", max_holders=5)` →
-`RaftLockManager.acquire(zone_id, "/__sem__/upload_slots", max_holders=5)`.
-Reuses existing Raft lock infra, zero new wire protocol.
+Callers see only `LockManagerProtocol`. Same async API regardless of backend.
 
 ---
 
-## 5. Migration Path
-
-| Phase | What | Test |
-|-------|------|------|
-| 1 | `core/semaphore.py` — VFSSemaphore (Rust + Python fallback) | SSOT, TTL, concurrent holders |
-| 2 | `lib/lock.py` — _LockRouter + unified API | Mock backends, routing logic |
-| 3 | Wire VFSLockManager into sys_read/sys_write | Concurrent R/W race tests |
-| 4 | EventsService delegates to lib/lock.py, deprecate PassthroughBackend.lock() | Existing E2E passes |
-| 5 | SemaphoreProtocol in contracts/ | Protocol conformance |
-| 6 | REST API routes through lib/lock.py | Existing REST E2E passes |
-| 7 | factory.py wires configure_locks() | Per-profile integration tests |
-
----
-
-## 6. Summary
+## 5. Summary
 
 | Primitive | Location | Latency | Visibility | TTL | Scope |
 |-----------|----------|---------|------------|-----|-------|
@@ -261,26 +237,23 @@ Reuses existing Raft lock infra, zero new wire protocol.
 
 ---
 
-## 7. Design Decisions
+## 6. Design Decisions
 
-**D1: VFSSemaphore mirrors Raft semaphore exactly** — same SSOT, TTL, ownership.
-Users write code once, routing is transparent across deployment profiles.
+**D1: Two locks, not one** — I/O lock (VFSLockManager, kernel-internal, ~200ns) and
+advisory lock (MetastoreABC, user-facing, TTL-based) are fundamentally different.
+Like Linux `i_rwsem` vs `flock(2)`.
 
-**D2: Separate RW lock and semaphore** — different invariants (hierarchical path RW
-vs named counting). Linux keeps `i_rwsem` / `struct semaphore` separate for same reason.
+**D2: Advisory locks are metadata** — stored in MetastoreABC (redb), queryable,
+Raft-replicated in federation. Like HDFS leases in NameNode FSImage+EditLog.
 
-**D3: lib/lock.py routes, doesn't implement** — thin router. Logic in kernel primitives
-(core/) or distributed driver (raft/). Follows lib = libc, core = kernel pattern.
+**D3: Factory DI, not runtime routing** — `LocalLockManager` or `RaftLockManager`
+injected at boot. No `_LockRouter`, no runtime auto-detect. Simpler, testable.
 
 **D4: PassthroughBackend.lock() deprecated** — duplicates kernel lock logic.
-EventsService migrates to `lib.lock.lock()`.
+EventsService should migrate to `LockManagerProtocol`.
 
-**D5: asyncio.Semaphore stays as-is** — internal concurrency limiters (not VFS
-semaphores). No names, TTL, or cross-node semantics needed. Lighter weight for
-purely local ephemeral use.
+**D5: asyncio.Semaphore stays as-is** — internal concurrency limiters (not advisory
+locks). No names, TTL, or cross-node semantics needed.
 
-**D6: Kernel lock mandatory, user lock advisory** — sys_read/sys_write always
-acquire VFSLockManager. lib/lock.py is cooperative like `flock(2)`.
-
-**D7: Never silent downgrade distributed → local** — `force_distributed=True` without
-Raft raises `ServiceUnavailableError`. Default (no force) auto-detects best available.
+**D6: Kernel lock mandatory, advisory lock cooperative** — sys_read/sys_write always
+acquire VFSLockManager. Advisory locks are cooperative like `flock(2)`.

--- a/src/nexus/factory/_bricks.py
+++ b/src/nexus/factory/_bricks.py
@@ -324,15 +324,29 @@ def _boot_independent_bricks(
     lock_manager: Any = None
     if not _on("ipc"):
         logger.debug("[BOOT:BRICK] IPC/EventBus brick disabled by profile")
-    elif ctx.dist.enable_locks or ctx.dist.enable_events:
-        from nexus.factory._distributed import _create_distributed_infra
+    else:
+        # Event bus requires explicit dist config
+        if ctx.dist.enable_locks or ctx.dist.enable_events:
+            from nexus.factory._distributed import _create_distributed_infra
 
-        event_bus, lock_manager = _create_distributed_infra(
-            ctx.dist,
-            ctx.metadata_store,
-            ctx.record_store,
-            ctx.dist.coordination_url,
-        )
+            event_bus, lock_manager = _create_distributed_infra(
+                ctx.dist,
+                ctx.metadata_store,
+                ctx.record_store,
+                ctx.dist.coordination_url,
+            )
+
+        # Always create lock manager if metastore satisfies LockStoreProtocol
+        # (standalone → LocalLockManager, Raft → RaftLockManager already created above)
+        if lock_manager is None:
+            try:
+                from nexus.lib.distributed_lock import LocalLockManager, LockStoreProtocol
+
+                if isinstance(ctx.metadata_store, LockStoreProtocol):
+                    lock_manager = LocalLockManager(ctx.metadata_store)
+                    logger.info("Local lock manager initialized (standalone, LockStoreProtocol)")
+            except Exception as _lm_exc:
+                logger.debug("[BOOT:BRICK] LocalLockManager unavailable: %s", _lm_exc)
 
     # --- Workflow engine ---
     workflow_engine: Any = None

--- a/src/nexus/lib/distributed_lock.py
+++ b/src/nexus/lib/distributed_lock.py
@@ -1,21 +1,28 @@
-"""Distributed lock manager interface (ABCs and Protocols).
+"""Advisory lock manager — ABCs, Protocols, and LocalLockManager.
 
-This module provides the lock manager abstractions for coordinating
-access to resources across multiple Nexus nodes.
+Advisory locks are *metadata* — visible, queryable, TTL-based.
+Used for user/service coordination (task queues, turn-taking, resource
+contention).  Distinct from kernel I/O locks (VFSLockManager, ~200ns,
+in-memory, process-scoped).
 
 Architecture:
-- LockManagerProtocol: Abstract interface for lock manager
-- LockManagerBase: Abstract base class with common functionality
+- LockStoreProtocol: Low-level store interface (MetastoreABC lock methods)
+- LockManagerProtocol / LockManagerBase: Async user-facing lock API
+- LocalLockManager: Standalone mode — wraps MetastoreABC (this file)
+- RaftLockManager: Federation mode — wraps RaftMetadataStore (raft/)
 
-Concrete implementations live outside core/:
-- ``nexus.raft.lock_manager.RaftLockManager``: Raft consensus locks
+Factory.py injects LocalLockManager (standalone) or RaftLockManager
+(federation).  Callers see only LockManagerProtocol.
 
 References:
+    - docs/architecture/lock-architecture.md
     - docs/architecture/federation-memo.md §6.9
-    - docs/architecture/KERNEL-ARCHITECTURE.md §3
 """
 
+import asyncio
 import logging
+import time
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol, runtime_checkable
@@ -334,3 +341,142 @@ class LockManagerBase(ABC):
     async def health_check(self) -> bool:
         """Check if the lock manager is healthy."""
         pass
+
+
+# =============================================================================
+# Concrete: LocalLockManager (standalone mode)
+# =============================================================================
+
+
+class LocalLockManager(LockManagerBase):
+    """Advisory lock manager for standalone mode (no Raft).
+
+    Wraps MetastoreABC's lock methods with async interface + retry.
+    Same LockManagerProtocol as RaftLockManager — callers don't know
+    the difference.  Factory.py injects this when Raft is not enabled.
+
+    Differences from RaftLockManager:
+    - Fixed retry interval (50ms) instead of exponential backoff
+      (local redb is ~5μs, no network jitter to absorb)
+    - Uses time.monotonic() instead of asyncio loop time
+    - No Raft consensus overhead
+    """
+
+    RETRY_INTERVAL = 0.05  # 50ms between retries (local store is fast)
+
+    def __init__(self, store: LockStoreProtocol) -> None:
+        self._store = store
+
+    def _lock_key(self, zone_id: str, path: str) -> str:
+        return f"{zone_id}:{path}"
+
+    def _parse_lock_key(self, lock_key: str) -> tuple[str, str]:
+        zone_id, _, path = lock_key.partition(":")
+        return zone_id, path
+
+    def _store_info_to_lock_info(self, store_info: dict[str, Any]) -> LockInfo:
+        """Convert store-level lock info dict to a LockInfo dataclass."""
+        lock_key = store_info["path"]
+        _, resource_path = self._parse_lock_key(lock_key)
+        max_holders = store_info["max_holders"]
+        holders = [
+            HolderInfo(
+                lock_id=h["lock_id"],
+                holder_info=h.get("holder_info", ""),
+                acquired_at=float(h.get("acquired_at", 0)),
+                expires_at=float(h.get("expires_at", 0)),
+            )
+            for h in store_info.get("holders", [])
+        ]
+        return LockInfo(
+            path=resource_path,
+            mode="mutex" if max_holders == 1 else "semaphore",
+            max_holders=max_holders,
+            holders=holders,
+            fence_token=store_info.get("fence_token", 0),
+        )
+
+    async def acquire(
+        self,
+        zone_id: str,
+        path: str,
+        timeout: float = LockManagerBase.DEFAULT_TIMEOUT,
+        ttl: float = LockManagerBase.DEFAULT_TTL,
+        max_holders: int = 1,
+    ) -> str | None:
+        if max_holders < 1:
+            raise ValueError(f"max_holders must be >= 1, got {max_holders}")
+
+        lock_key = self._lock_key(zone_id, path)
+        holder_id = str(uuid.uuid4())
+        ttl_secs = max(1, int(ttl))
+
+        # First attempt
+        if self._store.acquire_lock(
+            lock_key, holder_id, max_holders=max_holders, ttl_secs=ttl_secs
+        ):
+            logger.debug("Local lock acquired: %s -> %s", lock_key, holder_id)
+            return holder_id
+
+        if timeout <= 0:
+            return None
+
+        # Retry loop with fixed interval
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            await asyncio.sleep(min(self.RETRY_INTERVAL, deadline - time.monotonic()))
+            if self._store.acquire_lock(
+                lock_key, holder_id, max_holders=max_holders, ttl_secs=ttl_secs
+            ):
+                logger.debug("Local lock acquired: %s -> %s", lock_key, holder_id)
+                return holder_id
+
+        logger.debug("Local lock acquisition timeout: %s", lock_key)
+        return None
+
+    async def release(self, lock_id: str, zone_id: str, path: str) -> bool:
+        lock_key = self._lock_key(zone_id, path)
+        released = self._store.release_lock(lock_key, lock_id)
+        if released:
+            logger.debug("Local lock released: %s", lock_key)
+        return released
+
+    async def extend(
+        self,
+        lock_id: str,
+        zone_id: str,
+        path: str,
+        ttl: float = LockManagerBase.DEFAULT_TTL,
+    ) -> ExtendResult:
+        lock_key = self._lock_key(zone_id, path)
+        ttl_secs = max(1, int(ttl))
+        success = self._store.extend_lock(lock_key, lock_id, ttl_secs)
+        if not success:
+            return ExtendResult(success=False)
+        lock_info = await self.get_lock_info(zone_id, path)
+        return ExtendResult(success=True, lock_info=lock_info)
+
+    async def get_lock_info(self, zone_id: str, path: str) -> LockInfo | None:
+        lock_key = self._lock_key(zone_id, path)
+        store_info = self._store.get_lock_info(lock_key)
+        if store_info is None:
+            return None
+        return self._store_info_to_lock_info(store_info)
+
+    async def list_locks(self, zone_id: str, pattern: str = "", limit: int = 100) -> list[LockInfo]:
+        prefix = f"{zone_id}:"
+        store_locks = self._store.list_locks(prefix=prefix, limit=limit)
+        results = [self._store_info_to_lock_info(info) for info in store_locks]
+        if pattern:
+            results = [r for r in results if pattern in r.path]
+        return results
+
+    async def force_release(self, zone_id: str, path: str) -> bool:
+        lock_key = self._lock_key(zone_id, path)
+        released = self._store.force_release_lock(lock_key)
+        if released:
+            logger.debug("Local lock force-released: %s", lock_key)
+        return released
+
+    async def health_check(self) -> bool:
+        return True  # local store is always healthy

--- a/tests/unit/lib/test_local_lock_manager.py
+++ b/tests/unit/lib/test_local_lock_manager.py
@@ -1,0 +1,276 @@
+"""Unit tests for LocalLockManager (standalone advisory lock manager).
+
+Tests use a mock MetastoreABC with lock support — no real redb needed.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.lib.distributed_lock import ExtendResult, LocalLockManager
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_store(*, supports_locks: bool = True) -> MagicMock:
+    """Create a mock MetastoreABC with lock method stubs."""
+    store = MagicMock()
+    store.supports_locks = supports_locks
+    # Default: all lock ops succeed
+    store.acquire_lock.return_value = True
+    store.release_lock.return_value = True
+    store.extend_lock.return_value = True
+    store.force_release_lock.return_value = True
+    store.get_lock_info.return_value = None
+    store.list_locks.return_value = []
+    return store
+
+
+@pytest.fixture
+def store():
+    return _make_mock_store()
+
+
+@pytest.fixture
+def mgr(store):
+    return LocalLockManager(store)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acquire_release(mgr, store):
+    """acquire returns holder_id, release returns True."""
+    holder_id = await mgr.acquire("z1", "/file.txt")
+    assert holder_id is not None
+    assert isinstance(holder_id, str)
+    assert len(holder_id) == 36  # UUID format
+
+    store.acquire_lock.assert_called_once()
+    call_args = store.acquire_lock.call_args
+    assert call_args[0][0] == "z1:/file.txt"  # lock_key
+    assert call_args[0][1] == holder_id  # holder_id
+
+    released = await mgr.release(holder_id, "z1", "/file.txt")
+    assert released is True
+    store.release_lock.assert_called_once_with("z1:/file.txt", holder_id)
+
+
+@pytest.mark.asyncio
+async def test_acquire_timeout_zero(mgr, store):
+    """acquire with timeout=0 returns None on contention."""
+    store.acquire_lock.return_value = False
+
+    result = await mgr.acquire("z1", "/busy", timeout=0)
+    assert result is None
+    store.acquire_lock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_acquire_retry_succeeds(mgr, store):
+    """acquire retries until success within timeout."""
+    # Fail twice, succeed on third attempt
+    store.acquire_lock.side_effect = [False, False, True]
+
+    holder_id = await mgr.acquire("z1", "/contested", timeout=1.0)
+    assert holder_id is not None
+    assert store.acquire_lock.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_acquire_retry_timeout(mgr, store):
+    """acquire returns None when timeout expires during retries."""
+    store.acquire_lock.return_value = False
+
+    t0 = time.monotonic()
+    result = await mgr.acquire("z1", "/held", timeout=0.15)
+    elapsed = time.monotonic() - t0
+
+    assert result is None
+    assert elapsed >= 0.1  # at least a couple retries at 50ms
+    assert store.acquire_lock.call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_extend(mgr, store):
+    """extend delegates to store, returns ExtendResult."""
+    store.extend_lock.return_value = True
+    store.get_lock_info.return_value = {
+        "path": "z1:/file.txt",
+        "max_holders": 1,
+        "holders": [
+            {
+                "lock_id": "abc",
+                "holder_info": "",
+                "acquired_at": 1000.0,
+                "expires_at": 1060.0,
+            }
+        ],
+    }
+
+    result = await mgr.extend("abc", "z1", "/file.txt", ttl=60.0)
+    assert isinstance(result, ExtendResult)
+    assert result.success is True
+    assert result.lock_info is not None
+    assert result.lock_info.path == "/file.txt"
+
+    store.extend_lock.assert_called_once_with("z1:/file.txt", "abc", 60)
+
+
+@pytest.mark.asyncio
+async def test_extend_failure(mgr, store):
+    """extend returns success=False when store rejects."""
+    store.extend_lock.return_value = False
+
+    result = await mgr.extend("bad-id", "z1", "/file.txt")
+    assert result.success is False
+    assert result.lock_info is None
+
+
+@pytest.mark.asyncio
+async def test_release_unknown(mgr, store):
+    """release unknown lock_id returns False."""
+    store.release_lock.return_value = False
+    released = await mgr.release("nonexistent", "z1", "/file.txt")
+    assert released is False
+
+
+@pytest.mark.asyncio
+async def test_semaphore_mode(mgr, store):
+    """acquire with max_holders>1 passes through to store."""
+    holder_id = await mgr.acquire("z1", "/slots", max_holders=5)
+    assert holder_id is not None
+
+    call_kwargs = store.acquire_lock.call_args[1]
+    assert call_kwargs["max_holders"] == 5
+
+
+@pytest.mark.asyncio
+async def test_lock_key_format(mgr, store):
+    """lock key is {zone_id}:{path}."""
+    await mgr.acquire("zone-abc", "/deep/path/file.txt")
+    lock_key = store.acquire_lock.call_args[0][0]
+    assert lock_key == "zone-abc:/deep/path/file.txt"
+
+
+@pytest.mark.asyncio
+async def test_health_check(mgr):
+    """health_check always returns True for local store."""
+    assert await mgr.health_check() is True
+
+
+@pytest.mark.asyncio
+async def test_force_release(mgr, store):
+    """force_release delegates to store."""
+    store.force_release_lock.return_value = True
+    result = await mgr.force_release("z1", "/locked")
+    assert result is True
+    store.force_release_lock.assert_called_once_with("z1:/locked")
+
+
+@pytest.mark.asyncio
+async def test_force_release_no_lock(mgr, store):
+    """force_release returns False when no lock exists."""
+    store.force_release_lock.return_value = False
+    result = await mgr.force_release("z1", "/not-locked")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_ttl_enforced_minimum(mgr, store):
+    """ttl is always >= 1 second (prevents zero/negative TTL)."""
+    await mgr.acquire("z1", "/file.txt", ttl=0.1)
+    call_kwargs = store.acquire_lock.call_args[1]
+    assert call_kwargs["ttl_secs"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_get_lock_info_none(mgr, store):
+    """get_lock_info returns None when not locked."""
+    store.get_lock_info.return_value = None
+    info = await mgr.get_lock_info("z1", "/file.txt")
+    assert info is None
+
+
+@pytest.mark.asyncio
+async def test_get_lock_info_with_data(mgr, store):
+    """get_lock_info converts store dict to LockInfo."""
+    store.get_lock_info.return_value = {
+        "path": "z1:/file.txt",
+        "max_holders": 1,
+        "holders": [
+            {
+                "lock_id": "h1",
+                "holder_info": "test",
+                "acquired_at": 1000.0,
+                "expires_at": 1030.0,
+            }
+        ],
+    }
+    info = await mgr.get_lock_info("z1", "/file.txt")
+    assert info is not None
+    assert info.path == "/file.txt"
+    assert info.mode == "mutex"
+    assert len(info.holders) == 1
+    assert info.holders[0].lock_id == "h1"
+
+
+@pytest.mark.asyncio
+async def test_get_lock_info_semaphore(mgr, store):
+    """get_lock_info reports mode='semaphore' when max_holders>1."""
+    store.get_lock_info.return_value = {
+        "path": "z1:/slots",
+        "max_holders": 3,
+        "holders": [],
+    }
+    info = await mgr.get_lock_info("z1", "/slots")
+    assert info is not None
+    assert info.mode == "semaphore"
+
+
+@pytest.mark.asyncio
+async def test_list_locks_empty(mgr, store):
+    """list_locks returns empty list when no locks."""
+    store.list_locks.return_value = []
+    locks = await mgr.list_locks("z1")
+    assert locks == []
+    store.list_locks.assert_called_once_with(prefix="z1:", limit=100)
+
+
+@pytest.mark.asyncio
+async def test_list_locks_with_pattern(mgr, store):
+    """list_locks filters by pattern."""
+    store.list_locks.return_value = [
+        {"path": "z1:/a/file.txt", "max_holders": 1, "holders": []},
+        {"path": "z1:/b/other.txt", "max_holders": 1, "holders": []},
+    ]
+    locks = await mgr.list_locks("z1", pattern="/a/")
+    assert len(locks) == 1
+    assert locks[0].path == "/a/file.txt"
+
+
+@pytest.mark.asyncio
+async def test_is_locked(mgr, store):
+    """is_locked delegates to get_lock_info (inherited from LockManagerBase)."""
+    store.get_lock_info.return_value = None
+    assert await mgr.is_locked("z1", "/file.txt") is False
+
+    store.get_lock_info.return_value = {
+        "path": "z1:/file.txt",
+        "max_holders": 1,
+        "holders": [{"lock_id": "h1", "acquired_at": 0, "expires_at": 0}],
+    }
+    assert await mgr.is_locked("z1", "/file.txt") is True
+
+
+@pytest.mark.asyncio
+async def test_max_holders_validation(mgr):
+    """max_holders < 1 raises ValueError."""
+    with pytest.raises(ValueError, match="max_holders must be >= 1"):
+        await mgr.acquire("z1", "/file.txt", max_holders=0)


### PR DESCRIPTION
## Summary
- Add `LocalLockManager(LockManagerBase)` for standalone mode — wraps `LockStoreProtocol` with async retry, same API as `RaftLockManager`
- Factory always creates lock manager when metastore satisfies `LockStoreProtocol` (not just when `dist.enable_locks`)
- Docs: rewrite lock-architecture.md §4 with two-lock model, remove LockRouter concept
- Architecture decision: advisory locks stay on `LockStoreProtocol`, NOT on `MetastoreABC` — different interface concern

## Architecture
```
I/O Lock (core/)                     Advisory Lock (metastore)
VFSLockManager — in-memory HashMap   LockStoreProtocol — redb
~200ns, sync, handle-based           ~5μs standalone / ~ms Raft
Process-scoped (crash → released)    TTL-based (expire → released)
Kernel-internal (sys_read/write)     User/service-facing (coordination)
NO CHANGES                           THIS PR
```

## Test plan
- [x] 20 new unit tests for LocalLockManager (all pass)
- [x] 2209 existing unit/core tests pass (0 regression)
- [x] 64 existing unit/lib tests pass (0 regression)
- [x] ruff check + ruff format + mypy all pass
- [ ] CI green

Closes #909 (Phase 2)
Refs #908, #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)