### PR TITLE
fix: 6 proxy offline-replay bugs (data loss, circuit bypass, state machine)

### DIFF
--- a/src/nexus/proxy/brick.py
+++ b/src/nexus/proxy/brick.py
@@ -104,6 +104,7 @@ class ProxyBrick:
             circuit=self._circuit,
             batch_size=self._config.replay_batch_size,
             poll_interval=self._config.replay_poll_interval,
+            on_replay_success=self._on_replay_success,
         )
         self._replay_task = asyncio.create_task(self._replay_engine.run())
 
@@ -142,11 +143,13 @@ class ProxyBrick:
 
     async def _do_forward(self, method: str, *, data: bytes | None = None, **kwargs: Any) -> Any:
         """Unified forward — handles both regular and streaming calls (#6-A)."""
+        payload_ref = base64.b64encode(data).decode() if data is not None else None
+
         allowed = await self._circuit.allow_request()
         if not allowed:
             if self._edge_sync is not None:
                 self._edge_sync.notify_disconnected()
-            queue_id = await self._queue.enqueue(method, kwargs=kwargs)
+            queue_id = await self._queue.enqueue(method, kwargs=kwargs, payload_ref=payload_ref)
             self._wake_replay()
             logger.warning("Circuit open — operation '%s' queued (id=%d)", method, queue_id)
             raise CircuitOpenError(
@@ -168,7 +171,7 @@ class ProxyBrick:
                 await self._circuit.record_failure()
                 if self._edge_sync is not None:
                     self._edge_sync.notify_disconnected()
-                queue_id = await self._queue.enqueue(method, kwargs=kwargs)
+                queue_id = await self._queue.enqueue(method, kwargs=kwargs, payload_ref=payload_ref)
                 self._wake_replay()
                 logger.warning("Operation '%s' queued for offline replay (id=%d)", method, queue_id)
                 raise OfflineQueuedError(method, queue_id) from exc
@@ -186,6 +189,11 @@ class ProxyBrick:
         """Signal the replay engine to process the queue immediately."""
         if self._replay_engine is not None:
             self._replay_engine.wake()
+
+    def _on_replay_success(self) -> None:
+        """Called by ReplayEngine after a successful replay — advances reconnect state."""
+        if self._edge_sync is not None:
+            self._edge_sync.notify_connected()
 
     # ------------------------------------------------------------------
     # Properties

--- a/src/nexus/proxy/edge_sync.py
+++ b/src/nexus/proxy/edge_sync.py
@@ -149,7 +149,7 @@ class EdgeSyncManager:
             return not self._circuit.is_open
 
         try:
-            await self._transport.call("health.check", params={})
+            await self._transport.call(self._health_check_url, params={})
             logger.info("Health check passed for node %s", self._node_id)
             return True  # Any non-exception response = healthy
         except Exception:

--- a/src/nexus/proxy/queue_protocol.py
+++ b/src/nexus/proxy/queue_protocol.py
@@ -60,6 +60,8 @@ class OfflineQueueProtocol(Protocol):
 
     async def mark_dead_letter(self, op_id: int) -> None: ...
 
+    async def has_idempotency_key(self, key: str) -> bool: ...
+
     async def pending_count(self) -> int: ...
 
     async def close(self) -> None: ...
@@ -78,7 +80,9 @@ class InMemoryQueue:
         self._max_size = max_size
         self._counter = itertools.count(1)
         self._pending: deque[QueuedOperation] = deque()
+        self._in_flight: dict[int, QueuedOperation] = {}
         self._done: set[int] = set()
+        self._done_keys: set[str] = set()
         self._dead_letter: set[int] = set()
 
     async def initialize(self) -> None:
@@ -135,6 +139,7 @@ class InMemoryQueue:
             op = self._pending.popleft()
             if op.id not in self._done and op.id not in self._dead_letter:
                 batch.append(op)
+                self._in_flight[op.id] = op
             # else: skip already-completed ops
 
         # Put back unprocessed items
@@ -146,10 +151,32 @@ class InMemoryQueue:
     async def mark_done(self, op_id: int) -> None:
         """Mark an operation as successfully replayed."""
         self._done.add(op_id)
+        removed = self._in_flight.pop(op_id, None)
+        if removed and removed.idempotency_key:
+            self._done_keys.add(removed.idempotency_key)
         self._pending = deque(op for op in self._pending if op.id != op_id)
 
     async def mark_failed(self, op_id: int) -> None:
         """Re-enqueue with incremented retry count."""
+        # Check in-flight first (ops removed by dequeue_batch)
+        in_flight_op = self._in_flight.pop(op_id, None)
+        if in_flight_op is not None:
+            updated = QueuedOperation(
+                id=in_flight_op.id,
+                method=in_flight_op.method,
+                args_json=in_flight_op.args_json,
+                kwargs_json=in_flight_op.kwargs_json,
+                payload_ref=in_flight_op.payload_ref,
+                retry_count=in_flight_op.retry_count + 1,
+                created_at=in_flight_op.created_at,
+                idempotency_key=in_flight_op.idempotency_key,
+                vector_clock=in_flight_op.vector_clock,
+                priority=in_flight_op.priority,
+            )
+            self._pending.append(updated)
+            return
+
+        # Fallback: scan _pending (for ops not yet dequeued)
         new_pending: deque[QueuedOperation] = deque()
         for op in self._pending:
             if op.id == op_id:
@@ -173,14 +200,21 @@ class InMemoryQueue:
     async def mark_dead_letter(self, op_id: int) -> None:
         """Permanently remove an operation."""
         self._dead_letter.add(op_id)
+        self._in_flight.pop(op_id, None)
         self._pending = deque(op for op in self._pending if op.id != op_id)
+
+    async def has_idempotency_key(self, key: str) -> bool:
+        """Check if an operation with this idempotency key was already completed."""
+        return key in self._done_keys
 
     async def pending_count(self) -> int:
         """Return the number of pending operations."""
-        return len(self._pending)
+        return len(self._pending) + len(self._in_flight)
 
     async def close(self) -> None:
         """Clear all state."""
         self._pending.clear()
+        self._in_flight.clear()
         self._done.clear()
+        self._done_keys.clear()
         self._dead_letter.clear()

--- a/src/nexus/proxy/replay_engine.py
+++ b/src/nexus/proxy/replay_engine.py
@@ -5,9 +5,12 @@ when the circuit breaker allows requests.
 """
 
 import asyncio
+import base64
+import binascii
 import contextlib
 import json
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from nexus.proxy.errors import RemoteCallError, is_connection_error
@@ -44,12 +47,14 @@ class ReplayEngine:
         circuit: "AsyncCircuitBreaker",
         batch_size: int,
         poll_interval: float,
+        on_replay_success: Callable[[], None] | None = None,
     ) -> None:
         self._queue = queue
         self._transport = transport
         self._circuit = circuit
         self._batch_size = batch_size
         self._poll_interval = poll_interval
+        self._on_replay_success = on_replay_success
         self._stopped = False
         self._wake = asyncio.Event()
         self._replayed_keys: dict[str, None] = {}
@@ -80,28 +85,52 @@ class ReplayEngine:
 
                 logger.info("Replaying %d queued operations", len(batch))
                 for op in batch:
-                    # Re-check before each replay to avoid racing with circuit state changes
-                    if self._circuit.is_open:
-                        logger.warning("Circuit opened during replay — stopping batch")
+                    # Gate each op through allow_request() to respect half-open limits
+                    if not await self._circuit.allow_request():
+                        logger.warning("Circuit does not allow requests — stopping batch")
                         break
 
                     try:
-                        # Idempotency check: skip if already replayed
-                        if op.idempotency_key and op.idempotency_key in self._replayed_keys:
-                            logger.info(
-                                "Skipping duplicate op %d (key=%s)", op.id, op.idempotency_key[:8]
-                            )
-                            await self._queue.mark_done(op.id)
-                            continue
+                        # Idempotency: check persistent store first (survives restarts)
+                        if op.idempotency_key:
+                            if hasattr(
+                                self._queue, "has_idempotency_key"
+                            ) and await self._queue.has_idempotency_key(op.idempotency_key):
+                                logger.info(
+                                    "Skipping duplicate op %d (persistent key=%s)",
+                                    op.id,
+                                    op.idempotency_key[:8],
+                                )
+                                await self._queue.mark_done(op.id)
+                                continue
+                            if op.idempotency_key in self._replayed_keys:
+                                logger.info(
+                                    "Skipping duplicate op %d (key=%s)",
+                                    op.id,
+                                    op.idempotency_key[:8],
+                                )
+                                await self._queue.mark_done(op.id)
+                                continue
 
                         kwargs = json.loads(op.kwargs_json)
                         if not isinstance(kwargs, dict):
                             logger.error("Invalid kwargs_json for op %d: not a dict", op.id)
                             await self._queue.mark_dead_letter(op.id)
                             continue
-                        await self._transport.call(op.method, params=kwargs)
+
+                        # Dispatch: use stream_upload for ops with a stored payload
+                        if op.payload_ref:
+                            payload_data = base64.b64decode(op.payload_ref)
+                            await self._transport.stream_upload(
+                                op.method, payload_data, params=kwargs
+                            )
+                        else:
+                            await self._transport.call(op.method, params=kwargs)
+
                         await self._queue.mark_done(op.id)
                         await self._circuit.record_success()
+                        if self._on_replay_success is not None:
+                            self._on_replay_success()
                         if op.idempotency_key:
                             self._replayed_keys[op.idempotency_key] = None
                             if len(self._replayed_keys) > self._max_replayed_keys:
@@ -109,8 +138,8 @@ class ReplayEngine:
                                 excess = len(self._replayed_keys) - self._max_replayed_keys
                                 for evict_key in list(self._replayed_keys)[:excess]:
                                     del self._replayed_keys[evict_key]
-                    except json.JSONDecodeError as jexc:
-                        logger.error("Failed to decode op %d: %s", op.id, jexc)
+                    except (json.JSONDecodeError, binascii.Error) as decode_exc:
+                        logger.error("Failed to decode op %d: %s", op.id, decode_exc)
                         await self._queue.mark_dead_letter(op.id)
                     except RemoteCallError as exc:
                         if is_connection_error(exc):

--- a/tests/unit/proxy/test_edge_sync.py
+++ b/tests/unit/proxy/test_edge_sync.py
@@ -190,6 +190,49 @@ class TestEdgeSyncManagerNotifyIdempotency:
         await mgr.stop()
 
 
+class TestEdgeSyncManagerHealthCheckUrl:
+    """Bug #6: health_check_url value must be used, not hardcoded."""
+
+    async def test_custom_health_check_url_is_used(self) -> None:
+        deps = _make_deps()
+        mgr = EdgeSyncManager(
+            queue=deps["queue"],
+            transport=deps["transport"],
+            circuit=deps["circuit"],
+            health_check_url="custom.health.endpoint",
+        )
+        await mgr.start()
+
+        mgr.notify_disconnected()
+        mgr.notify_connected()
+        await asyncio.sleep(0.1)
+
+        # The transport should have been called with the custom URL, not "health.check"
+        deps["transport"].call.assert_called_with("custom.health.endpoint", params={})
+        await mgr.stop()
+
+    async def test_no_health_check_url_skips_transport_call(self) -> None:
+        deps = _make_deps()
+        deps["circuit"].is_open = False
+        mgr = EdgeSyncManager(
+            queue=deps["queue"],
+            transport=deps["transport"],
+            circuit=deps["circuit"],
+            # No health_check_url — should use circuit state
+        )
+        await mgr.start()
+
+        mgr.notify_disconnected()
+        mgr.notify_connected()
+        await asyncio.sleep(0.1)
+
+        # Transport.call should NOT be called for health check (circuit state used instead)
+        # But it might be called for other operations — check no "health" call was made
+        for call in deps["transport"].call.call_args_list:
+            assert "health" not in str(call), "Should not call transport for health check"
+        await mgr.stop()
+
+
 class TestEdgeSyncManagerStatusDict:
     """to_status_dict() returns monitoring info."""
 

--- a/tests/unit/proxy/test_queue_protocol.py
+++ b/tests/unit/proxy/test_queue_protocol.py
@@ -38,21 +38,24 @@ class TestInMemoryMarkFailed:
         await queue.initialize()
         op_id = await queue.enqueue("read", kwargs={"path": "/a"})
 
-        # Dequeue to get the op
+        # Dequeue to get the op (moves to in-flight)
         batch = await queue.dequeue_batch(10)
         assert batch[0].retry_count == 0
 
-        # Mark failed — should re-enqueue with retry_count + 1
+        # Mark failed — should re-enqueue from in-flight with retry_count + 1
         await queue.mark_failed(op_id)
-        # The op was already dequeued from pending, so mark_failed won't find it.
-        # Test with a fresh queue to verify retry_count increment.
-        q2 = InMemoryQueue()
-        await q2.initialize()
-        oid = await q2.enqueue("write", kwargs={"path": "/b"})
-        await q2.mark_failed(oid)
-        batch2 = await q2.dequeue_batch(10)
+        batch2 = await queue.dequeue_batch(10)
         assert len(batch2) == 1
         assert batch2[0].retry_count == 1
+
+    async def test_mark_failed_on_non_dequeued_op(self, queue: InMemoryQueue) -> None:
+        await queue.initialize()
+        op_id = await queue.enqueue("write", kwargs={"path": "/b"})
+        # Mark failed without dequeuing first (fallback path)
+        await queue.mark_failed(op_id)
+        batch = await queue.dequeue_batch(10)
+        assert len(batch) == 1
+        assert batch[0].retry_count == 1
 
 
 class TestInMemoryMarkDeadLetter:
@@ -111,3 +114,51 @@ class TestInMemoryInitializeIdempotent:
         await queue.enqueue("read", kwargs={"path": "/a"})
         await queue.initialize()  # Should not throw
         assert await queue.pending_count() == 1
+
+
+class TestInMemoryInFlightTracking:
+    """Bug #4: dequeued ops must survive mark_failed / mark_done."""
+
+    async def test_mark_done_clears_in_flight(self, queue: InMemoryQueue) -> None:
+        await queue.initialize()
+        op_id = await queue.enqueue("read", kwargs={"path": "/a"})
+        batch = await queue.dequeue_batch(10)
+        assert len(batch) == 1
+
+        await queue.mark_done(op_id)
+        assert await queue.pending_count() == 0
+
+    async def test_mark_dead_letter_clears_in_flight(self, queue: InMemoryQueue) -> None:
+        await queue.initialize()
+        op_id = await queue.enqueue("read", kwargs={"path": "/a"})
+        await queue.dequeue_batch(10)
+
+        await queue.mark_dead_letter(op_id)
+        assert await queue.pending_count() == 0
+
+    async def test_pending_count_includes_in_flight(self, queue: InMemoryQueue) -> None:
+        await queue.initialize()
+        await queue.enqueue("read", kwargs={"path": "/a"})
+        await queue.enqueue("write", kwargs={"path": "/b"})
+
+        # Dequeue 1 — still 2 pending (1 in-flight + 1 in queue)
+        await queue.dequeue_batch(1)
+        assert await queue.pending_count() == 2
+
+
+class TestInMemoryHasIdempotencyKey:
+    """Bug #5: persistent idempotency tracking in InMemoryQueue."""
+
+    async def test_done_key_is_tracked(self, queue: InMemoryQueue) -> None:
+        await queue.initialize()
+        op_id = await queue.enqueue("read", kwargs={"path": "/a"})
+        batch = await queue.dequeue_batch(10)
+        idem_key = batch[0].idempotency_key
+        assert idem_key is not None
+
+        await queue.mark_done(op_id)
+        assert await queue.has_idempotency_key(idem_key) is True
+
+    async def test_unknown_key_returns_false(self, queue: InMemoryQueue) -> None:
+        await queue.initialize()
+        assert await queue.has_idempotency_key("nonexistent") is False

--- a/tests/unit/proxy/test_replay_engine.py
+++ b/tests/unit/proxy/test_replay_engine.py
@@ -1,8 +1,9 @@
 """Tests for ReplayEngine and ProxyBrick._do_forward() (#11-A)."""
 
 import asyncio
+import base64
 import json
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -451,3 +452,249 @@ class TestProxyBrickWakeAfterEnqueue:
         assert wake_calls >= 1, "replay engine should have been woken after enqueue"
 
         await proxy.stop()
+
+
+# ---------------------------------------------------------------------------
+# Bug #1: Streamed write replay
+# ---------------------------------------------------------------------------
+
+
+class TestReplayStreamUpload:
+    """Bug #1: ops with payload_ref should replay via stream_upload."""
+
+    async def test_payload_ref_uses_stream_upload(
+        self, queue: AsyncMock, transport: AsyncMock, circuit: AsyncCircuitBreaker
+    ) -> None:
+        payload = b"large-binary-content"
+        op = QueuedOperation(
+            id=1,
+            method="write",
+            args_json="[]",
+            kwargs_json=json.dumps({"path": "/big"}),
+            payload_ref=base64.b64encode(payload).decode(),
+            retry_count=0,
+            created_at=1000.0,
+        )
+        queue.dequeue_batch = AsyncMock(side_effect=[[op], []])
+
+        engine = ReplayEngine(
+            queue=queue, transport=transport, circuit=circuit, batch_size=10, poll_interval=0.01
+        )
+        task = asyncio.create_task(engine.run())
+        await asyncio.sleep(0.05)
+        await engine.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        transport.stream_upload.assert_called_once_with("write", payload, params={"path": "/big"})
+        transport.call.assert_not_called()
+
+    async def test_no_payload_ref_uses_call(
+        self, queue: AsyncMock, transport: AsyncMock, circuit: AsyncCircuitBreaker
+    ) -> None:
+        op = _make_op(1, "read")
+        queue.dequeue_batch = AsyncMock(side_effect=[[op], []])
+
+        engine = ReplayEngine(
+            queue=queue, transport=transport, circuit=circuit, batch_size=10, poll_interval=0.01
+        )
+        task = asyncio.create_task(engine.run())
+        await asyncio.sleep(0.05)
+        await engine.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        transport.call.assert_called_once()
+        transport.stream_upload.assert_not_called()
+
+
+class TestDoForwardEnqueuesPayloadRef:
+    """Bug #1: _do_forward should store data as payload_ref on enqueue."""
+
+    async def test_stream_data_preserved_on_circuit_open(self, transport: AsyncMock) -> None:
+        from nexus.proxy.brick import ProxyBrick
+        from nexus.proxy.errors import CircuitOpenError
+
+        config = ProxyBrickConfig(remote_url="http://test:8000")
+        q = InMemoryQueue()
+        await q.initialize()
+        proxy = ProxyBrick(config, transport=transport, queue=q)
+
+        # Force circuit open
+        for _ in range(5):
+            await proxy._circuit.record_failure()
+
+        with pytest.raises(CircuitOpenError):
+            await proxy._do_forward("write", data=b"test-payload", path="/a")
+
+        batch = await q.dequeue_batch(10)
+        assert len(batch) == 1
+        assert batch[0].payload_ref == base64.b64encode(b"test-payload").decode()
+
+
+# ---------------------------------------------------------------------------
+# Bug #2: Replay respects half-open gate
+# ---------------------------------------------------------------------------
+
+
+class TestReplayRespectsHalfOpenGate:
+    """Bug #2: replay must use allow_request(), not is_open."""
+
+    async def test_half_open_limits_replay_ops(
+        self, queue: AsyncMock, transport: AsyncMock
+    ) -> None:
+        # Circuit with half_open_max_calls=1
+        circuit = AsyncCircuitBreaker(
+            failure_threshold=3, recovery_timeout=0.01, half_open_max_calls=1
+        )
+        # Force circuit to OPEN then let it transition to HALF_OPEN
+        for _ in range(3):
+            await circuit.record_failure()
+        # Wait for recovery timeout
+        await asyncio.sleep(0.02)
+        assert not circuit.is_open  # Should be HALF_OPEN now
+
+        ops = [_make_op(1), _make_op(2), _make_op(3)]
+        queue.dequeue_batch = AsyncMock(side_effect=[ops, []])
+
+        engine = ReplayEngine(
+            queue=queue, transport=transport, circuit=circuit, batch_size=10, poll_interval=0.01
+        )
+        task = asyncio.create_task(engine.run())
+        await asyncio.sleep(0.05)
+        await engine.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # With half_open_max_calls=1, first op gets a permit and succeeds
+        # (record_success closes the circuit), allowing the rest through.
+        # But the key is that allow_request() is used, not is_open.
+        # If the first op succeeded, circuit closes and remaining ops proceed.
+        assert transport.call.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Bug #3: Replay success callback
+# ---------------------------------------------------------------------------
+
+
+class TestReplaySuccessCallback:
+    """Bug #3: successful replay should fire on_replay_success callback."""
+
+    async def test_callback_fires_on_success(
+        self, queue: AsyncMock, transport: AsyncMock, circuit: AsyncCircuitBreaker
+    ) -> None:
+        ops = [_make_op(1)]
+        queue.dequeue_batch = AsyncMock(side_effect=[ops, []])
+        callback = MagicMock()
+
+        engine = ReplayEngine(
+            queue=queue,
+            transport=transport,
+            circuit=circuit,
+            batch_size=10,
+            poll_interval=0.01,
+            on_replay_success=callback,
+        )
+        task = asyncio.create_task(engine.run())
+        await asyncio.sleep(0.05)
+        await engine.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        callback.assert_called()
+
+    async def test_callback_not_fired_on_failure(
+        self, queue: AsyncMock, transport: AsyncMock, circuit: AsyncCircuitBreaker
+    ) -> None:
+        import httpx
+
+        ops = [_make_op(1)]
+        queue.dequeue_batch = AsyncMock(side_effect=[ops, []])
+        transport.call = AsyncMock(
+            side_effect=RemoteCallError("read", cause=httpx.ConnectError("fail"))
+        )
+        callback = MagicMock()
+
+        engine = ReplayEngine(
+            queue=queue,
+            transport=transport,
+            circuit=circuit,
+            batch_size=10,
+            poll_interval=0.01,
+            on_replay_success=callback,
+        )
+        task = asyncio.create_task(engine.run())
+        await asyncio.sleep(0.05)
+        await engine.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        callback.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Bug #5: Persistent idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestReplayPersistentIdempotency:
+    """Bug #5: replay should check persistent idempotency store."""
+
+    async def test_skips_op_with_persistent_key(
+        self, transport: AsyncMock, circuit: AsyncCircuitBreaker
+    ) -> None:
+        q = AsyncMock()
+        q.dequeue_batch = AsyncMock(
+            side_effect=[
+                [
+                    QueuedOperation(
+                        id=1,
+                        method="write",
+                        args_json="[]",
+                        kwargs_json='{"path": "/a"}',
+                        payload_ref=None,
+                        retry_count=0,
+                        created_at=1000.0,
+                        idempotency_key="abc123",
+                    )
+                ],
+                [],
+            ]
+        )
+        q.mark_done = AsyncMock()
+        q.mark_failed = AsyncMock()
+        q.mark_dead_letter = AsyncMock()
+        q.has_idempotency_key = AsyncMock(return_value=True)
+
+        engine = ReplayEngine(
+            queue=q, transport=transport, circuit=circuit, batch_size=10, poll_interval=0.01
+        )
+        task = asyncio.create_task(engine.run())
+        await asyncio.sleep(0.05)
+        await engine.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # Should skip the op and mark it done without calling transport
+        q.has_idempotency_key.assert_called_with("abc123")
+        q.mark_done.assert_called_with(1)
+        transport.call.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes 6 validated bugs in the proxy offline-replay subsystem:

- **Streamed writes not replayable**: `_do_forward()` dropped the `data` bytes on enqueue; replay always used `transport.call()`. Now stores data as base64 `payload_ref` and replays via `stream_upload()`.
- **Replay bypasses half-open gate**: Replay checked `is_open` instead of `allow_request()`, sending unlimited requests during HALF_OPEN. Now gates each op through `allow_request()`.
- **Successful replay never advances reconnect state machine**: `notify_connected()` was only called on foreground success. Added `on_replay_success` callback wired to `edge_sync.notify_connected()`.
- **InMemoryQueue drops failed dequeued ops**: `dequeue_batch()` removed ops from `_pending` so `mark_failed()` couldn't find them. Added `_in_flight` dict to track dequeued ops.
- **Persistent idempotency implemented but unused**: `has_idempotency_key()` existed in `OfflineQueue` but replay only used a process-local dict. Now checks persistent store first, surviving restarts.
- **`reconnect_health_check_url` ignored**: Value was only used as a boolean gate; `"health.check"` was hardcoded. Now passes the configured value to `transport.call()`.

## Test plan

- [x] All 34 existing proxy unit tests pass
- [x] 15 new tests added covering each bug fix
- [x] Lint (`ruff check`), format (`ruff format`), and type check (`mypy`) all pass
- [x] Pre-commit hooks pass
- [ ] CI pipeline green