### PR TITLE
feat(#1577): HotSwappable + PersistentService kernel protocols

### DIFF
--- a/src/nexus/contracts/protocols/__init__.py
+++ b/src/nexus/contracts/protocols/__init__.py
@@ -55,6 +55,7 @@ from nexus.contracts.protocols.rebac import ReBACBrickProtocol
 from nexus.contracts.protocols.sandbox import SandboxProtocol
 from nexus.contracts.protocols.scheduler import AgentRequest, SchedulerProtocol
 from nexus.contracts.protocols.search import SearchBrickProtocol, SearchProtocol
+from nexus.contracts.protocols.service_lifecycle import HotSwappable, PersistentService
 from nexus.contracts.protocols.share_link import ShareLinkProtocol
 from nexus.contracts.protocols.sync import SyncContext, SyncResult, SyncServiceProtocol
 from nexus.contracts.protocols.sync_job import SyncJobProtocol
@@ -75,6 +76,7 @@ __all__ = [
     "ChunkedUploadProtocol",
     "EntityRegistryProtocol",
     "FileReaderProtocol",
+    "HotSwappable",
     "LLMProviderProtocol",
     "LLMServiceProtocol",
     "LifecycleManagerProtocol",
@@ -91,6 +93,7 @@ __all__ = [
     "OperationLogProtocol",
     "ParseProtocol",
     "PaymentProtocol",
+    "PersistentService",
     "PermissionEnforcerProtocol",
     "PermissionProtocol",
     "ProgressCallback",

--- a/src/nexus/contracts/protocols/service_lifecycle.py
+++ b/src/nexus/contracts/protocols/service_lifecycle.py
@@ -1,0 +1,203 @@
+"""Service lifecycle contracts — HotSwappable + PersistentService (Issue #1577).
+
+Two runtime-checkable Protocols that let the kernel, coordinator, and CLI
+distinguish service lifecycle tiers without coupling to concrete classes:
+
+    HotSwappable        — service declares VFS hooks and supports drain/activate
+    PersistentService   — service requires a long-running process (background workers)
+
+Four-quadrant classification:
+
+    +------------------+-----------------+---------------------+
+    |                  | Invocation-only | Persistent-required |
+    +------------------+-----------------+---------------------+
+    | Static           | SearchService   | EventDeliveryWorker |
+    |                  | LLMService      |                     |
+    +------------------+-----------------+---------------------+
+    | HotSwappable     | ReBACService    | (future)            |
+    |                  | MountService    |                     |
+    +------------------+-----------------+---------------------+
+
+Usage::
+
+    from nexus.contracts.protocols.service_lifecycle import (
+        HotSwappable,
+        PersistentService,
+    )
+
+    if isinstance(svc, HotSwappable):
+        spec = svc.hook_spec()         # declare VFS hooks
+        await svc.drain()              # stop accepting new work
+        await svc.activate()           # start serving after swap
+
+    if isinstance(svc, PersistentService):
+        await svc.start()              # begin background work
+        await svc.stop()               # graceful shutdown
+
+Design decisions:
+    - Protocol (structural) over ABC (nominal) — services satisfy the contract
+      by implementing the methods, no explicit inheritance required.
+    - @runtime_checkable — coordinator and CLI can use isinstance() checks.
+    - Separate from BrickLifecycleProtocol — that protocol covers the full
+      FSM (REGISTERED -> ACTIVE -> UNMOUNTED) with health_check().  These
+      protocols are lighter-weight and composable.
+
+Linux analogy:
+    HotSwappable    ~ module with pre_remove()/post_install() callbacks
+    PersistentService ~ kthread (kernel thread that runs in background)
+
+References:
+    - docs/architecture/KERNEL-ARCHITECTURE.md
+    - Issue #1452: Service lifecycle / hot-swap
+    - Issue #1577: HotSwappable + PersistentService protocols
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
+
+
+# ---------------------------------------------------------------------------
+# HotSwappable — runtime hot-swap support
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class HotSwappable(Protocol):
+    """Service that supports runtime hot-swap via ServiceLifecycleCoordinator.
+
+    A HotSwappable service declares its VFS hooks and supports graceful
+    drain (stop accepting new work) and activate (start serving) transitions.
+
+    The coordinator uses this protocol to decide swap behaviour::
+
+        if isinstance(old_svc, HotSwappable):
+            spec = old_svc.hook_spec()
+            await old_svc.drain()
+            # ... unregister old hooks, register new hooks ...
+            await new_svc.activate()
+        else:
+            # Simple registry replace — no hook management
+            registry.replace_service(name, new_svc)
+
+    Implementors provide:
+        hook_spec()  — return a HookSpec describing VFS hooks this service owns
+        drain()      — stop accepting new work; called before hook unregistration
+        activate()   — start serving; called after hook registration
+
+    Example::
+
+        class MyPermissionService:
+            def hook_spec(self) -> HookSpec:
+                return HookSpec(
+                    read_hooks=(self._read_hook,),
+                    write_hooks=(self._write_hook,),
+                )
+
+            async def drain(self) -> None:
+                self._accepting = False
+
+            async def activate(self) -> None:
+                self._accepting = True
+    """
+
+    def hook_spec(self) -> HookSpec:
+        """Declare VFS hooks this service owns.
+
+        Called by the coordinator during swap to unregister old hooks
+        and register new hooks.  Must return a stable snapshot —
+        the coordinator may call this once and cache the result.
+        """
+        ...
+
+    async def drain(self) -> None:
+        """Stop accepting new work.
+
+        Called before hook unregistration during hot-swap.
+        In-flight calls tracked by ServiceRef will complete normally;
+        drain() is an additional signal for service-internal cleanup
+        (e.g., stop background polling, flush buffers).
+
+        Must be idempotent — may be called multiple times.
+        """
+        ...
+
+    async def activate(self) -> None:
+        """Start serving after swap.
+
+        Called after the new instance's hooks are registered and
+        BLM state transitions to ACTIVE.  The service should begin
+        accepting work and initialize any runtime state.
+
+        Must be idempotent — may be called multiple times.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# PersistentService — requires long-running process
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class PersistentService(Protocol):
+    """Service that requires a long-running process (background workers).
+
+    PersistentServices have background tasks that run continuously
+    (e.g., event delivery polling, deferred permission flushing).
+    They need an ``asyncio`` event loop and cannot operate in
+    invocation-only mode (Lambda, Cloud Run single-request).
+
+    The kernel and CLI use this protocol to determine distro type::
+
+        persistent = [
+            name for name, svc in registry.all()
+            if isinstance(svc, PersistentService)
+        ]
+        if persistent:
+            log.info("Persistent distro: %s", persistent)
+        else:
+            log.info("Invocation-compatible distro")
+
+    Implementors provide:
+        start()  — begin background work (spawn tasks, open connections)
+        stop()   — graceful shutdown (drain queues, close connections)
+
+    Example::
+
+        class EventDeliveryWorker:
+            async def start(self) -> None:
+                self._task = asyncio.create_task(self._poll_loop())
+
+            async def stop(self) -> None:
+                self._running = False
+                await self._task
+
+    Design note:
+        Separate from ``BrickLifecycleProtocol`` which adds ``health_check()``
+        and integrates with the BLM FSM.  ``PersistentService`` is lighter —
+        just the start/stop contract for distro classification.
+    """
+
+    async def start(self) -> None:
+        """Begin background work.
+
+        Called during ``nx.bootstrap()`` to start background tasks.
+        Must be safe to call at any point after ``nx.initialize()``.
+        Must be idempotent — calling start() on an already-started
+        service should be a no-op.
+        """
+        ...
+
+    async def stop(self) -> None:
+        """Gracefully shut down background work.
+
+        Called during ``nx.close()`` or process shutdown.
+        Must drain in-flight work and release resources.
+        Must be idempotent — calling stop() on an already-stopped
+        service should be a no-op.
+        """
+        ...

--- a/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
+++ b/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
@@ -11,14 +11,21 @@ Provides five Linux-inspired verbs for service lifecycle management:
 The coordinator lives at the System Services tier (not kernel) — it composes
 kernel-owned ServiceRegistry with system-service-tier BrickLifecycleManager.
 
-Hot-swap flow:
-    1. Atomic replace in ServiceRegistry (new calls immediately get new instance)
-    2. Drain old instance's refcount → 0 (ServiceRef proxies track in-flight calls)
-    3. Unregister old VFS hooks
-    4. Register new VFS hooks
-    5. BLM state transitions for old (unmount+unregister) and new (register+mount)
+Hot-swap flow (HotSwappable services only):
+    1. Validate old service implements HotSwappable (TypeError if not)
+    2. Call old_service.drain() — stop accepting new work
+    3. Drain ServiceRef refcount → 0 (wait for in-flight calls)
+    4. Unregister old VFS hooks (from old_service.hook_spec())
+    5. Atomic replace in ServiceRegistry
+    6. BLM state transitions for old (unmount+unregister) and new (register+mount)
+    7. Register new VFS hooks (from new_service.hook_spec() if HotSwappable)
+    8. Call new_service.activate() if HotSwappable
+
+Static (non-HotSwappable) services cannot be hot-swapped — they raise TypeError.
+Use full restart instead.
 
 Issue #1452 Phase 3.
+Issue #1577: HotSwappable + PersistentService protocol integration.
 """
 
 from __future__ import annotations
@@ -28,6 +35,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.protocols.service_hooks import HookSpec
+from nexus.contracts.protocols.service_lifecycle import HotSwappable, PersistentService
 
 if TYPE_CHECKING:
     from nexus.core.kernel_dispatch import KernelDispatch
@@ -158,31 +166,72 @@ class ServiceLifecycleCoordinator:
         timeout: float = 5.0,
         drain_timeout: float = DEFAULT_DRAIN_TIMEOUT,
     ) -> None:
-        """Hot-swap a service: atomic replace → drain → hook swap → BLM cycle.
+        """Hot-swap a service: validate → drain → hook swap → BLM cycle.
 
-        1. Atomic replace in ServiceRegistry (zero gap — new calls get new instance)
-        2. Drain old refcount (wait for in-flight calls on old instance to complete)
-        3. Unregister old VFS hooks
-        4. Cycle BLM for old instance (unmount + unregister)
-        5. Register + mount new instance in BLM
-        6. Register new VFS hooks
+        Only HotSwappable services can be swapped.  Static services raise
+        TypeError — use full restart instead.
+
+        Flow for HotSwappable services:
+            1. Validate old service is HotSwappable (TypeError if not)
+            2. Call old_service.drain() — stop accepting new work
+            3. Drain ServiceRef refcount → 0 (in-flight calls complete)
+            4. Unregister old VFS hooks (from old hook_spec or old_service.hook_spec())
+            5. Atomic replace in ServiceRegistry
+            6. BLM cycle for old → new
+            7. Register new VFS hooks (from hook_spec param, new_service.hook_spec(), or retroactive)
+            8. Call new_service.activate() if HotSwappable
+
+        Args:
+            name: Service registry name.
+            new_instance: Replacement service instance.
+            exports: EXPORT_SYMBOL methods for the new instance.
+            hook_spec: Explicit HookSpec override (bypasses protocol auto-detect).
+            timeout: BLM mount timeout.
+            drain_timeout: Max wait for in-flight calls to complete.
+
+        Raises:
+            TypeError: If old service is not HotSwappable.
+            KeyError: If service is not registered.
         """
+        # --- Resolve old instance ---
+        old_info = self._registry.service_info(name)
+        if old_info is None:
+            raise KeyError(f"swap_service: {name!r} not registered")
+        old_instance = old_info.instance
+
+        # --- Guard: only HotSwappable services can be swapped ---
+        if not isinstance(old_instance, HotSwappable):
+            raise TypeError(
+                f"swap_service: {name!r} ({type(old_instance).__name__}) is not HotSwappable. "
+                f"Static services cannot be hot-swapped — use full restart instead."
+            )
+
         # Snapshot old state
-        old_spec = self._blm.get_spec(name)
+        old_blm_spec = self._blm.get_spec(name)
+
+        # Resolve old hook spec: explicit retroactive > protocol auto-detect
         old_hook_spec = self._hook_specs.get(name)
+        if old_hook_spec is None:
+            old_hook_spec = old_instance.hook_spec()
+            if old_hook_spec is not None and not old_hook_spec.is_empty:
+                self._hook_specs[name] = old_hook_spec
 
-        # Step 1: Atomic replace — nx.service(name) now returns new instance
-        self._registry.replace_service(name, new_instance, exports=exports)
-        logger.info("[COORDINATOR] swap %r — atomic replace done", name)
+        # Step 1: Drain old service (service-internal cleanup)
+        await old_instance.drain()
+        logger.debug("[COORDINATOR] swap %r — old service drained", name)
 
-        # Step 2: Drain old instance (wait for in-flight ServiceRef calls)
+        # Step 2: Drain ServiceRef refcount (wait for in-flight calls)
         await self._drain(name, timeout=drain_timeout)
 
         # Step 3: Unregister old hooks
         if old_hook_spec is not None:
             self._unregister_hooks_for_spec(old_hook_spec)
 
-        # Step 4: BLM cycle for old — unmount + unregister
+        # Step 4: Atomic replace — nx.service(name) now returns new instance
+        self._registry.replace_service(name, new_instance, exports=exports)
+        logger.info("[COORDINATOR] swap %r — atomic replace done", name)
+
+        # Step 5: BLM cycle for old → new
         from nexus.contracts.protocols.brick_lifecycle import BrickState
 
         status = self._blm.get_status(name)
@@ -192,18 +241,23 @@ class ServiceLifecycleCoordinator:
         if status is not None and status.state == BrickState.UNMOUNTED:
             await self._blm.unregister(name)
 
-        # Step 5: BLM register + mount new
         self._blm.register(
             name,
             new_instance,
-            protocol_name=old_spec.protocol_name if old_spec else type(new_instance).__name__,
-            depends_on=old_spec.depends_on if old_spec else (),
+            protocol_name=old_blm_spec.protocol_name
+            if old_blm_spec
+            else type(new_instance).__name__,
+            depends_on=old_blm_spec.depends_on if old_blm_spec else (),
         )
         await self._blm.mount(name, timeout=timeout)
 
-        # Step 6: Register new hooks
-        if hook_spec is not None:
-            self._hook_specs[name] = hook_spec
+        # Step 6: Register new hooks — explicit param > protocol > clear
+        new_hook_spec = hook_spec
+        if new_hook_spec is None and isinstance(new_instance, HotSwappable):
+            new_hook_spec = new_instance.hook_spec()
+
+        if new_hook_spec is not None and not new_hook_spec.is_empty:
+            self._hook_specs[name] = new_hook_spec
         elif name in self._hook_specs:
             del self._hook_specs[name]
 
@@ -211,7 +265,44 @@ class ServiceLifecycleCoordinator:
         if status is not None and status.state == BrickState.ACTIVE:
             self._register_hooks(name)
 
+        # Step 7: Activate new service if HotSwappable
+        if isinstance(new_instance, HotSwappable):
+            await new_instance.activate()
+
         logger.info("[COORDINATOR] swap %r — complete", name)
+
+    # ------------------------------------------------------------------
+    # Distro classification — persistent vs invocation-compatible
+    # ------------------------------------------------------------------
+
+    def classify_distro(self) -> tuple[bool, list[str]]:
+        """Determine whether this distro requires a persistent process.
+
+        Scans all registered services for ``PersistentService`` protocol.
+        Returns ``(is_persistent, service_names)`` where ``is_persistent``
+        is True if any service requires background workers.
+
+        Used by nexusd startup and CLI ``nexus info`` to report distro type.
+        """
+        persistent_names: list[str] = []
+        for info in self._registry.list_all():
+            if isinstance(info.instance, PersistentService):
+                persistent_names.append(info.name)
+        return bool(persistent_names), persistent_names
+
+    def classify_hot_swappable(self) -> tuple[list[str], list[str]]:
+        """Classify services into hot-swappable vs static.
+
+        Returns ``(hot_swappable_names, static_names)``.
+        """
+        hot: list[str] = []
+        static: list[str] = []
+        for info in self._registry.list_all():
+            if isinstance(info.instance, HotSwappable):
+                hot.append(info.name)
+            else:
+                static.append(info.name)
+        return hot, static
 
     # ------------------------------------------------------------------
     # Hook spec management (retroactive spec capture for existing services)

--- a/tests/unit/contracts/test_service_lifecycle_protocols.py
+++ b/tests/unit/contracts/test_service_lifecycle_protocols.py
@@ -1,0 +1,178 @@
+"""Unit tests for HotSwappable and PersistentService protocols (Issue #1577).
+
+Verifies structural subtyping (Protocol) works correctly for service
+lifecycle classification without requiring explicit inheritance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.contracts.protocols.service_hooks import HookSpec
+from nexus.contracts.protocols.service_lifecycle import HotSwappable, PersistentService
+
+# ---------------------------------------------------------------------------
+# Test stubs — satisfy protocols structurally (no inheritance)
+# ---------------------------------------------------------------------------
+
+
+class _FullHotSwappable:
+    """Structurally satisfies HotSwappable — all 3 methods."""
+
+    def hook_spec(self) -> HookSpec:
+        return HookSpec(read_hooks=(object(),))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+
+class _FullPersistent:
+    """Structurally satisfies PersistentService — start + stop."""
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+
+class _BothProtocols:
+    """Satisfies both HotSwappable AND PersistentService."""
+
+    def hook_spec(self) -> HookSpec:
+        return HookSpec()
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+
+class _PlainService:
+    """No lifecycle methods — neither HotSwappable nor PersistentService."""
+
+    def do_work(self) -> str:
+        return "done"
+
+
+class _PartialHotSwappable:
+    """Has hook_spec and drain but missing activate — NOT HotSwappable."""
+
+    def hook_spec(self) -> HookSpec:
+        return HookSpec()
+
+    async def drain(self) -> None:
+        pass
+
+
+class _PartialPersistent:
+    """Has start but missing stop — NOT PersistentService."""
+
+    async def start(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# HotSwappable Protocol
+# ---------------------------------------------------------------------------
+
+
+class TestHotSwappableProtocol:
+    def test_full_implementation_detected(self) -> None:
+        assert isinstance(_FullHotSwappable(), HotSwappable)
+
+    def test_plain_service_not_detected(self) -> None:
+        assert not isinstance(_PlainService(), HotSwappable)
+
+    def test_partial_not_detected(self) -> None:
+        """Missing activate() → not HotSwappable."""
+        assert not isinstance(_PartialHotSwappable(), HotSwappable)
+
+    def test_both_protocols_detected(self) -> None:
+        svc = _BothProtocols()
+        assert isinstance(svc, HotSwappable)
+        assert isinstance(svc, PersistentService)
+
+    @pytest.mark.asyncio()
+    async def test_hook_spec_returns_hookspec(self) -> None:
+        svc = _FullHotSwappable()
+        spec = svc.hook_spec()
+        assert isinstance(spec, HookSpec)
+        assert spec.total_hooks == 1
+
+    @pytest.mark.asyncio()
+    async def test_drain_and_activate_are_async(self) -> None:
+        svc = _FullHotSwappable()
+        # Should be awaitable
+        await svc.drain()
+        await svc.activate()
+
+
+# ---------------------------------------------------------------------------
+# PersistentService Protocol
+# ---------------------------------------------------------------------------
+
+
+class TestPersistentServiceProtocol:
+    def test_full_implementation_detected(self) -> None:
+        assert isinstance(_FullPersistent(), PersistentService)
+
+    def test_plain_service_not_detected(self) -> None:
+        assert not isinstance(_PlainService(), PersistentService)
+
+    def test_partial_not_detected(self) -> None:
+        """Missing stop() → not PersistentService."""
+        assert not isinstance(_PartialPersistent(), PersistentService)
+
+    def test_hot_swappable_not_persistent(self) -> None:
+        """HotSwappable without start/stop is NOT PersistentService."""
+        assert not isinstance(_FullHotSwappable(), PersistentService)
+
+    @pytest.mark.asyncio()
+    async def test_start_and_stop_are_async(self) -> None:
+        svc = _FullPersistent()
+        await svc.start()
+        await svc.stop()
+
+
+# ---------------------------------------------------------------------------
+# Four-quadrant classification
+# ---------------------------------------------------------------------------
+
+
+class TestFourQuadrant:
+    """Verify the four-quadrant classification matrix."""
+
+    def test_static_invocation(self) -> None:
+        """Static + invocation-only: most common case."""
+        svc = _PlainService()
+        assert not isinstance(svc, HotSwappable)
+        assert not isinstance(svc, PersistentService)
+
+    def test_hot_swappable_invocation(self) -> None:
+        """HotSwappable + invocation-only: can be swapped, no background tasks."""
+        svc = _FullHotSwappable()
+        assert isinstance(svc, HotSwappable)
+        assert not isinstance(svc, PersistentService)
+
+    def test_static_persistent(self) -> None:
+        """Static + persistent: has background tasks but no hot-swap support."""
+        svc = _FullPersistent()
+        assert not isinstance(svc, HotSwappable)
+        assert isinstance(svc, PersistentService)
+
+    def test_hot_swappable_persistent(self) -> None:
+        """HotSwappable + persistent: full lifecycle management."""
+        svc = _BothProtocols()
+        assert isinstance(svc, HotSwappable)
+        assert isinstance(svc, PersistentService)

--- a/tests/unit/services/test_service_lifecycle_coordinator.py
+++ b/tests/unit/services/test_service_lifecycle_coordinator.py
@@ -1,4 +1,4 @@
-"""Unit tests for ServiceLifecycleCoordinator (Issue #1452 Phase 3)."""
+"""Unit tests for ServiceLifecycleCoordinator (Issue #1452 Phase 3, #1577)."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ import pytest
 
 from nexus.contracts.protocols.brick_lifecycle import BrickState
 from nexus.contracts.protocols.service_hooks import HookSpec
+from nexus.contracts.protocols.service_lifecycle import HotSwappable, PersistentService
 from nexus.core.kernel_dispatch import KernelDispatch
 from nexus.core.service_registry import ServiceRegistry
 from nexus.system_services.lifecycle.brick_lifecycle import BrickLifecycleManager
@@ -44,7 +45,7 @@ def coordinator(
 
 
 class _FakeService:
-    """Simple service stub with callable methods."""
+    """Simple static service stub (NOT HotSwappable)."""
 
     def glob(self, pattern: str) -> list[str]:
         return [pattern]
@@ -54,13 +55,64 @@ class _FakeService:
 
 
 class _FakeServiceV2:
-    """V2 replacement for hot-swap tests."""
+    """V2 static replacement (NOT HotSwappable)."""
 
     def glob(self, pattern: str) -> list[str]:
         return [f"v2:{pattern}"]
 
     def grep(self, pattern: str) -> list[str]:
         return [f"v2:{pattern}"]
+
+
+class _HotSwappableService:
+    """HotSwappable service stub — satisfies the Protocol structurally."""
+
+    def __init__(self, hook_spec_value: HookSpec | None = None) -> None:
+        self._hook_spec = hook_spec_value or HookSpec()
+        self.drained = False
+        self.activated = False
+
+    def hook_spec(self) -> HookSpec:
+        return self._hook_spec
+
+    async def drain(self) -> None:
+        self.drained = True
+
+    async def activate(self) -> None:
+        self.activated = True
+
+    def glob(self, pattern: str) -> list[str]:
+        return [pattern]
+
+    def grep(self, pattern: str) -> list[str]:
+        return [pattern]
+
+
+class _HotSwappableServiceV2(_HotSwappableService):
+    """V2 HotSwappable replacement."""
+
+    def glob(self, pattern: str) -> list[str]:
+        return [f"v2:{pattern}"]
+
+    def grep(self, pattern: str) -> list[str]:
+        return [f"v2:{pattern}"]
+
+
+class _PersistentFakeService:
+    """PersistentService stub — satisfies the Protocol structurally."""
+
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def do_work(self) -> str:
+        return "working"
 
 
 # ---------------------------------------------------------------------------
@@ -187,16 +239,16 @@ class TestSwapService:
         registry: ServiceRegistry,
         dispatch: KernelDispatch,
     ) -> None:
-        svc1 = _FakeService()
         hook1 = MagicMock()
         spec1 = HookSpec(read_hooks=(hook1,))
+        svc1 = _HotSwappableService(hook_spec_value=spec1)
         coordinator.register_service("search", svc1, exports=("glob",), hook_spec=spec1)
         await coordinator.mount_service("search")
         assert dispatch.read_hook_count == 1
 
-        svc2 = _FakeServiceV2()
         hook2 = MagicMock()
         spec2 = HookSpec(read_hooks=(hook2,))
+        svc2 = _HotSwappableServiceV2(hook_spec_value=spec2)
         await coordinator.swap_service("search", svc2, exports=("glob", "grep"), hook_spec=spec2)
 
         # New instance is served
@@ -206,9 +258,12 @@ class TestSwapService:
 
         # Old hooks removed, new hooks registered
         assert dispatch.read_hook_count == 1
-        # Verify it's the new hook (old was unregistered, new was registered)
         assert hook2 in dispatch._read_hooks
         assert hook1 not in dispatch._read_hooks
+
+        # Protocol methods called
+        assert svc1.drained is True
+        assert svc2.activated is True
 
     @pytest.mark.asyncio()
     async def test_swap_no_none_window(
@@ -217,20 +272,58 @@ class TestSwapService:
         registry: ServiceRegistry,
     ) -> None:
         """Verify that service(name) NEVER returns None during swap."""
-        svc1 = _FakeService()
+        svc1 = _HotSwappableService()
         coordinator.register_service("search", svc1, exports=("glob",))
         await coordinator.mount_service("search")
 
-        # Before swap
         assert registry.service("search") is not None
 
-        svc2 = _FakeServiceV2()
+        svc2 = _HotSwappableServiceV2()
         await coordinator.swap_service("search", svc2, exports=("glob",))
 
-        # After swap — should have new instance, never None
         ref = registry.service("search")
         assert ref is not None
         assert ref._service_instance is svc2
+
+    @pytest.mark.asyncio()
+    async def test_swap_rejects_non_hot_swappable(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """Static (non-HotSwappable) services cannot be hot-swapped."""
+        svc1 = _FakeService()  # NOT HotSwappable
+        coordinator.register_service("search", svc1, exports=("glob",))
+        await coordinator.mount_service("search")
+
+        svc2 = _FakeServiceV2()
+        with pytest.raises(TypeError, match="not HotSwappable"):
+            await coordinator.swap_service("search", svc2, exports=("glob",))
+
+    @pytest.mark.asyncio()
+    async def test_swap_auto_detects_hook_spec_from_protocol(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        registry: ServiceRegistry,
+        dispatch: KernelDispatch,
+    ) -> None:
+        """If no explicit hook_spec param, coordinator reads it from HotSwappable.hook_spec()."""
+        hook1 = MagicMock()
+        spec1 = HookSpec(read_hooks=(hook1,))
+        svc1 = _HotSwappableService(hook_spec_value=spec1)
+        # Register WITH explicit hook_spec (retroactive capture)
+        coordinator.register_service("search", svc1, hook_spec=spec1)
+        await coordinator.mount_service("search")
+        assert dispatch.read_hook_count == 1
+
+        hook2 = MagicMock()
+        spec2 = HookSpec(read_hooks=(hook2,))
+        svc2 = _HotSwappableServiceV2(hook_spec_value=spec2)
+        # Swap WITHOUT explicit hook_spec — coordinator auto-detects from protocol
+        await coordinator.swap_service("search", svc2)
+
+        assert dispatch.read_hook_count == 1
+        assert hook2 in dispatch._read_hooks
+        assert hook1 not in dispatch._read_hooks
 
     @pytest.mark.asyncio()
     async def test_swap_drains_in_flight_calls(
@@ -239,15 +332,15 @@ class TestSwapService:
         registry: ServiceRegistry,
     ) -> None:
         """Verify swap waits for in-flight async calls to complete."""
-        svc1 = MagicMock()
         call_completed = asyncio.Event()
 
-        async def _slow_glob(pattern: str) -> list[str]:
-            await asyncio.sleep(0.05)
-            call_completed.set()
-            return [pattern]
+        class _SlowHotSwappable(_HotSwappableService):
+            async def glob(self, pattern: str) -> list[str]:
+                await asyncio.sleep(0.05)
+                call_completed.set()
+                return [pattern]
 
-        svc1.glob = _slow_glob
+        svc1 = _SlowHotSwappable()
         coordinator.register_service("search", svc1, exports=("glob",))
         await coordinator.mount_service("search")
 
@@ -257,19 +350,16 @@ class TestSwapService:
         in_flight = asyncio.create_task(ref.glob("*.py"))
 
         # Swap should wait for the in-flight call to drain
-        svc2 = MagicMock()
-        svc2.glob = MagicMock(return_value=["v2"])
+        svc2 = _HotSwappableServiceV2()
         swap_task = asyncio.create_task(
             coordinator.swap_service("search", svc2, exports=("glob",), drain_timeout=2.0)
         )
 
-        # Wait for both
         result = await in_flight
         assert result == ["*.py"]
         assert call_completed.is_set()
 
         await swap_task
-        # New instance is now active
         new_ref = registry.service("search")
         assert new_ref is not None
         assert new_ref._service_instance is svc2
@@ -355,7 +445,6 @@ class TestSwapWithFullHookSpec:
         dispatch: KernelDispatch,
     ) -> None:
         """Multi-channel spec: old hooks removed, new hooks installed on same channels."""
-        svc1 = _FakeService()
         old_read = MagicMock()
         old_write = MagicMock()
         old_observer = MagicMock()
@@ -364,6 +453,7 @@ class TestSwapWithFullHookSpec:
             write_hooks=(old_write,),
             observers=(old_observer,),
         )
+        svc1 = _HotSwappableService(hook_spec_value=spec1)
         coordinator.register_service("rebac", svc1, hook_spec=spec1)
         await coordinator.mount_service("rebac")
 
@@ -371,7 +461,6 @@ class TestSwapWithFullHookSpec:
         assert dispatch.write_hook_count == 1
         assert dispatch.observer_count == 1
 
-        svc2 = _FakeServiceV2()
         new_read = MagicMock()
         new_write = MagicMock()
         new_observer = MagicMock()
@@ -380,6 +469,7 @@ class TestSwapWithFullHookSpec:
             write_hooks=(new_write,),
             observers=(new_observer,),
         )
+        svc2 = _HotSwappableServiceV2(hook_spec_value=spec2)
         await coordinator.swap_service("rebac", svc2, hook_spec=spec2)
 
         # Counts unchanged (old removed, new added)
@@ -400,16 +490,97 @@ class TestSwapWithFullHookSpec:
         dispatch: KernelDispatch,
     ) -> None:
         """Swap without new hook_spec should unregister old hooks and leave none."""
-        svc1 = _FakeService()
         old_hook = MagicMock()
         spec1 = HookSpec(read_hooks=(old_hook,))
+        svc1 = _HotSwappableService(hook_spec_value=spec1)
         coordinator.register_service("parser", svc1, hook_spec=spec1)
         await coordinator.mount_service("parser")
         assert dispatch.read_hook_count == 1
 
-        svc2 = _FakeServiceV2()
+        svc2 = _HotSwappableServiceV2()  # empty hook_spec
         await coordinator.swap_service("parser", svc2)
 
         # Old hook removed, no new hook registered
         assert dispatch.read_hook_count == 0
         assert old_hook not in dispatch._read_hooks
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance — isinstance checks (Issue #1577)
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    """Verify structural subtyping works for HotSwappable and PersistentService."""
+
+    def test_hot_swappable_detected(self) -> None:
+        svc = _HotSwappableService()
+        assert isinstance(svc, HotSwappable)
+
+    def test_static_service_not_hot_swappable(self) -> None:
+        svc = _FakeService()
+        assert not isinstance(svc, HotSwappable)
+
+    def test_persistent_service_detected(self) -> None:
+        svc = _PersistentFakeService()
+        assert isinstance(svc, PersistentService)
+
+    def test_static_service_not_persistent(self) -> None:
+        svc = _FakeService()
+        assert not isinstance(svc, PersistentService)
+
+    def test_hot_swappable_not_persistent(self) -> None:
+        """HotSwappable and PersistentService are independent protocols."""
+        svc = _HotSwappableService()
+        assert isinstance(svc, HotSwappable)
+        assert not isinstance(svc, PersistentService)
+
+    def test_persistent_not_hot_swappable(self) -> None:
+        svc = _PersistentFakeService()
+        assert isinstance(svc, PersistentService)
+        assert not isinstance(svc, HotSwappable)
+
+
+# ---------------------------------------------------------------------------
+# Distro classification (Issue #1577)
+# ---------------------------------------------------------------------------
+
+
+class TestDistroClassification:
+    def test_no_persistent_services(self, coordinator: ServiceLifecycleCoordinator) -> None:
+        """All static services → invocation-compatible distro."""
+        svc = _FakeService()
+        coordinator.register_service("search", svc)
+
+        is_persistent, names = coordinator.classify_distro()
+        assert is_persistent is False
+        assert names == []
+
+    def test_persistent_service_detected(self, coordinator: ServiceLifecycleCoordinator) -> None:
+        """PersistentService present → persistent distro."""
+        svc = _PersistentFakeService()
+        coordinator.register_service("delivery_worker", svc)
+
+        is_persistent, names = coordinator.classify_distro()
+        assert is_persistent is True
+        assert names == ["delivery_worker"]
+
+    def test_mixed_services(self, coordinator: ServiceLifecycleCoordinator) -> None:
+        """Mix of static and persistent → persistent distro."""
+        coordinator.register_service("search", _FakeService())
+        coordinator.register_service("worker", _PersistentFakeService())
+
+        is_persistent, names = coordinator.classify_distro()
+        assert is_persistent is True
+        assert names == ["worker"]
+
+    def test_classify_hot_swappable(self, coordinator: ServiceLifecycleCoordinator) -> None:
+        """Classify services into hot-swappable vs static."""
+        coordinator.register_service("search", _FakeService())
+        coordinator.register_service("rebac", _HotSwappableService())
+        coordinator.register_service("worker", _PersistentFakeService())
+
+        hot, static = coordinator.classify_hot_swappable()
+        assert "rebac" in hot
+        assert "search" in static
+        assert "worker" in static  # persistent but not hot-swappable


### PR DESCRIPTION
## Summary
- Add two `@runtime_checkable` Protocol contracts (`HotSwappable`, `PersistentService`) for kernel-level service lifecycle classification
- Guard `swap_service()` to reject non-HotSwappable services with `TypeError` — static services must use full restart
- Auto-detect `hook_spec()` from HotSwappable protocol during swap — no explicit parameter needed
- Add `classify_distro()` and `classify_hot_swappable()` to ServiceLifecycleCoordinator for runtime four-quadrant classification

## Four-quadrant classification matrix

| | Invocation-only | Persistent-required |
|---|---|---|
| **Static** | SearchService, LLMService | EventDeliveryWorker |
| **HotSwappable** | ReBACService, MountService | (future) |

## Files changed
- `src/nexus/contracts/protocols/service_lifecycle.py` — **NEW**: HotSwappable + PersistentService protocols
- `src/nexus/contracts/protocols/__init__.py` — export new protocols
- `src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py` — swap guard, auto-detect, classify methods
- `tests/unit/contracts/test_service_lifecycle_protocols.py` — **NEW**: 15 protocol conformance tests
- `tests/unit/services/test_service_lifecycle_coordinator.py` — 30 tests (up from 20), HotSwappable integration

## Test plan
- [x] `pytest tests/unit/contracts/test_service_lifecycle_protocols.py -xvs` — 15 pass
- [x] `pytest tests/unit/services/test_service_lifecycle_coordinator.py -xvs` — 30 pass
- [x] `ruff check` clean
- [x] Pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Issue #1577