### PR TITLE
feat: minimal profile Docker image (standalone server)

### DIFF
--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -1,0 +1,101 @@
+# Nexus Minimal Docker Image
+# Lightweight standalone server with storage only (no Zoekt, no ML, no cloud).
+# Includes _nexus_raft for embedded RaftMetadataStore.
+#
+# Build:
+#   docker build -f dockerfiles/Dockerfile.minimal -t nexus-minimal:latest .
+#
+# Usage:
+#   docker run --rm -p 2026:2026 -p 2126:2126 nexus-minimal:latest
+
+# ── Builder stage ────────────────────────────────────────────────────
+FROM python:3.13-slim AS builder
+
+# ---------- System dependencies ----------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc \
+        git \
+        curl \
+        build-essential \
+        ca-certificates \
+        protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------- Rust toolchain (for _nexus_raft) ----------
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# ---------- maturin ----------
+RUN pip install --no-cache-dir maturin
+
+# ---------- Install Python dependencies ----------
+COPY requirements-minimal.txt /tmp/requirements-minimal.txt
+RUN pip install --no-cache-dir --prefix=/install -r /tmp/requirements-minimal.txt
+
+# ---------- Install nexus package (source-only, no compiled extensions) ----------
+WORKDIR /build
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+RUN pip install --no-cache-dir --no-deps --prefix=/install .
+
+# ---------- Build nexus_raft Rust extension ----------
+COPY Cargo.toml Cargo.lock ./
+COPY proto/ ./proto/
+COPY rust/ ./rust/
+
+WORKDIR /build/rust/nexus_raft
+RUN maturin build --release --features full \
+    && pip install --no-cache-dir --prefix=/install /build/target/wheels/nexus_raft-*.whl
+
+WORKDIR /build
+
+# ── Runtime stage ────────────────────────────────────────────────────
+FROM python:3.13-slim
+
+LABEL org.opencontainers.image.title="Nexus Minimal Server"
+LABEL org.opencontainers.image.description="Lightweight standalone Nexus server (storage only)"
+LABEL org.opencontainers.image.source="https://github.com/nexi-lab/nexus"
+
+# ---------- Runtime dependencies ----------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------- Copy Python packages + Rust extension ----------
+COPY --from=builder /install/lib /usr/local/lib
+COPY --from=builder /install/bin /usr/local/bin
+
+# ---------- Verify extensions ----------
+RUN python3 -c "from _nexus_raft import Metastore; print('✓ nexus_raft Metastore available')" || echo "⚠ nexus_raft Metastore not available"
+
+# ---------- Copy application files ----------
+WORKDIR /app
+COPY src/ ./src/
+COPY alembic/ ./alembic/
+COPY alembic/alembic.ini pyproject.toml README.md ./
+COPY configs/ ./configs/
+COPY dockerfiles/docker-entrypoint-minimal.sh /usr/local/bin/docker-entrypoint-minimal.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-minimal.sh
+
+# ---------- Create non-root user ----------
+RUN useradd -r -m -u 1000 -s /bin/bash nexus \
+    && mkdir -p /app/data \
+    && chown -R nexus:nexus /app
+
+USER nexus
+
+# ---------- Environment variables ----------
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    NEXUS_PROFILE=minimal \
+    NEXUS_HOST=0.0.0.0 \
+    NEXUS_PORT=2026 \
+    NEXUS_DATA_DIR=/app/data
+
+EXPOSE 2026 2126
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:${NEXUS_PORT}/healthz/ready || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint-minimal.sh"]

--- a/dockerfiles/docker-entrypoint-minimal.sh
+++ b/dockerfiles/docker-entrypoint-minimal.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# docker-entrypoint-minimal.sh - Nexus Minimal Docker container entrypoint
+# Lightweight standalone server: storage only, no Zoekt, no semantic search,
+# no cluster join, no saved mounts.
+
+set -e
+set -o pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Configuration
+NEXUS_HOST="${NEXUS_HOST:-0.0.0.0}"
+NEXUS_PORT="${NEXUS_PORT:-2026}"
+NEXUS_DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
+SERVER_PID=""
+
+# Signal handling for graceful shutdown
+cleanup() {
+    echo ""
+    echo -e "${YELLOW}Shutting down Nexus server...${NC}"
+    if [ -n "$SERVER_PID" ]; then
+        kill -TERM "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    echo -e "${GREEN}Nexus server stopped.${NC}"
+    exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+print_banner() {
+    echo ""
+    echo "╔═══════════════════════════════════════════╗"
+    echo "║     Nexus Minimal Server - Docker Init    ║"
+    echo "╚═══════════════════════════════════════════╝"
+    echo ""
+    echo "  Profile: minimal (storage only)"
+    echo "  Host:    ${NEXUS_HOST}"
+    echo "  Port:    ${NEXUS_PORT}"
+    echo "  Data:    ${NEXUS_DATA_DIR}"
+    echo ""
+}
+
+ensure_data_dir() {
+    if [ ! -d "$NEXUS_DATA_DIR" ]; then
+        echo "Creating data directory: ${NEXUS_DATA_DIR}"
+        mkdir -p "$NEXUS_DATA_DIR"
+    fi
+    echo -e "${GREEN}✓ Data directory ready${NC}"
+}
+
+start_server() {
+    echo ""
+    echo "🚀 Starting Nexus server..."
+    echo ""
+
+    nexus serve --host "$NEXUS_HOST" --port "$NEXUS_PORT" &
+    SERVER_PID=$!
+
+    # Wait for server to become healthy
+    local i
+    for i in $(seq 1 30); do
+        if curl -sf "http://localhost:${NEXUS_PORT}/health" > /dev/null 2>&1; then
+            echo -e "${GREEN}✓ Server is ready${NC}"
+            break
+        fi
+        sleep 2
+    done
+
+    echo ""
+    echo -e "${GREEN}✓ Nexus minimal server running on port ${NEXUS_PORT}${NC}"
+    echo ""
+
+    wait $SERVER_PID
+}
+
+# Main
+print_banner
+ensure_data_dir
+start_server

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,0 +1,76 @@
+# Minimal dependencies for NEXUS_PROFILE=minimal (standalone server).
+# Subset of pyproject.toml for a lightweight Nexus server with storage only.
+# No cloud connectors, no LLM/ML packages, no Zoekt, no sandbox providers.
+
+# CLI
+click>=8.1.7
+rich>=13.7.0
+tqdm>=4.66.0
+
+# Config
+pydantic[email]>=2.5.0
+pyyaml>=6.0.1
+
+# HTTP client (used internally)
+httpx[http2]>=0.28.1
+requests>=2.31.0
+tenacity>=8.2.0
+aiohttp>=3.11.0
+frozenlist>=1.5.0
+
+# gRPC server
+grpcio>=1.68.0
+protobuf>=4.25.0
+
+# HTTP server
+fastapi>=0.124.0
+uvicorn[standard]>=0.38.0
+uvloop>=0.22.1
+watchfiles>=1.0.0
+
+# Database (RecordStore — imports exist even if skipped at runtime)
+sqlalchemy>=2.0.44
+alembic>=1.13.0
+greenlet>=3.0.0
+aiosqlite>=0.20.0
+
+# Caching
+cachetools>=6.2.2
+
+# Auth
+authlib>=1.6.5
+bcrypt>=4.0.0
+cryptography>=41.0.0
+PyJWT>=2.8.0
+
+# Fast JSON
+orjson>=3.10.0
+
+# Content hashing
+blake3>=1.0.0
+bsdiff4>=1.2.0
+fastcdc>=1.5.0
+
+# Fuzzy matching
+rapidfuzz>=3.0.0
+
+# Rate limiting
+slowapi>=0.1.9
+limits>=3.6.0
+
+# BM25 search (built-in)
+bm25s>=0.2.0
+
+# Logging
+structlog>=24.4.0
+
+# LZ4 compression
+lz4>=4.3.0
+
+# Roaring bitmaps
+pyroaring>=1.0.0
+
+# Misc
+aiofiles>=25.1.0
+dotenv>=0.9.9
+networkx>=3.2

--- a/src/nexus/system_services/event_subsystem/__init__.py
+++ b/src/nexus/system_services/event_subsystem/__init__.py
@@ -11,13 +11,21 @@ from nexus.core.file_events import FileEvent, FileEventType
 from nexus.system_services.event_subsystem.bus import (
     EventBusBase,
     EventBusProtocol,
-    NatsEventBus,
     RedisEventBus,
 )
 from nexus.system_services.event_subsystem.log import (
     EventReplayService,
 )
 from nexus.system_services.event_subsystem.subscriptions import ReactiveSubscriptionManager
+
+
+def __getattr__(name: str) -> type:
+    if name == "NatsEventBus":
+        from nexus.system_services.event_subsystem.bus.nats import NatsEventBus
+
+        return NatsEventBus
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "FileEvent",

--- a/src/nexus/system_services/event_subsystem/bus/__init__.py
+++ b/src/nexus/system_services/event_subsystem/bus/__init__.py
@@ -1,8 +1,16 @@
 """EventBus implementations — pub/sub event distribution."""
 
 from nexus.system_services.event_subsystem.bus.base import EventBusBase
-from nexus.system_services.event_subsystem.bus.nats import NatsEventBus
 from nexus.system_services.event_subsystem.bus.protocol import AckableEvent, EventBusProtocol
 from nexus.system_services.event_subsystem.bus.redis import RedisEventBus
+
+
+def __getattr__(name: str) -> type:
+    if name == "NatsEventBus":
+        from nexus.system_services.event_subsystem.bus.nats import NatsEventBus
+
+        return NatsEventBus
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["EventBusProtocol", "AckableEvent", "EventBusBase", "RedisEventBus", "NatsEventBus"]


### PR DESCRIPTION
## Summary
- Add `Dockerfile.minimal` for `NEXUS_PROFILE=minimal` — lightweight standalone Nexus server with storage only (~676 MB)
- Add `requirements-minimal.txt` with subset of Python dependencies (no cloud connectors, no ML/LLM, no Zoekt)
- Add `docker-entrypoint-minimal.sh` with simplified entrypoint (no Zoekt, no semantic search, no cluster join)
- Make `NatsEventBus` import lazy to avoid hard `nats-py` dependency in minimal/remote profiles

## What's included
- NexusFS core engine (read/write/delete/stat/list)
- `_nexus_raft` Rust extension (embedded RaftMetadataStore)
- gRPC + HTTP server (FastAPI, uvicorn, grpcio)
- CLI (`nexus serve`)

## What's excluded
- Go toolchain / Zoekt (search indexing)
- `nexus_fast` Rust extension (graceful fallback to pure Python)
- Cloud connectors (boto3, google-cloud-*, slack-sdk)
- LLM packages (litellm, anthropic, tiktoken)
- ML packages (numpy, scikit-learn, scipy, faiss, txtai)
- Observability (prometheus, opentelemetry-*)
- Sandbox providers (docker, e2b)
- MCP server (fastmcp)

## Test plan
- [x] `docker build -f dockerfiles/Dockerfile.minimal -t nexus-minimal:latest .` — builds successfully
- [x] Smoke test: `from _nexus_raft import Metastore; from nexus.core.nexus_fs import NexusFS` — OK
- [x] CLI: `docker run --rm --entrypoint nexus nexus-minimal:latest --help` — OK
- [x] Server: `curl http://localhost:2026/health` — returns healthy
- [x] Readiness: `curl http://localhost:2026/healthz/ready` — returns ready
- [x] Unit tests: 155 tests pass (gRPC servicer + event bus)
- [x] Image size: 676 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)