### PR TITLE
fix: extract pay data types to contracts/ — fix storage→bricks tier violation

### DIFF
--- a/src/nexus/bricks/pay/constants.py
+++ b/src/nexus/bricks/pay/constants.py
@@ -9,7 +9,15 @@ Related: Issue #1199 (Nexus Pay hybrid architecture)
 """
 
 import hashlib
-from decimal import Decimal
+
+# =============================================================================
+# Amount Conversion (re-exported from contracts/pay_types.py)
+# =============================================================================
+from nexus.contracts.pay_types import (  # noqa: F401
+    MICRO_UNIT_SCALE,
+    credits_to_micro,
+    micro_to_credits,
+)
 
 # =============================================================================
 # Ledger Codes
@@ -38,39 +46,6 @@ TRANSFER_CODE_REFUND = 6  # Refund/reversal
 # =============================================================================
 SYSTEM_TREASURY_TB_ID = 1
 ESCROW_ACCOUNT_TB_ID = 2
-
-# =============================================================================
-# Amount Conversion
-# =============================================================================
-# Credits are stored as integers in micro-units (6 decimal places)
-# Example: 1.0 credit = 1_000_000 micro-credits
-MICRO_UNIT_SCALE = 1_000_000
-
-
-def credits_to_micro(credits: Decimal | float | int) -> int:
-    """Convert credits to micro-credits (internal storage format).
-
-    Uses Decimal arithmetic internally to avoid float precision loss.
-
-    Args:
-        credits: Amount in credits (e.g., Decimal("1.5") or 1.5)
-
-    Returns:
-        Amount in micro-credits (e.g., 1_500_000)
-    """
-    return int(Decimal(str(credits)) * MICRO_UNIT_SCALE)
-
-
-def micro_to_credits(micro: int) -> Decimal:
-    """Convert micro-credits to credits (display format).
-
-    Args:
-        micro: Amount in micro-credits
-
-    Returns:
-        Amount in credits as Decimal.
-    """
-    return Decimal(str(micro)) / MICRO_UNIT_SCALE
 
 
 # =============================================================================

--- a/src/nexus/bricks/pay/spending_policy.py
+++ b/src/nexus/bricks/pay/spending_policy.py
@@ -16,12 +16,16 @@ Architecture:
 Default behavior: open by default (no policy = allow all transactions).
 """
 
-from dataclasses import dataclass, field
-from datetime import date, datetime
-from decimal import Decimal
-from typing import Any
-
 from nexus.bricks.pay.sdk import NexusPayError
+
+# Re-export pure data types from contracts tier so existing consumers
+# (within bricks/ and above) continue to work unchanged.
+from nexus.contracts.pay_types import (  # noqa: F401
+    PolicyEvaluation,
+    SpendingApproval,
+    SpendingLedgerEntry,
+    SpendingPolicy,
+)
 
 # =============================================================================
 # Exceptions
@@ -91,87 +95,14 @@ class SpendingRateLimitError(PolicyError):
         self.limit_type = limit_type
 
 
-# =============================================================================
-# Data Classes
-# =============================================================================
-
-
-@dataclass(frozen=True)
-class SpendingPolicy:
-    """Declarative spending policy for an agent or zone.
-
-    Resolution: agent-specific (highest priority) → zone default.
-    All limit amounts are in credits (Decimal), not micro-credits.
-
-    Fields with None mean "no limit for this period."
-    """
-
-    policy_id: str
-    zone_id: str
-    agent_id: str | None = None  # None = zone-level default
-    daily_limit: Decimal | None = None
-    weekly_limit: Decimal | None = None
-    monthly_limit: Decimal | None = None
-    per_tx_limit: Decimal | None = None
-    auto_approve_threshold: Decimal | None = None  # Phase 2: approval workflows
-    max_tx_per_hour: int | None = None  # Phase 3: rate controls
-    max_tx_per_day: int | None = None  # Phase 3: rate controls
-    rules: list[dict[str, Any]] | None = None  # Phase 4: policy DSL
-    priority: int = 0  # Higher value overrides lower
-    enabled: bool = True
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
-
-
-@dataclass(frozen=True)
-class SpendingLedgerEntry:
-    """Period-based spending counter for an agent.
-
-    One entry per (agent_id, zone_id, period_type, period_start).
-    Updated atomically via PostgreSQL UPSERT on each successful transfer.
-    """
-
-    agent_id: str
-    zone_id: str
-    period_type: str  # "daily" | "weekly" | "monthly"
-    period_start: date
-    amount_spent: Decimal = Decimal("0")
-    tx_count: int = 0
-
-
-@dataclass(frozen=True)
-class SpendingApproval:
-    """A pending or resolved approval for a transaction (Phase 2).
-
-    Created when a transaction exceeds the auto_approve_threshold.
-    An admin approves/rejects, then the agent retries with the approval_id.
-    """
-
-    approval_id: str
-    policy_id: str
-    agent_id: str
-    zone_id: str
-    amount: Decimal
-    to: str
-    memo: str = ""
-    status: str = "pending"  # pending | approved | rejected | expired
-    requested_at: datetime | None = None
-    decided_at: datetime | None = None
-    decided_by: str | None = None
-    expires_at: datetime | None = None
-
-
-@dataclass(frozen=True)
-class PolicyEvaluation:
-    """Result of evaluating a transaction against spending policies.
-
-    On denial, provides the specific reason and policy that blocked it.
-    On approval, optionally provides remaining budget information.
-    """
-
-    allowed: bool
-    denied_reason: str | None = None
-    policy_id: str | None = None
-    remaining_budget: dict[str, Decimal] = field(default_factory=dict)
-    requires_approval: bool = False  # Phase 2: needs admin approval
-    approval_id: str | None = None  # Phase 2: pending approval ID
+# Re-export __all__ so `from nexus.bricks.pay.spending_policy import *` works
+__all__ = [
+    "ApprovalRequiredError",
+    "PolicyDeniedError",
+    "PolicyError",
+    "PolicyEvaluation",
+    "SpendingApproval",
+    "SpendingLedgerEntry",
+    "SpendingPolicy",
+    "SpendingRateLimitError",
+]

--- a/src/nexus/contracts/pay_types.py
+++ b/src/nexus/contracts/pay_types.py
@@ -1,0 +1,133 @@
+"""Pay data types and conversion utilities (contracts tier).
+
+Pure data classes and conversion functions shared between bricks/pay
+and storage/repositories. Moved here so storage tier can import without
+violating the tier boundary (storage cannot import from bricks).
+
+Issue #2189: Spending policy data types.
+Issue #1199: Micro-credit conversion constants.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+# =============================================================================
+# Amount Conversion
+# =============================================================================
+# Credits are stored as integers in micro-units (6 decimal places)
+# Example: 1.0 credit = 1_000_000 micro-credits
+MICRO_UNIT_SCALE = 1_000_000
+
+
+def credits_to_micro(credits: Decimal | float | int) -> int:
+    """Convert credits to micro-credits (internal storage format).
+
+    Uses Decimal arithmetic internally to avoid float precision loss.
+
+    Args:
+        credits: Amount in credits (e.g., Decimal("1.5") or 1.5)
+
+    Returns:
+        Amount in micro-credits (e.g., 1_500_000)
+    """
+    return int(Decimal(str(credits)) * MICRO_UNIT_SCALE)
+
+
+def micro_to_credits(micro: int) -> Decimal:
+    """Convert micro-credits to credits (display format).
+
+    Args:
+        micro: Amount in micro-credits
+
+    Returns:
+        Amount in credits as Decimal.
+    """
+    return Decimal(str(micro)) / MICRO_UNIT_SCALE
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class SpendingPolicy:
+    """Declarative spending policy for an agent or zone.
+
+    Resolution: agent-specific (highest priority) -> zone default.
+    All limit amounts are in credits (Decimal), not micro-credits.
+
+    Fields with None mean "no limit for this period."
+    """
+
+    policy_id: str
+    zone_id: str
+    agent_id: str | None = None  # None = zone-level default
+    daily_limit: Decimal | None = None
+    weekly_limit: Decimal | None = None
+    monthly_limit: Decimal | None = None
+    per_tx_limit: Decimal | None = None
+    auto_approve_threshold: Decimal | None = None  # Phase 2: approval workflows
+    max_tx_per_hour: int | None = None  # Phase 3: rate controls
+    max_tx_per_day: int | None = None  # Phase 3: rate controls
+    rules: list[dict[str, Any]] | None = None  # Phase 4: policy DSL
+    priority: int = 0  # Higher value overrides lower
+    enabled: bool = True
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class SpendingLedgerEntry:
+    """Period-based spending counter for an agent.
+
+    One entry per (agent_id, zone_id, period_type, period_start).
+    Updated atomically via PostgreSQL UPSERT on each successful transfer.
+    """
+
+    agent_id: str
+    zone_id: str
+    period_type: str  # "daily" | "weekly" | "monthly"
+    period_start: date
+    amount_spent: Decimal = Decimal("0")
+    tx_count: int = 0
+
+
+@dataclass(frozen=True)
+class SpendingApproval:
+    """A pending or resolved approval for a transaction (Phase 2).
+
+    Created when a transaction exceeds the auto_approve_threshold.
+    An admin approves/rejects, then the agent retries with the approval_id.
+    """
+
+    approval_id: str
+    policy_id: str
+    agent_id: str
+    zone_id: str
+    amount: Decimal
+    to: str
+    memo: str = ""
+    status: str = "pending"  # pending | approved | rejected | expired
+    requested_at: datetime | None = None
+    decided_at: datetime | None = None
+    decided_by: str | None = None
+    expires_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class PolicyEvaluation:
+    """Result of evaluating a transaction against spending policies.
+
+    On denial, provides the specific reason and policy that blocked it.
+    On approval, optionally provides remaining budget information.
+    """
+
+    allowed: bool
+    denied_reason: str | None = None
+    policy_id: str | None = None
+    remaining_budget: dict[str, Decimal] = field(default_factory=dict)
+    requires_approval: bool = False  # Phase 2: needs admin approval
+    approval_id: str | None = None  # Phase 2: pending approval ID

--- a/src/nexus/storage/repositories/spending_policy.py
+++ b/src/nexus/storage/repositories/spending_policy.py
@@ -10,7 +10,6 @@ The service layer works exclusively in Decimal credits.
 Issue #2189: Extracted from bricks/pay/spending_policy_service.py.
 """
 
-import importlib as _il
 import json
 import logging
 import uuid
@@ -18,17 +17,15 @@ from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from nexus.contracts.pay_types import (
+    SpendingApproval,
+    SpendingPolicy,
+    credits_to_micro,
+    micro_to_credits,
+)
+
 if TYPE_CHECKING:
-    from nexus.bricks.pay.constants import credits_to_micro, micro_to_credits
-    from nexus.bricks.pay.spending_policy import SpendingApproval, SpendingPolicy
     from nexus.storage.record_store import RecordStoreABC
-else:
-    _pay_const = _il.import_module("nexus.bricks.pay.constants")
-    credits_to_micro = _pay_const.credits_to_micro
-    micro_to_credits = _pay_const.micro_to_credits
-    _pay_policy = _il.import_module("nexus.bricks.pay.spending_policy")
-    SpendingApproval = _pay_policy.SpendingApproval
-    SpendingPolicy = _pay_policy.SpendingPolicy
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Move pure data types (`SpendingPolicy`, `SpendingApproval`, `SpendingLedgerEntry`, `PolicyEvaluation`) and conversion functions (`credits_to_micro`, `micro_to_credits`, `MICRO_UNIT_SCALE`) from `bricks/pay/` to new `contracts/pay_types.py`
- `storage/repositories/spending_policy.py` now imports directly from `contracts/` instead of using `importlib` to bypass the tier boundary (storage cannot import from bricks)
- `bricks/pay/constants.py` and `bricks/pay/spending_policy.py` re-export all moved symbols for backward compatibility

## Test plan
- [x] All 27 pay unit tests pass
- [x] ruff check passes (lint + format)
- [x] mypy passes on all 4 modified files
- [x] Pre-commit hooks pass (brick zero-core-imports check, ruff, format, mypy)