### PR TITLE
fix: replace print() with logger in backends (slack, gmail, gdrive)

### DIFF
--- a/src/nexus/backends/gdrive_connector.py
+++ b/src/nexus/backends/gdrive_connector.py
@@ -185,7 +185,7 @@ class GoogleDriveConnectorBackend(Backend):
             For multi-user production, leave user_email=None to auto-detect from context.
             This ensures each user accesses their own Drive.
         """
-        print(f"[GDRIVE-INIT] __init__ called: user_email={user_email}, provider={provider}")
+        logger.info("GDrive __init__: user_email=%s, provider=%s", user_email, provider)
 
         # Import TokenManager here to avoid circular imports
         # Support both file paths and database URLs
@@ -219,10 +219,7 @@ class GoogleDriveConnectorBackend(Backend):
 
     def _register_oauth_provider(self) -> None:
         """Register OAuth provider with TokenManager using OAuthProviderFactory."""
-        import logging
         import traceback
-
-        logger = logging.getLogger(__name__)
 
         try:
             import importlib as _il_oauth
@@ -241,21 +238,18 @@ class GoogleDriveConnectorBackend(Backend):
                 )
                 # Register with TokenManager using the provider name from config
                 self.token_manager.register_provider(self.provider, provider_instance)
-                logger.info(
-                    f"✓ Registered OAuth provider '{self.provider}' for Google Drive backend"
-                )
-                print(f"[GDRIVE-INIT] ✓ Registered OAuth provider '{self.provider}' from config")
+                logger.info("Registered OAuth provider '%s' from config", self.provider)
             except ValueError as e:
                 # Provider not found in config or credentials not set
                 logger.warning(
-                    f"OAuth provider '{self.provider}' not available: {e}. "
-                    "OAuth flow must be initiated manually via the Integrations page."
+                    "OAuth provider '%s' not available: %s. "
+                    "OAuth flow must be initiated manually via the Integrations page.",
+                    self.provider,
+                    e,
                 )
-                print(f"[GDRIVE-INIT] ⚠ OAuth provider '{self.provider}' not available: {e}")
         except Exception as e:
             error_msg = f"Failed to register OAuth provider: {e}\n{traceback.format_exc()}"
-            logger.error(error_msg)
-            print(f"[GDRIVE-INIT] ✗ {error_msg}")
+            logger.error("Failed to register OAuth provider: %s", error_msg)
 
     def check_connection(self, context: "OperationContext | None" = None) -> HandlerStatusResponse:
         """

--- a/src/nexus/backends/gmail_connector_utils.py
+++ b/src/nexus/backends/gmail_connector_utils.py
@@ -177,7 +177,7 @@ def list_emails_by_folder(
     # Priority 1: SENT emails
     if "SENT" in folders_to_fetch:
         if not silent and "SENT" in folder_filter:
-            print("📥 Fetching SENT emails...")
+            logger.info("Fetching SENT emails")
         sent_messages = fetch_with_labels(["SENT"], max_results)
         for msg in sent_messages:
             thread_id = msg["threadId"]
@@ -196,14 +196,16 @@ def list_emails_by_folder(
                 folder_stats["SENT"]["threads"].add(thread_id)
             seen_ids.add(message_id)
         if not silent and "SENT" in folder_filter:
-            print(
-                f"   Found {len(sent_messages)} SENT emails in {len(folder_stats['SENT']['threads'])} threads"
+            logger.info(
+                "Found %d SENT emails in %d threads",
+                len(sent_messages),
+                len(folder_stats["SENT"]["threads"]),
             )
 
     # Priority 2: STARRED in INBOX (excluding SENT)
     if "STARRED" in folders_to_fetch:
         if not silent and "STARRED" in folder_filter:
-            print("📥 Fetching STARRED + INBOX emails...")
+            logger.info("Fetching STARRED + INBOX emails")
         starred_messages = fetch_with_labels(["STARRED", "INBOX"], max_results)
         for msg in starred_messages:
             message_id = msg["id"]
@@ -223,14 +225,16 @@ def list_emails_by_folder(
                     folder_stats["STARRED"]["threads"].add(thread_id)
                 seen_ids.add(message_id)
         if not silent and "STARRED" in folder_filter:
-            print(
-                f"   Found {folder_stats['STARRED']['emails']} STARRED emails in {len(folder_stats['STARRED']['threads'])} threads (excluding SENT)"
+            logger.info(
+                "Found %d STARRED emails in %d threads (excluding SENT)",
+                folder_stats["STARRED"]["emails"],
+                len(folder_stats["STARRED"]["threads"]),
             )
 
     # Priority 3: IMPORTANT in INBOX (excluding SENT, STARRED)
     if "IMPORTANT" in folders_to_fetch:
         if not silent and "IMPORTANT" in folder_filter:
-            print("📥 Fetching IMPORTANT + INBOX emails...")
+            logger.info("Fetching IMPORTANT + INBOX emails")
         important_messages = fetch_with_labels(["IMPORTANT", "INBOX"], max_results)
         for msg in important_messages:
             message_id = msg["id"]
@@ -250,14 +254,16 @@ def list_emails_by_folder(
                     folder_stats["IMPORTANT"]["threads"].add(thread_id)
                 seen_ids.add(message_id)
         if not silent and "IMPORTANT" in folder_filter:
-            print(
-                f"   Found {folder_stats['IMPORTANT']['emails']} IMPORTANT emails in {len(folder_stats['IMPORTANT']['threads'])} threads (excluding SENT, STARRED)"
+            logger.info(
+                "Found %d IMPORTANT emails in %d threads (excluding SENT, STARRED)",
+                folder_stats["IMPORTANT"]["emails"],
+                len(folder_stats["IMPORTANT"]["threads"]),
             )
 
     # Priority 4: Remaining INBOX emails
     if "INBOX" in folders_to_fetch:
         if not silent and "INBOX" in folder_filter:
-            print("📥 Fetching remaining INBOX emails...")
+            logger.info("Fetching remaining INBOX emails")
         inbox_messages = fetch_with_labels(["INBOX"], max_results)
         for msg in inbox_messages:
             message_id = msg["id"]
@@ -277,18 +283,22 @@ def list_emails_by_folder(
                     folder_stats["INBOX"]["threads"].add(thread_id)
                 seen_ids.add(message_id)
         if not silent and "INBOX" in folder_filter:
-            print(
-                f"   Found {folder_stats['INBOX']['emails']} remaining INBOX emails in {len(folder_stats['INBOX']['threads'])} threads"
+            logger.info(
+                "Found %d remaining INBOX emails in %d threads",
+                folder_stats["INBOX"]["emails"],
+                len(folder_stats["INBOX"]["threads"]),
             )
 
     if not silent:
-        print(f"\n✅ Categorized {len(seen_ids)} total emails")
-
-        # Print summary
-        print("\n📋 Summary:")
+        logger.info("Categorized %d total emails", len(seen_ids))
         for folder in ["SENT", "STARRED", "IMPORTANT", "INBOX"]:
             stats = folder_stats[folder]
-            print(f"   {folder}: {stats['emails']} emails in {len(stats['threads'])} threads")
+            logger.info(
+                "  %s: %d emails in %d threads",
+                folder,
+                stats["emails"],
+                len(stats["threads"]),
+            )
 
     return all_emails
 
@@ -299,10 +309,6 @@ def print_folder_statistics(emails: list[dict[str, Any]]) -> None:
     Args:
         emails: List of email objects with folder and thread information
     """
-    print("\n" + "=" * 80)
-    print("FOLDER STATISTICS (GROUPED BY THREADS)")
-    print("=" * 80)
-
     # Group by folder
     folder_groups: dict[str, list[dict]] = {
         "SENT": [],
@@ -313,7 +319,7 @@ def print_folder_statistics(emails: list[dict[str, Any]]) -> None:
 
     for email in emails:
         folder = email.get("folder")
-        if folder in folder_groups:
+        if folder and folder in folder_groups:
             folder_groups[folder].append(email)
 
     total_emails = len(emails)
@@ -324,8 +330,11 @@ def print_folder_statistics(emails: list[dict[str, Any]]) -> None:
         for email in folder_emails:
             all_threads.add(email["threadId"])
 
-    print(f"\n📊 Total emails: {total_emails}")
-    print(f"\n📊 Total threads: {len(all_threads)}")
+    logger.info(
+        "Folder statistics: %d total emails, %d total threads",
+        total_emails,
+        len(all_threads),
+    )
 
     for folder in ["SENT", "STARRED", "IMPORTANT", "INBOX"]:
         folder_emails = folder_groups[folder]
@@ -337,17 +346,13 @@ def print_folder_statistics(emails: list[dict[str, Any]]) -> None:
 
         percentage = (num_emails / total_emails * 100) if total_emails > 0 else 0
 
-        print(f"\n📁 {folder}:")
-        print(f"   Emails: {num_emails} ({percentage:.1f}%)")
-        print(f"   Threads: {num_threads}")
-
-        # Show first 3 emails as samples
-        if folder_emails:
-            print("   Sample paths:")
-            for email in folder_emails[:5]:
-                print(f"      {email['path']}")
-            if num_emails > 5:
-                print(f"      ... and {num_emails - 5} more")
+        logger.info(
+            "  %s: %d emails (%.1f%%), %d threads",
+            folder,
+            num_emails,
+            percentage,
+            num_threads,
+        )
 
 
 def fetch_emails_batch(

--- a/src/nexus/backends/slack_connector_utils.py
+++ b/src/nexus/backends/slack_connector_utils.py
@@ -39,7 +39,7 @@ def list_channels(
         ]
     """
     if not silent:
-        print(f"📥 Fetching channels (types: {types})...")
+        logger.info("Fetching channels (types: %s)", types)
 
     channels = []
     cursor = None
@@ -99,7 +99,7 @@ def list_channels(
             break
 
     if not silent:
-        print(f"   Found {len(channels)} channels")
+        logger.info("Found %d channels", len(channels))
 
     return channels
 
@@ -141,7 +141,7 @@ def list_messages_from_channel(
         ]
     """
     if not silent:
-        print(f"📥 Fetching messages from #{channel_name}...")
+        logger.info("Fetching messages from #%s", channel_name)
 
     messages = []
     cursor = None
@@ -213,7 +213,7 @@ def list_messages_from_channel(
             break
 
     if not silent:
-        print(f"   Found {len(messages)} messages in #{channel_name}")
+        logger.info("Found %d messages in #%s", len(messages), channel_name)
 
     return messages
 
@@ -249,7 +249,7 @@ def list_thread_replies(
         messages = result.get("messages", [])
 
         if not silent and len(messages) > 1:
-            print(f"   Found {len(messages) - 1} replies in thread {thread_ts}")
+            logger.info("Found %d replies in thread %s", len(messages) - 1, thread_ts)
 
         return messages
 
@@ -369,26 +369,25 @@ def print_channel_statistics(
         channels: List of channel objects
         messages_by_channel: Dict mapping channel_id -> messages
     """
-    print("\n" + "=" * 80)
-    print("SLACK CHANNEL STATISTICS")
-    print("=" * 80)
-
     total_messages = sum(len(msgs) for msgs in messages_by_channel.values())
-    print(f"\n📊 Total channels: {len(channels)}")
-    print(f"📊 Total messages: {total_messages}")
 
     # Group by channel type
     public_channels = [c for c in channels if not c.get("is_private")]
     private_channels = [c for c in channels if c.get("is_private")]
 
-    print(f"\n📁 Public channels: {len(public_channels)}")
-    print(f"🔒 Private channels: {len(private_channels)}")
-
     # Top channels by message count
     channel_msg_counts = [(c, len(messages_by_channel.get(c["id"], []))) for c in channels]
     channel_msg_counts.sort(key=lambda x: x[1], reverse=True)
 
-    print("\n📈 Top channels by message count:")
-    for channel, count in channel_msg_counts[:10]:
-        channel_name = channel.get("name", channel["id"])
-        print(f"   #{channel_name}: {count} messages")
+    top_channels = ", ".join(
+        f"#{c.get('name', c['id'])}={count}" for c, count in channel_msg_counts[:10]
+    )
+
+    logger.info(
+        "Slack channel statistics: %d channels (%d public, %d private), %d total messages. Top: %s",
+        len(channels),
+        len(public_channels),
+        len(private_channels),
+        total_messages,
+        top_channels,
+    )


### PR DESCRIPTION
## Summary
- Replace ~30 `print()` calls with proper `logger.info`/`warning`/`error` in 3 backend connector files
- Clean up redundant local `import logging` / `logger = logging.getLogger(__name__)` in `gdrive_connector._register_oauth_provider()` (module-level logger already exists)
- Also converts `print_channel_statistics()` and `print_folder_statistics()` from multi-line `print()` output to structured `logger.info()` calls

## Files changed
- `src/nexus/backends/slack_connector_utils.py` — 6 print→logger
- `src/nexus/backends/gmail_connector_utils.py` — ~20 print→logger  
- `src/nexus/backends/gdrive_connector.py` — 4 print→logger + cleanup duplicates

## Test plan
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `mypy` passes (pre-commit hook)
- [x] No remaining `print()` calls in modified files