### PR TITLE
refactor(#1381): extract service routing from kernel to factory

### DIFF
--- a/src/nexus/bricks/filesystem/scoped_filesystem.py
+++ b/src/nexus/bricks/filesystem/scoped_filesystem.py
@@ -206,7 +206,7 @@ class ScopedFilesystem(ScopedPathMixin):
 
     def glob(self, pattern: str, path: str = "/", context: Any = None) -> builtins.list[str]:
         """Find files matching a glob pattern."""
-        result = self._fs.glob(pattern, self._scope_path(path), context)
+        result = cast(Any, self._fs).glob(pattern, self._scope_path(path), context)
         return self._unscope_paths(result)
 
     def grep(
@@ -220,7 +220,7 @@ class ScopedFilesystem(ScopedPathMixin):
         context: Any = None,
     ) -> builtins.list[dict[str, Any]]:
         """Search file contents using regex patterns."""
-        result = self._fs.grep(
+        result = cast(Any, self._fs).grep(
             pattern,
             self._scope_path(path),
             file_pattern,

--- a/src/nexus/bricks/llm/llm_document_reader.py
+++ b/src/nexus/bricks/llm/llm_document_reader.py
@@ -132,7 +132,7 @@ class LLMDocumentReader:
 
         # If not using search, read document directly
         if not use_search:
-            file_paths = self.nx.glob(path, context=context) if "*" in path else [path]
+            file_paths = cast(Any, self.nx).glob(path, context=context) if "*" in path else [path]
 
             for file_path in file_paths[:search_limit]:
                 try:

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -659,7 +659,7 @@ def create_mcp_server(
             To find all Python files: nexus_glob("**/*.py", "/workspace")
             With pagination: nexus_glob("**/*.py", "/workspace", limit=50, offset=0)
         """
-        nx_instance = _get_nexus_instance(ctx)
+        nx_instance: Any = _get_nexus_instance(ctx)
         all_matches = nx_instance.glob(pattern, path)
         total = len(all_matches)
 
@@ -726,7 +726,7 @@ def create_mcp_server(
             To get first 50 matches: nexus_grep("TODO", "/workspace", limit=50)
             To get next 50 matches: nexus_grep("TODO", "/workspace", limit=50, offset=50)
         """
-        nx_instance = _get_nexus_instance(ctx)
+        nx_instance: Any = _get_nexus_instance(ctx)
         all_results = nx_instance.grep(pattern, path, ignore_case=ignore_case)
         total = len(all_results)
 

--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -337,28 +337,3 @@ class NexusFilesystemABC(ABC):
     ) -> builtins.list[dict[str, Any]]:
         """Write multiple files. Default: N × write()."""
         return [self.write(p, c, context=context) for p, c in files]
-
-    # ── Search (requires service override) ────────────────────────
-
-    def glob(self, pattern: str, path: str = "/", context: Any = None) -> builtins.list[str]:
-        """Find files matching a glob pattern (like glob(3)).
-
-        Requires SearchService. Override in NexusFS.
-        """
-        raise NotImplementedError("Override in NexusFS (requires SearchService)")
-
-    def grep(
-        self,
-        pattern: str,
-        path: str = "/",
-        file_pattern: str | None = None,
-        ignore_case: bool = False,
-        max_results: int = 1000,
-        search_mode: str = "auto",
-        context: Any = None,
-    ) -> builtins.list[dict[str, Any]]:
-        """Search file contents using regex patterns (like grep(1)).
-
-        Requires SearchService. Override in NexusFS.
-        """
-        raise NotImplementedError("Override in NexusFS (requires SearchService)")

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -28,7 +28,6 @@ from nexus.core.config import (
     ParseConfig,
     PermissionConfig,
     SystemServices,
-    WiredServices,
 )
 from nexus.core.file_events import FileEvent, FileEventType
 from nexus.core.hash_fast import hash_content
@@ -239,58 +238,8 @@ class NexusFS(  # type: ignore[misc]
 
         self._dispatch: KernelDispatch = KernelDispatch()
 
-    def _bind_wired_services(self, wired: WiredServices | dict[str, Any]) -> None:
-        """Bind wired services from factory two-phase init.
-
-        Args:
-            wired: WiredServices dataclass (from _boot_wired_services).
-                   Also accepts dict for backward compatibility with tests.
-
-        Issue #2133: Accepts WiredServices frozen dataclass.
-        """
-        if isinstance(wired, dict):
-            # Backward compat for tests that pass a dict
-            self.rebac_service = wired.get("rebac_service")
-            self.mount_service = wired.get("mount_service")
-            self._gateway = wired.get("gateway")
-            self._mount_core_service = wired.get("mount_core_service")
-            self._sync_service = wired.get("sync_service")
-            self._sync_job_service = wired.get("sync_job_service")
-            self._mount_persist_service = wired.get("mount_persist_service")
-            self.mcp_service = wired.get("mcp_service")
-            self.llm_service = wired.get("llm_service")
-            self.oauth_service = wired.get("oauth_service")
-            self.search_service = wired.get("search_service")
-            self.share_link_service = wired.get("share_link_service")
-            self.events_service = wired.get("events_service")
-            self._workspace_rpc_service = wired.get("workspace_rpc_service")
-            self._agent_rpc_service = wired.get("agent_rpc_service")
-            self._user_provisioning_service = wired.get("user_provisioning_service")
-            self._sandbox_rpc_service = wired.get("sandbox_rpc_service")
-            self._metadata_export_service = wired.get("metadata_export_service")
-            self._descendant_checker = wired.get("descendant_checker")
-            self._memory_provider = wired.get("memory_provider")
-            return
-        self.rebac_service = wired.rebac_service
-        self.mount_service = wired.mount_service
-        self._gateway = wired.gateway
-        self._mount_core_service = wired.mount_core_service
-        self._sync_service = wired.sync_service
-        self._sync_job_service = wired.sync_job_service
-        self._mount_persist_service = wired.mount_persist_service
-        self.mcp_service = wired.mcp_service
-        self.llm_service = wired.llm_service
-        self.oauth_service = wired.oauth_service
-        self.search_service = wired.search_service
-        self.share_link_service = wired.share_link_service
-        self.events_service = wired.events_service
-        self._workspace_rpc_service = wired.workspace_rpc_service
-        self._agent_rpc_service = wired.agent_rpc_service
-        self._user_provisioning_service = wired.user_provisioning_service
-        self._sandbox_rpc_service = wired.sandbox_rpc_service
-        self._metadata_export_service = wired.metadata_export_service
-        self._descendant_checker = wired.descendant_checker
-        self._memory_provider = wired.memory_provider
+    # Services wired by factory via bind_wired_services() (Issue #1381).
+    # See nexus.factory.service_routing.bind_wired_services().
 
     @property
     def _service_extras(self) -> dict[str, Any]:
@@ -4043,168 +3992,18 @@ class NexusFS(  # type: ignore[misc]
     # Generated dynamically below via _rebac_delegate().
     # ------------------------------------------------------------------
 
-    # Service forwarding: __getattr__ routes method calls to services (Issue #2033)
-
-    _SERVICE_METHODS: dict[str, str] = {
-        # WorkspaceRPCService
-        "workspace_snapshot": "_workspace_rpc_service",
-        "workspace_restore": "_workspace_rpc_service",
-        "workspace_log": "_workspace_rpc_service",
-        "workspace_diff": "_workspace_rpc_service",
-        "snapshot_begin": "_workspace_rpc_service",
-        "snapshot_commit": "_workspace_rpc_service",
-        "snapshot_rollback": "_workspace_rpc_service",
-        "load_workspace_memory_config": "_workspace_rpc_service",
-        "register_workspace": "_workspace_rpc_service",
-        "unregister_workspace": "_workspace_rpc_service",
-        "update_workspace": "_workspace_rpc_service",
-        "list_workspaces": "_workspace_rpc_service",
-        "get_workspace_info": "_workspace_rpc_service",
-        "register_memory": "_workspace_rpc_service",
-        "unregister_memory": "_workspace_rpc_service",
-        "list_registered_memories": "_workspace_rpc_service",
-        "get_memory_info": "_workspace_rpc_service",
-        # AgentRPCService
-        "register_agent": "_agent_rpc_service",
-        "update_agent": "_agent_rpc_service",
-        "list_agents": "_agent_rpc_service",
-        "get_agent": "_agent_rpc_service",
-        "delete_agent": "_agent_rpc_service",
-        # UserProvisioningService
-        "provision_user": "_user_provisioning_service",
-        "deprovision_user": "_user_provisioning_service",
-        # SandboxRPCService
-        "sandbox_create": "_sandbox_rpc_service",
-        "sandbox_run": "_sandbox_rpc_service",
-        "sandbox_validate": "_sandbox_rpc_service",
-        "sandbox_pause": "_sandbox_rpc_service",
-        "sandbox_resume": "_sandbox_rpc_service",
-        "sandbox_stop": "_sandbox_rpc_service",
-        "sandbox_list": "_sandbox_rpc_service",
-        "sandbox_status": "_sandbox_rpc_service",
-        "sandbox_get_or_create": "_sandbox_rpc_service",
-        "sandbox_connect": "_sandbox_rpc_service",
-        "sandbox_disconnect": "_sandbox_rpc_service",
-        # MetadataExportService
-        "export_metadata": "_metadata_export_service",
-        "import_metadata": "_metadata_export_service",
-        # MountCoreService
-        "add_mount": "_mount_core_service",
-        "remove_mount": "_mount_core_service",
-        "list_connectors": "_mount_core_service",
-        "list_mounts": "_mount_core_service",
-        "get_mount": "_mount_core_service",
-        "has_mount": "_mount_core_service",
-        # MountPersistService
-        "save_mount": "_mount_persist_service",
-        "list_saved_mounts": "_mount_persist_service",
-        "load_mount": "_mount_persist_service",
-        "delete_saved_mount": "_mount_persist_service",
-        # SearchService (list/glob/grep are thin forwarders, not __getattr__)
-        # asemantic_search* are in _SERVICE_ALIASES (name transformation: a-prefix removed)
-        "glob_batch": "search_service",
-        # MCPService
-        "mcp_list_mounts": "mcp_service",
-        # OAuthCredentialService — routed via _SERVICE_ALIASES (name differs)
-        # LLMService
-        "create_llm_reader": "llm_service",
-        # ReBACService direct methods (no _sync suffix)
-        "set_rebac_option": "rebac_service",
-        "get_rebac_option": "rebac_service",
-        "register_namespace": "rebac_service",
-        # EventsService (Issue #1166)
-        "wait_for_changes": "events_service",
-        "lock": "events_service",
-        "extend_lock": "events_service",
-        "unlock": "events_service",
-    }
-
-    # Special aliases where service method name differs
-    _SERVICE_ALIASES: dict[str, tuple[str, str]] = {
-        # OAuthCredentialService: RPC name → brick method name
-        "oauth_list_providers": ("oauth_service", "list_providers"),
-        "oauth_get_auth_url": ("oauth_service", "get_auth_url"),
-        "oauth_exchange_code": ("oauth_service", "exchange_code"),
-        "oauth_list_credentials": ("oauth_service", "list_credentials"),
-        "oauth_revoke_credential": ("oauth_service", "revoke_credential"),
-        "oauth_test_credential": ("oauth_service", "test_credential"),
-        "list_memories": ("_workspace_rpc_service", "list_registered_memories"),
-        "sandbox_available": ("_sandbox_rpc_service", "sandbox_available"),
-        "get_sync_job": ("_sync_job_service", "get_job"),
-        "list_sync_jobs": ("_sync_job_service", "list_jobs"),
-        "load_all_saved_mounts": ("_mount_persist_service", "load_all_mounts"),
-        # Dir visibility cache: NexusFS method names → cache method names
-        "get_dir_visibility_cache_metrics": ("_dir_visibility_cache", "get_metrics"),
-        "clear_dir_visibility_cache": ("_dir_visibility_cache", "clear"),
-        # SearchService async methods: a-prefix removed when calling service
-        "asemantic_search": ("search_service", "semantic_search"),
-        "asemantic_search_index": ("search_service", "semantic_search_index"),
-        "asemantic_search_stats": ("search_service", "semantic_search_stats"),
-        # SyncService / SyncJobService (Issue #2033)
-        "sync_mount": ("_sync_service", "sync_mount_flat"),
-        "sync_mount_async": ("_sync_job_service", "sync_mount_async"),
-        "cancel_sync_job": ("_sync_job_service", "cancel_sync_job"),
-        # VersionService async methods (Issue #2033)
-        "aget_version": ("version_service", "get_version"),
-        "alist_versions": ("version_service", "list_versions"),
-        "arollback": ("version_service", "rollback"),
-        "adiff_versions": ("version_service", "diff_versions"),
-        # ReBACService async methods (Issue #2033)
-        "arebac_create": ("rebac_service", "rebac_create"),
-        "arebac_delete": ("rebac_service", "rebac_delete"),
-        "arebac_check": ("rebac_service", "rebac_check"),
-        "arebac_check_batch": ("rebac_service", "rebac_check_batch"),
-        "arebac_expand": ("rebac_service", "rebac_expand"),
-        "arebac_explain": ("rebac_service", "rebac_explain"),
-        "arebac_list_tuples": ("rebac_service", "rebac_list_tuples"),
-        "aget_namespace": ("rebac_service", "get_namespace"),
-        # ReBACService sync methods with _sync suffix (Issue #2033)
-        "rebac_create": ("rebac_service", "rebac_create_sync"),
-        "rebac_check": ("rebac_service", "rebac_check_sync"),
-        "rebac_check_batch": ("rebac_service", "rebac_check_batch_sync"),
-        "rebac_delete": ("rebac_service", "rebac_delete_sync"),
-        "rebac_list_tuples": ("rebac_service", "rebac_list_tuples_sync"),
-        "rebac_expand": ("rebac_service", "rebac_expand_sync"),
-        "rebac_explain": ("rebac_service", "rebac_explain_sync"),
-        "share_with_user": ("rebac_service", "share_with_user_sync"),
-        "share_with_group": ("rebac_service", "share_with_group_sync"),
-        "grant_consent": ("rebac_service", "grant_consent_sync"),
-        "revoke_consent": ("rebac_service", "revoke_consent_sync"),
-        "make_public": ("rebac_service", "make_public_sync"),
-        "make_private": ("rebac_service", "make_private_sync"),
-        "apply_dynamic_viewer_filter": ("rebac_service", "apply_dynamic_viewer_filter_sync"),
-        "list_outgoing_shares": ("rebac_service", "list_outgoing_shares_sync"),
-        "list_incoming_shares": ("rebac_service", "list_incoming_shares_sync"),
-        "get_dynamic_viewer_config": ("rebac_service", "get_dynamic_viewer_config_sync"),
-        "namespace_create": ("rebac_service", "namespace_create_sync"),
-        "namespace_delete": ("rebac_service", "namespace_delete_sync"),
-        "namespace_list": ("rebac_service", "namespace_list_sync"),
-        "get_namespace": ("rebac_service", "get_namespace_sync"),
-        # ReBACService direct methods (no _sync suffix)
-        "rebac_expand_with_privacy": ("rebac_service", "rebac_expand_with_privacy_sync"),
-    }
+    # Service forwarding: __getattr__ delegates to factory routing (Issue #1381)
 
     def __getattr__(self, name: str) -> Any:
-        """Forward extracted facade methods to their service objects.
+        """Forward service method calls via factory routing tables.
 
-        This enables callers to continue using nx.method_name() after
-        facade methods were removed from NexusFS (Issue #2033).
+        Routing tables live in nexus.factory.service_routing (Issue #1381).
         """
-        # Check aliases first (method name differs on service)
-        alias = NexusFS._SERVICE_ALIASES.get(name)
-        if alias is not None:
-            svc_attr, svc_method = alias
-            svc = self.__dict__.get(svc_attr)
-            if svc is not None:
-                return getattr(svc, svc_method)
+        from nexus.factory.service_routing import resolve_service_attr
 
-        # Standard forwarding (same method name on service)
-        svc_attr_std = NexusFS._SERVICE_METHODS.get(name)
-        if svc_attr_std is not None:
-            svc = self.__dict__.get(svc_attr_std)
-            if svc is not None:
-                return getattr(svc, name)
-
+        result = resolve_service_attr(self, name)
+        if result is not None:
+            return result
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     def _grant_mount_owner_permission(self, mount_point: str, context: Any | None) -> None:
@@ -4290,45 +4089,7 @@ class NexusFS(  # type: ignore[misc]
             return [{"path": e.path, "size": e.size, "etag": e.etag} for e in entries]
         return [e.path for e in entries]
 
-    def glob(self, pattern: str, path: str = "/", context: Any = None) -> builtins.list[str]:
-        return self.search_service.glob(pattern=pattern, path=path, context=context)
-
-    def grep(
-        self,
-        pattern: str,
-        path: str = "/",
-        file_pattern: str | None = None,
-        ignore_case: bool = False,
-        max_results: int = 100,
-        search_mode: str = "auto",
-        context: Any = None,
-    ) -> builtins.list[dict[str, Any]]:
-        return self.search_service.grep(
-            pattern=pattern,
-            path=path,
-            file_pattern=file_pattern,
-            ignore_case=ignore_case,
-            max_results=max_results,
-            search_mode=search_mode,
-            context=context,
-        )
-
-    @staticmethod
-    def _run_async(coro: Any) -> Any:
-        """Run async coroutine safely, handling both running and non-running event loops.
-
-        Uses the unified sync_bridge to avoid the ThreadPoolExecutor + asyncio.run()
-        anti-pattern (Issue #1300).
-
-        Args:
-            coro: Coroutine to run
-
-        Returns:
-            Result of the coroutine
-        """
-        from nexus.lib.sync_bridge import run_sync
-
-        return run_sync(coro)
+    # _run_async: replaced by direct run_sync() calls (Issue #1381)
 
     @rpc_expose(description="Backfill sparse directory index for fast listings", admin_only=True)
     def backfill_directory_index(
@@ -4359,24 +4120,28 @@ class NexusFS(  # type: ignore[misc]
         self, path: str, version: int, context: OperationContext | None = None
     ) -> bytes:
         """Get a specific version of a file."""
-        return cast(
-            bytes, NexusFS._run_async(self.version_service.get_version(path, version, context))
-        )
+        from nexus.lib.sync_bridge import run_sync
+
+        return cast(bytes, run_sync(self.version_service.get_version(path, version, context)))
 
     @rpc_expose(description="List file versions")
     def list_versions(
         self, path: str, context: OperationContext | None = None
     ) -> builtins.list[dict[str, Any]]:
         """List all versions of a file."""
+        from nexus.lib.sync_bridge import run_sync
+
         return cast(
             builtins.list[dict[str, Any]],
-            NexusFS._run_async(self.version_service.list_versions(path, context)),
+            run_sync(self.version_service.list_versions(path, context)),
         )
 
     @rpc_expose(description="Rollback file to previous version")
     def rollback(self, path: str, version: int, context: OperationContext | None = None) -> None:
         """Rollback file to a previous version."""
-        cast(None, NexusFS._run_async(self.version_service.rollback(path, version, context)))
+        from nexus.lib.sync_bridge import run_sync
+
+        cast(None, run_sync(self.version_service.rollback(path, version, context)))
 
     @rpc_expose(description="Compare file versions")
     def diff_versions(
@@ -4388,9 +4153,11 @@ class NexusFS(  # type: ignore[misc]
         context: OperationContext | None = None,
     ) -> dict[str, Any] | str:
         """Compare two versions of a file."""
+        from nexus.lib.sync_bridge import run_sync
+
         return cast(
             dict[str, Any] | str,
-            NexusFS._run_async(self.version_service.diff_versions(path, v1, v2, mode, context)),
+            run_sync(self.version_service.diff_versions(path, v1, v2, mode, context)),
         )
 
     def _get_subject_from_context(self, context: Any) -> tuple[str, str] | None:
@@ -4399,7 +4166,7 @@ class NexusFS(  # type: ignore[misc]
 
         return get_subject_from_context(context)
 
-    # sync_mount, sync_mount_async, cancel_sync_job → _SERVICE_ALIASES (Issue #2033)
+    # sync_mount, sync_mount_async, cancel_sync_job → SERVICE_ALIASES (Issue #2033)
     async def ainitialize_semantic_search(
         self,
         embedding_provider: str | None = None,

--- a/src/nexus/factory/_remote.py
+++ b/src/nexus/factory/_remote.py
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# All fields accepted by NexusFS._bind_wired_services() (dict path).
-# Derived from nexus_fs.py:290-326.
+# All fields accepted by bind_wired_services() (dict path).
+# Derived from nexus.factory.service_routing.bind_wired_services.
 _WIRED_FIELDS: list[str] = [
     # Services
     "rebac_service",
@@ -70,9 +70,11 @@ def _boot_remote_services(nfs: "NexusFS", call_rpc: Callable[..., Any]) -> None:
 
     proxy = RemoteServiceProxy(call_rpc, service_name="universal")
 
-    # Fill all wired service slots via _bind_wired_services (dict path)
+    # Fill all wired service slots via bind_wired_services (dict path)
+    from nexus.factory.service_routing import bind_wired_services
+
     wired_dict: dict[str, Any] = dict.fromkeys(_WIRED_FIELDS, proxy)
-    nfs._bind_wired_services(wired_dict)
+    bind_wired_services(nfs, wired_dict)
 
     # BrickServices field not covered by WiredServices
     nfs.version_service = proxy

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -429,7 +429,9 @@ def create_nexus_fs(
         return name in _resolved_bricks
 
     _wired = _boot_wired_services(nx, kernel_services, system_services, brick_services, _brick_on)
-    nx._bind_wired_services(_wired)
+    from nexus.factory.service_routing import bind_wired_services
+
+    bind_wired_services(nx, _wired)
     _mds = getattr(_wired, "metadata_export_service", None)
     if _mds is not None:
         cast(Any, nx)._metadata_export_service = _mds

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -1,0 +1,226 @@
+"""Service method routing tables — maps NexusFS method names to services.
+
+Extracted from core/nexus_fs.py (Issue #1381). The kernel has zero
+service knowledge; all routing lives in factory tier.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.core.config import WiredServices
+
+# ---------------------------------------------------------------------------
+# Routing tables (moved verbatim from NexusFS._SERVICE_METHODS / _SERVICE_ALIASES)
+# ---------------------------------------------------------------------------
+
+SERVICE_METHODS: dict[str, str] = {
+    # WorkspaceRPCService
+    "workspace_snapshot": "_workspace_rpc_service",
+    "workspace_restore": "_workspace_rpc_service",
+    "workspace_log": "_workspace_rpc_service",
+    "workspace_diff": "_workspace_rpc_service",
+    "snapshot_begin": "_workspace_rpc_service",
+    "snapshot_commit": "_workspace_rpc_service",
+    "snapshot_rollback": "_workspace_rpc_service",
+    "load_workspace_memory_config": "_workspace_rpc_service",
+    "register_workspace": "_workspace_rpc_service",
+    "unregister_workspace": "_workspace_rpc_service",
+    "update_workspace": "_workspace_rpc_service",
+    "list_workspaces": "_workspace_rpc_service",
+    "get_workspace_info": "_workspace_rpc_service",
+    "register_memory": "_workspace_rpc_service",
+    "unregister_memory": "_workspace_rpc_service",
+    "list_registered_memories": "_workspace_rpc_service",
+    "get_memory_info": "_workspace_rpc_service",
+    # AgentRPCService
+    "register_agent": "_agent_rpc_service",
+    "update_agent": "_agent_rpc_service",
+    "list_agents": "_agent_rpc_service",
+    "get_agent": "_agent_rpc_service",
+    "delete_agent": "_agent_rpc_service",
+    # UserProvisioningService
+    "provision_user": "_user_provisioning_service",
+    "deprovision_user": "_user_provisioning_service",
+    # SandboxRPCService
+    "sandbox_create": "_sandbox_rpc_service",
+    "sandbox_run": "_sandbox_rpc_service",
+    "sandbox_validate": "_sandbox_rpc_service",
+    "sandbox_pause": "_sandbox_rpc_service",
+    "sandbox_resume": "_sandbox_rpc_service",
+    "sandbox_stop": "_sandbox_rpc_service",
+    "sandbox_list": "_sandbox_rpc_service",
+    "sandbox_status": "_sandbox_rpc_service",
+    "sandbox_get_or_create": "_sandbox_rpc_service",
+    "sandbox_connect": "_sandbox_rpc_service",
+    "sandbox_disconnect": "_sandbox_rpc_service",
+    # MetadataExportService
+    "export_metadata": "_metadata_export_service",
+    "import_metadata": "_metadata_export_service",
+    # MountCoreService
+    "add_mount": "_mount_core_service",
+    "remove_mount": "_mount_core_service",
+    "list_connectors": "_mount_core_service",
+    "list_mounts": "_mount_core_service",
+    "get_mount": "_mount_core_service",
+    "has_mount": "_mount_core_service",
+    # MountPersistService
+    "save_mount": "_mount_persist_service",
+    "list_saved_mounts": "_mount_persist_service",
+    "load_mount": "_mount_persist_service",
+    "delete_saved_mount": "_mount_persist_service",
+    # SearchService (glob/grep are userspace tools, not syscalls — Issue #1381)
+    "glob": "search_service",
+    "grep": "search_service",
+    "glob_batch": "search_service",
+    # MCPService
+    "mcp_list_mounts": "mcp_service",
+    # LLMService
+    "create_llm_reader": "llm_service",
+    # ReBACService direct methods (no _sync suffix)
+    "set_rebac_option": "rebac_service",
+    "get_rebac_option": "rebac_service",
+    "register_namespace": "rebac_service",
+    # EventsService (Issue #1166)
+    "wait_for_changes": "events_service",
+    "lock": "events_service",
+    "extend_lock": "events_service",
+    "unlock": "events_service",
+}
+
+SERVICE_ALIASES: dict[str, tuple[str, str]] = {
+    # OAuthCredentialService: RPC name → brick method name
+    "oauth_list_providers": ("oauth_service", "list_providers"),
+    "oauth_get_auth_url": ("oauth_service", "get_auth_url"),
+    "oauth_exchange_code": ("oauth_service", "exchange_code"),
+    "oauth_list_credentials": ("oauth_service", "list_credentials"),
+    "oauth_revoke_credential": ("oauth_service", "revoke_credential"),
+    "oauth_test_credential": ("oauth_service", "test_credential"),
+    "list_memories": ("_workspace_rpc_service", "list_registered_memories"),
+    "sandbox_available": ("_sandbox_rpc_service", "sandbox_available"),
+    "get_sync_job": ("_sync_job_service", "get_job"),
+    "list_sync_jobs": ("_sync_job_service", "list_jobs"),
+    "load_all_saved_mounts": ("_mount_persist_service", "load_all_mounts"),
+    # Dir visibility cache: NexusFS method names → cache method names
+    "get_dir_visibility_cache_metrics": ("_dir_visibility_cache", "get_metrics"),
+    "clear_dir_visibility_cache": ("_dir_visibility_cache", "clear"),
+    # SearchService async methods: a-prefix removed when calling service
+    "asemantic_search": ("search_service", "semantic_search"),
+    "asemantic_search_index": ("search_service", "semantic_search_index"),
+    "asemantic_search_stats": ("search_service", "semantic_search_stats"),
+    # SyncService / SyncJobService (Issue #2033)
+    "sync_mount": ("_sync_service", "sync_mount_flat"),
+    "sync_mount_async": ("_sync_job_service", "sync_mount_async"),
+    "cancel_sync_job": ("_sync_job_service", "cancel_sync_job"),
+    # VersionService async methods (Issue #2033)
+    "aget_version": ("version_service", "get_version"),
+    "alist_versions": ("version_service", "list_versions"),
+    "arollback": ("version_service", "rollback"),
+    "adiff_versions": ("version_service", "diff_versions"),
+    # ReBACService async methods (Issue #2033)
+    "arebac_create": ("rebac_service", "rebac_create"),
+    "arebac_delete": ("rebac_service", "rebac_delete"),
+    "arebac_check": ("rebac_service", "rebac_check"),
+    "arebac_check_batch": ("rebac_service", "rebac_check_batch"),
+    "arebac_expand": ("rebac_service", "rebac_expand"),
+    "arebac_explain": ("rebac_service", "rebac_explain"),
+    "arebac_list_tuples": ("rebac_service", "rebac_list_tuples"),
+    "aget_namespace": ("rebac_service", "get_namespace"),
+    # ReBACService sync methods with _sync suffix (Issue #2033)
+    "rebac_create": ("rebac_service", "rebac_create_sync"),
+    "rebac_check": ("rebac_service", "rebac_check_sync"),
+    "rebac_check_batch": ("rebac_service", "rebac_check_batch_sync"),
+    "rebac_delete": ("rebac_service", "rebac_delete_sync"),
+    "rebac_list_tuples": ("rebac_service", "rebac_list_tuples_sync"),
+    "rebac_expand": ("rebac_service", "rebac_expand_sync"),
+    "rebac_explain": ("rebac_service", "rebac_explain_sync"),
+    "share_with_user": ("rebac_service", "share_with_user_sync"),
+    "share_with_group": ("rebac_service", "share_with_group_sync"),
+    "grant_consent": ("rebac_service", "grant_consent_sync"),
+    "revoke_consent": ("rebac_service", "revoke_consent_sync"),
+    "make_public": ("rebac_service", "make_public_sync"),
+    "make_private": ("rebac_service", "make_private_sync"),
+    "apply_dynamic_viewer_filter": ("rebac_service", "apply_dynamic_viewer_filter_sync"),
+    "list_outgoing_shares": ("rebac_service", "list_outgoing_shares_sync"),
+    "list_incoming_shares": ("rebac_service", "list_incoming_shares_sync"),
+    "get_dynamic_viewer_config": ("rebac_service", "get_dynamic_viewer_config_sync"),
+    "namespace_create": ("rebac_service", "namespace_create_sync"),
+    "namespace_delete": ("rebac_service", "namespace_delete_sync"),
+    "namespace_list": ("rebac_service", "namespace_list_sync"),
+    "get_namespace": ("rebac_service", "get_namespace_sync"),
+    # ReBACService direct methods (no _sync suffix)
+    "rebac_expand_with_privacy": ("rebac_service", "rebac_expand_with_privacy_sync"),
+}
+
+
+def resolve_service_attr(obj: object, name: str) -> Any | None:
+    """Resolve a service method by name.
+
+    Two-phase lookup: aliases first (method name differs on service),
+    then standard forwarding (same method name on service).
+
+    Returns the bound method, or None if not found.
+    """
+    alias = SERVICE_ALIASES.get(name)
+    if alias is not None:
+        svc_attr, svc_method = alias
+        svc = obj.__dict__.get(svc_attr)
+        if svc is not None:
+            return getattr(svc, svc_method)
+
+    svc_attr_std = SERVICE_METHODS.get(name)
+    if svc_attr_std is not None:
+        svc = obj.__dict__.get(svc_attr_std)
+        if svc is not None:
+            return getattr(svc, name)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# bind_wired_services — moved from NexusFS._bind_wired_services
+# ---------------------------------------------------------------------------
+
+
+def bind_wired_services(target: object, wired: "WiredServices | dict[str, Any]") -> None:
+    """Bind wired service instances onto *target* object.
+
+    Called by factory (orchestrator / _remote) after NexusFS construction.
+
+    Args:
+        target: The NexusFS instance (or any object with matching attrs).
+        wired: WiredServices dataclass (from _boot_wired_services).
+               Also accepts dict for backward compatibility with tests.
+
+    Issue #2133: Accepts WiredServices frozen dataclass.
+    Issue #1381: Extracted from NexusFS to factory tier.
+    """
+    _SLOT_MAP: dict[str, str] = {
+        "rebac_service": "rebac_service",
+        "mount_service": "mount_service",
+        "gateway": "_gateway",
+        "mount_core_service": "_mount_core_service",
+        "sync_service": "_sync_service",
+        "sync_job_service": "_sync_job_service",
+        "mount_persist_service": "_mount_persist_service",
+        "mcp_service": "mcp_service",
+        "llm_service": "llm_service",
+        "oauth_service": "oauth_service",
+        "search_service": "search_service",
+        "share_link_service": "share_link_service",
+        "events_service": "events_service",
+        "workspace_rpc_service": "_workspace_rpc_service",
+        "agent_rpc_service": "_agent_rpc_service",
+        "user_provisioning_service": "_user_provisioning_service",
+        "sandbox_rpc_service": "_sandbox_rpc_service",
+        "metadata_export_service": "_metadata_export_service",
+        "descendant_checker": "_descendant_checker",
+        "memory_provider": "_memory_provider",
+    }
+    if isinstance(wired, dict):
+        for src_key, target_attr in _SLOT_MAP.items():
+            setattr(target, target_attr, wired.get(src_key))
+        return
+    for src_key, target_attr in _SLOT_MAP.items():
+        setattr(target, target_attr, getattr(wired, src_key))

--- a/tests/e2e/self_contained/test_validation_rpc_dispatch.py
+++ b/tests/e2e/self_contained/test_validation_rpc_dispatch.py
@@ -26,11 +26,10 @@ class TestSandboxValidateDispatch:
 
     def test_sandbox_validate_in_service_methods(self):
         """sandbox_validate is dispatched via _sandbox_rpc_service, not METHOD_PARAMS."""
-        from nexus.core.nexus_fs import NexusFS
+        from nexus.factory.service_routing import SERVICE_METHODS
 
-        dispatch = NexusFS._SERVICE_METHODS
-        assert "sandbox_validate" in dispatch
-        assert dispatch["sandbox_validate"] == "_sandbox_rpc_service"
+        assert "sandbox_validate" in SERVICE_METHODS
+        assert SERVICE_METHODS["sandbox_validate"] == "_sandbox_rpc_service"
 
 
 class TestValidationResultSerialization:

--- a/tests/integration/core/test_cold_start.py
+++ b/tests/integration/core/test_cold_start.py
@@ -62,19 +62,16 @@ class TestColdStartNexusFSConstruction:
     """Verify NexusFS can be constructed without factory (test mode)."""
 
     def test_nexus_fs_minimal_construction(self) -> None:
-        """NexusFS should construct with just backend + metadata_store."""
+        """NexusFS should construct with just metadata_store."""
         from unittest.mock import MagicMock
 
         from nexus.core.config import ParseConfig
         from nexus.core.nexus_fs import NexusFS
 
-        mock_backend = MagicMock()
-        mock_backend.content_cache = None
         mock_metadata = MagicMock()
         mock_metadata.list = MagicMock(return_value=[])
 
         nx = NexusFS(
-            backend=mock_backend,
             metadata_store=mock_metadata,
             parsing=ParseConfig(auto_parse=False),
         )
@@ -85,24 +82,22 @@ class TestColdStartNexusFSConstruction:
         assert nx.mcp_service is None
 
     def test_wired_services_can_be_bound(self) -> None:
-        """_bind_wired_services should accept WiredServices dataclass."""
+        """bind_wired_services should accept WiredServices dataclass."""
         from unittest.mock import MagicMock
 
         from nexus.core.config import ParseConfig, WiredServices
         from nexus.core.nexus_fs import NexusFS
+        from nexus.factory.service_routing import bind_wired_services
 
-        mock_backend = MagicMock()
-        mock_backend.content_cache = None
         mock_metadata = MagicMock()
         mock_metadata.list = MagicMock(return_value=[])
 
         nx = NexusFS(
-            backend=mock_backend,
             metadata_store=mock_metadata,
             parsing=ParseConfig(auto_parse=False),
         )
 
         mock_svc = MagicMock()
         ws = WiredServices(rebac_service=mock_svc)
-        nx._bind_wired_services(ws)
+        bind_wired_services(nx, ws)
         assert nx.rebac_service is mock_svc

--- a/tests/unit/core/test_nexus_fs_delegation.py
+++ b/tests/unit/core/test_nexus_fs_delegation.py
@@ -129,14 +129,12 @@ class TestSearchServiceDelegation:
         )
 
     def test_glob_delegates(self, mock_fs, context):
-        """glob forwards pattern, path, context."""
+        """glob forwards pattern, path, context via __getattr__ pass-through."""
         matches = ["/data/test.py"]
         mock_fs.search_service.glob = MagicMock(return_value=matches)
         result = mock_fs.glob("*.py", path="/data", context=context)
         assert result == matches
-        mock_fs.search_service.glob.assert_called_once_with(
-            pattern="*.py", path="/data", context=context
-        )
+        mock_fs.search_service.glob.assert_called_once_with("*.py", path="/data", context=context)
 
     def test_glob_batch_delegates(self, mock_fs, context):
         """glob_batch forwards patterns, path, context."""
@@ -146,7 +144,7 @@ class TestSearchServiceDelegation:
         assert result == batch
 
     def test_grep_delegates(self, mock_fs, context):
-        """grep forwards all args."""
+        """grep forwards all args via __getattr__ pass-through."""
         results = [{"path": "/a.py", "line": 1, "match": "import os"}]
         mock_fs.search_service.grep = MagicMock(return_value=results)
         result = mock_fs.grep(
@@ -157,12 +155,9 @@ class TestSearchServiceDelegation:
         )
         assert result == results
         mock_fs.search_service.grep.assert_called_once_with(
-            pattern="import os",
+            "import os",
             path="/src",
-            file_pattern=None,
             ignore_case=True,
-            max_results=100,
-            search_mode="auto",
             context=context,
         )
 

--- a/tests/unit/factory/test_service_routing.py
+++ b/tests/unit/factory/test_service_routing.py
@@ -1,0 +1,77 @@
+"""Tests for factory service routing tables (Issue #1381)."""
+
+from unittest.mock import MagicMock
+
+from nexus.factory.service_routing import (
+    SERVICE_ALIASES,
+    SERVICE_METHODS,
+    resolve_service_attr,
+)
+
+
+class TestResolveServiceAttr:
+    """Test resolve_service_attr two-phase lookup."""
+
+    def test_standard_forwarding(self) -> None:
+        """SERVICE_METHODS: same method name on service."""
+        obj = MagicMock()
+        obj.__dict__["_workspace_rpc_service"] = svc = MagicMock()
+        svc.workspace_snapshot = lambda: "snap"
+
+        result = resolve_service_attr(obj, "workspace_snapshot")
+        assert result is svc.workspace_snapshot
+
+    def test_alias_forwarding(self) -> None:
+        """SERVICE_ALIASES: method name differs on service."""
+        obj = MagicMock()
+        obj.__dict__["oauth_service"] = svc = MagicMock()
+        svc.list_providers = lambda: ["google"]
+
+        result = resolve_service_attr(obj, "oauth_list_providers")
+        assert result is svc.list_providers
+
+    def test_unknown_attr_returns_none(self) -> None:
+        obj = MagicMock()
+        assert resolve_service_attr(obj, "totally_unknown_method") is None
+
+    def test_service_not_wired_returns_none(self) -> None:
+        """Known method but service attr is None / missing → None."""
+        obj = MagicMock()
+        obj.__dict__.clear()
+        assert resolve_service_attr(obj, "workspace_snapshot") is None
+
+    def test_alias_takes_precedence(self) -> None:
+        """If a name is in both ALIASES and METHODS, alias wins."""
+        # "get_namespace" is in both — alias should be checked first
+        obj = MagicMock()
+        obj.__dict__["rebac_service"] = svc = MagicMock()
+        svc.get_namespace_sync = lambda: "aliased"
+
+        result = resolve_service_attr(obj, "get_namespace")
+        assert result is svc.get_namespace_sync
+
+    def test_glob_routed_via_methods(self) -> None:
+        """glob is a userspace tool routed via SERVICE_METHODS."""
+        assert SERVICE_METHODS["glob"] == "search_service"
+        obj = MagicMock()
+        obj.__dict__["search_service"] = svc = MagicMock()
+        result = resolve_service_attr(obj, "glob")
+        assert result is svc.glob
+
+    def test_grep_routed_via_methods(self) -> None:
+        """grep is a userspace tool routed via SERVICE_METHODS."""
+        assert SERVICE_METHODS["grep"] == "search_service"
+        obj = MagicMock()
+        obj.__dict__["search_service"] = svc = MagicMock()
+        result = resolve_service_attr(obj, "grep")
+        assert result is svc.grep
+
+
+class TestRoutingTableCompleteness:
+    """Sanity checks for the routing tables."""
+
+    def test_service_methods_non_empty(self) -> None:
+        assert len(SERVICE_METHODS) >= 57
+
+    def test_service_aliases_non_empty(self) -> None:
+        assert len(SERVICE_ALIASES) >= 53

--- a/tests/unit/factory/test_wired_services.py
+++ b/tests/unit/factory/test_wired_services.py
@@ -1,4 +1,4 @@
-"""Tests for WiredServices dataclass and _boot_wired_services typing (Issue #2133)."""
+"""Tests for WiredServices dataclass and bind_wired_services (Issue #2133, #1381)."""
 
 import dataclasses
 from typing import Any
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.core.config import WiredServices
+from nexus.factory.service_routing import bind_wired_services
 
 
 class TestWiredServicesDataclass:
@@ -40,8 +41,8 @@ class TestWiredServicesDataclass:
         assert len(dataclasses.fields(WiredServices)) == 22
 
 
-class TestNexusFSBindWiredServices:
-    """Test NexusFS._bind_wired_services accepts both WiredServices and dict."""
+class TestBindWiredServices:
+    """Test bind_wired_services accepts both WiredServices and dict."""
 
     @pytest.fixture()
     def nx(self) -> Any:
@@ -62,14 +63,14 @@ class TestNexusFSBindWiredServices:
     def test_bind_wired_services_dataclass(self, nx: Any) -> None:
         mock_svc = MagicMock()
         ws = WiredServices(rebac_service=mock_svc, mount_service=mock_svc)
-        nx._bind_wired_services(ws)
+        bind_wired_services(nx, ws)
         assert nx.rebac_service is mock_svc
         assert nx.mount_service is mock_svc
         assert nx.mcp_service is None
 
     def test_bind_wired_services_dict(self, nx: Any) -> None:
         mock_svc = MagicMock()
-        nx._bind_wired_services({"rebac_service": mock_svc, "mount_service": mock_svc})
+        bind_wired_services(nx, {"rebac_service": mock_svc, "mount_service": mock_svc})
         assert nx.rebac_service is mock_svc
         assert nx.mount_service is mock_svc
         assert nx.mcp_service is None

--- a/tests/unit/remote/test_service_proxy.py
+++ b/tests/unit/remote/test_service_proxy.py
@@ -128,47 +128,46 @@ class TestBootRemoteServices:
 
     def test_wires_all_service_slots(self):
         """_boot_remote_services fills all wired service slots with proxy."""
-        from unittest.mock import MagicMock
+        from unittest.mock import MagicMock, patch
 
         from nexus.factory._remote import _WIRED_FIELDS, _boot_remote_services
         from nexus.remote.service_proxy import RemoteServiceProxy
 
-        # Create a mock NexusFS with _bind_wired_services
         nfs = MagicMock()
-        nfs._bind_wired_services = MagicMock()
 
         _, call_rpc = _make_recorder()
-        _boot_remote_services(nfs, call_rpc)
+        with patch("nexus.factory.service_routing.bind_wired_services") as mock_bind:
+            _boot_remote_services(nfs, call_rpc)
 
-        # _bind_wired_services was called with a dict covering all fields
-        nfs._bind_wired_services.assert_called_once()
-        wired_dict = nfs._bind_wired_services.call_args[0][0]
-
-        assert isinstance(wired_dict, dict)
-        for field in _WIRED_FIELDS:
-            assert field in wired_dict
-            assert isinstance(wired_dict[field], RemoteServiceProxy)
+            # bind_wired_services was called with nfs and a dict covering all fields
+            mock_bind.assert_called_once()
+            target, wired_dict = mock_bind.call_args[0]
+            assert target is nfs
+            assert isinstance(wired_dict, dict)
+            for field in _WIRED_FIELDS:
+                assert field in wired_dict
+                assert isinstance(wired_dict[field], RemoteServiceProxy)
 
         # version_service also set
         assert isinstance(nfs.version_service, RemoteServiceProxy)
 
     def test_all_slots_are_same_proxy_instance(self):
         """All slots share one proxy instance (universal pass-through)."""
-        from unittest.mock import MagicMock
+        from unittest.mock import MagicMock, patch
 
         from nexus.factory._remote import _boot_remote_services
 
         nfs = MagicMock()
-        nfs._bind_wired_services = MagicMock()
 
         _, call_rpc = _make_recorder()
-        _boot_remote_services(nfs, call_rpc)
+        with patch("nexus.factory.service_routing.bind_wired_services") as mock_bind:
+            _boot_remote_services(nfs, call_rpc)
 
-        wired_dict = nfs._bind_wired_services.call_args[0][0]
-        proxies = list(wired_dict.values())
+            wired_dict = mock_bind.call_args[0][1]
+            proxies = list(wired_dict.values())
 
-        # All values should be the same object
-        assert all(p is proxies[0] for p in proxies)
+            # All values should be the same object
+            assert all(p is proxies[0] for p in proxies)
 
 
 # ---------------------------------------------------------------------------
@@ -180,9 +179,9 @@ class TestServiceMethodsEventEntries:
     """Verify event/locking methods are in the dispatch table."""
 
     def test_event_methods_registered(self):
-        """lock, unlock, extend_lock, wait_for_changes are in _SERVICE_METHODS."""
-        from nexus.core.nexus_fs import NexusFS
+        """lock, unlock, extend_lock, wait_for_changes are in SERVICE_METHODS."""
+        from nexus.factory.service_routing import SERVICE_METHODS
 
         for method in ("lock", "unlock", "extend_lock", "wait_for_changes"):
-            assert method in NexusFS._SERVICE_METHODS, f"{method} missing from _SERVICE_METHODS"
-            assert NexusFS._SERVICE_METHODS[method] == "events_service"
+            assert method in SERVICE_METHODS, f"{method} missing from SERVICE_METHODS"
+            assert SERVICE_METHODS[method] == "events_service"


### PR DESCRIPTION
## Summary
- Move `_SERVICE_METHODS`, `_SERVICE_ALIASES`, `__getattr__`, `_bind_wired_services`, `_run_async` from `nexus_fs.py` to new `factory/service_routing.py` (~280 lines removed from kernel)
- Remove `glob`/`grep` from `NexusFilesystemABC` (userspace tools, not syscalls) and route via `SERVICE_METHODS` -> `search_service`
- Replace `type:ignore` comments in `bind_wired_services` with `setattr()` loop
- Simplify `NexusFS.__getattr__` to 5-line delegator

## Test plan
- [x] 128 unit/integration/e2e tests pass
- [x] Pre-commit hooks pass (ruff, mypy, type-ignore check, brick zero-core-imports)
- [x] RPC handlers (handle_glob/handle_grep) still work via `__getattr__` routing
- [x] ScopedFilesystem.glob/grep works via `__getattr__` on NexusFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)