### PR TITLE
refactor(#1452): eliminate kernel reverse dependencies [Phase 2b]

### DIFF
--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -658,10 +658,9 @@ def create_mcp_server(
         """
         nx_instance: Any = _get_nexus_instance(ctx)
         _search = nx_instance.service("search")
-        if _search is not None:
-            all_matches = _search.glob(pattern, path)
-        else:
-            all_matches = nx_instance.glob(pattern, path)
+        if _search is None:
+            raise ValueError("SearchService not available — glob requires the search brick")
+        all_matches = _search.glob(pattern, path)
         total = len(all_matches)
 
         # Apply pagination
@@ -729,10 +728,9 @@ def create_mcp_server(
         """
         nx_instance: Any = _get_nexus_instance(ctx)
         _search = nx_instance.service("search")
-        if _search is not None:
-            all_results = _search.grep(pattern, path, ignore_case=ignore_case)
-        else:
-            all_results = nx_instance.grep(pattern, path, ignore_case=ignore_case)
+        if _search is None:
+            raise ValueError("SearchService not available — grep requires the search brick")
+        all_results = _search.grep(pattern, path, ignore_case=ignore_case)
         total = len(all_results)
 
         # Apply pagination

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -2357,15 +2357,13 @@ class NexusFS(  # type: ignore[misc]
                 "or pass coordination_url to NexusFS constructor."
             )
 
-        async with self.service("events").locked(path, timeout=timeout, ttl=ttl, _context=context):
-            # Read current content — sys_read (Tier 1) always returns bytes
+        lock_id = await self._lock_manager.acquire(path, timeout=timeout, ttl=ttl)
+        try:
             content = self.sys_read(path, context=context)
-
-            # Apply update function
             new_content = update_fn(content)
-
-            # Write back via Tier 2 write() (no lock since we already hold it)
             return self.write(path, new_content, context=context)
+        finally:
+            await self._lock_manager.release(lock_id, path)
 
     @rpc_expose(description="Append content to an existing file or create if it doesn't exist")
     def append(
@@ -3959,17 +3957,6 @@ class NexusFS(  # type: ignore[misc]
         limit: int | None = None,
         cursor: str | None = None,
     ) -> builtins.list[str] | builtins.list[dict[str, Any]]:
-        if self.service("search") is not None:
-            return self.service("search").list(
-                path=path,
-                recursive=recursive,
-                details=details,
-                show_parsed=show_parsed,
-                context=context,
-                limit=limit,
-                cursor=cursor,
-            )
-        # Kernel-only fallback: delegate directly to metadata store
         prefix = path if path != "/" else ""
         if prefix and not prefix.endswith("/"):
             prefix = prefix + "/"
@@ -3977,35 +3964,6 @@ class NexusFS(  # type: ignore[misc]
         if details:
             return [{"path": e.path, "size": e.size, "etag": e.etag} for e in entries]
         return [e.path for e in entries]
-
-    def glob(self, pattern: str, path: str = "/", context: Any = None) -> builtins.list[str]:
-        return self.service("search").glob(pattern=pattern, path=path, context=context)
-
-    def grep(
-        self,
-        pattern: str,
-        path: str = "/",
-        file_pattern: str | None = None,
-        ignore_case: bool = False,
-        max_results: int = 100,
-        search_mode: str = "auto",
-        context: Any = None,
-        before_context: int = 0,
-        after_context: int = 0,
-        invert_match: bool = False,
-    ) -> builtins.list[dict[str, Any]]:
-        return self.service("search").grep(
-            pattern=pattern,
-            path=path,
-            file_pattern=file_pattern,
-            ignore_case=ignore_case,
-            max_results=max_results,
-            search_mode=search_mode,
-            context=context,
-            before_context=before_context,
-            after_context=after_context,
-            invert_match=invert_match,
-        )
 
     # _run_async: replaced by direct run_sync() calls (Issue #1381)
 

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -255,7 +255,11 @@ def handle_list(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, Any
         kwargs["cursor"] = cursor
 
     _list_start = _time.time()
-    result = nexus_fs.sys_readdir(params.path, **kwargs)
+    search = nexus_fs.service("search")
+    if search is not None:
+        result = search.list(path=params.path, **kwargs)
+    else:
+        result = nexus_fs.sys_readdir(params.path, **kwargs)
     _list_elapsed = (_time.time() - _list_start) * 1000
 
     # Result is PaginatedResult when limit is provided


### PR DESCRIPTION
## Summary

- Delete `glob()` and `grep()` passthrough methods from NexusFS kernel
- Remove SearchService delegation from `sys_readdir()` — kernel always uses `metadata.list()`
- Replace `EventsService.locked()` in `atomic_update()` with kernel's own `_lock_manager`
- Push search-optimized listing to server/RPC layer (`handle_list`)
- MCP server now requires SearchService explicitly (no kernel fallback)

After this PR: `grep 'self\.service(' nexus_fs.py` returns **empty**. The kernel has zero knowledge of services — it only provides the `service()` accessor for external callers.

## Linux Analogy

| Removed | Linux equivalent |
|---------|-----------------|
| `glob()` | libc userspace function, not a syscall |
| `grep()` | Userspace tool (`/usr/bin/grep`) |
| `sys_readdir → search.list()` | VFS readdir() always calls fs driver, never a search daemon |
| `events.locked()` | Kernel uses `mutex_lock()` internally, not a loadable module |

## Depends on

PR #2871 (Phase 2a — external caller migration)

## Files changed (3)

| File | Change |
|------|--------|
| `src/nexus/core/nexus_fs.py` | Delete glob/grep, simplify sys_readdir, fix atomic_update |
| `src/nexus/server/rpc/handlers/filesystem.py` | handle_list now does search-vs-kernel decision |
| `src/nexus/bricks/mcp/server.py` | Remove kernel glob/grep fallback |

## Test plan

- [x] 26/26 ServiceRegistry + WiredServices tests pass
- [x] `grep 'self\.service(' nexus_fs.py` returns empty
- [x] ruff lint + format clean
- [x] mypy clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)