### PR TITLE
fix(#1424): skip Docker CLI tests for commands moved to nexusd

### DIFF
--- a/tests/e2e/self_contained/test_cli_lifecycle.py
+++ b/tests/e2e/self_contained/test_cli_lifecycle.py
@@ -120,6 +120,9 @@ docker_required = pytest.mark.skipif(
 )
 
 
+@pytest.mark.skip(
+    reason="up/down/logs moved to nexusd after PR #2842; nexus CLI no longer has these commands"
+)
 @docker_required
 class TestUpDownE2E:
     """Test ``nexus up`` and ``nexus down`` against real Docker.
@@ -173,6 +176,9 @@ class TestUpDownE2E:
         assert "nonexistent" in combined or "unknown" in combined
 
 
+@pytest.mark.skip(
+    reason="logs moved to nexusd after PR #2842; nexus CLI no longer has this command"
+)
 @docker_required
 class TestLogsE2E:
     """Test ``nexus logs`` against real Docker."""


### PR DESCRIPTION
## Summary
- Skip `TestUpDownE2E` and `TestLogsE2E` in `test_cli_lifecycle.py` — the `up`, `down`, and `logs` commands were moved from `nexus` to `nexusd` in PR #2842
- These tests cause 3 failures in Self-Contained E2E on develop

## Test plan
- [ ] CI Self-Contained E2E passes (the 3 Docker CLI failures should become skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)