### PR TITLE
fix(#1496): add missing metadata mock to benchmark fixture

### DIFF
--- a/tests/benchmarks/test_service_delegation.py
+++ b/tests/benchmarks/test_service_delegation.py
@@ -32,6 +32,8 @@ def mock_nexus_fs():
     pre-defined values to isolate delegation overhead.
     """
     fs = object.__new__(NexusFS)
+    fs.metadata = MagicMock()
+    fs.metadata.list = MagicMock(return_value=[])
     fs.version_service = MagicMock()
     fs.version_service.get_version = AsyncMock(return_value=b"benchmark")
     fs.version_service.list_versions = AsyncMock(return_value=[{"v": 1}])


### PR DESCRIPTION
## Summary
- Fix benchmark test `test_search_list_delegation` failing with `AttributeError: 'NexusFS' object has no attribute 'metadata'`
- After DT_PIPE PR merged, `sys_readdir()` now uses `self.metadata.list()` directly instead of delegating to SearchService
- The `mock_nexus_fs` fixture uses `object.__new__(NexusFS)` bypassing `__init__`, so `self.metadata` was never set
- Added `fs.metadata = MagicMock()` with `list` returning `[]` to the fixture

## Test plan
- [ ] Benchmark (Critical Subset) CI passes — `test_search_list_delegation` no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)