### PR TITLE
fix: resolve 9 FUSE layer security and correctness issues

### DIFF
--- a/src/nexus/fuse/ops/_shared.py
+++ b/src/nexus/fuse/ops/_shared.py
@@ -235,6 +235,22 @@ def dir_cache_key(ctx: FUSESharedContext, path: str) -> str | tuple[str, str, st
     return path
 
 
+def invalidate_dir_cache(ctx: FUSESharedContext, path: str) -> None:
+    """Invalidate readdir cache for the parent directory of a mutated path.
+
+    Mutations (create/unlink/mkdir/rmdir/rename) change directory contents
+    but FUSECacheManager.invalidate_path() only clears attr/content/parsed.
+    This clears the separate dir_cache (TTLCache on FUSESharedContext).
+    """
+    parent = path.rsplit("/", 1)[0] or "/"
+    with ctx.dir_cache_lock:
+        # Invalidate both the plain key and any context-keyed variants
+        ctx.dir_cache.pop(parent, None)
+        key = dir_cache_key(ctx, parent)
+        if key != parent:
+            ctx.dir_cache.pop(key, None)
+
+
 def check_namespace_visible(ctx: FUSESharedContext, path: str) -> None:
     """Pre-flight namespace visibility check for mutating operations (Issue #1305).
 
@@ -271,7 +287,6 @@ def get_file_content(
     path: str,
     view_type: str | None,
     *,
-    skip_auth: bool = False,
     cache_priority: int = 0,
 ) -> bytes:
     """Get file content with appropriate view transformation.
@@ -298,7 +313,7 @@ def get_file_content(
             logger.info(f"[FUSE-CONTENT] L2 DISK HIT: {path} ({len(content)} bytes)")
         else:
             # L3/L4: Read from backend
-            read_ctx = None if skip_auth else ctx.context
+            read_ctx = ctx.context
             logger.info(f"[FUSE-CONTENT] L3 BACKEND FETCH: {path}")
             fetch_start = time.time()
             raw_content = ctx.nexus_fs.sys_read(path, context=read_ctx)
@@ -366,7 +381,7 @@ def read_range_from_backend(ctx: FUSESharedContext, path: str, offset: int, size
     Used by ReadaheadManager for prefetching blocks.
     """
     try:
-        content = get_file_content(ctx, path, None, skip_auth=True)
+        content = get_file_content(ctx, path, None)
         end = min(offset + size, len(content))
         return content[offset:end]
     except Exception as e:
@@ -425,7 +440,7 @@ def put_to_local_disk_cache(
 
 def get_metadata(ctx: FUSESharedContext, path: str) -> Any:
     """Get file/directory metadata from filesystem."""
-    if hasattr(ctx.nexus_fs, "get_metadata"):
+    if hasattr(ctx.nexus_fs, "sys_stat"):
         metadata_dict = ctx.nexus_fs.sys_stat(path)
         if metadata_dict:
             return MetadataObj.from_dict(metadata_dict)

--- a/src/nexus/fuse/ops/attr_handler.py
+++ b/src/nexus/fuse/ops/attr_handler.py
@@ -40,7 +40,7 @@ class AttrHandler:
         check_namespace_visible(ctx, original_path)
 
         permission_bits = mode & 0o777
-        ctx.nexus_fs.chmod(original_path, permission_bits)  # type: ignore[attr-defined]
+        ctx.nexus_fs.sys_setattr(original_path, context=ctx.context, mode=permission_bits)
 
         ctx.cache.invalidate_path(original_path)
         if path != original_path:
@@ -59,40 +59,40 @@ class AttrHandler:
 
         check_namespace_visible(ctx, original_path)
 
-        try:
-            import grp
-            import pwd
+        if not ctx.nexus_fs.sys_access(original_path):
+            raise FuseOSError(errno.ENOENT)
 
-            if not ctx.nexus_fs.sys_access(original_path):
-                raise FuseOSError(errno.ENOENT)
+        attrs: dict[str, str] = {}
 
-            if uid != -1:
-                try:
-                    owner = pwd.getpwuid(uid).pw_name
-                    ctx.nexus_fs.chown(original_path, owner)  # type: ignore[attr-defined]
-                except KeyError:
-                    owner = str(uid)
-                    ctx.nexus_fs.chown(original_path, owner)  # type: ignore[attr-defined]
+        if uid != -1:
+            try:
+                import pwd
 
-            if gid != -1:
-                try:
-                    group = grp.getgrgid(gid).gr_name
-                    ctx.nexus_fs.chgrp(original_path, group)  # type: ignore[attr-defined]
-                except KeyError:
-                    group = str(gid)
-                    ctx.nexus_fs.chgrp(original_path, group)  # type: ignore[attr-defined]
+                owner = pwd.getpwuid(uid).pw_name
+            except (KeyError, ModuleNotFoundError):
+                owner = str(uid)
+            attrs["owner"] = owner
 
-            ctx.cache.invalidate_path(original_path)
-            if path != original_path:
-                ctx.cache.invalidate_path(path)
+        if gid != -1:
+            try:
+                import grp
 
-            if HAS_EVENT_BUS and FileEventType is not None:
-                ctx.events.fire(FileEventType.METADATA_CHANGE, original_path)
+                group = grp.getgrgid(gid).gr_name
+            except (KeyError, ModuleNotFoundError):
+                group = str(gid)
+            attrs["group"] = group
 
-        except (ModuleNotFoundError, AttributeError):
-            pass
+        if attrs:
+            ctx.nexus_fs.sys_setattr(original_path, context=ctx.context, **attrs)
 
-    def truncate(self, path: str, length: int, fh: int | None = None) -> None:
+        ctx.cache.invalidate_path(original_path)
+        if path != original_path:
+            ctx.cache.invalidate_path(path)
+
+        if HAS_EVENT_BUS and FileEventType is not None:
+            ctx.events.fire(FileEventType.METADATA_CHANGE, original_path)
+
+    def truncate(self, path: str, length: int, _fh: int | None = None) -> None:
         """Truncate file to specified length."""
         ctx = self._ctx
 
@@ -100,11 +100,8 @@ class AttrHandler:
         if view_type:
             raise FuseOSError(errno.EROFS)
 
-        # If called via ftruncate (with fh), auth was at open().
-        write_ctx = None if fh is not None else ctx.context
-
         if ctx.nexus_fs.sys_access(original_path):
-            raw_content = ctx.nexus_fs.sys_read(original_path, context=write_ctx)
+            raw_content = ctx.nexus_fs.sys_read(original_path, context=ctx.context)
             assert isinstance(raw_content, bytes), "Expected bytes from read()"
             content = raw_content
         else:
@@ -115,7 +112,7 @@ class AttrHandler:
         else:
             content += b"\x00" * (length - len(content))
 
-        ctx.nexus_fs.sys_write(original_path, content, context=write_ctx)
+        ctx.nexus_fs.sys_write(original_path, content, context=ctx.context)
 
         ctx.cache.invalidate_path(original_path)
         if path != original_path:

--- a/src/nexus/fuse/ops/io_handler.py
+++ b/src/nexus/fuse/ops/io_handler.py
@@ -112,7 +112,7 @@ class IOHandler:
 
         # Rust delegation for raw reads
         if view_type is None:
-            ok, content = try_rust(ctx, "READ", "read", original_path)
+            ok, content = try_rust(ctx, "READ", "sys_read", original_path)
             if ok:
                 return bytes(content)[offset : offset + size]
 
@@ -125,8 +125,6 @@ class IOHandler:
                 )
                 return cast("bytes", prefetched)
 
-        skip_auth = file_info.get("auth_verified", False)
-
         cache_priority = 0
         io_profile_str = file_info.get("io_profile", "balanced")
         try:
@@ -136,9 +134,7 @@ class IOHandler:
         except (ImportError, ValueError):
             pass
 
-        content = get_file_content(
-            ctx, original_path, view_type, skip_auth=skip_auth, cache_priority=cache_priority
-        )
+        content = get_file_content(ctx, original_path, view_type, cache_priority=cache_priority)
 
         return content[offset : offset + size]
 
@@ -166,12 +162,10 @@ class IOHandler:
             logger.debug(f"Blocked write to OS metadata file: {original_path}")
             raise FuseOSError(errno.EPERM)
 
-        write_ctx = None if file_info.get("auth_verified") else ctx.context
-
         # Read existing content
         existing_content = b""
         if ctx.nexus_fs.sys_access(original_path):
-            raw_content = ctx.nexus_fs.sys_read(original_path, context=write_ctx)
+            raw_content = ctx.nexus_fs.sys_read(original_path, context=ctx.context)
             assert isinstance(raw_content, bytes), "Expected bytes from read()"
             existing_content = raw_content
 
@@ -182,12 +176,9 @@ class IOHandler:
         new_content = existing_content[:offset] + data + existing_content[offset + len(data) :]
 
         # Write via Rust or Python
-        if not write_ctx:
-            ok, _ = try_rust(ctx, "WRITE", "write", original_path, new_content)
-            if not ok:
-                ctx.nexus_fs.sys_write(original_path, new_content, context=write_ctx)
-        else:
-            ctx.nexus_fs.sys_write(original_path, new_content, context=write_ctx)
+        ok, _ = try_rust(ctx, "WRITE", "sys_write", original_path, new_content)
+        if not ok:
+            ctx.nexus_fs.sys_write(original_path, new_content, context=ctx.context)
 
         # Invalidate caches
         ctx.cache.invalidate_path(original_path)

--- a/src/nexus/fuse/ops/metadata_handler.py
+++ b/src/nexus/fuse/ops/metadata_handler.py
@@ -217,9 +217,27 @@ class MetadataHandler:
             entries.append(".raw")
 
         # Rust delegation
-        ok, file_entries = try_rust(ctx, "READDIR", "list", path)
+        ok, file_entries = try_rust(ctx, "READDIR", "sys_readdir", path)
         if ok:
-            entries.extend([f.name for f in file_entries])
+            for f in file_entries:
+                name = f.name
+                if name and name not in entries:
+                    if is_os_metadata_file(name):
+                        continue
+                    entries.append(name)
+
+                    if (
+                        ctx.mode.value != "binary"
+                        and should_add_virtual_views(name)
+                        and f.entry_type != "directory"
+                    ):
+                        last_dot = name.rfind(".")
+                        if last_dot != -1:
+                            base_name = name[:last_dot]
+                            extension = name[last_dot:]
+                            parsed_name = f"{base_name}_parsed{extension}.md"
+                            entries.append(parsed_name)
+
             elapsed = time.time() - start_time
             logger.info(
                 f"[FUSE-PERF] readdir DONE via RUST: path={path}, "

--- a/src/nexus/fuse/ops/mutation_handler.py
+++ b/src/nexus/fuse/ops/mutation_handler.py
@@ -11,6 +11,7 @@ from nexus.fuse.filters import is_os_metadata_file
 from nexus.fuse.ops._shared import (
     FUSESharedContext,
     check_namespace_visible,
+    invalidate_dir_cache,
     parse_virtual_path_for_fuse,
     try_rust,
 )
@@ -55,6 +56,7 @@ class MutationHandler:
         ctx.cache.invalidate_path(original_path)
         if path != original_path:
             ctx.cache.invalidate_path(path)
+        invalidate_dir_cache(ctx, original_path)
 
         # Generate file descriptor
         with ctx.files_lock:
@@ -83,13 +85,14 @@ class MutationHandler:
 
         check_namespace_visible(ctx, original_path)
 
-        ok, _ = try_rust(ctx, "UNLINK", "delete", original_path)
+        ok, _ = try_rust(ctx, "UNLINK", "sys_unlink", original_path)
         if not ok:
-            ctx.nexus_fs.sys_unlink(original_path)
+            ctx.nexus_fs.sys_unlink(original_path, context=ctx.context)
 
         ctx.cache.invalidate_path(original_path)
         if path != original_path:
             ctx.cache.invalidate_path(path)
+        invalidate_dir_cache(ctx, original_path)
 
         if HAS_EVENT_BUS and FileEventType is not None:
             ctx.events.fire(FileEventType.FILE_DELETE, original_path)
@@ -103,9 +106,11 @@ class MutationHandler:
 
         check_namespace_visible(ctx, path)
 
-        ok, _ = try_rust(ctx, "MKDIR", "mkdir", path)
+        ok, _ = try_rust(ctx, "MKDIR", "sys_mkdir", path)
         if not ok:
-            ctx.nexus_fs.sys_mkdir(path, parents=True, exist_ok=True)
+            ctx.nexus_fs.sys_mkdir(path, parents=True, exist_ok=True, context=ctx.context)
+
+        invalidate_dir_cache(ctx, path)
 
         if HAS_EVENT_BUS and FileEventType is not None:
             ctx.events.fire(FileEventType.DIR_CREATE, path)
@@ -119,7 +124,9 @@ class MutationHandler:
 
         check_namespace_visible(ctx, path)
 
-        ctx.nexus_fs.sys_rmdir(path, recursive=False)
+        ctx.nexus_fs.sys_rmdir(path, recursive=False, context=ctx.context)
+
+        invalidate_dir_cache(ctx, path)
 
         if HAS_EVENT_BUS and FileEventType is not None:
             ctx.events.fire(FileEventType.DIR_DELETE, path)
@@ -152,6 +159,8 @@ class MutationHandler:
         # Invalidate caches for both paths
         ctx.cache.invalidate_path(old_path)
         ctx.cache.invalidate_path(new_path)
+        invalidate_dir_cache(ctx, old_path)
+        invalidate_dir_cache(ctx, new_path)
 
         old_parent = old_path.rsplit("/", 1)[0] or "/"
         new_parent = new_path.rsplit("/", 1)[0] or "/"
@@ -174,9 +183,9 @@ class MutationHandler:
         ctx = self._ctx
         logger.debug(f"Renaming file {old_path} to {new_path}")
 
-        ok, _ = try_rust(ctx, "RENAME", "rename", old_path, new_path)
+        ok, _ = try_rust(ctx, "RENAME", "sys_rename", old_path, new_path)
         if not ok:
-            ctx.nexus_fs.sys_rename(old_path, new_path)
+            ctx.nexus_fs.sys_rename(old_path, new_path, context=ctx.context)
 
     def _rename_directory(self, old_path: str, new_path: str) -> None:
         """Recursive directory rename: list + move files + rmdir source."""
@@ -184,7 +193,7 @@ class MutationHandler:
         logger.debug(f"Renaming directory {old_path} to {new_path}")
 
         try:
-            ctx.nexus_fs.sys_mkdir(new_path, parents=True, exist_ok=True)
+            ctx.nexus_fs.sys_mkdir(new_path, parents=True, exist_ok=True, context=ctx.context)
         except Exception as e:
             logger.debug(f"mkdir {new_path} failed (may already exist): {e}")
 
@@ -199,7 +208,7 @@ class MutationHandler:
                 src_file = file_info["path"]
                 dest_file = src_file.replace(old_path, new_path, 1)
                 logger.debug(f"  Moving file {src_file} to {dest_file}")
-                ctx.nexus_fs.sys_rename(src_file, dest_file)
+                ctx.nexus_fs.sys_rename(src_file, dest_file, context=ctx.context)
 
         logger.debug(f"Removing source directory {old_path}")
-        ctx.nexus_fs.sys_rmdir(old_path, recursive=True)
+        ctx.nexus_fs.sys_rmdir(old_path, recursive=True, context=ctx.context)

--- a/src/nexus/fuse/readahead.py
+++ b/src/nexus/fuse/readahead.py
@@ -597,6 +597,9 @@ class ReadaheadManager:
         self._sessions: dict[int, ReadSession] = {}
         self._sessions_lock = threading.RLock()
 
+        # File handles where readahead was explicitly disabled by IOProfile
+        self._disabled_fhs: set[int] = set()
+
         # Prefetch buffer pool
         self._buffer_pool = PrefetchBufferPool(config.buffer_pool_mb * 1024 * 1024)
 
@@ -649,6 +652,7 @@ class ReadaheadManager:
                         If provided and disables readahead, skips session creation.
         """
         # Issue #1413: If an io_profile is given and it disables readahead, skip entirely
+        # and record the fh so on_read() doesn't re-create a default session
         if io_profile is not None:
             profile_cfg = io_profile.config()
             if not profile_cfg.readahead_enabled:
@@ -656,6 +660,7 @@ class ReadaheadManager:
                     f"[READAHEAD] Skipping on_open for {path} "
                     f"(io_profile={io_profile} disables readahead)"
                 )
+                self._disabled_fhs.add(fh)
                 return
 
         if not self._config.enabled or not self._config.prefetch_on_open or self._shutdown:
@@ -734,6 +739,10 @@ class ReadaheadManager:
         if not self._config.enabled or self._shutdown:
             return None
 
+        # Respect IOProfile disabling readahead for this file handle
+        if fh in self._disabled_fhs:
+            return None
+
         # Get or create session
         session = self._get_or_create_session(fh, path)
 
@@ -786,6 +795,8 @@ class ReadaheadManager:
         Args:
             fh: File handle being released
         """
+        self._disabled_fhs.discard(fh)
+
         with self._sessions_lock:
             session = self._sessions.pop(fh, None)
 

--- a/src/nexus/fuse/rust_client.py
+++ b/src/nexus/fuse/rust_client.py
@@ -10,6 +10,7 @@ import json
 import os
 import socket
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -84,6 +85,7 @@ class RustFUSEClient:
         self.sock: socket.socket | None = None
         self.request_id = 0
         self._restart_count = 0
+        self._lock = threading.Lock()
 
         self._start_daemon()
         self._connect()
@@ -240,6 +242,9 @@ class RustFUSEClient:
     def _send_request(self, method: str, params: dict) -> dict:
         """Send JSON-RPC request to Rust daemon.
 
+        Thread-safe: serializes all requests through a lock so concurrent
+        FUSE threads cannot interleave sendall()/recv() on the shared socket.
+
         Issue 2A: Automatically reconnects if daemon has died.
         Issue 3B: Uses 64KB recv buffer for better large-file performance.
 
@@ -253,66 +258,67 @@ class RustFUSEClient:
         Raises:
             RuntimeError: If request fails after reconnect attempts
         """
-        # Issue 2A: Check daemon health before sending
-        if not self._is_daemon_alive():
-            self._reconnect()
+        with self._lock:
+            # Issue 2A: Check daemon health before sending
+            if not self._is_daemon_alive():
+                self._reconnect()
 
-        self.request_id += 1
-        request = {
-            "jsonrpc": "2.0",
-            "id": self.request_id,
-            "method": method,
-            "params": params,
-        }
+            self.request_id += 1
+            request = {
+                "jsonrpc": "2.0",
+                "id": self.request_id,
+                "method": method,
+                "params": params,
+            }
 
-        request_json = json.dumps(request) + "\n"
-        if not self.sock:
-            raise RuntimeError("Not connected to daemon")
-
-        try:
-            self.sock.sendall(request_json.encode())
-
-            # Issue 3B: Receive response with larger buffer (64KB vs old 4KB)
-            response_data = b""
-            while True:
-                chunk = self.sock.recv(_RECV_BUFFER_SIZE)
-                if not chunk:
-                    raise RuntimeError("Connection closed by daemon")
-                response_data += chunk
-                if b"\n" in response_data:
-                    break
-        except (ConnectionError, BrokenPipeError, OSError) as e:
-            # Issue 2A: Connection lost — try reconnecting and retrying once
-            logger.warning(f"Daemon connection lost during {method}: {e}")
-            self._reconnect()
-
-            # Retry the request on the new connection
+            request_json = json.dumps(request) + "\n"
             if not self.sock:
-                raise RuntimeError("Reconnection failed") from e
-            self.sock.sendall(request_json.encode())
+                raise RuntimeError("Not connected to daemon")
 
-            response_data = b""
-            while True:
-                chunk = self.sock.recv(_RECV_BUFFER_SIZE)
-                if not chunk:
-                    raise RuntimeError("Connection closed after reconnect") from None
-                response_data += chunk
-                if b"\n" in response_data:
-                    break
+            try:
+                self.sock.sendall(request_json.encode())
 
-        response = json.loads(response_data.decode())
+                # Issue 3B: Receive response with larger buffer (64KB vs old 4KB)
+                response_data = b""
+                while True:
+                    chunk = self.sock.recv(_RECV_BUFFER_SIZE)
+                    if not chunk:
+                        raise RuntimeError("Connection closed by daemon")
+                    response_data += chunk
+                    if b"\n" in response_data:
+                        break
+            except (ConnectionError, BrokenPipeError, OSError) as e:
+                # Issue 2A: Connection lost — try reconnecting and retrying once
+                logger.warning(f"Daemon connection lost during {method}: {e}")
+                self._reconnect()
 
-        # Reset restart counter on successful request
-        self._restart_count = 0
+                # Retry the request on the new connection
+                if not self.sock:
+                    raise RuntimeError("Reconnection failed") from e
+                self.sock.sendall(request_json.encode())
 
-        # Check for errors
-        if "error" in response:
-            error = response["error"]
-            error_errno = error.get("data", {}).get("errno", 5)  # Default to EIO
-            raise OSError(error_errno, error["message"])
+                response_data = b""
+                while True:
+                    chunk = self.sock.recv(_RECV_BUFFER_SIZE)
+                    if not chunk:
+                        raise RuntimeError("Connection closed after reconnect") from None
+                    response_data += chunk
+                    if b"\n" in response_data:
+                        break
 
-        result: dict[Any, Any] = response.get("result", {})
-        return result
+            response = json.loads(response_data.decode())
+
+            # Reset restart counter on successful request
+            self._restart_count = 0
+
+            # Check for errors
+            if "error" in response:
+                error = response["error"]
+                error_errno = error.get("data", {}).get("errno", 5)  # Default to EIO
+                raise OSError(error_errno, error["message"])
+
+            result: dict[Any, Any] = response.get("result", {})
+            return result
 
     def sys_read(self, path: str) -> bytes:
         """Read file contents.

--- a/tests/unit/fuse/test_attr_handler.py
+++ b/tests/unit/fuse/test_attr_handler.py
@@ -13,9 +13,9 @@ class TestChmod:
     """chmod: permission bit masking."""
 
     def test_chmod_masks_permission_bits(self, fuse_ops: Any, mock_nexus_fs: MagicMock) -> None:
-        # S_IFREG | 0o755 → only 0o755 should be passed to nexus_fs
+        # S_IFREG | 0o755 → only 0o755 should be passed to nexus_fs via sys_setattr
         fuse_ops.chmod("/file.txt", 0o100755)
-        mock_nexus_fs.chmod.assert_called_once_with("/file.txt", 0o755)
+        mock_nexus_fs.sys_setattr.assert_called_once_with("/file.txt", context=None, mode=0o755)
 
     def test_chmod_invalidates_cache(
         self, fuse_ops: Any, mock_nexus_fs: MagicMock, mock_cache: MagicMock

--- a/tests/unit/fuse/test_mutation_handler.py
+++ b/tests/unit/fuse/test_mutation_handler.py
@@ -42,7 +42,7 @@ class TestUnlink:
 
     def test_unlink_calls_delete(self, fuse_ops: Any, mock_nexus_fs: MagicMock) -> None:
         fuse_ops.unlink("/file.txt")
-        mock_nexus_fs.sys_unlink.assert_called_once_with("/file.txt")
+        mock_nexus_fs.sys_unlink.assert_called_once_with("/file.txt", context=None)
 
     def test_unlink_invalidates_cache(
         self, fuse_ops: Any, mock_nexus_fs: MagicMock, mock_cache: MagicMock
@@ -67,7 +67,9 @@ class TestMkdir:
 
     def test_mkdir_calls_fs(self, fuse_ops: Any, mock_nexus_fs: MagicMock) -> None:
         fuse_ops.mkdir("/newdir", 0o755)
-        mock_nexus_fs.sys_mkdir.assert_called_once_with("/newdir", parents=True, exist_ok=True)
+        mock_nexus_fs.sys_mkdir.assert_called_once_with(
+            "/newdir", parents=True, exist_ok=True, context=None
+        )
 
     def test_mkdir_rejects_raw(self, fuse_ops: Any) -> None:
         with pytest.raises(FuseOSError) as exc_info:
@@ -80,7 +82,7 @@ class TestRmdir:
 
     def test_rmdir_calls_fs(self, fuse_ops: Any, mock_nexus_fs: MagicMock) -> None:
         fuse_ops.rmdir("/emptydir")
-        mock_nexus_fs.sys_rmdir.assert_called_once_with("/emptydir", recursive=False)
+        mock_nexus_fs.sys_rmdir.assert_called_once_with("/emptydir", recursive=False, context=None)
 
     def test_rmdir_rejects_raw_root(self, fuse_ops: Any) -> None:
         with pytest.raises(FuseOSError) as exc_info:
@@ -96,7 +98,7 @@ class TestRename:
         mock_nexus_fs.sys_is_directory.return_value = False
 
         fuse_ops.rename("/old.txt", "/new.txt")
-        mock_nexus_fs.sys_rename.assert_called_once_with("/old.txt", "/new.txt")
+        mock_nexus_fs.sys_rename.assert_called_once_with("/old.txt", "/new.txt", context=None)
 
     def test_rename_rejects_existing_dest(self, fuse_ops: Any, mock_nexus_fs: MagicMock) -> None:
         mock_nexus_fs.sys_access.return_value = True
@@ -113,8 +115,10 @@ class TestRename:
         ]
 
         fuse_ops.rename("/olddir", "/newdir")
-        mock_nexus_fs.sys_rename.assert_called_once_with("/olddir/a.txt", "/newdir/a.txt")
-        mock_nexus_fs.sys_rmdir.assert_called_once_with("/olddir", recursive=True)
+        mock_nexus_fs.sys_rename.assert_called_once_with(
+            "/olddir/a.txt", "/newdir/a.txt", context=None
+        )
+        mock_nexus_fs.sys_rmdir.assert_called_once_with("/olddir", recursive=True, context=None)
 
     def test_rename_rejects_raw_paths(self, fuse_ops: Any) -> None:
         with pytest.raises(FuseOSError) as exc_info:


### PR DESCRIPTION
## Summary

Fixes 9 bugs in the FUSE layer identified via code audit — 4 high-severity (security/correctness), 5 medium (correctness/consistency).

**High severity:**
- **Context escape in I/O ops**: `read()`/`write()` dropped mount `OperationContext` via `skip_auth`/`auth_verified` optimization, allowing agent/zone mounts to execute I/O under the filesystem default context instead of the scoped mount context. Now always passes `ctx.context`.
- **Context escape in mutations**: `unlink()`/`mkdir()`/`rmdir()`/`rename()` called backend mutators without `context` while `create()` correctly passed it. Now all mutation ops pass `ctx.context`.
- **Wrong method names in attr_handler**: `chmod()`/`chown()`/`chgrp()` don't exist on the filesystem ABC (`sys_setattr` is the contract). `chmod` would raise `AttributeError`; `chown` silently returned success without changing anything. Now uses `sys_setattr()`.
- **Thread-unsafe Rust client**: Shared socket + mutable `request_id` with no locking while FUSE runs multi-threaded. Added `threading.Lock` around `_send_request()`.

**Medium severity:**
- **Rust method name mismatch**: Callers used `read`/`write`/`list`/`delete`/`mkdir`/`rename` but `RustFUSEClient` defines `sys_read`/`sys_write`/`sys_readdir`/`sys_unlink`/`sys_mkdir`/`sys_rename`. Everything except `stat()` silently fell back to Python. Fixed all call sites.
- **Readdir cache not invalidated**: Mutations never cleared `dir_cache` (TTLCache). Added `invalidate_dir_cache()` helper called from all mutation ops.
- **Wrong hasattr guard in get_metadata()**: Gated `sys_stat()` behind `hasattr(nexus_fs, "get_metadata")` — should be `"sys_stat"`. Backend metadata was never used for getattr responses.
- **Rust readdir missing post-processing**: Rust path returned raw names without OS metadata filtering or `_parsed.*.md` virtual view entries. Added both.
- **Readahead re-enabled after IOProfile disable**: `on_open()` skipped session creation but `on_read()` recreated default session. Added `_disabled_fhs` tracking set.

## Test plan

- [x] All 124 FUSE unit tests pass
- [x] Ruff lint clean
- [x] Mypy clean
- [x] All pre-commit hooks pass
- [ ] CI green