### PR TITLE
fix: resolve 10 factory boot issues from codex audit

### DIFF
--- a/src/nexus/factory/__init__.py
+++ b/src/nexus/factory/__init__.py
@@ -29,13 +29,20 @@ Usage::
     # Advanced: create services separately, inject into kernel
     from nexus.factory import create_nexus_services
 
-    services = create_nexus_services(
+    kernel_svc, system_svc, brick_svc = create_nexus_services(
         record_store=record_store,
         metadata_store=metadata_store,
         backend=backend,
         router=my_router,
     )
-    nx = NexusFS(backend=backend, metadata_store=metadata_store, services=services)
+    nx = create_nexus_fs(
+        backend=backend,
+        metadata_store=metadata_store,
+        record_store=record_store,
+        kernel_services=kernel_svc,
+        system_services=system_svc,
+        brick_services=brick_svc,
+    )
 """
 
 # Public API

--- a/src/nexus/factory/_bricks.py
+++ b/src/nexus/factory/_bricks.py
@@ -477,25 +477,28 @@ def _boot_independent_bricks(
     # --- Memory Brick (Issue #2177) ---
     memory_router: Any = None
     memory_permission: Any = None
-    try:
-        from nexus.bricks.memory.router import MemoryViewRouter as _MemoryViewRouter
+    if not _on("memory"):
+        logger.debug("[BOOT:BRICK] Memory brick disabled by profile")
+    else:
+        try:
+            from nexus.bricks.memory.router import MemoryViewRouter as _MemoryViewRouter
 
-        memory_router = _MemoryViewRouter(
-            session_factory=ctx.record_store.session_factory,
-            entity_registry=system["entity_registry"],
-        )
+            memory_router = _MemoryViewRouter(
+                session_factory=ctx.record_store.session_factory,
+                entity_registry=system["entity_registry"],
+            )
 
-        from nexus.bricks.rebac.memory_permission_enforcer import MemoryPermissionEnforcer
+            from nexus.bricks.rebac.memory_permission_enforcer import MemoryPermissionEnforcer
 
-        memory_permission = MemoryPermissionEnforcer(
-            metadata_store=ctx.metadata_store,
-            rebac_manager=system["rebac_manager"],
-            memory_router=memory_router,
-            entity_registry=system["entity_registry"],
-        )
-        logger.debug("[BOOT:BRICK] Memory brick created (router + permission)")
-    except Exception as _mem_exc:
-        logger.debug("[BOOT:BRICK] Memory brick unavailable: %s", _mem_exc)
+            memory_permission = MemoryPermissionEnforcer(
+                metadata_store=ctx.metadata_store,
+                rebac_manager=system["rebac_manager"],
+                memory_router=memory_router,
+                entity_registry=system["entity_registry"],
+            )
+            logger.debug("[BOOT:BRICK] Memory brick created (router + permission)")
+        except Exception as _mem_exc:
+            logger.debug("[BOOT:BRICK] Memory brick unavailable: %s", _mem_exc)
 
     # --- Governance Brick (Issue #2129) ---
     governance_anomaly_service: Any = None

--- a/src/nexus/factory/_distributed.py
+++ b/src/nexus/factory/_distributed.py
@@ -44,7 +44,7 @@ def _create_distributed_infra(
                 )
 
         # Initialize event bus
-        if dist.event_bus_backend == "nats":
+        if dist.event_bus_backend == "nats" and dist.enable_events:
             from nexus.system_services.event_subsystem.bus.factory import create_event_bus
 
             event_bus = create_event_bus(

--- a/src/nexus/factory/_memory.py
+++ b/src/nexus/factory/_memory.py
@@ -41,6 +41,13 @@ def create_memory_service(nx: Any) -> Any:
         MemoryService instance, or None if dependencies are unavailable.
     """
     try:
+        # NexusFS no longer exposes .backend — resolve from router (Issue #2034).
+        _root_backend: Any = None
+        try:
+            _root_backend = nx.router.route("/").backend
+        except Exception:
+            logger.debug("[FACTORY] No root backend mounted — MemoryService will degrade")
+
         memory_cfg = getattr(nx, "_memory_config_obj", None)
         _paging = getattr(memory_cfg, "enable_paging", False) if memory_cfg else False
         _main_cap = getattr(memory_cfg, "main_capacity", 1000) if memory_cfg else 1000
@@ -67,7 +74,7 @@ def create_memory_service(nx: Any) -> Any:
                 vector_db = _resolve_vector_db(engine)
                 return MemoryWithPaging(
                     session=session,
-                    backend=nx.backend,
+                    backend=_root_backend,
                     zone_id=zone_id,
                     user_id=user_id,
                     agent_id=agent_id,
@@ -84,7 +91,7 @@ def create_memory_service(nx: Any) -> Any:
 
                 return Memory(
                     session=session,
-                    backend=nx.backend,
+                    backend=_root_backend,
                     zone_id=zone_id,
                     user_id=user_id,
                     agent_id=agent_id,
@@ -109,7 +116,7 @@ def create_memory_service(nx: Any) -> Any:
         svc = MemoryService(
             memory_factory=_create_memory,
             session_factory=nx.SessionLocal,
-            backend=nx.backend,
+            backend=_root_backend,
             default_context=default_ctx,
             memory_config=memory_config,
         )

--- a/src/nexus/factory/_remote.py
+++ b/src/nexus/factory/_remote.py
@@ -51,6 +51,9 @@ _WIRED_FIELDS: list[str] = [
     "metadata_export_service",
     "descendant_checker",
     "memory_provider",
+    # Versioning services (Issue #882)
+    "time_travel_service",
+    "operations_service",
 ]
 
 

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -73,92 +73,103 @@ def _boot_system_services(
 
     # =====================================================================
     # CRITICAL SECTION (BootError on failure) — Issue #2193
+    # Gated by "permissions" brick — MINIMAL/EMBEDDED profiles skip this.
     # =====================================================================
     from nexus.contracts.exceptions import BootError
 
-    try:
-        # Config-time dialect flag (KERNEL-ARCHITECTURE §7)
-        _is_pg = not ctx.db_url.startswith("sqlite")
+    rebac_manager: Any = None
+    audit_store: Any = None
+    entity_registry: Any = None
+    permission_enforcer: Any = None
+    write_observer: Any = None
 
-        # --- ReBAC Manager ---
-        from nexus.bricks.rebac.manager import ReBACManager
-
-        rebac_manager = ReBACManager(
-            engine=ctx.engine,
-            cache_ttl_seconds=ctx.cache_ttl_seconds or 300,
-            max_depth=10,
-            enforce_zone_isolation=ctx.perm.enforce_zone_isolation,
-            enable_graph_limits=True,
-            enable_tiger_cache=ctx.perm.enable_tiger_cache,
-            read_engine=ctx.read_engine,
-            is_postgresql=_is_pg,
-        )
-
-        # --- Audit Store ---
-        from nexus.bricks.rebac.permissions_enhanced import AuditStore
-
-        audit_store = AuditStore(engine=ctx.engine, is_postgresql=_is_pg)
-
-        # --- Entity Registry ---
-        from nexus.bricks.rebac.entity_registry import EntityRegistry
-
-        entity_registry = EntityRegistry(ctx.record_store)
-
-        # --- Permission Enforcer ---
-        from nexus.bricks.rebac.enforcer import PermissionEnforcer
-
-        permission_enforcer = PermissionEnforcer(
-            metadata_store=ctx.metadata_store,
-            rebac_manager=rebac_manager,
-            allow_admin_bypass=ctx.perm.allow_admin_bypass,
-            allow_system_bypass=True,
-            audit_store=audit_store,
-            admin_bypass_paths=[],
-            router=ctx.router,
-            entity_registry=entity_registry,
-        )
-
-        # --- RecordStore Syncer (constructed, NOT started) ---
-        import os
-
-        write_observer: Any = None
-        use_buffer = ctx.enable_write_buffer
-        if use_buffer is None:
-            env_val = os.environ.get("NEXUS_ENABLE_WRITE_BUFFER", "").lower()
-            if env_val in ("true", "1", "yes"):
-                use_buffer = True
-            elif env_val in ("false", "0", "no"):
-                use_buffer = False
-            else:
-                use_buffer = ctx.db_url.startswith(("postgres", "postgresql"))
-
-        if use_buffer:
-            from nexus.storage.piped_record_store_write_observer import (
-                PipedRecordStoreWriteObserver,
-            )
-
-            write_observer = PipedRecordStoreWriteObserver(
-                ctx.record_store,
-                strict_mode=ctx.audit.strict_mode,
-            )
-        else:
-            from nexus.storage.record_store_write_observer import RecordStoreWriteObserver
-
-            write_observer = RecordStoreWriteObserver(
-                ctx.record_store,
-                strict_mode=ctx.audit.strict_mode,
-            )
-
+    if not _on("permissions"):
         logger.debug(
-            "[BOOT:SYSTEM] Critical services created: rebac_manager, audit_store, "
-            "entity_registry, permission_enforcer, write_observer"
+            "[BOOT:SYSTEM] Permissions brick disabled by profile — skipping critical section"
         )
+    else:
+        try:
+            # Config-time dialect flag (KERNEL-ARCHITECTURE §7)
+            _is_pg = not ctx.db_url.startswith("sqlite")
 
-    except BootError:
-        raise
-    except Exception as exc:
-        logger.critical("[BOOT:SYSTEM] Critical service failure: %s", exc)
-        raise BootError(str(exc), tier="system-critical") from exc
+            # --- ReBAC Manager ---
+            from nexus.bricks.rebac.manager import ReBACManager
+
+            rebac_manager = ReBACManager(
+                engine=ctx.engine,
+                cache_ttl_seconds=ctx.cache_ttl_seconds or 300,
+                max_depth=10,
+                enforce_zone_isolation=ctx.perm.enforce_zone_isolation,
+                enable_graph_limits=True,
+                enable_tiger_cache=ctx.perm.enable_tiger_cache,
+                read_engine=ctx.read_engine,
+                is_postgresql=_is_pg,
+            )
+
+            # --- Audit Store ---
+            from nexus.bricks.rebac.permissions_enhanced import AuditStore
+
+            audit_store = AuditStore(engine=ctx.engine, is_postgresql=_is_pg)
+
+            # --- Entity Registry ---
+            from nexus.bricks.rebac.entity_registry import EntityRegistry
+
+            entity_registry = EntityRegistry(ctx.record_store)
+
+            # --- Permission Enforcer ---
+            from nexus.bricks.rebac.enforcer import PermissionEnforcer
+
+            permission_enforcer = PermissionEnforcer(
+                metadata_store=ctx.metadata_store,
+                rebac_manager=rebac_manager,
+                allow_admin_bypass=ctx.perm.allow_admin_bypass,
+                allow_system_bypass=True,
+                audit_store=audit_store,
+                admin_bypass_paths=[],
+                router=ctx.router,
+                entity_registry=entity_registry,
+            )
+
+            # --- RecordStore Syncer (constructed, NOT started) ---
+            import os
+
+            use_buffer = ctx.enable_write_buffer
+            if use_buffer is None:
+                env_val = os.environ.get("NEXUS_ENABLE_WRITE_BUFFER", "").lower()
+                if env_val in ("true", "1", "yes"):
+                    use_buffer = True
+                elif env_val in ("false", "0", "no"):
+                    use_buffer = False
+                else:
+                    use_buffer = ctx.db_url.startswith(("postgres", "postgresql"))
+
+            if use_buffer:
+                from nexus.storage.piped_record_store_write_observer import (
+                    PipedRecordStoreWriteObserver,
+                )
+
+                write_observer = PipedRecordStoreWriteObserver(
+                    ctx.record_store,
+                    strict_mode=ctx.audit.strict_mode,
+                )
+            else:
+                from nexus.storage.record_store_write_observer import RecordStoreWriteObserver
+
+                write_observer = RecordStoreWriteObserver(
+                    ctx.record_store,
+                    strict_mode=ctx.audit.strict_mode,
+                )
+
+            logger.debug(
+                "[BOOT:SYSTEM] Critical services created: rebac_manager, audit_store, "
+                "entity_registry, permission_enforcer, write_observer"
+            )
+
+        except BootError:
+            raise
+        except Exception as exc:
+            logger.critical("[BOOT:SYSTEM] Critical service failure: %s", exc)
+            raise BootError(str(exc), tier="system-critical") from exc
 
     # =====================================================================
     # DEGRADABLE FORMER-KERNEL SECTION (WARNING + None) — Issue #2193

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -386,21 +386,24 @@ def _boot_wired_services(
         logger.debug("[BOOT:WIRED] DescendantAccessChecker unavailable: %s", exc)
 
     memory_provider: Any = None
-    try:
-        from nexus.bricks.memory.memory_provider import MemoryProvider
+    if not _on("memory"):
+        logger.debug("[BOOT:WIRED] MemoryProvider disabled by profile")
+    else:
+        try:
+            from nexus.bricks.memory.memory_provider import MemoryProvider
 
-        memory_provider = MemoryProvider(
-            session_factory=_nx_session_factory,
-            backend=_root_backend,
-            entity_registry=system_services.entity_registry,
-            enable_paging=getattr(nx, "_enable_memory_paging", True),
-            main_capacity=getattr(nx, "_memory_main_capacity", 100),
-            recall_max_age_hours=getattr(nx, "_memory_recall_max_age_hours", 24.0),
-            memory_config=_nx_memory_config,
-        )
-        logger.debug("[BOOT:WIRED] MemoryProvider created")
-    except Exception as exc:
-        logger.debug("[BOOT:WIRED] MemoryProvider unavailable: %s", exc)
+            memory_provider = MemoryProvider(
+                session_factory=_nx_session_factory,
+                backend=_root_backend,
+                entity_registry=system_services.entity_registry,
+                enable_paging=getattr(nx, "_enable_memory_paging", True),
+                main_capacity=getattr(nx, "_memory_main_capacity", 100),
+                recall_max_age_hours=getattr(nx, "_memory_recall_max_age_hours", 24.0),
+                memory_config=_nx_memory_config,
+            )
+            logger.debug("[BOOT:WIRED] MemoryProvider created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] MemoryProvider unavailable: %s", exc)
 
     # --- TimeTravelService: historical operation-point queries (Issue #882) ---
     time_travel_service: Any = None

--- a/src/nexus/factory/adapters.py
+++ b/src/nexus/factory/adapters.py
@@ -46,7 +46,17 @@ class _NexusFSFileReader:
         return result
 
     def list_files(self, path: str, recursive: bool = True) -> list[Any]:
-        result = self._nx.sys_readdir(path, recursive=recursive)
+        # Read with admin context so the search daemon can index all files
+        # regardless of per-user ReBAC permissions (same as read_text).
+        from nexus.contracts.types import OperationContext
+
+        admin_ctx = OperationContext(
+            user_id="system",
+            groups=[],
+            is_admin=True,
+            is_system=True,
+        )
+        result = self._nx.sys_readdir(path, recursive=recursive, context=admin_ctx)
         items: list[Any] = result.items if hasattr(result, "items") else result
         return items
 

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -326,6 +326,12 @@ def create_nexus_fs(
     # KERNEL mode (Issue #2194): When record_store is None (e.g. profile=kernel),
     # this branch is skipped — bare kernel with empty SystemServices/BrickServices.
     if kernel_services is None and record_store is not None:
+        if system_services is not None or brick_services is not None:
+            logger.warning(
+                "[FACTORY] system_services/brick_services provided without kernel_services — "
+                "they will be overwritten by create_nexus_services(). Pass kernel_services "
+                "to use pre-built service containers."
+            )
         kernel_services, system_services, brick_services = create_nexus_services(
             record_store=record_store,
             metadata_store=metadata_store,

--- a/src/nexus/factory/zoekt_pipe_consumer.py
+++ b/src/nexus/factory/zoekt_pipe_consumer.py
@@ -88,10 +88,9 @@ class ZoektPipeConsumer:
                 self._pipe_manager.pipe_write_nowait(_ZOEKT_PIPE_PATH, data)
                 return
             except (PipeClosedError, PipeFullError):
-                logger.warning("Zoekt pipe full/closed, dropping write notification: %s", path)
-                return
+                logger.warning("Zoekt pipe full/closed, falling back to direct call: %s", path)
 
-        # Fallback: direct call (CLI mode or pre-startup)
+        # Fallback: direct call (CLI mode, pre-startup, or pipe error)
         self._zoekt.notify_write(path)
 
     def notify_sync_complete(self, files_synced: int = 0) -> None:
@@ -104,10 +103,9 @@ class ZoektPipeConsumer:
                 self._pipe_manager.pipe_write_nowait(_ZOEKT_PIPE_PATH, data)
                 return
             except (PipeClosedError, PipeFullError):
-                logger.warning("Zoekt pipe full/closed, dropping sync notification")
-                return
+                logger.warning("Zoekt pipe full/closed, falling back to direct sync call")
 
-        # Fallback: direct call
+        # Fallback: direct call (CLI mode, pre-startup, or pipe error)
         self._zoekt.notify_sync_complete(files_synced)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes 10 validated issues from a codex audit of `src/nexus/factory/`. Two reported issues were invalid (#4 DynamicViewerReadHook — works via `__getattr__` delegation, #9 wallet env parsing — properly guarded by `_on("pay")`).

- **`_memory.py`**: `nx.backend` no longer exists — resolve from `nx.router.route("/").backend`
- **`_system.py`**: Gate ReBAC/audit/permission critical section behind `_on("permissions")` so MINIMAL/EMBEDDED profiles correctly skip it (respects deployment profile contract)
- **`_bricks.py`**: Gate memory brick (router + permission) behind `_on("memory")`
- **`_wired.py`**: Gate MemoryProvider behind `_on("memory")`
- **`orchestrator.py`**: Warn when `system_services`/`brick_services` are provided without `kernel_services` (silently overwritten)
- **`_remote.py`**: Add `time_travel_service` and `operations_service` to `_WIRED_FIELDS` (REMOTE mode left them as None)
- **`adapters.py`**: Use admin `OperationContext` in `list_files()` so search daemon indexes all files regardless of ReBAC (consistent with `read_text()`)
- **`_distributed.py`**: Check `dist.enable_events` for NATS branch (was only checked for Redis/Dragonfly)
- **`zoekt_pipe_consumer.py`**: Fall back to direct `ZoektIndexManager` call on `PipeFullError`/`PipeClosedError` instead of silently dropping notifications
- **`__init__.py`**: Update outdated advanced example to current 3-tuple API

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — all files formatted
- [x] `uv run mypy` — passed (pre-commit hook)
- [x] `uv run pytest tests/unit/factory/` — all sync tests pass (async failures pre-existing)
- [ ] Verify MINIMAL profile boot skips ReBAC stack
- [ ] Verify REMOTE mode proxies `time_travel_service` / `operations_service`
- [ ] Verify zoekt fallback triggers on pipe errors