### PR TITLE
fix: address federation code review findings across raft module

### DIFF
--- a/src/nexus/raft/federated_metadata_proxy.py
+++ b/src/nexus/raft/federated_metadata_proxy.py
@@ -58,6 +58,9 @@ class FederatedMetadataProxy(MetastoreABC):
         self._root_store = root_store
         self._zone_manager = zone_manager
         self._self_address = self_address
+        # Map EC tokens to the store that issued them, so is_committed()
+        # polls the correct zone's Raft log instead of always the root.
+        self._token_stores: dict[int, "RaftMetadataStore"] = {}
 
     @classmethod
     def from_zone_manager(
@@ -154,10 +157,14 @@ class FederatedMetadataProxy(MetastoreABC):
         resolved = self._resolve(metadata.path)
         zone_meta = self._to_zone_metadata(metadata, resolved)
         zone_meta = self._enrich_backend_name(zone_meta)
-        return resolved.store.put(zone_meta, consistency=consistency)
+        token = resolved.store.put(zone_meta, consistency=consistency)
+        if token is not None:
+            self._token_stores[token] = resolved.store
+        return token
 
     def is_committed(self, token: int) -> str | None:
-        return self._root_store.is_committed(token)
+        store = self._token_stores.get(token, self._root_store)
+        return store.is_committed(token)
 
     def delete(self, path: str, *, consistency: str = "sc") -> dict[str, Any] | None:
         resolved = self._resolve(path)
@@ -186,15 +193,18 @@ class FederatedMetadataProxy(MetastoreABC):
             return remapped
 
         # BFS queue: (mount_chain, zone_id)
-        visited: set[str] = {resolved.zone_id}
+        # Deduplicate by (zone_id, mount_path) to allow the same zone
+        # mounted at different paths while still preventing cycles.
+        visited: set[tuple[str, str]] = {(resolved.zone_id, resolved.path)}
         queue: list[tuple[list[tuple[str, str]], str]] = []
 
         for meta in results:
-            if meta.is_mount and meta.target_zone_id and meta.target_zone_id not in visited:
+            visit_key = (meta.target_zone_id or "", meta.path)
+            if meta.is_mount and meta.target_zone_id and visit_key not in visited:
                 queue.append(
                     (resolved.mount_chain + [(resolved.zone_id, meta.path)], meta.target_zone_id)
                 )
-                visited.add(meta.target_zone_id)
+                visited.add(visit_key)
 
         while queue:
             mount_chain, zone_id = queue.pop(0)
@@ -205,9 +215,10 @@ class FederatedMetadataProxy(MetastoreABC):
             child_results = store.list("/", recursive, **kwargs)
             for meta in child_results:
                 remapped.append(self._remap_metadata(meta, mount_chain))
-                if meta.is_mount and meta.target_zone_id and meta.target_zone_id not in visited:
+                visit_key = (meta.target_zone_id or "", meta.path)
+                if meta.is_mount and meta.target_zone_id and visit_key not in visited:
                     queue.append((mount_chain + [(zone_id, meta.path)], meta.target_zone_id))
-                    visited.add(meta.target_zone_id)
+                    visited.add(visit_key)
 
         return remapped
 

--- a/src/nexus/raft/federation.py
+++ b/src/nexus/raft/federation.py
@@ -82,7 +82,9 @@ class NexusFederation:
 
                 self._trust_store = TofuTrustStore(tls_cfg.known_zones_path)
 
-        # Cache TLS credentials for gRPC connections
+        # Cache TLS credentials for gRPC connections.
+        # Use TOFU trust store CA bundle when available so federation
+        # works across zones with different CAs (SSH-style TOFU).
         self._tls_config: ZoneTlsConfig | None = getattr(zone_manager, "tls_config", None)
 
     # =========================================================================
@@ -147,6 +149,20 @@ class NexusFederation:
         """
         root_zone = self._mgr.root_zone_id or ROOT_ZONE_ID
 
+        # Step 0: Validate local mount point before any remote operations.
+        # Fail fast so we don't join a Raft group we can't mount.
+        root_store = self._mgr.get_store(root_zone)
+        if root_store is None:
+            raise RuntimeError(f"Root zone '{root_zone}' not found locally")
+        mount_point = root_store.get(local_path)
+        if mount_point is None:
+            raise ValueError(
+                f"Mount point '{local_path}' does not exist in root zone. "
+                f"Create the directory first (mkdir -p)."
+            )
+        if mount_point.is_mount:
+            raise ValueError(f"Mount point '{local_path}' is already a DT_MOUNT. Unmount first.")
+
         # Step 1: Discover zone via peer's DT_MOUNT (VFS layer: sys_stat)
         metadata = await self._discover_mount(peer_addr, remote_path)
 
@@ -173,12 +189,20 @@ class NexusFederation:
 
         # Step 3: Request membership via JoinZone RPC (ConfChange)
         # Auto-forwarded to leader if peer is a follower.
-        await self._request_membership(
-            peer_addr=peer_addr,
-            zone_id=zone_id,
-            node_id=self._mgr.node_id,
-            node_address=getattr(self._mgr, "advertise_addr", peer_addr),
-        )
+        try:
+            await self._request_membership(
+                peer_addr=peer_addr,
+                zone_id=zone_id,
+                node_id=self._mgr.node_id,
+                node_address=getattr(self._mgr, "advertise_addr", peer_addr),
+            )
+        except Exception:
+            # Rollback: remove local zone if membership request failed
+            try:
+                self._mgr.remove_zone(zone_id, force=True)
+            except Exception:
+                logger.warning("Failed to rollback zone '%s' after join failure", zone_id)
+            raise
 
         # Step 4: Mount in root zone (JoinZone handler already incremented i_links_count)
         self._mgr.mount(root_zone, local_path, zone_id, increment_links=False)
@@ -191,10 +215,19 @@ class NexusFederation:
     # =========================================================================
 
     def _build_channel(self, address: str) -> grpc_aio.Channel:
-        """Create an async gRPC channel with optional mTLS."""
+        """Create an async gRPC channel with optional mTLS.
+
+        Uses TOFU trust store CA bundle when available, so federation
+        works across zones with different CAs.
+        """
         if self._tls_config is not None:
+            ca_pem = self._tls_config.ca_pem
+            # Use TOFU CA bundle if trust store has trusted zones
+            if self._trust_store is not None:
+                bundle = self._trust_store.build_ca_bundle(self._tls_config.ca_cert_path)
+                ca_pem = bundle.read_bytes()
             creds = grpc.ssl_channel_credentials(
-                root_certificates=self._tls_config.ca_pem,
+                root_certificates=ca_pem,
                 private_key=self._tls_config.node_key_pem,
                 certificate_chain=self._tls_config.node_cert_pem,
             )

--- a/src/nexus/raft/lock_manager.py
+++ b/src/nexus/raft/lock_manager.py
@@ -110,7 +110,7 @@ class RaftLockManager(LockManagerBase):
 
         lock_key = self._lock_key(path)
         holder_id = str(uuid.uuid4())
-        ttl_secs = int(ttl)
+        ttl_secs = max(1, int(ttl))
 
         deadline = asyncio.get_running_loop().time() + timeout
         retry_interval = self.RETRY_BASE_INTERVAL
@@ -163,7 +163,7 @@ class RaftLockManager(LockManagerBase):
         ttl: float = LockManagerBase.DEFAULT_TTL,
     ) -> ExtendResult:
         lock_key = self._lock_key(path)
-        ttl_secs = int(ttl)
+        ttl_secs = max(1, int(ttl))
         try:
             extended = self._store.extend_lock(lock_key, lock_id, ttl_secs)
             if not extended:

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -561,10 +561,17 @@ class ZoneManager:
         # Step 2: List all entries under path (including path itself if it's a dir)
         # Normalize: ensure path ends without trailing slash for prefix matching
         prefix = path.rstrip("/")
-        entries = list(parent_store.list_iter(prefix=prefix, recursive=True))
+        entries = [
+            e
+            for e in parent_store.list_iter(prefix=prefix, recursive=True)
+            if e.path == prefix or e.path.startswith(prefix + "/")
+        ]
 
         # Step 3: Copy entries to new zone with path rebasing
+        # Track nested DT_MOUNT targets so we can increment their link counts
         from dataclasses import replace
+
+        nested_mount_targets: list[str] = []
 
         for entry in entries:
             if entry.path == prefix:
@@ -581,7 +588,16 @@ class ZoneManager:
                 if not relative.startswith("/"):
                     relative = "/" + relative
                 rebased = replace(entry, path=relative, zone_id=new_zone_id)
+                # Track nested mounts for link count updates
+                if entry.is_mount and entry.target_zone_id:
+                    nested_mount_targets.append(entry.target_zone_id)
             new_store.put(rebased)
+
+        # Increment link counts for nested mount targets (Finding #4)
+        for nested_target_id in nested_mount_targets:
+            nested_store = self.get_store(nested_target_id)
+            if nested_store is not None:
+                self._increment_links(nested_store)
 
         # Ensure new zone has a root "/" even if no entries existed
         if new_store.get("/") is None:
@@ -721,19 +737,22 @@ class ZoneManager:
         """Check if all pending mounts are fully applied on this node.
 
         Uses target zone's i_links_count as mount-complete indicator:
-        Phase B (_increment_links) sets i_links_count >= 1 on the target
-        zone. This is the LAST phase of a mount, so i_links_count >= 1
-        implies Phase A (DT_MOUNT) is also done.
+        Phase B (_increment_links) sets i_links_count on the target zone.
+        The expected count equals the number of mounts referencing that zone.
 
         Works on both leader and follower nodes (reads replicated state).
         """
         if not self._pending_mounts:
             return True
-        for target_zone_id in self._pending_mounts.values():
+        # Count expected links per target zone
+        from collections import Counter
+
+        expected_counts = Counter(self._pending_mounts.values())
+        for target_zone_id, expected in expected_counts.items():
             target_store = self.get_store(target_zone_id)
             if target_store is None:
                 return False
-            if target_store.get_zone_links_count() < 1:
+            if target_store.get_zone_links_count() < expected:
                 return False
         return True
 
@@ -869,7 +888,10 @@ class ZoneManager:
                     continue
 
             # --- Phase B: i_links_count in target zone ---
-            if target_store.get_zone_links_count() < 1:
+            # Count how many pending mounts reference this target zone.
+            # i_links_count must reflect ALL mount references, not just the first.
+            expected_links = sum(1 for _, tz in sorted_mounts if tz == target_zone_id)
+            if target_store.get_zone_links_count() < expected_links:
                 if not self._is_zone_leader(target_store):
                     remaining[global_path] = target_zone_id
                     active_mounts[global_path] = target_zone_id

--- a/src/nexus/security/tls/trust_store.py
+++ b/src/nexus/security/tls/trust_store.py
@@ -183,6 +183,27 @@ class TofuTrustStore:
         logger.info("TOFU: removed zone '%s' from trust store", zone_id)
         return True
 
+    def build_ca_bundle(self, local_ca_path: Path) -> Path:
+        """Write a combined CA bundle (local CA + all trusted zone CAs).
+
+        Returns the path to the bundle file, which can be used as
+        ``tls_ca_path`` for gRPC channels that need to trust multiple CAs.
+        """
+        bundle_path = self._path.parent / "ca-bundle.pem"
+        parts: list[str] = []
+
+        # Include local CA first
+        if local_ca_path.exists():
+            parts.append(local_ca_path.read_text().strip())
+
+        # Append all trusted zone CAs
+        for entry in self._entries.values():
+            parts.append(entry.ca_pem.strip())
+
+        bundle_path.parent.mkdir(parents=True, exist_ok=True)
+        bundle_path.write_text("\n".join(parts) + "\n" if parts else "")
+        return bundle_path
+
     def list_trusted(self) -> list[TrustedZone]:
         """List all trusted zones."""
         return list(self._entries.values())


### PR DESCRIPTION
## Summary

- Fix 8 validated issues from code review across `zone_manager.py`, `federation.py`, `federated_metadata_proxy.py`, `lock_manager.py`, and `trust_store.py`
- Address prefix scan correctness, link counting, mount validation ordering, TOFU trust store wiring, BFS deduplication, EC token tracking, and TTL clamping

## Changes

### zone_manager.py (Findings #1, #3, #4)
- **Prefix scan** (`share_subtree`): Post-filter `list_iter` results to require exact match or `/` separator, so sharing `/corp` no longer copies `/corp-old`, `/corp_backup`, etc.
- **Nested DT_MOUNT link counts**: Track nested mount targets during `share_subtree()` and call `_increment_links()` for each, preventing orphaned references.
- **Duplicate mount i_links_count**: Use `Counter(pending_mounts.values())` to compute expected link counts per target zone instead of hardcoded `>= 1` check. Both `_all_mounts_ready()` and `_apply_topology()` Phase B updated.

### federation.py (Findings #5, #6)
- **Join before mount validation**: Added Step 0 that validates `local_path` exists and isn't already a `DT_MOUNT` **before** any remote operations or `join_zone()`. Prevents joining a Raft group that can't be mounted.
- **Join rollback**: If leader rejects voter addition, `remove_zone(force=True)` cleans up the local zone.
- **TOFU trust store wiring**: Client factory now uses `build_ca_bundle()` to combine local CA + trusted zone CAs, so federation works across zones with different CAs.

### federated_metadata_proxy.py (Findings #7, #8)
- **BFS deduplication**: Changed `visited` from `set[str]` (zone_id only) to `set[tuple[str, str]]` (zone_id + mount_path), so the same zone mounted at two different paths produces both subtrees.
- **EC token store tracking**: Added `_token_stores` dict mapping EC tokens to the store that issued them. `is_committed()` now polls the correct zone's Raft log instead of always the root store.

### lock_manager.py (Finding #12)
- **TTL clamping**: Changed `int(ttl)` to `max(1, int(ttl))` in both `acquire()` and `extend()`, preventing sub-second TTLs from truncating to 0 and creating immediately-expired locks.

### trust_store.py (Supporting #6)
- Added `build_ca_bundle()` method that writes a combined PEM file (local CA + all trusted zone CAs) for use as `tls_ca_path` in gRPC channels.

## Test plan

- [x] `uv run ruff check` — all 5 files pass
- [x] `uv run mypy` — all 5 files pass  
- [x] Pre-commit hooks pass (ruff, format, mypy, brick imports)
- [x] Unit tests pass (104 passing, failures are pre-existing Rust/zone-finalizer issues)
- [ ] E2E federation test with multi-zone mounts (validates #1, #3, #4, #7)
- [ ] E2E join test with invalid local_path (validates #5)
- [ ] Cross-CA federation test (validates #6)