### PR TITLE
fix(#2787): gRPC Write handler returns proper etag

### DIFF
--- a/src/nexus/grpc/servicer.py
+++ b/src/nexus/grpc/servicer.py
@@ -327,21 +327,37 @@ class VFSServicer(vfs_pb2_grpc.NexusVFSServiceServicer):
         request: "vfs_pb2.WriteRequest",
         _context: grpc.aio.ServicerContext,
     ) -> "vfs_pb2.WriteResponse":
-        """Typed write — accepts raw bytes, no JSON/base64 overhead."""
+        """Typed write — accepts raw bytes, no JSON/base64 overhead.
+
+        Uses write() (Tier 2) instead of sys_write() to get metadata back
+        (etag, version, size).  OCC is handled via occ_write() when the
+        client sends an etag — matching the JSON RPC handler pattern.
+
+        Issue #2787: sys_write() returns int (POSIX), not dict.
+        """
         try:
             _, op_context = await self._auth_and_context(request.auth_token)
-            kwargs: dict[str, Any] = {"context": op_context}
+            content = bytes(request.content)
+
             if request.etag:
-                kwargs["if_match"] = request.etag
-            result = await asyncio.to_thread(
-                self._nexus_fs.sys_write, request.path, request.content, **kwargs
-            )
+                # OCC: compare-and-swap via lib helper (Issue #1323)
+                from nexus.lib.occ import occ_write
+
+                result = await asyncio.to_thread(
+                    occ_write,
+                    self._nexus_fs,
+                    request.path,
+                    content,
+                    context=op_context,
+                    if_match=request.etag,
+                )
+            else:
+                result = await asyncio.to_thread(
+                    self._nexus_fs.write, request.path, content, context=op_context
+                )
+
             etag = result.get("etag", "") if isinstance(result, dict) else ""
-            size = (
-                result.get("size", len(request.content))
-                if isinstance(result, dict)
-                else len(request.content)
-            )
+            size = result.get("size", len(content)) if isinstance(result, dict) else len(content)
             return vfs_pb2.WriteResponse(etag=etag, size=size)
         except NexusPermissionError as e:
             return vfs_pb2.WriteResponse(

--- a/tests/unit/grpc/test_servicer.py
+++ b/tests/unit/grpc/test_servicer.py
@@ -313,8 +313,9 @@ class TestVFSServicerTypedRPCs:
         assert payload["code"] == -32000
 
     @pytest.mark.anyio
-    async def test_write_success(self, servicer) -> None:
-        """Write returns etag and size from sys_write."""
+    async def test_write_success(self, servicer, mock_nexus_fs) -> None:
+        """Write returns etag and size from write() (Issue #2787)."""
+        mock_nexus_fs.write.return_value = {"etag": "sha256-xyz", "size": 4}
         request = _make_typed_request(
             "WriteRequest", path="/file.txt", content=b"data", auth_token="", etag=""
         )
@@ -330,6 +331,53 @@ class TestVFSServicerTypedRPCs:
         assert response.is_error is False
         assert response.etag == "sha256-xyz"
         assert response.size == 4
+
+    @pytest.mark.anyio
+    async def test_write_calls_write_not_sys_write(self, servicer, mock_nexus_fs) -> None:
+        """Write handler uses write() (returns dict) not sys_write() (returns int).
+
+        Issue #2787: sys_write() returns int (POSIX), so etag was always empty.
+        """
+        request = _make_typed_request(
+            "WriteRequest", path="/file.txt", content=b"data", auth_token="", etag=""
+        )
+        context = MagicMock()
+
+        with patch(
+            "nexus.grpc.servicer.asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value={"etag": "sha256-xyz", "size": 4},
+        ) as mock_thread:
+            await servicer.Write(request, context)
+
+        # Verify write() was passed (not sys_write)
+        call_args = mock_thread.call_args
+        func = call_args[0][0]
+        assert "write" in str(func)
+        assert "sys_write" not in str(func)
+
+    @pytest.mark.anyio
+    async def test_write_with_occ_etag(self, servicer) -> None:
+        """Write with etag uses occ_write() for compare-and-swap (Issue #2787)."""
+        request = _make_typed_request(
+            "WriteRequest", path="/file.txt", content=b"data", auth_token="", etag="sha256-old"
+        )
+        context = MagicMock()
+
+        with patch(
+            "nexus.grpc.servicer.asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value={"etag": "sha256-new", "size": 4},
+        ) as mock_thread:
+            response = await servicer.Write(request, context)
+
+        assert response.is_error is False
+        assert response.etag == "sha256-new"
+
+        # Verify occ_write was called (not plain write)
+        call_args = mock_thread.call_args
+        func = call_args[0][0]
+        assert "occ_write" in str(func)
 
     @pytest.mark.anyio
     async def test_write_conflict(self, servicer) -> None:

--- a/tests/unit/services/event_subsystem/test_event_ordering.py
+++ b/tests/unit/services/event_subsystem/test_event_ordering.py
@@ -10,7 +10,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from nexus.core.file_events import FileEvent, FileEventType
-from nexus.services.event_subsystem.log.delivery import EventDeliveryWorker
+from nexus.system_services.event_subsystem.log.delivery import EventDeliveryWorker
 
 
 def _make_record(
@@ -156,7 +156,7 @@ class TestDeliveryWorkerOrdering:
         )
 
         with patch(
-            "nexus.services.event_subsystem.log.delivery._run_async",
+            "nexus.system_services.event_subsystem.log.delivery._run_async",
             side_effect=lambda coro, loop=None: asyncio.run(coro),  # noqa: ARG005
         ):
             worker._dispatch_event_internal(worker._build_file_event(record), record)
@@ -170,7 +170,7 @@ class TestKafkaExporterPartitionKey:
 
     def test_publish_uses_zone_id_key(self):
         """Single publish uses zone_id as Kafka key."""
-        from nexus.services.event_subsystem.log.exporters.kafka_exporter import (
+        from nexus.system_services.event_subsystem.log.exporters.kafka_exporter import (
             KafkaExporter,
         )
 
@@ -198,7 +198,7 @@ class TestKafkaExporterPartitionKey:
 
     def test_publish_batch_uses_zone_id_key(self):
         """Batch publish uses zone_id as Kafka key for each event."""
-        from nexus.services.event_subsystem.log.exporters.kafka_exporter import (
+        from nexus.system_services.event_subsystem.log.exporters.kafka_exporter import (
             KafkaExporter,
         )
 


### PR DESCRIPTION
## Summary
- gRPC `Write` handler used `sys_write()` (returns `int`, POSIX semantics) instead of `write()` (returns `dict` with etag/version/size), causing `WriteResponse.etag` to always be empty
- When OCC etag was provided, handler passed `if_match` kwarg to `sys_write()` which doesn't accept it — would cause `TypeError`
- Fix: use `write()` for normal writes and `occ_write()` for compare-and-swap, matching the JSON RPC `handle_write` pattern

## Test plan
- [x] Existing `test_write_success` still passes
- [x] New `test_write_calls_write_not_sys_write` verifies `write()` is called (not `sys_write()`)
- [x] New `test_write_with_occ_etag` verifies OCC path uses `occ_write()`
- [x] All 24 servicer tests pass
- [x] Lint (ruff check + format) passes
- [x] mypy passes
- [x] Pre-commit hooks pass

Closes #2787