### PR TITLE
fix: 11 verified CLI bugs across 8 command modules

### DIFF
--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -147,6 +147,9 @@ def create_user(
             "subject_type": subject_type,
         }
 
+        if email is not None:
+            params["email"] = email
+
         if expires_days is not None:
             params["expires_days"] = expires_days
 

--- a/src/nexus/cli/commands/directory.py
+++ b/src/nexus/cli/commands/directory.py
@@ -348,11 +348,16 @@ def tree(
             from pathlib import PurePosixPath
 
             tree_dict: dict[str, Any] = defaultdict(dict)
+            # Strip the base path prefix so depth is relative to target path
+            base_parts = PurePosixPath(path).parts
             for entry in data["files"]:
                 parts = PurePosixPath(entry["path"]).parts
+                rel_parts = parts[len(base_parts) :]
+                if not rel_parts:
+                    continue
                 current = tree_dict
-                for i, part in enumerate(parts):
-                    if i == len(parts) - 1:
+                for i, part in enumerate(rel_parts):
+                    if i == len(rel_parts) - 1:
                         current[part] = entry["size"]
                     else:
                         if part not in current or not isinstance(current[part], dict):

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -143,7 +143,10 @@ def cat(
                             file_size = 0
 
                     if file_size > STREAM_THRESHOLD:
-                        console.print(f"[dim]Streaming large file ({file_size:,} bytes)...[/dim]")
+                        print(
+                            f"Streaming large file ({file_size:,} bytes)...",
+                            file=sys.stderr,
+                        )
                         for chunk in nx.stream(  # type: ignore[attr-defined]
                             path, chunk_size=65536, context=operation_context
                         ):
@@ -209,7 +212,7 @@ def _cat_time_travel(
     time_travel = getattr(nx, "time_travel_service", None)
     if time_travel is None:
         console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
-        return
+        sys.exit(1)
 
     with timing.phase("server"):
         state = time_travel.get_file_at_operation(path, at_operation)

--- a/src/nexus/cli/commands/oauth.py
+++ b/src/nexus/cli/commands/oauth.py
@@ -68,7 +68,9 @@ def get_token_manager(db_path: str | None = None) -> TokenManager:
         return TokenManager(db_path=db_path)
     else:
         # Use provided db_path
-        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        parent_dir = os.path.dirname(db_path)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
         return TokenManager(db_path=db_path)
 
 
@@ -377,7 +379,7 @@ def setup_gdrive(
     # Exchange code for tokens
     console.print("\n[dim]Exchanging code for tokens...[/dim]")
 
-    async def _exchange_and_store() -> None:
+    async def _exchange_and_store() -> str:
         # Exchange code
         credential = await provider.exchange_code(auth_code)
 
@@ -393,6 +395,7 @@ def setup_gdrive(
         manager.close()
 
         console.print(f"[green]✓[/green] Stored credential with ID: {cred_id}")
+        return cred_id
 
     import asyncio
 
@@ -567,7 +570,4 @@ def setup_x(
         console.print("3. Try the example: [cyan]python examples/x_connector_example.py[/cyan]")
     except Exception as e:
         console.print(f"\n[red]✗[/red] Failed to setup X OAuth: {e}")
-        import traceback
-
-        console.print(f"[dim]{traceback.format_exc()}[/dim]")
         sys.exit(1)

--- a/src/nexus/cli/commands/rebac.py
+++ b/src/nexus/cli/commands/rebac.py
@@ -489,6 +489,12 @@ def rebac_expand_cmd(
 @click.argument("object_type", type=str)
 @click.argument("object_id", type=str)
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed path information")
+@click.option(
+    "--zone-id",
+    type=str,
+    default=None,
+    help="Zone ID for multi-zone isolation (e.g., 'org_acme'). Can also be set via NEXUS_ZONE_ID env var.",
+)
 @add_backend_options
 def rebac_explain_cmd(
     subject_type: str,
@@ -497,6 +503,7 @@ def rebac_explain_cmd(
     object_type: str,
     object_id: str,
     verbose: bool,
+    zone_id: str | None,
     remote_url: str | None,
     remote_api_key: str | None,
 ) -> None:
@@ -514,17 +521,30 @@ def rebac_explain_cmd(
 
         # Show detailed path information
         nexus rebac explain agent alice read file file123 --verbose
+
+        # Explain within a specific zone
+        nexus rebac explain agent alice read file file123 --zone-id org_acme
     """
     try:
         import json
+        import os
 
         nx = get_filesystem(remote_url, remote_api_key)
 
+        # Resolve zone_id from option or environment
+        resolved_zone_id = zone_id or os.getenv("NEXUS_ZONE_ID")
+
         # Get explanation
+        explain_kwargs: dict[str, Any] = {
+            "subject": (subject_type, subject_id),
+            "permission": permission,
+            "object": (object_type, object_id),
+        }
+        if resolved_zone_id:
+            explain_kwargs["zone_id"] = resolved_zone_id
+
         explanation = nx.rebac_service.rebac_explain_sync(  # type: ignore[attr-defined]
-            subject=(subject_type, subject_id),
-            permission=permission,
-            object=(object_type, object_id),
+            **explain_kwargs,
         )
 
         nx.close()

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -83,7 +83,7 @@ def glob(
                 for match in matches:
                     is_dir = (
                         nx.sys_is_directory(match)
-                        if hasattr(nx, "is_directory")
+                        if hasattr(nx, "sys_is_directory")
                         else match.endswith("/")
                     )
                     if (type == "d" and is_dir) or (type == "f" and not is_dir):
@@ -151,10 +151,28 @@ def glob(
 @click.option("-n", "--line-number", is_flag=True, help="Show line numbers (like grep -n)")
 @click.option("-l", "--files-with-matches", is_flag=True, help="Show only filenames with matches")
 @click.option("-c", "--count", is_flag=True, help="Show count of matches per file")
-@click.option("--invert-match", is_flag=True, help="Invert match (show non-matching lines)")
-@click.option("-A", "--after-context", type=int, default=0, help="Show N lines after match")
-@click.option("-B", "--before-context", type=int, default=0, help="Show N lines before match")
-@click.option("-C", "--context", type=int, default=0, help="Show N lines before and after match")
+@click.option("--invert-match", is_flag=True, help="Invert match (not yet wired to core grep)")
+@click.option(
+    "-A",
+    "--after-context",
+    type=int,
+    default=0,
+    help="Show N lines after match (not yet wired to core grep)",
+)
+@click.option(
+    "-B",
+    "--before-context",
+    type=int,
+    default=0,
+    help="Show N lines before match (not yet wired to core grep)",
+)
+@click.option(
+    "-C",
+    "--context",
+    type=int,
+    default=0,
+    help="Show N lines before and after match (not yet wired to core grep)",
+)
 @click.option("-m", "--max-results", default=100, help="Maximum results to show")
 @click.option(
     "--search-mode",

--- a/src/nexus/cli/commands/workflows.py
+++ b/src/nexus/cli/commands/workflows.py
@@ -19,8 +19,8 @@ def _get_engine_with_storage():  # type: ignore[no-untyped-def]
     """
     import nexus
 
-    # Get data directory from env or default
-    data_dir = os.getenv("NEXUS_DATA_DIR", "./nexus-data")
+    # Get data directory from env or default (consistent with rest of CLI)
+    data_dir = os.getenv("NEXUS_DATA_DIR", os.path.join(os.path.expanduser("~"), ".nexus", "data"))
 
     # Connect to Nexus — factory creates workflow_engine via _create_workflow_engine()
     nx = nexus.connect(config={"data_dir": str(data_dir)})

--- a/src/nexus/cli/commands/workspace.py
+++ b/src/nexus/cli/commands/workspace.py
@@ -389,13 +389,21 @@ def restore_cmd(
     try:
         nx: Any = get_filesystem(remote_url, remote_api_key)
 
-        # Get snapshot info
-        snapshots = nx._workspace_rpc_service.workspace_log(workspace_path=path, limit=1000)
+        # Get snapshot info — fetch by snapshot number directly if the API supports it,
+        # otherwise scan all snapshots without an arbitrary limit
         snap_info = None
-        for s in snapshots:
-            if s["snapshot_number"] == snapshot:
-                snap_info = s
-                break
+        try:
+            # Try direct lookup first (avoids scanning)
+            snap_info = nx._workspace_rpc_service.workspace_get_snapshot(
+                workspace_path=path, snapshot_number=snapshot
+            )
+        except (AttributeError, TypeError):
+            # Fallback: scan log without a hard limit so older snapshots are found
+            snapshots = nx._workspace_rpc_service.workspace_log(workspace_path=path, limit=0)
+            for s in snapshots:
+                if s["snapshot_number"] == snapshot:
+                    snap_info = s
+                    break
 
         if not snap_info:
             console.print(f"[red]✗[/red] Snapshot #{snapshot} not found")


### PR DESCRIPTION
## Summary

Fixes 11 real bugs found during a code review audit of the CLI surface. Each bug was independently verified against the source before fixing.

- **rebac**: `explain` command now accepts `--zone-id` / `NEXUS_ZONE_ID` for multi-zone correctness (was the only rebac subcommand ignoring zone context)
- **admin**: `--email` param on `create-user` is now sent to the backend (was silently dropped from the RPC params dict)
- **oauth**: `get_token_manager()` no longer crashes with `os.makedirs("")` when `--db-path` is a bare filename
- **oauth**: `setup-gdrive` `_exchange_and_store()` returns `cred_id` (was `-> None`, always printing `Credential ID: None`)
- **oauth**: `setup-x` no longer dumps full `traceback.format_exc()` on auth failure
- **search**: `glob -t` type filter checks `hasattr(nx, "sys_is_directory")` (was checking wrong name `"is_directory"`)
- **search**: `grep -v/-A/-B/-C` help text now notes "(not yet wired to core grep)" so users know the flags are accepted but inactive
- **file_ops**: `cat` streaming status message goes to `stderr` (was printing Rich markup to `stdout`, corrupting piped binary output)
- **file_ops**: `cat --at-operation` exits non-zero when time-travel is unavailable (was `return` → exit code 0)
- **directory**: `tree -L` depth is now relative to the target path (was counting from filesystem root via `PurePosixPath.parts`)
- **workspace**: `restore` tries direct snapshot lookup first, falls back to unlimited scan (was capped at `limit=1000`, missing older snapshots)
- **workflows**: default data dir changed from `./nexus-data` to `~/.nexus/data` (consistent with rest of CLI)

## Test plan

- [ ] `uv run ruff check .` passes
- [ ] `uv run ruff format --check .` passes
- [ ] Pre-commit hooks (ruff, mypy, format) all pass
- [ ] `nexus rebac explain --help` shows `--zone-id` option
- [ ] `nexus tree /some/path -L 2` counts depth from `/some/path`, not `/`
- [ ] `nexus cat /large-file | head` doesn't get Rich markup mixed in
- [ ] `nexus admin create-user x --name X --email y` sends email to backend