### PR TITLE
fix(#2775): use keyword args for gRPC Read handler

### DIFF
--- a/src/nexus/grpc/servicer.py
+++ b/src/nexus/grpc/servicer.py
@@ -278,11 +278,10 @@ class VFSServicer(vfs_pb2_grpc.NexusVFSServiceServicer):
         try:
             _, op_context = await self._auth_and_context(request.auth_token)
             result = await asyncio.to_thread(
-                self._nexus_fs.sys_read,
+                self._nexus_fs.read,
                 request.path,
-                op_context,
-                True,  # return_metadata — we need etag/size
-                False,  # parsed
+                context=op_context,
+                return_metadata=True,
             )
             if isinstance(result, dict):
                 content = result.get("content", b"")


### PR DESCRIPTION
## Summary
- Fix `NexusFS.sys_read() takes 2 positional arguments but 5 were given` error in gRPC Read handler
- The servicer was passing keyword-only args (`context`, `return_metadata`, `parsed`) as positional args to `sys_read()`
- Switched to `read(path, context=op_context, return_metadata=True)` which correctly uses keyword args and returns the dict with `content`/`etag`/`size` that the response builder expects

## Root cause
`sys_read` signature uses `*` after `path`, making all subsequent params keyword-only:
```python
def sys_read(self, path: str, *, count=None, offset=0, context=None) -> bytes
```
The gRPC handler was calling `sys_read(path, op_context, True, False)` — 3 extra positional args.

## Test plan
- [ ] gRPC E2E: write file via gRPC, read back — should return content + etag
- [ ] Verify `sys_write` still works (unaffected, already uses `**kwargs`)

Closes #2775