### PR TITLE
fix(#1410): fix develop CI — mypy + benchmark failures

### DIFF
--- a/src/nexus/server/rpc/handlers/memory.py
+++ b/src/nexus/server/rpc/handlers/memory.py
@@ -39,7 +39,7 @@ def _get_memory_api_with_context(nexus_fs: NexusFS, context: Any) -> Any:
         if hasattr(context, "agent_id") and context.agent_id:
             context_dict["agent_id"] = context.agent_id
 
-    provider = nexus_fs._memory_provider
+    provider = getattr(nexus_fs, "_memory_provider", None)
     if provider is None:
         raise RuntimeError("Memory provider not configured")
     return provider.get_for_context(context_dict if context_dict else None)

--- a/tests/benchmarks/test_service_delegation.py
+++ b/tests/benchmarks/test_service_delegation.py
@@ -125,11 +125,11 @@ class TestAsyncDelegationOverhead:
         benchmark(run)
 
     def test_rebac_check_delegation(self, benchmark, mock_nexus_fs):
-        """Benchmark arebac_check delegation overhead."""
+        """Benchmark rebac_check via rebac_service direct call."""
 
         def run():
             asyncio.run(
-                mock_nexus_fs.arebac_check(
+                mock_nexus_fs.rebac_service.rebac_check(
                     subject=("user", "alice"),
                     permission="read",
                     object=("file", "/doc.txt"),
@@ -140,11 +140,11 @@ class TestAsyncDelegationOverhead:
         benchmark(run)
 
     def test_rebac_list_tuples_with_param_rename(self, benchmark, mock_nexus_fs):
-        """Benchmark arebac_list_tuples with zone_id→_zone_id transformation."""
+        """Benchmark rebac_list_tuples via rebac_service direct call."""
 
         def run():
             asyncio.run(
-                mock_nexus_fs.arebac_list_tuples(
+                mock_nexus_fs.rebac_service.rebac_list_tuples(
                     subject=("user", "alice"),
                     zone_id="z1",
                     limit=100,

--- a/tests/e2e/self_contained/test_zone_admin_sharing.py
+++ b/tests/e2e/self_contained/test_zone_admin_sharing.py
@@ -43,7 +43,7 @@ def nx(temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[NexusFS, No
 
     # Grant admin ownership of root directory for tests
     admin_context = {"user_id": "admin", "groups": [], "is_admin": True, "is_system": False}
-    nx.rebac_create(
+    nx.rebac_service.rebac_create_sync(
         subject=("user", "admin"),
         relation="direct_owner",
         object=("file", "/"),
@@ -75,7 +75,7 @@ class TestZoneAdminSharing:
         nx.sys_write(file_path, b"test content", context=OperationContext(**admin_context))
 
         # Grant bob ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="direct_owner",
             object=("file", file_path),
@@ -95,7 +95,7 @@ class TestZoneAdminSharing:
             "zone_id": zone_id,
         }
 
-        share_id = nx.share_with_user(
+        share_id = nx.rebac_service.share_with_user_sync(
             resource=("file", file_path),
             user_id="charlie",
             relation="viewer",
@@ -104,7 +104,7 @@ class TestZoneAdminSharing:
 
         assert share_id
         # Verify charlie can now read the file
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "charlie"),
             permission="read",
             object=("file", file_path),
@@ -125,7 +125,7 @@ class TestZoneAdminSharing:
         nx.sys_write(file_path, b"test content", context=OperationContext(**admin_context))
 
         # Grant bob ownership of file
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="direct_owner",
             object=("file", file_path),
@@ -144,7 +144,7 @@ class TestZoneAdminSharing:
             "zone_id": zone_id,
         }
 
-        share_id = nx.share_with_user(
+        share_id = nx.rebac_service.share_with_user_sync(
             resource=("file", file_path),
             user_id="charlie",
             relation="viewer",
@@ -163,7 +163,7 @@ class TestZoneAdminSharing:
         nx.sys_mkdir(zone1_path, context=OperationContext(**admin_context))
         file1_path = f"{zone1_path}/doc.txt"
         nx.sys_write(file1_path, b"test", context=OperationContext(**admin_context))
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="direct_owner",
             object=("file", file1_path),
@@ -175,7 +175,7 @@ class TestZoneAdminSharing:
         nx.sys_mkdir(zone2_path, context=OperationContext(**admin_context))
         file2_path = f"{zone2_path}/doc.txt"
         nx.sys_write(file2_path, b"test", context=OperationContext(**admin_context))
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "dave"),
             relation="direct_owner",
             object=("file", file2_path),
@@ -195,7 +195,7 @@ class TestZoneAdminSharing:
         }
 
         with pytest.raises(PermissionError, match="Only owners or zone admins can share"):
-            nx.share_with_user(
+            nx.rebac_service.share_with_user_sync(
                 resource=("file", file2_path),  # File in techcorp
                 user_id="charlie",
                 relation="viewer",
@@ -215,7 +215,7 @@ class TestZoneAdminSharing:
         nx.sys_write(file_path, b"test content", context=OperationContext(**admin_context))
 
         # Grant bob ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="direct_owner",
             object=("file", file_path),
@@ -236,7 +236,7 @@ class TestZoneAdminSharing:
         }
 
         with pytest.raises(PermissionError, match="Only owners or zone admins can share"):
-            nx.share_with_user(
+            nx.rebac_service.share_with_user_sync(
                 resource=("file", file_path),
                 user_id="charlie",
                 relation="viewer",
@@ -256,7 +256,7 @@ class TestZoneAdminSharing:
         nx.sys_write(file_path, b"test content", context=OperationContext(**admin_context))
 
         # Grant bob ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="direct_owner",
             object=("file", file_path),
@@ -265,13 +265,13 @@ class TestZoneAdminSharing:
         )
 
         # Create group with members
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "charlie"),
             relation="member",
             object=("group", "developers"),
             context=admin_context,
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "dave"),
             relation="member",
             object=("group", "developers"),
@@ -290,7 +290,7 @@ class TestZoneAdminSharing:
             "zone_id": zone_id,
         }
 
-        share_id = nx.share_with_group(
+        share_id = nx.rebac_service.share_with_group_sync(
             resource=("file", file_path),
             group_id="developers",
             relation="viewer",
@@ -299,12 +299,12 @@ class TestZoneAdminSharing:
 
         assert share_id
         # Verify group members can read the file
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "charlie"),
             permission="read",
             object=("file", file_path),
         )
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "dave"),
             permission="read",
             object=("file", file_path),
@@ -327,7 +327,7 @@ class TestBackwardCompatibility:
         nx.sys_write(file_path, b"test content", context=OperationContext(**admin_context))
 
         # Grant bob ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="direct_owner",
             object=("file", file_path),
@@ -344,7 +344,7 @@ class TestBackwardCompatibility:
             "zone_id": zone_id,
         }
 
-        share_id = nx.share_with_user(
+        share_id = nx.rebac_service.share_with_user_sync(
             resource=("file", file_path),
             user_id="alice",
             relation="viewer",

--- a/tests/unit/core/test_mount_permissions.py
+++ b/tests/unit/core/test_mount_permissions.py
@@ -197,7 +197,7 @@ class TestListMountsPermissionFiltering:
         )
 
         # Grant Bob direct_viewer permission on the shared mount
-        nx_with_permissions.rebac_create(
+        nx_with_permissions.rebac_service.rebac_create_sync(
             subject=("user", "bob@example.com"),
             relation="direct_viewer",
             object=("file", "/mnt/shared"),

--- a/tests/unit/core/test_nexus_fs_list_workspaces.py
+++ b/tests/unit/core/test_nexus_fs_list_workspaces.py
@@ -60,37 +60,37 @@ class TestListWorkspacesAuthGuard:
     def test_raises_when_context_is_none(self, nexus_fs) -> None:
         """No context at all should raise ValueError."""
         with pytest.raises(ValueError, match="requires authenticated context"):
-            nexus_fs.list_workspaces(context=None)
+            nexus_fs._workspace_rpc_service.list_workspaces(context=None)
 
     def test_raises_when_user_id_missing(self, nexus_fs) -> None:
         """Context without user_id should raise ValueError."""
         ctx = _make_context(user_id=None, zone_id="root")
         with pytest.raises(ValueError, match="requires authenticated context"):
-            nexus_fs.list_workspaces(context=ctx)
+            nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
     def test_raises_when_zone_id_missing(self, nexus_fs) -> None:
         """Context without zone_id should raise ValueError."""
         ctx = _make_context(user_id="alice", zone_id=None)
         with pytest.raises(ValueError, match="requires authenticated context"):
-            nexus_fs.list_workspaces(context=ctx)
+            nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
     def test_raises_when_both_missing(self, nexus_fs) -> None:
         """Context with neither user_id nor zone_id should raise ValueError."""
         ctx = _make_context(user_id=None, zone_id=None)
         with pytest.raises(ValueError, match="requires authenticated context"):
-            nexus_fs.list_workspaces(context=ctx)
+            nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
     def test_raises_when_user_id_empty_string(self, nexus_fs) -> None:
         """Context with empty string user_id should raise ValueError."""
         ctx = _make_context(user_id="", zone_id="root")
         with pytest.raises(ValueError, match="requires authenticated context"):
-            nexus_fs.list_workspaces(context=ctx)
+            nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
     def test_raises_when_zone_id_empty_string(self, nexus_fs) -> None:
         """Context with empty string zone_id should raise ValueError."""
         ctx = _make_context(user_id="alice", zone_id="")
         with pytest.raises(ValueError, match="requires authenticated context"):
-            nexus_fs.list_workspaces(context=ctx)
+            nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
 
 class TestListWorkspacesFiltering:
@@ -104,7 +104,7 @@ class TestListWorkspacesFiltering:
         ]
 
         ctx = _make_context(user_id="alice", zone_id="root")
-        result = nexus_fs.list_workspaces(context=ctx)
+        result = nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
         assert len(result) == 1
         assert result[0]["path"] == "/zone/root/user/alice/workspace/project1"
@@ -117,7 +117,7 @@ class TestListWorkspacesFiltering:
         ]
 
         ctx = _make_context(user_id="alice", zone_id="root")
-        result = nexus_fs.list_workspaces(context=ctx)
+        result = nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
         assert len(result) == 1
         assert result[0]["path"] == "/shared/team-project"
@@ -134,7 +134,7 @@ class TestListWorkspacesFiltering:
         ]
 
         ctx = _make_context(user_id="alice", zone_id="root")
-        result = nexus_fs.list_workspaces(context=ctx)
+        result = nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
         assert len(result) == 2
         paths = [r["path"] for r in result]
@@ -148,7 +148,7 @@ class TestListWorkspacesFiltering:
         ]
 
         ctx = _make_context(user_id="alice", zone_id="root")
-        result = nexus_fs.list_workspaces(context=ctx)
+        result = nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
         assert result == []
 
@@ -157,7 +157,7 @@ class TestListWorkspacesFiltering:
         nexus_fs._workspace_registry.list_workspaces.return_value = []
 
         ctx = _make_context(user_id="alice", zone_id="root")
-        result = nexus_fs.list_workspaces(context=ctx)
+        result = nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
         assert result == []
 
@@ -169,7 +169,7 @@ class TestListWorkspacesFiltering:
         ]
 
         ctx = _make_context(user_id="alice", zone_id="root")
-        result = nexus_fs.list_workspaces(context=ctx)
+        result = nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
         assert len(result) == 1
         assert result[0]["path"] == "/zone/root/user/alice/workspace/legacy"
@@ -182,7 +182,7 @@ class TestListWorkspacesFiltering:
 
         # Some contexts use 'user' instead of 'user_id'
         ctx = SimpleNamespace(user_id="alice", zone_id="root")
-        result = nexus_fs.list_workspaces(context=ctx)
+        result = nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
         assert len(result) == 1
         assert result[0]["created_by"] == "alice"
@@ -194,6 +194,6 @@ class TestListWorkspacesFiltering:
         ]
 
         ctx = _make_context(user_id="alice", zone_id="root")
-        result = nexus_fs.list_workspaces(context=ctx)
+        result = nexus_fs._workspace_rpc_service.list_workspaces(context=ctx)
 
         assert len(result) == 1

--- a/tests/unit/core/test_nexus_fs_mounts.py
+++ b/tests/unit/core/test_nexus_fs_mounts.py
@@ -68,7 +68,7 @@ class TestListMounts:
 
     def test_list_mounts_empty(self, nx: NexusFS) -> None:
         """Test listing mounts when only root mount exists."""
-        mounts = nx.list_mounts()
+        mounts = nx._mount_core_service.list_mounts()
         # Should have at least the root mount
         assert isinstance(mounts, list)
         # Root mount always exists
@@ -76,7 +76,7 @@ class TestListMounts:
 
     def test_list_mounts_returns_mount_info(self, nx: NexusFS) -> None:
         """Test that list_mounts returns proper mount info structure."""
-        mounts = nx.list_mounts()
+        mounts = nx._mount_core_service.list_mounts()
         assert len(mounts) >= 1
 
         mount = mounts[0]
@@ -91,7 +91,7 @@ class TestListMounts:
         mount_data_dir.mkdir()
 
         # Add a local mount
-        mount_id = nx.add_mount(
+        mount_id = nx._mount_core_service.add_mount(
             mount_point="/mnt/test",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -99,7 +99,7 @@ class TestListMounts:
 
         assert mount_id == "/mnt/test"
 
-        mounts = nx.list_mounts()
+        mounts = nx._mount_core_service.list_mounts()
         mount_points = [m["mount_point"] for m in mounts]
         assert "/mnt/test" in mount_points
 
@@ -114,13 +114,13 @@ class TestGetMount:
 
     def test_get_mount_root(self, nx: NexusFS) -> None:
         """Test getting the root mount."""
-        mount = nx.get_mount("/")
+        mount = nx._mount_core_service.get_mount("/")
         assert mount is not None
         assert mount["mount_point"] == "/"
 
     def test_get_mount_nonexistent(self, nx: NexusFS) -> None:
         """Test getting a nonexistent mount returns None."""
-        mount = nx.get_mount("/nonexistent")
+        mount = nx._mount_core_service.get_mount("/nonexistent")
         assert mount is None
 
     def test_get_mount_after_add(self, nx: NexusFS, temp_dir: Path) -> None:
@@ -128,14 +128,14 @@ class TestGetMount:
         mount_data_dir = temp_dir / "mount_data"
         mount_data_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/test",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
             readonly=True,
         )
 
-        mount = nx.get_mount("/mnt/test")
+        mount = nx._mount_core_service.get_mount("/mnt/test")
         assert mount is not None
         assert mount["mount_point"] == "/mnt/test"
         assert mount["readonly"] is True
@@ -146,26 +146,26 @@ class TestHasMount:
 
     def test_has_mount_root(self, nx: NexusFS) -> None:
         """Test has_mount returns True for root mount."""
-        assert nx.has_mount("/") is True
+        assert nx._mount_core_service.has_mount("/") is True
 
     def test_has_mount_nonexistent(self, nx: NexusFS) -> None:
         """Test has_mount returns False for nonexistent mount."""
-        assert nx.has_mount("/nonexistent") is False
+        assert nx._mount_core_service.has_mount("/nonexistent") is False
 
     def test_has_mount_after_add(self, nx: NexusFS, temp_dir: Path) -> None:
         """Test has_mount after adding a mount."""
         mount_data_dir = temp_dir / "mount_data"
         mount_data_dir.mkdir()
 
-        assert nx.has_mount("/mnt/test") is False
+        assert nx._mount_core_service.has_mount("/mnt/test") is False
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/test",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
         )
 
-        assert nx.has_mount("/mnt/test") is True
+        assert nx._mount_core_service.has_mount("/mnt/test") is True
 
 
 class TestAddMount:
@@ -176,28 +176,28 @@ class TestAddMount:
         mount_data_dir = temp_dir / "local_mount"
         mount_data_dir.mkdir()
 
-        mount_id = nx.add_mount(
+        mount_id = nx._mount_core_service.add_mount(
             mount_point="/mnt/local",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
         )
 
         assert mount_id == "/mnt/local"
-        assert nx.has_mount("/mnt/local")
+        assert nx._mount_core_service.has_mount("/mnt/local")
 
     def test_add_mount_with_io_profile(self, nx: NexusFS, temp_dir: Path) -> None:
         """Test adding a mount with custom io_profile."""
         mount_data_dir = temp_dir / "profile_mount"
         mount_data_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/fast_read",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
             io_profile="fast_read",
         )
 
-        mount = nx.get_mount("/mnt/fast_read")
+        mount = nx._mount_core_service.get_mount("/mnt/fast_read")
         assert mount is not None
 
     def test_add_mount_readonly(self, nx: NexusFS, temp_dir: Path) -> None:
@@ -205,21 +205,21 @@ class TestAddMount:
         mount_data_dir = temp_dir / "readonly_mount"
         mount_data_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/readonly",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
             readonly=True,
         )
 
-        mount = nx.get_mount("/mnt/readonly")
+        mount = nx._mount_core_service.get_mount("/mnt/readonly")
         assert mount is not None
         assert mount["readonly"] is True
 
     def test_add_mount_unsupported_backend_raises_error(self, nx: NexusFS) -> None:
         """Test adding an unsupported backend type raises RuntimeError."""
         with pytest.raises(RuntimeError, match="Unsupported backend type"):
-            nx.add_mount(
+            nx._mount_core_service.add_mount(
                 mount_point="/mnt/unsupported",
                 backend_type="unsupported_backend",
                 backend_config={},
@@ -244,14 +244,14 @@ class TestAddMount:
             is_admin=True,
         )
 
-        nx_with_permissions.add_mount(
+        nx_with_permissions._mount_core_service.add_mount(
             mount_point="/mnt/alice",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
             context=context,
         )
 
-        assert nx_with_permissions.has_mount("/mnt/alice")
+        assert nx_with_permissions._mount_core_service.has_mount("/mnt/alice")
 
 
 class TestRemoveMount:
@@ -262,21 +262,21 @@ class TestRemoveMount:
         mount_data_dir = temp_dir / "removable_mount"
         mount_data_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/removable",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
         )
 
-        assert nx.has_mount("/mnt/removable")
+        assert nx._mount_core_service.has_mount("/mnt/removable")
 
-        result = nx.remove_mount("/mnt/removable")
+        result = nx._mount_core_service.remove_mount("/mnt/removable")
         assert result["removed"] is True
-        assert nx.has_mount("/mnt/removable") is False
+        assert nx._mount_core_service.has_mount("/mnt/removable") is False
 
     def test_remove_mount_nonexistent(self, nx: NexusFS) -> None:
         """Test removing a nonexistent mount returns error."""
-        result = nx.remove_mount("/mnt/nonexistent")
+        result = nx._mount_core_service.remove_mount("/mnt/nonexistent")
         assert result["removed"] is False
         assert "Mount not found" in result["errors"][0]
 
@@ -285,13 +285,13 @@ class TestRemoveMount:
         mount_data_dir = temp_dir / "cleanup_mount"
         mount_data_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/cleanup",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
         )
 
-        result = nx.remove_mount("/mnt/cleanup")
+        result = nx._mount_core_service.remove_mount("/mnt/cleanup")
 
         assert "removed" in result
         assert "directory_deleted" in result
@@ -318,7 +318,7 @@ class TestSaveMount:
             # Check if mount_manager is available
             if not hasattr(nx, "mount_manager") or nx.mount_manager is None:
                 with pytest.raises(RuntimeError, match="Mount manager not available"):
-                    nx.save_mount(
+                    nx._mount_persist_service.save_mount(
                         mount_point="/mnt/test",
                         backend_type="cas_local",
                         backend_config={"data_dir": str(temp_dir)},
@@ -334,7 +334,7 @@ class TestSaveMount:
         mount_data_dir = temp_dir / "saved_mount"
         mount_data_dir.mkdir()
 
-        mount_id = nx.save_mount(
+        mount_id = nx._mount_persist_service.save_mount(
             mount_point="/mnt/saved",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -443,7 +443,7 @@ class TestSyncMount:
     def test_sync_mount_nonexistent_raises_error(self, nx: NexusFS) -> None:
         """Test that sync_mount raises ValueError for nonexistent mount."""
         with pytest.raises(ValueError, match="Mount not found"):
-            nx.sync_mount("/mnt/nonexistent")
+            nx._sync_service.sync_mount_flat("/mnt/nonexistent")
 
     def test_sync_mount_non_connector_backend_raises_error(
         self, nx: NexusFS, temp_dir: Path
@@ -455,7 +455,7 @@ class TestSyncMount:
         mount_data_dir = temp_dir / "sync_mount"
         mount_data_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/sync",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -463,7 +463,7 @@ class TestSyncMount:
 
         # CASLocalBackend has list_dir, so it won't raise the "does not support" error
         # but we can test the sync functionality
-        result = nx.sync_mount("/mnt/sync")
+        result = nx._sync_service.sync_mount_flat("/mnt/sync")
         assert "files_scanned" in result
         assert "files_created" in result
         assert "files_updated" in result
@@ -479,14 +479,14 @@ class TestSyncMount:
         (mount_data_dir / "file1.txt").write_text("content1")
         (mount_data_dir / "file2.txt").write_text("content2")
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/dryrun",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
         )
 
         # Dry run should not create entries in database
-        result = nx.sync_mount("/mnt/dryrun", dry_run=True)
+        result = nx._sync_service.sync_mount_flat("/mnt/dryrun", dry_run=True)
 
         assert result["files_scanned"] >= 0
         assert result["files_created"] == 0  # Dry run doesn't create
@@ -504,13 +504,13 @@ class TestSyncMount:
         (mount_data_dir / "file1.txt").write_text("content1")
         (subdir / "file2.txt").write_text("content2")
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/recursive",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
         )
 
-        result = nx.sync_mount("/mnt/recursive", recursive=True)
+        result = nx._sync_service.sync_mount_flat("/mnt/recursive", recursive=True)
 
         assert "files_scanned" in result
         assert "files_created" in result
@@ -529,7 +529,7 @@ class TestSyncMount:
         mount_data_dir.mkdir()
         (mount_data_dir / "file.txt").write_text("content")
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/context",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -544,7 +544,7 @@ class TestSyncMount:
             is_admin=True,
         )
 
-        result = nx.sync_mount("/mnt/context", context=context)
+        result = nx._sync_service.sync_mount_flat("/mnt/context", context=context)
 
         assert "files_scanned" in result
         assert "errors" in result
@@ -573,7 +573,7 @@ class TestMountPermissionEnforcement:
         )
 
         with pytest.raises(PermissionError, match="no write permission"):
-            nx_with_permissions.add_mount(
+            nx_with_permissions._mount_core_service.add_mount(
                 mount_point="/mnt/bob_mount",
                 backend_type="cas_local",
                 backend_config={"data_dir": str(mount_data_dir)},
@@ -598,7 +598,7 @@ class TestMountPermissionEnforcement:
             subject_id="admin",
             is_admin=True,
         )
-        nx_with_permissions.add_mount(
+        nx_with_permissions._mount_core_service.add_mount(
             mount_point="/mnt/admin_mount",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -616,7 +616,9 @@ class TestMountPermissionEnforcement:
         )
 
         with pytest.raises(PermissionError, match="no write permission"):
-            nx_with_permissions.remove_mount("/mnt/admin_mount", context=user_context)
+            nx_with_permissions._mount_core_service.remove_mount(
+                "/mnt/admin_mount", context=user_context
+            )
 
     def test_sync_mount_requires_read_permission(
         self, nx_with_permissions: NexusFS, temp_dir: Path
@@ -636,7 +638,7 @@ class TestMountPermissionEnforcement:
             subject_id="admin",
             is_admin=True,
         )
-        nx_with_permissions.add_mount(
+        nx_with_permissions._mount_core_service.add_mount(
             mount_point="/mnt/sync_test",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -654,7 +656,9 @@ class TestMountPermissionEnforcement:
         )
 
         with pytest.raises(PermissionError, match="no read permission"):
-            nx_with_permissions.sync_mount("/mnt/sync_test", context=user_context)
+            nx_with_permissions._sync_service.sync_mount_flat(
+                "/mnt/sync_test", context=user_context
+            )
 
     def test_get_mount_returns_none_without_read_permission(
         self, nx_with_permissions: NexusFS, temp_dir: Path
@@ -674,7 +678,7 @@ class TestMountPermissionEnforcement:
             subject_id="admin",
             is_admin=True,
         )
-        nx_with_permissions.add_mount(
+        nx_with_permissions._mount_core_service.add_mount(
             mount_point="/mnt/get_test",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -691,7 +695,9 @@ class TestMountPermissionEnforcement:
             is_admin=False,
         )
 
-        result = nx_with_permissions.get_mount("/mnt/get_test", context=user_context)
+        result = nx_with_permissions._mount_core_service.get_mount(
+            "/mnt/get_test", context=user_context
+        )
         assert result is None
 
     def test_no_context_allows_operations_for_backward_compatibility(
@@ -702,7 +708,7 @@ class TestMountPermissionEnforcement:
         mount_data_dir.mkdir()
 
         # Should succeed without context
-        mount_id = nx.add_mount(
+        mount_id = nx._mount_core_service.add_mount(
             mount_point="/mnt/no_ctx",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -711,15 +717,15 @@ class TestMountPermissionEnforcement:
         assert mount_id == "/mnt/no_ctx"
 
         # get_mount should also work
-        mount = nx.get_mount("/mnt/no_ctx", context=None)
+        mount = nx._mount_core_service.get_mount("/mnt/no_ctx", context=None)
         assert mount is not None
 
         # sync_mount should work
-        result = nx.sync_mount("/mnt/no_ctx", context=None)
+        result = nx._sync_service.sync_mount_flat("/mnt/no_ctx", context=None)
         assert "files_scanned" in result
 
         # remove_mount should work
-        result = nx.remove_mount("/mnt/no_ctx", context=None)
+        result = nx._mount_core_service.remove_mount("/mnt/no_ctx", context=None)
         assert result["removed"] is True
 
 
@@ -755,7 +761,7 @@ class TestMountIntegration:
         mount_data_dir = temp_dir / "write_mount"
         mount_data_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/write",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -773,7 +779,7 @@ class TestMountIntegration:
         mount_data_dir = temp_dir / "list_mount"
         mount_data_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/list",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -796,21 +802,21 @@ class TestMountIntegration:
         mount1_dir.mkdir()
         mount2_dir.mkdir()
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/one",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount1_dir)},
         )
 
-        nx.add_mount(
+        nx._mount_core_service.add_mount(
             mount_point="/mnt/two",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount2_dir)},
         )
 
         # Both mounts should exist
-        assert nx.has_mount("/mnt/one")
-        assert nx.has_mount("/mnt/two")
+        assert nx._mount_core_service.has_mount("/mnt/one")
+        assert nx._mount_core_service.has_mount("/mnt/two")
 
         # Write to each
         nx.sys_write("/mnt/one/file.txt", b"Mount 1")
@@ -851,7 +857,7 @@ class TestMountContextUtilsIntegration:
             mock_get_zone.return_value = "test_zone"
             mock_get_user.return_value = ("user", "alice")
 
-            nx_with_permissions.add_mount(
+            nx_with_permissions._mount_core_service.add_mount(
                 mount_point="/mnt/context_test",
                 backend_type="cas_local",
                 backend_config={"data_dir": str(mount_data_dir)},
@@ -880,7 +886,7 @@ class TestMountContextUtilsIntegration:
         )
 
         # Add mount first
-        nx_with_permissions.add_mount(
+        nx_with_permissions._mount_core_service.add_mount(
             mount_point="/mnt/remove_test",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -888,11 +894,13 @@ class TestMountContextUtilsIntegration:
         )
 
         # Remove mount with context - should work correctly
-        result = nx_with_permissions.remove_mount("/mnt/remove_test", context=context)
+        result = nx_with_permissions._mount_core_service.remove_mount(
+            "/mnt/remove_test", context=context
+        )
 
         # Verify mount was removed
         assert result["removed"] is True
-        assert not nx_with_permissions.has_mount("/mnt/remove_test")
+        assert not nx_with_permissions._mount_core_service.has_mount("/mnt/remove_test")
 
     def test_add_mount_oauth_backend_uses_context_utils_database_url(
         self, nx: NexusFS, temp_dir: Path
@@ -915,7 +923,7 @@ class TestMountContextUtilsIntegration:
 
             # This should use get_database_url for gdrive_connector
             with contextlib.suppress(Exception):
-                nx.add_mount(
+                nx._mount_core_service.add_mount(
                     mount_point="/mnt/gdrive",
                     backend_type="gdrive_connector",
                     backend_config={},
@@ -957,7 +965,7 @@ class TestMountContextUtilsIntegration:
 
         # Should not raise error with None context - context_utils provides defaults
         # This tests that the refactored code works with None context
-        nx_with_permissions.add_mount(
+        nx_with_permissions._mount_core_service.add_mount(
             mount_point="/mnt/none_context",
             backend_type="cas_local",
             backend_config={"data_dir": str(mount_data_dir)},
@@ -965,4 +973,4 @@ class TestMountContextUtilsIntegration:
         )
 
         # Verify mount was created successfully
-        assert nx_with_permissions.has_mount("/mnt/none_context")
+        assert nx_with_permissions._mount_core_service.has_mount("/mnt/none_context")

--- a/tests/unit/core/test_nexus_fs_rebac_mixin.py
+++ b/tests/unit/core/test_nexus_fs_rebac_mixin.py
@@ -118,7 +118,7 @@ class TestRebacCreate:
 
     def test_rebac_create_basic(self, nx: NexusFS) -> None:
         """Test creating a basic relationship tuple."""
-        result = nx.rebac_create(
+        result = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("file", "/test.txt"),
@@ -130,7 +130,7 @@ class TestRebacCreate:
 
     def test_rebac_create_with_zone(self, nx: NexusFS) -> None:
         """Test creating relationship with zone_id."""
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("file", "/test.txt"),
@@ -143,7 +143,7 @@ class TestRebacCreate:
         """Test creating relationship with expiration."""
         expires = datetime.now(UTC) + timedelta(hours=1)
 
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("file", "/test.txt"),
@@ -155,7 +155,7 @@ class TestRebacCreate:
     def test_rebac_create_invalid_subject_raises_error(self, nx: NexusFS) -> None:
         """Test that invalid subject raises ValueError."""
         with pytest.raises(ValueError, match="subject must be"):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject="invalid",  # type: ignore[arg-type]
                 relation="viewer-of",
                 object=("file", "/test.txt"),
@@ -164,7 +164,7 @@ class TestRebacCreate:
     def test_rebac_create_invalid_object_raises_error(self, nx: NexusFS) -> None:
         """Test that invalid object raises ValueError."""
         with pytest.raises(ValueError, match="object must be"):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject=("user", "alice"),
                 relation="viewer-of",
                 object="invalid",  # type: ignore[arg-type]
@@ -172,7 +172,7 @@ class TestRebacCreate:
 
     def test_rebac_create_group_membership(self, nx: NexusFS) -> None:
         """Test creating group membership relationship."""
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="member-of",
             object=("group", "developers"),
@@ -182,7 +182,7 @@ class TestRebacCreate:
 
     def test_rebac_create_owner_relationship(self, nx: NexusFS) -> None:
         """Test creating owner relationship."""
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("group", "admins"),
             relation="owner-of",
             object=("file", "/workspace"),
@@ -198,7 +198,7 @@ class TestRebacCheck:
         """Test checking a direct permission."""
         # Create a direct_owner relationship with zone_id
         # direct_owner is a standard relation that grants read access
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/test.txt"),
@@ -206,7 +206,7 @@ class TestRebacCheck:
         )
 
         # Check permission with zone_id
-        has_permission = nx.rebac_check(
+        has_permission = nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/test.txt"),
@@ -217,7 +217,7 @@ class TestRebacCheck:
 
     def test_rebac_check_no_permission(self, nx: NexusFS) -> None:
         """Test checking when no permission exists."""
-        has_permission = nx.rebac_check(
+        has_permission = nx.rebac_service.rebac_check_sync(
             subject=("user", "bob"),
             permission="read",
             object=("file", "/secret.txt"),
@@ -229,7 +229,7 @@ class TestRebacCheck:
     def test_rebac_check_invalid_subject_raises_error(self, nx: NexusFS) -> None:
         """Test that invalid subject raises ValueError."""
         with pytest.raises(ValueError, match="subject must be"):
-            nx.rebac_check(
+            nx.rebac_service.rebac_check_sync(
                 subject="invalid",  # type: ignore[arg-type]
                 permission="read",
                 object=("file", "/test.txt"),
@@ -238,7 +238,7 @@ class TestRebacCheck:
     def test_rebac_check_invalid_object_raises_error(self, nx: NexusFS) -> None:
         """Test that invalid object raises ValueError."""
         with pytest.raises(ValueError, match="object must be"):
-            nx.rebac_check(
+            nx.rebac_service.rebac_check_sync(
                 subject=("user", "alice"),
                 permission="read",
                 object="invalid",  # type: ignore[arg-type]
@@ -247,7 +247,7 @@ class TestRebacCheck:
     def test_rebac_check_with_zone_isolation(self, nx: NexusFS) -> None:
         """Test that zone isolation works."""
         # Create permission in zone "acme"
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/test.txt"),
@@ -255,7 +255,7 @@ class TestRebacCheck:
         )
 
         # Check in same zone
-        has_permission = nx.rebac_check(
+        has_permission = nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/test.txt"),
@@ -264,7 +264,7 @@ class TestRebacCheck:
         assert has_permission is True
 
         # Check in different zone (should not have access)
-        has_permission = nx.rebac_check(
+        has_permission = nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/test.txt"),
@@ -279,13 +279,13 @@ class TestRebacExpand:
     def test_rebac_expand_basic(self, nx: NexusFS) -> None:
         """Test expanding permissions to find all subjects."""
         # Create some relationships with zone_id using direct_owner relation
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "expand_alice"),
             relation="direct_owner",
             object=("file", "/expand_test.txt"),
             zone_id="root",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "expand_bob"),
             relation="direct_owner",
             object=("file", "/expand_test.txt"),
@@ -293,7 +293,7 @@ class TestRebacExpand:
         )
 
         # Expand to find all subjects with read permission
-        subjects = nx.rebac_expand(
+        subjects = nx.rebac_service.rebac_expand_sync(
             permission="read",
             object=("file", "/expand_test.txt"),
         )
@@ -303,7 +303,7 @@ class TestRebacExpand:
 
     def test_rebac_expand_empty(self, nx: NexusFS) -> None:
         """Test expanding when no subjects have permission."""
-        subjects = nx.rebac_expand(
+        subjects = nx.rebac_service.rebac_expand_sync(
             permission="read",
             object=("file", "/totally_unique_nonexistent.txt"),
         )
@@ -314,7 +314,7 @@ class TestRebacExpand:
     def test_rebac_expand_invalid_object_raises_error(self, nx: NexusFS) -> None:
         """Test that invalid object raises ValueError."""
         with pytest.raises(ValueError, match="object must be"):
-            nx.rebac_expand(
+            nx.rebac_service.rebac_expand_sync(
                 permission="read",
                 object="invalid",  # type: ignore[arg-type]
             )
@@ -325,18 +325,18 @@ class TestRebacDelete:
 
     def test_rebac_delete_existing_tuple(self, nx: NexusFS) -> None:
         """Test deleting an existing tuple."""
-        write_result = nx.rebac_create(
+        write_result = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("file", "/test.txt"),
         )
 
         # Delete the tuple
-        deleted = nx.rebac_delete(write_result["tuple_id"])
+        deleted = nx.rebac_service.rebac_delete_sync(write_result["tuple_id"])
         assert deleted is True
 
         # Check permission should now fail
-        has_permission = nx.rebac_check(
+        has_permission = nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/test.txt"),
@@ -345,7 +345,7 @@ class TestRebacDelete:
 
     def test_rebac_delete_nonexistent_tuple(self, nx: NexusFS) -> None:
         """Test deleting a nonexistent tuple returns False."""
-        deleted = nx.rebac_delete("nonexistent-tuple-id")
+        deleted = nx.rebac_service.rebac_delete_sync("nonexistent-tuple-id")
         assert deleted is False
 
 
@@ -354,14 +354,14 @@ class TestRebacExplain:
 
     def test_rebac_explain_with_permission(self, nx: NexusFS) -> None:
         """Test explaining a granted permission."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/test.txt"),
             zone_id="root",
         )
 
-        explanation = nx.rebac_explain(
+        explanation = nx.rebac_service.rebac_explain_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/test.txt"),
@@ -374,7 +374,7 @@ class TestRebacExplain:
 
     def test_rebac_explain_without_permission(self, nx: NexusFS) -> None:
         """Test explaining a denied permission."""
-        explanation = nx.rebac_explain(
+        explanation = nx.rebac_service.rebac_explain_sync(
             subject=("user", "bob"),
             permission="write",
             object=("file", "/test.txt"),
@@ -388,7 +388,7 @@ class TestRebacExplain:
     def test_rebac_explain_invalid_subject_raises_error(self, nx: NexusFS) -> None:
         """Test that invalid subject raises ValueError."""
         with pytest.raises(ValueError, match="subject must be"):
-            nx.rebac_explain(
+            nx.rebac_service.rebac_explain_sync(
                 subject="invalid",  # type: ignore[arg-type]
                 permission="read",
                 object=("file", "/test.txt"),
@@ -401,13 +401,13 @@ class TestRebacCheckBatch:
     def test_rebac_check_batch_basic(self, nx: NexusFS) -> None:
         """Test batch permission checks."""
         # Create some relationships with zone_id using direct_owner relation
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "batch_alice"),
             relation="direct_owner",
             object=("file", "/batch_file1.txt"),
             zone_id="root",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "batch_alice"),
             relation="direct_owner",
             object=("file", "/batch_file2.txt"),
@@ -421,7 +421,7 @@ class TestRebacCheckBatch:
             (("user", "batch_bob"), "read", ("file", "/batch_file1.txt")),
         ]
 
-        results = nx.rebac_check_batch(checks)
+        results = nx.rebac_service.rebac_check_batch_sync(checks)
 
         assert isinstance(results, list)
         assert len(results) == 3
@@ -431,7 +431,7 @@ class TestRebacCheckBatch:
     def test_rebac_check_batch_invalid_check_raises_error(self, nx: NexusFS) -> None:
         """Test that invalid check format raises ValueError."""
         with pytest.raises(ValueError, match="Check 0 must be"):
-            nx.rebac_check_batch(["invalid"])  # type: ignore[list-item]
+            nx.rebac_service.rebac_check_batch_sync(["invalid"])  # type: ignore[list-item]
 
 
 class TestRebacListTuples:
@@ -440,36 +440,36 @@ class TestRebacListTuples:
     def test_rebac_list_tuples_all(self, nx: NexusFS) -> None:
         """Test listing all tuples."""
         # Create some tuples
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("file", "/test.txt"),
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="editor-of",
             object=("file", "/test.txt"),
         )
 
-        tuples = nx.rebac_list_tuples()
+        tuples = nx.rebac_service.rebac_list_tuples_sync()
 
         assert isinstance(tuples, list)
         assert len(tuples) >= 2
 
     def test_rebac_list_tuples_by_subject(self, nx: NexusFS) -> None:
         """Test filtering tuples by subject."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("file", "/test1.txt"),
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="viewer-of",
             object=("file", "/test2.txt"),
         )
 
-        tuples = nx.rebac_list_tuples(subject=("user", "alice"))
+        tuples = nx.rebac_service.rebac_list_tuples_sync(subject=("user", "alice"))
 
         # All returned tuples should have alice as subject
         for t in tuples:
@@ -478,18 +478,18 @@ class TestRebacListTuples:
 
     def test_rebac_list_tuples_by_relation(self, nx: NexusFS) -> None:
         """Test filtering tuples by relation."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("file", "/test.txt"),
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="editor-of",
             object=("file", "/test.txt"),
         )
 
-        tuples = nx.rebac_list_tuples(relation="viewer-of")
+        tuples = nx.rebac_service.rebac_list_tuples_sync(relation="viewer-of")
 
         # All returned tuples should have viewer-of relation
         for t in tuples:
@@ -497,18 +497,18 @@ class TestRebacListTuples:
 
     def test_rebac_list_tuples_by_object(self, nx: NexusFS) -> None:
         """Test filtering tuples by object."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("file", "/target.txt"),
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="viewer-of",
             object=("file", "/other.txt"),
         )
 
-        tuples = nx.rebac_list_tuples(object=("file", "/target.txt"))
+        tuples = nx.rebac_service.rebac_list_tuples_sync(object=("file", "/target.txt"))
 
         # All returned tuples should have target.txt as object
         for t in tuples:
@@ -594,7 +594,7 @@ class TestNamespaceOperations:
 
     def test_namespace_create(self, nx: NexusFS) -> None:
         """Test creating/updating a namespace."""
-        nx.namespace_create(
+        nx.rebac_service.namespace_create_sync(
             "project",
             {
                 "relations": {
@@ -614,12 +614,12 @@ class TestNamespaceOperations:
     def test_namespace_create_invalid_config(self, nx: NexusFS) -> None:
         """Test creating namespace with invalid config raises ValueError."""
         with pytest.raises(ValueError, match="relations"):
-            nx.namespace_create("invalid", {"permissions": {}})
+            nx.rebac_service.namespace_create_sync("invalid", {"permissions": {}})
 
     def test_namespace_list(self, nx: NexusFS) -> None:
         """Test listing namespaces."""
         # Create a namespace
-        nx.namespace_create(
+        nx.rebac_service.namespace_create_sync(
             "test_list",
             {
                 "relations": {"viewer": {}},
@@ -627,13 +627,13 @@ class TestNamespaceOperations:
             },
         )
 
-        namespaces = nx.namespace_list()
+        namespaces = nx.rebac_service.namespace_list_sync()
         assert isinstance(namespaces, list)
 
     def test_namespace_delete(self, nx: NexusFS) -> None:
         """Test deleting a namespace."""
         # Create namespace
-        nx.namespace_create(
+        nx.rebac_service.namespace_create_sync(
             "deletable",
             {
                 "relations": {"viewer": {}},
@@ -642,7 +642,7 @@ class TestNamespaceOperations:
         )
 
         # Delete it
-        deleted = nx.namespace_delete("deletable")
+        deleted = nx.rebac_service.namespace_delete_sync("deletable")
         assert deleted is True
 
         # Verify deleted
@@ -651,7 +651,7 @@ class TestNamespaceOperations:
 
     def test_namespace_delete_nonexistent(self, nx: NexusFS) -> None:
         """Test deleting nonexistent namespace returns False."""
-        deleted = nx.namespace_delete("nonexistent_namespace")
+        deleted = nx.rebac_service.namespace_delete_sync("nonexistent_namespace")
         assert deleted is False
 
 
@@ -660,7 +660,7 @@ class TestConsentAndPrivacy:
 
     def test_grant_consent(self, nx: NexusFS) -> None:
         """Test granting consent for discovery."""
-        tuple_id = nx.grant_consent(
+        tuple_id = nx.rebac_service.grant_consent_sync(
             from_subject=("profile", "alice"),
             to_subject=("user", "bob"),
             zone_id="root",
@@ -672,7 +672,7 @@ class TestConsentAndPrivacy:
         """Test granting consent with expiration."""
         expires = datetime.now(UTC) + timedelta(days=30)
 
-        tuple_id = nx.grant_consent(
+        tuple_id = nx.rebac_service.grant_consent_sync(
             from_subject=("profile", "alice"),
             to_subject=("user", "bob"),
             expires_at=expires,
@@ -684,7 +684,7 @@ class TestConsentAndPrivacy:
     def test_revoke_consent(self, nx: NexusFS) -> None:
         """Test revoking consent."""
         # Grant consent
-        tuple_id = nx.grant_consent(
+        tuple_id = nx.rebac_service.grant_consent_sync(
             from_subject=("profile", "consent_alice"),
             to_subject=("user", "consent_bob"),
             zone_id="root",
@@ -694,7 +694,7 @@ class TestConsentAndPrivacy:
 
         # Revoke consent - should work or return False if already revoked
         try:
-            revoked = nx.revoke_consent(
+            revoked = nx.rebac_service.revoke_consent_sync(
                 from_subject=("profile", "consent_alice"),
                 to_subject=("user", "consent_bob"),
                 zone_id="root",
@@ -708,7 +708,7 @@ class TestConsentAndPrivacy:
     def test_revoke_consent_nonexistent(self, nx: NexusFS) -> None:
         """Test revoking nonexistent consent."""
         try:
-            revoked = nx.revoke_consent(
+            revoked = nx.rebac_service.revoke_consent_sync(
                 from_subject=("profile", "nonexistent_charlie"),
                 to_subject=("user", "nonexistent_dave"),
                 zone_id="root",
@@ -720,17 +720,19 @@ class TestConsentAndPrivacy:
 
     def test_make_public(self, nx: NexusFS) -> None:
         """Test making a resource publicly discoverable."""
-        tuple_id = nx.make_public(("profile", "public_alice"), zone_id="root")
+        tuple_id = nx.rebac_service.make_public_sync(("profile", "public_alice"), zone_id="root")
         assert tuple_id is not None
 
     def test_make_private(self, nx: NexusFS) -> None:
         """Test making a resource private."""
         # Make public first
-        nx.make_public(("profile", "private_alice"), zone_id="root")
+        nx.rebac_service.make_public_sync(("profile", "private_alice"), zone_id="root")
 
         # Make private - implementation varies
         try:
-            made_private = nx.make_private(("profile", "private_alice"), zone_id="root")
+            made_private = nx.rebac_service.make_private_sync(
+                ("profile", "private_alice"), zone_id="root"
+            )
             assert isinstance(made_private, bool)
         except (ValueError, RuntimeError, TypeError):
             # Some implementations may raise if public relation doesn't exist
@@ -739,7 +741,9 @@ class TestConsentAndPrivacy:
     def test_make_private_already_private(self, nx: NexusFS) -> None:
         """Test making already private resource."""
         try:
-            made_private = nx.make_private(("profile", "already_private_bob"), zone_id="root")
+            made_private = nx.rebac_service.make_private_sync(
+                ("profile", "already_private_bob"), zone_id="root"
+            )
             assert isinstance(made_private, bool)
         except (ValueError, RuntimeError, TypeError):
             # Some implementations may raise if public relation doesn't exist
@@ -748,7 +752,7 @@ class TestConsentAndPrivacy:
     def test_rebac_expand_with_privacy(self, nx: NexusFS) -> None:
         """Test privacy-aware expansion."""
         # Create direct_owner relationship (standard relation)
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "privacy_alice"),
             relation="direct_owner",
             object=("file", "/privacy_doc.txt"),
@@ -756,7 +760,7 @@ class TestConsentAndPrivacy:
         )
 
         # Without privacy filtering
-        subjects = nx.rebac_expand_with_privacy(
+        subjects = nx.rebac_service.rebac_expand_with_privacy_sync(
             "read",
             ("file", "/privacy_doc.txt"),
             respect_consent=False,
@@ -774,7 +778,7 @@ class TestDynamicViewer:
         """Test basic dynamic viewer filter application."""
         csv_data = "name,email,age,password\nalice,a@ex.com,30,secret\nbob,b@ex.com,25,pwd\n"
 
-        result = nx.apply_dynamic_viewer_filter(
+        result = nx.rebac_service.apply_dynamic_viewer_filter_sync(
             data=csv_data,
             column_config={
                 "hidden_columns": ["password"],
@@ -797,7 +801,7 @@ class TestDynamicViewer:
         """Test dynamic viewer filter with aggregations."""
         csv_data = "name,salary\nalice,50000\nbob,60000\n"
 
-        result = nx.apply_dynamic_viewer_filter(
+        result = nx.rebac_service.apply_dynamic_viewer_filter_sync(
             data=csv_data,
             column_config={
                 "hidden_columns": [],
@@ -813,7 +817,7 @@ class TestDynamicViewer:
     def test_apply_dynamic_viewer_filter_unsupported_format(self, nx: NexusFS) -> None:
         """Test that unsupported format raises ValueError."""
         with pytest.raises(ValueError, match="Unsupported file format"):
-            nx.apply_dynamic_viewer_filter(
+            nx.rebac_service.apply_dynamic_viewer_filter_sync(
                 data="some data",
                 column_config={},
                 file_format="json",
@@ -821,7 +825,7 @@ class TestDynamicViewer:
 
     def test_get_dynamic_viewer_config_no_config(self, nx: NexusFS) -> None:
         """Test getting dynamic viewer config when none exists."""
-        config = nx.get_dynamic_viewer_config(
+        config = nx.rebac_service.get_dynamic_viewer_config_sync(
             subject=("user", "alice"),
             file_path="/nonexistent.csv",
         )
@@ -848,7 +852,7 @@ class TestRebacIntegration:
         nx_no_permissions.sys_write("/protected.txt", b"Secret content")
 
         # Create read permission for alice with direct_owner relation
-        nx_no_permissions.rebac_create(
+        nx_no_permissions.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/protected.txt"),
@@ -856,7 +860,7 @@ class TestRebacIntegration:
         )
 
         # This tests that the permission check works
-        has_read = nx_no_permissions.rebac_check(
+        has_read = nx_no_permissions.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/protected.txt"),
@@ -865,7 +869,7 @@ class TestRebacIntegration:
         assert has_read is True
 
         # Bob should not have permission
-        has_read = nx_no_permissions.rebac_check(
+        has_read = nx_no_permissions.rebac_service.rebac_check_sync(
             subject=("user", "bob"),
             permission="read",
             object=("file", "/protected.txt"),
@@ -876,7 +880,7 @@ class TestRebacIntegration:
     def test_group_inheritance(self, nx: NexusFS) -> None:
         """Test that relationships can be created for groups."""
         # Alice is member of developers
-        tuple1 = nx.rebac_create(
+        tuple1 = nx.rebac_service.rebac_create_sync(
             subject=("user", "group_alice"),
             relation="member",
             object=("group", "group_developers"),
@@ -884,7 +888,7 @@ class TestRebacIntegration:
         )
 
         # Developers group has direct_owner access to file
-        tuple2 = nx.rebac_create(
+        tuple2 = nx.rebac_service.rebac_create_sync(
             subject=("group", "group_developers"),
             relation="direct_owner",
             object=("file", "/project/group_code.py"),

--- a/tests/unit/core/test_rebac_manager_operations.py
+++ b/tests/unit/core/test_rebac_manager_operations.py
@@ -63,7 +63,7 @@ class TestRebacCreate:
 
     def test_create_basic_tuple(self, nx: NexusFS) -> None:
         """Test creating a basic relationship tuple."""
-        result = nx.rebac_create(
+        result = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/doc.txt"),
@@ -75,7 +75,7 @@ class TestRebacCreate:
 
     def test_create_with_different_zone(self, nx: NexusFS) -> None:
         """Test creating tuple with specific zone_id."""
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/doc.txt"),
@@ -86,7 +86,7 @@ class TestRebacCreate:
     def test_create_with_expiration(self, nx: NexusFS) -> None:
         """Test creating tuple with TTL expiration."""
         future_time = datetime.now(UTC) + timedelta(hours=1)
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/doc.txt"),
@@ -98,14 +98,14 @@ class TestRebacCreate:
     def test_create_userset_as_subject(self, nx: NexusFS) -> None:
         """Test creating tuple with userset-as-subject (3-tuple)."""
         # First create group membership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="member-of",
             object=("group", "engineering"),
             zone_id="root",
         )
         # Then grant permission to group members
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("group", "engineering", "member"),
             relation="direct_owner",
             object=("file", "/docs/readme.txt"),
@@ -116,7 +116,7 @@ class TestRebacCreate:
     def test_create_invalid_subject_raises(self, nx: NexusFS) -> None:
         """Test that invalid subject raises ValueError."""
         with pytest.raises(ValueError, match="subject must be"):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject="invalid",  # type: ignore
                 relation="direct_owner",
                 object=("file", "/doc.txt"),
@@ -126,7 +126,7 @@ class TestRebacCreate:
     def test_create_invalid_object_raises(self, nx: NexusFS) -> None:
         """Test that invalid object raises ValueError."""
         with pytest.raises(ValueError, match="object must be"):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject=("user", "alice"),
                 relation="direct_owner",
                 object="invalid",  # type: ignore
@@ -135,20 +135,20 @@ class TestRebacCreate:
 
     def test_create_prevents_cycles(self, nx: NexusFS) -> None:
         """Test that cycle detection prevents circular parent relations."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("file", "/a"),
             relation="parent",
             object=("file", "/b"),
             zone_id="root",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("file", "/b"),
             relation="parent",
             object=("file", "/c"),
             zone_id="root",
         )
         with pytest.raises(ValueError, match="[Cc]ycle"):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject=("file", "/c"),
                 relation="parent",
                 object=("file", "/a"),
@@ -161,39 +161,39 @@ class TestRebacDelete:
 
     def test_delete_existing_tuple(self, nx: NexusFS) -> None:
         """Test deleting an existing tuple."""
-        write_result = nx.rebac_create(
+        write_result = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/doc.txt"),
             zone_id="root",
         )
-        result = nx.rebac_delete(write_result["tuple_id"])
+        result = nx.rebac_service.rebac_delete_sync(write_result["tuple_id"])
         assert result is True
 
     def test_delete_nonexistent_tuple(self, nx: NexusFS) -> None:
         """Test deleting a non-existent tuple returns False."""
         fake_id = str(uuid.uuid4())
-        result = nx.rebac_delete(fake_id)
+        result = nx.rebac_service.rebac_delete_sync(fake_id)
         assert result is False
 
     def test_delete_revokes_permission(self, nx: NexusFS) -> None:
         """Test that deleting a tuple revokes the permission."""
-        write_result = nx.rebac_create(
+        write_result = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/doc.txt"),
             zone_id="root",
         )
         # Verify permission exists
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/doc.txt"),
             zone_id="root",
         )
         # Delete and verify permission revoked
-        nx.rebac_delete(write_result["tuple_id"])
-        assert not nx.rebac_check(
+        nx.rebac_service.rebac_delete_sync(write_result["tuple_id"])
+        assert not nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/doc.txt"),
@@ -206,13 +206,13 @@ class TestRebacCheck:
 
     def test_check_direct_permission(self, nx: NexusFS) -> None:
         """Test checking direct permission via relation."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/doc.txt"),
             zone_id="root",
         )
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/doc.txt"),
@@ -221,7 +221,7 @@ class TestRebacCheck:
 
     def test_check_no_permission(self, nx: NexusFS) -> None:
         """Test that users without relation have no permission."""
-        assert not nx.rebac_check(
+        assert not nx.rebac_service.rebac_check_sync(
             subject=("user", "unknown"),
             permission="read",
             object=("file", "/doc.txt"),
@@ -231,7 +231,7 @@ class TestRebacCheck:
     def test_check_invalid_subject_raises(self, nx: NexusFS) -> None:
         """Test that invalid subject raises ValueError."""
         with pytest.raises(ValueError, match="subject must be"):
-            nx.rebac_check(
+            nx.rebac_service.rebac_check_sync(
                 subject="invalid",  # type: ignore
                 permission="read",
                 object=("file", "/doc.txt"),
@@ -241,7 +241,7 @@ class TestRebacCheck:
     def test_check_invalid_object_raises(self, nx: NexusFS) -> None:
         """Test that invalid object raises ValueError."""
         with pytest.raises(ValueError, match="object must be"):
-            nx.rebac_check(
+            nx.rebac_service.rebac_check_sync(
                 subject=("user", "alice"),
                 permission="read",
                 object="invalid",  # type: ignore
@@ -255,28 +255,28 @@ class TestRebacCheck:
         # Note: "member-of" is a separate relation name; the userset
         # (group, engineering, "member") resolves by checking the exact
         # "member" relation on the group namespace.
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="member",
             object=("group", "engineering"),
             zone_id="root",
         )
         # Grant permission to group members
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("group", "engineering", "member"),
             relation="direct_owner",
             object=("file", "/team-docs/readme.txt"),
             zone_id="root",
         )
         # Alice should have access through group
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/team-docs/readme.txt"),
             zone_id="root",
         )
         # Non-member should not have access
-        assert not nx.rebac_check(
+        assert not nx.rebac_service.rebac_check_sync(
             subject=("user", "bob"),
             permission="read",
             object=("file", "/team-docs/readme.txt"),
@@ -289,13 +289,13 @@ class TestRebacCheckBatch:
 
     def test_check_batch_multiple_permissions(self, nx: NexusFS) -> None:
         """Test batch checking multiple permissions."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "batch_alice"),
             relation="direct_owner",
             object=("file", "/batch_doc1.txt"),
             zone_id="root",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "batch_alice"),
             relation="direct_owner",
             object=("file", "/batch_doc2.txt"),
@@ -307,13 +307,13 @@ class TestRebacCheckBatch:
             (("user", "batch_alice"), "read", ("file", "/batch_doc2.txt")),
             (("user", "batch_bob"), "read", ("file", "/batch_doc1.txt")),  # No permission
         ]
-        results = nx.rebac_check_batch(checks)
+        results = nx.rebac_service.rebac_check_batch_sync(checks)
         assert len(results) == 3
         assert all(isinstance(r, bool) for r in results)
 
     def test_check_batch_empty_list(self, nx: NexusFS) -> None:
         """Test batch with empty list returns empty results."""
-        results = nx.rebac_check_batch([])
+        results = nx.rebac_service.rebac_check_batch_sync([])
         assert results == []
 
 
@@ -322,21 +322,21 @@ class TestCrossZone:
 
     def test_zone_isolation(self, nx: NexusFS) -> None:
         """Test strict zone isolation."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "zone_iso_alice"),
             relation="direct_owner",
             object=("file", "/zone_iso_doc.txt"),
             zone_id="iso_zone_a",
         )
         # Access in same zone
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "zone_iso_alice"),
             permission="read",
             object=("file", "/zone_iso_doc.txt"),
             zone_id="iso_zone_a",
         )
         # No access in different zone
-        assert not nx.rebac_check(
+        assert not nx.rebac_service.rebac_check_sync(
             subject=("user", "zone_iso_alice"),
             permission="read",
             object=("file", "/zone_iso_doc.txt"),
@@ -345,21 +345,21 @@ class TestCrossZone:
 
     def test_different_zones_no_cross_access(self, nx: NexusFS) -> None:
         """Test that permissions in one zone don't grant access in another."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "cross_alice"),
             relation="direct_owner",
             object=("file", "/cross_doc.txt"),
             zone_id="cross_zone_a",
         )
         # Has permission in cross_zone_a
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "cross_alice"),
             permission="read",
             object=("file", "/cross_doc.txt"),
             zone_id="cross_zone_a",
         )
         # No permission in cross_zone_b
-        assert not nx.rebac_check(
+        assert not nx.rebac_service.rebac_check_sync(
             subject=("user", "cross_alice"),
             permission="read",
             object=("file", "/cross_doc.txt"),
@@ -372,19 +372,19 @@ class TestRebacExpand:
 
     def test_expand_returns_list(self, nx: NexusFS) -> None:
         """Test expanding to find subjects with permission returns a list."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "expand_user1"),
             relation="direct_owner",
             object=("file", "/expand_test_doc.txt"),
             zone_id="root",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "expand_user2"),
             relation="direct_owner",
             object=("file", "/expand_test_doc.txt"),
             zone_id="root",
         )
-        subjects = nx.rebac_expand(
+        subjects = nx.rebac_service.rebac_expand_sync(
             permission="read",
             object=("file", "/expand_test_doc.txt"),
         )
@@ -393,7 +393,7 @@ class TestRebacExpand:
 
     def test_expand_nonexistent_object(self, nx: NexusFS) -> None:
         """Test expand on nonexistent object returns a list."""
-        subjects = nx.rebac_expand(
+        subjects = nx.rebac_service.rebac_expand_sync(
             permission="read",
             object=("file", "/totally_unique_nonexistent_expand.txt"),
         )
@@ -406,13 +406,13 @@ class TestRebacExplain:
 
     def test_explain_direct_access(self, nx: NexusFS) -> None:
         """Test explaining direct access path."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_owner",
             object=("file", "/explain_doc.txt"),
             zone_id="root",
         )
-        explanation = nx.rebac_explain(
+        explanation = nx.rebac_service.rebac_explain_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/explain_doc.txt"),
@@ -422,7 +422,7 @@ class TestRebacExplain:
 
     def test_explain_no_access(self, nx: NexusFS) -> None:
         """Test explaining denied access."""
-        explanation = nx.rebac_explain(
+        explanation = nx.rebac_service.rebac_explain_sync(
             subject=("user", "unknown"),
             permission="read",
             object=("file", "/explain_doc.txt"),
@@ -442,7 +442,7 @@ class TestConcurrency:
         """Test that multiple creates work correctly."""
         results = []
         for i in range(5):
-            result = nx.rebac_create(
+            result = nx.rebac_service.rebac_create_sync(
                 subject=("user", f"seq_user_{i}"),
                 relation="direct_owner",
                 object=("file", f"/seq_doc_{i}.txt"),
@@ -458,7 +458,7 @@ class TestConcurrency:
 
         # Pre-create tuples with small delay to avoid SQLite locking
         for i in range(3):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject=("user", f"seqcheck_user_{i}"),
                 relation="direct_owner",
                 object=("file", f"/seqcheck_doc_{i}.txt"),
@@ -469,7 +469,7 @@ class TestConcurrency:
         # Check permissions
         results = []
         for i in range(3):
-            result = nx.rebac_check(
+            result = nx.rebac_service.rebac_check_sync(
                 subject=("user", f"seqcheck_user_{i}"),
                 permission="read",
                 object=("file", f"/seqcheck_doc_{i}.txt"),
@@ -487,21 +487,21 @@ class TestCacheBehavior:
     def test_cache_invalidated_on_write(self, nx: NexusFS) -> None:
         """Test that cache is invalidated when tuples are written."""
         # Initially no access
-        assert not nx.rebac_check(
+        assert not nx.rebac_service.rebac_check_sync(
             subject=("user", "cache_alice"),
             permission="read",
             object=("file", "/cache_doc.txt"),
             zone_id="root",
         )
         # Write tuple
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "cache_alice"),
             relation="direct_owner",
             object=("file", "/cache_doc.txt"),
             zone_id="root",
         )
         # Now should have access (cache invalidated)
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "cache_alice"),
             permission="read",
             object=("file", "/cache_doc.txt"),
@@ -510,7 +510,7 @@ class TestCacheBehavior:
 
     def test_cache_hit_on_repeated_check(self, nx: NexusFS) -> None:
         """Test that repeated checks use cache."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "repeat_alice"),
             relation="direct_owner",
             object=("file", "/repeat_doc.txt"),
@@ -518,7 +518,7 @@ class TestCacheBehavior:
         )
         # Multiple checks should all succeed (using cache)
         for _ in range(5):
-            assert nx.rebac_check(
+            assert nx.rebac_service.rebac_check_sync(
                 subject=("user", "repeat_alice"),
                 permission="read",
                 object=("file", "/repeat_doc.txt"),
@@ -531,51 +531,51 @@ class TestRebacListTuples:
 
     def test_list_tuples_by_subject(self, nx: NexusFS) -> None:
         """Test listing tuples by subject."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "list_alice"),
             relation="direct_owner",
             object=("file", "/list_doc1.txt"),
             zone_id="root",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "list_alice"),
             relation="direct_owner",
             object=("file", "/list_doc2.txt"),
             zone_id="root",
         )
-        tuples = nx.rebac_list_tuples(
+        tuples = nx.rebac_service.rebac_list_tuples_sync(
             subject=("user", "list_alice"),
         )
         assert len(tuples) >= 2
 
     def test_list_tuples_by_object(self, nx: NexusFS) -> None:
         """Test listing tuples by object."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "obj_alice"),
             relation="direct_owner",
             object=("file", "/obj_doc.txt"),
             zone_id="root",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "obj_bob"),
             relation="direct_owner",
             object=("file", "/obj_doc.txt"),
             zone_id="root",
         )
-        tuples = nx.rebac_list_tuples(
+        tuples = nx.rebac_service.rebac_list_tuples_sync(
             object=("file", "/obj_doc.txt"),
         )
         assert len(tuples) >= 2
 
     def test_list_tuples_by_relation(self, nx: NexusFS) -> None:
         """Test listing tuples by relation."""
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "rel_alice"),
             relation="direct_owner",
             object=("file", "/rel_doc.txt"),
             zone_id="root",
         )
-        tuples = nx.rebac_list_tuples(
+        tuples = nx.rebac_service.rebac_list_tuples_sync(
             relation="direct_owner",
         )
         assert len(tuples) >= 1

--- a/tests/unit/core/test_share_permission_security.py
+++ b/tests/unit/core/test_share_permission_security.py
@@ -41,7 +41,7 @@ def nx(temp_dir: Path) -> Generator[NexusFS, None, None]:
 
     # Grant admin ownership of root directory for tests
     admin_context = {"user_id": "admin", "groups": [], "is_admin": True, "is_system": False}
-    nx.rebac_create(
+    nx.rebac_service.rebac_create_sync(
         subject=("user", "admin"),
         relation="direct_owner",
         object=("file", "/"),
@@ -68,7 +68,7 @@ class TestIssue817ShareWithUserSecurity:
         nx.sys_write(test_file, b"test content", context=OperationContext(**admin_context))
 
         # Grant admin ownership
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="direct_owner",
             object=("file", test_file),
@@ -77,7 +77,7 @@ class TestIssue817ShareWithUserSecurity:
         assert tuple_id
 
         # Admin should be able to share the file
-        share_id = nx.share_with_user(
+        share_id = nx.rebac_service.share_with_user_sync(
             resource=("file", test_file),
             user_id="alice",
             relation="viewer",
@@ -86,7 +86,7 @@ class TestIssue817ShareWithUserSecurity:
         assert share_id
 
         # Verify alice can now read the file
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", test_file),
@@ -101,7 +101,7 @@ class TestIssue817ShareWithUserSecurity:
         nx.sys_write(test_file, b"test content", context=OperationContext(**admin_context))
 
         # Grant admin ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="direct_owner",
             object=("file", test_file),
@@ -109,7 +109,7 @@ class TestIssue817ShareWithUserSecurity:
         )
 
         # Grant alice viewer permission
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_viewer",
             object=("file", test_file),
@@ -124,7 +124,7 @@ class TestIssue817ShareWithUserSecurity:
             "is_system": False,
         }
         with pytest.raises(PermissionError, match="does not have EXECUTE permission"):
-            nx.share_with_user(
+            nx.rebac_service.share_with_user_sync(
                 resource=("file", test_file),
                 user_id="bob",
                 relation="viewer",
@@ -138,7 +138,7 @@ class TestIssue817ShareWithUserSecurity:
         nx.sys_write(test_file, b"test content", context=OperationContext(**admin_context))
 
         # Admin can share without ownership
-        share_id = nx.share_with_user(
+        share_id = nx.rebac_service.share_with_user_sync(
             resource=("file", test_file),
             user_id="alice",
             relation="viewer",
@@ -161,7 +161,7 @@ class TestIssue817ShareWithUserSecurity:
             "is_admin": False,
             "is_system": True,
         }
-        share_id = nx.share_with_user(
+        share_id = nx.rebac_service.share_with_user_sync(
             resource=("file", test_file),
             user_id="alice",
             relation="viewer",
@@ -180,7 +180,7 @@ class TestIssue818ShareWithGroup:
         nx.sys_write(test_file, b"test content", context=OperationContext(**admin_context))
 
         # Grant admin ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="direct_owner",
             object=("file", test_file),
@@ -188,13 +188,13 @@ class TestIssue818ShareWithGroup:
         )
 
         # Create group membership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="member",
             object=("group", "developers"),
             context=admin_context,
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="member",
             object=("group", "developers"),
@@ -202,7 +202,7 @@ class TestIssue818ShareWithGroup:
         )
 
         # Share file with group
-        share_id = nx.share_with_group(
+        share_id = nx.rebac_service.share_with_group_sync(
             resource=("file", test_file),
             group_id="developers",
             relation="viewer",
@@ -211,12 +211,12 @@ class TestIssue818ShareWithGroup:
         assert share_id
 
         # Verify both group members can read the file
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", test_file),
         )
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "bob"),
             permission="read",
             object=("file", test_file),
@@ -231,7 +231,7 @@ class TestIssue818ShareWithGroup:
         nx.sys_write(test_file, b"test content", context=OperationContext(**admin_context))
 
         # Grant admin ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="direct_owner",
             object=("file", test_file),
@@ -239,7 +239,7 @@ class TestIssue818ShareWithGroup:
         )
 
         # Grant alice viewer permission
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_viewer",
             object=("file", test_file),
@@ -254,7 +254,7 @@ class TestIssue818ShareWithGroup:
             "is_system": False,
         }
         with pytest.raises(PermissionError, match="does not have EXECUTE permission"):
-            nx.share_with_group(
+            nx.rebac_service.share_with_group_sync(
                 resource=("file", test_file),
                 group_id="developers",
                 relation="viewer",
@@ -270,7 +270,7 @@ class TestIssue818ShareWithGroup:
         nx.sys_write(test_file, b"test content", context=OperationContext(**admin_context))
 
         # Grant admin ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="direct_owner",
             object=("file", test_file),
@@ -278,7 +278,7 @@ class TestIssue818ShareWithGroup:
         )
 
         # Create group membership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="member",
             object=("group", "editors"),
@@ -286,7 +286,7 @@ class TestIssue818ShareWithGroup:
         )
 
         # Share file with group as editor
-        share_id = nx.share_with_group(
+        share_id = nx.rebac_service.share_with_group_sync(
             resource=("file", test_file),
             group_id="editors",
             relation="editor",
@@ -295,7 +295,7 @@ class TestIssue818ShareWithGroup:
         assert share_id
 
         # Verify alice has write permission
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="write",
             object=("file", test_file),
@@ -309,7 +309,7 @@ class TestNonFileResourceSecurity:
         """Test that group owner can grant permissions on the group."""
         # Create group ownership
         admin_context = {"user_id": "admin", "groups": [], "is_admin": True, "is_system": False}
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="owner-of",
             object=("group", "developers"),
@@ -317,7 +317,7 @@ class TestNonFileResourceSecurity:
         )
 
         # Admin should be able to grant permissions on the group
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("group", "developers"),
@@ -329,7 +329,7 @@ class TestNonFileResourceSecurity:
         """Test that non-owner cannot grant permissions on group."""
         # Create group ownership for admin
         admin_context = {"user_id": "admin", "groups": [], "is_admin": True, "is_system": False}
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="owner-of",
             object=("group", "developers"),
@@ -337,7 +337,7 @@ class TestNonFileResourceSecurity:
         )
 
         # Grant alice viewer permission on the group
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="viewer-of",
             object=("group", "developers"),
@@ -352,7 +352,7 @@ class TestNonFileResourceSecurity:
             "is_system": False,
         }
         with pytest.raises(PermissionError, match="does not have owner permission"):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject=("user", "bob"),
                 relation="viewer-of",
                 object=("group", "developers"),
@@ -363,7 +363,7 @@ class TestNonFileResourceSecurity:
         """Test permission management for workspace resources."""
         # Create workspace ownership
         admin_context = {"user_id": "admin", "groups": [], "is_admin": True, "is_system": False}
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="owner-of",
             object=("workspace", "/workspace1"),
@@ -371,7 +371,7 @@ class TestNonFileResourceSecurity:
         )
 
         # Admin should be able to grant permissions on workspace
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="editor-of",
             object=("workspace", "/workspace1"),
@@ -387,7 +387,7 @@ class TestNonFileResourceSecurity:
             "is_system": False,
         }
         with pytest.raises(PermissionError, match="does not have owner permission"):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject=("user", "bob"),
                 relation="viewer-of",
                 object=("workspace", "/workspace1"),
@@ -407,7 +407,7 @@ class TestHelperMethodIntegration:
         nx.sys_write(test_file, b"test content", context=OperationContext(**admin_context))
 
         # Grant admin ownership
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="direct_owner",
             object=("file", test_file),
@@ -422,7 +422,7 @@ class TestHelperMethodIntegration:
             "is_system": False,
         }
         with pytest.raises(PermissionError):
-            nx.rebac_create(
+            nx.rebac_service.rebac_create_sync(
                 subject=("user", "bob"),
                 relation="direct_viewer",
                 object=("file", test_file),
@@ -438,7 +438,7 @@ class TestHelperMethodIntegration:
         nx.sys_write(test_file, b"test content", context=OperationContext(**admin_context))
 
         # Operation without context should succeed
-        tuple_id = nx.rebac_create(
+        tuple_id = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_viewer",
             object=("file", test_file),
@@ -468,7 +468,7 @@ class TestHelperMethodIntegration:
                 "is_admin": False,
                 "is_system": False,
             }
-            share_id = nx.share_with_user(
+            share_id = nx.rebac_service.share_with_user_sync(
                 resource=("file", test_file),
                 user_id="bob",
                 relation="viewer",
@@ -498,7 +498,7 @@ class TestCrossZoneSharing:
             "is_system": False,
             "zone_id": "zone1",
         }
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="direct_owner",
             object=("file", test_file),
@@ -507,7 +507,7 @@ class TestCrossZoneSharing:
         )
 
         # Share with user in zone2
-        share_id = nx.share_with_user(
+        share_id = nx.rebac_service.share_with_user_sync(
             resource=("file", test_file),
             user_id="alice",
             relation="viewer",
@@ -533,7 +533,7 @@ class TestCrossZoneSharing:
             "is_system": False,
             "zone_id": "zone1",
         }
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "admin"),
             relation="direct_owner",
             object=("file", test_file),
@@ -542,7 +542,7 @@ class TestCrossZoneSharing:
         )
 
         # Share with group in zone2
-        share_id = nx.share_with_group(
+        share_id = nx.rebac_service.share_with_group_sync(
             resource=("file", test_file),
             group_id="partner-team",
             relation="viewer",

--- a/tests/unit/storage/test_time_travel.py
+++ b/tests/unit/storage/test_time_travel.py
@@ -313,7 +313,7 @@ class TestTimeTravelDebug:
         nx.sys_write(path, b"Content")
 
         # Set permissions using ReBAC (v0.6.0+)
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "testowner"), relation="direct_owner", object=("file", path)
         )
 


### PR DESCRIPTION
## Summary
- **mypy**: `memory.py` accessed `nexus_fs._memory_provider` directly, which mypy can't resolve after `__getattr__` removal (PR #2782). Changed to `getattr()` pattern consistent with `orchestrator.py` and `manifest.py`.
- **Benchmark**: Two tests (`test_rebac_check_delegation`, `test_rebac_list_tuples_with_param_rename`) called `mock_nexus_fs.arebac_check()` / `mock_nexus_fs.arebac_list_tuples()` which relied on `__getattr__` routing. Updated to call `rebac_service` directly.

## Test plan
- [ ] mypy passes (0 new errors)
- [ ] Benchmark (Critical Subset) passes — 2 previously failing tests now route through rebac_service

🤖 Generated with [Claude Code](https://claude.com/claude-code)