### PR TITLE
fix: convert f-string logger calls to lazy % in fuse/ layer

### DIFF
--- a/src/nexus/fuse/mount.py
+++ b/src/nexus/fuse/mount.py
@@ -144,7 +144,7 @@ class NexusFUSE:
 
         # Check if mount point is empty
         if list(self.mount_point.iterdir()):
-            logger.warning(f"Mount point is not empty: {self.mount_point}")
+            logger.warning("Mount point is not empty: %s", self.mount_point)
 
         # Issue #1305: Build OperationContext for namespace-scoped mounts
         context = None
@@ -165,8 +165,10 @@ class NexusFUSE:
                 groups=[],
             )
             logger.info(
-                f"[FUSE] Namespace-scoped mount: agent_id={self._agent_id}, "
-                f"subject_type={subject_type}, zone_id={self._zone_id}"
+                "[FUSE] Namespace-scoped mount: agent_id=%s, subject_type=%s, zone_id=%s",
+                self._agent_id,
+                subject_type,
+                self._zone_id,
             )
 
             # A2-B: Try to obtain NamespaceManager for direct visibility checks
@@ -239,10 +241,10 @@ class NexusFUSE:
                     "auto_cache": True,  # Enable automatic kernel caching
                 }
             )
-            logger.info(f"FUSE options: {fuse_options}")
+            logger.info("FUSE options: %s", fuse_options)
 
         # Mount filesystem
-        logger.info(f"Mounting Nexus to {self.mount_point} (mode={self.mode.value})")
+        logger.info("Mounting Nexus to %s (mode=%s)", self.mount_point, self.mode.value)
 
         if foreground:
             # Run in foreground (blocking)
@@ -265,7 +267,7 @@ class NexusFUSE:
                         **fuse_options,
                     )
                 except Exception as e:
-                    logger.error(f"FUSE mount error: {e}")
+                    logger.error("FUSE mount error: %s", e)
                 finally:
                     self._mounted = False
 
@@ -282,7 +284,7 @@ class NexusFUSE:
             if not self._mounted:
                 raise RuntimeError("Failed to mount filesystem")
 
-            logger.info(f"Mounted Nexus to {self.mount_point} (background)")
+            logger.info("Mounted Nexus to %s (background)", self.mount_point)
 
             # Issue #1076: Automatic cache warmup after mount
             # Always enabled - non-blocking, lightweight, reduces first-access latency
@@ -303,8 +305,9 @@ class NexusFUSE:
                 WarmupConfig = _cw.WarmupConfig
 
                 logger.info(
-                    f"[WARMUP] Starting automatic warmup for mount at / "
-                    f"(depth={self.warmup_depth}, max_files={self.warmup_max_files})"
+                    "[WARMUP] Starting automatic warmup for mount at / (depth=%d, max_files=%d)",
+                    self.warmup_depth,
+                    self.warmup_max_files,
                 )
 
                 config = WarmupConfig(
@@ -329,12 +332,12 @@ class NexusFUSE:
                 asyncio.set_event_loop(loop)
                 try:
                     stats = loop.run_until_complete(do_warmup())
-                    logger.info(f"[WARMUP] Mount warmup complete: {stats.to_dict()}")
+                    logger.info("[WARMUP] Mount warmup complete: %s", stats.to_dict())
                 finally:
                     loop.close()
 
             except Exception as e:
-                logger.warning(f"[WARMUP] Mount warmup failed (non-critical): {e}")
+                logger.warning("[WARMUP] Mount warmup failed (non-critical): %s", e)
 
         self._warmup_thread = threading.Thread(target=warmup_thread, daemon=True)
         self._warmup_thread.start()
@@ -348,7 +351,7 @@ class NexusFUSE:
         if not self._mounted:
             raise RuntimeError("Filesystem is not mounted")
 
-        logger.info(f"Unmounting {self.mount_point}")
+        logger.info("Unmounting %s", self.mount_point)
 
         # Use platform-specific unmount command
         import platform
@@ -373,7 +376,7 @@ class NexusFUSE:
                 raise RuntimeError(f"Unsupported platform: {system}")
 
             self._mounted = False
-            logger.info(f"Unmounted {self.mount_point}")
+            logger.info("Unmounted %s", self.mount_point)
 
             # Issue #1115: Stop event loop thread
             if self._event_loop is not None:
@@ -382,7 +385,7 @@ class NexusFUSE:
                 logger.info("[FUSE] Event loop stopped")
 
         except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to unmount: {e.stderr.decode()}")
+            logger.error("Failed to unmount: %s", e.stderr.decode())
             raise RuntimeError(f"Failed to unmount: {e.stderr.decode()}") from e
 
     def is_mounted(self) -> bool:
@@ -412,7 +415,7 @@ class NexusFUSE:
             try:
                 self.unmount()
             except Exception as e:
-                logger.error(f"Error unmounting in context manager: {e}")
+                logger.error("Error unmounting in context manager: %s", e)
 
 
 def mount_nexus(

--- a/src/nexus/fuse/operations.py
+++ b/src/nexus/fuse/operations.py
@@ -119,7 +119,7 @@ class NexusFUSEOperations(Operations):
                     )
                     use_rust = False
             except Exception as e:
-                logger.error(f"[FUSE] Failed to initialize Rust client: {e}")
+                logger.error("[FUSE] Failed to initialize Rust client: %s", e)
                 logger.warning("[FUSE] Falling back to Python client")
                 use_rust = False
 
@@ -145,7 +145,7 @@ class NexusFUSEOperations(Operations):
                 local_disk_cache = LocalDiskCache(**ldc_kwargs)
                 logger.info("[FUSE] L2 LocalDiskCache enabled for faster reads")
             except Exception as e:
-                logger.warning(f"[FUSE] Failed to initialize LocalDiskCache: {e}")
+                logger.warning("[FUSE] Failed to initialize LocalDiskCache: %s", e)
 
         # Initialize event dispatcher
         enable_events = cache_config.get("events_enabled", True) and HAS_EVENT_BUS
@@ -198,11 +198,12 @@ class NexusFUSEOperations(Operations):
                     zone_id=get_zone_id(self._ctx),
                 )
                 logger.info(
-                    f"[FUSE] Readahead enabled: buffer={readahead_config.buffer_pool_mb}MB, "
-                    f"workers={readahead_config.prefetch_workers}"
+                    "[FUSE] Readahead enabled: buffer=%sMB, workers=%s",
+                    readahead_config.buffer_pool_mb,
+                    readahead_config.prefetch_workers,
                 )
             except Exception as e:
-                logger.warning(f"[FUSE] Failed to initialize ReadaheadManager: {e}")
+                logger.warning("[FUSE] Failed to initialize ReadaheadManager: %s", e)
         self._ctx.readahead = readahead
 
         # Expose shared state for backward compatibility (tests access these directly)

--- a/src/nexus/fuse/ops/_events.py
+++ b/src/nexus/fuse/ops/_events.py
@@ -80,10 +80,10 @@ class FUSEEventDispatcher:
                     self._event_loop,
                 )
             else:
-                logger.debug(f"[FUSE-EVENT] No event loop, skipping: {event_type} {path}")
+                logger.debug("[FUSE-EVENT] No event loop, skipping: %s %s", event_type, path)
 
         except Exception as e:
-            logger.debug(f"[FUSE-EVENT] Failed to fire event: {e}")
+            logger.debug("[FUSE-EVENT] Failed to fire event: %s", e)
 
     async def _dispatch(self, event: Any) -> None:
         """Dispatch event to all downstream systems."""
@@ -92,7 +92,7 @@ class FUSEEventDispatcher:
                 try:
                     await self._event_bus.publish(event)
                 except Exception as e:
-                    logger.debug(f"[FUSE-EVENT] Event bus publish failed: {e}")
+                    logger.debug("[FUSE-EVENT] Event bus publish failed: %s", e)
 
             try:
                 sub_manager = self._subscription_manager
@@ -111,9 +111,9 @@ class FUSEEventDispatcher:
                         zone_id=event.zone_id or ROOT_ZONE_ID,
                     )
             except Exception as e:
-                logger.debug(f"[FUSE-EVENT] Webhook broadcast failed: {e}")
+                logger.debug("[FUSE-EVENT] Webhook broadcast failed: %s", e)
 
-            logger.debug(f"[FUSE-EVENT] Dispatched: {event.type} {event.path}")
+            logger.debug("[FUSE-EVENT] Dispatched: %s %s", event.type, event.path)
 
         except Exception as e:
-            logger.debug(f"[FUSE-EVENT] Dispatch failed: {e}")
+            logger.debug("[FUSE-EVENT] Dispatch failed: %s", e)

--- a/src/nexus/fuse/ops/_shared.py
+++ b/src/nexus/fuse/ops/_shared.py
@@ -138,16 +138,16 @@ def _handle_remote_exception(e: Exception, operation: str, path: str, **context:
     context_str = ", ".join(f"{k}={v}" for k, v in context.items()) if context else ""
 
     if isinstance(e, RemoteTimeoutError):
-        logger.error(f"[FUSE-{operation}] Timeout: {path} - {e} ({context_str})")
+        logger.error("[FUSE-%s] Timeout: %s - %s (%s)", operation, path, e, context_str)
         raise FuseOSError(errno.ETIMEDOUT) from e
     if isinstance(e, RemoteConnectionError):
-        logger.error(f"[FUSE-{operation}] Connection error: {path} - {e}")
+        logger.error("[FUSE-%s] Connection error: %s - %s", operation, path, e)
         raise FuseOSError(errno.ECONNREFUSED) from e
     if isinstance(e, RemoteFilesystemError):
-        logger.error(f"[FUSE-{operation}] Remote error: {path} - {e}")
+        logger.error("[FUSE-%s] Remote error: %s - %s", operation, path, e)
         raise FuseOSError(errno.EIO) from e
 
-    logger.exception(f"[FUSE-{operation}] Unexpected error: {path} ({context_str})")
+    logger.exception("[FUSE-%s] Unexpected error: %s (%s)", operation, path, context_str)
     raise FuseOSError(errno.EIO) from e
 
 
@@ -171,7 +171,7 @@ def fuse_operation(op_name: str) -> Callable[..., Any]:
             except NexusFileNotFoundError:
                 raise FuseOSError(errno.ENOENT) from None
             except NexusPermissionError as e:
-                logger.error(f"[FUSE-{op_name}] Permission denied: {path_arg} - {e}")
+                logger.error("[FUSE-%s] Permission denied: %s - %s", op_name, path_arg, e)
                 raise FuseOSError(errno.EACCES) from e
             except Exception as e:
                 _handle_remote_exception(e, op_name, path_arg)
@@ -220,10 +220,10 @@ def try_rust(
     except OSError as e:
         if e.errno == errno.ENOENT:
             raise FuseOSError(errno.ENOENT) from None
-        logger.warning(f"[FUSE-{op_name}] Rust failed: {e}, using Python")
+        logger.warning("[FUSE-%s] Rust failed: %s, using Python", op_name, e)
         return (False, None)
     except Exception as e:
-        logger.warning(f"[FUSE-{op_name}] Rust failed: {e}, using Python")
+        logger.warning("[FUSE-%s] Rust failed: %s, using Python", op_name, e)
         return (False, None)
 
 
@@ -282,31 +282,34 @@ def get_file_content(
     if view_type and (ctx.mode.value == "text" or ctx.mode.value == "smart"):
         cached_parsed = ctx.cache.get_parsed(path, view_type)
         if cached_parsed is not None:
-            logger.debug(f"[FUSE-CONTENT] PARSED CACHE HIT: {path}")
+            logger.debug("[FUSE-CONTENT] PARSED CACHE HIT: %s", path)
             return cached_parsed
 
     # L1: Check in-memory content cache
     content = ctx.cache.get_content(path)
 
     if content is not None:
-        logger.info(f"[FUSE-CONTENT] L1 MEMORY HIT: {path} ({len(content)} bytes)")
+        logger.info("[FUSE-CONTENT] L1 MEMORY HIT: %s (%d bytes)", path, len(content))
     else:
         # L2: Check local disk cache
         content = get_from_local_disk_cache(ctx, path)
 
         if content is not None:
-            logger.info(f"[FUSE-CONTENT] L2 DISK HIT: {path} ({len(content)} bytes)")
+            logger.info("[FUSE-CONTENT] L2 DISK HIT: %s (%d bytes)", path, len(content))
         else:
             # L3/L4: Read from backend
             read_ctx = None if skip_auth else ctx.context
-            logger.info(f"[FUSE-CONTENT] L3 BACKEND FETCH: {path}")
+            logger.info("[FUSE-CONTENT] L3 BACKEND FETCH: %s", path)
             fetch_start = time.time()
             raw_content = ctx.nexus_fs.sys_read(path, context=read_ctx)
             fetch_time = time.time() - fetch_start
             assert isinstance(raw_content, bytes), "Expected bytes from read()"
             content = raw_content
             logger.info(
-                f"[FUSE-CONTENT] L3 BACKEND GOT: {path} ({len(content)} bytes) in {fetch_time:.3f}s"
+                "[FUSE-CONTENT] L3 BACKEND GOT: %s (%d bytes) in %.3fs",
+                path,
+                len(content),
+                fetch_time,
             )
 
             put_to_local_disk_cache(ctx, path, content, priority=cache_priority)
@@ -370,7 +373,7 @@ def read_range_from_backend(ctx: FUSESharedContext, path: str, offset: int, size
         end = min(offset + size, len(content))
         return content[offset:end]
     except Exception as e:
-        logger.warning(f"[FUSE-READAHEAD] Failed to read {path}:{offset}+{size}: {e}")
+        logger.warning("[FUSE-READAHEAD] Failed to read %s:%d+%d: %s", path, offset, size, e)
         return b""
 
 
@@ -388,10 +391,10 @@ def get_from_local_disk_cache(ctx: FUSESharedContext, path: str) -> bytes | None
             "bytes | None", ctx.local_disk_cache.get(content_hash, zone_id=zone_id)
         )
         if content is not None:
-            logger.debug(f"[FUSE-L2] HIT: {path} (zone={zone_id})")
+            logger.debug("[FUSE-L2] HIT: %s (zone=%s)", path, zone_id)
         return content
     except Exception as e:
-        logger.debug(f"[FUSE-L2] Error reading {path}: {e}")
+        logger.debug("[FUSE-L2] Error reading %s: %s", path, e)
         return None
 
 
@@ -418,9 +421,9 @@ def put_to_local_disk_cache(
             store_blocks=store_blocks,
             priority=priority,
         )
-        logger.debug(f"[FUSE-L2] CACHED: {path} ({len(content)} bytes, zone={zone_id})")
+        logger.debug("[FUSE-L2] CACHED: %s (%d bytes, zone=%s)", path, len(content), zone_id)
     except Exception as e:
-        logger.debug(f"[FUSE-L2] Error caching {path}: {e}")
+        logger.debug("[FUSE-L2] Error caching %s: %s", path, e)
 
 
 def get_metadata(ctx: FUSESharedContext, path: str) -> Any:
@@ -449,7 +452,7 @@ def stat_size_fallback(ctx: FUSESharedContext, path: str) -> int:
             pass  # stat fallback — handled below with default return 0
 
     # Issue 15A: Return 0 instead of reading full content
-    logger.debug(f"[FUSE-PERF] stat fallback: returning 0 for {path}")
+    logger.debug("[FUSE-PERF] stat fallback: returning 0 for %s", path)
     return 0
 
 

--- a/src/nexus/fuse/ops/io_handler.py
+++ b/src/nexus/fuse/ops/io_handler.py
@@ -50,11 +50,13 @@ class IOHandler:
 
         if file_exists:
             logger.debug(
-                f"[FUSE-OPEN] Cache HIT for {original_path} "
-                f"(content={content_cached}, attr={attr_cached})"
+                "[FUSE-OPEN] Cache HIT for %s (content=%s, attr=%s)",
+                original_path,
+                content_cached,
+                attr_cached,
             )
         else:
-            logger.debug(f"[FUSE-OPEN] Cache MISS for {original_path}, checking remote")
+            logger.debug("[FUSE-OPEN] Cache MISS for %s, checking remote", original_path)
             if not ctx.nexus_fs.sys_access(original_path):
                 raise FuseOSError(errno.ENOENT)
 
@@ -92,9 +94,9 @@ class IOHandler:
 
                 ctx.readahead.on_open(fd, original_path, file_size, io_profile=io_profile_arg)
             except Exception as e:
-                logger.debug(f"[FUSE-OPEN] Readahead on_open failed (non-critical): {e}")
+                logger.debug("[FUSE-OPEN] Readahead on_open failed (non-critical): %s", e)
         elif content_cached:
-            logger.debug(f"[FUSE-OPEN] Skipping readahead (L1 cached): {original_path}")
+            logger.debug("[FUSE-OPEN] Skipping readahead (L1 cached): %s", original_path)
 
         return fd
 
@@ -121,7 +123,7 @@ class IOHandler:
             prefetched = ctx.readahead.on_read(fh, original_path, offset, size)
             if prefetched is not None:
                 logger.debug(
-                    f"[FUSE-READ] READAHEAD HIT: {original_path}[{offset}:{offset + size}]"
+                    "[FUSE-READ] READAHEAD HIT: %s[%d:%d]", original_path, offset, offset + size
                 )
                 return cast("bytes", prefetched)
 
@@ -163,7 +165,7 @@ class IOHandler:
 
         basename = original_path.split("/")[-1]
         if is_os_metadata_file(basename):
-            logger.debug(f"Blocked write to OS metadata file: {original_path}")
+            logger.debug("Blocked write to OS metadata file: %s", original_path)
             raise FuseOSError(errno.EPERM)
 
         write_ctx = None if file_info.get("auth_verified") else ctx.context

--- a/src/nexus/fuse/ops/metadata_handler.py
+++ b/src/nexus/fuse/ops/metadata_handler.py
@@ -46,7 +46,7 @@ class MetadataHandler:
         if cached_attrs is not None:
             elapsed = time.time() - start_time
             if elapsed > 0.001:
-                logger.debug(f"[FUSE-PERF] getattr CACHED: path={path}, {elapsed:.3f}s")
+                logger.debug("[FUSE-PERF] getattr CACHED: path=%s, %.3fs", path, elapsed)
             return cached_attrs
 
         # Handle virtual views (.raw, .txt, .md)
@@ -70,7 +70,7 @@ class MetadataHandler:
                     attrs = self._build_file_attrs(rust_meta.size)
                 ctx.cache.cache_attr(path, attrs)
                 elapsed = time.time() - start_time
-                logger.debug(f"[FUSE-PERF] getattr via RUST: path={path}, {elapsed:.3f}s")
+                logger.debug("[FUSE-PERF] getattr via RUST: path=%s, %.3fs", path, elapsed)
                 return attrs
 
         # Check if it's a directory
@@ -117,7 +117,7 @@ class MetadataHandler:
 
         elapsed = time.time() - start_time
         if elapsed > 0.01:
-            logger.info(f"[FUSE-PERF] getattr UNCACHED: path={path}, {elapsed:.3f}s")
+            logger.info("[FUSE-PERF] getattr UNCACHED: path=%s, %.3fs", path, elapsed)
         return attrs
 
     def _build_file_attrs(self, file_size: int) -> dict[str, Any]:
@@ -205,11 +205,11 @@ class MetadataHandler:
             cached_entries = ctx.dir_cache.get(cache_key)
         if cached_entries is not None:
             logger.info(
-                f"[FUSE-PERF] readdir CACHE HIT: path={path}, {len(cached_entries)} entries"
+                "[FUSE-PERF] readdir CACHE HIT: path=%s, %d entries", path, len(cached_entries)
             )
             return cast("list[str]", cached_entries)
 
-        logger.info(f"[FUSE-PERF] readdir START: path={path}")
+        logger.info("[FUSE-PERF] readdir START: path=%s", path)
 
         entries = [".", ".."]
 
@@ -222,8 +222,10 @@ class MetadataHandler:
             entries.extend([f.name for f in file_entries])
             elapsed = time.time() - start_time
             logger.info(
-                f"[FUSE-PERF] readdir DONE via RUST: path={path}, "
-                f"{len(entries)} entries, {elapsed:.3f}s"
+                "[FUSE-PERF] readdir DONE via RUST: path=%s, %d entries, %.3fs",
+                path,
+                len(entries),
+                elapsed,
             )
             with ctx.dir_cache_lock:
                 ctx.dir_cache[cache_key] = entries
@@ -237,7 +239,7 @@ class MetadataHandler:
         list_elapsed = time.time() - list_start
         files = files_raw if isinstance(files_raw, list) else []
         logger.info(
-            f"[FUSE-PERF] readdir list() took {list_elapsed:.3f}s, returned {len(files)} items"
+            "[FUSE-PERF] readdir list() took %.3fs, returned %d items", list_elapsed, len(files)
         )
 
         for file_info in files:
@@ -279,9 +281,11 @@ class MetadataHandler:
                 and (not isinstance(f, dict) or f.get("size", 0) < prefetch_max_file_size)
             ]
             logger.info(
-                f"[FUSE-PERF] readdir prefetch check: {len(small_files)} small files, "
-                f"has_read_bulk={hasattr(ctx.nexus_fs, 'read_bulk')}, "
-                f"sample_paths={small_files[:3] if small_files else []}"
+                "[FUSE-PERF] readdir prefetch check: %d small files, "
+                "has_read_bulk=%s, sample_paths=%s",
+                len(small_files),
+                hasattr(ctx.nexus_fs, "read_bulk"),
+                small_files[:3] if small_files else [],
             )
             if small_files and hasattr(ctx.nexus_fs, "read_bulk"):
                 try:
@@ -292,16 +296,19 @@ class MetadataHandler:
                             ctx.cache.cache_content(fpath, content)
                     prefetch_elapsed = time.time() - prefetch_start
                     logger.info(
-                        f"[FUSE-PERF] readdir content prefetch: "
-                        f"{len(bulk_content)} files in {prefetch_elapsed:.3f}s"
+                        "[FUSE-PERF] readdir content prefetch: %d files in %.3fs",
+                        len(bulk_content),
+                        prefetch_elapsed,
                     )
                 except Exception as e:
-                    logger.warning(f"[FUSE-PERF] readdir content prefetch failed: {e}")
+                    logger.warning("[FUSE-PERF] readdir content prefetch failed: %s", e)
 
         total_elapsed = time.time() - start_time
         logger.info(
-            f"[FUSE-PERF] readdir DONE: path={path}, {len(entries)} entries, "
-            f"{total_elapsed:.3f}s total"
+            "[FUSE-PERF] readdir DONE: path=%s, %d entries, %.3fs total",
+            path,
+            len(entries),
+            total_elapsed,
         )
 
         with ctx.dir_cache_lock:

--- a/src/nexus/fuse/ops/mutation_handler.py
+++ b/src/nexus/fuse/ops/mutation_handler.py
@@ -40,7 +40,7 @@ class MutationHandler:
         # Block OS metadata files
         basename = path.split("/")[-1]
         if is_os_metadata_file(basename):
-            logger.debug(f"Blocked creation of OS metadata file: {path}")
+            logger.debug("Blocked creation of OS metadata file: %s", path)
             raise FuseOSError(errno.EPERM)
 
         original_path, view_type = parse_virtual_path_for_fuse(ctx, path)
@@ -141,7 +141,7 @@ class MutationHandler:
         check_namespace_visible(ctx, new_path)
 
         if ctx.nexus_fs.sys_access(new_path):
-            logger.error(f"Destination {new_path} already exists")
+            logger.error("Destination %s already exists", new_path)
             raise FuseOSError(errno.EEXIST)
 
         if ctx.nexus_fs.sys_is_directory(old_path, context=ctx.context):
@@ -172,7 +172,7 @@ class MutationHandler:
     def _rename_file(self, old_path: str, new_path: str) -> None:
         """Metadata-only file rename."""
         ctx = self._ctx
-        logger.debug(f"Renaming file {old_path} to {new_path}")
+        logger.debug("Renaming file %s to %s", old_path, new_path)
 
         ok, _ = try_rust(ctx, "RENAME", "rename", old_path, new_path)
         if not ok:
@@ -181,12 +181,12 @@ class MutationHandler:
     def _rename_directory(self, old_path: str, new_path: str) -> None:
         """Recursive directory rename: list + move files + rmdir source."""
         ctx = self._ctx
-        logger.debug(f"Renaming directory {old_path} to {new_path}")
+        logger.debug("Renaming directory %s to %s", old_path, new_path)
 
         try:
             ctx.nexus_fs.sys_mkdir(new_path, parents=True, exist_ok=True)
         except Exception as e:
-            logger.debug(f"mkdir {new_path} failed (may already exist): {e}")
+            logger.debug("mkdir %s failed (may already exist): %s", new_path, e)
 
         files = ctx.nexus_fs.sys_readdir(
             old_path, recursive=True, details=True, context=ctx.context
@@ -198,8 +198,8 @@ class MutationHandler:
             if not file_info.get("is_directory", False):
                 src_file = file_info["path"]
                 dest_file = src_file.replace(old_path, new_path, 1)
-                logger.debug(f"  Moving file {src_file} to {dest_file}")
+                logger.debug("  Moving file %s to %s", src_file, dest_file)
                 ctx.nexus_fs.sys_rename(src_file, dest_file)
 
-        logger.debug(f"Removing source directory {old_path}")
+        logger.debug("Removing source directory %s", old_path)
         ctx.nexus_fs.sys_rmdir(old_path, recursive=True)

--- a/src/nexus/fuse/readahead.py
+++ b/src/nexus/fuse/readahead.py
@@ -233,8 +233,10 @@ class ReadSession:
                 new_window = min(self.readahead_window * 2, self.max_window)
                 if new_window != self.readahead_window:
                     logger.debug(
-                        f"[READAHEAD] Window growth: {self.readahead_window} -> {new_window} "
-                        f"(sequential_count={self.sequential_count})"
+                        "[READAHEAD] Window growth: %s -> %s (sequential_count=%d)",
+                        self.readahead_window,
+                        new_window,
+                        self.sequential_count,
                     )
                 self.readahead_window = new_window
 
@@ -243,8 +245,10 @@ class ReadSession:
             # Random access detected - reset state
             if self.sequential_count > 0:
                 logger.debug(
-                    f"[READAHEAD] Random access detected: expected={expected_offset}, "
-                    f"actual={offset}, diff={offset_diff}"
+                    "[READAHEAD] Random access detected: expected=%s, actual=%s, diff=%s",
+                    expected_offset,
+                    offset,
+                    offset_diff,
                 )
             self.sequential_count = 0
             self.readahead_window = DEFAULT_INITIAL_WINDOW
@@ -363,7 +367,8 @@ class PrefetchBufferPool:
         }
 
         logger.info(
-            f"[READAHEAD] PrefetchBufferPool initialized: max_size={max_size_bytes / (1024 * 1024):.1f}MB"
+            "[READAHEAD] PrefetchBufferPool initialized: max_size=%.1fMB",
+            max_size_bytes / (1024 * 1024),
         )
 
     def get(self, path: str, offset: int, size: int) -> bytes | None:
@@ -430,7 +435,9 @@ class PrefetchBufferPool:
         # Don't store if larger than entire pool
         if data_size > self._max_size:
             logger.warning(
-                f"[READAHEAD] Block too large for buffer pool: {data_size} > {self._max_size}"
+                "[READAHEAD] Block too large for buffer pool: %s > %s",
+                data_size,
+                self._max_size,
             )
             return False
 
@@ -462,8 +469,11 @@ class PrefetchBufferPool:
             self._access_order.append((path, offset))
 
             logger.debug(
-                f"[READAHEAD] Buffered {data_size} bytes at {path}:{offset} "
-                f"(pool: {self._current_size / (1024 * 1024):.1f}MB)"
+                "[READAHEAD] Buffered %s bytes at %s:%s (pool: %.1fMB)",
+                data_size,
+                path,
+                offset,
+                self._current_size / (1024 * 1024),
             )
             return True
 
@@ -484,7 +494,7 @@ class PrefetchBufferPool:
         if not self._buffers[path]:
             del self._buffers[path]
 
-        logger.debug(f"[READAHEAD] Evicted buffer {path}:{offset}")
+        logger.debug("[READAHEAD] Evicted buffer %s:%s", path, offset)
 
     def invalidate_path(self, path: str) -> int:
         """Invalidate all buffers for a path.
@@ -510,7 +520,7 @@ class PrefetchBufferPool:
             # Clean up access order
             self._access_order = [(p, o) for p, o in self._access_order if p != path]
 
-            logger.debug(f"[READAHEAD] Invalidated {count} buffers for {path}")
+            logger.debug("[READAHEAD] Invalidated %d buffers for %s", count, path)
             return count
 
     def clear(self) -> None:
@@ -623,9 +633,13 @@ class ReadaheadManager:
         self._shutdown = False
 
         logger.info(
-            f"[READAHEAD] Manager initialized: workers={config.prefetch_workers}, "
-            f"buffer={config.buffer_pool_mb}MB, block_size={config.block_size / (1024 * 1024):.1f}MB, "
-            f"max_blocks={config.max_blocks_per_trigger}, prefetch_on_open={config.prefetch_on_open}"
+            "[READAHEAD] Manager initialized: workers=%d, buffer=%dMB, "
+            "block_size=%.1fMB, max_blocks=%d, prefetch_on_open=%s",
+            config.prefetch_workers,
+            config.buffer_pool_mb,
+            config.block_size / (1024 * 1024),
+            config.max_blocks_per_trigger,
+            config.prefetch_on_open,
         )
 
     def on_open(
@@ -653,8 +667,9 @@ class ReadaheadManager:
             profile_cfg = io_profile.config()
             if not profile_cfg.readahead_enabled:
                 logger.debug(
-                    f"[READAHEAD] Skipping on_open for {path} "
-                    f"(io_profile={io_profile} disables readahead)"
+                    "[READAHEAD] Skipping on_open for %s (io_profile=%s disables readahead)",
+                    path,
+                    io_profile,
                 )
                 return
 
@@ -671,7 +686,7 @@ class ReadaheadManager:
         # Immediately trigger prefetch from offset 0
         # This assumes most files will be read sequentially from start
         # (common pattern for Docker sandbox: cat, head, reading config files)
-        logger.debug(f"[READAHEAD] Prefetch on open: {path} (fh={fh})")
+        logger.debug("[READAHEAD] Prefetch on open: %s (fh=%d)", path, fh)
 
         # Set sequential count to trigger prefetch immediately
         session.sequential_count = self._config.min_sequential_count
@@ -714,7 +729,7 @@ class ReadaheadManager:
                 with self._stats_lock:
                     self._stats["prefetch_triggered"] += 1
 
-        logger.info(f"[READAHEAD] Prefetch on open started: {path} ({num_blocks} blocks)")
+        logger.info("[READAHEAD] Prefetch on open started: %s (%d blocks)", path, num_blocks)
 
     def on_read(self, fh: int, path: str, offset: int, size: int) -> bytes | None:
         """Called before each read operation.
@@ -744,7 +759,7 @@ class ReadaheadManager:
         prefetched = self._buffer_pool.get(path, offset, size)
         if prefetched is not None:
             session.record_prefetch_hit()
-            logger.debug(f"[READAHEAD] HIT: {path}:{offset}+{size}")
+            logger.debug("[READAHEAD] HIT: %s:%s+%s", path, offset, size)
             return prefetched
 
         session.record_prefetch_miss()
@@ -810,8 +825,10 @@ class ReadaheadManager:
                 self._buffer_pool.invalidate_path(session.path)
 
             logger.debug(
-                f"[READAHEAD] Session released: {session.path} "
-                f"(hits={session.prefetch_hits}, misses={session.prefetch_misses})"
+                "[READAHEAD] Session released: %s (hits=%d, misses=%d)",
+                session.path,
+                session.prefetch_hits,
+                session.prefetch_misses,
             )
 
     def invalidate_path(self, path: str) -> None:
@@ -862,7 +879,7 @@ class ReadaheadManager:
                     max_window=max_window,
                     sequential_tolerance=self._config.sequential_tolerance,
                 )
-                logger.debug(f"[READAHEAD] New session: fh={fh}, path={path}")
+                logger.debug("[READAHEAD] New session: fh=%d, path=%s", fh, path)
             return self._sessions[fh]
 
     def _trigger_prefetch(self, session: ReadSession, start_offset: int) -> None:
@@ -920,8 +937,11 @@ class ReadaheadManager:
 
         if blocks_submitted > 0:
             logger.debug(
-                f"[READAHEAD] Prefetch triggered: {session.path}:{block_start} "
-                f"({blocks_submitted} blocks, window={session.readahead_window})"
+                "[READAHEAD] Prefetch triggered: %s:%s (%d blocks, window=%s)",
+                session.path,
+                block_start,
+                blocks_submitted,
+                session.readahead_window,
             )
 
     def _prefetch_block(
@@ -960,14 +980,16 @@ class ReadaheadManager:
                     self._stats["prefetch_completed"] += 1
                     self._stats["bytes_prefetched"] += len(data)
 
-                logger.debug(f"[READAHEAD] Prefetch complete: {path}:{offset} ({len(data)} bytes)")
+                logger.debug(
+                    "[READAHEAD] Prefetch complete: %s:%s (%d bytes)", path, offset, len(data)
+                )
             else:
                 session.cancel_prefetch(offset)
                 with self._stats_lock:
                     self._stats["prefetch_failed"] += 1
 
         except Exception as e:
-            logger.warning(f"[READAHEAD] Prefetch failed: {path}:{offset} - {e}")
+            logger.warning("[READAHEAD] Prefetch failed: %s:%s - %s", path, offset, e)
             session.cancel_prefetch(offset)
             with self._stats_lock:
                 self._stats["prefetch_failed"] += 1
@@ -1009,10 +1031,10 @@ class ReadaheadManager:
                     with self._stats_lock:
                         self._stats["l2_cache_warms"] += 1
 
-                    logger.debug(f"[READAHEAD] L2 cache warmed: {path}:{offset}")
+                    logger.debug("[READAHEAD] L2 cache warmed: %s:%s", path, offset)
 
         except Exception as e:
-            logger.debug(f"[READAHEAD] L2 cache warm failed: {path}:{offset} - {e}")
+            logger.debug("[READAHEAD] L2 cache warm failed: %s:%s - %s", path, offset, e)
 
     def get_stats(self) -> dict[str, Any]:
         """Get readahead statistics."""

--- a/src/nexus/fuse/rust_client.py
+++ b/src/nexus/fuse/rust_client.py
@@ -283,7 +283,7 @@ class RustFUSEClient:
                     break
         except (ConnectionError, BrokenPipeError, OSError) as e:
             # Issue 2A: Connection lost — try reconnecting and retrying once
-            logger.warning(f"Daemon connection lost during {method}: {e}")
+            logger.warning("Daemon connection lost during %s: %s", method, e)
             self._reconnect()
 
             # Retry the request on the new connection


### PR DESCRIPTION
## Summary
- Convert ~82 f-string logger calls to lazy `%` formatting across 9 fuse/ files
- F-string interpolation evaluates eagerly even when log level is disabled; lazy `%` defers string construction
- Zero f-string logger calls remain in the entire `fuse/` directory

## Files changed
- `fuse/ops/_shared.py` (18), `fuse/readahead.py` (19), `fuse/mount.py` (11)
- `fuse/ops/metadata_handler.py` (10), `fuse/ops/mutation_handler.py` (7)
- `fuse/ops/_events.py` (6), `fuse/ops/io_handler.py` (6)
- `fuse/operations.py` (4), `fuse/rust_client.py` (1)

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy` passes on all 9 files
- [x] Pre-commit hooks pass
- [x] `grep 'logger\.\w+(f"'` returns 0 matches in fuse/