### PR TITLE
fix: resolve 10 bugs identified by Codex review

### DIFF
--- a/src/nexus/bricks/a2a/task_manager.py
+++ b/src/nexus/bricks/a2a/task_manager.py
@@ -77,6 +77,8 @@ class TaskManager:
             self._stream_registry = _SR()
 
         self._artifact_observers = artifact_observers or []
+        # Per-task locks to prevent TOCTOU races in state transitions
+        self._task_locks: dict[str, "asyncio.Lock"] = {}
 
     @property
     def stream_registry(self) -> "StreamRegistry":
@@ -201,32 +203,36 @@ class TaskManager:
         Raises ``TaskNotFoundError`` if the task does not exist.
         Raises ``InvalidStateTransitionError`` if the transition is invalid.
         """
-        # TODO(race-condition): update_task_state has a TOCTOU race under
-        # concurrent calls.  Fix requires optimistic locking (version column)
-        # in TaskStoreProtocol.
-        task = await self._store.get(task_id, zone_id=zone_id)
-        if task is None:
-            raise TaskNotFoundError(data={"taskId": task_id})
+        import asyncio
 
-        current_state = task.status.state
-        if not is_valid_transition(current_state, new_state):
-            raise InvalidStateTransitionError(
-                message=f"Cannot transition from {current_state.value} to {new_state.value}",
-                data={
-                    "taskId": task_id,
-                    "currentState": current_state.value,
-                    "requestedState": new_state.value,
-                },
-            )
+        # Per-task lock prevents TOCTOU race on concurrent transitions.
+        if task_id not in self._task_locks:
+            self._task_locks[task_id] = asyncio.Lock()
 
-        now = datetime.now(UTC)
-        new_status = TaskStatus(state=new_state, message=message, timestamp=now)
-        task = task.model_copy(update={"status": new_status})
+        async with self._task_locks[task_id]:
+            task = await self._store.get(task_id, zone_id=zone_id)
+            if task is None:
+                raise TaskNotFoundError(data={"taskId": task_id})
 
-        if message is not None:
-            task = task.model_copy(update={"history": [*task.history, message]})
+            current_state = task.status.state
+            if not is_valid_transition(current_state, new_state):
+                raise InvalidStateTransitionError(
+                    message=f"Cannot transition from {current_state.value} to {new_state.value}",
+                    data={
+                        "taskId": task_id,
+                        "currentState": current_state.value,
+                        "requestedState": new_state.value,
+                    },
+                )
 
-        await self._store.save(task, zone_id=zone_id)
+            now = datetime.now(UTC)
+            new_status = TaskStatus(state=new_state, message=message, timestamp=now)
+            task = task.model_copy(update={"status": new_status})
+
+            if message is not None:
+                task = task.model_copy(update={"history": [*task.history, message]})
+
+            await self._store.save(task, zone_id=zone_id)
 
         # Push status update to active streams
         event = TaskStatusUpdateEvent(

--- a/src/nexus/bricks/governance/governance_graph_service.py
+++ b/src/nexus/bricks/governance/governance_graph_service.py
@@ -163,7 +163,7 @@ class GovernanceGraphService:
         cache_key = (zone_id, from_agent, to_agent)
         now = time.monotonic()
 
-        # Check cache
+        # Check cache — exact pair
         cached = self._cache.get(cache_key)
         if cached is not None:
             if cached[1] > now:
@@ -171,13 +171,22 @@ class GovernanceGraphService:
             # Expired — evict zombie entry before DB lookup
             self._cache.pop(cache_key, None)
 
+        # Check cache — wildcard (from_agent, "*")
+        wildcard_key = (zone_id, from_agent, "*")
+        cached_wc = self._cache.get(wildcard_key)
+        if cached_wc is not None:
+            if cached_wc[1] > now and not cached_wc[0].allowed:
+                return cached_wc[0]
+            if cached_wc[1] <= now:
+                self._cache.pop(wildcard_key, None)
+
         # Periodic sweep of expired entries
         self._lookup_count += 1
         if self._lookup_count >= _SWEEP_INTERVAL:
             self._sweep_expired(now)
             self._lookup_count = 0
 
-        # DB lookup
+        # DB lookup (checks both exact and wildcard to_node)
         result = await self._lookup_constraint(from_agent, to_agent, zone_id)
 
         # Cache result (LRU eviction when full — Issue #2129 §14A)
@@ -264,8 +273,12 @@ class GovernanceGraphService:
         to_agent: str,
         zone_id: str,
     ) -> ConstraintCheckResult:
-        """Look up constraint from database."""
-        from sqlalchemy import select
+        """Look up constraint from database.
+
+        Checks both the exact (from_agent, to_agent) pair and any
+        wildcard constraint where to_node="*" (global blocks/rate-limits).
+        """
+        from sqlalchemy import or_, select
 
         from nexus.bricks.governance.db_models import GovernanceEdgeModel
 
@@ -273,7 +286,10 @@ class GovernanceGraphService:
             stmt = select(GovernanceEdgeModel).where(
                 GovernanceEdgeModel.zone_id == zone_id,
                 GovernanceEdgeModel.from_node == from_agent,
-                GovernanceEdgeModel.to_node == to_agent,
+                or_(
+                    GovernanceEdgeModel.to_node == to_agent,
+                    GovernanceEdgeModel.to_node == "*",
+                ),
                 GovernanceEdgeModel.edge_type == EdgeType.CONSTRAINT,
             )
             result = await session.execute(stmt)

--- a/src/nexus/bricks/ipc/protocols.py
+++ b/src/nexus/bricks/ipc/protocols.py
@@ -150,6 +150,9 @@ class KeyRecord(Protocol):
     def revoked_at(self) -> Any | None: ...
 
     @property
+    def expires_at(self) -> Any | None: ...
+
+    @property
     def public_key_bytes(self) -> bytes: ...
 
 

--- a/src/nexus/bricks/ipc/signing.py
+++ b/src/nexus/bricks/ipc/signing.py
@@ -154,6 +154,17 @@ class MessageVerifier:
                 detail=f"Key {record.key_id} was revoked at {record.revoked_at}",
             )
 
+        # Check key expiration
+        expires_at = getattr(record, "expires_at", None)
+        if expires_at is not None:
+            from datetime import UTC, datetime
+
+            if datetime.now(UTC) >= expires_at:
+                return VerifyResult(
+                    valid=False,
+                    detail=f"Key {record.key_id} expired at {expires_at}",
+                )
+
         # Decode signature
         try:
             raw_signature = base64.b64decode(envelope.signature)

--- a/src/nexus/bricks/mcp/mcp_service.py
+++ b/src/nexus/bricks/mcp/mcp_service.py
@@ -266,8 +266,8 @@ class MCPService:
         env: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         description: str | None = None,
-        tier: str = "system",
-        context: "OperationContext | None" = None,
+        tier: str = "system",  # noqa: ARG002
+        context: "OperationContext | None" = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         """Mount an MCP server.
 
@@ -366,7 +366,7 @@ class MCPService:
         manager = self._get_mcp_mount_manager()
 
         # Mount the server (async operation)
-        await manager.mount(mount_config, tier=tier, context=context)
+        await manager.mount(mount_config)
 
         # Sync tools (async operation)
         tool_count = await manager.sync_tools(name)

--- a/src/nexus/bricks/portability/import_service.py
+++ b/src/nexus/bricks/portability/import_service.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _create_import_context() -> "OperationContext":
+def _create_import_context(zone_id: str | None = None) -> "OperationContext":
     """Create a system context for import operations.
 
     Import is a privileged system operation that bypasses normal permission checks.
@@ -47,6 +47,7 @@ def _create_import_context() -> "OperationContext":
         groups=[],
         is_admin=True,
         is_system=True,  # System operations bypass all checks
+        zone_id=zone_id,
     )
 
 
@@ -257,8 +258,8 @@ class ZoneImportService:
         if remapped_path != original_path:
             result.paths_remapped += 1
 
-        # Determine target zone (used for logging/tracking)
-        _ = options.target_zone_id or record.zone_id
+        # Determine target zone for write context
+        target_zone_id = options.target_zone_id or record.zone_id
 
         # Check if file already exists
         existing = self.nexus_fs.metadata.get(remapped_path)
@@ -297,10 +298,12 @@ class ZoneImportService:
 
         # Import content blob if needed
         content: bytes | None = None
+        content_ref_valid = False  # True when content_hash exists in CAS/backend
         if options.content_mode == ContentMode.INCLUDE and record.content_hash:
             # Check if we already imported this content (deduplication)
             if record.content_hash in content_hashes_imported:
                 result.content_blobs_skipped += 1
+                content_ref_valid = True  # Already in CAS from a prior file
             else:
                 content = reader.read_content_blob(record.content_hash)
                 if content is not None:
@@ -322,6 +325,8 @@ class ZoneImportService:
                     result.add_warning(
                         f"Referenced content not found: {record.content_hash} for {remapped_path}"
                     )
+                else:
+                    content_ref_valid = True  # Verified in backend
             except Exception as e:
                 result.add_warning(
                     f"Failed to verify content reference: {record.content_hash}: {e}"
@@ -331,7 +336,7 @@ class ZoneImportService:
         if content is not None:
             try:
                 # Use system context for import (privileged operation)
-                import_context = _create_import_context()
+                import_context = _create_import_context(zone_id=target_zone_id)
                 # force=True (skip OCC) → just call write() directly.
                 # Issue #1323: OCC extracted to lib/occ.py, write() is now OCC-free.
                 write_result = self.nexus_fs.write(
@@ -364,8 +369,10 @@ class ZoneImportService:
                 )
                 result.files_failed += 1
 
-        elif options.content_mode == ContentMode.SKIP:
-            # Metadata-only import
+        elif content_ref_valid or options.content_mode == ContentMode.SKIP:
+            # Content already in CAS (dedup) / verified in backend (reference) /
+            # metadata-only import (SKIP) — create metadata entry pointing to
+            # the existing content_hash.
             self._import_metadata_only(
                 path=remapped_path,
                 record=record,

--- a/src/nexus/bricks/snapshot/service.py
+++ b/src/nexus/bricks/snapshot/service.py
@@ -169,6 +169,30 @@ class TransactionalSnapshotService:
             new_hash=None,
         )
 
+    def validate_path_available(self, transaction_id: str, path: str) -> None:
+        """Check that *path* can be tracked by *transaction_id*.
+
+        Call this **before** performing the filesystem mutation so that a
+        conflict is detected before the write/delete occurs.
+
+        Raises:
+            TransactionConflictError: if *path* is owned by another transaction.
+        """
+        if not self._registry.has_active_transactions():
+            return
+        existing_txn = self._registry.get_transaction_for_path(path)
+        if existing_txn is not None and existing_txn != transaction_id:
+            raise TransactionConflictError(
+                conflicts=[
+                    ConflictInfo(
+                        path=path,
+                        expected_hash=None,
+                        current_hash=None,
+                        reason=f"Path already tracked by transaction {existing_txn}",
+                    )
+                ]
+            )
+
     def _track_operation(
         self,
         transaction_id: str,
@@ -193,15 +217,19 @@ class TransactionalSnapshotService:
         # Register path in memory registry
         tracked = self._registry.track_path(transaction_id, path)
         if not tracked:
-            logger.warning(
-                "Path %s already tracked by different transaction (txn=%s)",
-                path,
-                transaction_id,
-            )
             # Release the hold we just acquired since we can't track
             if original_hash is not None:
                 self._cas_store.release(original_hash)
-            return
+            raise TransactionConflictError(
+                conflicts=[
+                    ConflictInfo(
+                        path=path,
+                        expected_hash=original_hash,
+                        current_hash=new_hash,
+                        reason=f"Path already tracked by a different transaction (txn={transaction_id})",
+                    )
+                ]
+            )
 
         # Persist entry to DB
         metadata_json = json.dumps(original_metadata) if original_metadata else None

--- a/src/nexus/bricks/upload/chunked_upload_service.py
+++ b/src/nexus/bricks/upload/chunked_upload_service.py
@@ -624,11 +624,26 @@ class ChunkedUploadService:
                     content = await asyncio.to_thread(self._backend.read_content, part_hash)
                     assembled.extend(content)
 
-            # Write assembled content
+            # Write assembled content to CAS
             content = bytes(assembled)
             _write = self._backend.write_content
             result = await asyncio.to_thread(_write, content)
             content_hash = result.content_hash
+
+            # Link content to target_path via metadata store so the file is
+            # reachable (multipart backends do this inside complete_multipart).
+            if self._metadata_store is not None:
+                from nexus.contracts.metadata import FileMetadata
+
+                backend_name = getattr(self._backend, "name", "default")
+                metadata = FileMetadata(
+                    path=session.target_path,
+                    backend_name=backend_name,
+                    physical_path=content_hash,
+                    size=len(content),
+                    etag=content_hash,
+                )
+                await asyncio.to_thread(self._metadata_store.put, metadata)
 
         # Update session to completed
         completed = UploadSession(

--- a/src/nexus/bricks/workflows/engine.py
+++ b/src/nexus/bricks/workflows/engine.py
@@ -13,7 +13,12 @@ from cachetools import LRUCache
 
 from nexus.bricks.workflows.actions import BUILTIN_ACTIONS
 from nexus.bricks.workflows.protocol import WorkflowServices
-from nexus.bricks.workflows.triggers import BUILTIN_TRIGGERS, TriggerFactory, TriggerManager
+from nexus.bricks.workflows.triggers import (
+    BUILTIN_TRIGGERS,
+    BaseTrigger,
+    TriggerFactory,
+    TriggerManager,
+)
 from nexus.bricks.workflows.types import (
     TriggerType,
     WorkflowContext,
@@ -47,6 +52,8 @@ class WorkflowEngine:
         self.workflow_ids: LRUCache[str, str] = LRUCache(maxsize=max_workflows)
         self.action_registry = BUILTIN_ACTIONS.copy()
         self.trigger_registry: dict[TriggerType, TriggerFactory] = BUILTIN_TRIGGERS.copy()
+        # Track triggers per workflow for proper cleanup on unload/disable
+        self._workflow_triggers: dict[str, list["BaseTrigger"]] = {}
 
         if plugin_registry:
             self._discover_plugin_extensions()
@@ -95,7 +102,11 @@ class WorkflowEngine:
 
     def _register_triggers_for(self, definition: WorkflowDefinition) -> None:
         """Register triggers for a workflow definition."""
+        # Unregister any existing triggers first to prevent duplicates on reload
+        self._unregister_triggers_for(definition.name)
+
         glob_match = self._services.glob_match if self._services else None
+        triggers: list[BaseTrigger] = []
         for trigger_def in definition.triggers:
             trigger_class = self.trigger_registry.get(trigger_def.type)
             if not trigger_class:
@@ -103,6 +114,7 @@ class WorkflowEngine:
                 continue
 
             trigger = trigger_class(trigger_def.config, glob_match=glob_match)
+            triggers.append(trigger)
 
             async def trigger_callback(
                 event_context: dict[str, Any], wf_name: str = definition.name
@@ -110,6 +122,14 @@ class WorkflowEngine:
                 await self.trigger_workflow(wf_name, event_context)
 
             self.trigger_manager.register_trigger(trigger, trigger_callback)  # type: ignore[arg-type]
+
+        self._workflow_triggers[definition.name] = triggers
+
+    def _unregister_triggers_for(self, name: str) -> None:
+        """Unregister all triggers belonging to a workflow."""
+        triggers = self._workflow_triggers.pop(name, [])
+        for trigger in triggers:
+            self.trigger_manager.unregister_trigger(trigger)
 
     def load_workflow(self, definition: WorkflowDefinition, *, enabled: bool = True) -> bool:
         """Load a workflow definition."""
@@ -175,6 +195,9 @@ class WorkflowEngine:
             except Exception as e:
                 logger.error("Failed to delete workflow from storage: %s", e)
 
+        # Unregister triggers before removing the workflow
+        self._unregister_triggers_for(name)
+
         del self.workflows[name]
         self.enabled_workflows.pop(name, None)
         self.workflow_ids.pop(name, None)
@@ -186,6 +209,9 @@ class WorkflowEngine:
         """Enable a workflow."""
         if name in self.workflows:
             self.enabled_workflows[name] = True
+
+            # Re-register triggers so events are routed again
+            self._register_triggers_for(self.workflows[name])
 
             if self.workflow_store:
                 import asyncio
@@ -205,6 +231,9 @@ class WorkflowEngine:
         """Disable a workflow."""
         if name in self.workflows:
             self.enabled_workflows[name] = False
+
+            # Unregister triggers so disabled workflows don't fire
+            self._unregister_triggers_for(name)
 
             if self.workflow_store:
                 import asyncio

--- a/src/nexus/bricks/workflows/triggers.py
+++ b/src/nexus/bricks/workflows/triggers.py
@@ -130,7 +130,10 @@ class ScheduleTrigger(BaseTrigger):
         self.interval_seconds = config.get("interval_seconds")
 
     def matches(self, _event_context: dict[str, Any]) -> bool:
-        return False
+        # Schedule triggers always match when fired by the scheduler.
+        # The scheduler is responsible for evaluating cron/interval timing;
+        # fire_event(TriggerType.SCHEDULE, ...) means "it's time to fire."
+        return True
 
 
 class WebhookTrigger(BaseTrigger):

--- a/tests/unit/services/snapshot/test_service.py
+++ b/tests/unit/services/snapshot/test_service.py
@@ -191,13 +191,16 @@ class TestTrackWrite:
             info1.transaction_id, "/file.txt", "hash1", {"size": 1}, "hash2"
         )
 
-        # Second transaction tries same path — should not track
+        # Second transaction tries same path — should raise conflict
         mock_cas_store.hold_reference.reset_mock()
-        snapshot_service.track_write(
-            info2.transaction_id, "/file.txt", "hash2", {"size": 2}, "hash3"
-        )
+        with pytest.raises(TransactionConflictError) as exc_info:
+            snapshot_service.track_write(
+                info2.transaction_id, "/file.txt", "hash2", {"size": 2}, "hash3"
+            )
         # CAS release should be called since tracking failed
         mock_cas_store.release.assert_called_with("hash2")
+        assert len(exc_info.value.conflicts) == 1
+        assert exc_info.value.conflicts[0].path == "/file.txt"
 
 
 class TestTrackDelete:


### PR DESCRIPTION
## Summary

Fixes 10 high/medium severity bugs identified by Codex static analysis across multiple bricks and services:

- **import_service** (High): Fix silent file drops when content_hash is deduplicated or ContentMode.REFERENCE — now creates metadata entries for files with existing content
- **import_service** (High): Apply `target_zone_id` to the write context instead of discarding it (`_ = ...`)
- **snapshot/service** (High): Raise `TransactionConflictError` when a path is already tracked by another transaction instead of silently returning after the mutation. Add `validate_path_available()` for pre-mutation conflict checks
- **workflows/engine** (High): Track triggers per workflow and unregister them on `unload_workflow()` / `disable_workflow()`, re-register on `enable_workflow()`. Prevents stale callbacks and duplicate executions on repeated loads
- **mcp_service** (High): Remove `tier=` / `context=` kwargs from `manager.mount()` call — `MCPMountManager.mount()` only accepts `mount_config`, so this path was raising `TypeError`
- **chunked_upload_service** (High): Non-multipart upload completion now links assembled content to `target_path` via metadata store (matching what `complete_multipart` does for multipart backends)
- **governance_graph_service** (High): `_lookup_constraint()` now matches wildcard `to_node="*"` entries so global blocks/rate-limits are enforced against real recipients
- **signing** (High): Enforce `expires_at` on key records during IPC signature verification — previously only checked `is_active` and `revoked_at`
- **task_manager** (Medium): Add per-task `asyncio.Lock` to prevent TOCTOU race in `update_task_state()` concurrent transitions
- **triggers** (Medium): `ScheduleTrigger.matches()` returns `True` so schedule workflows fire when the scheduler sends events

## Test plan

- [x] `uv run ruff check` — all 10 source files pass
- [x] `uv run ruff format --check` — all formatted
- [x] `uv run mypy` — no issues in all 10 files
- [x] Pre-commit hooks pass (ruff, mypy, format, brick-zero-core-imports)
- [x] Updated `test_track_write_conflict_with_different_txn` to expect `TransactionConflictError` raise
- [x] 68 IPC tests pass (includes signing verification)
- [x] 9 sync workflow engine tests pass
- [x] 303 MCP tests pass
- [ ] CI full test suite