### PR TITLE
refactor(#1410): delete memory + rebac_manager properties from NexusFS

### DIFF
--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -857,23 +857,25 @@ def create_mcp_server(
             Success message or error
         """
         nx_instance = _get_nexus_instance(ctx)
-        if not hasattr(nx_instance, "memory"):
+        _provider = getattr(nx_instance, "_memory_provider", None)
+        if _provider is None:
             return tool_error("unavailable", "Memory system not available (requires NexusFS).")
+        mem = _provider.get_or_create()
 
         try:
-            nx_instance.memory.store(
+            mem.store(
                 content,
                 scope="user",
                 memory_type=memory_type,
                 importance=importance,
             )
-            if hasattr(nx_instance.memory, "session"):
-                nx_instance.memory.session.commit()
+            if hasattr(mem, "session"):
+                mem.session.commit()
             return f"Successfully stored memory: {content[:80]}..."
         except Exception as e:
-            if hasattr(nx_instance.memory, "session"):
+            if hasattr(mem, "session"):
                 try:
-                    nx_instance.memory.session.rollback()
+                    mem.session.rollback()
                 except Exception as rb_err:
                     logger.debug("Failed to rollback memory session: %s", rb_err)
             return tool_error("internal", f"Error storing memory: {e}", str(e))
@@ -904,10 +906,12 @@ def create_mcp_server(
             JSON string with matching memories
         """
         nx_instance = _get_nexus_instance(ctx)
-        if not hasattr(nx_instance, "memory"):
+        _provider = getattr(nx_instance, "_memory_provider", None)
+        if _provider is None:
             return tool_error("unavailable", "Memory system not available (requires NexusFS).")
+        mem = _provider.get_or_create()
 
-        memories = nx_instance.memory.search(
+        memories = mem.search(
             query,
             scope="user",
             memory_type=memory_type,

--- a/src/nexus/bricks/memory/memory_provider.py
+++ b/src/nexus/bricks/memory/memory_provider.py
@@ -142,3 +142,24 @@ class MemoryProvider:
             EntityRegistry = _rebac.EntityRegistry
             self._entity_registry = EntityRegistry(self._session_factory)
         return self._entity_registry
+
+
+def get_memory_api(nx: Any) -> Any:
+    """Get Memory API from a NexusFS instance.
+
+    Replaces the deleted ``NexusFS.memory`` property (Issue #1410 Phase 5).
+    Accesses the ``_memory_provider`` (wired via ``bind_wired_services``).
+
+    Args:
+        nx: NexusFS instance with ``_memory_provider`` attribute.
+
+    Returns:
+        Memory or MemoryWithPaging instance.
+
+    Raises:
+        AttributeError: If ``_memory_provider`` is not configured.
+    """
+    provider = getattr(nx, "_memory_provider", None)
+    if provider is None:
+        raise AttributeError("Memory provider not configured on NexusFS")
+    return provider.get_or_create()

--- a/src/nexus/bricks/tools/langgraph/nexus_tools.py
+++ b/src/nexus/bricks/tools/langgraph/nexus_tools.py
@@ -675,8 +675,11 @@ def get_nexus_tools() -> list[BaseTool]:
         try:
             nx = _get_nexus_client(config)
 
-            # Query active memories using RemoteMemory API
-            memories = nx.memory.query(state="active", limit=100)
+            # Query active memories via _memory_provider (Issue #1410)
+            _provider = getattr(nx, "_memory_provider", None)
+            if _provider is None:
+                return "Memory system not available"
+            memories = _provider.get_or_create().query(state="active", limit=100)
 
             if not memories:
                 return "No memories found"

--- a/src/nexus/cli/commands/memory.py
+++ b/src/nexus/cli/commands/memory.py
@@ -9,6 +9,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from nexus.bricks.memory.memory_provider import get_memory_api
 from nexus.cli.utils import (
     BackendConfig,
     add_backend_options,
@@ -61,7 +62,7 @@ def store(
     nx = get_default_filesystem()
 
     try:
-        memory_id = nx.memory.store(  # type: ignore[attr-defined]
+        memory_id = get_memory_api(nx).store(
             content=content,
             scope=scope,
             memory_type=memory_type,
@@ -126,7 +127,7 @@ def query(
 
     try:
         # Note: user_id and agent_id filtering not supported in remote mode yet
-        results = nx.memory.query(  # type: ignore[attr-defined]
+        results = get_memory_api(nx).query(
             scope=scope,
             memory_type=memory_type,
             state=state,
@@ -257,7 +258,7 @@ def search(
             )
             search_mode = "keyword"
 
-        results = nx.memory.search(  # type: ignore[attr-defined]
+        results = get_memory_api(nx).search(
             query=query_text,
             scope=scope,
             memory_type=memory_type,
@@ -351,7 +352,7 @@ def list(
     nx = get_default_filesystem()
 
     try:
-        results = nx.memory.list(  # type: ignore[attr-defined]
+        results = get_memory_api(nx).list(
             scope=scope,
             memory_type=memory_type,
             namespace=namespace,
@@ -407,8 +408,7 @@ def get(memory_id: str, output_json: bool) -> None:
     nx = get_default_filesystem()
 
     try:
-        result = nx.memory.get(memory_id)  # type: ignore[attr-defined]
-
+        result = get_memory_api(nx).get(memory_id)
         if not result:
             click.echo(f"Memory not found: {memory_id}", err=True)
             raise click.Abort()
@@ -446,8 +446,7 @@ def retrieve(path: str, output_json: bool) -> None:
     nx = get_default_filesystem()
 
     try:
-        result = nx.memory.retrieve(path=path)  # type: ignore[attr-defined]
-
+        result = get_memory_api(nx).retrieve(path=path)
         if not result:
             click.echo(f"Memory not found at path: {path}", err=True)
             raise click.Abort()
@@ -485,7 +484,7 @@ def delete(memory_id: str) -> None:
     nx = get_default_filesystem()
 
     try:
-        if nx.memory.delete(memory_id):  # type: ignore[attr-defined]
+        if get_memory_api(nx).delete(memory_id):
             click.echo(f"Memory deleted: {memory_id}")
         else:
             click.echo(f"Memory not found or no permission: {memory_id}", err=True)
@@ -508,7 +507,7 @@ def approve(memory_id: str) -> None:
     nx = get_default_filesystem()
 
     try:
-        if nx.memory.approve(memory_id):  # type: ignore[attr-defined]
+        if get_memory_api(nx).approve(memory_id):
             click.echo(f"Memory approved: {memory_id}")
         else:
             click.echo(f"Memory not found or no permission: {memory_id}", err=True)
@@ -531,7 +530,7 @@ def deactivate(memory_id: str) -> None:
     nx = get_default_filesystem()
 
     try:
-        if nx.memory.deactivate(memory_id):  # type: ignore[attr-defined]
+        if get_memory_api(nx).deactivate(memory_id):
             click.echo(f"Memory deactivated: {memory_id}")
         else:
             click.echo(f"Memory not found or no permission: {memory_id}", err=True)
@@ -556,8 +555,7 @@ def approve_batch(memory_ids: tuple[str, ...], output_json: bool) -> None:
     nx = get_default_filesystem()
 
     try:
-        result = nx.memory.approve_batch(list(memory_ids))  # type: ignore[attr-defined]
-
+        result = get_memory_api(nx).approve_batch(list(memory_ids))
         if output_json:
             click.echo(json.dumps(result, indent=2))
         else:
@@ -585,8 +583,7 @@ def deactivate_batch(memory_ids: tuple[str, ...], output_json: bool) -> None:
     nx = get_default_filesystem()
 
     try:
-        result = nx.memory.deactivate_batch(list(memory_ids))  # type: ignore[attr-defined]
-
+        result = get_memory_api(nx).deactivate_batch(list(memory_ids))
         if output_json:
             click.echo(json.dumps(result, indent=2))
         else:
@@ -614,8 +611,7 @@ def delete_batch(memory_ids: tuple[str, ...], output_json: bool) -> None:
     nx = get_default_filesystem()
 
     try:
-        result = nx.memory.delete_batch(list(memory_ids))  # type: ignore[attr-defined]
-
+        result = get_memory_api(nx).delete_batch(list(memory_ids))
         if output_json:
             click.echo(json.dumps(result, indent=2))
         else:

--- a/src/nexus/cli/commands/rebac.py
+++ b/src/nexus/cli/commands/rebac.py
@@ -5,7 +5,7 @@ Enables team-based permissions, hierarchical access, and dynamic inheritance.
 """
 
 import sys
-from typing import Any
+from typing import Any, cast
 
 import click
 from rich.table import Table
@@ -769,7 +769,7 @@ def rebac_check_batch_cmd(
         console.print(
             f"[cyan]Checking {len(checks)} permissions (Rust acceleration enabled)...[/cyan]"
         )
-        results = nx.rebac_manager.rebac_check_batch_fast(checks)  # type: ignore[attr-defined]
+        results = cast(Any, nx).rebac_service.rebac_check_batch_sync(checks)
         nx.close()
 
         # Output results

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -246,16 +246,6 @@ class NexusFS(  # type: ignore[misc]
         """Public accessor for the runtime configuration object."""
         return self._config
 
-    @property
-    def rebac_manager(self) -> Any | None:
-        """Public accessor for the ReBACManager instance."""
-        return getattr(self, "_rebac_manager", None)
-
-    @property
-    def memory(self) -> Any:
-        """Get Memory API instance (lazy init on first access)."""
-        return self._memory_provider.get_or_create()
-
     def _get_created_by(self, context: OperationContext | dict | None = None) -> str | None:
         """Get the created_by value for version history tracking."""
         from nexus.lib.context_utils import get_created_by

--- a/src/nexus/server/api/v2/dependencies.py
+++ b/src/nexus/server/api/v2/dependencies.py
@@ -80,21 +80,27 @@ async def get_memory_api(
     nexus_fs: Any = Depends(get_nexus_fs),
 ) -> Any:
     """Get Memory API instance from NexusFS."""
-    return nexus_fs.memory
+    from nexus.bricks.memory.memory_provider import get_memory_api as _get_mem
+
+    return _get_mem(nexus_fs)
 
 
 async def get_db_session(
     nexus_fs: Any = Depends(get_nexus_fs),
 ) -> Any:
     """Get database session from NexusFS."""
-    return nexus_fs.memory.session
+    from nexus.bricks.memory.memory_provider import get_memory_api as _get_mem
+
+    return _get_mem(nexus_fs).session
 
 
 async def get_backend(
     nexus_fs: Any = Depends(get_nexus_fs),
 ) -> Any:
     """Get storage backend from NexusFS."""
-    return nexus_fs.memory.backend
+    from nexus.bricks.memory.memory_provider import get_memory_api as _get_mem
+
+    return _get_mem(nexus_fs).backend
 
 
 async def get_llm_provider(

--- a/src/nexus/tools/langgraph/nexus_tools.py
+++ b/src/nexus/tools/langgraph/nexus_tools.py
@@ -675,8 +675,11 @@ def get_nexus_tools() -> list[BaseTool]:
         try:
             nx = _get_nexus_client(config)
 
-            # Query active memories using RemoteMemory API
-            memories = nx.memory.query(state="active", limit=100)
+            # Query active memories via _memory_provider (Issue #1410)
+            _provider = getattr(nx, "_memory_provider", None)
+            if _provider is None:
+                return "Memory system not available"
+            memories = _provider.get_or_create().query(state="active", limit=100)
 
             if not memories:
                 return "No memories found"

--- a/tests/e2e/test_lego_decomp_e2e.py
+++ b/tests/e2e/test_lego_decomp_e2e.py
@@ -25,6 +25,7 @@ from typing import Any
 
 import pytest
 
+from nexus.bricks.memory.memory_provider import get_memory_api
 from nexus.contracts.types import OperationContext
 from nexus.core.config import (
     DistributedConfig,
@@ -257,8 +258,8 @@ class TestMemoryDelegation:
     """Verify memory property and helpers delegate correctly with PG backend."""
 
     def test_memory_property_returns_memory_api(self, nx):
-        """memory property should return a Memory instance via MemoryProvider."""
-        mem = nx.memory
+        """get_memory_api() should return a Memory instance via MemoryProvider."""
+        mem = get_memory_api(nx)
         assert mem is not None
         assert hasattr(mem, "store")
         assert hasattr(mem, "query")
@@ -267,13 +268,13 @@ class TestMemoryDelegation:
 
     def test_memory_property_is_singleton(self, nx):
         """Same Memory instance should be returned on repeated access."""
-        mem1 = nx.memory
-        mem2 = nx.memory
+        mem1 = get_memory_api(nx)
+        mem2 = get_memory_api(nx)
         assert mem1 is mem2
 
     def test_memory_store_and_query(self, nx):
-        """End-to-end memory store + query through delegated property with PG."""
-        mem = nx.memory
+        """End-to-end memory store + query through get_memory_api() with PG."""
+        mem = get_memory_api(nx)
         mid = mem.store(
             content="Test memory from E2E with PostgreSQL",
             scope="user",
@@ -577,9 +578,9 @@ class TestFastAPIIntegration:
         assert isinstance(result.get("result"), list)
 
     def test_memory_store_via_server(self, client):
-        """Memory store should work via the memory property delegation with PG."""
+        """Memory store should work via get_memory_api() delegation with PG."""
         nx = client["nx"]
-        mem = nx.memory
+        mem = get_memory_api(nx)
         mid = mem.store(
             content="E2E memory test via FastAPI + PostgreSQL",
             scope="user",
@@ -709,7 +710,7 @@ class TestFastAPIWithPermissions:
     def test_memory_with_perms(self, client_perms):
         """Memory store should work with permissions enabled."""
         nx = client_perms["nx"]
-        mem = nx.memory
+        mem = get_memory_api(nx)
         mid = mem.store(
             content="E2E memory with permissions + PG",
             scope="user",

--- a/tests/unit/bricks/mcp/test_mcp_server_tools.py
+++ b/tests/unit/bricks/mcp/test_mcp_server_tools.py
@@ -81,15 +81,19 @@ def mock_nx_with_memory():
     nx.sys_read = Mock(return_value=b"test")
     nx.sys_write = Mock()
 
-    # Add memory system
-    nx.memory = Mock()
-    nx.memory.store = Mock()
-    nx.memory.search = Mock(
+    # Add memory system via _memory_provider (get_memory_api() reads this)
+    mock_memory = Mock()
+    mock_memory.store = Mock()
+    mock_memory.search = Mock(
         return_value=[{"content": "test memory", "importance": 0.8, "type": "technical"}]
     )
-    nx.memory.session = Mock()
-    nx.memory.session.commit = Mock()
-    nx.memory.session.rollback = Mock()
+    mock_memory.session = Mock()
+    mock_memory.session.commit = Mock()
+    mock_memory.session.rollback = Mock()
+    mock_provider = Mock()
+    mock_provider.get_or_create.return_value = mock_memory
+    nx._memory_provider = mock_provider
+    nx.memory = mock_memory  # alias for assertions
 
     return nx
 
@@ -192,13 +196,17 @@ def mock_nx_full():
     nx.sys_mkdir = Mock()
     nx.sys_rmdir = Mock()
 
-    # Memory system
-    nx.memory = Mock()
-    nx.memory.store = Mock()
-    nx.memory.search = Mock(return_value=[])
-    nx.memory.session = Mock()
-    nx.memory.session.commit = Mock()
-    nx.memory.session.rollback = Mock()
+    # Memory system via _memory_provider (get_memory_api() reads this)
+    mock_memory = Mock()
+    mock_memory.store = Mock()
+    mock_memory.search = Mock(return_value=[])
+    mock_memory.session = Mock()
+    mock_memory.session.commit = Mock()
+    mock_memory.session.rollback = Mock()
+    mock_provider = Mock()
+    mock_provider.get_or_create.return_value = mock_memory
+    nx._memory_provider = mock_provider
+    nx.memory = mock_memory  # alias for assertions
 
     # Workflow system
     nx.workflows = Mock()


### PR DESCRIPTION
## Summary
- Phase 5 PR 3: Delete active service properties from NexusFS that violate kernel purity
- Removed `memory` property → replaced with `get_memory_api(nx)` utility in `memory_provider.py`
- Removed `rebac_manager` property → CLI caller migrated to `rebac_service.rebac_check_batch_sync()`
- 23 production callers migrated across 8 files
- Brick boundary compliance: MCP/LangGraph bricks inline `_memory_provider` access to avoid cross-brick imports
- Test mocks updated to wire `_memory_provider` instead of `.memory` attribute

## Test plan
- [ ] `pytest tests/unit/bricks/mcp/test_mcp_server_tools.py -v` — MCP memory tests pass with updated mocks
- [ ] `pytest tests/e2e/test_lego_decomp_e2e.py -v` — memory delegation tests use get_memory_api()
- [ ] `ruff check src/nexus/core/nexus_fs.py` — no lint issues
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)