### PR TITLE
docs(#1447): fix duplicate §9 in backend-architecture.md

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -554,31 +554,6 @@ contract concern.
 
 ---
 
-## 9. Files Changed
-
-### New Files
-
-| File | Lines | Purpose |
-|---|---|---|
-| `backends/transports/local_transport.py` | 317 | `LocalBlobTransport` — local filesystem `BlobTransport` |
-| `backends/engines/cdc.py` | 373 | `CDCEngine` — extracted from `ChunkedStorageMixin` |
-
-### Renamed Files
-
-See Section 5.2 for the full rename table (thin connector files + classes + registration names).
-
-### Refactored Files
-
-| File | Change |
-|---|---|
-| `backends/cas_backend.py` (588L) | Optional `bloom_filter`, `content_cache`, `stripe_lock`, `on_write_callback` DI params |
-| `backends/factory.py` (177L) | Rewire `"local"`, `"local_connector"` connector creation |
-| `backends/registry.py` (650L) | Update connector registration + add old-name aliases (Section 5.2) |
-| `backends/__init__.py` (130L) | Update exports: remove old, add `LocalBlobTransport`, `CDCEngine` |
-
-
----
-
 ## 9. Verification
 
 ```bash


### PR DESCRIPTION
## Summary
- Remove duplicate §9 "Files Changed" section (changelog-style tracking, not needed in architecture doc)
- Verification and Open Questions now correctly numbered §9/§10

🤖 Generated with [Claude Code](https://claude.com/claude-code)