### PR TITLE
fix(#1331): remove duplicate sys_write from PortabilityFSProtocol

### DIFF
--- a/src/nexus/contracts/portability_types.py
+++ b/src/nexus/contracts/portability_types.py
@@ -46,8 +46,8 @@ class PortabilityFSProtocol(Protocol):
     defines the minimal surface the portability export/import services
     need from NexusFS.
 
-    Method names use the sys_ prefix to match NexusFS's POSIX-inspired
-    syscall API (sys_read, sys_write, sys_unlink, etc.).
+    Bricks access content/metadata through these properties, not through
+    the full NexusFilesystemABC syscall API.
     """
 
     @property
@@ -58,16 +58,4 @@ class PortabilityFSProtocol(Protocol):
     @property
     def backend(self) -> Any:
         """Backend for reading content blobs."""
-        ...
-
-    def sys_write(
-        self,
-        path: str,
-        buf: bytes | str,
-        *,
-        count: int | None = None,
-        offset: int = 0,
-        context: Any = None,
-    ) -> int:
-        """Write content to a file (POSIX pwrite(2))."""
         ...


### PR DESCRIPTION
## Summary
- Removed unused `sys_write()` from `PortabilityFSProtocol` in `contracts/portability_types.py`
- This method duplicated `NexusFilesystemABC.sys_write()` and was never called by any portability brick code
- The Protocol now only declares `metadata` and `backend` properties — the narrow surface the portability brick actually uses

## Test plan
- [x] Grep confirms `sys_write` never called through `PortabilityFSProtocol`
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary)
- [ ] CI lint/type check

🤖 Generated with [Claude Code](https://claude.com/claude-code)