### PR TITLE
fix(#2753): make chunk deletion and reindex atomic

### DIFF
--- a/src/nexus/bricks/search/indexing_service.py
+++ b/src/nexus/bricks/search/indexing_service.py
@@ -120,16 +120,11 @@ class IndexingService:
         # --- Step 2: Read document content ---------------------------------
         content = self._read_content(path)
 
-        # --- Step 3: Delete stale chunks -----------------------------------
-        with self._get_session() as session:
-            session.execute(
-                delete(DocumentChunkModel).where(
-                    DocumentChunkModel.path_id == path_id,
-                ),
-            )
-            session.commit()
-
-        # --- Step 4: Delegate to pipeline ----------------------------------
+        # --- Step 3: Delegate to pipeline (atomic delete+insert) -----------
+        # The pipeline's _bulk_insert handles DELETE old chunks + INSERT new
+        # chunks in a single transaction.  We do NOT delete chunks beforehand
+        # because a pipeline failure (e.g. embedding API timeout) would leave
+        # the document with zero chunks — an incomplete index (Issue #2753).
         try:
             result: IndexResult = await self._pipeline.index_document(
                 path,

--- a/tests/unit/bricks/search/test_indexing_service.py
+++ b/tests/unit/bricks/search/test_indexing_service.py
@@ -2,9 +2,10 @@
 
 Tests the unified indexing service that wraps IndexingPipeline + FileReaderProtocol.
 Validates content-hash skip logic, delegation to pipeline, directory indexing,
-delete operations, and stats retrieval.
+delete operations, stats retrieval, and atomic reindex safety (Issue #2753).
 """
 
+import asyncio
 from contextlib import contextmanager
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
@@ -329,6 +330,96 @@ class TestDeleteDocumentIndex:
         # Verify session.execute was called with a delete statement
         session.execute.assert_called()
         session.commit.assert_called()
+
+
+class TestAtomicReindex:
+    """Tests for atomic reindex safety (Issue #2753).
+
+    Verifies that pipeline failure does NOT leave the index in an incomplete
+    state — old chunks must remain until new chunks are fully committed.
+    """
+
+    def test_pipeline_failure_does_not_delete_old_chunks(self) -> None:
+        """When pipeline.index_document raises, no DELETE is executed on the session."""
+        file_model = _mock_file_model(
+            path_id="pid-1",
+            content_hash="new_hash",
+            indexed_content_hash="old_hash",
+        )
+        pipeline = _mock_pipeline()
+        pipeline.index_document.side_effect = ConnectionError("embedding API timeout")
+
+        service, _, session, _ = _build_service(
+            pipeline=pipeline,
+            file_model=file_model,
+            content="updated content",
+        )
+
+        async def run():
+            with pytest.raises(ConnectionError, match="embedding API timeout"):
+                await service.index_document("test.py")
+
+        asyncio.run(run())
+
+        # The service should NOT have called session.execute with a DELETE
+        # (the old premature delete was removed in Issue #2753).
+        for call in session.execute.call_args_list:
+            stmt = call[0][0]
+            stmt_str = str(stmt)
+            assert "DELETE" not in stmt_str.upper() or "document_chunks" not in stmt_str
+
+    def test_successful_reindex_delegates_delete_to_pipeline(self) -> None:
+        """On success, pipeline handles delete+insert atomically (no service-level delete)."""
+        file_model = _mock_file_model(
+            path_id="pid-1",
+            content_hash="new_hash",
+            indexed_content_hash="old_hash",
+        )
+        pipeline = _mock_pipeline()
+        pipeline.index_document.return_value = IndexResult(path="test.py", chunks_indexed=10)
+
+        service, _, session, _ = _build_service(
+            pipeline=pipeline,
+            file_model=file_model,
+            content="new content",
+        )
+
+        async def run():
+            return await service.index_document("test.py")
+
+        result = asyncio.run(run())
+
+        assert result == 10
+        pipeline.index_document.assert_awaited_once_with("test.py", "new content", "pid-1")
+        # No DELETE from the service layer — pipeline owns the atomic swap
+        for call in session.execute.call_args_list:
+            stmt = call[0][0]
+            stmt_str = str(stmt)
+            assert "DELETE" not in stmt_str.upper() or "document_chunks" not in stmt_str
+
+    def test_hash_not_updated_on_pipeline_failure(self) -> None:
+        """When pipeline fails, indexed_content_hash must NOT be updated."""
+        file_model = _mock_file_model(
+            path_id="pid-1",
+            content_hash="new_hash",
+            indexed_content_hash="old_hash",
+        )
+        pipeline = _mock_pipeline()
+        pipeline.index_document.side_effect = RuntimeError("chunking error")
+
+        service, _, _, _ = _build_service(
+            pipeline=pipeline,
+            file_model=file_model,
+        )
+
+        async def run():
+            with pytest.raises(RuntimeError, match="chunking error"):
+                await service.index_document("test.py")
+
+        asyncio.run(run())
+
+        # indexed_content_hash should remain unchanged
+        assert file_model.indexed_content_hash == "old_hash"
 
 
 class TestGetIndexStats:


### PR DESCRIPTION
## Summary

- Remove premature `DELETE FROM document_chunks` in `IndexingService.index_document()` that ran in a **separate sync session** before the pipeline
- The pipeline's `_bulk_insert` already performs DELETE + INSERT within a **single async session transaction** — making the service-level delete both redundant and dangerous
- A pipeline failure (e.g. embedding API timeout) previously left documents with **zero chunks** — an incomplete index

## What changed

- `src/nexus/bricks/search/indexing_service.py`: Removed step 3 (premature delete). Pipeline now owns the atomic swap entirely. Service only updates `indexed_content_hash` and `last_indexed_at` on success.
- `tests/unit/bricks/search/test_indexing_service.py`: Added `TestAtomicReindex` class with 3 tests:
  - `test_pipeline_failure_does_not_delete_old_chunks` — verifies no DELETE on session when pipeline raises
  - `test_successful_reindex_delegates_delete_to_pipeline` — verifies pipeline handles delete+insert atomically
  - `test_hash_not_updated_on_pipeline_failure` — verifies `indexed_content_hash` stays unchanged on failure

Closes #2753

## Test plan

- [x] All 3 new atomic reindex tests pass
- [x] Pre-commit hooks pass (ruff, ruff format, mypy, brick imports check)
- [ ] CI pipeline passes