### PR TITLE
refactor(#1410): delete version + search delegation wrappers from NexusFS

### DIFF
--- a/examples/deepagents/test_nexus_backend.py
+++ b/examples/deepagents/test_nexus_backend.py
@@ -71,7 +71,9 @@ def test_basic_operations():
             nx.sys_write(test_path, new_content.encode("utf-8"))
             print(f"   ✓ Wrote version {i + 1}")
 
-        versions = nx.list_versions(test_path)
+        from nexus.lib.sync_bridge import run_sync
+
+        versions = run_sync(nx.version_service.list_versions(test_path))
         print(f"   ✓ File has {len(versions)} versions")
         assert len(versions) >= 4, f"Expected at least 4 versions, got {len(versions)}"
 

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -435,7 +435,9 @@ def search_init(
 
             async def init_search() -> None:
                 nxfs = cast("NexusFS", nx)
-                await nxfs.ainitialize_semantic_search(
+                await nxfs.search_service.ainitialize_semantic_search(
+                    nx=nxfs,
+                    record_store_engine=None,
                     embedding_provider=provider,
                     embedding_model=model,
                     api_key=api_key,
@@ -501,7 +503,9 @@ def search_index(
             async def do_index() -> dict[str, int]:
                 # Auto-initialize semantic search if not already initialized (standalone mode)
                 if isinstance(nx, NexusFS):
-                    await nx.ainitialize_semantic_search()
+                    await nx.search_service.ainitialize_semantic_search(
+                        nx=nx, record_store_engine=None
+                    )
                 result: dict[str, int] = await nx.search_service.semantic_search_index(
                     path, recursive=recursive
                 )
@@ -592,8 +596,11 @@ def search_query(
             async def do_search() -> list[dict[str, Any]]:
                 # Auto-initialize semantic search if not already initialized (standalone mode)
                 if isinstance(nx, NexusFS):
-                    await nx.ainitialize_semantic_search(
-                        embedding_provider=provider, api_key=api_key
+                    await nx.search_service.ainitialize_semantic_search(
+                        nx=nx,
+                        record_store_engine=None,
+                        embedding_provider=provider,
+                        api_key=api_key,
                     )
                 result: list[dict[str, Any]] = await nx.search_service.semantic_search(
                     query, path=path, limit=limit, search_mode=mode
@@ -653,7 +660,7 @@ def search_stats(backend_config: BackendConfig) -> None:
         async def get_stats() -> dict[str, Any]:
             # Auto-initialize semantic search if not already initialized (standalone mode)
             if isinstance(nx, NexusFS):
-                await nx.ainitialize_semantic_search()
+                await nx.search_service.ainitialize_semantic_search(nx=nx, record_store_engine=None)
             result: dict[str, Any] = await nx.search_service.semantic_search_stats()
             return result
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -6,7 +6,7 @@ import logging
 import time
 from collections.abc import Callable, Generator, Iterator
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any
 
 from nexus.contracts.cache_store import CacheStoreABC, NullCacheStore
 from nexus.contracts.constants import ROOT_ZONE_ID
@@ -202,7 +202,6 @@ class NexusFS(  # type: ignore[misc]
 
         # Lazy-init sentinels
         self._token_manager = None
-        self._semantic_search = None
         self._sandbox_manager: Any = None
         self._coordination_client: Any = None
         self._event_client: Any = None
@@ -3873,87 +3872,6 @@ class NexusFS(  # type: ignore[misc]
         """
         created = self.metadata.backfill_directory_index(prefix=prefix, zone_id=zone_id)
         return {"entries_created": created, "prefix": prefix}
-
-    @rpc_expose(description="Get specific file version")
-    def get_version(
-        self, path: str, version: int, context: OperationContext | None = None
-    ) -> bytes:
-        """Get a specific version of a file."""
-        from nexus.lib.sync_bridge import run_sync
-
-        return cast(bytes, run_sync(self.version_service.get_version(path, version, context)))
-
-    @rpc_expose(description="List file versions")
-    def list_versions(
-        self, path: str, context: OperationContext | None = None
-    ) -> builtins.list[dict[str, Any]]:
-        """List all versions of a file."""
-        from nexus.lib.sync_bridge import run_sync
-
-        return cast(
-            builtins.list[dict[str, Any]],
-            run_sync(self.version_service.list_versions(path, context)),
-        )
-
-    @rpc_expose(description="Rollback file to previous version")
-    def rollback(self, path: str, version: int, context: OperationContext | None = None) -> None:
-        """Rollback file to a previous version."""
-        from nexus.lib.sync_bridge import run_sync
-
-        cast(None, run_sync(self.version_service.rollback(path, version, context)))
-
-    @rpc_expose(description="Compare file versions")
-    def diff_versions(
-        self,
-        path: str,
-        v1: int,
-        v2: int,
-        mode: str = "metadata",
-        context: OperationContext | None = None,
-    ) -> dict[str, Any] | str:
-        """Compare two versions of a file."""
-        from nexus.lib.sync_bridge import run_sync
-
-        return cast(
-            dict[str, Any] | str,
-            run_sync(self.version_service.diff_versions(path, v1, v2, mode, context)),
-        )
-
-    async def ainitialize_semantic_search(
-        self,
-        embedding_provider: str | None = None,
-        embedding_model: str | None = None,
-        api_key: str | None = None,
-        chunk_size: int = 1024,
-        chunk_strategy: str = "semantic",
-        async_mode: bool = True,
-        cache_url: str | None = None,
-        embedding_cache_ttl: int = 86400 * 3,
-    ) -> None:
-        """Initialize semantic search engine.
-
-        Delegates to SearchService.ainitialize_semantic_search() (Issue #1287).
-        """
-        if self._record_store is None:
-            raise RuntimeError("Semantic search requires RecordStore (SQL engine)")
-
-        await self.search_service.ainitialize_semantic_search(
-            nx=self,
-            record_store_engine=self._record_store.engine,
-            embedding_provider=embedding_provider,
-            embedding_model=embedding_model,
-            api_key=api_key,
-            chunk_size=chunk_size,
-            chunk_strategy=chunk_strategy,
-            async_mode=async_mode,
-            cache_url=cache_url,
-            embedding_cache_ttl=embedding_cache_ttl,
-        )
-        # Keep backward-compat reference on NexusFS
-        self._semantic_search = self.search_service._semantic_search  # type: ignore[assignment]  # allowed
-        # Wire search engine into LLMService (Issue #684: DI instead of kernel access)
-        if hasattr(self, "llm_service") and self._semantic_search is not None:
-            self.llm_service._semantic_search_engine = self._semantic_search
 
     def close(self) -> None:
         """Close the filesystem and release resources."""

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -353,6 +353,10 @@ def create_app(
             _brick_sources.append(_meta_export_svc)
     except Exception as _exc:
         logger.debug("MetadataExportService unavailable: %s", _exc)
+    # Issue #1410: VersionService @rpc_expose methods (moved from NexusFS)
+    _version_svc = getattr(nexus_fs, "version_service", None)
+    if _version_svc is not None:
+        _brick_sources.append(_version_svc)
     app.state.exposed_methods = _discover_exposed_methods(nexus_fs, *_brick_sources)
 
     # Defaults for optional services are set by init_app_state() above (Issue #2135)

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -456,7 +456,9 @@ async def handle_semantic_search_index(
     recursive = getattr(params, "recursive", True)
 
     try:
-        await nexus_fs.ainitialize_semantic_search()
+        await nexus_fs.search_service.ainitialize_semantic_search(
+            nx=nexus_fs, record_store_engine=None
+        )
     except Exception as e:
         raise ValueError(
             f"Semantic search is not initialized and could not be auto-initialized: {e}"

--- a/tests/e2e/test_lego_decomp_e2e.py
+++ b/tests/e2e/test_lego_decomp_e2e.py
@@ -361,51 +361,33 @@ class TestVersionDelegation:
         """list_versions should return version history after writes."""
         path = f"/ver-{uuid.uuid4().hex[:8]}.txt"
         nx.sys_write(path, b"v1")
-        versions = nx.list_versions(path)
+        from nexus.lib.sync_bridge import run_sync
+
+        versions = run_sync(nx.version_service.list_versions(path))
         assert isinstance(versions, list)
         assert len(versions) >= 1
 
     def test_get_version_returns_content(self, nx):
         """get_version should retrieve specific version content."""
+        from nexus.lib.sync_bridge import run_sync
+
         path = f"/ver2-{uuid.uuid4().hex[:8]}.txt"
         nx.sys_write(path, b"version-one")
-        versions = nx.list_versions(path)
+        versions = run_sync(nx.version_service.list_versions(path))
         assert len(versions) >= 1
         ver_num = versions[0].get("version", 1)
-        content = nx.get_version(path, ver_num)
+        content = run_sync(nx.version_service.get_version(path, ver_num))
         assert isinstance(content, bytes)
 
     def test_multiple_versions(self, nx):
         """Multiple writes should produce multiple versions."""
+        from nexus.lib.sync_bridge import run_sync
+
         path = f"/multi-ver-{uuid.uuid4().hex[:8]}.txt"
         nx.sys_write(path, b"v1")
         nx.sys_write(path, b"v2")
-        versions = nx.list_versions(path)
+        versions = run_sync(nx.version_service.list_versions(path))
         assert len(versions) >= 2
-
-    def test_aget_version_is_coroutine(self, nx):
-        """aget_version should be a coroutine function (via __getattr__)."""
-        import inspect
-
-        assert inspect.iscoroutinefunction(nx.aget_version)
-
-    def test_alist_versions_is_coroutine(self, nx):
-        """alist_versions should be a coroutine function (via __getattr__)."""
-        import inspect
-
-        assert inspect.iscoroutinefunction(nx.alist_versions)
-
-    def test_arollback_is_coroutine(self, nx):
-        """arollback should be a coroutine function (via __getattr__)."""
-        import inspect
-
-        assert inspect.iscoroutinefunction(nx.arollback)
-
-    def test_adiff_versions_is_coroutine(self, nx):
-        """adiff_versions should be a coroutine function (via __getattr__)."""
-        import inspect
-
-        assert inspect.iscoroutinefunction(nx.adiff_versions)
 
 
 # ---------------------------------------------------------------------------
@@ -507,7 +489,9 @@ class TestPermissionEnforcement:
         )
         path = f"/perm-ver-{uuid.uuid4().hex[:8]}.txt"
         nx_perms.sys_write(path, b"version with perms", context=ctx)
-        versions = nx_perms.list_versions(path, context=ctx)
+        from nexus.lib.sync_bridge import run_sync
+
+        versions = run_sync(nx_perms.version_service.list_versions(path, ctx))
         assert isinstance(versions, list)
         assert len(versions) >= 1
 

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -50,6 +50,11 @@ def get_all_rpc_exposed_methods():
     """
     exposed = get_rpc_exposed_methods(NexusFS)
 
+    # Issue #1410: Version methods moved from NexusFS to VersionService
+    from nexus.bricks.versioning.version_service import VersionService
+
+    exposed.update(get_rpc_exposed_methods(VersionService))
+
     return exposed
 
 
@@ -121,11 +126,8 @@ def test_all_public_methods_are_exposed_or_excluded():
         # Phase 2 Service Composition - Async delegation methods (Issue #988)
         # These are internal async methods that delegate to services. The original
         # sync mixin methods (without "a" prefix) already have @rpc_expose decorators.
-        # VersionService delegation (4 methods)
-        "aget_version",  # Delegates to version_service.get_version()
-        "alist_versions",  # Delegates to version_service.list_versions()
-        "arollback",  # Delegates to version_service.rollback()
-        "adiff_versions",  # Delegates to version_service.diff_versions()
+        # VersionService delegation (removed: sync wrappers moved to VersionService,
+        # async __getattr__ magic deleted in PR #2782)
         # ReBACService delegation (8 methods)
         "arebac_create",  # Delegates to rebac_service.rebac_create()
         "arebac_delete",  # Delegates to rebac_service.rebac_delete()
@@ -160,7 +162,7 @@ def test_all_public_methods_are_exposed_or_excluded():
         "asemantic_search",  # Delegates to search_service.semantic_search()
         "asemantic_search_index",  # Delegates to search_service.semantic_search_index()
         "asemantic_search_stats",  # Delegates to search_service.semantic_search_stats()
-        "ainitialize_semantic_search",  # Delegates to search_service.initialize_semantic_search()
+        # ainitialize_semantic_search — deleted from NexusFS, callers use search_service directly
         # Distributed Lock methods - async context managers require special handling
         # Tracked in Issue #1141
         "atomic_update",  # Async - read-modify-write with distributed lock


### PR DESCRIPTION
## Summary
- Phase 5 PR 2: Delete thin delegation wrappers from NexusFS that violate kernel purity
- Removed `get_version`, `list_versions`, `rollback`, `diff_versions` (→ VersionService already has @rpc_expose)
- Removed `ainitialize_semantic_search` (→ SearchService) + dead `_semantic_search` sentinel
- ~80 lines deleted, all callers migrated to direct service access
- Added VersionService to fastapi_server.py RPC brick_sources for discovery continuity

## Test plan
- [ ] `pytest tests/unit/server/test_rpc_parity.py -v` — RPC parity passes with VersionService scanning
- [ ] `pytest tests/e2e/test_lego_decomp_e2e.py -v` — version tests use version_service directly
- [ ] `ruff check src/nexus/core/nexus_fs.py` — no lint issues
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)