### PR TITLE
feat(#2809): kubectl-style profile management with ~/.nexus/config.yaml

### DIFF
--- a/src/nexus/cli/commands/__init__.py
+++ b/src/nexus/cli/commands/__init__.py
@@ -54,6 +54,10 @@ _REGISTER_COMMANDS = [
     "status",  # status [--watch] [--json]
     "doctor",  # doctor [--json] [--fix]
     "start",  # start (federation-ready)
+    # Issue #2809: Profile management
+    "profile",  # profile list/add/use/delete/show/rename
+    "connect_cmd",  # Interactive connection setup
+    "config_cmd",  # Config show/set/get/reset
 ]
 
 # Modules that expose a single Click command/group to add via cli.add_command

--- a/src/nexus/cli/commands/config_cmd.py
+++ b/src/nexus/cli/commands/config_cmd.py
@@ -1,0 +1,146 @@
+"""Configuration commands — `nexus config show/get/set/reset`.
+
+Manages runtime settings in ~/.nexus/config.yaml under the `settings:` section.
+
+Supported keys:
+    default-zone-id, output.format, output.color,
+    timing.enabled, timing.verbosity,
+    connection.timeout, connection.pool-size
+"""
+
+import json
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from nexus.cli.config import (
+    SUPPORTED_SETTINGS,
+    get_config_path,
+    get_merged_settings,
+    get_setting,
+    load_cli_config,
+    reset_setting,
+    save_cli_config,
+    set_setting,
+)
+
+console = Console()
+
+
+@click.group(name="config")
+def config_group() -> None:
+    """View and modify Nexus CLI configuration.
+
+    Settings are stored in ~/.nexus/config.yaml under the `settings:` section.
+    Precedence: CLI flag > env var > config file > default.
+
+    Examples:
+        nexus config show
+        nexus config set output.format json
+        nexus config get timing.enabled
+        nexus config reset output.format
+    """
+
+
+@config_group.command(name="show")
+@click.option(
+    "--json-output", "--json", "json_out", is_flag=True, default=False, help="Output as JSON"
+)
+def show_cmd(json_out: bool) -> None:
+    """Show merged configuration with source annotations.
+
+    Examples:
+        nexus config show
+        nexus config show --json
+    """
+    config = load_cli_config()
+    merged = get_merged_settings(config)
+
+    if json_out:
+        output = {key: value for key, (value, _source) in merged.items()}
+        console.print(json.dumps(output, indent=2))
+        return
+
+    table = Table(title=f"Configuration ({get_config_path()})")
+    table.add_column("Key", style="bold")
+    table.add_column("Value")
+    table.add_column("Source", style="dim")
+
+    for key in sorted(merged):
+        value, source = merged[key]
+        value_str = str(value) if value is not None else "[dim]null[/dim]"
+        table.add_row(key, value_str, source)
+
+    console.print(table)
+
+    # Also show active profile info
+    if config.current_profile:
+        console.print(f"\nActive profile: [bold]{config.current_profile}[/bold]")
+
+
+@config_group.command(name="get")
+@click.argument("key", type=str)
+def get_cmd(key: str) -> None:
+    """Get a specific configuration value.
+
+    Examples:
+        nexus config get output.format
+        nexus config get timing.enabled
+    """
+    if key not in SUPPORTED_SETTINGS:
+        console.print(f"[red]Error:[/red] Unknown setting: {key}")
+        console.print(f"[dim]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/dim]")
+        raise SystemExit(1)
+
+    config = load_cli_config()
+    value = get_setting(config.settings, key)
+    click.echo(value)
+
+
+@config_group.command(name="set")
+@click.argument("key", type=str)
+@click.argument("value", type=str)
+def set_cmd(key: str, value: str) -> None:
+    """Set a configuration value.
+
+    Examples:
+        nexus config set output.format json
+        nexus config set timing.enabled true
+        nexus config set connection.timeout 60
+    """
+    if key not in SUPPORTED_SETTINGS:
+        console.print(f"[red]Error:[/red] Unknown setting: {key}")
+        console.print(f"[dim]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/dim]")
+        raise SystemExit(1)
+
+    config = load_cli_config()
+    config.settings = set_setting(config.settings, key, value)
+    save_cli_config(config)
+    console.print(f"Set [bold]{key}[/bold] = {value}")
+
+
+@config_group.command(name="reset")
+@click.argument("key", type=str)
+def reset_cmd(key: str) -> None:
+    """Reset a configuration value to its default.
+
+    Examples:
+        nexus config reset output.format
+        nexus config reset timing.enabled
+    """
+    if key not in SUPPORTED_SETTINGS:
+        console.print(f"[red]Error:[/red] Unknown setting: {key}")
+        console.print(f"[dim]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/dim]")
+        raise SystemExit(1)
+
+    config = load_cli_config()
+    config.settings = reset_setting(config.settings, key)
+    save_cli_config(config)
+    default = SUPPORTED_SETTINGS[key]
+    console.print(f"Reset [bold]{key}[/bold] to default ({default})")
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register config commands."""
+    cli.add_command(config_group)

--- a/src/nexus/cli/commands/connect_cmd.py
+++ b/src/nexus/cli/commands/connect_cmd.py
@@ -1,0 +1,143 @@
+"""Interactive connection setup — `nexus connect <url>`.
+
+Guides the user through:
+  1. Prompt for API key
+  2. Test connection (Ping RPC, 3s timeout)
+  3. Save as named profile
+"""
+
+import os
+from urllib.parse import urlparse
+
+import click
+from rich.console import Console
+
+from nexus.cli.config import (
+    ProfileEntry,
+    load_cli_config,
+    save_cli_config,
+)
+
+console = Console()
+
+_CONNECT_TIMEOUT = 3.0
+
+
+@click.command(name="connect")
+@click.argument("url", type=str)
+@click.option(
+    "--name", "-n", type=str, default=None, help="Profile name (default: derived from URL hostname)"
+)
+@click.option("--api-key", "-k", type=str, default=None, help="API key (skips interactive prompt)")
+@click.option("--zone-id", "-z", type=str, default=None, help="Default zone ID for this profile")
+@click.option("--skip-test", is_flag=True, default=False, help="Skip connection test")
+def connect_cmd(
+    url: str,
+    name: str | None,
+    api_key: str | None,
+    zone_id: str | None,
+    skip_test: bool,
+) -> None:
+    """Interactively set up a connection to a Nexus server.
+
+    Prompts for API key, tests the connection, and saves as a named profile.
+
+    Examples:
+        nexus connect https://nexus.prod.example.com
+        nexus connect http://localhost:2026 --name local --skip-test
+        nexus connect https://nexus.staging.example.com -k nx_test_xxx -n staging
+    """
+    # Derive profile name from hostname if not provided
+    if not name:
+        parsed = urlparse(url)
+        hostname = parsed.hostname or "unknown"
+        # Use first segment of hostname: nexus.prod.example.com -> nexus-prod
+        parts = hostname.split(".")
+        name = "-".join(parts[:2]) if len(parts) > 1 else parts[0]
+        if name in ("localhost", "127-0-0-1"):
+            name = "local"
+
+    # Prompt for API key if not provided
+    if api_key is None:
+        api_key = click.prompt(
+            "API key",
+            default="",
+            hide_input=True,
+            show_default=False,
+            prompt_suffix=": ",
+        )
+        if not api_key:
+            api_key = None
+
+    # Test connection
+    test_passed = True
+    if not skip_test:
+        test_passed = _test_connection_interactive(url, api_key)
+
+    if not test_passed:
+        # Connection failed — offer to save anyway
+        save_anyway = click.confirm(
+            "Connection test failed. Save profile anyway?",
+            default=False,
+        )
+        if not save_anyway:
+            console.print("[dim]Aborted. Profile not saved.[/dim]")
+            return
+
+    # Save profile
+    config = load_cli_config()
+    if name in config.profiles:
+        overwrite = click.confirm(
+            f"Profile '{name}' already exists. Overwrite?",
+            default=True,
+        )
+        if not overwrite:
+            console.print("[dim]Aborted. Profile not saved.[/dim]")
+            return
+
+    config.profiles[name] = ProfileEntry(url=url, api_key=api_key, zone_id=zone_id)
+    config.current_profile = name
+    save_cli_config(config)
+
+    console.print(f"\nSaved and activated profile [bold]'{name}'[/bold]")
+    console.print(f"  URL: {url}")
+    if zone_id:
+        console.print(f"  Zone: {zone_id}")
+
+
+def _test_connection_interactive(url: str, api_key: str | None) -> bool:
+    """Test connection with 3s timeout. Returns True if successful."""
+    console.print(f"[dim]Testing connection to {url}...[/dim]")
+
+    try:
+        from nexus.remote.rpc_transport import RPCTransport
+
+        grpc_port = int(os.getenv("NEXUS_GRPC_PORT", "2028"))
+        parsed = urlparse(url)
+        grpc_address = f"{parsed.hostname}:{grpc_port}"
+
+        transport = RPCTransport(
+            server_address=grpc_address,
+            auth_token=api_key,
+            timeout=_CONNECT_TIMEOUT,
+            connect_timeout=_CONNECT_TIMEOUT,
+        )
+        result = transport.ping()
+        console.print(
+            f"[green]Connected![/green] "
+            f"Server version {result.get('version', '?')}, "
+            f"zone '{result.get('zone_id', 'default')}'"
+        )
+        return True
+    except Exception as e:
+        console.print(f"[red]Connection failed:[/red] {e}")
+        # Offer retry
+        retry = click.confirm("Retry?", default=True)
+        if retry:
+            return _test_connection_interactive(url, api_key)
+        return False
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register connect command."""
+    cli.add_command(connect_cmd)

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -1,0 +1,279 @@
+"""Profile management commands — kubectl-style connection profiles.
+
+Commands:
+    nexus profile list          Show all profiles (* = active)
+    nexus profile use <name>    Switch active profile
+    nexus profile add <name>    Add a new profile
+    nexus profile show          Show current profile details
+    nexus profile delete <name> Delete a profile
+    nexus profile rename <old> <new>  Rename a profile
+"""
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from nexus.cli.config import (
+    ProfileEntry,
+    get_config_path,
+    load_cli_config,
+    save_cli_config,
+)
+
+console = Console()
+
+
+@click.group(name="profile")
+def profile_group() -> None:
+    """Manage connection profiles for different Nexus environments.
+
+    Profiles store connection parameters (URL, API key, zone ID) in
+    ~/.nexus/config.yaml. Switch between local, staging, and production
+    with a single command.
+
+    Examples:
+        nexus profile list
+        nexus profile add staging --url https://nexus.staging.example.com
+        nexus profile use staging
+        nexus --profile staging ls /
+    """
+
+
+@profile_group.command(name="list")
+def list_cmd() -> None:
+    """Show all saved profiles (* = active).
+
+    Examples:
+        nexus profile list
+    """
+    config = load_cli_config()
+
+    if not config.profiles:
+        console.print("[dim]No profiles configured.[/dim]")
+        console.print("[dim]Add one with:[/dim] nexus profile add <name> --url <url>")
+        return
+
+    table = Table(title=f"Profiles ({get_config_path()})")
+    table.add_column("", width=1)
+    table.add_column("Name", style="bold")
+    table.add_column("URL")
+    table.add_column("Zone ID")
+    table.add_column("API Key")
+
+    for name, entry in sorted(config.profiles.items()):
+        is_active = name == config.current_profile
+        marker = "[green]*[/green]" if is_active else ""
+        api_key_display = _mask_api_key(entry.api_key) if entry.api_key else "[dim]-[/dim]"
+        table.add_row(
+            marker,
+            name,
+            entry.url or "[dim]-[/dim]",
+            entry.zone_id or "[dim]-[/dim]",
+            api_key_display,
+        )
+
+    console.print(table)
+
+
+@profile_group.command(name="use")
+@click.argument("name", type=str)
+def use_cmd(name: str) -> None:
+    """Switch the active profile.
+
+    Examples:
+        nexus profile use staging
+        nexus profile use production
+    """
+    config = load_cli_config()
+
+    if name not in config.profiles:
+        console.print(f"[red]Error:[/red] Profile '{name}' not found.")
+        available = ", ".join(sorted(config.profiles.keys())) if config.profiles else "none"
+        console.print(f"[dim]Available profiles: {available}[/dim]")
+        raise SystemExit(1)
+
+    config.current_profile = name
+    save_cli_config(config)
+    profile = config.profiles[name]
+    console.print(f"Switched to profile [bold]'{name}'[/bold]")
+    if profile.url:
+        console.print(f"  URL: {profile.url}")
+
+
+@profile_group.command(name="add")
+@click.argument("name", type=str)
+@click.option("--url", type=str, default=None, help="Nexus server URL")
+@click.option("--api-key", type=str, default=None, help="API key for authentication")
+@click.option("--zone-id", type=str, default=None, help="Default zone ID")
+@click.option("--use/--no-use", default=False, help="Set as active profile after adding")
+def add_cmd(
+    name: str,
+    url: str | None,
+    api_key: str | None,
+    zone_id: str | None,
+    use: bool,
+) -> None:
+    """Add a new connection profile.
+
+    Examples:
+        nexus profile add staging --url https://nexus.staging.example.com --api-key nx_test_xxx
+        nexus profile add local --url http://localhost:2026 --use
+    """
+    config = load_cli_config()
+
+    if name in config.profiles:
+        console.print(f"[red]Error:[/red] Profile '{name}' already exists.")
+        console.print("[dim]Use 'nexus profile delete' first, or choose a different name.[/dim]")
+        raise SystemExit(1)
+
+    config.profiles[name] = ProfileEntry(url=url, api_key=api_key, zone_id=zone_id)
+    if use:
+        config.current_profile = name
+    save_cli_config(config)
+
+    console.print(f"Added profile [bold]'{name}'[/bold]")
+    if use:
+        console.print("  Set as active profile")
+
+
+@profile_group.command(name="delete")
+@click.argument("name", type=str)
+@click.option("--force", is_flag=True, default=False, help="Skip confirmation")
+def delete_cmd(name: str, force: bool) -> None:
+    """Delete a saved profile.
+
+    Examples:
+        nexus profile delete old-staging
+        nexus profile delete old-staging --force
+    """
+    config = load_cli_config()
+
+    if name not in config.profiles:
+        console.print(f"[red]Error:[/red] Profile '{name}' not found.")
+        raise SystemExit(1)
+
+    if not force:
+        click.confirm(f"Delete profile '{name}'?", abort=True)
+
+    del config.profiles[name]
+    if config.current_profile == name:
+        config.current_profile = None
+        console.print(
+            f"[yellow]Note:[/yellow] '{name}' was the active profile. No profile is now active."
+        )
+
+    save_cli_config(config)
+    console.print(f"Deleted profile [bold]'{name}'[/bold]")
+
+
+@profile_group.command(name="show")
+@click.option(
+    "--test", is_flag=True, default=False, help="Test connection to the active profile's server"
+)
+def show_cmd(test: bool) -> None:
+    """Show the current active profile and its settings.
+
+    Examples:
+        nexus profile show
+        nexus profile show --test
+    """
+    from nexus.cli.config import resolve_connection
+
+    config = load_cli_config()
+    resolved = resolve_connection(config=config)
+
+    if config.current_profile:
+        console.print(f"Active profile: [bold]{config.current_profile}[/bold]")
+    else:
+        console.print("[dim]No active profile (using defaults)[/dim]")
+
+    console.print(f"  URL:    {resolved.url or '[dim]local[/dim]'}")
+    console.print(f"  Zone:   {resolved.zone_id or '[dim]not set[/dim]'}")
+    console.print(f"  Source: {resolved.source}")
+
+    if resolved.api_key:
+        console.print(f"  Key:    {_mask_api_key(resolved.api_key)}")
+
+    if test and resolved.is_remote:
+        _test_connection(resolved.url, resolved.api_key)
+    elif test and not resolved.is_remote:
+        console.print("[dim]Skipping connection test (local mode)[/dim]")
+
+
+@profile_group.command(name="rename")
+@click.argument("old_name", type=str)
+@click.argument("new_name", type=str)
+def rename_cmd(old_name: str, new_name: str) -> None:
+    """Rename an existing profile.
+
+    Examples:
+        nexus profile rename staging staging-v2
+    """
+    config = load_cli_config()
+
+    if old_name not in config.profiles:
+        console.print(f"[red]Error:[/red] Profile '{old_name}' not found.")
+        raise SystemExit(1)
+
+    if new_name in config.profiles:
+        console.print(f"[red]Error:[/red] Profile '{new_name}' already exists.")
+        raise SystemExit(1)
+
+    config.profiles[new_name] = config.profiles.pop(old_name)
+    if config.current_profile == old_name:
+        config.current_profile = new_name
+
+    save_cli_config(config)
+    console.print(f"Renamed profile [bold]'{old_name}'[/bold] to [bold]'{new_name}'[/bold]")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mask_api_key(key: str) -> str:
+    """Mask an API key for display (show first 8 chars + last 4)."""
+    if len(key) <= 12:
+        return key[:4] + "****"
+    return key[:8] + "****" + key[-4:]
+
+
+def _test_connection(url: str | None, api_key: str | None) -> None:
+    """Test connection to a remote Nexus server."""
+    import os
+    from urllib.parse import urlparse
+
+    if not url:
+        console.print("[red]Error:[/red] No URL to test")
+        return
+
+    console.print("[dim]Testing connection...[/dim]")
+
+    try:
+        from nexus.remote.rpc_transport import RPCTransport
+
+        grpc_port = int(os.getenv("NEXUS_GRPC_PORT", "2028"))
+        parsed = urlparse(url)
+        grpc_address = f"{parsed.hostname}:{grpc_port}"
+
+        transport = RPCTransport(
+            server_address=grpc_address,
+            auth_token=api_key,
+            timeout=3.0,
+            connect_timeout=3.0,
+        )
+        result = transport.ping()
+        console.print(
+            f"[green]Connection OK[/green] "
+            f"(version={result.get('version', '?')}, "
+            f"zone={result.get('zone_id', '?')}, "
+            f"uptime={result.get('uptime', '?')}s)"
+        )
+    except Exception as e:
+        console.print(f"[red]Connection failed:[/red] {e}")
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register profile commands."""
+    cli.add_command(profile_group)

--- a/src/nexus/cli/config.py
+++ b/src/nexus/cli/config.py
@@ -1,0 +1,379 @@
+"""CLI configuration — profile management and connection resolution.
+
+Manages ~/.nexus/config.yaml with named connection profiles and settings.
+Provides resolve_connection() as the single source of truth for "which server
+am I connecting to and why?"
+
+Config file format:
+    current-profile: production
+    profiles:
+      local:
+        url: http://localhost:2026
+        api-key: nx_test_local_dev
+        zone-id: default
+      production:
+        url: https://nexus.prod.example.com
+        api-key: nx_live_prod_abc123
+        zone-id: us-west-1
+    settings:
+      output:
+        format: table
+        color: true
+      connection:
+        timeout: 30
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CONFIG_DIR = Path.home() / ".nexus"
+CONFIG_FILE = CONFIG_DIR / "config.yaml"
+_FILE_PERMISSIONS = 0o600  # Owner read/write only
+_DIR_PERMISSIONS = 0o700  # Owner rwx only
+
+# Settings that nexus config set/get/reset can modify
+SUPPORTED_SETTINGS: dict[str, Any] = {
+    "default-zone-id": None,
+    "output.format": "table",
+    "output.color": True,
+    "timing.enabled": False,
+    "timing.verbosity": "normal",
+    "connection.timeout": 30,
+    "connection.pool-size": 10,
+}
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProfileEntry:
+    """A single named connection profile."""
+
+    url: str | None = None
+    api_key: str | None = None
+    zone_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        if self.url is not None:
+            d["url"] = self.url
+        if self.api_key is not None:
+            d["api-key"] = self.api_key
+        if self.zone_id is not None:
+            d["zone-id"] = self.zone_id
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProfileEntry:
+        return cls(
+            url=data.get("url"),
+            api_key=data.get("api-key"),
+            zone_id=data.get("zone-id"),
+        )
+
+
+@dataclass
+class NexusCliConfig:
+    """Parsed ~/.nexus/config.yaml."""
+
+    current_profile: str | None = None
+    profiles: dict[str, ProfileEntry] = field(default_factory=dict)
+    settings: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        if self.current_profile is not None:
+            d["current-profile"] = self.current_profile
+        if self.profiles:
+            d["profiles"] = {name: p.to_dict() for name, p in self.profiles.items()}
+        if self.settings:
+            d["settings"] = self.settings
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NexusCliConfig:
+        profiles: dict[str, ProfileEntry] = {}
+        raw_profiles = data.get("profiles", {})
+        if isinstance(raw_profiles, dict):
+            for name, pdata in raw_profiles.items():
+                if isinstance(pdata, dict):
+                    profiles[name] = ProfileEntry.from_dict(pdata)
+        settings = data.get("settings", {})
+        if not isinstance(settings, dict):
+            settings = {}
+        return cls(
+            current_profile=data.get("current-profile"),
+            profiles=profiles,
+            settings=settings,
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedConnection:
+    """Result of resolve_connection() — the effective connection config with source annotations."""
+
+    url: str | None = None
+    api_key: str | None = None
+    zone_id: str | None = None
+    source: str = "default (local)"
+
+    @property
+    def is_remote(self) -> bool:
+        return bool(self.url and self.url.strip())
+
+
+# ---------------------------------------------------------------------------
+# Config file I/O
+# ---------------------------------------------------------------------------
+
+
+def get_config_path() -> Path:
+    """Return the config file path (~/.nexus/config.yaml)."""
+    return CONFIG_FILE
+
+
+def load_cli_config(path: Path | None = None) -> NexusCliConfig:
+    """Load CLI config from disk. Returns empty config if file doesn't exist."""
+    config_path = path or CONFIG_FILE
+    if not config_path.exists():
+        return NexusCliConfig()
+    _check_file_permissions(config_path)
+    with open(config_path) as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        return NexusCliConfig()
+    return NexusCliConfig.from_dict(data)
+
+
+def save_cli_config(config: NexusCliConfig, path: Path | None = None) -> None:
+    """Save CLI config to disk with 0600 permissions."""
+    config_path = path or CONFIG_FILE
+    _ensure_config_dir(config_path.parent)
+    data = config.to_dict()
+    tmp_path = config_path.with_suffix(".yaml.tmp")
+    with open(tmp_path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+    os.chmod(tmp_path, _FILE_PERMISSIONS)
+    tmp_path.rename(config_path)
+
+
+def _ensure_config_dir(dir_path: Path) -> None:
+    """Create config directory with 0700 permissions if it doesn't exist."""
+    if not dir_path.exists():
+        dir_path.mkdir(parents=True, mode=_DIR_PERMISSIONS)
+    elif not dir_path.is_dir():
+        msg = f"Config path exists but is not a directory: {dir_path}"
+        raise FileExistsError(msg)
+
+
+def _check_file_permissions(path: Path) -> None:
+    """Warn if config file has overly permissive permissions."""
+    try:
+        file_stat = path.stat()
+        mode = file_stat.st_mode
+        if mode & (stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH):
+            from rich.console import Console
+
+            Console(stderr=True).print(
+                f"[yellow]Warning:[/yellow] {path} has permissions "
+                f"{oct(stat.S_IMODE(mode))}. "
+                f"Recommended: {oct(_FILE_PERMISSIONS)} (owner read/write only). "
+                f"Fix with: chmod 600 {path}"
+            )
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Connection resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_connection(
+    remote_url: str | None = None,
+    remote_api_key: str | None = None,
+    profile_name: str | None = None,
+    zone_id: str | None = None,
+    config: NexusCliConfig | None = None,
+) -> ResolvedConnection:
+    """Resolve the effective connection parameters.
+
+    Precedence (highest to lowest):
+        1. Explicit CLI flags (--remote-url / --remote-api-key)
+           Note: NEXUS_URL / NEXUS_API_KEY env vars are mapped to these by Click.
+        2. Named profile (--profile flag)
+        3. current-profile from ~/.nexus/config.yaml
+        4. Local default (no URL)
+
+    Args:
+        remote_url: From --remote-url flag or NEXUS_URL env (via Click envvar).
+        remote_api_key: From --remote-api-key flag or NEXUS_API_KEY env.
+        profile_name: From --profile flag.
+        zone_id: From --zone-id flag or NEXUS_ZONE_ID env.
+        config: Pre-loaded CLI config (loaded lazily if None).
+
+    Returns:
+        ResolvedConnection with effective values and source annotation.
+    """
+    # Strip whitespace from URL to avoid connecting to " " (whitespace bug fix)
+    if remote_url is not None:
+        remote_url = remote_url.strip() or None
+    if remote_api_key is not None:
+        remote_api_key = remote_api_key.strip() or None
+
+    # Precedence 1: Explicit CLI flags / env vars
+    if remote_url:
+        return ResolvedConnection(
+            url=remote_url,
+            api_key=remote_api_key,
+            zone_id=zone_id,
+            source="--remote-url flag / NEXUS_URL env",
+        )
+
+    # Load config lazily if not provided
+    if config is None:
+        config = load_cli_config()
+
+    # Precedence 2: Named profile from --profile flag
+    effective_profile_name = profile_name
+    source_prefix = "--profile flag"
+
+    # Precedence 3: current-profile from config file
+    if effective_profile_name is None and config.current_profile:
+        effective_profile_name = config.current_profile
+        source_prefix = f"current-profile in {get_config_path()}"
+
+    if effective_profile_name and effective_profile_name in config.profiles:
+        profile = config.profiles[effective_profile_name]
+        return ResolvedConnection(
+            url=profile.url,
+            api_key=profile.api_key,
+            zone_id=zone_id or profile.zone_id,
+            source=f"profile '{effective_profile_name}' ({source_prefix})",
+        )
+
+    if effective_profile_name and effective_profile_name not in config.profiles:
+        from rich.console import Console
+
+        Console(stderr=True).print(
+            f"[yellow]Warning:[/yellow] Profile '{effective_profile_name}' "
+            f"not found in {get_config_path()}. Falling back to local default."
+        )
+
+    # Precedence 4: Local default
+    return ResolvedConnection(
+        url=None,
+        api_key=None,
+        zone_id=zone_id,
+        source="default (local)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Settings helpers
+# ---------------------------------------------------------------------------
+
+
+def get_setting(settings: dict[str, Any], key: str) -> Any:
+    """Get a nested setting by dotted key (e.g., 'output.format')."""
+    parts = key.split(".")
+    current: Any = settings
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            return SUPPORTED_SETTINGS.get(key)
+        current = current[part]
+    return current
+
+
+def set_setting(settings: dict[str, Any], key: str, value: Any) -> dict[str, Any]:
+    """Set a nested setting by dotted key. Returns new dict (immutable)."""
+    parts = key.split(".")
+    result = _deep_copy_dict(settings)
+    current = result
+    for part in parts[:-1]:
+        if part not in current or not isinstance(current[part], dict):
+            current[part] = {}
+        current = current[part]
+    current[parts[-1]] = _coerce_value(value)
+    return result
+
+
+def reset_setting(settings: dict[str, Any], key: str) -> dict[str, Any]:
+    """Reset a setting to its default. Returns new dict (immutable)."""
+    default = SUPPORTED_SETTINGS.get(key)
+    if default is None:
+        # Remove the key entirely
+        parts = key.split(".")
+        result = _deep_copy_dict(settings)
+        current = result
+        for part in parts[:-1]:
+            if part not in current or not isinstance(current[part], dict):
+                return result  # Key path doesn't exist, nothing to reset
+            current = current[part]
+        current.pop(parts[-1], None)
+        return result
+    return set_setting(settings, key, default)
+
+
+def _coerce_value(value: str | Any) -> Any:
+    """Coerce string values to appropriate Python types."""
+    if not isinstance(value, str):
+        return value
+    lower = value.lower()
+    if lower in ("true", "yes"):
+        return True
+    if lower in ("false", "no"):
+        return False
+    if lower == "null" or lower == "none":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value
+
+
+def _deep_copy_dict(d: dict[str, Any]) -> dict[str, Any]:
+    """Deep copy a dict of primitives and nested dicts."""
+    result: dict[str, Any] = {}
+    for k, v in d.items():
+        if isinstance(v, dict):
+            result[k] = _deep_copy_dict(v)
+        elif isinstance(v, list):
+            result[k] = list(v)
+        else:
+            result[k] = v
+    return result
+
+
+def get_merged_settings(config: NexusCliConfig) -> dict[str, tuple[Any, str]]:
+    """Get all settings with their values and sources.
+
+    Returns dict of key -> (value, source) for display in `nexus config show`.
+    """
+    merged: dict[str, tuple[Any, str]] = {}
+    for key, default in SUPPORTED_SETTINGS.items():
+        file_value = get_setting(config.settings, key)
+        if file_value != default:
+            merged[key] = (file_value, str(get_config_path()))
+        else:
+            merged[key] = (default, "default")
+    return merged

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -23,7 +23,14 @@ setup_uvloop()
 
 @click.group()
 @click.version_option(version=nexus.__version__, prog_name="nexus")
-def main() -> None:
+@click.option(
+    "--profile",
+    type=str,
+    default=None,
+    help="Use named connection profile from ~/.nexus/config.yaml.",
+)
+@click.pass_context
+def main(ctx: click.Context, profile: str | None) -> None:
     """Nexus - AI-Native Distributed Filesystem.
 
     Beautiful command-line interface for file operations, discovery, and management.
@@ -55,10 +62,15 @@ def main() -> None:
         nexus serve --host 0.0.0.0 --port 2026
         nexus mount /mnt/nexus
 
+        # Profile management
+        nexus profile list
+        nexus --profile staging ls /
+
     For more information on specific commands, use:
         nexus <command> --help
     """
-    pass
+    ctx.ensure_object(dict)
+    ctx.obj["profile"] = profile
 
 
 # Register all commands from the modular structure

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -97,7 +97,8 @@ ZONE_ID_OPTION = click.option(
     "--zone-id",
     type=str,
     default=None,
-    help="Zone ID for multi-zone isolation (e.g., 'org_acme'). Can also be set via NEXUS_ZONE_ID env var.",
+    envvar="NEXUS_ZONE_ID",
+    help="Zone ID for multi-zone isolation (e.g., 'org_acme').",
 )
 
 IS_ADMIN_OPTION = click.option(
@@ -199,6 +200,9 @@ def get_filesystem(
 ) -> NexusFilesystem:
     """Get Nexus filesystem instance from backend configuration.
 
+    Uses resolve_connection() to determine the effective connection target
+    when no explicit --remote-url, --config, or --backend=gcs is provided.
+
     Args:
         backend_config: Backend configuration
         enforce_permissions: Whether to enforce permissions (None = use environment/config default)
@@ -223,12 +227,13 @@ def get_filesystem(
     try:
         # If server_profile is set, the caller is a server — always use local NexusFS
         if not server_profile and backend_config.remote_url:
-            # Client mode: use remote server connection via nexus.connect()
+            # Client mode: explicit --remote-url flag takes highest priority
+            resolved = _resolve_backend_url(backend_config)
             return nexus.connect(
                 config={
                     "profile": "remote",
-                    "url": backend_config.remote_url,
-                    "api_key": backend_config.remote_api_key,
+                    "url": resolved.url,
+                    "api_key": resolved.api_key,
                 }
             )
         elif backend_config.config_path:
@@ -243,7 +248,6 @@ def get_filesystem(
                 }
                 _apply_common_config(config_dict, **common_kwargs)
                 nx_fs = nexus.connect(config=config_dict)
-                # Store full config object for OAuth factory access
                 if hasattr(nx_fs, "_config") or hasattr(nx_fs, "__dict__"):
                     nx_fs._config = config_obj
                 return nx_fs
@@ -268,7 +272,17 @@ def get_filesystem(
             _apply_common_config(config, **common_kwargs)
             return nexus.connect(config=config)
         else:
-            # Use local backend (default)
+            # No explicit flags — resolve via profiles
+            resolved = _resolve_backend_url(backend_config)
+            if resolved.is_remote:
+                return nexus.connect(
+                    config={
+                        "profile": "remote",
+                        "url": resolved.url,
+                        "api_key": resolved.api_key,
+                    }
+                )
+            # Local backend (default)
             config = {
                 "profile": server_profile or "full",
                 "data_dir": backend_config.data_dir,
@@ -278,6 +292,26 @@ def get_filesystem(
     except Exception as e:
         console.print(f"[red]Error connecting to Nexus:[/red] {e}")
         sys.exit(1)
+
+
+def _resolve_backend_url(backend_config: BackendConfig) -> Any:
+    """Resolve connection using profile config when backend_config has a URL or needs profile lookup."""
+    from nexus.cli.config import resolve_connection
+
+    # Get profile name from Click context if available
+    profile_name = None
+    try:
+        ctx = click.get_current_context(silent=True)
+        if ctx and ctx.obj:
+            profile_name = ctx.obj.get("profile")
+    except RuntimeError:
+        pass
+
+    return resolve_connection(
+        remote_url=backend_config.remote_url,
+        remote_api_key=backend_config.remote_api_key,
+        profile_name=profile_name,
+    )
 
 
 def create_backend_from_config(
@@ -315,30 +349,29 @@ def get_default_filesystem() -> NexusFilesystem:
     """Get Nexus filesystem instance with default configuration.
 
     Used by commands that don't accept backend options (e.g., memory commands).
-    Supports both local and remote profiles via environment variables:
-    - NEXUS_URL: Remote server URL (if set, uses remote profile)
-    - NEXUS_API_KEY: API key for remote authentication
-    - NEXUS_DATA_DIR: Data directory for local profile (default: ~/.nexus)
+    Resolves connection via the standard precedence chain:
+    NEXUS_URL env > active profile > local default.
 
     Returns:
-        NexusFilesystem instance (remote if NEXUS_URL is set, otherwise local)
+        NexusFilesystem instance (remote if NEXUS_URL is set or profile is active, otherwise local)
     """
     try:
-        import os
+        from nexus.cli.config import resolve_connection
 
-        # Check for remote URL first (priority over local)
-        remote_url = os.environ.get("NEXUS_URL")
-        if remote_url:
-            # Use remote server connection via nexus.connect()
+        resolved = resolve_connection(
+            remote_url=os.environ.get("NEXUS_URL"),
+            remote_api_key=os.environ.get("NEXUS_API_KEY"),
+        )
+
+        if resolved.is_remote:
             return nexus.connect(
                 config={
                     "profile": "remote",
-                    "url": remote_url,
-                    "api_key": os.environ.get("NEXUS_API_KEY"),
+                    "url": resolved.url,
+                    "api_key": resolved.api_key,
                 }
             )
 
-        # Fall back to local mode
         data_dir = os.environ.get("NEXUS_DATA_DIR", str(Path.home() / ".nexus"))
         return nexus.connect(config={"data_dir": data_dir})
     except Exception as e:
@@ -408,14 +441,12 @@ def get_zone_id(zone_id: str | None) -> str | None:
     """Get zone ID from parameter or environment.
 
     Args:
-        zone_id: Zone ID from CLI parameter
+        zone_id: Zone ID from CLI parameter (or NEXUS_ZONE_ID via Click envvar)
 
     Returns:
         Zone ID or None
     """
-    if zone_id:
-        return zone_id
-    return os.getenv("NEXUS_ZONE_ID")
+    return zone_id or None
 
 
 def create_operation_context(

--- a/tests/unit/cli/__init__.py
+++ b/tests/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI unit tests."""

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,17 +1,101 @@
-"""Shared fixtures for CLI command tests."""
+"""Shared test fixtures for CLI tests."""
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from click.testing import CliRunner
+
+from nexus.cli.config import NexusCliConfig, ProfileEntry
 
 
 @pytest.fixture()
 def cli_runner() -> CliRunner:
     """Click CLI test runner with isolated filesystem."""
     return CliRunner()
+
+
+@pytest.fixture()
+def tmp_config_dir(tmp_path: Path) -> Path:
+    """Temporary ~/.nexus/ directory."""
+    config_dir = tmp_path / ".nexus"
+    config_dir.mkdir()
+    return config_dir
+
+
+@pytest.fixture()
+def tmp_config_file(tmp_config_dir: Path) -> Path:
+    """Path to temporary config.yaml (not yet created)."""
+    return tmp_config_dir / "config.yaml"
+
+
+@pytest.fixture()
+def sample_config() -> NexusCliConfig:
+    """Sample config with two profiles."""
+    return NexusCliConfig(
+        current_profile="local",
+        profiles={
+            "local": ProfileEntry(
+                url="http://localhost:2026",
+                api_key="nx_test_local_dev",
+                zone_id="default",
+            ),
+            "production": ProfileEntry(
+                url="https://nexus.prod.example.com",
+                api_key="nx_live_prod_abc123",
+                zone_id="us-west-1",
+            ),
+        },
+        settings={
+            "output": {"format": "table", "color": True},
+            "timing": {"enabled": False},
+        },
+    )
+
+
+def write_config(path: Path, config: NexusCliConfig) -> None:
+    """Write a NexusCliConfig to a YAML file."""
+    with open(path, "w") as f:
+        yaml.dump(config.to_dict(), f, default_flow_style=False, sort_keys=False)
+
+
+@pytest.fixture()
+def mock_connect() -> MagicMock:
+    """Mock for nexus.connect() that captures config dicts."""
+    mock = MagicMock()
+    mock.return_value = MagicMock(spec=["close", "sys_read", "sys_write"])
+    return mock
+
+
+def make_config(
+    *,
+    current_profile: str | None = None,
+    profiles: dict[str, dict[str, Any]] | None = None,
+    settings: dict[str, Any] | None = None,
+) -> NexusCliConfig:
+    """Factory for creating NexusCliConfig in tests."""
+    parsed_profiles: dict[str, ProfileEntry] = {}
+    if profiles:
+        for name, data in profiles.items():
+            parsed_profiles[name] = ProfileEntry(
+                url=data.get("url"),
+                api_key=data.get("api_key") or data.get("api-key"),
+                zone_id=data.get("zone_id") or data.get("zone-id"),
+            )
+    return NexusCliConfig(
+        current_profile=current_profile,
+        profiles=parsed_profiles,
+        settings=settings or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure / Compose fixtures (from develop)
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -1,0 +1,410 @@
+"""Tests for nexus.cli.config — profile management and connection resolution."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from nexus.cli.config import (
+    NexusCliConfig,
+    ProfileEntry,
+    ResolvedConnection,
+    _coerce_value,
+    get_setting,
+    load_cli_config,
+    reset_setting,
+    resolve_connection,
+    save_cli_config,
+    set_setting,
+)
+from tests.unit.cli.conftest import make_config
+
+# ---------------------------------------------------------------------------
+# ProfileEntry
+# ---------------------------------------------------------------------------
+
+
+class TestProfileEntry:
+    def test_from_dict_full(self) -> None:
+        entry = ProfileEntry.from_dict(
+            {
+                "url": "http://localhost:2026",
+                "api-key": "nx_test_abc",
+                "zone-id": "us-west-1",
+            }
+        )
+        assert entry.url == "http://localhost:2026"
+        assert entry.api_key == "nx_test_abc"
+        assert entry.zone_id == "us-west-1"
+
+    def test_from_dict_minimal(self) -> None:
+        entry = ProfileEntry.from_dict({})
+        assert entry.url is None
+        assert entry.api_key is None
+        assert entry.zone_id is None
+
+    def test_to_dict_roundtrip(self) -> None:
+        original = ProfileEntry(url="http://x", api_key="key", zone_id="z1")
+        restored = ProfileEntry.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_to_dict_omits_none(self) -> None:
+        entry = ProfileEntry(url="http://x")
+        d = entry.to_dict()
+        assert "url" in d
+        assert "api-key" not in d
+        assert "zone-id" not in d
+
+    def test_frozen(self) -> None:
+        entry = ProfileEntry(url="http://x")
+        with pytest.raises(AttributeError):
+            entry.url = "http://y"
+
+
+# ---------------------------------------------------------------------------
+# NexusCliConfig
+# ---------------------------------------------------------------------------
+
+
+class TestNexusCliConfig:
+    def test_from_dict_empty(self) -> None:
+        config = NexusCliConfig.from_dict({})
+        assert config.current_profile is None
+        assert config.profiles == {}
+        assert config.settings == {}
+
+    def test_from_dict_full(self) -> None:
+        config = NexusCliConfig.from_dict(
+            {
+                "current-profile": "prod",
+                "profiles": {
+                    "prod": {"url": "http://prod", "api-key": "k1"},
+                    "dev": {"url": "http://dev"},
+                },
+                "settings": {"output": {"format": "json"}},
+            }
+        )
+        assert config.current_profile == "prod"
+        assert len(config.profiles) == 2
+        assert config.profiles["prod"].api_key == "k1"
+        assert config.settings == {"output": {"format": "json"}}
+
+    def test_to_dict_roundtrip(self, sample_config: NexusCliConfig) -> None:
+        d = sample_config.to_dict()
+        restored = NexusCliConfig.from_dict(d)
+        assert restored.current_profile == sample_config.current_profile
+        assert len(restored.profiles) == len(sample_config.profiles)
+
+    def test_from_dict_ignores_invalid_profiles(self) -> None:
+        config = NexusCliConfig.from_dict(
+            {
+                "profiles": {
+                    "good": {"url": "http://x"},
+                    "bad": "not-a-dict",
+                },
+            }
+        )
+        assert "good" in config.profiles
+        assert "bad" not in config.profiles
+
+    def test_from_dict_invalid_settings(self) -> None:
+        config = NexusCliConfig.from_dict({"settings": "not-a-dict"})
+        assert config.settings == {}
+
+
+# ---------------------------------------------------------------------------
+# File I/O
+# ---------------------------------------------------------------------------
+
+
+class TestFileIO:
+    def test_save_and_load(self, tmp_config_file: Path) -> None:
+        config = make_config(
+            current_profile="dev",
+            profiles={"dev": {"url": "http://localhost:2026", "api_key": "key123"}},
+        )
+        save_cli_config(config, path=tmp_config_file)
+
+        loaded = load_cli_config(path=tmp_config_file)
+        assert loaded.current_profile == "dev"
+        assert loaded.profiles["dev"].url == "http://localhost:2026"
+        assert loaded.profiles["dev"].api_key == "key123"
+
+    def test_load_nonexistent_returns_empty(self, tmp_path: Path) -> None:
+        config = load_cli_config(path=tmp_path / "does-not-exist.yaml")
+        assert config.current_profile is None
+        assert config.profiles == {}
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "config.yaml"
+        config = make_config(current_profile="x", profiles={"x": {"url": "http://x"}})
+        save_cli_config(config, path=nested)
+        assert nested.exists()
+
+    def test_save_sets_file_permissions(self, tmp_config_file: Path) -> None:
+        config = make_config()
+        save_cli_config(config, path=tmp_config_file)
+        mode = tmp_config_file.stat().st_mode
+        assert stat.S_IMODE(mode) == 0o600
+
+    def test_load_empty_file(self, tmp_config_file: Path) -> None:
+        tmp_config_file.write_text("")
+        config = load_cli_config(path=tmp_config_file)
+        assert config.current_profile is None
+
+    def test_load_invalid_yaml_type(self, tmp_config_file: Path) -> None:
+        tmp_config_file.write_text("just a string")
+        config = load_cli_config(path=tmp_config_file)
+        assert config.current_profile is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_connection — precedence matrix
+# ---------------------------------------------------------------------------
+
+
+class TestResolveConnection:
+    """Parametrized tests for the full precedence chain."""
+
+    def test_explicit_url_wins_over_everything(self) -> None:
+        config = make_config(
+            current_profile="prod",
+            profiles={"prod": {"url": "http://prod-from-profile"}},
+        )
+        resolved = resolve_connection(
+            remote_url="http://explicit-flag",
+            remote_api_key="flag-key",
+            profile_name="prod",
+            config=config,
+        )
+        assert resolved.url == "http://explicit-flag"
+        assert resolved.api_key == "flag-key"
+        assert "flag" in resolved.source.lower() or "env" in resolved.source.lower()
+
+    def test_profile_flag_wins_over_current_profile(self) -> None:
+        config = make_config(
+            current_profile="default-profile",
+            profiles={
+                "default-profile": {"url": "http://default"},
+                "staging": {"url": "http://staging"},
+            },
+        )
+        resolved = resolve_connection(profile_name="staging", config=config)
+        assert resolved.url == "http://staging"
+        assert "staging" in resolved.source
+
+    def test_current_profile_used_when_no_flags(self) -> None:
+        config = make_config(
+            current_profile="prod",
+            profiles={"prod": {"url": "http://prod", "api_key": "k1", "zone_id": "z1"}},
+        )
+        resolved = resolve_connection(config=config)
+        assert resolved.url == "http://prod"
+        assert resolved.api_key == "k1"
+        assert resolved.zone_id == "z1"
+        assert "current-profile" in resolved.source
+
+    def test_local_default_when_nothing_set(self) -> None:
+        resolved = resolve_connection(config=NexusCliConfig())
+        assert resolved.url is None
+        assert resolved.api_key is None
+        assert not resolved.is_remote
+        assert "local" in resolved.source.lower()
+
+    def test_whitespace_url_treated_as_none(self) -> None:
+        resolved = resolve_connection(remote_url="   ", config=NexusCliConfig())
+        assert resolved.url is None
+        assert not resolved.is_remote
+
+    def test_whitespace_api_key_treated_as_none(self) -> None:
+        resolved = resolve_connection(
+            remote_url="http://x",
+            remote_api_key="   ",
+            config=NexusCliConfig(),
+        )
+        assert resolved.api_key is None
+
+    def test_unknown_profile_warns_and_falls_back(self, capsys: pytest.CaptureFixture[str]) -> None:
+        config = make_config(profiles={"real": {"url": "http://real"}})
+        resolved = resolve_connection(profile_name="nonexistent", config=config)
+        assert not resolved.is_remote
+        assert "local" in resolved.source.lower()
+
+    def test_zone_id_from_flag_overrides_profile(self) -> None:
+        config = make_config(
+            current_profile="prod",
+            profiles={"prod": {"url": "http://prod", "zone_id": "profile-zone"}},
+        )
+        resolved = resolve_connection(zone_id="flag-zone", config=config)
+        assert resolved.zone_id == "flag-zone"
+
+    def test_zone_id_from_profile_when_no_flag(self) -> None:
+        config = make_config(
+            current_profile="prod",
+            profiles={"prod": {"url": "http://prod", "zone_id": "profile-zone"}},
+        )
+        resolved = resolve_connection(config=config)
+        assert resolved.zone_id == "profile-zone"
+
+    @pytest.mark.parametrize(
+        (
+            "remote_url",
+            "profile_name",
+            "current_profile",
+            "profiles",
+            "expected_url",
+            "expected_source_contains",
+        ),
+        [
+            # Precedence 1: Explicit URL always wins
+            ("http://flag", None, "prod", {"prod": {"url": "http://prod"}}, "http://flag", "flag"),
+            # Precedence 2: --profile flag
+            (
+                None,
+                "staging",
+                "prod",
+                {"prod": {"url": "http://prod"}, "staging": {"url": "http://staging"}},
+                "http://staging",
+                "staging",
+            ),
+            # Precedence 3: current-profile from config
+            (
+                None,
+                None,
+                "prod",
+                {"prod": {"url": "http://prod"}},
+                "http://prod",
+                "current-profile",
+            ),
+            # Precedence 4: No URL → local
+            (None, None, None, {}, None, "local"),
+            # Env var URL (mapped to remote_url by Click)
+            (
+                "http://from-env",
+                None,
+                "prod",
+                {"prod": {"url": "http://prod"}},
+                "http://from-env",
+                "flag",
+            ),
+            # Profile with no URL → local-like
+            (None, None, "local", {"local": {}}, None, "local"),
+        ],
+        ids=[
+            "explicit-url-wins",
+            "profile-flag-wins",
+            "current-profile-used",
+            "fallback-to-local",
+            "env-var-as-url-wins",
+            "profile-with-no-url",
+        ],
+    )
+    def test_precedence_matrix(
+        self,
+        remote_url: str | None,
+        profile_name: str | None,
+        current_profile: str | None,
+        profiles: dict[str, dict[str, str]],
+        expected_url: str | None,
+        expected_source_contains: str,
+    ) -> None:
+        config = make_config(current_profile=current_profile, profiles=profiles)
+        resolved = resolve_connection(
+            remote_url=remote_url,
+            profile_name=profile_name,
+            config=config,
+        )
+        assert resolved.url == expected_url
+        assert expected_source_contains in resolved.source.lower()
+
+
+# ---------------------------------------------------------------------------
+# ResolvedConnection
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedConnection:
+    def test_is_remote_true(self) -> None:
+        r = ResolvedConnection(url="http://x")
+        assert r.is_remote is True
+
+    def test_is_remote_false_none(self) -> None:
+        r = ResolvedConnection(url=None)
+        assert r.is_remote is False
+
+    def test_is_remote_false_empty(self) -> None:
+        r = ResolvedConnection(url="")
+        assert r.is_remote is False
+
+    def test_is_remote_false_whitespace(self) -> None:
+        r = ResolvedConnection(url="   ")
+        assert r.is_remote is False
+
+    def test_frozen(self) -> None:
+        r = ResolvedConnection(url="http://x")
+        with pytest.raises(AttributeError):
+            r.url = "http://y"
+
+
+# ---------------------------------------------------------------------------
+# Settings helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSettings:
+    def test_get_setting_nested(self) -> None:
+        settings = {"output": {"format": "json"}}
+        assert get_setting(settings, "output.format") == "json"
+
+    def test_get_setting_top_level(self) -> None:
+        settings = {"default-zone-id": "z1"}
+        assert get_setting(settings, "default-zone-id") == "z1"
+
+    def test_get_setting_missing_returns_default(self) -> None:
+        assert get_setting({}, "output.format") == "table"
+
+    def test_set_setting_creates_nested(self) -> None:
+        result = set_setting({}, "output.format", "json")
+        assert result == {"output": {"format": "json"}}
+
+    def test_set_setting_immutable(self) -> None:
+        original = {"output": {"format": "table"}}
+        result = set_setting(original, "output.format", "json")
+        assert original["output"]["format"] == "table"  # unchanged
+        assert result["output"]["format"] == "json"
+
+    def test_reset_setting(self) -> None:
+        settings = {"output": {"format": "json"}}
+        result = reset_setting(settings, "output.format")
+        assert result["output"]["format"] == "table"
+
+    def test_reset_nonexistent_key(self) -> None:
+        result = reset_setting({}, "output.format")
+        assert result == {"output": {"format": "table"}}
+
+
+class TestCoerceValue:
+    @pytest.mark.parametrize(
+        ("input_val", "expected"),
+        [
+            ("true", True),
+            ("True", True),
+            ("yes", True),
+            ("false", False),
+            ("False", False),
+            ("no", False),
+            ("null", None),
+            ("none", None),
+            ("42", 42),
+            ("3.14", 3.14),
+            ("hello", "hello"),
+        ],
+    )
+    def test_coerce(self, input_val: str, expected: object) -> None:
+        assert _coerce_value(input_val) == expected
+
+    def test_non_string_passthrough(self) -> None:
+        assert _coerce_value(42) == 42
+        assert _coerce_value(True) is True

--- a/tests/unit/cli/test_config_commands.py
+++ b/tests/unit/cli/test_config_commands.py
@@ -1,0 +1,91 @@
+"""Tests for nexus config show/get/set/reset commands."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from nexus.cli.commands.config_cmd import config_group
+from tests.unit.cli.conftest import make_config
+
+
+class TestConfigShow:
+    def test_show_defaults(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config):
+            result = cli_runner.invoke(config_group, ["show"])
+        assert result.exit_code == 0
+        assert "output.format" in result.output
+
+    def test_show_json(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config):
+            result = cli_runner.invoke(config_group, ["show", "--json"])
+        assert result.exit_code == 0
+        assert "output.format" in result.output
+
+
+class TestConfigGet:
+    def test_get_known_key(self, cli_runner: CliRunner) -> None:
+        config = make_config(settings={"output": {"format": "json"}})
+        with patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config):
+            result = cli_runner.invoke(config_group, ["get", "output.format"])
+        assert result.exit_code == 0
+        assert "json" in result.output
+
+    def test_get_unknown_key(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config):
+            result = cli_runner.invoke(config_group, ["get", "nonexistent.key"])
+        assert result.exit_code == 1
+        assert "Unknown" in result.output
+
+
+class TestConfigSet:
+    def test_set_value(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.config_cmd.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(config_group, ["set", "output.format", "json"])
+        assert result.exit_code == 0
+        saved = mock_save.call_args[0][0]
+        assert saved.settings["output"]["format"] == "json"
+
+    def test_set_boolean(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.config_cmd.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(config_group, ["set", "timing.enabled", "true"])
+        assert result.exit_code == 0
+        saved = mock_save.call_args[0][0]
+        assert saved.settings["timing"]["enabled"] is True
+
+    def test_set_unknown_key(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config):
+            result = cli_runner.invoke(config_group, ["set", "bad.key", "val"])
+        assert result.exit_code == 1
+
+
+class TestConfigReset:
+    def test_reset_to_default(self, cli_runner: CliRunner) -> None:
+        config = make_config(settings={"output": {"format": "json"}})
+        with (
+            patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.config_cmd.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(config_group, ["reset", "output.format"])
+        assert result.exit_code == 0
+        saved = mock_save.call_args[0][0]
+        assert saved.settings["output"]["format"] == "table"
+
+    def test_reset_unknown_key(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with patch("nexus.cli.commands.config_cmd.load_cli_config", return_value=config):
+            result = cli_runner.invoke(config_group, ["reset", "bad.key"])
+        assert result.exit_code == 1

--- a/tests/unit/cli/test_profile_commands.py
+++ b/tests/unit/cli/test_profile_commands.py
@@ -1,0 +1,238 @@
+"""Tests for nexus profile commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from nexus.cli.commands.profile import profile_group
+from nexus.cli.config import NexusCliConfig
+from tests.unit.cli.conftest import make_config
+
+# ---------------------------------------------------------------------------
+# profile list
+# ---------------------------------------------------------------------------
+
+
+class TestProfileList:
+    def test_no_profiles(self, cli_runner: CliRunner, tmp_config_file: Path) -> None:
+        with patch("nexus.cli.commands.profile.load_cli_config") as mock_load:
+            mock_load.return_value = NexusCliConfig()
+            result = cli_runner.invoke(profile_group, ["list"])
+        assert result.exit_code == 0
+        assert "No profiles" in result.output
+
+    def test_lists_profiles_with_active_marker(self, cli_runner: CliRunner) -> None:
+        config = make_config(
+            current_profile="prod",
+            profiles={
+                "prod": {"url": "http://prod", "api_key": "nx_live_prod_abc123"},
+                "local": {"url": "http://localhost:2026"},
+            },
+        )
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(profile_group, ["list"])
+        assert result.exit_code == 0
+        assert "prod" in result.output
+        assert "local" in result.output
+
+    def test_api_key_masked(self, cli_runner: CliRunner) -> None:
+        config = make_config(
+            profiles={"test": {"url": "http://x", "api_key": "nx_live_supersecretkey123"}},
+        )
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(profile_group, ["list"])
+        assert result.exit_code == 0
+        # Full key should NOT appear in output
+        assert "nx_live_supersecretkey123" not in result.output
+        # But partial should
+        assert "nx_live_" in result.output
+
+
+# ---------------------------------------------------------------------------
+# profile use
+# ---------------------------------------------------------------------------
+
+
+class TestProfileUse:
+    def test_switch_profile(self, cli_runner: CliRunner) -> None:
+        config = make_config(
+            current_profile="local",
+            profiles={
+                "local": {"url": "http://localhost:2026"},
+                "staging": {"url": "http://staging"},
+            },
+        )
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(profile_group, ["use", "staging"])
+        assert result.exit_code == 0
+        assert "staging" in result.output
+        saved_config = mock_save.call_args[0][0]
+        assert saved_config.current_profile == "staging"
+
+    def test_use_nonexistent_profile(self, cli_runner: CliRunner) -> None:
+        config = make_config(profiles={"real": {"url": "http://real"}})
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(profile_group, ["use", "fake"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# profile add
+# ---------------------------------------------------------------------------
+
+
+class TestProfileAdd:
+    def test_add_new_profile(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(
+                profile_group,
+                ["add", "staging", "--url", "http://staging", "--api-key", "key1"],
+            )
+        assert result.exit_code == 0
+        assert "staging" in result.output
+        saved = mock_save.call_args[0][0]
+        assert "staging" in saved.profiles
+        assert saved.profiles["staging"].url == "http://staging"
+        assert saved.profiles["staging"].api_key == "key1"
+
+    def test_add_with_use_flag(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(
+                profile_group,
+                ["add", "new-env", "--url", "http://new", "--use"],
+            )
+        assert result.exit_code == 0
+        saved = mock_save.call_args[0][0]
+        assert saved.current_profile == "new-env"
+
+    def test_add_duplicate_fails(self, cli_runner: CliRunner) -> None:
+        config = make_config(profiles={"existing": {"url": "http://x"}})
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(
+                profile_group,
+                ["add", "existing", "--url", "http://y"],
+            )
+        assert result.exit_code == 1
+        assert "already exists" in result.output
+
+
+# ---------------------------------------------------------------------------
+# profile delete
+# ---------------------------------------------------------------------------
+
+
+class TestProfileDelete:
+    def test_delete_profile(self, cli_runner: CliRunner) -> None:
+        config = make_config(
+            current_profile="other",
+            profiles={"victim": {"url": "http://x"}, "other": {"url": "http://y"}},
+        )
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(profile_group, ["delete", "victim", "--force"])
+        assert result.exit_code == 0
+        saved = mock_save.call_args[0][0]
+        assert "victim" not in saved.profiles
+
+    def test_delete_active_profile_clears_current(self, cli_runner: CliRunner) -> None:
+        config = make_config(
+            current_profile="active",
+            profiles={"active": {"url": "http://x"}},
+        )
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(profile_group, ["delete", "active", "--force"])
+        assert result.exit_code == 0
+        saved = mock_save.call_args[0][0]
+        assert saved.current_profile is None
+
+    def test_delete_nonexistent(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(profile_group, ["delete", "nope", "--force"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# profile show
+# ---------------------------------------------------------------------------
+
+
+class TestProfileShow:
+    def test_show_active_profile(self, cli_runner: CliRunner) -> None:
+        config = make_config(
+            current_profile="prod",
+            profiles={
+                "prod": {"url": "http://prod", "api_key": "nx_live_abc", "zone_id": "us-west-1"}
+            },
+        )
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(profile_group, ["show"])
+        assert result.exit_code == 0
+        assert "prod" in result.output
+        assert "http://prod" in result.output
+
+    def test_show_no_active(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(profile_group, ["show"])
+        assert result.exit_code == 0
+        assert "No active profile" in result.output or "local" in result.output
+
+
+# ---------------------------------------------------------------------------
+# profile rename
+# ---------------------------------------------------------------------------
+
+
+class TestProfileRename:
+    def test_rename_profile(self, cli_runner: CliRunner) -> None:
+        config = make_config(
+            current_profile="old",
+            profiles={"old": {"url": "http://x"}},
+        )
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.save_cli_config") as mock_save,
+        ):
+            result = cli_runner.invoke(profile_group, ["rename", "old", "new"])
+        assert result.exit_code == 0
+        saved = mock_save.call_args[0][0]
+        assert "new" in saved.profiles
+        assert "old" not in saved.profiles
+        assert saved.current_profile == "new"
+
+    def test_rename_nonexistent(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(profile_group, ["rename", "nope", "new"])
+        assert result.exit_code == 1
+
+    def test_rename_to_existing(self, cli_runner: CliRunner) -> None:
+        config = make_config(
+            profiles={"a": {"url": "http://a"}, "b": {"url": "http://b"}},
+        )
+        with patch("nexus.cli.commands.profile.load_cli_config", return_value=config):
+            result = cli_runner.invoke(profile_group, ["rename", "a", "b"])
+        assert result.exit_code == 1
+        assert "already exists" in result.output

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -1,9 +1,27 @@
-"""Tests for CLI utility functions."""
+"""Tests for nexus.cli.utils — BackendConfig, get_zone_id, parse_subject, handle_error."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
 
 import pytest
 
+import nexus
 from nexus.cli.exit_codes import ExitCode
-from nexus.cli.utils import BackendConfig, resolve_content
+from nexus.cli.utils import (
+    BackendConfig,
+    _apply_common_config,
+    create_operation_context,
+    get_zone_id,
+    handle_error,
+    parse_subject,
+    resolve_content,
+)
+
+# ---------------------------------------------------------------------------
+# BackendConfig
+# ---------------------------------------------------------------------------
 
 
 class TestBackendConfig:
@@ -12,7 +30,10 @@ class TestBackendConfig:
     def test_defaults(self) -> None:
         config = BackendConfig()
         assert config.backend == "local"
+        assert config.data_dir == str(Path(nexus.NEXUS_STATE_DIR) / "data")
+        assert config.config_path is None
         assert config.remote_url is None
+        assert config.remote_api_key is None
         assert config.gcs_bucket is None
 
     def test_frozen(self) -> None:
@@ -20,15 +41,167 @@ class TestBackendConfig:
         with pytest.raises(AttributeError):
             config.backend = "gcs"
 
-    def test_custom_values(self) -> None:
+    def test_all_params(self) -> None:
         config = BackendConfig(
             backend="gcs",
+            data_dir="/custom",
+            config_path="/etc/nexus.yaml",
             gcs_bucket="my-bucket",
+            gcs_project="my-project",
+            gcs_credentials="/creds.json",
             remote_url="http://localhost:2026",
+            remote_api_key="nx_test_key",
         )
         assert config.backend == "gcs"
+        assert config.data_dir == "/custom"
+        assert config.config_path == "/etc/nexus.yaml"
         assert config.gcs_bucket == "my-bucket"
+        assert config.gcs_project == "my-project"
+        assert config.gcs_credentials == "/creds.json"
         assert config.remote_url == "http://localhost:2026"
+        assert config.remote_api_key == "nx_test_key"
+
+    def test_none_vs_empty_string(self) -> None:
+        config = BackendConfig(remote_url="", remote_api_key=None)
+        assert config.remote_url == ""
+        assert config.remote_api_key is None
+
+
+# ---------------------------------------------------------------------------
+# _apply_common_config
+# ---------------------------------------------------------------------------
+
+
+class TestApplyCommonConfig:
+    def test_applies_optional_params_when_set(self) -> None:
+        d: dict[str, Any] = {}
+        _apply_common_config(
+            d,
+            enforce_permissions=True,
+            allow_admin_bypass=False,
+            enforce_zone_isolation=True,
+        )
+        assert d["enforce_permissions"] is True
+        assert d["allow_admin_bypass"] is False
+        assert d["enforce_zone_isolation"] is True
+
+    def test_skips_unset_optional_params(self) -> None:
+        d: dict[str, Any] = {}
+        _apply_common_config(d)
+        assert "enforce_permissions" not in d
+        assert "allow_admin_bypass" not in d
+        assert "enforce_zone_isolation" not in d
+
+    def test_mutates_input_dict(self) -> None:
+        d: dict[str, Any] = {"profile": "standalone"}
+        _apply_common_config(d)
+        assert d["profile"] == "standalone"  # Original key preserved
+
+    def test_custom_memory_settings(self) -> None:
+        d: dict[str, Any] = {}
+        _apply_common_config(d, memory_main_capacity=50, memory_recall_max_age_hours=12.0)
+        assert d["memory_main_capacity"] == 50
+        assert d["memory_recall_max_age_hours"] == 12.0
+
+
+# ---------------------------------------------------------------------------
+# get_zone_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetZoneId:
+    def test_returns_param_when_set(self) -> None:
+        assert get_zone_id("my-zone") == "my-zone"
+
+    def test_returns_none_when_not_set(self) -> None:
+        assert get_zone_id(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        # Empty string is falsy, so get_zone_id returns None
+        assert get_zone_id("") is None
+
+
+# ---------------------------------------------------------------------------
+# parse_subject
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubject:
+    def test_valid_subject(self) -> None:
+        result = parse_subject("user:alice")
+        assert result == ("user", "alice")
+
+    def test_subject_with_colon_in_id(self) -> None:
+        result = parse_subject("agent:ns:bot1")
+        assert result == ("agent", "ns:bot1")
+
+    def test_none_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_SUBJECT", raising=False)
+        monkeypatch.delenv("NEXUS_SUBJECT_TYPE", raising=False)
+        monkeypatch.delenv("NEXUS_SUBJECT_ID", raising=False)
+        result = parse_subject(None)
+        assert result is None
+
+    def test_invalid_format_exits(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            parse_subject("no_colon")
+        assert exc_info.value.code == 1
+
+    def test_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_SUBJECT", "user:bob")
+        result = parse_subject(None)
+        assert result == ("user", "bob")
+
+    def test_env_var_type_id_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_SUBJECT", raising=False)
+        monkeypatch.setenv("NEXUS_SUBJECT_TYPE", "agent")
+        monkeypatch.setenv("NEXUS_SUBJECT_ID", "bot1")
+        result = parse_subject(None)
+        assert result == ("agent", "bot1")
+
+
+# ---------------------------------------------------------------------------
+# create_operation_context
+# ---------------------------------------------------------------------------
+
+
+class TestCreateOperationContext:
+    def test_empty_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_SUBJECT", raising=False)
+        monkeypatch.delenv("NEXUS_SUBJECT_TYPE", raising=False)
+        monkeypatch.delenv("NEXUS_SUBJECT_ID", raising=False)
+        monkeypatch.delenv("NEXUS_ZONE_ID", raising=False)
+        ctx = create_operation_context()
+        assert ctx == {}
+
+    def test_full_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_SUBJECT", raising=False)
+        monkeypatch.delenv("NEXUS_SUBJECT_TYPE", raising=False)
+        monkeypatch.delenv("NEXUS_ZONE_ID", raising=False)
+        ctx = create_operation_context(
+            subject="user:alice",
+            zone_id="z1",
+            is_admin=True,
+            is_system=True,
+            admin_capabilities=("admin:read:*",),
+        )
+        assert ctx["subject"] == ("user", "alice")
+        assert ctx["zone"] == "z1"
+        assert ctx["is_admin"] is True
+        assert ctx["is_system"] is True
+        assert ctx["admin_capabilities"] == {"admin:read:*"}
+
+    def test_only_subject(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_SUBJECT", raising=False)
+        monkeypatch.delenv("NEXUS_SUBJECT_TYPE", raising=False)
+        monkeypatch.delenv("NEXUS_ZONE_ID", raising=False)
+        ctx = create_operation_context(subject="agent:bot")
+        assert ctx == {"subject": ("agent", "bot")}
+
+
+# ---------------------------------------------------------------------------
+# resolve_content
+# ---------------------------------------------------------------------------
 
 
 class TestResolveContent:
@@ -67,12 +240,15 @@ class TestResolveContent:
         assert exc_info.value.code == ExitCode.USAGE_ERROR
 
 
+# ---------------------------------------------------------------------------
+# handle_error
+# ---------------------------------------------------------------------------
+
+
 class TestHandleError:
     """handle_error maps exceptions to semantic exit codes."""
 
     def _assert_exit_code(self, exc: Exception, expected_code: int) -> None:
-        from nexus.cli.utils import handle_error
-
         with pytest.raises(SystemExit) as exc_info:
             handle_error(exc)
         assert exc_info.value.code == expected_code


### PR DESCRIPTION
## Summary

- Add `nexus profile list|add|use|delete|show|rename` commands for managing named connection profiles
- Add `nexus connect <url>` interactive setup wizard with 3s connection test + retry/save-anyway UX
- Add `nexus config show|get|set|reset` commands for runtime settings
- Add `nexus --profile <name>` global option for per-command profile override
- Single `~/.nexus/config.yaml` file with `profiles:` + `settings:` sections (API keys stored with 0600 permissions)
- New `cli/config.py` module with `resolve_connection()` as single source of truth for connection precedence: CLI flag > NEXUS_URL env > --profile flag > current-profile > local default
- Refactor: extract `_apply_common_config()` to deduplicate 3×8 boilerplate in `get_filesystem()`
- Fix: `ZONE_ID_OPTION` now uses Click's `envvar="NEXUS_ZONE_ID"` (was manual `os.getenv` fallback)
- Fix: whitespace-only `NEXUS_URL` no longer treated as valid URL (strip before truthy check)
- 104 new unit tests with shared `tests/unit/cli/conftest.py` fixtures

Closes #2809

## Test plan

- [x] `uv run pytest tests/unit/cli/ -v` — 104 tests pass
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean
- [x] All pre-commit hooks pass
- [ ] Manual: `nexus profile add local --url http://localhost:2026 --use`
- [ ] Manual: `nexus profile list` shows `*` for active
- [ ] Manual: `nexus --profile local ls /`
- [ ] Manual: `nexus connect https://nexus.example.com` interactive flow
- [ ] Manual: `nexus config show` displays merged settings with sources
- [ ] Manual: `nexus config set timing.enabled true` persists
- [ ] Manual: Verify `~/.nexus/config.yaml` has 0600 permissions after save
- [ ] Manual: Verify env var `NEXUS_URL` overrides active profile