### PR TITLE
refactor: migrate serve command and CLI utils from mode to profile

### DIFF
--- a/src/nexus/cli/commands/server.py
+++ b/src/nexus/cli/commands/server.py
@@ -590,7 +590,7 @@ def serve(
 
         # Connect from Python
         import nexus
-        nx = nexus.connect(config={"mode": "remote", "url": "http://localhost:2026", "api_key": "<admin-key>"})
+        nx = nexus.connect(config={"profile": "remote", "url": "http://localhost:2026", "api_key": "<admin-key>"})
         nx.sys_write("/workspace/file.txt", b"Hello, World!")
 
         # Mount with FUSE
@@ -784,30 +784,45 @@ def serve(
             # Default: enable zone isolation for security
             enforce_zone_isolation = True
 
-        # Determine server deployment mode from NEXUS_MODE env var
-        # Server always runs local NexusFS (never REMOTE profile)
-        raw_server_mode = os.getenv("NEXUS_MODE", "standalone")
+        # Determine server deployment profile
+        # Priority: 1. CLI --profile, 2. NEXUS_PROFILE env, 3. NEXUS_MODE (deprecated)
+        server_profile = os.getenv("NEXUS_PROFILE")
+        if not server_profile:
+            raw_mode = os.getenv("NEXUS_MODE")
+            if raw_mode:
+                import logging as _logging
 
-        if raw_server_mode == "remote":
+                _logging.getLogger(__name__).warning(
+                    "NEXUS_MODE is deprecated and will be removed in v1.0. "
+                    "Use NEXUS_PROFILE instead (standalone -> full, remote -> remote, federation -> cloud)."
+                )
+                _mode_to_profile = {
+                    "standalone": "full",
+                    "federation": "cloud",
+                    "remote": "remote",
+                }
+                server_profile = _mode_to_profile.get(raw_mode)
+                if not server_profile:
+                    console.print(f"[red]Error:[/red] Unknown NEXUS_MODE: '{raw_mode}'")
+                    console.print("[yellow]Allowed values:[/yellow] standalone, federation, remote")
+                    sys.exit(1)
+            else:
+                server_profile = "full"
+
+        # Server cannot run in remote profile (would be a thin client of another server)
+        if server_profile == "remote":
             console.print(
-                "[red]Error:[/red] Server cannot run in mode='remote' "
+                "[red]Error:[/red] Server cannot run in profile='remote' "
                 "(a server cannot be a thin client of another server)"
             )
             sys.exit(1)
 
-        if raw_server_mode not in ("standalone", "federation"):
-            console.print(f"[red]Error:[/red] Unknown NEXUS_MODE: '{raw_server_mode}'")
-            console.print("[yellow]Allowed values:[/yellow] standalone, federation")
-            sys.exit(1)
-
-        console.print(f"  Mode: [cyan]{raw_server_mode}[/cyan]")
-        _active_profile = os.getenv("NEXUS_PROFILE", "full")
-        console.print(f"  Profile: [cyan]{_active_profile}[/cyan]")
+        console.print(f"  Profile: [cyan]{server_profile}[/cyan]")
 
         nx = get_filesystem(
             backend_config,
             enforce_permissions=enforce_permissions,
-            server_mode=raw_server_mode,
+            server_profile=server_profile,
             allow_admin_bypass=allow_admin_bypass,
             enforce_zone_isolation=enforce_zone_isolation,
             enable_memory_paging=enable_memory_paging,
@@ -1413,11 +1428,11 @@ def serve(
         console.print("  import nexus")
         if api_key or auth_provider:
             console.print(
-                f'  nx = nexus.connect(config={{"mode": "remote", "url": "http://{host}:{port}", "api_key": "<your-key>"}})'
+                f'  nx = nexus.connect(config={{"profile": "remote", "url": "http://{host}:{port}", "api_key": "<your-key>"}})'
             )
         else:
             console.print(
-                f'  nx = nexus.connect(config={{"mode": "remote", "url": "http://{host}:{port}"}})'
+                f'  nx = nexus.connect(config={{"profile": "remote", "url": "http://{host}:{port}"}})'
             )
         console.print("  nx.sys_write('/workspace/file.txt', b'Hello!')")
         console.print()

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -181,7 +181,7 @@ def add_backend_options(func: Any) -> Any:
 def get_filesystem(
     backend_config: BackendConfig,
     enforce_permissions: bool | None = None,
-    server_mode: str | None = None,
+    server_profile: str | None = None,
     allow_admin_bypass: bool | None = None,
     enforce_zone_isolation: bool | None = None,
     enable_memory_paging: bool = True,
@@ -193,7 +193,7 @@ def get_filesystem(
     Args:
         backend_config: Backend configuration
         enforce_permissions: Whether to enforce permissions (None = use environment/config default)
-        server_mode: Explicit mode for server use ("standalone" or "federation").
+        server_profile: Deployment profile for server use (e.g. "full", "cloud").
             When set, forces a local NexusFS (never remote) to prevent
             circular dependency when the server itself has NEXUS_URL set.
         allow_admin_bypass: Whether admin keys can bypass permission checks (None = use default False)
@@ -203,23 +203,23 @@ def get_filesystem(
         NexusFilesystem instance
     """
     try:
-        # If server_mode is set, the caller is a server — always use local NexusFS
-        if not server_mode and backend_config.remote_url:
+        # If server_profile is set, the caller is a server — always use local NexusFS
+        if not server_profile and backend_config.remote_url:
             # Client mode: use remote server connection via nexus.connect()
             return nexus.connect(
                 config={
-                    "mode": "remote",
+                    "profile": "remote",
                     "url": backend_config.remote_url,
                     "api_key": backend_config.remote_api_key,
                 }
             )
         elif backend_config.config_path:
             # Use explicit config file
-            if server_mode:
-                # Server mode: override mode to prevent remote NexusFS
+            if server_profile:
+                # Server profile: override to prevent remote NexusFS
                 config_obj = load_config(Path(backend_config.config_path))
                 config_dict: dict[str, Any] = {
-                    "mode": server_mode,
+                    "profile": server_profile,
                     "data_dir": config_obj.data_dir,
                     "backend": config_obj.backend,
                 }
@@ -248,7 +248,7 @@ def get_filesystem(
                 console.print("[red]Error:[/red] --gcs-bucket is required when using --backend=gcs")
                 sys.exit(1)
             config: dict[str, Any] = {
-                "mode": server_mode or "standalone",
+                "profile": server_profile or "full",
                 "backend": "gcs",
                 "gcs_bucket_name": backend_config.gcs_bucket,
                 "gcs_project_id": backend_config.gcs_project,
@@ -269,7 +269,7 @@ def get_filesystem(
         else:
             # Use local backend (default)
             config = {
-                "mode": server_mode or "standalone",
+                "profile": server_profile or "full",
                 "data_dir": backend_config.data_dir,
             }
             if enforce_permissions is not None:
@@ -323,10 +323,10 @@ def get_default_filesystem() -> NexusFilesystem:
     """Get Nexus filesystem instance with default configuration.
 
     Used by commands that don't accept backend options (e.g., memory commands).
-    Supports both local and remote modes via environment variables:
-    - NEXUS_URL: Remote server URL (if set, uses remote mode)
+    Supports both local and remote profiles via environment variables:
+    - NEXUS_URL: Remote server URL (if set, uses remote profile)
     - NEXUS_API_KEY: API key for remote authentication
-    - NEXUS_DATA_DIR: Data directory for local mode (default: ~/.nexus)
+    - NEXUS_DATA_DIR: Data directory for local profile (default: ~/.nexus)
 
     Returns:
         NexusFilesystem instance (remote if NEXUS_URL is set, otherwise local)
@@ -340,7 +340,7 @@ def get_default_filesystem() -> NexusFilesystem:
             # Use remote server connection via nexus.connect()
             return nexus.connect(
                 config={
-                    "mode": "remote",
+                    "profile": "remote",
                     "url": remote_url,
                     "api_key": os.environ.get("NEXUS_API_KEY"),
                 }


### PR DESCRIPTION
## Summary
- Rename `server_mode` parameter to `server_profile` in `get_filesystem()` and replace all `"mode"` config keys with `"profile"`
- Refactor serve command to prioritize `NEXUS_PROFILE` env var over deprecated `NEXUS_MODE`, with automatic mapping (standalone→full, federation→cloud, remote→remote) and deprecation warning
- Update all example connect snippets in CLI output to use `"profile": "remote"` instead of `"mode": "remote"`

## Test plan
- [x] Verify `nexus serve` defaults to profile=full when no env vars set
- [x] Verify `NEXUS_PROFILE=cloud nexus serve` uses cloud profile
- [x] Verify `NEXUS_MODE=standalone nexus serve` maps to full with deprecation warning
- [x] Verify `NEXUS_PROFILE=remote nexus serve` exits with error (server can't be thin client)
- [x] Verify `nexus serve --profile minimal` propagates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)