### PR TITLE
fix: address 5 bugs from codex review

### DIFF
--- a/nexus-fuse/src/cache.rs
+++ b/nexus-fuse/src/cache.rs
@@ -45,19 +45,8 @@ pub struct FileCache {
 }
 
 impl FileCache {
-    /// Create or open a cache database.
-    pub fn new(server_url: &str) -> Result<Self> {
-        let cache_path = Self::cache_path(server_url)?;
-
-        // Ensure cache directory exists
-        if let Some(parent) = cache_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        info!("Opening cache at: {}", cache_path.display());
-
-        let conn = Connection::open(&cache_path)?;
-
+    /// Initialise a cache from an already-opened SQLite connection.
+    fn open_connection(conn: Connection) -> Result<Self> {
         // Configure SQLite for performance
         conn.execute_batch(
             "
@@ -102,6 +91,21 @@ impl FileCache {
         }
 
         Ok(cache)
+    }
+
+    /// Create or open a cache database.
+    pub fn new(server_url: &str) -> Result<Self> {
+        let cache_path = Self::cache_path(server_url)?;
+
+        // Ensure cache directory exists
+        if let Some(parent) = cache_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        info!("Opening cache at: {}", cache_path.display());
+
+        let conn = Connection::open(&cache_path)?;
+        Self::open_connection(conn)
     }
 
     /// Get cache file path based on server URL.
@@ -149,13 +153,13 @@ impl FileCache {
                 if age < MAX_CACHE_AGE_SECS {
                     // Fresh cache hit
                     debug!("Cache hit for {} (age: {}s)", path, age);
-                    CacheLookup::Hit(CacheEntry {
-                        content,
-                        etag,
-                    })
+                    CacheLookup::Hit(CacheEntry { content, etag })
                 } else if let Some(etag) = etag {
                     // Stale but has etag - can revalidate
-                    debug!("Cache stale for {} (age: {}s), needs revalidation", path, age);
+                    debug!(
+                        "Cache stale for {} (age: {}s), needs revalidation",
+                        path, age
+                    );
                     CacheLookup::NeedsRevalidation { etag }
                 } else {
                     // Stale with no etag - treat as miss
@@ -208,7 +212,12 @@ impl FileCache {
         ) {
             error!("Failed to cache {}: {}", path, e);
         } else {
-            debug!("Cached {} ({} bytes, etag: {:?})", path, content.len(), etag);
+            debug!(
+                "Cached {} ({} bytes, etag: {:?})",
+                path,
+                content.len(),
+                etag
+            );
         }
     }
 
@@ -250,11 +259,10 @@ impl FileCache {
         )?;
 
         // Check total cache size
-        let total_size: u64 = conn.query_row(
-            "SELECT COALESCE(SUM(size), 0) FROM file_cache",
-            [],
-            |row| row.get(0),
-        )?;
+        let total_size: u64 =
+            conn.query_row("SELECT COALESCE(SUM(size), 0) FROM file_cache", [], |row| {
+                row.get(0)
+            })?;
 
         if total_size > MAX_CACHE_SIZE {
             info!(
@@ -314,9 +322,10 @@ pub struct CacheStats {
 mod tests {
     use super::*;
 
-    /// Helper: create an in-memory cache for testing (unique URL per test).
-    fn test_cache(label: &str) -> FileCache {
-        FileCache::new(&format!("http://test-{}.local:2026", label)).unwrap()
+    /// Helper: create an in-memory cache for testing (no filesystem access).
+    fn test_cache(_label: &str) -> FileCache {
+        let conn = Connection::open_in_memory().unwrap();
+        FileCache::open_connection(conn).unwrap()
     }
 
     // ──────────────────────────────────────────────────────
@@ -614,6 +623,9 @@ mod tests {
         let cache = test_cache("inv-noop");
         // Should not panic or error
         cache.invalidate("/does-not-exist.txt");
-        assert!(matches!(cache.get("/does-not-exist.txt"), CacheLookup::Miss));
+        assert!(matches!(
+            cache.get("/does-not-exist.txt"),
+            CacheLookup::Miss
+        ));
     }
 }

--- a/rust/nexus_raft/src/raft/node.rs
+++ b/rust/nexus_raft/src/raft/node.rs
@@ -50,7 +50,9 @@ use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use raft::eraftpb::{ConfChange, ConfChangeType, ConfState, Entry, EntryType, Message, Snapshot};
+use raft::eraftpb::{
+    ConfChange, ConfChangeType, ConfChangeV2, ConfState, Entry, EntryType, Message, Snapshot,
+};
 use raft::{Config, RawNode, Storage};
 use slog::{o, Logger};
 use tokio::sync::{mpsc, oneshot, RwLock};
@@ -894,7 +896,7 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         let _ = proposal.tx.send(Ok(result));
                     }
                 }
-                EntryType::EntryConfChange | EntryType::EntryConfChangeV2 => {
+                EntryType::EntryConfChange => {
                     let cc: ConfChange = protobuf::Message::parse_from_bytes(&entry.data)
                         .map_err(|e| RaftError::Serialization(e.to_string()))?;
 
@@ -992,6 +994,102 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                     // Notify waiting JoinZone caller (if any)
                     if let Some(tx) = self.pending_conf_changes.remove(&cc.node_id) {
                         let _ = tx.send(Ok(cs));
+                    }
+                }
+                EntryType::EntryConfChangeV2 => {
+                    let cc: ConfChangeV2 = protobuf::Message::parse_from_bytes(&entry.data)
+                        .map_err(|e| RaftError::Serialization(e.to_string()))?;
+
+                    let cs = self
+                        .raw_node
+                        .apply_conf_change(&cc)
+                        .map_err(|e| RaftError::Raft(e.to_string()))?;
+
+                    self.raw_node
+                        .mut_store()
+                        .set_conf_state(&cs)
+                        .map_err(|e| RaftError::Storage(e.to_string()))?;
+
+                    let mut has_add = false;
+
+                    #[cfg(all(feature = "grpc", has_protos))]
+                    if let Some(ref peer_map) = self.peer_map {
+                        for single in &cc.changes {
+                            match single.get_change_type() {
+                                ConfChangeType::AddNode | ConfChangeType::AddLearnerNode => {
+                                    has_add = true;
+                                    if !cc.context.is_empty() {
+                                        let address =
+                                            String::from_utf8_lossy(&cc.context).to_string();
+                                        let endpoint = if address.starts_with("http") {
+                                            address.clone()
+                                        } else {
+                                            format!("http://{}", address)
+                                        };
+                                        peer_map.write().unwrap().insert(
+                                            single.node_id,
+                                            NodeAddress::new(single.node_id, endpoint),
+                                        );
+                                    }
+                                }
+                                ConfChangeType::RemoveNode => {
+                                    peer_map.write().unwrap().remove(&single.node_id);
+                                }
+                            }
+                        }
+                    }
+
+                    // Without grpc feature, still detect AddNode for snapshot creation
+                    #[cfg(not(all(feature = "grpc", has_protos)))]
+                    {
+                        for single in &cc.changes {
+                            if matches!(
+                                single.get_change_type(),
+                                ConfChangeType::AddNode | ConfChangeType::AddLearnerNode
+                            ) {
+                                has_add = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    tracing::info!(
+                        index = entry.index,
+                        num_changes = cc.changes.len(),
+                        voters = ?cs.voters,
+                        "raft.conf_change_v2.applied",
+                    );
+
+                    if has_add {
+                        let sm_data = sm.snapshot().map_err(|e| {
+                            RaftError::Storage(format!("snapshot for new voter: {e}"))
+                        })?;
+                        let mut snapshot = Snapshot::new();
+                        {
+                            let meta = snapshot.mut_metadata();
+                            meta.index = entry.index;
+                            meta.term = entry.term;
+                            *meta.mut_conf_state() = cs.clone();
+                        }
+                        snapshot.data = sm_data.into();
+
+                        self.raw_node
+                            .mut_store()
+                            .store_snapshot(&snapshot)
+                            .map_err(|e| RaftError::Storage(format!("store snapshot: {e}")))?;
+                        self.raw_node
+                            .mut_store()
+                            .compact(entry.index)
+                            .map_err(|e| {
+                                RaftError::Storage(format!("compact after AddNode v2: {e}"))
+                            })?;
+                    }
+
+                    // Notify waiting JoinZone callers for each added node
+                    for single in &cc.changes {
+                        if let Some(tx) = self.pending_conf_changes.remove(&single.node_id) {
+                            let _ = tx.send(Ok(cs.clone()));
+                        }
                     }
                 }
             }

--- a/rust/nexus_tasks/src/store.rs
+++ b/rust/nexus_tasks/src/store.rs
@@ -149,11 +149,21 @@ impl TaskStore {
             }
         }
 
-        // Normal path: grab the first key in pending_idx (highest priority, earliest time)
+        // Normal path: scan pending_idx for the first due task, skipping future-scheduled ones.
+        // The index is sorted by (priority, run_at, task_id), so within a priority band
+        // run_at increases monotonically — but a lower-priority band may have due tasks.
         if target_key.is_none() {
-            if let Some(guard) = self.pending_idx.first_key_value() {
-                if let Ok((key, _)) = guard.into_inner() {
-                    target_key = Some(key.as_ref().to_vec());
+            for guard in self.pending_idx.iter() {
+                match guard.into_inner() {
+                    Ok((key, _)) => {
+                        if let Some((_, run_at, _)) = decode_pending_key(key.as_ref()) {
+                            if run_at <= now {
+                                target_key = Some(key.as_ref().to_vec());
+                                break;
+                            }
+                        }
+                    }
+                    Err(_) => continue,
                 }
             }
         }

--- a/src/nexus/bricks/watch/file_watcher.py
+++ b/src/nexus/bricks/watch/file_watcher.py
@@ -18,6 +18,7 @@ Used by NexusFS for:
 
 import asyncio
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -187,6 +188,7 @@ class FileWatcher:
     _loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
     _watches: dict[str, _WatchInfo] = field(default_factory=dict, init=False, repr=False)
     _stop_event: asyncio.Event = field(default_factory=asyncio.Event, init=False, repr=False)
+    _force_polling: bool = field(default=False, init=False, repr=False)
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -204,6 +206,11 @@ class FileWatcher:
 
         self._loop = loop or asyncio.get_running_loop()
         self._stop_event.clear()
+        self._force_polling = os.environ.get("NEXUS_FILE_WATCHER_POLL", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
         self._started = True
         logger.info("FileWatcher started")
 
@@ -316,6 +323,7 @@ class FileWatcher:
                     recursive=True,
                     step=50,  # 50 ms debounce for responsive one-shot
                     stop_event=stop,
+                    force_polling=self._force_polling,
                 ):
                     file_changes = _RenameDetector.process(changes)
                     if file_changes:
@@ -346,6 +354,7 @@ class FileWatcher:
                 recursive=recursive,
                 step=100,  # 100 ms debounce for persistent watches
                 stop_event=self._stop_event,
+                force_polling=self._force_polling,
             ):
                 file_changes = _RenameDetector.process(changes)
                 for fc in file_changes:

--- a/src/nexus/bricks/workspace/workspace_registry.py
+++ b/src/nexus/bricks/workspace/workspace_registry.py
@@ -14,7 +14,7 @@ Key Concepts:
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -266,8 +266,6 @@ class WorkspaceRegistry:
         # Calculate expiry
         expires_at = None
         if ttl:
-            from datetime import UTC
-
             expires_at = datetime.now(UTC) + ttl
 
         # Create config
@@ -285,7 +283,7 @@ class WorkspaceRegistry:
             path=path,
             name=name,
             description=description,
-            created_at=datetime.now(),
+            created_at=datetime.now(UTC),
             created_by=created_by or user_id,
             metadata=ws_metadata,
         )
@@ -533,8 +531,6 @@ class WorkspaceRegistry:
         # Calculate expiry
         expires_at = None
         if ttl:
-            from datetime import UTC
-
             expires_at = datetime.now(UTC) + ttl
 
         # Create config
@@ -542,7 +538,7 @@ class WorkspaceRegistry:
             path=path,
             name=name,
             description=description,
-            created_at=datetime.now(),
+            created_at=datetime.now(UTC),
             created_by=created_by or user_id,
             metadata=metadata or {},
         )
@@ -655,7 +651,7 @@ class WorkspaceRegistry:
                 path=config.path,
                 name=config.name,
                 description=config.description,
-                created_at=config.created_at or datetime.now(),
+                created_at=config.created_at or datetime.now(UTC),
                 created_by=config.created_by,
                 user_id=user_id,  # v0.5.0
                 agent_id=agent_id,  # v0.5.0
@@ -698,7 +694,7 @@ class WorkspaceRegistry:
                 path=config.path,
                 name=config.name,
                 description=config.description,
-                created_at=config.created_at or datetime.now(),
+                created_at=config.created_at or datetime.now(UTC),
                 created_by=config.created_by,
                 user_id=user_id,  # v0.5.0
                 agent_id=agent_id,  # v0.5.0


### PR DESCRIPTION
## Summary

Fixes 5 issues identified during codex code review across Rust and Python subsystems:

- **(High) Task queue starvation** — `claim_next` in `nexus_tasks/store.rs` now scans the pending index for the first *due* task instead of returning `None` when the head entry is future-scheduled. A single future high-priority task no longer blocks all ready lower-priority work behind it.
- **(Medium) Raft ConfChangeV2 misparse** — `nexus_raft/node.rs` now handles `EntryConfChangeV2` in its own match arm, parsing it as `ConfChangeV2` instead of `ConfChange`. Peer map updates iterate `cc.changes`; snapshot creation triggers on any `AddNode`.
- **(Medium) File watcher polling fallback** — `file_watcher.py` passes `force_polling` to both `awatch` call sites, controlled by the `NEXUS_FILE_WATCHER_POLL` env var. Enables reliable watching in Docker/NFS/CI environments without native FS notifications.
- **(Medium) Non-hermetic cache tests** — `nexus-fuse/cache.rs` extracts `open_connection(conn)` and tests now use `Connection::open_in_memory()`, removing the dependency on write access to the system cache directory.
- **(Low) Naive vs UTC timestamps** — `workspace_registry.py` replaces all `datetime.now()` with `datetime.now(UTC)`, matching the SQLAlchemy model default and preventing naive-vs-aware inconsistencies.

## Test plan

- [x] `cargo test -p nexus_tasks --lib` — all 36 tests pass (includes `claim_next` priority ordering)
- [x] `cargo check -p nexus_raft` — compiles clean
- [x] `uv run ruff check` — no lint errors
- [x] `uv run mypy` — no type errors
- [x] All pre-commit hooks pass (ruff, mypy, rustfmt, clippy)
- [ ] CI pipeline