### PR TITLE
fix: resolve 6 security and correctness issues from codex audit

### DIFF
--- a/src/nexus/backends/base/path_backend.py
+++ b/src/nexus/backends/base/path_backend.py
@@ -100,8 +100,25 @@ class PathBackend(Backend):
         return content_type
 
     def _get_blob_path(self, backend_path: str) -> str:
-        """Convert backend-relative path to full blob path."""
+        """Convert backend-relative path to full blob path.
+
+        Raises:
+            BackendError: If path contains traversal components (e.g., "..").
+        """
+        import posixpath
+
         backend_path = backend_path.lstrip("/")
+
+        # Security: reject path traversal attempts (e.g., "../../etc/passwd")
+        normalized = posixpath.normpath(backend_path) if backend_path else ""
+        if normalized == ".." or normalized.startswith("../"):
+            raise BackendError(
+                f"Path traversal detected: {backend_path}",
+                backend=getattr(self, "name", "blob"),
+                path=backend_path,
+            )
+        backend_path = normalized
+
         if self.prefix:
             if backend_path:
                 return f"{self.prefix}/{backend_path}"

--- a/src/nexus/backends/cache/service.py
+++ b/src/nexus/backends/cache/service.py
@@ -237,8 +237,17 @@ class CacheService:
         self,
         path: str,
         original: bool = False,
+        zone_id: str | None = None,
     ) -> CacheEntry | None:
-        """Read content from cache (L1 Rust metadata cache, then L2 disk)."""
+        """Read content from cache (L1 Rust metadata cache, then L2 disk).
+
+        Args:
+            path: Cache key path.
+            original: If True, also read binary content from disk.
+            zone_id: Explicit zone override. When provided, L2 disk reads use
+                     this zone instead of the connector's default zone. This
+                     ensures multi-zone isolation on shared connectors.
+        """
         l1_cache = self._l1_cache
 
         # L1: Check Rust metadata cache first
@@ -268,7 +277,7 @@ class CacheService:
             return None
 
         file_cache = self.file_cache
-        cache_zone = self._get_cache_zone()
+        cache_zone = zone_id or self._get_cache_zone()
         meta = file_cache.read_meta(cache_zone, path)
 
         if not meta:
@@ -307,8 +316,16 @@ class CacheService:
         self,
         paths: list[str],
         original: bool = False,
+        zone_id: str | None = None,
     ) -> dict[str, CacheEntry]:
-        """Read multiple entries from cache in bulk (L1 + L2)."""
+        """Read multiple entries from cache in bulk (L1 + L2).
+
+        Args:
+            paths: List of cache key paths.
+            original: If True, also read binary content from disk.
+            zone_id: Explicit zone override for L2 disk reads. Ensures
+                     multi-zone isolation on shared connectors.
+        """
         if not paths:
             return {}
 
@@ -349,7 +366,7 @@ class CacheService:
 
         # L2: Disk-based lookup for remaining paths
         file_cache = self.file_cache
-        cache_zone = self._get_cache_zone()
+        cache_zone = zone_id or self._get_cache_zone()
 
         meta_entries = file_cache.read_meta_bulk(cache_zone, paths_needing_l2)
 
@@ -706,15 +723,24 @@ class CacheService:
         path: str | None = None,
         mount_prefix: str | None = None,
         delete: bool = False,
+        zone_id: str | None = None,
     ) -> int:
         """Invalidate cache entries (L1 memory + L2 disk).
+
+        Args:
+            path: Specific path to invalidate.
+            mount_prefix: Invalidate all paths under this mount prefix.
+            delete: Whether this is a delete operation.
+            zone_id: Explicit zone override. Ensures invalidation targets the
+                     correct zone on shared connectors instead of defaulting
+                     to the connector's zone_id.
 
         Bug fix: L1 removal now uses bare `path` key (matches stored key)
         instead of `f"cache_entry:{path}"` which never matched.
         """
         memory_cache = self._l1_cache
         file_cache = self.file_cache
-        cache_zone = self._get_cache_zone()
+        cache_zone = zone_id or self._get_cache_zone()
 
         if path:
             # FIX: Use bare path (matches the key used in l1_cache.put)
@@ -818,9 +844,9 @@ class CacheService:
         path = self.get_cache_path(context) or context.backend_path
         zone_id = getattr(context, "zone_id", None)
 
-        # Step 1: Check cache
+        # Step 1: Check cache (pass zone_id for multi-zone isolation)
         if self.has_caching():
-            cached = self.read_from_cache(path, original=True)
+            cached = self.read_from_cache(path, original=True, zone_id=zone_id)
             if cached and not cached.stale and cached.content_binary:
                 logger.debug("[CACHE] HIT: %s", path)
                 return CachedReadResult(

--- a/src/nexus/backends/connectors/calendar/connector.py
+++ b/src/nexus/backends/connectors/calendar/connector.py
@@ -733,13 +733,12 @@ send_notifications: true
         calendar_id = parts[0]
         event_id = parts[1].replace(".yaml", "")
 
-        # For delete, we need to read the delete request content
-        # This should be passed through context or as a separate call
-        # For now, require explicit confirmation via a different mechanism
-        data = {"agent_intent": "Delete requested", "confirm": True}
-
-        # Validate traits (requires confirm: true)
-        self.validate_traits("delete_event", data)
+        # delete_content is a backend-level interface method. Agent-facing
+        # deletes must go through write_content() with YAML containing
+        # "# agent_intent: ..." and "# confirm: true" — trait validation
+        # is enforced in that path. Do NOT fabricate confirmation data here
+        # as that would bypass the explicit-confirmation safety contract.
+        logger.info("delete_content called for event %s in calendar %s", event_id, calendar_id)
 
         service = self._get_calendar_service(context)
 

--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -607,6 +607,48 @@ class GoogleDriveConnectorBackend(Backend):
                 f"Failed to get/create folder '{path}': {e}", backend="gdrive"
             ) from e
 
+    def _find_folder(
+        self,
+        service: "Resource",
+        name: str,
+        parent_id: str,
+    ) -> str | None:
+        """Find an existing folder by name under a parent (read-only, never creates).
+
+        Args:
+            service: Google Drive service
+            name: Folder name to find
+            parent_id: Parent folder ID
+
+        Returns:
+            Folder ID if found, None if not found
+        """
+        query = (
+            f"name='{name}' and '{parent_id}' in parents "
+            f"and mimeType='application/vnd.google-apps.folder' and trashed=false"
+        )
+        if self.use_shared_drives:
+            results = (
+                service.files()
+                .list(
+                    q=query,
+                    spaces="drive",
+                    fields="files(id, name)",
+                    includeItemsFromAllDrives=True,
+                    supportsAllDrives=True,
+                )
+                .execute()
+            )
+        else:
+            results = (
+                service.files().list(q=query, spaces="drive", fields="files(id, name)").execute()
+            )
+
+        files = results.get("files", [])
+        if files:
+            return str(files[0]["id"])
+        return None
+
     def _resolve_path_to_folder_id(
         self, service: "Resource", backend_path: str, context: "OperationContext | str | None"
     ) -> tuple[str, str]:
@@ -1105,10 +1147,17 @@ class GoogleDriveConnectorBackend(Backend):
         service = self._get_drive_service(None)
         root_folder_id = self._get_or_create_root_folder(service, None)
 
-        # Resolve path to folder ID
-        folder_id = self._resolve_path_to_folder_id(service, path, root_folder_id)
-        if not folder_id:
-            raise NexusFileNotFoundError(path)
+        # Navigate path to resolve the target folder ID (read-only)
+        parts = path.split("/")
+        current_id = root_folder_id
+        for part in parts:
+            if not part:
+                continue
+            found_id = self._find_folder(service, part, current_id)
+            if found_id is None:
+                raise NexusFileNotFoundError(path)
+            current_id = found_id
+        folder_id = current_id
 
         if not recursive:
             # Check if directory is empty
@@ -1226,7 +1275,7 @@ class GoogleDriveConnectorBackend(Backend):
             service = self._get_drive_service(context)
             root_folder_id = self._get_or_create_root_folder(service, context)
 
-            # Navigate to target folder
+            # Navigate to target folder (read-only — never create missing folders)
             if path:
                 # Split path and navigate
                 parts = path.split("/")
@@ -1234,9 +1283,10 @@ class GoogleDriveConnectorBackend(Backend):
                 for part in parts:
                     if not part:
                         continue
-                    current_folder_id = self._get_or_create_folder(
-                        service, part, current_folder_id, context
-                    )
+                    found_id = self._find_folder(service, part, current_folder_id)
+                    if found_id is None:
+                        raise FileNotFoundError(f"Directory not found: {path}")
+                    current_folder_id = found_id
                 folder_id = current_folder_id
             else:
                 # List root folder

--- a/src/nexus/backends/connectors/slack/connector.py
+++ b/src/nexus/backends/connectors/slack/connector.py
@@ -50,7 +50,7 @@ from nexus.backends.connectors.slack.utils import (
     list_channels,
     list_messages_from_channel,
 )
-from nexus.backends.wrappers.cache_mixin import IMMUTABLE_VERSION, CacheConnectorMixin
+from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
 from nexus.contracts.capabilities import OAUTH_CONNECTOR_CAPABILITIES, ConnectorCapability
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import WriteResult
@@ -525,14 +525,17 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
         # Format as YAML
         content = self._format_messages_as_yaml(messages)
 
-        # Cache the result
+        # Cache the result with a timestamp-based version so sync_pipeline
+        # will refresh when the channel is re-synced. Slack channels contain
+        # live message history that can change (new messages, edits, deletes).
         if self._has_caching():
             try:
                 zone_id = getattr(context, "zone_id", None)
+                version = str(int(datetime.now(UTC).timestamp()))
                 self._write_to_cache(
                     path=cache_path,
                     content=content,
-                    backend_version=IMMUTABLE_VERSION,  # Messages are immutable
+                    backend_version=version,
                     zone_id=zone_id,
                 )
             except Exception as e:
@@ -623,17 +626,18 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
         context: "OperationContext | None" = None,
     ) -> str | None:
         """
-        Get version for a Slack message file.
+        Get version for a Slack channel snapshot file.
 
-        Slack messages are immutable (read-only) - once sent, they never change.
-        Therefore, we return a fixed version "immutable" for all message files.
+        Slack channel snapshots are mutable (messages can be added/edited/deleted),
+        so we return a timestamp-based version that allows sync_pipeline to detect
+        changes and refresh the cache.
 
         Args:
             path: Virtual file path (or backend_path from context)
             context: Operation context with optional backend_path
 
         Returns:
-            "immutable" for message files, None for directories/non-files
+            Timestamp-based version for .yaml files, None for directories
         """
         try:
             # Get backend path
@@ -642,12 +646,12 @@ class SlackConnectorBackend(Backend, CacheConnectorMixin, OAuthConnectorMixin):
             else:
                 backend_path = path.lstrip("/")
 
-            # Check if this is a message file (ends with .json)
-            if not backend_path.endswith(".json"):
+            # Check if this is a channel snapshot file (exposed as .yaml)
+            if not backend_path.endswith(".yaml"):
                 return None  # Not a file (likely a directory)
 
-            # Return fixed version for immutable Slack messages
-            return IMMUTABLE_VERSION
+            # Return timestamp-based version so sync_pipeline can detect staleness
+            return str(int(datetime.now(UTC).timestamp()))
 
         except Exception as e:
             logger.debug("Slack version check failed: %s", e)

--- a/src/nexus/backends/wrappers/cache_mixin.py
+++ b/src/nexus/backends/wrappers/cache_mixin.py
@@ -176,15 +176,17 @@ class CacheConnectorMixin:
         """Get path_ids for multiple virtual paths in a single query."""
         return self._cache_service.get_path_ids_bulk(paths, session)
 
-    def _read_from_cache(self, path: str, original: bool = False) -> CacheEntry | None:
+    def _read_from_cache(
+        self, path: str, original: bool = False, zone_id: str | None = None
+    ) -> CacheEntry | None:
         """Read content from cache (L1 then L2)."""
-        return self._cache_service.read_from_cache(path, original)
+        return self._cache_service.read_from_cache(path, original, zone_id=zone_id)
 
     def _read_bulk_from_cache(
-        self, paths: list[str], original: bool = False
+        self, paths: list[str], original: bool = False, zone_id: str | None = None
     ) -> dict[str, CacheEntry]:
         """Read multiple entries from cache in bulk (L1 + L2)."""
-        return self._cache_service.read_bulk_from_cache(paths, original)
+        return self._cache_service.read_bulk_from_cache(paths, original, zone_id=zone_id)
 
     def read_content_bulk(
         self, paths: list[str], context: OperationContext | None = None
@@ -236,9 +238,10 @@ class CacheConnectorMixin:
         path: str | None = None,
         mount_prefix: str | None = None,
         delete: bool = False,
+        zone_id: str | None = None,
     ) -> int:
         """Invalidate cache entries (L1 memory + L2 disk)."""
-        return self._cache_service.invalidate_cache(path, mount_prefix, delete)
+        return self._cache_service.invalidate_cache(path, mount_prefix, delete, zone_id=zone_id)
 
     def _check_version(
         self,


### PR DESCRIPTION
## Summary

Fixes 6 validated findings from a codex security/correctness audit (2 of 8 original findings were invalid and excluded).

- **Path traversal** (`base_blob_connector.py`): `_get_blob_path()` only stripped leading `/`, allowing `../` to escape storage root. Now normalizes via `posixpath.normpath` and rejects traversal.
- **Calendar delete bypass** (`gcalendar_connector.py`): `delete_content()` fabricated `{"confirm": True}` to pass `validate_traits()`, bypassing the explicit-confirmation contract. Removed — backend-level deletes no longer fake confirmation; agent-facing deletes must use `write_content()` with proper YAML.
- **GDrive list_dir creates folders** (`gdrive_connector.py`): `list_dir()` used `_get_or_create_folder()` which creates missing folders on Drive. Added read-only `_find_folder()` method; `list_dir()` now raises `FileNotFoundError` for missing paths.
- **GDrive rmdir tuple bug** (`gdrive_connector.py`): `rmdir()` treated the `(parent_id, filename)` tuple from `_resolve_path_to_folder_id()` as a single folder ID string, breaking directory deletion. Now navigates the path properly using `_find_folder()`.
- **Cache zone mismatch** (`cache_service.py`, `cache_mixin.py`): Writes used request `zone_id` but reads/invalidation used `_get_cache_zone()` (connector default). Added optional `zone_id` parameter to `read_from_cache()`, `read_bulk_from_cache()`, and `invalidate_cache()` for multi-zone isolation.
- **Slack immutable caching** (`slack_connector.py`): Channel snapshots were cached with `IMMUTABLE_VERSION`, causing `sync_pipeline` to skip refresh forever. Now uses timestamp-based versions. Also fixed `get_version()` checking `.json` when files are actually `.yaml`.

## Test plan

- [x] `uv run ruff check .` — all clean
- [x] `uv run mypy` — all clean
- [x] `uv run pytest tests/unit/backends/` — 752 passed (30 pre-existing failures in unrelated wrapper/compression tests)
- [ ] Verify path traversal rejection with `../../` paths on local blob transport
- [ ] Verify GDrive `list_dir` on nonexistent path raises error instead of creating folders
- [ ] Verify `rmdir` on GDrive works end-to-end
- [ ] Verify Slack sync refreshes channel content after initial cache
- [ ] Verify multi-zone cache reads/writes/invalidation on shared connectors