### PR TITLE
fix: align memory tool tests with _memory_provider implementation

### DIFF
--- a/tests/unit/bricks/mcp/test_mcp_server_tools.py
+++ b/tests/unit/bricks/mcp/test_mcp_server_tools.py
@@ -798,9 +798,8 @@ class TestMemoryTools:
 
     def test_store_memory_not_available(self, mock_nx_basic):
         """Test storing memory when system not available."""
-        # Remove memory attribute
-        if hasattr(mock_nx_basic, "memory"):
-            delattr(mock_nx_basic, "memory")
+        # Implementation checks _memory_provider, not .memory
+        mock_nx_basic._memory_provider = None
 
         server = create_mcp_server(nx=mock_nx_basic)
 
@@ -834,9 +833,8 @@ class TestMemoryTools:
 
     def test_query_memory_not_available(self, mock_nx_basic):
         """Test querying memory when system not available."""
-        # Remove memory attribute
-        if hasattr(mock_nx_basic, "memory"):
-            delattr(mock_nx_basic, "memory")
+        # Implementation checks _memory_provider, not .memory
+        mock_nx_basic._memory_provider = None
 
         server = create_mcp_server(nx=mock_nx_basic)
 


### PR DESCRIPTION
## Summary
- Fix 2 failing tests in `test_mcp_server_tools.py::TestMemoryTools` on develop
- `test_store_memory_not_available` and `test_query_memory_not_available` were deleting `.memory` attribute, but the implementation checks `_memory_provider` via `getattr()`. Since `Mock()` auto-creates attributes on access, `getattr(mock, "_memory_provider", None)` returned a Mock instead of `None`, so the "not available" code path was never reached.
- Fix: set `mock_nx_basic._memory_provider = None` instead of deleting `.memory`

## Test plan
- [x] Both previously failing tests now pass locally
- [x] All 8 `TestMemoryTools` tests pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)