### PR TITLE
feat(#2811): CLI commands for pay/audit/lock/governance/events/snapshot/exchange + grep fix + A2A cleanup

### DIFF
--- a/src/nexus/backends/connectors/x/connector.py
+++ b/src/nexus/backends/connectors/x/connector.py
@@ -280,7 +280,8 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
 
         # Check cache
         if user_email in self._user_id_cache:
-            return self._user_id_cache[user_email]
+            cached_id: str = self._user_id_cache[user_email]
+            return cached_id
 
         # Fetch from API
         client = await self._get_api_client_async(context)
@@ -344,7 +345,8 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
             content, timestamp = self._memory_cache[mem_key]
             if time.time() - timestamp < max_age:
                 logger.debug(f"[X-CACHE] Memory hit: {cache_key}")
-                return content
+                cached_content: bytes | None = content
+                return cached_content
 
         # Check disk cache
         cache_file = Path(self.cache_dir) / f"{cache_key}.json"
@@ -1130,6 +1132,9 @@ class XConnectorBackend(Backend, OAuthConnectorMixin):
         ignore_case: bool = False,
         max_results: int = 100,
         context: Any = None,
+        before_context: int = 0,  # noqa: ARG002
+        after_context: int = 0,  # noqa: ARG002
+        invert_match: bool = False,  # noqa: ARG002
     ) -> list[dict[str, Any]]:
         """
         Search content using pattern.

--- a/src/nexus/bricks/a2a/stream_reaper.py
+++ b/src/nexus/bricks/a2a/stream_reaper.py
@@ -1,0 +1,98 @@
+"""Periodic cleanup of abandoned A2A SSE streams.
+
+Runs as a background asyncio.Task, checking for idle streams every
+``check_interval`` seconds and closing any that have been idle longer
+than ``max_idle_seconds``.
+
+Issue #2811: A2A abandoned stream cleanup.
+"""
+
+import asyncio
+import logging
+from contextlib import suppress as _suppress
+
+from nexus.bricks.a2a.stream_registry import StreamRegistry
+
+logger = logging.getLogger(__name__)
+
+# Defaults
+_DEFAULT_CHECK_INTERVAL = 60.0  # seconds
+_DEFAULT_MAX_IDLE = 300.0  # 5 minutes
+
+
+class StreamReaper:
+    """Periodic reaper for idle A2A SSE streams.
+
+    Parameters
+    ----------
+    registry:
+        The StreamRegistry to monitor.
+    max_idle_seconds:
+        Streams idle longer than this are reaped (default: 300s).
+    check_interval:
+        How often to check for idle streams (default: 60s).
+    """
+
+    def __init__(
+        self,
+        registry: StreamRegistry,
+        max_idle_seconds: float = _DEFAULT_MAX_IDLE,
+        check_interval: float = _DEFAULT_CHECK_INTERVAL,
+    ) -> None:
+        self._registry = registry
+        self._max_idle_seconds = max_idle_seconds
+        self._check_interval = check_interval
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start the reaper background task."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._run(), name="stream-reaper")
+        logger.info(
+            "StreamReaper started (interval=%.0fs, max_idle=%.0fs)",
+            self._check_interval,
+            self._max_idle_seconds,
+        )
+
+    async def stop(self) -> None:
+        """Stop the reaper and wait for clean shutdown."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        with _suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+        logger.info("StreamReaper stopped")
+
+    async def _run(self) -> None:
+        """Main reaper loop."""
+        try:
+            while True:
+                await asyncio.sleep(self._check_interval)
+                self._reap()
+        except asyncio.CancelledError:
+            raise  # Let cancellation propagate
+
+    def _reap(self) -> None:
+        """Check for and close idle streams."""
+        idle_tasks = self._registry.get_idle_tasks(self._max_idle_seconds)
+        if not idle_tasks:
+            return
+
+        total_closed = 0
+        for task_id in idle_tasks:
+            closed = self._registry.close_task_streams(task_id, reason="idle_timeout")
+            total_closed += closed
+
+        if total_closed > 0:
+            logger.info(
+                "Reaped %d idle stream(s) across %d task(s)",
+                total_closed,
+                len(idle_tasks),
+            )
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the reaper task is active."""
+        return self._task is not None and not self._task.done()

--- a/src/nexus/bricks/a2a/stream_registry.py
+++ b/src/nexus/bricks/a2a/stream_registry.py
@@ -9,6 +9,7 @@ Principle (mirrors the HeartbeatBuffer extraction pattern).
 
 import asyncio
 import logging
+import time
 from contextlib import suppress as _suppress
 from typing import Any
 
@@ -29,6 +30,7 @@ class StreamRegistry:
     def __init__(self, maxsize: int = 100) -> None:
         self._maxsize = maxsize
         self._active_streams: dict[str, list[asyncio.Queue[dict[str, Any] | None]]] = {}
+        self._last_activity: dict[str, float] = {}
 
     def register(self, task_id: str) -> asyncio.Queue[dict[str, Any] | None]:
         """Register a new SSE stream for a task.
@@ -39,6 +41,7 @@ class StreamRegistry:
         """
         queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(maxsize=self._maxsize)
         self._active_streams.setdefault(task_id, []).append(queue)
+        self._last_activity[task_id] = time.monotonic()
         return queue
 
     def unregister(self, task_id: str, queue: asyncio.Queue[dict[str, Any] | None]) -> None:
@@ -50,6 +53,7 @@ class StreamRegistry:
             streams.remove(queue)
         if not streams:
             del self._active_streams[task_id]
+            self._last_activity.pop(task_id, None)
 
     def push_event(self, task_id: str, event: dict[str, Any]) -> None:
         """Push an event to all active streams for a task.
@@ -60,8 +64,48 @@ class StreamRegistry:
         streams = self._active_streams.get(task_id)
         if not streams:
             return
+        self._last_activity[task_id] = time.monotonic()
         for queue in list(streams):
             try:
                 queue.put_nowait(event)
             except asyncio.QueueFull:
                 logger.warning("SSE queue full for task %s, dropping event", task_id)
+
+    def get_idle_tasks(self, max_idle_seconds: float) -> list[str]:
+        """Return task IDs whose streams have been idle longer than *max_idle_seconds*."""
+        now = time.monotonic()
+        return [
+            task_id
+            for task_id, last in self._last_activity.items()
+            if now - last > max_idle_seconds
+        ]
+
+    def close_task_streams(self, task_id: str, reason: str = "idle_timeout") -> int:
+        """Close all streams for *task_id* by pushing a ``None`` sentinel.
+
+        Returns the number of streams that were closed.
+        """
+        streams = self._active_streams.pop(task_id, None)
+        self._last_activity.pop(task_id, None)
+        if not streams:
+            return 0
+        for queue in streams:
+            with _suppress(asyncio.QueueFull):
+                queue.put_nowait(None)
+        logger.info(
+            "Closed %d stream(s) for task %s (reason=%s)",
+            len(streams),
+            task_id,
+            reason,
+        )
+        return len(streams)
+
+    @property
+    def active_stream_count(self) -> int:
+        """Total number of active subscriber queues across all tasks."""
+        return sum(len(qs) for qs in self._active_streams.values())
+
+    @property
+    def task_count(self) -> int:
+        """Number of tasks with at least one active stream."""
+        return len(self._active_streams)

--- a/src/nexus/bricks/filesystem/scoped_filesystem.py
+++ b/src/nexus/bricks/filesystem/scoped_filesystem.py
@@ -219,6 +219,9 @@ class ScopedFilesystem(ScopedPathMixin):
         max_results: int = 1000,
         search_mode: str = "auto",
         context: Any = None,
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
     ) -> builtins.list[dict[str, Any]]:
         """Search file contents using regex patterns."""
         search = cast(Any, self._fs).search_service
@@ -230,6 +233,9 @@ class ScopedFilesystem(ScopedPathMixin):
             max_results,
             search_mode,
             context,
+            before_context=before_context,
+            after_context=after_context,
+            invert_match=invert_match,
         )
         return [self._unscope_dict(r, ["file", "path"]) for r in result]
 

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -1685,6 +1685,9 @@ class SearchService:
         max_results: int = 100,
         search_mode: str = "auto",  # noqa: ARG002
         context: Any = None,
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
     ) -> builtins.list[dict[str, Any]]:
         r"""Search file contents using regex patterns.
 
@@ -1698,6 +1701,9 @@ class SearchService:
             max_results: Maximum number of results (default: 100)
             search_mode: Unused (reserved for future search mode selection)
             context: Operation context for permission filtering
+            before_context: Number of lines to include before each match
+            after_context: Number of lines to include after each match
+            invert_match: If True, return non-matching lines
         """
         if path and path != "/":
             path = self._validate_path(path)
@@ -1769,19 +1775,18 @@ class SearchService:
             for file_path, text in searchable_texts.items():
                 if len(results) >= max_results:
                     break
-                for line_num, line in enumerate(text.splitlines(), start=1):
-                    if len(results) >= max_results:
-                        break
-                    match_obj = regex.search(line)
-                    if match_obj:
-                        results.append(
-                            {
-                                "file": file_path,
-                                "line": line_num,
-                                "content": line,
-                                "match": match_obj.group(0),
-                            }
-                        )
+                lines = text.splitlines()
+                results.extend(
+                    self._grep_lines(
+                        regex=regex,
+                        lines=lines,
+                        file_path=file_path,
+                        before_context=before_context,
+                        after_context=after_context,
+                        invert_match=invert_match,
+                        max_results=max_results - len(results),
+                    )
+                )
             if strategy == SearchStrategy.CACHED_TEXT and len(results) >= max_results:
                 return results[:max_results]
 
@@ -1813,6 +1818,9 @@ class SearchService:
                     ignore_case=ignore_case,
                     remaining_results=remaining_results,
                     context=context,
+                    before_context=before_context,
+                    after_context=after_context,
+                    invert_match=invert_match,
                 )
             )
 
@@ -1821,6 +1829,89 @@ class SearchService:
     # =========================================================================
     # Grep Helpers
     # =========================================================================
+
+    @staticmethod
+    def _grep_lines(
+        regex: re.Pattern[str],
+        lines: builtins.list[str],
+        file_path: str,
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
+        max_results: int = 100,
+    ) -> builtins.list[dict[str, Any]]:
+        """Search lines with optional context and invert-match support.
+
+        Args:
+            regex: Compiled regex pattern
+            lines: List of text lines to search
+            file_path: File path for result entries
+            before_context: Number of context lines before each match
+            after_context: Number of context lines after each match
+            invert_match: If True, return non-matching lines
+            max_results: Maximum results to return
+        """
+        results: builtins.list[dict[str, Any]] = []
+
+        if invert_match:
+            # Return lines that do NOT match
+            matching_indices: set[int] = set()
+            for idx, line in enumerate(lines):
+                if regex.search(line):
+                    matching_indices.add(idx)
+
+            for idx, line in enumerate(lines):
+                if len(results) >= max_results:
+                    break
+                if idx not in matching_indices:
+                    entry: dict[str, Any] = {
+                        "file": file_path,
+                        "line": idx + 1,
+                        "content": line,
+                    }
+                    if before_context > 0 or after_context > 0:
+                        b_start = max(0, idx - before_context)
+                        a_end = min(len(lines), idx + after_context + 1)
+                        if before_context > 0:
+                            entry["before_context"] = [
+                                {"line": i + 1, "content": lines[i]} for i in range(b_start, idx)
+                            ]
+                        if after_context > 0:
+                            entry["after_context"] = [
+                                {"line": i + 1, "content": lines[i]} for i in range(idx + 1, a_end)
+                            ]
+                    results.append(entry)
+        else:
+            # Normal matching: find matching indices first
+            match_data: builtins.list[tuple[int, re.Match[str]]] = []
+            for idx, line in enumerate(lines):
+                match_obj = regex.search(line)
+                if match_obj:
+                    match_data.append((idx, match_obj))
+
+            for idx, match_obj in match_data:
+                if len(results) >= max_results:
+                    break
+                entry = {
+                    "file": file_path,
+                    "line": idx + 1,
+                    "content": lines[idx],
+                    "match": match_obj.group(0),
+                }
+                if before_context > 0 or after_context > 0:
+                    b_start = max(0, idx - before_context)
+                    a_end = min(len(lines), idx + after_context + 1)
+                    if before_context > 0:
+                        entry["before_context"] = [
+                            {"line": i + 1, "content": lines[i]} for i in range(b_start, idx)
+                        ]
+                    if after_context > 0:
+                        entry["after_context"] = [
+                            {"line": i + 1, "content": lines[i]} for i in range(idx + 1, a_end)
+                        ]
+                results.append(entry)
+
+        return results
 
     def _grep_raw_content(
         self,
@@ -1831,6 +1922,9 @@ class SearchService:
         ignore_case: bool,
         remaining_results: int,
         context: Any,
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
     ) -> builtins.list[dict[str, Any]]:
         """Process files needing raw content read (mmap, Rust bulk, sequential)."""
         results: builtins.list[dict[str, Any]] = []
@@ -1899,19 +1993,18 @@ class SearchService:
                         text = read_result.decode("utf-8")
                     except UnicodeDecodeError:
                         continue
-                    for line_num, line in enumerate(text.splitlines(), start=1):
-                        if len(results) >= remaining_results:
-                            break
-                        match_obj = regex.search(line)
-                        if match_obj:
-                            results.append(
-                                {
-                                    "file": file_path,
-                                    "line": line_num,
-                                    "content": line,
-                                    "match": match_obj.group(0),
-                                }
-                            )
+                    lines = text.splitlines()
+                    results.extend(
+                        self._grep_lines(
+                            regex=regex,
+                            lines=lines,
+                            file_path=file_path,
+                            before_context=before_context,
+                            after_context=after_context,
+                            invert_match=invert_match,
+                            max_results=remaining_results - len(results),
+                        )
+                    )
                 except Exception as e:
                     logger.debug("Failed to grep file %s: %s", file_path, e)
                     continue

--- a/src/nexus/cli/client.py
+++ b/src/nexus/cli/client.py
@@ -1,0 +1,263 @@
+"""HTTP client for Nexus REST API — used by non-filesystem CLI commands.
+
+Provides a thin wrapper around httpx for calling /api/v2/* endpoints
+that don't map to the NexusFS abstraction (pay, audit, locks, governance,
+events, snapshots).
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class NexusAPIError(Exception):
+    """Error from Nexus REST API."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"HTTP {status_code}: {detail}")
+
+
+class NexusServiceClient:
+    """HTTP client for Nexus service-level REST endpoints.
+
+    Usage::
+
+        with NexusServiceClient(url, api_key) as client:
+            balance = client.pay_balance()
+            client.pay_transfer("bob", "10.00")
+    """
+
+    def __init__(self, url: str, api_key: str | None = None) -> None:
+        import httpx  # Lazy import — heavy dependency
+
+        self._url = url.rstrip("/")
+        self._api_key = api_key
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._client = httpx.Client(base_url=self._url, headers=headers, timeout=30.0)
+
+    def __enter__(self) -> "NexusServiceClient":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self._client.close()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Make HTTP request and return parsed JSON response."""
+        # Filter None values from params
+        if params:
+            params = {k: v for k, v in params.items() if v is not None}
+
+        response = self._client.request(method, path, params=params, json=json_body)
+
+        if response.status_code >= 400:
+            try:
+                detail = response.json().get("detail", response.text)
+            except Exception:
+                detail = response.text
+            raise NexusAPIError(response.status_code, str(detail))
+
+        if response.status_code == 204:
+            return {}
+
+        result: dict[str, Any] = response.json()
+        return result
+
+    # ----- Pay -----
+
+    def pay_balance(self, agent_id: str | None = None) -> dict[str, Any]:
+        params = {"agent_id": agent_id} if agent_id else None
+        return self._request("GET", "/api/v2/pay/balance", params=params)
+
+    def pay_transfer(
+        self,
+        to: str,
+        amount: str,
+        memo: str = "",
+        method: str = "auto",
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            "/api/v2/pay/transfer",
+            json_body={
+                "to": to,
+                "amount": amount,
+                "memo": memo,
+                "method": method,
+            },
+        )
+
+    def pay_history(
+        self,
+        since: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request(
+            "GET",
+            "/api/v2/audit/transactions",
+            params={
+                "since": since,
+                "limit": limit,
+                "cursor": cursor,
+            },
+        )
+
+    # ----- Audit -----
+
+    def audit_list(
+        self,
+        since: str | None = None,
+        until: str | None = None,
+        agent_id: str | None = None,
+        action: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request(
+            "GET",
+            "/api/v2/audit/transactions",
+            params={
+                "since": since,
+                "until": until,
+                "agent_id": agent_id,
+                "status": action,
+                "limit": limit,
+                "cursor": cursor,
+            },
+        )
+
+    def audit_export(
+        self,
+        fmt: str = "json",
+        since: str | None = None,
+        until: str | None = None,
+    ) -> str:
+        """Export audit data — returns raw response text."""
+        params: dict[str, Any] = {"format": fmt}
+        if since:
+            params["since"] = since
+        if until:
+            params["until"] = until
+        params = {k: v for k, v in params.items() if v is not None}
+
+        response = self._client.request("GET", "/api/v2/audit/transactions/export", params=params)
+        if response.status_code >= 400:
+            try:
+                detail = response.json().get("detail", response.text)
+            except Exception:
+                detail = response.text
+            raise NexusAPIError(response.status_code, str(detail))
+        return response.text
+
+    # ----- Locks -----
+
+    def lock_list(self, zone_id: str | None = None) -> dict[str, Any]:
+        return self._request("GET", "/api/v2/locks", params={"zone_id": zone_id})
+
+    def lock_info(self, path: str) -> dict[str, Any]:
+        path = path.lstrip("/")
+        return self._request("GET", f"/api/v2/locks/{path}")
+
+    def lock_release(
+        self, path: str, lock_id: str | None = None, force: bool = False
+    ) -> dict[str, Any]:
+        path = path.lstrip("/")
+        params: dict[str, Any] = {}
+        if lock_id:
+            params["lock_id"] = lock_id
+        if force:
+            params["force"] = "true"
+        return self._request("DELETE", f"/api/v2/locks/{path}", params=params)
+
+    # ----- Governance -----
+
+    def governance_alerts(
+        self,
+        severity: str | None = None,
+        since: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        return self._request(
+            "GET",
+            "/api/v2/governance/alerts",
+            params={
+                "severity": severity,
+                "since": since,
+                "limit": limit,
+            },
+        )
+
+    def governance_status(self) -> dict[str, Any]:
+        """Get governance overview (alerts + fraud scores summary)."""
+        alerts = self._request("GET", "/api/v2/governance/alerts", params={"limit": 5})
+        rings = self._request("GET", "/api/v2/governance/rings")
+        return {"recent_alerts": alerts, "fraud_rings": rings}
+
+    def governance_rings(self) -> dict[str, Any]:
+        return self._request("GET", "/api/v2/governance/rings")
+
+    # ----- Events -----
+
+    def events_replay(
+        self,
+        since: str | None = None,
+        event_type: str | None = None,
+        path: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        return self._request(
+            "GET",
+            "/api/v2/events/replay",
+            params={
+                "since": since,
+                "event_type": event_type,
+                "path": path,
+                "limit": limit,
+            },
+        )
+
+    def events_subscribe(self, pattern: str) -> str:
+        """Subscribe to events via SSE — returns raw response text."""
+        response = self._client.request(
+            "GET",
+            "/api/v2/events/stream",
+            params={"pattern": pattern},
+            headers={"Accept": "text/event-stream"},
+        )
+        if response.status_code >= 400:
+            try:
+                detail = response.json().get("detail", response.text)
+            except Exception:
+                detail = response.text
+            raise NexusAPIError(response.status_code, str(detail))
+        return response.text
+
+    # ----- Snapshots -----
+
+    def snapshot_create(
+        self, description: str | None = None, ttl_seconds: int = 3600
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"ttl_seconds": ttl_seconds}
+        if description:
+            body["description"] = description
+        return self._request("POST", "/api/v2/snapshots", json_body=body)
+
+    def snapshot_list(self) -> dict[str, Any]:
+        return self._request("GET", "/api/v2/snapshots")
+
+    def snapshot_restore(self, txn_id: str) -> dict[str, Any]:
+        return self._request("POST", f"/api/v2/snapshots/{txn_id}/rollback")

--- a/src/nexus/cli/commands/__init__.py
+++ b/src/nexus/cli/commands/__init__.py
@@ -62,6 +62,14 @@ _ADD_COMMAND: dict[str, str] = {
     "sandbox": "sandbox",
     "oauth": "oauth",
     "zone": "zone",
+    # Issue #2811: New CLI command groups
+    "pay": "pay",
+    "audit": "audit",
+    "locks": "lock",
+    "governance_cli": "governance",
+    "events_cli": "events",
+    "snapshots": "snapshot",
+    "exchange": "exchange",
 }
 
 

--- a/src/nexus/cli/commands/audit.py
+++ b/src/nexus/cli/commands/audit.py
@@ -1,0 +1,149 @@
+"""Audit CLI commands — transaction listing and export.
+
+Maps to /api/v2/audit/* REST endpoints via NexusServiceClient.
+Issue #2811.
+"""
+
+import click
+
+from nexus.cli.utils import (
+    JSON_OUTPUT_OPTION,
+    REMOTE_API_KEY_OPTION,
+    REMOTE_URL_OPTION,
+    console,
+    get_service_client,
+    output_result,
+)
+
+
+@click.group()
+def audit() -> None:
+    """Audit trail for exchange transactions.
+
+    \b
+    Prerequisites:
+        - Running Nexus server with database authentication
+        - Server URL (set via NEXUS_URL or --remote-url)
+        - API key (set via NEXUS_API_KEY or --remote-api-key)
+
+    \b
+    Examples:
+        nexus audit list --since 1h
+        nexus audit list --agent-id alice --json
+        nexus audit export --format csv --output report.csv
+    """
+
+
+@audit.command("list")
+@click.option("--since", default=None, help="Start time (ISO format)")
+@click.option("--until", default=None, help="End time (ISO format)")
+@click.option("--agent-id", default=None, help="Filter by agent ID")
+@click.option("--action", default=None, help="Filter by action/status")
+@click.option("--limit", default=50, help="Maximum entries", show_default=True)
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def audit_list(
+    since: str | None,
+    until: str | None,
+    agent_id: str | None,
+    action: str | None,
+    limit: int,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """List audit trail entries.
+
+    \b
+    Examples:
+        nexus audit list
+        nexus audit list --since 2024-01-01 --limit 100
+        nexus audit list --agent-id alice --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.audit_list(
+                since=since,
+                until=until,
+                agent_id=agent_id,
+                action=action,
+                limit=limit,
+            )
+
+        def _render(d: dict) -> None:
+            from rich.table import Table
+
+            txns = d.get("transactions", [])
+            if not txns:
+                console.print("[yellow]No audit entries found[/yellow]")
+                return
+
+            table = Table(title=f"Audit Trail ({len(txns)} entries)")
+            table.add_column("Time", style="dim")
+            table.add_column("Buyer")
+            table.add_column("Seller")
+            table.add_column("Amount", justify="right", style="green")
+            table.add_column("Protocol")
+            table.add_column("Status")
+
+            for tx in txns:
+                table.add_row(
+                    tx.get("created_at", "")[:19],
+                    tx.get("buyer_agent_id", ""),
+                    tx.get("seller_agent_id", ""),
+                    tx.get("amount", ""),
+                    tx.get("protocol", ""),
+                    tx.get("status", ""),
+                )
+            console.print(table)
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@audit.command("export")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["csv", "json"]),
+    default="json",
+    help="Export format",
+    show_default=True,
+)
+@click.option("--output", "output_file", default=None, help="Output file path (default: stdout)")
+@click.option("--since", default=None, help="Start time (ISO format)")
+@click.option("--until", default=None, help="End time (ISO format)")
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def audit_export(
+    fmt: str,
+    output_file: str | None,
+    since: str | None,
+    until: str | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Export audit data to file.
+
+    \b
+    Examples:
+        nexus audit export --format csv --output report.csv
+        nexus audit export --format json --since 2024-01-01
+        nexus audit export --format csv > transactions.csv
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            content = client.audit_export(format=fmt, since=since, until=until)
+
+        if output_file:
+            with open(output_file, "w") as f:
+                f.write(content)
+            console.print(f"[green]Exported to {output_file}[/green]")
+        else:
+            click.echo(content)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None

--- a/src/nexus/cli/commands/audit.py
+++ b/src/nexus/cli/commands/audit.py
@@ -136,7 +136,7 @@ def audit_export(
     """
     try:
         with get_service_client(remote_url, remote_api_key) as client:
-            content = client.audit_export(format=fmt, since=since, until=until)
+            content = client.audit_export(fmt=fmt, since=since, until=until)
 
         if output_file:
             with open(output_file, "w") as f:

--- a/src/nexus/cli/commands/events_cli.py
+++ b/src/nexus/cli/commands/events_cli.py
@@ -1,0 +1,140 @@
+"""Events CLI commands — replay and subscribe.
+
+Maps to /api/v2/events/* REST endpoints via NexusServiceClient.
+Issue #2811.
+"""
+
+import click
+
+from nexus.cli.utils import (
+    JSON_OUTPUT_OPTION,
+    REMOTE_API_KEY_OPTION,
+    REMOTE_URL_OPTION,
+    console,
+    get_service_client,
+    output_result,
+)
+
+
+@click.group()
+def events() -> None:
+    """Event replay and subscription.
+
+    \b
+    Prerequisites:
+        - Running Nexus server
+        - Server URL (set via NEXUS_URL or --remote-url)
+        - API key (set via NEXUS_API_KEY or --remote-api-key)
+
+    \b
+    Examples:
+        nexus events replay --since 1h
+        nexus events subscribe "file_write"
+    """
+
+
+@events.command("replay")
+@click.option("--since", default=None, help="Start time (ISO format or relative)")
+@click.option("--type", "event_type", default=None, help="Filter by event type")
+@click.option("--path", "event_path", default=None, help="Filter by file path")
+@click.option("--limit", default=50, help="Maximum events", show_default=True)
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def events_replay(
+    since: str | None,
+    event_type: str | None,
+    event_path: str | None,
+    limit: int,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Replay historical events.
+
+    \b
+    Examples:
+        nexus events replay --since 1h
+        nexus events replay --type file_write --path /data/
+        nexus events replay --since 2024-01-01 --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.events_replay(
+                since=since,
+                event_type=event_type,
+                path=event_path,
+                limit=limit,
+            )
+
+        def _render(d: dict) -> None:
+            from rich.table import Table
+
+            evts = d.get("events", [])
+            if not evts:
+                console.print("[yellow]No events found[/yellow]")
+                return
+
+            table = Table(title=f"Events ({len(evts)})")
+            table.add_column("Seq", style="dim", justify="right")
+            table.add_column("Time", style="dim")
+            table.add_column("Type")
+            table.add_column("Path")
+            table.add_column("Agent")
+
+            for ev in evts:
+                table.add_row(
+                    str(ev.get("seq_number", "")),
+                    ev.get("timestamp", "")[:19],
+                    ev.get("event_type", ""),
+                    ev.get("path", ""),
+                    ev.get("agent_id", ""),
+                )
+            console.print(table)
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@events.command("subscribe")
+@click.argument("pattern")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def events_subscribe(
+    pattern: str,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Subscribe to real-time events (SSE).
+
+    Streams events matching the given pattern until interrupted (Ctrl+C).
+
+    \b
+    Examples:
+        nexus events subscribe "file_write"
+        nexus events subscribe "*" --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            console.print(f"[yellow]Subscribing to events matching:[/yellow] {pattern}")
+            console.print("[dim]Press Ctrl+C to stop[/dim]\n")
+            content = client.events_subscribe(pattern)
+
+        # Display the received events
+        if json_output:
+            click.echo(content)
+        else:
+            for line in content.splitlines():
+                if line.startswith("data:"):
+                    console.print(f"  {line[5:].strip()}")
+                elif line.strip():
+                    console.print(f"  [dim]{line}[/dim]")
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Subscription ended[/yellow]")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None

--- a/src/nexus/cli/commands/exchange.py
+++ b/src/nexus/cli/commands/exchange.py
@@ -1,0 +1,114 @@
+"""Exchange CLI commands — agent marketplace offers (Phase 2).
+
+Issue #2811. Exchange offer endpoints are not yet implemented on the
+server side; these commands will work once the backend is available.
+"""
+
+import click
+
+from nexus.cli.utils import (
+    JSON_OUTPUT_OPTION,
+    REMOTE_API_KEY_OPTION,
+    REMOTE_URL_OPTION,
+    console,
+)
+
+
+@click.group()
+def exchange() -> None:
+    """Agent exchange marketplace (Phase 2).
+
+    \b
+    Note: Exchange offer endpoints are under development.
+    Commands will become functional when the backend is available.
+
+    \b
+    Examples:
+        nexus exchange list
+        nexus exchange create /data/dataset.csv --price 100
+        nexus exchange show <offer-id>
+        nexus exchange cancel <offer-id>
+    """
+
+
+@exchange.command("list")
+@click.option("--status", type=click.Choice(["active", "completed"]), default=None)
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def exchange_list(
+    **_kwargs: object,  # noqa: ARG001 — Phase 2 stub
+) -> None:
+    """List exchange offers.
+
+    \b
+    Examples:
+        nexus exchange list
+        nexus exchange list --status active --json
+    """
+    console.print(
+        "[yellow]Exchange offer listing is not yet available.[/yellow]\n"
+        "This feature is planned for Phase 2. See issue #2811."
+    )
+
+
+@exchange.command("create")
+@click.argument("resource")
+@click.option("--price", required=True, help="Asking price in credits")
+@click.option("--description", default="", help="Offer description")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def exchange_create(
+    **_kwargs: object,  # noqa: ARG001 — Phase 2 stub
+) -> None:
+    """Create an exchange offer.
+
+    \b
+    Examples:
+        nexus exchange create /data/dataset.csv --price 100
+        nexus exchange create /models/v2.bin --price 500 --description "Trained model"
+    """
+    console.print(
+        "[yellow]Exchange offer creation is not yet available.[/yellow]\n"
+        "This feature is planned for Phase 2. See issue #2811."
+    )
+
+
+@exchange.command("show")
+@click.argument("offer_id")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def exchange_show(
+    **_kwargs: object,  # noqa: ARG001 — Phase 2 stub
+) -> None:
+    """Show exchange offer details.
+
+    \b
+    Examples:
+        nexus exchange show abc123 --json
+    """
+    console.print(
+        "[yellow]Exchange offer details are not yet available.[/yellow]\n"
+        "This feature is planned for Phase 2. See issue #2811."
+    )
+
+
+@exchange.command("cancel")
+@click.argument("offer_id")
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def exchange_cancel(
+    **_kwargs: object,  # noqa: ARG001 — Phase 2 stub
+) -> None:
+    """Cancel an exchange offer.
+
+    \b
+    Examples:
+        nexus exchange cancel abc123
+    """
+    console.print(
+        "[yellow]Exchange offer cancellation is not yet available.[/yellow]\n"
+        "This feature is planned for Phase 2. See issue #2811."
+    )

--- a/src/nexus/cli/commands/governance_cli.py
+++ b/src/nexus/cli/commands/governance_cli.py
@@ -1,0 +1,177 @@
+"""Governance CLI commands — alerts, fraud rings, and status.
+
+Maps to /api/v2/governance/* REST endpoints via NexusServiceClient.
+Issue #2811.
+"""
+
+import click
+
+from nexus.cli.utils import (
+    JSON_OUTPUT_OPTION,
+    REMOTE_API_KEY_OPTION,
+    REMOTE_URL_OPTION,
+    console,
+    get_service_client,
+    output_result,
+)
+
+
+@click.group()
+def governance() -> None:
+    """Governance and anti-fraud operations (admin).
+
+    \b
+    Prerequisites:
+        - Running Nexus server with admin privileges
+        - Server URL (set via NEXUS_URL or --remote-url)
+        - Admin API key (set via NEXUS_API_KEY or --remote-api-key)
+
+    \b
+    Examples:
+        nexus governance status
+        nexus governance alerts --severity high --json
+        nexus governance rings --json
+    """
+
+
+@governance.command("status")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def governance_status(
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Show governance overview.
+
+    Displays recent alerts and detected fraud rings.
+
+    \b
+    Examples:
+        nexus governance status
+        nexus governance status --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.governance_status()
+
+        def _render(d: dict) -> None:
+            alerts = d.get("recent_alerts", {})
+            rings = d.get("fraud_rings", {})
+
+            alert_list = alerts.get("alerts", []) if isinstance(alerts, dict) else []
+            ring_list = rings.get("rings", []) if isinstance(rings, dict) else []
+
+            console.print("[bold cyan]Governance Status[/bold cyan]")
+            console.print(f"  Active alerts: [yellow]{len(alert_list)}[/yellow]")
+            console.print(f"  Fraud rings:   [yellow]{len(ring_list)}[/yellow]")
+
+            if alert_list:
+                console.print("\n[bold]Recent Alerts:[/bold]")
+                for alert in alert_list[:5]:
+                    sev = alert.get("severity", "unknown")
+                    color = "red" if sev == "high" else "yellow"
+                    console.print(f"  [{color}]{sev}[/{color}] {alert.get('description', 'N/A')}")
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@governance.command("alerts")
+@click.option("--severity", default=None, help="Filter by severity (low/medium/high)")
+@click.option("--since", default=None, help="Start time (ISO format)")
+@click.option("--limit", default=50, help="Maximum entries", show_default=True)
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def governance_alerts(
+    severity: str | None,
+    since: str | None,
+    limit: int,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """List anomaly alerts.
+
+    \b
+    Examples:
+        nexus governance alerts
+        nexus governance alerts --severity high --since 2024-01-01
+        nexus governance alerts --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.governance_alerts(severity=severity, since=since, limit=limit)
+
+        def _render(d: dict) -> None:
+            from rich.table import Table
+
+            alerts = d.get("alerts", [])
+            if not alerts:
+                console.print("[green]No anomaly alerts[/green]")
+                return
+
+            table = Table(title=f"Anomaly Alerts ({len(alerts)})")
+            table.add_column("Time", style="dim")
+            table.add_column("Severity")
+            table.add_column("Agent")
+            table.add_column("Description")
+
+            for alert in alerts:
+                sev = alert.get("severity", "")
+                sev_style = "red" if sev == "high" else "yellow" if sev == "medium" else "dim"
+                table.add_row(
+                    alert.get("created_at", "")[:19],
+                    f"[{sev_style}]{sev}[/{sev_style}]",
+                    alert.get("agent_id", ""),
+                    alert.get("description", ""),
+                )
+            console.print(table)
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@governance.command("rings")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def governance_rings(
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """List detected fraud rings.
+
+    \b
+    Examples:
+        nexus governance rings
+        nexus governance rings --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.governance_rings()
+
+        def _render(d: dict) -> None:
+            rings = d.get("rings", [])
+            if not rings:
+                console.print("[green]No fraud rings detected[/green]")
+                return
+
+            console.print(f"[bold cyan]Detected Fraud Rings ({len(rings)})[/bold cyan]")
+            for i, ring in enumerate(rings, 1):
+                members = ring.get("members", [])
+                score = ring.get("risk_score", 0)
+                console.print(f"\n  [bold]Ring {i}[/bold] (risk: [red]{score:.2f}[/red])")
+                console.print(f"  Members: {', '.join(members)}")
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None

--- a/src/nexus/cli/commands/locks.py
+++ b/src/nexus/cli/commands/locks.py
@@ -1,0 +1,155 @@
+"""Lock CLI commands — list, info, and release distributed locks.
+
+Maps to /api/v2/locks/* REST endpoints via NexusServiceClient.
+Issue #2811.
+"""
+
+import click
+
+from nexus.cli.utils import (
+    JSON_OUTPUT_OPTION,
+    REMOTE_API_KEY_OPTION,
+    REMOTE_URL_OPTION,
+    console,
+    get_service_client,
+    output_result,
+)
+
+
+@click.group()
+def lock() -> None:
+    """Distributed lock management.
+
+    \b
+    Prerequisites:
+        - Running Nexus server with Redis/Dragonfly
+        - Server URL (set via NEXUS_URL or --remote-url)
+        - API key (set via NEXUS_API_KEY or --remote-api-key)
+
+    \b
+    Examples:
+        nexus lock list
+        nexus lock info /data/shared.db
+        nexus lock release /data/shared.db --force
+    """
+
+
+@lock.command("list")
+@click.option("--zone-id", default=None, help="Filter by zone ID")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def lock_list(
+    zone_id: str | None,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """List active locks.
+
+    \b
+    Examples:
+        nexus lock list
+        nexus lock list --zone-id org_acme --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.lock_list(zone_id=zone_id)
+
+        def _render(d: dict) -> None:
+            from rich.table import Table
+
+            locks = d.get("locks", [])
+            if not locks:
+                console.print("[yellow]No active locks[/yellow]")
+                return
+
+            table = Table(title=f"Active Locks ({d.get('count', len(locks))})")
+            table.add_column("Path")
+            table.add_column("Mode")
+            table.add_column("Holders", justify="right")
+            table.add_column("Expires At", style="dim")
+
+            for lk in locks:
+                table.add_row(
+                    lk.get("path", ""),
+                    lk.get("mode", ""),
+                    str(lk.get("current_holders", 1)),
+                    lk.get("expires_at", "")[:19],
+                )
+            console.print(table)
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@lock.command("info")
+@click.argument("path")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def lock_info(
+    path: str,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Show lock status for a path.
+
+    \b
+    Examples:
+        nexus lock info /data/shared.db
+        nexus lock info /workspace/file.txt --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.lock_info(path)
+
+        def _render(d: dict) -> None:
+            console.print(f"[bold cyan]Lock Status: {path}[/bold cyan]")
+            console.print(
+                f"  Locked:  {'[red]Yes[/red]' if d.get('locked') else '[green]No[/green]'}"
+            )
+            info = d.get("lock_info")
+            if info:
+                console.print(f"  Mode:    {info.get('mode', 'N/A')}")
+                console.print(f"  Lock ID: {info.get('lock_id', 'N/A')}")
+                console.print(f"  Fence:   {info.get('fence_token', 'N/A')}")
+                if info.get("expires_at"):
+                    console.print(f"  Expires: {info['expires_at'][:19]}")
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@lock.command("release")
+@click.argument("path")
+@click.option("--lock-id", default=None, help="Lock ID (required for non-force release)")
+@click.option("--force", is_flag=True, help="Force-release (admin only)")
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def lock_release(
+    path: str,
+    lock_id: str | None,
+    force: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Release a lock.
+
+    \b
+    Examples:
+        nexus lock release /data/shared.db --lock-id abc123
+        nexus lock release /data/shared.db --force
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            client.lock_release(path, lock_id=lock_id, force=force)
+        console.print(f"[green]Lock released:[/green] {path}")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None

--- a/src/nexus/cli/commands/pay.py
+++ b/src/nexus/cli/commands/pay.py
@@ -1,0 +1,175 @@
+"""Pay CLI commands — agent balance, transfer, and history.
+
+Maps to /api/v2/pay/* REST endpoints via NexusServiceClient.
+Issue #2811.
+"""
+
+import click
+
+from nexus.cli.utils import (
+    JSON_OUTPUT_OPTION,
+    REMOTE_API_KEY_OPTION,
+    REMOTE_URL_OPTION,
+    console,
+    get_service_client,
+    output_result,
+)
+
+
+@click.group()
+def pay() -> None:
+    """Agent payment operations.
+
+    \b
+    Prerequisites:
+        - Running Nexus server
+        - Server URL (set via NEXUS_URL or --remote-url)
+        - API key (set via NEXUS_API_KEY or --remote-api-key)
+
+    \b
+    Examples:
+        nexus pay balance
+        nexus pay transfer bob 10.00 --memo "For data access"
+        nexus pay history --limit 20 --json
+    """
+
+
+@pay.command("balance")
+@click.argument("agent_id", required=False, default=None)
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def pay_balance(
+    agent_id: str | None,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Show agent credit balance.
+
+    \b
+    Examples:
+        nexus pay balance              # Own balance
+        nexus pay balance agent_abc    # Specific agent
+        nexus pay balance --json       # JSON output
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.pay_balance(agent_id)
+
+        def _render(d: dict) -> None:
+            console.print("[bold cyan]Balance[/bold cyan]")
+            console.print(f"  Available: [green]{d.get('available', '0')}[/green]")
+            console.print(f"  Reserved:  [yellow]{d.get('reserved', '0')}[/yellow]")
+            console.print(f"  Total:     [bold]{d.get('total', '0')}[/bold]")
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@pay.command("transfer")
+@click.argument("to")
+@click.argument("amount")
+@click.option("--memo", default="", help="Transfer memo/description")
+@click.option(
+    "--method",
+    type=click.Choice(["auto", "credits", "x402"]),
+    default="auto",
+    help="Payment method",
+    show_default=True,
+)
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def pay_transfer(
+    to: str,
+    amount: str,
+    memo: str,
+    method: str,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Transfer credits to another agent.
+
+    \b
+    Examples:
+        nexus pay transfer bob 10.00
+        nexus pay transfer bob 50.00 --memo "Data license fee"
+        nexus pay transfer 0x1234...abcd 5.00 --method x402
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.pay_transfer(to, amount, memo=memo, method=method)
+
+        def _render(d: dict) -> None:
+            console.print("[green]Transfer successful[/green]")
+            console.print(f"  ID:     {d.get('id', 'N/A')}")
+            console.print(f"  To:     {d.get('to_agent', to)}")
+            console.print(f"  Amount: {d.get('amount', amount)}")
+            console.print(f"  Method: {d.get('method', method)}")
+            if d.get("memo"):
+                console.print(f"  Memo:   {d['memo']}")
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@pay.command("history")
+@click.option("--since", default=None, help="Start time (ISO format or relative, e.g., '1h')")
+@click.option("--limit", default=20, help="Maximum entries to show", show_default=True)
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def pay_history(
+    since: str | None,
+    limit: int,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Show payment history.
+
+    \b
+    Examples:
+        nexus pay history
+        nexus pay history --since 2024-01-01 --limit 50
+        nexus pay history --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.pay_history(since=since, limit=limit)
+
+        def _render(d: dict) -> None:
+            from rich.table import Table
+
+            txns = d.get("transactions", [])
+            if not txns:
+                console.print("[yellow]No transactions found[/yellow]")
+                return
+
+            table = Table(title="Payment History")
+            table.add_column("Time", style="dim")
+            table.add_column("From")
+            table.add_column("To")
+            table.add_column("Amount", justify="right", style="green")
+            table.add_column("Status")
+
+            for tx in txns:
+                table.add_row(
+                    tx.get("created_at", "")[:19],
+                    tx.get("buyer_agent_id", ""),
+                    tx.get("seller_agent_id", ""),
+                    tx.get("amount", ""),
+                    tx.get("status", ""),
+                )
+            console.print(table)
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None

--- a/src/nexus/cli/commands/snapshots.py
+++ b/src/nexus/cli/commands/snapshots.py
@@ -1,0 +1,170 @@
+"""Snapshot CLI commands — create, list, and restore transactional snapshots.
+
+Maps to /api/v2/snapshots/* REST endpoints via NexusServiceClient.
+Issue #2811.
+"""
+
+import click
+
+from nexus.cli.utils import (
+    JSON_OUTPUT_OPTION,
+    REMOTE_API_KEY_OPTION,
+    REMOTE_URL_OPTION,
+    console,
+    get_service_client,
+    output_result,
+)
+
+
+@click.group()
+def snapshot() -> None:
+    """Transactional snapshot management.
+
+    \b
+    Prerequisites:
+        - Running Nexus server
+        - Server URL (set via NEXUS_URL or --remote-url)
+        - API key (set via NEXUS_API_KEY or --remote-api-key)
+
+    \b
+    Examples:
+        nexus snapshot create --description "Before migration"
+        nexus snapshot list --json
+        nexus snapshot restore <txn_id>
+    """
+
+
+@snapshot.command("create")
+@click.option("--description", default=None, help="Snapshot description")
+@click.option(
+    "--ttl",
+    default=3600,
+    help="Time-to-live in seconds (60-86400)",
+    show_default=True,
+)
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def snapshot_create(
+    description: str | None,
+    ttl: int,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Create a new transactional snapshot.
+
+    \b
+    Examples:
+        nexus snapshot create
+        nexus snapshot create --description "Pre-deploy backup"
+        nexus snapshot create --ttl 7200 --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.snapshot_create(description=description, ttl_seconds=ttl)
+
+        def _render(d: dict) -> None:
+            console.print("[green]Snapshot created[/green]")
+            console.print(f"  Transaction ID: [bold]{d.get('transaction_id', 'N/A')}[/bold]")
+            console.print(f"  Status:         {d.get('status', 'N/A')}")
+            console.print(f"  Expires:        {d.get('expires_at', 'N/A')[:19]}")
+            if d.get("description"):
+                console.print(f"  Description:    {d['description']}")
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@snapshot.command("list")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def snapshot_list(
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """List snapshots/transactions.
+
+    \b
+    Examples:
+        nexus snapshot list
+        nexus snapshot list --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.snapshot_list()
+
+        def _render(d: dict) -> None:
+            from rich.table import Table
+
+            txns = d.get("transactions", [])
+            if not txns:
+                console.print("[yellow]No snapshots found[/yellow]")
+                return
+
+            table = Table(title=f"Snapshots ({len(txns)})")
+            table.add_column("Transaction ID", style="bold")
+            table.add_column("Status")
+            table.add_column("Description")
+            table.add_column("Created", style="dim")
+            table.add_column("Entries", justify="right")
+
+            for tx in txns:
+                status = tx.get("status", "")
+                status_style = (
+                    "green"
+                    if status == "committed"
+                    else "red"
+                    if status == "rolled_back"
+                    else "yellow"
+                )
+                table.add_row(
+                    tx.get("transaction_id", "")[:12] + "...",
+                    f"[{status_style}]{status}[/{status_style}]",
+                    tx.get("description", "") or "-",
+                    tx.get("created_at", "")[:19],
+                    str(tx.get("entry_count", 0)),
+                )
+            console.print(table)
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None
+
+
+@snapshot.command("restore")
+@click.argument("txn_id")
+@JSON_OUTPUT_OPTION
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def snapshot_restore(
+    txn_id: str,
+    json_output: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Restore (rollback) a snapshot transaction.
+
+    \b
+    Examples:
+        nexus snapshot restore abc123
+        nexus snapshot restore abc123 --json
+    """
+    try:
+        with get_service_client(remote_url, remote_api_key) as client:
+            data = client.snapshot_restore(txn_id)
+
+        def _render(d: dict) -> None:
+            console.print(f"[green]Snapshot restored:[/green] {txn_id}")
+            if d:
+                console.print(f"  Status: {d.get('status', 'rolled_back')}")
+
+        output_result(data, json_output, _render)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from None

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -442,3 +442,51 @@ def open_filesystem(
         yield nx
     finally:
         nx.close()
+
+
+# =============================================================================
+# JSON output helpers (Issue #2811)
+# =============================================================================
+
+JSON_OUTPUT_OPTION = click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+
+
+def output_result(data: Any, json_output: bool, rich_fn: Any) -> None:
+    """Output data as JSON or rich-formatted text.
+
+    Args:
+        data: The data to output.
+        json_output: If True, output as JSON.
+        rich_fn: Callable that renders data using Rich (called with data).
+    """
+    if json_output:
+        import json as json_mod
+
+        console.print(json_mod.dumps(data, indent=2, default=str))
+    else:
+        rich_fn(data)
+
+
+def get_service_client(
+    remote_url: str | None = None,
+    remote_api_key: str | None = None,
+) -> Any:
+    """Create a NexusServiceClient from URL/API key, with validation.
+
+    Args:
+        remote_url: Server URL (from --remote-url or NEXUS_URL env var)
+        remote_api_key: API key (from --remote-api-key or NEXUS_API_KEY env var)
+
+    Returns:
+        NexusServiceClient instance
+
+    Raises:
+        SystemExit: If URL is not provided
+    """
+    if not remote_url:
+        console.print("[red]Error:[/red] Server URL required. Set NEXUS_URL or use --remote-url")
+        sys.exit(1)
+
+    from nexus.cli.client import NexusServiceClient
+
+    return NexusServiceClient(url=remote_url, api_key=remote_api_key)

--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -337,3 +337,29 @@ class NexusFilesystemABC(ABC):
     ) -> builtins.list[dict[str, Any]]:
         """Write multiple files. Default: N × write()."""
         return [self.write(p, c, context=context) for p, c in files]
+
+    def glob(self, pattern: str, path: str = "/", context: Any = None) -> builtins.list[str]:
+        """Find files matching a glob pattern (like glob(3)).
+
+        Requires SearchService. Override in NexusFS.
+        """
+        raise NotImplementedError("Override in NexusFS (requires SearchService)")
+
+    def grep(
+        self,
+        pattern: str,
+        path: str = "/",
+        file_pattern: str | None = None,
+        ignore_case: bool = False,
+        max_results: int = 1000,
+        search_mode: str = "auto",
+        context: Any = None,
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
+    ) -> builtins.list[dict[str, Any]]:
+        """Search file contents using regex patterns (like grep(1)).
+
+        Requires SearchService. Override in NexusFS.
+        """
+        raise NotImplementedError("Override in NexusFS (requires SearchService)")

--- a/src/nexus/contracts/protocols/search.py
+++ b/src/nexus/contracts/protocols/search.py
@@ -116,6 +116,9 @@ class SearchProtocol(Protocol):
         max_results: int = 100,
         search_mode: str = "auto",
         context: "OperationContext | None" = None,
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
     ) -> builtins.list[dict[str, Any]]: ...
 
     # ── Async operations (semantic search requires I/O) ─────────────────

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3958,6 +3958,35 @@ class NexusFS(  # type: ignore[misc]
             return [{"path": e.path, "size": e.size, "etag": e.etag} for e in entries]
         return [e.path for e in entries]
 
+    def glob(self, pattern: str, path: str = "/", context: Any = None) -> builtins.list[str]:
+        return self.search_service.glob(pattern=pattern, path=path, context=context)
+
+    def grep(
+        self,
+        pattern: str,
+        path: str = "/",
+        file_pattern: str | None = None,
+        ignore_case: bool = False,
+        max_results: int = 100,
+        search_mode: str = "auto",
+        context: Any = None,
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
+    ) -> builtins.list[dict[str, Any]]:
+        return self.search_service.grep(
+            pattern=pattern,
+            path=path,
+            file_pattern=file_pattern,
+            ignore_case=ignore_case,
+            max_results=max_results,
+            search_mode=search_mode,
+            context=context,
+            before_context=before_context,
+            after_context=after_context,
+            invert_match=invert_match,
+        )
+
     # _run_async: replaced by direct run_sync() calls (Issue #1381)
 
     @rpc_expose(description="Backfill sparse directory index for fast listings", admin_only=True)

--- a/src/nexus/grpc/exchange_servicer.py
+++ b/src/nexus/grpc/exchange_servicer.py
@@ -1,0 +1,77 @@
+"""ExchangeService gRPC servicer — stub returning UNIMPLEMENTED.
+
+Issue #2811: The ExchangeService proto defines 17 RPCs (identity,
+payment, audit) but none are implemented as gRPC yet.  This stub
+returns ``UNIMPLEMENTED`` with descriptive messages for all RPCs,
+allowing clients to detect the service and get actionable feedback.
+
+Once generated Python code from the exchange proto is available,
+this servicer will extend the generated base class and delegate
+to existing REST endpoint handlers.
+
+Proto: proto/nexus/exchange/v1/exchange.proto
+"""
+
+import logging
+from typing import Any
+
+import grpc
+
+logger = logging.getLogger(__name__)
+
+# All RPCs defined in ExchangeService proto
+_EXCHANGE_RPCS: dict[str, str] = {
+    # Identity
+    "VerifyIdentity": "Use POST /api/v2/identity/verify",
+    "ListKeys": "Use GET /api/v2/identity/keys",
+    "RotateKey": "Use POST /api/v2/identity/keys/rotate",
+    "RevokeKey": "Use POST /api/v2/identity/keys/revoke",
+    # Payment
+    "GetBalance": "Use GET /api/v2/pay/balance",
+    "Transfer": "Use POST /api/v2/pay/transfer",
+    "BatchTransfer": "Use POST /api/v2/pay/transfer/batch",
+    "Reserve": "Use POST /api/v2/pay/reserve",
+    "CommitReservation": "Use POST /api/v2/pay/reserve/{id}/commit",
+    "ReleaseReservation": "Use POST /api/v2/pay/reserve/{id}/release",
+    "Meter": "Use POST /api/v2/pay/meter",
+    "CanAfford": "Use GET /api/v2/pay/can-afford",
+    # Audit
+    "ListTransactions": "Use GET /api/v2/audit/transactions",
+    "GetTransaction": "Use GET /api/v2/audit/transactions/{id}",
+    "GetAggregations": "Use GET /api/v2/audit/transactions/aggregations",
+    "VerifyIntegrity": "Use GET /api/v2/audit/integrity/{id}",
+    "ExportTransactions": "Use GET /api/v2/audit/transactions/export",
+}
+
+
+class ExchangeServiceStub:
+    """Stub servicer that returns UNIMPLEMENTED for all ExchangeService RPCs.
+
+    This is registered as a generic service handler so that gRPC clients
+    calling ExchangeService methods get a clear ``UNIMPLEMENTED`` status
+    with a message pointing to the REST API equivalent.
+
+    Once proto codegen is integrated, replace this with a proper servicer
+    extending ``ExchangeServiceServicer``.
+    """
+
+    async def handle_unimplemented(
+        self,
+        _request: Any,  # noqa: ARG002
+        context: grpc.aio.ServicerContext,
+    ) -> None:
+        """Handle any ExchangeService RPC with UNIMPLEMENTED."""
+        method_name = "unknown"
+
+        rest_hint = _EXCHANGE_RPCS.get(method_name, "Use the REST API instead")
+        msg = f"ExchangeService.{method_name} is not yet implemented via gRPC. {rest_hint}."
+        logger.debug("ExchangeService UNIMPLEMENTED: %s", method_name)
+        await context.abort(grpc.StatusCode.UNIMPLEMENTED, msg)
+
+
+def get_unimplemented_rpcs() -> dict[str, str]:
+    """Return the map of unimplemented RPC names to REST hints.
+
+    Useful for ``nexus doctor`` to report ExchangeService status.
+    """
+    return dict(_EXCHANGE_RPCS)

--- a/tests/e2e/server/test_cli_commands_e2e.py
+++ b/tests/e2e/server/test_cli_commands_e2e.py
@@ -1,0 +1,694 @@
+"""E2E tests for new CLI command groups against a real HTTP server.
+
+Issue #2811: Verifies that CLI commands (pay, audit, lock, governance,
+events, snapshot, exchange) work end-to-end by:
+1. Starting a real FastAPI server (uvicorn) with actual routers on a real port
+2. Seeding test data (audit records)
+3. Running CLI commands via subprocess pointing at the server
+4. Verifying exit codes and output
+
+Exchange commands are Phase 2 stubs that don't need a server.
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from contextlib import closing
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+_src_path = Path(__file__).parent.parent.parent / "src"
+
+
+def _find_free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+def _run_cli(
+    *args: str,
+    base_url: str,
+    api_key: str,
+    env: dict[str, str],
+    timeout: float = 30.0,
+) -> subprocess.CompletedProcess[str]:
+    """Run a nexus CLI command via subprocess with --remote-url and --remote-api-key."""
+    cmd_args = list(args) + ["--remote-url", base_url, "--remote-api-key", api_key]
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"from nexus.cli import main; main({cmd_args!r})",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+
+
+def _run_cli_no_server(
+    *args: str,
+    env: dict[str, str],
+    timeout: float = 30.0,
+) -> subprocess.CompletedProcess[str]:
+    """Run a nexus CLI command that doesn't need a server (e.g. exchange stubs)."""
+    cmd_args = list(args)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"from nexus.cli import main; main({cmd_args!r})",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def cli_server(tmp_path_factory):
+    """Start a real FastAPI server with actual API v2 routers on a real TCP port.
+
+    Uses uvicorn in a background thread so it's accessible via subprocess CLI
+    commands. This avoids needing the full `nexus serve` startup path (which
+    requires the Raft Rust extension) while still testing real HTTP → real CLI.
+
+    Yields dict with base_url, api_key, env.
+    """
+    import uvicorn
+    from fastapi import FastAPI
+
+    from nexus.contracts.constants import ROOT_ZONE_ID
+    from nexus.server.dependencies import get_auth_result, require_admin, require_auth
+
+    tmp_path = tmp_path_factory.mktemp("cli_e2e")
+    db_path = tmp_path / "cli_e2e.db"
+
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    api_key = "test-cli-e2e-key"
+
+    # Build env for CLI subprocesses
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("CONDA_PREFIX", "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy")
+    }
+    env.update(
+        {
+            "PYTHONPATH": str(_src_path),
+            "NO_PROXY": "*",
+        }
+    )
+
+    # --- Build FastAPI app with real routers ---
+    app = FastAPI()
+
+    # Auth overrides: simulate authenticated admin
+    _auth_result = {
+        "authenticated": True,
+        "is_admin": True,
+        "subject_id": "admin",
+        "subject_type": "user",
+        "zone_id": ROOT_ZONE_ID,
+    }
+    app.dependency_overrides[require_auth] = lambda: _auth_result
+    app.dependency_overrides[require_admin] = lambda: _auth_result
+    app.dependency_overrides[get_auth_result] = lambda: _auth_result
+
+    # --- Mount routers ---
+
+    # Audit router
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    engine = create_engine(f"sqlite:///{db_path}")
+
+    # Create tables
+    from nexus.storage.models import Base
+
+    Base.metadata.create_all(engine)
+
+    session_factory = sessionmaker(bind=engine)
+
+    from nexus.server.api.v2.routers.audit import router as audit_router
+
+    app.include_router(audit_router)
+
+    # Snapshot router
+    from nexus.server.api.v2.routers.snapshots import router as snapshots_router
+
+    app.include_router(snapshots_router)
+
+    # Events replay router
+    from nexus.server.api.v2.routers.events_replay import router as events_router
+
+    app.include_router(events_router)
+
+    # Governance router (admin-only)
+    from nexus.server.api.v2.routers.governance import router as governance_router
+
+    app.include_router(governance_router)
+
+    # Pay router
+    from nexus.server.api.v2.routers.pay import router as pay_router
+
+    app.include_router(pay_router)
+
+    # Locks router
+    from nexus.server.api.v2.routers.locks import router as locks_router
+
+    app.include_router(locks_router)
+
+    # Health endpoint
+    @app.get("/health")
+    def health():
+        return {"status": "healthy"}
+
+    # Wire up record store and services on app.state
+    from unittest.mock import MagicMock
+
+    from nexus.storage.record_store import RecordStoreABC
+
+    mock_record_store = MagicMock(spec=RecordStoreABC)
+    mock_record_store.session_factory = session_factory
+    app.state.record_store = mock_record_store
+
+    # Override get_exchange_audit_logger (used by audit router)
+    from nexus.server.api.v2.dependencies import get_exchange_audit_logger
+    from nexus.storage.exchange_audit_logger import ExchangeAuditLogger as _EAL
+
+    _eal_instance = _EAL(record_store=mock_record_store)
+    app.dependency_overrides[get_exchange_audit_logger] = lambda: (_eal_instance, ROOT_ZONE_ID)
+
+    # Wire audit logger for seeding
+    from nexus.storage.exchange_audit_logger import ExchangeAuditLogger
+
+    audit_logger = ExchangeAuditLogger(record_store=mock_record_store)
+
+    # Wire governance services
+    try:
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.ext.asyncio import async_sessionmaker as AsyncSessionMaker
+
+        import nexus.bricks.governance.db_models  # noqa: F401
+        from nexus.bricks.governance.anomaly_service import (
+            AnomalyService,
+            StatisticalAnomalyDetector,
+        )
+        from nexus.bricks.governance.collusion_service import CollusionService
+        from nexus.bricks.governance.governance_graph_service import GovernanceGraphService
+        from nexus.bricks.governance.response_service import ResponseService
+        from nexus.lib.db_base import Base as GovBase
+
+        async_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+
+        import asyncio
+
+        async def _create_gov_tables():
+            async with async_engine.begin() as conn:
+                await conn.run_sync(GovBase.metadata.create_all)
+
+        asyncio.get_event_loop_policy().new_event_loop().run_until_complete(_create_gov_tables())
+
+        async_session_factory = AsyncSessionMaker(
+            async_engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        detector = StatisticalAnomalyDetector()
+        anomaly_svc = AnomalyService(session_factory=async_session_factory, detector=detector)
+        collusion_svc = CollusionService(session_factory=async_session_factory)
+        graph_svc = GovernanceGraphService(session_factory=async_session_factory)
+        response_svc = ResponseService(
+            session_factory=async_session_factory,
+            anomaly_service=anomaly_svc,
+            collusion_service=collusion_svc,
+            graph_service=graph_svc,
+        )
+
+        app.state.governance_anomaly_service = anomaly_svc
+        app.state.governance_collusion_service = collusion_svc
+        app.state.governance_graph_service = graph_svc
+        app.state.governance_response_service = response_svc
+        governance_wired = True
+    except Exception:
+        governance_wired = False
+
+    # Snapshot router requires nexus_fs._snapshot_service (needs CAS + metadata
+    # stores). Without a full server stack we can't wire it, so snapshot
+    # endpoints will return 503 and tests handle this gracefully.
+
+    # Seed audit records
+    audit_seeded = False
+    try:
+        for i in range(5):
+            audit_logger.record(
+                protocol="internal" if i < 3 else "x402",
+                buyer_agent_id=f"buyer-{i % 2}",
+                seller_agent_id=f"seller-{i % 3}",
+                amount=Decimal(str(10 * (i + 1))),
+                currency="credits",
+                status="settled" if i < 4 else "failed",
+                application="gateway",
+                zone_id="root",
+                transfer_id=f"cli-e2e-tx-{i}",
+            )
+        audit_seeded = True
+    except Exception:
+        pass
+
+    # Start uvicorn in background thread
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    # Wait for server to be ready
+    import httpx
+
+    start = time.time()
+    while time.time() - start < 30.0:
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=1.0, trust_env=False)
+            if resp.status_code == 200:
+                break
+        except (httpx.ConnectError, httpx.ReadTimeout):
+            pass
+        time.sleep(0.1)
+    else:
+        pytest.fail(f"Server failed to start on port {port}")
+
+    yield {
+        "port": port,
+        "base_url": base_url,
+        "api_key": api_key,
+        "env": env,
+        "audit_seeded": audit_seeded,
+        "governance_wired": governance_wired,
+    }
+
+    server.should_exit = True
+    thread.join(timeout=5)
+    engine.dispose()
+
+
+# =============================================================================
+# Health check
+# =============================================================================
+
+
+class TestServerHealth:
+    def test_health(self, cli_server):
+        import httpx
+
+        resp = httpx.get(f"{cli_server['base_url']}/health", trust_env=False)
+        assert resp.status_code == 200
+
+
+# =============================================================================
+# Audit CLI
+# =============================================================================
+
+
+class TestAuditCLI:
+    """Test `nexus audit` commands against real server."""
+
+    def test_audit_list_json(self, cli_server):
+        if not cli_server["audit_seeded"]:
+            pytest.skip("Audit records not seeded")
+        result = _run_cli(
+            "audit",
+            "list",
+            "--json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert "transactions" in data
+        assert len(data["transactions"]) >= 1
+
+    def test_audit_list_rich(self, cli_server):
+        if not cli_server["audit_seeded"]:
+            pytest.skip("Audit records not seeded")
+        result = _run_cli(
+            "audit",
+            "list",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "Audit" in result.stdout or "Time" in result.stdout
+
+    def test_audit_list_with_limit(self, cli_server):
+        if not cli_server["audit_seeded"]:
+            pytest.skip("Audit records not seeded")
+        result = _run_cli(
+            "audit",
+            "list",
+            "--limit",
+            "2",
+            "--json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert len(data["transactions"]) <= 2
+
+    def test_audit_export_json(self, cli_server):
+        if not cli_server["audit_seeded"]:
+            pytest.skip("Audit records not seeded")
+        result = _run_cli(
+            "audit",
+            "export",
+            "--format",
+            "json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_audit_export_csv(self, cli_server):
+        if not cli_server["audit_seeded"]:
+            pytest.skip("Audit records not seeded")
+        result = _run_cli(
+            "audit",
+            "export",
+            "--format",
+            "csv",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+
+# =============================================================================
+# Governance CLI (admin-only)
+# =============================================================================
+
+
+class TestGovernanceCLI:
+    """Test `nexus governance` commands against real server (admin API key)."""
+
+    def test_governance_alerts_json(self, cli_server):
+        if not cli_server["governance_wired"]:
+            pytest.skip("Governance services not wired")
+        result = _run_cli(
+            "governance",
+            "alerts",
+            "--json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert "alerts" in data
+
+    def test_governance_alerts_rich(self, cli_server):
+        if not cli_server["governance_wired"]:
+            pytest.skip("Governance services not wired")
+        result = _run_cli(
+            "governance",
+            "alerts",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_governance_rings_json(self, cli_server):
+        if not cli_server["governance_wired"]:
+            pytest.skip("Governance services not wired")
+        result = _run_cli(
+            "governance",
+            "rings",
+            "--json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_governance_status_json(self, cli_server):
+        if not cli_server["governance_wired"]:
+            pytest.skip("Governance services not wired")
+        result = _run_cli(
+            "governance",
+            "status",
+            "--json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert "recent_alerts" in data
+        assert "fraud_rings" in data
+
+    def test_governance_status_rich(self, cli_server):
+        if not cli_server["governance_wired"]:
+            pytest.skip("Governance services not wired")
+        result = _run_cli(
+            "governance",
+            "status",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "Governance" in result.stdout
+
+
+# =============================================================================
+# Pay CLI
+# =============================================================================
+
+
+class TestPayCLI:
+    """Test `nexus pay` commands against real server.
+
+    Pay endpoints depend on CreditsService (TigerBeetle). Without it,
+    /api/v2/pay/balance returns 500/503. We test that the CLI handles
+    the response correctly either way.
+    """
+
+    def test_pay_balance_graceful(self, cli_server):
+        result = _run_cli(
+            "pay",
+            "balance",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        # Either shows balance (if CreditsService available) or error exit
+        if result.returncode == 0:
+            assert "Balance" in result.stdout or "available" in result.stdout
+        else:
+            assert result.returncode == 1
+            assert "Error" in result.stdout
+
+    def test_pay_history_json(self, cli_server):
+        result = _run_cli(
+            "pay",
+            "history",
+            "--json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        # pay history calls /api/v2/audit/transactions
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert "transactions" in data
+
+    def test_pay_transfer_graceful(self, cli_server):
+        result = _run_cli(
+            "pay",
+            "transfer",
+            "agent-bob",
+            "10.00",
+            "--memo",
+            "e2e test",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        # Transfer requires CreditsService; either succeeds or fails gracefully
+        assert result.returncode in (0, 1)
+
+
+# =============================================================================
+# Lock CLI
+# =============================================================================
+
+
+class TestLockCLI:
+    """Test `nexus lock` commands against real server.
+
+    Lock endpoints require Redis/Dragonfly. Without it, server returns 503.
+    We test that the CLI handles the response correctly.
+    """
+
+    def test_lock_list_graceful(self, cli_server):
+        result = _run_cli(
+            "lock",
+            "list",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        # 503 from missing lock manager → CLI error exit 1
+        assert result.returncode in (0, 1)
+
+    def test_lock_info_graceful(self, cli_server):
+        result = _run_cli(
+            "lock",
+            "info",
+            "/data/test.txt",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode in (0, 1)
+
+
+# =============================================================================
+# Events CLI
+# =============================================================================
+
+
+class TestEventsCLI:
+    """Test `nexus events` commands against real server."""
+
+    def test_events_replay_json(self, cli_server):
+        result = _run_cli(
+            "events",
+            "replay",
+            "--json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert "events" in data
+
+    def test_events_replay_rich(self, cli_server):
+        result = _run_cli(
+            "events",
+            "replay",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+
+# =============================================================================
+# Snapshot CLI
+# =============================================================================
+
+
+class TestSnapshotCLI:
+    """Test `nexus snapshot` commands against real server.
+
+    Snapshot endpoints require nexus_fs._snapshot_service (CAS + metadata stores).
+    Without a full server, endpoints return 503. We test that the CLI handles
+    the response correctly either way.
+    """
+
+    def test_snapshot_list_graceful(self, cli_server):
+        result = _run_cli(
+            "snapshot",
+            "list",
+            "--json",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        # 503 from missing snapshot service → CLI error exit 1
+        assert result.returncode in (0, 1)
+
+    def test_snapshot_create_graceful(self, cli_server):
+        result = _run_cli(
+            "snapshot",
+            "create",
+            "--description",
+            "CLI e2e test",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode in (0, 1)
+
+    def test_snapshot_restore_graceful(self, cli_server):
+        result = _run_cli(
+            "snapshot",
+            "restore",
+            "fake-txn-id",
+            base_url=cli_server["base_url"],
+            api_key=cli_server["api_key"],
+            env=cli_server["env"],
+        )
+        assert result.returncode in (0, 1)
+
+
+# =============================================================================
+# Exchange CLI (Phase 2 stubs — no server needed)
+# =============================================================================
+
+
+class TestExchangeCLI:
+    """Test `nexus exchange` Phase 2 stubs.
+
+    These commands don't call the server; they print 'not yet available'.
+    """
+
+    def test_exchange_list(self, cli_server):
+        result = _run_cli_no_server("exchange", "list", env=cli_server["env"])
+        assert result.returncode == 0
+        assert "not yet available" in result.stdout
+
+    def test_exchange_create(self, cli_server):
+        result = _run_cli_no_server(
+            "exchange",
+            "create",
+            "/data/dataset.csv",
+            "--price",
+            "100",
+            env=cli_server["env"],
+        )
+        assert result.returncode == 0
+        assert "not yet available" in result.stdout
+
+    def test_exchange_show(self, cli_server):
+        result = _run_cli_no_server("exchange", "show", "offer-123", env=cli_server["env"])
+        assert result.returncode == 0
+        assert "not yet available" in result.stdout
+
+    def test_exchange_cancel(self, cli_server):
+        result = _run_cli_no_server("exchange", "cancel", "offer-123", env=cli_server["env"])
+        assert result.returncode == 0
+        assert "not yet available" in result.stdout

--- a/tests/unit/a2a/test_stream_reaper.py
+++ b/tests/unit/a2a/test_stream_reaper.py
@@ -1,0 +1,130 @@
+"""Tests for StreamReaper -- periodic cleanup of idle A2A streams."""
+
+import asyncio
+import time
+
+import pytest
+
+from nexus.bricks.a2a.stream_reaper import StreamReaper
+from nexus.bricks.a2a.stream_registry import StreamRegistry
+
+
+@pytest.fixture
+def anyio_backend():
+    """Restrict anyio tests to asyncio (trio is not installed)."""
+    return "asyncio"
+
+
+class TestStreamReaperInit:
+    def test_default_config(self) -> None:
+        registry = StreamRegistry()
+        reaper = StreamReaper(registry)
+        assert reaper._max_idle_seconds == 300.0
+        assert reaper._check_interval == 60.0
+        assert not reaper.is_running
+
+    def test_custom_config(self) -> None:
+        registry = StreamRegistry()
+        reaper = StreamReaper(registry, max_idle_seconds=60.0, check_interval=10.0)
+        assert reaper._max_idle_seconds == 60.0
+        assert reaper._check_interval == 10.0
+
+
+class TestStreamReaperReap:
+    def test_reap_no_idle_tasks(self) -> None:
+        registry = StreamRegistry()
+        registry.register("task-1")
+        reaper = StreamReaper(registry, max_idle_seconds=300.0)
+        reaper._reap()
+        # Nothing should be reaped -- task was just registered
+        assert registry.task_count == 1
+
+    def test_reap_idle_task(self) -> None:
+        registry = StreamRegistry()
+        queue = registry.register("task-1")
+
+        # Simulate idle time by backdating last_activity
+        registry._last_activity["task-1"] = time.monotonic() - 600  # 10 min ago
+
+        reaper = StreamReaper(registry, max_idle_seconds=300.0)
+        reaper._reap()
+
+        # Task should be reaped
+        assert registry.task_count == 0
+        # Queue should receive sentinel
+        assert queue.get_nowait() is None
+
+    def test_reap_multiple_idle_tasks(self) -> None:
+        registry = StreamRegistry()
+        q1 = registry.register("task-1")
+        q2 = registry.register("task-2")
+        registry.register("task-3")  # Will remain active
+
+        now = time.monotonic()
+        registry._last_activity["task-1"] = now - 600
+        registry._last_activity["task-2"] = now - 400
+        # task-3 keeps its recent timestamp
+
+        reaper = StreamReaper(registry, max_idle_seconds=300.0)
+        reaper._reap()
+
+        assert registry.task_count == 1  # Only task-3 remains
+        assert q1.get_nowait() is None
+        assert q2.get_nowait() is None
+
+    def test_reap_preserves_active_tasks(self) -> None:
+        registry = StreamRegistry()
+        registry.register("active-task")
+        reaper = StreamReaper(registry, max_idle_seconds=300.0)
+        reaper._reap()
+        assert registry.task_count == 1
+
+
+class TestStreamReaperLifecycle:
+    @pytest.mark.anyio
+    async def test_start_creates_task(self) -> None:
+        registry = StreamRegistry()
+        reaper = StreamReaper(registry, check_interval=0.1)
+        await reaper.start()
+        assert reaper.is_running
+        await reaper.stop()
+        assert not reaper.is_running
+
+    @pytest.mark.anyio
+    async def test_start_idempotent(self) -> None:
+        registry = StreamRegistry()
+        reaper = StreamReaper(registry, check_interval=0.1)
+        await reaper.start()
+        task1 = reaper._task
+        await reaper.start()  # Second start should be no-op
+        assert reaper._task is task1
+        await reaper.stop()
+
+    @pytest.mark.anyio
+    async def test_stop_without_start(self) -> None:
+        registry = StreamRegistry()
+        reaper = StreamReaper(registry)
+        await reaper.stop()  # Should not raise
+
+    @pytest.mark.anyio
+    async def test_reaper_runs_periodically(self) -> None:
+        registry = StreamRegistry()
+        registry.register("task-1")
+        registry._last_activity["task-1"] = time.monotonic() - 600
+
+        reaper = StreamReaper(registry, max_idle_seconds=300.0, check_interval=0.05)
+        await reaper.start()
+        await asyncio.sleep(0.15)  # Wait for at least one reap cycle
+        await reaper.stop()
+
+        # Task should have been reaped
+        assert registry.task_count == 0
+
+    @pytest.mark.anyio
+    async def test_stop_cancels_cleanly(self) -> None:
+        registry = StreamRegistry()
+        reaper = StreamReaper(registry, check_interval=10.0)
+        await reaper.start()
+        assert reaper.is_running
+        await reaper.stop()
+        assert not reaper.is_running

--- a/tests/unit/a2a/test_stream_registry.py
+++ b/tests/unit/a2a/test_stream_registry.py
@@ -98,3 +98,57 @@ class TestPushEvent:
         # Only the first event should be in the queue
         assert queue.get_nowait() == {"event": 1}
         assert queue.empty()
+
+
+class TestStreamRegistryActivity:
+    """Tests for last_activity tracking (Issue #2811)."""
+
+    def test_register_sets_last_activity(self) -> None:
+        reg = StreamRegistry()
+        reg.register("task-1")
+        assert "task-1" in reg._last_activity
+
+    def test_push_event_updates_last_activity(self) -> None:
+        reg = StreamRegistry()
+        reg.register("task-1")
+        old_activity = reg._last_activity["task-1"]
+        import time
+
+        time.sleep(0.01)
+        reg.push_event("task-1", {"type": "test"})
+        assert reg._last_activity["task-1"] >= old_activity
+
+    def test_unregister_cleans_last_activity(self) -> None:
+        reg = StreamRegistry()
+        queue = reg.register("task-1")
+        reg.unregister("task-1", queue)
+        assert "task-1" not in reg._last_activity
+
+    def test_get_idle_tasks(self) -> None:
+        import time
+
+        reg = StreamRegistry()
+        reg.register("task-1")
+        reg.register("task-2")
+        reg._last_activity["task-1"] = time.monotonic() - 600
+        idle = reg.get_idle_tasks(300.0)
+        assert "task-1" in idle
+        assert "task-2" not in idle
+
+    def test_close_task_streams_sends_sentinel(self) -> None:
+        reg = StreamRegistry()
+        q1 = reg.register("task-1")
+        q2 = reg.register("task-1")
+        closed = reg.close_task_streams("task-1")
+        assert closed == 2
+        assert q1.get_nowait() is None
+        assert q2.get_nowait() is None
+        assert reg.task_count == 0
+
+    def test_active_stream_count(self) -> None:
+        reg = StreamRegistry()
+        reg.register("task-1")
+        reg.register("task-1")
+        reg.register("task-2")
+        assert reg.active_stream_count == 3
+        assert reg.task_count == 2

--- a/tests/unit/cli/test_service_client.py
+++ b/tests/unit/cli/test_service_client.py
@@ -1,0 +1,606 @@
+"""Tests for NexusServiceClient — HTTP client for non-FS CLI commands.
+
+Covers:
+- Client initialization (base_url, auth headers, trailing slash stripping)
+- Context manager lifecycle
+- Request method (param filtering, error handling, 204 responses)
+- Pay endpoints (balance, transfer, history)
+- Audit endpoints (list, export)
+- Lock endpoints (list, info, release)
+- Governance endpoints (alerts, status, rings)
+- Event endpoints (replay, subscribe)
+- Snapshot endpoints (create, list, restore)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.cli.client import NexusAPIError, NexusServiceClient
+
+# ── Helpers ───────────────────────────────────────────────
+
+
+def _make_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    text: str = "",
+) -> MagicMock:
+    """Build a mock httpx.Response with the given status and body."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.return_value = {}
+    return resp
+
+
+# ── Fixtures ──────────────────────────────────────────────
+
+
+@pytest.fixture()
+def client_and_mock():
+    """Create a NexusServiceClient with a mocked underlying httpx.Client.
+
+    Since httpx is lazily imported inside ``__init__``, we patch ``httpx.Client``
+    at the module level so the lazy import picks up the mock.
+    """
+    mock_http_client = MagicMock()
+    with patch("httpx.Client", return_value=mock_http_client):
+        client = NexusServiceClient("http://localhost:2026", "test-key")
+    yield client, mock_http_client
+    client.close()
+
+
+# ── TestNexusServiceClientInit ────────────────────────────
+
+
+class TestNexusServiceClientInit:
+    """Test client initialization."""
+
+    def test_init_sets_base_url(self) -> None:
+        with patch("httpx.Client") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            client = NexusServiceClient("http://localhost:2026", "test-key")
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["base_url"] == "http://localhost:2026"
+            client.close()
+
+    def test_init_strips_trailing_slash(self) -> None:
+        with patch("httpx.Client") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            client = NexusServiceClient("http://localhost:2026/", "key")
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["base_url"] == "http://localhost:2026"
+            client.close()
+
+    def test_init_strips_multiple_trailing_slashes(self) -> None:
+        with patch("httpx.Client") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            client = NexusServiceClient("http://localhost:2026///", "key")
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["base_url"] == "http://localhost:2026"
+            client.close()
+
+    def test_init_sets_auth_header(self) -> None:
+        with patch("httpx.Client") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            client = NexusServiceClient("http://localhost:2026", "my-api-key")
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["headers"]["Authorization"] == "Bearer my-api-key"
+            client.close()
+
+    def test_init_no_auth_header_when_no_key(self) -> None:
+        with patch("httpx.Client") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            client = NexusServiceClient("http://localhost:2026")
+            call_kwargs = mock_cls.call_args[1]
+            assert "Authorization" not in call_kwargs["headers"]
+            client.close()
+
+    def test_init_sets_content_type_header(self) -> None:
+        with patch("httpx.Client") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            client = NexusServiceClient("http://localhost:2026")
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["headers"]["Content-Type"] == "application/json"
+            client.close()
+
+    def test_init_sets_timeout(self) -> None:
+        with patch("httpx.Client") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            client = NexusServiceClient("http://localhost:2026")
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["timeout"] == 30.0
+            client.close()
+
+
+# ── TestContextManager ────────────────────────────────────
+
+
+class TestContextManager:
+    """Test __enter__ / __exit__ lifecycle."""
+
+    def test_context_manager_closes_client(self) -> None:
+        mock_http = MagicMock()
+        with (
+            patch("httpx.Client", return_value=mock_http),
+            NexusServiceClient("http://localhost:2026") as client,
+        ):
+            assert client is not None
+        mock_http.close.assert_called_once()
+
+    def test_context_manager_returns_self(self) -> None:
+        with patch("httpx.Client", return_value=MagicMock()):
+            svc = NexusServiceClient("http://localhost:2026")
+            with svc as ctx:
+                assert ctx is svc
+            svc.close()
+
+
+# ── TestRequest ───────────────────────────────────────────
+
+
+class TestRequest:
+    """Test the internal _request method behavior."""
+
+    def test_request_filters_none_params(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"ok": True})
+
+        client._request("GET", "/test", params={"keep": "yes", "drop": None})
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["params"] == {"keep": "yes"}
+
+    def test_request_raises_on_4xx(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(404, {"detail": "Not found"})
+
+        with pytest.raises(NexusAPIError) as exc_info:
+            client._request("GET", "/missing")
+
+        assert exc_info.value.status_code == 404
+        assert "Not found" in exc_info.value.detail
+
+    def test_request_raises_on_5xx(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(500, {"detail": "Server error"})
+
+        with pytest.raises(NexusAPIError) as exc_info:
+            client._request("POST", "/broken")
+
+        assert exc_info.value.status_code == 500
+        assert "Server error" in exc_info.value.detail
+
+    def test_request_raises_on_error_with_unparseable_json(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        resp = MagicMock()
+        resp.status_code = 502
+        resp.text = "Bad Gateway"
+        resp.json.side_effect = ValueError("No JSON")
+        mock_http.request.return_value = resp
+
+        with pytest.raises(NexusAPIError) as exc_info:
+            client._request("GET", "/bad-gateway")
+
+        assert exc_info.value.status_code == 502
+        assert "Bad Gateway" in exc_info.value.detail
+
+    def test_request_returns_empty_dict_on_204(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(204)
+
+        result = client._request("DELETE", "/resource")
+
+        assert result == {}
+
+    def test_request_returns_json(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        expected = {"id": "abc", "status": "ok"}
+        mock_http.request.return_value = _make_response(200, expected)
+
+        result = client._request("GET", "/resource")
+
+        assert result == expected
+
+    def test_request_passes_json_body(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"created": True})
+
+        body = {"name": "test"}
+        client._request("POST", "/resource", json_body=body)
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["json"] == body
+
+
+# ── TestPayMethods ────────────────────────────────────────
+
+
+class TestPayMethods:
+    """Test pay_balance, pay_transfer, pay_history."""
+
+    def test_pay_balance_no_agent(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(
+            200, {"available": "100", "reserved": "0", "total": "100"}
+        )
+
+        result = client.pay_balance()
+
+        mock_http.request.assert_called_once_with(
+            "GET", "/api/v2/pay/balance", params=None, json=None
+        )
+        assert result == {"available": "100", "reserved": "0", "total": "100"}
+
+    def test_pay_balance_with_agent(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(
+            200, {"available": "50", "reserved": "10", "total": "60"}
+        )
+
+        result = client.pay_balance(agent_id="agent-42")
+
+        mock_http.request.assert_called_once_with(
+            "GET", "/api/v2/pay/balance", params={"agent_id": "agent-42"}, json=None
+        )
+        assert result["available"] == "50"
+
+    def test_pay_transfer(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(
+            200, {"txn_id": "tx-1", "status": "completed"}
+        )
+
+        result = client.pay_transfer("bob", "10.00", memo="lunch", method="credits")
+
+        mock_http.request.assert_called_once_with(
+            "POST",
+            "/api/v2/pay/transfer",
+            params=None,
+            json={"to": "bob", "amount": "10.00", "memo": "lunch", "method": "credits"},
+        )
+        assert result["txn_id"] == "tx-1"
+
+    def test_pay_transfer_defaults(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"txn_id": "tx-2"})
+
+        client.pay_transfer("alice", "5.00")
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["json"]["memo"] == ""
+        assert call_kwargs["json"]["method"] == "auto"
+
+    def test_pay_history(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"items": [], "cursor": None})
+
+        result = client.pay_history(since="2025-01-01", limit=10)
+
+        _, call_kwargs = mock_http.request.call_args
+        # None values are filtered by _request
+        assert call_kwargs["params"]["since"] == "2025-01-01"
+        assert call_kwargs["params"]["limit"] == 10
+        assert result["items"] == []
+
+
+# ── TestAuditMethods ──────────────────────────────────────
+
+
+class TestAuditMethods:
+    """Test audit_list and audit_export."""
+
+    def test_audit_list_default_params(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"items": [], "total": 0})
+
+        result = client.audit_list()
+
+        mock_http.request.assert_called_once()
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["params"]["limit"] == 50
+        assert result["total"] == 0
+
+    def test_audit_list_with_filters(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"items": [{"id": "1"}]})
+
+        result = client.audit_list(
+            since="2025-01-01",
+            until="2025-12-31",
+            agent_id="agent-1",
+            action="transfer",
+            limit=10,
+            cursor="abc",
+        )
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["params"]["since"] == "2025-01-01"
+        assert call_kwargs["params"]["until"] == "2025-12-31"
+        assert call_kwargs["params"]["agent_id"] == "agent-1"
+        assert call_kwargs["params"]["status"] == "transfer"
+        assert call_kwargs["params"]["limit"] == 10
+        assert call_kwargs["params"]["cursor"] == "abc"
+        assert len(result["items"]) == 1
+
+    def test_audit_export(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        resp = _make_response(200, text="col1,col2\nval1,val2")
+        resp.text = "col1,col2\nval1,val2"
+        mock_http.request.return_value = resp
+
+        result = client.audit_export(fmt="csv", since="2025-01-01")
+
+        mock_http.request.assert_called_once()
+        call_args = mock_http.request.call_args
+        assert call_args[0] == ("GET", "/api/v2/audit/transactions/export")
+        assert call_args[1]["params"]["format"] == "csv"
+        assert call_args[1]["params"]["since"] == "2025-01-01"
+        assert result == "col1,col2\nval1,val2"
+
+    def test_audit_export_error_raises(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(403, {"detail": "Forbidden"})
+
+        with pytest.raises(NexusAPIError) as exc_info:
+            client.audit_export()
+
+        assert exc_info.value.status_code == 403
+
+
+# ── TestLockMethods ───────────────────────────────────────
+
+
+class TestLockMethods:
+    """Test lock_list, lock_info, lock_release."""
+
+    def test_lock_list(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"locks": []})
+
+        result = client.lock_list(zone_id="zone-a")
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["params"]["zone_id"] == "zone-a"
+        assert result == {"locks": []}
+
+    def test_lock_info_strips_slash(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(
+            200, {"path": "data/file.txt", "locked": True}
+        )
+
+        result = client.lock_info("/data/file.txt")
+
+        call_args = mock_http.request.call_args
+        # The leading slash should be stripped from the path segment
+        assert call_args[0] == ("GET", "/api/v2/locks/data/file.txt")
+        assert result["locked"] is True
+
+    def test_lock_release_force(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(204)
+
+        result = client.lock_release("/data/file.txt", lock_id="lk-1", force=True)
+
+        call_args = mock_http.request.call_args
+        assert call_args[0] == ("DELETE", "/api/v2/locks/data/file.txt")
+        assert call_args[1]["params"]["lock_id"] == "lk-1"
+        assert call_args[1]["params"]["force"] == "true"
+        assert result == {}
+
+    def test_lock_release_no_force(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(204)
+
+        client.lock_release("data/file.txt")
+
+        _, call_kwargs = mock_http.request.call_args
+        assert "force" not in call_kwargs["params"]
+        assert "lock_id" not in call_kwargs["params"]
+
+
+# ── TestGovernanceMethods ─────────────────────────────────
+
+
+class TestGovernanceMethods:
+    """Test governance_alerts, governance_status, governance_rings."""
+
+    def test_governance_alerts(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"alerts": [{"id": "a1"}]})
+
+        result = client.governance_alerts(severity="high", since="2025-01-01", limit=10)
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["params"]["severity"] == "high"
+        assert call_kwargs["params"]["since"] == "2025-01-01"
+        assert call_kwargs["params"]["limit"] == 10
+        assert len(result["alerts"]) == 1
+
+    def test_governance_status_combines_alerts_and_rings(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        alerts_resp = _make_response(200, {"alerts": [{"id": "a1"}]})
+        rings_resp = _make_response(200, {"rings": []})
+        mock_http.request.side_effect = [alerts_resp, rings_resp]
+
+        result = client.governance_status()
+
+        assert mock_http.request.call_count == 2
+        assert result["recent_alerts"] == {"alerts": [{"id": "a1"}]}
+        assert result["fraud_rings"] == {"rings": []}
+
+    def test_governance_rings(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"rings": [{"id": "r1"}]})
+
+        result = client.governance_rings()
+
+        call_args = mock_http.request.call_args
+        assert call_args[0] == ("GET", "/api/v2/governance/rings")
+        assert result["rings"] == [{"id": "r1"}]
+
+
+# ── TestEventMethods ──────────────────────────────────────
+
+
+class TestEventMethods:
+    """Test events_replay and events_subscribe."""
+
+    def test_events_replay(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"events": [{"type": "write"}]})
+
+        result = client.events_replay(
+            since="2025-01-01", event_type="write", path="/data", limit=25
+        )
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["params"]["event_type"] == "write"
+        assert call_kwargs["params"]["path"] == "/data"
+        assert call_kwargs["params"]["limit"] == 25
+        assert len(result["events"]) == 1
+
+    def test_events_replay_defaults(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"events": []})
+
+        client.events_replay()
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["params"]["limit"] == 50
+
+    def test_events_subscribe(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = 'data: {"type": "write"}\n\n'
+        mock_http.request.return_value = resp
+
+        result = client.events_subscribe("/**")
+
+        call_args = mock_http.request.call_args
+        assert call_args[0] == ("GET", "/api/v2/events/stream")
+        assert call_args[1]["params"] == {"pattern": "/**"}
+        assert call_args[1]["headers"]["Accept"] == "text/event-stream"
+        assert result == resp.text
+
+    def test_events_subscribe_error_raises(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(401, {"detail": "Unauthorized"})
+
+        with pytest.raises(NexusAPIError) as exc_info:
+            client.events_subscribe("/**")
+
+        assert exc_info.value.status_code == 401
+
+
+# ── TestSnapshotMethods ───────────────────────────────────
+
+
+class TestSnapshotMethods:
+    """Test snapshot_create, snapshot_list, snapshot_restore."""
+
+    def test_snapshot_create(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"txn_id": "snap-1"})
+
+        result = client.snapshot_create(description="backup", ttl_seconds=7200)
+
+        _, call_kwargs = mock_http.request.call_args
+        assert call_kwargs["json"] == {"ttl_seconds": 7200, "description": "backup"}
+        assert result["txn_id"] == "snap-1"
+
+    def test_snapshot_create_no_description(
+        self, client_and_mock: tuple[NexusServiceClient, MagicMock]
+    ) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"txn_id": "snap-2"})
+
+        client.snapshot_create()
+
+        _, call_kwargs = mock_http.request.call_args
+        # description should NOT be in the body when omitted
+        assert "description" not in call_kwargs["json"]
+        assert call_kwargs["json"]["ttl_seconds"] == 3600
+
+    def test_snapshot_list(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"snapshots": [{"id": "s1"}]})
+
+        result = client.snapshot_list()
+
+        call_args = mock_http.request.call_args
+        assert call_args[0] == ("GET", "/api/v2/snapshots")
+        assert len(result["snapshots"]) == 1
+
+    def test_snapshot_restore(self, client_and_mock: tuple[NexusServiceClient, MagicMock]) -> None:
+        client, mock_http = client_and_mock
+        mock_http.request.return_value = _make_response(200, {"status": "restored"})
+
+        result = client.snapshot_restore("txn-abc")
+
+        call_args = mock_http.request.call_args
+        assert call_args[0] == ("POST", "/api/v2/snapshots/txn-abc/rollback")
+        assert result["status"] == "restored"
+
+
+# ── TestNexusAPIError ─────────────────────────────────────
+
+
+class TestNexusAPIError:
+    """Test the NexusAPIError exception."""
+
+    def test_stores_status_code_and_detail(self) -> None:
+        err = NexusAPIError(422, "Validation failed")
+        assert err.status_code == 422
+        assert err.detail == "Validation failed"
+
+    def test_str_includes_status_and_detail(self) -> None:
+        err = NexusAPIError(500, "Internal server error")
+        assert "500" in str(err)
+        assert "Internal server error" in str(err)

--- a/tests/unit/services/test_search_service.py
+++ b/tests/unit/services/test_search_service.py
@@ -7,6 +7,7 @@ SearchService uses dependency injection with MetastoreABC,
 PermissionEnforcer, PathRouter, and NexusFSGateway.
 """
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -444,3 +445,143 @@ class TestGrepValidation:
         with patch.object(service, "list", return_value=[]):
             results = service.grep(pattern="def\\s+\\w+", context=context)
             assert results == []
+
+
+# =============================================================================
+# grep context lines (_grep_lines)
+# =============================================================================
+
+
+class TestGrepContext:
+    """Tests for grep context line support (Issue #2811)."""
+
+    @staticmethod
+    def _make_lines():
+        """Sample file content for testing."""
+        return [
+            "line 1: header",
+            "line 2: import os",
+            "line 3: import sys",
+            "line 4:",
+            "line 5: def main():",
+            "line 6:     print('hello')",
+            "line 7:     return 0",
+            "line 8:",
+            "line 9: def helper():",
+            "line 10:    pass",
+        ]
+
+    def test_basic_match_no_context(self):
+        """Basic grep without context returns just matching lines."""
+        lines = self._make_lines()
+        regex = re.compile(r"def \w+")
+        results = SearchService._grep_lines(regex, lines, "/test.py")
+        assert len(results) == 2
+        assert results[0]["line"] == 5
+        assert results[0]["content"] == "line 5: def main():"
+        assert results[1]["line"] == 9
+        assert "before_context" not in results[0]
+        assert "after_context" not in results[0]
+
+    def test_after_context(self):
+        """After-context returns N lines after each match."""
+        lines = self._make_lines()
+        regex = re.compile(r"def main")
+        results = SearchService._grep_lines(regex, lines, "/test.py", after_context=2)
+        assert len(results) == 1
+        assert results[0]["line"] == 5
+        ctx = results[0]["after_context"]
+        assert len(ctx) == 2
+        assert ctx[0]["line"] == 6
+        assert ctx[1]["line"] == 7
+
+    def test_before_context(self):
+        """Before-context returns N lines before each match."""
+        lines = self._make_lines()
+        regex = re.compile(r"def main")
+        results = SearchService._grep_lines(regex, lines, "/test.py", before_context=2)
+        assert len(results) == 1
+        ctx = results[0]["before_context"]
+        assert len(ctx) == 2
+        assert ctx[0]["line"] == 3
+        assert ctx[1]["line"] == 4
+
+    def test_combined_context(self):
+        """Both before and after context."""
+        lines = self._make_lines()
+        regex = re.compile(r"def main")
+        results = SearchService._grep_lines(
+            regex, lines, "/test.py", before_context=1, after_context=1
+        )
+        assert len(results) == 1
+        assert len(results[0]["before_context"]) == 1
+        assert results[0]["before_context"][0]["line"] == 4
+        assert len(results[0]["after_context"]) == 1
+        assert results[0]["after_context"][0]["line"] == 6
+
+    def test_context_at_file_start(self):
+        """Before-context at line 1 doesn't go negative."""
+        lines = self._make_lines()
+        regex = re.compile(r"header")
+        results = SearchService._grep_lines(regex, lines, "/test.py", before_context=5)
+        assert len(results) == 1
+        assert results[0]["line"] == 1
+        assert results[0].get("before_context", []) == []
+
+    def test_context_at_file_end(self):
+        """After-context at last line doesn't go past end."""
+        lines = self._make_lines()
+        regex = re.compile(r"pass")
+        results = SearchService._grep_lines(regex, lines, "/test.py", after_context=5)
+        assert len(results) == 1
+        assert results[0]["line"] == 10
+        assert results[0].get("after_context", []) == []
+
+    def test_invert_match(self):
+        """Invert match returns non-matching lines."""
+        lines = self._make_lines()
+        regex = re.compile(r"def \w+")
+        results = SearchService._grep_lines(regex, lines, "/test.py", invert_match=True)
+        # 10 lines, 2 match "def", so 8 should be returned
+        assert len(results) == 8
+        for r in results:
+            assert "def " not in r["content"]
+
+    def test_invert_match_with_context(self):
+        """Invert match with context lines."""
+        lines = self._make_lines()
+        regex = re.compile(r"def \w+")
+        results = SearchService._grep_lines(
+            regex, lines, "/test.py", invert_match=True, after_context=1
+        )
+        assert len(results) == 8
+        # First result (line 1) should have after_context
+        assert results[0]["line"] == 1
+        assert len(results[0]["after_context"]) == 1
+
+    def test_max_results_limit(self):
+        """Max results is respected."""
+        lines = self._make_lines()
+        regex = re.compile(r"line")
+        results = SearchService._grep_lines(regex, lines, "/test.py", max_results=3)
+        assert len(results) == 3
+
+    def test_no_matches(self):
+        """No matches returns empty list."""
+        lines = self._make_lines()
+        regex = re.compile(r"NONEXISTENT")
+        results = SearchService._grep_lines(regex, lines, "/test.py")
+        assert results == []
+
+    def test_empty_lines(self):
+        """Empty file returns empty list."""
+        regex = re.compile(r"test")
+        results = SearchService._grep_lines(regex, [], "/test.py")
+        assert results == []
+
+    def test_match_includes_match_group(self):
+        """Match dict includes the matched text."""
+        lines = ["hello world"]
+        regex = re.compile(r"world")
+        results = SearchService._grep_lines(regex, lines, "/test.py")
+        assert results[0]["match"] == "world"


### PR DESCRIPTION
## Summary

- **New CLI command groups**: `nexus pay`, `nexus audit`, `nexus lock`, `nexus governance`, `nexus events`, `nexus snapshot`, `nexus exchange` — all backed by `NexusServiceClient` HTTP client hitting `/api/v2/*` endpoints
- **grep context lines**: Added `-A`, `-B`, `-C` (after/before/context) flags to `nexus grep` command, matching standard grep behavior
- **A2A stream cleanup**: `StreamReaper` for periodic idle-stream pruning + enhanced `StreamRegistry` with `task_count`, `touch()`, activity tracking
- **Exchange gRPC servicer**: Stub `ExchangeServicer` for future exchange protocol support
- **Bug fix**: Fixed `audit_export` CLI passing wrong kwarg (`format` → `fmt`) to client method

## Files changed (26 files, +3436/-35)
- `src/nexus/cli/client.py` — `NexusServiceClient` with typed methods for all REST endpoints
- `src/nexus/cli/commands/{audit,pay,locks,governance_cli,events_cli,snapshots,exchange}.py` — Click command groups
- `src/nexus/cli/utils.py` — Shared CLI utilities (`--remote-url`, `--json`, `get_service_client`, `output_result`)
- `src/nexus/bricks/a2a/{stream_reaper,stream_registry}.py` — A2A stream lifecycle management
- `src/nexus/grpc/exchange_servicer.py` — gRPC exchange stub
- `src/nexus/services/search/search_service.py` — grep context lines support
- `tests/e2e/server/test_cli_commands_e2e.py` — 25 e2e tests against real FastAPI/uvicorn server
- `tests/unit/cli/test_service_client.py` — 42 unit tests for NexusServiceClient
- `tests/unit/a2a/test_stream_{reaper,registry}.py` — 23 tests for A2A stream management
- `tests/unit/services/test_search_service.py` — 12 tests for grep context lines

## Test plan
- [x] All 25 e2e tests pass (real HTTP server, subprocess CLI invocations)
- [x] All 42 unit tests for NexusServiceClient pass
- [x] All 23 A2A stream tests pass (reaper + registry)
- [x] All 12 grep context line tests pass
- [x] Pre-commit hooks pass (ruff, ruff format, mypy, Block New Type Ignores)
- [x] Graceful handling for backends not available in test env (TigerBeetle, Redis)