### PR TITLE
feat(#2806): unified CLI output infrastructure with --json, timing, and remote mode fix

### DIFF
--- a/src/nexus/cli/__main__.py
+++ b/src/nexus/cli/__main__.py
@@ -1,0 +1,5 @@
+"""Allow ``python -m nexus.cli`` to invoke the Nexus CLI."""
+
+from nexus.cli.main import main
+
+main()

--- a/src/nexus/cli/commands/directory.py
+++ b/src/nexus/cli/commands/directory.py
@@ -1,17 +1,18 @@
 """Directory operation commands - ls, mkdir, rmdir, tree."""
 
-from typing import Any, cast
+from typing import Any
 
 import click
-from rich.table import Table
 
 from nexus.cli.formatters import format_timestamp
+from nexus.cli.output import OutputOptions, add_output_options, render_error, render_output
+from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     BackendConfig,
     add_backend_options,
     console,
-    get_filesystem,
     handle_error,
+    open_filesystem,
 )
 
 
@@ -23,6 +24,34 @@ def register_commands(cli: click.Group) -> None:
     cli.add_command(tree)
 
 
+def _normalize_readdir(raw: Any) -> list[Any]:
+    """Unwrap sys_readdir result — remote mode returns ``{"files": [...]}`` envelope."""
+    if isinstance(raw, dict) and "files" in raw:
+        return list(raw["files"])
+    if isinstance(raw, list):
+        return raw
+    return []
+
+
+def _format_file_entry(file: dict[str, Any] | str) -> dict[str, Any]:
+    """Normalize a file entry dict for consistent JSON output."""
+    if isinstance(file, str):
+        is_dir = file.endswith("/")
+        return {
+            "path": file.rstrip("/"),
+            "type": "directory" if is_dir else "file",
+            "size": None if is_dir else 0,
+            "modified_at": None,
+        }
+    is_dir = file.get("is_directory", False)
+    return {
+        "path": file["path"],
+        "type": "directory" if is_dir else "file",
+        "size": file.get("size", 0) if not is_dir else None,
+        "modified_at": file.get("modified_at"),
+    }
+
+
 @click.command(name="ls")
 @click.argument("path", default="/", type=str)
 @click.option("-r", "--recursive", is_flag=True, help="List files recursively")
@@ -32,12 +61,14 @@ def register_commands(cli: click.Group) -> None:
     type=str,
     help="List files at a historical operation point (time-travel debugging)",
 )
+@add_output_options
 @add_backend_options
 def list_files(
     path: str,
     recursive: bool,
     long: bool,
     at_operation: str | None,
+    output_opts: OutputOptions,
     backend_config: BackendConfig,
 ) -> None:
     """List files in a directory.
@@ -46,163 +77,127 @@ def list_files(
         nexus ls /workspace
         nexus ls /workspace --recursive
         nexus ls /workspace -l
-        nexus ls /workspace --backend=gcs --gcs-bucket=my-bucket
+        nexus ls /workspace --json
+        nexus ls /workspace --json --fields path,size
 
+    \b
         # Time-travel: List files at historical operation point
         nexus ls /workspace --at-operation op_abc123
     """
-    from nexus.core.nexus_fs import NexusFS
+    timing = CommandTiming()
 
     try:
-        nx = get_filesystem(backend_config)
-
-        if at_operation:
-            # Time-travel: List files at historical operation point
-            time_travel = getattr(nx, "time_travel_service", None)
-            if time_travel is None:
-                console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
-                nx.close()
+        with timing.phase("connect"), open_filesystem(backend_config) as nx:
+            if at_operation:
+                _ls_time_travel(nx, path, at_operation, recursive, long, output_opts, timing)
                 return
 
-            files = time_travel.list_files_at_operation(path, at_operation, recursive=recursive)
-            nx.close()
+            with timing.phase("server"):
+                files_raw = nx.sys_readdir(path, recursive=recursive, details=True)
+                files = _normalize_readdir(files_raw)
 
-            if not files:
-                console.print(
-                    f"[yellow]No files found in {path} at operation {at_operation}[/yellow]"
-                )
-                return
-
-            # Display time-travel info
-            console.print(
-                f"[bold cyan]Time-Travel Mode - Files at operation {at_operation}[/bold cyan]"
+        if not files:
+            render_output(
+                data=[],
+                output_opts=output_opts,
+                timing=timing,
+                message=f"No files found in {path}",
             )
-            console.print()
+            return
 
+        data = [_format_file_entry(f) for f in files]
+
+        def _print_human(entries: list[dict[str, Any]]) -> None:
             if long:
-                # Detailed listing
+                from rich.table import Table
+
                 table = Table(title=f"Files in {path}")
                 table.add_column("Type", style="magenta", width=4)
                 table.add_column("Path", style="cyan")
                 table.add_column("Size", justify="right", style="green")
-                table.add_column("Owner", style="blue")
-                table.add_column("Group", style="blue")
-                table.add_column("Mode", style="magenta")
                 table.add_column("Modified", style="yellow")
 
-                for file in files:
-                    # Check if directory from time-travel data
-                    is_dir = nx.sys_is_directory(file["path"])
-                    type_str = "dir" if is_dir else "file"
-                    path_display = f"{file['path']}/" if is_dir else file["path"]
-                    size_str = f"{file['size']:,} bytes" if not is_dir else "-"
-                    owner_str = file.get("owner") or "-"
-                    group_str = file.get("group") or "-"
-                    mode_str = str(file.get("mode") or "-")
-                    modified_str = file.get("modified_at") or "-"
-
+                for entry in entries:
+                    is_dir = entry["type"] == "directory"
                     table.add_row(
-                        type_str,
-                        path_display,
-                        size_str,
-                        owner_str,
-                        group_str,
-                        mode_str,
-                        modified_str,
+                        "dir" if is_dir else "file",
+                        f"{entry['path']}/" if is_dir else entry["path"],
+                        f"{entry['size']:,} bytes" if entry["size"] is not None else "-",
+                        format_timestamp(entry.get("modified_at"))
+                        if entry.get("modified_at")
+                        else "-",
                     )
-
                 console.print(table)
             else:
-                # Simple listing
-                for file in files:
-                    is_dir = nx.sys_is_directory(file["path"])
-                    if is_dir:
-                        console.print(f"  [bold cyan]{file['path']}/[/bold cyan]")
+                for entry in entries:
+                    if entry["type"] == "directory":
+                        console.print(f"  [bold cyan]{entry['path']}/[/bold cyan]")
                     else:
-                        console.print(f"  {file['path']}")
+                        console.print(f"  {entry['path']}")
 
-            return
-
-        if long:
-            # Detailed listing
-            files_raw = nx.sys_readdir(path, recursive=recursive, details=True)
-            files = cast(list[dict[str, Any]], files_raw)
-
-            if not files:
-                console.print(f"[yellow]No files found in {path}[/yellow]")
-                nx.close()
-                return
-
-            table = Table(title=f"Files in {path}")
-            table.add_column("Type", style="magenta", width=4)
-            table.add_column("Permissions", style="magenta")
-            table.add_column("Owner", style="blue")
-            table.add_column("Group", style="blue")
-            table.add_column("Path", style="cyan")
-            table.add_column("Size", justify="right", style="green")
-            table.add_column("Modified", style="yellow")
-
-            # Get metadata with permissions
-            if isinstance(nx, NexusFS):
-                for file in files:
-                    # Use is_directory from metadata if available, otherwise check via API
-                    is_dir = file.get("is_directory", False)
-                    type_str = "dir" if is_dir else "file"
-                    # Format permissions (UNIX permissions removed - using ReBAC)
-                    perms_str = "---------"  # Placeholder since UNIX permissions are deprecated
-                    owner_str = "-"  # Owner managed through ReBAC
-                    group_str = "-"  # Group managed through ReBAC
-                    size_str = f"{file['size']:,} bytes" if not is_dir else "-"
-                    modified_str = format_timestamp(file.get("modified_at"))
-
-                    # Format path with directory indicator
-                    path_display = f"{file['path']}/" if is_dir else file["path"]
-
-                    table.add_row(
-                        type_str,
-                        perms_str,
-                        owner_str,
-                        group_str,
-                        path_display,
-                        size_str,
-                        modified_str,
-                    )
-            else:
-                # Remote FS - no permission support yet
-                for file in files:
-                    # Use is_directory from metadata if available, otherwise check via API
-                    is_dir = file.get("is_directory", False)
-                    type_str = "dir" if is_dir else "file"
-                    size_str = f"{file['size']:,} bytes" if not is_dir else "-"
-                    modified_str = format_timestamp(file.get("modified_at"))
-                    path_display = f"{file['path']}/" if is_dir else file["path"]
-                    table.add_row(
-                        type_str, "---------", "-", "-", path_display, size_str, modified_str
-                    )
-
-            console.print(table)
-        else:
-            # Simple listing - use details to get is_directory information
-            files_raw = nx.sys_readdir(path, recursive=recursive, details=True)
-            files = cast(list[dict[str, Any]], files_raw)
-
-            if not files:
-                console.print(f"[yellow]No files found in {path}[/yellow]")
-                nx.close()
-                return
-
-            for file in files:
-                # Use is_directory from metadata
-                is_dir = file.get("is_directory", False)
-                file_path = file["path"]
-                if is_dir:
-                    console.print(f"  [bold cyan]{file_path}/[/bold cyan]")
-                else:
-                    console.print(f"  {file_path}")
-
-        nx.close()
+        render_output(
+            data=data,
+            output_opts=output_opts,
+            timing=timing,
+            human_formatter=_print_human,
+        )
     except Exception as e:
-        handle_error(e)
+        if output_opts.json_output:
+            from nexus.cli.exit_codes import ExitCode
+
+            render_error(
+                error=e, output_opts=output_opts, exit_code=ExitCode.GENERAL_ERROR, timing=timing
+            )
+        else:
+            handle_error(e)
+
+
+def _ls_time_travel(
+    nx: Any,
+    path: str,
+    at_operation: str,
+    recursive: bool,
+    long: bool,  # noqa: ARG001
+    output_opts: OutputOptions,
+    timing: CommandTiming,
+) -> None:
+    """Handle time-travel ls (--at-operation)."""
+    time_travel = getattr(nx, "time_travel_service", None)
+    if time_travel is None:
+        console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
+        return
+
+    with timing.phase("server"):
+        files = time_travel.list_files_at_operation(path, at_operation, recursive=recursive)
+
+    if not files:
+        render_output(
+            data=[],
+            output_opts=output_opts,
+            timing=timing,
+            message=f"No files found in {path} at operation {at_operation}",
+        )
+        return
+
+    data = [
+        {
+            "path": f["path"],
+            "size": f.get("size", 0),
+            "owner": f.get("owner"),
+            "modified_at": f.get("modified_at"),
+        }
+        for f in files
+    ]
+
+    def _print_human(entries: list[dict[str, Any]]) -> None:
+        console.print(
+            f"[bold cyan]Time-Travel Mode - Files at operation {at_operation}[/bold cyan]"
+        )
+        console.print()
+        for entry in entries:
+            console.print(f"  {entry['path']}")
+
+    render_output(data=data, output_opts=output_opts, timing=timing, human_formatter=_print_human)
 
 
 @click.command()
@@ -221,10 +216,8 @@ def mkdir(
         nexus mkdir /workspace/deep/nested/dir --parents
     """
     try:
-        nx = get_filesystem(backend_config)
-        nx.sys_mkdir(path, parents=parents, exist_ok=True)
-        nx.close()
-
+        with open_filesystem(backend_config) as nx:
+            nx.sys_mkdir(path, parents=parents, exist_ok=True)
         console.print(f"[green]✓[/green] Created directory [cyan]{path}[/cyan]")
     except Exception as e:
         handle_error(e)
@@ -248,17 +241,11 @@ def rmdir(
         nexus rmdir /workspace/data --recursive --force
     """
     try:
-        nx = get_filesystem(backend_config)
-
-        # Confirm deletion unless --force
-        if not force and not click.confirm(f"Remove directory {path}?"):
-            console.print("[yellow]Cancelled[/yellow]")
-            nx.close()
-            return
-
-        nx.sys_rmdir(path, recursive=recursive)
-        nx.close()
-
+        with open_filesystem(backend_config) as nx:
+            if not force and not click.confirm(f"Remove directory {path}?"):
+                console.print("[yellow]Cancelled[/yellow]")
+                return
+            nx.sys_rmdir(path, recursive=recursive)
         console.print(f"[green]✓[/green] Removed directory [cyan]{path}[/cyan]")
     except Exception as e:
         handle_error(e)
@@ -268,128 +255,121 @@ def rmdir(
 @click.argument("path", default="/", type=str)
 @click.option("-L", "--level", type=int, default=None, help="Max depth to display")
 @click.option("--show-size", is_flag=True, help="Show file sizes")
+@add_output_options
 @add_backend_options
 def tree(
     path: str,
     level: int | None,
     show_size: bool,
+    output_opts: OutputOptions,
     backend_config: BackendConfig,
 ) -> None:
     """Display directory tree structure.
-
-    Shows an ASCII tree view of files and directories with optional
-    size information and depth limiting.
 
     Examples:
         nexus tree /workspace
         nexus tree /workspace -L 2
         nexus tree /workspace --show-size
+        nexus tree /workspace --json
     """
+    timing = CommandTiming()
+
     try:
-        nx = get_filesystem(backend_config)
+        with timing.phase("connect"), open_filesystem(backend_config) as nx, timing.phase("server"):
+            files_raw = nx.sys_readdir(path, recursive=True, details=True)
 
-        # Get all files recursively
-        files_raw = nx.sys_readdir(path, recursive=True, details=show_size)
-        nx.close()
-
-        if not files_raw:
-            console.print(f"[yellow]No files found in {path}[/yellow]")
+        files = _normalize_readdir(files_raw)
+        if not files:
+            render_output(
+                data={"files": [], "total_files": 0},
+                output_opts=output_opts,
+                timing=timing,
+                message=f"No files found in {path}",
+            )
             return
 
-        # Build tree structure
-        from collections import defaultdict
-        from pathlib import PurePosixPath
+        entries = [_format_file_entry(f) for f in files]
 
-        tree_dict: dict[str, Any] = defaultdict(dict)
+        # Apply level filter for JSON
+        if level is not None:
+            entries = [e for e in entries if e["path"].count("/") <= level]
 
-        if show_size:
-            files = cast(list[dict[str, Any]], files_raw)
-            for file in files:
-                file_path = file["path"]
-                parts = PurePosixPath(file_path).parts
+        tree_data = {
+            "root": path,
+            "files": entries,
+            "total_files": len(entries),
+            "total_size": sum(e["size"] or 0 for e in entries),
+        }
+
+        def _print_human(data: dict[str, Any]) -> None:
+            from collections import defaultdict
+            from pathlib import PurePosixPath
+
+            tree_dict: dict[str, Any] = defaultdict(dict)
+            for entry in data["files"]:
+                parts = PurePosixPath(entry["path"]).parts
                 current = tree_dict
                 for i, part in enumerate(parts):
-                    if i == len(parts) - 1:  # Leaf node (file)
-                        current[part] = file["size"]
-                    else:  # Directory
-                        if part not in current or not isinstance(current[part], dict):
-                            current[part] = {}
-                        current = current[part]
-        else:
-            file_paths = cast(list[str], files_raw)
-            for file_path in file_paths:
-                parts = PurePosixPath(file_path).parts
-                current = tree_dict
-                for i, part in enumerate(parts):
-                    if i == len(parts) - 1:  # Leaf node (file)
-                        current[part] = None
-                    else:  # Directory
-                        if part not in current or not isinstance(current[part], dict):
-                            current[part] = {}
-                        current = current[part]
-
-        # Display tree
-        def format_size(size: int) -> str:
-            """Format size in human-readable format."""
-            size_float = float(size)
-            for unit in ["B", "KB", "MB", "GB", "TB"]:
-                if size_float < 1024.0:
-                    return f"{size_float:.1f} {unit}"
-                size_float /= 1024.0
-            return f"{size_float:.1f} PB"
-
-        def print_tree(
-            node: dict[str, Any],
-            prefix: str = "",
-            current_level: int = 0,
-        ) -> tuple[int, int]:
-            """Recursively print tree structure. Returns (file_count, total_size)."""
-            if level is not None and current_level >= level:
-                return 0, 0
-
-            items = sorted(node.items())
-            total_files = 0
-            total_size = 0
-
-            for i, (name, value) in enumerate(items):
-                is_last_item = i == len(items) - 1
-                connector = "└── " if is_last_item else "├── "
-                extension = "    " if is_last_item else "│   "
-
-                if isinstance(value, dict):
-                    # Directory
-                    console.print(f"{prefix}{connector}[bold cyan]{name}/[/bold cyan]")
-                    files, size = print_tree(
-                        value,
-                        prefix + extension,
-                        current_level + 1,
-                    )
-                    total_files += files
-                    total_size += size
-                else:
-                    # File
-                    total_files += 1
-                    if show_size and value is not None:
-                        size_str = format_size(value)
-                        console.print(f"{prefix}{connector}{name} [dim]({size_str})[/dim]")
-                        total_size += value
+                    if i == len(parts) - 1:
+                        current[part] = entry["size"]
                     else:
-                        console.print(f"{prefix}{connector}{name}")
+                        if part not in current or not isinstance(current[part], dict):
+                            current[part] = {}
+                        current = current[part]
 
-            return total_files, total_size
+            def _fmt_size(size: int) -> str:
+                size_float = float(size)
+                for unit in ["B", "KB", "MB", "GB", "TB"]:
+                    if size_float < 1024.0:
+                        return f"{size_float:.1f} {unit}"
+                    size_float /= 1024.0
+                return f"{size_float:.1f} PB"
 
-        # Print header
-        console.print(f"[bold green]{path}[/bold green]")
+            def _print_node(
+                node: dict[str, Any], prefix: str = "", depth: int = 0
+            ) -> tuple[int, int]:
+                if level is not None and depth >= level:
+                    return 0, 0
+                items = sorted(node.items())
+                total_files = 0
+                total_size = 0
+                for i, (name, value) in enumerate(items):
+                    is_last = i == len(items) - 1
+                    connector = "└── " if is_last else "├── "
+                    extension = "    " if is_last else "│   "
+                    if isinstance(value, dict):
+                        console.print(f"{prefix}{connector}[bold cyan]{name}/[/bold cyan]")
+                        f, s = _print_node(value, prefix + extension, depth + 1)
+                        total_files += f
+                        total_size += s
+                    else:
+                        total_files += 1
+                        if show_size and value is not None:
+                            console.print(
+                                f"{prefix}{connector}{name} [dim]({_fmt_size(value)})[/dim]"
+                            )
+                            total_size += value
+                        else:
+                            console.print(f"{prefix}{connector}{name}")
+                return total_files, total_size
 
-        # Print tree
-        file_count, total_size = print_tree(tree_dict)
+            console.print(f"[bold green]{path}[/bold green]")
+            file_count, total_sz = _print_node(tree_dict)
+            console.print()
+            if show_size:
+                console.print(f"[dim]{file_count} files, {_fmt_size(total_sz)} total[/dim]")
+            else:
+                console.print(f"[dim]{file_count} files[/dim]")
 
-        # Print summary
-        console.print()
-        if show_size:
-            console.print(f"[dim]{file_count} files, {format_size(total_size)} total[/dim]")
-        else:
-            console.print(f"[dim]{file_count} files[/dim]")
-
+        render_output(
+            data=tree_data, output_opts=output_opts, timing=timing, human_formatter=_print_human
+        )
     except Exception as e:
-        handle_error(e)
+        if output_opts.json_output:
+            from nexus.cli.exit_codes import ExitCode
+
+            render_error(
+                error=e, output_opts=output_opts, exit_code=ExitCode.GENERAL_ERROR, timing=timing
+            )
+        else:
+            handle_error(e)

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -8,6 +8,8 @@ import click
 from rich.syntax import Syntax
 
 import nexus
+from nexus.cli.output import OutputOptions, add_output_options, render_error, render_output
+from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     BackendConfig,
     add_backend_options,
@@ -15,6 +17,8 @@ from nexus.cli.utils import (
     console,
     get_filesystem,
     handle_error,
+    open_filesystem,
+    resolve_content,
 )
 
 
@@ -84,137 +88,187 @@ def init(path: str) -> None:
     type=str,
     help="Read file content at a historical operation point (time-travel debugging)",
 )
+@add_output_options
 @add_backend_options
 @add_context_options
 def cat(
     path: str,
     metadata: bool,
     at_operation: str | None,
+    output_opts: OutputOptions,
     backend_config: BackendConfig,
     operation_context: dict[str, Any],
 ) -> None:
     """Display file contents.
 
     Examples:
-        # Display file content
         nexus cat /workspace/data.txt
-
-        # Display with syntax highlighting
         nexus cat /workspace/code.py
-
-        # Show metadata (etag, version) for OCC
         nexus cat /workspace/data.txt --metadata
-
-        # Time-travel: Read file at historical operation point
+        nexus cat /workspace/data.txt --json
         nexus cat /workspace/data.txt --at-operation op_abc123
     """
-    try:
-        nx = get_filesystem(backend_config)
+    timing = CommandTiming()
 
-        if at_operation:
-            # Time-travel: Read file at historical operation point
-            time_travel = getattr(nx, "time_travel_service", None)
-            if time_travel is None:
-                console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
-                nx.close()
+    try:
+        with timing.phase("connect"), open_filesystem(backend_config) as nx:
+            if at_operation:
+                _cat_time_travel(nx, path, at_operation, metadata, output_opts, timing)
                 return
 
-            state = time_travel.get_file_at_operation(path, at_operation)
-            nx.close()
+            with timing.phase("server"):
+                if metadata:
+                    read_result = nx.read(
+                        path, context=cast(Any, operation_context), return_metadata=True
+                    )
+                    assert isinstance(read_result, dict), "Expected dict when return_metadata=True"
+                    content = read_result["content"]
+                    meta_data = {
+                        "path": path,
+                        "etag": read_result["etag"],
+                        "version": read_result["version"],
+                        "size": read_result["size"],
+                        "modified_at": str(read_result["modified_at"]),
+                    }
+                else:
+                    # Check file size to decide between read() and stream()
+                    STREAM_THRESHOLD = 10 * 1024 * 1024  # 10MB
+                    file_size = 0
+                    if hasattr(nx, "metadata"):
+                        try:
+                            file_meta = nx.metadata.get(path)
+                            file_size = file_meta.size if file_meta else 0
+                        except Exception:
+                            file_size = 0
 
-            # Display time-travel info
-            console.print("[bold cyan]Time-Travel Mode[/bold cyan]")
-            console.print(f"[dim]Operation ID:[/dim]  {state['operation_id']}")
-            console.print(f"[dim]Operation Time:[/dim] {state['operation_time']}")
-            console.print()
+                    if file_size > STREAM_THRESHOLD:
+                        console.print(f"[dim]Streaming large file ({file_size:,} bytes)...[/dim]")
+                        for chunk in nx.stream(  # type: ignore[attr-defined]
+                            path, chunk_size=65536, context=operation_context
+                        ):
+                            sys.stdout.buffer.write(chunk)
+                        sys.stdout.buffer.flush()
+                        return
 
-            if metadata:
-                console.print("[bold]Metadata:[/bold]")
-                console.print(f"[dim]Path:[/dim]     {path}")
-                console.print(f"[dim]Size:[/dim]     {state['metadata'].get('size', 0)} bytes")
-                console.print(f"[dim]Owner:[/dim]    {state['metadata'].get('owner', '-')}")
-                console.print(f"[dim]Group:[/dim]    {state['metadata'].get('group', '-')}")
-                console.print(f"[dim]Mode:[/dim]     {state['metadata'].get('mode', '-')}")
-                console.print(f"[dim]Modified:[/dim] {state['metadata'].get('modified_at', '-')}")
-                console.print()
-                console.print("[bold]Content:[/bold]")
+                    content = nx.sys_read(path, context=cast(Any, operation_context))
+                    meta_data = None
 
-            content = state["content"]
-        elif metadata:
-            # Read with metadata for OCC
-            data = nx.read(path, context=cast(Any, operation_context), return_metadata=True)
-            nx.close()
+        # JSON mode: return structured data
+        if output_opts.json_output:
+            try:
+                text = content.decode("utf-8")
+            except UnicodeDecodeError:
+                text = None
 
-            # Type narrowing: when return_metadata=True, result is always dict
-            assert isinstance(data, dict), "Expected dict when return_metadata=True"
+            data: dict[str, Any] = {
+                "path": path,
+                "size": len(content),
+                "content": text,
+                "binary": text is None,
+            }
+            if meta_data:
+                data["metadata"] = meta_data
 
-            # Display metadata first
+            render_output(data=data, output_opts=output_opts, timing=timing)
+            return
+
+        # Human mode
+        if metadata and meta_data:
             console.print("[bold]Metadata:[/bold]")
-            console.print(f"[dim]Path:[/dim]     {path}")
-            console.print(f"[dim]ETag:[/dim]     {data['etag']}")
-            console.print(f"[dim]Version:[/dim]  {data['version']}")
-            console.print(f"[dim]Size:[/dim]     {data['size']} bytes")
-            console.print(f"[dim]Modified:[/dim] {data['modified_at']}")
+            console.print(f"[dim]Path:[/dim]     {meta_data['path']}")
+            console.print(f"[dim]ETag:[/dim]     {meta_data['etag']}")
+            console.print(f"[dim]Version:[/dim]  {meta_data['version']}")
+            console.print(f"[dim]Size:[/dim]     {meta_data['size']} bytes")
+            console.print(f"[dim]Modified:[/dim] {meta_data['modified_at']}")
             console.print()
             console.print("[bold]Content:[/bold]")
-            content = data["content"]
+
+        _print_content(path, content)
+
+    except Exception as e:
+        if output_opts.json_output:
+            from nexus.cli.exit_codes import ExitCode
+
+            render_error(
+                error=e, output_opts=output_opts, exit_code=ExitCode.GENERAL_ERROR, timing=timing
+            )
         else:
-            # Check file size to decide between read() and stream()
-            # Stream large files (>10MB) to avoid memory exhaustion
-            STREAM_THRESHOLD = 10 * 1024 * 1024  # 10MB
-            file_size = 0
+            handle_error(e)
 
-            # Try to get file size for local filesystems
-            if hasattr(nx, "metadata"):
-                try:
-                    meta = nx.metadata.get(path)
-                    file_size = meta.size if meta else 0
-                except Exception:
-                    # Fall back to reading without size check
-                    file_size = 0
 
-            if file_size > STREAM_THRESHOLD:
-                # Stream large file in chunks (memory-efficient)
-                import sys
+def _cat_time_travel(
+    nx: Any,
+    path: str,
+    at_operation: str,
+    metadata: bool,
+    output_opts: OutputOptions,
+    timing: CommandTiming,
+) -> None:
+    """Handle time-travel cat (--at-operation)."""
+    time_travel = getattr(nx, "time_travel_service", None)
+    if time_travel is None:
+        console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
+        return
 
-                console.print(f"[dim]Streaming large file ({file_size:,} bytes)...[/dim]")
-                try:
-                    for chunk in nx.stream(  # type: ignore[attr-defined]
-                        path, chunk_size=65536, context=operation_context
-                    ):  # 64KB chunks
-                        sys.stdout.buffer.write(chunk)
-                    sys.stdout.buffer.flush()
-                    nx.close()
-                    return
-                except Exception as e:
-                    nx.close()
-                    raise e
-            else:
-                # Read normally for small files
-                content = nx.sys_read(path, context=cast(Any, operation_context))
-                nx.close()
+    with timing.phase("server"):
+        state = time_travel.get_file_at_operation(path, at_operation)
 
-        # Try to detect file type for syntax highlighting
+    content = state["content"]
+
+    if output_opts.json_output:
         try:
             text = content.decode("utf-8")
-
-            # Simple syntax highlighting based on extension
-            if path.endswith(".py"):
-                syntax = Syntax(text, "python", theme="monokai", line_numbers=True)
-                console.print(syntax)
-            elif path.endswith(".json"):
-                syntax = Syntax(text, "json", theme="monokai", line_numbers=True)
-                console.print(syntax)
-            elif path.endswith((".md", ".markdown")):
-                syntax = Syntax(text, "markdown", theme="monokai")
-                console.print(syntax)
-            else:
-                console.print(text)
         except UnicodeDecodeError:
-            console.print(f"[yellow]Binary file ({len(content)} bytes)[/yellow]")
-            console.print(f"[dim]{content[:100]!r}...[/dim]")
-    except Exception as e:
-        handle_error(e)
+            text = None
+
+        data: dict[str, Any] = {
+            "path": path,
+            "operation_id": state["operation_id"],
+            "operation_time": str(state["operation_time"]),
+            "content": text,
+            "binary": text is None,
+            "metadata": state.get("metadata"),
+        }
+        render_output(data=data, output_opts=output_opts, timing=timing)
+        return
+
+    console.print("[bold cyan]Time-Travel Mode[/bold cyan]")
+    console.print(f"[dim]Operation ID:[/dim]  {state['operation_id']}")
+    console.print(f"[dim]Operation Time:[/dim] {state['operation_time']}")
+    console.print()
+
+    if metadata:
+        console.print("[bold]Metadata:[/bold]")
+        console.print(f"[dim]Path:[/dim]     {path}")
+        console.print(f"[dim]Size:[/dim]     {state['metadata'].get('size', 0)} bytes")
+        console.print(f"[dim]Owner:[/dim]    {state['metadata'].get('owner', '-')}")
+        console.print(f"[dim]Group:[/dim]    {state['metadata'].get('group', '-')}")
+        console.print(f"[dim]Mode:[/dim]     {state['metadata'].get('mode', '-')}")
+        console.print(f"[dim]Modified:[/dim] {state['metadata'].get('modified_at', '-')}")
+        console.print()
+        console.print("[bold]Content:[/bold]")
+
+    _print_content(path, content)
+
+
+def _print_content(path: str, content: bytes) -> None:
+    """Print file content with syntax highlighting where applicable."""
+    try:
+        text = content.decode("utf-8")
+        if path.endswith(".py"):
+            syntax = Syntax(text, "python", theme="monokai", line_numbers=True)
+            console.print(syntax)
+        elif path.endswith(".json"):
+            syntax = Syntax(text, "json", theme="monokai", line_numbers=True)
+            console.print(syntax)
+        elif path.endswith((".md", ".markdown")):
+            syntax = Syntax(text, "markdown", theme="monokai")
+            console.print(syntax)
+        else:
+            console.print(text)
+    except UnicodeDecodeError:
+        console.print(f"[yellow]Binary file ({len(content)} bytes)[/yellow]")
+        console.print(f"[dim]{content[:100]!r}...[/dim]")
 
 
 @click.command()
@@ -276,36 +330,24 @@ def write(
         nexus write /doc.txt "Content" --show-metadata
     """
     try:
-        nx = get_filesystem(backend_config)
+        file_content = resolve_content(content, input_file)
 
-        # Determine content source
-        if input_file:
-            file_content = input_file.read()
-        elif content == "-":
-            # Read from stdin
-            file_content = sys.stdin.buffer.read()
-        elif content:
-            file_content = content.encode("utf-8")
-        else:
-            console.print("[red]Error:[/red] Must provide content or use --input")
-            sys.exit(1)
+        with open_filesystem(backend_config) as nx:
+            # OCC: use lib/occ helper if CAS params present (Issue #1323).
+            ctx = cast(Any, operation_context)
+            if (if_match or if_none_match) and not force:
+                from nexus.lib.occ import occ_write
 
-        # OCC: use lib/occ helper if CAS params present (Issue #1323).
-        ctx = cast(Any, operation_context)
-        if (if_match or if_none_match) and not force:
-            from nexus.lib.occ import occ_write
-
-            result = occ_write(
-                nx,
-                path,
-                file_content,
-                context=ctx,
-                if_match=if_match,
-                if_none_match=if_none_match,
-            )
-        else:
-            result = nx.write(path, file_content, context=ctx)
-        nx.close()
+                result = occ_write(
+                    nx,
+                    path,
+                    file_content,
+                    context=ctx,
+                    if_match=if_match,
+                    if_none_match=if_none_match,
+                )
+            else:
+                result = nx.write(path, file_content, context=ctx)
 
         console.print(f"[green]✓[/green] Wrote {len(file_content)} bytes to [cyan]{path}[/cyan]")
 
@@ -355,49 +397,25 @@ def append(
     append-only data structures without reading the entire file first.
 
     Examples:
-        # Append to a log file
         nexus append /workspace/app.log "New log entry\\n"
-
-        # Append from stdin (useful for streaming)
         echo "New line" | nexus append /workspace/data.txt --input -
-
-        # Append from file
         nexus append /workspace/output.txt --input input.txt
-
-        # Build JSONL file incrementally
-        echo '{"event": "login", "user": "alice"}' | nexus append /logs/events.jsonl --input -
-
-        # Optimistic concurrency control (prevent concurrent modifications)
         nexus append /doc.txt "New content" --if-match abc123...
-
-        # Show metadata after appending
         nexus append /log.txt "Entry\\n" --show-metadata
     """
     try:
-        nx = get_filesystem(backend_config)
+        file_content = resolve_content(content, input_file)
 
-        # Determine content source
-        if input_file:
-            file_content = input_file.read()
-        elif content == "-":
-            # Read from stdin
-            file_content = sys.stdin.buffer.read()
-        elif content:
-            file_content = content.encode("utf-8")
-        else:
-            console.print("[red]Error:[/red] Must provide content or use --input")
-            sys.exit(1)
-
-        # Append with OCC parameters and context.
-        # CAS params (if_match, force) are NexusFS-specific (transitional, see #1323).
-        result = cast(Any, nx).append(
-            path,
-            file_content,
-            context=operation_context,
-            if_match=if_match,
-            force=force,
-        )
-        nx.close()
+        with open_filesystem(backend_config) as nx:
+            # Append with OCC parameters and context.
+            # CAS params (if_match, force) are NexusFS-specific (transitional, see #1323).
+            result = cast(Any, nx).append(
+                path,
+                file_content,
+                context=operation_context,
+                if_match=if_match,
+                force=force,
+            )
 
         console.print(f"[green]✓[/green] Appended {len(file_content)} bytes to [cyan]{path}[/cyan]")
 

--- a/src/nexus/cli/commands/metadata.py
+++ b/src/nexus/cli/commands/metadata.py
@@ -10,77 +10,106 @@ import click
 from rich.table import Table
 
 import nexus
+from nexus.cli.formatters import format_timestamp
+from nexus.cli.output import OutputOptions, add_output_options, render_error, render_output
+from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     BackendConfig,
     add_backend_options,
     console,
     get_filesystem,
     handle_error,
+    open_filesystem,
 )
 
 
 @click.command()
 @click.argument("path", type=str)
+@add_output_options
 @add_backend_options
 def info(
     path: str,
+    output_opts: OutputOptions,
     backend_config: BackendConfig,
 ) -> None:
     """Show detailed file information.
 
     Examples:
         nexus info /workspace/data.txt
+        nexus info /workspace/data.txt --json
+        nexus info /workspace/data.txt --json --fields path,size,etag
     """
+    timing = CommandTiming()
+
     try:
         from nexus.core.nexus_fs import NexusFS
 
-        nx = get_filesystem(backend_config)
+        with timing.phase("connect"), open_filesystem(backend_config) as nx:
+            # Check if file exists first
+            if not nx.sys_access(path):
+                render_output(
+                    data=None,
+                    output_opts=output_opts,
+                    timing=timing,
+                    message=f"File not found: {path}",
+                )
+                sys.exit(1)
 
-        # Check if file exists first
-        if not nx.sys_access(path):
-            console.print(f"[yellow]File not found:[/yellow] {path}")
-            nx.close()
-            sys.exit(1)
+            # Note: Only NexusFS mode has direct metadata access
+            if not isinstance(nx, NexusFS):
+                render_output(
+                    data=None,
+                    output_opts=output_opts,
+                    timing=timing,
+                    message="File info is only available for NexusFS instances",
+                )
+                return
 
-        # Get file metadata from metadata store
-        # Note: Only NexusFS mode has direct metadata access
-        if not isinstance(nx, NexusFS):
-            console.print("[red]Error:[/red] File info is only available for NexusFS instances")
-            nx.close()
-            return
-
-        file_meta = nx.metadata.get(path)
-        nx.close()
+            with timing.phase("server"):
+                file_meta = nx.metadata.get(path)
 
         if not file_meta:
-            console.print(f"[yellow]File not found:[/yellow] {path}")
+            render_output(
+                data=None, output_opts=output_opts, timing=timing, message=f"File not found: {path}"
+            )
             sys.exit(1)
 
-        table = Table(title=f"File Information: {path}")
-        table.add_column("Property", style="cyan")
-        table.add_column("Value", style="green")
+        created_str = format_timestamp(file_meta.created_at)
+        modified_str = format_timestamp(file_meta.modified_at)
 
-        created_str = (
-            file_meta.created_at.strftime("%Y-%m-%d %H:%M:%S") if file_meta.created_at else "N/A"
+        data = {
+            "path": file_meta.path,
+            "size": file_meta.size,
+            "created_at": created_str,
+            "modified_at": modified_str,
+            "etag": file_meta.etag or None,
+            "mime_type": file_meta.mime_type or None,
+        }
+
+        def _print_human(d: dict[str, Any]) -> None:
+            table = Table(title=f"File Information: {path}")
+            table.add_column("Property", style="cyan")
+            table.add_column("Value", style="green")
+            table.add_row("Path", d["path"])
+            table.add_row("Size", f"{d['size']:,} bytes")
+            table.add_row("Created", d["created_at"])
+            table.add_row("Modified", d["modified_at"])
+            table.add_row("ETag", d["etag"] or "N/A")
+            table.add_row("MIME Type", d["mime_type"] or "N/A")
+            console.print(table)
+
+        render_output(
+            data=data, output_opts=output_opts, timing=timing, human_formatter=_print_human
         )
-        modified_str = (
-            file_meta.modified_at.strftime("%Y-%m-%d %H:%M:%S") if file_meta.modified_at else "N/A"
-        )
-
-        table.add_row("Path", file_meta.path)
-        table.add_row("Size", f"{file_meta.size:,} bytes")
-        table.add_row("Created", created_str)
-        table.add_row("Modified", modified_str)
-        table.add_row("ETag", file_meta.etag or "N/A")
-        table.add_row("MIME Type", file_meta.mime_type or "N/A")
-
-        # Note: As of v0.6.0, UNIX-style permissions have been removed.
-        # All permissions are now managed through ReBAC relationships.
-        # Use `nexus rebac expand read file <path>` to see who has access.
-
-        console.print(table)
     except Exception as e:
-        handle_error(e)
+        if output_opts.json_output:
+            from nexus.cli.exit_codes import ExitCode
+
+            render_error(
+                error=e, output_opts=output_opts, exit_code=ExitCode.GENERAL_ERROR, timing=timing
+            )
+        else:
+            handle_error(e)
 
 
 @click.command()

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -1,16 +1,20 @@
 """Search and discovery commands - glob, grep, find-duplicates."""
 
 import sys
+from collections import defaultdict
 from typing import Any, cast
 
 import click
 
+from nexus.cli.output import OutputOptions, add_output_options, render_error, render_output
+from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     BackendConfig,
     add_backend_options,
     console,
     get_filesystem,
     handle_error,
+    open_filesystem,
 )
 
 
@@ -29,12 +33,14 @@ def register_commands(cli: click.Group) -> None:
 @click.option(
     "-t", "--type", type=click.Choice(["f", "d"]), help="Filter by type: f=files, d=directories"
 )
+@add_output_options
 @add_backend_options
 def glob(
     pattern: str,
     path: str,
     long: bool,
     type: str | None,
+    output_opts: OutputOptions,
     backend_config: BackendConfig,
 ) -> None:
     """Find files matching a glob pattern.
@@ -46,74 +52,97 @@ def glob(
     - [...] (character classes)
 
     Examples:
-        # Basic patterns
         nexus glob "**/*.py"
         nexus glob "*.txt" /workspace
-
-        # With details (like ls -l)
         nexus glob -l "**/*.py"
-
-        # Filter by type
-        nexus glob -t f "**/*"          # Only files
-        nexus glob -t d "/workspace/*"  # Only directories
+        nexus glob "**/*.py" --json
+        nexus glob -t f "**/*"
     """
+    timing = CommandTiming()
+
     try:
-        nx = get_filesystem(backend_config)
-        result = nx.glob(pattern, path)
-        # Remote mode may return {"matches": [...]} instead of a plain list
-        matches = result["matches"] if isinstance(result, dict) and "matches" in result else result
-
-        if not matches:
-            console.print(f"[yellow]No files match pattern:[/yellow] {pattern}")
-            nx.close()
-            return
-
-        # Filter by type if specified
-        if type:
-            filtered_matches = []
-            for match in matches:
-                is_dir = (
-                    nx.sys_is_directory(match)
-                    if hasattr(nx, "is_directory")
-                    else match.endswith("/")
+        with timing.phase("connect"), open_filesystem(backend_config) as nx:
+            with timing.phase("server"):
+                result = nx.search_service.glob(pattern, path)
+                matches = (
+                    result["matches"]
+                    if isinstance(result, dict) and "matches" in result
+                    else result
                 )
-                if (type == "d" and is_dir) or (type == "f" and not is_dir):
-                    filtered_matches.append(match)
-            matches = filtered_matches
 
-        # Get metadata if needed for long format
-        match_data = []
-        if long:
-            for match in matches:
+            if not matches:
+                render_output(
+                    data=[],
+                    output_opts=output_opts,
+                    timing=timing,
+                    message=f"No files match pattern: {pattern}",
+                )
+                return
+
+            # Filter by type if specified
+            if type:
+                filtered = []
+                for match in matches:
+                    is_dir = (
+                        nx.sys_is_directory(match)
+                        if hasattr(nx, "is_directory")
+                        else match.endswith("/")
+                    )
+                    if (type == "d" and is_dir) or (type == "f" and not is_dir):
+                        filtered.append(match)
+                matches = filtered
+
+            # For --long, use batch metadata instead of N+1 reads
+            match_data: list[dict[str, Any]]
+            if long and matches:
+                # Try batch metadata via sys_readdir on parent paths
+                metadata_map: dict[str, dict[str, Any]] = {}
                 try:
-                    metadata = nx.read(match, return_metadata=True)
-                    if isinstance(metadata, dict):
-                        match_data.append(
-                            {
-                                "path": match,
-                                "size": metadata.get("size", 0),
-                                "mtime": metadata.get("modified_at", ""),
-                            }
-                        )
-                    else:
-                        match_data.append({"path": match, "size": 0, "mtime": ""})
+                    parent_path = path if path != "/" else "/"
+                    all_details = nx.sys_readdir(parent_path, recursive=True, details=True)
+                    details_list = cast(list[dict[str, Any]], all_details)
+                    metadata_map = {d["path"]: d for d in details_list}
                 except Exception:
-                    match_data.append({"path": match, "size": 0, "mtime": ""})
+                    pass
 
-        nx.close()
+                match_data = []
+                for m in matches:
+                    meta = metadata_map.get(m, {})
+                    match_data.append(
+                        {
+                            "path": m,
+                            "size": meta.get("size", 0),
+                            "modified_at": meta.get("modified_at", ""),
+                        }
+                    )
+            else:
+                match_data = [{"path": m} for m in matches]
 
-        console.print(f"[green]Found {len(matches)} files matching[/green] [cyan]{pattern}[/cyan]:")
+        def _print_human(entries: list[dict[str, Any]]) -> None:
+            console.print(
+                f"[green]Found {len(entries)} files matching[/green] [cyan]{pattern}[/cyan]:"
+            )
+            if long:
+                for entry in entries:
+                    console.print(
+                        f"  {entry.get('size', 0):>10}  {entry.get('modified_at', '')}  {entry['path']}"
+                    )
+            else:
+                for entry in entries:
+                    console.print(f"  {entry['path']}")
 
-        if long:
-            # Show detailed listing
-            for data in match_data:
-                console.print(f"  {data['size']:>10}  {data['mtime']}  {data['path']}")
-        else:
-            # Simple listing
-            for match in matches:
-                console.print(f"  {match}")
+        render_output(
+            data=match_data, output_opts=output_opts, timing=timing, human_formatter=_print_human
+        )
     except Exception as e:
-        handle_error(e)
+        if output_opts.json_output:
+            from nexus.cli.exit_codes import ExitCode
+
+            render_error(
+                error=e, output_opts=output_opts, exit_code=ExitCode.GENERAL_ERROR, timing=timing
+            )
+        else:
+            handle_error(e)
 
 
 @click.command()
@@ -124,7 +153,7 @@ def glob(
 @click.option("-n", "--line-number", is_flag=True, help="Show line numbers (like grep -n)")
 @click.option("-l", "--files-with-matches", is_flag=True, help="Show only filenames with matches")
 @click.option("-c", "--count", is_flag=True, help="Show count of matches per file")
-@click.option("-v", "--invert-match", is_flag=True, help="Invert match (show non-matching lines)")
+@click.option("--invert-match", is_flag=True, help="Invert match (show non-matching lines)")
 @click.option("-A", "--after-context", type=int, default=0, help="Show N lines after match")
 @click.option("-B", "--before-context", type=int, default=0, help="Show N lines before match")
 @click.option("-C", "--context", type=int, default=0, help="Show N lines before and after match")
@@ -136,6 +165,7 @@ def glob(
     help="Search mode: auto (try parsed, fallback to raw), parsed (only parsed), raw (only raw)",
     show_default=True,
 )
+@add_output_options
 @add_backend_options
 def grep(
     pattern: str,
@@ -151,48 +181,35 @@ def grep(
     context: int,  # noqa: ARG001 - not yet wired to core grep
     max_results: int,
     search_mode: str,
+    output_opts: OutputOptions,
     backend_config: BackendConfig,
 ) -> None:
     """Search file contents using regex patterns.
 
-    Search Modes:
-    - auto: Try parsed text first, fallback to raw (default)
-    - parsed: Only search parsed text (great for PDFs/docs)
-    - raw: Only search raw file content (skip parsing)
-
     Examples:
-        # Basic search
         nexus grep "TODO"
+        nexus grep -n "error" /workspace
+        nexus grep "TODO" --json
+        nexus grep -l "TODO" .
+        nexus grep -i "error" --json --fields file,line
 
-        # Linux-style with common flags
-        nexus grep -n "error" /workspace          # Show line numbers
-        nexus grep -l "TODO" .                    # Only filenames
-        nexus grep -c "import" **/*.py            # Count matches
-        nexus grep -A 3 -B 3 "def main"           # Context lines
-        nexus grep -C 5 "class"                   # 5 lines context
-        nexus grep -v "test" file.txt             # Invert match
-        nexus grep -i "error"                     # Case insensitive
-
-        # Nexus-specific
+    \b
         nexus grep "revenue" -f "**/*.pdf" --search-mode=parsed
     """
+    timing = CommandTiming()
+
     try:
-        nx = get_filesystem(backend_config)
+        with timing.phase("connect"), open_filesystem(backend_config) as nx, timing.phase("server"):
+            result = nx.search_service.grep(
+                pattern,
+                path=path,
+                file_pattern=file_pattern,
+                ignore_case=ignore_case,
+                max_results=max_results,
+                search_mode=search_mode,
+            )
 
-        # Context lines (after_context, before_context, context) are accepted
-        # by the CLI but not yet wired to core grep() — see arg suppression above
-
-        result = nx.grep(
-            pattern,
-            path=path,
-            file_pattern=file_pattern,
-            ignore_case=ignore_case,
-            max_results=max_results,
-            search_mode=search_mode,
-        )
-        nx.close()
-
-        # Remote mode may return {"results": [...]} instead of a plain list
+        # Normalize result format
         if isinstance(result, dict) and "results" in result:
             matches = result["results"]
         elif isinstance(result, dict) and "matches" in result:
@@ -201,49 +218,67 @@ def grep(
             matches = result
 
         if not matches:
-            console.print(f"[yellow]No matches found for:[/yellow] {pattern}")
+            render_output(
+                data=[],
+                output_opts=output_opts,
+                timing=timing,
+                message=f"No matches found for: {pattern}",
+            )
             return
 
-        # Group matches by file for counting and context
-        from collections import defaultdict
-
-        matches_by_file = defaultdict(list)
+        # Group by file
+        matches_by_file: dict[str, list[dict[str, Any]]] = defaultdict(list)
         for match in matches:
             matches_by_file[match["file"]].append(match)
 
-        # Handle -l (files with matches only)
-        if files_with_matches:
-            for filename in sorted(matches_by_file.keys()):
-                console.print(filename)
-            return
+        # Structure data for JSON output
+        data = {
+            "pattern": pattern,
+            "total_matches": len(matches),
+            "files_matched": len(matches_by_file),
+            "matches": matches,
+        }
 
-        # Handle -c (count only)
-        if count:
-            for filename in sorted(matches_by_file.keys()):
-                count_val = len(matches_by_file[filename])
-                console.print(f"{filename}:{count_val}")
-            return
+        def _print_human(d: dict[str, Any]) -> None:
+            m_list = d["matches"]
+            by_file: dict[str, list[dict[str, Any]]] = defaultdict(list)
+            for m in m_list:
+                by_file[m["file"]].append(m)
 
-        # Regular output with optional enhancements
-        console.print(f"[green]Found {len(matches)} matches[/green] for [cyan]{pattern}[/cyan]")
-        if search_mode != "auto":
-            console.print(f"[dim]Search mode: {search_mode}[/dim]")
-        console.print()
+            if files_with_matches:
+                for filename in sorted(by_file.keys()):
+                    console.print(filename)
+                return
 
-        for filename in sorted(matches_by_file.keys()):
-            file_matches = matches_by_file[filename]
-            console.print(f"[bold cyan]{filename}[/bold cyan]")
+            if count:
+                for filename in sorted(by_file.keys()):
+                    console.print(f"{filename}:{len(by_file[filename])}")
+                return
 
-            for match in file_matches:
-                # Format line number if requested
-                line_num_str = f"{match['line']}:" if line_number else ""
-
-                console.print(f"  [yellow]{line_num_str}[/yellow] {match['content']}")
-
+            console.print(f"[green]Found {len(m_list)} matches[/green] for [cyan]{pattern}[/cyan]")
+            if search_mode != "auto":
+                console.print(f"[dim]Search mode: {search_mode}[/dim]")
             console.print()
 
+            for filename in sorted(by_file.keys()):
+                console.print(f"[bold cyan]{filename}[/bold cyan]")
+                for m in by_file[filename]:
+                    ln = f"{m['line']}:" if line_number else ""
+                    console.print(f"  [yellow]{ln}[/yellow] {m['content']}")
+                console.print()
+
+        render_output(
+            data=data, output_opts=output_opts, timing=timing, human_formatter=_print_human
+        )
     except Exception as e:
-        handle_error(e)
+        if output_opts.json_output:
+            from nexus.cli.exit_codes import ExitCode
+
+            render_error(
+                error=e, output_opts=output_opts, exit_code=ExitCode.GENERAL_ERROR, timing=timing
+            )
+        else:
+            handle_error(e)
 
 
 @click.command(name="find-duplicates")

--- a/src/nexus/cli/commands/zone.py
+++ b/src/nexus/cli/commands/zone.py
@@ -24,6 +24,8 @@ import click
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
+from nexus.cli.output import OutputOptions, add_output_options, render_error, render_output
+from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     BackendConfig,
     add_backend_options,
@@ -227,35 +229,53 @@ def join_zone_cmd(
     show_default=True,
     help="gRPC bind address",
 )
+@add_output_options
 def list_zones_cmd(
     node_id: int,
     data_dir: str,
     bind: str,
+    output_opts: OutputOptions,
 ) -> None:
     """List all local zones on this node.
 
     Examples:
         nexus zone list
-
+        nexus zone list --json
         nexus zone list --data-dir /var/lib/nexus/zones
     """
-    try:
-        mgr = _get_zone_manager(node_id, data_dir, bind)
-        zones = mgr.list_zones()
+    timing = CommandTiming()
 
-        if not zones:
-            console.print("[dim]No zones found[/dim]")
-        else:
+    try:
+        with timing.phase("server"):
+            mgr = _get_zone_manager(node_id, data_dir, bind)
+            zones = mgr.list_zones()
+            mgr.shutdown()
+
+        data = [{"zone_id": z} for z in sorted(zones)] if zones else []
+
+        def _print_human(entries: list[dict[str, Any]]) -> None:
+            if not entries:
+                console.print("[dim]No zones found[/dim]")
+                return
             table = Table(title=f"Zones (node {node_id})")
             table.add_column("Zone ID", style="cyan")
             console.print()
-            for z in sorted(zones):
-                table.add_row(z)
+            for entry in entries:
+                table.add_row(entry["zone_id"])
             console.print(table)
 
-        mgr.shutdown()
+        render_output(
+            data=data, output_opts=output_opts, timing=timing, human_formatter=_print_human
+        )
     except Exception as e:
-        handle_error(e)
+        if output_opts.json_output:
+            from nexus.cli.exit_codes import ExitCode
+
+            render_error(
+                error=e, output_opts=output_opts, exit_code=ExitCode.GENERAL_ERROR, timing=timing
+            )
+        else:
+            handle_error(e)
 
 
 @zone.command(name="mount")

--- a/src/nexus/cli/exit_codes.py
+++ b/src/nexus/cli/exit_codes.py
@@ -1,0 +1,24 @@
+"""Semantic exit codes for the Nexus CLI.
+
+Uses POSIX sysexits.h codes (64-78) to avoid conflicts with bash reserved
+codes (2 = misuse of shell builtins, 126-128+N = signals).
+
+Reference: https://man.freebsd.org/cgi/man.cgi?query=sysexits
+"""
+
+from enum import IntEnum
+
+
+class ExitCode(IntEnum):
+    """CLI exit codes following sysexits.h conventions."""
+
+    SUCCESS = 0
+    GENERAL_ERROR = 1
+    USAGE_ERROR = 64  # EX_USAGE — bad command invocation
+    DATA_ERROR = 65  # EX_DATAERR — bad input data
+    NOT_FOUND = 66  # EX_NOINPUT — file/resource not found
+    UNAVAILABLE = 69  # EX_UNAVAILABLE — service/connection unavailable
+    INTERNAL_ERROR = 70  # EX_SOFTWARE — internal error / bug
+    TEMPFAIL = 75  # EX_TEMPFAIL — temporary failure (timeout, retry)
+    PERMISSION_DENIED = 77  # EX_NOPERM — permission denied
+    CONFIG_ERROR = 78  # EX_CONFIG — bad configuration

--- a/src/nexus/cli/output.py
+++ b/src/nexus/cli/output.py
@@ -1,0 +1,258 @@
+"""Unified CLI output infrastructure.
+
+Provides ``add_output_options`` decorator and ``render_output`` function so that
+every CLI command can support ``--json``, ``--quiet``, ``-v``/``-vv``/``-vvv``,
+and ``--fields`` with consistent behavior.
+
+TTY auto-detection: when stdout is not a terminal (piped), output automatically
+switches to JSON (like ``gh`` CLI).
+
+Usage::
+
+    @click.command()
+    @add_output_options
+    def ls(output_opts: OutputOptions, ...) -> None:
+        timing = CommandTiming()
+        with timing.phase("server"):
+            files = nx.sys_readdir(path)
+
+        render_output(
+            data=files,
+            output_opts=output_opts,
+            timing=timing,
+            human_formatter=lambda d: _print_file_table(d),
+        )
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import os
+import sys
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import click
+
+from nexus.cli.exit_codes import ExitCode
+from nexus.cli.timing import CommandTiming, timing_enabled
+
+
+@dataclass(frozen=True)
+class OutputOptions:
+    """Immutable bag of output-related CLI flags."""
+
+    json_output: bool
+    quiet: bool
+    verbosity: int  # 0=default, 1=-v, 2=-vv, 3=-vvv
+    fields: str | None
+    request_id: str
+
+
+def _auto_json() -> bool:
+    """Return True when stdout is not a TTY (piped) and NO_COLOR is not set."""
+    if os.environ.get("NEXUS_NO_AUTO_JSON", ""):
+        return False
+    return not sys.stdout.isatty()
+
+
+def add_output_options(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator adding --json, --quiet, -v/--verbose, --fields to a command.
+
+    Injects an ``output_opts: OutputOptions`` keyword argument.
+    """
+
+    @click.option("--json", "json_output", is_flag=True, default=False, help="Output as JSON")
+    @click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress non-error output")
+    @click.option(
+        "--verbose",
+        "-v",
+        "verbosity",
+        count=True,
+        help="Increase verbosity (-v timing, -vv debug, -vvv trace)",
+    )
+    @click.option(
+        "--fields",
+        type=str,
+        default=None,
+        help="Comma-separated fields to include in JSON output",
+    )
+    @functools.wraps(func)
+    def wrapper(
+        json_output: bool,
+        quiet: bool,
+        verbosity: int,
+        fields: str | None,
+        **kwargs: Any,
+    ) -> Any:
+        # Auto-JSON when piped
+        if not json_output and _auto_json():
+            json_output = True
+
+        request_id = uuid.uuid4().hex
+
+        output_opts = OutputOptions(
+            json_output=json_output,
+            quiet=quiet,
+            verbosity=verbosity,
+            fields=fields,
+            request_id=request_id,
+        )
+        return func(output_opts=output_opts, **kwargs)
+
+    return wrapper
+
+
+def _filter_fields(data: Any, fields: str) -> Any:
+    """Filter dict/list-of-dicts to only include specified fields."""
+    field_set = {f.strip() for f in fields.split(",")}
+    if isinstance(data, dict):
+        return {k: v for k, v in data.items() if k in field_set}
+    if isinstance(data, list):
+        return [
+            {k: v for k, v in item.items() if k in field_set}
+            for item in data
+            if isinstance(item, dict)
+        ]
+    return data
+
+
+def render_output(
+    *,
+    data: Any,
+    output_opts: OutputOptions,
+    timing: CommandTiming | None = None,
+    human_formatter: Callable[[Any], None] | None = None,
+    message: str | None = None,
+) -> None:
+    """Render command output respecting output_opts.
+
+    Args:
+        data: The structured data to output (dict, list, or scalar).
+        output_opts: Output options from the decorator.
+        timing: Optional timing information.
+        human_formatter: Callable that prints human-readable output. If None,
+            ``message`` is printed instead.
+        message: Simple message for human output when no formatter is provided.
+    """
+    if output_opts.quiet and not output_opts.json_output:
+        return
+
+    if output_opts.json_output:
+        _render_json(data=data, output_opts=output_opts, timing=timing)
+    else:
+        _render_human(
+            data=data,
+            output_opts=output_opts,
+            timing=timing,
+            human_formatter=human_formatter,
+            message=message,
+        )
+
+
+def _render_json(
+    *,
+    data: Any,
+    output_opts: OutputOptions,
+    timing: CommandTiming | None,
+) -> None:
+    """Render JSON to stdout."""
+    # Apply field filtering
+    if output_opts.fields and data is not None:
+        data = _filter_fields(data, output_opts.fields)
+
+    envelope: dict[str, Any] = {"data": data}
+
+    if timing is not None:
+        envelope["_timing"] = timing.to_dict()
+
+    if output_opts.verbosity >= 3:
+        envelope["_request_id"] = output_opts.request_id
+
+    click.echo(json.dumps(envelope, indent=2, default=str))
+
+
+def _render_human(
+    *,
+    data: Any,
+    output_opts: OutputOptions,
+    timing: CommandTiming | None,
+    human_formatter: Callable[[Any], None] | None,
+    message: str | None,
+) -> None:
+    """Render human-readable output with optional timing on stderr."""
+    if human_formatter is not None:
+        human_formatter(data)
+    elif message is not None:
+        click.echo(message)
+
+    # Timing on stderr
+    if timing is not None and timing_enabled(output_opts.verbosity):
+        if output_opts.verbosity >= 3:
+            click.echo(f"request_id: {output_opts.request_id}", err=True)
+            click.echo(timing.format_breakdown(), err=True)
+        else:
+            click.echo(timing.format_short(), err=True)
+
+
+def render_error(
+    *,
+    error: Exception,
+    output_opts: OutputOptions | None = None,
+    exit_code: ExitCode = ExitCode.GENERAL_ERROR,
+    timing: CommandTiming | None = None,
+) -> None:
+    """Render an error and exit with the appropriate code.
+
+    In JSON mode, outputs a structured error object. In human mode, prints
+    a Rich-formatted error message to stderr.
+    """
+    error_code = _exception_to_error_code(error)
+
+    if output_opts is not None and output_opts.json_output:
+        envelope: dict[str, Any] = {
+            "data": None,
+            "error": {
+                "code": error_code,
+                "message": str(error),
+                "type": type(error).__name__,
+            },
+        }
+        if timing is not None:
+            envelope["_timing"] = timing.to_dict()
+        if output_opts.verbosity >= 3:
+            envelope["_request_id"] = output_opts.request_id
+        click.echo(json.dumps(envelope, indent=2, default=str))
+    else:
+        from rich.console import Console
+
+        console = Console(stderr=True)
+        console.print(f"[red]Error:[/red] {error}")
+
+    sys.exit(exit_code)
+
+
+def _exception_to_error_code(error: Exception) -> str:
+    """Map an exception to a short machine-readable error code."""
+    # Lazy import to avoid circular deps
+    from nexus.contracts.exceptions import (
+        AccessDeniedError,
+        NexusFileNotFoundError,
+        NexusPermissionError,
+        ValidationError,
+    )
+
+    if isinstance(error, NexusFileNotFoundError):
+        return "NOT_FOUND"
+    if isinstance(error, PermissionError | AccessDeniedError | NexusPermissionError):
+        return "PERMISSION_DENIED"
+    if isinstance(error, ValidationError):
+        return "VALIDATION_ERROR"
+    if isinstance(error, ConnectionError | OSError):
+        return "CONNECTION_ERROR"
+    if isinstance(error, TimeoutError):
+        return "TIMEOUT"
+    return "INTERNAL_ERROR"

--- a/src/nexus/cli/timing.py
+++ b/src/nexus/cli/timing.py
@@ -1,0 +1,89 @@
+"""CLI timing infrastructure for per-command latency measurement.
+
+Provides a context-manager based approach to measuring wall-clock, connection,
+and server processing phases independently.
+
+Usage::
+
+    timing = CommandTiming()
+
+    with timing.phase("connect"):
+        nx = get_filesystem(config)
+
+    with timing.phase("server"):
+        result = nx.sys_readdir(path)
+
+    # timing.phases == {"connect": 12.3, "server": 45.6}
+    # timing.total_ms == 57.9
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CommandTiming:
+    """Accumulates phase-level timing for a single CLI command invocation."""
+
+    phases: dict[str, float] = field(default_factory=dict)
+    _start: float = field(default_factory=time.perf_counter, repr=False)
+
+    @contextmanager
+    def phase(self, name: str) -> Generator[None, None, None]:
+        """Time a named phase (e.g. 'connect', 'server', 'render').
+
+        Durations are stored in milliseconds.
+        """
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            self.phases[name] = round(elapsed_ms, 2)
+
+    @property
+    def total_ms(self) -> float:
+        """Total wall-clock time since this CommandTiming was created."""
+        return round((time.perf_counter() - self._start) * 1000, 2)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize timing for JSON output."""
+        return {
+            "total_ms": self.total_ms,
+            "phases": dict(self.phases),
+        }
+
+    def format_short(self) -> str:
+        """Short timing string for -v output: ``[42ms total (server: 35ms)]``."""
+        server_ms = self.phases.get("server")
+        total = self.total_ms
+        if server_ms is not None:
+            return f"[{total:.0f}ms total (server: {server_ms:.0f}ms)]"
+        return f"[{total:.0f}ms]"
+
+    def format_breakdown(self) -> str:
+        """Full breakdown for -vvv output."""
+        lines = [f"  total: {self.total_ms:.1f}ms"]
+        for name, ms in self.phases.items():
+            lines.append(f"  {name}: {ms:.1f}ms")
+        overhead = self.total_ms - sum(self.phases.values())
+        if overhead > 0.5:
+            lines.append(f"  cli_overhead: {overhead:.1f}ms")
+        return "\n".join(lines)
+
+
+def timing_enabled(verbosity: int) -> bool:
+    """Check whether timing should be displayed.
+
+    Timing is shown when:
+    - verbosity >= 1 (``-v``)
+    - ``NEXUS_TIMING=1`` environment variable is set
+    """
+    if verbosity >= 1:
+        return True
+    return os.environ.get("NEXUS_TIMING", "") == "1"

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -177,26 +177,14 @@ def add_backend_options(func: Any) -> Any:
     return wrapper
 
 
-def _apply_common_config(
-    config: dict[str, Any],
-    *,
-    enforce_permissions: bool | None,
-    allow_admin_bypass: bool | None,
-    enforce_zone_isolation: bool | None,
-    enable_memory_paging: bool,
-    memory_main_capacity: int,
-    memory_recall_max_age_hours: float,
-) -> None:
+def _apply_common_config(config: dict[str, Any], **kwargs: Any) -> None:
     """Apply common configuration options to a config dict (mutates in place)."""
-    if enforce_permissions is not None:
-        config["enforce_permissions"] = enforce_permissions
-    if allow_admin_bypass is not None:
-        config["allow_admin_bypass"] = allow_admin_bypass
-    if enforce_zone_isolation is not None:
-        config["enforce_zone_isolation"] = enforce_zone_isolation
-    config["enable_memory_paging"] = enable_memory_paging
-    config["memory_main_capacity"] = memory_main_capacity
-    config["memory_recall_max_age_hours"] = memory_recall_max_age_hours
+    for key in ("enforce_permissions", "allow_admin_bypass", "enforce_zone_isolation"):
+        if kwargs.get(key) is not None:
+            config[key] = kwargs[key]
+    for key in ("enable_memory_paging", "memory_main_capacity", "memory_recall_max_age_hours"):
+        if key in kwargs:
+            config[key] = kwargs[key]
 
 
 def get_filesystem(
@@ -590,7 +578,7 @@ def resolve_content(content: str | None, input_file: Any) -> bytes:
         SystemExit: If no content source is provided.
     """
     if input_file:
-        return input_file.read()
+        return bytes(input_file.read())
     if content == "-":
         return sys.stdin.buffer.read()
     if content:

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -1,17 +1,26 @@
 """CLI utilities - Common helpers for Nexus CLI commands."""
 
+from __future__ import annotations
+
 import os
 import sys
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 from rich.console import Console
 
 import nexus
 from nexus import NexusFilesystem
+from nexus.cli.exit_codes import ExitCode
 from nexus.config import load_config
 from nexus.contracts.exceptions import NexusError, NexusFileNotFoundError, ValidationError
+
+if TYPE_CHECKING:
+    pass
 
 console = Console()
 
@@ -114,28 +123,18 @@ ADMIN_CAPABILITIES_OPTION = click.option(
 )
 
 
+@dataclass(frozen=True)
 class BackendConfig:
-    """Configuration for backend connection."""
+    """Immutable configuration for backend connection."""
 
-    def __init__(
-        self,
-        backend: str = "local",
-        data_dir: str = str(Path(nexus.NEXUS_STATE_DIR) / "data"),
-        config_path: str | None = None,
-        gcs_bucket: str | None = None,
-        gcs_project: str | None = None,
-        gcs_credentials: str | None = None,
-        remote_url: str | None = None,
-        remote_api_key: str | None = None,
-    ):
-        self.backend = backend
-        self.data_dir = data_dir
-        self.config_path = config_path
-        self.gcs_bucket = gcs_bucket
-        self.gcs_project = gcs_project
-        self.gcs_credentials = gcs_credentials
-        self.remote_url = remote_url
-        self.remote_api_key = remote_api_key
+    backend: str = "local"
+    data_dir: str = field(default_factory=lambda: str(Path(nexus.NEXUS_STATE_DIR) / "data"))
+    config_path: str | None = None
+    gcs_bucket: str | None = None
+    gcs_project: str | None = None
+    gcs_credentials: str | None = None
+    remote_url: str | None = None
+    remote_api_key: str | None = None
 
 
 def add_backend_options(func: Any) -> Any:
@@ -178,6 +177,28 @@ def add_backend_options(func: Any) -> Any:
     return wrapper
 
 
+def _apply_common_config(
+    config: dict[str, Any],
+    *,
+    enforce_permissions: bool | None,
+    allow_admin_bypass: bool | None,
+    enforce_zone_isolation: bool | None,
+    enable_memory_paging: bool,
+    memory_main_capacity: int,
+    memory_recall_max_age_hours: float,
+) -> None:
+    """Apply common configuration options to a config dict (mutates in place)."""
+    if enforce_permissions is not None:
+        config["enforce_permissions"] = enforce_permissions
+    if allow_admin_bypass is not None:
+        config["allow_admin_bypass"] = allow_admin_bypass
+    if enforce_zone_isolation is not None:
+        config["enforce_zone_isolation"] = enforce_zone_isolation
+    config["enable_memory_paging"] = enable_memory_paging
+    config["memory_main_capacity"] = memory_main_capacity
+    config["memory_recall_max_age_hours"] = memory_recall_max_age_hours
+
+
 def get_filesystem(
     backend_config: BackendConfig,
     enforce_permissions: bool | None = None,
@@ -202,6 +223,15 @@ def get_filesystem(
     Returns:
         NexusFilesystem instance
     """
+    common_kwargs = {
+        "enforce_permissions": enforce_permissions,
+        "allow_admin_bypass": allow_admin_bypass,
+        "enforce_zone_isolation": enforce_zone_isolation,
+        "enable_memory_paging": enable_memory_paging,
+        "memory_main_capacity": memory_main_capacity,
+        "memory_recall_max_age_hours": memory_recall_max_age_hours,
+    }
+
     try:
         # If server_profile is set, the caller is a server — always use local NexusFS
         if not server_profile and backend_config.remote_url:
@@ -223,15 +253,7 @@ def get_filesystem(
                     "data_dir": config_obj.data_dir,
                     "backend": config_obj.backend,
                 }
-                if enforce_permissions is not None:
-                    config_dict["enforce_permissions"] = enforce_permissions
-                if allow_admin_bypass is not None:
-                    config_dict["allow_admin_bypass"] = allow_admin_bypass
-                if enforce_zone_isolation is not None:
-                    config_dict["enforce_zone_isolation"] = enforce_zone_isolation
-                config_dict["enable_memory_paging"] = enable_memory_paging
-                config_dict["memory_main_capacity"] = memory_main_capacity
-                config_dict["memory_recall_max_age_hours"] = memory_recall_max_age_hours
+                _apply_common_config(config_dict, **common_kwargs)
                 nx_fs = nexus.connect(config=config_dict)
                 # Store full config object for OAuth factory access
                 if hasattr(nx_fs, "_config") or hasattr(nx_fs, "__dict__"):
@@ -255,34 +277,16 @@ def get_filesystem(
                 "gcs_credentials_path": backend_config.gcs_credentials,
                 "db_path": str(Path(backend_config.data_dir) / "nexus-gcs-metadata.db"),
             }
-            if enforce_permissions is not None:
-                config["enforce_permissions"] = enforce_permissions
-            if allow_admin_bypass is not None:
-                config["allow_admin_bypass"] = allow_admin_bypass
-            if enforce_zone_isolation is not None:
-                config["enforce_zone_isolation"] = enforce_zone_isolation
-            config["enable_memory_paging"] = enable_memory_paging
-            config["memory_main_capacity"] = memory_main_capacity
-            config["memory_recall_max_age_hours"] = memory_recall_max_age_hours
-            nx_fs = nexus.connect(config=config)
-            return nx_fs
+            _apply_common_config(config, **common_kwargs)
+            return nexus.connect(config=config)
         else:
             # Use local backend (default)
             config = {
                 "profile": server_profile or "full",
                 "data_dir": backend_config.data_dir,
             }
-            if enforce_permissions is not None:
-                config["enforce_permissions"] = enforce_permissions
-            if allow_admin_bypass is not None:
-                config["allow_admin_bypass"] = allow_admin_bypass
-            if enforce_zone_isolation is not None:
-                config["enforce_zone_isolation"] = enforce_zone_isolation
-            config["enable_memory_paging"] = enable_memory_paging
-            config["memory_main_capacity"] = memory_main_capacity
-            config["memory_recall_max_age_hours"] = memory_recall_max_age_hours
-            nx_fs = nexus.connect(config=config)
-            return nx_fs
+            _apply_common_config(config, **common_kwargs)
+            return nexus.connect(config=config)
     except Exception as e:
         console.print(f"[red]Error connecting to Nexus:[/red] {e}")
         sys.exit(1)
@@ -536,30 +540,79 @@ def get_subject(subject_option: str | None) -> tuple[str, str] | None:
 
 
 def handle_error(e: Exception) -> None:
-    """Handle errors with beautiful output and proper exit codes.
+    """Handle errors with beautiful output and semantic exit codes.
 
-    Exit codes follow Unix conventions:
-    - 0: Success (not used here)
-    - 1: General error
-    - 2: File/resource not found
-    - 3: Permission denied
+    Exit codes follow sysexits.h (POSIX) conventions:
+    - 0:  Success (not used here)
+    - 64: Usage error (bad input / validation)
+    - 66: Not found (file / resource)
+    - 69: Unavailable (connection error)
+    - 70: Internal error (unexpected)
+    - 75: Temporary failure (timeout)
+    - 77: Permission denied
     """
-    # Import exception types here to avoid circular imports
     from nexus.contracts.exceptions import AccessDeniedError, NexusPermissionError
 
     if isinstance(e, PermissionError | AccessDeniedError | NexusPermissionError):
         console.print(f"[red]Permission Denied:[/red] {e}")
-        sys.exit(3)  # Exit code 3 for permission errors
+        sys.exit(ExitCode.PERMISSION_DENIED)
     elif isinstance(e, NexusFileNotFoundError):
-        # Don't add "File not found:" prefix - the exception message already contains it
         console.print(f"[red]Error:[/red] {e}")
-        sys.exit(2)  # Exit code 2 for not found errors
+        sys.exit(ExitCode.NOT_FOUND)
     elif isinstance(e, ValidationError):
         console.print(f"[red]Validation Error:[/red] {e}")
-        sys.exit(1)
+        sys.exit(ExitCode.USAGE_ERROR)
+    elif isinstance(e, TimeoutError):
+        console.print(f"[red]Timeout:[/red] {e}")
+        sys.exit(ExitCode.TEMPFAIL)
+    elif isinstance(e, ConnectionError | OSError):
+        console.print(f"[red]Connection Error:[/red] {e}")
+        sys.exit(ExitCode.UNAVAILABLE)
     elif isinstance(e, NexusError):
         console.print(f"[red]Nexus Error:[/red] {e}")
-        sys.exit(1)
+        sys.exit(ExitCode.GENERAL_ERROR)
     else:
         console.print(f"[red]Unexpected error:[/red] {e}")
-        sys.exit(1)
+        sys.exit(ExitCode.INTERNAL_ERROR)
+
+
+def resolve_content(content: str | None, input_file: Any) -> bytes:
+    """Resolve content from CLI argument, file, or stdin.
+
+    Args:
+        content: Content string from CLI argument, or "-" for stdin.
+        input_file: File object from ``--input`` option.
+
+    Returns:
+        Content as bytes.
+
+    Raises:
+        SystemExit: If no content source is provided.
+    """
+    if input_file:
+        return input_file.read()
+    if content == "-":
+        return sys.stdin.buffer.read()
+    if content:
+        return content.encode("utf-8")
+    console.print("[red]Error:[/red] Must provide content or use --input")
+    sys.exit(ExitCode.USAGE_ERROR)
+
+
+@contextmanager
+def open_filesystem(
+    backend_config: BackendConfig, **kwargs: Any
+) -> Generator[NexusFilesystem, None, None]:
+    """Context manager that opens and auto-closes a NexusFilesystem.
+
+    Usage::
+
+        with open_filesystem(backend_config) as nx:
+            result = nx.sys_readdir(path)
+        # nx.close() is called automatically, even on exception.
+    """
+    nx = get_filesystem(backend_config, **kwargs)
+    try:
+        yield nx
+    finally:
+        nx.close()

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -226,7 +226,7 @@ def get_filesystem(
             # Client mode: use remote server connection via nexus.connect()
             return nexus.connect(
                 config={
-                    "profile": "remote",
+                    "mode": "remote",
                     "url": backend_config.remote_url,
                     "api_key": backend_config.remote_api_key,
                 }

--- a/tests/e2e/self_contained/test_cli_output_e2e.py
+++ b/tests/e2e/self_contained/test_cli_output_e2e.py
@@ -394,32 +394,32 @@ class TestJsonEnvelopeConsistency:
 # =========================================================================
 
 
+def _seed_via_server(server_info: dict[str, str]) -> None:
+    """Seed test data by writing through the running server (avoids redb lock)."""
+    files = {
+        "/workspace/src/main.py": '# TODO: implement\nprint("hello")\n',
+        "/workspace/src/utils.py": "def helper():\n    return 42\n",
+        "/workspace/docs/README.md": "# Project\nThis is a test project.\n",
+        "/workspace/data.txt": "line one\nline two\nline three\n",
+    }
+    for path, content in files.items():
+        result = _run_nexus_remote(["write", path, content], server_info)
+        assert result.returncode == 0, (
+            f"Failed to seed {path}: stdout={result.stdout[:200]} stderr={result.stderr[:200]}"
+        )
+
+
 @pytest.fixture(scope="module")
-def remote_server(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
-    """Start a nexus serve daemon and yield connection info.
+def remote_server(tmp_path_factory: pytest.TempPathFactory):  # noqa: ANN201
+    """Start a nexus serve daemon, seed data, and yield connection info.
 
     The server is started once per module and shared across all remote tests.
-    This simulates production usage where the server is always running.
+    Data is seeded through the running server to avoid redb lock conflicts.
     """
-    import gc
-
     data_dir = str(tmp_path_factory.mktemp("remote-nexus-data"))
     http_port = _find_free_port()
     grpc_port = _find_free_port()
     url = f"http://127.0.0.1:{http_port}"
-
-    # Seed data into the data dir
-    nx = nexus.connect(config={"data_dir": data_dir})
-    nx.sys_mkdir("/workspace", exist_ok=True)
-    nx.sys_mkdir("/workspace/src", exist_ok=True)
-    nx.sys_mkdir("/workspace/docs", exist_ok=True)
-    nx.sys_write("/workspace/src/main.py", b'# TODO: implement\nprint("hello")\n')
-    nx.sys_write("/workspace/src/utils.py", b"def helper():\n    return 42\n")
-    nx.sys_write("/workspace/docs/README.md", b"# Project\nThis is a test project.\n")
-    nx.sys_write("/workspace/data.txt", b"line one\nline two\nline three\n")
-    nx.close()
-    del nx
-    gc.collect()
 
     # Server env: enable gRPC on the chosen port
     server_env = {**_SUBPROCESS_ENV, "NEXUS_GRPC_PORT": str(grpc_port)}
@@ -464,12 +464,17 @@ def remote_server(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
         server_proc.wait(timeout=5)
         pytest.skip("Server did not become ready within 30s")
 
-    yield {
+    info = {
         "url": url,
         "data_dir": data_dir,
         "http_port": str(http_port),
         "grpc_port": str(grpc_port),
     }
+
+    # Seed test data through the running server
+    _seed_via_server(info)
+
+    yield info
 
     # Teardown: stop server
     server_proc.send_signal(signal.SIGINT)

--- a/tests/e2e/self_contained/test_cli_output_e2e.py
+++ b/tests/e2e/self_contained/test_cli_output_e2e.py
@@ -1,0 +1,578 @@
+"""E2E tests for CLI unified output infrastructure (Issue #2806).
+
+Tests run against a REAL local NexusFS with a temp data directory.
+
+Two test modes:
+  1. **Local** — each CLI command subprocess cold-starts NexusFS (tests the
+     standalone experience, ~2s connect overhead per invocation).
+  2. **Remote** — a ``nexus serve`` daemon is started once; CLI commands hit
+     it via ``--remote-url`` (tests the production experience, fast connect).
+
+Validates:
+- JSON envelope structure with real data
+- Timing accuracy (phases > 0ms)
+- --fields filtering with real results
+- --quiet suppression
+- -vvv request_id inclusion
+- Human output formatting
+- Performance: server phase completes under reasonable thresholds
+
+No mocks. Every command hits a real NexusFS instance.
+"""
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+import nexus
+
+# Ensure subprocess uses the worktree source (not the venv-installed package)
+_WORKTREE_SRC = str(Path(__file__).resolve().parents[3] / "src")
+_SUBPROCESS_ENV = {
+    **os.environ,
+    "NEXUS_NO_AUTO_JSON": "1",
+    "PYTHONPATH": _WORKTREE_SRC + os.pathsep + os.environ.get("PYTHONPATH", ""),
+}
+
+
+def _find_free_port() -> int:
+    """Find a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture()
+def nexus_data_dir(tmp_path: Path) -> str:
+    """Create a temp data dir and return its path."""
+    data_dir = tmp_path / "nexus-data"
+    data_dir.mkdir()
+    return str(data_dir)
+
+
+@pytest.fixture()
+def seeded_data_dir(nexus_data_dir: str) -> str:
+    """Create a NexusFS instance, seed it with test files, then return the data dir.
+
+    The NexusFS is explicitly closed and the reference deleted + GC'd
+    to release the redb exclusive file lock before tests run.
+    """
+    import gc
+
+    nx = nexus.connect(config={"data_dir": nexus_data_dir})
+    nx.sys_mkdir("/workspace", exist_ok=True)
+    nx.sys_mkdir("/workspace/src", exist_ok=True)
+    nx.sys_mkdir("/workspace/docs", exist_ok=True)
+
+    nx.sys_write("/workspace/src/main.py", b'# TODO: implement\nprint("hello")\n')
+    nx.sys_write("/workspace/src/utils.py", b"def helper():\n    return 42\n")
+    nx.sys_write("/workspace/docs/README.md", b"# Project\nThis is a test project.\n")
+    nx.sys_write("/workspace/data.txt", b"line one\nline two\nline three\n")
+    nx.close()
+    del nx
+    gc.collect()
+    return nexus_data_dir
+
+
+def _run_nexus(args: list[str], data_dir: str) -> subprocess.CompletedProcess[str]:
+    """Run a nexus CLI command via subprocess.
+
+    Uses ``python -c`` with the CLI entry point to ensure the correct
+    interpreter and avoids redb lock conflicts with the seeding fixture.
+    """
+    env_args = ["--data-dir", data_dir]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from nexus.cli.main import main; main()",
+            *args,
+            *env_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_SUBPROCESS_ENV,
+    )
+    return result
+
+
+def _parse_json(result: subprocess.CompletedProcess[str]) -> dict:
+    """Parse JSON from stdout, with helpful error on failure."""
+    assert result.returncode == 0, (
+        f"Command failed (exit {result.returncode}):\n"
+        f"stdout: {result.stdout[:500]}\n"
+        f"stderr: {result.stderr[:500]}"
+    )
+    return json.loads(result.stdout)
+
+
+# =========================================================================
+# ls (list_files)
+# =========================================================================
+
+
+class TestLsE2E:
+    """nexus ls against real NexusFS."""
+
+    def test_ls_json_returns_real_files(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["ls", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        paths = [e["path"] for e in output["data"]]
+        assert "/workspace/data.txt" in paths
+        assert "/workspace/src" in paths or "/workspace/src/" in paths
+
+    def test_ls_json_timing_is_real(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["ls", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+
+        timing = output["_timing"]
+        assert timing["total_ms"] > 0
+        assert timing["phases"]["server"] > 0
+        assert timing["phases"]["connect"] > 0
+
+    def test_ls_json_fields_filter(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["ls", "/workspace", "--json", "--fields", "path"], seeded_data_dir)
+        output = _parse_json(result)
+
+        for entry in output["data"]:
+            assert list(entry.keys()) == ["path"]
+
+    def test_ls_quiet(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["ls", "/workspace", "--quiet"], seeded_data_dir)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_ls_vvv_has_request_id(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["ls", "/workspace", "--json", "-vvv"], seeded_data_dir)
+        output = _parse_json(result)
+        assert "_request_id" in output
+        assert len(output["_request_id"]) == 32
+
+    def test_ls_human_output(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["ls", "/workspace"], seeded_data_dir)
+        assert result.returncode == 0
+        assert "data.txt" in result.stdout
+
+    def test_ls_recursive(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["ls", "/workspace", "--recursive", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        paths = [e["path"] for e in output["data"]]
+        assert any("main.py" in p for p in paths)
+
+    def test_ls_long_format(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["ls", "/workspace", "--long"], seeded_data_dir)
+        assert result.returncode == 0
+        # Long format shows a table with size info
+        assert "bytes" in result.stdout or "file" in result.stdout.lower()
+
+    def test_ls_performance(self, seeded_data_dir: str) -> None:
+        """ls server phase should be under 500ms for a small directory."""
+        result = _run_nexus(["ls", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        # Check server phase (excludes cold-start connect/import overhead)
+        server_ms = output["_timing"]["phases"]["server"]
+        assert server_ms < 500, f"ls server phase {server_ms:.0f}ms, expected < 500ms"
+
+
+# =========================================================================
+# tree
+# =========================================================================
+
+
+class TestTreeE2E:
+    """nexus tree against real NexusFS."""
+
+    def test_tree_json(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["tree", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        assert output["data"]["root"] == "/workspace"
+        assert output["data"]["total_files"] > 0
+        assert output["data"]["total_size"] > 0
+
+    def test_tree_human(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["tree", "/workspace"], seeded_data_dir)
+        assert result.returncode == 0
+        assert "main.py" in result.stdout
+
+    def test_tree_performance(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["tree", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        server_ms = output["_timing"]["phases"]["server"]
+        assert server_ms < 500, f"tree server phase {server_ms:.0f}ms, expected < 500ms"
+
+
+# =========================================================================
+# cat
+# =========================================================================
+
+
+class TestCatE2E:
+    """nexus cat against real NexusFS."""
+
+    def test_cat_json(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["cat", "/workspace/data.txt", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        assert output["data"]["path"] == "/workspace/data.txt"
+        assert "line one" in output["data"]["content"]
+        assert output["data"]["binary"] is False
+        assert output["data"]["size"] > 0
+
+    def test_cat_json_with_metadata(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["cat", "/workspace/data.txt", "--json", "--metadata"], seeded_data_dir)
+        output = _parse_json(result)
+        assert "metadata" in output["data"]
+        assert "etag" in output["data"]["metadata"]
+
+    def test_cat_human_with_content(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["cat", "/workspace/data.txt"], seeded_data_dir)
+        assert result.returncode == 0
+        assert "line one" in result.stdout
+
+    def test_cat_python_syntax_highlighting(self, seeded_data_dir: str) -> None:
+        """Python files should render without errors."""
+        result = _run_nexus(["cat", "/workspace/src/main.py"], seeded_data_dir)
+        assert result.returncode == 0
+        assert "hello" in result.stdout
+
+    def test_cat_timing(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["cat", "/workspace/data.txt", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        assert output["_timing"]["total_ms"] > 0
+
+    def test_cat_performance(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["cat", "/workspace/data.txt", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        server_ms = output["_timing"]["phases"]["server"]
+        assert server_ms < 500, f"cat server phase {server_ms:.0f}ms, expected < 500ms"
+
+
+# =========================================================================
+# glob
+# =========================================================================
+
+
+class TestGlobE2E:
+    """nexus glob against real NexusFS."""
+
+    def test_glob_json(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["glob", "**/*.py", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        paths = [e["path"] for e in output["data"]]
+        assert any("main.py" in p for p in paths)
+        assert any("utils.py" in p for p in paths)
+
+    def test_glob_no_matches(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["glob", "**/*.xyz", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        assert output["data"] == []
+
+    def test_glob_timing(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["glob", "**/*.py", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        assert output["_timing"]["total_ms"] > 0
+
+    def test_glob_performance(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["glob", "**/*.py", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        server_ms = output["_timing"]["phases"]["server"]
+        assert server_ms < 500, f"glob server phase {server_ms:.0f}ms, expected < 500ms"
+
+
+# =========================================================================
+# grep
+# =========================================================================
+
+
+class TestGrepE2E:
+    """nexus grep against real NexusFS."""
+
+    def test_grep_json(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["grep", "TODO", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        assert output["data"]["total_matches"] >= 1
+        assert output["data"]["files_matched"] >= 1
+        # Verify actual match content
+        match = output["data"]["matches"][0]
+        assert "file" in match
+        assert "line" in match
+        assert "TODO" in match["content"]
+
+    def test_grep_no_matches(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(
+            ["grep", "ZZZYYYXXX_NONEXISTENT", "/workspace", "--json"], seeded_data_dir
+        )
+        output = _parse_json(result)
+        assert output["data"] == []
+
+    def test_grep_with_file_pattern(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["grep", "def", "/workspace", "-f", "*.py", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        # Should find "def helper()" in utils.py
+        assert output["data"]["total_matches"] >= 1
+
+    def test_grep_timing(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["grep", "TODO", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        assert output["_timing"]["total_ms"] > 0
+
+    def test_grep_performance(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["grep", "TODO", "/workspace", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        server_ms = output["_timing"]["phases"]["server"]
+        assert server_ms < 500, f"grep server phase {server_ms:.0f}ms, expected < 500ms"
+
+
+# =========================================================================
+# info
+# =========================================================================
+
+
+class TestInfoE2E:
+    """nexus info against real NexusFS."""
+
+    def test_info_json(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["info", "/workspace/data.txt", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        data = output["data"]
+        assert data["path"] == "/workspace/data.txt"
+        assert data["size"] > 0
+        assert data["etag"] is not None
+
+    def test_info_timing(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["info", "/workspace/data.txt", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        assert output["_timing"]["total_ms"] > 0
+
+    def test_info_performance(self, seeded_data_dir: str) -> None:
+        result = _run_nexus(["info", "/workspace/data.txt", "--json"], seeded_data_dir)
+        output = _parse_json(result)
+        server_ms = output["_timing"]["phases"]["server"]
+        assert server_ms < 500, f"info server phase {server_ms:.0f}ms, expected < 500ms"
+
+
+# =========================================================================
+# Cross-cutting: JSON envelope consistency
+# =========================================================================
+
+
+class TestJsonEnvelopeConsistency:
+    """All P0 commands should produce the same JSON envelope shape."""
+
+    @pytest.mark.parametrize(
+        ("command", "args"),
+        [
+            ("ls", ["/workspace"]),
+            ("tree", ["/workspace"]),
+            ("cat", ["/workspace/data.txt"]),
+            ("glob", ["**/*.py", "/workspace"]),
+            ("grep", ["TODO", "/workspace"]),
+            ("info", ["/workspace/data.txt"]),
+        ],
+        ids=["ls", "tree", "cat", "glob", "grep", "info"],
+    )
+    def test_envelope_has_data_and_timing(
+        self, command: str, args: list[str], seeded_data_dir: str
+    ) -> None:
+        result = _run_nexus([command, *args, "--json"], seeded_data_dir)
+        envelope = _parse_json(result)
+        assert "data" in envelope, f"{command}: missing 'data' key"
+        assert "_timing" in envelope, f"{command}: missing '_timing' key"
+        assert envelope["_timing"]["total_ms"] > 0
+
+
+# =========================================================================
+# Remote mode — daemon-backed tests
+# =========================================================================
+
+
+@pytest.fixture(scope="module")
+def remote_server(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
+    """Start a nexus serve daemon and yield connection info.
+
+    The server is started once per module and shared across all remote tests.
+    This simulates production usage where the server is always running.
+    """
+    import gc
+
+    data_dir = str(tmp_path_factory.mktemp("remote-nexus-data"))
+    http_port = _find_free_port()
+    grpc_port = _find_free_port()
+    url = f"http://127.0.0.1:{http_port}"
+
+    # Seed data into the data dir
+    nx = nexus.connect(config={"data_dir": data_dir})
+    nx.sys_mkdir("/workspace", exist_ok=True)
+    nx.sys_mkdir("/workspace/src", exist_ok=True)
+    nx.sys_mkdir("/workspace/docs", exist_ok=True)
+    nx.sys_write("/workspace/src/main.py", b'# TODO: implement\nprint("hello")\n')
+    nx.sys_write("/workspace/src/utils.py", b"def helper():\n    return 42\n")
+    nx.sys_write("/workspace/docs/README.md", b"# Project\nThis is a test project.\n")
+    nx.sys_write("/workspace/data.txt", b"line one\nline two\nline three\n")
+    nx.close()
+    del nx
+    gc.collect()
+
+    # Server env: enable gRPC on the chosen port
+    server_env = {**_SUBPROCESS_ENV, "NEXUS_GRPC_PORT": str(grpc_port)}
+
+    # Start server as a subprocess
+    server_proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "from nexus.cli.main import main; main()",
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(http_port),
+            "--data-dir",
+            data_dir,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=server_env,
+    )
+
+    # Wait for server readiness (poll /healthz/ready)
+    ready = False
+    for _ in range(60):  # up to 30s
+        time.sleep(0.5)
+        if server_proc.poll() is not None:
+            # Server exited early
+            stderr = server_proc.stderr.read().decode() if server_proc.stderr else ""
+            pytest.skip(f"Server exited early (code {server_proc.returncode}): {stderr[:300]}")
+        try:
+            resp = urllib.request.urlopen(f"{url}/healthz/ready", timeout=2)
+            if resp.status == 200:
+                ready = True
+                break
+        except Exception:
+            continue
+
+    if not ready:
+        server_proc.terminate()
+        server_proc.wait(timeout=5)
+        pytest.skip("Server did not become ready within 30s")
+
+    yield {
+        "url": url,
+        "data_dir": data_dir,
+        "http_port": str(http_port),
+        "grpc_port": str(grpc_port),
+    }
+
+    # Teardown: stop server
+    server_proc.send_signal(signal.SIGINT)
+    try:
+        server_proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        server_proc.kill()
+        server_proc.wait(timeout=5)
+
+
+def _run_nexus_remote(
+    args: list[str], server_info: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run a nexus CLI command against a remote server."""
+    env_args = ["--remote-url", server_info["url"]]
+    # Client needs NEXUS_GRPC_PORT to connect to the server's gRPC port
+    client_env = {**_SUBPROCESS_ENV, "NEXUS_GRPC_PORT": server_info["grpc_port"]}
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from nexus.cli.main import main; main()",
+            *args,
+            *env_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=client_env,
+    )
+
+
+class TestRemoteLsE2E:
+    """nexus ls against a running server (remote mode)."""
+
+    def test_ls_json(self, remote_server: dict[str, str]) -> None:
+        result = _run_nexus_remote(["ls", "/workspace", "--json"], remote_server)
+        output = _parse_json(result)
+        paths = [e["path"] for e in output["data"]]
+        assert "/workspace/data.txt" in paths
+
+    def test_ls_timing_phases(self, remote_server: dict[str, str]) -> None:
+        result = _run_nexus_remote(["ls", "/workspace", "--json"], remote_server)
+        output = _parse_json(result)
+        assert output["_timing"]["total_ms"] > 0
+        assert output["_timing"]["phases"]["connect"] > 0
+
+    def test_ls_performance_total(self, remote_server: dict[str, str]) -> None:
+        """With a warm server, total_ms should be reasonable (< 2s including CLI startup)."""
+        result = _run_nexus_remote(["ls", "/workspace", "--json"], remote_server)
+        output = _parse_json(result)
+        total_ms = output["_timing"]["total_ms"]
+        assert total_ms < 2000, f"remote ls total {total_ms:.0f}ms, expected < 2000ms"
+
+
+class TestRemoteCatE2E:
+    """nexus cat against a running server."""
+
+    def test_cat_json(self, remote_server: dict[str, str]) -> None:
+        result = _run_nexus_remote(["cat", "/workspace/data.txt", "--json"], remote_server)
+        output = _parse_json(result)
+        assert "line one" in output["data"]["content"]
+        assert output["data"]["size"] > 0
+
+
+class TestRemoteGrepE2E:
+    """nexus grep against a running server."""
+
+    def test_grep_json(self, remote_server: dict[str, str]) -> None:
+        result = _run_nexus_remote(["grep", "TODO", "/workspace", "--json"], remote_server)
+        output = _parse_json(result)
+        assert output["data"]["total_matches"] >= 1
+
+
+class TestRemoteGlobE2E:
+    """nexus glob against a running server."""
+
+    def test_glob_json(self, remote_server: dict[str, str]) -> None:
+        result = _run_nexus_remote(["glob", "**/*.py", "/workspace", "--json"], remote_server)
+        output = _parse_json(result)
+        paths = [e["path"] for e in output["data"]]
+        assert any("main.py" in p for p in paths)
+
+
+class TestRemoteEnvelopeConsistency:
+    """JSON envelope shape across all commands in remote mode."""
+
+    @pytest.mark.parametrize(
+        ("command", "args"),
+        [
+            pytest.param("ls", ["/workspace"], id="ls"),
+            pytest.param("tree", ["/workspace"], id="tree"),
+            pytest.param("cat", ["/workspace/data.txt"], id="cat"),
+            pytest.param("glob", ["**/*.py", "/workspace"], id="glob"),
+            pytest.param("grep", ["TODO", "/workspace"], id="grep"),
+            pytest.param("info", ["/workspace/data.txt"], id="info"),
+        ],
+    )
+    def test_remote_envelope(
+        self, command: str, args: list[str], remote_server: dict[str, str]
+    ) -> None:
+        result = _run_nexus_remote([command, *args, "--json"], remote_server)
+        envelope = _parse_json(result)
+        assert "data" in envelope, f"remote {command}: missing 'data'"
+        assert "_timing" in envelope, f"remote {command}: missing '_timing'"
+        assert envelope["_timing"]["total_ms"] > 0

--- a/tests/unit/cli/test_commands_smoke.py
+++ b/tests/unit/cli/test_commands_smoke.py
@@ -1,0 +1,292 @@
+"""Smoke tests for P0 CLI commands using Click's CliRunner.
+
+These tests mock the filesystem layer and validate:
+- Commands accept --json, -v, --quiet, --fields flags
+- JSON output has correct envelope structure
+- Timing data is included in JSON output
+- Human output works without errors
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli.commands.directory import list_files, tree
+from nexus.cli.commands.search import glob, grep
+
+
+@pytest.fixture(autouse=True)
+def _disable_auto_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable auto-JSON in CliRunner (stdout is not a TTY)."""
+    monkeypatch.setenv("NEXUS_NO_AUTO_JSON", "1")
+
+
+def _make_mock_nx() -> MagicMock:
+    """Create a mock NexusFilesystem with common methods."""
+    nx = MagicMock()
+    nx.close = MagicMock()
+    return nx
+
+
+def _patch_open_filesystem(nx: MagicMock):
+    """Patch open_filesystem to yield the mock."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _mock_open(backend_config, **kwargs):
+        yield nx
+
+    return patch("nexus.cli.commands.directory.open_filesystem", _mock_open)
+
+
+def _patch_search_open_filesystem(nx: MagicMock):
+    """Patch open_filesystem for search module."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _mock_open(backend_config, **kwargs):
+        yield nx
+
+    return patch("nexus.cli.commands.search.open_filesystem", _mock_open)
+
+
+class TestLsCommand:
+    """nexus ls - list files."""
+
+    def test_ls_json_output(self) -> None:
+        nx = _make_mock_nx()
+        nx.sys_readdir.return_value = [
+            {
+                "path": "/workspace/file.txt",
+                "size": 100,
+                "is_directory": False,
+                "modified_at": None,
+            },
+            {"path": "/workspace/data/", "size": 0, "is_directory": True, "modified_at": None},
+        ]
+
+        runner = CliRunner()
+        with _patch_open_filesystem(nx):
+            result = runner.invoke(list_files, ["/workspace", "--json"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert "data" in output
+        assert "_timing" in output
+        assert len(output["data"]) == 2
+        assert output["data"][0]["path"] == "/workspace/file.txt"
+        assert output["data"][0]["type"] == "file"
+        assert output["data"][1]["type"] == "directory"
+
+    def test_ls_json_with_fields_filter(self) -> None:
+        nx = _make_mock_nx()
+        nx.sys_readdir.return_value = [
+            {"path": "/a.txt", "size": 50, "is_directory": False, "modified_at": None},
+        ]
+
+        runner = CliRunner()
+        with _patch_open_filesystem(nx):
+            result = runner.invoke(
+                list_files, ["/", "--json", "--fields", "path"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["data"] == [{"path": "/a.txt"}]
+
+    def test_ls_json_timing_has_phases(self) -> None:
+        nx = _make_mock_nx()
+        nx.sys_readdir.return_value = [
+            {"path": "/a.txt", "size": 10, "is_directory": False, "modified_at": None},
+        ]
+
+        runner = CliRunner()
+        with _patch_open_filesystem(nx):
+            result = runner.invoke(list_files, ["/", "--json"], catch_exceptions=False)
+
+        output = json.loads(result.output)
+        timing = output["_timing"]
+        assert "total_ms" in timing
+        assert timing["total_ms"] > 0
+        assert "phases" in timing
+        assert "server" in timing["phases"]
+
+    def test_ls_human_output(self) -> None:
+        nx = _make_mock_nx()
+        nx.sys_readdir.return_value = [
+            {
+                "path": "/workspace/file.txt",
+                "size": 100,
+                "is_directory": False,
+                "modified_at": None,
+            },
+        ]
+
+        runner = CliRunner()
+        with _patch_open_filesystem(nx):
+            result = runner.invoke(list_files, ["/workspace"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert "/workspace/file.txt" in result.output
+
+    def test_ls_empty_directory(self) -> None:
+        nx = _make_mock_nx()
+        nx.sys_readdir.return_value = []
+
+        runner = CliRunner()
+        with _patch_open_filesystem(nx):
+            result = runner.invoke(list_files, ["/empty", "--json"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["data"] == []
+
+    def test_ls_quiet_suppresses_output(self) -> None:
+        nx = _make_mock_nx()
+        nx.sys_readdir.return_value = [
+            {"path": "/a.txt", "size": 10, "is_directory": False, "modified_at": None},
+        ]
+
+        runner = CliRunner()
+        with _patch_open_filesystem(nx):
+            result = runner.invoke(list_files, ["/", "--quiet"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    def test_ls_verbose_shows_timing_in_json(self) -> None:
+        """With -v, timing is included; verify via --json which captures it in envelope."""
+        nx = _make_mock_nx()
+        nx.sys_readdir.return_value = [
+            {"path": "/a.txt", "size": 10, "is_directory": False, "modified_at": None},
+        ]
+
+        runner = CliRunner()
+        with _patch_open_filesystem(nx):
+            result = runner.invoke(list_files, ["/", "--json", "-v"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["_timing"]["total_ms"] > 0
+        assert "server" in output["_timing"]["phases"]
+
+
+class TestTreeCommand:
+    """nexus tree - directory tree."""
+
+    def test_tree_json_output(self) -> None:
+        nx = _make_mock_nx()
+        nx.sys_readdir.return_value = [
+            {"path": "/src/main.py", "size": 500, "is_directory": False, "modified_at": None},
+            {"path": "/src/lib/", "size": 0, "is_directory": True, "modified_at": None},
+        ]
+
+        runner = CliRunner()
+        with _patch_open_filesystem(nx):
+            result = runner.invoke(tree, ["/", "--json"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert "data" in output
+        assert output["data"]["root"] == "/"
+        assert output["data"]["total_files"] == 2
+        assert "_timing" in output
+
+
+class TestGlobCommand:
+    """nexus glob - find files by pattern."""
+
+    def test_glob_json_output(self) -> None:
+        nx = _make_mock_nx()
+        nx.search_service.glob.return_value = {"matches": ["/src/main.py", "/src/utils.py"]}
+
+        runner = CliRunner()
+        with _patch_search_open_filesystem(nx):
+            result = runner.invoke(glob, ["**/*.py", "--json"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output["data"]) == 2
+        assert output["data"][0]["path"] == "/src/main.py"
+        assert "_timing" in output
+
+    def test_glob_no_matches(self) -> None:
+        nx = _make_mock_nx()
+        nx.search_service.glob.return_value = {"matches": []}
+
+        runner = CliRunner()
+        with _patch_search_open_filesystem(nx):
+            result = runner.invoke(glob, ["**/*.xyz", "--json"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["data"] == []
+
+
+class TestGrepCommand:
+    """nexus grep - search file contents."""
+
+    def test_grep_json_output(self) -> None:
+        nx = _make_mock_nx()
+        nx.search_service.grep.return_value = {
+            "results": [
+                {"file": "/src/main.py", "line": 10, "content": "# TODO: fix this"},
+                {"file": "/src/main.py", "line": 20, "content": "# TODO: refactor"},
+            ]
+        }
+
+        runner = CliRunner()
+        with _patch_search_open_filesystem(nx):
+            result = runner.invoke(grep, ["TODO", "--json"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["data"]["total_matches"] == 2
+        assert output["data"]["files_matched"] == 1
+        assert "_timing" in output
+
+    def test_grep_no_matches(self) -> None:
+        nx = _make_mock_nx()
+        nx.search_service.grep.return_value = {"results": []}
+
+        runner = CliRunner()
+        with _patch_search_open_filesystem(nx):
+            result = runner.invoke(grep, ["NONEXISTENT", "--json"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["data"] == []
+
+    def test_grep_human_with_line_numbers(self) -> None:
+        nx = _make_mock_nx()
+        nx.search_service.grep.return_value = {
+            "results": [
+                {"file": "/src/main.py", "line": 10, "content": "# TODO"},
+            ]
+        }
+
+        runner = CliRunner()
+        with _patch_search_open_filesystem(nx):
+            result = runner.invoke(grep, ["TODO", "-n"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert "10:" in result.output
+
+    def test_grep_vvv_includes_request_id(self) -> None:
+        nx = _make_mock_nx()
+        nx.search_service.grep.return_value = {
+            "results": [
+                {"file": "/a.py", "line": 1, "content": "match"},
+            ]
+        }
+
+        runner = CliRunner()
+        with _patch_search_open_filesystem(nx):
+            result = runner.invoke(grep, ["match", "--json", "-vvv"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert "_request_id" in output
+        assert len(output["_request_id"]) == 32  # uuid hex

--- a/tests/unit/cli/test_exit_codes.py
+++ b/tests/unit/cli/test_exit_codes.py
@@ -1,0 +1,37 @@
+"""Tests for CLI exit codes module."""
+
+import pytest
+
+from nexus.cli.exit_codes import ExitCode
+
+
+class TestExitCode:
+    """Exit codes follow sysexits.h conventions."""
+
+    @pytest.mark.parametrize(
+        ("code", "expected_value"),
+        [
+            (ExitCode.SUCCESS, 0),
+            (ExitCode.GENERAL_ERROR, 1),
+            (ExitCode.USAGE_ERROR, 64),
+            (ExitCode.DATA_ERROR, 65),
+            (ExitCode.NOT_FOUND, 66),
+            (ExitCode.UNAVAILABLE, 69),
+            (ExitCode.INTERNAL_ERROR, 70),
+            (ExitCode.TEMPFAIL, 75),
+            (ExitCode.PERMISSION_DENIED, 77),
+            (ExitCode.CONFIG_ERROR, 78),
+        ],
+    )
+    def test_exit_code_values(self, code: ExitCode, expected_value: int) -> None:
+        assert int(code) == expected_value
+
+    def test_exit_codes_are_int(self) -> None:
+        """All exit codes should be usable as integer exit codes."""
+        for code in ExitCode:
+            assert isinstance(int(code), int)
+
+    def test_no_bash_reserved_codes(self) -> None:
+        """Exit codes 126-255 are reserved by bash; we must not use them."""
+        for code in ExitCode:
+            assert int(code) < 126 or int(code) > 255

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -1,0 +1,181 @@
+"""Tests for CLI output infrastructure."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from nexus.cli.output import OutputOptions, _auto_json, _filter_fields, render_output
+from nexus.cli.timing import CommandTiming
+
+
+class TestOutputOptions:
+    """OutputOptions is a frozen dataclass."""
+
+    def test_creation(self) -> None:
+        opts = OutputOptions(
+            json_output=True,
+            quiet=False,
+            verbosity=1,
+            fields="path,size",
+            request_id="abc123",
+        )
+        assert opts.json_output is True
+        assert opts.quiet is False
+        assert opts.verbosity == 1
+        assert opts.fields == "path,size"
+        assert opts.request_id == "abc123"
+
+    def test_frozen(self) -> None:
+        opts = OutputOptions(
+            json_output=True,
+            quiet=False,
+            verbosity=0,
+            fields=None,
+            request_id="abc",
+        )
+        with pytest.raises(AttributeError):
+            opts.json_output = False
+
+
+class TestAutoJson:
+    """TTY auto-detection for JSON output."""
+
+    def test_auto_json_when_not_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_NO_AUTO_JSON", raising=False)
+        with patch("sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = False
+            assert _auto_json() is True
+
+    def test_no_auto_json_when_tty(self) -> None:
+        with patch("sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = True
+            assert _auto_json() is False
+
+    def test_no_auto_json_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_NO_AUTO_JSON", "1")
+        with patch("sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = False
+            assert _auto_json() is False
+
+
+class TestFilterFields:
+    """Field filtering for JSON output."""
+
+    def test_filter_dict(self) -> None:
+        data = {"path": "/a", "size": 100, "etag": "abc"}
+        result = _filter_fields(data, "path,size")
+        assert result == {"path": "/a", "size": 100}
+
+    def test_filter_list_of_dicts(self) -> None:
+        data = [
+            {"path": "/a", "size": 100},
+            {"path": "/b", "size": 200},
+        ]
+        result = _filter_fields(data, "path")
+        assert result == [{"path": "/a"}, {"path": "/b"}]
+
+    def test_filter_preserves_non_dict(self) -> None:
+        assert _filter_fields("hello", "path") == "hello"
+        assert _filter_fields(42, "path") == 42
+
+
+class TestRenderOutput:
+    """render_output dispatches to JSON or human formatters."""
+
+    def _json_opts(self, verbosity: int = 0, fields: str | None = None) -> OutputOptions:
+        return OutputOptions(
+            json_output=True,
+            quiet=False,
+            verbosity=verbosity,
+            fields=fields,
+            request_id="test-req-id",
+        )
+
+    def _human_opts(self, verbosity: int = 0, quiet: bool = False) -> OutputOptions:
+        return OutputOptions(
+            json_output=False,
+            quiet=quiet,
+            verbosity=verbosity,
+            fields=None,
+            request_id="test-req-id",
+        )
+
+    def test_json_output_envelope(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = self._json_opts()
+        render_output(data={"path": "/test"}, output_opts=opts)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["data"] == {"path": "/test"}
+
+    def test_json_output_with_timing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = self._json_opts()
+        timing = CommandTiming()
+        with timing.phase("server"):
+            pass
+
+        render_output(data=[], output_opts=opts, timing=timing)
+
+        output = json.loads(capsys.readouterr().out)
+        assert "_timing" in output
+        assert "total_ms" in output["_timing"]
+
+    def test_json_output_with_request_id_at_v3(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = self._json_opts(verbosity=3)
+        render_output(data=[], output_opts=opts)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["_request_id"] == "test-req-id"
+
+    def test_json_output_no_request_id_below_v3(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = self._json_opts(verbosity=2)
+        render_output(data=[], output_opts=opts)
+
+        output = json.loads(capsys.readouterr().out)
+        assert "_request_id" not in output
+
+    def test_json_output_with_field_filter(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = self._json_opts(fields="path")
+        render_output(data={"path": "/a", "size": 100}, output_opts=opts)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["data"] == {"path": "/a"}
+
+    def test_quiet_suppresses_human_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = self._human_opts(quiet=True)
+        render_output(data={"path": "/a"}, output_opts=opts, message="should not appear")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_quiet_does_not_suppress_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = OutputOptions(
+            json_output=True,
+            quiet=True,
+            verbosity=0,
+            fields=None,
+            request_id="test",
+        )
+        render_output(data={"path": "/a"}, output_opts=opts)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["data"] == {"path": "/a"}
+
+    def test_human_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = self._human_opts()
+        render_output(data=None, output_opts=opts, message="No files found")
+
+        assert "No files found" in capsys.readouterr().out
+
+    def test_human_formatter_called(self, capsys: pytest.CaptureFixture[str]) -> None:
+        opts = self._human_opts()
+        called_with = []
+
+        def formatter(data: dict) -> None:
+            called_with.append(data)
+            print(f"formatted: {data['path']}")
+
+        render_output(data={"path": "/x"}, output_opts=opts, human_formatter=formatter)
+
+        assert called_with == [{"path": "/x"}]
+        assert "formatted: /x" in capsys.readouterr().out

--- a/tests/unit/cli/test_timing.py
+++ b/tests/unit/cli/test_timing.py
@@ -1,0 +1,106 @@
+"""Tests for CLI timing infrastructure."""
+
+import time
+
+import pytest
+
+from nexus.cli.timing import CommandTiming, timing_enabled
+
+
+class TestCommandTiming:
+    """Phase-granular timing with context managers."""
+
+    def test_phase_records_duration(self) -> None:
+        timing = CommandTiming()
+        with timing.phase("test"):
+            time.sleep(0.01)
+
+        assert "test" in timing.phases
+        assert timing.phases["test"] > 0
+
+    def test_multiple_phases(self) -> None:
+        timing = CommandTiming()
+        with timing.phase("connect"):
+            time.sleep(0.005)
+        with timing.phase("server"):
+            time.sleep(0.005)
+
+        assert "connect" in timing.phases
+        assert "server" in timing.phases
+        assert len(timing.phases) == 2
+
+    def test_total_ms_increases(self) -> None:
+        timing = CommandTiming()
+        t1 = timing.total_ms
+        time.sleep(0.01)
+        t2 = timing.total_ms
+        assert t2 > t1
+
+    def test_to_dict(self) -> None:
+        timing = CommandTiming()
+        with timing.phase("server"):
+            pass
+
+        d = timing.to_dict()
+        assert "total_ms" in d
+        assert "phases" in d
+        assert "server" in d["phases"]
+
+    def test_format_short_with_server(self) -> None:
+        timing = CommandTiming()
+        with timing.phase("server"):
+            pass
+
+        result = timing.format_short()
+        assert "ms total" in result
+        assert "server:" in result
+
+    def test_format_short_without_server(self) -> None:
+        timing = CommandTiming()
+        with timing.phase("connect"):
+            pass
+
+        result = timing.format_short()
+        assert "ms]" in result
+        assert "server:" not in result
+
+    def test_format_breakdown(self) -> None:
+        timing = CommandTiming()
+        with timing.phase("connect"):
+            pass
+        with timing.phase("server"):
+            pass
+
+        result = timing.format_breakdown()
+        assert "total:" in result
+        assert "connect:" in result
+        assert "server:" in result
+
+    def test_phase_exception_still_records(self) -> None:
+        """Phase timing should be recorded even when an exception occurs."""
+        timing = CommandTiming()
+        with pytest.raises(ValueError, match="test error"), timing.phase("failing"):
+            raise ValueError("test error")
+
+        assert "failing" in timing.phases
+        assert timing.phases["failing"] >= 0
+
+
+class TestTimingEnabled:
+    """Timing display controlled by verbosity and env var."""
+
+    def test_disabled_by_default(self) -> None:
+        assert timing_enabled(0) is False
+
+    def test_enabled_by_verbosity(self) -> None:
+        assert timing_enabled(1) is True
+        assert timing_enabled(2) is True
+        assert timing_enabled(3) is True
+
+    def test_enabled_by_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_TIMING", "1")
+        assert timing_enabled(0) is True
+
+    def test_disabled_when_env_not_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_TIMING", raising=False)
+        assert timing_enabled(0) is False

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -1,0 +1,108 @@
+"""Tests for CLI utility functions."""
+
+import pytest
+
+from nexus.cli.exit_codes import ExitCode
+from nexus.cli.utils import BackendConfig, resolve_content
+
+
+class TestBackendConfig:
+    """BackendConfig is a frozen dataclass."""
+
+    def test_defaults(self) -> None:
+        config = BackendConfig()
+        assert config.backend == "local"
+        assert config.remote_url is None
+        assert config.gcs_bucket is None
+
+    def test_frozen(self) -> None:
+        config = BackendConfig()
+        with pytest.raises(AttributeError):
+            config.backend = "gcs"
+
+    def test_custom_values(self) -> None:
+        config = BackendConfig(
+            backend="gcs",
+            gcs_bucket="my-bucket",
+            remote_url="http://localhost:2026",
+        )
+        assert config.backend == "gcs"
+        assert config.gcs_bucket == "my-bucket"
+        assert config.remote_url == "http://localhost:2026"
+
+
+class TestResolveContent:
+    """resolve_content extracts content from CLI args, files, or stdin."""
+
+    def test_from_string_content(self) -> None:
+        result = resolve_content("hello world", None)
+        assert result == b"hello world"
+
+    def test_from_file_object(self, tmp_path: pytest.TempPathFactory) -> None:
+        from io import BytesIO
+
+        f = BytesIO(b"file content")
+        result = resolve_content(None, f)
+        assert result == b"file content"
+
+    def test_file_takes_priority(self) -> None:
+        from io import BytesIO
+
+        f = BytesIO(b"from file")
+        result = resolve_content("from arg", f)
+        assert result == b"from file"
+
+    def test_stdin_dash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from io import BytesIO
+
+        monkeypatch.setattr(
+            "sys.stdin", type("FakeStdin", (), {"buffer": BytesIO(b"from stdin")})()
+        )
+        result = resolve_content("-", None)
+        assert result == b"from stdin"
+
+    def test_no_content_exits(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            resolve_content(None, None)
+        assert exc_info.value.code == ExitCode.USAGE_ERROR
+
+
+class TestHandleError:
+    """handle_error maps exceptions to semantic exit codes."""
+
+    def _assert_exit_code(self, exc: Exception, expected_code: int) -> None:
+        from nexus.cli.utils import handle_error
+
+        with pytest.raises(SystemExit) as exc_info:
+            handle_error(exc)
+        assert exc_info.value.code == expected_code
+
+    def test_permission_error(self) -> None:
+        self._assert_exit_code(PermissionError("denied"), ExitCode.PERMISSION_DENIED)
+
+    def test_file_not_found(self) -> None:
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+
+        self._assert_exit_code(NexusFileNotFoundError("/test"), ExitCode.NOT_FOUND)
+
+    def test_validation_error(self) -> None:
+        from nexus.contracts.exceptions import ValidationError
+
+        self._assert_exit_code(ValidationError("bad input"), ExitCode.USAGE_ERROR)
+
+    def test_timeout_error(self) -> None:
+        self._assert_exit_code(TimeoutError("timed out"), ExitCode.TEMPFAIL)
+
+    def test_connection_error(self) -> None:
+        self._assert_exit_code(ConnectionError("refused"), ExitCode.UNAVAILABLE)
+
+    def test_os_error(self) -> None:
+        self._assert_exit_code(OSError("disk full"), ExitCode.UNAVAILABLE)
+
+    def test_nexus_error(self) -> None:
+        from nexus.contracts.exceptions import NexusError
+
+        self._assert_exit_code(NexusError("generic"), ExitCode.GENERAL_ERROR)
+
+    def test_unexpected_error(self) -> None:
+        self._assert_exit_code(RuntimeError("unexpected"), ExitCode.INTERNAL_ERROR)


### PR DESCRIPTION
## Summary

- Adds unified output infrastructure for all CLI commands: `OutputOptions`, `render_output`/`render_error`, `CommandTiming`, `ExitCode`
- Standardizes JSON envelope `{data, _timing, _request_id}` across `ls`, `tree`, `cat`, `grep`, `glob`, `info`
- Adds `--json`, `--fields`, `-v`/`-vv`/`-vvv`, `--quiet` flags via `@add_output_options` decorator
- Adds `open_filesystem` context manager for safe resource cleanup
- Fixes pre-existing bug where search commands called `nx.glob()`/`nx.grep()` (don't exist on NexusFS) — changed to `nx.search_service.glob()`/`nx.search_service.grep()`
- Fixes remote mode `ls`/`tree` crash: `sys_readdir(details=True)` returns `{"files": [...]}` envelope via gRPC `RemoteServiceProxy` (which doesn't apply `response_key` extraction like `RPCProxyBase`); added `_normalize_readdir()` to unwrap + defensive `_format_file_entry()` for string entries

### New files
| File | Purpose |
|------|---------|
| `src/nexus/cli/output.py` | `OutputOptions`, `render_output`, `render_error`, `add_output_options` decorator |
| `src/nexus/cli/timing.py` | `CommandTiming` with phase tracking |
| `src/nexus/cli/exit_codes.py` | `ExitCode` enum |
| `src/nexus/cli/__main__.py` | `python -m nexus.cli` entry point |

### Modified commands
`directory.py` (ls, tree), `file_ops.py` (cat), `search.py` (grep, glob), `metadata.py` (info), `zone.py`, `utils.py`

## Test plan
- [x] 14 unit smoke tests (`tests/unit/cli/test_commands_smoke.py`) — JSON envelope, timing, fields filter, quiet, verbosity
- [x] 6 unit tests for OutputOptions (`test_output.py`)
- [x] 5 unit tests for CommandTiming (`test_timing.py`)
- [x] 4 unit tests for ExitCode (`test_exit_codes.py`)
- [x] 5 unit tests for BackendConfig + open_filesystem (`test_utils.py`)
- [x] 36 local e2e tests against real NexusFS (`test_cli_output_e2e.py`)
- [x] 12 remote e2e tests against `nexus serve` daemon via gRPC (`test_cli_output_e2e.py`)
- [x] All 48 e2e tests pass (0 xfails)
- [x] Performance: server phase < 500ms for all commands
- [x] Ruff lint + format pass