### PR TITLE
fix: EventsService _backend attr removed in #1458

### DIFF
--- a/tests/unit/core/test_nexus_fs_services.py
+++ b/tests/unit/core/test_nexus_fs_services.py
@@ -98,8 +98,8 @@ class TestNexusFSServiceComposition:
         # ShareLinkService should have gateway
         assert fs.share_link_service._gw is not None
 
-        # EventsService should have backend
-        assert fs.events_service._backend == fs.router.route("/").backend
+        # EventsService should exist
+        assert fs.events_service is not None
 
     def test_version_service_delegation(self, tmp_path: Path):
         """Test that VersionService is available on NexusFS."""


### PR DESCRIPTION
## Summary
- Fix `test_nexus_fs_services.py` — `EventsService` no longer has `_backend` after #1458 (kernel OBSERVE refactor)
- This was the CI failure on PR #2841

## Test plan
- [x] `uv run pytest tests/unit/core/test_nexus_fs_services.py` — 2 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)