### PR TITLE
feat(#1452): ServiceRegistry — kernel service symbol table

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -238,6 +238,12 @@ class NexusFS(  # type: ignore[misc]
 
         self._dispatch: KernelDispatch = KernelDispatch()
 
+        # Service registry — /proc/modules of Nexus (Issue #1452).
+        # Populated by factory via populate_service_registry() at link().
+        from nexus.core.service_registry import ServiceRegistry
+
+        self._service_registry: ServiceRegistry = ServiceRegistry()
+
         # Lifecycle state — set by link() / initialize() / bootstrap()
         self._linked: bool = False
         self._initialized: bool = False
@@ -309,6 +315,20 @@ class NexusFS(  # type: ignore[misc]
         for cb in self._bootstrap_callbacks:
             await cb()
         self._bootstrapped = True
+
+    # -- Service registry accessors (Issue #1452) ---------------------------
+
+    def service(self, name: str) -> Any | None:
+        """Look up a registered service by canonical name.
+
+        Returns the service instance, or ``None`` if not registered.
+        """
+        return self._service_registry.service(name)
+
+    @property
+    def service_registry(self) -> Any:
+        """Read-only access to the kernel ServiceRegistry.  Factory / diagnostics."""
+        return self._service_registry
 
     # Services wired by factory via bind_wired_services() (Issue #1381).
     # See nexus.factory.service_routing.bind_wired_services().

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -1,0 +1,148 @@
+"""Kernel service symbol table — ``/proc/modules`` of Nexus.
+
+Provides ``ServiceRegistry``, a typed registry for wired service instances.
+Extends ``BaseRegistry[ServiceInfo]`` with dependency validation, convenience
+accessors, bulk registration, and diagnostic snapshots.
+
+Phase 1 (Issue #1452): infrastructure + dual-write alongside ``bind_wired_services()``.
+Phase 2: caller migration (``nx.search_service`` → ``nx.service("search")``).
+Phase 3: ``EXPORT_SYMBOL`` pattern + runtime hot-swap.
+
+Linux analogy:
+
+    insmod          → registry.register_service("search", svc)
+    EXPORT_SYMBOL() → nx.service("search")
+    rmmod           → registry.unregister("search")
+    /proc/modules   → registry.snapshot()
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+
+from nexus.lib.registry import BaseRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ServiceInfo:
+    """Immutable service registration descriptor (``struct module``).
+
+    Unlike ``BrickInfo.brick_cls`` (stores a *class*), ``instance`` stores
+    a live service object — wired services are singletons created at link().
+    """
+
+    name: str
+    instance: Any
+    dependencies: tuple[str, ...] = ()
+    profile_gate: str | None = None
+    is_remote: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+
+class ServiceRegistry(BaseRegistry["ServiceInfo"]):
+    """Kernel service symbol table — ``/proc/modules`` of Nexus.
+
+    Inherits ``BaseRegistry``: thread-safe register/get/list/unregister.
+    Adds: dependency validation, convenience accessors, bulk registration.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(name="services")
+
+    # -- registration ------------------------------------------------------
+
+    def register_service(
+        self,
+        name: str,
+        instance: Any,
+        *,
+        dependencies: tuple[str, ...] | list[str] = (),
+        profile_gate: str | None = None,
+        is_remote: bool = False,
+        metadata: dict[str, Any] | None = None,
+        allow_overwrite: bool = False,
+    ) -> None:
+        """Register a service instance under *name* (``insmod``).
+
+        Validates that all declared *dependencies* are already registered.
+        """
+        deps = tuple(dependencies)
+        # Dependency validation — fail-fast on missing prerequisites.
+        missing = [d for d in deps if d not in self]
+        if missing:
+            raise ValueError(
+                f"services: cannot register {name!r} — missing dependencies: {missing}"
+            )
+
+        info = ServiceInfo(
+            name=name,
+            instance=instance,
+            dependencies=deps,
+            profile_gate=profile_gate,
+            is_remote=is_remote,
+            metadata=MappingProxyType(metadata or {}),
+        )
+        self.register(name, info, allow_overwrite=allow_overwrite)
+
+    # -- convenience accessors ---------------------------------------------
+
+    def service(self, name: str) -> Any | None:
+        """Primary lookup API (``EXPORT_SYMBOL``).
+
+        Returns the service *instance*, not the ``ServiceInfo`` envelope.
+        """
+        info = self.get(name)
+        return info.instance if info is not None else None
+
+    def service_or_raise(self, name: str) -> Any:
+        """Like :meth:`service` but raises ``KeyError`` if absent."""
+        return self.get_or_raise(name).instance
+
+    def service_info(self, name: str) -> ServiceInfo | None:
+        """Return the full ``ServiceInfo`` envelope, or ``None``."""
+        return self.get(name)
+
+    # -- bulk registration -------------------------------------------------
+
+    def register_many(
+        self,
+        services: dict[str, Any],
+        *,
+        is_remote: bool = False,
+    ) -> int:
+        """Register multiple services at once (skips ``None`` values).
+
+        Used by factory ``populate_service_registry()`` for batch wiring.
+        Returns the number of services actually registered.
+        """
+        count = 0
+        for name, instance in services.items():
+            if instance is None:
+                continue
+            self.register_service(name, instance, is_remote=is_remote)
+            count += 1
+        return count
+
+    # -- diagnostics -------------------------------------------------------
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Diagnostic snapshot — ``cat /proc/modules``."""
+        result = []
+        for info in self.list_all():
+            result.append(
+                {
+                    "name": info.name,
+                    "type": type(info.instance).__name__,
+                    "dependencies": list(info.dependencies),
+                    "profile_gate": info.profile_gate,
+                    "is_remote": info.is_remote,
+                    "metadata": dict(info.metadata),
+                }
+            )
+        return result

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -29,7 +29,7 @@ def _do_link(
 
     from nexus.contracts.deployment_profile import DeploymentProfile as _DP
     from nexus.factory._wired import _boot_wired_services
-    from nexus.factory.service_routing import bind_wired_services
+    from nexus.factory.service_routing import bind_wired_services, populate_service_registry
 
     _parsing = parsing if parsing is not None else nx._parse_config
 
@@ -96,6 +96,7 @@ def _do_link(
         _brick_on,
     )
     bind_wired_services(nx, _wired)
+    populate_service_registry(nx._service_registry, _wired)
 
     # MetadataExportService lives outside the slot map
     _mds = getattr(_wired, "metadata_export_service", None)

--- a/src/nexus/factory/_remote.py
+++ b/src/nexus/factory/_remote.py
@@ -71,10 +71,11 @@ def _boot_remote_services(nfs: "NexusFS", call_rpc: Callable[..., Any]) -> None:
     proxy = RemoteServiceProxy(call_rpc, service_name="universal")
 
     # Fill all wired service slots via bind_wired_services (dict path)
-    from nexus.factory.service_routing import bind_wired_services
+    from nexus.factory.service_routing import bind_wired_services, populate_service_registry
 
     wired_dict: dict[str, Any] = dict.fromkeys(_WIRED_FIELDS, proxy)
     bind_wired_services(nfs, wired_dict)
+    populate_service_registry(nfs._service_registry, wired_dict, is_remote=True)
 
     # BrickServices field not covered by WiredServices
     nfs.version_service = proxy

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -2,7 +2,11 @@
 
 Issue #1410: SERVICE_METHODS, SERVICE_ALIASES, and resolve_service_attr()
 deleted — zero callers (dead code from the retired __getattr__ proxy).
-Only bind_wired_services() remains as the active DI mechanism.
+
+Issue #1452: ``populate_service_registry()`` added as dual-write companion.
+During the transition period both ``bind_wired_services()`` (setattr) and
+``populate_service_registry()`` (ServiceRegistry) are called; callers are
+migrated from ``nx.xxx_service`` to ``nx.service("xxx")`` in Phase 2.
 """
 
 from __future__ import annotations
@@ -11,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from nexus.core.config import WiredServices
+    from nexus.core.service_registry import ServiceRegistry
 
 
 def bind_wired_services(target: object, wired: "WiredServices | dict[str, Any]") -> None:
@@ -56,3 +61,55 @@ def bind_wired_services(target: object, wired: "WiredServices | dict[str, Any]")
         return
     for src_key, target_attr in _SLOT_MAP.items():
         setattr(target, target_attr, getattr(wired, src_key))
+
+
+# ---------------------------------------------------------------------------
+# Canonical name mapping: WiredServices field → short registry key
+# ---------------------------------------------------------------------------
+
+_CANONICAL_NAMES: dict[str, str] = {
+    "rebac_service": "rebac",
+    "mount_service": "mount",
+    "gateway": "gateway",
+    "mount_core_service": "mount_core",
+    "sync_service": "sync",
+    "sync_job_service": "sync_job",
+    "mount_persist_service": "mount_persist",
+    "mcp_service": "mcp",
+    "llm_service": "llm",
+    "oauth_service": "oauth",
+    "search_service": "search",
+    "share_link_service": "share_link",
+    "events_service": "events",
+    "time_travel_service": "time_travel",
+    "operations_service": "operations",
+    "workspace_rpc_service": "workspace_rpc",
+    "agent_rpc_service": "agent_rpc",
+    "user_provisioning_service": "user_provisioning",
+    "sandbox_rpc_service": "sandbox_rpc",
+    "metadata_export_service": "metadata_export",
+    "descendant_checker": "descendant_checker",
+    "memory_provider": "memory_provider",
+}
+
+
+def populate_service_registry(
+    registry: "ServiceRegistry",
+    wired: "WiredServices | dict[str, Any]",
+    *,
+    is_remote: bool = False,
+) -> int:
+    """Dual-write companion — populate ServiceRegistry from WiredServices.
+
+    Called alongside ``bind_wired_services()`` during the transition period.
+    Extracts non-None service instances and registers them under canonical
+    short names (e.g. ``"search"`` instead of ``"search_service"``).
+
+    Returns the number of services registered.
+    """
+    services: dict[str, Any] = {}
+    for src_key, canonical in _CANONICAL_NAMES.items():
+        val = wired.get(src_key) if isinstance(wired, dict) else getattr(wired, src_key, None)
+        if val is not None:
+            services[canonical] = val
+    return registry.register_many(services, is_remote=is_remote)

--- a/tests/unit/core/test_service_registry.py
+++ b/tests/unit/core/test_service_registry.py
@@ -1,0 +1,237 @@
+"""Unit tests for ServiceRegistry (Issue #1452)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.core.service_registry import ServiceInfo, ServiceRegistry
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def registry() -> ServiceRegistry:
+    return ServiceRegistry()
+
+
+@pytest.fixture()
+def mock_svc() -> MagicMock:
+    return MagicMock(spec=["glob", "search"])
+
+
+# ---------------------------------------------------------------------------
+# ServiceInfo dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestServiceInfo:
+    def test_frozen(self) -> None:
+        info = ServiceInfo(name="x", instance=object())
+        with pytest.raises(AttributeError):
+            object.__setattr__(info, "name", "y")
+
+    def test_defaults(self) -> None:
+        svc = object()
+        info = ServiceInfo(name="search", instance=svc)
+        assert info.dependencies == ()
+        assert info.profile_gate is None
+        assert info.is_remote is False
+        assert dict(info.metadata) == {}
+
+    def test_metadata_immutable(self) -> None:
+        info = ServiceInfo(name="x", instance=object())
+        with pytest.raises(TypeError):
+            dict.__setitem__(info.metadata, "k", "v")
+
+
+# ---------------------------------------------------------------------------
+# register_service + service lookup
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAndLookup:
+    def test_register_and_service(self, registry: ServiceRegistry, mock_svc: Any) -> None:
+        registry.register_service("search", mock_svc)
+        assert registry.service("search") is mock_svc
+
+    def test_service_missing_returns_none(self, registry: ServiceRegistry) -> None:
+        assert registry.service("nonexistent") is None
+
+    def test_service_or_raise_missing(self, registry: ServiceRegistry) -> None:
+        with pytest.raises(KeyError, match="nonexistent"):
+            registry.service_or_raise("nonexistent")
+
+    def test_service_or_raise_found(self, registry: ServiceRegistry, mock_svc: Any) -> None:
+        registry.register_service("search", mock_svc)
+        assert registry.service_or_raise("search") is mock_svc
+
+    def test_service_info_returns_envelope(self, registry: ServiceRegistry, mock_svc: Any) -> None:
+        registry.register_service("search", mock_svc, profile_gate="discovery")
+        info = registry.service_info("search")
+        assert info is not None
+        assert isinstance(info, ServiceInfo)
+        assert info.name == "search"
+        assert info.instance is mock_svc
+        assert info.profile_gate == "discovery"
+
+    def test_service_info_missing(self, registry: ServiceRegistry) -> None:
+        assert registry.service_info("nope") is None
+
+
+# ---------------------------------------------------------------------------
+# Duplicate / overwrite
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateRegistration:
+    def test_duplicate_raises(self, registry: ServiceRegistry) -> None:
+        registry.register_service("search", MagicMock())
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register_service("search", MagicMock())
+
+    def test_allow_overwrite(self, registry: ServiceRegistry) -> None:
+        svc1 = MagicMock()
+        svc2 = MagicMock()
+        registry.register_service("search", svc1)
+        registry.register_service("search", svc2, allow_overwrite=True)
+        assert registry.service("search") is svc2
+
+
+# ---------------------------------------------------------------------------
+# Dependency validation
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyValidation:
+    def test_missing_dep_raises(self, registry: ServiceRegistry) -> None:
+        with pytest.raises(ValueError, match="missing dependencies.*gateway"):
+            registry.register_service("mount", MagicMock(), dependencies=("gateway",))
+
+    def test_satisfied_deps_ok(self, registry: ServiceRegistry) -> None:
+        registry.register_service("gateway", MagicMock())
+        registry.register_service("mount", MagicMock(), dependencies=("gateway",))
+        assert registry.service("mount") is not None
+
+    def test_multiple_missing_deps(self, registry: ServiceRegistry) -> None:
+        with pytest.raises(ValueError, match="missing dependencies"):
+            registry.register_service("mount", MagicMock(), dependencies=("gateway", "rebac"))
+
+
+# ---------------------------------------------------------------------------
+# register_many
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterMany:
+    def test_skips_none(self, registry: ServiceRegistry) -> None:
+        svc = MagicMock()
+        count = registry.register_many({"search": svc, "mcp": None, "llm": None})
+        assert count == 1
+        assert registry.service("search") is svc
+        assert registry.service("mcp") is None
+
+    def test_is_remote_flag(self, registry: ServiceRegistry) -> None:
+        svc = MagicMock()
+        registry.register_many({"search": svc}, is_remote=True)
+        info = registry.service_info("search")
+        assert info is not None
+        assert info.is_remote is True
+
+    def test_empty_dict(self, registry: ServiceRegistry) -> None:
+        assert registry.register_many({}) == 0
+
+
+# ---------------------------------------------------------------------------
+# snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    def test_snapshot_format(self, registry: ServiceRegistry) -> None:
+        registry.register_service("search", MagicMock(), profile_gate="discovery")
+        registry.register_service("gateway", MagicMock())
+        snap = registry.snapshot()
+        assert len(snap) == 2
+        names = {s["name"] for s in snap}
+        assert names == {"gateway", "search"}
+        search_entry = next(s for s in snap if s["name"] == "search")
+        assert search_entry["profile_gate"] == "discovery"
+        assert search_entry["is_remote"] is False
+        assert isinstance(search_entry["type"], str)
+
+
+# ---------------------------------------------------------------------------
+# Dual-write invariant: populate_service_registry
+# ---------------------------------------------------------------------------
+
+
+class TestPopulateServiceRegistry:
+    """Verify populate_service_registry produces the same instances as bind_wired_services."""
+
+    def test_dual_write_same_instances(self) -> None:
+        from nexus.core.config import KernelServices, ParseConfig
+        from nexus.core.nexus_fs import NexusFS
+        from nexus.core.service_registry import ServiceRegistry
+        from nexus.factory.service_routing import (
+            _CANONICAL_NAMES,
+            bind_wired_services,
+            populate_service_registry,
+        )
+
+        mock_metadata = MagicMock()
+        mock_metadata.list = MagicMock(return_value=[])
+        nx = NexusFS(
+            metadata_store=mock_metadata,
+            kernel_services=KernelServices(),
+            parsing=ParseConfig(auto_parse=False),
+        )
+
+        # Build a dict with a unique mock per service
+        wired_dict: dict[str, Any] = {}
+        for src_key in _CANONICAL_NAMES:
+            wired_dict[src_key] = MagicMock(name=f"mock_{src_key}")
+
+        bind_wired_services(nx, wired_dict)
+
+        reg = ServiceRegistry()
+        count = populate_service_registry(reg, wired_dict)
+        assert count == len(_CANONICAL_NAMES)
+
+        # Every registry entry must be the exact same instance as the attr on nx
+        # Re-read the slot map to get attr names
+        _SLOT_MAP = {
+            "rebac_service": "rebac_service",
+            "mount_service": "mount_service",
+            "gateway": "_gateway",
+            "mount_core_service": "_mount_core_service",
+            "sync_service": "_sync_service",
+            "sync_job_service": "_sync_job_service",
+            "mount_persist_service": "_mount_persist_service",
+            "mcp_service": "mcp_service",
+            "llm_service": "llm_service",
+            "oauth_service": "oauth_service",
+            "search_service": "search_service",
+            "share_link_service": "share_link_service",
+            "events_service": "events_service",
+            "workspace_rpc_service": "_workspace_rpc_service",
+            "agent_rpc_service": "_agent_rpc_service",
+            "user_provisioning_service": "_user_provisioning_service",
+            "sandbox_rpc_service": "_sandbox_rpc_service",
+            "metadata_export_service": "_metadata_export_service",
+            "descendant_checker": "_descendant_checker",
+            "memory_provider": "_memory_provider",
+            "time_travel_service": "time_travel_service",
+            "operations_service": "operations_service",
+        }
+        for src_key, canonical in _CANONICAL_NAMES.items():
+            attr_name = _SLOT_MAP[src_key]
+            attr_val = getattr(nx, attr_name)
+            reg_val = reg.service(canonical)
+            assert attr_val is reg_val, (
+                f"Mismatch for {src_key}: attr ({attr_name}) is not registry ({canonical})"
+            )

--- a/tests/unit/core/test_service_registry.py
+++ b/tests/unit/core/test_service_registry.py
@@ -33,7 +33,7 @@ class TestServiceInfo:
     def test_frozen(self) -> None:
         info = ServiceInfo(name="x", instance=object())
         with pytest.raises(AttributeError):
-            object.__setattr__(info, "name", "y")
+            info.name = "y"
 
     def test_defaults(self) -> None:
         svc = object()

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -110,6 +110,7 @@ def test_all_public_methods_are_exposed_or_excluded():
         "link",  # Boot phase 1 - pure memory wiring, not an RPC operation
         "initialize",  # Boot phase 2 - one-time side effects, not an RPC operation
         "bootstrap",  # Boot phase 3 - async task startup, server-only
+        "service",  # ServiceRegistry lookup — local kernel API, not an RPC operation (Issue #1452)
         "load_all_saved_mounts",  # Internal initialization method - called automatically on startup
         # Server-side only methods (clients get this via HTTP headers)
         "get_etag",  # Returns ETag for early 304 check - clients receive ETags via HTTP headers on read


### PR DESCRIPTION
## Summary

- Introduce `ServiceRegistry` (Linux `/proc/modules` analogy) as the centralized lookup table for wired services, extending `BaseRegistry[ServiceInfo]`
- `ServiceInfo` frozen dataclass stores service instance, dependencies, profile gate, and remote flag
- NexusFS gains `service("search")` convenience method and `service_registry` property
- `populate_service_registry()` dual-writes alongside existing `bind_wired_services()` in both local and remote paths — zero caller impact

This is Phase 1: infrastructure + dual-write. Caller migration (`nx.search_service` → `nx.service("search")`) follows in subsequent PRs.

## Test plan

- [x] 19 unit tests covering: ServiceInfo frozen/defaults, register/lookup, duplicate/overwrite, dependency validation, register_many, snapshot, and dual-write invariant
- [x] Existing `test_wired_services.py` (7 tests) still passes
- [x] ruff lint + format clean
- [x] mypy passes
- [x] No import cycles verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)