### PR TITLE
fix: eliminate litellm import delay for remote CLI commands

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -265,6 +265,7 @@ def connect(
             metadata_store=remote_metastore,
             record_store=None,
             permissions=_PermissionConfig(enforce=False),
+            enabled_bricks=frozenset(),  # REMOTE profile: no local bricks
         )
         nfs.router.add_mount("/", remote_backend)
 


### PR DESCRIPTION
## Summary

- Pass `enabled_bricks=frozenset()` to `create_nexus_fs()` in remote mode, matching the existing `_REMOTE_BRICKS` definition
- Prevents eager import of `LLMService` → `litellm`, which fetches a remote model cost map from GitHub and causes ~13s startup delay on machines without internet access

## Test plan

- [ ] Run `time nexus ls / --remote-url http://localhost:2026` — should complete in <1s without litellm warning
- [ ] Verify remote CLI commands (`nexus cat`, `nexus ls`) still work correctly against a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)