### PR TITLE
fix(#2788,#2789,#2790): REMOTE mode gRPC response unwrapping + auto-parse fixes

### DIFF
--- a/src/nexus/bricks/parsers/auto_parse_hook.py
+++ b/src/nexus/bricks/parsers/auto_parse_hook.py
@@ -21,7 +21,7 @@ class AutoParseWriteHook:
 
     Dependencies injected at construction:
       - get_parser:  (path) -> parser | raises if unsupported
-      - parse_fn:    async (path, store_result=True) -> result
+      - parse_fn:    (content: bytes, path: str) -> bytes | None
       - metadata:    MetastoreABC (optional, for cache invalidation)
     """
 
@@ -58,7 +58,7 @@ class AutoParseWriteHook:
 
         thread = threading.Thread(
             target=self._run_parse,
-            args=(ctx.path,),
+            args=(ctx.content, ctx.path),
             daemon=False,
             name=f"parser-{ctx.path}",
         )
@@ -67,11 +67,9 @@ class AutoParseWriteHook:
             self._threads.append(thread)
         thread.start()
 
-    def _run_parse(self, path: str) -> None:
+    def _run_parse(self, content: bytes, path: str) -> None:
         try:
-            from nexus.lib.sync_bridge import run_sync
-
-            run_sync(self._parse_fn(path, store_result=True))
+            self._parse_fn(content, path)
         except Exception as e:
             error_type = type(e).__name__
             error_msg = str(e)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -445,7 +445,7 @@ class NexusFS(  # type: ignore[misc]
 
         for parent_dir in reversed(parents_to_create):
             self._create_directory_metadata(parent_dir, context=ctx)
-            if hasattr(self, "_hierarchy_manager"):
+            if hasattr(self, "_hierarchy_manager") and self._hierarchy_manager is not None:
                 try:
                     logger.debug(
                         f"mkdir: Creating parent tuples for intermediate dir: {parent_dir}"
@@ -570,7 +570,7 @@ class NexusFS(  # type: ignore[misc]
 
         ctx = context or self._default_context
 
-        if hasattr(self, "_hierarchy_manager"):
+        if hasattr(self, "_hierarchy_manager") and self._hierarchy_manager is not None:
             try:
                 logger.debug(
                     f"mkdir: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or ROOT_ZONE_ID}"
@@ -2299,7 +2299,7 @@ class NexusFS(  # type: ignore[misc]
                 logger.warning(f"write: Failed to queue deferred permissions for {path}: {e}")
         else:
             # SYNC PATH: Execute permission operations immediately (original behavior)
-            if hasattr(self, "_hierarchy_manager"):
+            if hasattr(self, "_hierarchy_manager") and self._hierarchy_manager is not None:
                 try:
                     logger.info(
                         f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or ROOT_ZONE_ID}"
@@ -2937,8 +2937,10 @@ class NexusFS(  # type: ignore[misc]
         # PERF: Batch hierarchy tuple creation (single transaction instead of N)
         _hierarchy_start = time.perf_counter()
         all_paths = [path for path, _ in validated_files]
-        if hasattr(self, "_hierarchy_manager") and hasattr(
-            self._hierarchy_manager, "ensure_parent_tuples_batch"
+        if (
+            hasattr(self, "_hierarchy_manager")
+            and self._hierarchy_manager is not None
+            and hasattr(self._hierarchy_manager, "ensure_parent_tuples_batch")
         ):
             try:
                 created_count = self._hierarchy_manager.ensure_parent_tuples_batch(
@@ -2961,7 +2963,7 @@ class NexusFS(  # type: ignore[misc]
                         logger.warning(
                             f"write_batch: Failed to create parent tuples for {path}: {e2}"
                         )
-        elif hasattr(self, "_hierarchy_manager"):
+        elif hasattr(self, "_hierarchy_manager") and self._hierarchy_manager is not None:
             # No batch method available, use individual calls
             for path in all_paths:
                 try:

--- a/tests/unit/remote/test_rpc_transport.py
+++ b/tests/unit/remote/test_rpc_transport.py
@@ -84,7 +84,31 @@ class TestRPCTransportCallRPC:
     """call_rpc success and error paths."""
 
     def test_success_returns_decoded_result(self, transport) -> None:
-        """Successful call returns decoded payload."""
+        """Successful call extracts 'result' key from server response."""
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        # Server wraps results as {"result": <actual>}
+        mock_response.payload = encode_rpc_message({"result": {"key": "value"}})
+        transport._mock_stub.Call.return_value = mock_response
+
+        result = transport.call_rpc("sys_read", {"path": "/file.txt"})
+
+        assert result == {"key": "value"}
+        transport._mock_stub.Call.assert_called_once()
+
+    def test_success_extracts_list_result(self, transport) -> None:
+        """Server response with list result is unwrapped correctly."""
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.payload = encode_rpc_message({"result": [{"path": "/a.txt", "size": 10}]})
+        transport._mock_stub.Call.return_value = mock_response
+
+        result = transport.call_rpc("list", {"path": "/"})
+
+        assert result == [{"path": "/a.txt", "size": 10}]
+
+    def test_success_fallback_when_no_result_key(self, transport) -> None:
+        """Response without 'result' key returns full dict (backwards compat)."""
         mock_response = MagicMock()
         mock_response.is_error = False
         mock_response.payload = encode_rpc_message({"key": "value"})
@@ -93,7 +117,6 @@ class TestRPCTransportCallRPC:
         result = transport.call_rpc("sys_read", {"path": "/file.txt"})
 
         assert result == {"key": "value"}
-        transport._mock_stub.Call.assert_called_once()
 
     def test_is_error_raises_nexus_error(self, transport) -> None:
         """is_error=True should raise via _handle_rpc_error."""


### PR DESCRIPTION
## Summary

Fixes three related bugs in REMOTE deployment mode:

- **#2788 / #2789**: `nexus ls` throws `'str' object has no attribute 'get'` when `NEXUS_URL` is set. Root cause: `RPCTransport.call_rpc()` returned the server's `{"result": <actual>}` wrapper instead of extracting the inner value, causing all remote operations to receive malformed data.
- **#2790**: Write operations succeed but files are unreadable. Root causes:
  - `AutoParseWriteHook._run_parse()` called `parse_fn(path, store_result=True)` but actual signature is `(content: bytes, path: str)`
  - `NexusFS._parse_in_thread()` called nonexistent `self.parse()` method
  - `_hierarchy_manager` was `None` but only checked with `hasattr()`, causing `ensure_parent_tuples` AttributeError

## Changes

| File | Change |
|------|--------|
| `src/nexus/remote/rpc_transport.py` | Extract `"result"` key from server response wrapper in `call_rpc()` |
| `src/nexus/bricks/parsers/auto_parse_hook.py` | Fix `_run_parse` to accept `(content, path)` and call `parse_fn` synchronously |
| `src/nexus/core/nexus_fs.py` | Fix `_parse_in_thread` to use `_virtual_view_parse_fn`; add `is not None` guard at 3 `_hierarchy_manager` call sites |
| `tests/unit/remote/test_rpc_transport.py` | Update existing test + add 2 new tests for result unwrapping |

## Test plan

- [x] Unit tests: 25 RPC transport tests pass (including 2 new)
- [x] Unit tests: 39 remote + RPC parity tests pass
- [x] Lint: ruff check + ruff format + mypy all pass
- [x] E2E: `nexus write`, `nexus cat`, `nexus ls`, `nexus ls -l` verified against live server with `NEXUS_URL` set
- [x] E2E: Server logs show no `Auto-parse FAILED` or `ensure_parent_tuples` errors

Closes #2788, closes #2789, closes #2790