### PR TITLE
feat(#1509): kernel ProcessTable — process lifecycle management

### DIFF
--- a/src/nexus/contracts/process_types.py
+++ b/src/nexus/contracts/process_types.py
@@ -1,0 +1,217 @@
+"""Process lifecycle types — kernel-level process management (Issue #1509).
+
+Pure value objects for the kernel ProcessTable. Zero runtime dependencies
+on kernel/services/bricks — only stdlib + contracts.
+
+    contracts/process_types.py = include/linux/sched.h (task_struct fields)
+
+Defines:
+    ProcessState     — finite state machine (CREATED → RUNNING → … → ZOMBIE)
+    ProcessSignal    — POSIX-like signals (SIGTERM, SIGSTOP, SIGCONT, SIGKILL, SIGUSR1)
+    ProcessKind      — INTERNAL (async coroutine) vs EXTERNAL (OS process via gRPC)
+    ProcessDescriptor — frozen PCB (Process Control Block)
+    ExternalProcessInfo — connection metadata for external agents
+
+See: core/process_table.py for the ProcessTable implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class ProcessState(StrEnum):
+    """Process lifecycle states — mirrors Linux task_struct.state."""
+
+    CREATED = "created"
+    RUNNING = "running"
+    SLEEPING = "sleeping"
+    STOPPED = "stopped"
+    ZOMBIE = "zombie"
+
+
+VALID_PROCESS_TRANSITIONS: dict[ProcessState, frozenset[ProcessState]] = {
+    ProcessState.CREATED: frozenset({ProcessState.RUNNING}),
+    ProcessState.RUNNING: frozenset(
+        {ProcessState.SLEEPING, ProcessState.STOPPED, ProcessState.ZOMBIE}
+    ),
+    ProcessState.SLEEPING: frozenset(
+        {ProcessState.RUNNING, ProcessState.STOPPED, ProcessState.ZOMBIE}
+    ),
+    ProcessState.STOPPED: frozenset({ProcessState.SLEEPING, ProcessState.ZOMBIE}),
+    ProcessState.ZOMBIE: frozenset(),  # terminal
+}
+
+
+class ProcessSignal(StrEnum):
+    """POSIX-like process signals."""
+
+    SIGTERM = "SIGTERM"  # Graceful shutdown → ZOMBIE
+    SIGSTOP = "SIGSTOP"  # Suspend → STOPPED
+    SIGCONT = "SIGCONT"  # Resume → SLEEPING
+    SIGKILL = "SIGKILL"  # Immediate kill + reap
+    SIGUSR1 = "SIGUSR1"  # User-defined (agent steering)
+
+
+class ProcessKind(StrEnum):
+    """Process kind — determines lifecycle depth."""
+
+    INTERNAL = "internal"  # async coroutine inside nexusd
+    EXTERNAL = "external"  # separate OS process via gRPC/MCP
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ProcessError(Exception):
+    """Base exception for process operations."""
+
+
+class ProcessNotFoundError(ProcessError):
+    """Raised when a PID does not exist in the process table."""
+
+
+class InvalidTransitionError(ProcessError):
+    """Raised when a state transition is not allowed."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalProcessInfo:
+    """Connection metadata for external (gRPC/MCP) processes."""
+
+    connection_id: str
+    host_pid: int | None = None
+    remote_addr: str | None = None
+    protocol: str = "grpc"  # "grpc" | "mcp" | "stdio"
+    last_heartbeat: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessDescriptor:
+    """Frozen PCB (Process Control Block) — kernel process descriptor.
+
+    Immutable. Use ``dataclasses.replace()`` for state transitions.
+    """
+
+    # Identity
+    pid: str
+    ppid: str | None
+    name: str
+    owner_id: str
+    zone_id: str
+    kind: ProcessKind
+
+    # Lifecycle
+    state: ProcessState
+    exit_code: int | None = None
+
+    # Filesystem
+    cwd: str = "/"
+    root: str = "/"
+
+    # Sub-processes
+    children: tuple[str, ...] = ()
+
+    # Timestamps
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    # External-only metadata
+    external_info: ExternalProcessInfo | None = None
+
+    # Opaque extension — Kubernetes-style labels
+    labels: dict[str, str] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-safe dict."""
+        d: dict[str, Any] = {
+            "pid": self.pid,
+            "ppid": self.ppid,
+            "name": self.name,
+            "owner_id": self.owner_id,
+            "zone_id": self.zone_id,
+            "kind": str(self.kind),
+            "state": str(self.state),
+            "exit_code": self.exit_code,
+            "cwd": self.cwd,
+            "root": self.root,
+            "children": list(self.children),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "labels": dict(self.labels),
+        }
+        if self.external_info is not None:
+            d["external_info"] = {
+                "connection_id": self.external_info.connection_id,
+                "host_pid": self.external_info.host_pid,
+                "remote_addr": self.external_info.remote_addr,
+                "protocol": self.external_info.protocol,
+                "last_heartbeat": (
+                    self.external_info.last_heartbeat.isoformat()
+                    if self.external_info.last_heartbeat
+                    else None
+                ),
+            }
+        else:
+            d["external_info"] = None
+        return d
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ProcessDescriptor:
+        """Deserialize from dict."""
+        ext_raw = d.get("external_info")
+        ext_info = None
+        if ext_raw is not None:
+            hb = ext_raw.get("last_heartbeat")
+            ext_info = ExternalProcessInfo(
+                connection_id=ext_raw["connection_id"],
+                host_pid=ext_raw.get("host_pid"),
+                remote_addr=ext_raw.get("remote_addr"),
+                protocol=ext_raw.get("protocol", "grpc"),
+                last_heartbeat=datetime.fromisoformat(hb) if hb else None,
+            )
+        return cls(
+            pid=d["pid"],
+            ppid=d.get("ppid"),
+            name=d["name"],
+            owner_id=d["owner_id"],
+            zone_id=d["zone_id"],
+            kind=ProcessKind(d["kind"]),
+            state=ProcessState(d["state"]),
+            exit_code=d.get("exit_code"),
+            cwd=d.get("cwd", "/"),
+            root=d.get("root", "/"),
+            children=tuple(d.get("children", ())),
+            created_at=datetime.fromisoformat(d["created_at"]),
+            updated_at=datetime.fromisoformat(d["updated_at"]),
+            external_info=ext_info,
+            labels=d.get("labels", {}),
+        )
+
+    @classmethod
+    def from_json(cls, s: str) -> ProcessDescriptor:
+        """Deserialize from JSON string."""
+        return cls.from_dict(json.loads(s))

--- a/src/nexus/contracts/protocols/process_table.py
+++ b/src/nexus/contracts/protocols/process_table.py
@@ -1,0 +1,90 @@
+"""ProcessTableProtocol — kernel-level process lifecycle contract (Issue #1509).
+
+Kernel contract for process management. No LLM, no tools, no agent logic.
+Those belong in the service-layer AgentService (Phase 4).
+
+    contracts/protocols/process_table.py = kernel syscall interface
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from nexus.contracts.process_types import (
+        ExternalProcessInfo,
+        ProcessDescriptor,
+        ProcessKind,
+        ProcessSignal,
+        ProcessState,
+    )
+
+
+@runtime_checkable
+class ProcessTableProtocol(Protocol):
+    """Kernel process table — PID allocation, state machine, signals, wait()."""
+
+    def spawn(
+        self,
+        name: str,
+        owner_id: str,
+        zone_id: str,
+        *,
+        kind: ProcessKind = ...,
+        parent_pid: str | None = None,
+        cwd: str = "/",
+        external_info: ExternalProcessInfo | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> ProcessDescriptor: ...
+
+    def kill(
+        self,
+        pid: str,
+        *,
+        exit_code: int = 0,
+    ) -> ProcessDescriptor: ...
+
+    def signal(
+        self,
+        pid: str,
+        sig: ProcessSignal,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> ProcessDescriptor: ...
+
+    async def wait(
+        self,
+        pid: str,
+        *,
+        target_states: frozenset[ProcessState] | None = None,
+        timeout: float | None = None,
+    ) -> ProcessDescriptor | None: ...
+
+    def get(self, pid: str) -> ProcessDescriptor | None: ...
+
+    def list_processes(
+        self,
+        *,
+        zone_id: str | None = None,
+        owner_id: str | None = None,
+        kind: ProcessKind | None = None,
+        state: ProcessState | None = None,
+    ) -> list[ProcessDescriptor]: ...
+
+    def register_external(
+        self,
+        name: str,
+        owner_id: str,
+        zone_id: str,
+        *,
+        connection_id: str,
+        host_pid: int | None = None,
+        remote_addr: str | None = None,
+        protocol: str = "grpc",
+        parent_pid: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> ProcessDescriptor: ...
+
+    def heartbeat(self, pid: str) -> ProcessDescriptor: ...
+
+    def unregister_external(self, pid: str) -> None: ...

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -258,6 +258,9 @@ class SystemServices:
     # DT_PIPE manager — VFS named-pipe IPC (Issue #809)
     pipe_manager: Any = None
 
+    # Process lifecycle — kernel process table (Issue #1509)
+    process_table: Any = None
+
     # Scheduler — task scheduling service (Issue #2195, #2360)
     scheduler_service: Any = None
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -191,6 +191,8 @@ class NexusFS(  # type: ignore[misc]
         self._zone_lifecycle = getattr(sys_svc, "zone_lifecycle", None)
         # DT_PIPE manager — kernel primitive (§4.2), None when unavailable (CLI mode)
         self._pipe_manager = sys_svc.pipe_manager
+        # Process lifecycle — kernel process table (Issue #1509)
+        self._process_table = sys_svc.process_table
 
         # =====================================================================
         # Tier 2: BRICK services (Issue #2034: from BrickServices)
@@ -4165,6 +4167,10 @@ class NexusFS(  # type: ignore[misc]
 
     def close(self) -> None:
         """Close the filesystem and release resources."""
+        # Close ProcessTable — kill all processes, clear state
+        if hasattr(self, "_process_table") and self._process_table is not None:
+            self._process_table.close_all()
+
         # Stop DeferredPermissionBuffer first to flush pending permissions
         if hasattr(self, "_deferred_permission_buffer") and self._deferred_permission_buffer:
             self._deferred_permission_buffer.stop()

--- a/src/nexus/core/process_table.py
+++ b/src/nexus/core/process_table.py
@@ -1,0 +1,471 @@
+"""ProcessTable — kernel process lifecycle manager (Issue #1509).
+
+Manages generic process lifecycle for both internal agents (async
+coroutines) and external agents (OS processes via gRPC). Follows
+the PipeManager pattern: DI with MetastoreABC, in-memory hot state,
+metastore persistence, degradable boot.
+
+    core/process_table.py = kernel/fork.c + kernel/exit.c + kernel/signal.c
+
+Concurrency model:
+  - spawn/kill/signal/get/list are synchronous (fast PID allocation
+    + metastore write). Safe under asyncio event loop (no await).
+  - wait() is async (blocks on asyncio.Event until target state).
+  - State transitions are validated against VALID_PROCESS_TRANSITIONS.
+
+Persistence:
+  - Descriptor JSON stored via metastore.set_file_metadata() at
+    /{zone}/proc/{pid}/status using the __proc_descriptor__ key.
+  - Recovery on boot: scan metastore, rebuild in-memory table.
+
+See: contracts/process_types.py for ProcessDescriptor, ProcessState.
+"""
+
+import asyncio
+import contextlib
+import json
+import logging
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import Any
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.process_types import (
+    VALID_PROCESS_TRANSITIONS,
+    ExternalProcessInfo,
+    InvalidTransitionError,
+    ProcessDescriptor,
+    ProcessError,
+    ProcessKind,
+    ProcessNotFoundError,
+    ProcessSignal,
+    ProcessState,
+)
+
+logger = logging.getLogger(__name__)
+
+# Metastore custom-metadata key for process descriptors
+PROC_DESCRIPTOR_KEY = "__proc_descriptor__"
+
+
+class ProcessTable:
+    """Manages process lifecycle — PID allocation, state machine, signals, wait().
+
+    Analogous to Linux's task_struct table + scheduler interaction.
+    In-memory dict is the hot path; metastore is the persistence layer.
+    """
+
+    def __init__(self, metastore: Any, zone_id: str = ROOT_ZONE_ID) -> None:
+        self._metastore = metastore
+        self._zone_id = zone_id
+        self._processes: dict[str, ProcessDescriptor] = {}
+        self._wait_events: dict[str, list[asyncio.Event]] = {}
+
+    # ------------------------------------------------------------------
+    # PID allocation
+    # ------------------------------------------------------------------
+
+    def _alloc_pid(self) -> str:
+        """Allocate a unique PID (UUID4 hex prefix)."""
+        return uuid.uuid4().hex[:12]
+
+    # ------------------------------------------------------------------
+    # Metastore persistence
+    # ------------------------------------------------------------------
+
+    def _proc_path(self, pid: str, zone_id: str) -> str:
+        """VFS path for process status inode."""
+        return f"/{zone_id}/proc/{pid}/status"
+
+    def _persist(self, desc: ProcessDescriptor) -> None:
+        """Write descriptor to metastore."""
+        from nexus.contracts.metadata import DT_REG, FileMetadata
+
+        path = self._proc_path(desc.pid, desc.zone_id)
+
+        # Ensure inode exists
+        existing = self._metastore.get(path)
+        if existing is None:
+            meta = FileMetadata(
+                path=path,
+                backend_name="proc",
+                physical_path=f"proc://{desc.pid}",
+                size=0,
+                entry_type=DT_REG,
+                zone_id=desc.zone_id,
+                owner_id=desc.owner_id,
+            )
+            self._metastore.put(meta)
+
+        self._metastore.set_file_metadata(path, PROC_DESCRIPTOR_KEY, desc.to_json())
+
+    def _unpersist(self, desc: ProcessDescriptor) -> None:
+        """Remove descriptor from metastore."""
+        path = self._proc_path(desc.pid, desc.zone_id)
+        self._metastore.delete(path)
+
+    # ------------------------------------------------------------------
+    # State machine
+    # ------------------------------------------------------------------
+
+    def _transition(
+        self,
+        desc: ProcessDescriptor,
+        new_state: ProcessState,
+        **kwargs: Any,
+    ) -> ProcessDescriptor:
+        """Validate and apply state transition. Returns new descriptor."""
+        allowed = VALID_PROCESS_TRANSITIONS.get(desc.state, frozenset())
+        if new_state not in allowed:
+            raise InvalidTransitionError(
+                f"cannot transition {desc.pid} from {desc.state} to {new_state}"
+            )
+        now = datetime.now(UTC)
+        updated = replace(desc, state=new_state, updated_at=now, **kwargs)
+        self._processes[desc.pid] = updated
+        self._persist(updated)
+        self._notify_waiters(desc.pid)
+        return updated
+
+    def _notify_waiters(self, pid: str) -> None:
+        """Wake all waiters for a PID."""
+        events = self._wait_events.get(pid)
+        if events:
+            for ev in events:
+                ev.set()
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+
+    def spawn(
+        self,
+        name: str,
+        owner_id: str,
+        zone_id: str,
+        *,
+        kind: ProcessKind = ProcessKind.INTERNAL,
+        parent_pid: str | None = None,
+        cwd: str = "/",
+        external_info: ExternalProcessInfo | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> ProcessDescriptor:
+        """Create a new process in CREATED state."""
+        # Validate parent
+        if parent_pid is not None:
+            parent = self._processes.get(parent_pid)
+            if parent is None:
+                raise ProcessNotFoundError(f"parent not found: {parent_pid}")
+
+        pid = self._alloc_pid()
+        now = datetime.now(UTC)
+
+        desc = ProcessDescriptor(
+            pid=pid,
+            ppid=parent_pid,
+            name=name,
+            owner_id=owner_id,
+            zone_id=zone_id,
+            kind=kind,
+            state=ProcessState.CREATED,
+            cwd=cwd,
+            external_info=external_info,
+            labels=labels or {},
+            created_at=now,
+            updated_at=now,
+        )
+
+        self._processes[pid] = desc
+        self._persist(desc)
+
+        # Update parent.children
+        if parent_pid is not None:
+            parent = self._processes[parent_pid]
+            updated_parent = replace(
+                parent,
+                children=parent.children + (pid,),
+                updated_at=now,
+            )
+            self._processes[parent_pid] = updated_parent
+            self._persist(updated_parent)
+
+        logger.debug("process spawned: pid=%s name=%s kind=%s", pid, name, kind)
+        return desc
+
+    def kill(self, pid: str, *, exit_code: int = 0) -> ProcessDescriptor:
+        """Kill a process — transition to ZOMBIE, auto-reap if orphan."""
+        desc = self._processes.get(pid)
+        if desc is None:
+            raise ProcessNotFoundError(f"process not found: {pid}")
+
+        if desc.state == ProcessState.ZOMBIE:
+            return desc  # already dead
+
+        updated = self._transition(desc, ProcessState.ZOMBIE, exit_code=exit_code)
+
+        # Auto-reap if orphan (no parent to wait())
+        if updated.ppid is None:
+            self._reap(updated)
+
+        return updated
+
+    def signal(
+        self,
+        pid: str,
+        sig: ProcessSignal,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> ProcessDescriptor:
+        """Send a signal to a process."""
+        desc = self._processes.get(pid)
+        if desc is None:
+            raise ProcessNotFoundError(f"process not found: {pid}")
+
+        match sig:
+            case ProcessSignal.SIGSTOP:
+                return self._transition(desc, ProcessState.STOPPED)
+            case ProcessSignal.SIGCONT:
+                return self._transition(desc, ProcessState.SLEEPING)
+            case ProcessSignal.SIGTERM:
+                return self.kill(pid)
+            case ProcessSignal.SIGKILL:
+                # Force kill + immediate reap regardless of parent
+                if desc.state != ProcessState.ZOMBIE:
+                    desc = self._transition(desc, ProcessState.ZOMBIE, exit_code=-9)
+                self._reap(desc)
+                return desc
+            case ProcessSignal.SIGUSR1:
+                # User-defined signal — merge payload into labels, notify waiters
+                if payload:
+                    merged = {**desc.labels, **{k: str(v) for k, v in payload.items()}}
+                    desc = replace(desc, labels=merged, updated_at=datetime.now(UTC))
+                    self._processes[pid] = desc
+                    self._persist(desc)
+                self._notify_waiters(pid)
+                return desc
+            case _:
+                raise ProcessError(f"unknown signal: {sig}")
+
+    async def wait(
+        self,
+        pid: str,
+        *,
+        target_states: frozenset[ProcessState] | None = None,
+        timeout: float | None = None,
+    ) -> ProcessDescriptor | None:
+        """Wait for process to reach target state. Reaps ZOMBIE on return."""
+        if target_states is None:
+            target_states = frozenset({ProcessState.ZOMBIE})
+
+        desc = self._processes.get(pid)
+        if desc is None:
+            raise ProcessNotFoundError(f"process not found: {pid}")
+
+        # Already in target state?
+        if desc.state in target_states:
+            if desc.state == ProcessState.ZOMBIE:
+                self._reap(desc)
+            return desc
+
+        # Create event and wait
+        event = asyncio.Event()
+        waiters = self._wait_events.setdefault(pid, [])
+        waiters.append(event)
+        try:
+            while True:
+                try:
+                    await asyncio.wait_for(event.wait(), timeout=timeout)
+                except TimeoutError:
+                    return None
+
+                desc = self._processes.get(pid)
+                if desc is None:
+                    return None  # reaped by someone else
+
+                if desc.state in target_states:
+                    if desc.state == ProcessState.ZOMBIE:
+                        self._reap(desc)
+                    return desc
+
+                # Not in target state yet — reset and wait again
+                event.clear()
+        finally:
+            waiters = self._wait_events.get(pid, [])
+            if event in waiters:
+                waiters.remove(event)
+            if not waiters:
+                self._wait_events.pop(pid, None)
+
+    def get(self, pid: str) -> ProcessDescriptor | None:
+        """Look up process by PID."""
+        return self._processes.get(pid)
+
+    def list_processes(
+        self,
+        *,
+        zone_id: str | None = None,
+        owner_id: str | None = None,
+        kind: ProcessKind | None = None,
+        state: ProcessState | None = None,
+    ) -> list[ProcessDescriptor]:
+        """List processes with optional filters."""
+        result = list(self._processes.values())
+        if zone_id is not None:
+            result = [p for p in result if p.zone_id == zone_id]
+        if owner_id is not None:
+            result = [p for p in result if p.owner_id == owner_id]
+        if kind is not None:
+            result = [p for p in result if p.kind == kind]
+        if state is not None:
+            result = [p for p in result if p.state == state]
+        return result
+
+    # ------------------------------------------------------------------
+    # External process management
+    # ------------------------------------------------------------------
+
+    def register_external(
+        self,
+        name: str,
+        owner_id: str,
+        zone_id: str,
+        *,
+        connection_id: str,
+        host_pid: int | None = None,
+        remote_addr: str | None = None,
+        protocol: str = "grpc",
+        parent_pid: str | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> ProcessDescriptor:
+        """Register an external process (gRPC agent connects)."""
+        now = datetime.now(UTC)
+        ext_info = ExternalProcessInfo(
+            connection_id=connection_id,
+            host_pid=host_pid,
+            remote_addr=remote_addr,
+            protocol=protocol,
+            last_heartbeat=now,
+        )
+        return self.spawn(
+            name,
+            owner_id,
+            zone_id,
+            kind=ProcessKind.EXTERNAL,
+            parent_pid=parent_pid,
+            external_info=ext_info,
+            labels=labels,
+        )
+
+    def heartbeat(self, pid: str) -> ProcessDescriptor:
+        """Update heartbeat timestamp for an external process."""
+        desc = self._processes.get(pid)
+        if desc is None:
+            raise ProcessNotFoundError(f"process not found: {pid}")
+        if desc.kind != ProcessKind.EXTERNAL:
+            raise ProcessError(f"heartbeat only for external processes: {pid}")
+        if desc.external_info is None:
+            raise ProcessError(f"missing external_info: {pid}")
+
+        now = datetime.now(UTC)
+        new_ext = replace(desc.external_info, last_heartbeat=now)
+        updated = replace(desc, external_info=new_ext, updated_at=now)
+        self._processes[pid] = updated
+        self._persist(updated)
+        return updated
+
+    def unregister_external(self, pid: str) -> None:
+        """Unregister an external process — ZOMBIE + reap."""
+        desc = self._processes.get(pid)
+        if desc is None:
+            raise ProcessNotFoundError(f"process not found: {pid}")
+        if desc.kind != ProcessKind.EXTERNAL:
+            raise ProcessError(f"unregister_external only for external processes: {pid}")
+
+        if desc.state != ProcessState.ZOMBIE:
+            desc = self._transition(desc, ProcessState.ZOMBIE)
+        self._reap(desc)
+
+    # ------------------------------------------------------------------
+    # Reap — remove process from table
+    # ------------------------------------------------------------------
+
+    def _reap(self, desc: ProcessDescriptor) -> None:
+        """Remove process from table and clean up parent.children."""
+        pid = desc.pid
+        self._processes.pop(pid, None)
+        self._unpersist(desc)
+        self._wait_events.pop(pid, None)
+
+        # Remove from parent's children list
+        if desc.ppid is not None:
+            parent = self._processes.get(desc.ppid)
+            if parent is not None:
+                new_children = tuple(c for c in parent.children if c != pid)
+                updated_parent = replace(
+                    parent,
+                    children=new_children,
+                    updated_at=datetime.now(UTC),
+                )
+                self._processes[desc.ppid] = updated_parent
+                self._persist(updated_parent)
+
+        logger.debug("process reaped: pid=%s name=%s", pid, desc.name)
+
+    # ------------------------------------------------------------------
+    # Recovery + shutdown
+    # ------------------------------------------------------------------
+
+    def recover(self) -> int:
+        """Recover processes from metastore on boot.
+
+        - RUNNING/SLEEPING/STOPPED/CREATED → ZOMBIE (crashed)
+        - ZOMBIE → kept as-is (waiting for wait())
+        - EXTERNAL → deleted entirely (must reconnect)
+
+        Returns number of recovered processes.
+        """
+        prefix = f"/{self._zone_id}/proc/"
+        recovered = 0
+
+        entries = self._metastore.list(prefix, recursive=True)
+        for entry in entries:
+            raw = self._metastore.get_file_metadata(entry.path, PROC_DESCRIPTOR_KEY)
+            if raw is None:
+                continue
+
+            try:
+                desc = ProcessDescriptor.from_json(raw)
+            except (json.JSONDecodeError, KeyError, ValueError) as exc:
+                logger.warning("skipping corrupt process at %s: %s", entry.path, exc)
+                continue
+
+            # External processes: clean slate on restart
+            if desc.kind == ProcessKind.EXTERNAL:
+                self._metastore.delete(entry.path)
+                logger.debug("removed stale external process: pid=%s", desc.pid)
+                continue
+
+            # Non-terminal processes: mark as crashed (ZOMBIE)
+            if desc.state != ProcessState.ZOMBIE:
+                now = datetime.now(UTC)
+                desc = replace(desc, state=ProcessState.ZOMBIE, exit_code=-1, updated_at=now)
+                self._metastore.set_file_metadata(entry.path, PROC_DESCRIPTOR_KEY, desc.to_json())
+
+            self._processes[desc.pid] = desc
+            recovered += 1
+
+        if recovered:
+            logger.info("ProcessTable recovered %d processes", recovered)
+        return recovered
+
+    def close_all(self) -> None:
+        """Shutdown: kill all processes, clear state."""
+        for pid in list(self._processes):
+            desc = self._processes.get(pid)
+            if desc is not None and desc.state != ProcessState.ZOMBIE:
+                with contextlib.suppress(ProcessError, InvalidTransitionError):
+                    self.kill(pid)
+        self._processes.clear()
+        self._wait_events.clear()
+        logger.debug("ProcessTable closed — all processes cleared")

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -498,6 +498,20 @@ def _boot_system_services(
     except Exception as exc:
         logger.warning("[BOOT:SYSTEM] PipeManager unavailable: %s", exc)
 
+    # --- ProcessTable (Issue #1509: kernel process lifecycle) ---
+    process_table: Any = None
+    try:
+        from nexus.core.process_table import ProcessTable
+
+        process_table = ProcessTable(ctx.metadata_store, zone_id=ctx.zone_id or ROOT_ZONE_ID)
+        recovered = process_table.recover()
+        if recovered > 0:
+            logger.info("[BOOT:SYSTEM] ProcessTable recovered %d processes", recovered)
+        else:
+            logger.debug("[BOOT:SYSTEM] ProcessTable created")
+    except Exception as exc:
+        logger.warning("[BOOT:SYSTEM] ProcessTable unavailable: %s", exc)
+
     # --- Agent Runtime (Agent Process Engine, AGENT-PROCESS-ARCHITECTURE) ---
     agent_runtime: Any = None
     if _on("agent_runtime") and agent_registry is not None:
@@ -532,6 +546,7 @@ def _boot_system_services(
         "permission_enforcer": permission_enforcer,
         "write_observer": write_observer,
         "pipe_manager": pipe_manager,
+        "process_table": process_table,
         # Former-kernel degradable
         "dir_visibility_cache": dir_visibility_cache,
         "hierarchy_manager": hierarchy_manager,

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -73,6 +73,7 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "brick_reconciler",
         "zone_lifecycle",
         "pipe_manager",
+        "process_table",
         "scheduler_service",
         "agent_runtime",
     }

--- a/tests/unit/core/test_kernel_config.py
+++ b/tests/unit/core/test_kernel_config.py
@@ -330,6 +330,7 @@ class TestSystemServices:
             "resiliency_manager",
             "zone_lifecycle",
             "pipe_manager",
+            "process_table",
             "scheduler_service",
         }
         assert field_names == expected_fields, (

--- a/tests/unit/core/test_process_table.py
+++ b/tests/unit/core/test_process_table.py
@@ -1,0 +1,533 @@
+"""Tests for kernel ProcessTable (Issue #1509).
+
+Uses DictMetastore (like test_pipe.py) for isolation.
+Covers: spawn, kill, signal, wait, external processes, recovery, serialization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from nexus.contracts.process_types import (
+    VALID_PROCESS_TRANSITIONS,
+    ExternalProcessInfo,
+    InvalidTransitionError,
+    ProcessDescriptor,
+    ProcessError,
+    ProcessKind,
+    ProcessNotFoundError,
+    ProcessSignal,
+    ProcessState,
+)
+from nexus.core.process_table import PROC_DESCRIPTOR_KEY, ProcessTable
+from tests.helpers.dict_metastore import DictMetastore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ZONE = "test-zone"
+OWNER = "user-1"
+
+
+def _make_table() -> ProcessTable:
+    return ProcessTable(DictMetastore(), zone_id=ZONE)
+
+
+# ---------------------------------------------------------------------------
+# Spawn / Get / List
+# ---------------------------------------------------------------------------
+
+
+class TestSpawn:
+    def test_spawn_creates_process(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("agent-1", OWNER, ZONE)
+        assert desc.name == "agent-1"
+        assert desc.owner_id == OWNER
+        assert desc.zone_id == ZONE
+        assert desc.state == ProcessState.CREATED
+        assert desc.kind == ProcessKind.INTERNAL
+        assert len(desc.pid) == 12
+
+    def test_spawn_unique_pids(self) -> None:
+        pt = _make_table()
+        pids = {pt.spawn(f"a{i}", OWNER, ZONE).pid for i in range(10)}
+        assert len(pids) == 10
+
+    def test_spawn_with_parent(self) -> None:
+        pt = _make_table()
+        parent = pt.spawn("parent", OWNER, ZONE)
+        child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
+        assert child.ppid == parent.pid
+        # Parent's children updated
+        updated_parent = pt.get(parent.pid)
+        assert updated_parent is not None
+        assert child.pid in updated_parent.children
+
+    def test_spawn_invalid_parent_raises(self) -> None:
+        pt = _make_table()
+        with pytest.raises(ProcessNotFoundError):
+            pt.spawn("child", OWNER, ZONE, parent_pid="nonexistent")
+
+    def test_spawn_with_labels(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("agent", OWNER, ZONE, labels={"model": "claude"})
+        assert desc.labels == {"model": "claude"}
+
+    def test_spawn_with_cwd(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("agent", OWNER, ZONE, cwd="/workspace")
+        assert desc.cwd == "/workspace"
+
+    def test_get_existing(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("agent", OWNER, ZONE)
+        assert pt.get(desc.pid) == desc
+
+    def test_get_nonexistent(self) -> None:
+        pt = _make_table()
+        assert pt.get("nonexistent") is None
+
+    def test_list_all(self) -> None:
+        pt = _make_table()
+        pt.spawn("a1", OWNER, ZONE)
+        pt.spawn("a2", OWNER, ZONE)
+        assert len(pt.list_processes()) == 2
+
+    def test_list_filter_zone(self) -> None:
+        pt = _make_table()
+        pt.spawn("a1", OWNER, ZONE)
+        pt.spawn("a2", OWNER, "other-zone")
+        assert len(pt.list_processes(zone_id=ZONE)) == 1
+
+    def test_list_filter_owner(self) -> None:
+        pt = _make_table()
+        pt.spawn("a1", OWNER, ZONE)
+        pt.spawn("a2", "user-2", ZONE)
+        assert len(pt.list_processes(owner_id=OWNER)) == 1
+
+    def test_list_filter_kind(self) -> None:
+        pt = _make_table()
+        pt.spawn("internal", OWNER, ZONE, kind=ProcessKind.INTERNAL)
+        pt.spawn("external", OWNER, ZONE, kind=ProcessKind.EXTERNAL)
+        assert len(pt.list_processes(kind=ProcessKind.INTERNAL)) == 1
+
+    def test_list_filter_state(self) -> None:
+        pt = _make_table()
+        pt.spawn("a1", OWNER, ZONE)
+        desc = pt.spawn("a2", OWNER, ZONE)
+        # Transition a2 to RUNNING
+        pt._transition(desc, ProcessState.RUNNING)
+        assert len(pt.list_processes(state=ProcessState.CREATED)) == 1
+        assert len(pt.list_processes(state=ProcessState.RUNNING)) == 1
+
+    def test_spawn_persists_to_metastore(self) -> None:
+        ms = DictMetastore()
+        pt = ProcessTable(ms, zone_id=ZONE)
+        desc = pt.spawn("agent", OWNER, ZONE)
+        path = f"/{ZONE}/proc/{desc.pid}/status"
+        raw = ms.get_file_metadata(path, PROC_DESCRIPTOR_KEY)
+        assert raw is not None
+        recovered = ProcessDescriptor.from_json(raw)
+        assert recovered.pid == desc.pid
+        assert recovered.name == "agent"
+
+
+# ---------------------------------------------------------------------------
+# State Transitions
+# ---------------------------------------------------------------------------
+
+
+class TestTransitions:
+    def test_created_to_running(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        updated = pt._transition(desc, ProcessState.RUNNING)
+        assert updated.state == ProcessState.RUNNING
+
+    def test_running_to_sleeping(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        updated = pt._transition(desc, ProcessState.SLEEPING)
+        assert updated.state == ProcessState.SLEEPING
+
+    def test_running_to_stopped(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        updated = pt._transition(desc, ProcessState.STOPPED)
+        assert updated.state == ProcessState.STOPPED
+
+    def test_stopped_to_sleeping(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        desc = pt._transition(desc, ProcessState.STOPPED)
+        updated = pt._transition(desc, ProcessState.SLEEPING)
+        assert updated.state == ProcessState.SLEEPING
+
+    def test_invalid_transition_raises(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        with pytest.raises(InvalidTransitionError):
+            pt._transition(desc, ProcessState.SLEEPING)  # CREATED→SLEEPING invalid
+
+    def test_zombie_is_terminal(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        desc = pt._transition(desc, ProcessState.ZOMBIE)
+        with pytest.raises(InvalidTransitionError):
+            pt._transition(desc, ProcessState.RUNNING)
+
+    def test_all_valid_transitions(self) -> None:
+        """Verify VALID_PROCESS_TRANSITIONS is comprehensive."""
+        for state in ProcessState:
+            assert state in VALID_PROCESS_TRANSITIONS
+
+
+# ---------------------------------------------------------------------------
+# Signals
+# ---------------------------------------------------------------------------
+
+
+class TestSignals:
+    def test_sigstop(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        updated = pt.signal(desc.pid, ProcessSignal.SIGSTOP)
+        assert updated.state == ProcessState.STOPPED
+
+    def test_sigcont(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        desc = pt.signal(desc.pid, ProcessSignal.SIGSTOP)
+        updated = pt.signal(desc.pid, ProcessSignal.SIGCONT)
+        assert updated.state == ProcessState.SLEEPING
+
+    def test_sigterm(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        updated = pt.signal(desc.pid, ProcessSignal.SIGTERM)
+        assert updated.state == ProcessState.ZOMBIE
+
+    def test_sigkill(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        pt.signal(desc.pid, ProcessSignal.SIGKILL)
+        # SIGKILL reaps immediately
+        assert pt.get(desc.pid) is None
+
+    def test_sigusr1_merges_payload(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE, labels={"existing": "value"})
+        updated = pt.signal(desc.pid, ProcessSignal.SIGUSR1, payload={"steering": "pause"})
+        assert updated.labels["existing"] == "value"
+        assert updated.labels["steering"] == "pause"
+
+    def test_signal_unknown_pid_raises(self) -> None:
+        pt = _make_table()
+        with pytest.raises(ProcessNotFoundError):
+            pt.signal("nonexistent", ProcessSignal.SIGTERM)
+
+
+# ---------------------------------------------------------------------------
+# Kill / Reap
+# ---------------------------------------------------------------------------
+
+
+class TestKillReap:
+    def test_kill_orphan_auto_reaps(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, ProcessState.RUNNING)
+        pt.kill(desc.pid)
+        assert pt.get(desc.pid) is None  # reaped
+
+    def test_kill_with_parent_keeps_zombie(self) -> None:
+        pt = _make_table()
+        parent = pt.spawn("parent", OWNER, ZONE)
+        child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
+        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
+        pt.kill(child.pid)
+        # Not reaped — parent can wait()
+        zombie = pt.get(child.pid)
+        assert zombie is not None
+        assert zombie.state == ProcessState.ZOMBIE
+
+    def test_kill_nonexistent_raises(self) -> None:
+        pt = _make_table()
+        with pytest.raises(ProcessNotFoundError):
+            pt.kill("nonexistent")
+
+    def test_kill_already_zombie(self) -> None:
+        pt = _make_table()
+        parent = pt.spawn("parent", OWNER, ZONE)
+        child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
+        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
+        pt.kill(child.pid)
+        # Kill again — should be idempotent
+        result = pt.kill(child.pid)
+        assert result.state == ProcessState.ZOMBIE
+
+    def test_reap_removes_from_parent_children(self) -> None:
+        pt = _make_table()
+        parent = pt.spawn("parent", OWNER, ZONE)
+        child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
+        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
+        # SIGKILL forces immediate reap
+        pt.signal(child.pid, ProcessSignal.SIGKILL)
+        updated_parent = pt.get(parent.pid)
+        assert updated_parent is not None
+        assert child.pid not in updated_parent.children
+
+
+# ---------------------------------------------------------------------------
+# Wait (async)
+# ---------------------------------------------------------------------------
+
+
+class TestWait:
+    @pytest.mark.asyncio
+    async def test_wait_already_zombie(self) -> None:
+        pt = _make_table()
+        parent = pt.spawn("parent", OWNER, ZONE)
+        child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
+        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
+        pt.kill(child.pid)  # ZOMBIE (not reaped — has parent)
+        result = await pt.wait(child.pid)
+        assert result is not None
+        assert result.state == ProcessState.ZOMBIE
+
+    @pytest.mark.asyncio
+    async def test_wait_blocks_until_state_change(self) -> None:
+        pt = _make_table()
+        parent = pt.spawn("parent", OWNER, ZONE)
+        child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
+        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
+
+        async def _killer() -> None:
+            await asyncio.sleep(0.05)
+            pt.kill(child.pid)
+
+        task = asyncio.create_task(_killer())
+        result = await pt.wait(child.pid, timeout=2.0)
+        assert result is not None
+        assert result.state == ProcessState.ZOMBIE
+        await task
+
+    @pytest.mark.asyncio
+    async def test_wait_timeout(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        result = await pt.wait(desc.pid, timeout=0.05)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_wait_nonexistent_raises(self) -> None:
+        pt = _make_table()
+        with pytest.raises(ProcessNotFoundError):
+            await pt.wait("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_wait_custom_target_states(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        pt._transition(desc, ProcessState.RUNNING)
+
+        async def _stopper() -> None:
+            await asyncio.sleep(0.05)
+            pt.signal(desc.pid, ProcessSignal.SIGSTOP)
+
+        task = asyncio.create_task(_stopper())
+        result = await pt.wait(
+            desc.pid,
+            target_states=frozenset({ProcessState.STOPPED}),
+            timeout=2.0,
+        )
+        assert result is not None
+        assert result.state == ProcessState.STOPPED
+        await task
+
+    @pytest.mark.asyncio
+    async def test_multiple_waiters(self) -> None:
+        pt = _make_table()
+        parent = pt.spawn("parent", OWNER, ZONE)
+        child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
+        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
+
+        results: list[ProcessDescriptor | None] = []
+
+        async def _waiter() -> None:
+            r = await pt.wait(child.pid, timeout=2.0)
+            results.append(r)
+
+        t1 = asyncio.create_task(_waiter())
+        t2 = asyncio.create_task(_waiter())
+        await asyncio.sleep(0.05)
+        pt.kill(child.pid)
+        await asyncio.gather(t1, t2)
+        # At least one waiter gets the result (the other may get None
+        # if the process was already reaped)
+        assert any(r is not None for r in results)
+
+
+# ---------------------------------------------------------------------------
+# External Processes
+# ---------------------------------------------------------------------------
+
+
+class TestExternalProcesses:
+    def test_register_external(self) -> None:
+        pt = _make_table()
+        desc = pt.register_external(
+            "claude-code",
+            OWNER,
+            ZONE,
+            connection_id="conn-1",
+            host_pid=12345,
+            remote_addr="127.0.0.1:50051",
+        )
+        assert desc.kind == ProcessKind.EXTERNAL
+        assert desc.external_info is not None
+        assert desc.external_info.connection_id == "conn-1"
+        assert desc.external_info.host_pid == 12345
+
+    def test_heartbeat(self) -> None:
+        pt = _make_table()
+        desc = pt.register_external("agent", OWNER, ZONE, connection_id="c1")
+        before = desc.external_info.last_heartbeat
+        updated = pt.heartbeat(desc.pid)
+        assert updated.external_info.last_heartbeat >= before
+
+    def test_heartbeat_on_internal_raises(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("internal", OWNER, ZONE)
+        with pytest.raises(ProcessError, match="heartbeat only for external"):
+            pt.heartbeat(desc.pid)
+
+    def test_unregister_external(self) -> None:
+        pt = _make_table()
+        desc = pt.register_external("agent", OWNER, ZONE, connection_id="c1")
+        pt._transition(pt.get(desc.pid), ProcessState.RUNNING)
+        pt.unregister_external(desc.pid)
+        assert pt.get(desc.pid) is None  # reaped
+
+
+# ---------------------------------------------------------------------------
+# Recovery
+# ---------------------------------------------------------------------------
+
+
+class TestRecovery:
+    def test_recover_running_becomes_zombie(self) -> None:
+        ms = DictMetastore()
+        pt = ProcessTable(ms, zone_id=ZONE)
+        desc = pt.spawn("a", OWNER, ZONE)
+        pt._transition(desc, ProcessState.RUNNING)
+
+        # New ProcessTable on same metastore
+        pt2 = ProcessTable(ms, zone_id=ZONE)
+        recovered = pt2.recover()
+        assert recovered == 1
+        result = pt2.get(desc.pid)
+        assert result is not None
+        assert result.state == ProcessState.ZOMBIE
+
+    def test_recover_external_deleted(self) -> None:
+        ms = DictMetastore()
+        pt = ProcessTable(ms, zone_id=ZONE)
+        desc = pt.register_external("ext", OWNER, ZONE, connection_id="c1")
+
+        pt2 = ProcessTable(ms, zone_id=ZONE)
+        recovered = pt2.recover()
+        assert recovered == 0
+        assert pt2.get(desc.pid) is None
+
+    def test_recover_zombie_kept(self) -> None:
+        ms = DictMetastore()
+        pt = ProcessTable(ms, zone_id=ZONE)
+        parent = pt.spawn("parent", OWNER, ZONE)
+        child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
+        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
+        pt.kill(child.pid)  # ZOMBIE
+
+        pt2 = ProcessTable(ms, zone_id=ZONE)
+        recovered = pt2.recover()
+        # Both parent (now ZOMBIE from crash) and child (already ZOMBIE)
+        assert recovered >= 1
+
+    def test_close_all(self) -> None:
+        pt = _make_table()
+        pt.spawn("a", OWNER, ZONE)
+        desc = pt.spawn("b", OWNER, ZONE)
+        pt._transition(desc, ProcessState.RUNNING)
+        pt.close_all()
+        assert len(pt.list_processes()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_roundtrip(self) -> None:
+        now = datetime.now(UTC)
+        desc = ProcessDescriptor(
+            pid="abc123",
+            ppid=None,
+            name="test",
+            owner_id=OWNER,
+            zone_id=ZONE,
+            kind=ProcessKind.INTERNAL,
+            state=ProcessState.RUNNING,
+            exit_code=None,
+            cwd="/workspace",
+            children=("child1", "child2"),
+            created_at=now,
+            updated_at=now,
+            labels={"key": "value"},
+        )
+        json_str = desc.to_json()
+        recovered = ProcessDescriptor.from_json(json_str)
+        assert recovered.pid == desc.pid
+        assert recovered.name == desc.name
+        assert recovered.state == desc.state
+        assert recovered.children == desc.children
+        assert recovered.labels == desc.labels
+
+    def test_roundtrip_with_external_info(self) -> None:
+        now = datetime.now(UTC)
+        desc = ProcessDescriptor(
+            pid="ext123",
+            ppid=None,
+            name="external",
+            owner_id=OWNER,
+            zone_id=ZONE,
+            kind=ProcessKind.EXTERNAL,
+            state=ProcessState.CREATED,
+            created_at=now,
+            updated_at=now,
+            external_info=ExternalProcessInfo(
+                connection_id="conn-1",
+                host_pid=9999,
+                remote_addr="10.0.0.1:50051",
+                protocol="grpc",
+                last_heartbeat=now,
+            ),
+        )
+        json_str = desc.to_json()
+        recovered = ProcessDescriptor.from_json(json_str)
+        assert recovered.external_info is not None
+        assert recovered.external_info.connection_id == "conn-1"
+        assert recovered.external_info.host_pid == 9999

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -185,6 +185,8 @@ class TestBootSystemServices:
             "zone_lifecycle",
             # DT_PIPE manager (Issue #809)
             "pipe_manager",
+            # Process lifecycle (Issue #1509)
+            "process_table",
             "scheduler_service",
             # Agent Runtime (AGENT-PROCESS-ARCHITECTURE)
             "agent_runtime",


### PR DESCRIPTION
## Summary
- Add kernel-level **ProcessTable** for generic process lifecycle (spawn/kill/wait/signal) supporting both internal agents (async coroutines) and external agents (OS processes via gRPC)
- Follows PipeManager pattern: DI with MetastoreABC, in-memory hot state, metastore persistence, degradable boot
- State machine: CREATED → RUNNING → SLEEPING → STOPPED → ZOMBIE with validated transitions
- POSIX-like signals: SIGTERM, SIGSTOP, SIGCONT, SIGKILL, SIGUSR1 (labels merge)

## New files
| File | Description |
|------|-------------|
| `contracts/process_types.py` | ProcessState, ProcessSignal, ProcessKind, ProcessDescriptor, ExternalProcessInfo |
| `contracts/protocols/process_table.py` | ProcessTableProtocol (kernel contract) |
| `core/process_table.py` | ProcessTable implementation (47 tests) |
| `tests/unit/core/test_process_table.py` | Spawn, kill, signal, wait, external, recovery, serialization |

## Modified files
| File | Change |
|------|--------|
| `core/config.py` | Add `process_table` field to SystemServices |
| `factory/_system.py` | Wire ProcessTable boot (degradable) |
| `core/nexus_fs.py` | Wire `_process_table` + `close_all()` in close() |
| `tests/unit/core/test_factory_boot.py` | Add `process_table` to expected keys |
| `tests/unit/core/test_kernel_config.py` | Add `process_table` to expected fields |

## Test plan
- [x] 47 ProcessTable unit tests pass
- [x] test_factory_boot.py passes
- [x] test_kernel_config.py passes
- [x] ruff lint clean
- [x] mypy clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)