### PR TITLE
fix: migrate 127 test callers from retired __getattr__ to direct service access

### DIFF
--- a/tests/benchmarks/test_thread_pool_exhaustion.py
+++ b/tests/benchmarks/test_thread_pool_exhaustion.py
@@ -266,7 +266,7 @@ def test_in_process_thread_exhaustion(
         )
 
         # Grant read permission to test user
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "test_user"),
             relation="reader",
             object=("file", "/"),
@@ -382,7 +382,7 @@ async def test_async_thread_exhaustion(
         )
 
         # Grant test user read permission on root
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "test_user"),
             relation="reader",
             object=("file", "/"),

--- a/tests/e2e/server/test_directory_grants_e2e.py
+++ b/tests/e2e/server/test_directory_grants_e2e.py
@@ -141,7 +141,7 @@ class TestDirectoryGrantExpansion:
         directory_path = "/workspace/project/"
 
         # Grant read permission on the directory
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="reader",
             object=("file", directory_path),
@@ -196,7 +196,7 @@ class TestDirectoryGrantExpansion:
         assert len(listed) == 3, f"Expected 3 files, got {len(listed)}"
 
         # Grant read permission on the directory
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="reader",
             object=("file", "/workspace/project/"),
@@ -245,7 +245,7 @@ class TestDirectoryGrantExpansion:
         )
 
         # First grant permission on the directory
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "charlie"),
             relation="reader",
             object=("file", "/workspace/shared/"),
@@ -257,7 +257,7 @@ class TestDirectoryGrantExpansion:
         nx.sys_write(new_file, "new content", context=ctx)
 
         # The new file should inherit the permission via Tiger Cache
-        has_access = nx.rebac_check(
+        has_access = nx.rebac_service.rebac_check_sync(
             subject=("user", "charlie"),
             permission="read",
             object=("file", new_file),
@@ -289,13 +289,13 @@ class TestDirectoryGrantExpansion:
         # Create two directories with different grants
         # Directory A: alice has read
         # Directory B: bob has read
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="reader",
             object=("file", "/dir_a/"),
             zone_id="root",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="reader",
             object=("file", "/dir_b/"),
@@ -309,7 +309,7 @@ class TestDirectoryGrantExpansion:
         time.sleep(0.2)
 
         # Verify alice has access via Tiger Cache
-        assert nx.rebac_check(
+        assert nx.rebac_service.rebac_check_sync(
             subject=("user", "alice"),
             permission="read",
             object=("file", "/dir_a/moveme.txt"),
@@ -323,7 +323,7 @@ class TestDirectoryGrantExpansion:
         time.sleep(0.2)
 
         # After move: bob should gain access
-        has_bob_access = nx.rebac_check(
+        has_bob_access = nx.rebac_service.rebac_check_sync(
             subject=("user", "bob"),
             permission="read",
             object=("file", "/dir_b/moveme.txt"),
@@ -487,7 +487,7 @@ class TestTigerCacheIntegration:
             nx.sys_write(path, f"content of {path}")
 
         # Grant permission on directory
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "diana"),
             relation="reader",
             object=("file", "/cache_test/"),

--- a/tests/e2e/server/test_namespace_dcache_e2e.py
+++ b/tests/e2e/server/test_namespace_dcache_e2e.py
@@ -210,7 +210,7 @@ def main():
         # ── Test 5: Grant → IMMEDIATE visibility (Issue #1244 core) ──────
         print("\n[Test 5] Grant → IMMEDIATE visibility (Issue #1244)")
 
-        result = nx.rebac_create(
+        result = nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_viewer",
             object=("file", "/workspace/proj/data.csv"),
@@ -246,13 +246,13 @@ def main():
         rpc("write", {"path": "/workspace/bob-dir/f.txt", "content": "Bob-data"}, ADMIN_H)
 
         # Grant each user their own file
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "alice"),
             relation="direct_viewer",
             object=("file", "/workspace/alice-dir/f.txt"),
             zone_id="test",
         )
-        nx.rebac_create(
+        nx.rebac_service.rebac_create_sync(
             subject=("user", "bob"),
             relation="direct_viewer",
             object=("file", "/workspace/bob-dir/f.txt"),
@@ -274,7 +274,7 @@ def main():
         # ── Test 8: Rapid grant/revoke/grant (cache churn) ───────────────
         print("\n[Test 8] Rapid grant/revoke/grant (cache churn)")
         for i in range(5):
-            tid_result = nx.rebac_create(
+            tid_result = nx.rebac_service.rebac_create_sync(
                 subject=("user", "alice"),
                 relation="direct_viewer",
                 object=("file", "/workspace/proj/data.csv"),

--- a/tests/unit/core/test_nexus_fs_list_workspaces.py
+++ b/tests/unit/core/test_nexus_fs_list_workspaces.py
@@ -31,8 +31,8 @@ def _make_context(user_id: str | None = None, zone_id: str | None = None) -> Sim
 def nexus_fs():
     """Create a NexusFS instance with a mocked workspace RPC service.
 
-    list_workspaces was extracted from NexusFS to WorkspaceRPCService (Issue #2033).
-    NexusFS.__getattr__ forwards to _workspace_rpc_service.list_workspaces().
+    list_workspaces lives on WorkspaceRPCService (Issue #2033).
+    Tests call nx._workspace_rpc_service.list_workspaces() directly.
     """
     from nexus.system_services.workspace.workspace_rpc_service import WorkspaceRPCService
 

--- a/tests/unit/core/test_nexus_fs_mounts.py
+++ b/tests/unit/core/test_nexus_fs_mounts.py
@@ -1,14 +1,15 @@
-"""Unit tests for NexusFSMountsMixin.
+"""Unit tests for mount management via direct service access.
 
-Tests cover mount management operations:
-- add_mount: Add dynamic backend mount
-- remove_mount: Remove backend mount
-- list_mounts: List all active mounts
-- get_mount: Get mount details
-- has_mount: Check if mount exists
-- save_mount: Persist mount to database
-- load_mount: Load persisted mount
-- sync_mount: Sync metadata from connector backend
+Tests cover mount management operations via _mount_core_service,
+_mount_persist_service, and _sync_service (replacing old __getattr__ routing):
+- add_mount: Add dynamic backend mount (MountCoreService)
+- remove_mount: Remove backend mount (MountCoreService)
+- list_mounts: List all active mounts (MountCoreService)
+- get_mount: Get mount details (MountCoreService)
+- has_mount: Check if mount exists (MountCoreService)
+- save_mount: Persist mount to database (MountPersistService)
+- load_mount: Load persisted mount (MountPersistService)
+- sync_mount: Sync metadata from connector backend (SyncService)
 """
 
 from __future__ import annotations
@@ -365,7 +366,7 @@ class TestListSavedMounts:
         try:
             if not hasattr(nx, "mount_manager") or nx.mount_manager is None:
                 with pytest.raises(RuntimeError, match="Mount manager not available"):
-                    nx.list_saved_mounts()
+                    nx._mount_persist_service.list_saved_mounts()
         finally:
             nx.close()
 
@@ -386,7 +387,7 @@ class TestLoadMount:
         try:
             if not hasattr(nx, "mount_manager") or nx.mount_manager is None:
                 with pytest.raises(RuntimeError, match="Mount manager not available"):
-                    nx.load_mount("/mnt/test")
+                    nx._mount_persist_service.load_mount("/mnt/test")
         finally:
             nx.close()
 
@@ -409,7 +410,7 @@ class TestDeleteSavedMount:
         try:
             if not hasattr(nx, "mount_manager") or nx.mount_manager is None:
                 with pytest.raises(RuntimeError, match="Mount manager not available"):
-                    nx.delete_saved_mount("/mnt/test")
+                    nx._mount_persist_service.delete_saved_mount("/mnt/test")
         finally:
             nx.close()
 
@@ -947,7 +948,7 @@ class TestMountContextUtilsIntegration:
         # The function should resolve the database URL from nx.db_path
         # It may fail due to missing OAuth config, but should not fail due to missing database URL
         try:
-            nx.load_mount(mount_config)
+            nx._mount_persist_service.load_mount(mount_config["mount_point"])
         except RuntimeError as e:
             # Should not fail with "No database path configured" error
             # (may fail for other reasons like missing OAuth config)

--- a/tests/unit/core/test_nexus_fs_rebac_mixin.py
+++ b/tests/unit/core/test_nexus_fs_rebac_mixin.py
@@ -431,7 +431,7 @@ class TestRebacCheckBatch:
     def test_rebac_check_batch_invalid_check_raises_error(self, nx: NexusFS) -> None:
         """Test that invalid check format raises ValueError."""
         with pytest.raises(ValueError, match="Check 0 must be"):
-            nx.rebac_service.rebac_check_batch_sync(["invalid"])  # type: ignore[list-item]
+            nx.rebac_service.rebac_check_batch_sync(["invalid"])
 
 
 class TestRebacListTuples:


### PR DESCRIPTION
## Summary
- After PR #2782 deleted `NexusFS.__getattr__` routing, 127 tests + 2 benchmarks + 1 mypy error remained calling methods that no longer exist on NexusFS
- Migrated all callers to use direct service access: `nx.rebac_service.*_sync()`, `nx._mount_core_service.*()`, `nx._mount_persist_service.*()`, `nx._sync_service.sync_mount_flat()`
- Fixed mypy error in `memory.py` by using `getattr()` instead of direct private attribute access

## Files changed (6)
| File | Fix |
|------|-----|
| `test_nexus_fs_rebac_mixin.py` | 70+ calls → `nx.rebac_service.*_sync()` |
| `test_nexus_fs_mounts.py` | 27 calls → `nx._mount_core_service.*()` / `_mount_persist_service` / `_sync_service` |
| `test_share_permission_security.py` | 38 calls → `nx.rebac_service.*_sync()` |
| `test_time_travel.py` | 1 call → `nx.rebac_service.rebac_create_sync()` |
| `test_service_delegation.py` | 2 calls → `nx.rebac_service.rebac_*()` |
| `memory.py` | `_memory_provider` → `getattr(nexus_fs, "_memory_provider", None)` |

## Test plan
- [x] All 5 affected test files pass locally
- [x] mypy: 0 errors (1105 files)
- [x] ruff format: all formatted
- [x] ruff lint: all passed
- [x] Pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)