### PR TITLE
refactor(#1459): delete cfg.mode — dispatch via profile + auto-detection

### DIFF
--- a/configs/config.demo.yaml
+++ b/configs/config.demo.yaml
@@ -1,8 +1,8 @@
 # Nexus Demo Configuration
 # Configuration for docker-compose demo environment with GCS connector
 
-# Deployment mode (standalone = single-node redb, no Raft)
-mode: standalone
+# Deployment profile
+profile: full
 
 # Database path (for TokenManager and other components that need DB access)
 # Uses NEXUS_DATABASE_URL env var if set, falls back to postgres:5432 for Docker

--- a/configs/config.evaluation.yaml
+++ b/configs/config.evaluation.yaml
@@ -1,8 +1,8 @@
 # Nexus Evaluation Configuration
 # Configuration for MCP evaluation testing with semantic search enabled
 
-# Deployment mode (standalone = single-node redb, no Raft)
-mode: standalone
+# Deployment profile
+profile: full
 
 # Database path (for TokenManager and other components that need DB access)
 db_path: postgresql://postgres:nexus@postgres:5432/nexus

--- a/configs/config.integration-test.yaml
+++ b/configs/config.integration-test.yaml
@@ -2,8 +2,8 @@
 # Minimal configuration for CI integration tests
 # No external backends (gcs_connector, gdrive_connector) - those are tested separately via API
 
-# Deployment mode (standalone = single-process server with local backends)
-mode: standalone
+# Deployment profile
+profile: full
 
 # Database path (for TokenManager and other components that need DB access)
 db_path: postgresql://postgres:nexus@postgres:5432/nexus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - NEXUS_HOST=0.0.0.0
       - NEXUS_PORT=2026
       - NEXUS_DATA_DIR=/app/data
-      - NEXUS_MODE=standalone
+      - NEXUS_PROFILE=full
       - NEXUS_DATABASE_URL=${NEXUS_DATABASE_URL:-postgresql://postgres:nexus@postgres:5432/nexus}
       - NEXUS_API_KEY=${NEXUS_API_KEY:-}
       - NEXUS_BACKEND=${NEXUS_BACKEND:-local}

--- a/dockerfiles/docker-compose.cross-platform-test.yml
+++ b/dockerfiles/docker-compose.cross-platform-test.yml
@@ -171,8 +171,8 @@ services:
       NEXUS_PORT: 2026
       NEXUS_DATA_DIR: /app/data
 
-      # --- Deployment mode (explicit federation for Raft cluster) ---
-      NEXUS_MODE: federation
+      # --- Deployment profile (cloud = all bricks + federation) ---
+      NEXUS_PROFILE: cloud
 
       # --- Raft consensus (static bootstrap — all nodes know all peers) ---
       NEXUS_NODE_ID: 1
@@ -272,8 +272,8 @@ services:
       NEXUS_PORT: 2026
       NEXUS_DATA_DIR: /app/data
 
-      # --- Deployment mode (explicit federation for Raft cluster) ---
-      NEXUS_MODE: federation
+      # --- Deployment profile (cloud = all bricks + federation) ---
+      NEXUS_PROFILE: cloud
 
       NEXUS_NODE_ID: 2
       NEXUS_BIND_ADDR: 0.0.0.0:2126

--- a/dockerfiles/docker-compose.demo.yml
+++ b/dockerfiles/docker-compose.demo.yml
@@ -104,7 +104,7 @@ services:
       NEXUS_HOST: 0.0.0.0
       NEXUS_PORT: 2026
       NEXUS_DATA_DIR: /app/data
-      NEXUS_MODE: standalone
+      NEXUS_PROFILE: full
 
       # Database configuration (PostgreSQL)
       # IMPORTANT: Always use the Docker service name for container-to-container DB access.

--- a/dockerfiles/docker-compose.evaluation.yml
+++ b/dockerfiles/docker-compose.evaluation.yml
@@ -73,7 +73,7 @@ services:
       NEXUS_HOST: 0.0.0.0
       NEXUS_PORT: 2026
       NEXUS_DATA_DIR: /app/data
-      NEXUS_MODE: standalone
+      NEXUS_PROFILE: full
 
       # Database configuration (PostgreSQL)
       NEXUS_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}

--- a/examples/tutorials/deployment-profiles/test_profiles_cli.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_cli.py
@@ -36,7 +36,7 @@ FILES = {
 _CLEAN_ENV = {
     k: v
     for k, v in os.environ.items()
-    if k not in ("NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE", "NEXUS_PROFILE")
+    if k not in ("NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_PROFILE")
 }
 
 

--- a/examples/tutorials/deployment-profiles/test_profiles_federation.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_federation.py
@@ -50,7 +50,7 @@ def main() -> int:
         env = os.environ.copy()
         env["NEXUS_PROFILE"] = "cloud"
         env["NEXUS_DATA_DIR"] = data_dir
-        for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE"]:
+        for k in ["NEXUS_URL", "NEXUS_DATABASE_URL"]:
             env.pop(k, None)
         # Note: NEXUS_PROFILE is set to "cloud" above, don't clear it
 

--- a/examples/tutorials/deployment-profiles/test_profiles_sdk.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_sdk.py
@@ -69,7 +69,7 @@ def test_profile(profile: str) -> dict[str, str]:
     data_dir = f"{BASE_DIR}/{profile}"
     os.makedirs(data_dir, exist_ok=True)
 
-    for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE", "NEXUS_PROFILE"]:
+    for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_PROFILE"]:
         os.environ.pop(k, None)
     os.environ["NEXUS_PROFILE"] = profile
 

--- a/examples/tutorials/deployment-profiles/test_profiles_serve.py
+++ b/examples/tutorials/deployment-profiles/test_profiles_serve.py
@@ -38,7 +38,7 @@ def main() -> int:
 
         env = os.environ.copy()
         env["NEXUS_DATA_DIR"] = data_dir
-        for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE", "NEXUS_PROFILE"]:
+        for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_PROFILE"]:
             env.pop(k, None)
 
         proc = subprocess.Popen(

--- a/examples/tutorials/deployment-profiles/test_remote_client.py
+++ b/examples/tutorials/deployment-profiles/test_remote_client.py
@@ -51,7 +51,7 @@ def main() -> int:
     env = os.environ.copy()
     env["NEXUS_GRPC_PORT"] = str(GRPC_PORT)
     env["NEXUS_DATA_DIR"] = f"{BASE_DIR}/server"
-    for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_MODE", "NEXUS_PROFILE"]:
+    for k in ["NEXUS_URL", "NEXUS_DATABASE_URL", "NEXUS_PROFILE"]:
         env.pop(k, None)
 
     server = subprocess.Popen(

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -3,12 +3,15 @@ Nexus: AI-Native Distributed Filesystem Architecture
 
 Nexus is a complete AI agent infrastructure platform that combines distributed
 unified filesystem, self-evolving agent memory, intelligent document processing,
-and seamless deployment across three modes.
+and seamless deployment across deployment profiles.
 
-Three Deployment Modes, One Codebase:
-- Standalone: Single-node redb, no Raft (like SQLite) — default mode
-- Remote: NexusFS with RemoteBackend + RemoteServiceProxy (thin HTTP client)
-- Federation: ZoneManager + Raft consensus for multi-node clusters
+Deployment profiles control which bricks are enabled:
+- kernel: Bare VFS, storage only
+- embedded: Storage + eventlog
+- lite: Core services
+- full: All bricks (default)
+- cloud: All bricks + federation
+- remote: Thin gRPC client (RemoteBackend + RemoteServiceProxy)
 
 SDK vs CLI:
 -----------
@@ -146,11 +149,11 @@ def connect(
     Connect to Nexus filesystem.
 
     This is the main entry point for using Nexus. It dispatches based on the
-    deployment mode in configuration:
+    deployment profile in configuration:
 
-    - **standalone** (default): Single-node redb, no Raft. Like SQLite.
-    - **remote**: NexusFS with RemoteBackend + RemoteServiceProxy (thin HTTP client).
-    - **federation**: ZoneManager + Raft consensus for multi-node clusters.
+    - **profile="remote"**: Thin gRPC client (RemoteBackend + RemoteServiceProxy).
+    - **All other profiles**: Local NexusFS. Federation (Raft + ZoneManager) is
+      auto-detected based on whether the Rust extensions are importable.
 
     Args:
         config: Configuration source:
@@ -160,31 +163,27 @@ def connect(
             - NexusConfig: Already loaded config
 
     Returns:
-        NexusFilesystem instance (mode-dependent):
-            - remote: Returns NexusFS with RemoteBackend + RemoteServiceProxy
-            - standalone/federation: Returns NexusFS with local backend
-
-        All modes implement the NexusFilesystem interface, ensuring consistent
-        API across deployment modes.
+        NexusFilesystem instance. All profiles implement the NexusFilesystem
+        interface, ensuring consistent API.
 
     Raises:
-        ValueError: If configuration is invalid or mode is unknown
+        ValueError: If configuration is invalid
 
     Examples:
-        Remote mode (production client):
+        Remote profile (production client):
             >>> nx = nexus.connect(config={
-            ...     "mode": "remote",
+            ...     "profile": "remote",
             ...     "url": "http://localhost:2026",
             ...     "api_key": "your-api-key"
             ... })
 
-        Standalone mode (development/testing):
+        Default (development/testing):
             >>> nx = nexus.connect()
             >>> nx.sys_write("/workspace/file.txt", b"Hello World")
 
-        Federation mode (multi-node cluster):
+        Federation (auto-detected when Rust extensions available):
             >>> # Requires NEXUS_NODE_ID, NEXUS_BIND_ADDR env vars
-            >>> nx = nexus.connect(config={"mode": "federation"})
+            >>> nx = nexus.connect(config={"profile": "cloud"})
     """
     import os
     from pathlib import Path
@@ -194,14 +193,14 @@ def connect(
     # Load configuration
     cfg = load_config(config)
 
-    # ── Mode: remote ─────────────────────────────────────────────────
-    if cfg.mode == "remote":
+    # ── Profile: remote ──────────────────────────────────────────────
+    if cfg.profile == "remote":
         from urllib.parse import urlparse
 
         server_url = cfg.url or os.getenv("NEXUS_URL")
         if not server_url:
             raise ValueError(
-                "mode='remote' requires a server URL. "
+                "profile='remote' requires a server URL. "
                 "Set 'url' in config or NEXUS_URL environment variable."
             )
         api_key = cfg.api_key or os.getenv("NEXUS_API_KEY")
@@ -256,13 +255,8 @@ def connect(
 
         return nfs
 
-    # ── Modes: standalone / federation ───────────────────────────────
-    if cfg.mode not in ("standalone", "federation"):
-        raise ValueError(
-            f"Unknown mode: '{cfg.mode}'. Must be one of: standalone, remote, federation"
-        )
-
-    # Heavy imports only needed for standalone/federation
+    # ── Local node (single-node or federated, auto-detected) ────────
+    # Heavy imports for local profiles
     from nexus.backends.base.backend import Backend
     from nexus.backends.storage.cas_local import CASLocalBackend
     from nexus.core.nexus_fs import NexusFS
@@ -305,18 +299,14 @@ def connect(
     metadata_path = cfg.metastore_path or cfg.db_path or str(Path(nexus_root) / "metastore")
     record_store_path = cfg.record_store_path or None
 
-    # Create metadata store based on mode
+    # Create metadata store — auto-detect federation capability
     metadata_store: MetastoreABC
-    if cfg.mode == "federation":
-        try:
-            from nexus.contracts.constants import DEFAULT_GRPC_BIND_ADDR
-            from nexus.raft import FederatedMetadataProxy
-            from nexus.raft.zone_manager import ZoneManager
-        except ImportError as err:
-            raise ImportError(
-                "mode='federation' requires the Rust Raft extension built with --features full. "
-                "Build with: maturin develop -m rust/nexus_raft/Cargo.toml --features full"
-            ) from err
+    zone_mgr = None
+
+    try:
+        from nexus.contracts.constants import DEFAULT_GRPC_BIND_ADDR
+        from nexus.raft import FederatedMetadataProxy
+        from nexus.raft.zone_manager import ZoneManager
 
         node_id = int(os.environ.get("NEXUS_NODE_ID", "1"))
         bind_addr = os.environ.get("NEXUS_BIND_ADDR", DEFAULT_GRPC_BIND_ADDR)
@@ -359,8 +349,8 @@ def connect(
             zone_mgr.bootstrap_static(zones=zones, peers=peers, mounts=mounts)
 
         metadata_store = FederatedMetadataProxy.from_zone_manager(zone_mgr)
-    else:
-        # standalone: single-node embedded Raft (no peers), with fallback
+    except ImportError:
+        # Raft extensions not available — single-node embedded Raft, with fallback
         try:
             from nexus.storage.raft_metadata_store import RaftMetadataStore
 
@@ -494,7 +484,7 @@ def connect(
     nx_fs._config = cfg
 
     # Store zone manager for federation topology initialization (health check)
-    if cfg.mode == "federation":
+    if zone_mgr is not None:
         nx_fs._zone_mgr = zone_mgr
 
         # Register federation content resolver (PRE-DISPATCH, Issue #163)

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -131,7 +131,7 @@ def create_mcp_server(
         if remote_url:
             import nexus as _nexus
 
-            nx = _nexus.connect(config={"mode": "remote", "url": remote_url, "api_key": api_key})
+            nx = _nexus.connect(config={"profile": "remote", "url": remote_url, "api_key": api_key})
         else:
             import importlib as _il
 
@@ -191,7 +191,7 @@ def create_mcp_server(
         import nexus as _nexus
 
         new_nx = _nexus.connect(
-            config={"mode": "remote", "url": _remote_url, "api_key": request_api_key}
+            config={"profile": "remote", "url": _remote_url, "api_key": request_api_key}
         )
         _connection_cache[request_api_key] = new_nx
         return new_nx

--- a/src/nexus/bricks/sandbox/sandbox_e2b_provider.py
+++ b/src/nexus/bricks/sandbox/sandbox_e2b_provider.py
@@ -671,7 +671,7 @@ try:
     import nexus
     from nexus.fuse.mount import NexusFUSE, MountMode
     log.info("Imports complete, connecting to server...")
-    nx = nexus.connect(config={{"mode": "remote", "url": "{nexus_url}", "api_key": api_key}})
+    nx = nexus.connect(config={{"profile": "remote", "url": "{nexus_url}", "api_key": api_key}})
     {"nx.agent_id = '" + agent_id + "'" if agent_id else ""}
     log.info("Creating FUSE mount...")
     fuse = NexusFUSE(nx, "{mount_path}", mode=MountMode.SMART)

--- a/src/nexus/cli/commands/server.py
+++ b/src/nexus/cli/commands/server.py
@@ -785,29 +785,7 @@ def serve(
             enforce_zone_isolation = True
 
         # Determine server deployment profile
-        # Priority: 1. CLI --profile, 2. NEXUS_PROFILE env, 3. NEXUS_MODE (deprecated)
-        server_profile = os.getenv("NEXUS_PROFILE")
-        if not server_profile:
-            raw_mode = os.getenv("NEXUS_MODE")
-            if raw_mode:
-                import logging as _logging
-
-                _logging.getLogger(__name__).warning(
-                    "NEXUS_MODE is deprecated and will be removed in v1.0. "
-                    "Use NEXUS_PROFILE instead (standalone -> full, remote -> remote, federation -> cloud)."
-                )
-                _mode_to_profile = {
-                    "standalone": "full",
-                    "federation": "cloud",
-                    "remote": "remote",
-                }
-                server_profile = _mode_to_profile.get(raw_mode)
-                if not server_profile:
-                    console.print(f"[red]Error:[/red] Unknown NEXUS_MODE: '{raw_mode}'")
-                    console.print("[yellow]Allowed values:[/yellow] standalone, federation, remote")
-                    sys.exit(1)
-            else:
-                server_profile = "full"
+        server_profile = os.getenv("NEXUS_PROFILE", "full")
 
         # Server cannot run in remote profile (would be a thin client of another server)
         if server_profile == "remote":

--- a/src/nexus/cli/commands/start.py
+++ b/src/nexus/cli/commands/start.py
@@ -111,24 +111,18 @@ def start(
         # ============================================
         os.environ["NEXUS_GRPC_PORT"] = str(grpc_port)
 
-        # Try federation mode first; fall back to standalone if Rust extensions
-        # are not available (pure pip install without maturin develop).
+        # Detect federation capability (Rust extensions) for user-facing messages.
+        # connect() auto-detects at runtime — no env var needed.
         enforce_permissions = bool(auth_type or api_key)
         try:
             from nexus.raft.zone_manager import _get_py_zone_manager
 
             if _get_py_zone_manager() is None:
                 raise ImportError("PyO3 ZoneManager not available")
-            os.environ["NEXUS_MODE"] = "federation"
             console.print(f"  gRPC: [cyan]port {grpc_port}[/cyan]")
         except (ImportError, RuntimeError):
-            os.environ["NEXUS_MODE"] = "standalone"
-            console.print(
-                "  [yellow]Federation mode unavailable (Rust extensions not built).[/yellow]"
-            )
-            console.print(
-                "  [yellow]Falling back to standalone mode (in-memory metastore).[/yellow]"
-            )
+            console.print("  [yellow]Federation unavailable (Rust extensions not built).[/yellow]")
+            console.print("  [yellow]Running with in-memory metastore.[/yellow]")
 
         # ============================================
         # Step 3: Create filesystem

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -226,7 +226,7 @@ def get_filesystem(
             # Client mode: use remote server connection via nexus.connect()
             return nexus.connect(
                 config={
-                    "mode": "remote",
+                    "profile": "remote",
                     "url": backend_config.remote_url,
                     "api_key": backend_config.remote_api_key,
                 }

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -120,12 +120,6 @@ class NexusConfig(BaseModel):
         ),
     )
 
-    # Deployment mode
-    mode: str = Field(
-        default="standalone",
-        description="Deployment mode: standalone (single-node redb), remote (thin HTTP client), or federation (ZoneManager + Raft)",
-    )
-
     # Backend selection
     backend: str = Field(
         default="local",
@@ -352,18 +346,6 @@ class NexusConfig(BaseModel):
             raise ValueError(f"profile must be one of {allowed}, got '{v}'")
         return v
 
-    @field_validator("mode")
-    @classmethod
-    def validate_mode(cls, v: str) -> str:
-        """Validate deployment mode.
-
-        Valid modes: standalone, remote, federation
-        """
-        allowed = ["standalone", "remote", "federation"]
-        if v not in allowed:
-            raise ValueError(f"mode must be one of {allowed}, got '{v}'")
-        return v
-
     @field_validator("backend")
     @classmethod
     def validate_backend(cls, v: str) -> str:
@@ -388,13 +370,13 @@ class NexusConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_url_for_remote(self) -> "NexusConfig":
-        """Validate URL is required for remote mode."""
-        if self.mode == "remote" and not self.url:
+        """Validate URL is required for remote profile."""
+        if self.profile == "remote" and not self.url:
             env_url = os.getenv("NEXUS_URL")
             if env_url:
                 self.url = env_url
             else:
-                raise ValueError("url is required for mode='remote'")
+                raise ValueError("url is required for profile='remote'")
         return self
 
     model_config = ConfigDict(
@@ -475,7 +457,6 @@ def _load_from_environment() -> NexusConfig:
     # Map environment variables to config fields
     env_mapping = {
         "NEXUS_PROFILE": "profile",
-        "NEXUS_MODE": "mode",
         "NEXUS_BACKEND": "backend",
         "NEXUS_DATA_DIR": "data_dir",
         "NEXUS_GCS_BUCKET_NAME": "gcs_bucket_name",

--- a/src/nexus/remote/__init__.py
+++ b/src/nexus/remote/__init__.py
@@ -1,7 +1,7 @@
 """Remote Nexus filesystem transport layer.
 
 This module provides the transport and proxy infrastructure for REMOTE
-deployment profile. Use ``nexus.connect(config={"mode": "remote", ...})``
+deployment profile. Use ``nexus.connect(config={"profile": "remote", ...})``
 to create a remote NexusFS instance.
 
 Domain-specific operations are organized into domain clients:
@@ -15,7 +15,7 @@ Domain-specific operations are organized into domain clients:
 
 Example:
     >>> import nexus
-    >>> nx = nexus.connect(config={"mode": "remote", "url": "http://localhost:2026", "api_key": "sk-xxx"})
+    >>> nx = nexus.connect(config={"profile": "remote", "url": "http://localhost:2026", "api_key": "sk-xxx"})
     >>> content = nx.sys_read("/workspace/file.txt")
 """
 

--- a/src/nexus/sdk/__init__.py
+++ b/src/nexus/sdk/__init__.py
@@ -30,9 +30,9 @@ Quick Start (Server Mode - Recommended):
     >>> python_files = nx.glob("**/*.py")
     >>> todos = nx.grep("TODO", file_pattern="**/*.py")
 
-Quick Start (Standalone Mode - Development Only):
+Quick Start (Local - Development Only):
     >>> # No server required, but less suitable for production
-    >>> nx = connect(config={"mode": "standalone", "data_dir": "./nexus-data"})
+    >>> nx = connect(config={"data_dir": "./nexus-data"})
     >>> nx.sys_write("/workspace/file.txt", b"Hello World")
 
 Configuration:
@@ -46,9 +46,8 @@ Configuration:
     ...     "api_key": "your-api-key"
     ... })
     >>>
-    >>> # Standalone mode (development/testing only)
+    >>> # Local mode (development/testing only)
     >>> nx = connect(config={
-    ...     "mode": "standalone",
     ...     "data_dir": "./nexus-data"
     ... })
     >>>

--- a/tests/e2e/self_contained/mcp/conftest.py
+++ b/tests/e2e/self_contained/mcp/conftest.py
@@ -19,7 +19,7 @@ def isolate_mcp_integration_tests(monkeypatch):
         "NEXUS_DATABASE_URL",
         "NEXUS_URL",
         "NEXUS_API_KEY",
-        "NEXUS_MODE",
+        "NEXUS_PROFILE",
     ]
 
     for var in env_vars_to_clear:

--- a/tests/unit/bricks/mcp/conftest.py
+++ b/tests/unit/bricks/mcp/conftest.py
@@ -19,7 +19,7 @@ def isolate_mcp_tests(monkeypatch):
         "NEXUS_DATABASE_URL",
         "NEXUS_URL",
         "NEXUS_API_KEY",
-        "NEXUS_MODE",
+        "NEXUS_PROFILE",
     ]
 
     for var in env_vars_to_clear:

--- a/tests/unit/storage/conftest.py
+++ b/tests/unit/storage/conftest.py
@@ -19,7 +19,7 @@ def isolate_storage_tests(monkeypatch):
         "NEXUS_DATABASE_URL",
         "NEXUS_URL",
         "NEXUS_API_KEY",
-        "NEXUS_MODE",
+        "NEXUS_PROFILE",
     ]
 
     for var in env_vars_to_clear:


### PR DESCRIPTION
## Summary
- Remove `mode` field from `NexusConfig` (standalone/remote/federation)
- `connect()` dispatches on `cfg.profile == "remote"` for remote path
- Federation auto-detected via `try: import nexus.raft` — no explicit mode needed
- No backward-compat shim — `NEXUS_MODE` env var fully removed across all configs, docker-compose, and tests

## Test plan
- [ ] `ruff check` passes (verified)
- [ ] `grep -r "NEXUS_MODE\|cfg\.mode" src/ configs/ dockerfiles/` returns zero matches (verified)
- [ ] `python -c "import nexus; nx = nexus.connect()"` works (default profile)
- [ ] Remote profile: `nexus.connect(config={"profile": "remote", "url": "..."})` works
- [ ] Federation auto-detects when Rust extensions available

🤖 Generated with [Claude Code](https://claude.com/claude-code)