### PR TITLE
refactor: NexusFS lifecycle methods link() / initialize() / bootstrap()

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -238,8 +238,88 @@ class NexusFS(  # type: ignore[misc]
 
         self._dispatch: KernelDispatch = KernelDispatch()
 
+        # Lifecycle state — set by link() / initialize() / bootstrap()
+        self._linked: bool = False
+        self._initialized: bool = False
+        self._bootstrapped: bool = False
+        self._bootstrap_callbacks: list[Callable[[], Any]] = []
+        self._permission_checker: Any = None  # set by link()
+        # Factory-injected lifecycle implementations.
+        # Keeps nexus.core free of nexus.factory / nexus.bricks imports.
+        self._link_fn: Callable[..., None] | None = None
+        self._initialize_fn: Callable[..., None] | None = None
+
+    # =====================================================================
+    # Lifecycle methods: link() → initialize() → bootstrap()
+    # =====================================================================
+
+    def link(
+        self,
+        *,
+        enabled_bricks: "frozenset[str] | None" = None,
+        parsing: Any = None,
+        workflow_engine: Any = None,
+    ) -> None:
+        """Phase 1: Wire service topology.  Pure memory — NO I/O.
+
+        Implementation is injected via ``_link_fn`` by the factory layer,
+        keeping the kernel free of factory/bricks imports.
+
+        Idempotent — guarded by ``_linked`` flag.
+        """
+        if self._linked:
+            return
+        if self._link_fn is not None:
+            self._link_fn(
+                self,
+                enabled_bricks=enabled_bricks,
+                parsing=parsing,
+                workflow_engine=workflow_engine,
+            )
+        self._linked = True
+
+    def initialize(self) -> None:
+        """Phase 2: One-time side effects.  NO background threads.
+
+        Implementation is injected via ``_initialize_fn`` by the factory layer.
+
+        Idempotent — guarded by ``_initialized`` flag.
+        """
+        if self._initialized:
+            return
+        if not self._linked:
+            self.link()
+        if self._initialize_fn is not None:
+            self._initialize_fn(self)
+        self._initialized = True
+
+    async def bootstrap(self) -> None:
+        """Phase 3: Start async tasks.  Server/Worker only.
+
+        Executes registered bootstrap callbacks.  Reserved for future
+        server-specific active components (Feishu WS, EventBus consumers,
+        background sync workers, etc.).
+
+        Idempotent — guarded by ``_bootstrapped`` flag.
+        """
+        if self._bootstrapped:
+            return
+        if not self._initialized:
+            self.initialize()
+        for cb in self._bootstrap_callbacks:
+            await cb()
+        self._bootstrapped = True
+
     # Services wired by factory via bind_wired_services() (Issue #1381).
     # See nexus.factory.service_routing.bind_wired_services().
+
+    @property
+    def namespace_manager(self) -> Any | None:
+        """Public accessor for the NamespaceManager (via PermissionEnforcer)."""
+        enforcer = self._permission_enforcer
+        if enforcer is not None:
+            return getattr(enforcer, "namespace_manager", None)
+        return None
 
     @property
     def config(self) -> Any | None:

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -1,0 +1,186 @@
+"""NexusFS lifecycle implementations — link() / initialize() / bootstrap().
+
+These factory-layer functions are injected into NexusFS as callables,
+keeping the kernel free of factory/bricks/system_services imports.
+
+See NexusFS.link(), NexusFS.initialize(), NexusFS.bootstrap().
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _do_link(
+    nx: Any,
+    *,
+    enabled_bricks: "frozenset[str] | None" = None,
+    parsing: Any = None,
+    workflow_engine: Any = None,
+) -> None:
+    """Phase 1 implementation: wire service topology.  Pure memory — NO I/O.
+
+    Creates ParsersBrick, CacheBrick, ContentCache; packs them into
+    BrickServices; boots wired services that need a NexusFS reference;
+    binds them onto ``nx``; creates PermissionChecker.
+    """
+    from dataclasses import replace as _dc_replace
+
+    from nexus.contracts.deployment_profile import DeploymentProfile as _DP
+    from nexus.factory._wired import _boot_wired_services
+    from nexus.factory.service_routing import bind_wired_services
+
+    _parsing = parsing if parsing is not None else nx._parse_config
+
+    # --- ParsersBrick (owns both registries — Issue #1523) ---
+    from nexus.bricks.parsers.brick import ParsersBrick
+
+    parsers_brick = ParsersBrick(parsing_config=_parsing)
+    _parse_fn = parsers_brick.create_parse_fn()
+
+    # --- CacheBrick (owns all cache domain services — Issue #1524) ---
+    from nexus.cache.brick import CacheBrick
+
+    _cache_brick = CacheBrick(
+        cache_store=nx.cache_store,
+        record_store=nx._record_store,
+    )
+
+    # --- ContentCache (Issue #657) ---
+    _content_cache = None
+    _cache_cfg = nx._cache_config
+    if _cache_cfg.enable_content_cache:
+        _root_backend: Any = None
+        try:
+            _root_backend = nx.router.route("/").backend
+        except Exception:
+            logger.debug("No root backend mounted — ContentCache disabled")
+        if _root_backend is not None and getattr(_root_backend, "has_root_path", False):
+            from nexus.storage.content_cache import ContentCache
+
+            _content_cache = ContentCache(max_size_mb=_cache_cfg.content_cache_size_mb)
+
+    # --- Pack factory-created bricks into BrickServices (Issue #2134) ---
+    _brick_updates: dict[str, Any] = {
+        "cache_brick": _cache_brick,
+        "parse_fn": _parse_fn,
+        "content_cache": _content_cache,
+        "parser_registry": parsers_brick.parser_registry,
+        "provider_registry": parsers_brick.provider_registry,
+    }
+    if workflow_engine is not None:
+        _brick_updates["workflow_engine"] = workflow_engine
+    nx._brick_services = _dc_replace(nx._brick_services, **_brick_updates)
+
+    # Update kernel-side references set by __init__ from original BrickServices
+    nx.parser_registry = parsers_brick.parser_registry
+    nx.provider_registry = parsers_brick.provider_registry
+    nx._virtual_view_parse_fn = _parse_fn
+    nx._parsers_brick = parsers_brick  # kept for BLM registration in initialize()
+
+    # --- Resolve enabled_bricks for profile gating ---
+    _resolved_bricks = enabled_bricks
+    if _resolved_bricks is None:
+        _resolved_bricks = _DP.FULL.default_bricks()
+
+    def _brick_on(name: str) -> bool:
+        return name in _resolved_bricks
+
+    # --- Boot + bind wired services (Tier 2b) ---
+    _wired = _boot_wired_services(
+        nx,
+        nx._kernel_services,
+        nx._system_services,
+        nx._brick_services,
+        _brick_on,
+    )
+    bind_wired_services(nx, _wired)
+
+    # MetadataExportService lives outside the slot map
+    _mds = getattr(_wired, "metadata_export_service", None)
+    if _mds is not None:
+        nx._metadata_export_service = _mds
+
+    # --- PermissionChecker (services layer — Issue #899) ---
+    from nexus.bricks.rebac.checker import PermissionChecker as _PC
+
+    nx._permission_checker = _PC(
+        permission_enforcer=nx._permission_enforcer,
+        metadata_store=nx.metadata,
+        default_context=nx._default_context,
+        enforce_permissions=nx._enforce_permissions,
+    )
+
+
+def _do_initialize(nx: Any) -> None:
+    """Phase 2 implementation: one-time side effects.  NO background threads.
+
+    Prepares resources but remains static — no active threads or async loops.
+    Background .start() calls are deferred to bootstrap() via callbacks.
+
+    IPC adapter bind + mount, VFS hook registration, BLM brick
+    registration, bootstrap callback registration for background workers.
+    """
+    # --- IPC adapter bind + mount (extracted from _boot_wired_services) ---
+    from nexus.factory._wired import _initialize_wired_ipc
+
+    _initialize_wired_ipc(nx, nx._brick_services)
+
+    # --- Register VFS hooks (INTERCEPT + OBSERVE — Issue #900) ---
+    from nexus.factory.orchestrator import _register_vfs_hooks
+
+    _register_vfs_hooks(
+        nx,
+        permission_checker=nx._permission_checker,
+        auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
+    )
+
+    # --- BLM registration for parsers/cache bricks (Issue #1704) ---
+    _blm = getattr(nx._system_services, "brick_lifecycle_manager", None)
+    if _blm is not None:
+        _cache_brick = getattr(nx._brick_services, "cache_brick", None)
+        _parsers_brick = getattr(nx, "_parsers_brick", None)
+        if _parsers_brick is not None:
+            _blm.register("parsers", _parsers_brick, protocol_name="ParsersProtocol")
+        if _cache_brick is not None:
+            _blm.register("cache", _cache_brick, protocol_name="CacheProtocol")
+
+    # --- Register background services as bootstrap callbacks ---
+    # TL directive: initialize() prepares resources but stays static.
+    # bootstrap() is the only phase allowed to spawn active threads/async loops.
+
+    _dpb = nx._deferred_permission_buffer
+    if _dpb is not None and hasattr(_dpb, "start"):
+
+        async def _start_dpb() -> None:
+            _dpb.start()
+            logger.debug("[LIFECYCLE] DeferredPermissionBuffer started (bootstrap)")
+
+        nx._bootstrap_callbacks.append(_start_dpb)
+
+    _dw = getattr(nx._system_services, "delivery_worker", None)
+    if _dw is not None and hasattr(_dw, "start"):
+
+        async def _start_dw() -> None:
+            _dw.start()
+            logger.debug("[LIFECYCLE] EventDeliveryWorker started (bootstrap)")
+
+        nx._bootstrap_callbacks.append(_start_dw)
+
+    _zl = nx._zone_lifecycle
+    if _zl is not None and hasattr(_zl, "load_terminating_zones"):
+
+        async def _load_zones() -> None:
+            try:
+                _sf = getattr(_zl, "_session_factory", None)
+                if _sf is not None:
+                    with _sf() as session:
+                        _zl.load_terminating_zones(session)
+                    logger.debug(
+                        "[LIFECYCLE] ZoneLifecycleService loaded terminating zones (bootstrap)"
+                    )
+            except Exception as exc:
+                logger.warning("[LIFECYCLE] Failed to load terminating zones: %s", exc)
+
+        nx._bootstrap_callbacks.append(_load_zones)

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -66,26 +66,7 @@ def _boot_wired_services(
     except Exception as exc:
         logger.warning("[BOOT:WIRED] NexusFSGateway unavailable: %s", exc)
 
-    # --- IPC KernelVFSAdapter: bind to NexusFS + mount LocalConnector ---
-    _ipc_adapter = getattr(brick_services, "ipc_storage_driver", None)
-    if _ipc_adapter is not None and hasattr(_ipc_adapter, "bind"):
-        try:
-            _ipc_adapter.bind(nx)
-
-            # Mount a LocalConnector at /agents for IPC file storage
-            from pathlib import Path
-
-            from nexus.backends.storage.local_connector import LocalConnectorBackend
-
-            _ipc_data_dir = Path(getattr(nx, "_data_dir", "data")) / "ipc"
-            _ipc_data_dir.mkdir(parents=True, exist_ok=True)
-            _ipc_connector = LocalConnectorBackend(local_path=_ipc_data_dir)
-            nx.router.add_mount("/agents", _ipc_connector)
-            logger.debug(
-                "[BOOT:WIRED] IPC KernelVFSAdapter bound + LocalConnector mounted at /agents"
-            )
-        except Exception as exc:
-            logger.warning("[BOOT:WIRED] IPC adapter bind failed: %s", exc)
+    # --- IPC KernelVFSAdapter: deferred to initialize() via _initialize_wired_ipc() ---
 
     # --- ReBACService: Permission and access control operations ---
     rebac_service: Any = None
@@ -493,3 +474,29 @@ def _boot_wired_services(
         elapsed,
     )
     return result
+
+
+def _initialize_wired_ipc(nx: Any, brick_services: "BrickServices") -> None:
+    """IPC adapter bind + mount — deferred from link() to initialize().
+
+    Performs I/O (mkdir) so it cannot run in the pure-memory link() phase.
+    """
+    _ipc_adapter = getattr(brick_services, "ipc_storage_driver", None)
+    if _ipc_adapter is not None and hasattr(_ipc_adapter, "bind"):
+        try:
+            _ipc_adapter.bind(nx)
+
+            # Mount a LocalConnector at /agents for IPC file storage
+            from pathlib import Path
+
+            from nexus.backends.storage.local_connector import LocalConnectorBackend
+
+            _ipc_data_dir = Path(getattr(nx, "_data_dir", "data")) / "ipc"
+            _ipc_data_dir.mkdir(parents=True, exist_ok=True)
+            _ipc_connector = LocalConnectorBackend(local_path=_ipc_data_dir)
+            nx.router.add_mount("/agents", _ipc_connector)
+            logger.debug(
+                "[BOOT:WIRED] IPC KernelVFSAdapter bound + LocalConnector mounted at /agents"
+            )
+        except Exception as exc:
+            logger.warning("[BOOT:WIRED] IPC adapter bind failed: %s", exc)

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from nexus.backends.base.backend import Backend
@@ -86,7 +86,6 @@ def create_nexus_services(
     from nexus.core.config import KernelServices as _KernelServices
     from nexus.core.config import PermissionConfig as _PermissionConfig
     from nexus.core.config import SystemServices as _SystemServices
-    from nexus.factory._background import _start_background_services
     from nexus.factory._boot_context import _BootContext
     from nexus.factory._bricks import _boot_dependent_bricks, _boot_independent_bricks
     from nexus.factory._helpers import _register_factory_bricks
@@ -160,8 +159,7 @@ def create_nexus_services(
     # --- Tier 2b: DEPENDENT BRICK (Issue #1861: artifact auto-indexing) ---
     _boot_dependent_bricks(ctx, system_dict, brick_dict)
 
-    # --- Start background threads post-construction ---
-    _start_background_services(system_dict)
+    # --- Background threads deferred to NexusFS.initialize() ---
 
     # --- Register factory-created bricks with lifecycle manager (Issue #1704) ---
     _blm = system_dict.get("brick_lifecycle_manager")
@@ -298,7 +296,6 @@ def create_nexus_fs(
     from nexus.core.config import SystemServices as _SystemServices
     from nexus.core.nexus_fs import NexusFS
     from nexus.core.router import PathRouter
-    from nexus.factory._wired import _boot_wired_services
 
     # Create and configure router
     router = PathRouter(metadata_store)
@@ -357,49 +354,7 @@ def create_nexus_fs(
     if brick_services is None:
         brick_services = _BrickServices()
 
-    from dataclasses import replace as _dc_replace
-
-    # Create ParsersBrick — owns both registries (Issue #1523)
-    from nexus.bricks.parsers.brick import ParsersBrick
-
-    parsers_brick = ParsersBrick(parsing_config=parsing)
-    _parse_fn = parsers_brick.create_parse_fn()
-
-    # Create CacheBrick — owns all cache domain services (Issue #1524)
-    from nexus.cache.brick import CacheBrick
-
-    _cache_brick = CacheBrick(
-        cache_store=cache_store,
-        record_store=record_store,
-    )
-
-    # Create content cache (Issue #657)
-    _content_cache = None
-    if cache is None:
-        from nexus.core.config import CacheConfig as _CC
-
-        _cache_for_cc = _CC()
-    else:
-        _cache_for_cc = cache
-    if _cache_for_cc.enable_content_cache and backend.has_root_path is True:
-        from nexus.storage.content_cache import ContentCache
-
-        _content_cache = ContentCache(max_size_mb=_cache_for_cc.content_cache_size_mb)
-
-    # NOTE: VFSLockManager is now kernel-internal (NexusFS.__init__ creates it).
-    # No longer injected via BrickServices. See write-path-extraction-design.md.
-
-    # Pack factory-created bricks into BrickServices container (Issue #2134)
-    _brick_updates: dict[str, Any] = {
-        "cache_brick": _cache_brick,
-        "parse_fn": _parse_fn,
-        "content_cache": _content_cache,
-        "parser_registry": parsers_brick.parser_registry,
-        "provider_registry": parsers_brick.provider_registry,
-    }
-    if workflow_engine is not None:
-        _brick_updates["workflow_engine"] = workflow_engine
-    brick_services = _dc_replace(brick_services, **_brick_updates)
+    from nexus.factory._lifecycle import _do_initialize, _do_link
 
     nx = NexusFS(
         metadata_store=metadata_store,
@@ -415,50 +370,14 @@ def create_nexus_fs(
         system_services=system_services,
         brick_services=brick_services,
     )
-
-    # --- Phase 2: Wire services needing NexusFS reference (Issue #643) ---
-    # Resolve enabled_bricks for brick gating (same pattern as create_nexus_services)
-    from nexus.contracts.deployment_profile import DeploymentProfile as _DP
-
-    _resolved_bricks = enabled_bricks
-    if _resolved_bricks is None:
-        _resolved_bricks = _DP.FULL.default_bricks()
-
-    def _brick_on(name: str) -> bool:
-        return name in _resolved_bricks
-
-    _wired = _boot_wired_services(nx, kernel_services, system_services, brick_services, _brick_on)
-    from nexus.factory.service_routing import bind_wired_services
-
-    bind_wired_services(nx, _wired)
-    _mds = getattr(_wired, "metadata_export_service", None)
-    if _mds is not None:
-        cast(Any, nx)._metadata_export_service = _mds
-
-    # Create PermissionChecker (services layer) — Issue #899
-    # Not stored on NexusFS; passed to hook registration below.
-    from nexus.bricks.rebac.checker import PermissionChecker as _PC
-
-    _permission_checker = _PC(
-        permission_enforcer=nx._permission_enforcer,
-        metadata_store=nx.metadata,
-        default_context=nx._default_context,
-        enforce_permissions=nx._enforce_permissions,
+    nx._link_fn = _do_link
+    nx._initialize_fn = _do_initialize
+    nx.link(
+        enabled_bricks=enabled_bricks,
+        parsing=parsing,
+        workflow_engine=workflow_engine,
     )
-
-    # Register bricks created in create_nexus_fs with lifecycle manager (Issue #1704)
-    _blm = getattr(system_services, "brick_lifecycle_manager", None)
-    if _blm is not None:
-        _blm.register("parsers", parsers_brick, protocol_name="ParsersProtocol")
-        _blm.register("cache", _cache_brick, protocol_name="CacheProtocol")
-
-    # --- Register INTERCEPT hooks on KernelDispatch (Issue #900) ---
-    _register_vfs_hooks(
-        nx,
-        permission_checker=_permission_checker,
-        auto_parse=parsing.auto_parse if parsing else True,
-    )
-
+    nx.initialize()
     return nx
 
 

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -159,7 +159,12 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
         if tracker is not None:
             tracker.complete(phase)
 
-    # --- Startup (order matters: observability first, then core, then services) ---
+    # --- Startup (order matters: bootstrap first, then observability, then services) ---
+
+    # NexusFS lifecycle Phase 3: start async tasks owned by NexusFS
+    nx = getattr(app.state, "nexus_fs", None)
+    if nx is not None and hasattr(nx, "bootstrap"):
+        await nx.bootstrap()
 
     await startup_observability(app, svc)
     # Re-extract observability_registry after startup_observability writes it

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -107,6 +107,9 @@ def test_all_public_methods_are_exposed_or_excluded():
     INTERNAL_ONLY_METHODS = {
         # Lifecycle/infrastructure methods
         "close",  # Connection management - handled differently for remote
+        "link",  # Boot phase 1 - pure memory wiring, not an RPC operation
+        "initialize",  # Boot phase 2 - one-time side effects, not an RPC operation
+        "bootstrap",  # Boot phase 3 - async task startup, server-only
         "load_all_saved_mounts",  # Internal initialization method - called automatically on startup
         # Server-side only methods (clients get this via HTTP headers)
         "get_etag",  # Returns ETag for early 304 check - clients receive ETags via HTTP headers on read


### PR DESCRIPTION
## Summary
- Adds three explicit lifecycle phases to NexusFS: `link()` (pure memory wiring), `initialize()` (one-time side effects), `bootstrap()` (async server tasks)
- Simplifies `create_nexus_fs()` from ~100 lines of inline wiring to `nx.link(); nx.initialize(); return nx`
- Extracts IPC adapter bind+mount from `_boot_wired_services()` into standalone `_initialize_wired_ipc()` for the initialize phase
- Background service `.start()` calls (DPB, EventDeliveryWorker, ZoneLifecycle) are registered as bootstrap callbacks during `initialize()`, executed during `bootstrap()` — server/worker only

## Architecture
```
create_nexus_fs()
  nx = NexusFS(...)
  nx.link()         # Phase 1: pure memory wiring (ParsersBrick, CacheBrick, wired services, PermissionChecker)
  nx.initialize()   # Phase 2: side effects (IPC bind, VFS hooks, BLM registration, register bootstrap callbacks)
  return nx

# Server lifespan only:
await nx.bootstrap()  # Phase 3: execute registered callbacks (DPB.start, EventDeliveryWorker.start, ZoneLifecycle.load)
```

## Files Changed
| File | Change |
|------|--------|
| `src/nexus/core/nexus_fs.py` | +80 — lifecycle flags, `link()`/`initialize()`/`bootstrap()`, `namespace_manager` property |
| `src/nexus/factory/_lifecycle.py` | +186 — `_do_link()` and `_do_initialize()` implementations (factory layer) |
| `src/nexus/factory/_wired.py` | +29/−20 — extract `_initialize_wired_ipc()` from `_boot_wired_services()` |
| `src/nexus/factory/orchestrator.py` | +14/−101 — simplify `create_nexus_fs()`, inject lifecycle callables |
| `src/nexus/server/lifespan/__init__.py` | +5/−2 — add `await nx.bootstrap()` in server startup |
| `tests/unit/server/test_rpc_parity.py` | +3 — add `link`/`initialize`/`bootstrap` to `INTERNAL_ONLY_METHODS` |

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, brick zero-core-imports)
- [x] RPC parity tests pass (4/4)
- [x] Local CLI: write/cat/info/ls/glob/grep ✅
- [x] Remote CLI via gRPC: write/cat/info/ls/glob/grep ✅
- [x] Lifecycle methods are idempotent (guarded by `_linked`/`_initialized`/`_bootstrapped` flags)
- [x] Backward compatible — NexusFS constructed without lifecycle calls still works
- [x] Rebased onto latest develop, squashed to single commit (312 insertions, 112 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)