### PR TITLE
fix: cache correctness bugs (retry, fallback, glob injection)

### DIFF
--- a/src/nexus/cache/brick.py
+++ b/src/nexus/cache/brick.py
@@ -111,9 +111,15 @@ class CacheBrick:
         if self._started:
             return
         try:
-            await self._store.health_check()
+            healthy = await self._store.health_check()
             self._started = True
-            logger.info("[CacheBrick] started (backend=%s)", self.backend_name)
+            if not healthy:
+                logger.warning(
+                    "[CacheBrick] started but health check returned unhealthy (backend=%s)",
+                    self.backend_name,
+                )
+            else:
+                logger.info("[CacheBrick] started (backend=%s)", self.backend_name)
         except Exception as exc:
             logger.warning("[CacheBrick] start health check failed: %s", exc)
             self._started = True  # Still mark as started — silent degradation

--- a/src/nexus/cache/domain.py
+++ b/src/nexus/cache/domain.py
@@ -21,12 +21,21 @@ NOTE: These are SERVICE-LEVEL domain caches, NOT kernel code.
 import hashlib
 import json
 import logging
+import re
 import struct
 from collections.abc import Awaitable, Callable
 
 from nexus.contracts.cache_store import CacheStoreABC
 
 logger = logging.getLogger(__name__)
+
+# Characters that have special meaning in Redis SCAN/glob patterns.
+_GLOB_SPECIAL_RE = re.compile(r"([*?\[\]])")
+
+
+def _escape_glob(value: str) -> str:
+    """Escape glob special characters so *value* is matched literally."""
+    return _GLOB_SPECIAL_RE.sub(r"[\1]", value)
 
 
 class PermissionCache:
@@ -97,7 +106,10 @@ class PermissionCache:
         subject_id: str,
         zone_id: str,
     ) -> int:
-        pattern = f"perm:{zone_id}:{subject_type}:{subject_id}:*"
+        pattern = (
+            f"perm:{_escape_glob(zone_id)}:{_escape_glob(subject_type)}"
+            f":{_escape_glob(subject_id)}:*"
+        )
         return await self._store.delete_by_pattern(pattern)
 
     async def invalidate_object(
@@ -106,7 +118,10 @@ class PermissionCache:
         object_id: str,
         zone_id: str,
     ) -> int:
-        pattern = f"perm:{zone_id}:*:*:*:{object_type}:{object_id}"
+        pattern = (
+            f"perm:{_escape_glob(zone_id)}:*:*:*"
+            f":{_escape_glob(object_type)}:{_escape_glob(object_id)}"
+        )
         return await self._store.delete_by_pattern(pattern)
 
     async def invalidate_subject_object(
@@ -117,11 +132,15 @@ class PermissionCache:
         object_id: str,
         zone_id: str,
     ) -> int:
-        pattern = f"perm:{zone_id}:{subject_type}:{subject_id}:*:{object_type}:{object_id}"
+        pattern = (
+            f"perm:{_escape_glob(zone_id)}:{_escape_glob(subject_type)}"
+            f":{_escape_glob(subject_id)}:*"
+            f":{_escape_glob(object_type)}:{_escape_glob(object_id)}"
+        )
         return await self._store.delete_by_pattern(pattern)
 
     async def clear(self, zone_id: str | None = None) -> int:
-        pattern = f"perm:{zone_id}:*" if zone_id else "perm:*"
+        pattern = f"perm:{_escape_glob(zone_id)}:*" if zone_id else "perm:*"
         return await self._store.delete_by_pattern(pattern)
 
     async def health_check(self) -> bool:
@@ -206,11 +225,11 @@ class TigerCache:
         zone_id: str | None = None,
     ) -> int:
         parts = [
-            zone_id or "*",
-            subject_type or "*",
-            subject_id or "*",
-            permission or "*",
-            resource_type or "*",
+            _escape_glob(zone_id) if zone_id else "*",
+            _escape_glob(subject_type) if subject_type else "*",
+            _escape_glob(subject_id) if subject_id else "*",
+            _escape_glob(permission) if permission else "*",
+            _escape_glob(resource_type) if resource_type else "*",
         ]
         pattern = f"tiger:{':'.join(parts)}"
         return await self._store.delete_by_pattern(pattern)
@@ -437,7 +456,11 @@ class EmbeddingCache:
             return False
 
     async def clear(self, model: str | None = None) -> int:
-        pattern = f"emb:{self.CACHE_VERSION}:{model}:*" if model else f"emb:{self.CACHE_VERSION}:*"
+        pattern = (
+            f"emb:{self.CACHE_VERSION}:{_escape_glob(model)}:*"
+            if model
+            else f"emb:{self.CACHE_VERSION}:*"
+        )
         return await self._store.delete_by_pattern(pattern)
 
     async def health_check(self) -> bool:

--- a/src/nexus/cache/dragonfly.py
+++ b/src/nexus/cache/dragonfly.py
@@ -32,6 +32,8 @@ try:
     import redis.asyncio as redis
     from redis.asyncio import BlockingConnectionPool
     from redis.backoff import ExponentialBackoff
+    from redis.exceptions import ConnectionError as RedisConnectionError
+    from redis.exceptions import TimeoutError as RedisTimeoutError
     from redis.retry import Retry
 
     REDIS_AVAILABLE = True
@@ -147,7 +149,7 @@ class DragonflyClient:
             # Exponential backoff retry: 3 retries with backoff
             retry = Retry(ExponentialBackoff(), retries=3)
             client_kwargs["retry"] = retry
-            client_kwargs["retry_on_error"] = [ConnectionError, TimeoutError]
+            client_kwargs["retry_on_error"] = [RedisConnectionError, RedisTimeoutError]
 
         self._client = redis.Redis(**client_kwargs)
 

--- a/src/nexus/cache/factory.py
+++ b/src/nexus/cache/factory.py
@@ -124,6 +124,8 @@ class CacheFactory:
             return
 
         # Auto-create from settings
+        dragonfly_ok = False
+
         if self._settings.should_use_dragonfly():
             try:
                 from nexus.cache.dragonfly import DragonflyCacheStore, DragonflyClient
@@ -141,23 +143,32 @@ class CacheFactory:
                 await self._cache_client.connect()
                 self._cache_store = DragonflyCacheStore(self._cache_client)
                 self._has_cache_store = True
+                dragonfly_ok = True
                 logger.info("Cache factory initialized with Dragonfly backend (hot cache only)")
 
             except ImportError:
-                logger.warning("redis package not installed, falling back to NullCacheStore")
+                if self._settings.cache_backend == "dragonfly":
+                    raise ImportError(
+                        "cache_backend='dragonfly' but redis package is not installed"
+                    ) from None
+                logger.warning("redis package not installed, falling back")
                 self._has_cache_store = False
             except Exception as e:
                 if self._settings.cache_backend == "dragonfly":
                     raise
-                logger.warning(
-                    f"Failed to connect to Dragonfly ({e}), falling back to NullCacheStore"
-                )
+                logger.warning(f"Failed to connect to Dragonfly ({e}), falling back")
                 self._has_cache_store = False
-        elif self._record_store is not None:
-            self._using_postgres = True
-            logger.info("Cache factory initialized with PostgreSQL cache backend (fallback)")
-        else:
-            logger.info("Cache factory initialized with NullCacheStore (no Dragonfly configured)")
+
+        # PostgreSQL fallback: used when Dragonfly is not configured OR when
+        # Dragonfly failed in auto mode and a record_store is available.
+        if not dragonfly_ok and self._record_store is not None:
+            if self._settings.cache_backend == "postgres" or not dragonfly_ok:
+                self._using_postgres = True
+                logger.info("Cache factory initialized with PostgreSQL cache backend (fallback)")
+        elif not dragonfly_ok:
+            if self._settings.cache_backend == "postgres":
+                raise RuntimeError("cache_backend='postgres' but no record_store was provided")
+            logger.info("Cache factory initialized with NullCacheStore (no backend available)")
             self._has_cache_store = False
 
         self._initialized = True


### PR DESCRIPTION
## Summary

- **dragonfly.py**: `retry_on_error` was wired to `builtins.ConnectionError`/`TimeoutError`, but redis-py 7.x exceptions don't inherit from builtins — retries never fired. Fixed to use `redis.exceptions.ConnectionError`/`TimeoutError`.
- **factory.py**: PostgreSQL fallback never engaged when Dragonfly failed in auto mode (`elif` prevented fall-through). Restructured to an independent check so PG fallback activates after Dragonfly failure. Forced backends (`cache_backend="dragonfly"` on ImportError, `"postgres"` without record_store) now fail fast instead of silently degrading to NullCacheStore.
- **domain.py**: Invalidation patterns interpolated raw IDs into glob expressions without escaping `*`, `?`, `[]`. Added `_escape_glob()` to prevent over/under-invalidation when IDs contain glob characters (e.g., file paths like `/docs/[ab]`).
- **brick.py**: `start()` ignored `health_check()` return value — a `False` result was logged as a successful start. Now logs a warning when the store reports unhealthy.

## Test plan

- [x] `uv run ruff check` passes on all 4 changed files
- [x] `uv run mypy` passes on all 4 changed files
- [x] `_escape_glob()` verified: `*` → `[*]`, `?` → `[?]`, `[` → `[[]`, `]` → `[]]`
- [x] Pre-commit hooks (ruff, ruff-format, mypy, brick zero-core-imports) all pass
- [ ] CI pipeline passes