### PR TITLE
feat(#2750): per-exporter circuit breaker and timeout in ExporterRegistry

### DIFF
--- a/src/nexus/system_services/event_subsystem/log/exporter_registry.py
+++ b/src/nexus/system_services/event_subsystem/log/exporter_registry.py
@@ -1,14 +1,18 @@
 """ExporterRegistry — manages and dispatches to registered exporters.
 
 Dispatches event batches to all registered exporters in parallel via
-asyncio.gather(). Collects per-exporter failures for DLQ routing.
+asyncio.gather(). Per-exporter circuit breaker and timeout prevent one
+slow/dead exporter from blocking delivery to healthy exporters.
 
 Issue #1138: Event Stream Export.
+Issue #2750: Per-exporter circuit breaker and timeout.
 """
 
 import asyncio
 import logging
 from typing import TYPE_CHECKING
+
+from nexus.lib.circuit_breaker import CircuitBreakerBase, CircuitState
 
 if TYPE_CHECKING:
     from nexus.system_services.event_subsystem.log.exporter_protocol import (
@@ -18,21 +22,50 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Defaults matching issue #2750 acceptance criteria
+_DEFAULT_FAILURE_THRESHOLD = 3
+_DEFAULT_RESET_TIMEOUT = 60.0
+_DEFAULT_EXPORTER_TIMEOUT = 30.0
+
 
 class ExporterRegistry:
-    """Registry of event stream exporters with parallel dispatch."""
+    """Registry of event stream exporters with parallel dispatch.
 
-    def __init__(self) -> None:
+    Each exporter gets its own circuit breaker (trip after 3 consecutive
+    failures, auto-reset after 60s) and a per-dispatch timeout (default
+    30s).  A tripped breaker fast-fails without attempting the network
+    call, returning all event IDs as failed for DLQ routing.
+
+    Issue #2750.
+    """
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int = _DEFAULT_FAILURE_THRESHOLD,
+        reset_timeout: float = _DEFAULT_RESET_TIMEOUT,
+        exporter_timeout: float = _DEFAULT_EXPORTER_TIMEOUT,
+    ) -> None:
         self._exporters: dict[str, EventStreamExporterProtocol] = {}
+        self._breakers: dict[str, CircuitBreakerBase] = {}
+        self._failure_threshold = failure_threshold
+        self._reset_timeout = reset_timeout
+        self._exporter_timeout = exporter_timeout
 
     def register(self, exporter: "EventStreamExporterProtocol") -> None:
         """Register an exporter. Overwrites if name already exists."""
         self._exporters[exporter.name] = exporter
+        self._breakers[exporter.name] = CircuitBreakerBase(
+            failure_threshold=self._failure_threshold,
+            success_threshold=1,
+            reset_timeout=self._reset_timeout,
+        )
         logger.info("Registered event exporter: %s", exporter.name)
 
     def unregister(self, name: str) -> None:
         """Remove an exporter by name."""
         removed = self._exporters.pop(name, None)
+        self._breakers.pop(name, None)
         if removed:
             logger.info("Unregistered event exporter: %s", name)
 
@@ -40,8 +73,16 @@ class ExporterRegistry:
     def exporter_names(self) -> list[str]:
         return list(self._exporters)
 
+    @property
+    def breaker_states(self) -> dict[str, str]:
+        """Return circuit breaker state for each exporter (observability)."""
+        return {name: breaker.current_state.value for name, breaker in self._breakers.items()}
+
     async def dispatch_batch(self, events: "list[FileEvent]") -> dict[str, list[str]]:
         """Dispatch a batch of events to all registered exporters in parallel.
+
+        Per-exporter circuit breaker and timeout ensure one slow/dead
+        exporter does not block delivery to other healthy exporters.
 
         Returns:
             Dict mapping exporter_name → list of failed event_ids.
@@ -50,20 +91,59 @@ class ExporterRegistry:
         if not self._exporters or not events:
             return {}
 
-        async def _dispatch_one(
-            name: str, exporter: "EventStreamExporterProtocol"
-        ) -> tuple[str, list[str]]:
-            try:
-                failed_ids = await exporter.publish_batch(events)
-                return (name, failed_ids)
-            except Exception:
-                logger.exception("Exporter %s batch dispatch failed", name)
-                return (name, [e.event_id for e in events])
-
         results = await asyncio.gather(
-            *[_dispatch_one(name, exp) for name, exp in self._exporters.items()]
+            *[self._dispatch_one(name, exp, events) for name, exp in self._exporters.items()]
         )
         return {name: failed for name, failed in results if failed}
+
+    async def _dispatch_one(
+        self,
+        name: str,
+        exporter: "EventStreamExporterProtocol",
+        events: "list[FileEvent]",
+    ) -> tuple[str, list[str]]:
+        """Dispatch to a single exporter with circuit breaker + timeout."""
+        breaker = self._breakers.get(name)
+        all_ids = [e.event_id for e in events]
+
+        # Fast-fail if circuit is OPEN
+        if breaker and breaker.current_state is CircuitState.OPEN:
+            logger.warning(
+                "Exporter %s circuit OPEN — fast-failing %d events to DLQ",
+                name,
+                len(events),
+            )
+            return (name, all_ids)
+
+        try:
+            async with asyncio.timeout(self._exporter_timeout):
+                failed_ids = await exporter.publish_batch(events)
+
+            # Record outcome on breaker
+            if breaker:
+                if failed_ids:
+                    await breaker._record_failure()
+                else:
+                    await breaker._record_success()
+
+            return (name, failed_ids)
+
+        except TimeoutError:
+            logger.error(
+                "Exporter %s timed out after %.1fs dispatching %d events",
+                name,
+                self._exporter_timeout,
+                len(events),
+            )
+            if breaker:
+                await breaker._record_failure()
+            return (name, all_ids)
+
+        except Exception:
+            logger.exception("Exporter %s batch dispatch failed", name)
+            if breaker:
+                await breaker._record_failure()
+            return (name, all_ids)
 
     async def close_all(self) -> None:
         """Gracefully close all registered exporters."""
@@ -74,6 +154,7 @@ class ExporterRegistry:
             except Exception:
                 logger.exception("Error closing exporter: %s", name)
         self._exporters.clear()
+        self._breakers.clear()
 
     async def health_check(self) -> dict[str, bool]:
         """Check health of all registered exporters."""

--- a/src/nexus/system_services/event_subsystem/log/exporters/config.py
+++ b/src/nexus/system_services/event_subsystem/log/exporters/config.py
@@ -18,6 +18,7 @@ class KafkaExporterConfig(BaseModel):
     compression: str = "lz4"
     enable_idempotence: bool = True
     batch_size: int = 100
+    send_timeout: float = 10.0
 
 
 class NatsExporterConfig(BaseModel):
@@ -27,6 +28,7 @@ class NatsExporterConfig(BaseModel):
     subject_prefix: str = "nexus.export"
     stream_name: str = "NEXUS_EXPORT"
     max_payload: int = 1_048_576  # 1MB
+    send_timeout: float = 10.0
 
 
 class PubSubExporterConfig(BaseModel):

--- a/src/nexus/system_services/event_subsystem/log/exporters/kafka_exporter.py
+++ b/src/nexus/system_services/event_subsystem/log/exporters/kafka_exporter.py
@@ -4,9 +4,12 @@ Publishes FileEvents to Apache Kafka topics using aiokafka.
 Topics: ``{topic_prefix}.{zone_id}`` with LZ4 compression and
 idempotent producer for exactly-once semantics.
 
+Issue #2750: Per-message timeout via ``send_timeout`` config.
+
 Optional dependency: ``pip install nexus-ai-fs[kafka]``
 """
 
+import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING, Any
@@ -62,19 +65,22 @@ class KafkaExporter:
         """Publish a single event to Kafka."""
         producer = await self._ensure_producer()
         topic = f"{self._config.topic_prefix}.{event.zone_id or ROOT_ZONE_ID}"
+        send_timeout = getattr(self._config, "send_timeout", 10.0)
         # Use zone_id as partition key so all events for a zone land in the
         # same partition, guaranteeing per-zone ordering (#2755).
-        await producer.send_and_wait(
-            topic,
-            value=event.to_dict(),
-            key=event.zone_id or ROOT_ZONE_ID,
-        )
+        async with asyncio.timeout(send_timeout):
+            await producer.send_and_wait(
+                topic,
+                value=event.to_dict(),
+                key=event.zone_id or ROOT_ZONE_ID,
+            )
 
     async def publish_batch(self, events: list[FileEvent]) -> list[str]:
         """Publish a batch of events, internally chunking to configured batch_size."""
         producer = await self._ensure_producer()
         failed_ids: list[str] = []
         chunk_size = self._config.batch_size
+        send_timeout = getattr(self._config, "send_timeout", 10.0)
 
         for i in range(0, len(events), chunk_size):
             chunk = events[i : i + chunk_size]
@@ -82,11 +88,12 @@ class KafkaExporter:
                 topic = f"{self._config.topic_prefix}.{event.zone_id or ROOT_ZONE_ID}"
                 try:
                     # zone_id as partition key for per-zone ordering (#2755)
-                    await producer.send_and_wait(
-                        topic,
-                        value=event.to_dict(),
-                        key=event.zone_id or ROOT_ZONE_ID,
-                    )
+                    async with asyncio.timeout(send_timeout):
+                        await producer.send_and_wait(
+                            topic,
+                            value=event.to_dict(),
+                            key=event.zone_id or ROOT_ZONE_ID,
+                        )
                 except Exception:
                     logger.warning(
                         "Kafka publish failed for event %s",

--- a/src/nexus/system_services/event_subsystem/log/exporters/nats_exporter.py
+++ b/src/nexus/system_services/event_subsystem/log/exporters/nats_exporter.py
@@ -9,6 +9,7 @@ Uses Nats-Msg-Id header for server-side deduplication.
 Optional dependency: ``pip install nexus-ai-fs[nats-export]``
 """
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -78,25 +79,29 @@ class NatsExporter:
         """Publish a single event to NATS JetStream."""
         js = await self._ensure_connection()
         payload = serialize_event(event)
-        await js.publish(
-            self._subject(event),
-            payload,
-            headers={"Nats-Msg-Id": event.event_id},
-        )
+        send_timeout = getattr(self._config, "send_timeout", 10.0)
+        async with asyncio.timeout(send_timeout):
+            await js.publish(
+                self._subject(event),
+                payload,
+                headers={"Nats-Msg-Id": event.event_id},
+            )
 
     async def publish_batch(self, events: list[FileEvent]) -> list[str]:
         """Publish a batch of events to NATS JetStream."""
         js = await self._ensure_connection()
         failed_ids: list[str] = []
+        send_timeout = getattr(self._config, "send_timeout", 10.0)
 
         for event in events:
             try:
                 payload = serialize_event(event)
-                await js.publish(
-                    self._subject(event),
-                    payload,
-                    headers={"Nats-Msg-Id": event.event_id},
-                )
+                async with asyncio.timeout(send_timeout):
+                    await js.publish(
+                        self._subject(event),
+                        payload,
+                        headers={"Nats-Msg-Id": event.event_id},
+                    )
             except Exception:
                 logger.warning(
                     "NATS publish failed for event %s",

--- a/tests/unit/services/event_log/test_exporter_registry.py
+++ b/tests/unit/services/event_log/test_exporter_registry.py
@@ -1,13 +1,14 @@
-"""Unit tests for ExporterRegistry — parallel dispatch and failure collection.
+"""Unit tests for ExporterRegistry — parallel dispatch, circuit breaker, and timeout.
 
 Issue #1138: Event Stream Export.
+Issue #2750: Per-exporter circuit breaker and timeout.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
-import pytest
-
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.lib.circuit_breaker import CircuitState
 from nexus.system_services.event_subsystem.log.exporter_registry import ExporterRegistry
 from nexus.system_services.event_subsystem.types import FileEvent, FileEventType
 
@@ -49,63 +50,57 @@ class TestExporterRegistry:
         registry = ExporterRegistry()
         registry.unregister("nonexistent")  # Should not raise
 
-    @pytest.mark.asyncio
-    async def test_dispatch_batch_empty_events(self) -> None:
+    def test_dispatch_batch_empty_events(self) -> None:
         registry = ExporterRegistry()
         exporter = _make_mock_exporter("kafka")
         registry.register(exporter)
 
-        result = await registry.dispatch_batch([])
+        result = asyncio.run(registry.dispatch_batch([]))
         assert result == {}
         exporter.publish_batch.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_dispatch_batch_empty_registry(self) -> None:
+    def test_dispatch_batch_empty_registry(self) -> None:
         registry = ExporterRegistry()
         events = [_make_event()]
 
-        result = await registry.dispatch_batch(events)
+        result = asyncio.run(registry.dispatch_batch(events))
         assert result == {}
 
-    @pytest.mark.asyncio
-    async def test_dispatch_batch_success(self) -> None:
+    def test_dispatch_batch_success(self) -> None:
         registry = ExporterRegistry()
         exporter = _make_mock_exporter("kafka")
         registry.register(exporter)
 
         events = [_make_event("e1"), _make_event("e2")]
-        result = await registry.dispatch_batch(events)
+        result = asyncio.run(registry.dispatch_batch(events))
 
         assert result == {}  # No failures
         exporter.publish_batch.assert_called_once_with(events)
 
-    @pytest.mark.asyncio
-    async def test_dispatch_batch_partial_failure(self) -> None:
+    def test_dispatch_batch_partial_failure(self) -> None:
         registry = ExporterRegistry()
         exporter = _make_mock_exporter("kafka", fail_ids=["e2"])
         registry.register(exporter)
 
         events = [_make_event("e1"), _make_event("e2")]
-        result = await registry.dispatch_batch(events)
+        result = asyncio.run(registry.dispatch_batch(events))
 
         assert result == {"kafka": ["e2"]}
 
-    @pytest.mark.asyncio
-    async def test_dispatch_batch_exporter_exception(self) -> None:
+    def test_dispatch_batch_exporter_exception(self) -> None:
         registry = ExporterRegistry()
         exporter = _make_mock_exporter("kafka")
         exporter.publish_batch = AsyncMock(side_effect=ConnectionError("down"))
         registry.register(exporter)
 
         events = [_make_event("e1"), _make_event("e2")]
-        result = await registry.dispatch_batch(events)
+        result = asyncio.run(registry.dispatch_batch(events))
 
         # All events should be reported as failed
         assert "kafka" in result
         assert set(result["kafka"]) == {"e1", "e2"}
 
-    @pytest.mark.asyncio
-    async def test_parallel_dispatch_to_multiple_exporters(self) -> None:
+    def test_parallel_dispatch_to_multiple_exporters(self) -> None:
         registry = ExporterRegistry()
         kafka = _make_mock_exporter("kafka")
         nats = _make_mock_exporter("nats", fail_ids=["e1"])
@@ -113,7 +108,7 @@ class TestExporterRegistry:
         registry.register(nats)
 
         events = [_make_event("e1"), _make_event("e2")]
-        result = await registry.dispatch_batch(events)
+        result = asyncio.run(registry.dispatch_batch(events))
 
         # Kafka succeeded, NATS failed for e1
         assert "kafka" not in result
@@ -121,22 +116,20 @@ class TestExporterRegistry:
         kafka.publish_batch.assert_called_once()
         nats.publish_batch.assert_called_once()
 
-    @pytest.mark.asyncio
-    async def test_close_all(self) -> None:
+    def test_close_all(self) -> None:
         registry = ExporterRegistry()
         kafka = _make_mock_exporter("kafka")
         nats = _make_mock_exporter("nats")
         registry.register(kafka)
         registry.register(nats)
 
-        await registry.close_all()
+        asyncio.run(registry.close_all())
 
         kafka.close.assert_called_once()
         nats.close.assert_called_once()
         assert registry.exporter_names == []
 
-    @pytest.mark.asyncio
-    async def test_health_check(self) -> None:
+    def test_health_check(self) -> None:
         registry = ExporterRegistry()
         kafka = _make_mock_exporter("kafka")
         kafka.health_check = AsyncMock(return_value=True)
@@ -145,16 +138,249 @@ class TestExporterRegistry:
         registry.register(kafka)
         registry.register(nats)
 
-        result = await registry.health_check()
+        result = asyncio.run(registry.health_check())
 
         assert result == {"kafka": True, "nats": False}
 
-    @pytest.mark.asyncio
-    async def test_health_check_exception_returns_false(self) -> None:
+    def test_health_check_exception_returns_false(self) -> None:
         registry = ExporterRegistry()
         exporter = _make_mock_exporter("kafka")
         exporter.health_check = AsyncMock(side_effect=Exception("boom"))
         registry.register(exporter)
 
-        result = await registry.health_check()
+        result = asyncio.run(registry.health_check())
         assert result == {"kafka": False}
+
+
+class TestExporterRegistryCircuitBreaker:
+    """Test per-exporter circuit breaker behavior (Issue #2750)."""
+
+    def test_register_creates_breaker(self) -> None:
+        """Each registered exporter gets its own circuit breaker."""
+        registry = ExporterRegistry()
+        exporter = _make_mock_exporter("kafka")
+        registry.register(exporter)
+
+        assert "kafka" in registry.breaker_states
+        assert registry.breaker_states["kafka"] == CircuitState.CLOSED.value
+
+    def test_unregister_removes_breaker(self) -> None:
+        """Unregistering an exporter removes its circuit breaker."""
+        registry = ExporterRegistry()
+        exporter = _make_mock_exporter("kafka")
+        registry.register(exporter)
+        registry.unregister("kafka")
+
+        assert "kafka" not in registry.breaker_states
+
+    def test_custom_failure_threshold(self) -> None:
+        """Registry accepts custom failure_threshold parameter."""
+        registry = ExporterRegistry(failure_threshold=5)
+        assert registry._failure_threshold == 5
+
+    def test_custom_reset_timeout(self) -> None:
+        """Registry accepts custom reset_timeout parameter."""
+        registry = ExporterRegistry(reset_timeout=120.0)
+        assert registry._reset_timeout == 120.0
+
+    def test_custom_exporter_timeout(self) -> None:
+        """Registry accepts custom exporter_timeout parameter."""
+        registry = ExporterRegistry(exporter_timeout=15.0)
+        assert registry._exporter_timeout == 15.0
+
+    def test_success_keeps_breaker_closed(self) -> None:
+        """Successful dispatches keep the circuit breaker CLOSED."""
+        registry = ExporterRegistry()
+        exporter = _make_mock_exporter("kafka")
+        registry.register(exporter)
+
+        events = [_make_event("e1")]
+        asyncio.run(registry.dispatch_batch(events))
+
+        assert registry.breaker_states["kafka"] == CircuitState.CLOSED.value
+
+    def test_breaker_trips_after_threshold_failures(self) -> None:
+        """Circuit breaker opens after failure_threshold consecutive failures."""
+
+        async def _run():
+            registry = ExporterRegistry(failure_threshold=3)
+            exporter = _make_mock_exporter("kafka")
+            exporter.publish_batch = AsyncMock(side_effect=ConnectionError("down"))
+            registry.register(exporter)
+
+            events = [_make_event("e1")]
+            for _ in range(3):
+                await registry.dispatch_batch(events)
+
+            assert registry.breaker_states["kafka"] == CircuitState.OPEN.value
+
+        asyncio.run(_run())
+
+    def test_open_breaker_fast_fails(self) -> None:
+        """OPEN circuit breaker returns all event IDs without calling exporter."""
+
+        async def _run():
+            registry = ExporterRegistry(failure_threshold=3)
+            exporter = _make_mock_exporter("kafka")
+            exporter.publish_batch = AsyncMock(side_effect=ConnectionError("down"))
+            registry.register(exporter)
+
+            events = [_make_event("e1")]
+            for _ in range(3):
+                await registry.dispatch_batch(events)
+
+            # Reset the mock to verify it's not called during fast-fail
+            exporter.publish_batch.reset_mock()
+
+            result = await registry.dispatch_batch([_make_event("e2"), _make_event("e3")])
+
+            assert result == {"kafka": ["e2", "e3"]}
+            exporter.publish_batch.assert_not_called()
+
+        asyncio.run(_run())
+
+    def test_partial_failure_records_failure_on_breaker(self) -> None:
+        """Partial failures (some event IDs returned) record as failure."""
+
+        async def _run():
+            registry = ExporterRegistry(failure_threshold=3)
+            exporter = _make_mock_exporter("kafka", fail_ids=["e1"])
+            registry.register(exporter)
+
+            events = [_make_event("e1"), _make_event("e2")]
+            for _ in range(3):
+                await registry.dispatch_batch(events)
+
+            assert registry.breaker_states["kafka"] == CircuitState.OPEN.value
+
+        asyncio.run(_run())
+
+    def test_success_records_success_on_breaker(self) -> None:
+        """Successful dispatch after failures keeps breaker CLOSED."""
+
+        async def _run():
+            registry = ExporterRegistry(failure_threshold=3)
+            exporter = _make_mock_exporter("kafka")
+            registry.register(exporter)
+
+            events = [_make_event("e1")]
+
+            # 2 failures then 1 success
+            exporter.publish_batch = AsyncMock(side_effect=ConnectionError("down"))
+            for _ in range(2):
+                await registry.dispatch_batch(events)
+
+            exporter.publish_batch = AsyncMock(return_value=[])
+            await registry.dispatch_batch(events)
+
+            assert registry.breaker_states["kafka"] == CircuitState.CLOSED.value
+
+        asyncio.run(_run())
+
+    def test_independent_breakers_per_exporter(self) -> None:
+        """Each exporter has its own independent circuit breaker."""
+
+        async def _run():
+            registry = ExporterRegistry(failure_threshold=3)
+            kafka = _make_mock_exporter("kafka")
+            kafka.publish_batch = AsyncMock(side_effect=ConnectionError("down"))
+            nats = _make_mock_exporter("nats")  # succeeds
+            registry.register(kafka)
+            registry.register(nats)
+
+            events = [_make_event("e1")]
+            for _ in range(3):
+                await registry.dispatch_batch(events)
+
+            assert registry.breaker_states["kafka"] == CircuitState.OPEN.value
+            assert registry.breaker_states["nats"] == CircuitState.CLOSED.value
+
+        asyncio.run(_run())
+
+
+class TestExporterRegistryTimeout:
+    """Test per-exporter timeout behavior (Issue #2750)."""
+
+    def test_timeout_returns_all_ids_as_failed(self) -> None:
+        """Exporter timeout returns all event IDs as failed."""
+
+        async def _run():
+            registry = ExporterRegistry(exporter_timeout=0.05)
+            exporter = _make_mock_exporter("kafka")
+
+            async def slow_publish(events):  # noqa: ARG001
+                await asyncio.sleep(1.0)
+                return []
+
+            exporter.publish_batch = slow_publish
+            registry.register(exporter)
+
+            events = [_make_event("e1"), _make_event("e2")]
+            result = await registry.dispatch_batch(events)
+
+            assert result == {"kafka": ["e1", "e2"]}
+
+        asyncio.run(_run())
+
+    def test_timeout_records_failure_on_breaker(self) -> None:
+        """Timeout records a failure on the circuit breaker."""
+
+        async def _run():
+            registry = ExporterRegistry(failure_threshold=3, exporter_timeout=0.05)
+            exporter = _make_mock_exporter("kafka")
+
+            async def slow_publish(events):  # noqa: ARG001
+                await asyncio.sleep(1.0)
+                return []
+
+            exporter.publish_batch = slow_publish
+            registry.register(exporter)
+
+            events = [_make_event("e1")]
+            for _ in range(3):
+                await registry.dispatch_batch(events)
+
+            assert registry.breaker_states["kafka"] == CircuitState.OPEN.value
+
+        asyncio.run(_run())
+
+    def test_slow_exporter_does_not_block_fast_exporter(self) -> None:
+        """A slow exporter does not block delivery to a fast exporter."""
+
+        async def _run():
+            registry = ExporterRegistry(exporter_timeout=0.05)
+
+            slow = _make_mock_exporter("slow")
+
+            async def slow_publish(events):  # noqa: ARG001
+                await asyncio.sleep(1.0)
+                return []
+
+            slow.publish_batch = slow_publish
+
+            fast = _make_mock_exporter("fast")
+            registry.register(slow)
+            registry.register(fast)
+
+            events = [_make_event("e1")]
+            result = await registry.dispatch_batch(events)
+
+            assert result == {"slow": ["e1"]}
+            fast.publish_batch.assert_called_once()
+
+        asyncio.run(_run())
+
+    def test_default_timeout_is_30s(self) -> None:
+        """Default exporter timeout is 30 seconds."""
+        registry = ExporterRegistry()
+        assert registry._exporter_timeout == 30.0
+
+    def test_default_failure_threshold_is_3(self) -> None:
+        """Default failure threshold is 3."""
+        registry = ExporterRegistry()
+        assert registry._failure_threshold == 3
+
+    def test_default_reset_timeout_is_60(self) -> None:
+        """Default reset timeout is 60 seconds."""
+        registry = ExporterRegistry()
+        assert registry._reset_timeout == 60.0

--- a/tests/unit/services/event_subsystem/test_event_ordering.py
+++ b/tests/unit/services/event_subsystem/test_event_ordering.py
@@ -176,6 +176,7 @@ class TestKafkaExporterPartitionKey:
 
         config = Mock()
         config.topic_prefix = "nexus.events"
+        config.send_timeout = 10.0
 
         exporter = KafkaExporter(config)
         mock_producer = AsyncMock()
@@ -205,6 +206,7 @@ class TestKafkaExporterPartitionKey:
         config = Mock()
         config.topic_prefix = "nexus.events"
         config.batch_size = 100
+        config.send_timeout = 10.0
 
         exporter = KafkaExporter(config)
         mock_producer = AsyncMock()


### PR DESCRIPTION
## Summary

Closes #2750.

- **ExporterRegistry**: Each registered exporter gets its own `CircuitBreakerBase` (trip after 3 consecutive failures, auto-reset after 60s) and a per-dispatch timeout (default 30s). An OPEN breaker fast-fails all events to DLQ without attempting the network call.
- **Kafka/NATS exporters**: Per-message `send_timeout` (default 10s) wrapping `send_and_wait()`/`js.publish()` calls via `asyncio.timeout()`.
- **Config**: Added `send_timeout: float = 10.0` to `KafkaExporterConfig` and `NatsExporterConfig`.
- **Tests**: 17 new tests (28 total) covering breaker trip/fast-fail/recovery, timeout behavior, slow-exporter isolation, and default parameter values.

## Files changed

| File | Change |
|------|--------|
| `exporter_registry.py` | CircuitBreakerBase per exporter, `asyncio.timeout()` per dispatch, `breaker_states` property |
| `kafka_exporter.py` | `asyncio.timeout(send_timeout)` on `send_and_wait()` in `publish()` and `publish_batch()` |
| `nats_exporter.py` | `asyncio.timeout(send_timeout)` on `js.publish()` in `publish()` and `publish_batch()` |
| `config.py` | `send_timeout: float = 10.0` on `KafkaExporterConfig` and `NatsExporterConfig` |
| `test_exporter_registry.py` | 17 new tests in `TestExporterRegistryCircuitBreaker` and `TestExporterRegistryTimeout` |

## Test plan

- [x] All 28 exporter registry tests pass
- [x] ruff check + format clean
- [x] mypy passes
- [x] Pre-commit hooks pass