### PR TITLE
feat: system deployment configs and remote profile stability fixes

### DIFF
--- a/deployment/linux/INSTALL.md
+++ b/deployment/linux/INSTALL.md
@@ -1,0 +1,1 @@
+# Installing Nexus Server as a Background Service (Linux)\n\nPlaceholder for systemd instructions.

--- a/deployment/macos/INSTALL.md
+++ b/deployment/macos/INSTALL.md
@@ -11,18 +11,18 @@ This guide explains how to set up the Nexus RPC server as an "Always-On" backgro
 
 1. **Copy the template:**
    ```bash
-   cp deployment/macos/io.nexi.nexus.server.plist ~/Library/LaunchAgents/
+   cp deployment/macos/ai.nexus.server.plist ~/Library/LaunchAgents/
    ```
 
 2. **Configure the plist:**
-   Open `~/Library/LaunchAgents/io.nexi.nexus.server.plist` in an editor and replace the following placeholders:
+   Open `~/Library/LaunchAgents/ai.nexus.server.plist` in an editor and replace the following placeholders:
    - `{{NEXUS_PATH}}`: The output of `which nexus` (e.g., `/usr/local/bin/nexus`).
    - `{{USER}}`: Your macOS username.
    - `{{PYTHONPATH}}`: Absolute path to your project `src` directory and site-packages (e.g., `/path/to/nexus/src:/path/to/nexus/.venv/lib/python3.13/site-packages`).
 
 3. **Load the service:**
    ```bash
-   launchctl load ~/Library/LaunchAgents/io.nexi.nexus.server.plist
+   launchctl load ~/Library/LaunchAgents/ai.nexus.server.plist
    ```
 
 ## Management Commands
@@ -33,7 +33,7 @@ This guide explains how to set up the Nexus RPC server as an "Always-On" backgro
   ```
 - **Stop Service:**
   ```bash
-  launchctl unload ~/Library/LaunchAgents/io.nexi.nexus.server.plist
+  launchctl unload ~/Library/LaunchAgents/ai.nexus.server.plist
   ```
 - **View Logs:**
   ```bash

--- a/deployment/macos/INSTALL.md
+++ b/deployment/macos/INSTALL.md
@@ -1,0 +1,47 @@
+# Installing Nexus Server as a Background Service (macOS)
+
+This guide explains how to set up the Nexus RPC server as an "Always-On" background service using `launchd`.
+
+## Prerequisites
+- Nexus must be installed and initialized (`nexus init`).
+- Identify your nexus path: `which nexus`
+- Identify your project path (where `src` and `.venv` are located).
+
+## Installation Steps
+
+1. **Copy the template:**
+   ```bash
+   cp deployment/macos/io.nexi.nexus.server.plist ~/Library/LaunchAgents/
+   ```
+
+2. **Configure the plist:**
+   Open `~/Library/LaunchAgents/io.nexi.nexus.server.plist` in an editor and replace the following placeholders:
+   - `{{NEXUS_PATH}}`: The output of `which nexus` (e.g., `/usr/local/bin/nexus`).
+   - `{{USER}}`: Your macOS username.
+   - `{{PYTHONPATH}}`: Absolute path to your project `src` directory and site-packages (e.g., `/path/to/nexus/src:/path/to/nexus/.venv/lib/python3.13/site-packages`).
+
+3. **Load the service:**
+   ```bash
+   launchctl load ~/Library/LaunchAgents/io.nexi.nexus.server.plist
+   ```
+
+## Management Commands
+
+- **Check Status:**
+  ```bash
+  launchctl list | grep nexi
+  ```
+- **Stop Service:**
+  ```bash
+  launchctl unload ~/Library/LaunchAgents/io.nexi.nexus.server.plist
+  ```
+- **View Logs:**
+  ```bash
+  tail -f ~/.nexus/logs/launcher-stdout.log
+  tail -f ~/.nexus/logs/launcher-stderr.log
+  ```
+
+## Why run as a background service?
+- **Always-On:** Required for real-time features like the Feishu WebSocket Gateway.
+- **Auto-Restart:** Automatically restarts if the process crashes.
+- **Login Start:** Starts automatically when you log into your Mac.

--- a/deployment/macos/ai.nexus.server.plist
+++ b/deployment/macos/ai.nexus.server.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>io.nexi.nexus.server</string>
+    <string>ai.nexus.server</string>
     <key>ProgramArguments</key>
     <array>
         <string>{{NEXUS_PATH}}</string> <!-- Path to nexus CLI, e.g., /usr/local/bin/nexus -->

--- a/deployment/macos/io.nexi.nexus.server.plist
+++ b/deployment/macos/io.nexi.nexus.server.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.nexi.nexus.server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{NEXUS_PATH}}</string> <!-- Path to nexus CLI, e.g., /usr/local/bin/nexus -->
+        <string>serve</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/{{USER}}/.nexus/logs/launcher-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/{{USER}}/.nexus/logs/launcher-stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>NEXUS_HOME</key>
+        <string>/Users/{{USER}}/.nexus</string>
+        <key>PYTHONPATH</key>
+        <string>{{PYTHONPATH}}</string>
+    </dict>
+</dict>
+</plist>

--- a/deployment/windows/INSTALL.md
+++ b/deployment/windows/INSTALL.md
@@ -1,0 +1,1 @@
+# Installing Nexus Server as a Background Service (Windows)\n\nPlaceholder for Task Scheduler/NSSM instructions.

--- a/src/nexus/cli/commands/directory.py
+++ b/src/nexus/cli/commands/directory.py
@@ -119,9 +119,14 @@ def list_files(
 
                 for entry in entries:
                     is_dir = entry["type"] == "directory"
+                    # Prevent double-slash for root or already-trailed paths
+                    display_path = entry["path"]
+                    if is_dir and not display_path.endswith("/"):
+                        display_path = f"{display_path}/"
+
                     table.add_row(
                         "dir" if is_dir else "file",
-                        f"{entry['path']}/" if is_dir else entry["path"],
+                        display_path,
                         f"{entry['size']:,} bytes" if entry["size"] is not None else "-",
                         format_timestamp(entry.get("modified_at"))
                         if entry.get("modified_at")
@@ -131,7 +136,10 @@ def list_files(
             else:
                 for entry in entries:
                     if entry["type"] == "directory":
-                        console.print(f"  [bold cyan]{entry['path']}/[/bold cyan]")
+                        display_path = entry["path"]
+                        if not display_path.endswith("/"):
+                            display_path = f"{display_path}/"
+                        console.print(f"  [bold cyan]{display_path}[/bold cyan]")
                     else:
                         console.print(f"  {entry['path']}")
 

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -14,6 +14,10 @@ from nexus.core import setup_uvloop
 
 # Suppress pydub warning about missing ffmpeg/avconv
 warnings.filterwarnings("ignore", message="Couldn't find ffmpeg or avconv", category=RuntimeWarning)
+# Suppress runpy warning when running via python -m (Issue #2103)
+warnings.filterwarnings(
+    "ignore", message=".*found in sys.modules after import of package.*", category=RuntimeWarning
+)
 
 # Install uvloop early for better async performance in all CLI commands
 # This affects all asyncio.run() calls throughout the CLI

--- a/src/nexus/remote/method_registry.py
+++ b/src/nexus/remote/method_registry.py
@@ -41,6 +41,7 @@ class MethodSpec:
 METHOD_REGISTRY: dict[str, MethodSpec] = {
     # --- Discovery (response_key extraction) ---
     "sys_readdir": MethodSpec(response_key="files"),
+    "list": MethodSpec(response_key="files"),
     "glob": MethodSpec(response_key="matches"),
     "grep": MethodSpec(response_key="results"),
     # --- Boolean result extraction ---

--- a/src/nexus/remote/service_proxy.py
+++ b/src/nexus/remote/service_proxy.py
@@ -20,10 +20,12 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from nexus.remote.rpc_proxy import RPCProxyBase
+
 logger = logging.getLogger(__name__)
 
 
-class RemoteServiceProxy:
+class RemoteServiceProxy(RPCProxyBase):
     """Universal RPC proxy injected as every service attribute in REMOTE mode.
 
     A single instance fills all 25+ service slots on NexusFS. The proxy
@@ -41,7 +43,7 @@ class RemoteServiceProxy:
         service_name: Optional label for debug logging (e.g. "universal").
     """
 
-    __slots__ = ("_call_rpc", "_service_name")
+    __slots__ = ("_call_rpc_cb", "_service_name")
 
     def __init__(
         self,
@@ -49,10 +51,21 @@ class RemoteServiceProxy:
         service_name: str = "",
     ) -> None:
         # Use object.__setattr__ to avoid triggering our __getattr__
-        object.__setattr__(self, "_call_rpc", call_rpc)
+        object.__setattr__(self, "_call_rpc_cb", call_rpc)
         object.__setattr__(self, "_service_name", service_name)
 
-    def __getattr__(self, name: str) -> Callable[..., Any]:
+    def _call_rpc(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        read_timeout: float | None = None,
+    ) -> Any:
+        """Call RPC callback. Satisfies RPCProxyBase interface."""
+        # Use object.__getattribute__ to avoid __getattr__ loops
+        call_rpc = object.__getattribute__(self, "_call_rpc_cb")
+        return call_rpc(method, params, read_timeout=read_timeout)
+
+    def __getattr__(self, name: str) -> Any:
         """Return an RPC forwarder for any public method access.
 
         Private/dunder attributes raise AttributeError immediately so
@@ -62,33 +75,28 @@ class RemoteServiceProxy:
         if name.startswith("_"):
             raise AttributeError(name)
 
-        # Lazy import to avoid circular dependency at module load
-        from nexus.remote.rpc_proxy import RPCProxyBase
+        from nexus.remote.method_registry import METHOD_REGISTRY
 
-        def rpc_forwarder(*args: Any, **kwargs: Any) -> Any:
-            # Server exposes async @rpc_expose methods; client-side sync
-            # wrappers append "_sync" — strip suffix for RPC dispatch.
-            rpc_name = name
-            if rpc_name.endswith("_sync"):
-                rpc_name = rpc_name[:-5]
+        spec = METHOD_REGISTRY.get(name)
 
-            # Map positional args to keyword args using ABC signature
-            if args:
-                param_names = RPCProxyBase._get_param_names(rpc_name)
-                for i, val in enumerate(args):
-                    if i < len(param_names):
-                        kwargs[param_names[i]] = val
+        # Server exposes async @rpc_expose methods; client-side sync
+        # wrappers append "_sync" — strip suffix for RPC dispatch.
+        rpc_name = name
+        if rpc_name.endswith("_sync"):
+            rpc_name = rpc_name[:-5]
+            # Update spec if it was found under the original name
+            if spec:
+                from dataclasses import replace
 
-            # Strip context params (handled server-side via auth headers)
-            kwargs.pop("context", None)
-            kwargs.pop("_context", None)
+                spec = replace(spec, rpc_name=rpc_name)
 
-            return self._call_rpc(rpc_name, kwargs or None)
+        def _proxy(*args: Any, **kwargs: Any) -> Any:
+            return self._dispatch_rpc(name, spec, args, kwargs)
 
         # Preserve method name for debugging
-        rpc_forwarder.__name__ = name
-        rpc_forwarder.__qualname__ = f"RemoteServiceProxy.{name}"
-        return rpc_forwarder
+        _proxy.__name__ = name
+        _proxy.__qualname__ = f"RemoteServiceProxy.{name}"
+        return _proxy
 
     def __repr__(self) -> str:
         name = object.__getattribute__(self, "_service_name")


### PR DESCRIPTION
## Summary
This PR enables reliable, always-on Nexus operation by providing system-level daemon configurations and fixing critical bugs in the Remote Profile transport.

### Changes:
- **Deployment:** Added `deployment/macos` with `launchd` plist template and `INSTALL.md`.
- **Remote Profile Fix:** Refactored `RemoteServiceProxy` to inherit from `RPCProxyBase`.
- **RPC Unwrapping:** Added `list` method to `METHOD_REGISTRY` to ensure correct response unwrapping for SearchService calls.
- **Verification:** Successfully tested `nexus ls /` using **Remote Mode** over **gRPC (Port 2028)**.

These changes are essential for the upcoming Feishu WebSocket Gateway, ensuring the CLI remains functional while the server holds the metastore lock.