### PR TITLE
fix: resolve mypy CI errors from PR #2838

### DIFF
--- a/src/nexus/bricks/governance/trust_math.py
+++ b/src/nexus/bricks/governance/trust_math.py
@@ -12,6 +12,8 @@ Algorithm:
         Convergence when ||t(k+1) - t(k)||_1 < epsilon
 """
 
+from typing import cast
+
 import numpy as np
 from scipy import sparse
 
@@ -61,7 +63,7 @@ def eigentrust(
     t = p.copy()
 
     # Power iteration — transpose once
-    ct = c.T.tocsr() if sparse.issparse(c) else c.T
+    ct = cast("sparse.spmatrix", c).T.tocsr() if sparse.issparse(c) else c.T
 
     for _ in range(max_iter):
         t_new = (1 - alpha) * (ct @ t) + alpha * p
@@ -147,7 +149,7 @@ def detect_sybil_cluster(
 def _row_normalize(matrix: np.ndarray | sparse.spmatrix) -> np.ndarray | sparse.spmatrix:
     """Row-normalize a matrix (each row sums to 1, or 0 if all zeros)."""
     if sparse.issparse(matrix):
-        mat = matrix.tocsr().astype(np.float64, copy=True)
+        mat = cast("sparse.spmatrix", matrix).tocsr().astype(np.float64, copy=True)
         row_sums = np.asarray(mat.sum(axis=1)).flatten()
         nonzero = row_sums > 0
         # Scale rows in-place

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -6,6 +6,7 @@ Nexus functionality to AI agents and tools using the fastmcp framework.
 
 import contextlib
 import contextvars
+import inspect
 import json
 import logging
 from typing import Any, cast
@@ -238,7 +239,9 @@ def create_mcp_server(
             # Store in FastMCP's context state so tools can access it via Context.get_state()
             if api_key and context.fastmcp_context:
                 try:
-                    await context.fastmcp_context.set_state("api_key", api_key)
+                    _result = cast(Any, context.fastmcp_context.set_state)("api_key", api_key)
+                    if inspect.isawaitable(_result):
+                        await _result
                     # Also set in context variable (sync path for tool functions)
                     _request_api_key.set(api_key)
                 except Exception:


### PR DESCRIPTION
## Summary
- **trust_math.py**: Use `cast("sparse.spmatrix", ...)` to properly narrow `ndarray | spmatrix` union before calling `.tocsr()`, replacing removed `type: ignore[union-attr]`
- **mcp/server.py**: Use `cast(Any, set_state)()` + `inspect.isawaitable()` to handle both sync (fastmcp 2.x) and async (fastmcp 3.x) `set_state` signatures

Fixes 3 mypy errors introduced by PR #2838's merge.

## Test plan
- [ ] CI "Lint and Type Check" passes (mypy clean)
- [ ] No new `type: ignore` comments added

🤖 Generated with [Claude Code](https://claude.com/claude-code)