### PR TITLE
fix: convert f-string logger calls to lazy % in bricks/rebac/

### DIFF
--- a/src/nexus/bricks/rebac/async_permissions.py
+++ b/src/nexus/bricks/rebac/async_permissions.py
@@ -118,8 +118,12 @@ class AsyncPermissionEnforcer:
         subject = context.get_subject()
 
         logger.debug(
-            f"[ASYNC-PERM] Checking: subject={subject}, permission={permission_name}, "
-            f"object=({object_type}, {path}), zone={zone_id}"
+            "[ASYNC-PERM] Checking: subject=%s, permission=%s, object=(%s, %s), zone=%s",
+            subject,
+            permission_name,
+            object_type,
+            path,
+            zone_id,
         )
 
         start_time = time.perf_counter()
@@ -134,7 +138,7 @@ class AsyncPermissionEnforcer:
 
         if result:
             elapsed = (time.perf_counter() - start_time) * 1000
-            logger.debug(f"[ASYNC-PERM] Direct check passed ({elapsed:.1f}ms)")
+            logger.debug("[ASYNC-PERM] Direct check passed (%.1fms)", elapsed)
             return True
 
         # 2. Check parent directories for inherited permissions
@@ -149,7 +153,7 @@ class AsyncPermissionEnforcer:
                 break
 
             checked_parents.append(parent_path)
-            logger.debug(f"[ASYNC-PERM] Checking parent: {parent_path}")
+            logger.debug("[ASYNC-PERM] Checking parent: %s", parent_path)
 
             parent_result = await self.rebac_manager.rebac_check(
                 subject=subject,
@@ -160,7 +164,7 @@ class AsyncPermissionEnforcer:
 
             if parent_result:
                 elapsed = (time.perf_counter() - start_time) * 1000
-                logger.debug(f"[ASYNC-PERM] Parent check passed: {parent_path} ({elapsed:.1f}ms)")
+                logger.debug("[ASYNC-PERM] Parent check passed: %s (%.1fms)", parent_path, elapsed)
                 return True
 
             current_path = parent_path
@@ -169,7 +173,7 @@ class AsyncPermissionEnforcer:
         if context.agent_id:
             parent = await self._get_agent_owner(context.agent_id, zone_id)
             if parent and parent[0] == "user":
-                logger.debug(f"[ASYNC-PERM] Checking agent owner: {parent}")
+                logger.debug("[ASYNC-PERM] Checking agent owner: %s", parent)
                 user_result = await self.rebac_manager.rebac_check(
                     subject=("user", parent[1]),
                     permission=permission_name,
@@ -178,11 +182,11 @@ class AsyncPermissionEnforcer:
                 )
                 if user_result:
                     elapsed = (time.perf_counter() - start_time) * 1000
-                    logger.debug(f"[ASYNC-PERM] Agent owner check passed ({elapsed:.1f}ms)")
+                    logger.debug("[ASYNC-PERM] Agent owner check passed (%.1fms)", elapsed)
                     return True
 
         elapsed = (time.perf_counter() - start_time) * 1000
-        logger.debug(f"[ASYNC-PERM] Permission denied ({elapsed:.1f}ms)")
+        logger.debug("[ASYNC-PERM] Permission denied (%.1fms)", elapsed)
         return False
 
     async def filter_paths_by_permission(
@@ -241,7 +245,10 @@ class AsyncPermissionEnforcer:
                 filtered.append(path)
 
         logger.info(
-            f"[ASYNC-PERM] Bulk filter: {len(paths)} paths -> {len(filtered)} allowed ({elapsed:.1f}ms)"
+            "[ASYNC-PERM] Bulk filter: %d paths -> %d allowed (%.1fms)",
+            len(paths),
+            len(filtered),
+            elapsed,
         )
 
         return filtered

--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -124,14 +124,14 @@ class BulkPermissionChecker:
             Dict mapping each check tuple to its result (True/False)
         """
         bulk_start = time_module.perf_counter()
-        logger.debug(f"rebac_check_bulk: Checking {len(checks)} permissions in batch")
+        logger.debug("rebac_check_bulk: Checking %d permissions in batch", len(checks))
 
         # Log sample of checks for debugging
         if checks and len(checks) <= 10:
-            logger.debug(f"[BULK-DEBUG] All checks: {checks}")
+            logger.debug("[BULK-DEBUG] All checks: %s", checks)
         elif checks:
-            logger.debug(f"[BULK-DEBUG] First 5 checks: {checks[:5]}")
-            logger.debug(f"[BULK-DEBUG] Last 5 checks: {checks[-5:]}")
+            logger.debug("[BULK-DEBUG] First 5 checks: %s", checks[:5])
+            logger.debug("[BULK-DEBUG] Last 5 checks: %s", checks[-5:])
 
         if not checks:
             return {}
@@ -166,7 +166,7 @@ class BulkPermissionChecker:
         if not cache_misses:
             return results
 
-        logger.debug(f"Cache misses: {len(cache_misses)}, fetching tuples in bulk")
+        logger.debug("Cache misses: %d, fetching tuples in bulk", len(cache_misses))
 
         # PHASE 1: Fetch all relevant tuples in bulk
         tuples_graph, _ancestor_paths = self._phase_fetch_tuples(cache_misses, zone_id)
@@ -176,7 +176,8 @@ class BulkPermissionChecker:
         memo_stats = {"hits": 0, "misses": 0, "max_depth": 0}
 
         logger.debug(
-            f"Starting computation for {len(cache_misses)} cache misses with shared memo cache"
+            "Starting computation for %d cache misses with shared memo cache",
+            len(cache_misses),
         )
 
         # Log schema verification for first check
@@ -223,7 +224,9 @@ class BulkPermissionChecker:
         l1_hits = 0
         l1_cache_enabled = self._l1_cache is not None
         logger.debug(
-            f"[BULK-DEBUG] L1 cache enabled: {l1_cache_enabled}, consistency: {consistency}"
+            "[BULK-DEBUG] L1 cache enabled: %s, consistency: %s",
+            l1_cache_enabled,
+            consistency,
         )
 
         cache_misses: list[tuple[tuple[str, str], str, tuple[str, str]]] = []
@@ -234,7 +237,7 @@ class BulkPermissionChecker:
             and consistency == ConsistencyLevel.EVENTUAL
         ):
             l1_cache_stats = self._l1_cache.get_stats()
-            logger.debug(f"[BULK-DEBUG] L1 cache stats before lookup: {l1_cache_stats}")
+            logger.debug("[BULK-DEBUG] L1 cache stats before lookup: %s", l1_cache_stats)
 
             for check in checks:
                 subject, permission, obj = check
@@ -249,7 +252,10 @@ class BulkPermissionChecker:
 
             l1_elapsed = (time_module.perf_counter() - l1_start) * 1000
             logger.debug(
-                f"[BULK-PERF] L1 cache lookup: {l1_hits} hits, {len(cache_misses)} misses in {l1_elapsed:.1f}ms"
+                "[BULK-PERF] L1 cache lookup: %d hits, %d misses in %.1fms",
+                l1_hits,
+                len(cache_misses),
+                l1_elapsed,
             )
 
             if not cache_misses:
@@ -262,7 +268,9 @@ class BulkPermissionChecker:
         else:
             cache_misses = list(checks)
             logger.debug(
-                f"[BULK-DEBUG] Skipping L1 cache (enabled={l1_cache_enabled}, consistency={consistency})"
+                "[BULK-DEBUG] Skipping L1 cache (enabled=%s, consistency=%s)",
+                l1_cache_enabled,
+                consistency,
             )
 
         return cache_misses
@@ -309,7 +317,10 @@ class BulkPermissionChecker:
 
         tiger_elapsed = (time_module.perf_counter() - tiger_start) * 1000
         logger.debug(
-            f"[BULK-PERF] Tiger Cache BULK: {tiger_hits} hits, {len(tiger_remaining)} remaining in {tiger_elapsed:.1f}ms (2 queries)"
+            "[BULK-PERF] Tiger Cache BULK: %d hits, %d remaining in %.1fms (2 queries)",
+            tiger_hits,
+            len(tiger_remaining),
+            tiger_elapsed,
         )
 
         if not tiger_remaining:
@@ -363,8 +374,11 @@ class BulkPermissionChecker:
             all_entities = list(all_subjects | all_objects)
 
             logger.debug(
-                f"[BULK-UNNEST] Fetching tuples for {len(all_entities)} entities in single query "
-                f"(was: {len(all_subjects_list)} subjects + {len(all_objects_list)} objects in batches)"
+                "[BULK-UNNEST] Fetching tuples for %d entities in single query "
+                "(was: %d subjects + %d objects in batches)",
+                len(all_entities),
+                len(all_subjects_list),
+                len(all_objects_list),
             )
 
             fetch_start = time_module.perf_counter()
@@ -372,7 +386,9 @@ class BulkPermissionChecker:
             fetch_duration = (time_module.perf_counter() - fetch_start) * 1000
 
             logger.debug(
-                f"[BULK-UNNEST] Fetched {len(tuples_graph)} tuples in {fetch_duration:.1f}ms"
+                "[BULK-UNNEST] Fetched %d tuples in %.1fms",
+                len(tuples_graph),
+                fetch_duration,
             )
 
             # Cross-zone shares
@@ -382,7 +398,8 @@ class BulkPermissionChecker:
                 )
                 if cross_zone_count > 0:
                     logger.debug(
-                        f"[BULK-UNNEST] Fetched {cross_zone_count} cross-zone tuples in single query"
+                        "[BULK-UNNEST] Fetched %d cross-zone tuples in single query",
+                        cross_zone_count,
                     )
 
                 # Compute parent relationships in memory
@@ -392,11 +409,13 @@ class BulkPermissionChecker:
                     )
                     if computed_parent_count > 0:
                         logger.debug(
-                            f"Computed {computed_parent_count} parent tuples in memory for file hierarchy"
+                            "Computed %d parent tuples in memory for file hierarchy",
+                            computed_parent_count,
                         )
 
             logger.debug(
-                f"Fetched {len(tuples_graph)} tuples in bulk for graph computation (includes parent hierarchy)"
+                "Fetched %d tuples in bulk for graph computation (includes parent hierarchy)",
+                len(tuples_graph),
             )
 
         return tuples_graph, ancestor_paths
@@ -648,7 +667,11 @@ class BulkPermissionChecker:
         if namespace and namespace.has_permission(permission):
             usersets = namespace.get_permission_usersets(permission)
             logger.debug(
-                f"[SCHEMA-VERIFY] Permission '{permission}' on '{obj_type}' expands to {len(usersets)} relations: {usersets}"
+                "[SCHEMA-VERIFY] Permission '%s' on '%s' expands to %d relations: %s",
+                permission,
+                obj_type,
+                len(usersets),
+                usersets,
             )
             logger.debug(
                 "[SCHEMA-VERIFY] Expected: 3 for hybrid schema (viewer, editor, owner) or 9 for flattened"
@@ -691,7 +714,9 @@ class BulkPermissionChecker:
                 sample_type = list(namespace_configs.keys())[0]
                 sample_config = namespace_configs[sample_type]
                 logger.debug(
-                    f"[RUST-DEBUG] Sample namespace config for '{sample_type}': {str(sample_config)[:200]}"
+                    "[RUST-DEBUG] Sample namespace config for '%s': %s",
+                    sample_type,
+                    str(sample_config)[:200],
                 )
 
             import time
@@ -707,7 +732,10 @@ class BulkPermissionChecker:
             rust_elapsed = time.perf_counter() - rust_start
             per_check_us = (rust_elapsed / len(cache_misses)) * 1_000_000
             logger.debug(
-                f"[RUST-TIMING] {len(cache_misses)} checks in {rust_elapsed * 1000:.1f}ms = {per_check_us:.1f}µs/check"
+                "[RUST-TIMING] %d checks in %.1fms = %.1fus/check",
+                len(cache_misses),
+                rust_elapsed * 1000,
+                per_check_us,
             )
 
             # Convert results and cache in L1
@@ -734,7 +762,7 @@ class BulkPermissionChecker:
                     l1_cache_writes += 1
 
             if l1_cache_writes > 0:
-                logger.debug(f"[RUST-PERF] Wrote {l1_cache_writes} results to L1 in-memory cache")
+                logger.debug("[RUST-PERF] Wrote %d results to L1 in-memory cache", l1_cache_writes)
 
             # Write-through to Tiger Cache (Issue #935)
             self._write_through_tiger_cache(
@@ -786,7 +814,7 @@ class BulkPermissionChecker:
                     memo_stats=memo_stats,
                 )
             except (RuntimeError, ValueError, OperationalError) as e:
-                logger.warning(f"Bulk check failed for {check}, falling back: {e}")
+                logger.warning("Bulk check failed for %s, falling back: %s", check, e)
                 result = self._rebac_check_single(
                     subject, permission, obj, zone_id=zone_id, consistency=consistency
                 )
@@ -832,7 +860,7 @@ class BulkPermissionChecker:
                         tiger_updates[group_key].add(resource_int_id)
                         tiger_writes += 1
                 except (KeyError, ValueError) as e:
-                    logger.debug(f"[TIGER] Failed to get int_id for {obj}: {e}")
+                    logger.debug("[TIGER] Failed to get int_id for %s: %s", obj, e)
 
         # Bulk add to Tiger Cache bitmaps (memory)
         for group_key, int_ids in tiger_updates.items():
@@ -862,7 +890,7 @@ class BulkPermissionChecker:
                         zone_id=t,
                     )
                 except (RuntimeError, OperationalError) as e:
-                    logger.debug(f"[TIGER] Background persist failed: {e}")
+                    logger.debug("[TIGER] Background persist failed: %s", e)
 
         threading.Thread(
             target=_persist_updates,
@@ -872,8 +900,10 @@ class BulkPermissionChecker:
 
         if tiger_writes > 0:
             logger.debug(
-                f"[TIGER] Write-through: {tiger_writes} positive results "
-                f"to {len(tiger_updates)} Tiger Cache bitmaps (async persist started)"
+                "[TIGER] Write-through: %d positive results "
+                "to %d Tiger Cache bitmaps (async persist started)",
+                tiger_writes,
+                len(tiger_updates),
             )
 
     def _log_bulk_stats(
@@ -887,21 +917,27 @@ class BulkPermissionChecker:
         total_accesses = memo_stats["hits"] + memo_stats["misses"]
         hit_rate = (memo_stats["hits"] / total_accesses * 100) if total_accesses > 0 else 0
 
-        logger.debug(f"Bulk memo cache stats: {len(bulk_memo_cache)} unique checks stored")
+        logger.debug("Bulk memo cache stats: %d unique checks stored", len(bulk_memo_cache))
         logger.debug(
-            f"Cache performance: {memo_stats['hits']} hits + {memo_stats['misses']} misses = {total_accesses} total accesses"
+            "Cache performance: %d hits + %d misses = %d total accesses",
+            memo_stats["hits"],
+            memo_stats["misses"],
+            total_accesses,
         )
-        logger.debug(f"Cache hit rate: {hit_rate:.1f}% ({memo_stats['hits']}/{total_accesses})")
-        logger.debug(f"Max traversal depth reached: {memo_stats.get('max_depth', 0)}")
+        logger.debug("Cache hit rate: %.1f%% (%d/%d)", hit_rate, memo_stats["hits"], total_accesses)
+        logger.debug("Max traversal depth reached: %d", memo_stats.get("max_depth", 0))
 
         total_elapsed = (time_module.perf_counter() - bulk_start) * 1000
         allowed_count = sum(1 for r in results.values() if r)
         denied_count = len(results) - allowed_count
         logger.debug(
-            f"[BULK-PERF] rebac_check_bulk completed: {len(results)} results "
-            f"({allowed_count} allowed, {denied_count} denied) in {total_elapsed:.1f}ms"
+            "[BULK-PERF] rebac_check_bulk completed: %d results (%d allowed, %d denied) in %.1fms",
+            len(results),
+            allowed_count,
+            denied_count,
+            total_elapsed,
         )
 
         if self._l1_cache is not None:
             l1_stats_after = self._l1_cache.get_stats()
-            logger.debug(f"[BULK-DEBUG] L1 cache stats after: {l1_stats_after}")
+            logger.debug("[BULK-DEBUG] L1 cache stats after: %s", l1_stats_after)

--- a/src/nexus/bricks/rebac/cache/enforcer_cache.py
+++ b/src/nexus/bricks/rebac/cache/enforcer_cache.py
@@ -156,7 +156,7 @@ class PermissionCacheCoordinator:
             logger.debug("[TIGER-BITMAP] pyroaring not available")
             return None
         except Exception as e:
-            logger.warning(f"[TIGER-BITMAP] Bitmap filtering failed: {e}")
+            logger.warning("[TIGER-BITMAP] Bitmap filtering failed: %s", e)
             return None
 
     # =========================================================================
@@ -241,8 +241,9 @@ class PermissionCacheCoordinator:
 
         if allowed:
             logger.info(
-                f"[LEOPARD-INDEX] Allowed {len(allowed)} paths via cached directory grants, "
-                f"{len(remaining)} remaining"
+                "[LEOPARD-INDEX] Allowed %d paths via cached directory grants, %d remaining",
+                len(allowed),
+                len(remaining),
             )
 
         return (allowed, remaining)
@@ -264,8 +265,11 @@ class PermissionCacheCoordinator:
         new_dirs = existing_dirs | dirs
         self._leopard_dir_index[key] = new_dirs
         logger.info(
-            f"[LEOPARD-INDEX] Cached {len(dirs)} accessible directories "
-            f"for {subject_type}:{subject_id} (total: {len(new_dirs)})"
+            "[LEOPARD-INDEX] Cached %d accessible directories for %s:%s (total: %d)",
+            len(dirs),
+            subject_type,
+            subject_id,
+            len(new_dirs),
         )
 
     # =========================================================================

--- a/src/nexus/bricks/rebac/cache/iterator.py
+++ b/src/nexus/bricks/rebac/cache/iterator.py
@@ -127,8 +127,10 @@ class IteratorCache:
                     if self._enable_metrics:
                         self._hits += 1
                     logger.debug(
-                        f"Iterator cache hit for query_hash={query_hash}, "
-                        f"cursor_id={cursor_id}, count={cached.total_count}"
+                        "Iterator cache hit for query_hash=%s, cursor_id=%s, count=%d",
+                        query_hash,
+                        cursor_id,
+                        cached.total_count,
                     )
                     return cursor_id, cached.results, cached.total_count
                 else:
@@ -139,12 +141,15 @@ class IteratorCache:
                 self._misses += 1
 
         # Compute results outside lock to avoid blocking
-        logger.debug(f"Iterator cache miss for query_hash={query_hash}, computing...")
+        logger.debug("Iterator cache miss for query_hash=%s, computing...", query_hash)
         start_time = time.perf_counter()
         results = compute_fn()
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         logger.debug(
-            f"Computed {len(results)} results in {elapsed_ms:.1f}ms for query_hash={query_hash}"
+            "Computed %d results in %.1fms for query_hash=%s",
+            len(results),
+            elapsed_ms,
+            query_hash,
         )
 
         with self._lock:
@@ -242,8 +247,9 @@ class IteratorCache:
 
             if cursors_to_delete:
                 logger.debug(
-                    f"Iterator cache: Invalidated {len(cursors_to_delete)} entries "
-                    f"for zone {zone_id}"
+                    "Iterator cache: Invalidated %d entries for zone %s",
+                    len(cursors_to_delete),
+                    zone_id,
                 )
 
             return len(cursors_to_delete)
@@ -282,7 +288,7 @@ class IteratorCache:
             self._query_to_cursor.clear()
             if self._enable_metrics:
                 self._evictions += count
-            logger.info(f"Iterator cache cleared ({count} entries)")
+            logger.info("Iterator cache cleared (%d entries)", count)
 
     def get_stats(self) -> dict[str, Any]:
         """

--- a/src/nexus/bricks/rebac/cache/leopard.py
+++ b/src/nexus/bricks/rebac/cache/leopard.py
@@ -292,7 +292,10 @@ class LeopardIndex:
             if cached is not None:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(
-                        f"[LEOPARD] Cache hit for {member_type}:{member_id} -> {len(cached)} groups"
+                        "[LEOPARD] Cache hit for %s:%s -> %d groups",
+                        member_type,
+                        member_id,
+                        len(cached),
                     )
                 return cached
 
@@ -303,7 +306,9 @@ class LeopardIndex:
         if self._cache:
             self._cache.set_transitive_groups(member_type, member_id, zone_id, groups)
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"[LEOPARD] Cached {member_type}:{member_id} -> {len(groups)} groups")
+                logger.debug(
+                    "[LEOPARD] Cached %s:%s -> %d groups", member_type, member_id, len(groups)
+                )
 
         return groups
 

--- a/src/nexus/bricks/rebac/cache/result_cache.py
+++ b/src/nexus/bricks/rebac/cache/result_cache.py
@@ -464,7 +464,7 @@ class ReBACPermissionCache:
                 self._revision_cache[effective_zone] = (revision, current_time)
                 return revision // self._revision_quantization_window
             except Exception as e:  # fail-safe: returns 0 → shared bucket (still functional)
-                logger.warning(f"Failed to fetch revision for {effective_zone}: {e}")
+                logger.warning("Failed to fetch revision for %s: %s", effective_zone, e)
 
         return 0  # Fallback: all entries share same bucket (still functional)
 
@@ -495,7 +495,7 @@ class ReBACPermissionCache:
                 self._revision_cache[effective_zone] = (revision, current_time)
                 return revision
             except Exception as e:  # fail-safe: returns 0 fallback
-                logger.warning(f"Failed to fetch revision for {effective_zone}: {e}")
+                logger.warning("Failed to fetch revision for %s: %s", effective_zone, e)
 
         return 0  # Fallback
 
@@ -834,7 +834,7 @@ class ReBACPermissionCache:
             if self._enable_metrics:
                 with self._lock:
                     self._stampede_timeouts += 1
-            logger.warning(f"Stampede wait timeout for key: {key[:50]}...")
+            logger.warning("Stampede wait timeout for key: %s...", key[:50])
             return None
 
         # Computation finished, get result from cache

--- a/src/nexus/bricks/rebac/cache/tiger/expander.py
+++ b/src/nexus/bricks/rebac/cache/tiger/expander.py
@@ -112,7 +112,7 @@ class DirectoryGrantExpander:
                     )
                 return grants
         except Exception as e:
-            logger.error(f"[LEOPARD-WORKER] Failed to get pending grants: {e}")
+            logger.error("[LEOPARD-WORKER] Failed to get pending grants: %s", e)
             return []
 
     def _mark_in_progress(self, grant_id: int, total_count: int) -> bool:
@@ -143,7 +143,7 @@ class DirectoryGrantExpander:
                 result = conn.execute(stmt)
                 return result.rowcount > 0
         except Exception as e:
-            logger.error(f"[LEOPARD-WORKER] Failed to mark in_progress: {e}")
+            logger.error("[LEOPARD-WORKER] Failed to mark in_progress: %s", e)
             return False
 
     def _update_progress(self, grant_id: int, expanded_count: int) -> bool:
@@ -173,7 +173,7 @@ class DirectoryGrantExpander:
                 result = conn.execute(stmt)
                 return result.rowcount > 0
         except Exception as e:
-            logger.error(f"[LEOPARD-WORKER] Failed to update progress: {e}")
+            logger.error("[LEOPARD-WORKER] Failed to update progress: %s", e)
             return False
 
     def _mark_completed(self, grant_id: int, expanded_count: int) -> bool:
@@ -205,7 +205,7 @@ class DirectoryGrantExpander:
                 result = conn.execute(stmt)
                 return result.rowcount > 0
         except Exception as e:
-            logger.error(f"[LEOPARD-WORKER] Failed to mark completed: {e}")
+            logger.error("[LEOPARD-WORKER] Failed to mark completed: %s", e)
             return False
 
     def _mark_failed(self, grant_id: int, error_message: str) -> bool:
@@ -236,7 +236,7 @@ class DirectoryGrantExpander:
                 result = conn.execute(stmt)
                 return result.rowcount > 0
         except Exception as e:
-            logger.error(f"[LEOPARD-WORKER] Failed to mark failed: {e}")
+            logger.error("[LEOPARD-WORKER] Failed to mark failed: %s", e)
             return False
 
     def _get_directory_descendants(
@@ -265,7 +265,7 @@ class DirectoryGrantExpander:
             )
             return [f.path for f in files if f.path]
         except Exception as e:
-            logger.error(f"[LEOPARD-WORKER] Failed to list directory: {e}")
+            logger.error("[LEOPARD-WORKER] Failed to list directory: %s", e)
             return []
 
     def expand_grant(self, grant: dict) -> tuple[int, bool]:
@@ -287,8 +287,12 @@ class DirectoryGrantExpander:
         already_expanded = grant.get("expanded_count", 0)
 
         logger.info(
-            f"[LEOPARD-WORKER] Starting expansion for grant {grant_id}: "
-            f"{directory_path} -> {subject_type}:{subject_id} ({permission})"
+            "[LEOPARD-WORKER] Starting expansion for grant %s: %s -> %s:%s (%s)",
+            grant_id,
+            directory_path,
+            subject_type,
+            subject_id,
+            permission,
         )
 
         try:
@@ -298,7 +302,7 @@ class DirectoryGrantExpander:
             if not descendants:
                 # No files - mark as completed
                 self._mark_completed(grant_id, 0)
-                logger.info(f"[LEOPARD-WORKER] Grant {grant_id}: no files to expand")
+                logger.info("[LEOPARD-WORKER] Grant %s: no files to expand", grant_id)
                 return 0, True
 
             total_count = len(descendants)
@@ -306,14 +310,17 @@ class DirectoryGrantExpander:
             # Mark as in_progress with total count
             if not self._mark_in_progress(grant_id, total_count):
                 # Someone else is processing this grant
-                logger.info(f"[LEOPARD-WORKER] Grant {grant_id} already being processed")
+                logger.info("[LEOPARD-WORKER] Grant %s already being processed", grant_id)
                 return 0, False
 
             # Skip already expanded files (for resume)
             if already_expanded > 0:
                 descendants = descendants[already_expanded:]
                 logger.info(
-                    f"[LEOPARD-WORKER] Grant {grant_id}: resuming from {already_expanded}/{total_count}"
+                    "[LEOPARD-WORKER] Grant %s: resuming from %d/%d",
+                    grant_id,
+                    already_expanded,
+                    total_count,
                 )
 
             # Process in batches
@@ -338,20 +345,25 @@ class DirectoryGrantExpander:
                 self._update_progress(grant_id, expanded_count)
 
                 logger.debug(
-                    f"[LEOPARD-WORKER] Grant {grant_id}: {expanded_count}/{total_count} "
-                    f"({100 * expanded_count / total_count:.1f}%)"
+                    "[LEOPARD-WORKER] Grant %s: %d/%d (%.1f%%)",
+                    grant_id,
+                    expanded_count,
+                    total_count,
+                    100 * expanded_count / total_count,
                 )
 
             # Mark as completed
             self._mark_completed(grant_id, expanded_count)
             logger.info(
-                f"[LEOPARD-WORKER] Grant {grant_id} completed: {expanded_count} files expanded"
+                "[LEOPARD-WORKER] Grant %s completed: %d files expanded",
+                grant_id,
+                expanded_count,
             )
             return expanded_count, True
 
         except Exception as e:
             error_msg = f"Expansion failed: {e}"
-            logger.error(f"[LEOPARD-WORKER] Grant {grant_id}: {error_msg}")
+            logger.error("[LEOPARD-WORKER] Grant %s: %s", grant_id, error_msg)
             self._mark_failed(grant_id, error_msg)
             return 0, False
 
@@ -369,7 +381,7 @@ class DirectoryGrantExpander:
         if not grants:
             return 0
 
-        logger.info(f"[LEOPARD-WORKER] Processing {len(grants)} pending grants")
+        logger.info("[LEOPARD-WORKER] Processing %d pending grants", len(grants))
 
         total_expanded = 0
         for grant in grants:
@@ -400,7 +412,7 @@ class DirectoryGrantExpander:
                 expanded = await asyncio.to_thread(self.process_pending_grants)
 
                 if expanded > 0:
-                    logger.info(f"[LEOPARD-WORKER] Expanded {expanded} files this cycle")
+                    logger.info("[LEOPARD-WORKER] Expanded %d files this cycle", expanded)
 
                 # Wait before next poll (or until stopped)
                 try:
@@ -415,7 +427,7 @@ class DirectoryGrantExpander:
                     pass
 
             except Exception as e:
-                logger.error(f"[LEOPARD-WORKER] Worker error: {e}")
+                logger.error("[LEOPARD-WORKER] Worker error: %s", e)
                 # Wait before retrying on error
                 await asyncio.sleep(self.POLL_INTERVAL * 2)
 

--- a/src/nexus/bricks/rebac/cache/tiger/rename_hook.py
+++ b/src/nexus/bricks/rebac/cache/tiger/rename_hook.py
@@ -78,7 +78,7 @@ class TigerCacheRenameHook:
                         resource_int_id=int_id,
                     )
                 except Exception as e:
-                    logger.warning(f"[LEOPARD] Failed to remove from bitmap: {e}")
+                    logger.warning("[LEOPARD] Failed to remove from bitmap: %s", e)
 
             for grant in new_grants:
                 key = grant_key(grant)
@@ -104,7 +104,7 @@ class TigerCacheRenameHook:
                         zone_id,
                     )
                 except Exception as e:
-                    logger.warning(f"[LEOPARD] Failed to add to bitmap: {e}")
+                    logger.warning("[LEOPARD] Failed to add to bitmap: %s", e)
 
     def _get_directory_files(
         self, old_dir: str, new_dir: str, zone_id: str
@@ -127,5 +127,5 @@ class TigerCacheRenameHook:
                     result.append((old_file_path, new_file_path))
             return result
         except Exception as e:
-            logger.warning(f"[LEOPARD] Failed to list directory files: {e}")
+            logger.warning("[LEOPARD] Failed to list directory files: %s", e)
             return []

--- a/src/nexus/bricks/rebac/cache/tiger/updater.py
+++ b/src/nexus/bricks/rebac/cache/tiger/updater.py
@@ -137,7 +137,7 @@ class TigerCacheUpdater:
             result = connection.execute(stmt)
             count = result.rowcount
             if count > 0:
-                logger.info(f"[TIGER] Reset {count} stuck queue entries to pending")
+                logger.info("[TIGER] Reset %d stuck queue entries to pending", count)
             return count
 
         if conn:
@@ -199,10 +199,12 @@ class TigerCacheUpdater:
             processed = 0
             result = connection.execute(select_query)
             entries = list(result)
-            logger.info(f"[TIGER] do_process: fetched {len(entries)} entries from queue")
+            logger.info("[TIGER] do_process: fetched %d entries from queue", len(entries))
 
             for i, entry in enumerate(entries):
-                logger.info(f"[TIGER] Processing entry {i + 1}/{len(entries)}: {entry.subject_id}")
+                logger.info(
+                    "[TIGER] Processing entry %d/%d: %s", i + 1, len(entries), entry.subject_id
+                )
                 try:
                     # Mark as processing
                     connection.execute(
@@ -249,10 +251,13 @@ class TigerCacheUpdater:
                     # Leave entry in 'processing' state - it will be cleaned up later
                     if is_lock_error(e):
                         logger.debug(
-                            f"[TIGER] Database lock during queue processing for entry {entry.queue_id}, will retry later"
+                            "[TIGER] Database lock during queue processing for entry %s, will retry later",
+                            entry.queue_id,
                         )
                     else:
-                        logger.error(f"[TIGER] Failed to process queue entry {entry.queue_id}: {e}")
+                        logger.error(
+                            "[TIGER] Failed to process queue entry %s: %s", entry.queue_id, e
+                        )
                         try:
                             connection.execute(
                                 update(TCQ)
@@ -266,7 +271,8 @@ class TigerCacheUpdater:
                         except (OperationalError, RuntimeError) as update_err:
                             # fail-safe: if status update fails, just log and continue
                             logger.debug(
-                                f"[TIGER] Could not update queue entry status: {update_err}"
+                                "[TIGER] Could not update queue entry status: %s",
+                                update_err,
                             )
 
             return processed
@@ -274,22 +280,23 @@ class TigerCacheUpdater:
         try:
             if conn:
                 result = do_process(conn)
-                logger.info(f"[TIGER] Queue processing complete (external conn): {result} entries")
+                logger.info("[TIGER] Queue processing complete (external conn): %d entries", result)
                 return result
             else:
                 with self._engine.begin() as new_conn:
                     result = do_process(new_conn)
                 # Commit happens here when 'with' block exits
-                logger.info(f"[TIGER] Queue processing COMMITTED: {result} entries processed")
+                logger.info("[TIGER] Queue processing COMMITTED: %d entries processed", result)
                 return result
         except (OperationalError, RuntimeError) as e:
             # Handle lock errors at the top level (e.g., during SELECT)
             if is_lock_error(e):
                 logger.debug(
-                    f"[TIGER] Database lock during queue processing, will retry later: {e}"
+                    "[TIGER] Database lock during queue processing, will retry later: %s",
+                    e,
                 )
                 return 0
-            logger.error(f"[TIGER] Queue processing FAILED: {e}")
+            logger.error("[TIGER] Queue processing FAILED: %s", e)
             raise
 
     def _compute_accessible_resources(

--- a/src/nexus/bricks/rebac/cache/visibility.py
+++ b/src/nexus/bricks/rebac/cache/visibility.py
@@ -99,13 +99,18 @@ class DirectoryVisibilityCache:
                 if (time.time() - entry.computed_at) < self._ttl:
                     self._hits += 1
                     logger.debug(
-                        f"[DirVisCache] HIT: {subject_type}:{subject_id} -> {dir_path} = {entry.visible} ({entry.reason})"
+                        "[DirVisCache] HIT: %s:%s -> %s = %s (%s)",
+                        subject_type,
+                        subject_id,
+                        dir_path,
+                        entry.visible,
+                        entry.reason,
                     )
                     return entry.visible
                 else:
                     # Expired - remove and return miss
                     del self._cache[key]
-                    logger.debug(f"[DirVisCache] EXPIRED: {key}")
+                    logger.debug("[DirVisCache] EXPIRED: %s", key)
 
             self._misses += 1
             return None
@@ -142,7 +147,12 @@ class DirectoryVisibilityCache:
                 reason=reason,
             )
             logger.debug(
-                f"[DirVisCache] SET: {subject_type}:{subject_id} -> {dir_path} = {visible} ({reason})"
+                "[DirVisCache] SET: %s:%s -> %s = %s (%s)",
+                subject_type,
+                subject_id,
+                dir_path,
+                visible,
+                reason,
             )
 
     def compute_from_tiger_bitmap(
@@ -219,14 +229,16 @@ class DirectoryVisibilityCache:
                         True,
                         f"descendant:{res_path}",
                     )
-                    logger.debug(f"[DirVisCache] BITMAP_COMPUTE: {dir_path} visible via {res_path}")
+                    logger.debug(
+                        "[DirVisCache] BITMAP_COMPUTE: %s visible via %s", dir_path, res_path
+                    )
                     return True
 
         # No descendants found
         self.set_visible(
             zone_id, subject_type, subject_id, dir_path, False, "no_descendants_in_bitmap"
         )
-        logger.debug(f"[DirVisCache] BITMAP_COMPUTE: {dir_path} not visible")
+        logger.debug("[DirVisCache] BITMAP_COMPUTE: %s not visible", dir_path)
         return False
 
     def invalidate(
@@ -293,8 +305,12 @@ class DirectoryVisibilityCache:
 
             if invalidated > 0:
                 logger.debug(
-                    f"[DirVisCache] INVALIDATE: {invalidated} entries "
-                    f"(zone={zone_id}, subject={subject_type}:{subject_id}, path={dir_path})"
+                    "[DirVisCache] INVALIDATE: %d entries (zone=%s, subject=%s:%s, path=%s)",
+                    invalidated,
+                    zone_id,
+                    subject_type,
+                    subject_id,
+                    dir_path,
                 )
 
         return invalidated
@@ -360,7 +376,7 @@ class DirectoryVisibilityCache:
         for key, _ in entries[:to_remove]:
             del self._cache[key]
 
-        logger.debug(f"[DirVisCache] EVICT: removed {to_remove} oldest entries")
+        logger.debug("[DirVisCache] EVICT: removed %d oldest entries", to_remove)
 
     def get_metrics(self) -> dict:
         """Get cache metrics.

--- a/src/nexus/bricks/rebac/checker.py
+++ b/src/nexus/bricks/rebac/checker.py
@@ -125,14 +125,20 @@ class PermissionChecker:
         # ----------------------------------------------------------
         if ctx.is_admin or ctx.is_system:
             logger.debug(
-                f"_check_permission: SKIPPED (admin/system bypass) - "
-                f"path={path}, permission={permission.name}, user={ctx.user_id}"
+                "_check_permission: SKIPPED (admin/system bypass) - "
+                "path=%s, permission=%s, user=%s",
+                path,
+                permission.name,
+                ctx.user_id,
             )
             return
 
         logger.debug(
-            f"_check_permission: path={path}, permission={permission.name}, "
-            f"user={ctx.user_id}, zone={getattr(ctx, 'zone_id', None)}"
+            "_check_permission: path=%s, permission=%s, user=%s, zone=%s",
+            path,
+            permission.name,
+            ctx.user_id,
+            getattr(ctx, "zone_id", None),
         )
 
         # ----------------------------------------------------------
@@ -147,7 +153,8 @@ class PermissionChecker:
         original_path, view_type = parse_virtual_path(path, metadata_exists)
         if view_type == "md":
             logger.debug(
-                f"  -> Virtual view detected: checking permissions on original file {original_path}"
+                "  -> Virtual view detected: checking permissions on original file %s",
+                original_path,
             )
             permission_path = original_path
         else:
@@ -167,7 +174,9 @@ class PermissionChecker:
             subject_id = ctx.subject_id or ctx.user_id
             if file_meta.owner_id == subject_id:
                 logger.debug(
-                    f"  -> OWNER FAST-PATH: {subject_id} owns {permission_path}, skipping ReBAC"
+                    "  -> OWNER FAST-PATH: %s owns %s, skipping ReBAC",
+                    subject_id,
+                    permission_path,
                 )
                 return  # Owner has all permissions
 
@@ -180,7 +189,7 @@ class PermissionChecker:
                 f"cannot check {permission.name} permission for '{path}'"
             )
         result = self._permission_enforcer.check(permission_path, permission, ctx)
-        logger.debug(f"  -> permission_enforcer.check returned: {result}")
+        logger.debug("  -> permission_enforcer.check returned: %s", result)
 
         if not result:
             raise PermissionError(

--- a/src/nexus/bricks/rebac/deferred_permission_buffer.py
+++ b/src/nexus/bricks/rebac/deferred_permission_buffer.py
@@ -89,8 +89,9 @@ class DeferredPermissionBuffer:
         self._flush_thread.start()
         self._started = True
         logger.info(
-            f"DeferredPermissionBuffer started (interval={self._flush_interval}s, "
-            f"max_batch={self._max_batch_size})"
+            "DeferredPermissionBuffer started (interval=%ss, max_batch=%d)",
+            self._flush_interval,
+            self._max_batch_size,
         )
 
     def stop(self, timeout: float = 5.0) -> None:
@@ -113,10 +114,10 @@ class DeferredPermissionBuffer:
 
         self._started = False
         logger.info(
-            f"DeferredPermissionBuffer stopped. Stats: "
-            f"hierarchy={self._total_hierarchy_flushed}, "
-            f"grants={self._total_grants_flushed}, "
-            f"flushes={self._flush_count}"
+            "DeferredPermissionBuffer stopped. Stats: hierarchy=%d, grants=%d, flushes=%d",
+            self._total_hierarchy_flushed,
+            self._total_grants_flushed,
+            self._flush_count,
         )
 
     def queue_hierarchy(self, path: str, zone_id: str) -> None:
@@ -204,7 +205,7 @@ class DeferredPermissionBuffer:
                 try:
                     self._flush_sync()
                 except Exception as e:  # fail-safe: background flush must not crash thread
-                    logger.error(f"DeferredPermissionBuffer flush error: {e}")
+                    logger.error("DeferredPermissionBuffer flush error: %s", e)
 
     def _flush_sync(self) -> None:
         """Flush all pending operations using batch APIs."""
@@ -240,7 +241,7 @@ class DeferredPermissionBuffer:
 
                 self._total_hierarchy_flushed += hierarchy_count
             except (OperationalError, TimeoutError, RuntimeError) as e:
-                logger.warning(f"Hierarchy flush failed, re-queueing: {e}")
+                logger.warning("Hierarchy flush failed, re-queueing: %s", e)
                 # Re-queue on failure
                 with self._lock:
                     self._pending_hierarchy.extend(hierarchy_batch)
@@ -252,7 +253,7 @@ class DeferredPermissionBuffer:
                 grants_count = len(grants_batch)
                 self._total_grants_flushed += grants_count
             except (OperationalError, TimeoutError, RuntimeError) as e:
-                logger.warning(f"Grant flush failed, re-queueing: {e}")
+                logger.warning("Grant flush failed, re-queueing: %s", e)
                 # Re-queue on failure
                 with self._lock:
                     self._pending_grants.extend(grants_batch)
@@ -261,8 +262,10 @@ class DeferredPermissionBuffer:
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             self._flush_count += 1
             logger.debug(
-                f"[DEFERRED-FLUSH] hierarchy={hierarchy_count}, "
-                f"grants={grants_count}, elapsed={elapsed_ms:.1f}ms"
+                "[DEFERRED-FLUSH] hierarchy=%d, grants=%d, elapsed=%.1fms",
+                hierarchy_count,
+                grants_count,
+                elapsed_ms,
             )
 
 

--- a/src/nexus/bricks/rebac/dynamic_viewer_hook.py
+++ b/src/nexus/bricks/rebac/dynamic_viewer_hook.py
@@ -54,7 +54,10 @@ class DynamicViewerReadHook:
             return
 
         logger.info(
-            f"[DynamicViewerHook] Applying filter for {subject} on {ctx.path}: {column_config}"
+            "[DynamicViewerHook] Applying filter for %s on %s: %s",
+            subject,
+            ctx.path,
+            column_config,
         )
 
         content_str = ctx.content.decode("utf-8") if isinstance(ctx.content, bytes) else ctx.content
@@ -68,4 +71,4 @@ class DynamicViewerReadHook:
         else:
             ctx.content = str(filtered).encode("utf-8")
 
-        logger.info(f"[DynamicViewerHook] Successfully filtered {ctx.path}")
+        logger.info("[DynamicViewerHook] Successfully filtered %s", ctx.path)

--- a/src/nexus/bricks/rebac/enforcer.py
+++ b/src/nexus/bricks/rebac/enforcer.py
@@ -219,8 +219,8 @@ class PermissionEnforcer:
         """
         self._cache.invalidate(subject_type, subject_id, zone_id)
         logger.debug(
-            f"[CACHE-INVALIDATE] Invalidated cache for "
-            f"{(subject_type, subject_id, zone_id) if subject_type else 'all'}"
+            "[CACHE-INVALIDATE] Invalidated cache for %s",
+            (subject_type, subject_id, zone_id) if subject_type else "all",
         )
 
     def has_accessible_descendants(
@@ -286,14 +286,16 @@ class PermissionEnforcer:
 
             if accessible_paths is None:
                 logger.debug(
-                    f"[BATCH-OPT] No bitmap for {subject_type}:{subject_id}, "
-                    f"returning all True for {len(prefixes)} prefixes"
+                    "[BATCH-OPT] No bitmap for %s:%s, returning all True for %d prefixes",
+                    subject_type,
+                    subject_id,
+                    len(prefixes),
                 )
                 return dict.fromkeys(prefixes, True)
 
             if not accessible_paths:
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(f"[BATCH-OPT] Empty paths for {subject_type}:{subject_id}")
+                    logger.debug("[BATCH-OPT] Empty paths for %s:%s", subject_type, subject_id)
                 return dict.fromkeys(prefixes, False)
 
             # Try Rust-accelerated prefix matching (Issue #1565)
@@ -316,9 +318,13 @@ class PermissionEnforcer:
             elapsed = (time.time() - start) * 1000
             found_count = sum(1 for v in results.values() if v)
             logger.debug(
-                f"[BATCH-OPT] has_accessible_descendants_batch: "
-                f"{found_count}/{len(prefixes)} accessible in {elapsed:.1f}ms "
-                f"(paths: {len(accessible_paths)})"
+                "[BATCH-OPT] has_accessible_descendants_batch: "
+                "%d/%d accessible in %.1fms "
+                "(paths: %d)",
+                found_count,
+                len(prefixes),
+                elapsed,
+                len(accessible_paths),
             )
             return results
 
@@ -363,7 +369,12 @@ class PermissionEnforcer:
             True
         """
         logger.debug(
-            f"[PermissionEnforcer.check] path={path}, perm={permission.name}, user={context.user_id}, is_admin={context.is_admin}, is_system={context.is_system}"
+            "[PermissionEnforcer.check] path=%s, perm=%s, user=%s, is_admin=%s, is_system=%s",
+            path,
+            permission.name,
+            context.user_id,
+            context.is_admin,
+            context.is_system,
         )
 
         # Map Permission enum to string
@@ -497,7 +508,10 @@ class PermissionEnforcer:
             True if ReBAC grants permission, False otherwise
         """
         logger.debug(
-            f"[_check_rebac] path={path}, permission={permission}, context.user_id={context.user_id}"
+            "[_check_rebac] path=%s, permission=%s, context.user_id=%s",
+            path,
+            permission,
+            context.user_id,
         )
 
         if not self.rebac_manager:
@@ -510,7 +524,7 @@ class PermissionEnforcer:
         permission_name = self._permission_to_string(permission)
         if permission_name == "unknown":
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"  -> DENY (unknown permission: {permission})")
+                logger.debug("  -> DENY (unknown permission: %s)", permission)
             return False
 
         # Get backend-specific object type for ReBAC check
@@ -560,7 +574,12 @@ class PermissionEnforcer:
         subject = context.get_subject()
 
         logger.debug(
-            f"[_check_rebac] Calling rebac_check: subject={subject}, permission={permission_name}, object=('{object_type}', '{object_id}'), zone_id={zone_id}"
+            "[_check_rebac] Calling rebac_check: subject=%s, permission=%s, object=('%s', '%s'), zone_id=%s",
+            subject,
+            permission_name,
+            object_type,
+            object_id,
+            zone_id,
         )
 
         # Issue #921: Record access for hotspot detection (before cache/graph check)
@@ -631,7 +650,8 @@ class PermissionEnforcer:
                     zone_id=zone_id,
                 ):
                     logger.debug(
-                        f"[_check_rebac] ALLOW TRAVERSE (has {implied_perm.upper()} permission)"
+                        "[_check_rebac] ALLOW TRAVERSE (has %s permission)",
+                        implied_perm.upper(),
                     )
                     return True
 
@@ -653,7 +673,9 @@ class PermissionEnforcer:
                     )
                     if boundary_result:
                         logger.debug(
-                            f"[_check_rebac] ALLOW (boundary cache hit: {object_id} → {boundary})"
+                            "[_check_rebac] ALLOW (boundary cache hit: %s → %s)",
+                            object_id,
+                            boundary,
                         )
                         return True
                     self._boundary_cache.invalidate_permission_change(
@@ -675,7 +697,9 @@ class PermissionEnforcer:
                 )
                 if parent_result:
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug(f"[_check_rebac] ALLOW (inherited from parent: {parent_path})")
+                        logger.debug(
+                            "[_check_rebac] ALLOW (inherited from parent: %s)", parent_path
+                        )
                     if self._boundary_cache:
                         self._boundary_cache.set_boundary(
                             zone_id,
@@ -724,8 +748,9 @@ class PermissionEnforcer:
                 )
                 if boundary_result:
                     logger.debug(
-                        f"[_check_rebac_batched] ALLOW (boundary cache hit: "
-                        f"{object_id} → {boundary})"
+                        "[_check_rebac_batched] ALLOW (boundary cache hit: %s → %s)",
+                        object_id,
+                        boundary,
                     )
                     return True
                 self._boundary_cache.invalidate_permission_change(
@@ -764,7 +789,9 @@ class PermissionEnforcer:
             if results.get(check, False):
                 granting_path = check[2][1]  # object_id from the check tuple
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(f"[_check_rebac_batched] ALLOW via {check[1]} on {granting_path}")
+                    logger.debug(
+                        "[_check_rebac_batched] ALLOW via %s on %s", check[1], granting_path
+                    )
                 # Update boundary cache if granted via an ancestor
                 if self._boundary_cache and granting_path != object_id:
                     self._boundary_cache.set_boundary(
@@ -778,8 +805,11 @@ class PermissionEnforcer:
                 return True
 
         logger.debug(
-            f"[_check_rebac_batched] DENY {permission_name} on {object_id} "
-            f"(checked {len(checks)} tuples across {len(ancestors)} ancestors)"
+            "[_check_rebac_batched] DENY %s on %s (checked %d tuples across %d ancestors)",
+            permission_name,
+            object_id,
+            len(checks),
+            len(ancestors),
         )
         return False
 
@@ -1013,8 +1043,10 @@ class PermissionEnforcer:
             subject = context.get_subject()
 
             logger.debug(
-                f"[PERF-FILTER] filter_list START: {len(paths)} paths, "
-                f"subject={subject}, zone={zone_id}"
+                "[PERF-FILTER] filter_list START: %d paths, subject=%s, zone=%s",
+                len(paths),
+                subject,
+                zone_id,
             )
 
             from nexus.bricks.rebac.permission_filter_chain import (
@@ -1036,8 +1068,10 @@ class PermissionEnforcer:
 
             overall_elapsed = time.time() - overall_start
             logger.info(
-                f"[PERF-FILTER] filter_list DONE: {overall_elapsed:.3f}s total, "
-                f"allowed {len(filtered)}/{len(paths)} paths"
+                "[PERF-FILTER] filter_list DONE: %.3fs total, allowed %d/%d paths",
+                overall_elapsed,
+                len(filtered),
+                len(paths),
             )
             return filtered
 

--- a/src/nexus/bricks/rebac/entity_registry.py
+++ b/src/nexus/bricks/rebac/entity_registry.py
@@ -97,13 +97,17 @@ class EntityRegistry:
             ValueError: If entity_type is invalid or parent is inconsistent.
         """
         logger.debug(
-            f"[ENTITY-REG] register_entity called: {entity_type}:{entity_id}, parent={parent_type}:{parent_id}"
+            "[ENTITY-REG] register_entity called: %s:%s, parent=%s:%s",
+            entity_type,
+            entity_id,
+            parent_type,
+            parent_id,
         )
 
         # Check if entity already exists
         existing = self.get_entity(entity_type, entity_id)
         if existing:
-            logger.debug(f"[ENTITY-REG] Entity already exists: {entity_type}:{entity_id}")
+            logger.debug("[ENTITY-REG] Entity already exists: %s:%s", entity_type, entity_id)
             return existing
 
         # Create new entity
@@ -130,7 +134,9 @@ class EntityRegistry:
 
             # Refresh to ensure we have the committed state
             session.refresh(entity)
-            logger.debug(f"[ENTITY-REG] Entity registered successfully: {entity_type}:{entity_id}")
+            logger.debug(
+                "[ENTITY-REG] Entity registered successfully: %s:%s", entity_type, entity_id
+            )
             return entity
 
     def get_entity(self, entity_type: str, entity_id: str) -> EntityRegistryModel | None:
@@ -206,17 +212,23 @@ class EntityRegistry:
             ...     print(f"Agent owned by user: {parent.parent_id}")
         """
         logger.debug(
-            f"[ENTITY-REG] get_parent called: entity_type={entity_type}, entity_id={entity_id}"
+            "[ENTITY-REG] get_parent called: entity_type=%s, entity_id=%s",
+            entity_type,
+            entity_id,
         )
 
         entity = self.get_entity(entity_type, entity_id)
 
         if not entity:
-            logger.debug(f"[ENTITY-REG] Entity NOT found in database: {entity_type}:{entity_id}")
+            logger.debug("[ENTITY-REG] Entity NOT found in database: %s:%s", entity_type, entity_id)
             return None
 
         logger.debug(
-            f"[ENTITY-REG] Entity found: {entity.entity_type}:{entity.entity_id}, parent={entity.parent_type}:{entity.parent_id}"
+            "[ENTITY-REG] Entity found: %s:%s, parent=%s:%s",
+            entity.entity_type,
+            entity.entity_id,
+            entity.parent_type,
+            entity.parent_id,
         )
 
         if not entity.parent_type or not entity.parent_id:
@@ -226,9 +238,11 @@ class EntityRegistry:
         # Get the parent entity
         parent = self.get_entity(entity.parent_type, entity.parent_id)
         if parent:
-            logger.debug(f"[ENTITY-REG] Parent found: {parent.entity_type}:{parent.entity_id}")
+            logger.debug("[ENTITY-REG] Parent found: %s:%s", parent.entity_type, parent.entity_id)
         else:
-            logger.debug(f"[ENTITY-REG] Parent NOT found: {entity.parent_type}:{entity.parent_id}")
+            logger.debug(
+                "[ENTITY-REG] Parent NOT found: %s:%s", entity.parent_type, entity.parent_id
+            )
         return parent
 
     def get_children(self, parent_type: str, parent_id: str) -> list[EntityRegistryModel]:

--- a/src/nexus/bricks/rebac/filter_chain.py
+++ b/src/nexus/bricks/rebac/filter_chain.py
@@ -67,11 +67,11 @@ class TigerBitmapStrategy:
             return FilterResult(allowed=[], remaining=remaining)
 
         allowed, still_remaining = result
-        logger.debug(f"[TIGER-BITMAP] {len(allowed)} allowed, {len(still_remaining)} remaining")
+        logger.debug("[TIGER-BITMAP] %d allowed, %d remaining", len(allowed), len(still_remaining))
 
         # Check bitmap completeness — if complete, skip fallback
         if still_remaining and ctx.cache.is_bitmap_complete(ctx.subject, ctx.zone_id):
-            logger.info(f"[BITMAP-COMPLETE] Skipped {len(still_remaining)} fallback checks")
+            logger.info("[BITMAP-COMPLETE] Skipped %d fallback checks", len(still_remaining))
             return FilterResult(allowed=allowed, remaining=[], short_circuit=True)
 
         return FilterResult(allowed=allowed, remaining=still_remaining)
@@ -145,8 +145,9 @@ class HierarchyPreFilterStrategy:
         }
 
         logger.info(
-            f"[HIERARCHY-PREFILTER] {len(accessible_parents)}/{len(unique_parents)} "
-            f"parents accessible"
+            "[HIERARCHY-PREFILTER] %d/%d parents accessible",
+            len(accessible_parents),
+            len(unique_parents),
         )
 
         # Store accessible directories in Leopard index
@@ -161,8 +162,11 @@ class HierarchyPreFilterStrategy:
 
             skipped = len(remaining) - len(kept)
             logger.info(
-                f"[HIERARCHY-PREFILTER] Reduced fallback: {len(remaining)} -> "
-                f"{len(kept)} paths (skipped {skipped} under denied parents)"
+                "[HIERARCHY-PREFILTER] Reduced fallback: %d -> "
+                "%d paths (skipped %d under denied parents)",
+                len(remaining),
+                len(kept),
+                skipped,
             )
 
             if not accessible_parents and len(remaining) > 100:
@@ -204,9 +208,11 @@ class HierarchyPreFilterStrategy:
                     filtered_parents.append(parent)
 
             logger.info(
-                f"[HIERARCHY-TOPLEVEL] {len(denied_top_level)}/{len(top_level_dirs)} "
-                f"top-level dirs denied, reduced parents: "
-                f"{len(unique_parents)} -> {len(filtered_parents)}"
+                "[HIERARCHY-TOPLEVEL] %d/%d top-level dirs denied, reduced parents: %d -> %d",
+                len(denied_top_level),
+                len(top_level_dirs),
+                len(unique_parents),
+                len(filtered_parents),
             )
             return filtered_parents
 
@@ -236,7 +242,7 @@ class ZonePreFilterStrategy:
             kept.append(path)
 
         if skipped:
-            logger.debug(f"[ZONE-PREFILTER] Skipped {skipped} paths not in zone {ctx.zone_id}")
+            logger.debug("[ZONE-PREFILTER] Skipped %d paths not in zone %s", skipped, ctx.zone_id)
 
         return FilterResult(allowed=[], remaining=kept)
 
@@ -277,14 +283,14 @@ class BulkReBACStrategy:
         try:
             results = ctx.rebac_manager.rebac_check_bulk(checks, zone_id=ctx.zone_id)
         except (OSError, ConnectionError, TimeoutError) as e:
-            logger.warning(f"[BULK-REBAC] Bulk check failed, retrying once: {e}")
+            logger.warning("[BULK-REBAC] Bulk check failed, retrying once: %s", e)
             try:
                 results = ctx.rebac_manager.rebac_check_bulk(checks, zone_id=ctx.zone_id)
             except Exception as e2:
-                logger.error(f"[BULK-REBAC] Bulk check failed twice: {e2}")
+                logger.error("[BULK-REBAC] Bulk check failed twice: %s", e2)
                 return FilterResult(allowed=[], remaining=[], short_circuit=True)
         except Exception as e:
-            logger.error(f"[BULK-REBAC] Bulk check failed (non-retryable): {e}")
+            logger.error("[BULK-REBAC] Bulk check failed (non-retryable): %s", e)
             return FilterResult(allowed=[], remaining=[], short_circuit=True)
 
         allowed = [

--- a/src/nexus/bricks/rebac/graph/zone_traversal.py
+++ b/src/nexus/bricks/rebac/graph/zone_traversal.py
@@ -110,11 +110,18 @@ class ZoneAwareTraversal:
         if memo_key in memo:
             cached_result = memo[memo_key]
             stats.cache_hits += 1
-            logger.debug(f"{indent}[MEMO-HIT] {memo_key} = {cached_result}")
+            logger.debug("%s[MEMO-HIT] %s = %s", indent, memo_key, cached_result)
             return cached_result
 
         logger.debug(
-            f"{indent}┌─[PERM-CHECK depth={depth}] {subject.entity_type}:{subject.entity_id} → '{permission}' → {obj.entity_type}:{obj.entity_id}"
+            "%s┌─[PERM-CHECK depth=%d] %s:%s → '%s' → %s:%s",
+            indent,
+            depth,
+            subject.entity_type,
+            subject.entity_id,
+            permission,
+            obj.entity_type,
+            obj.entity_id,
         )
 
         # P0-5: Check execution time (using perf_counter for monotonic measurement)
@@ -132,7 +139,7 @@ class ZoneAwareTraversal:
         # Check for cycles (within this traversal path only)
         visit_key = memo_key  # Same key format
         if visit_key in visited:
-            logger.debug(f"{indent}← CYCLE DETECTED, returning False")
+            logger.debug("%s← CYCLE DETECTED, returning False", indent)
             return False
         visited.add(visit_key)
         stats.nodes_visited += 1
@@ -144,12 +151,14 @@ class ZoneAwareTraversal:
         # Get namespace config
         namespace = self._get_namespace(obj.entity_type)
         if not namespace:
-            logger.debug(f"{indent}  No namespace for {obj.entity_type}, checking direct relation")
+            logger.debug(
+                "%s  No namespace for %s, checking direct relation", indent, obj.entity_type
+            )
             stats.queries += 1
             if self.enable_graph_limits and stats.queries > GraphLimits.MAX_TUPLE_QUERIES:
                 raise GraphLimitExceeded("queries", GraphLimits.MAX_TUPLE_QUERIES, stats.queries)
             result = self.has_direct_relation(subject, permission, obj, zone_id, context)
-            logger.debug(f"{indent}← RESULT: {result}")
+            logger.debug("%s← RESULT: %s", indent, result)
             memo[memo_key] = result
             return result
 
@@ -178,25 +187,39 @@ class ZoneAwareTraversal:
             usersets = namespace.get_permission_usersets(permission)
             if usersets:
                 logger.debug(
-                    f"{indent}├─[PERM-MAPPING] Permission '{permission}' maps to relations: {usersets}"
+                    "%s├─[PERM-MAPPING] Permission '%s' maps to relations: %s",
+                    indent,
+                    permission,
+                    usersets,
                 )
                 for i, relation in enumerate(usersets):
                     logger.debug(
-                        f"{indent}├─[PERM-REL {i + 1}/{len(usersets)}] Checking relation '{relation}' for permission '{permission}'"
+                        "%s├─[PERM-REL %d/%d] Checking relation '%s' for permission '%s'",
+                        indent,
+                        i + 1,
+                        len(usersets),
+                        relation,
+                        permission,
                     )
                     try:
                         result = _recurse(subject, relation, obj)
-                        logger.debug(f"{indent}│ └─[RESULT] '{relation}' = {result}")
+                        logger.debug("%s│ └─[RESULT] '%s' = %s", indent, relation, result)
                         if result:
-                            logger.debug(f"{indent}└─[✅ GRANTED] via relation '{relation}'")
+                            logger.debug("%s└─[GRANTED] via relation '%s'", indent, relation)
                             return _store(True)
                     except (RuntimeError, ValueError) as e:
                         logger.error(
-                            f"{indent}│ └─[ERROR] Exception while checking '{relation}': {type(e).__name__}: {e}"
+                            "%s│ └─[ERROR] Exception while checking '%s': %s: %s",
+                            indent,
+                            relation,
+                            type(e).__name__,
+                            e,
                         )
                         raise
                 logger.debug(
-                    f"{indent}└─[❌ DENIED] No relations granted access for permission '{permission}'"
+                    "%s└─[DENIED] No relations granted access for permission '%s'",
+                    indent,
+                    permission,
                 )
                 return _store(False)
 
@@ -204,20 +227,24 @@ class ZoneAwareTraversal:
         rel_config = namespace.get_relation_config(permission)
         if not rel_config:
             logger.debug(
-                f"{indent}  No relation config for '{permission}', checking direct relation"
+                "%s  No relation config for '%s', checking direct relation",
+                indent,
+                permission,
             )
             stats.queries += 1
             if self.enable_graph_limits and stats.queries > GraphLimits.MAX_TUPLE_QUERIES:
                 raise GraphLimitExceeded("queries", GraphLimits.MAX_TUPLE_QUERIES, stats.queries)
             result = self.has_direct_relation(subject, permission, obj, zone_id, context)
-            logger.debug(f"{indent}← RESULT: {result}")
+            logger.debug("%s← RESULT: %s", indent, result)
             memo[memo_key] = result
             return result
 
         # Handle union (OR of multiple relations)
         if namespace.has_union(permission):
             union_relations = namespace.get_union_relations(permission)
-            logger.debug(f"{indent}├─[UNION] Relation '{permission}' expands to: {union_relations}")
+            logger.debug(
+                "%s├─[UNION] Relation '%s' expands to: %s", indent, permission, union_relations
+            )
 
             # P0-5: Check fan-out limit
             if self.enable_graph_limits and len(union_relations) > GraphLimits.MAX_FAN_OUT:
@@ -225,25 +252,44 @@ class ZoneAwareTraversal:
 
             for i, rel in enumerate(union_relations):
                 logger.debug(
-                    f"{indent}│ ├─[UNION {i + 1}/{len(union_relations)}] Checking: '{rel}'"
+                    "%s│ ├─[UNION %d/%d] Checking: '%s'",
+                    indent,
+                    i + 1,
+                    len(union_relations),
+                    rel,
                 )
                 try:
                     result = _recurse(subject, rel, obj)
-                    logger.debug(f"{indent}│ │ └─[RESULT] '{rel}' = {result}")
+                    logger.debug("%s│ │ └─[RESULT] '%s' = %s", indent, rel, result)
                     if result:
-                        logger.debug(f"{indent}└─[✅ GRANTED] via union member '{rel}'")
+                        logger.debug("%s└─[GRANTED] via union member '%s'", indent, rel)
                         return _store(True)
                 except GraphLimitExceeded as e:
                     logger.error(
-                        f"{indent}[depth={depth}]   [{i + 1}/{len(union_relations)}] GraphLimitExceeded while checking '{rel}': limit_type={e.limit_type}, limit_value={e.limit_value}, actual_value={e.actual_value}"
+                        "%s[depth=%d]   [%d/%d] GraphLimitExceeded while checking '%s': limit_type=%s, limit_value=%s, actual_value=%s",
+                        indent,
+                        depth,
+                        i + 1,
+                        len(union_relations),
+                        rel,
+                        e.limit_type,
+                        e.limit_value,
+                        e.actual_value,
                     )
                     raise
                 except (RuntimeError, ValueError) as e:
                     logger.error(
-                        f"{indent}[depth={depth}]   [{i + 1}/{len(union_relations)}] Unexpected exception while checking '{rel}': {type(e).__name__}: {e}"
+                        "%s[depth=%d]   [%d/%d] Unexpected exception while checking '%s': %s: %s",
+                        indent,
+                        depth,
+                        i + 1,
+                        len(union_relations),
+                        rel,
+                        type(e).__name__,
+                        e,
                     )
                     raise
-            logger.debug(f"{indent}└─[❌ DENIED] - no union members granted access")
+            logger.debug("%s└─[DENIED] - no union members granted access", indent)
             return _store(False)
 
         # Handle tupleToUserset (indirect relation via another object)
@@ -253,7 +299,11 @@ class ZoneAwareTraversal:
                 tupleset_relation = ttu["tupleset"]
                 computed_userset = ttu["computedUserset"]
                 logger.debug(
-                    f"{indent}├─[TTU] '{permission}' = tupleToUserset(tupleset='{tupleset_relation}', computed='{computed_userset}')"
+                    "%s├─[TTU] '%s' = tupleToUserset(tupleset='%s', computed='%s')",
+                    indent,
+                    permission,
+                    tupleset_relation,
+                    computed_userset,
                 )
 
                 # Pattern 1 (parent-style): Find objects where (obj, tupleset_relation, ?)
@@ -265,7 +315,11 @@ class ZoneAwareTraversal:
 
                 related_objects = self.find_related_objects(obj, tupleset_relation, zone_id)
                 logger.debug(
-                    f"{indent}│ ├─[TTU-PARENT] Found {len(related_objects)} objects via '{tupleset_relation}': {[f'{o.entity_type}:{o.entity_id}' for o in related_objects]}"
+                    "%s│ ├─[TTU-PARENT] Found %d objects via '%s': %s",
+                    indent,
+                    len(related_objects),
+                    tupleset_relation,
+                    [f"{o.entity_type}:{o.entity_id}" for o in related_objects],
                 )
 
                 # P0-5: Check fan-out limit
@@ -276,11 +330,18 @@ class ZoneAwareTraversal:
 
                 for related_obj in related_objects:
                     logger.debug(
-                        f"{indent}  Checking '{computed_userset}' on related object {related_obj.entity_type}:{related_obj.entity_id}"
+                        "%s  Checking '%s' on related object %s:%s",
+                        indent,
+                        computed_userset,
+                        related_obj.entity_type,
+                        related_obj.entity_id,
                     )
                     if _recurse(subject, computed_userset, related_obj):
                         logger.debug(
-                            f"{indent}← RESULT: True (via tupleToUserset parent pattern on {related_obj.entity_type}:{related_obj.entity_id})"
+                            "%s← RESULT: True (via tupleToUserset parent pattern on %s:%s)",
+                            indent,
+                            related_obj.entity_type,
+                            related_obj.entity_id,
                         )
                         return _store(True)
 
@@ -289,7 +350,8 @@ class ZoneAwareTraversal:
                 # NOT for parent relations which would cause exponential blow-up
                 if tupleset_relation == "parent":
                     logger.debug(
-                        f"{indent}│ └─[TTU-SKIP] Skipping Pattern 2 for 'parent' tupleset (not a group pattern)"
+                        "%s│ └─[TTU-SKIP] Skipping Pattern 2 for 'parent' tupleset (not a group pattern)",
+                        indent,
                     )
                     return _store(False)
 
@@ -301,7 +363,12 @@ class ZoneAwareTraversal:
 
                 related_subjects = self.find_subjects(obj, tupleset_relation, zone_id)
                 logger.debug(
-                    f"{indent}[depth={depth}]   Pattern 2 (group): Found {len(related_subjects)} subjects with '{tupleset_relation}' on obj: {[f'{s.entity_type}:{s.entity_id}' for s in related_subjects]}"
+                    "%s[depth=%d]   Pattern 2 (group): Found %d subjects with '%s' on obj: %s",
+                    indent,
+                    depth,
+                    len(related_subjects),
+                    tupleset_relation,
+                    [f"{s.entity_type}:{s.entity_id}" for s in related_subjects],
                 )
 
                 # P0-5: Check fan-out limit for group pattern
@@ -312,24 +379,32 @@ class ZoneAwareTraversal:
 
                 for related_subj in related_subjects:
                     logger.debug(
-                        f"{indent}  Checking if {subject} has '{computed_userset}' on {related_subj.entity_type}:{related_subj.entity_id}"
+                        "%s  Checking if %s has '%s' on %s:%s",
+                        indent,
+                        subject,
+                        computed_userset,
+                        related_subj.entity_type,
+                        related_subj.entity_id,
                     )
                     if _recurse(subject, computed_userset, related_subj):
                         logger.debug(
-                            f"{indent}← RESULT: True (via tupleToUserset group pattern on {related_subj.entity_type}:{related_subj.entity_id})"
+                            "%s← RESULT: True (via tupleToUserset group pattern on %s:%s)",
+                            indent,
+                            related_subj.entity_type,
+                            related_subj.entity_id,
                         )
                         return _store(True)
 
-            logger.debug(f"{indent}← RESULT: False (tupleToUserset found no access)")
+            logger.debug("%s← RESULT: False (tupleToUserset found no access)", indent)
             return _store(False)
 
         # Direct relation check (fallback)
-        logger.debug(f"{indent}[depth={depth}] Checking direct relation (fallback)")
+        logger.debug("%s[depth=%d] Checking direct relation (fallback)", indent, depth)
         stats.queries += 1
         if self.enable_graph_limits and stats.queries > GraphLimits.MAX_TUPLE_QUERIES:
             raise GraphLimitExceeded("queries", GraphLimits.MAX_TUPLE_QUERIES, stats.queries)
         result = self.has_direct_relation(subject, permission, obj, zone_id, context)
-        logger.debug(f"{indent}← [EXIT depth={depth}] Direct relation result: {result}")
+        logger.debug("%s← [EXIT depth=%d] Direct relation result: %s", indent, depth, result)
         memo[memo_key] = result
         return result
 
@@ -501,7 +576,10 @@ class ZoneAwareTraversal:
                         return True
                 except GraphLimitExceeded:
                     logger.warning(
-                        f"Userset check hit limits: {subject} -> {userset_relation} -> {userset_entity}, skipping"
+                        "Userset check hit limits: %s -> %s -> %s, skipping",
+                        subject,
+                        userset_relation,
+                        userset_entity,
                     )
                     continue
 
@@ -524,14 +602,18 @@ class ZoneAwareTraversal:
         Returns:
             List of related object entities within the zone
         """
-        logger.debug(f"find_related_objects: obj={obj}, relation={relation}, zone_id={zone_id}")
+        logger.debug(
+            "find_related_objects: obj=%s, relation=%s, zone_id=%s", obj, relation, zone_id
+        )
 
         # For parent relation on files, compute from path instead of querying DB
         if relation == "parent" and obj.entity_type == "file":
             parent_path = str(PurePosixPath(obj.entity_id).parent)
             if parent_path != obj.entity_id and parent_path != ".":
                 logger.debug(
-                    f"find_related_objects: Computed parent from path: {obj.entity_id} -> {parent_path}"
+                    "find_related_objects: Computed parent from path: %s -> %s",
+                    obj.entity_id,
+                    parent_path,
                 )
                 return [Entity("file", parent_path)]
             return []
@@ -549,7 +631,11 @@ class ZoneAwareTraversal:
             results = [Entity(row.object_type, row.object_id) for row in conn.execute(stmt)]
 
             logger.debug(
-                f"find_related_objects: Found {len(results)} objects for {obj} via '{relation}': {[str(r) for r in results]}"
+                "find_related_objects: Found %d objects for %s via '%s': %s",
+                len(results),
+                obj,
+                relation,
+                [str(r) for r in results],
             )
             return results
 
@@ -566,7 +652,7 @@ class ZoneAwareTraversal:
         Returns:
             List of subject entities (the subjects from matching tuples)
         """
-        logger.debug(f"find_subjects: Looking for (?, '{relation}', {obj})")
+        logger.debug("find_subjects: Looking for (?, '%s', %s)", relation, obj)
 
         now = datetime.now(UTC)
         stmt = select(RT.subject_type, RT.subject_id).where(
@@ -581,6 +667,10 @@ class ZoneAwareTraversal:
             results = [Entity(row.subject_type, row.subject_id) for row in conn.execute(stmt)]
 
             logger.debug(
-                f"find_subjects: Found {len(results)} subjects for (?, '{relation}', {obj}): {[str(r) for r in results]}"
+                "find_subjects: Found %d subjects for (?, '%s', %s): %s",
+                len(results),
+                relation,
+                obj,
+                [str(r) for r in results],
             )
             return results

--- a/src/nexus/bricks/rebac/hotspot_detector.py
+++ b/src/nexus/bricks/rebac/hotspot_detector.py
@@ -298,9 +298,12 @@ class HotspotDetector:
                 if time_until_expiry < self._config.prefetch_before_expiry_seconds:
                     candidates.append(entry)
                     logger.debug(
-                        f"[HOTSPOT] Prefetch candidate: {entry.subject_type}:{entry.subject_id} "
-                        f"-> {entry.permission} (expires in {time_until_expiry:.1f}s, "
-                        f"accesses={entry.access_count})"
+                        "[HOTSPOT] Prefetch candidate: %s:%s -> %s (expires in %.1fs, accesses=%d)",
+                        entry.subject_type,
+                        entry.subject_id,
+                        entry.permission,
+                        time_until_expiry,
+                        entry.access_count,
                     )
 
         return candidates[: self._config.max_prefetch_batch]
@@ -329,7 +332,7 @@ class HotspotDetector:
                 removed += 1
 
         if removed > 0:
-            logger.debug(f"[HOTSPOT] Cleaned up {removed} stale entries")
+            logger.debug("[HOTSPOT] Cleaned up %d stale entries", removed)
 
         return removed
 
@@ -396,8 +399,9 @@ class HotspotPrefetcher:
         """
         self._running = True
         logger.info(
-            f"[HOTSPOT] Starting prefetcher (interval: {self._config.prefetch_interval_seconds}s, "
-            f"batch: {self._config.max_prefetch_batch})"
+            "[HOTSPOT] Starting prefetcher (interval: %ds, batch: %d)",
+            self._config.prefetch_interval_seconds,
+            self._config.max_prefetch_batch,
         )
 
         cleanup_counter = 0
@@ -410,7 +414,9 @@ class HotspotPrefetcher:
 
                 if prefetched > 0:
                     logger.info(
-                        f"[HOTSPOT] Prefetched {prefetched} entries in {self._last_cycle_duration:.2f}s"
+                        "[HOTSPOT] Prefetched %d entries in %.2fs",
+                        prefetched,
+                        self._last_cycle_duration,
                     )
 
                 # Periodic cleanup
@@ -422,7 +428,7 @@ class HotspotPrefetcher:
                     cleanup_counter = 0
 
             except Exception as e:  # fail-safe: background prefetch must not crash loop
-                logger.error(f"[HOTSPOT] Prefetch cycle failed: {e}", exc_info=True)
+                logger.error("[HOTSPOT] Prefetch cycle failed: %s", e, exc_info=True)
 
             await asyncio.sleep(self._config.prefetch_interval_seconds)
 
@@ -462,13 +468,18 @@ class HotspotPrefetcher:
                 self._detector._prefetches_triggered += 1
 
                 logger.debug(
-                    f"[HOTSPOT] Queued prefetch: {entry.subject_type}:{entry.subject_id} "
-                    f"-> {entry.permission} (priority=1)"
+                    "[HOTSPOT] Queued prefetch: %s:%s -> %s (priority=1)",
+                    entry.subject_type,
+                    entry.subject_id,
+                    entry.permission,
                 )
 
             except (RuntimeError, ValueError, KeyError) as e:
                 logger.warning(
-                    f"[HOTSPOT] Failed to queue prefetch for {entry.subject_type}:{entry.subject_id}: {e}"
+                    "[HOTSPOT] Failed to queue prefetch for %s:%s: %s",
+                    entry.subject_type,
+                    entry.subject_id,
+                    e,
                 )
 
         return prefetched

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -429,7 +429,9 @@ class ReBACManager:
             # Legacy ConsistencyLevel
             consistency_level = consistency
         logger.debug(
-            f"ReBACManager.rebac_check called: enforce_zone_isolation={self.enforce_zone_isolation}, MAX_DEPTH={GraphLimits.MAX_DEPTH}"
+            "ReBACManager.rebac_check called: enforce_zone_isolation=%s, MAX_DEPTH=%s",
+            self.enforce_zone_isolation,
+            GraphLimits.MAX_DEPTH,
         )
 
         # Issue #702: OTel tracing — wrap the entire check in a root span
@@ -488,12 +490,14 @@ class ReBACManager:
                 )
                 if boundary_result:
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug(f"  -> Boundary Cache HIT: {object_id} → {boundary}")
+                        logger.debug("  -> Boundary Cache HIT: %s → %s", object_id, boundary)
                     return True
                 else:
                     # Boundary no longer valid - invalidate
                     logger.debug(
-                        f"  -> Boundary Cache STALE: {boundary} no longer grants {permission}"
+                        "  -> Boundary Cache STALE: %s no longer grants %s",
+                        boundary,
+                        permission,
                     )
                     self._boundary_cache.invalidate_permission_change(
                         effective_zone, subject_type, subject_id, permission, boundary
@@ -520,7 +524,7 @@ class ReBACManager:
         # If zone isolation is disabled, use base (non-zone-aware) check path
         if not self.enforce_zone_isolation:
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"  -> Falling back to base check path, max_depth={self.max_depth}")
+                logger.debug("  -> Falling back to base check path, max_depth=%s", self.max_depth)
             result = self._rebac_check_base(subject, permission, object, context, zone_id)
 
             # Write-through to Tiger Cache (Issue #935)
@@ -538,7 +542,9 @@ class ReBACManager:
             subject, permission, object, context, zone_id, consistency_level, min_revision
         )
         logger.debug(
-            f"  -> rebac_check_detailed result: allowed={detailed_result.allowed}, indeterminate={detailed_result.indeterminate}"
+            "  -> rebac_check_detailed result: allowed=%s, indeterminate=%s",
+            detailed_result.allowed,
+            detailed_result.indeterminate,
         )
 
         # Write-through to Tiger Cache (Issue #935)
@@ -715,8 +721,12 @@ class ReBACManager:
                     effective_zone, subject_type, subject_id, permission, object_id, parent_path
                 )
                 logger.info(
-                    f"[BoundaryCache] Cached: {subject_type}:{subject_id} {permission} "
-                    f"{object_id} → {parent_path}"
+                    "[BoundaryCache] Cached: %s:%s %s %s → %s",
+                    subject_type,
+                    subject_id,
+                    permission,
+                    object_id,
+                    parent_path,
                 )
                 return
 
@@ -772,8 +782,9 @@ class ReBACManager:
             elif not is_public_check:
                 # Development/test: Allow defaulting but log stack trace for debugging
                 logger.warning(
-                    f"rebac_check called without zone_id, defaulting to 'root'. "
-                    f"This is only allowed in development. Stack:\n{''.join(traceback.format_stack()[-5:])}"
+                    "rebac_check called without zone_id, defaulting to 'root'. "
+                    "This is only allowed in development. Stack:\n%s",
+                    "".join(traceback.format_stack()[-5:]),
                 )
             zone_id = ROOT_ZONE_ID
 
@@ -844,7 +855,7 @@ class ReBACManager:
             )
             if cached is not None:
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(f"  -> CACHE HIT: returning cached result={cached}")
+                    logger.debug("  -> CACHE HIT: returning cached result=%s", cached)
                 decision_time_ms = (time.perf_counter() - start_time) * 1000
                 return CheckResult(
                     allowed=cached,
@@ -975,14 +986,19 @@ class ReBACManager:
                 elapsed_ms = (time.perf_counter() - start_time) * 1000
                 stats.duration_ms = elapsed_ms
                 logger.debug(
-                    f"[RUST-SINGLE] Permission check completed in {elapsed_ms:.2f}ms: "
-                    f"{subject.entity_type}:{subject.entity_id} {permission} "
-                    f"{obj.entity_type}:{obj.entity_id} = {result}"
+                    "[RUST-SINGLE] Permission check completed in %.2fms: %s:%s %s %s:%s = %s",
+                    elapsed_ms,
+                    subject.entity_type,
+                    subject.entity_id,
+                    permission,
+                    obj.entity_type,
+                    obj.entity_id,
+                    result,
                 )
                 return result
 
         except (RuntimeError, ValueError) as e:
-            logger.warning(f"Rust single permission check failed, falling back to Python: {e}")
+            logger.warning("Rust single permission check failed, falling back to Python: %s", e)
             # Fall through to Python implementation
 
         # Fallback to Python implementation
@@ -1100,7 +1116,7 @@ class ReBACManager:
                 for permission in permissions:
                     callback(zone_id, subject_type, subject_id, permission, object_id)
             except (RuntimeError, ValueError, KeyError) as e:
-                logger.warning(f"[BOUNDARY-CACHE] Invalidator {callback_id} failed: {e}")
+                logger.warning("[BOUNDARY-CACHE] Invalidator %s failed: %s", callback_id, e)
 
     # =========================================================================
     # Issue #919: Directory Visibility Cache Invalidation
@@ -1205,10 +1221,13 @@ class ReBACManager:
             try:
                 callback(zone_id, object_path)
                 logger.debug(
-                    f"[DIR-VIS-CACHE] Invalidator {callback_id} called for {zone_id}:{object_path}"
+                    "[DIR-VIS-CACHE] Invalidator %s called for %s:%s",
+                    callback_id,
+                    zone_id,
+                    object_path,
                 )
             except (RuntimeError, ValueError, KeyError) as e:
-                logger.warning(f"[DIR-VIS-CACHE] Invalidator {callback_id} failed: {e}")
+                logger.warning("[DIR-VIS-CACHE] Invalidator %s failed: %s", callback_id, e)
 
     def rebac_write(
         self,
@@ -1781,7 +1800,7 @@ class ReBACManager:
                             )
                         except (OperationalError, ProgrammingError) as e:
                             if logger.isEnabledFor(logging.DEBUG):
-                                logger.debug(f"[TIGER] Revoke failed: {e}")
+                                logger.debug("[TIGER] Revoke failed: %s", e)
 
             # Leopard: Update transitive closure for membership relations
             if tuple_info["relation"] in self.MEMBERSHIP_RELATIONS:
@@ -2284,9 +2303,15 @@ class ReBACManager:
         zone_id = normalize_zone_id(zone_id)
 
         logger.debug(
-            f"[LIST-OBJECTS] Starting for {subject_type}:{subject_id} "
-            f"permission={permission} object_type={object_type} "
-            f"path_prefix={path_prefix} zone_id={zone_id}"
+            "[LIST-OBJECTS] Starting for %s:%s "
+            "permission=%s object_type=%s "
+            "path_prefix=%s zone_id=%s",
+            subject_type,
+            subject_id,
+            permission,
+            object_type,
+            path_prefix,
+            zone_id,
         )
 
         # Fetch all relevant tuples for this zone
@@ -2294,13 +2319,15 @@ class ReBACManager:
         # CROSS-ZONE FIX: Include cross-zone shares where this user is the recipient
         tuples = self._fetch_tuples_for_zone(zone_id, include_cross_zone_for_user=subject_id)
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"[LIST-OBJECTS] Fetched {len(tuples)} tuples for zone {zone_id}")
+            logger.debug("[LIST-OBJECTS] Fetched %d tuples for zone %s", len(tuples), zone_id)
 
         # Get namespace configs
         namespace_configs = self._get_namespace_configs_dict()
 
         logger.debug(
-            f"[LIST-OBJECTS] Namespace configs: file relations={len(namespace_configs.get('file', {}).get('relations', {}))} permissions={len(namespace_configs.get('file', {}).get('permissions', {}))}"
+            "[LIST-OBJECTS] Namespace configs: file relations=%d permissions=%d",
+            len(namespace_configs.get("file", {}).get("relations", {})),
+            len(namespace_configs.get("file", {}).get("permissions", {})),
         )
 
         # Try Rust implementation first (much faster)
@@ -2319,11 +2346,15 @@ class ReBACManager:
                 )
                 elapsed = (time.perf_counter() - start_time) * 1000
                 logger.debug(
-                    f"[LIST-OBJECTS] Rust completed: {len(result)} objects in {elapsed:.1f}ms"
+                    "[LIST-OBJECTS] Rust completed: %d objects in %.1fms",
+                    len(result),
+                    elapsed,
                 )
                 return result
             except (RuntimeError, ValueError) as e:
-                logger.warning(f"Rust list_objects_for_subject failed, falling back to Python: {e}")
+                logger.warning(
+                    "Rust list_objects_for_subject failed, falling back to Python: %s", e
+                )
                 # Fall through to Python implementation
 
         # Python fallback implementation
@@ -2492,8 +2523,10 @@ class ReBACManager:
 
         elapsed = (time.perf_counter() - start_time) * 1000
         logger.debug(
-            f"[LIST-OBJECTS] Python completed: {len(result)} objects "
-            f"(from {len(candidate_objects)} candidates) in {elapsed:.1f}ms"
+            "[LIST-OBJECTS] Python completed: %d objects (from %d candidates) in %.1fms",
+            len(result),
+            len(candidate_objects),
+            elapsed,
         )
 
         return result
@@ -2822,7 +2855,7 @@ class ReBACManager:
                     logger.info("Default namespaces initialized successfully")
                 except Exception as e:  # fail-safe: namespace init is best-effort at startup
                     sa_conn.rollback()
-                    logger.warning(f"Failed to initialize namespaces: {type(e).__name__}: {e}")
+                    logger.warning("Failed to initialize namespaces: %s: %s", type(e).__name__, e)
                     logger.debug(traceback.format_exc())
 
     def _fix_sql_placeholders(self, sql: str) -> str:
@@ -2912,7 +2945,7 @@ class ReBACManager:
             conn.commit()
         except Exception as e:  # fail-safe: tables may not exist yet at startup
             logger = logging.getLogger(__name__)
-            logger.warning(f"Failed to register default namespaces: {type(e).__name__}: {e}")
+            logger.warning("Failed to register default namespaces: %s: %s", type(e).__name__, e)
             logger.debug(traceback.format_exc())
 
     def _initialize_default_namespaces(self) -> None:
@@ -3253,7 +3286,11 @@ class ReBACManager:
         object_entity = Entity(object[0], object[1])
 
         logger.debug(
-            f"🔍 REBAC CHECK: subject={subject_entity}, permission={permission}, object={object_entity}, zone_id={zone_id}"
+            "REBAC CHECK: subject=%s, permission=%s, object=%s, zone_id=%s",
+            subject_entity,
+            permission,
+            object_entity,
+            zone_id,
         )
 
         # Clean up expired tuples first (this will invalidate affected caches)
@@ -3275,7 +3312,9 @@ class ReBACManager:
                 if cached is not None:
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.debug(
-                            f"✅ CACHE HIT: result={cached}, needs_refresh={needs_refresh}"
+                            "CACHE HIT: result=%s, needs_refresh=%s",
+                            cached,
+                            needs_refresh,
                         )
                     if needs_refresh:
                         # Schedule background refresh without blocking
@@ -3288,7 +3327,7 @@ class ReBACManager:
                 cached = self._get_cached_check(subject_entity, permission, object_entity, zone_id)
                 if cached is not None:
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug(f"✅ CACHE HIT: result={cached}")
+                        logger.debug("CACHE HIT: result=%s", cached)
                     return cached
 
             # Cache miss - use stampede prevention (Issue #878)
@@ -3309,7 +3348,7 @@ class ReBACManager:
                     wait_result = self._l1_cache.wait_for_compute(cache_key)
                     if wait_result is not None:
                         if logger.isEnabledFor(logging.DEBUG):
-                            logger.debug(f"✅ STAMPEDE: Got result from leader: {wait_result}")
+                            logger.debug("STAMPEDE: Got result from leader: %s", wait_result)
                         return wait_result
                     # Timeout or error - fall through to compute ourselves
                     logger.debug("⚠️ STAMPEDE: Wait timeout, computing ourselves")
@@ -3329,7 +3368,7 @@ class ReBACManager:
                     )
                     delta = time.perf_counter() - start_time
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug(f"{'✅' if result else '❌'} REBAC RESULT: {result}")
+                        logger.debug("REBAC RESULT: %s", result)
 
                     # Cache result and release lock with delta for XFetch (Issue #718)
                     self._l1_cache.release_compute(
@@ -3367,7 +3406,7 @@ class ReBACManager:
         delta = time.perf_counter() - start_time
 
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"{'✅' if result else '❌'} REBAC RESULT: {result}")
+            logger.debug("REBAC RESULT: %s", result)
 
         # Cache result (only if no context) with delta for XFetch (Issue #718)
         if context is None:
@@ -3494,8 +3533,11 @@ class ReBACManager:
                 uncached_checks.append((i, (subject, permission, obj)))
 
         logger.debug(
-            f"🚀 Batch check: {len(checks)} total, {len(results)} cached, "
-            f"{len(uncached_checks)} to compute (Rust={'enabled' if use_rust and is_rust_available() else 'disabled'})"
+            "Batch check: %d total, %d cached, %d to compute (Rust=%s)",
+            len(checks),
+            len(results),
+            len(uncached_checks),
+            "enabled" if use_rust and is_rust_available() else "disabled",
         )
 
         # Phase 2: Compute uncached checks
@@ -3503,7 +3545,8 @@ class ReBACManager:
             if use_rust and is_rust_available() and len(uncached_checks) >= 10:
                 # Use Rust for bulk computation (efficient for 10+ checks)
                 logger.debug(
-                    f"⚡ Using Rust acceleration for {len(uncached_checks)} uncached checks"
+                    "Using Rust acceleration for %d uncached checks",
+                    len(uncached_checks),
                 )
                 try:
                     start_time = time.perf_counter()
@@ -3528,7 +3571,7 @@ class ReBACManager:
                             delta=avg_delta,
                         )
                 except Exception as e:  # fail-safe: Rust fallback to Python computation
-                    logger.warning(f"Rust batch computation failed, falling back to Python: {e}")
+                    logger.warning("Rust batch computation failed, falling back to Python: %s", e)
                     # Fall back to Python computation
                     self._compute_batch_python(uncached_checks, results)
             else:
@@ -3537,7 +3580,9 @@ class ReBACManager:
                     "batch too small (<10)" if len(uncached_checks) < 10 else "Rust not available"
                 )
                 logger.debug(
-                    f"🐍 Using Python computation for {len(uncached_checks)} checks ({reason})"
+                    "Using Python computation for %d checks (%s)",
+                    len(uncached_checks),
+                    reason,
                 )
                 self._compute_batch_python(uncached_checks, results)
 
@@ -3643,7 +3688,7 @@ class ReBACManager:
                 )
 
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"📦 Fetched {len(tuples)} tuples for batch computation")
+                logger.debug("Fetched %d tuples for batch computation", len(tuples))
             return tuples
 
     # ====================================================================================
@@ -3983,7 +4028,7 @@ class ReBACManager:
         )
         thread.start()
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"🔄 REFRESH: Scheduled background refresh for {cache_key[:50]}...")
+            logger.debug("REFRESH: Scheduled background refresh for %s...", cache_key[:50])
 
     def _background_refresh_worker(
         self,
@@ -4036,9 +4081,9 @@ class ReBACManager:
             self._cache_check_result(subject_entity, permission, object_entity, result, zone_id)
 
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"✅ REFRESH: Background refresh complete for {cache_key[:50]}...")
+                logger.debug("REFRESH: Background refresh complete for %s...", cache_key[:50])
         except Exception as e:  # fail-safe: background refresh must not crash thread
-            logger.warning(f"REFRESH: Background refresh failed for {cache_key[:50]}: {e}")
+            logger.warning("REFRESH: Background refresh failed for %s: %s", cache_key[:50], e)
         finally:
             if self._l1_cache:
                 self._l1_cache.complete_refresh(cache_key)

--- a/src/nexus/bricks/rebac/namespace_manager.py
+++ b/src/nexus/bricks/rebac/namespace_manager.py
@@ -729,7 +729,7 @@ class NamespaceManager:
         try:
             current_revision = self._rebac_manager.get_zone_revision(zone_id)
         except Exception:  # fail-safe: thread-isolated SQLite, defaults to 0
-            logger.warning(f"[NAMESPACE] Failed to get zone revision for {zone_id}, using 0")
+            logger.warning("[NAMESPACE] Failed to get zone revision for %s, using 0", zone_id)
             current_revision = 0
 
         # Cache the result (5-tuple: mount_entries, mount_paths, revision, zone_id, grants_hash)
@@ -764,8 +764,12 @@ class NamespaceManager:
 
         elapsed_ms = (time.perf_counter() - start) * 1000
         logger.debug(
-            f"[NAMESPACE] Rebuilt mount table for {subject_type}:{subject_id}: "
-            f"{len(mount_entries)} mounts from {len(object_paths)} objects in {elapsed_ms:.1f}ms"
+            "[NAMESPACE] Rebuilt mount table for %s:%s: %d mounts from %d objects in %.1fms",
+            subject_type,
+            subject_id,
+            len(mount_entries),
+            len(object_paths),
+            elapsed_ms,
         )
 
         return mount_entries, mount_paths

--- a/src/nexus/bricks/rebac/permission_cache.py
+++ b/src/nexus/bricks/rebac/permission_cache.py
@@ -156,7 +156,7 @@ class PermissionCacheCoordinator:
             logger.debug("[TIGER-BITMAP] pyroaring not available")
             return None
         except Exception as e:  # fail-safe: bitmap filtering is optional optimization
-            logger.warning(f"[TIGER-BITMAP] Bitmap filtering failed: {e}")
+            logger.warning("[TIGER-BITMAP] Bitmap filtering failed: %s", e)
             return None
 
     # =========================================================================

--- a/src/nexus/bricks/rebac/permission_filter_chain.py
+++ b/src/nexus/bricks/rebac/permission_filter_chain.py
@@ -69,7 +69,7 @@ class TigerBitmapStrategy:
             return FilterResult(allowed=[], remaining=remaining)
 
         allowed, still_remaining = result
-        logger.debug(f"[TIGER-BITMAP] {len(allowed)} allowed, {len(still_remaining)} remaining")
+        logger.debug("[TIGER-BITMAP] %d allowed, %d remaining", len(allowed), len(still_remaining))
 
         # Check bitmap completeness — if complete, skip fallback.
         # Only short-circuit when the bitmap found SOME allowed paths.
@@ -77,7 +77,7 @@ class TigerBitmapStrategy:
         # zone-prefixed vs non-prefixed path mismatch) — fall through to
         # the full ReBAC check to avoid false denials.
         if still_remaining and allowed and ctx.cache.is_bitmap_complete(ctx.subject, ctx.zone_id):
-            logger.info(f"[BITMAP-COMPLETE] Skipped {len(still_remaining)} fallback checks")
+            logger.info("[BITMAP-COMPLETE] Skipped %d fallback checks", len(still_remaining))
             return FilterResult(allowed=allowed, remaining=[], short_circuit=True)
 
         return FilterResult(allowed=allowed, remaining=still_remaining)
@@ -153,8 +153,9 @@ class HierarchyPreFilterStrategy:
         }
 
         logger.info(
-            f"[HIERARCHY-PREFILTER] {len(accessible_parents)}/{len(unique_parents)} "
-            f"parents accessible"
+            "[HIERARCHY-PREFILTER] %d/%d parents accessible",
+            len(accessible_parents),
+            len(unique_parents),
         )
 
         # Store accessible directories in Leopard index
@@ -169,8 +170,11 @@ class HierarchyPreFilterStrategy:
 
             skipped = len(remaining) - len(kept)
             logger.info(
-                f"[HIERARCHY-PREFILTER] Reduced fallback: {len(remaining)} -> "
-                f"{len(kept)} paths (skipped {skipped} under denied parents)"
+                "[HIERARCHY-PREFILTER] Reduced fallback: %d -> "
+                "%d paths (skipped %d under denied parents)",
+                len(remaining),
+                len(kept),
+                skipped,
             )
 
             if not accessible_parents and len(remaining) > 100:
@@ -214,9 +218,11 @@ class HierarchyPreFilterStrategy:
                     filtered_parents.append(parent)
 
             logger.info(
-                f"[HIERARCHY-TOPLEVEL] {len(denied_top_level)}/{len(top_level_dirs)} "
-                f"top-level dirs denied, reduced parents: "
-                f"{len(unique_parents)} -> {len(filtered_parents)}"
+                "[HIERARCHY-TOPLEVEL] %d/%d top-level dirs denied, reduced parents: %d -> %d",
+                len(denied_top_level),
+                len(top_level_dirs),
+                len(unique_parents),
+                len(filtered_parents),
             )
             return filtered_parents
 
@@ -246,7 +252,7 @@ class ZonePreFilterStrategy:
             kept.append(path)
 
         if skipped:
-            logger.debug(f"[ZONE-PREFILTER] Skipped {skipped} paths not in zone {ctx.zone_id}")
+            logger.debug("[ZONE-PREFILTER] Skipped %d paths not in zone %s", skipped, ctx.zone_id)
 
         return FilterResult(allowed=[], remaining=kept)
 
@@ -287,14 +293,14 @@ class BulkReBACStrategy:
         try:
             results = ctx.rebac_manager.rebac_check_bulk(checks, zone_id=ctx.zone_id)
         except (OSError, ConnectionError, TimeoutError) as e:
-            logger.warning(f"[BULK-REBAC] Bulk check failed, retrying once: {e}")
+            logger.warning("[BULK-REBAC] Bulk check failed, retrying once: %s", e)
             try:
                 results = ctx.rebac_manager.rebac_check_bulk(checks, zone_id=ctx.zone_id)
             except Exception as e2:  # fail-safe: second failure → deny all (fail-closed)
-                logger.error(f"[BULK-REBAC] Bulk check failed twice: {e2}")
+                logger.error("[BULK-REBAC] Bulk check failed twice: %s", e2)
                 return FilterResult(allowed=[], remaining=[], short_circuit=True)
         except Exception as e:  # fail-safe: non-retryable error → deny all (fail-closed)
-            logger.error(f"[BULK-REBAC] Bulk check failed (non-retryable): {e}")
+            logger.error("[BULK-REBAC] Bulk check failed (non-retryable): %s", e)
             return FilterResult(allowed=[], remaining=[], short_circuit=True)
 
         allowed = [

--- a/src/nexus/bricks/rebac/tiger_cache_manager.py
+++ b/src/nexus/bricks/rebac/tiger_cache_manager.py
@@ -62,7 +62,7 @@ class TigerCacheManager:
             ):
                 synced = self.sync_resource_map()
                 if synced > 0:
-                    logger.info(f"Synced {synced} resources to Tiger resource map")
+                    logger.info("Synced %d resources to Tiger resource map", synced)
 
             # 2. Warm Tiger Cache (optional, can be slow for large systems)
             # Only warm if explicitly enabled via environment variable
@@ -72,14 +72,14 @@ class TigerCacheManager:
             ):
                 entries = self._warm_cache_fn(zone_id=self._default_zone_id)
                 if entries > 0:
-                    logger.info(f"Warmed Tiger Cache with {entries} entries")
+                    logger.info("Warmed Tiger Cache with %d entries", entries)
 
             # 3. Start Tiger Cache background worker
             self.start_worker()
 
         except Exception as e:
             # Don't fail initialization if optimizations fail
-            logger.warning(f"Failed to initialize performance optimizations: {e}")
+            logger.warning("Failed to initialize performance optimizations: %s", e)
 
     def sync_resource_map(self) -> int:
         """Populate tiger_resource_map from existing metadata.
@@ -127,13 +127,13 @@ class TigerCacheManager:
                 count += 1
 
                 if count % log_interval == 0:
-                    logger.debug(f"Tiger resource map sync progress: {count} resources...")
+                    logger.debug("Tiger resource map sync progress: %d resources...", count)
 
-            logger.info(f"Tiger resource map sync complete: {count} resources")
+            logger.info("Tiger resource map sync complete: %d resources", count)
             return count
 
         except Exception as e:
-            logger.warning(f"Failed to sync resource map from metadata: {e}")
+            logger.warning("Failed to sync resource map from metadata: %s", e)
             return 0
 
     def start_worker(self) -> None:
@@ -180,9 +180,9 @@ class TigerCacheManager:
                     if process_queue_fn is not None:
                         processed = process_queue_fn(batch_size=1)
                         if processed > 0:
-                            logger.debug(f"Tiger Cache worker processed {processed} updates")
+                            logger.debug("Tiger Cache worker processed %d updates", processed)
                 except Exception as e:
-                    logger.warning(f"Tiger Cache worker error: {e}")
+                    logger.warning("Tiger Cache worker error: %s", e)
 
                 # Sleep longer since write-through handles new grants
                 # This worker is just for legacy queue cleanup
@@ -196,7 +196,7 @@ class TigerCacheManager:
             daemon=True,
         )
         self._tiger_worker_thread.start()
-        logger.debug(f"Tiger Cache worker started (interval={interval}s)")
+        logger.debug("Tiger Cache worker started (interval=%ss)", interval)
 
     def stop_worker(self) -> None:
         """Stop the Tiger Cache background worker.

--- a/src/nexus/bricks/rebac/utils/fast.py
+++ b/src/nexus/bricks/rebac/utils/fast.py
@@ -122,7 +122,7 @@ def check_permissions_bulk_rust(
 
         return result  # type: ignore[no-any-return]  # allowed
     except (RuntimeError, ValueError) as e:
-        logger.error(f"Rust permission check failed: {e}", exc_info=True)
+        logger.error("Rust permission check failed: %s", e, exc_info=True)
         raise
 
 
@@ -167,15 +167,17 @@ def check_permissions_bulk_with_fallback(
             result = check_permissions_bulk_rust(checks, tuples, namespace_configs, tuple_version)
             elapsed = time.perf_counter() - start
             logger.info(
-                f"[RUST-INNER] Pure Rust computation: {elapsed * 1000:.1f}ms for {len(checks)} checks"
+                "[RUST-INNER] Pure Rust computation: %.1fms for %d checks",
+                elapsed * 1000,
+                len(checks),
             )
             return result
         except (RuntimeError, ValueError) as e:
-            logger.warning(f"Rust permission check failed, falling back to Python: {e}")
+            logger.warning("Rust permission check failed, falling back to Python: %s", e)
             # Fall through to Python implementation
 
     # Fallback: compute in Python
-    logger.debug(f"Computing {len(checks)} permissions in Python")
+    logger.debug("Computing %d permissions in Python", len(checks))
     return _check_permissions_bulk_python(checks, tuples, namespace_configs)
 
 
@@ -357,12 +359,18 @@ def check_permission_single_rust(
         )
         elapsed = time.perf_counter() - start
         logger.debug(
-            f"[RUST-SINGLE] Permission check: {subject_type}:{subject_id} "
-            f"{permission} {object_type}:{object_id} = {result} ({elapsed * 1000:.2f}ms)"
+            "[RUST-SINGLE] Permission check: %s:%s %s %s:%s = %s (%.2fms)",
+            subject_type,
+            subject_id,
+            permission,
+            object_type,
+            object_id,
+            result,
+            elapsed * 1000,
         )
         return result
     except (RuntimeError, ValueError) as e:
-        logger.error(f"Rust single permission check failed: {e}", exc_info=True)
+        logger.error("Rust single permission check failed: %s", e, exc_info=True)
         raise
 
 
@@ -408,7 +416,7 @@ def check_permission_single_with_fallback(
                 namespace_configs,
             )
         except (RuntimeError, ValueError) as e:
-            logger.warning(f"Rust single check failed, falling back to Python: {e}")
+            logger.warning("Rust single check failed, falling back to Python: %s", e)
             # Fall through to Python
 
     # Fallback: use Python bulk check with single item
@@ -494,13 +502,17 @@ def expand_subjects_rust(
         )
         elapsed = time.perf_counter() - start
         logger.debug(
-            f"[RUST-EXPAND] Expand {permission} on {object_type}:{object_id} "
-            f"found {len(result)} subjects ({elapsed * 1000:.2f}ms)"
+            "[RUST-EXPAND] Expand %s on %s:%s found %d subjects (%.2fms)",
+            permission,
+            object_type,
+            object_id,
+            len(result),
+            elapsed * 1000,
         )
         # Convert from list of tuples to list of tuples (already correct format)
         return [(t[0], t[1]) for t in result]
     except (RuntimeError, ValueError) as e:
-        logger.error(f"Rust expand_subjects failed: {e}", exc_info=True)
+        logger.error("Rust expand_subjects failed: %s", e, exc_info=True)
         raise
 
 
@@ -539,7 +551,7 @@ def expand_subjects_with_fallback(
                 namespace_configs,
             )
         except (RuntimeError, ValueError) as e:
-            logger.warning(f"Rust expand_subjects failed, falling back to Python: {e}")
+            logger.warning("Rust expand_subjects failed, falling back to Python: %s", e)
             # Fall through to Python
 
     # Fallback: Python implementation
@@ -617,14 +629,19 @@ def list_objects_for_subject_rust(
         )
         elapsed = time.perf_counter() - start
         logger.debug(
-            f"[RUST-LIST-OBJECTS] List {object_type}s with {permission} for "
-            f"{subject_type}:{subject_id} (prefix={path_prefix}) "
-            f"found {len(result)} objects ({elapsed * 1000:.2f}ms)"
+            "[RUST-LIST-OBJECTS] List %ss with %s for %s:%s (prefix=%s) found %d objects (%.2fms)",
+            object_type,
+            permission,
+            subject_type,
+            subject_id,
+            path_prefix,
+            len(result),
+            elapsed * 1000,
         )
         # Convert from list of tuples to list of tuples (already correct format)
         return [(t[0], t[1]) for t in result]
     except (RuntimeError, ValueError) as e:
-        logger.error(f"Rust list_objects_for_subject failed: {e}", exc_info=True)
+        logger.error("Rust list_objects_for_subject failed: %s", e, exc_info=True)
         raise
 
 
@@ -675,7 +692,7 @@ def list_objects_for_subject_with_fallback(
                 offset,
             )
         except (RuntimeError, ValueError) as e:
-            logger.warning(f"Rust list_objects_for_subject failed, falling back to Python: {e}")
+            logger.warning("Rust list_objects_for_subject failed, falling back to Python: %s", e)
             # Fall through to Python
 
     # Fallback: Python implementation


### PR DESCRIPTION
## Summary
- Convert ~137 f-string logger calls to lazy `%` formatting across 24 files in `bricks/rebac/`
- Covers: manager, zone_traversal, bulk_checker, tiger_cache_manager, enforcer, filter chains, cache subsystem (tiger/expander, updater, rename_hook, visibility, iterator, result_cache, enforcer_cache, leopard), utilities, and misc
- Zero f-string logger calls remain in the entire `bricks/rebac/` directory

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes (70 files already formatted)
- [x] `mypy` passes
- [x] Pre-commit hooks pass
- [x] `grep 'logger\.\w+(f"'` returns 0 matches in bricks/rebac/