### PR TITLE
fix: 8 correctness bugs across Rust crates

### DIFF
--- a/rust/nexus_core/src/glob.rs
+++ b/rust/nexus_core/src/glob.rs
@@ -31,7 +31,7 @@ pub fn filter_paths_exclude(
         .iter()
         .filter(|path| {
             let filename = path.rsplit('/').next().unwrap_or(path);
-            !globset.is_match(filename)
+            !globset.is_match(path.as_str()) && !globset.is_match(filename)
         })
         .cloned()
         .collect())
@@ -70,5 +70,31 @@ mod tests {
         let paths = vec!["test.rs".to_string()];
         let matched = glob_match(&[], &paths).unwrap();
         assert!(matched.is_empty());
+    }
+
+    #[test]
+    fn exclude_path_patterns() {
+        let paths = vec![
+            "src/main.rs".to_string(),
+            "target/debug/build".to_string(),
+            "target/release/nexus".to_string(),
+            "docs/readme.md".to_string(),
+        ];
+        let exclude = vec!["target/**".to_string()];
+        let filtered = filter_paths_exclude(&paths, &exclude).unwrap();
+        assert_eq!(filtered, vec!["src/main.rs", "docs/readme.md"]);
+    }
+
+    #[test]
+    fn exclude_works_for_both_basename_and_path() {
+        let paths = vec![
+            "src/main.rs".to_string(),
+            "src/.hidden".to_string(),
+            "target/debug/build".to_string(),
+        ];
+        // ".*" matches basenames, "target/**" matches paths
+        let exclude = vec![".*".to_string(), "target/**".to_string()];
+        let filtered = filter_paths_exclude(&paths, &exclude).unwrap();
+        assert_eq!(filtered, vec!["src/main.rs"]);
     }
 }

--- a/rust/nexus_core/src/rebac/graph.rs
+++ b/rust/nexus_core/src/rebac/graph.rs
@@ -302,6 +302,13 @@ pub fn compute_permission_interned(
                     }
                 }
 
+                // Direct tuples always apply (Zanzibar: direct fallback)
+                if !allowed {
+                    allowed = check_relation_with_usersets_interned(
+                        subject, permission, object, graph, namespaces, memo_cache, visited, depth,
+                    );
+                }
+
                 allowed
             }
         }

--- a/rust/nexus_core/src/rebac/mod.rs
+++ b/rust/nexus_core/src/rebac/mod.rs
@@ -451,6 +451,9 @@ pub fn expand_permission(
                         depth + 1,
                     );
                 }
+
+                // Direct tuples always apply (Zanzibar: direct fallback)
+                add_direct_subjects(permission, object, graph, subjects);
             }
         }
         return;

--- a/rust/nexus_core/src/search/mod.rs
+++ b/rust/nexus_core/src/search/mod.rs
@@ -39,6 +39,56 @@ pub fn build_search_mode(pattern: &str, ignore_case: bool) -> Result<SearchMode,
     }
 }
 
+/// Map byte offsets in a lowercased string back to the corresponding substring
+/// in the original string. Handles cases where `to_lowercase()` changes byte
+/// lengths (e.g., Turkish İ → i̇, German ß → ss).
+pub fn extract_original_match(
+    original: &str,
+    lowered: &str,
+    byte_start: usize,
+    byte_end: usize,
+) -> String {
+    let mut orig_chars = original.chars();
+    let mut lower_chars = lowered.chars();
+    let mut lower_byte_pos: usize = 0;
+    let mut orig_byte_start: Option<usize> = None;
+    let mut orig_byte_pos: usize = 0;
+
+    loop {
+        if lower_byte_pos >= byte_end {
+            let end = orig_byte_pos;
+            let start = orig_byte_start.unwrap_or(end);
+            return original[start..end].to_string();
+        }
+        if lower_byte_pos == byte_start {
+            orig_byte_start = Some(orig_byte_pos);
+        }
+
+        // Advance one original char and its corresponding lowered char(s)
+        let orig_ch = match orig_chars.next() {
+            Some(ch) => ch,
+            None => break,
+        };
+        let orig_ch_len = orig_ch.len_utf8();
+
+        // Count how many lowered bytes correspond to this original char
+        let mut lower_consumed = 0usize;
+        for lch in orig_ch.to_lowercase() {
+            match lower_chars.next() {
+                Some(_) => lower_consumed += lch.len_utf8(),
+                None => break,
+            }
+        }
+
+        orig_byte_pos += orig_ch_len;
+        lower_byte_pos += lower_consumed;
+    }
+
+    // Fallback: return whatever we can
+    let start = orig_byte_start.unwrap_or(0);
+    original[start..orig_byte_pos.min(original.len())].to_string()
+}
+
 /// Search lines of content for matches. Returns up to `max_results` matches.
 ///
 /// This is the unified search function extracted from `grep_bulk` — it works on
@@ -84,11 +134,8 @@ pub fn search_lines(
                 let line_lower = line.to_lowercase();
                 if let Some(start) = finder.find(line_lower.as_bytes()) {
                     let end = start + pattern_lower.len();
-                    let match_text = line
-                        .chars()
-                        .skip(line[..start].chars().count())
-                        .take(end - start)
-                        .collect::<String>();
+                    let match_text =
+                        extract_original_match(line, &line_lower, start, end);
                     results.push(GrepMatch {
                         file: file_path.to_string(),
                         line: line_num + 1,
@@ -186,5 +233,25 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].line, 1);
         assert_eq!(results[1].line, 3);
+    }
+
+    #[test]
+    fn unicode_ignore_case_match_text() {
+        // Turkish İ (U+0130, 2 bytes) lowercases to i\u{0307} (3 bytes).
+        // This verifies byte-offset mapping handles length changes correctly.
+        // Search for "i\u{0307}b" (lowercase form) in "AİB" (original casing)
+        let mode = build_search_mode("i\u{0307}b", true).unwrap();
+        let results = search_lines("test.txt", "A\u{0130}B", &mode, 100);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_text, "\u{0130}B");
+    }
+
+    #[test]
+    fn unicode_ignore_case_ascii() {
+        // Basic ASCII case-insensitive should still work
+        let mode = build_search_mode("hello", true).unwrap();
+        let results = search_lines("test.txt", "Say HELLO World", &mode, 100);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].match_text, "HELLO");
     }
 }

--- a/rust/nexus_pyo3/src/search.rs
+++ b/rust/nexus_pyo3/src/search.rs
@@ -2,6 +2,7 @@
 
 use memchr::memmem;
 use memmap2::Mmap;
+use nexus_core::search::extract_original_match;
 use nexus_core::search::grep::GrepMatch;
 use nexus_core::search::literal::is_literal_pattern;
 use pyo3::prelude::*;
@@ -123,10 +124,8 @@ pub fn grep_bulk<'py>(
                 if let Some((start, end)) = match_result {
                     let match_text = if matches!(&search_mode, SearchMode::LiteralIgnoreCase { .. })
                     {
-                        line.chars()
-                            .skip(line[..start].chars().count())
-                            .take(end - start)
-                            .collect::<String>()
+                        let line_lower = line.to_lowercase();
+                        extract_original_match(line, &line_lower, start, end)
                     } else {
                         simd_from_utf8(&line_bytes[start..end])
                             .unwrap_or("")
@@ -351,11 +350,8 @@ fn grep_single_file_mmap(
                 let line_lower = line.to_lowercase();
                 if let Some(start) = finder.find(line_lower.as_bytes()) {
                     let end = start + pattern_lower.len();
-                    let match_text = line
-                        .chars()
-                        .skip(line[..start].chars().count())
-                        .take(end - start)
-                        .collect::<String>();
+                    let match_text =
+                        extract_original_match(line, &line_lower, start, end);
 
                     results.push(GrepMatch {
                         file: file_path.to_string(),

--- a/rust/nexus_raft/src/raft/replication_log.rs
+++ b/rust/nexus_raft/src/raft/replication_log.rs
@@ -125,6 +125,9 @@ impl ReplicationLog {
     /// Returns the sequence number which serves as the WriteToken.
     /// The caller should have already applied this command to the local
     /// state machine before calling this.
+    ///
+    /// Both the log entry and the next_seq counter are written in a single
+    /// redb transaction to prevent sequence reuse after a crash.
     pub fn append(&self, command_bytes: &[u8]) -> Result<u64> {
         let seq = self.next_seq.fetch_add(1, Ordering::SeqCst);
 
@@ -139,10 +142,32 @@ impl ReplicationLog {
 
         let key = seq.to_be_bytes();
         let value = bincode::serialize(&entry)?;
-        self.log_tree.set(&key, &value)?;
+        let next_seq_bytes = (seq + 1).to_be_bytes();
 
-        // Persist next_seq so we don't reuse sequence numbers after restart
-        self.meta_tree.set(KEY_NEXT_SEQ, &(seq + 1).to_be_bytes())?;
+        // Atomic: write log entry + persist next_seq in a single transaction
+        let log_table_def = redb::TableDefinition::<&[u8], &[u8]>::new(self.log_tree.name());
+        let meta_table_def = redb::TableDefinition::<&[u8], &[u8]>::new(self.meta_tree.name());
+        let db = self.log_tree.raw_db();
+        let write_txn = db
+            .begin_write()
+            .map_err(|e| super::RaftError::Storage(e.to_string()))?;
+        {
+            let mut log_table = write_txn
+                .open_table(log_table_def)
+                .map_err(|e| super::RaftError::Storage(e.to_string()))?;
+            log_table
+                .insert(key.as_slice(), value.as_slice())
+                .map_err(|e| super::RaftError::Storage(e.to_string()))?;
+            let mut meta_table = write_txn
+                .open_table(meta_table_def)
+                .map_err(|e| super::RaftError::Storage(e.to_string()))?;
+            meta_table
+                .insert(KEY_NEXT_SEQ, next_seq_bytes.as_slice())
+                .map_err(|e| super::RaftError::Storage(e.to_string()))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| super::RaftError::Storage(e.to_string()))?;
 
         tracing::trace!(seq, "EC write appended to replication log");
         Ok(seq)

--- a/rust/nexus_raft/src/storage/redb_store.rs
+++ b/rust/nexus_raft/src/storage/redb_store.rs
@@ -270,6 +270,16 @@ impl RedbTree {
         TableDefinition::new(self.table_name)
     }
 
+    /// Get the underlying database handle (for cross-tree atomic transactions).
+    pub fn raw_db(&self) -> &Database {
+        &self.db
+    }
+
+    /// Get the table name (for cross-tree atomic transactions).
+    pub fn name(&self) -> &'static str {
+        self.table_name
+    }
+
     /// Get a value by key.
     pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         let read_txn = self.db.begin_read()?;

--- a/rust/nexus_raft/src/transport/transport_loop.rs
+++ b/rust/nexus_raft/src/transport/transport_loop.rs
@@ -286,16 +286,37 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
 
             // Anti-entropy: check if peer fell behind compacted WAL region
             let earliest = repl_log.earliest_seq();
-            if state.acked_seq > 0 && state.acked_seq < earliest {
-                if !state.needs_snapshot {
+
+            // Clear needs_snapshot if peer has caught up (e.g., via external
+            // snapshot delivery or WAL re-expansion)
+            if state.needs_snapshot {
+                if state.acked_seq >= earliest {
+                    tracing::info!(
+                        peer = peer_id,
+                        acked = state.acked_seq,
+                        earliest,
+                        "Peer caught up — clearing needs_snapshot"
+                    );
+                    state.needs_snapshot = false;
+                } else {
                     tracing::warn!(
                         peer = peer_id,
                         acked = state.acked_seq,
                         earliest,
-                        "Peer fell behind compacted WAL — needs snapshot"
+                        "Peer needs snapshot (not yet implemented) — skipping"
                     );
-                    state.needs_snapshot = true;
+                    continue;
                 }
+            }
+
+            if state.acked_seq > 0 && state.acked_seq < earliest {
+                tracing::warn!(
+                    peer = peer_id,
+                    acked = state.acked_seq,
+                    earliest,
+                    "Peer fell behind compacted WAL — needs snapshot"
+                );
+                state.needs_snapshot = true;
                 continue; // Skip — incremental replication impossible
             }
 

--- a/rust/nexus_tasks/src/engine.rs
+++ b/rust/nexus_tasks/src/engine.rs
@@ -84,7 +84,8 @@ impl Engine {
             .claim_next(worker_id, lease_secs, now, self.max_wait_secs)
     }
 
-    /// Update heartbeat/progress for a running task.
+    /// Update heartbeat/progress for a running task. Also renews the lease
+    /// so the task is not reaped by `requeue_abandoned()` while actively heartbeating.
     /// Returns false if the task was cancelled (worker should stop).
     pub fn heartbeat(&self, task_id: u64, progress_pct: u8, message: &str) -> Result<bool> {
         let mut task = self
@@ -110,21 +111,27 @@ impl Engine {
             task.progress_message = Some(message.to_string());
         }
 
-        self.store.update_task(&task)?;
+        // Renew lease: update running_idx key with new expiry
+        let now = now_secs();
+        let new_lease_expires = now + task.lease_secs as u64;
+        self.store.renew_lease(task_id, new_lease_expires, &task)?;
         Ok(true)
     }
 
     /// Mark a task as completed with a result payload.
-    pub fn complete(&self, task_id: u64, result: &[u8]) -> Result<()> {
+    /// `worker_id` must match the current owner (prevents stale workers from
+    /// overwriting a re-claimed task after lease expiry).
+    pub fn complete(&self, task_id: u64, result: &[u8], worker_id: &str) -> Result<()> {
         let now = now_secs();
-        self.store.complete_task(task_id, result, now)?;
+        self.store.complete_task(task_id, result, now, worker_id)?;
         Ok(())
     }
 
     /// Mark a task as failed. Auto-retries if attempts remain; otherwise dead-letters.
-    pub fn fail(&self, task_id: u64, error_message: &str) -> Result<()> {
+    /// `worker_id` must match the current owner.
+    pub fn fail(&self, task_id: u64, error_message: &str, worker_id: &str) -> Result<()> {
         let now = now_secs();
-        self.store.fail_task(task_id, error_message, now)?;
+        self.store.fail_task(task_id, error_message, now, worker_id)?;
         Ok(())
     }
 
@@ -215,7 +222,7 @@ mod tests {
         assert!(alive);
 
         // Complete
-        engine.complete(tid, b"result").unwrap();
+        engine.complete(tid, b"result", "w-0").unwrap();
 
         // Verify final state
         let task = engine.status(tid).unwrap().unwrap();
@@ -252,7 +259,7 @@ mod tests {
             .unwrap();
 
         engine.claim_next("w-0", 300).unwrap();
-        engine.fail(tid, "oops").unwrap();
+        engine.fail(tid, "oops", "w-0").unwrap();
 
         // Should be back in pending (attempt 1 < max_retries 3)
         let task = engine.status(tid).unwrap().unwrap();
@@ -268,7 +275,7 @@ mod tests {
             .unwrap();
 
         engine.claim_next("w-0", 300).unwrap();
-        engine.fail(tid, "fatal").unwrap();
+        engine.fail(tid, "fatal", "w-0").unwrap();
 
         let task = engine.status(tid).unwrap().unwrap();
         assert_eq!(task.status, TaskStatus::DeadLetter);
@@ -383,11 +390,11 @@ mod tests {
         let (engine, _dir) = test_engine();
 
         assert!(matches!(
-            engine.complete(999, b""),
+            engine.complete(999, b"", "w-0"),
             Err(TaskError::NotFound(999))
         ));
         assert!(matches!(
-            engine.fail(999, "err"),
+            engine.fail(999, "err", "w-0"),
             Err(TaskError::NotFound(999))
         ));
         assert!(matches!(engine.cancel(999), Err(TaskError::NotFound(999))));

--- a/rust/nexus_tasks/src/error.rs
+++ b/rust/nexus_tasks/src/error.rs
@@ -20,6 +20,9 @@ pub enum TaskError {
 
     #[error("queue full: {pending} pending tasks (max: {max_pending})")]
     QueueFull { pending: usize, max_pending: usize },
+
+    #[error("task {task_id} not owned by worker {worker_id}")]
+    NotOwner { task_id: u64, worker_id: String },
 }
 
 pub type Result<T> = std::result::Result<T, TaskError>;

--- a/rust/nexus_tasks/src/lib.rs
+++ b/rust/nexus_tasks/src/lib.rs
@@ -182,14 +182,20 @@ impl PyTaskEngine {
     }
 
     /// Mark a task as completed with an optional result payload.
-    #[pyo3(signature = (task_id, result=vec![]))]
-    fn complete(&self, task_id: u64, result: Vec<u8>) -> PyResult<()> {
-        self.engine.complete(task_id, &result).map_err(to_py_err)
+    /// `worker_id` must match the current owner to prevent stale workers.
+    #[pyo3(signature = (task_id, worker_id, result=vec![]))]
+    fn complete(&self, task_id: u64, worker_id: &str, result: Vec<u8>) -> PyResult<()> {
+        self.engine
+            .complete(task_id, &result, worker_id)
+            .map_err(to_py_err)
     }
 
     /// Mark a task as failed. Will auto-retry if attempts remain.
-    fn fail(&self, task_id: u64, error_message: &str) -> PyResult<()> {
-        self.engine.fail(task_id, error_message).map_err(to_py_err)
+    /// `worker_id` must match the current owner to prevent stale workers.
+    fn fail(&self, task_id: u64, worker_id: &str, error_message: &str) -> PyResult<()> {
+        self.engine
+            .fail(task_id, error_message, worker_id)
+            .map_err(to_py_err)
     }
 
     /// Cancel a pending or running task.

--- a/rust/nexus_tasks/src/store.rs
+++ b/rust/nexus_tasks/src/store.rs
@@ -204,7 +204,15 @@ impl TaskStore {
     }
 
     /// Move a running task to completed state. Removes from running_idx.
-    pub fn complete_task(&self, task_id: u64, result: &[u8], now: u64) -> Result<TaskRecord> {
+    /// Verifies that `worker_id` matches the current owner to prevent stale workers
+    /// from overwriting a re-claimed task after lease expiry.
+    pub fn complete_task(
+        &self,
+        task_id: u64,
+        result: &[u8],
+        now: u64,
+        worker_id: &str,
+    ) -> Result<TaskRecord> {
         let mut task = self
             .get_task(task_id)?
             .ok_or(TaskError::NotFound(task_id))?;
@@ -214,6 +222,13 @@ impl TaskStore {
                 task_id,
                 current: task.status.to_string(),
                 target: "COMPLETED".to_string(),
+            });
+        }
+
+        if task.claimed_by.as_deref() != Some(worker_id) {
+            return Err(TaskError::NotOwner {
+                task_id,
+                worker_id: worker_id.to_string(),
             });
         }
 
@@ -229,11 +244,14 @@ impl TaskStore {
     }
 
     /// Fail a running task. If retries remain, re-queue to pending; otherwise dead-letter.
+    /// Verifies that `worker_id` matches the current owner to prevent stale workers
+    /// from overwriting a re-claimed task after lease expiry.
     pub fn fail_task(
         &self,
         task_id: u64,
         error_message: &str,
         now: u64,
+        worker_id: &str,
     ) -> Result<(TaskRecord, bool)> {
         let mut task = self
             .get_task(task_id)?
@@ -244,6 +262,13 @@ impl TaskStore {
                 task_id,
                 current: task.status.to_string(),
                 target: "FAILED".to_string(),
+            });
+        }
+
+        if task.claimed_by.as_deref() != Some(worker_id) {
+            return Err(TaskError::NotOwner {
+                task_id,
+                worker_id: worker_id.to_string(),
             });
         }
 
@@ -495,6 +520,43 @@ impl TaskStore {
         Ok(results)
     }
 
+    /// Renew the lease for a running task. Atomically removes old running_idx entry,
+    /// inserts new one with updated expiry, and updates the task record.
+    pub fn renew_lease(
+        &self,
+        task_id: u64,
+        new_lease_expires: u64,
+        task: &TaskRecord,
+    ) -> Result<()> {
+        // Find old running_idx entry
+        let mut old_key: Option<Vec<u8>> = None;
+        for guard in self.running_idx.iter() {
+            if let Ok((key, _)) = guard.into_inner() {
+                if let Some((_, tid)) = decode_running_key(key.as_ref()) {
+                    if tid == task_id {
+                        old_key = Some(key.as_ref().to_vec());
+                        break;
+                    }
+                }
+            }
+        }
+
+        let new_running_key = encode_running_key(new_lease_expires, task_id);
+        let task_value = bincode::serialize(task)?;
+
+        let mut batch = self.db.batch();
+        if let Some(ref old) = old_key {
+            batch.remove(&self.running_idx, old);
+        }
+        batch.insert(&self.running_idx, new_running_key, vec![]);
+        batch.insert(&self.tasks, task_id.to_be_bytes(), task_value);
+        batch
+            .commit()
+            .map_err(|e| TaskError::Storage(e.to_string()))?;
+
+        Ok(())
+    }
+
     /// Remove a task from the running index by scanning for its task_id.
     fn remove_from_running_idx(&self, task_id: u64) -> Result<()> {
         for guard in self.running_idx.iter() {
@@ -636,7 +698,9 @@ mod tests {
         assert_eq!(claimed.status, TaskStatus::Running);
         assert_eq!(claimed.attempt, 1);
 
-        let completed = store.complete_task(task_id, b"done", 1700000001).unwrap();
+        let completed = store
+            .complete_task(task_id, b"done", 1700000001, "w-0")
+            .unwrap();
         assert_eq!(completed.status, TaskStatus::Completed);
         assert_eq!(completed.result.as_deref(), Some(b"done".as_slice()));
 
@@ -654,7 +718,9 @@ mod tests {
 
         // Claim and fail — should re-queue (attempt 1 < max_retries 3)
         store.claim_next("w-0", 300, 1700000000, 0).unwrap();
-        let (failed, dead) = store.fail_task(task_id, "oops", 1700000001).unwrap();
+        let (failed, dead) = store
+            .fail_task(task_id, "oops", 1700000001, "w-0")
+            .unwrap();
         assert!(!dead);
         assert_eq!(failed.status, TaskStatus::Pending);
         assert!(failed.run_at > 1700000001); // backoff applied
@@ -670,7 +736,9 @@ mod tests {
 
         // Claim and fail — attempt 1 >= max_retries 1 → dead letter
         store.claim_next("w-0", 300, 1700000000, 0).unwrap();
-        let (failed, dead) = store.fail_task(task_id, "fatal", 1700000001).unwrap();
+        let (failed, dead) = store
+            .fail_task(task_id, "fatal", 1700000001, "w-0")
+            .unwrap();
         assert!(dead);
         assert_eq!(failed.status, TaskStatus::DeadLetter);
     }


### PR DESCRIPTION
## Summary

Fixes 8 correctness bugs across `nexus_tasks`, `nexus_core`, `nexus_pyo3`, and `nexus_raft`:

- **nexus_tasks**: Heartbeat now renews lease (prevents false reaping of active tasks); `complete()`/`fail()` verify worker ownership (prevents stale workers from overwriting re-claimed tasks)
- **nexus_core (search)**: Fixed Unicode case-folding offset mapping in `LiteralIgnoreCase` — `to_lowercase()` can change byte lengths (e.g. Turkish İ → i̇), breaking `.chars().skip().take()`
- **nexus_core (glob)**: `filter_paths_exclude()` now matches against both full path and basename, so patterns like `*.pyc` work correctly
- **nexus_core (ReBAC)**: TupleToUserset now includes direct-relation fallback per Zanzibar spec (both string-keyed and interned paths)
- **nexus_raft (replication_log)**: `append()` uses a single redb write transaction for log entry + next_seq (was two separate transactions, risking torn writes on crash)
- **nexus_raft (transport_loop)**: `needs_snapshot` recovery — peers that catch up can now clear the flag instead of being permanently stuck

## Changes

| Crate | File | Fix |
|-------|------|-----|
| nexus_tasks | `store.rs` | `renew_lease()`, worker ownership checks in `complete_task()`/`fail_task()` |
| nexus_tasks | `engine.rs` | Heartbeat calls `renew_lease()`; `complete`/`fail` pass `worker_id` |
| nexus_tasks | `error.rs` | Added `NotOwner` error variant |
| nexus_tasks | `lib.rs` | PyO3 bindings updated for `worker_id` parameter |
| nexus_core | `search/mod.rs` | `extract_original_match()` for correct Unicode offset mapping |
| nexus_core | `glob.rs` | Exclude matches both full path and basename |
| nexus_core | `rebac/graph.rs` | Direct-relation fallback in interned TupleToUserset |
| nexus_core | `rebac/mod.rs` | Direct-relation fallback in string-keyed TupleToUserset |
| nexus_pyo3 | `search.rs` | Use `extract_original_match()` in `grep_bulk` and `grep_single_file_mmap` |
| nexus_raft | `replication_log.rs` | Atomic single-transaction append |
| nexus_raft | `storage/redb_store.rs` | `raw_db()`/`name()` accessors for cross-table transactions |
| nexus_raft | `transport_loop.rs` | `needs_snapshot` catch-up recovery |

## Test plan

- [x] `cargo test -p nexus_core` — 94 tests pass
- [x] `cargo test -p nexus_tasks --lib` — 36 tests pass
- [x] `cargo test -p nexus_raft` — 35 tests pass
- [x] `cargo check --workspace` — clean
- [ ] CI validation