### PR TITLE
feat(#2751): persist retry counts for EventDeliveryWorker across restarts

### DIFF
--- a/alembic/versions/add_retry_count_to_operation_log.py
+++ b/alembic/versions/add_retry_count_to_operation_log.py
@@ -16,7 +16,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "add_retry_count_oplog"
-down_revision: Union[str, Sequence[str], None] = "add_delivered_col_oplog"
+down_revision: Union[str, Sequence[str], None] = "add_credentials_and_manifests"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/add_retry_count_to_operation_log.py
+++ b/alembic/versions/add_retry_count_to_operation_log.py
@@ -1,0 +1,32 @@
+"""Add retry_count column to operation_log table.
+
+Revision ID: add_retry_count_oplog
+Revises: add_delivered_col_oplog
+Create Date: 2026-03-06
+
+Issue #2751: Persist retry counts for EventDeliveryWorker across restarts.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_retry_count_oplog"
+down_revision: Union[str, Sequence[str], None] = "add_delivered_col_oplog"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "operation_log",
+        sa.Column("retry_count", sa.BigInteger(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("operation_log", "retry_count")

--- a/src/nexus/storage/models/operation_log.py
+++ b/src/nexus/storage/models/operation_log.py
@@ -65,6 +65,12 @@ class OperationLogModel(Base):
     # Nullable for backfill of existing rows; new rows auto-populated via trigger/app.
     sequence_number: Mapped[int | None] = mapped_column(BigInteger, nullable=True, default=None)
 
+    # Persistent retry count for delivery worker (Issue #2751).
+    # Survives worker restarts; prevents over-retry and DLQ bypass.
+    retry_count: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, server_default="0"
+    )
+
     # Indexes
     __table_args__ = (
         Index("idx_operation_log_type", "operation_type"),

--- a/src/nexus/system_services/event_subsystem/log/delivery.py
+++ b/src/nexus/system_services/event_subsystem/log/delivery.py
@@ -114,9 +114,6 @@ class EventDeliveryWorker:
         self._stop_event = threading.Event()
         self._consecutive_empty = 0
 
-        # In-memory retry tracking: operation_id -> retry count
-        self._retry_counts: dict[str, int] = {}
-
         # Metrics
         self._total_dispatched = 0
         self._total_failed = 0
@@ -242,8 +239,6 @@ class EventDeliveryWorker:
                         self._dispatch_event_internal(event, record)
                         dispatched_ids.append(record.operation_id)
                         self._total_dispatched += 1
-                        # Clear retry count on success
-                        self._retry_counts.pop(record.operation_id, None)
                     except Exception as exc:
                         self._handle_dispatch_failure(session, record, event, exc)
 
@@ -300,13 +295,17 @@ class EventDeliveryWorker:
     def _handle_dispatch_failure(
         self, session: "Session", record: Any, event: FileEvent, exc: Exception
     ) -> None:
-        """Handle a failed dispatch: track retries or route to DLQ."""
+        """Handle a failed dispatch: increment persistent retry_count or route to DLQ.
+
+        Uses ``record.retry_count`` (persisted in DB) instead of an in-memory
+        dict so retry state survives worker restarts (Issue #2751).
+        """
         op_id = record.operation_id
-        self._retry_counts[op_id] = self._retry_counts.get(op_id, 0) + 1
-        retries = self._retry_counts[op_id]
+        record.retry_count = record.retry_count + 1
+        retries = record.retry_count
 
         if retries >= self._max_retries:
-            # Route to DLQ
+            # Route to DLQ and mark delivered to stop re-polling
             try:
                 from nexus.system_services.event_subsystem.log.dead_letter import DeadLetterHandler
 
@@ -319,8 +318,8 @@ class EventDeliveryWorker:
                     event=event,
                     retry_count=retries,
                 )
+                record.delivered = True
                 self._total_dlq += 1
-                self._retry_counts.pop(op_id, None)
             except Exception:
                 logger.exception("Failed to route event %s to DLQ", op_id)
         else:

--- a/tests/unit/services/event_log/test_delivery_worker.py
+++ b/tests/unit/services/event_log/test_delivery_worker.py
@@ -1,10 +1,10 @@
-"""Unit tests for EventDeliveryWorker — extended for Issue #1138/#1139.
+"""Unit tests for EventDeliveryWorker — extended for Issue #1138/#1139/#2751.
 
 Tests cover the new features added to the delivery worker:
 - ExporterRegistry integration (parallel dispatch)
 - DLQ routing after max_retries
 - _run_async helper (fire-and-forget fix)
-- Error classification and retry tracking
+- Persistent retry counts across restarts (Issue #2751)
 """
 
 import asyncio
@@ -187,7 +187,7 @@ class TestDLQRouting:
     def test_routes_to_dlq_after_max_retries(self, record_store: SQLAlchemyRecordStore) -> None:
         from nexus.system_services.event_subsystem.log.delivery import EventDeliveryWorker
 
-        _insert_undelivered(record_store.session_factory)
+        op_id = _insert_undelivered(record_store.session_factory)
 
         mock_bus = MagicMock()
         mock_bus.publish = AsyncMock(side_effect=ConnectionError("down"))
@@ -206,10 +206,17 @@ class TestDLQRouting:
         worker._poll_and_dispatch()
         assert worker.metrics["total_dlq"] == 1
 
-    def test_retry_count_clears_on_success(self, record_store: SQLAlchemyRecordStore) -> None:
+        # DLQ'd row should be marked delivered so it's not re-polled
+        with record_store.session_factory() as session:
+            row = session.get(OperationLogModel, op_id)
+            assert row.delivered is True
+            assert row.retry_count == 2
+
+    def test_retry_count_persists_then_delivers(self, record_store: SQLAlchemyRecordStore) -> None:
+        """After a failure bumps retry_count, a successful retry marks delivered."""
         from nexus.system_services.event_subsystem.log.delivery import EventDeliveryWorker
 
-        _insert_undelivered(record_store.session_factory)
+        op_id = _insert_undelivered(record_store.session_factory)
 
         call_count = 0
 
@@ -229,12 +236,108 @@ class TestDLQRouting:
             max_retries=3,
         )
 
-        # First poll: fail
+        # First poll: fail -> retry_count bumped to 1 in DB
         worker._poll_and_dispatch()
         assert worker.metrics["total_failed"] == 1
 
-        # Second poll: succeed -> retry count should be cleared
+        # Verify retry_count persisted in DB
+        with record_store.session_factory() as session:
+            row = session.get(OperationLogModel, op_id)
+            assert row.retry_count == 1
+            assert row.delivered is False
+
+        # Second poll: succeed -> delivered
         worker._poll_and_dispatch()
         assert worker.metrics["total_dispatched"] == 1
-        # Internal retry counts should be empty
-        assert len(worker._retry_counts) == 0
+
+        # Verify delivered in DB
+        with record_store.session_factory() as session:
+            row = session.get(OperationLogModel, op_id)
+            assert row.delivered is True
+
+
+# =========================================================================
+# Persistent retry counts across restarts (Issue #2751)
+# =========================================================================
+
+
+class TestPersistentRetryCounts:
+    """Test that retry counts survive worker restarts via DB persistence."""
+
+    def test_retry_count_survives_worker_restart(self, record_store: SQLAlchemyRecordStore) -> None:
+        """A new worker picks up retry_count from DB, not from scratch."""
+        from nexus.system_services.event_subsystem.log.delivery import EventDeliveryWorker
+
+        op_id = _insert_undelivered(record_store.session_factory)
+
+        mock_bus = MagicMock()
+        mock_bus.publish = AsyncMock(side_effect=ConnectionError("down"))
+
+        # Worker 1: fails once, bumps retry_count to 1
+        worker1 = EventDeliveryWorker(
+            record_store,
+            event_bus=mock_bus,
+            max_retries=3,
+        )
+        worker1._poll_and_dispatch()
+        assert worker1.metrics["total_failed"] == 1
+
+        with record_store.session_factory() as session:
+            row = session.get(OperationLogModel, op_id)
+            assert row.retry_count == 1
+
+        # "Restart": create a brand-new worker (simulates process restart)
+        worker2 = EventDeliveryWorker(
+            record_store,
+            event_bus=mock_bus,
+            max_retries=3,
+        )
+        # Worker 2 fails again -> retry_count goes from 1 to 2
+        worker2._poll_and_dispatch()
+
+        with record_store.session_factory() as session:
+            row = session.get(OperationLogModel, op_id)
+            assert row.retry_count == 2
+
+        # Worker 2 fails once more -> retry_count 3 >= max_retries 3 -> DLQ
+        worker2._poll_and_dispatch()
+        assert worker2.metrics["total_dlq"] == 1
+
+        with record_store.session_factory() as session:
+            row = session.get(OperationLogModel, op_id)
+            assert row.retry_count == 3
+            assert row.delivered is True  # marked to stop re-polling
+
+    def test_dlq_row_not_repolled(self, record_store: SQLAlchemyRecordStore) -> None:
+        """Once routed to DLQ and marked delivered, row is never picked up again."""
+        from nexus.system_services.event_subsystem.log.delivery import EventDeliveryWorker
+
+        _insert_undelivered(record_store.session_factory)
+
+        mock_bus = MagicMock()
+        mock_bus.publish = AsyncMock(side_effect=ConnectionError("down"))
+
+        worker = EventDeliveryWorker(
+            record_store,
+            event_bus=mock_bus,
+            max_retries=1,
+        )
+
+        # First poll: retry_count 1 >= max_retries 1 -> DLQ + delivered=True
+        worker._poll_and_dispatch()
+        assert worker.metrics["total_dlq"] == 1
+
+        # Second poll: should find zero undelivered rows
+        count = worker._poll_and_dispatch()
+        assert count == 0
+        assert worker.metrics["total_dlq"] == 1  # no new DLQ entries
+
+    def test_new_row_starts_with_zero_retry_count(
+        self, record_store: SQLAlchemyRecordStore
+    ) -> None:
+        """Freshly inserted rows have retry_count=0."""
+        op_id = _insert_undelivered(record_store.session_factory)
+
+        with record_store.session_factory() as session:
+            row = session.get(OperationLogModel, op_id)
+            assert row.retry_count == 0


### PR DESCRIPTION
## Summary
- Replace in-memory `_retry_counts` dict with DB-persisted `retry_count` column on `operation_log` table so retry state survives worker restarts
- Mark DLQ'd rows as `delivered=True` to prevent re-polling after exhausting retries
- Add Alembic migration `add_retry_count_oplog`

## Changes
- `src/nexus/storage/models/operation_log.py` — add `retry_count: Mapped[int]` column (BigInteger, default 0)
- `alembic/versions/add_retry_count_to_operation_log.py` — migration adding the column
- `src/nexus/system_services/event_subsystem/log/delivery.py` — rewrite `_handle_dispatch_failure` to use `record.retry_count`, remove `_retry_counts` dict, set `record.delivered = True` on DLQ
- `tests/unit/services/event_log/test_delivery_worker.py` — update existing tests + add 3 new persistence tests (restart survival, DLQ not re-polled, default zero)

## Test plan
- [x] All 10 delivery worker tests pass (`.venv/bin/python -m pytest tests/unit/services/event_log/test_delivery_worker.py -v`)
- [x] `test_retry_count_survives_worker_restart` — verifies new worker reads retry_count from DB
- [x] `test_dlq_row_not_repolled` — verifies DLQ'd rows marked delivered are skipped
- [x] `test_new_row_starts_with_zero_retry_count` — verifies default value
- [x] Lint passes (ruff check + format + mypy)

Closes #2751