### PR TITLE
fix: address 18 codex audit findings across auth, scheduling, and runtime

### DIFF
--- a/src/nexus/bricks/rebac/namespace_manager.py
+++ b/src/nexus/bricks/rebac/namespace_manager.py
@@ -416,6 +416,55 @@ class NamespaceManager:
                 for k in keys_to_remove:
                     self._dcache_negative.pop(k, None)
 
+    def update_mount_table(
+        self,
+        subject: tuple[str, str],
+        mount_entries: list[MountEntry],
+        zone_id: str | None = None,
+    ) -> None:
+        """Replace a subject's cached mount table with the given entries.
+
+        Used by ``AgentNamespaceForkService.merge()`` to apply the merged
+        mount table back to the live namespace without a full ReBAC rebuild.
+
+        Invalidates dcache for the subject to ensure subsequent visibility
+        checks use the updated mount table.
+
+        Args:
+            subject: (subject_type, subject_id) tuple.
+            mount_entries: Sorted list of MountEntry to install.
+            zone_id: Zone ID for multi-zone isolation.
+        """
+        mount_paths = [m.virtual_path for m in mount_entries]
+
+        # Compute grants_hash from mount_paths (deterministic)
+        sorted_paths = sorted(f"file:{p}" for p in mount_paths)
+        grants_hash = hashlib.sha256("|".join(sorted_paths).encode()).hexdigest()[:16]
+
+        try:
+            current_revision = self._rebac_manager.get_zone_revision(zone_id)
+        except Exception:
+            current_revision = 0
+
+        with self._lock:
+            self._cache[subject] = (
+                mount_entries,
+                mount_paths,
+                current_revision,
+                zone_id,
+                grants_hash,
+            )
+
+        # Invalidate dcache so visibility checks pick up the new mount table
+        self.invalidate_dcache(subject)
+
+        logger.debug(
+            "[NAMESPACE] Updated mount table for %s:%s: %d mounts",
+            subject[0],
+            subject[1],
+            len(mount_entries),
+        )
+
     def invalidate(self, subject: tuple[str, str]) -> None:
         """Explicitly invalidate a subject's cached mount table, dcache, and L3 entries.
 

--- a/src/nexus/core/protocols/vfs_router.py
+++ b/src/nexus/core/protocols/vfs_router.py
@@ -42,18 +42,24 @@ class MountInfo:
     """Describes a registered mount point.
 
     Returned by ``list_mounts()`` — carries mount-level metadata without
-    exposing the backend object or route-resolution details.
+    exposing route-resolution details.
 
     Attributes:
         mount_point: Virtual path prefix (e.g. "/workspace").
         readonly: Whether the mount is read-only.
         admin_only: Whether the mount requires admin privileges.
+        backend: The storage backend instance (ObjectStoreABC), if available.
+        priority: Mount priority for ordering (higher = checked first).
+        conflict_strategy: Write-back conflict resolution strategy, or None.
     """
 
     mount_point: str
     readonly: bool
     admin_only: bool = False
     status: str = "active"  # "active" or "stale"
+    backend: "ObjectStoreABC | None" = None
+    priority: int = 0
+    conflict_strategy: str | None = None
 
 
 @runtime_checkable

--- a/src/nexus/core/router.py
+++ b/src/nexus/core/router.py
@@ -249,6 +249,7 @@ class PathRouter:
                 mount_point=normalized,
                 readonly=entry.readonly,
                 admin_only=entry.admin_only,
+                backend=entry.backend,
             )
         except ValueError:
             return None
@@ -282,7 +283,12 @@ class PathRouter:
 
         active_mps: set[str] = set(self._backends.keys())
         result: list[MountInfo] = [
-            MountInfo(mount_point=mp, readonly=entry.readonly, admin_only=entry.admin_only)
+            MountInfo(
+                mount_point=mp,
+                readonly=entry.readonly,
+                admin_only=entry.admin_only,
+                backend=entry.backend,
+            )
             for mp, entry in sorted(self._backends.items())
         ]
 

--- a/src/nexus/system_services/agent_runtime/loop.py
+++ b/src/nexus/system_services/agent_runtime/loop.py
@@ -195,7 +195,51 @@ def _trim_to_budget(
                 lo = mid + 1  # need to drop more
         except Exception:
             return candidate
+    # Align trim point to respect tool-call / tool-result boundaries.
+    # A tool-call group is: ASSISTANT(tool_calls) followed by one or more TOOL
+    # messages.  Splitting inside a group produces orphaned messages that
+    # cause LLM API errors.
+    best = _align_trim_boundary(messages, best)
+
     return [system_msg, *messages[best:]]
+
+
+def _align_trim_boundary(messages: list[Message], idx: int) -> int:
+    """Adjust *idx* so the kept slice ``messages[idx:]`` never splits a
+    tool-call / tool-result group.
+
+    Rules
+    -----
+    * If ``messages[idx]`` is a TOOL message, move *idx* backwards to include
+      the preceding ASSISTANT message that owns the tool call.
+    * If ``messages[idx]`` is an ASSISTANT message **with** ``tool_calls``,
+      verify that all its TOOL results are present after it.  If not (i.e.
+      we are at the very end and some results were trimmed from the *right*,
+      which shouldn't happen in practice), skip past the group.
+    """
+    if idx <= 0 or idx >= len(messages):
+        return idx
+
+    # Case 1: trim point lands on a TOOL result — walk back to include
+    # the ASSISTANT message that started this group.
+    if messages[idx].role == MessageRole.TOOL:
+        while idx > 0 and messages[idx].role == MessageRole.TOOL:
+            idx -= 1
+        # idx now points at the ASSISTANT message (or another non-TOOL msg)
+        return idx
+
+    # Case 2: trim point lands on an ASSISTANT message with tool_calls but
+    # the following TOOL results would be cut.  This can't happen with our
+    # binary search (we keep messages[idx:] i.e. everything *after* idx),
+    # but guard defensively: if the next message is missing or isn't a TOOL,
+    # skip past this incomplete group.
+    msg = messages[idx]
+    has_tool_calls = msg.role == MessageRole.ASSISTANT and getattr(msg, "tool_calls", None)
+    if has_tool_calls and (idx + 1 >= len(messages) or messages[idx + 1].role != MessageRole.TOOL):
+        # Skip past this lonely assistant tool-call message
+        return idx + 1
+
+    return idx
 
 
 def _extract_tool_calls(response: object) -> list[ToolCall]:

--- a/src/nexus/system_services/agent_runtime/process_manager.py
+++ b/src/nexus/system_services/agent_runtime/process_manager.py
@@ -69,6 +69,7 @@ class ProcessManager:
         self._session_store = SessionStore(vfs)
         self._processes: dict[str, AgentProcess] = {}
         self._dispatchers: dict[str, ToolDispatcher] = {}  # cached per process
+        self._tasks: dict[str, asyncio.Task[None]] = {}  # running loop tasks per PID
 
     # ------------------------------------------------------------------
     # spawn
@@ -188,6 +189,10 @@ class ProcessManager:
             yield Error(error=f"Process not found: {pid}")
             return
 
+        if process.state == AgentProcessState.RUNNING:
+            yield Error(error=f"Process {pid} is already running")
+            return
+
         config = process.config
         if config is None:
             yield Error(error=f"Process {pid} has no config")
@@ -277,6 +282,7 @@ class ProcessManager:
                     on_event=_on_event,
                     on_checkpoint=_on_checkpoint,
                     cwd=agent_cwd,
+                    sandbox_id=config.sandbox_id,
                 )
                 # Final save (captures the last assistant message / Completed)
                 await self._session_store.save(pid, result_messages, ctx, cwd=agent_cwd)
@@ -285,9 +291,11 @@ class ProcessManager:
                 logger.error(error_msg)
                 await queue.put(Error(error=error_msg))
             finally:
+                self._tasks.pop(pid, None)
                 await queue.put(None)  # sentinel
 
         task = asyncio.create_task(_run_loop())
+        self._tasks[pid] = task
         try:
             while True:
                 event = await queue.get()
@@ -299,6 +307,7 @@ class ProcessManager:
                 task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+            self._tasks.pop(pid, None)
             # Transition to SLEEPING
             process = replace(process, state=AgentProcessState.SLEEPING)
             self._processes[pid] = process
@@ -331,6 +340,11 @@ class ProcessManager:
         if process is None:
             logger.warning("Cannot terminate unknown process: %s", pid)
             return
+
+        # Cancel running loop task if any
+        task = self._tasks.pop(pid, None)
+        if task is not None and not task.done():
+            task.cancel()
 
         # Transition to ZOMBIE
         process = replace(process, state=AgentProcessState.ZOMBIE)
@@ -373,6 +387,9 @@ class ProcessManager:
 
         match sig:
             case AgentSignal.SIGSTOP:
+                task = self._tasks.pop(pid, None)
+                if task is not None and not task.done():
+                    task.cancel()
                 process = replace(process, state=AgentProcessState.STOPPED)
                 self._processes[pid] = process
                 logger.info("Process stopped: pid=%s", pid)
@@ -387,6 +404,9 @@ class ProcessManager:
 
             case AgentSignal.SIGKILL:
                 # Immediate removal, no cleanup
+                task = self._tasks.pop(pid, None)
+                if task is not None and not task.done():
+                    task.cancel()
                 self._processes.pop(pid, None)
                 logger.info("Process killed: pid=%s", pid)
 

--- a/src/nexus/system_services/agent_runtime/types.py
+++ b/src/nexus/system_services/agent_runtime/types.py
@@ -114,6 +114,9 @@ class AgentProcessConfig:
     qos_class: QoSClass = QoSClass.STANDARD
     priority: int = 0
 
+    # Sandbox
+    sandbox_id: str | None = None
+
     # Filesystem
     cwd: str | None = None
     mount_paths: tuple[str, ...] = ()

--- a/src/nexus/system_services/agents/agent_rpc_service.py
+++ b/src/nexus/system_services/agents/agent_rpc_service.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import NexusPermissionError
 from nexus.contracts.rpc import rpc_expose
 from nexus.contracts.types import VFSOperations, parse_operation_context
 
@@ -644,6 +645,15 @@ class AgentRPCService:
     @rpc_expose(description="Delete an agent")
     def delete_agent(self, agent_id: str, _context: dict | None = None) -> bool:
         """Delete a registered agent."""
+        # Ownership check: caller must own the agent or be admin
+        ctx = parse_operation_context(_context)
+        if "," in agent_id:
+            owner_user_id = agent_id.split(",", 1)[0]
+            if ctx.user_id and ctx.user_id != owner_user_id and not ctx.is_admin:
+                raise NexusPermissionError(
+                    f"Permission denied: only the agent owner or an admin can delete agent {agent_id}"
+                )
+
         try:
             if "," in agent_id:
                 user_id, agent_name_part = agent_id.split(",", 1)

--- a/src/nexus/system_services/agents/agent_service.py
+++ b/src/nexus/system_services/agents/agent_service.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import NexusPermissionError
 from nexus.contracts.types import OperationContext
 from nexus.lib.rpc_decorator import rpc_expose
 
@@ -692,7 +693,10 @@ class AgentService:
                 try:
                     if "," in e.entity_id:
                         user_id, agent_name = e.entity_id.split(",", 1)
-                        config_path = f"/zone/default/user/{user_id}/agent/{agent_name}/config.yaml"
+                        zone_id = _extract_zone_id(_context) or ROOT_ZONE_ID
+                        config_path = (
+                            f"/zone/{zone_id}/user/{user_id}/agent/{agent_name}/config.yaml"
+                        )
                         try:
                             config_content = self._fs.sys_read(
                                 config_path, context=_parse_context(_context)
@@ -831,6 +835,15 @@ class AgentService:
     @rpc_expose(description="Delete an agent")
     def delete_agent(self, agent_id: str, _context: dict | None = None) -> bool:
         """Delete a registered agent (v0.5.0)."""
+        # Ownership check: caller must own the agent or be admin
+        ctx = _parse_context(_context)
+        if "," in agent_id:
+            owner_user_id = agent_id.split(",", 1)[0]
+            if ctx.user_id and ctx.user_id != owner_user_id and not ctx.is_admin:
+                raise NexusPermissionError(
+                    f"Permission denied: only the agent owner or an admin can delete agent {agent_id}"
+                )
+
         try:
             if "," in agent_id:
                 user_id, agent_name_part = agent_id.split(",", 1)

--- a/src/nexus/system_services/agents/eviction_manager.py
+++ b/src/nexus/system_services/agents/eviction_manager.py
@@ -164,7 +164,7 @@ class EvictionManager:
                     connected_count,
                     self._tuning.max_active_agents,
                 )
-            elif requesting_qos is not None:
+            elif requesting_qos is not None and connected_count >= self._tuning.max_active_agents:
                 # Preemption trigger: at cap, premium needs slot
                 over_cap = True
                 logger.info(

--- a/src/nexus/system_services/gateway.py
+++ b/src/nexus/system_services/gateway.py
@@ -506,6 +506,8 @@ class NexusFSGateway:
         """Get mount info and backend-relative path for a virtual path.
 
         Used by WriteBackService to resolve which backend to write back to.
+        Mounts are checked longest-prefix-first so that more-specific mounts
+        (e.g. ``/mnt/foo``) match before less-specific ones (e.g. ``/``).
 
         Args:
             path: Virtual file path
@@ -514,7 +516,9 @@ class NexusFSGateway:
             Dict with mount_point, backend, backend_path, readonly keys,
             or None if no mount matches.
         """
-        for mount in self.router.list_mounts():
+        # Sort by mount_point length descending so longest prefix matches first
+        mounts = sorted(self.router.list_mounts(), key=lambda m: len(m.mount_point), reverse=True)
+        for mount in mounts:
             mp = mount.mount_point
             if path == mp or path.startswith(mp + "/") or mp == "/":
                 # Strip mount prefix to get backend-relative path

--- a/src/nexus/system_services/lifecycle/user_provisioning.py
+++ b/src/nexus/system_services/lifecycle/user_provisioning.py
@@ -67,7 +67,7 @@ class UserProvisioningService:
     # Public RPC Methods
     # ------------------------------------------------------------------
 
-    @rpc_expose(description="Provision a new user account with all resources")
+    @rpc_expose(description="Provision a new user account with all resources", admin_only=True)
     def provision_user(
         self,
         user_id: str,
@@ -309,7 +309,7 @@ class UserProvisioningService:
             "created_resources": created_resources,
         }
 
-    @rpc_expose(description="Deprovision a user and remove all their resources")
+    @rpc_expose(description="Deprovision a user and remove all their resources", admin_only=True)
     def deprovision_user(
         self,
         user_id: str,

--- a/src/nexus/system_services/namespace/descendant_access.py
+++ b/src/nexus/system_services/namespace/descendant_access.py
@@ -162,7 +162,7 @@ class DescendantAccessChecker:
             subject=subject_tuple,
             permission=rebac_permission,
             object=("file", path),
-            zone_id=context.zone_id,
+            zone_id=zone_id,
         )
         if direct_access:
             # Cache this positive result
@@ -241,9 +241,7 @@ class DescendantAccessChecker:
 
             try:
                 # Perform bulk permission check
-                results = self._rebac_manager.rebac_check_bulk(
-                    checks, zone_id=context.zone_id or ROOT_ZONE_ID
-                )
+                results = self._rebac_manager.rebac_check_bulk(checks, zone_id=zone_id)
 
                 # OPTIMIZATION 5: Early exit on first accessible descendant
                 for check in checks:
@@ -286,7 +284,7 @@ class DescendantAccessChecker:
                 subject=subject_tuple,
                 permission=rebac_permission,
                 object=("file", meta.path),
-                zone_id=context.zone_id,
+                zone_id=zone_id,
             )
             if descendant_access:
                 # Found accessible descendant! User can see this parent

--- a/src/nexus/system_services/namespace/namespace_fork_service.py
+++ b/src/nexus/system_services/namespace/namespace_fork_service.py
@@ -192,6 +192,16 @@ class AgentNamespaceForkService:
             for k in conflict_keys
         )
 
+        # Apply merged mount table back to the live namespace.
+        # For each merged key, prefer the fork's entry (left), fall back to parent (right).
+        merged_entries = [left.get(k) or right.get(k) for k in sorted(merged_str)]
+        merged_mount_entries = [e for e in merged_entries if e is not None]
+        self._namespace_manager.update_mount_table(
+            ("agent", ns.agent_id),
+            merged_mount_entries,
+            zone_id=ns.zone_id,
+        )
+
         # Clean up fork
         with self._lock:
             self._forks.pop(fork_id, None)

--- a/src/nexus/system_services/scheduler/queue.py
+++ b/src/nexus/system_services/scheduler/queue.py
@@ -4,7 +4,7 @@ Uses SELECT ... FOR UPDATE SKIP LOCKED for concurrent, safe dequeue.
 Tasks are ordered by (effective_tier ASC, enqueued_at ASC) for
 strict priority ordering with FIFO within each tier.
 
-HRRN dequeue (Issue #1274) orders by priority_class ASC,
+HRRN dequeue (Issue #1274) orders by priority_class DESC,
 inline HRRN score DESC, enqueued_at ASC for Astraea-style scheduling.
 
 Related: Issue #1212, #1274
@@ -47,7 +47,18 @@ INSERT INTO scheduled_tasks (
     zone_id, idempotency_key,
     request_state, priority_class, estimated_service_time
 ) VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-ON CONFLICT (idempotency_key) DO UPDATE SET agent_id = EXCLUDED.agent_id
+ON CONFLICT (idempotency_key) DO UPDATE SET
+    agent_id = EXCLUDED.agent_id,
+    payload = EXCLUDED.payload,
+    deadline = EXCLUDED.deadline,
+    priority_tier = EXCLUDED.priority_tier,
+    effective_tier = EXCLUDED.effective_tier,
+    boost_amount = EXCLUDED.boost_amount,
+    boost_tiers = EXCLUDED.boost_tiers,
+    boost_reservation_id = EXCLUDED.boost_reservation_id,
+    request_state = EXCLUDED.request_state,
+    priority_class = EXCLUDED.priority_class,
+    estimated_service_time = EXCLUDED.estimated_service_time
 RETURNING id::text
 """
 
@@ -124,7 +135,7 @@ WHERE id = (
       AND (deadline IS NULL OR deadline <= now())
       AND executor_state IN ('CONNECTED', 'IDLE', 'UNKNOWN')
     ORDER BY
-        priority_class ASC,
+        priority_class DESC,
         (EXTRACT(EPOCH FROM (now() - enqueued_at)) + estimated_service_time)
             / GREATEST(estimated_service_time, 0.001) DESC,
         enqueued_at ASC
@@ -143,7 +154,7 @@ WHERE id = (
       AND (deadline IS NULL OR deadline <= now())
       AND executor_state IN ('CONNECTED', 'IDLE', 'UNKNOWN')
     ORDER BY
-        priority_class ASC,
+        priority_class DESC,
         (EXTRACT(EPOCH FROM (now() - enqueued_at)) + estimated_service_time)
             / GREATEST(estimated_service_time, 0.001) DESC,
         enqueued_at ASC
@@ -424,7 +435,7 @@ class TaskQueue:
     ) -> ScheduledTask | None:
         """Dequeue using HRRN scoring within priority classes (Astraea).
 
-        Orders by: priority_class ASC, HRRN score DESC, enqueued_at ASC.
+        Orders by: priority_class DESC, HRRN score DESC, enqueued_at ASC.
         Filters out tasks whose executor is SUSPENDED.
 
         Args:

--- a/src/nexus/system_services/sync/write_back_service.py
+++ b/src/nexus/system_services/sync/write_back_service.py
@@ -293,6 +293,8 @@ class WriteBackService:
             await self._handle_write(entry, backend, backend_path, mount_info)
         elif entry.operation_type == "delete":
             await self._handle_delete(backend, backend_path)
+        elif entry.operation_type == "rename":
+            await self._handle_rename(entry, backend, backend_path)
         elif entry.operation_type == "mkdir":
             await self._handle_mkdir(backend, backend_path)
         else:
@@ -526,6 +528,51 @@ class WriteBackService:
         else:
             # delete_content raises on error, returns None on success
             await asyncio.to_thread(backend.delete_content, backend_path, ctx)
+
+    async def _handle_rename(
+        self,
+        entry: "SyncBacklogEntry",
+        backend: Any,
+        backend_path: str,
+    ) -> None:
+        """Handle rename/move of a file on the backend.
+
+        entry.path is the new (current) path; entry.new_path stores the old path.
+        Tries backend.rename() or rename_file() first, falling back to
+        delete-old + write-new.
+
+        Args:
+            entry: Backlog entry with path (new) and new_path (old)
+            backend: Backend instance
+            backend_path: Backend-relative new path
+        """
+        old_virtual_path = entry.new_path
+        if old_virtual_path is None:
+            raise RuntimeError(f"Rename entry missing old path for {entry.path}")
+
+        # Resolve old path to backend-relative path
+        old_mount_info = self._gw.get_mount_for_path(old_virtual_path)
+        if old_mount_info is None:
+            raise RuntimeError(f"No mount found for old path: {old_virtual_path}")
+        old_backend_path = old_mount_info["backend_path"]
+
+        ctx = dataclasses.replace(self._system_ctx, backend_path=backend_path)
+
+        # Prefer native rename if available
+        if hasattr(backend, "rename"):
+            result = await asyncio.to_thread(backend.rename, old_backend_path, backend_path, ctx)
+            if hasattr(result, "success") and not result.success:
+                raise RuntimeError(f"Backend rename failed: {getattr(result, 'error', 'unknown')}")
+        elif hasattr(backend, "rename_file"):
+            await asyncio.to_thread(backend.rename_file, old_backend_path, backend_path, ctx)
+        else:
+            # Fallback: delete old path, write new content
+            await self._handle_delete(backend, old_backend_path)
+            content = self._read_nexus_content(entry.path)
+            if content is None:
+                raise RuntimeError(f"Failed to read content for rename of {entry.path}")
+            op_ctx = dataclasses.replace(self._system_ctx, backend_path=backend_path)
+            await asyncio.to_thread(backend.write_content, content, op_ctx)
 
     async def _handle_mkdir(self, backend: Any, backend_path: str) -> None:
         """Handle directory creation on the backend."""

--- a/src/nexus/system_services/workspace/workspace_rpc_service.py
+++ b/src/nexus/system_services/workspace/workspace_rpc_service.py
@@ -197,7 +197,7 @@ class WorkspaceRPCService:
     def snapshot_begin(
         self,
         agent_id: str | None = None,
-        zone_id: str = ROOT_ZONE_ID,
+        zone_id: str | None = None,
         description: str | None = None,
         ttl_seconds: int = 3600,
         context: OperationContext | None = None,
@@ -207,11 +207,12 @@ class WorkspaceRPCService:
             raise RuntimeError("Transactional snapshot service not available")
         ctx = context or self._default_ctx
         resolved_agent = agent_id or ctx.agent_id or "default"
+        resolved_zone = zone_id or (ctx.zone_id if ctx else None) or ROOT_ZONE_ID
         import asyncio
 
-        info = asyncio.get_event_loop().run_until_complete(
+        info = asyncio.run(
             self._snapshot_service.begin(
-                zone_id=zone_id,
+                zone_id=resolved_zone,
                 agent_id=resolved_agent,
                 description=description,
                 ttl_seconds=ttl_seconds,
@@ -230,7 +231,7 @@ class WorkspaceRPCService:
             raise RuntimeError("Transactional snapshot service not available")
         import asyncio
 
-        asyncio.get_event_loop().run_until_complete(self._snapshot_service.commit(snapshot_id))
+        asyncio.run(self._snapshot_service.commit(snapshot_id))
         return {"status": "committed", "snapshot_id": snapshot_id}
 
     @rpc_expose(description="Rollback transactional snapshot")
@@ -244,9 +245,7 @@ class WorkspaceRPCService:
             raise RuntimeError("Transactional snapshot service not available")
         import asyncio
 
-        info = asyncio.get_event_loop().run_until_complete(
-            self._snapshot_service.rollback(snapshot_id)
-        )
+        info = asyncio.run(self._snapshot_service.rollback(snapshot_id))
         return {
             "snapshot_id": info.snapshot_id,
             "status": info.status,

--- a/tests/unit/core/protocols/test_vfs_router.py
+++ b/tests/unit/core/protocols/test_vfs_router.py
@@ -64,7 +64,15 @@ class TestMountInfo:
 
     def test_fields(self) -> None:
         fields = {f.name for f in dataclasses.fields(MountInfo)}
-        assert fields == {"mount_point", "readonly", "admin_only", "status"}
+        assert fields == {
+            "mount_point",
+            "readonly",
+            "admin_only",
+            "status",
+            "backend",
+            "priority",
+            "conflict_strategy",
+        }
 
     def test_equality(self) -> None:
         assert MountInfo("/ws", False) == MountInfo("/ws", False)


### PR DESCRIPTION
## Summary

Fixes 18 valid findings from codex security/correctness audit across 16 files.

### Security (HIGH) — 3 fixes
- **agent_service.py, agent_rpc_service.py**: `delete_agent()` now verifies caller owns the agent or is admin before proceeding
- **user_provisioning.py**: `provision_user()` and `deprovision_user()` now require `admin_only=True` via `@rpc_expose` decorator

### Correctness (HIGH) — 9 fixes
- **namespace_fork_service.py + namespace_manager.py**: `merge()` now applies merged mount table back to live namespace via new `update_mount_table()` instead of silently discarding changes
- **vfs_router.py, router.py**: Added `backend`, `priority`, `conflict_strategy` fields to `MountInfo` to match gateway.py expectations (was `AttributeError` at runtime)
- **gateway.py**: Sort mounts longest-prefix-first so `/mnt/foo` matches before `/`
- **process_manager.py, types.py**: Pass `sandbox_id` to `agent_loop()` (bash/python tools were broken); store loop tasks for signal cancellation (SIGSTOP/SIGTERM were no-ops); reject overlapping `resume()` on same PID
- **queue.py**: Fix HRRN priority inversion (`ASC`→`DESC` so "interactive" dequeues before "background"); update all columns on idempotency key conflict (was only updating `agent_id`)
- **write_back_service.py**: Add `_handle_rename()` with native rename + delete/write fallback (was `RuntimeError`)
- **workspace_rpc_service.py**: Replace `get_event_loop().run_until_complete()` with `asyncio.run()` in sync RPC methods dispatched via threadpool

### Correctness (MEDIUM) — 6 fixes
- **loop.py**: Align history trim boundary to keep tool-call/tool-result pairs intact
- **descendant_access.py**: Use local `zone_id` (with `ROOT_ZONE_ID` fallback) consistently in all `rebac_check_sync/bulk` calls
- **agent_service.py**: Use actual zone_id instead of hardcoded `/zone/default/` in `list_agents()` config lookup
- **eviction_manager.py**: Only trigger preemption when `connected_count >= max_active_agents`
- **workspace_rpc_service.py**: `snapshot_begin()` falls back to `ctx.zone_id` before `ROOT_ZONE_ID`

### Not fixed (invalid/inconclusive)
- **delivery.py** (#12): Finding was invalid — exporter failures go to DLQ but do NOT mark `delivered=True`
- **sync_job_service.py** (#17): Finding was inconclusive
- **session_store.py**: File not found at expected path

## Test plan
- [x] `uv run ruff check` passes on all 16 modified files
- [x] `uv run ruff format --check` passes on all 16 modified files
- [x] `uv run mypy` passes on all 16 modified files
- [x] Pre-commit hooks pass (ruff, format, mypy, file size, merge conflicts, brick imports)
- [x] Unit tests pass (8319 passed, no regressions from changes)
- [ ] CI pipeline green