### PR TITLE
refactor(#1410): Phase 1 SearchService DI — bypass __getattr__ for glob/grep

### DIFF
--- a/src/nexus/bricks/filesystem/scoped_filesystem.py
+++ b/src/nexus/bricks/filesystem/scoped_filesystem.py
@@ -206,7 +206,8 @@ class ScopedFilesystem(ScopedPathMixin):
 
     def glob(self, pattern: str, path: str = "/", context: Any = None) -> builtins.list[str]:
         """Find files matching a glob pattern."""
-        result = cast(Any, self._fs).glob(pattern, self._scope_path(path), context)
+        search = cast(Any, self._fs).search_service
+        result = search.glob(pattern, self._scope_path(path), context)
         return self._unscope_paths(result)
 
     def grep(
@@ -220,7 +221,8 @@ class ScopedFilesystem(ScopedPathMixin):
         context: Any = None,
     ) -> builtins.list[dict[str, Any]]:
         """Search file contents using regex patterns."""
-        result = cast(Any, self._fs).grep(
+        search = cast(Any, self._fs).search_service
+        result = search.grep(
             pattern,
             self._scope_path(path),
             file_pattern,

--- a/src/nexus/bricks/llm/llm_document_reader.py
+++ b/src/nexus/bricks/llm/llm_document_reader.py
@@ -132,7 +132,11 @@ class LLMDocumentReader:
 
         # If not using search, read document directly
         if not use_search:
-            file_paths = cast(Any, self.nx).glob(path, context=context) if "*" in path else [path]
+            file_paths = (
+                cast(Any, self.nx).search_service.glob(path, context=context)
+                if "*" in path
+                else [path]
+            )
 
             for file_path in file_paths[:search_limit]:
                 try:

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -660,7 +660,11 @@ def create_mcp_server(
             With pagination: nexus_glob("**/*.py", "/workspace", limit=50, offset=0)
         """
         nx_instance: Any = _get_nexus_instance(ctx)
-        all_matches = nx_instance.glob(pattern, path)
+        _search = getattr(nx_instance, "search_service", None)
+        if _search is not None:
+            all_matches = _search.glob(pattern, path)
+        else:
+            all_matches = nx_instance.glob(pattern, path)
         total = len(all_matches)
 
         # Apply pagination
@@ -727,7 +731,11 @@ def create_mcp_server(
             To get next 50 matches: nexus_grep("TODO", "/workspace", limit=50, offset=50)
         """
         nx_instance: Any = _get_nexus_instance(ctx)
-        all_results = nx_instance.grep(pattern, path, ignore_case=ignore_case)
+        _search = getattr(nx_instance, "search_service", None)
+        if _search is not None:
+            all_results = _search.grep(pattern, path, ignore_case=ignore_case)
+        else:
+            all_results = nx_instance.grep(pattern, path, ignore_case=ignore_case)
         total = len(all_results)
 
         # Apply pagination

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -70,10 +70,6 @@ SERVICE_METHODS: dict[str, str] = {
     "list_saved_mounts": "_mount_persist_service",
     "load_mount": "_mount_persist_service",
     "delete_saved_mount": "_mount_persist_service",
-    # SearchService (glob/grep are userspace tools, not syscalls — Issue #1381)
-    "glob": "search_service",
-    "grep": "search_service",
-    "glob_batch": "search_service",
     # MCPService
     "mcp_list_mounts": "mcp_service",
     # LLMService

--- a/src/nexus/server/cache_warmer.py
+++ b/src/nexus/server/cache_warmer.py
@@ -497,7 +497,7 @@ class CacheWarmer:
 
             # Get files using glob
             pattern = self._build_glob_pattern(path, depth)
-            files = self._nexus.glob(pattern, path="/", context=context)
+            files = self._nexus.search_service.glob(pattern, path="/", context=context)
             files = files[:max_files]
 
             logger.info(f"[WARMUP] Found {len(files)} files to warm")

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -410,7 +410,7 @@ def handle_glob(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, Any
     if hasattr(params, "path") and params.path:
         kwargs["path"] = params.path
 
-    matches = nexus_fs.glob(params.pattern, **kwargs)
+    matches = nexus_fs.search_service.glob(params.pattern, **kwargs)
     matches = [unscope_internal_path(m) if isinstance(m, str) else m for m in matches]
     return {"matches": matches}
 
@@ -429,7 +429,7 @@ def handle_grep(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, Any
     if hasattr(params, "search_mode") and params.search_mode is not None:
         kwargs["search_mode"] = params.search_mode
 
-    results = nexus_fs.grep(params.pattern, **kwargs)
+    results = nexus_fs.search_service.grep(params.pattern, **kwargs)
     results = [unscope_result(r) for r in results]
     return {"results": results}
 
@@ -462,7 +462,7 @@ async def handle_semantic_search_index(
             f"Semantic search is not initialized and could not be auto-initialized: {e}"
         ) from e
 
-    results = await nexus_fs.asemantic_search_index(path=path, recursive=recursive)
+    results = await nexus_fs.search_service.semantic_search_index(path=path, recursive=recursive)
 
     total_chunks = 0
     for v in results.values():

--- a/tests/unit/bricks/mcp/test_mcp_server_tools.py
+++ b/tests/unit/bricks/mcp/test_mcp_server_tools.py
@@ -53,8 +53,11 @@ def mock_nx_basic():
     nx.sys_write = Mock()
     nx.sys_unlink = Mock()
     nx.sys_readdir = Mock(return_value=["/file1.txt", "/file2.txt"])
-    nx.glob = Mock(return_value=["test.py", "main.py"])
-    nx.grep = Mock(return_value=[{"file": "test.py", "line": 10, "content": "match"}])
+    nx.search_service = Mock()
+    nx.search_service.glob = Mock(return_value=["test.py", "main.py"])
+    nx.search_service.grep = Mock(
+        return_value=[{"file": "test.py", "line": 10, "content": "match"}]
+    )
     nx.sys_access = Mock(return_value=True)
     nx.sys_is_directory = Mock(return_value=False)
     nx.sys_mkdir = Mock()
@@ -615,7 +618,7 @@ class TestSearchTools:
         assert "total" in response
         assert isinstance(response["items"], list)
         assert "test.py" in response["items"]
-        mock_nx_basic.glob.assert_called_once_with("*.py", "/src")
+        mock_nx_basic.search_service.glob.assert_called_once_with("*.py", "/src")
 
     def test_glob_default_path(self, mock_nx_basic):
         """Test glob with default path."""
@@ -624,11 +627,11 @@ class TestSearchTools:
         glob_tool = get_tool(server, "nexus_glob")
         glob_tool.fn(pattern="*.txt")
 
-        mock_nx_basic.glob.assert_called_once_with("*.txt", "/")
+        mock_nx_basic.search_service.glob.assert_called_once_with("*.txt", "/")
 
     def test_glob_error(self, mock_nx_basic):
         """Test glob error handling."""
-        mock_nx_basic.glob.side_effect = ValueError("Invalid pattern")
+        mock_nx_basic.search_service.glob.side_effect = ValueError("Invalid pattern")
         server = create_mcp_server(nx=mock_nx_basic)
 
         glob_tool = get_tool(server, "nexus_glob")
@@ -649,7 +652,7 @@ class TestSearchTools:
         assert "items" in response
         assert "total" in response
         assert isinstance(response["items"], list)
-        mock_nx_basic.grep.assert_called_once_with("TODO", "/src", ignore_case=False)
+        mock_nx_basic.search_service.grep.assert_called_once_with("TODO", "/src", ignore_case=False)
 
     def test_grep_ignore_case(self, mock_nx_basic):
         """Test grep with case-insensitive search."""
@@ -658,13 +661,15 @@ class TestSearchTools:
         grep_tool = get_tool(server, "nexus_grep")
         grep_tool.fn(pattern="error", path="/logs", ignore_case=True)
 
-        mock_nx_basic.grep.assert_called_once_with("error", "/logs", ignore_case=True)
+        mock_nx_basic.search_service.grep.assert_called_once_with(
+            "error", "/logs", ignore_case=True
+        )
 
     def test_grep_result_limiting(self, mock_nx_basic):
         """Test grep pagination with default limit of 100 matches."""
         # Create 150 fake results
         large_results = [{"file": f"file{i}.py", "line": i, "content": "match"} for i in range(150)]
-        mock_nx_basic.grep.return_value = large_results
+        mock_nx_basic.search_service.grep.return_value = large_results
         server = create_mcp_server(nx=mock_nx_basic)
 
         grep_tool = get_tool(server, "nexus_grep")
@@ -680,7 +685,7 @@ class TestSearchTools:
 
     def test_grep_error(self, mock_nx_basic):
         """Test grep error handling."""
-        mock_nx_basic.grep.side_effect = ValueError("Invalid regex")
+        mock_nx_basic.search_service.grep.side_effect = ValueError("Invalid regex")
         server = create_mcp_server(nx=mock_nx_basic)
 
         grep_tool = get_tool(server, "nexus_grep")

--- a/tests/unit/core/test_embedded.py
+++ b/tests/unit/core/test_embedded.py
@@ -548,18 +548,18 @@ def test_glob_simple_pattern(embedded: NexusFS) -> None:
     embedded.sys_write("/data.csv", b"Content")
 
     # Glob for .txt files
-    files = embedded.glob("*.txt")
+    files = embedded.search_service.glob("*.txt")
     assert len(files) == 2
     assert "/test1.txt" in files
     assert "/test2.txt" in files
 
     # Glob for .py files
-    files = embedded.glob("*.py")
+    files = embedded.search_service.glob("*.py")
     assert len(files) == 1
     assert "/file.py" in files
 
     # Glob for test* files
-    files = embedded.glob("test*")
+    files = embedded.search_service.glob("test*")
     assert len(files) == 2
     assert "/test1.txt" in files
     assert "/test2.txt" in files
@@ -574,14 +574,14 @@ def test_glob_recursive_pattern(embedded: NexusFS) -> None:
     embedded.sys_write("/README.md", b"Content")
 
     # Find all Python files recursively
-    files = embedded.glob("**/*.py")
+    files = embedded.search_service.glob("**/*.py")
     assert len(files) == 3
     assert "/src/main.py" in files
     assert "/src/utils/helper.py" in files
     assert "/tests/test_main.py" in files
 
     # Find all files recursively (filter out system entries)
-    files = [f for f in embedded.glob("**/*") if f not in _SYSTEM_PATHS]
+    files = [f for f in embedded.search_service.glob("**/*") if f not in _SYSTEM_PATHS]
     assert len(files) == 4
 
 
@@ -593,7 +593,7 @@ def test_glob_with_base_path(embedded: NexusFS) -> None:
     embedded.sys_write("/other/file3.csv", b"Content")
 
     # Glob in data directory
-    files = embedded.glob("*.csv", path="/data")
+    files = embedded.search_service.glob("*.csv", path="/data")
     assert len(files) == 2
     assert "/data/file1.csv" in files
     assert "/data/file2.csv" in files
@@ -607,7 +607,7 @@ def test_glob_question_mark_pattern(embedded: NexusFS) -> None:
     embedded.sys_write("/file10.txt", b"Content")
 
     # Match single character
-    files = embedded.glob("file?.txt")
+    files = embedded.search_service.glob("file?.txt")
     assert len(files) == 2
     assert "/file1.txt" in files
     assert "/file2.txt" in files
@@ -621,7 +621,7 @@ def test_grep_simple_search(embedded: NexusFS) -> None:
     embedded.sys_write("/file2.txt", b"Goodbye\nWorld Peace")
 
     # Search for "Hello"
-    results = embedded.grep("Hello")
+    results = embedded.search_service.grep("Hello")
 
     assert len(results) == 2
     assert results[0]["file"] == "/file1.txt"
@@ -640,7 +640,7 @@ def test_grep_regex_pattern(embedded: NexusFS) -> None:
     embedded.sys_write("/code.py", b"def foo():\n    pass\ndef bar():\n    return 42")
 
     # Search for function definitions
-    results = embedded.grep(r"def \w+")
+    results = embedded.search_service.grep(r"def \w+")
 
     assert len(results) == 2
     assert results[0]["match"] == "def foo"
@@ -655,7 +655,7 @@ def test_grep_with_file_pattern(embedded: NexusFS) -> None:
     embedded.sys_write("/file.txt", b"import nothing")
 
     # Search only in .py files
-    results = embedded.grep("import", file_pattern="*.py")
+    results = embedded.search_service.grep("import", file_pattern="*.py")
 
     assert len(results) == 3
     # Should not include file.txt
@@ -670,11 +670,11 @@ def test_grep_case_insensitive(embedded: NexusFS) -> None:
     )
 
     # Case-sensitive (default)
-    results = embedded.grep("ERROR")
+    results = embedded.search_service.grep("ERROR")
     assert len(results) == 1
 
     # Case-insensitive
-    results = embedded.grep("ERROR", ignore_case=True)
+    results = embedded.search_service.grep("ERROR", ignore_case=True)
     assert len(results) == 3
 
 
@@ -685,7 +685,7 @@ def test_grep_max_results(embedded: NexusFS) -> None:
     embedded.sys_write("/file.txt", content.encode())
 
     # Limit results
-    results = embedded.grep("MATCH", max_results=10)
+    results = embedded.search_service.grep("MATCH", max_results=10)
     assert len(results) == 10
 
 
@@ -698,7 +698,7 @@ def test_grep_skips_binary_files(embedded: NexusFS) -> None:
     embedded.sys_write("/text.txt", b"findme")
 
     # Search should only find text file
-    results = embedded.grep("findme")
+    results = embedded.search_service.grep("findme")
     assert len(results) == 1
     assert results[0]["file"] == "/text.txt"
 
@@ -707,7 +707,7 @@ def test_grep_empty_results(embedded: NexusFS) -> None:
     """Test grep with no matches."""
     embedded.sys_write("/file.txt", b"Hello World")
 
-    results = embedded.grep("nonexistent")
+    results = embedded.search_service.grep("nonexistent")
     assert len(results) == 0
 
 

--- a/tests/unit/core/test_nexus_fs_delegation.py
+++ b/tests/unit/core/test_nexus_fs_delegation.py
@@ -128,37 +128,37 @@ class TestSearchServiceDelegation:
             cursor=None,
         )
 
-    def test_glob_delegates(self, mock_fs, context):
-        """glob forwards pattern, path, context via __getattr__ pass-through."""
+    def test_glob_not_routed_via_getattr(self, mock_fs):
+        """glob is no longer in SERVICE_METHODS — callers use search_service directly."""
+        with pytest.raises(AttributeError):
+            mock_fs.glob("*.py")
+
+    def test_glob_batch_not_routed_via_getattr(self, mock_fs):
+        """glob_batch is no longer in SERVICE_METHODS — callers use search_service directly."""
+        with pytest.raises(AttributeError):
+            mock_fs.glob_batch(["*.py"])
+
+    def test_grep_not_routed_via_getattr(self, mock_fs):
+        """grep is no longer in SERVICE_METHODS — callers use search_service directly."""
+        with pytest.raises(AttributeError):
+            mock_fs.grep("pattern")
+
+    def test_search_service_glob_direct(self, mock_fs, context):
+        """Callers should use search_service.glob() directly."""
         matches = ["/data/test.py"]
         mock_fs.search_service.glob = MagicMock(return_value=matches)
-        result = mock_fs.glob("*.py", path="/data", context=context)
+        result = mock_fs.search_service.glob("*.py", path="/data", context=context)
         assert result == matches
         mock_fs.search_service.glob.assert_called_once_with("*.py", path="/data", context=context)
 
-    def test_glob_batch_delegates(self, mock_fs, context):
-        """glob_batch forwards patterns, path, context."""
-        batch = {"*.py": ["/a.py"], "*.txt": ["/b.txt"]}
-        mock_fs.search_service.glob_batch = MagicMock(return_value=batch)
-        result = mock_fs.glob_batch(["*.py", "*.txt"], context=context)
-        assert result == batch
-
-    def test_grep_delegates(self, mock_fs, context):
-        """grep forwards all args via __getattr__ pass-through."""
+    def test_search_service_grep_direct(self, mock_fs, context):
+        """Callers should use search_service.grep() directly."""
         results = [{"path": "/a.py", "line": 1, "match": "import os"}]
         mock_fs.search_service.grep = MagicMock(return_value=results)
-        result = mock_fs.grep(
-            "import os",
-            path="/src",
-            ignore_case=True,
-            context=context,
-        )
+        result = mock_fs.search_service.grep("import os", path="/src", context=context)
         assert result == results
         mock_fs.search_service.grep.assert_called_once_with(
-            "import os",
-            path="/src",
-            ignore_case=True,
-            context=context,
+            "import os", path="/src", context=context
         )
 
     def test_asemantic_search_delegates(self, mock_fs):

--- a/tests/unit/core/test_scoped_filesystem.py
+++ b/tests/unit/core/test_scoped_filesystem.py
@@ -238,19 +238,19 @@ class TestFileDiscoveryOperations:
 
     def test_glob(self, scoped_fs: ScopedFilesystem, mock_fs: MagicMock) -> None:
         """Test glob returns unscoped paths."""
-        mock_fs.glob.return_value = [
+        mock_fs.search_service.glob.return_value = [
             "/zones/team_12/users/user_1/workspace/test_a.py",
             "/zones/team_12/users/user_1/workspace/test_b.py",
         ]
         result = scoped_fs.glob("test_*.py", "/workspace")
-        mock_fs.glob.assert_called_once_with(
+        mock_fs.search_service.glob.assert_called_once_with(
             "test_*.py", "/zones/team_12/users/user_1/workspace", None
         )
         assert result == ["/workspace/test_a.py", "/workspace/test_b.py"]
 
     def test_grep(self, scoped_fs: ScopedFilesystem, mock_fs: MagicMock) -> None:
         """Test grep returns unscoped file paths."""
-        mock_fs.grep.return_value = [
+        mock_fs.search_service.grep.return_value = [
             {
                 "file": "/zones/team_12/users/user_1/workspace/app.py",
                 "line": 10,
@@ -258,7 +258,7 @@ class TestFileDiscoveryOperations:
             }
         ]
         result = scoped_fs.grep("TODO", "/workspace")
-        mock_fs.grep.assert_called_once()
+        mock_fs.search_service.grep.assert_called_once()
         assert result[0]["file"] == "/workspace/app.py"
 
 

--- a/tests/unit/factory/test_service_routing.py
+++ b/tests/unit/factory/test_service_routing.py
@@ -50,28 +50,27 @@ class TestResolveServiceAttr:
         result = resolve_service_attr(obj, "get_namespace")
         assert result is svc.get_namespace_sync
 
-    def test_glob_routed_via_methods(self) -> None:
-        """glob is a userspace tool routed via SERVICE_METHODS."""
-        assert SERVICE_METHODS["glob"] == "search_service"
+    def test_glob_not_in_service_methods(self) -> None:
+        """glob removed from SERVICE_METHODS — callers use search_service directly."""
+        assert "glob" not in SERVICE_METHODS
+        assert "glob_batch" not in SERVICE_METHODS
         obj = MagicMock()
-        obj.__dict__["search_service"] = svc = MagicMock()
-        result = resolve_service_attr(obj, "glob")
-        assert result is svc.glob
+        obj.__dict__["search_service"] = MagicMock()
+        assert resolve_service_attr(obj, "glob") is None
 
-    def test_grep_routed_via_methods(self) -> None:
-        """grep is a userspace tool routed via SERVICE_METHODS."""
-        assert SERVICE_METHODS["grep"] == "search_service"
+    def test_grep_not_in_service_methods(self) -> None:
+        """grep removed from SERVICE_METHODS — callers use search_service directly."""
+        assert "grep" not in SERVICE_METHODS
         obj = MagicMock()
-        obj.__dict__["search_service"] = svc = MagicMock()
-        result = resolve_service_attr(obj, "grep")
-        assert result is svc.grep
+        obj.__dict__["search_service"] = MagicMock()
+        assert resolve_service_attr(obj, "grep") is None
 
 
 class TestRoutingTableCompleteness:
     """Sanity checks for the routing tables."""
 
     def test_service_methods_non_empty(self) -> None:
-        assert len(SERVICE_METHODS) >= 57
+        assert len(SERVICE_METHODS) >= 54
 
     def test_service_aliases_non_empty(self) -> None:
         assert len(SERVICE_ALIASES) >= 53


### PR DESCRIPTION
## Summary
- Migrate all server-side callers from `nx.glob/grep()` (via `__getattr__` → `SERVICE_METHODS`) to `search_service.glob/grep()` directly
- Remove `glob`, `grep`, `glob_batch` from `SERVICE_METHODS` routing table — no remaining server-side `__getattr__` callers
- MCP server uses `getattr(nx, "search_service", None)` fallback for local vs remote mode
- Keep `asemantic_search*` in `SERVICE_ALIASES` — CLI remote callers still need them

## Files Changed (11)
**Source (6):** `server/rpc/handlers/filesystem.py`, `server/cache_warmer.py`, `bricks/filesystem/scoped_filesystem.py`, `bricks/mcp/server.py`, `bricks/llm/llm_document_reader.py`, `factory/service_routing.py`

**Tests (5):** `test_nexus_fs_delegation.py`, `test_service_routing.py`, `test_mcp_server_tools.py`, `test_embedded.py`, `test_scoped_filesystem.py`

## Not in scope (kept as-is)
- `cli/commands/search.py` — remote mode via `RPCProxyBase.__getattr__`
- `bricks/tools/langgraph/nexus_tools.py` — always remote mode
- `asemantic_search*` aliases — separate follow-up

## Test plan
- [x] `test_nexus_fs_delegation.py` — 13 passed (glob/grep now raise `AttributeError` via `__getattr__`)
- [x] `test_service_routing.py` — 9 passed (glob/grep not in `SERVICE_METHODS`)
- [x] `test_mcp_server_tools.py` — 7 search tests passed
- [x] `test_embedded.py` — 11 glob/grep tests passed
- [x] `test_scoped_filesystem.py` — 2 glob/grep tests passed
- [x] Full `tests/ -k "glob or grep"` — 82 passed, 1 skipped
- [x] Ruff lint + format clean
- [x] mypy clean
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)