### PR TITLE
chore: gitignore deploy/ for environment-specific configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,5 +216,8 @@ docs/plans/
 NUL
 NUL
 
+# Deployment configs (environment-specific)
+deploy/
+
 # Build tools (binary)
 tools/


### PR DESCRIPTION
## Summary
- Add `deploy/` to `.gitignore` — deployment configs contain environment-specific data (server IPs, domains, ports) and should not be tracked

## Test plan
- [x] `git check-ignore -v deploy/headscale/*` confirms all files ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)