### PR TITLE
fix: address 9 security/correctness issues from Codex review

### DIFF
--- a/src/nexus/core/_compact_generated.py
+++ b/src/nexus/core/_compact_generated.py
@@ -15,6 +15,7 @@ and timezone information across serialization boundaries.
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -25,10 +26,12 @@ if TYPE_CHECKING:
 # --- String interning ---
 # Single global pool: string -> int ID, and reverse lookup.
 # All string fields share one pool for simplicity.
+# Protected by _POOL_LOCK against concurrent first-seen collisions.
 
 _STRING_POOL: dict[str, int] = {}
 _STRING_POOL_REVERSE: dict[int, str] = {}
 _NEXT_ID: int = 0
+_POOL_LOCK = threading.Lock()
 
 
 def _intern(s: str | None) -> int:
@@ -36,11 +39,18 @@ def _intern(s: str | None) -> int:
     global _NEXT_ID
     if s is None:
         return -1
-    if s not in _STRING_POOL:
+    # Fast path: already interned (read-only, safe without lock)
+    existing = _STRING_POOL.get(s)
+    if existing is not None:
+        return existing
+    with _POOL_LOCK:
+        # Re-check under lock (another thread may have inserted)
+        if s in _STRING_POOL:
+            return _STRING_POOL[s]
         _STRING_POOL[s] = _NEXT_ID
         _STRING_POOL_REVERSE[_NEXT_ID] = s
         _NEXT_ID += 1
-    return _STRING_POOL[s]
+        return _NEXT_ID - 1
 
 
 def _resolve(id: int) -> str | None:
@@ -139,6 +149,7 @@ def get_intern_pool_stats() -> dict[str, int]:
 def clear_intern_pool() -> None:
     """Clear the intern pool. Use only for testing."""
     global _NEXT_ID
-    _STRING_POOL.clear()
-    _STRING_POOL_REVERSE.clear()
-    _NEXT_ID = 0
+    with _POOL_LOCK:
+        _STRING_POOL.clear()
+        _STRING_POOL_REVERSE.clear()
+        _NEXT_ID = 0

--- a/src/nexus/core/hash_fast.py
+++ b/src/nexus/core/hash_fast.py
@@ -168,15 +168,34 @@ def get_hash_backend() -> str:
         return "sha256"
 
 
+class _RustOnePassHasher:
+    """Accumulate chunks, then delegate to Rust BLAKE3 one-shot on finalize.
+
+    Used when only the Rust backend is available (no Python blake3 package).
+    Ensures streaming writes produce the same hash as hash_content().
+    """
+
+    __slots__ = ("_chunks",)
+
+    def __init__(self) -> None:
+        self._chunks: list[bytes] = []
+
+    def update(self, data: bytes) -> None:
+        self._chunks.append(data)
+
+    def hexdigest(self) -> str:
+        return hash_content(b"".join(self._chunks))
+
+
 def create_hasher() -> Any:
     """Create an incremental hasher for streaming content.
 
     Returns a hasher object with .update(chunk) and .hexdigest() methods.
-    Uses Python blake3 if available, otherwise SHA-256.
 
-    NOTE: This always uses the Python blake3 or SHA-256 backend.
-    The Rust backend is only available for one-shot hashing via
-    hash_content() and hash_content_smart().
+    Backend priority (matches hash_content() to avoid hash mismatches):
+        1. Python blake3 (incremental, consistent with Rust BLAKE3)
+        2. Rust BLAKE3 via accumulate-then-hash wrapper
+        3. SHA-256 (last resort)
 
     Example:
         >>> hasher = create_hasher()
@@ -186,5 +205,6 @@ def create_hasher() -> Any:
     """
     if _PYTHON_BLAKE3_AVAILABLE:
         return _python_blake3.blake3()
-    else:
-        return hashlib.sha256()
+    if _RUST_AVAILABLE:
+        return _RustOnePassHasher()
+    return hashlib.sha256()

--- a/src/nexus/core/lock_fast.py
+++ b/src/nexus/core/lock_fast.py
@@ -58,16 +58,18 @@ class _LockEntry:
 
 
 def _normalize_path(path: str) -> str:
-    """Normalize a path: collapse repeated slashes, remove trailing slash (except root)."""
+    """Normalize a path: resolve ./.., collapse repeated slashes, remove trailing slash."""
     if not path:
         return "/"
-    # Collapse repeated slashes.
-    import re
+    import posixpath
 
-    result = re.sub(r"/+", "/", path)
-    # Remove trailing slash (keep root "/").
-    if len(result) > 1 and result.endswith("/"):
-        result = result[:-1]
+    result = posixpath.normpath(path)
+    # posixpath.normpath preserves leading // per POSIX; collapse to single /
+    if result.startswith("//"):
+        result = result[1:]
+    # Ensure leading slash is preserved for absolute paths
+    if path.startswith("/") and not result.startswith("/"):
+        result = "/" + result
     return result
 
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1016,10 +1016,11 @@ class NexusFS(  # type: ignore[misc]
         if meta is None:
             raise NexusFileNotFoundError(path)
 
-        from dataclasses import fields, replace
+        from dataclasses import replace
 
-        valid_fields = {f.name for f in fields(meta)}
-        valid_attrs = {k: v for k, v in attrs.items() if k in valid_fields}
+        # Only allow safe, user-mutable fields — block structural invariants
+        _MUTABLE_FIELDS = frozenset({"mime_type", "modified_at"})
+        valid_attrs = {k: v for k, v in attrs.items() if k in _MUTABLE_FIELDS}
         if not valid_attrs:
             return {"path": path, "updated": []}
 
@@ -3019,13 +3020,12 @@ class NexusFS(  # type: ignore[misc]
                     )
         except Exception as e:
             # If file doesn't exist, treat as empty (will create new file)
-            # Permission errors on non-existent files are OK - write() will check parent permissions
             from nexus.contracts.exceptions import NexusFileNotFoundError
 
-            if not isinstance(e, NexusFileNotFoundError | PermissionError):
-                # Re-raise unexpected errors
+            if not isinstance(e, NexusFileNotFoundError):
+                # Re-raise unexpected errors (including PermissionError)
                 raise
-            # For FileNotFoundError or PermissionError, continue with empty content
+            # For FileNotFoundError, continue with empty content
             # write() will check if user has permission to create the file
 
         # Combine existing content with new content
@@ -4202,11 +4202,11 @@ class NexusFS(  # type: ignore[misc]
                         return True
                     # Fall back to descendant access check for non-root implicit dirs
                     # (e.g., /zones/zone_1 where user may have access to children)
-                    if not self._has_descendant_access(path, Permission.READ, ctx):  # type: ignore[attr-defined]  # allowed
+                    if not self._descendant_checker.has_access(path, Permission.READ, ctx):
                         return False
                 else:
                     # Issue #1147: OPTIMIZATION for real files - use direct permission check (O(1))
-                    # instead of _has_descendant_access (O(n) fallback).
+                    # instead of descendant access (O(n) fallback).
                     # Real files have no descendants, so descendant check is unnecessary.
                     # This reduces exists() latency from 300-500ms to 10-20ms.
                     if not self._permission_enforcer.check(path, Permission.READ, ctx):
@@ -4320,7 +4320,7 @@ class NexusFS(  # type: ignore[misc]
                 # Check permission if enforcement enabled
                 if self._enforce_permissions:  # type: ignore[attr-defined]  # allowed
                     ctx = context if context is not None else self._default_context
-                    if not self._has_descendant_access(path, Permission.READ, ctx):  # type: ignore[attr-defined]  # allowed
+                    if not self._descendant_checker.has_access(path, Permission.READ, ctx):
                         results[path] = None
                         continue
 

--- a/src/nexus/core/workspace_manifest.py
+++ b/src/nexus/core/workspace_manifest.py
@@ -123,9 +123,18 @@ class WorkspaceManifest:
         Raises:
             json.JSONDecodeError: If data is not valid JSON
             KeyError: If required fields are missing
+            ValueError: If any path contains traversal segments
         """
+        import posixpath
+
         parsed = json.loads(data)
-        entries = {path: ManifestEntry.from_dict(entry_data) for path, entry_data in parsed.items()}
+        entries: dict[str, ManifestEntry] = {}
+        for path, entry_data in parsed.items():
+            # Reject path traversal attempts (e.g., "../escape.txt")
+            normalized = posixpath.normpath(path)
+            if normalized.startswith("..") or "/../" in path or path.startswith("/"):
+                raise ValueError(f"Manifest path contains traversal or absolute segment: {path!r}")
+            entries[normalized] = ManifestEntry.from_dict(entry_data)
         return cls(entries=entries)
 
     @classmethod

--- a/src/nexus/core/zone_helpers.py
+++ b/src/nexus/core/zone_helpers.py
@@ -250,12 +250,16 @@ def remove_user_from_zone(
         group_id = f"{group_id}-admins"
     # else: role == "member" -> use base group_id
 
-    rebac_manager.rebac_delete(
+    # Find matching tuples via list, then delete by tuple_id
+    tuples = rebac_manager.rebac_list_tuples(
         subject=("user", user_id),
         relation="member",
         object=("group", group_id),
-        zone_id=zone_id,
     )
+    for t in tuples:
+        tid = t.get("tuple_id")
+        if tid:
+            rebac_manager.rebac_delete(tid)
 
 
 def get_user_zones(rebac_manager: Any, user_id: str) -> list[str]:

--- a/src/nexus/server/services/zone_membership.py
+++ b/src/nexus/server/services/zone_membership.py
@@ -188,12 +188,16 @@ def remove_user_from_zone(
     elif role == "admin":
         group_id = f"{group_id}-admins"
 
-    rebac_manager.rebac_delete(
+    # Find matching tuples via list, then delete by tuple_id
+    tuples = rebac_manager.rebac_list_tuples(
         subject=("user", user_id),
         relation="member",
         object=("group", group_id),
-        zone_id=zone_id,
     )
+    for t in tuples:
+        tid = t.get("tuple_id")
+        if tid:
+            rebac_manager.rebac_delete(tid)
 
 
 def get_user_zones(rebac_manager: Any, user_id: str) -> list[str]:


### PR DESCRIPTION
## Summary

Fixes 9 validated issues from a Codex security review (11 valid of 15 reported; 2 partially valid, 1 invalid, 2 skipped for architectural scope).

- **sys_setattr field allowlist** — callers could overwrite `etag`, `owner_id`, `zone_id` and other invariants; now restricted to `{mime_type, modified_at}`
- **append() PermissionError** — write-only callers silently lost existing content; now re-raises PermissionError instead of treating it as file-missing
- **Hash backend consistency** — `create_hasher()` fell back to SHA-256 when only Rust BLAKE3 was available, causing streaming vs one-shot hash mismatches; added `_RustOnePassHasher` wrapper
- **String intern synchronization** — `_compact_generated._intern()` had no locking; concurrent first-seen strings could collide on IDs
- **lock_fast path normalization** — `_normalize_path()` didn't resolve `..`, so `/a/../b` and `/b` took independent locks for the same target
- **Manifest path traversal** — `WorkspaceManifest.from_json()` accepted `../escape.txt` entries; now validates and rejects traversal/absolute paths
- **rebac_delete kwargs bug** — `core/zone_helpers.py` and `server/services/zone_membership.py` called `rebac_delete()` with kwargs instead of `tuple_id`; fixed to list-then-delete pattern
- **_has_descendant_access undefined** — `sys_access()` and `metadata_batch()` called non-existent method; replaced with `_descendant_checker.has_access()`

### Not addressed (need separate review)
- #3 write_stream invariants (architectural — needs lock/ownership plumbing)
- #4 sys_stat metadata exposure (POSIX stat semantics debate)
- #7 pipe missed-wakeup (mitigated by while-loop recheck)
- #13 context normalization (complex multi-method plumbing)
- #15 semaphore extend (file doesn't exist in codebase)

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff format, mypy, brick-zero-core-imports)
- [x] 74 targeted unit tests pass (lock manager, workspace manifest, zone helpers)
- [x] Smoke tests for lock normalization, intern pool, manifest traversal rejection
- [ ] CI pipeline green