### PR TITLE
fix: convert f-string logger calls to lazy % in remaining bricks/

### DIFF
--- a/src/nexus/bricks/auth/oauth/credential_service.py
+++ b/src/nexus/bricks/auth/oauth/credential_service.py
@@ -117,7 +117,7 @@ class OAuthCredentialService:
                 provider_dict["icon_url"] = provider_config.icon_url
             providers.append(provider_dict)
 
-        logger.info(f"Listed {len(providers)} OAuth providers")
+        logger.info("Listed %d OAuth providers", len(providers))
         return providers
 
     # =========================================================================
@@ -136,7 +136,7 @@ class OAuthCredentialService:
         """Get OAuth authorization URL for any provider."""
         import secrets
 
-        logger.info(f"Generating OAuth authorization URL for provider={provider}")
+        logger.info("Generating OAuth authorization URL for provider=%s", provider)
 
         state = secrets.token_urlsafe(32)
         provider_instance = self._create_provider(provider, redirect_uri, scopes)
@@ -163,8 +163,9 @@ class OAuthCredentialService:
         from nexus.lib.context_utils import get_zone_id
 
         logger.info(
-            f"Exchanging OAuth code for provider={provider}, "
-            f"user_email={'provided' if user_email else 'will fetch'}"
+            "Exchanging OAuth code for provider=%s, user_email=%s",
+            provider,
+            "provided" if user_email else "will fetch",
         )
 
         provider_instance = self._create_provider(provider, redirect_uri)
@@ -184,7 +185,7 @@ class OAuthCredentialService:
         except ValueError:
             raise
         except Exception as e:
-            logger.error(f"Failed to exchange OAuth code: {e}")
+            logger.error("Failed to exchange OAuth code: %s", e)
             raise ValueError(f"Failed to exchange authorization code: {e}") from e
 
         if not user_email:
@@ -217,8 +218,9 @@ class OAuthCredentialService:
             )
 
             logger.info(
-                f"Successfully stored OAuth credential for {user_email} "
-                f"(credential_id={credential_id})"
+                "Successfully stored OAuth credential for %s (credential_id=%s)",
+                user_email,
+                credential_id,
             )
 
             return {
@@ -230,7 +232,7 @@ class OAuthCredentialService:
                 "success": True,
             }
         except Exception as e:
-            logger.error(f"Failed to store OAuth credential: {e}")
+            logger.error("Failed to store OAuth credential: %s", e)
             raise ValueError(f"Failed to store credential: {e}") from e
 
     # =========================================================================
@@ -277,8 +279,11 @@ class OAuthCredentialService:
             result.append(cred)
 
         logger.info(
-            f"Listed {len(result)} OAuth credentials for user_id={current_user_id}, "
-            f"zone={zone_id}, provider={provider}"
+            "Listed %d OAuth credentials for user_id=%s, zone=%s, provider=%s",
+            len(result),
+            current_user_id,
+            zone_id,
+            provider,
         )
         return result
 
@@ -307,13 +312,13 @@ class OAuthCredentialService:
             )
 
             if success:
-                logger.info(f"Revoked OAuth credential for {provider}:{user_email}")
+                logger.info("Revoked OAuth credential for %s:%s", provider, user_email)
                 return {"success": True}
             else:
                 raise ValueError(f"Credential not found: {provider}:{user_email}")
 
         except Exception as e:
-            logger.error(f"Failed to revoke credential: {e}")
+            logger.error("Failed to revoke credential: %s", e)
             raise ValueError(f"Failed to revoke credential: {e}") from e
 
     @rpc_expose(name="oauth_test_credential", description="Test OAuth credential validity")
@@ -349,7 +354,7 @@ class OAuthCredentialService:
                     None,
                 )
 
-                logger.info(f"OAuth credential test successful for {provider}:{user_email}")
+                logger.info("OAuth credential test successful for %s:%s", provider, user_email)
                 return {
                     "valid": True,
                     "refreshed": True,
@@ -362,7 +367,7 @@ class OAuthCredentialService:
                 }
 
         except Exception as e:
-            logger.error(f"OAuth credential test failed: {e}")
+            logger.error("OAuth credential test failed: %s", e)
             return {
                 "valid": False,
                 "error": str(e),
@@ -435,7 +440,7 @@ class OAuthCredentialService:
                 logger.debug("TokenManager database not configured; OAuth credentials unavailable")
                 return None
 
-            logger.debug(f"TokenManager database URL resolved to: {db_path}")
+            logger.debug("TokenManager database URL resolved to: %s", db_path)
 
             if db_path.startswith(("postgresql://", "mysql://", "sqlite://")):
                 self._token_manager = TokenManager(db_url=db_path)
@@ -471,7 +476,7 @@ class OAuthCredentialService:
             scopes=scopes,
         )
 
-        logger.debug(f"Created provider {provider} using factory (config: {config_name})")
+        logger.debug("Created provider %s using factory (config: %s)", provider, config_name)
         return provider_instance
 
     def _register_provider(self, provider_instance: Any) -> None:
@@ -606,6 +611,6 @@ class OAuthCredentialService:
                         logger.debug("X/Twitter user lookup failed: %s", e)
 
         except Exception as e:
-            logger.warning(f"Failed to fetch user email from provider {provider_name}: {e}")
+            logger.warning("Failed to fetch user email from provider %s: %s", provider_name, e)
 
         return None

--- a/src/nexus/bricks/auth/oauth/token_manager.py
+++ b/src/nexus/bricks/auth/oauth/token_manager.py
@@ -180,7 +180,7 @@ class TokenManager:
     def register_provider(self, provider_name: str, provider: Any) -> None:
         """Register an OAuth provider."""
         self.providers[provider_name] = provider
-        logger.info(f"Registered OAuth provider: {provider_name}")
+        logger.info("Registered OAuth provider: %s", provider_name)
 
     async def store_credential(
         self,
@@ -240,7 +240,10 @@ class TokenManager:
                 session.commit()
 
                 logger.info(
-                    f"Updated OAuth credential: {provider}:{user_email} (user_id={user_id})"
+                    "Updated OAuth credential: %s:%s (user_id=%s)",
+                    provider,
+                    user_email,
+                    user_id,
                 )
                 self._log_audit(
                     "credential_updated",
@@ -277,7 +280,7 @@ class TokenManager:
                 session.commit()
                 session.refresh(model)
 
-                logger.info(f"Stored OAuth credential: {provider}:{user_email}")
+                logger.info("Stored OAuth credential: %s:%s", provider, user_email)
                 self._log_audit(
                     "credential_created",
                     provider,
@@ -356,8 +359,9 @@ class TokenManager:
                     # Rate limit: skip if refreshed recently
                     if self._is_refresh_rate_limited(model):
                         logger.debug(
-                            f"Refresh rate limited for {provider}:{user_email}, "
-                            f"returning current token"
+                            "Refresh rate limited for %s:%s, returning current token",
+                            provider,
+                            user_email,
                         )
                         if self._cache_store is not None:
                             await self._cache_store.set(
@@ -367,7 +371,7 @@ class TokenManager:
                             )
                         return credential.access_token
 
-                    logger.info(f"Token expired for {provider}:{user_email}, refreshing...")
+                    logger.info("Token expired for %s:%s, refreshing...", provider, user_email)
 
                     if provider not in self.providers:
                         raise AuthenticationError(f"Provider not registered: {provider}")
@@ -381,7 +385,7 @@ class TokenManager:
                                 timeout=_PROVIDER_REFRESH_TIMEOUT_SECONDS,
                             )
                         except TimeoutError:
-                            logger.error(f"OAuth refresh timed out for {provider}:{user_email}")
+                            logger.error("OAuth refresh timed out for %s:%s", provider, user_email)
                             raise AuthenticationError(
                                 f"OAuth refresh timed out for {provider}"
                             ) from None
@@ -448,8 +452,10 @@ class TokenManager:
 
                             rotated = True
                             logger.info(
-                                f"Refresh token rotated for {provider}:{user_email} "
-                                f"(counter={model.rotation_counter})"
+                                "Refresh token rotated for %s:%s (counter=%s)",
+                                provider,
+                                user_email,
+                                model.rotation_counter,
                             )
                         elif new_credential.refresh_token:
                             # Same refresh token returned — just update access token
@@ -472,7 +478,9 @@ class TokenManager:
                         refreshed = True
 
                     except OAuthError as e:
-                        logger.error(f"Failed to refresh token for {provider}:{user_email}: {e}")
+                        logger.error(
+                            "Failed to refresh token for %s:%s: %s", provider, user_email, e
+                        )
                         raise AuthenticationError(f"Failed to refresh token: {e}") from e
 
                 # Single commit: all credential updates + last_used_at
@@ -599,7 +607,7 @@ class TokenManager:
                 try:
                     await oauth_provider.revoke_token(credential)
                 except Exception as e:
-                    logger.warning(f"Failed to revoke via provider API: {e}")
+                    logger.warning("Failed to revoke via provider API: %s", e)
 
             # Capture audit fields before commit (avoids DetachedInstanceError)
             audit_credential_id = model.credential_id
@@ -609,7 +617,7 @@ class TokenManager:
             model.revoked_at = datetime.now(UTC)
             session.commit()
 
-            logger.info(f"Revoked OAuth credential: {provider}:{user_email}")
+            logger.info("Revoked OAuth credential: %s:%s", provider, user_email)
             self._log_audit(
                 "credential_revoked",
                 provider,
@@ -729,7 +737,11 @@ class TokenManager:
         audit log.  Always falls back to the Python logger.
         """
         logger.info(
-            f"AUDIT: {operation} | provider={provider} | user={user_email} | zone={zone_id}"
+            "AUDIT: %s | provider=%s | user=%s | zone=%s",
+            operation,
+            provider,
+            user_email,
+            zone_id,
         )
 
         if self._audit_logger is not None:

--- a/src/nexus/bricks/mcp/connection_manager.py
+++ b/src/nexus/bricks/mcp/connection_manager.py
@@ -158,9 +158,9 @@ class MCPConnectionManager:
                             key = f"{conn.provider}:{conn.user_id}"
                             self._connections[key] = conn
                         except Exception as e:
-                            logger.warning(f"Failed to load connection from {path}: {e}")
+                            logger.warning("Failed to load connection from %s: %s", path, e)
         except Exception as e:
-            logger.warning(f"Failed to load connections: {e}")
+            logger.warning("Failed to load connections: %s", e)
 
     def _save_connection(self, conn: "MCPConnection") -> None:
         """Save a connection to storage."""
@@ -181,7 +181,7 @@ class MCPConnectionManager:
                 self.filesystem.sys_write(path, content.encode("utf-8"))
 
         except Exception as e:
-            logger.error(f"Failed to save connection: {e}")
+            logger.error("Failed to save connection: %s", e)
 
     def _delete_connection(self, provider: str, user_id: str) -> None:
         """Delete a connection from storage."""
@@ -192,7 +192,7 @@ class MCPConnectionManager:
                 if self.filesystem.sys_access(path):
                     self.filesystem.sys_unlink(path)
         except Exception as e:
-            logger.warning(f"Failed to delete connection file: {e}")
+            logger.warning("Failed to delete connection file: %s", e)
 
     async def connect(
         self,
@@ -250,7 +250,7 @@ class MCPConnectionManager:
 
         try:
             # 1. Create MCP instance - this returns both the MCP URL and OAuth URL if needed
-            logger.info(f"Creating MCP instance for {config.name}...")
+            logger.info("Creating MCP instance for %s...", config.name)
             mcp_instance = await self.klavis.create_mcp_instance(
                 provider=klavis_name,
                 user_id=user_id,
@@ -259,10 +259,10 @@ class MCPConnectionManager:
 
             # 2. If OAuth is required, do the OAuth flow
             if mcp_instance.oauth_url:
-                logger.info(f"OAuth required for {config.name}")
+                logger.info("OAuth required for %s", config.name)
 
                 if open_browser:
-                    logger.info(f"Opening browser for {config.name} authorization...")
+                    logger.info("Opening browser for %s authorization...", config.name)
                     webbrowser.open(mcp_instance.oauth_url)
 
                     # Wait for OAuth callback
@@ -271,13 +271,13 @@ class MCPConnectionManager:
                 else:
                     # Don't wait for callback when browser is not opened
                     # User will manually complete OAuth
-                    logger.info(f"OAuth URL (complete manually): {mcp_instance.oauth_url}")
+                    logger.info("OAuth URL (complete manually): %s", mcp_instance.oauth_url)
                     logger.info("Skipping callback wait (--no-browser mode)")
             else:
-                logger.info(f"No OAuth required for {config.name}, instance ready")
+                logger.info("No OAuth required for %s, instance ready", config.name)
 
             # 3. Mount the MCP server in Nexus
-            logger.info(f"Mounting MCP server: {mcp_instance.url}")
+            logger.info("Mounting MCP server: %s", mcp_instance.url)
             mount = MCPMount(
                 name=config.name,
                 description=config.description or f"{config.display_name} via Klavis",
@@ -299,7 +299,7 @@ class MCPConnectionManager:
             self._connections[key] = connection
             self._save_connection(connection)
 
-            logger.info(f"Connected to {config.name} via Klavis")
+            logger.info("Connected to %s via Klavis", config.name)
             return connection
 
         except KlavisError as e:
@@ -323,8 +323,10 @@ class MCPConnectionManager:
         # The full OAuth flow would require the TokenManager integration
 
         logger.warning(
-            f"Local OAuth flow for {config.name} requires manual setup. "
-            f"Use 'nexus oauth setup-{config.name}' to configure credentials first."
+            "Local OAuth flow for %s requires manual setup. "
+            "Use 'nexus oauth setup-%s' to configure credentials first.",
+            config.name,
+            config.name,
         )
 
         # Create connection record
@@ -393,7 +395,7 @@ class MCPConnectionManager:
 
         try:
             await site.start()
-            logger.debug(f"OAuth callback server listening on port {port}")
+            logger.debug("OAuth callback server listening on port %s", port)
 
             # Wait for callback or timeout
             try:
@@ -429,7 +431,7 @@ class MCPConnectionManager:
         try:
             await self.mount_manager.unmount(provider)
         except Exception as e:
-            logger.warning(f"Failed to unmount {provider}: {e}")
+            logger.warning("Failed to unmount %s: %s", provider, e)
 
         # Disconnect from Klavis if applicable
         if connection.provider_type == ProviderType.KLAVIS and self.klavis:
@@ -438,13 +440,13 @@ class MCPConnectionManager:
                 klavis_name = config.klavis_name if config and config.klavis_name else provider
                 await self.klavis.disconnect(klavis_name, user_id)
             except Exception as e:
-                logger.warning(f"Failed to disconnect from Klavis: {e}")
+                logger.warning("Failed to disconnect from Klavis: %s", e)
 
         # Remove from storage
         del self._connections[key]
         self._delete_connection(provider, user_id)
 
-        logger.info(f"Disconnected from {provider}")
+        logger.info("Disconnected from %s", provider)
         return True
 
     def list_connections(self, user_id: str | None = None) -> "list[MCPConnection]":

--- a/src/nexus/bricks/mcp/exporter.py
+++ b/src/nexus/bricks/mcp/exporter.py
@@ -600,11 +600,11 @@ class MCPToolExporter:
                 tool_def = self._create_tool_definition(tool_data)
                 await self._export_tool(tool_def, output_path)
                 exported += 1
-                logger.debug(f"Exported tool: {tool_def.name}")
+                logger.debug("Exported tool: %s", tool_def.name)
             except Exception as e:
-                logger.warning(f"Failed to export tool {tool_data.get('name')}: {e}")
+                logger.warning("Failed to export tool %s: %s", tool_data.get("name"), e)
 
-        logger.info(f"Exported {exported} Nexus MCP tools to {output_path}")
+        logger.info("Exported %s Nexus MCP tools to %s", exported, output_path)
         return exported
 
     def _create_tool_definition(self, tool_data: dict[str, Any]) -> MCPToolDefinition:

--- a/src/nexus/bricks/mcp/klavis_client.py
+++ b/src/nexus/bricks/mcp/klavis_client.py
@@ -233,10 +233,10 @@ class KlavisClient:
 
             except httpx.HTTPStatusError as e:
                 # This endpoint might not exist, return empty list
-                logger.warning(f"Failed to list Klavis providers: {e}")
+                logger.warning("Failed to list Klavis providers: %s", e)
                 return []
             except Exception as e:
-                logger.warning(f"Failed to list Klavis providers: {e}")
+                logger.warning("Failed to list Klavis providers: %s", e)
                 return []
 
     async def get_connection_status(

--- a/src/nexus/bricks/mcp/oauth_mappings.py
+++ b/src/nexus/bricks/mcp/oauth_mappings.py
@@ -98,7 +98,7 @@ class OAuthKlavisMappings:
         """
         path = Path(path)
         if not path.exists():
-            logger.warning(f"OAuth mappings config not found: {path}")
+            logger.warning("OAuth mappings config not found: %s", path)
             return cls()
 
         with open(path) as f:
@@ -146,7 +146,8 @@ class OAuthKlavisMappings:
 
         # Return empty mappings with built-in defaults
         logger.warning(
-            f"No oauth-klavis-mappings.yaml found, using built-in defaults. Tried: {tried_paths}"
+            "No oauth-klavis-mappings.yaml found, using built-in defaults. Tried: %s",
+            tried_paths,
         )
         return cls.with_builtin_defaults()
 

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -1808,7 +1808,7 @@ def main() -> None:
             import logging
 
             logger = logging.getLogger(__name__)
-            logger.warning(f"Failed to add API key middleware: {e}")
+            logger.warning("Failed to add API key middleware: %s", e)
 
     # Run with selected transport
     if transport == "stdio":

--- a/src/nexus/bricks/memory/memory_paging/archival_store.py
+++ b/src/nexus/bricks/memory/memory_paging/archival_store.py
@@ -80,10 +80,10 @@ class ArchivalStore:
 
             # TODO: Trigger hierarchical consolidation (Issue #4 from review)
             if trigger_consolidation and logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Consolidation not implemented yet for memory {merged.memory_id}")
+                logger.debug("Consolidation not implemented yet for memory %s", merged.memory_id)
 
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Stored memory {merged.memory_id} in archival")
+                logger.debug("Stored memory %s in archival", merged.memory_id)
         except Exception:
             session.rollback()
             raise
@@ -113,7 +113,7 @@ class ArchivalStore:
             try:
                 return self._db_vector_search(query_embedding, threshold, limit)
             except Exception as e:
-                logger.warning(f"DB vector search failed, falling back to Python: {e}")
+                logger.warning("DB vector search failed, falling back to Python: %s", e)
 
         # Fallback to Python-based similarity search (capped to prevent O(n) full scan)
         session = self._session_factory()
@@ -132,8 +132,9 @@ class ArchivalStore:
 
             if len(archival_memories) >= _PYTHON_SEARCH_CAP:
                 logger.warning(
-                    f"Archival Python search capped at {_PYTHON_SEARCH_CAP} memories. "
-                    f"Enable pgvector for full semantic search over large archives."
+                    "Archival Python search capped at %d memories. "
+                    "Enable pgvector for full semantic search over large archives.",
+                    _PYTHON_SEARCH_CAP,
                 )
 
             return self._simple_similarity_search(

--- a/src/nexus/bricks/memory/memory_paging/context_manager.py
+++ b/src/nexus/bricks/memory/memory_paging/context_manager.py
@@ -151,7 +151,7 @@ class ContextManager:
             try:
                 self._importance_cache[mid] = memory.importance or 0.5
             except DetachedInstanceError:
-                logger.debug(f"Detached instance for {mid}, using default importance 0.5")
+                logger.debug("Detached instance for %s, using default importance 0.5", mid)
                 self._importance_cache[mid] = 0.5
 
             # Enforce max capacity (drop oldest if over limit)
@@ -164,8 +164,11 @@ class ContextManager:
 
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
-                    f"Added memory {mid} to context "
-                    f"({len(self._buffer)}/{self.max_items}), evicted {len(evicted)}"
+                    "Added memory %s to context (%d/%d), evicted %d",
+                    mid,
+                    len(self._buffer),
+                    self.max_items,
+                    len(evicted),
                 )
 
             return evicted
@@ -285,8 +288,10 @@ class ContextManager:
         loaded_count = self._add_batch(memories)
 
         logger.info(
-            f"Warm-up loaded {loaded_count} memories into context "
-            f"(zone={zone_id}, capacity={self.max_items})"
+            "Warm-up loaded %d memories into context (zone=%s, capacity=%d)",
+            loaded_count,
+            zone_id,
+            self.max_items,
         )
         return loaded_count
 
@@ -316,7 +321,7 @@ class ContextManager:
                 try:
                     self._importance_cache[mid] = memory.importance or 0.5
                 except DetachedInstanceError:
-                    logger.debug(f"Detached instance for {mid}, using default importance 0.5")
+                    logger.debug("Detached instance for %s, using default importance 0.5", mid)
                     self._importance_cache[mid] = 0.5
 
             # Enforce max capacity (drop oldest if over limit)
@@ -374,7 +379,9 @@ class ContextManager:
 
         if logger.isEnabledFor(logging.INFO):
             logger.info(
-                f"Evicted {len(evicted)} memories (scores: {[s.score for s in scores[:3]]}...)"
+                "Evicted %d memories (scores: %s...)",
+                len(evicted),
+                [s.score for s in scores[:3]],
             )
 
         return evicted

--- a/src/nexus/bricks/memory/memory_paging/pager.py
+++ b/src/nexus/bricks/memory/memory_paging/pager.py
@@ -116,7 +116,7 @@ class MemoryPager:
         # Move evicted memories to recall (single transaction for the batch)
         if evicted:
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Evicting {len(evicted)} memories from main -> recall")
+                logger.debug("Evicting %d memories from main -> recall", len(evicted))
             self.recall.append_batch(evicted)
 
         # Thread-safe debounced archival check + cache invalidation
@@ -185,8 +185,10 @@ class MemoryPager:
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                f"Search results: {len(main_memories)} main, "
-                f"{len(recall_memories)} recall, {len(archival_results)} archival"
+                "Search results: %d main, %d recall, %d archival",
+                len(main_memories),
+                len(recall_memories),
+                len(archival_results),
             )
 
         return results
@@ -324,8 +326,9 @@ class MemoryPager:
 
             if archived_count > 0:
                 logger.info(
-                    f"Archived {archived_count} old memories from recall -> archival "
-                    f"(older than {self.recall_max_age_hours}h)"
+                    "Archived %d old memories from recall -> archival (older than %sh)",
+                    archived_count,
+                    self.recall_max_age_hours,
                 )
         except Exception:
             session.rollback()

--- a/src/nexus/bricks/memory/memory_paging/recall_store.py
+++ b/src/nexus/bricks/memory/memory_paging/recall_store.py
@@ -70,7 +70,7 @@ class RecallStore:
 
             session.commit()
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Appended memory {merged.memory_id} to recall store")
+                logger.debug("Appended memory %s to recall store", merged.memory_id)
         except Exception:
             session.rollback()
             raise
@@ -95,7 +95,7 @@ class RecallStore:
                 merged.namespace = f"{self.namespace}/{strip_tier_prefix(merged.namespace)}"
             session.commit()
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(f"Batch appended {len(memories)} memories to recall store")
+                logger.debug("Batch appended %d memories to recall store", len(memories))
         except Exception:
             session.rollback()
             raise

--- a/src/nexus/bricks/memory/memory_with_paging.py
+++ b/src/nexus/bricks/memory/memory_with_paging.py
@@ -116,9 +116,9 @@ class MemoryWithPaging(Memory):
                 vector_db=vector_db,
             )
             logger.info(
-                f"MemGPT 3-tier paging enabled: "
-                f"main_capacity={main_capacity}, "
-                f"recall_max_age={recall_max_age_hours}h"
+                "MemGPT 3-tier paging enabled: main_capacity=%d, recall_max_age=%sh",
+                main_capacity,
+                recall_max_age_hours,
             )
         else:
             self.pager = None
@@ -213,7 +213,7 @@ class MemoryWithPaging(Memory):
             memory = self.memory_router.get_memory_by_id(memory_id)
             if memory:
                 self.pager.add_to_main(memory)
-                logger.debug(f"Added memory {memory_id} to main context via paging")
+                logger.debug("Added memory %s to main context via paging", memory_id)
 
         return memory_id
 

--- a/src/nexus/bricks/mount/mount_core_service.py
+++ b/src/nexus/bricks/mount/mount_core_service.py
@@ -173,7 +173,7 @@ class MountCoreService:
             return result
 
         result["removed"] = True
-        logger.info(f"Removed mount from router: {mount_point}")
+        logger.info("Removed mount from router: %s", mount_point)
 
         # Extract zone_id once for all cleanup operations
         zone_id = get_zone_id(context)
@@ -186,7 +186,7 @@ class MountCoreService:
             paths_to_delete.append(mount_point)  # Include mount point itself
             self._gw.metadata_delete_batch(paths_to_delete)
             result["files_deleted"] = len(paths_to_delete)
-            logger.info(f"Deleted {len(paths_to_delete)} metadata entries for {mount_point}")
+            logger.info("Deleted %d metadata entries for %s", len(paths_to_delete), mount_point)
         except Exception as e:
             _record_error(result, f"Failed to delete metadata entries for {mount_point}: {e}")
 
@@ -195,7 +195,9 @@ class MountCoreService:
             dir_entries_deleted = self._gw.delete_directory_entries_recursive(mount_point, zone_id)
             result["directory_entries_deleted"] = dir_entries_deleted
             logger.info(
-                f"Deleted {dir_entries_deleted} directory index entries under {mount_point}"
+                "Deleted %d directory index entries under %s",
+                dir_entries_deleted,
+                mount_point,
             )
         except Exception as e:
             _record_error(result, f"Failed to clean up directory index: {e}")
@@ -204,7 +206,7 @@ class MountCoreService:
         try:
             removed = self._gw.remove_parent_tuples(mount_point, zone_id)
             result["permissions_cleaned"] += removed
-            logger.info(f"Removed {removed} parent tuples for {mount_point}")
+            logger.info("Removed %d parent tuples for %s", removed, mount_point)
         except Exception as e:
             _record_error(result, f"Failed to clean up parent tuples: {e}")
 
@@ -215,17 +217,20 @@ class MountCoreService:
                 zone_id=zone_id,
             )
             result["permissions_cleaned"] += deleted
-            logger.info(f"Removed {deleted} permission tuples for {mount_point}")
+            logger.info("Removed %d permission tuples for %s", deleted, mount_point)
         except Exception as e:
             _record_error(result, f"Failed to delete permission tuples: {e}")
 
         if result["errors"]:
-            logger.warning(f"Mount removed with {len(result['errors'])} errors: {result['errors']}")
+            logger.warning(
+                "Mount removed with %d errors: %s", len(result["errors"]), result["errors"]
+            )
         else:
             logger.info(
-                f"Successfully removed mount {mount_point} "
-                f"(directory_deleted={result['directory_deleted']}, "
-                f"permissions_cleaned={result['permissions_cleaned']})"
+                "Successfully removed mount %s (directory_deleted=%s, permissions_cleaned=%s)",
+                mount_point,
+                result["directory_deleted"],
+                result["permissions_cleaned"],
             )
 
         return result
@@ -245,7 +250,7 @@ class MountCoreService:
         mounts = []
 
         router_mounts = list(self._gw.router.list_mounts())
-        logger.info(f"[LIST_MOUNTS] Total mounts in router: {len(router_mounts)}")
+        logger.info("[LIST_MOUNTS] Total mounts in router: %d", len(router_mounts))
 
         for mount_info in router_mounts:
             mount_point = mount_info.mount_point
@@ -376,14 +381,14 @@ class MountCoreService:
             mount_point: Virtual path
             context: Operation context
         """
-        logger.info(f"Setting up mount point: {mount_point}")
+        logger.info("Setting up mount point: %s", mount_point)
 
         # Create directory entry
         try:
             self._gw.sys_mkdir(mount_point, parents=True, exist_ok=True, context=context)
-            logger.info(f"Created directory entry for mount point: {mount_point}")
+            logger.info("Created directory entry for mount point: %s", mount_point)
         except Exception as e:
-            logger.warning(f"Failed to create directory entry: {e}")
+            logger.warning("Failed to create directory entry: %s", e)
 
         # Grant owner permission
         self._grant_owner_permission(mount_point, context)
@@ -419,11 +424,14 @@ class MountCoreService:
             )
 
             logger.info(
-                f"Granted direct_owner to {subject_type}:{subject_id} "
-                f"for {mount_point} (tuple_id={tuple_id})"
+                "Granted direct_owner to %s:%s for %s (tuple_id=%s)",
+                subject_type,
+                subject_id,
+                mount_point,
+                tuple_id,
             )
         except Exception as e:
-            logger.warning(f"Failed to grant permission for {mount_point}: {e}")
+            logger.warning("Failed to grant permission for %s: %s", mount_point, e)
 
     def _check_permission(
         self,
@@ -533,11 +541,11 @@ class MountCoreService:
             try:
                 self._rmdir_fn(mount_point, recursive=True, context=context)
                 result["directory_deleted"] = True
-                logger.info(f"Deleted mount point directory: {mount_point}")
+                logger.info("Deleted mount point directory: %s", mount_point)
             except Exception as e:
                 result["warnings"].append(
                     f"Failed to delete mount point directory (non-fatal): {e}"
                 )
-                logger.warning(f"Failed to delete mount point directory {mount_point}: {e}")
+                logger.warning("Failed to delete mount point directory %s: %s", mount_point, e)
 
         return result

--- a/src/nexus/bricks/mount/mount_persist_service.py
+++ b/src/nexus/bricks/mount/mount_persist_service.py
@@ -110,12 +110,12 @@ class MountPersistService:
             subject_type, subject_id = get_user_identity(context)
             if subject_id:
                 owner_user_id = f"{subject_type}:{subject_id}"
-                logger.info(f"[SAVE_MOUNT] Auto-populated owner_user_id: {owner_user_id}")
+                logger.info("[SAVE_MOUNT] Auto-populated owner_user_id: %s", owner_user_id)
 
         if zone_id is None and context:
             zone_id = get_zone_id(context)
             if zone_id:
-                logger.info(f"[SAVE_MOUNT] Auto-populated zone_id: {zone_id}")
+                logger.info("[SAVE_MOUNT] Auto-populated zone_id: %s", zone_id)
 
         assert self._manager is not None
         mount_id = self._manager.save_mount(
@@ -140,7 +140,7 @@ class MountPersistService:
                 context=context,
             )
         except Exception as e:
-            logger.warning(f"[SAVE_MOUNT] Mount saved but activation failed: {e}")
+            logger.warning("[SAVE_MOUNT] Mount saved but activation failed: %s", e)
 
         return mount_id
 
@@ -165,7 +165,7 @@ class MountPersistService:
 
         # Check if mount is already active
         if self._mounts.has_mount(mount_point):
-            logger.info(f"[LOAD_MOUNT] Mount already active: {mount_point}")
+            logger.info("[LOAD_MOUNT] Mount already active: %s", mount_point)
             # Return the mount_id from database
             assert self._manager is not None
             config = self._manager.get_mount(mount_point)
@@ -213,7 +213,7 @@ class MountPersistService:
             logger.info("No saved mounts found in database")
             return {"loaded": 0, "synced": 0, "failed": 0, "errors": []}
 
-        logger.info(f"Found {len(saved_mounts)} saved mount(s) to load")
+        logger.info("Found %d saved mount(s) to load", len(saved_mounts))
 
         loaded = 0
         failed = 0
@@ -223,7 +223,7 @@ class MountPersistService:
         for mount in saved_mounts:
             mount_point = mount["mount_point"]
             try:
-                logger.info(f"Loading mount: {mount_point} ({mount['backend_type']})")
+                logger.info("Loading mount: %s (%s)", mount_point, mount["backend_type"])
 
                 # Parse backend config
                 backend_config = mount["backend_config"]
@@ -240,7 +240,7 @@ class MountPersistService:
                 )
 
                 loaded += 1
-                logger.info(f"Successfully loaded mount: {mount_point}")
+                logger.info("Successfully loaded mount: %s", mount_point)
 
                 # Auto-sync if requested
                 if auto_sync and self._sync:
@@ -252,7 +252,7 @@ class MountPersistService:
 
                     if is_connector:
                         try:
-                            logger.info(f"Auto-syncing connector mount: {mount_point}")
+                            logger.info("Auto-syncing connector mount: %s", mount_point)
                             from nexus.contracts.types import SyncContext
 
                             # Build context from mount owner if available
@@ -267,14 +267,15 @@ class MountPersistService:
                             result = self._sync.sync_mount(ctx)
                             synced += 1
                             logger.info(
-                                f"Synced {mount_point}: "
-                                f"{result.files_scanned} scanned, "
-                                f"{result.files_created} created"
+                                "Synced %s: %d scanned, %d created",
+                                mount_point,
+                                result.files_scanned,
+                                result.files_created,
                             )
                         except Exception as sync_e:
-                            logger.warning(f"Failed to sync {mount_point}: {sync_e}")
+                            logger.warning("Failed to sync %s: %s", mount_point, sync_e)
                     else:
-                        logger.info(f"Skipping auto-sync for {mount_point} (not a connector)")
+                        logger.info("Skipping auto-sync for %s (not a connector)", mount_point)
 
             except Exception as e:
                 failed += 1
@@ -282,7 +283,9 @@ class MountPersistService:
                 errors.append(error_msg)
                 logger.error(error_msg)
 
-        logger.info(f"Mount loading complete: {loaded} loaded, {synced} synced, {failed} failed")
+        logger.info(
+            "Mount loading complete: %d loaded, %d synced, %d failed", loaded, synced, failed
+        )
 
         return {"loaded": loaded, "synced": synced, "failed": failed, "errors": errors}
 
@@ -309,12 +312,12 @@ class MountPersistService:
             subject_type, subject_id = get_user_identity(context)
             if subject_id:
                 owner_user_id = f"{subject_type}:{subject_id}"
-                logger.info(f"[LIST_SAVED_MOUNTS] Auto-filtering by owner: {owner_user_id}")
+                logger.info("[LIST_SAVED_MOUNTS] Auto-filtering by owner: %s", owner_user_id)
 
         if zone_id is None and context:
             zone_id = get_zone_id(context)
             if zone_id:
-                logger.info(f"[LIST_SAVED_MOUNTS] Auto-filtering by zone: {zone_id}")
+                logger.info("[LIST_SAVED_MOUNTS] Auto-filtering by zone: %s", zone_id)
 
         assert self._manager is not None
         return self._manager.list_mounts(owner_user_id=owner_user_id, zone_id=zone_id)
@@ -364,5 +367,5 @@ class MountPersistService:
                 subject_id=subject_id,
             )
         except Exception as e:
-            logger.warning(f"Failed to build sync context: {e}")
+            logger.warning("Failed to build sync context: %s", e)
             return None

--- a/src/nexus/bricks/mount/mount_service.py
+++ b/src/nexus/bricks/mount/mount_service.py
@@ -239,7 +239,7 @@ class MountService:
                 return result
 
             result["removed"] = True
-            logger.info(f"Removed mount from router: {mount_point}")
+            logger.info("Removed mount from router: %s", mount_point)
 
             # Delete the mount point directory (but not the files inside)
             if self.nexus_fs and hasattr(self.nexus_fs, "metadata"):
@@ -248,7 +248,7 @@ class MountService:
                         # Soft delete the directory entry from metadata
                         self.nexus_fs.metadata.delete(mount_point)
                         result["directory_deleted"] = True
-                        logger.info(f"Deleted mount point directory: {mount_point}")
+                        logger.info("Deleted mount point directory: %s", mount_point)
                 except Exception as e:
                     error_msg = f"Failed to delete mount point directory {mount_point}: {e}"
                     result["errors"].append(error_msg)
@@ -263,7 +263,7 @@ class MountService:
                             mount_point, zone_id
                         )
                         result["permissions_cleaned"] += tuples_removed
-                        logger.info(f"Removed {tuples_removed} parent tuples for {mount_point}")
+                        logger.info("Removed %d parent tuples for %s", tuples_removed, mount_point)
                 except Exception as e:
                     error_msg = f"Failed to clean up parent tuples: {e}"
                     result["errors"].append(error_msg)
@@ -281,7 +281,7 @@ class MountService:
                         if tid and svc.rebac_delete_sync(tid):
                             deleted += 1
                     result["permissions_cleaned"] += deleted
-                    logger.info(f"Removed {deleted} permission tuples for {mount_point}")
+                    logger.info("Removed %d permission tuples for %s", deleted, mount_point)
                 except Exception as e:
                     error_msg = f"Failed to delete permission tuples: {e}"
                     result["errors"].append(error_msg)
@@ -289,13 +289,14 @@ class MountService:
 
             if result["errors"]:
                 logger.warning(
-                    f"Mount removed with {len(result['errors'])} errors: {result['errors']}"
+                    "Mount removed with %d errors: %s", len(result["errors"]), result["errors"]
                 )
             else:
                 logger.info(
-                    f"Successfully removed mount {mount_point} "
-                    f"(directory_deleted={result['directory_deleted']}, "
-                    f"permissions_cleaned={result['permissions_cleaned']})"
+                    "Successfully removed mount %s (directory_deleted=%s, permissions_cleaned=%s)",
+                    mount_point,
+                    result["directory_deleted"],
+                    result["permissions_cleaned"],
                 )
 
             return result
@@ -378,12 +379,12 @@ class MountService:
                     _nx: Any = self.nexus_fs
                     _nx.sys_rmdir(mount_point, recursive=True, context=context)
                     result["directory_deleted"] = True
-                    logger.info(f"Deleted mount point directory: {mount_point}")
+                    logger.info("Deleted mount point directory: %s", mount_point)
                 except Exception as e:
                     result["warnings"].append(
                         f"Failed to delete mount point directory (non-fatal): {e}"
                     )
-                    logger.warning(f"Failed to delete mount point directory {mount_point}: {e}")
+                    logger.warning("Failed to delete mount point directory %s: %s", mount_point, e)
 
             return result
 
@@ -476,22 +477,25 @@ class MountService:
             mounts = []
 
             # Log context details for debugging
-            logger.info(f"[LIST_MOUNTS] Called with context: {context}")
+            logger.info("[LIST_MOUNTS] Called with context: %s", context)
             if context:
-                logger.info(f"[LIST_MOUNTS] Context type: {type(context)}")
+                logger.info("[LIST_MOUNTS] Context type: %s", type(context))
                 subject_type, subject_id = get_user_identity(context)
                 zone_id = get_zone_id(context)
                 logger.info(
-                    f"[LIST_MOUNTS] Extracted: subject={subject_type}:{subject_id}, zone={zone_id}"
+                    "[LIST_MOUNTS] Extracted: subject=%s:%s, zone=%s",
+                    subject_type,
+                    subject_id,
+                    zone_id,
                 )
 
             router_mounts = list(self.router.list_mounts())
-            logger.info(f"[LIST_MOUNTS] Total mounts in router: {len(router_mounts)}")
+            logger.info("[LIST_MOUNTS] Total mounts in router: %d", len(router_mounts))
 
             for mount_info in router_mounts:
                 # Filter by permission - only include mounts the user can access
                 mount_point = mount_info.mount_point
-                logger.info(f"[LIST_MOUNTS] Checking mount: {mount_point}")
+                logger.info("[LIST_MOUNTS] Checking mount: %s", mount_point)
 
                 # Check if user has permission to access this mount
                 has_permission = False
@@ -501,8 +505,11 @@ class MountService:
                         zone_id = get_zone_id(context)
 
                         logger.info(
-                            f"[LIST_MOUNTS] Checking permission for {subject_type}:{subject_id} "
-                            f"on {mount_point} (zone={zone_id})"
+                            "[LIST_MOUNTS] Checking permission for %s:%s on %s (zone=%s)",
+                            subject_type,
+                            subject_id,
+                            mount_point,
+                            zone_id,
                         )
 
                         # Admin users can see all mounts
@@ -510,8 +517,10 @@ class MountService:
                         if is_admin:
                             has_permission = True
                             logger.info(
-                                f"[LIST_MOUNTS] Admin user {subject_type}:{subject_id} - "
-                                f"granting access to {mount_point}"
+                                "[LIST_MOUNTS] Admin user %s:%s - granting access to %s",
+                                subject_type,
+                                subject_id,
+                                mount_point,
                             )
                         elif subject_id:
                             # Check if user has read permission (includes owner, editor, viewer)
@@ -522,24 +531,29 @@ class MountService:
                                 zone_id=zone_id,
                             )
                             logger.info(
-                                f"[LIST_MOUNTS] Permission check result for "
-                                f"{subject_type}:{subject_id} on {mount_point}: {has_permission}"
+                                "[LIST_MOUNTS] Permission check result for %s:%s on %s: %s",
+                                subject_type,
+                                subject_id,
+                                mount_point,
+                                has_permission,
                             )
                         else:
                             logger.warning(
-                                f"[LIST_MOUNTS] No subject_id in context for {mount_point}"
+                                "[LIST_MOUNTS] No subject_id in context for %s", mount_point
                             )
                     except Exception as e:
                         # If permission check fails, exclude this mount for safety
                         logger.error(
-                            f"[LIST_MOUNTS] Permission check failed for {mount_point}: {e}",
+                            "[LIST_MOUNTS] Permission check failed for %s: %s",
+                            mount_point,
+                            e,
                             exc_info=True,
                         )
                         has_permission = False
                 else:
                     # No context or no ReBAC configured — include all mounts
                     logger.info(
-                        f"[LIST_MOUNTS] No context or no rebac_check - allowing {mount_point}"
+                        "[LIST_MOUNTS] No context or no rebac_check - allowing %s", mount_point
                     )
                     has_permission = True
 
@@ -673,12 +687,12 @@ class MountService:
                 subject_type, subject_id = get_user_identity(context)
                 if subject_id:
                     owner_user_id = f"{subject_type}:{subject_id}"
-                    logger.info(f"[SAVE_MOUNT] Auto-populated owner_user_id: {owner_user_id}")
+                    logger.info("[SAVE_MOUNT] Auto-populated owner_user_id: %s", owner_user_id)
 
             if zone_id is None and context:
                 zone_id = get_zone_id(context)
                 if zone_id:
-                    logger.info(f"[SAVE_MOUNT] Auto-populated zone_id: {zone_id}")
+                    logger.info("[SAVE_MOUNT] Auto-populated zone_id: %s", zone_id)
 
             assert self.mount_manager is not None
             mount_id = self.mount_manager.save_mount(
@@ -743,12 +757,12 @@ class MountService:
                 subject_type, subject_id = get_user_identity(context)
                 if subject_id:
                     owner_user_id = f"{subject_type}:{subject_id}"
-                    logger.info(f"[LIST_SAVED_MOUNTS] Auto-filtering by owner: {owner_user_id}")
+                    logger.info("[LIST_SAVED_MOUNTS] Auto-filtering by owner: %s", owner_user_id)
 
             if zone_id is None and context:
                 zone_id = get_zone_id(context)
                 if zone_id:
-                    logger.info(f"[LIST_SAVED_MOUNTS] Auto-filtering by zone: {zone_id}")
+                    logger.info("[LIST_SAVED_MOUNTS] Auto-filtering by zone: %s", zone_id)
 
             assert self.mount_manager is not None
             return self.mount_manager.list_mounts(owner_user_id=owner_user_id, zone_id=zone_id)
@@ -1088,15 +1102,15 @@ class MountService:
             mount_point: The virtual path of the mount
             context: Operation context containing user/subject information
         """
-        logger.info(f"Setting up mount point: {mount_point}")
+        logger.info("Setting up mount point: %s", mount_point)
 
         # Create directory entry for the mount point
         if self.nexus_fs and hasattr(self.nexus_fs, "sys_mkdir"):
             try:
                 self.nexus_fs.sys_mkdir(mount_point, parents=True, exist_ok=True)
-                logger.info(f"✓ Created directory entry for mount point: {mount_point}")
+                logger.info("✓ Created directory entry for mount point: %s", mount_point)
             except Exception as e:
-                logger.warning(f"Failed to create directory entry for mount {mount_point}: {e}")
+                logger.warning("Failed to create directory entry for mount %s: %s", mount_point, e)
 
         # Grant direct_owner permission to the creating user
         if context:
@@ -1112,11 +1126,17 @@ class MountService:
                         zone_id=zone_id,
                     )
                     logger.info(
-                        f"✓ Granted direct_owner to {subject_type}:{subject_id} for {mount_point}"
+                        "✓ Granted direct_owner to %s:%s for %s",
+                        subject_type,
+                        subject_id,
+                        mount_point,
                     )
                 except Exception as e:
                     logger.warning(
-                        f"Failed to grant direct_owner for {mount_point}: {type(e).__name__}: {e}"
+                        "Failed to grant direct_owner for %s: %s: %s",
+                        mount_point,
+                        type(e).__name__,
+                        e,
                     )
             else:
                 logger.warning(

--- a/src/nexus/bricks/parsers/auto_parse_hook.py
+++ b/src/nexus/bricks/parsers/auto_parse_hook.py
@@ -78,30 +78,38 @@ class AutoParseWriteHook:
 
             if "disk" in error_msg.lower() or "space" in error_msg.lower():
                 logger.error(
-                    f"Auto-parse FAILED for {path}: Disk error - {error_type}: {error_msg}"
+                    "Auto-parse FAILED for %s: Disk error - %s: %s", path, error_type, error_msg
                 )
             elif "database" in error_msg.lower() or "connection" in error_msg.lower():
-                logger.error(f"Auto-parse FAILED for {path}: DB error - {error_type}: {error_msg}")
+                logger.error(
+                    "Auto-parse FAILED for %s: DB error - %s: %s", path, error_type, error_msg
+                )
             elif "memory" in error_msg.lower() or isinstance(e, MemoryError):
                 logger.error(
-                    f"Auto-parse FAILED for {path}: Memory error - {error_type}: {error_msg}"
+                    "Auto-parse FAILED for %s: Memory error - %s: %s", path, error_type, error_msg
                 )
             elif "permission" in error_msg.lower() or isinstance(e, PermissionError | OSError):
                 logger.warning(
-                    f"Auto-parse FAILED for {path}: Permission error - {error_type}: {error_msg}"
+                    "Auto-parse FAILED for %s: Permission error - %s: %s",
+                    path,
+                    error_type,
+                    error_msg,
                 )
             elif (
                 "unsupported" in error_msg.lower()
                 or "not supported" in error_msg.lower()
                 or error_type == "UnsupportedFormatException"
             ):
-                logger.debug(f"Auto-parse skipped for {path}: Unsupported format - {error_msg}")
+                logger.debug("Auto-parse skipped for %s: Unsupported format - %s", path, error_msg)
             else:
                 import traceback
 
                 logger.warning(
-                    f"Auto-parse FAILED for {path}: {error_type}: {error_msg}\n"
-                    f"Stack trace:\n{traceback.format_exc()}"
+                    "Auto-parse FAILED for %s: %s: %s\nStack trace:\n%s",
+                    path,
+                    error_type,
+                    error_msg,
+                    traceback.format_exc(),
                 )
 
     def shutdown(self, timeout: float = 10.0) -> dict[str, Any]:
@@ -117,7 +125,7 @@ class AutoParseWriteHook:
         if total == 0:
             return {"total_threads": 0, "completed": 0, "timed_out": 0, "timeout_threads": []}
 
-        logger.info(f"Waiting for {total} parser threads to complete (timeout: {timeout}s)...")
+        logger.info("Waiting for %d parser threads to complete (timeout: %ss)...", total, timeout)
 
         completed = 0
         timed_out = 0
@@ -128,14 +136,16 @@ class AutoParseWriteHook:
             if thread.is_alive():
                 timed_out += 1
                 timeout_threads.append(thread.name)
-                logger.warning(f"Parser thread '{thread.name}' did not complete within {timeout}s.")
+                logger.warning(
+                    "Parser thread '%s' did not complete within %ss.", thread.name, timeout
+                )
             else:
                 completed += 1
 
         with self._lock:
             self._threads.clear()
 
-        logger.info(f"Parser thread shutdown: {completed} completed, {timed_out} timed out")
+        logger.info("Parser thread shutdown: %d completed, %d timed out", completed, timed_out)
         return {
             "total_threads": total,
             "completed": completed,

--- a/src/nexus/bricks/parsers/engine.py
+++ b/src/nexus/bricks/parsers/engine.py
@@ -49,19 +49,19 @@ class ContentParserEngine:
                 parse_info["parsed"] = True
                 parse_info["cached"] = True
                 parse_info["provider"] = self._metadata.get_file_metadata(path, "parser_name")
-                logger.debug(f"Using cached parsed_text for {path}")
+                logger.debug("Using cached parsed_text for %s", path)
                 return (
                     cached_text.encode("utf-8") if isinstance(cached_text, str) else cached_text,
                     parse_info,
                 )
 
             if self._provider_registry is None:
-                logger.debug(f"No provider registry available for parsing {path}")
+                logger.debug("No provider registry available for parsing %s", path)
                 return content, parse_info
 
             provider = self._provider_registry.get_provider(path)
             if not provider:
-                logger.debug(f"No parse provider available for {path}")
+                logger.debug("No parse provider available for %s", path)
                 return content, parse_info
 
             try:
@@ -81,16 +81,16 @@ class ContentParserEngine:
                         )
                         self._metadata.set_file_metadata(path, "parser_name", provider.name)
                     except Exception as cache_err:
-                        logger.warning(f"Failed to cache parsed content for {path}: {cache_err}")
+                        logger.warning("Failed to cache parsed content for %s: %s", path, cache_err)
 
                     return parsed_content, parse_info
 
             except Exception as parse_err:
-                logger.warning(f"Failed to parse {path} with {provider.name}: {parse_err}")
+                logger.warning("Failed to parse %s with %s: %s", path, provider.name, parse_err)
                 return content, parse_info
 
         except Exception as e:
-            logger.warning(f"Error getting parsed content for {path}: {e}")
+            logger.warning("Error getting parsed content for %s: %s", path, e)
 
         return content, parse_info
 

--- a/src/nexus/bricks/pay/x402.py
+++ b/src/nexus/bricks/pay/x402.py
@@ -266,7 +266,7 @@ class X402Client:
         """Get cached verification if still valid (TTLCache handles expiration)."""
         cached = self._verification_cache.get(cache_key)
         if cached is not None:
-            logger.debug(f"Cache hit for payment verification: {cache_key[:20]}...")
+            logger.debug("Cache hit for payment verification: %s...", cache_key[:20])
         return cached
 
     def _cache_verification(self, cache_key: str, verification: X402PaymentVerification) -> None:

--- a/src/nexus/bricks/sandbox/sandbox_e2b_provider.py
+++ b/src/nexus/bricks/sandbox/sandbox_e2b_provider.py
@@ -151,11 +151,11 @@ class E2BSandboxProvider(SandboxProvider):
             sandbox_id = str(sandbox.sandbox_id)
 
             template_info = f"template={template}" if template else "default template"
-            logger.info(f"Created E2B sandbox: {sandbox_id} ({template_info})")
+            logger.info("Created E2B sandbox: %s (%s)", sandbox_id, template_info)
             return sandbox_id
 
         except Exception as e:
-            logger.error(f"Failed to create E2B sandbox: {e}")
+            logger.error("Failed to create E2B sandbox: %s", e)
             raise SandboxCreationError(f"E2B sandbox creation failed: {e}") from e
 
     async def run_code(
@@ -258,8 +258,10 @@ class E2BSandboxProvider(SandboxProvider):
             stderr = "\n".join(stderr_parts)
 
             logger.debug(
-                f"Executed Python code in sandbox {sandbox_id} (Jupyter kernel): "
-                f"exit_code={exit_code}, time={execution_time:.2f}s"
+                "Executed Python code in sandbox %s (Jupyter kernel): exit_code=%s, time=%.2fs",
+                sandbox_id,
+                exit_code,
+                execution_time,
             )
 
             return CodeExecutionResult(
@@ -270,12 +272,12 @@ class E2BSandboxProvider(SandboxProvider):
             )
 
         except TimeoutError as timeout_err:
-            logger.warning(f"Python execution timeout in sandbox {sandbox_id}")
+            logger.warning("Python execution timeout in sandbox %s", sandbox_id)
             raise ExecutionTimeoutError(
                 f"Code execution exceeded {timeout} second timeout"
             ) from timeout_err
         except Exception as e:
-            logger.error(f"Python execution failed in sandbox {sandbox_id}: {e}")
+            logger.error("Python execution failed in sandbox %s: %s", sandbox_id, e)
             raise
 
     async def _run_shell_code(
@@ -313,8 +315,11 @@ class E2BSandboxProvider(SandboxProvider):
             execution_time = time.time() - start_time
 
             logger.debug(
-                f"Executed {language} code in sandbox {sandbox_id}: "
-                f"exit_code={result.exit_code}, time={execution_time:.2f}s"
+                "Executed %s code in sandbox %s: exit_code=%s, time=%.2fs",
+                language,
+                sandbox_id,
+                result.exit_code,
+                execution_time,
             )
 
             return CodeExecutionResult(
@@ -325,7 +330,7 @@ class E2BSandboxProvider(SandboxProvider):
             )
 
         except TimeoutError as timeout_err:
-            logger.warning(f"Code execution timeout in sandbox {sandbox_id}")
+            logger.warning("Code execution timeout in sandbox %s", sandbox_id)
             raise ExecutionTimeoutError(
                 f"Code execution exceeded {timeout} second timeout"
             ) from timeout_err
@@ -334,8 +339,10 @@ class E2BSandboxProvider(SandboxProvider):
             # This is normal behavior - return the result with the exit code
             execution_time = time.time() - start_time
             logger.debug(
-                f"Command exited with non-zero code in sandbox {sandbox_id}: "
-                f"exit_code={cmd_err.exit_code}, stderr={cmd_err.stderr}"
+                "Command exited with non-zero code in sandbox %s: exit_code=%s, stderr=%s",
+                sandbox_id,
+                cmd_err.exit_code,
+                cmd_err.stderr,
             )
             return CodeExecutionResult(
                 stdout=cmd_err.stdout or "",
@@ -344,7 +351,7 @@ class E2BSandboxProvider(SandboxProvider):
                 execution_time=execution_time,
             )
         except Exception as e:
-            logger.error(f"Code execution failed in sandbox {sandbox_id}: {e}")
+            logger.error("Code execution failed in sandbox %s: %s", sandbox_id, e)
             raise
 
     async def pause(self, _sandbox_id: str) -> None:
@@ -392,14 +399,14 @@ class E2BSandboxProvider(SandboxProvider):
                 sandbox_id, api_key=self.api_key, request_timeout=E2B_RECONNECT_TIMEOUT
             )
         except Exception as e:
-            logger.error(f"Failed to connect to sandbox {sandbox_id} for destruction: {e}")
+            logger.error("Failed to connect to sandbox %s for destruction: %s", sandbox_id, e)
             raise SandboxNotFoundError(f"Sandbox {sandbox_id} not found") from e
 
         try:
             await sandbox.kill()
-            logger.info(f"Destroyed E2B sandbox: {sandbox_id}")
+            logger.info("Destroyed E2B sandbox: %s", sandbox_id)
         except Exception as e:
-            logger.error(f"Failed to destroy sandbox {sandbox_id}: {e}")
+            logger.error("Failed to destroy sandbox %s: %s", sandbox_id, e)
             raise
 
     async def get_info(self, sandbox_id: str) -> SandboxInfo:
@@ -454,10 +461,10 @@ class E2BSandboxProvider(SandboxProvider):
                 "from nexus.fuse.mount import NexusFUSE' > /dev/null 2>&1 &"
             )
             await sandbox.commands.run(prewarm_cmd)
-            logger.info(f"Started pre-warm for sandbox {sandbox_id}")
+            logger.info("Started pre-warm for sandbox %s", sandbox_id)
         except Exception as e:
             # Non-fatal - mount will still work, just slower
-            logger.debug(f"Pre-warm failed for {sandbox_id}: {e}")
+            logger.debug("Pre-warm failed for %s: %s", sandbox_id, e)
 
     async def mount_nexus(
         self,
@@ -496,7 +503,7 @@ class E2BSandboxProvider(SandboxProvider):
 
         sandbox = await self._get_sandbox(sandbox_id)
 
-        logger.info(f"Mounting Nexus at {mount_path} in sandbox {sandbox_id}")
+        logger.info("Mounting Nexus at %s in sandbox %s", mount_path, sandbox_id)
 
         # Create mount directory
         mkdir_result = await sandbox.commands.run(
@@ -567,7 +574,7 @@ class E2BSandboxProvider(SandboxProvider):
                     )
                     logger.info("Successfully installed libfuse")
                 except CommandExitException as e:
-                    logger.warning(f"Failed to install libfuse via apt: {e.stderr}")
+                    logger.warning("Failed to install libfuse via apt: %s", e.stderr)
 
             if not python_nexus_installed:
                 # Python nexus not found, try to install
@@ -621,13 +628,15 @@ class E2BSandboxProvider(SandboxProvider):
                         )
                         logger.info("Successfully installed fusepy")
                     except CommandExitException as e:
-                        logger.warning(f"Failed to install fusepy: {e.stderr}")
+                        logger.warning("Failed to install fusepy: %s", e.stderr)
 
         # Mount the filesystem
         # Note: api_key is logged freely here — RedactingFormatter handles redaction (Issue #86)
         logger.info(
-            f"Mounting with nexus_url={nexus_url}, api_key={api_key}"
-            + (f", agent_id={agent_id}" if agent_id else "")
+            "Mounting with nexus_url=%s, api_key=%s%s",
+            nexus_url,
+            api_key,
+            f", agent_id={agent_id}" if agent_id else "",
         )
 
         # Write API key to temp file (never pass inline in commands — CWE-214)
@@ -651,7 +660,7 @@ class E2BSandboxProvider(SandboxProvider):
                 f"--allow-other "
                 f"{mount_path} > /tmp/nexus-mount.log 2>&1 &"
             )
-            logger.debug(f"Mount command: nexus-fuse mount --url ... --allow-other {mount_path}")
+            logger.debug("Mount command: nexus-fuse mount --url ... --allow-other %s", mount_path)
             max_wait = 5  # Rust mount is fast (~600ms)
         else:
             # Fall back to Python FUSE mount
@@ -692,7 +701,7 @@ except Exception as e:
             mount_cmd = (
                 f"nohup {api_key_source}sudo -E python3 {script_path} > /tmp/nexus-mount.log 2>&1 &"
             )
-            logger.debug(f"Mount command: {mount_cmd}")
+            logger.debug("Mount command: %s", mount_cmd)
             max_wait = 10  # Python mount is slower due to imports
 
         # Run mount in background
@@ -720,7 +729,7 @@ except Exception as e:
                 if mount_result.exit_code == 0:
                     mount_verified = True
                     elapsed = (attempt + 1) * poll_interval
-                    logger.info(f"FUSE mount verified after {elapsed:.1f}s")
+                    logger.info("FUSE mount verified after %.1fs", elapsed)
                     break
             except CommandExitException:
                 pass
@@ -767,7 +776,7 @@ except Exception as e:
             ls_result = await sandbox.commands.run(
                 f"ls {mount_path}/ 2>&1", timeout=E2B_LS_VERIFY_TIMEOUT
             )
-            logger.info(f"Successfully mounted Nexus at {mount_path} (verified with mount + ls)")
+            logger.info("Successfully mounted Nexus at %s (verified with mount + ls)", mount_path)
             return {
                 "success": True,
                 "mount_path": mount_path,
@@ -778,7 +787,8 @@ except Exception as e:
             }
         except CommandExitException as e:
             logger.warning(
-                f"FUSE mount present but ls failed: {e.stderr}. Mount may still be initializing."
+                "FUSE mount present but ls failed: %s. Mount may still be initializing.",
+                e.stderr,
             )
             return {
                 "success": True,
@@ -811,7 +821,7 @@ except Exception as e:
             )
             return sandbox
         except Exception as e:
-            logger.error(f"Failed to connect to sandbox {sandbox_id}: {e}")
+            logger.error("Failed to connect to sandbox %s: %s", sandbox_id, e)
             raise SandboxNotFoundError(f"Sandbox {sandbox_id} not found") from e
 
 

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -234,8 +234,9 @@ class SearchDaemon:
                 embedding_provider=self._embedding_provider,
             )
             logger.info(
-                f"Entropy filtering enabled: threshold={self.config.entropy_threshold}, "
-                f"alpha={self.config.entropy_alpha}"
+                "Entropy filtering enabled: threshold=%s, alpha=%s",
+                self.config.entropy_threshold,
+                self.config.entropy_alpha,
             )
 
         # Initialize indexing pipeline for parallel refresh (Issue #1094)
@@ -345,8 +346,10 @@ class SearchDaemon:
                 self.stats.bm25_documents = doc_count
                 self.stats.bm25_load_time_ms = (time.perf_counter() - start) * 1000
                 logger.info(
-                    f"BM25S index loaded: {doc_count} documents in "
-                    f"{self.stats.bm25_load_time_ms:.1f}ms (mmap={self.config.bm25s_mmap})"
+                    "BM25S index loaded: %d documents in %.1fms (mmap=%s)",
+                    doc_count,
+                    self.stats.bm25_load_time_ms,
+                    self.config.bm25s_mmap,
                 )
             else:
                 logger.warning("BM25S index initialization failed")
@@ -354,7 +357,7 @@ class SearchDaemon:
         except ImportError:
             logger.debug("BM25S not available")
         except Exception as e:
-            logger.error(f"Failed to initialize BM25S index: {e}")
+            logger.error("Failed to initialize BM25S index: %s", e)
 
     async def _init_database_pool(self) -> None:
         """Initialize and warm the database connection pool."""
@@ -395,12 +398,13 @@ class SearchDaemon:
             self.stats.db_pool_warmup_time_ms = (time.perf_counter() - start) * 1000
 
             logger.info(
-                f"Database pool warmed: {self.stats.db_pool_size} connections in "
-                f"{self.stats.db_pool_warmup_time_ms:.1f}ms"
+                "Database pool warmed: %d connections in %.1fms",
+                self.stats.db_pool_size,
+                self.stats.db_pool_warmup_time_ms,
             )
 
         except Exception as e:
-            logger.error(f"Failed to initialize database pool: {e}")
+            logger.error("Failed to initialize database pool: %s", e)
 
     async def _warm_vector_index(self) -> None:
         """Warm the vector index by executing a dummy query.
@@ -439,11 +443,11 @@ class SearchDaemon:
                     logger.debug("Vector index warmup query skipped: %s", e)
 
             self.stats.vector_warmup_time_ms = (time.perf_counter() - start) * 1000
-            logger.info(f"Vector index warmed in {self.stats.vector_warmup_time_ms:.1f}ms")
+            logger.info("Vector index warmed in %.1fms", self.stats.vector_warmup_time_ms)
 
         except Exception as e:
             # Non-fatal - vector search will still work, just slower first time
-            logger.debug(f"Vector index warmup skipped: {e}")
+            logger.debug("Vector index warmup skipped: %s", e)
 
     async def _check_zoekt(self) -> None:
         """Check if Zoekt trigram search is available."""
@@ -538,7 +542,7 @@ class SearchDaemon:
             return results
 
         except TimeoutError:
-            logger.warning(f"Search timeout after {self.config.query_timeout_seconds}s")
+            logger.warning("Search timeout after %ss", self.config.query_timeout_seconds)
             return []
 
     async def _keyword_search(
@@ -643,7 +647,7 @@ class SearchDaemon:
                 ]
 
         except Exception as e:
-            logger.error(f"Semantic search error: {e}")
+            logger.error("Semantic search error: %s", e)
             return []
 
     async def _splade_search(
@@ -668,7 +672,7 @@ class SearchDaemon:
                 for r in results
             ]
         except Exception as e:
-            logger.debug(f"SPLADE search failed: {e}")
+            logger.debug("SPLADE search failed: %s", e)
             return []
 
     async def _hybrid_search(
@@ -777,7 +781,7 @@ class SearchDaemon:
             ]
 
         except Exception as e:
-            logger.debug(f"Zoekt search failed: {e}")
+            logger.debug("Zoekt search failed: %s", e)
             return []
 
     async def _search_bm25s(
@@ -810,7 +814,7 @@ class SearchDaemon:
             ]
 
         except Exception as e:
-            logger.debug(f"BM25S search failed: {e}")
+            logger.debug("BM25S search failed: %s", e)
             return []
 
     async def _search_fts(
@@ -875,7 +879,7 @@ class SearchDaemon:
                 ]
 
         except Exception as e:
-            logger.error(f"FTS search error: {e}")
+            logger.error("FTS search error: %s", e)
             return []
 
     async def _get_query_embedding(self, query: str) -> list[float] | None:
@@ -892,7 +896,7 @@ class SearchDaemon:
             embedding = await provider.embed_text(query)
             return list(embedding) if embedding else None
         except Exception as e:
-            logger.debug(f"Could not get query embedding: {e}")
+            logger.debug("Could not get query embedding: %s", e)
             return None
 
     # =========================================================================
@@ -934,7 +938,7 @@ class SearchDaemon:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error(f"Index refresh error: {e}")
+                logger.error("Index refresh error: %s", e)
 
     @staticmethod
     def _strip_zone_prefix(path: str) -> str:
@@ -1179,7 +1183,7 @@ class SearchDaemon:
             logger.info("[BULK-EMBED] BM25S corpus is empty")
             return 0
 
-        logger.info(f"[BULK-EMBED] Processing {total} documents from BM25S corpus")
+        logger.info("[BULK-EMBED] Processing %d documents from BM25S corpus", total)
 
         # Step 1: Build deterministic UUID5 path_ids for each virtual path
         ns = uuid.UUID("12345678-1234-5678-1234-567812345678")
@@ -1229,7 +1233,7 @@ class SearchDaemon:
                         {"pid": pid, "vpath": vpath, "now": now},
                     )
                 await session.commit()
-            logger.info(f"[BULK-EMBED] Registered {len(new_vpaths)} new files in file_paths")
+            logger.info("[BULK-EMBED] Registered %d new files in file_paths", len(new_vpaths))
 
         # Step 2: Feed to standard indexing pipeline with UUID path_ids
         docs_to_embed: list[tuple[str, str, str]] = []
@@ -1249,11 +1253,11 @@ class SearchDaemon:
                 )
                 embedded += len(batch)
                 if batch_start % (batch_size * 5) == 0:
-                    logger.info(f"[BULK-EMBED] Progress: {embedded}/{len(docs_to_embed)}")
+                    logger.info("[BULK-EMBED] Progress: %d/%d", embedded, len(docs_to_embed))
             except Exception as e:
-                logger.warning(f"[BULK-EMBED] Batch failed at {batch_start}: {e}")
+                logger.warning("[BULK-EMBED] Batch failed at %d: %s", batch_start, e)
 
-        logger.info(f"[BULK-EMBED] Complete: {embedded}/{len(docs_to_embed)} documents embedded")
+        logger.info("[BULK-EMBED] Complete: %d/%d documents embedded", embedded, len(docs_to_embed))
         return embedded
 
     # =========================================================================

--- a/src/nexus/bricks/search/query_expansion.py
+++ b/src/nexus/bricks/search/query_expansion.py
@@ -422,26 +422,27 @@ class OpenRouterQueryExpander(QueryExpander):
                     expansions = self._parse_response(response.choices[0].message.content)
                     if expansions:
                         logger.debug(
-                            f"Query expansion succeeded with model={model}, "
-                            f"expansions={len(expansions)}"
+                            "Query expansion succeeded with model=%s, expansions=%d",
+                            model,
+                            len(expansions),
                         )
                         return expansions
 
             except TimeoutError:
-                logger.warning(f"Query expansion timeout with model={model}")
+                logger.warning("Query expansion timeout with model=%s", model)
                 last_error = TimeoutError(f"Timeout with {model}")
             except Exception as e:
                 error_str = str(e).lower()
                 if "rate_limit" in error_str or "429" in error_str:
-                    logger.warning(f"Rate limited on model={model}, trying next")
+                    logger.warning("Rate limited on model=%s, trying next", model)
                     last_error = e
                 else:
-                    logger.warning(f"Query expansion error with model={model}: {e}")
+                    logger.warning("Query expansion error with model=%s: %s", model, e)
                     last_error = e
 
         # All models failed
         if last_error:
-            logger.error(f"All query expansion models failed. Last error: {last_error}")
+            logger.error("All query expansion models failed. Last error: %s", last_error)
 
         return []
 
@@ -540,8 +541,10 @@ class SignalDetector:
 
         if is_strong:
             logger.debug(
-                f"Strong BM25 signal detected: top={top_score:.3f}, "
-                f"second={second_score:.3f}, gap={top_score - second_score:.3f}"
+                "Strong BM25 signal detected: top=%.3f, second=%.3f, gap=%.3f",
+                top_score,
+                second_score,
+                top_score - second_score,
             )
 
         return is_strong
@@ -641,10 +644,10 @@ class CachedQueryExpander(QueryExpander):
         try:
             cached = await self.cache.get(cache_key)
             if cached is not None:
-                logger.debug(f"Query expansion cache hit for key={cache_key}")
+                logger.debug("Query expansion cache hit for key=%s", cache_key)
                 return self._deserialize(cached.decode())
         except Exception as e:
-            logger.warning(f"Cache read error: {e}")
+            logger.warning("Cache read error: %s", e)
 
         # Cache miss - generate expansions
         expansions = await self.expander.expand(query, context)
@@ -653,9 +656,9 @@ class CachedQueryExpander(QueryExpander):
         if expansions:
             try:
                 await self.cache.set(cache_key, self._serialize(expansions).encode(), ttl=self.ttl)
-                logger.debug(f"Cached query expansion for key={cache_key}")
+                logger.debug("Cached query expansion for key=%s", cache_key)
             except Exception as e:
-                logger.warning(f"Cache write error: {e}")
+                logger.warning("Cache write error: %s", e)
 
         return expansions
 
@@ -756,7 +759,7 @@ class QueryExpansionService:
                 latency_ms=latency_ms,
             )
         except Exception as e:
-            logger.error(f"Query expansion failed: {e}")
+            logger.error("Query expansion failed: %s", e)
             latency_ms = (time.perf_counter() - start_time) * 1000
 
             return ExpansionResult(

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -424,7 +424,10 @@ class SearchService:
                 import traceback
 
                 logger.debug(
-                    f"Dynamic connector list_dir failed for {path}: {e}\n{traceback.format_exc()}"
+                    "Dynamic connector list_dir failed for %s: %s\n%s",
+                    path,
+                    e,
+                    traceback.format_exc(),
                 )
 
         # Issue #904: Extract zone_id for PREWHERE-style DB filtering
@@ -459,9 +462,14 @@ class SearchService:
         )
 
         logger.info(
-            f"[LIST-DEBUG] START path={path}, recursive={recursive}, zone={list_zone_id}, "
-            f"details={details}, has_list_dir_entries={hasattr(self.metadata, 'list_directory_entries')}, "
-            f"has_context={context is not None}"
+            "[LIST-DEBUG] START path=%s, recursive=%s, zone=%s, "
+            "details=%s, has_list_dir_entries=%s, has_context=%s",
+            path,
+            recursive,
+            list_zone_id,
+            details,
+            hasattr(self.metadata, "list_directory_entries"),
+            context is not None,
         )
         if (
             not recursive
@@ -483,7 +491,7 @@ class SearchService:
                 _rebac_manager,
             )
             sample_paths = [m.path for m in all_files[:5]]
-            logger.info(f"[LIST-DEBUG] FALLBACK all_files sample: {sample_paths}")
+            logger.info("[LIST-DEBUG] FALLBACK all_files sample: %s", sample_paths)
 
         # Issue #904: Fetch cross-zone shared files
         if list_zone_id and subject_type and subject_id:
@@ -495,8 +503,9 @@ class SearchService:
                 prefix=list_prefix,
             )
             logger.info(
-                f"[LIST-TIMING] cross_zone_lookup: {(_time.time() - _ct_start) * 1000:.1f}ms, "
-                f"{len(cross_zone_paths) if cross_zone_paths else 0} paths"
+                "[LIST-TIMING] cross_zone_lookup: %.1fms, %d paths",
+                (_time.time() - _ct_start) * 1000,
+                len(cross_zone_paths) if cross_zone_paths else 0,
             )
             if cross_zone_paths:
                 existing_paths = {meta.path for meta in all_files}
@@ -524,8 +533,9 @@ class SearchService:
                 if "/" not in rel_path:
                     results.append(meta)
             logger.info(
-                f"[LIST-DEBUG] after non-recursive filter: {len(results)} results "
-                f"(from {len(all_files)} all_files)"
+                "[LIST-DEBUG] after non-recursive filter: %d results (from %d all_files)",
+                len(results),
+                len(all_files),
             )
 
         # Issue #900: Single Permission Pass
@@ -542,7 +552,9 @@ class SearchService:
             results_before = len(results)
             results = [meta for meta in results if meta.path in allowed_set]
             logger.info(
-                f"[LIST-DEBUG] after perm filter: {len(results)} results (was {results_before})"
+                "[LIST-DEBUG] after perm filter: %d results (was %d)",
+                len(results),
+                results_before,
             )
         else:
             if not recursive:
@@ -551,7 +563,7 @@ class SearchService:
         # Sort by path
         _sort_start = _time.time()
         results.sort(key=lambda m: m.path)
-        logger.info(f"[LIST-TIMING] sort_results: {(_time.time() - _sort_start) * 1000:.1f}ms")
+        logger.info("[LIST-TIMING] sort_results: %.1fms", (_time.time() - _sort_start) * 1000)
 
         # Add directories to results
         directories = self._list_infer_directories(
@@ -565,7 +577,7 @@ class SearchService:
             zone_id=list_zone_id,
         )
 
-        logger.info(f"[LIST-DEBUG] FINAL directories: {sorted(directories)[:10]}")
+        logger.info("[LIST-DEBUG] FINAL directories: %s", sorted(directories)[:10])
 
         # Build output
         if details:
@@ -680,15 +692,16 @@ class SearchService:
                         else:
                             results.append(full_path)
                 except Exception as e:
-                    logger.warning(f"[LIST-PARALLEL] Failed to list '{virtual_path}': {e}")
+                    logger.warning("[LIST-PARALLEL] Failed to list '%s': %s", virtual_path, e)
 
         if depth >= LIST_PARALLEL_MAX_DEPTH:
             logger.warning(
-                f"[LIST-PARALLEL] Hit max depth {LIST_PARALLEL_MAX_DEPTH}, truncating traversal"
+                "[LIST-PARALLEL] Hit max depth %d, truncating traversal",
+                LIST_PARALLEL_MAX_DEPTH,
             )
 
         elapsed = time.time() - start_time
-        logger.debug(f"[LIST-PARALLEL] Completed: {len(results)} entries in {elapsed:.3f}s")
+        logger.debug("[LIST-PARALLEL] Completed: %d entries in %.3fs", len(results), elapsed)
 
         return results
 
@@ -845,13 +858,15 @@ class SearchService:
 
         if dir_entries is None:
             logger.info(
-                f"[LIST-TIMING] list_directory_entries(): {_idx_elapsed:.1f}ms (sparse index MISS)"
+                "[LIST-TIMING] list_directory_entries(): %.1fms (sparse index MISS)",
+                _idx_elapsed,
             )
             return [], set(), False, _revision_before
 
         logger.info(
-            f"[LIST-TIMING] list_directory_entries(): {_idx_elapsed:.1f}ms, "
-            f"{len(dir_entries)} entries (sparse index HIT)"
+            "[LIST-TIMING] list_directory_entries(): %.1fms, %d entries (sparse index HIT)",
+            _idx_elapsed,
+            len(dir_entries),
         )
 
         all_files = []
@@ -885,8 +900,9 @@ class SearchService:
                     )
                 )
         logger.info(
-            f"[LIST-TIMING] has_accessible_descendants(): "
-            f"{(_time.time() - _perm_start) * 1000:.1f}ms for {len(dir_entries)} entries"
+            "[LIST-TIMING] has_accessible_descendants(): %.1fms for %d entries",
+            (_time.time() - _perm_start) * 1000,
+            len(dir_entries),
         )
 
         # Check revision consistency
@@ -899,8 +915,9 @@ class SearchService:
             _revision_after = _rebac_manager._get_zone_revision_for_grant(list_zone_id)
             if _revision_after != _revision_before:
                 logger.warning(
-                    f"[LIST-TIMING] Revision changed ({_revision_before} -> {_revision_after}), "
-                    f"falling back to full list"
+                    "[LIST-TIMING] Revision changed (%s -> %s), falling back to full list",
+                    _revision_before,
+                    _revision_after,
                 )
                 _use_fast_path = False
 
@@ -945,14 +962,15 @@ class SearchService:
                     if _accessible_int_ids is not None:
                         if len(_accessible_int_ids) > 0:
                             logger.info(
-                                f"[PREDICATE-PUSHDOWN] Got {len(_accessible_int_ids)} accessible "
-                                f"int IDs in {(_time.time() - _pushdown_start) * 1000:.1f}ms"
+                                "[PREDICATE-PUSHDOWN] Got %d accessible int IDs in %.1fms",
+                                len(_accessible_int_ids),
+                                (_time.time() - _pushdown_start) * 1000,
                             )
                         else:
                             logger.info("[PREDICATE-PUSHDOWN] Empty int IDs, falling back")
                             _accessible_int_ids = None
                 except Exception as e:
-                    logger.warning(f"[PREDICATE-PUSHDOWN] Failed to get int IDs: {e}")
+                    logger.warning("[PREDICATE-PUSHDOWN] Failed to get int IDs: %s", e)
                     _accessible_int_ids = None
 
         _meta_start = _time.time()
@@ -961,8 +979,9 @@ class SearchService:
             zone_id=list_zone_id,
         )
         logger.info(
-            f"[LIST-TIMING] metadata.list(): {(_time.time() - _meta_start) * 1000:.1f}ms, "
-            f"{len(all_files)} files"
+            "[LIST-TIMING] metadata.list(): %.1fms, %d files",
+            (_time.time() - _meta_start) * 1000,
+            len(all_files),
         )
 
         # Predicate pushdown: filter by accessible_int_ids at service layer
@@ -977,9 +996,11 @@ class SearchService:
                     in _accessible_int_ids
                 ]
                 logger.info(
-                    f"[PREDICATE-PUSHDOWN] Service-layer filter: "
-                    f"{before_count} -> {len(all_files)} files "
-                    f"({len(_accessible_int_ids)} accessible int IDs)"
+                    "[PREDICATE-PUSHDOWN] Service-layer filter: "
+                    "%d -> %d files (%d accessible int IDs)",
+                    before_count,
+                    len(all_files),
+                    len(_accessible_int_ids),
                 )
 
             # Issue #1147: Check if revision changed during query (TOCTOU race detection)
@@ -999,8 +1020,9 @@ class SearchService:
                         zone_id=list_zone_id,
                     )
                     logger.info(
-                        f"[LIST-TIMING] metadata.list() retry: "
-                        f"{(_time.time() - _meta_start) * 1000:.1f}ms, {len(all_files)} files"
+                        "[LIST-TIMING] metadata.list() retry: %.1fms, %d files",
+                        (_time.time() - _meta_start) * 1000,
+                        len(all_files),
                     )
                     _accessible_int_ids = None
 
@@ -1044,8 +1066,8 @@ class SearchService:
         if _accessible_int_ids is not None:
             allowed_set = {meta.path for meta in all_files}
             logger.info(
-                f"[PREDICATE-PUSHDOWN] Skipped filter_list() - "
-                f"using {len(allowed_set)} pre-filtered paths"
+                "[PREDICATE-PUSHDOWN] Skipped filter_list() - using %d pre-filtered paths",
+                len(allowed_set),
             )
         else:
             allowed_list = self._permission_enforcer.filter_list(list(candidate_paths), ctx)
@@ -1056,10 +1078,12 @@ class SearchService:
             allowed_set.update(_preapproved_dirs)
 
         logger.debug(
-            f"[PERF-LIST] Permission filter: {filter_elapsed:.3f}s, "
-            f"allowed {len(allowed_set)}/{len(candidate_paths)} paths"
+            "[PERF-LIST] Permission filter: %.3fs, allowed %d/%d paths",
+            filter_elapsed,
+            len(allowed_set),
+            len(candidate_paths),
         )
-        logger.debug(f"[PERF-LIST] Total: {time.time() - perm_start:.3f}s")
+        logger.debug("[PERF-LIST] Total: %.3fs", time.time() - perm_start)
 
         return allowed_set, backend_dirs
 
@@ -1115,8 +1139,9 @@ class SearchService:
                 directories.update(backend_dirs)
 
         logger.info(
-            f"[LIST-TIMING] dir_processing: {(_time.time() - _dir_start) * 1000:.1f}ms, "
-            f"{len(directories)} dirs"
+            "[LIST-TIMING] dir_processing: %.1fms, %d dirs",
+            (_time.time() - _dir_start) * 1000,
+            len(directories),
         )
         return directories
 
@@ -1203,9 +1228,12 @@ class SearchService:
                     directories.add(dir_path)
 
         logger.info(
-            f"[LIST-TIMING] backend_dir_checks: {(_time.time() - _bd_start) * 1000:.1f}ms, "
-            f"traverse={_traverse_checks}, prefix={_prefix_checks}, "
-            f"skipped_cross_zone={_skipped_cross_zone}"
+            "[LIST-TIMING] backend_dir_checks: %.1fms, "
+            "traverse=%d, prefix=%d, skipped_cross_zone=%d",
+            (_time.time() - _bd_start) * 1000,
+            _traverse_checks,
+            _prefix_checks,
+            _skipped_cross_zone,
         )
 
     def _list_build_details(
@@ -1250,7 +1278,9 @@ class SearchService:
         all_results = file_results + dir_results
         all_results.sort(key=lambda x: str(x["path"]))
         logger.info(
-            f"[LIST-TIMING] TOTAL: {(_time.time() - _list_start) * 1000:.1f}ms for path={path}"
+            "[LIST-TIMING] TOTAL: %.1fms for path=%s",
+            (_time.time() - _list_start) * 1000,
+            path,
         )
         self._record_read_if_tracking(context, "directory", path, "list")
         return all_results
@@ -1276,7 +1306,9 @@ class SearchService:
         all_paths = file_paths + sorted(directories)
         all_paths.sort()
         logger.info(
-            f"[LIST-TIMING] TOTAL: {(_time.time() - _list_start) * 1000:.1f}ms for path={path}"
+            "[LIST-TIMING] TOTAL: %.1fms for path=%s",
+            (_time.time() - _list_start) * 1000,
+            path,
         )
         self._record_read_if_tracking(context, "directory", path, "list")
         return all_paths
@@ -1464,7 +1496,10 @@ class SearchService:
             )
             if paths:
                 logger.debug(
-                    f"[CROSS-ZONE] Found {len(paths)} shared paths for {subject_type}:{subject_id}"
+                    "[CROSS-ZONE] Found %d shared paths for %s:%s",
+                    len(paths),
+                    subject_type,
+                    subject_id,
                 )
             self._cross_zone_cache[cache_key] = paths
             return paths
@@ -1518,8 +1553,9 @@ class SearchService:
             list[str], self.list(search_path, recursive=True, context=context)
         )
         logger.debug(
-            f"[GLOB] Phase 2: list() found {len(accessible_files)} files "
-            f"in {time.time() - list_start:.3f}s"
+            "[GLOB] Phase 2: list() found %d files in %.3fs",
+            len(accessible_files),
+            time.time() - list_start,
         )
         if not accessible_files:
             return []
@@ -1529,7 +1565,8 @@ class SearchService:
         accessible_files = _filter_ignored_paths(accessible_files)
         if pre_filter_count != len(accessible_files):
             logger.debug(
-                f"[GLOB] Issue #538: Filtered {pre_filter_count - len(accessible_files)} paths"
+                "[GLOB] Issue #538: Filtered %d paths",
+                pre_filter_count - len(accessible_files),
             )
 
         # Phase 3: Strategy selection (Issue #929)
@@ -1575,8 +1612,12 @@ class SearchService:
                     matches.append(file_path)
 
         logger.debug(
-            f"[GLOB] {strategy.value}: matched {len(matches)}/{len(accessible_files)} files "
-            f"in {time.time() - match_start:.3f}s (total: {time.time() - glob_start:.3f}s)"
+            "[GLOB] %s: matched %d/%d files in %.3fs (total: %.3fs)",
+            strategy.value,
+            len(matches),
+            len(accessible_files),
+            time.time() - match_start,
+            time.time() - glob_start,
         )
 
         # Sort by mtime (newest first) (Issue #538)
@@ -1588,7 +1629,7 @@ class SearchService:
                     key=lambda p: (-(metadata_map.get(p, 0) or 0), p),
                 )
             except Exception as e:
-                logger.debug(f"[GLOB] mtime sort failed ({e}), falling back to alphabetical")
+                logger.debug("[GLOB] mtime sort failed (%s), falling back to alphabetical", e)
                 return sorted(matches)
         return []
 
@@ -1716,7 +1757,7 @@ class SearchService:
             pre_filter_count = len(files)
             files = _filter_ignored_paths(files)
             if pre_filter_count != len(files):
-                logger.debug(f"[GREP] Issue #538: Filtered {pre_filter_count - len(files)} paths")
+                logger.debug("[GREP] Issue #538: Filtered %d paths", pre_filter_count - len(files))
 
         if not files:
             return []
@@ -1862,7 +1903,7 @@ class SearchService:
                             ]
                             remaining_results = remaining_results - len(results)
             except Exception as e:
-                logger.debug(f"[GREP] Mmap optimization failed: {e}")
+                logger.debug("[GREP] Mmap optimization failed: %s", e)
 
         # Rust-accelerated grep for remaining
         if (
@@ -1986,7 +2027,7 @@ class SearchService:
                         break
             return results
         except Exception as e:
-            logger.warning(f"[GREP] Zoekt search failed: {e}")
+            logger.warning("[GREP] Zoekt search failed: %s", e)
             return None
 
     def _try_grep_with_trigram(
@@ -2204,12 +2245,14 @@ class SearchService:
                 if len(all_results) >= max_results:
                     break
             except Exception as e:
-                logger.debug(f"[GREP-PARALLEL] Chunk failed: {e}")
+                logger.debug("[GREP-PARALLEL] Chunk failed: %s", e)
 
         timer.__exit__(None, None, None)
         logger.debug(
-            f"[GREP-PARALLEL] {len(files)} files, {len(all_results)} results "
-            f"in {timer.elapsed:.3f}s"
+            "[GREP-PARALLEL] %d files, %d results in %.3fs",
+            len(files),
+            len(all_results),
+            timer.elapsed,
         )
         return all_results[:max_results]
 

--- a/src/nexus/bricks/search/splade_search.py
+++ b/src/nexus/bricks/search/splade_search.py
@@ -81,7 +81,9 @@ class SpladeRetriever:
             self._model = AutoModelForMaskedLM.from_pretrained(self._model_name)
             self._model.eval()
             logger.info(
-                f"SPLADE model loaded: {self._model_name} (vocab={self._tokenizer.vocab_size})"
+                "SPLADE model loaded: %s (vocab=%d)",
+                self._model_name,
+                self._tokenizer.vocab_size,
             )
 
         await asyncio.to_thread(_load)
@@ -135,7 +137,7 @@ class SpladeRetriever:
             raise RuntimeError("SPLADE not initialized")
 
         total = len(documents)
-        logger.info(f"[SPLADE] Indexing {total} documents...")
+        logger.info("[SPLADE] Indexing %d documents...", total)
 
         def _index_batch(batch: list[tuple[str, str]]) -> list[tuple[str, str, dict]]:
             results = []
@@ -158,9 +160,9 @@ class SpladeRetriever:
                 indexed += 1
 
             if (start // batch_size) % 10 == 0:
-                logger.info(f"[SPLADE] Indexed {indexed}/{total} docs")
+                logger.info("[SPLADE] Indexed %d/%d docs", indexed, total)
 
-        logger.info(f"[SPLADE] Indexing complete: {indexed} documents")
+        logger.info("[SPLADE] Indexing complete: %d documents", indexed)
         return indexed
 
     async def search(

--- a/src/nexus/bricks/versioning/version_service.py
+++ b/src/nexus/bricks/versioning/version_service.py
@@ -299,7 +299,7 @@ class VersionService:
             Rollback creates a new version rather than deleting history.
             This preserves the audit trail and allows rolling forward again.
         """
-        logger.info(f"[ROLLBACK] path={path}, version={version}")
+        logger.info("[ROLLBACK] path=%s, version=%s", path, version)
 
         # Validate and normalize path
         path = self._validate_path(path)
@@ -374,7 +374,7 @@ class VersionService:
             self.metadata._cache.invalidate_path(path)
             logger.debug("Cache invalidated for path=%s", path)
 
-        logger.info(f"[ROLLBACK] Completed for path={path}")
+        logger.info("[ROLLBACK] Completed for path=%s", path)
 
     @rpc_expose(description="Compare file versions")
     async def diff_versions(

--- a/src/nexus/bricks/workflows/loader.py
+++ b/src/nexus/bricks/workflows/loader.py
@@ -130,7 +130,7 @@ class WorkflowLoader:
             WorkflowTrigger or None if invalid
         """
         if not isinstance(data, dict):
-            logger.warning(f"Invalid trigger data: {data}")
+            logger.warning("Invalid trigger data: %s", data)
             return None
 
         trigger_type_str = data.get("type")
@@ -142,7 +142,7 @@ class WorkflowLoader:
         try:
             trigger_type = TriggerType(trigger_type_str)
         except ValueError:
-            logger.warning(f"Unknown trigger type: {trigger_type_str}")
+            logger.warning("Unknown trigger type: %s", trigger_type_str)
             return None
 
         # Extract config (everything except 'type')
@@ -161,7 +161,7 @@ class WorkflowLoader:
             WorkflowAction or None if invalid
         """
         if not isinstance(data, dict):
-            logger.warning(f"Invalid action data: {data}")
+            logger.warning("Invalid action data: %s", data)
             return None
 
         action_name = data.get("name")
@@ -217,7 +217,7 @@ class WorkflowLoader:
         with open(file_path, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
-        logger.info(f"Saved workflow definition to {file_path}")
+        logger.info("Saved workflow definition to %s", file_path)
 
     @staticmethod
     def discover_workflows(directory: str | Path) -> list[WorkflowDefinition]:
@@ -231,7 +231,7 @@ class WorkflowLoader:
         """
         directory = Path(directory)
         if not directory.exists():
-            logger.warning(f"Workflow directory not found: {directory}")
+            logger.warning("Workflow directory not found: %s", directory)
             return []
 
         workflows = []
@@ -239,16 +239,16 @@ class WorkflowLoader:
             try:
                 workflow = WorkflowLoader.load_from_file(yaml_file)
                 workflows.append(workflow)
-                logger.info(f"Discovered workflow: {workflow.name} from {yaml_file}")
+                logger.info("Discovered workflow: %s from %s", workflow.name, yaml_file)
             except Exception as e:
-                logger.error(f"Failed to load workflow from {yaml_file}: {e}")
+                logger.error("Failed to load workflow from %s: %s", yaml_file, e)
 
         for yml_file in directory.glob("**/*.yml"):
             try:
                 workflow = WorkflowLoader.load_from_file(yml_file)
                 workflows.append(workflow)
-                logger.info(f"Discovered workflow: {workflow.name} from {yml_file}")
+                logger.info("Discovered workflow: %s from %s", workflow.name, yml_file)
             except Exception as e:
-                logger.error(f"Failed to load workflow from {yml_file}: {e}")
+                logger.error("Failed to load workflow from %s: %s", yml_file, e)
 
         return workflows

--- a/src/nexus/bricks/workflows/triggers.py
+++ b/src/nexus/bricks/workflows/triggers.py
@@ -181,7 +181,7 @@ class TriggerManager:
         """Register a trigger with a callback."""
         trigger_type = trigger.trigger_type.value
         self.triggers[trigger_type].append((trigger, callback))
-        logger.info(f"Registered {trigger_type} trigger with pattern: {trigger.get_pattern()}")
+        logger.info("Registered %s trigger with pattern: %s", trigger_type, trigger.get_pattern())
 
     def unregister_trigger(self, trigger: BaseTrigger) -> None:
         """Unregister a trigger."""
@@ -212,7 +212,7 @@ class TriggerManager:
                     await callback(event_context)
                     triggered_count += 1
                 except Exception as e:
-                    logger.error(f"Error executing trigger callback: {e}")
+                    logger.error("Error executing trigger callback: %s", e)
 
         return triggered_count
 

--- a/src/nexus/bricks/workspace/workspace_registry.py
+++ b/src/nexus/bricks/workspace/workspace_registry.py
@@ -240,21 +240,29 @@ class WorkspaceRegistry:
         if context:
             # Handle both dict (from RPC) and OperationContext (direct calls)
             logger.warning(
-                f"[CONTEXT-DEBUG] register_workspace: context type={type(context)}, context={context}"
+                "[CONTEXT-DEBUG] register_workspace: context type=%s, context=%s",
+                type(context),
+                context,
             )
             if isinstance(context, dict):
                 user_id = context.get("user_id") or context.get("user_id")
                 agent_id = context.get("agent_id")
                 zone_id = context.get("zone_id") or context.get("zone")
                 logger.warning(
-                    f"[CONTEXT-DEBUG] Extracted from dict: user_id={user_id}, agent_id={agent_id}, zone_id={zone_id}"
+                    "[CONTEXT-DEBUG] Extracted from dict: user_id=%s, agent_id=%s, zone_id=%s",
+                    user_id,
+                    agent_id,
+                    zone_id,
                 )
             else:
                 user_id = getattr(context, "user_id", None)
                 agent_id = getattr(context, "agent_id", None)
                 zone_id = getattr(context, "zone_id", None)
                 logger.warning(
-                    f"[CONTEXT-DEBUG] Extracted from object: user_id={user_id}, agent_id={agent_id}, zone_id={zone_id}"
+                    "[CONTEXT-DEBUG] Extracted from object: user_id=%s, agent_id=%s, zone_id=%s",
+                    user_id,
+                    agent_id,
+                    zone_id,
                 )
 
             # Validate agent ownership
@@ -300,25 +308,32 @@ class WorkspaceRegistry:
         # Workspaces are just directories, so we grant permission on the FILE object
         # The workspace manager will check FILE permissions (using the file namespace)
         logger.warning(
-            f"[AUTO-GRANT] workspace_registry: path={path}, user_id={user_id}, rebac_manager={self.rebac_manager is not None}"
+            "[AUTO-GRANT] workspace_registry: path=%s, user_id=%s, rebac_manager=%s",
+            path,
+            user_id,
+            self.rebac_manager is not None,
         )
         if self.rebac_manager and user_id:
             try:
                 # Grant permission on FILE object (for both file operations and workspace operations)
-                logger.warning(f"[AUTO-GRANT] Creating tuple: user:{user_id} → owner → file:{path}")
+                logger.warning(
+                    "[AUTO-GRANT] Creating tuple: user:%s -> owner -> file:%s", user_id, path
+                )
                 self.rebac_manager.rebac_write(
                     subject=("user", user_id),
                     relation="direct_owner",  # Use concrete relation, not computed union
                     object=("file", path),
                     zone_id=zone_id,  # v0.5.0: Pass zone_id from context
                 )
-                logger.warning(f"[AUTO-GRANT] ✓ SUCCESS: user:{user_id} → owner → file:{path}")
+                logger.warning("[AUTO-GRANT] SUCCESS: user:%s -> owner -> file:%s", user_id, path)
             except Exception as e:
                 # Don't fail registration if permission grant fails
-                logger.error(f"[AUTO-GRANT] ✗ FAILED: {e}", exc_info=True)
+                logger.error("[AUTO-GRANT] FAILED: %s", e, exc_info=True)
         else:
             logger.warning(
-                f"[AUTO-GRANT] SKIPPED: rebac={self.rebac_manager is not None}, user={user_id}"
+                "[AUTO-GRANT] SKIPPED: rebac=%s, user=%s",
+                self.rebac_manager is not None,
+                user_id,
             )
 
         return config
@@ -555,24 +570,31 @@ class WorkspaceRegistry:
 
         # v0.5.0: Auto-grant ownership to registering user
         logger.warning(
-            f"[AUTO-GRANT] workspace_registry: path={path}, user_id={user_id}, rebac_manager={self.rebac_manager is not None}"
+            "[AUTO-GRANT] workspace_registry: path=%s, user_id=%s, rebac_manager=%s",
+            path,
+            user_id,
+            self.rebac_manager is not None,
         )
         if self.rebac_manager and user_id:
             try:
-                logger.warning(f"[AUTO-GRANT] Creating tuple: user:{user_id} → owner → file:{path}")
+                logger.warning(
+                    "[AUTO-GRANT] Creating tuple: user:%s -> owner -> file:%s", user_id, path
+                )
                 self.rebac_manager.rebac_write(
                     subject=("user", user_id),
                     relation="direct_owner",  # Use concrete relation, not computed union
                     object=("file", path),
                     zone_id=zone_id,  # v0.5.0: Pass zone_id from context
                 )
-                logger.warning(f"[AUTO-GRANT] ✓ SUCCESS: user:{user_id} → owner → file:{path}")
+                logger.warning("[AUTO-GRANT] SUCCESS: user:%s -> owner -> file:%s", user_id, path)
             except Exception as e:
                 # Don't fail registration if permission grant fails
-                logger.error(f"[AUTO-GRANT] ✗ FAILED: {e}", exc_info=True)
+                logger.error("[AUTO-GRANT] FAILED: %s", e, exc_info=True)
         else:
             logger.warning(
-                f"[AUTO-GRANT] SKIPPED: rebac={self.rebac_manager is not None}, user={user_id}"
+                "[AUTO-GRANT] SKIPPED: rebac=%s, user=%s",
+                self.rebac_manager is not None,
+                user_id,
             )
 
         return config


### PR DESCRIPTION
## Summary
- Convert ~200 f-string logger calls to lazy `%` formatting across 27 files in remaining `bricks/` subdirectories
- Covers: mount (3), search (4), sandbox (1), mcp (5), auth/oauth (2), workflows (2), workspace (1), parsers (2), memory (5), versioning (1), pay (1)
- Combined with PR #2769 (bricks/rebac), this eliminates all f-string logger calls from the entire `bricks/` directory

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy` passes
- [x] Pre-commit hooks pass