### PR TITLE
fix: address 12 security/correctness issues from Codex audit

### DIFF
--- a/src/nexus/bricks/reputation/reputation_service.py
+++ b/src/nexus/bricks/reputation/reputation_service.py
@@ -176,6 +176,7 @@ class ReputationService(SessionMixin):
         agent_id: str,
         context: str = "general",
         window: str = "all_time",
+        zone_id: str | None = None,
     ) -> ReputationScore | None:
         """Get materialized reputation score for an agent.
 
@@ -183,16 +184,21 @@ class ReputationService(SessionMixin):
             agent_id: Agent to look up.
             context: Reputation context (default "general").
             window: Time window (default "all_time").
+            zone_id: Zone to scope the lookup (default ROOT_ZONE_ID).
 
         Returns:
             ReputationScore record or None if not found.
         """
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        effective_zone = zone_id or ROOT_ZONE_ID
         with self._get_session() as session:
             model = session.execute(
                 select(ReputationScoreModel).where(
                     ReputationScoreModel.agent_id == agent_id,
                     ReputationScoreModel.context == context,
                     ReputationScoreModel.window == window,
+                    ReputationScoreModel.zone_id == effective_zone,
                 )
             ).scalar_one_or_none()
 
@@ -325,12 +331,13 @@ class ReputationService(SessionMixin):
         context: str,
     ) -> None:
         """Incrementally update the materialized reputation score."""
-        # Get or create score record (all_time window)
+        # Get or create score record (all_time window, zone-scoped)
         model = session.execute(
             select(ReputationScoreModel).where(
                 ReputationScoreModel.agent_id == rated_agent_id,
                 ReputationScoreModel.context == context,
                 ReputationScoreModel.window == "all_time",
+                ReputationScoreModel.zone_id == zone_id,
             )
         ).scalar_one_or_none()
 

--- a/src/nexus/lib/zone.py
+++ b/src/nexus/lib/zone.py
@@ -1,4 +1,4 @@
-"""Zone ID normalization — tier-neutral utility.
+"""Zone ID normalization and validation — tier-neutral utility.
 
 Moved from ``nexus.bricks.rebac.utils.zone`` (Issue #194) so that
 kernel code can call ``normalize_zone_id`` without importing from bricks/.
@@ -7,9 +7,14 @@ Replaces the 48+ inline ``zone_id or ROOT_ZONE_ID`` occurrences with a single
 canonical function so the default zone sentinel is defined in one place.
 """
 
+import re
+
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 DEFAULT_ZONE: str = ROOT_ZONE_ID
+
+# Zone IDs must be alphanumeric, hyphens, underscores, or dots (no path separators).
+_SAFE_ZONE_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 
 
 def normalize_zone_id(zone_id: str | None) -> str:
@@ -23,3 +28,30 @@ def normalize_zone_id(zone_id: str | None) -> str:
     'root'
     """
     return zone_id or DEFAULT_ZONE
+
+
+def validate_zone_id(zone_id: str) -> str:
+    """Validate zone_id is safe for use in filesystem paths.
+
+    Rejects path traversal sequences (``..``, ``/``, ``\\``) and other
+    unsafe characters that could escape a cache root directory.
+
+    Args:
+        zone_id: Zone identifier to validate.
+
+    Returns:
+        The validated zone_id (unchanged).
+
+    Raises:
+        ValueError: If zone_id contains unsafe characters.
+    """
+    if not zone_id:
+        raise ValueError("zone_id must not be empty")
+    if not _SAFE_ZONE_RE.match(zone_id):
+        raise ValueError(
+            f"zone_id contains unsafe characters: {zone_id!r}. "
+            "Only alphanumeric, hyphens, underscores, and dots are allowed."
+        )
+    if zone_id.startswith(".") or ".." in zone_id:
+        raise ValueError(f"zone_id must not start with '.' or contain '..': {zone_id!r}")
+    return zone_id

--- a/src/nexus/storage/auth_stores/sqlalchemy_api_key_store.py
+++ b/src/nexus/storage/auth_stores/sqlalchemy_api_key_store.py
@@ -73,11 +73,18 @@ class SQLAlchemyAPIKeyStore:
             return _to_dto(key)
 
     def get_by_hash(self, key_hash: str) -> APIKeyDTO | None:
+        from sqlalchemy import or_
+
+        now = datetime.now(UTC)
         with self._session_factory() as session:
             key = session.scalar(
                 select(APIKeyModel).where(
                     APIKeyModel.key_hash == key_hash,
                     APIKeyModel.revoked == 0,
+                    or_(
+                        APIKeyModel.expires_at.is_(None),
+                        APIKeyModel.expires_at > now,
+                    ),
                 )
             )
             return _to_dto(key) if key else None

--- a/src/nexus/storage/auth_stores/sqlalchemy_oauth_credential.py
+++ b/src/nexus/storage/auth_stores/sqlalchemy_oauth_credential.py
@@ -69,7 +69,9 @@ class SQLAlchemyOAuthCredentialStore:
 
             if existing:
                 existing.encrypted_access_token = encrypted_access_token
-                existing.encrypted_refresh_token = encrypted_refresh_token
+                # Preserve existing refresh token if new one is not provided
+                if encrypted_refresh_token is not None:
+                    existing.encrypted_refresh_token = encrypted_refresh_token
                 existing.token_type = token_type
                 existing.expires_at = expires_at
                 existing.scopes = scopes

--- a/src/nexus/storage/auth_stores/sqlalchemy_user_store.py
+++ b/src/nexus/storage/auth_stores/sqlalchemy_user_store.py
@@ -30,7 +30,7 @@ def _to_dto(user: UserModel) -> UserDTO:
         password_hash=user.password_hash,
         primary_auth_method=user.primary_auth_method,
         is_global_admin=bool(user.is_global_admin),
-        api_key=user.api_key,
+        api_key=None,  # Never expose plaintext legacy api_key; use hashed api_keys table
         last_login_at=user.last_login_at,
         created_at=user.created_at,
         updated_at=user.updated_at,

--- a/src/nexus/storage/file_cache.py
+++ b/src/nexus/storage/file_cache.py
@@ -171,6 +171,13 @@ class FileContentCache:
         hash_hex: str = blake3.blake3(virtual_path.encode()).hexdigest()
         return hash_hex[:32]
 
+    @staticmethod
+    def _safe_zone_id(zone_id: str) -> str:
+        """Validate zone_id is safe for filesystem path construction."""
+        from nexus.lib.zone import validate_zone_id
+
+        return validate_zone_id(zone_id)
+
     def _get_cache_path(self, zone_id: str, virtual_path: str) -> Path:
         """Get the file path for cached content.
 
@@ -178,17 +185,20 @@ class FileContentCache:
         This prevents too many files in a single directory (max 256 per level).
         """
         path_hash = self._path_hash(virtual_path)
-        return self.cache_dir / zone_id / path_hash[:2] / path_hash[2:4] / f"{path_hash}.bin"
+        safe_zone = self._safe_zone_id(zone_id)
+        return self.cache_dir / safe_zone / path_hash[:2] / path_hash[2:4] / f"{path_hash}.bin"
 
     def _get_text_cache_path(self, zone_id: str, virtual_path: str) -> Path:
         """Get the file path for cached parsed text."""
         path_hash = self._path_hash(virtual_path)
-        return self.cache_dir / zone_id / path_hash[:2] / path_hash[2:4] / f"{path_hash}.txt"
+        safe_zone = self._safe_zone_id(zone_id)
+        return self.cache_dir / safe_zone / path_hash[:2] / path_hash[2:4] / f"{path_hash}.txt"
 
     def _get_meta_cache_path(self, zone_id: str, virtual_path: str) -> Path:
         """Get the file path for cached metadata (replaces DB ContentCacheModel)."""
         path_hash = self._path_hash(virtual_path)
-        return self.cache_dir / zone_id / path_hash[:2] / path_hash[2:4] / f"{path_hash}.meta"
+        safe_zone = self._safe_zone_id(zone_id)
+        return self.cache_dir / safe_zone / path_hash[:2] / path_hash[2:4] / f"{path_hash}.meta"
 
     def write(
         self,
@@ -547,7 +557,8 @@ class FileContentCache:
         Returns:
             Number of files deleted
         """
-        zone_dir = self.cache_dir / zone_id
+        safe_zone = self._safe_zone_id(zone_id)
+        zone_dir = self.cache_dir / safe_zone
         if not zone_dir.exists():
             return 0
 

--- a/src/nexus/storage/local_disk_cache.py
+++ b/src/nexus/storage/local_disk_cache.py
@@ -51,7 +51,7 @@ DEFAULT_BLOOM_CAPACITY = 1_000_000
 DEFAULT_BLOOM_FP_RATE = 0.01
 
 # Metadata file format version
-METADATA_VERSION = 1
+METADATA_VERSION = 2
 
 
 @dataclass
@@ -197,6 +197,9 @@ class LocalDiskCache:
             Cache key in format "{zone_id}:{content_hash}" or just "{content_hash}"
         """
         if zone_id:
+            from nexus.lib.zone import validate_zone_id
+
+            validate_zone_id(zone_id)
             return f"{zone_id}:{content_hash}"
         return content_hash
 
@@ -634,8 +637,9 @@ class LocalDiskCache:
 
                 # Read entries
                 for _ in range(entry_count):
-                    # Hash (32 bytes hex = 64 bytes)
-                    content_hash = f.read(64).decode("ascii")
+                    # Key length (2 bytes) + variable-length key
+                    key_len = struct.unpack("!H", f.read(2))[0]
+                    content_hash = f.read(key_len).decode("ascii")
                     # Size, created, accessed, access_count, priority
                     size, created, accessed, access_count, priority = struct.unpack(
                         "!QddIi", f.read(8 + 8 + 8 + 4 + 4)
@@ -675,7 +679,13 @@ class LocalDiskCache:
         for cache_file in self.content_dir.rglob("*.bin"):
             try:
                 content_hash = cache_file.stem
-                if len(content_hash) != 64:  # SHA-256 hex length
+                # Accept plain SHA-256 hashes (64 chars) and zone-prefixed
+                # keys (zone_id:hash, variable length > 64 with ':' separator).
+                if len(content_hash) == 64:
+                    pass  # plain hash
+                elif ":" in content_hash and len(content_hash.rsplit(":", 1)[-1]) == 64:
+                    pass  # zone_id:hash
+                else:
                     continue
 
                 size = cache_file.stat().st_size
@@ -714,7 +724,9 @@ class LocalDiskCache:
 
                     # Entries
                     for content_hash, entry in self._entries.items():
-                        f.write(content_hash.encode("ascii"))
+                        key_bytes = content_hash.encode("ascii")
+                        f.write(struct.pack("!H", len(key_bytes)))
+                        f.write(key_bytes)
                         f.write(
                             struct.pack(
                                 "!QddIi",

--- a/src/nexus/storage/models/file_path.py
+++ b/src/nexus/storage/models/file_path.py
@@ -79,12 +79,12 @@ class FilePathModel(Base):
     # Indexes and constraints
     __table_args__ = (
         Index(
-            "uq_virtual_path",
+            "uq_zone_virtual_path",
+            "zone_id",
             "virtual_path",
             unique=True,
             postgresql_where=text("deleted_at IS NULL"),
         ),
-        Index("idx_file_paths_zone_path", "zone_id", "virtual_path"),
         Index("idx_file_paths_backend_id", "backend_id"),
         Index("idx_file_paths_content_hash", "content_hash"),
         Index("idx_file_paths_virtual_path", "virtual_path"),

--- a/src/nexus/storage/models/operation_log.py
+++ b/src/nexus/storage/models/operation_log.py
@@ -63,7 +63,9 @@ class OperationLogModel(Base):
 
     # Monotonic sequence for cursor-based replay pagination (Issue #1138/#1139).
     # Nullable for backfill of existing rows; new rows auto-populated via trigger/app.
-    sequence_number: Mapped[int | None] = mapped_column(BigInteger, nullable=True, default=None)
+    sequence_number: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None, unique=True
+    )
 
     # Persistent retry count for delivery worker (Issue #2751).
     # Survives worker restarts; prevents over-retry and DLQ bypass.

--- a/src/nexus/storage/models/reputation_score.py
+++ b/src/nexus/storage/models/reputation_score.py
@@ -29,13 +29,16 @@ class ReputationScoreModel(Base):
 
     __tablename__ = "reputation_scores"
 
-    # Composite primary key
+    # Composite primary key (zone_id included for cross-zone isolation)
     agent_id: Mapped[str] = mapped_column(String(255), primary_key=True, nullable=False)
     context: Mapped[str] = mapped_column(
         String(100), primary_key=True, nullable=False, default="general"
     )
     window: Mapped[str] = mapped_column(
         String(20), primary_key=True, nullable=False, default="all_time"
+    )
+    zone_id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, nullable=False, default=ROOT_ZONE_ID
     )
 
     # Per-dimension Beta distribution parameters (prior = 1.0)
@@ -60,9 +63,6 @@ class ReputationScoreModel(Base):
 
     # Cross-zone trust
     global_trust_score: Mapped[float | None] = mapped_column(Float, nullable=True)
-
-    # Zone scope
-    zone_id: Mapped[str] = mapped_column(String(36), nullable=False, default=ROOT_ZONE_ID)
 
     # Last update timestamp
     updated_at: Mapped[datetime] = mapped_column(

--- a/src/nexus/storage/models/spending_policy.py
+++ b/src/nexus/storage/models/spending_policy.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -62,6 +63,15 @@ class SpendingPolicyModel(Base):
 
     __table_args__ = (
         UniqueConstraint("agent_id", "zone_id", name="uq_spending_policy_agent_zone"),
+        # PostgreSQL treats NULLs as distinct in unique constraints, so the
+        # above does not prevent multiple zone-default rows (agent_id IS NULL).
+        # This partial unique index enforces at most one default per zone.
+        Index(
+            "uq_spending_policy_zone_default",
+            "zone_id",
+            unique=True,
+            postgresql_where=text("agent_id IS NULL"),
+        ),
         Index("ix_spending_policies_zone_priority", "zone_id", "priority"),
     )
 

--- a/src/nexus/storage/operation_logger.py
+++ b/src/nexus/storage/operation_logger.py
@@ -107,9 +107,11 @@ class OperationLogger:
             operation_id: UUID of logged operation
         """
         # Auto-assign sequence_number for cursor-based replay (#1138/#1139).
-        # Uses MAX+1 within the current session for gap-free ordering.
+        # Uses SELECT ... FOR UPDATE to prevent concurrent duplicate sequences.
         next_seq = self.session.execute(
-            select(func.coalesce(func.max(OperationLogModel.sequence_number), 0) + 1)
+            select(
+                func.coalesce(func.max(OperationLogModel.sequence_number), 0) + 1
+            ).with_for_update()
         ).scalar()
 
         operation = OperationLogModel(

--- a/src/nexus/storage/piped_record_store_write_observer.py
+++ b/src/nexus/storage/piped_record_store_write_observer.py
@@ -425,6 +425,9 @@ class PipedRecordStoreWriteObserver:
                     metadata_snapshot=event.get("metadata_snapshot"),
                     status="success",
                 )
+                new_path = event.get("new_path")
+                if new_path:
+                    recorder.record_rename(event["path"], new_path)
 
             elif op == "mkdir":
                 op_logger.log_operation(

--- a/src/nexus/storage/raft_metadata_store.py
+++ b/src/nexus/storage/raft_metadata_store.py
@@ -581,17 +581,28 @@ class RaftMetadataStore(MetastoreABC):
         serialized: list[tuple[str, bytes]] = [
             (m.path, _serialize_metadata(m)) for m in metadata_list
         ]
+        path_list = [path for path, _ in serialized]
 
-        # Phase 2: apply all writes in a single FFI call
+        # Phase 2: capture existing metadata for rollback (single FFI call)
+        if hasattr(self._engine, "get_metadata_multi"):
+            snapshots = self._engine.get_metadata_multi(path_list)
+        else:
+            snapshots = [(p, self._engine.get_metadata(p)) for p in path_list]
+
+        # Phase 3: apply all writes in a single FFI call
         try:
             self._engine.batch_set_metadata(serialized)
         except Exception as e:
-            # Best-effort rollback: delete entries that were written
-            paths_to_rollback = [path for path, _ in serialized]
+            # Best-effort rollback: restore pre-existing entries, delete new ones
+            restore_items = [(path, data) for path, data in snapshots if data is not None]
+            delete_paths = [path for path, data in snapshots if data is None]
             try:
-                self._engine.batch_delete_metadata(paths_to_rollback)
+                if restore_items:
+                    self._engine.batch_set_metadata(restore_items)
+                if delete_paths:
+                    self._engine.batch_delete_metadata(delete_paths)
             except Exception:
-                logger.warning("put_batch rollback failed for %d paths", len(paths_to_rollback))
+                logger.warning("put_batch rollback failed for %d paths", len(path_list))
             raise RuntimeError(f"put_batch failed writing {len(serialized)} entries: {e}") from e
 
     def delete_batch(self, paths: Sequence[str]) -> None:

--- a/src/nexus/storage/record_store_write_observer.py
+++ b/src/nexus/storage/record_store_write_observer.py
@@ -158,6 +158,7 @@ class RecordStoreWriteObserver:
     ) -> None:
         """Sync a rename operation to RecordStore."""
         from nexus.storage.operation_logger import OperationLogger
+        from nexus.storage.version_recorder import VersionRecorder
 
         try:
             with self._session_factory() as session:
@@ -171,6 +172,7 @@ class RecordStoreWriteObserver:
                     metadata_snapshot=metadata.to_dict() if metadata else None,
                     status="success",
                 )
+                VersionRecorder(session).record_rename(old_path, new_path)
                 session.commit()
         except Exception as e:
             self._handle_error("rename", old_path, e)

--- a/src/nexus/storage/remote_metastore.py
+++ b/src/nexus/storage/remote_metastore.py
@@ -48,11 +48,12 @@ class RemoteMetastore(MetastoreABC):
     # === MetastoreABC Implementation ===
 
     def get(self, path: str) -> FileMetadata | None:
-        """Get metadata for a file by proxying ``stat`` to the server."""
-        try:
-            result = self._call_rpc("sys_stat", {"path": path})
-        except Exception:
-            return None
+        """Get metadata for a file by proxying ``stat`` to the server.
+
+        Raises transport errors so callers can distinguish "not found"
+        from "server unreachable".
+        """
+        result = self._call_rpc("sys_stat", {"path": path})
         if result is None:
             return None
         if isinstance(result, dict):
@@ -66,16 +67,12 @@ class RemoteMetastore(MetastoreABC):
         """Store metadata by proxying ``sys_setattr`` to the server.
 
         The *consistency* hint is forwarded so the server can honour it.
-        Non-fatal: in REMOTE mode the server already owns metadata —
-        failures here (e.g. during init) are logged but not raised.
+        Raises on transport failure so callers are aware of write failures.
         """
-        try:
-            self._call_rpc(
-                "sys_setattr",
-                {"path": metadata.path, "metadata": metadata.to_dict(), "consistency": consistency},
-            )
-        except Exception as exc:
-            logger.debug("RemoteMetastore.put(%s) failed (non-fatal): %s", metadata.path, exc)
+        self._call_rpc(
+            "sys_setattr",
+            {"path": metadata.path, "metadata": metadata.to_dict(), "consistency": consistency},
+        )
         return None
 
     def delete(self, path: str, *, consistency: str = "sc") -> dict[str, Any] | None:

--- a/src/nexus/storage/time_travel.py
+++ b/src/nexus/storage/time_travel.py
@@ -148,43 +148,45 @@ class TimeTravelReader:
             if next_write.metadata_snapshot:
                 metadata_dict = json.loads(next_write.metadata_snapshot)
         else:
-            # No next write, or next write has no snapshot (new file creation)
-            # Check if file still exists in current metadata
-            path_stmt = select(FilePathModel).where(FilePathModel.virtual_path == path)
-            if zone_id is not None:
-                path_stmt = path_stmt.where(FilePathModel.zone_id == zone_id)
+            # No next write — try snapshots from subsequent operations first,
+            # then fall back to current metadata only if no delete+recreate occurred.
+            # Look for any subsequent operation with a snapshot (delete, rename, etc.)
+            for op in ops_after_write:
+                if op.snapshot_hash:
+                    content = self.backend.read_content(op.snapshot_hash)
+                    if op.metadata_snapshot:
+                        metadata_dict = json.loads(op.metadata_snapshot)
+                    break
 
-            current_path = self.session.execute(path_stmt).scalar_one_or_none()
-
-            if current_path:
-                # File still exists with same content from last_write
-                content = self.backend.read_content(current_path.content_hash)
-                metadata_dict = {
-                    "size": current_path.size_bytes,
-                    # v0.5.0: owner/group/mode removed - use ReBAC for permissions
-                    "version": current_path.current_version,
-                    "etag": current_path.content_hash,
-                    "modified_at": current_path.updated_at.isoformat()
-                    if current_path.updated_at
-                    else None,
-                }
-            else:
-                # File was deleted after last_write but we need content at last_write
-                # Look for delete operation's snapshot
-                next_delete = None
-                for op in ops_after_write:
-                    if op.operation_type == "delete":
-                        next_delete = op
-                        break
-
-                if next_delete and next_delete.snapshot_hash:
-                    content = self.backend.read_content(next_delete.snapshot_hash)
-                    if next_delete.metadata_snapshot:
-                        metadata_dict = json.loads(next_delete.metadata_snapshot)
-                else:
-                    raise NexusFileNotFoundError(
-                        f"Cannot reconstruct content for {path} at operation {operation_id}"
+            if content is None:
+                # No subsequent operation captured a snapshot.
+                # Safe to use current metadata only if no delete occurred after
+                # last_write (i.e., the file has been continuously live).
+                has_delete_after = any(op.operation_type == "delete" for op in ops_after_write)
+                if not has_delete_after:
+                    path_stmt = select(FilePathModel).where(
+                        FilePathModel.virtual_path == path,
+                        FilePathModel.deleted_at.is_(None),
                     )
+                    if zone_id is not None:
+                        path_stmt = path_stmt.where(FilePathModel.zone_id == zone_id)
+
+                    current_path = self.session.execute(path_stmt).scalar_one_or_none()
+                    if current_path:
+                        content = self.backend.read_content(current_path.content_hash)
+                        metadata_dict = {
+                            "size": current_path.size_bytes,
+                            "version": current_path.current_version,
+                            "etag": current_path.content_hash,
+                            "modified_at": current_path.updated_at.isoformat()
+                            if current_path.updated_at
+                            else None,
+                        }
+
+            if content is None:
+                raise NexusFileNotFoundError(
+                    f"Cannot reconstruct content for {path} at operation {operation_id}"
+                )
 
         if content is None:
             raise NexusFileNotFoundError(

--- a/src/nexus/storage/version_recorder.py
+++ b/src/nexus/storage/version_recorder.py
@@ -55,6 +55,27 @@ class VersionRecorder:
         else:
             self._record_update(metadata)
 
+    def record_rename(self, old_path: str, new_path: str) -> None:
+        """Record a file rename (update virtual_path in FilePathModel).
+
+        Args:
+            old_path: Previous virtual path.
+            new_path: New virtual path after rename.
+        """
+        existing = self.session.execute(
+            select(FilePathModel).where(
+                FilePathModel.virtual_path == old_path,
+                FilePathModel.deleted_at.is_(None),
+            )
+        ).scalar_one_or_none()
+
+        if existing:
+            self.session.execute(
+                update(FilePathModel)
+                .where(FilePathModel.path_id == existing.path_id)
+                .values(virtual_path=new_path, updated_at=_utcnow_naive())
+            )
+
     def record_delete(self, path: str) -> None:
         """Record a file deletion (soft-delete FilePathModel).
 

--- a/tests/unit/storage/test_remote_metastore.py
+++ b/tests/unit/storage/test_remote_metastore.py
@@ -94,11 +94,13 @@ class TestRemoteMetastoreRPC:
             result = metastore.get("/nonexistent.txt")
             assert result is None
 
-    def test_get_returns_none_on_exception(self, metastore: RemoteMetastore) -> None:
-        """get() should return None when RPC raises an exception."""
-        with patch.object(metastore, "_call_rpc", side_effect=Exception("boom")):
-            result = metastore.get("/error.txt")
-            assert result is None
+    def test_get_propagates_exception(self, metastore: RemoteMetastore) -> None:
+        """get() should propagate RPC exceptions so callers can distinguish errors from not-found."""
+        with (
+            patch.object(metastore, "_call_rpc", side_effect=Exception("boom")),
+            pytest.raises(Exception, match="boom"),
+        ):
+            metastore.get("/error.txt")
 
     def test_put_calls_sys_setattr(self, metastore: RemoteMetastore) -> None:
         """put() should call _call_rpc('sys_setattr', ...)."""


### PR DESCRIPTION
## Summary

- **CRITICAL**: Fix path traversal in both disk caches via unsanitized `zone_id` — added `validate_zone_id()` rejecting `../`, `/`, `\` chars
- Fix rename events being audit-only — added `VersionRecorder.record_rename()` to update `file_paths.virtual_path`
- Fix `LocalDiskCache` persistence for zone-scoped entries — length-prefixed keys in binary format, scan accepts `zone_id:hash` stems
- Fix `file_paths` unique constraint from `(virtual_path)` to `(zone_id, virtual_path)` for proper zone isolation
- Fix reputation scores cross-zone overwrite — `zone_id` added to composite PK, queries now filter by zone
- Fix spending policy NULL agent_id uniqueness — added partial unique index `WHERE agent_id IS NULL`
- Fix `put_batch()` rollback destroying pre-existing metadata — now snapshots before write, restores on failure
- Fix operation log `sequence_number` race — added `unique=True` constraint and `FOR UPDATE` lock on MAX query
- Fix time travel returning wrong content after delete+recreate — only falls through to current metadata if no delete occurred
- Fix `get_by_hash()` ignoring `expires_at` — expired keys now filtered at store layer
- Stop leaking plaintext `api_key` in `UserDTO` — set to `None` in `_to_dto()`
- Fix OAuth `store_credential()` clearing refresh token on upsert — now preserves when `None` (matching `update_tokens()`)
- Fix `RemoteMetastore` silently suppressing transport failures — errors now propagate to callers

## Test plan

- [x] All ruff lint checks pass
- [x] All ruff format checks pass  
- [x] All mypy type checks pass (pre-commit hook)
- [x] 169 relevant unit tests pass (remaining failures are pre-existing: missing `pytest-asyncio`, `hypothesis`, Rust extensions)
- [ ] Verify schema changes with Alembic migration generation
- [ ] Integration test zone isolation with new `(zone_id, virtual_path)` constraint
- [ ] Integration test cache path traversal rejection with malicious zone_id
- [ ] Verify `RemoteMetastore` callers handle propagated exceptions