### PR TITLE
fix(#1481): atomize i_links_count with AdjustCounter Raft command

### DIFF
--- a/rust/nexus_raft/src/pyo3_bindings.rs
+++ b/rust/nexus_raft/src/pyo3_bindings.rs
@@ -332,6 +332,34 @@ impl PyMetastore {
         Ok(count)
     }
 
+    /// Atomically adjust a metadata counter by a signed delta.
+    ///
+    /// Read-modify-write in a single operation. The value is stored as
+    /// i64 big-endian in the metadata tree. Result clamped to >= 0.
+    ///
+    /// Args:
+    ///     key: The metadata key (e.g., "__i_links_count__").
+    ///     delta: Signed adjustment (+1 to increment, -1 to decrement).
+    ///
+    /// Returns:
+    ///     New counter value after adjustment.
+    pub fn adjust_counter(&mut self, key: &str, delta: i64) -> PyResult<i64> {
+        let cmd = Command::AdjustCounter {
+            key: key.to_string(),
+            delta,
+        };
+        let result = self.apply_command_raw(cmd)?;
+        match result {
+            CommandResult::Value(bytes) => {
+                let arr: [u8; 8] = bytes
+                    .try_into()
+                    .map_err(|_| PyRuntimeError::new_err("Invalid counter value"))?;
+                Ok(i64::from_be_bytes(arr))
+            }
+            _ => Err(PyRuntimeError::new_err("Unexpected result type")),
+        }
+    }
+
     /// Delete multiple metadata entries in a single batch operation.
     ///
     /// Args:
@@ -956,6 +984,34 @@ impl PyZoneHandle {
                 current_version,
             } => Ok((success, current_version)),
             _ => Err(PyRuntimeError::new_err("Unexpected CAS result type")),
+        }
+    }
+
+    /// Atomically adjust a metadata counter by a signed delta (Raft-replicated).
+    ///
+    /// The read-modify-write happens during apply() on each node,
+    /// serialized by Raft — no lost updates under concurrency.
+    ///
+    /// Args:
+    ///     key: The metadata key (e.g., "__i_links_count__").
+    ///     delta: Signed adjustment (+1 to increment, -1 to decrement).
+    ///
+    /// Returns:
+    ///     New counter value after adjustment.
+    pub fn adjust_counter(&self, py: Python<'_>, key: &str, delta: i64) -> PyResult<i64> {
+        let cmd = Command::AdjustCounter {
+            key: key.to_string(),
+            delta,
+        };
+        let result = self.propose_command_raw(py, cmd)?;
+        match result {
+            CommandResult::Value(bytes) => {
+                let arr: [u8; 8] = bytes
+                    .try_into()
+                    .map_err(|_| PyRuntimeError::new_err("Invalid counter value"))?;
+                Ok(i64::from_be_bytes(arr))
+            }
+            _ => Err(PyRuntimeError::new_err("Unexpected result type")),
         }
     }
 

--- a/rust/nexus_raft/src/raft/state_machine.rs
+++ b/rust/nexus_raft/src/raft/state_machine.rs
@@ -79,6 +79,18 @@ pub enum Command {
         expected_version: u32,
     },
 
+    /// Atomically adjust a metadata counter by a signed delta.
+    ///
+    /// Read-modify-write happens in `apply()` — serial by Raft guarantee.
+    /// The value is stored as `i64` big-endian in the metadata tree.
+    /// Result is clamped to `>= 0`.
+    AdjustCounter {
+        /// The metadata key (e.g., `"__i_links_count__"`).
+        key: String,
+        /// Signed delta to add (positive = increment, negative = decrement).
+        delta: i64,
+    },
+
     /// No-op command (used for leader election confirmation).
     Noop,
 }
@@ -522,6 +534,23 @@ impl FullStateMachine {
         Ok(CommandResult::Success)
     }
 
+    /// Apply AdjustCounter command — atomic read-modify-write in apply().
+    ///
+    /// Reads the current i64 value (0 if absent), adds delta, clamps to >= 0,
+    /// writes back. All within the serial `apply()` — no race possible.
+    /// Returns the new value as `Value(i64 big-endian bytes)`.
+    fn apply_adjust_counter(&self, key: &str, delta: i64) -> Result<CommandResult> {
+        let current = self
+            .metadata
+            .get(key.as_bytes())?
+            .and_then(|b| <[u8; 8]>::try_from(b.as_slice()).ok())
+            .map(i64::from_be_bytes)
+            .unwrap_or(0);
+        let new_val = (current + delta).max(0);
+        self.metadata.set(key.as_bytes(), &new_val.to_be_bytes())?;
+        Ok(CommandResult::Value(new_val.to_be_bytes().to_vec()))
+    }
+
     /// Apply CasSetMetadata command — atomic compare-and-swap on version.
     ///
     /// Reads the current value, extracts its version, and only writes
@@ -886,6 +915,7 @@ impl FullStateMachine {
                 lock_id,
                 new_ttl_secs,
             } => self.apply_extend_lock(path, lock_id, *new_ttl_secs),
+            Command::AdjustCounter { key, delta } => self.apply_adjust_counter(key, *delta),
             Command::Noop => Ok(CommandResult::Success),
         }
     }
@@ -1653,6 +1683,80 @@ mod tests {
             assert_eq!(current_version, 4);
         } else {
             panic!("Expected CasResult");
+        }
+    }
+
+    #[test]
+    fn test_adjust_counter() {
+        let store = RedbStore::open_temporary().unwrap();
+        let mut sm = FullStateMachine::new(&store).unwrap();
+
+        // Increment from zero
+        let result = sm
+            .apply(
+                1,
+                &Command::AdjustCounter {
+                    key: "__i_links_count__".into(),
+                    delta: 1,
+                },
+            )
+            .unwrap();
+        if let CommandResult::Value(bytes) = result {
+            let val = i64::from_be_bytes(bytes.try_into().unwrap());
+            assert_eq!(val, 1);
+        } else {
+            panic!("Expected Value result");
+        }
+
+        // Increment again
+        let result = sm
+            .apply(
+                2,
+                &Command::AdjustCounter {
+                    key: "__i_links_count__".into(),
+                    delta: 1,
+                },
+            )
+            .unwrap();
+        if let CommandResult::Value(bytes) = result {
+            let val = i64::from_be_bytes(bytes.try_into().unwrap());
+            assert_eq!(val, 2);
+        } else {
+            panic!("Expected Value result");
+        }
+
+        // Decrement
+        let result = sm
+            .apply(
+                3,
+                &Command::AdjustCounter {
+                    key: "__i_links_count__".into(),
+                    delta: -1,
+                },
+            )
+            .unwrap();
+        if let CommandResult::Value(bytes) = result {
+            let val = i64::from_be_bytes(bytes.try_into().unwrap());
+            assert_eq!(val, 1);
+        } else {
+            panic!("Expected Value result");
+        }
+
+        // Decrement below zero should clamp to 0
+        let result = sm
+            .apply(
+                4,
+                &Command::AdjustCounter {
+                    key: "__i_links_count__".into(),
+                    delta: -100,
+                },
+            )
+            .unwrap();
+        if let CommandResult::Value(bytes) = result {
+            let val = i64::from_be_bytes(bytes.try_into().unwrap());
+            assert_eq!(val, 0);
+        } else {
+            panic!("Expected Value result");
         }
     }
 }

--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -798,22 +798,14 @@ impl ZoneApiService for ZoneApiServiceImpl {
             .await
         {
             Ok(conf_state) => {
-                // Increment zone's i_links_count (Raft-replicated via SetMetadata).
+                // Increment zone's i_links_count (Raft-replicated, atomic).
+                // AdjustCounter does read-modify-write in apply() — no lost updates.
                 // This runs on the leader, so the follower's join() can skip
                 // _increment_links() and avoid a Raft leader-only-write violation.
-                let current_count: u64 = node
-                    .with_state_machine(|sm| sm.get_metadata("__i_links_count__"))
-                    .await
-                    .ok()
-                    .flatten()
-                    .and_then(|bytes| <[u8; 8]>::try_from(bytes.as_slice()).ok())
-                    .map(u64::from_be_bytes)
-                    .unwrap_or(0);
-
                 if let Err(e) = node
-                    .propose(Command::SetMetadata {
+                    .propose(Command::AdjustCounter {
                         key: "__i_links_count__".to_string(),
-                        value: (current_count + 1).to_be_bytes().to_vec(),
+                        delta: 1,
                     })
                     .await
                 {

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -488,25 +488,19 @@ class ZoneManager:
 
     @staticmethod
     def _increment_links(store: "RaftMetadataStore") -> int:
-        """Increment a zone's i_links_count via reserved key.
+        """Increment a zone's i_links_count via atomic Raft command.
 
         Returns the new count.
         """
-        current = store.get_zone_links_count()
-        new_count = current + 1
-        store.set_zone_links_count(new_count)
-        return new_count
+        return store.adjust_zone_links_count(1)
 
     @staticmethod
     def _decrement_links(store: "RaftMetadataStore") -> int:
-        """Decrement a zone's i_links_count via reserved key.
+        """Decrement a zone's i_links_count via atomic Raft command.
 
-        Returns the new count. Never goes below 0.
+        Returns the new count. Never goes below 0 (clamped in state machine).
         """
-        current = store.get_zone_links_count()
-        new_count = max(0, current - 1)
-        store.set_zone_links_count(new_count)
-        return new_count
+        return store.adjust_zone_links_count(-1)
 
     def get_links_count(self, zone_id: str) -> int:
         """Get a zone's current i_links_count.

--- a/src/nexus/storage/raft_metadata_store.py
+++ b/src/nexus/storage/raft_metadata_store.py
@@ -491,6 +491,20 @@ class RaftMetadataStore(MetastoreABC):
         """
         self._engine.set_metadata(self._KEY_LINKS_COUNT, count.to_bytes(8, "big"))
 
+    def adjust_zone_links_count(self, delta: int) -> int:
+        """Atomically adjust the zone's i_links_count by delta.
+
+        Uses AdjustCounter Raft command — read-modify-write happens
+        in apply(), serialized by Raft. No lost updates under concurrency.
+
+        Args:
+            delta: Signed adjustment (+1 to increment, -1 to decrement).
+
+        Returns:
+            New count after adjustment.
+        """
+        return self._engine.adjust_counter(self._KEY_LINKS_COUNT, delta)
+
     # =========================================================================
     # Revision Counter (Issue #1330 Phase 4.2)
     # =========================================================================


### PR DESCRIPTION
## Summary

- Add `AdjustCounter { key, delta }` Raft command that performs atomic read-modify-write in `apply()`, leveraging Raft's serial execution guarantee
- Replace the read-then-write pattern in `_increment_links` / `_decrement_links` (theoretical lost-update race under concurrent mount/join)
- Simplify JoinZone gRPC handler from 10-line read+propose to single `AdjustCounter` propose

## Changes

| File | Change |
|------|--------|
| `rust/.../state_machine.rs` | Add `AdjustCounter` command variant + `apply_adjust_counter()` with floor-clamp at 0 |
| `rust/.../pyo3_bindings.rs` | Add `adjust_counter()` to both `Metastore` (embedded) and `ZoneHandle` (Raft) |
| `rust/.../server.rs` | Simplify JoinZone handler to single `AdjustCounter` propose |
| `src/nexus/storage/raft_metadata_store.py` | Add `adjust_zone_links_count(delta)` method |
| `src/nexus/raft/zone_manager.py` | Migrate `_increment_links` / `_decrement_links` to use atomic operation |

## Design

Intent-based Raft command: encode the intent ("+1") not the pre-computed result ("set to 6"). The state machine reads current state, applies delta, and clamps to >= 0 — all within serial `apply()`. Same pattern as `AcquireLock` and `CasSetMetadata`.

Existing `get_zone_links_count()` / `set_zone_links_count()` remain for read-only checks and absolute resets.

## Test plan

- [x] `cargo test -p nexus_raft` — 36 tests pass including new `test_adjust_counter`
- [x] `cargo clippy -p nexus_raft` — no warnings
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [x] Pre-commit hooks — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)