### PR TITLE
fix: update E2E tests to use nexusd instead of nexus serve

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -4,7 +4,7 @@ Provides fixtures for:
 - isolated_db: Isolated SQLite database for each test
 - metadata_store: Raft metadata store (from integration tests)
 - record_store: In-memory SQLAlchemy record store (from integration tests)
-- nexus_server: Actual nexus serve process running on a free port
+- nexus_server: Actual nexusd process running on a free port
 - test_app: httpx client for making real HTTP requests
 - nexus_fs: Direct NexusFS instance (no server)
 
@@ -110,12 +110,12 @@ def isolated_db(tmp_path, monkeypatch):
 
 @pytest.fixture(scope="function")
 def nexus_server(isolated_db, tmp_path):
-    """Start actual nexus serve process for true e2e testing.
+    """Start actual nexusd process for true e2e testing.
 
     This fixture:
     1. Creates storage directory and database
     2. Finds a free port
-    3. Starts `nexus serve` as subprocess
+    3. Starts ``nexusd`` as subprocess
     4. Waits for server to be ready
     5. Yields server info (port, base_url)
     6. Kills server process on cleanup
@@ -154,8 +154,8 @@ def nexus_server(isolated_db, tmp_path):
         env["NEXUS_DRAGONFLY_COORDINATION_URL"] = dragonfly_url
         env["NEXUS_ALLOW_SINGLE_DRAGONFLY"] = "true"
 
-    # Start nexus serve process
-    # Using python -c to invoke the CLI entry point from source
+    # Start nexusd process
+    # Using python -c to invoke the daemon entry point from source
     # --data-dir sets both storage path and database location
     # Uses FastAPI async server (default) for full API support including Graph API
     process = subprocess.Popen(
@@ -163,8 +163,8 @@ def nexus_server(isolated_db, tmp_path):
             sys.executable,
             "-c",
             (
-                f"from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                f"from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}'])"
             ),
         ],

--- a/tests/e2e/self_contained/conftest.py
+++ b/tests/e2e/self_contained/conftest.py
@@ -1,6 +1,6 @@
 """Conftest for self-contained E2E tests.
 
-Provides a lightweight ``nexus_server`` fixture that spins up ``nexus serve``
+Provides a lightweight ``nexus_server`` fixture that spins up ``nexusd``
 with a temp SQLite database. No external infrastructure required.
 """
 
@@ -41,7 +41,7 @@ def _drain_pipe(pipe, lines: list[str], ready: threading.Event | None = None) ->
 
 @pytest.fixture(scope="function")
 def nexus_server(tmp_path: Path):
-    """Start a lightweight ``nexus serve`` process for E2E testing.
+    """Start a lightweight ``nexusd`` process for E2E testing.
 
     Uses SQLite (no PostgreSQL required). Yields a dict with 'port' and 'base_url'.
     """
@@ -49,7 +49,7 @@ def nexus_server(tmp_path: Path):
     base_url = f"http://127.0.0.1:{port}"
 
     # Use the console_scripts entry point from the same venv
-    nexus_bin = str(Path(sys.executable).parent / "nexus")
+    nexusd_bin = str(Path(sys.executable).parent / "nexusd")
 
     env = os.environ.copy()
     env["NEXUS_DATABASE_URL"] = f"sqlite:///{tmp_path / 'test.db'}"
@@ -59,8 +59,7 @@ def nexus_server(tmp_path: Path):
 
     process = subprocess.Popen(
         [
-            nexus_bin,
-            "serve",
+            nexusd_bin,
             "--host",
             "127.0.0.1",
             "--port",

--- a/tests/e2e/self_contained/test_cli_output_e2e.py
+++ b/tests/e2e/self_contained/test_cli_output_e2e.py
@@ -5,7 +5,7 @@ Tests run against a REAL local NexusFS with a temp data directory.
 Two test modes:
   1. **Local** — each CLI command subprocess cold-starts NexusFS (tests the
      standalone experience, ~2s connect overhead per invocation).
-  2. **Remote** — a ``nexus serve`` daemon is started once; CLI commands hit
+  2. **Remote** — a ``nexusd`` daemon is started once; CLI commands hit
      it via ``--remote-url`` (tests the production experience, fast connect).
 
 Validates:
@@ -423,7 +423,7 @@ def _seed_via_server(server_info: dict[str, str]) -> None:
 
 @pytest.fixture(scope="module")
 def remote_server(tmp_path_factory: pytest.TempPathFactory):  # noqa: ANN201
-    """Start a nexus serve daemon, seed data, and yield connection info.
+    """Start a nexusd daemon, seed data, and yield connection info.
 
     The server is started once per module and shared across all remote tests.
     Data is seeded through the running server to avoid redb lock conflicts.
@@ -440,13 +440,11 @@ def remote_server(tmp_path_factory: pytest.TempPathFactory):  # noqa: ANN201
         "NEXUS_DATA_DIR": data_dir,
     }
 
-    # Start server as a subprocess
+    # Start server as a subprocess using nexusd entry point
+    nexusd_bin = str(Path(sys.executable).parent / "nexusd")
     server_proc = subprocess.Popen(
         [
-            sys.executable,
-            "-c",
-            "from nexus.cli.main import main; main()",
-            "serve",
+            nexusd_bin,
             "--host",
             "127.0.0.1",
             "--port",

--- a/tests/e2e/server/test_a2a_auth_e2e.py
+++ b/tests/e2e/server/test_a2a_auth_e2e.py
@@ -63,8 +63,8 @@ def auth_server(isolated_db, tmp_path):
             sys.executable,
             "-c",
             (
-                f"from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                f"from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', "
                 f"'--api-key', '{API_KEY}'])"
             ),

--- a/tests/e2e/server/test_agent_registry_pg_e2e.py
+++ b/tests/e2e/server/test_agent_registry_pg_e2e.py
@@ -432,8 +432,8 @@ class TestServerE2E:
                 sys.executable,
                 "-c",
                 (
-                    "from nexus.cli import main; "
-                    f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                    "from nexus.daemon.main import main; "
+                    f"main(['--host', '127.0.0.1', '--port', '{port}', "
                     f"'--data-dir', '{tmp_path}', '--auth-type', 'database', "
                     f"'--init', '--reset', '--admin-user', 'e2e-admin'])"
                 ),
@@ -787,8 +787,8 @@ class TestRPCEndpoints:
                 sys.executable,
                 "-c",
                 (
-                    "from nexus.cli import main; "
-                    f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                    "from nexus.daemon.main import main; "
+                    f"main(['--host', '127.0.0.1', '--port', '{port}', "
                     f"'--data-dir', '{tmp_path}', '--auth-type', 'database', "
                     f"'--init', '--reset', '--admin-user', 'e2e-rpc-admin'])"
                 ),
@@ -1201,8 +1201,8 @@ class TestDualWriteBridge:
                 sys.executable,
                 "-c",
                 (
-                    "from nexus.cli import main; "
-                    f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                    "from nexus.daemon.main import main; "
+                    f"main(['--host', '127.0.0.1', '--port', '{port}', "
                     f"'--data-dir', '{tmp_path}', '--auth-type', 'database', "
                     f"'--init', '--reset', '--admin-user', 'e2e-dual-admin'])"
                 ),

--- a/tests/e2e/server/test_agent_wallet_e2e.py
+++ b/tests/e2e/server/test_agent_wallet_e2e.py
@@ -151,8 +151,8 @@ def nexus_server_with_pay(tmp_path, pg_engine):
             sys.executable,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', '--auth-type', 'database', "
                 f"'--init', '--reset', '--admin-user', 'e2e-wallet-admin'])"
             ),
@@ -423,7 +423,7 @@ def _build_permissions_startup_script(port: int, data_dir: str) -> str:
         sys.path.insert(0, os.getenv("PYTHONPATH", ""))
 
         from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
-        from nexus.cli import main as cli_main
+        from nexus.daemon.main import main as cli_main
 
         auth_config = {{
             "api_keys": {{
@@ -451,7 +451,7 @@ def _build_permissions_startup_script(port: int, data_dir: str) -> str:
         factory.create_auth_provider = _patched
 
         cli_main([
-            'serve', '--host', '127.0.0.1', '--port', '{port}',
+            '--host', '127.0.0.1', '--port', '{port}',
             '--data-dir', '{data_dir}',
             '--auth-type', 'static', '--api-key', '{ADMIN_KEY}',
         ])

--- a/tests/e2e/server/test_async_files_permissions_e2e.py
+++ b/tests/e2e/server/test_async_files_permissions_e2e.py
@@ -117,8 +117,8 @@ def server():
             PYTHON,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{data_dir}'])"
             ),
         ],

--- a/tests/e2e/server/test_audit_e2e.py
+++ b/tests/e2e/server/test_audit_e2e.py
@@ -101,8 +101,8 @@ def audit_server(tmp_path_factory):
             sys.executable,
             "-c",
             (
-                f"from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                f"from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', "
                 f"'--auth-type', 'database', '--init'])"
             ),

--- a/tests/e2e/server/test_batch_optimization_e2e.py
+++ b/tests/e2e/server/test_batch_optimization_e2e.py
@@ -71,7 +71,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         sys.path.insert(0, os.getenv("PYTHONPATH", ""))
 
         from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
-        from nexus.cli import main as cli_main
+        from nexus.daemon.main import main as cli_main
 
         auth_config = {{
             "api_keys": {{
@@ -114,7 +114,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         ns_mod.NamespaceManager = _NoCacheNS
 
         cli_main([
-            'serve', '--host', '127.0.0.1', '--port', '{port}',
+            '--host', '127.0.0.1', '--port', '{port}',
             '--data-dir', '{data_dir}',
             '--auth-type', 'static', '--api-key', '{ADMIN_API_KEY}',
         ])

--- a/tests/e2e/server/test_conflict_api_e2e.py
+++ b/tests/e2e/server/test_conflict_api_e2e.py
@@ -70,7 +70,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         sys.path.insert(0, os.getenv("PYTHONPATH", ""))
 
         from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
-        from nexus.cli import main as cli_main
+        from nexus.daemon.main import main as cli_main
 
         auth_config = {{
             "api_keys": {{
@@ -106,7 +106,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         ns_mod.NamespaceManager = _NoCacheNS
 
         cli_main([
-            'serve', '--host', '127.0.0.1', '--port', '{port}',
+            '--host', '127.0.0.1', '--port', '{port}',
             '--data-dir', '{data_dir}',
             '--auth-type', 'static', '--api-key', '{ADMIN_API_KEY}',
         ])

--- a/tests/e2e/server/test_delta_sync_e2e.py
+++ b/tests/e2e/server/test_delta_sync_e2e.py
@@ -145,8 +145,8 @@ def nexus_server_pg(tmp_path, admin_api_key):
             sys.executable,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', '--auth-type', 'database'])"
             ),
         ],
@@ -264,8 +264,8 @@ def nexus_server_pg_with_users(tmp_path, admin_api_key, non_admin_api_key):
             sys.executable,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', '--auth-type', 'database'])"
             ),
         ],

--- a/tests/e2e/server/test_ipc_e2e.py
+++ b/tests/e2e/server/test_ipc_e2e.py
@@ -65,8 +65,8 @@ def auth_server(tmp_path):
             sys.executable,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', "
                 "'--auth-type', 'database', '--init'])"
             ),

--- a/tests/e2e/server/test_log_redaction_e2e.py
+++ b/tests/e2e/server/test_log_redaction_e2e.py
@@ -78,8 +78,8 @@ def redaction_server(tmp_path, monkeypatch):
             sys.executable,
             "-c",
             (
-                f"from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                f"from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', '--init', '--auth-type', 'database'])"
             ),
         ],
@@ -230,8 +230,8 @@ def test_log_redaction_disabled_e2e(tmp_path, monkeypatch) -> None:
             sys.executable,
             "-c",
             (
-                f"from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                f"from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', '--init', '--auth-type', 'database'])"
             ),
         ],

--- a/tests/e2e/server/test_namespace_async_e2e.py
+++ b/tests/e2e/server/test_namespace_async_e2e.py
@@ -52,7 +52,7 @@ def _wait_for_health(base_url: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> 
 
 @pytest.fixture(scope="module")
 def server():
-    """Start nexus serve with database auth and permissions enabled."""
+    """Start nexusd with database auth and permissions enabled."""
     port = _find_free_port()
     data_dir = tempfile.mkdtemp(prefix="nexus_ns_e2e_")
     backend_root = os.path.join(data_dir, "backend")
@@ -81,7 +81,7 @@ def server():
         [
             PYTHON,
             "-c",
-            f"from nexus.cli import main; main(['serve', '--host', '127.0.0.1', '--port', '{port}', '--data-dir', '{data_dir}'])",
+            f"from nexus.daemon.main import main; main(['--host', '127.0.0.1', '--port', '{port}', '--data-dir', '{data_dir}'])",
         ],
         env=env,
         stdout=subprocess.PIPE,

--- a/tests/e2e/server/test_namespace_dcache_database_e2e.py
+++ b/tests/e2e/server/test_namespace_dcache_database_e2e.py
@@ -324,8 +324,8 @@ def server():
             PYTHON,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{data_dir}', '--auth-type', 'database'])"
             ),
         ],

--- a/tests/e2e/server/test_namespace_fuse_e2e.py
+++ b/tests/e2e/server/test_namespace_fuse_e2e.py
@@ -123,8 +123,8 @@ def server():
             PYTHON,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{data_dir}', '--auth-type', 'static', '--api-key', 'test-api-key'])"
             ),
         ],

--- a/tests/e2e/server/test_namespace_permissions_e2e.py
+++ b/tests/e2e/server/test_namespace_permissions_e2e.py
@@ -182,8 +182,8 @@ def server():
             PYTHON,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{data_dir}'])"
             ),
         ],

--- a/tests/e2e/server/test_normal_user_e2e.py
+++ b/tests/e2e/server/test_normal_user_e2e.py
@@ -147,8 +147,8 @@ def e2e_server():
                 PYTHON,
                 "-c",
                 (
-                    "from nexus.cli import main; "
-                    f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                    "from nexus.daemon.main import main; "
+                    f"main(['--host', '127.0.0.1', '--port', '{port}', "
                     f"'--data-dir', '{data_dir}', "
                     "'--auth-type', 'database', '--init', '--reset'])"
                 ),

--- a/tests/e2e/server/test_operations_e2e.py
+++ b/tests/e2e/server/test_operations_e2e.py
@@ -94,8 +94,8 @@ def operations_server(tmp_path_factory):
             sys.executable,
             "-c",
             (
-                f"from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                f"from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', "
                 f"'--auth-type', 'database', '--init'])"
             ),

--- a/tests/e2e/server/test_permission_portability_server_e2e.py
+++ b/tests/e2e/server/test_permission_portability_server_e2e.py
@@ -247,8 +247,8 @@ def e2e_env():
                 PYTHON,
                 "-c",
                 (
-                    "from nexus.cli import main; "
-                    f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                    "from nexus.daemon.main import main; "
+                    f"main(['--host', '127.0.0.1', '--port', '{port}', "
                     f"'--data-dir', '{target_dir}'])"
                 ),
             ],

--- a/tests/e2e/server/test_persistent_views_e2e.py
+++ b/tests/e2e/server/test_persistent_views_e2e.py
@@ -146,7 +146,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         sys.path.insert(0, os.getenv("PYTHONPATH", ""))
 
         from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
-        from nexus.cli import main as cli_main
+        from nexus.daemon.main import main as cli_main
 
         # Multi-key auth config
         auth_config = {{
@@ -191,7 +191,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         ns_mod.NamespaceManager = _NoCacheNS
 
         cli_main([
-            'serve', '--host', '127.0.0.1', '--port', '{port}',
+            '--host', '127.0.0.1', '--port', '{port}',
             '--data-dir', '{data_dir}',
             '--auth-type', 'static', '--api-key', '{ADMIN_API_KEY}',
         ])

--- a/tests/e2e/server/test_pg_metrics_e2e.py
+++ b/tests/e2e/server/test_pg_metrics_e2e.py
@@ -75,8 +75,8 @@ def server(tmp_path_factory):
             PYTHON,
             "-c",
             (
-                f"from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                f"from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp}'])"
             ),
         ],

--- a/tests/e2e/server/test_prefix_filtering_e2e.py
+++ b/tests/e2e/server/test_prefix_filtering_e2e.py
@@ -85,7 +85,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         sys.path.insert(0, os.getenv("PYTHONPATH", ""))
 
         from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
-        from nexus.cli import main as cli_main
+        from nexus.daemon.main import main as cli_main
 
         auth_config = {{
             "api_keys": {{
@@ -121,7 +121,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         ns_mod.NamespaceManager = _NoCacheNS
 
         cli_main([
-            'serve', '--host', '127.0.0.1', '--port', '{port}',
+            '--host', '127.0.0.1', '--port', '{port}',
             '--data-dir', '{data_dir}',
             '--auth-type', 'static', '--api-key', '{ADMIN_API_KEY}',
         ])

--- a/tests/e2e/server/test_raft_auth_permissions_e2e.py
+++ b/tests/e2e/server/test_raft_auth_permissions_e2e.py
@@ -111,8 +111,8 @@ def db_auth_server(
             sys.executable,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', "
                 "'--auth-type', 'database', '--init'])"
             ),

--- a/tests/e2e/server/test_rebac_latency_e2e.py
+++ b/tests/e2e/server/test_rebac_latency_e2e.py
@@ -127,8 +127,8 @@ def server():
             PYTHON,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{data_dir}'])"
             ),
         ],

--- a/tests/e2e/server/test_reputation_e2e.py
+++ b/tests/e2e/server/test_reputation_e2e.py
@@ -125,8 +125,8 @@ def nexus_server(tmp_path_factory, pg_engine):
             sys.executable,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{tmp_path}', '--auth-type', 'database', "
                 f"'--init', '--reset', '--admin-user', 'e2e-reputation-admin'])"
             ),

--- a/tests/e2e/server/test_rpc_proxy_e2e.py
+++ b/tests/e2e/server/test_rpc_proxy_e2e.py
@@ -96,8 +96,8 @@ def e2e_server(tmp_path_factory):
             PYTHON,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{data_dir}', "
                 "'--auth-type', 'database', '--init', '--reset'])"
             ),

--- a/tests/e2e/server/test_stale_session_server_e2e.py
+++ b/tests/e2e/server/test_stale_session_server_e2e.py
@@ -109,8 +109,8 @@ def server():
             PYTHON,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--data-dir', '{data_dir}', "
                 f"'--auth-type', 'database', '--init'])"
             ),

--- a/tests/e2e/server/test_streaming_e2e.py
+++ b/tests/e2e/server/test_streaming_e2e.py
@@ -63,7 +63,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         sys.path.insert(0, os.getenv("PYTHONPATH", ""))
 
         from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
-        from nexus.cli import main as cli_main
+        from nexus.daemon.main import main as cli_main
 
         auth_config = {{
             "api_keys": {{
@@ -99,7 +99,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         ns_mod.NamespaceManager = _NoCacheNS
 
         cli_main([
-            'serve', '--host', '127.0.0.1', '--port', '{port}',
+            '--host', '127.0.0.1', '--port', '{port}',
             '--data-dir', '{data_dir}',
             '--auth-type', 'static', '--api-key', '{ADMIN_API_KEY}',
         ])

--- a/tests/e2e/server/test_v2_auth_e2e.py
+++ b/tests/e2e/server/test_v2_auth_e2e.py
@@ -144,8 +144,8 @@ def server(db_and_keys):
             sys.executable,
             "-c",
             (
-                "from nexus.cli import main; "
-                f"main(['serve', '--host', '127.0.0.1', '--port', '{port}', "
+                "from nexus.daemon.main import main; "
+                f"main(['--host', '127.0.0.1', '--port', '{port}', "
                 f"'--auth-type', 'database', "
                 f"'--data-dir', '{tmp_dir}'])"
             ),

--- a/tests/e2e/server/test_write_back_permissions_e2e.py
+++ b/tests/e2e/server/test_write_back_permissions_e2e.py
@@ -84,7 +84,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         sys.path.insert(0, os.getenv("PYTHONPATH", ""))
 
         from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
-        from nexus.cli import main as cli_main
+        from nexus.daemon.main import main as cli_main
 
         # Create multi-key auth provider BEFORE starting the CLI
         # The CLI will pick up the auth via the global _auth_override
@@ -137,7 +137,7 @@ def _build_startup_script(port: int, data_dir: str) -> str:
         nf_mod.NamespaceManager = _TightRevisionNS
 
         cli_main([
-            'serve', '--host', '127.0.0.1', '--port', '{port}',
+            '--host', '127.0.0.1', '--port', '{port}',
             '--data-dir', '{data_dir}',
             '--auth-type', 'static', '--api-key', '{ADMIN_API_KEY}',
         ])


### PR DESCRIPTION
## Summary
- Update all 31 E2E test files to use `nexusd` instead of deleted `nexus serve`
- Replace `from nexus.cli import main; main(['serve', ...])` with `from nexus.daemon.main import main; main([...])`
- Update self-contained conftest.py to use `nexusd` binary entry point
- Follow-up to PR #2849 which introduced `nexusd` and deleted `nexus serve`

## Test plan
- [ ] E2E Tests (Self-Contained) should pass (was failing due to `nexus serve` removal)
- [ ] All other CI checks should remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)