### PR TITLE
fix: convert f-string logger calls to lazy % in sync/server/backends

### DIFF
--- a/src/nexus/backends/backend_io.py
+++ b/src/nexus/backends/backend_io.py
@@ -112,7 +112,7 @@ class BackendIOService:
 
         # Check if this connector has bulk download support
         if hasattr(connector, "_bulk_download_blobs") and hasattr(connector, "_get_blob_path"):
-            logger.info(f"[BATCH-READ] Using bulk download for {len(paths)} paths")
+            logger.info("[BATCH-READ] Using bulk download for %d paths", len(paths))
 
             blob_paths = [connector._get_blob_path(path) for path in paths]
 
@@ -137,22 +137,22 @@ class BackendIOService:
                     results[backend_path] = content
 
             logger.info(
-                f"[BATCH-READ] Bulk download complete: {len(results)}/{len(paths)} successful"
+                "[BATCH-READ] Bulk download complete: %d/%d successful", len(results), len(paths)
             )
             return results
 
         # Check if this connector has custom bulk download support
         if hasattr(connector, "_bulk_download_contents"):
-            logger.info(f"[BATCH-READ] Using connector bulk download for {len(paths)} paths")
+            logger.info("[BATCH-READ] Using connector bulk download for %d paths", len(paths))
             results = connector._bulk_download_contents(paths, contexts)
             logger.info(
-                f"[BATCH-READ] Bulk download complete: {len(results)}/{len(paths)} successful"
+                "[BATCH-READ] Bulk download complete: %d/%d successful", len(results), len(paths)
             )
             return results
 
         # Fallback: sequential reads for non-blob connectors
         # Use connector's _read_content_from_backend (preserves MRO overrides)
-        logger.info(f"[BATCH-READ] Falling back to sequential reads for {len(paths)} paths")
+        logger.info("[BATCH-READ] Falling back to sequential reads for %d paths", len(paths))
         results = {}
         for path in paths:
             context = contexts.get(path) if contexts else None

--- a/src/nexus/backends/chunked_storage.py
+++ b/src/nexus/backends/chunked_storage.py
@@ -320,10 +320,10 @@ class ChunkedStorageMixin:
         is_new = self._cas.store(chunk_hash, chunk_bytes, extra_meta={"is_chunk": True})
         if is_new:
             self._cas_bloom_add(chunk_hash)
-            logger.debug(f"Wrote new chunk {chunk_hash[:16]}... ({len(chunk_bytes)} bytes)")
+            logger.debug("Wrote new chunk %s... (%d bytes)", chunk_hash[:16], len(chunk_bytes))
         else:
             meta = self._cas.read_meta(chunk_hash)
-            logger.debug(f"Chunk {chunk_hash[:16]}... exists, ref_count={meta.ref_count}")
+            logger.debug("Chunk %s... exists, ref_count=%d", chunk_hash[:16], meta.ref_count)
         return chunk_hash
 
     def _write_chunked(
@@ -356,8 +356,10 @@ class ChunkedStorageMixin:
         chunk_tuples = self._chunk_content_cdc(content)
 
         logger.info(
-            f"Chunking {len(content)} bytes -> {len(chunk_tuples)} chunks "
-            f"(avg {len(content) // len(chunk_tuples) if chunk_tuples else 0} bytes)"
+            "Chunking %d bytes -> %d chunks (avg %d bytes)",
+            len(content),
+            len(chunk_tuples),
+            len(content) // len(chunk_tuples) if chunk_tuples else 0,
         )
 
         # Write chunks in parallel for better throughput
@@ -422,8 +424,11 @@ class ChunkedStorageMixin:
 
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         logger.info(
-            f"Wrote chunked content: {len(content)} bytes -> {len(chunk_infos)} chunks "
-            f"in {elapsed_ms:.1f}ms (manifest={manifest_hash[:16]}...)"
+            "Wrote chunked content: %d bytes -> %d chunks in %.1fms (manifest=%s...)",
+            len(content),
+            len(chunk_infos),
+            elapsed_ms,
+            manifest_hash[:16],
         )
 
         return manifest_hash
@@ -486,8 +491,10 @@ class ChunkedStorageMixin:
 
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         logger.debug(
-            f"Read chunked content: {len(content)} bytes from {manifest.chunk_count} chunks "
-            f"in {elapsed_ms:.1f}ms"
+            "Read chunked content: %d bytes from %d chunks in %.1fms",
+            len(content),
+            manifest.chunk_count,
+            elapsed_ms,
         )
 
         return content
@@ -517,10 +524,10 @@ class ChunkedStorageMixin:
         """
         deleted = self._cas.release(chunk_hash)
         if deleted:
-            logger.debug(f"Deleted chunk {chunk_hash[:16]}... (ref_count=0)")
+            logger.debug("Deleted chunk %s... (ref_count=0)", chunk_hash[:16])
         else:
             meta = self._cas.read_meta(chunk_hash)
-            logger.debug(f"Decremented chunk {chunk_hash[:16]}... ref_count to {meta.ref_count}")
+            logger.debug("Decremented chunk %s... ref_count to %d", chunk_hash[:16], meta.ref_count)
 
     def _delete_chunked(
         self,
@@ -545,7 +552,7 @@ class ChunkedStorageMixin:
         deleted = self._cas.release(content_hash)
 
         if not deleted:
-            logger.debug(f"Decremented manifest {content_hash[:16]}... ref_count")
+            logger.debug("Decremented manifest %s... ref_count", content_hash[:16])
             return
 
         # Last reference — parallelize chunk releases
@@ -557,8 +564,9 @@ class ChunkedStorageMixin:
                 future.result()  # Propagate exceptions
 
         logger.info(
-            f"Deleted chunked content {content_hash[:16]}... "
-            f"({manifest.chunk_count} chunks unreferenced)"
+            "Deleted chunked content %s... (%d chunks unreferenced)",
+            content_hash[:16],
+            manifest.chunk_count,
         )
 
     def _get_content_size_chunked(self, content_hash: str) -> int:

--- a/src/nexus/backends/gcalendar_connector.py
+++ b/src/nexus/backends/gcalendar_connector.py
@@ -291,14 +291,16 @@ send_notifications: true
             try:
                 provider_instance = factory.create_provider(name=self.provider)
                 self.token_manager.register_provider(self.provider, provider_instance)
-                logger.info(f"Registered OAuth provider '{self.provider}' for Calendar backend")
+                logger.info("Registered OAuth provider '%s' for Calendar backend", self.provider)
             except ValueError as e:
                 logger.warning(
-                    f"OAuth provider '{self.provider}' not available: {e}. "
-                    "OAuth flow must be initiated manually via the Integrations page."
+                    "OAuth provider '%s' not available: %s. "
+                    "OAuth flow must be initiated manually via the Integrations page.",
+                    self.provider,
+                    e,
                 )
         except Exception as e:
-            logger.error(f"Failed to register OAuth provider: {e}")
+            logger.error("Failed to register OAuth provider: %s", e)
 
     @property
     def name(self) -> str:
@@ -604,7 +606,7 @@ send_notifications: true
         # Validate traits
         warnings = self.validate_traits("create_event", data)
         for warning in warnings:
-            logger.warning(f"Create event warning: {warning}")
+            logger.warning("Create event warning: %s", warning)
 
         # Validate schema
         validated = self.validate_schema("create_event", data)
@@ -630,7 +632,7 @@ send_notifications: true
                     {"event_id": event_id, "calendar_id": calendar_id},
                 )
 
-            logger.info(f"Created calendar event: {event_id}")
+            logger.info("Created calendar event: %s", event_id)
             return event_id
 
         except Exception as e:
@@ -662,7 +664,7 @@ send_notifications: true
         # Validate traits
         warnings = self.validate_traits("update_event", data)
         for warning in warnings:
-            logger.warning(f"Update event warning: {warning}")
+            logger.warning("Update event warning: %s", warning)
 
         # Validate schema
         validated = self.validate_schema("update_event", data)
@@ -698,7 +700,7 @@ send_notifications: true
             if checkpoint:
                 self.clear_checkpoint(checkpoint.checkpoint_id)
 
-            logger.info(f"Updated calendar event: {event_id}")
+            logger.info("Updated calendar event: %s", event_id)
             return "updated"
 
         except Exception as e:
@@ -766,7 +768,7 @@ send_notifications: true
             if checkpoint:
                 self.clear_checkpoint(checkpoint.checkpoint_id)
 
-            logger.info(f"Deleted calendar event: {event_id}")
+            logger.info("Deleted calendar event: %s", event_id)
 
         except Exception as e:
             if checkpoint:

--- a/src/nexus/backends/gcs.py
+++ b/src/nexus/backends/gcs.py
@@ -140,7 +140,7 @@ class GCSBackend(CASBackend):
                 ctx = contexts.get(h, context) if contexts else context
                 return (h, self.read_content(h, context=ctx))
             except Exception as e:
-                logger.warning(f"[GCS] batch_read_content failed for {h}: {e}")
+                logger.warning("[GCS] batch_read_content failed for %s: %s", h, e)
                 return (h, None)
 
         result: dict[str, bytes | None] = {}

--- a/src/nexus/backends/gcs_connector.py
+++ b/src/nexus/backends/gcs_connector.py
@@ -240,7 +240,7 @@ class GCSConnectorBackend(PathBackend, CacheConnectorMixin):
             return versions
 
         except Exception as e:
-            logger.warning(f"[GCS] Batch version fetch failed: {e}, falling back")
+            logger.warning("[GCS] Batch version fetch failed: %s, falling back", e)
             return super().batch_get_versions(backend_paths, contexts)
 
     # === Signed URLs ===

--- a/src/nexus/backends/gmail_connector.py
+++ b/src/nexus/backends/gmail_connector.py
@@ -274,12 +274,14 @@ class GmailConnectorBackend(
                 )
                 # Register with TokenManager using the provider name from config
                 self.token_manager.register_provider(self.provider, provider_instance)  # type: ignore[arg-type]
-                logger.info(f"✓ Registered OAuth provider '{self.provider}' for Gmail backend")
+                logger.info("Registered OAuth provider '%s' for Gmail backend", self.provider)
             except ValueError as e:
                 # Provider not found in config or credentials not set
                 logger.warning(
-                    f"OAuth provider '{self.provider}' not available: {e}. "
-                    "OAuth flow must be initiated manually via the Integrations page."
+                    "OAuth provider '%s' not available: %s. "
+                    "OAuth flow must be initiated manually via the Integrations page.",
+                    self.provider,
+                    e,
                 )
         except Exception as e:
             error_msg = f"Failed to register OAuth provider: {e}\n{traceback.format_exc()}"
@@ -327,7 +329,7 @@ class GmailConnectorBackend(
 
             return skill_md_content
         except Exception as e:
-            logger.warning(f"Failed to load static SKILL.md: {e}, using auto-generated")
+            logger.warning("Failed to load static SKILL.md: %s, using auto-generated", e)
             return super().generate_skill_doc(mount_path)
 
     def write_skill_docs(self, mount_path: str, filesystem: Any = None) -> dict[str, Any]:

--- a/src/nexus/backends/gmail_connector_utils.py
+++ b/src/nexus/backends/gmail_connector_utils.py
@@ -143,18 +143,22 @@ def list_emails_by_folder(
                         if retry < max_retries - 1:
                             delay = base_delay * (2**retry)
                             logger.warning(
-                                f"[LIST-EMAILS] Rate limit hit (429), retrying in {delay}s "
-                                f"(attempt {retry + 1}/{max_retries})"
+                                "[LIST-EMAILS] Rate limit hit (429), retrying in %ss "
+                                "(attempt %d/%d)",
+                                delay,
+                                retry + 1,
+                                max_retries,
                             )
                             time.sleep(delay)
                         else:
                             logger.error(
-                                f"[LIST-EMAILS] Rate limit exceeded after {max_retries} retries"
+                                "[LIST-EMAILS] Rate limit exceeded after %d retries",
+                                max_retries,
                             )
                             raise
                     else:
                         # Non-rate-limit error
-                        logger.error(f"[LIST-EMAILS] Failed to list messages: {e}")
+                        logger.error("[LIST-EMAILS] Failed to list messages: %s", e)
                         raise
 
             if result is None:
@@ -388,7 +392,7 @@ def fetch_emails_batch(
                     else:
                         # Log non-429 errors immediately (these won't be retried)
                         logger.warning(
-                            f"[BATCH-FETCH] Error fetching message {request_id}: {exception}"
+                            "[BATCH-FETCH] Error fetching message %s: %s", request_id, exception
                         )
                     return  # Skip on error
 
@@ -398,7 +402,7 @@ def fetch_emails_batch(
                         email_data = parse_message_func(response)
                         email_cache[message_id] = email_data
                     except Exception as e:
-                        logger.warning(f"[BATCH-FETCH] Error parsing message {request_id}: {e}")
+                        logger.warning("[BATCH-FETCH] Error parsing message %s: %s", request_id, e)
                         pass  # Skip on parse error
 
             return _callback
@@ -433,8 +437,12 @@ def fetch_emails_batch(
                         # Exponential backoff: 1s, 2s, 4s, 8s, 16s
                         delay = base_delay * (2**retry)
                         logger.warning(
-                            f"[BATCH-FETCH] {len(failed_429_ids)} messages hit rate limit (429), "
-                            f"retrying in {delay}s (attempt {retry + 1}/{max_retries})"
+                            "[BATCH-FETCH] %d messages hit rate limit (429), "
+                            "retrying in %ss (attempt %d/%d)",
+                            len(failed_429_ids),
+                            delay,
+                            retry + 1,
+                            max_retries,
                         )
                         time.sleep(delay)
                         # Set up next iteration to retry only the failed messages
@@ -442,8 +450,10 @@ def fetch_emails_batch(
                         continue  # Retry with failed messages
                     else:
                         logger.warning(
-                            f"[BATCH-FETCH] {len(failed_429_ids)} messages still failing after "
-                            f"{max_retries} retries: {failed_429_ids[:5]}..."
+                            "[BATCH-FETCH] %d messages still failing after %d retries: %s...",
+                            len(failed_429_ids),
+                            max_retries,
+                            failed_429_ids[:5],
                         )
 
                 # Success - no failures or retries exhausted
@@ -458,19 +468,27 @@ def fetch_emails_batch(
                         # Exponential backoff: 1s, 2s, 4s, 8s, 16s
                         delay = base_delay * (2**retry)
                         logger.warning(
-                            f"[BATCH-FETCH] Batch request hit rate limit (429), retrying in {delay}s "
-                            f"(attempt {retry + 1}/{max_retries}) for {len(ids_to_fetch)} messages"
+                            "[BATCH-FETCH] Batch request hit rate limit (429), retrying in %ss "
+                            "(attempt %d/%d) for %d messages",
+                            delay,
+                            retry + 1,
+                            max_retries,
+                            len(ids_to_fetch),
                         )
                         time.sleep(delay)
                         # Keep same ids_to_fetch for next iteration
                     else:
                         logger.warning(
-                            f"[BATCH-FETCH] Batch rate limit exceeded after {max_retries} retries "
-                            f"for {len(ids_to_fetch)} messages"
+                            "[BATCH-FETCH] Batch rate limit exceeded after %d retries "
+                            "for %d messages",
+                            max_retries,
+                            len(ids_to_fetch),
                         )
                 else:
                     # Non-rate-limit error - log and break
                     logger.warning(
-                        f"[BATCH-FETCH] Batch execute failed for {len(ids_to_fetch)} messages: {e}"
+                        "[BATCH-FETCH] Batch execute failed for %d messages: %s",
+                        len(ids_to_fetch),
+                        e,
                     )
                     break

--- a/src/nexus/backends/hn_connector.py
+++ b/src/nexus/backends/hn_connector.py
@@ -223,7 +223,7 @@ class HNConnectorBackend(Backend, CacheConnectorMixin, SkillDocMixin):
             result: dict[str, Any] | None = response.json()
             return result
         except Exception as e:
-            logger.warning(f"Failed to fetch item {item_id}: {e}")
+            logger.warning("Failed to fetch item %s: %s", item_id, e)
             return None
 
     async def _fetch_items_batch(self, item_ids: list[int]) -> list[dict[str, Any]]:
@@ -427,7 +427,7 @@ class HNConnectorBackend(Backend, CacheConnectorMixin, SkillDocMixin):
         if self._has_caching():
             cached = self._read_from_cache(cache_path, original=True)
             if cached and not cached.stale and cached.content_binary:
-                logger.info(f"[HN] Cache hit: {path}")
+                logger.info("[HN] Cache hit: %s", path)
                 return cached.content_binary
 
         # Resolve path
@@ -440,7 +440,7 @@ class HNConnectorBackend(Backend, CacheConnectorMixin, SkillDocMixin):
             )
 
         # Fetch from HN API
-        logger.info(f"[HN] Fetching from API: {feed}/{rank}")
+        logger.info("[HN] Fetching from API: %s/%s", feed, rank)
 
         async def _fetch() -> bytes:
             try:
@@ -465,7 +465,7 @@ class HNConnectorBackend(Backend, CacheConnectorMixin, SkillDocMixin):
                     zone_id=zone_id,
                 )
             except Exception as e:
-                logger.warning(f"Failed to cache {path}: {e}")
+                logger.warning("Failed to cache %s: %s", path, e)
 
         return content
 

--- a/src/nexus/backends/local.py
+++ b/src/nexus/backends/local.py
@@ -162,14 +162,16 @@ class LocalBackend(Backend, ChunkedStorageMixin, MultipartUploadMixin):
             self._cas_bloom = BloomFilter(self._bloom_capacity, self._bloom_fp_rate)
             self._populate_cas_bloom_from_disk()
             logger.debug(
-                f"CAS Bloom filter initialized: capacity={self._bloom_capacity}, "
-                f"fp_rate={self._bloom_fp_rate}, memory={self._cas_bloom.memory_bytes} bytes"
+                "CAS Bloom filter initialized: capacity=%d, fp_rate=%s, memory=%d bytes",
+                self._bloom_capacity,
+                self._bloom_fp_rate,
+                self._cas_bloom.memory_bytes,
             )
         except ImportError:
             logger.warning("nexus_fast not available, CAS Bloom filter disabled")
             self._cas_bloom = None
         except Exception as e:
-            logger.warning(f"Failed to initialize CAS Bloom filter: {e}")
+            logger.warning("Failed to initialize CAS Bloom filter: %s", e)
             self._cas_bloom = None
 
     def _populate_cas_bloom_from_disk(self) -> None:
@@ -192,9 +194,9 @@ class LocalBackend(Backend, ChunkedStorageMixin, MultipartUploadMixin):
 
             if keys:
                 self._cas_bloom.add_bulk(keys)
-                logger.info(f"CAS Bloom filter populated with {len(keys)} entries from disk")
+                logger.info("CAS Bloom filter populated with %d entries from disk", len(keys))
         except Exception as e:
-            logger.warning(f"Failed to populate CAS Bloom filter from disk: {e}")
+            logger.warning("Failed to populate CAS Bloom filter from disk: %s", e)
 
     def _cas_bloom_check(self, content_hash: str) -> bool:
         """Check Bloom filter for possible CAS content existence.
@@ -863,7 +865,7 @@ class LocalBackend(Backend, ChunkedStorageMixin, MultipartUploadMixin):
         meta_path = upload_dir / "_meta.json"
         meta_path.write_text(json.dumps(meta), encoding="utf-8")
 
-        logger.debug(f"Initialized multipart upload {upload_id} for {backend_path}")
+        logger.debug("Initialized multipart upload %s for %s", upload_id, backend_path)
         return upload_id
 
     def upload_part(
@@ -945,7 +947,7 @@ class LocalBackend(Backend, ChunkedStorageMixin, MultipartUploadMixin):
 
         # Clean up temp directory
         shutil.rmtree(upload_dir, ignore_errors=True)
-        logger.debug(f"Completed multipart upload {upload_id} -> {content_hash}")
+        logger.debug("Completed multipart upload %s -> %s", upload_id, content_hash)
 
         return content_hash
 
@@ -963,4 +965,4 @@ class LocalBackend(Backend, ChunkedStorageMixin, MultipartUploadMixin):
         upload_dir = self.root_path / "uploads" / upload_id
         if upload_dir.exists():
             shutil.rmtree(upload_dir, ignore_errors=True)
-            logger.debug(f"Aborted multipart upload {upload_id}")
+            logger.debug("Aborted multipart upload %s", upload_id)

--- a/src/nexus/backends/local_connector.py
+++ b/src/nexus/backends/local_connector.py
@@ -330,13 +330,13 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
             try:
                 cached = self._read_from_cache(cache_path, original=True)
                 if cached and not cached.stale and cached.content_binary:
-                    logger.info(f"[LocalConnectorBackend] L1 cache hit: {cache_path}")
+                    logger.info("[LocalConnectorBackend] L1 cache hit: %s", cache_path)
                     return cached.content_binary
             except Exception as e:
                 logger.debug("[CACHE] Cache read failed for %s: %s", cache_path, e)
 
         # Step 2: L1 miss - read from disk
-        logger.debug(f"[LocalConnectorBackend] L1 cache miss, reading from disk: {path}")
+        logger.debug("[LocalConnectorBackend] L1 cache miss, reading from disk: %s", path)
         physical = self._to_physical(path)
 
         if not physical.exists():
@@ -490,7 +490,7 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
                     entries.append(entry)
                 except OSError:
                     # Skip entries we can't stat (broken symlinks, permission issues)
-                    logger.debug(f"Skipping unreadable entry: {item}")
+                    logger.debug("Skipping unreadable entry: %s", item)
                     continue
             return HandlerResponse.ok(data=entries)
         except PermissionError as e:

--- a/src/nexus/backends/passthrough.py
+++ b/src/nexus/backends/passthrough.py
@@ -161,7 +161,7 @@ class PassthroughBackend(Backend):
 
             os.replace(str(tmp_path), str(pointer_path))
             tmp_path = None
-            logger.debug(f"Wrote pointer: {virtual_path} -> {content_hash}")
+            logger.debug("Wrote pointer: %s -> %s", virtual_path, content_hash)
 
         except OSError as e:
             raise BackendError(
@@ -185,10 +185,10 @@ class PassthroughBackend(Backend):
             content = pointer_path.read_text(encoding="utf-8").strip()
             if content.startswith(POINTER_PREFIX):
                 return content[len(POINTER_PREFIX) :]
-            logger.warning(f"Invalid pointer format at {virtual_path}: {content[:50]}")
+            logger.warning("Invalid pointer format at %s: %s", virtual_path, content[:50])
             return None
         except OSError as e:
-            logger.warning(f"Failed to read pointer {virtual_path}: {e}")
+            logger.warning("Failed to read pointer %s: %s", virtual_path, e)
             return None
 
     def _delete_pointer(self, virtual_path: str) -> bool:
@@ -273,7 +273,7 @@ class PassthroughBackend(Backend):
 
                 os.replace(str(tmp_path), str(cas_path))
                 tmp_path = None
-                logger.debug(f"Wrote CAS content: {content_hash}")
+                logger.debug("Wrote CAS content: %s", content_hash)
 
             except OSError as e:
                 raise BackendError(

--- a/src/nexus/backends/slack_connector.py
+++ b/src/nexus/backends/slack_connector.py
@@ -178,12 +178,14 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
                 provider_instance = factory.create_provider(name=self.provider)
                 # Register with TokenManager using the provider name from config
                 self.token_manager.register_provider(self.provider, provider_instance)
-                logger.info(f"✓ Registered OAuth provider '{self.provider}' for Slack backend")
+                logger.info("Registered OAuth provider '%s' for Slack backend", self.provider)
             except ValueError as e:
                 # Provider not found in config or credentials not set
                 logger.warning(
-                    f"OAuth provider '{self.provider}' not available: {e}. "
-                    "OAuth flow must be initiated manually via the Integrations page."
+                    "OAuth provider '%s' not available: %s. "
+                    "OAuth flow must be initiated manually via the Integrations page.",
+                    self.provider,
+                    e,
                 )
         except Exception as e:
             error_msg = f"Failed to register OAuth provider: {e}\n{traceback.format_exc()}"

--- a/src/nexus/backends/slack_connector_utils.py
+++ b/src/nexus/backends/slack_connector_utils.py
@@ -66,17 +66,20 @@ def list_channels(
                         if retry < max_retries - 1:
                             delay = base_delay * (2**retry)
                             logger.warning(
-                                f"[LIST-CHANNELS] Rate limit hit, retrying in {delay}s "
-                                f"(attempt {retry + 1}/{max_retries})"
+                                "[LIST-CHANNELS] Rate limit hit, retrying in %ss (attempt %d/%d)",
+                                delay,
+                                retry + 1,
+                                max_retries,
                             )
                             time.sleep(delay)
                         else:
                             logger.error(
-                                f"[LIST-CHANNELS] Rate limit exceeded after {max_retries} retries"
+                                "[LIST-CHANNELS] Rate limit exceeded after %d retries",
+                                max_retries,
                             )
                             raise
                     else:
-                        logger.error(f"[LIST-CHANNELS] Failed to list channels: {e}")
+                        logger.error("[LIST-CHANNELS] Failed to list channels: %s", e)
                         raise
 
             if result is None or not result.get("ok"):
@@ -95,7 +98,7 @@ def list_channels(
                 break
 
         except Exception as e:
-            logger.error(f"[LIST-CHANNELS] Error listing channels: {e}")
+            logger.error("[LIST-CHANNELS] Error listing channels: %s", e)
             break
 
     if not silent:
@@ -174,17 +177,22 @@ def list_messages_from_channel(
                         if retry < max_retries - 1:
                             delay = base_delay * (2**retry)
                             logger.warning(
-                                f"[LIST-MESSAGES] Rate limit hit for #{channel_name}, "
-                                f"retrying in {delay}s (attempt {retry + 1}/{max_retries})"
+                                "[LIST-MESSAGES] Rate limit hit for #%s, "
+                                "retrying in %ss (attempt %d/%d)",
+                                channel_name,
+                                delay,
+                                retry + 1,
+                                max_retries,
                             )
                             time.sleep(delay)
                         else:
                             logger.error(
-                                f"[LIST-MESSAGES] Rate limit exceeded after {max_retries} retries"
+                                "[LIST-MESSAGES] Rate limit exceeded after %d retries",
+                                max_retries,
                             )
                             raise
                     else:
-                        logger.error(f"[LIST-MESSAGES] Failed to list messages: {e}")
+                        logger.error("[LIST-MESSAGES] Failed to list messages: %s", e)
                         raise
 
             if result is None or not result.get("ok"):
@@ -209,7 +217,7 @@ def list_messages_from_channel(
                 break
 
         except Exception as e:
-            logger.error(f"[LIST-MESSAGES] Error listing messages from #{channel_name}: {e}")
+            logger.error("[LIST-MESSAGES] Error listing messages from #%s: %s", channel_name, e)
             break
 
     if not silent:
@@ -243,7 +251,7 @@ def list_thread_replies(
 
         if not result.get("ok"):
             error = result.get("error", "unknown_error")
-            logger.error(f"[LIST-THREAD-REPLIES] Slack API error: {error}")
+            logger.error("[LIST-THREAD-REPLIES] Slack API error: %s", error)
             return []
 
         messages = result.get("messages", [])
@@ -254,7 +262,7 @@ def list_thread_replies(
         return messages
 
     except Exception as e:
-        logger.error(f"[LIST-THREAD-REPLIES] Error fetching thread replies: {e}")
+        logger.error("[LIST-THREAD-REPLIES] Error fetching thread replies: %s", e)
         return []
 
 
@@ -292,7 +300,7 @@ def get_user_info(
 
         if not result.get("ok"):
             error = result.get("error", "unknown_error")
-            logger.warning(f"[GET-USER-INFO] Failed to get user {user_id}: {error}")
+            logger.warning("[GET-USER-INFO] Failed to get user %s: %s", user_id, error)
             return None
 
         user_info = result.get("user")
@@ -304,7 +312,7 @@ def get_user_info(
         return user_info
 
     except Exception as e:
-        logger.warning(f"[GET-USER-INFO] Error fetching user {user_id}: {e}")
+        logger.warning("[GET-USER-INFO] Error fetching user %s: %s", user_id, e)
         return None
 
 

--- a/src/nexus/backends/sync_pipeline.py
+++ b/src/nexus/backends/sync_pipeline.py
@@ -104,7 +104,7 @@ class SyncPipelineService:
         virtual_paths = list(backend_to_virtual.values())
 
         # STEP 2: Bulk load existing cache entries (L1 + L2)
-        logger.info(f"[CACHE-SYNC] Step 2: Bulk loading cache for {len(virtual_paths)} paths...")
+        logger.info("[CACHE-SYNC] Step 2: Bulk loading cache for %d paths...", len(virtual_paths))
         cached_entries = self._step2_load_cache(virtual_paths)
 
         # STEP 3: Determine which files need backend reads
@@ -115,7 +115,8 @@ class SyncPipelineService:
 
         # STEP 4: Batch read content from backend
         logger.info(
-            f"[CACHE-SYNC] Step 4: Batch reading {len(files_needing_backend)} files from backend..."
+            "[CACHE-SYNC] Step 4: Batch reading %d files from backend...",
+            len(files_needing_backend),
         )
         backend_contents = self._step4_read_backend(files_needing_backend, file_contexts)
 
@@ -128,20 +129,22 @@ class SyncPipelineService:
         # STEP 6: Batch write to cache (single transaction)
         if cache_entries_to_write:
             logger.info(
-                f"[CACHE-SYNC] Step 6: Batch writing {len(cache_entries_to_write)} entries..."
+                "[CACHE-SYNC] Step 6: Batch writing %d entries...", len(cache_entries_to_write)
             )
             self._step6_write_cache(cache_entries_to_write, result)
 
         # STEP 7: Generate embeddings (optional)
         if files_to_embed:
             logger.info(
-                f"[CACHE-SYNC] Step 7: Generating embeddings for {len(files_to_embed)} files..."
+                "[CACHE-SYNC] Step 7: Generating embeddings for %d files...", len(files_to_embed)
             )
             self._step7_generate_embeddings(files_to_embed, result)
 
         logger.info(
-            f"[CACHE-SYNC] Complete: synced={result.files_synced}, "
-            f"skipped={result.files_skipped}, errors={len(result.errors)}"
+            "[CACHE-SYNC] Complete: synced=%d, skipped=%d, errors=%d",
+            result.files_synced,
+            result.files_skipped,
+            len(result.errors),
         )
 
         # Notify search indexer to reindex if files were synced (Issue #2188: DI callback)
@@ -225,8 +228,9 @@ class SyncPipelineService:
             result.files_skipped += original_count - len(backend_to_virtual)
 
         logger.info(
-            f"[CACHE-SYNC] Step 1 complete: {len(backend_to_virtual)} files to process "
-            f"(filtered {result.files_skipped} by patterns)"
+            "[CACHE-SYNC] Step 1 complete: %d files to process (filtered %d by patterns)",
+            len(backend_to_virtual),
+            result.files_skipped,
         )
         return list(backend_to_virtual.keys()), backend_to_virtual
 
@@ -236,8 +240,9 @@ class SyncPipelineService:
             virtual_paths, original=True
         )
         logger.info(
-            f"[CACHE-SYNC] Step 2 complete: {len(cached_entries)} entries found in cache "
-            f"({len(virtual_paths) - len(cached_entries)} not cached)"
+            "[CACHE-SYNC] Step 2 complete: %d entries found in cache (%d not cached)",
+            len(cached_entries),
+            len(virtual_paths) - len(cached_entries),
         )
         return cached_entries
 
@@ -280,7 +285,7 @@ class SyncPipelineService:
 
             # Skip immutable cached files (Gmail emails never change)
             if cached and not cached.stale and cached.backend_version == IMMUTABLE_VERSION:
-                logger.debug(f"[CACHE] SYNC SKIP (immutable): {vpath}")
+                logger.debug("[CACHE] SYNC SKIP (immutable): %s", vpath)
                 result.files_skipped += 1
                 continue
 
@@ -291,14 +296,14 @@ class SyncPipelineService:
         # Batch fetch versions if supported
         if paths_needing_version_check and hasattr(connector, "batch_get_versions"):
             logger.info(
-                f"[CACHE-SYNC] Batch fetching versions for "
-                f"{len(paths_needing_version_check)} files..."
+                "[CACHE-SYNC] Batch fetching versions for %d files...",
+                len(paths_needing_version_check),
             )
             try:
                 versions = connector.batch_get_versions(paths_needing_version_check, all_contexts)
-                logger.info(f"[CACHE-SYNC] Batch version fetch complete: {len(versions)} versions")
+                logger.info("[CACHE-SYNC] Batch version fetch complete: %d versions", len(versions))
             except Exception as e:
-                logger.warning(f"[CACHE-SYNC] Batch version fetch failed: {e}")
+                logger.warning("[CACHE-SYNC] Batch version fetch failed: %s", e)
                 versions = {}
 
         # Filter files based on version checks
@@ -328,7 +333,7 @@ class SyncPipelineService:
                     and cached.backend_version
                     and cached.backend_version == version
                 ):
-                    logger.debug(f"[CACHE] SYNC SKIP (version match): {vpath}")
+                    logger.debug("[CACHE] SYNC SKIP (version match): %s", vpath)
                     result.files_skipped += 1
                     continue
 
@@ -345,8 +350,9 @@ class SyncPipelineService:
                 result.errors.append(f"Failed to prepare sync for {backend_path}: {e}")
 
         logger.info(
-            f"[CACHE-SYNC] Step 3 complete: {len(files_needing_backend)} files need backend reads "
-            f"({len(files) - len(files_needing_backend)} skipped as fresh)"
+            "[CACHE-SYNC] Step 3 complete: %d files need backend reads (%d skipped as fresh)",
+            len(files_needing_backend),
+            len(files) - len(files_needing_backend),
         )
         return files_needing_backend, file_contexts, file_metadata
 
@@ -360,8 +366,10 @@ class SyncPipelineService:
             files, contexts
         )
         logger.info(
-            f"[CACHE-SYNC] Step 4 complete: {len(backend_contents)}/{len(files)} files read "
-            f"({len(files) - len(backend_contents)} failed)"
+            "[CACHE-SYNC] Step 4 complete: %d/%d files read (%d failed)",
+            len(backend_contents),
+            len(files),
+            len(files) - len(backend_contents),
         )
         return backend_contents
 
@@ -391,13 +399,15 @@ class SyncPipelineService:
                     content_hash = hash_content(content)
                     cached_hash = hash_content(cached.content_binary)
                     if content_hash == cached_hash:
-                        logger.debug(f"[CACHE] SYNC SKIP (hash match): {vpath}")
+                        logger.debug("[CACHE] SYNC SKIP (hash match): %s", vpath)
                         result.files_skipped += 1
                         continue
 
                 # Skip if too large
                 if len(content) > max_size:
-                    logger.debug(f"[CACHE] SYNC SKIP (too large): {vpath} ({len(content)} bytes)")
+                    logger.debug(
+                        "[CACHE] SYNC SKIP (too large): %s (%d bytes)", vpath, len(content)
+                    )
                     result.files_skipped += 1
                     continue
 
@@ -431,8 +441,9 @@ class SyncPipelineService:
                 result.errors.append(f"Failed to process {backend_path}: {e}")
 
         logger.info(
-            f"[CACHE-SYNC] Step 5 complete: {len(cache_entries_to_write)} entries prepared "
-            f"({result.bytes_synced} bytes total)"
+            "[CACHE-SYNC] Step 5 complete: %d entries prepared (%d bytes total)",
+            len(cache_entries_to_write),
+            result.bytes_synced,
         )
         return cache_entries_to_write, files_to_embed
 
@@ -444,10 +455,10 @@ class SyncPipelineService:
         """Step 6: Batch write to cache (single transaction)."""
         try:
             self._connector.batch_write_to_cache(cache_entries)
-            logger.info(f"[CACHE-SYNC] Step 6 complete: {len(cache_entries)} entries written")
+            logger.info("[CACHE-SYNC] Step 6 complete: %d entries written", len(cache_entries))
         except Exception as e:
             result.errors.append(f"Failed to batch write cache entries: {e}")
-            logger.error(f"[CACHE-SYNC] Step 6 failed: {e}")
+            logger.error("[CACHE-SYNC] Step 6 failed: %s", e)
 
     def _step7_generate_embeddings(
         self,
@@ -463,7 +474,7 @@ class SyncPipelineService:
                 result.errors.append(f"Failed to generate embeddings for {vpath}: {e}")
 
         logger.info(
-            f"[CACHE-SYNC] Step 7 complete: {result.embeddings_generated} embeddings generated"
+            "[CACHE-SYNC] Step 7 complete: %d embeddings generated", result.embeddings_generated
         )
 
     # =========================================================================

--- a/src/nexus/server/cache_warmer.py
+++ b/src/nexus/server/cache_warmer.py
@@ -371,7 +371,7 @@ class FileAccessTracker:
                 removed += 1
 
         if removed > 0:
-            logger.debug(f"[WARMUP] Cleaned up {removed} stale file access entries")
+            logger.debug("[WARMUP] Cleaned up %d stale file access entries", removed)
 
         return removed
 
@@ -491,8 +491,12 @@ class CacheWarmer:
 
         try:
             logger.info(
-                f"[WARMUP] Starting directory warmup: path={path}, depth={depth}, "
-                f"include_content={include_content}, max_files={max_files}"
+                "[WARMUP] Starting directory warmup: path=%s, depth=%s, "
+                "include_content=%s, max_files=%s",
+                path,
+                depth,
+                include_content,
+                max_files,
             )
 
             # Get files using glob
@@ -500,7 +504,7 @@ class CacheWarmer:
             files = self._nexus.glob(pattern, path="/", context=context)
             files = files[:max_files]
 
-            logger.info(f"[WARMUP] Found {len(files)} files to warm")
+            logger.info("[WARMUP] Found %d files to warm", len(files))
 
             # Parallel metadata warmup
             metadata_tasks = [self._warmup_metadata(f, zone_id, context) for f in files]
@@ -518,12 +522,12 @@ class CacheWarmer:
             self._current_stats.duration_seconds = time.time() - start_time
             self._current_stats.files_warmed = len(files)
 
-            logger.info(f"[WARMUP] Directory warmup complete: {self._current_stats.to_dict()}")
+            logger.info("[WARMUP] Directory warmup complete: %s", self._current_stats.to_dict())
 
             return self._current_stats
 
         except Exception as e:
-            logger.error(f"[WARMUP] Directory warmup failed: {e}", exc_info=True)
+            logger.error("[WARMUP] Directory warmup failed: %s", e, exc_info=True)
             self._current_stats.errors += 1
             raise
 
@@ -566,8 +570,10 @@ class CacheWarmer:
 
         try:
             logger.info(
-                f"[WARMUP] Starting history warmup: user={user}, hours={hours}, "
-                f"max_files={max_files}"
+                "[WARMUP] Starting history warmup: user=%s, hours=%s, max_files=%s",
+                user,
+                hours,
+                max_files,
             )
 
             # Get recent files from tracker
@@ -580,7 +586,7 @@ class CacheWarmer:
 
             # Identify hot files (accessed multiple times)
             hot_files = [f for f in recent_files if f.access_count >= 2]
-            logger.info(f"[WARMUP] Found {len(hot_files)} hot files from history")
+            logger.info("[WARMUP] Found %d hot files from history", len(hot_files))
 
             # Warm content for hot files
             content_tasks = [self._warmup_content(f.path, zone_id, context) for f in hot_files]
@@ -589,12 +595,12 @@ class CacheWarmer:
             self._current_stats.duration_seconds = time.time() - start_time
             self._current_stats.files_warmed = len(hot_files)
 
-            logger.info(f"[WARMUP] History warmup complete: {self._current_stats.to_dict()}")
+            logger.info("[WARMUP] History warmup complete: %s", self._current_stats.to_dict())
 
             return self._current_stats
 
         except Exception as e:
-            logger.error(f"[WARMUP] History warmup failed: {e}", exc_info=True)
+            logger.error("[WARMUP] History warmup failed: %s", e, exc_info=True)
             self._current_stats.errors += 1
             raise
 
@@ -626,7 +632,7 @@ class CacheWarmer:
         start_time = time.time()
 
         try:
-            logger.info(f"[WARMUP] Starting permission warmup: user={user}")
+            logger.info("[WARMUP] Starting permission warmup: user=%s", user)
 
             # Get rebac manager
             rebac_manager = getattr(self._nexus, "rebac_manager", None)
@@ -645,17 +651,17 @@ class CacheWarmer:
                     await self._warmup_permission_check(rebac_manager, user, path, zone_id)
                     self._current_stats.permissions_warmed += 1
                 except Exception as e:
-                    logger.debug(f"[WARMUP] Permission check failed for {path}: {e}")
+                    logger.debug("[WARMUP] Permission check failed for %s: %s", path, e)
                     self._current_stats.errors += 1
 
             self._current_stats.duration_seconds = time.time() - start_time
 
-            logger.info(f"[WARMUP] Permission warmup complete: {self._current_stats.to_dict()}")
+            logger.info("[WARMUP] Permission warmup complete: %s", self._current_stats.to_dict())
 
             return self._current_stats
 
         except Exception as e:
-            logger.error(f"[WARMUP] Permission warmup failed: {e}", exc_info=True)
+            logger.error("[WARMUP] Permission warmup failed: %s", e, exc_info=True)
             self._current_stats.errors += 1
             raise
 
@@ -688,7 +694,7 @@ class CacheWarmer:
         start_time = time.time()
 
         try:
-            logger.info(f"[WARMUP] Warming {len(paths)} specific paths")
+            logger.info("[WARMUP] Warming %d specific paths", len(paths))
 
             # Warm metadata
             metadata_tasks = [self._warmup_metadata(p, zone_id, context) for p in paths]
@@ -747,7 +753,7 @@ class CacheWarmer:
                     self._current_stats.metadata_warmed += 1
 
             except Exception as e:
-                logger.debug(f"[WARMUP] Metadata warmup failed for {path}: {e}")
+                logger.debug("[WARMUP] Metadata warmup failed for %s: %s", path, e)
                 self._current_stats.errors += 1
 
     async def _warmup_content(
@@ -782,7 +788,7 @@ class CacheWarmer:
                             )
 
             except Exception as e:
-                logger.debug(f"[WARMUP] Content warmup failed for {path}: {e}")
+                logger.debug("[WARMUP] Content warmup failed for %s: %s", path, e)
                 self._current_stats.errors += 1
 
     async def _filter_small_files(
@@ -825,7 +831,7 @@ class CacheWarmer:
                     zone_id=zone_id,
                 )
         except Exception as e:
-            logger.debug(f"[WARMUP] Permission check warming failed: {e}")
+            logger.debug("[WARMUP] Permission check warming failed: %s", e)
 
     async def _get_common_paths(self, _zone_id: str) -> list[str]:
         """Get common paths for permission warming."""
@@ -914,7 +920,8 @@ class BackgroundCacheWarmer:
 
         self._running = True
         logger.info(
-            f"[WARMUP] Starting background warmer (interval: {self._config.interval_seconds}s)"
+            "[WARMUP] Starting background warmer (interval: %ds)",
+            self._config.interval_seconds,
         )
 
         cleanup_counter = 0
@@ -933,7 +940,7 @@ class BackgroundCacheWarmer:
                     cleanup_counter = 0
 
             except Exception as e:
-                logger.error(f"[WARMUP] Background cycle failed: {e}", exc_info=True)
+                logger.error("[WARMUP] Background cycle failed: %s", e, exc_info=True)
 
             await asyncio.sleep(self._config.interval_seconds)
 
@@ -954,7 +961,7 @@ class BackgroundCacheWarmer:
         paths = [f.path for f in hot_files]
         await self._warmer.warmup_paths(paths, include_content=True)
 
-        logger.debug(f"[WARMUP] Background cycle warmed {len(paths)} files")
+        logger.debug("[WARMUP] Background cycle warmed %d files", len(paths))
 
     def get_stats(self) -> dict[str, Any]:
         """Get background warmer statistics."""

--- a/src/nexus/server/dependencies.py
+++ b/src/nexus/server/dependencies.py
@@ -197,7 +197,7 @@ async def resolve_auth(
             result = await _state.auth_provider.authenticate(token)
             _auth_elapsed = (_time.time() - _auth_start) * 1000
             if _auth_elapsed > 10:  # Log if auth takes >10ms
-                logger.info(f"[AUTH-TIMING] provider auth took {_auth_elapsed:.1f}ms (cache miss)")
+                logger.info("[AUTH-TIMING] provider auth took %.1fms (cache miss)", _auth_elapsed)
             if result is None:
                 # Issue #16: random delay on auth failure to mitigate timing side-channel.
                 # Delay BEFORE set_result so singleflight waiters also experience it.

--- a/src/nexus/server/rpc/dispatch.py
+++ b/src/nexus/server/rpc/dispatch.py
@@ -175,7 +175,7 @@ async def fire_rpc_event(
 
         await subscription_manager.broadcast(event_type, data, zone_id)
     except Exception as e:
-        logger.warning(f"[RPC] Failed to fire event {event_type} for {path}: {e}")
+        logger.warning("[RPC] Failed to fire event %s for %s: %s", event_type, path, e)
 
 
 async def dispatch_method(

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -106,7 +106,7 @@ def generate_download_url(
         return None
 
     except Exception as e:
-        logger.warning(f"Failed to generate download URL for {path}: {e}")
+        logger.warning("Failed to generate download URL for %s: %s", path, e)
         return None
 
 
@@ -277,9 +277,13 @@ def handle_list(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, Any
         _build_elapsed = (_time.time() - _build_start) * 1000
         _total_elapsed = (_time.time() - _handle_start) * 1000
         logger.info(
-            f"[HANDLE-LIST] path={params.path}, list={_list_elapsed:.1f}ms, "
-            f"build={_build_elapsed:.1f}ms, total={_total_elapsed:.1f}ms, "
-            f"files={len(items)}, has_more={paginated['has_more']}"
+            "[HANDLE-LIST] path=%s, list=%.1fms, build=%.1fms, total=%.1fms, files=%d, has_more=%s",
+            params.path,
+            _list_elapsed,
+            _build_elapsed,
+            _total_elapsed,
+            len(items),
+            paginated["has_more"],
         )
         return response
 
@@ -296,8 +300,12 @@ def handle_list(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, Any
     _build_elapsed = (_time.time() - _build_start) * 1000
     _total_elapsed = (_time.time() - _handle_start) * 1000
     logger.info(
-        f"[HANDLE-LIST] path={params.path}, list={_list_elapsed:.1f}ms, "
-        f"build={_build_elapsed:.1f}ms, total={_total_elapsed:.1f}ms, files={len(entries)}"
+        "[HANDLE-LIST] path=%s, list=%.1fms, build=%.1fms, total=%.1fms, files=%d",
+        params.path,
+        _list_elapsed,
+        _build_elapsed,
+        _total_elapsed,
+        len(entries),
     )
     return response
 

--- a/src/nexus/server/telemetry.py
+++ b/src/nexus/server/telemetry.py
@@ -137,16 +137,18 @@ def setup_telemetry(
         _set_rebac_tracer(trace.get_tracer("nexus.bricks.rebac"))
 
         logger.info(
-            f"OpenTelemetry initialized: service={_service_name}, "
-            f"endpoint={_endpoint}, sample_ratio={_sample_ratio}"
+            "OpenTelemetry initialized: service=%s, endpoint=%s, sample_ratio=%s",
+            _service_name,
+            _endpoint,
+            _sample_ratio,
         )
         return True
 
     except ImportError as e:
-        logger.warning(f"OpenTelemetry packages not installed: {e}")
+        logger.warning("OpenTelemetry packages not installed: %s", e)
         return False
     except Exception as e:
-        logger.error(f"Failed to initialize OpenTelemetry: {e}")
+        logger.error("Failed to initialize OpenTelemetry: %s", e)
         return False
 
 
@@ -161,7 +163,7 @@ def _instrument_libraries() -> None:
     except ImportError:
         logger.debug("httpx instrumentation not available")
     except Exception as e:
-        logger.warning(f"Failed to instrument httpx: {e}")
+        logger.warning("Failed to instrument httpx: %s", e)
 
     # SQLAlchemy - database
     try:
@@ -175,7 +177,7 @@ def _instrument_libraries() -> None:
     except ImportError:
         logger.debug("sqlalchemy instrumentation not available")
     except Exception as e:
-        logger.warning(f"Failed to instrument sqlalchemy: {e}")
+        logger.warning("Failed to instrument sqlalchemy: %s", e)
 
     # Redis - cache
     try:
@@ -186,7 +188,7 @@ def _instrument_libraries() -> None:
     except ImportError:
         logger.debug("redis instrumentation not available")
     except Exception as e:
-        logger.warning(f"Failed to instrument redis: {e}")
+        logger.warning("Failed to instrument redis: %s", e)
 
     # aiohttp - async HTTP client (used by some backends)
     try:
@@ -197,7 +199,7 @@ def _instrument_libraries() -> None:
     except ImportError:
         logger.debug("aiohttp instrumentation not available")
     except Exception as e:
-        logger.warning(f"Failed to instrument aiohttp: {e}")
+        logger.warning("Failed to instrument aiohttp: %s", e)
 
 
 def instrument_fastapi_app(app: object) -> bool:
@@ -227,7 +229,7 @@ def instrument_fastapi_app(app: object) -> bool:
         logger.debug("FastAPI instrumentation not available")
         return False
     except Exception as e:
-        logger.warning(f"Failed to instrument FastAPI: {e}")
+        logger.warning("Failed to instrument FastAPI: %s", e)
         return False
 
 
@@ -246,7 +248,7 @@ def shutdown_telemetry() -> None:
             provider.shutdown()
         logger.info("OpenTelemetry shutdown complete")
     except Exception as e:
-        logger.warning(f"Error during OpenTelemetry shutdown: {e}")
+        logger.warning("Error during OpenTelemetry shutdown: %s", e)
     finally:
         reset_telemetry_state()
         # Reset rebac tracer

--- a/src/nexus/system_services/sync/sync_backlog_store.py
+++ b/src/nexus/system_services/sync/sync_backlog_store.py
@@ -118,7 +118,7 @@ class SyncBacklogStore(SyncStoreBase):
             session.commit()
             return True
         except Exception as e:
-            logger.warning(f"Failed to enqueue backlog for {path}: {e}")
+            logger.warning("Failed to enqueue backlog for %s: %s", path, e)
             session.rollback()
             return False
         finally:
@@ -150,7 +150,7 @@ class SyncBacklogStore(SyncStoreBase):
             rows = session.execute(stmt).all()
             return [(row[0], row[1]) for row in rows]
         except Exception as e:
-            logger.warning(f"Failed to fetch distinct backend zones: {e}")
+            logger.warning("Failed to fetch distinct backend zones: %s", e)
             return []
         finally:
             session.close()
@@ -193,7 +193,7 @@ class SyncBacklogStore(SyncStoreBase):
             rows = session.execute(stmt).scalars().all()
             return [self._to_entry(row) for row in rows]
         except Exception as e:
-            logger.warning(f"Failed to fetch pending backlog for {backend_name}: {e}")
+            logger.warning("Failed to fetch pending backlog for %s: %s", backend_name, e)
             return []
         finally:
             session.close()
@@ -256,7 +256,7 @@ class SyncBacklogStore(SyncStoreBase):
             session.commit()
             return True
         except Exception as e:
-            logger.warning(f"Failed to mark backlog {entry_id} as failed: {e}")
+            logger.warning("Failed to mark backlog %s as failed: %s", entry_id, e)
             session.rollback()
             return False
         finally:
@@ -329,11 +329,14 @@ class SyncBacklogStore(SyncStoreBase):
             total: int = ttl_expired + cap_expired
             if total > 0:
                 logger.info(
-                    f"[SYNC_BACKLOG] Expired {total} entries (ttl={ttl_expired}, cap={cap_expired})"
+                    "[SYNC_BACKLOG] Expired %d entries (ttl=%d, cap=%d)",
+                    total,
+                    ttl_expired,
+                    cap_expired,
                 )
             return total
         except Exception as e:
-            logger.warning(f"Failed to expire stale backlog entries: {e}")
+            logger.warning("Failed to expire stale backlog entries: %s", e)
             session.rollback()
             return 0
         finally:
@@ -368,7 +371,7 @@ class SyncBacklogStore(SyncStoreBase):
             rows = session.execute(stmt).all()
             return dict(rows)
         except Exception as e:
-            logger.warning(f"Failed to get backlog stats: {e}")
+            logger.warning("Failed to get backlog stats: %s", e)
             return {}
         finally:
             session.close()
@@ -414,7 +417,11 @@ class SyncBacklogStore(SyncStoreBase):
             return bool(result.rowcount > 0)
         except Exception as e:
             logger.warning(
-                f"Failed to transition backlog {entry_id} from {from_status} to {new_status}: {e}"
+                "Failed to transition backlog %s from %s to %s: %s",
+                entry_id,
+                from_status,
+                new_status,
+                e,
             )
             session.rollback()
             return False

--- a/src/nexus/system_services/sync/sync_job_manager.py
+++ b/src/nexus/system_services/sync/sync_job_manager.py
@@ -138,7 +138,7 @@ class SyncJobManager:
             session.add(job)
             session.commit()
 
-        logger.info(f"Created sync job {job_id} for mount {mount_point}")
+        logger.info("Created sync job %s for mount %s", job_id, mount_point)
         return job_id
 
     async def start_job(self, job_id: str, nexus_fs: "NexusFS") -> None:
@@ -165,7 +165,7 @@ class SyncJobManager:
         task = asyncio.create_task(self._run_sync(job_id, nexus_fs))
         self._active_jobs[job_id] = task
 
-        logger.info(f"Started sync job {job_id}")
+        logger.info("Started sync job %s", job_id)
 
     def cancel_job(self, job_id: str) -> bool:
         """Request cancellation of a running sync job.
@@ -181,12 +181,12 @@ class SyncJobManager:
             return False
 
         if job["status"] != "running":
-            logger.warning(f"Cannot cancel job {job_id}: status is {job['status']}")
+            logger.warning("Cannot cancel job %s: status is %s", job_id, job["status"])
             return False
 
         # Set cancellation flag
         self._cancellation_flags[job_id] = True
-        logger.info(f"Requested cancellation for sync job {job_id}")
+        logger.info("Requested cancellation for sync job %s", job_id)
 
         return True
 
@@ -256,7 +256,7 @@ class SyncJobManager:
             job = session.execute(stmt).scalar_one_or_none()
 
             if not job:
-                logger.warning(f"Job {job_id} not found for status update")
+                logger.warning("Job %s not found for status update", job_id)
                 return
 
             job.status = status
@@ -376,7 +376,9 @@ class SyncJobManager:
             )
 
             logger.info(
-                f"Sync job {job_id} completed: {result.get('files_scanned', 0)} files scanned"
+                "Sync job %s completed: %d files scanned",
+                job_id,
+                result.get("files_scanned", 0),
             )
 
         except SyncCancelled:
@@ -386,7 +388,7 @@ class SyncJobManager:
                 status="cancelled",
                 error_message="Job was cancelled by user",
             )
-            logger.info(f"Sync job {job_id} was cancelled")
+            logger.info("Sync job %s was cancelled", job_id)
 
         except Exception as e:
             # Mark as failed
@@ -396,7 +398,7 @@ class SyncJobManager:
                 status="failed",
                 error_message=error_msg,
             )
-            logger.error(f"Sync job {job_id} failed: {error_msg}", exc_info=True)
+            logger.error("Sync job %s failed: %s", job_id, error_msg, exc_info=True)
 
         finally:
             # Cleanup

--- a/src/nexus/system_services/sync/sync_job_service.py
+++ b/src/nexus/system_services/sync/sync_job_service.py
@@ -104,7 +104,7 @@ class SyncJobService:
 
                 job = manager.get_job(job_id)
                 if not job:
-                    logger.error(f"[SYNC_JOB] Job not found: {job_id}")
+                    logger.error("[SYNC_JOB] Job not found: %s", job_id)
                     return
 
                 params = job.get("params", {})
@@ -133,18 +133,18 @@ class SyncJobService:
 
                 result = self._sync.sync_mount(ctx)
                 manager.complete_job(job_id, asdict(result))
-                logger.info(f"[SYNC_JOB] Job {job_id} completed successfully")
+                logger.info("[SYNC_JOB] Job %s completed successfully", job_id)
 
             except SyncCancelled:
                 manager.mark_cancelled(job_id)
-                logger.info(f"[SYNC_JOB] Job {job_id} was cancelled")
+                logger.info("[SYNC_JOB] Job %s was cancelled", job_id)
             except Exception as e:
                 manager.fail_job(job_id, str(e))
-                logger.error(f"[SYNC_JOB] Job {job_id} failed: {e}")
+                logger.error("[SYNC_JOB] Job %s failed: %s", job_id, e)
 
         thread = threading.Thread(target=execute, daemon=True, name=f"sync-job-{job_id[:8]}")
         thread.start()
-        logger.info(f"[SYNC_JOB] Started job {job_id} in background thread")
+        logger.info("[SYNC_JOB] Started job %s in background thread", job_id)
 
     def get_job(self, job_id: str) -> dict[str, Any] | None:
         """Get job status and progress.

--- a/src/nexus/system_services/sync/sync_service.py
+++ b/src/nexus/system_services/sync/sync_service.py
@@ -138,7 +138,7 @@ class SyncService:
         # Step 1.5: Acquire per-mount lock (non-blocking to avoid queueing)
         lock = self._get_mount_lock(ctx.mount_point)
         if not lock.acquire(blocking=False):
-            logger.warning(f"[SYNC_MOUNT] Sync already in progress for {ctx.mount_point}")
+            logger.warning("[SYNC_MOUNT] Sync already in progress for %s", ctx.mount_point)
             result = SyncResult()
             result.errors.append(f"Sync already in progress for {ctx.mount_point}")
             return result
@@ -234,7 +234,7 @@ class SyncService:
                 result.mounts_skipped += 1
                 continue
 
-            logger.info(f"[SYNC_MOUNT] Syncing mount: {mp}")
+            logger.info("[SYNC_MOUNT] Syncing mount: %s", mp)
             try:
                 # Create new context for this mount
                 mount_ctx = SyncContext(
@@ -269,7 +269,7 @@ class SyncService:
 
             except Exception as e:
                 result.errors.append(f"[{mp}] Failed to sync: {e}")
-                logger.warning(f"[SYNC_MOUNT] Failed to sync {mp}: {e}")
+                logger.warning("[SYNC_MOUNT] Failed to sync %s: %s", mp, e)
 
         logger.info(
             f"[SYNC_MOUNT] All mounts sync complete: "
@@ -508,7 +508,7 @@ class SyncService:
 
                 if isinstance(cb_error, SyncCancelled):
                     raise
-                logger.warning(f"Progress callback error: {cb_error}")
+                logger.warning("Progress callback error: %s", cb_error)
 
         files_found.add(virtual_path)
 
@@ -552,7 +552,7 @@ class SyncService:
                         )
             except Exception as e:
                 # Delta check failed - proceed with full sync for this file
-                logger.warning(f"[DELTA_SYNC] Change detection failed for {virtual_path}: {e}")
+                logger.warning("[DELTA_SYNC] Change detection failed for %s: %s", virtual_path, e)
 
         # Check if file exists in metadata
         existing_meta = self._gw.metadata_get(virtual_path)
@@ -770,7 +770,7 @@ class SyncService:
 
         except Exception as e:
             result.errors.append(f"Failed to create directory marker for {virtual_path}: {e}")
-            logger.warning(f"Failed to create directory marker for {virtual_path}: {e}")
+            logger.warning("Failed to create directory marker for %s: %s", virtual_path, e)
 
     def _sync_deletions(
         self,
@@ -807,7 +807,7 @@ class SyncService:
                     if mp and mp != ctx.mount_point and mp != "/":
                         other_mount_points.add(mp)
             except (OSError, ValueError, KeyError) as e:
-                logger.debug(f"Could not list other mount points: {e}")
+                logger.debug("Could not list other mount points: %s", e)
 
             # Resolve zone_id for change log cleanup
             zone_id = self._resolve_zone_id(ctx)
@@ -846,7 +846,7 @@ class SyncService:
                         paths_to_delete.append(existing_path)
                 except Exception as e:
                     result.errors.append(f"Failed to delete {existing_path}: {e}")
-                    logger.warning(f"Failed to delete {existing_path}: {e}")
+                    logger.warning("Failed to delete %s: %s", existing_path, e)
 
             # Issue #1127: Batch-delete stale change log entries (single DB session)
             if paths_to_delete:
@@ -856,7 +856,7 @@ class SyncService:
 
         except Exception as e:
             result.errors.append(f"Failed to check for deletions: {e}")
-            logger.warning(f"Failed to check for deletions: {e}")
+            logger.warning("Failed to check for deletions: %s", e)
 
     def _sync_content(
         self,
@@ -925,7 +925,7 @@ class SyncService:
 
         except Exception as e:
             result.errors.append(f"Failed to sync content cache: {e}")
-            logger.warning(f"Failed to sync content cache: {e}")
+            logger.warning("Failed to sync content cache: %s", e)
 
     # =========================================================================
     # Helper Methods
@@ -1000,7 +1000,7 @@ class SyncService:
             # list_dir on a file path raises OS-level errors — treat as single file
             return True
         except Exception as e:
-            logger.warning(f"Unexpected error checking if single file {backend_path}: {e}")
+            logger.warning("Unexpected error checking if single file %s: %s", backend_path, e)
             return False
 
     def _sync_single_file(
@@ -1038,11 +1038,11 @@ class SyncService:
         Returns:
             Set of files found
         """
-        logger.info(f"[SYNC_MOUNT] Syncing single file: {virtual_path}")
+        logger.info("[SYNC_MOUNT] Syncing single file: %s", virtual_path)
 
         # Check pattern match with explicit logging for single-file sync
         if not self._matches_patterns(virtual_path, ctx):
-            logger.info(f"[SYNC_MOUNT] Skipping {virtual_path} - filtered by patterns")
+            logger.info("[SYNC_MOUNT] Skipping %s - filtered by patterns", virtual_path)
             return files_found
 
         # Delegate to _sync_file for full processing (including delta sync)
@@ -1095,7 +1095,7 @@ class SyncService:
                 result: int = backend.get_content_size("", size_context)
                 return result
         except (OSError, ValueError, AttributeError) as e:
-            logger.debug(f"Could not get file size for {backend_path}: {e}")
+            logger.debug("Could not get file size for %s: %s", backend_path, e)
         return 0
 
     def _matches_patterns(self, file_path: str, ctx: SyncContext) -> bool:

--- a/src/nexus/system_services/sync/write_back_service.py
+++ b/src/nexus/system_services/sync/write_back_service.py
@@ -145,7 +145,7 @@ class WriteBackService:
         except asyncio.CancelledError:
             pass
         except Exception as e:
-            logger.error(f"[WRITE_BACK] Subscribe loop error: {e}")
+            logger.error("[WRITE_BACK] Subscribe loop error: %s", e)
 
     async def _on_file_event(self, event: FileEvent) -> None:
         """Handle an incoming file event: filter and enqueue if applicable."""
@@ -196,7 +196,7 @@ class WriteBackService:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error(f"[WRITE_BACK] Poll loop error: {e}")
+                logger.error("[WRITE_BACK] Poll loop error: %s", e)
             await asyncio.sleep(self._poll_interval)
 
     async def _process_all_backends(self) -> None:
@@ -242,7 +242,7 @@ class WriteBackService:
                     )
                 )
             except ConflictAbortError as e:
-                logger.warning(f"[WRITE_BACK] Conflict ABORT on {entry.path}: {e}")
+                logger.warning("[WRITE_BACK] Conflict ABORT on %s: %s", entry.path, e)
                 self._backlog_store.mark_failed(entry.id, str(e))
                 self._metrics.record_failure(entry.backend_name)
                 await self._event_bus.publish(
@@ -253,7 +253,7 @@ class WriteBackService:
                     )
                 )
             except Exception as e:
-                logger.warning(f"[WRITE_BACK] Failed to write-back {entry.path}: {e}")
+                logger.warning("[WRITE_BACK] Failed to write-back %s: %s", entry.path, e)
                 self._backlog_store.mark_failed(entry.id, str(e))
                 self._metrics.record_failure(entry.backend_name)
                 await self._event_bus.publish(
@@ -434,7 +434,7 @@ class WriteBackService:
             try:
                 self._conflict_log_store.log_conflict(record)
             except Exception as e:
-                logger.warning(f"[WRITE_BACK] Failed to log conflict: {e}")
+                logger.warning("[WRITE_BACK] Failed to log conflict: %s", e)
 
         # Act on outcome
         match outcome:
@@ -444,18 +444,21 @@ class WriteBackService:
                 )
             case ResolutionOutcome.BACKEND_WINS:
                 logger.info(
-                    f"[WRITE_BACK] Conflict on {entry.path}: backend wins, skipping write-back"
+                    "[WRITE_BACK] Conflict on %s: backend wins, skipping write-back",
+                    entry.path,
                 )
                 return False
             case ResolutionOutcome.NEXUS_WINS:
                 logger.info(
-                    f"[WRITE_BACK] Conflict on {entry.path}: nexus wins, proceeding with write-back"
+                    "[WRITE_BACK] Conflict on %s: nexus wins, proceeding with write-back",
+                    entry.path,
                 )
                 return True
             case ResolutionOutcome.RENAME_CONFLICT:
                 logger.info(
-                    f"[WRITE_BACK] Conflict on {entry.path}: creating conflict "
-                    f"copy at {conflict_copy_path}"
+                    "[WRITE_BACK] Conflict on %s: creating conflict copy at %s",
+                    entry.path,
+                    conflict_copy_path,
                 )
                 self._create_conflict_copy(entry.path, conflict_copy_path)  # type: ignore[arg-type]
                 return True
@@ -491,7 +494,7 @@ class WriteBackService:
             if content is not None:
                 self._gw.sys_write(conflict_path, content)
         except Exception as e:
-            logger.warning(f"[WRITE_BACK] Failed to create conflict copy: {e}")
+            logger.warning("[WRITE_BACK] Failed to create conflict copy: %s", e)
 
     @staticmethod
     def _generate_conflict_copy_path(path: str, backend_name: str) -> str:
@@ -555,7 +558,7 @@ class WriteBackService:
                 return result
             return getattr(result, "data", None) if result else None
         except Exception as e:
-            logger.warning(f"[WRITE_BACK] Failed to read {path}: {e}")
+            logger.warning("[WRITE_BACK] Failed to read %s: %s", path, e)
             return None
 
     def _get_semaphore(self, backend_name: str) -> asyncio.Semaphore:


### PR DESCRIPTION
## Summary
- Convert ~130 f-string logger calls to lazy `%` formatting across 24 files in 3 layers
- **sync/** (5 files, ~44 calls): sync_service, write_back_service, sync_job_manager, sync_backlog_store, sync_job_service
- **server/** (5 files, ~28 calls): cache_warmer, telemetry, dependencies, rpc/handlers/filesystem, rpc/dispatch
- **backends/** (14 files, ~86 calls): sync_pipeline, slack/gmail/gcalendar connectors, local, chunked_storage, passthrough, etc.
- Zero f-string logger calls remain in the sync/ layer

## Test plan
- [x] `ruff check` passes on all 3 directories
- [x] `ruff format --check` passes
- [x] Pre-commit hooks pass (ruff, mypy, format)
- [x] Zero `logger.xxx(f"` matches in sync/