### PR TITLE
fix(#2752): startup_sync checkpoint safety — stop on first failure

### DIFF
--- a/src/nexus/system_services/event_subsystem/bus/base.py
+++ b/src/nexus/system_services/event_subsystem/bus/base.py
@@ -273,12 +273,12 @@ class EventBusBase(ABC):
             # First run: use default lookback
             # Use naive datetime to match database (TIMESTAMP WITHOUT TIME ZONE)
             checkpoint = _utcnow_naive() - timedelta(hours=default_lookback_hours)
-            logger.info(f"No checkpoint found, using default lookback: {default_lookback_hours}h")
+            logger.info("No checkpoint found, using default lookback: %dh", default_lookback_hours)
         elif checkpoint.tzinfo is not None:
             # Convert to naive if checkpoint has timezone info
             checkpoint = checkpoint.replace(tzinfo=None)
 
-        logger.info(f"Starting sync from checkpoint: {checkpoint.isoformat()}")
+        logger.info("Starting sync from checkpoint: %s", checkpoint.isoformat())
 
         # Query operations since checkpoint
         with self._session_factory() as session:
@@ -296,7 +296,7 @@ class EventBusBase(ABC):
                 await self._update_checkpoint(_utcnow_naive())
                 return 0
 
-            logger.info(f"Found {len(operations)} missed events to sync")
+            logger.info("Found %d missed events to sync", len(operations))
 
             # Convert all operations to events
             events = [
@@ -310,31 +310,53 @@ class EventBusBase(ABC):
                 for op in operations
             ]
 
-            # Process ALL events concurrently (bounded by semaphore) - 10x speedup
+            # Process events sequentially to preserve ordering guarantees.
+            # On first failure we stop — remaining events will be retried on
+            # next startup because the checkpoint only advances to the last
+            # successfully processed event (Issue #2752).
+            synced_count = 0
+            failed_count = 0
+
             if event_handler:
-                semaphore = asyncio.Semaphore(50)  # Max 50 concurrent
-
-                async def _handle_with_limit(event: FileEvent) -> bool:
-                    async with semaphore:
-                        try:
-                            await event_handler(event)
-                            return True  # Success
-                        except Exception as e:
-                            logger.error(f"Failed to handle event {event.event_id}: {e}")
-                            return False  # Failure
-
-                tasks = [_handle_with_limit(event) for event in events]
-                results = await asyncio.gather(*tasks)
-                synced_count: int = sum(results)
+                for i, event in enumerate(events):
+                    try:
+                        await event_handler(event)
+                        synced_count += 1
+                    except Exception as e:
+                        logger.error("Failed to handle event %s: %s", event.event_id, e)
+                        failed_count += 1
+                        skipped = len(events) - i - 1
+                        if skipped > 0:
+                            logger.warning(
+                                "Stopping startup sync: %d events skipped after failure",
+                                skipped,
+                            )
+                        break
             else:
                 synced_count = len(events)
                 for event in events:
-                    logger.debug(f"Synced event: {event.type} on {event.path}")
+                    logger.debug("Synced event: %s on %s", event.type, event.path)
 
-            # Update checkpoint to latest operation timestamp
-            latest_timestamp = max(op.created_at for op in operations)
-            await self._update_checkpoint(latest_timestamp)
-            logger.info(f"Startup sync complete: {synced_count}/{len(events)} events processed")
+            # Only advance checkpoint to the last *successfully* processed
+            # event.  If nothing succeeded, leave checkpoint unchanged so the
+            # entire batch is retried on next startup (Issue #2752).
+            if synced_count > 0:
+                safe_timestamp = operations[synced_count - 1].created_at
+                await self._update_checkpoint(safe_timestamp)
+
+            if len(operations) == self._max_sync_events and failed_count == 0:
+                logger.warning(
+                    "Startup sync hit max_sync_events limit (%d). "
+                    "More events may exist beyond this batch.",
+                    self._max_sync_events,
+                )
+
+            logger.info(
+                "Startup sync complete: synced=%d, failed=%d, total=%d",
+                synced_count,
+                failed_count,
+                len(events),
+            )
 
             return synced_count
 

--- a/tests/unit/services/event_subsystem/test_startup_sync_checkpoint.py
+++ b/tests/unit/services/event_subsystem/test_startup_sync_checkpoint.py
@@ -1,0 +1,268 @@
+"""Tests for startup_sync checkpoint safety (Issue #2752).
+
+Verifies that:
+- Checkpoint only advances to the last successfully processed event
+- Failed events are retried on next startup (checkpoint not advanced past them)
+- Truncated batches (hit max_sync_events) log a warning
+- All-succeed case still works correctly
+"""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from nexus.services.event_subsystem.bus.base import EventBusBase
+
+
+def _make_operation(op_id: str, created_at: datetime, op_type: str = "write") -> Mock:
+    """Create a mock OperationLogModel row."""
+    op = Mock()
+    op.operation_id = op_id
+    op.operation_type = op_type
+    op.path = f"/test/{op_id}.txt"
+    op.new_path = None
+    op.zone_id = "zone-1"
+    op.status = "success"
+    op.created_at = created_at
+    return op
+
+
+class ConcreteEventBus(EventBusBase):
+    """Minimal concrete subclass for testing the ABC's startup_sync."""
+
+    async def _do_start(self) -> None:
+        pass
+
+    async def _do_stop(self) -> None:
+        pass
+
+    async def publish(self, event):
+        return 0
+
+    async def wait_for_event(self, zone_id, path_pattern, timeout=30.0, since_version=None):
+        return None
+
+    async def health_check(self) -> bool:
+        return True
+
+    def subscribe(self, zone_id):
+        pass
+
+    def subscribe_durable(self, zone_id, consumer_name, deliver_policy="all"):
+        pass
+
+
+def _make_bus(
+    operations: list[Mock],
+    max_sync_events: int = 10_000,
+) -> ConcreteEventBus:
+    """Create a bus with mocked DB that returns the given operations."""
+    mock_record_store = MagicMock()
+    mock_session = MagicMock()
+
+    # Mock the query chain
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = operations
+    mock_execute = MagicMock()
+    mock_execute.scalars.return_value = mock_scalars
+    mock_session.execute.return_value = mock_execute
+    mock_session.__enter__ = Mock(return_value=mock_session)
+    mock_session.__exit__ = Mock(return_value=False)
+    mock_record_store.session_factory.return_value = mock_session
+
+    bus = ConcreteEventBus(
+        record_store=mock_record_store,
+        node_id="test-node",
+        max_sync_events=max_sync_events,
+    )
+    return bus
+
+
+class TestStartupSyncCheckpointSafety:
+    """Test that checkpoint advances correctly based on success/failure."""
+
+    def test_all_succeed_advances_to_last(self):
+        """When all events succeed, checkpoint advances to last event's timestamp."""
+        t1 = datetime(2026, 1, 1, 0, 0, 1)
+        t2 = datetime(2026, 1, 1, 0, 0, 2)
+        t3 = datetime(2026, 1, 1, 0, 0, 3)
+        ops = [
+            _make_operation("op-1", t1),
+            _make_operation("op-2", t2),
+            _make_operation("op-3", t3),
+        ]
+
+        bus = _make_bus(ops)
+        handler = AsyncMock()
+        checkpoint_updates: list[datetime] = []
+
+        async def run():
+            bus._update_checkpoint = AsyncMock(side_effect=lambda ts: checkpoint_updates.append(ts))
+            bus._get_checkpoint = AsyncMock(return_value=datetime(2026, 1, 1, 0, 0, 0))
+            result = await bus.startup_sync(event_handler=handler)
+            return result
+
+        result = asyncio.run(run())
+
+        assert result == 3
+        assert handler.call_count == 3
+        assert len(checkpoint_updates) == 1
+        assert checkpoint_updates[0] == t3
+
+    def test_partial_failure_stops_at_last_success(self):
+        """When event #2 fails, checkpoint advances to event #1 only."""
+        t1 = datetime(2026, 1, 1, 0, 0, 1)
+        t2 = datetime(2026, 1, 1, 0, 0, 2)
+        t3 = datetime(2026, 1, 1, 0, 0, 3)
+        ops = [
+            _make_operation("op-1", t1),
+            _make_operation("op-2", t2),
+            _make_operation("op-3", t3),
+        ]
+
+        bus = _make_bus(ops)
+        call_count = 0
+
+        async def handler(event):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise ConnectionError("down")
+
+        checkpoint_updates: list[datetime] = []
+
+        async def run():
+            bus._update_checkpoint = AsyncMock(side_effect=lambda ts: checkpoint_updates.append(ts))
+            bus._get_checkpoint = AsyncMock(return_value=datetime(2026, 1, 1, 0, 0, 0))
+            result = await bus.startup_sync(event_handler=handler)
+            return result
+
+        result = asyncio.run(run())
+
+        assert result == 1  # only first event succeeded
+        assert call_count == 2  # tried 2, stopped after failure
+        assert len(checkpoint_updates) == 1
+        assert checkpoint_updates[0] == t1  # checkpoint at first event, NOT t3
+
+    def test_first_event_fails_no_checkpoint_update(self):
+        """When the very first event fails, checkpoint is NOT updated at all."""
+        t1 = datetime(2026, 1, 1, 0, 0, 1)
+        t2 = datetime(2026, 1, 1, 0, 0, 2)
+        ops = [
+            _make_operation("op-1", t1),
+            _make_operation("op-2", t2),
+        ]
+
+        bus = _make_bus(ops)
+        handler = AsyncMock(side_effect=ConnectionError("down"))
+        checkpoint_updates: list[datetime] = []
+
+        async def run():
+            bus._update_checkpoint = AsyncMock(side_effect=lambda ts: checkpoint_updates.append(ts))
+            bus._get_checkpoint = AsyncMock(return_value=datetime(2026, 1, 1, 0, 0, 0))
+            result = await bus.startup_sync(event_handler=handler)
+            return result
+
+        result = asyncio.run(run())
+
+        assert result == 0
+        assert handler.call_count == 1  # tried first, failed, stopped
+        assert len(checkpoint_updates) == 0  # NO checkpoint update
+
+    def test_truncated_batch_logs_warning(self):
+        """When batch hits max_sync_events, a warning is logged."""
+        ops = [_make_operation(f"op-{i}", datetime(2026, 1, 1, 0, 0, i)) for i in range(1, 6)]
+
+        bus = _make_bus(ops, max_sync_events=5)
+        handler = AsyncMock()
+
+        async def run():
+            bus._update_checkpoint = AsyncMock()
+            bus._get_checkpoint = AsyncMock(return_value=datetime(2026, 1, 1, 0, 0, 0))
+            with patch("nexus.services.event_subsystem.bus.base.logger") as mock_logger:
+                await bus.startup_sync(event_handler=handler)
+                # Check that warning about truncation was logged
+                warning_calls = [
+                    c for c in mock_logger.warning.call_args_list if "max_sync_events" in str(c)
+                ]
+                assert len(warning_calls) == 1
+
+        asyncio.run(run())
+
+    def test_no_handler_still_advances_checkpoint(self):
+        """When no event_handler is provided, all events count as synced."""
+        t1 = datetime(2026, 1, 1, 0, 0, 1)
+        t2 = datetime(2026, 1, 1, 0, 0, 2)
+        ops = [
+            _make_operation("op-1", t1),
+            _make_operation("op-2", t2),
+        ]
+
+        bus = _make_bus(ops)
+        checkpoint_updates: list[datetime] = []
+
+        async def run():
+            bus._update_checkpoint = AsyncMock(side_effect=lambda ts: checkpoint_updates.append(ts))
+            bus._get_checkpoint = AsyncMock(return_value=datetime(2026, 1, 1, 0, 0, 0))
+            result = await bus.startup_sync(event_handler=None)
+            return result
+
+        result = asyncio.run(run())
+
+        assert result == 2
+        assert len(checkpoint_updates) == 1
+        assert checkpoint_updates[0] == t2
+
+    def test_failed_events_retried_on_next_startup(self):
+        """Simulate two startups: first has a failure, second retries from checkpoint."""
+        t1 = datetime(2026, 1, 1, 0, 0, 1)
+        t2 = datetime(2026, 1, 1, 0, 0, 2)
+        t3 = datetime(2026, 1, 1, 0, 0, 3)
+
+        # First startup: event 2 fails
+        ops_run1 = [
+            _make_operation("op-1", t1),
+            _make_operation("op-2", t2),
+            _make_operation("op-3", t3),
+        ]
+        bus1 = _make_bus(ops_run1)
+        saved_checkpoint = [None]
+
+        call_count = 0
+
+        async def handler_run1(event):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise ConnectionError("down")
+
+        async def run1():
+            bus1._get_checkpoint = AsyncMock(return_value=datetime(2026, 1, 1, 0, 0, 0))
+            bus1._update_checkpoint = AsyncMock(
+                side_effect=lambda ts: saved_checkpoint.__setitem__(0, ts)
+            )
+            return await bus1.startup_sync(event_handler=handler_run1)
+
+        result1 = asyncio.run(run1())
+        assert result1 == 1
+        assert saved_checkpoint[0] == t1  # checkpoint at event 1
+
+        # Second startup: all events succeed (simulating events after checkpoint)
+        ops_run2 = [
+            _make_operation("op-2", t2),
+            _make_operation("op-3", t3),
+        ]
+        bus2 = _make_bus(ops_run2)
+        handler_run2 = AsyncMock()
+
+        async def run2():
+            bus2._get_checkpoint = AsyncMock(return_value=saved_checkpoint[0])
+            bus2._update_checkpoint = AsyncMock(
+                side_effect=lambda ts: saved_checkpoint.__setitem__(0, ts)
+            )
+            return await bus2.startup_sync(event_handler=handler_run2)
+
+        result2 = asyncio.run(run2())
+        assert result2 == 2
+        assert handler_run2.call_count == 2
+        assert saved_checkpoint[0] == t3  # now advanced to last event

--- a/tests/unit/services/event_subsystem/test_startup_sync_checkpoint.py
+++ b/tests/unit/services/event_subsystem/test_startup_sync_checkpoint.py
@@ -11,7 +11,7 @@ import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-from nexus.services.event_subsystem.bus.base import EventBusBase
+from nexus.system_services.event_subsystem.bus.base import EventBusBase
 
 
 def _make_operation(op_id: str, created_at: datetime, op_type: str = "write") -> Mock:
@@ -179,7 +179,7 @@ class TestStartupSyncCheckpointSafety:
         async def run():
             bus._update_checkpoint = AsyncMock()
             bus._get_checkpoint = AsyncMock(return_value=datetime(2026, 1, 1, 0, 0, 0))
-            with patch("nexus.services.event_subsystem.bus.base.logger") as mock_logger:
+            with patch("nexus.system_services.event_subsystem.bus.base.logger") as mock_logger:
                 await bus.startup_sync(event_handler=handler)
                 # Check that warning about truncation was logged
                 warning_calls = [


### PR DESCRIPTION
## Summary

- **Replace concurrent `asyncio.gather` with sequential processing** in `startup_sync()` so ordering guarantees are preserved and checkpoint only advances to the last successfully processed event
- **On first handler failure**: stop processing, skip remaining events (retried on next startup since checkpoint stays at last success)
- **If all events fail**: checkpoint is NOT updated at all — entire batch retried on next startup
- **Add `max_sync_events` parameter** to `EventBusBase.__init__` with truncation warning when batch hits the limit
- Fix 3 f-string logger calls → lazy `%` formatting

Fixes #2752

## Test plan
- [x] `test_all_succeed_advances_to_last` — checkpoint advances to last event
- [x] `test_partial_failure_stops_at_last_success` — checkpoint at event #1 when #2 fails
- [x] `test_first_event_fails_no_checkpoint_update` — no checkpoint update at all
- [x] `test_truncated_batch_logs_warning` — warning logged when hitting limit
- [x] `test_no_handler_still_advances_checkpoint` — no-handler path works correctly
- [x] `test_failed_events_retried_on_next_startup` — simulates 2 startups: first fails, second retries