### PR TITLE
docs: update deployment-profiles tutorials from mode to profile

### DIFF
--- a/examples/tutorials/deployment-profiles/README.md
+++ b/examples/tutorials/deployment-profiles/README.md
@@ -1,6 +1,6 @@
-# Deployment Profiles & Modes Tutorial
+# Deployment Profiles Tutorial
 
-This tutorial covers Nexus deployment profiles, server modes, and how to verify
+This tutorial covers Nexus deployment profiles and how to verify
 that core filesystem operations work across all configurations.
 
 ## Concepts
@@ -23,17 +23,11 @@ Profile hierarchy: `minimal` ⊂ `embedded` ⊂ `lite` ⊂ `full` ⊂ `cloud`. `
 
 Core filesystem operations (write, read, stat, list, glob, grep) live in the **kernel** (`NexusFS`), not in bricks, so they work across all profiles.
 
-### Modes (NEXUS_MODE)
+### Topology
 
-Modes control the **deployment topology** and are orthogonal to profiles:
-
-| Mode | Description |
-|------|-------------|
-| `standalone` | Single-node, local redb storage (default) |
-| `federation` | Multi-zone Raft consensus via ZoneManager |
-| `remote` | Client-side thin proxy (SDK/CLI only, not for servers) |
-
-You can combine any profile with `standalone` or `federation` mode.
+The `cloud` profile enables federation (multi-zone Raft consensus).
+The `remote` profile creates a thin client proxy (SDK/CLI only, not for servers).
+All other profiles run as single-node local storage by default.
 
 ## Prerequisites
 
@@ -41,7 +35,7 @@ You can combine any profile with `standalone` or `federation` mode.
 pip install -e .  # Install nexus-ai-fs from source
 ```
 
-For federation mode, you also need the Rust extension built with full features:
+For the `cloud` profile (federation), you also need the Rust extension built with full features:
 
 ```bash
 # Requires protobuf 3.x (brew install protobuf@21)
@@ -87,7 +81,7 @@ The SDK can connect directly (no server needed) for local testing:
 ```python
 import nexus
 
-nx = nexus.connect(config={"mode": "standalone", "data_dir": "/tmp/nexus-tutorial/sdk"})
+nx = nexus.connect(config={"profile": "full", "data_dir": "/tmp/nexus-tutorial/sdk"})
 
 # Write
 nx.sys_write("/project/main.py", b'print("Hello, Nexus!")\n')
@@ -163,14 +157,13 @@ Run the automated test across all profiles:
 python3 examples/tutorials/deployment-profiles/test_profiles_cli.py
 ```
 
-## Tutorial 4: Federation Mode
+## Tutorial 4: Cloud Profile (Federation)
 
-Federation mode uses Raft consensus for multi-zone metadata replication.
-It works with any profile:
+The `cloud` profile enables Raft consensus for multi-zone metadata replication:
 
 ```bash
-# Start with federation mode + lite profile
-NEXUS_MODE=federation nexus serve --profile lite --port 3030 \
+# Start with cloud profile (federation enabled)
+nexus serve --profile cloud --port 3030 \
   --data-dir /tmp/nexus-tutorial/federation
 ```
 
@@ -180,9 +173,9 @@ Run the automated test:
 python3 examples/tutorials/deployment-profiles/test_profiles_federation.py
 ```
 
-## Tutorial 5: Remote Client Mode (Python SDK)
+## Tutorial 5: Remote Client Profile (Python SDK)
 
-Remote mode creates a thin gRPC proxy to a running server.
+The `remote` profile creates a thin gRPC proxy to a running server.
 
 ### Step 1: Start a server with gRPC enabled
 
@@ -199,7 +192,7 @@ import os, nexus
 os.environ["NEXUS_GRPC_PORT"] = "3051"
 
 nx = nexus.connect(config={
-    "mode": "remote",
+    "profile": "remote",
     "url": "http://localhost:3050",
 })
 
@@ -234,15 +227,7 @@ verified across the following dimensions:
 | `remote`   | OK                      | —                   | OK         | OK             |
 | `auto`     | OK                      | —                   | OK         | OK             |
 
-### By Mode
-
-| Mode          | Server startup | Python SDK | CLI   |
-|---------------|:--------------:|:----------:|:-----:|
-| `standalone`  | 7/7 profiles   | 7/7        | 7/7   |
-| `federation`  | 7/7 profiles   | —          | —     |
-| `remote`      | n/a (client)   | OK         | OK    |
-
-Note: remote mode tested against a `minimal` server. The gRPC transport
+Note: `remote` profile tested against a `minimal` server. The gRPC transport
 is profile-agnostic so one server profile is sufficient.
 
 ### By Operation × Interface

--- a/examples/tutorials/deployment-profiles/test_profiles_cli.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_cli.py
@@ -36,7 +36,7 @@ FILES = {
 _CLEAN_ENV = {
     k: v
     for k, v in os.environ.items()
-    if k not in ("NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE")
+    if k not in ("NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE", "NEXUS_PROFILE")
 }
 
 

--- a/examples/tutorials/deployment-profiles/test_profiles_federation.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_federation.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """
-Test nexus serve with NEXUS_MODE=federation across all deployment profiles.
+Test nexus serve with profile=cloud (federation) across all deployment profiles.
 
-Federation mode uses Raft consensus for multi-zone metadata replication.
-It is orthogonal to profiles — any profile can run in federation mode.
+The cloud profile enables Raft consensus for multi-zone metadata replication.
 
 Prerequisites:
     pip install -e .
@@ -49,10 +48,11 @@ def main() -> int:
         os.makedirs(data_dir, exist_ok=True)
 
         env = os.environ.copy()
-        env["NEXUS_MODE"] = "federation"
+        env["NEXUS_PROFILE"] = "cloud"
         env["NEXUS_DATA_DIR"] = data_dir
-        for k in ["NEXUS_URL", "NEXUS_DATABASE_URL"]:
+        for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE"]:
             env.pop(k, None)
+        # Note: NEXUS_PROFILE is set to "cloud" above, don't clear it
 
         proc = subprocess.Popen(
             [
@@ -89,10 +89,10 @@ def main() -> int:
                 pass
 
         if started:
-            print(f"  {profile} + federation: OK (port {port}, {_attempt + 1}s)")
+            print(f"  {profile} + cloud: OK (port {port}, {_attempt + 1}s)")
             results[profile] = "OK"
         else:
-            print(f"  {profile} + federation: FAILED")
+            print(f"  {profile} + cloud: FAILED")
             results[profile] = "FAILED"
 
         proc.terminate()
@@ -103,7 +103,7 @@ def main() -> int:
         time.sleep(0.5)
 
     # Summary
-    print(f"\n{'Profile':<12} {'federation mode'}")
+    print(f"\n{'Profile':<12} {'cloud (federation)'}")
     print("-" * 30)
     for profile in PROFILES:
         print(f"{profile:<12} {results[profile]}")
@@ -114,7 +114,7 @@ def main() -> int:
     if failed:
         print(f"\n{failed} profile(s) failed.")
         return 1
-    print("\nAll profiles work with federation mode.")
+    print("\nAll profiles work with cloud (federation) profile.")
     return 0
 
 

--- a/examples/tutorials/deployment-profiles/test_profiles_sdk.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_sdk.py
@@ -69,14 +69,14 @@ def test_profile(profile: str) -> dict[str, str]:
     data_dir = f"{BASE_DIR}/{profile}"
     os.makedirs(data_dir, exist_ok=True)
 
-    for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE"]:
+    for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE", "NEXUS_PROFILE"]:
         os.environ.pop(k, None)
     os.environ["NEXUS_PROFILE"] = profile
 
     row: dict[str, str] = {}
 
     try:
-        nx = nexus.connect(config={"mode": "standalone", "data_dir": data_dir})
+        nx = nexus.connect(config={"profile": "full", "data_dir": data_dir})
     except Exception as e:
         print(f"  CONNECT FAILED: {e}")
         return dict.fromkeys(OPS, "FAIL")

--- a/examples/tutorials/deployment-profiles/test_profiles_serve.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_serve.py
@@ -38,7 +38,7 @@ def main() -> int:
 
         env = os.environ.copy()
         env["NEXUS_DATA_DIR"] = data_dir
-        for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE"]:
+        for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE", "NEXUS_PROFILE"]:
             env.pop(k, None)
 
         proc = subprocess.Popen(

--- a/examples/tutorials/deployment-profiles/test_remote_client.py
+++ b/examples/tutorials/deployment-profiles/test_remote_client.py
@@ -51,7 +51,7 @@ def main() -> int:
     env = os.environ.copy()
     env["NEXUS_GRPC_PORT"] = str(GRPC_PORT)
     env["NEXUS_DATA_DIR"] = f"{BASE_DIR}/server"
-    for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE"]:
+    for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE", "NEXUS_PROFILE"]:
         env.pop(k, None)
 
     server = subprocess.Popen(
@@ -97,7 +97,7 @@ def main() -> int:
 
     nx = nexus.connect(
         config={
-            "mode": "remote",
+            "profile": "remote",
             "url": f"http://localhost:{HTTP_PORT}",
         }
     )


### PR DESCRIPTION
## Summary
- Replace `NEXUS_MODE` env var references with `NEXUS_PROFILE` across all tutorial test scripts
- Update SDK config keys from `"mode"` to `"profile"` (e.g., `"mode": "standalone"` → `"profile": "full"`)
- Clean up env variable handling to include `NEXUS_PROFILE` in cleanup lists

Follow-up to #2820 which migrated the serve command and CLI utils.

## Changed files
- `examples/tutorials/deployment-profiles/README.md` — rewrite mode references to profile terminology
- `test_profiles_federation.py` — `NEXUS_MODE=federation` → `NEXUS_PROFILE=cloud`
- `test_profiles_sdk.py` — `"mode": "standalone"` → `"profile": "full"`, add `NEXUS_PROFILE` to env cleanup
- `test_profiles_cli.py` — add `NEXUS_PROFILE` to env cleanup
- `test_profiles_serve.py` — add `NEXUS_PROFILE` to env cleanup
- `test_remote_client.py` — `"mode": "remote"` → `"profile": "remote"`, add `NEXUS_PROFILE` to env cleanup

## Test plan
- [x] `nexus.connect(config={"profile": "minimal", ...})` — write, read, stat, readdir pass
- [x] Profile resolution logic (NEXUS_PROFILE priority, NEXUS_MODE fallback, default) — all scenarios pass
- [x] 130 deployment profile/boot unit tests — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)