### PR TITLE
Align positioning and verify local quickstart paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@ Nexus gives agents one place to read, write, search, and carry context across fi
 
 ## Quick Start
 
-This is the local SDK path verified against this repo with `PYTHONPATH=src`
-and Python 3.13. If you installed from PyPI, drop `PYTHONPATH=src`.
+This is the verified source-checkout path as of March 11, 2026. It uses `uv`,
+Python 3.14, the lightweight `requirements-minimal.txt` set, and does not
+require a Rust build.
 
 ```bash
-PYTHONPATH=src python3.13 - <<'PY'
+uv venv --python 3.14
+source .venv/bin/activate
+uv pip install -r requirements-minimal.txt
+uv pip install -e . --no-deps
+
+python - <<'PY'
 from nexus.sdk import connect
 
 nx = connect(
@@ -50,18 +56,34 @@ Expected output:
 Hello, Nexus!
 ```
 
+The commands below assume the same activated `.venv`.
+
 Local CLI path from a source checkout:
 
 ```bash
-PYTHONPATH=src python3.13 -m nexus.cli.main init .nexus-cli-demo
+python -m nexus.cli.main init .nexus-cli-demo
 export NEXUS_DATA_DIR="$PWD/.nexus-cli-demo/nexus-data"
 
-PYTHONPATH=src python3.13 -m nexus.cli.main write /workspace/hello.txt "hello from cli"
-PYTHONPATH=src python3.13 -m nexus.cli.main cat /workspace/hello.txt
-PYTHONPATH=src python3.13 -m nexus.cli.main ls /workspace
+python -m nexus.cli.main write /workspace/hello.txt "hello from cli"
+python -m nexus.cli.main cat /workspace/hello.txt
+python -m nexus.cli.main ls /workspace
 ```
 
-If you installed from PyPI, use `nexus` instead of `python3.13 -m nexus.cli.main`.
+If you installed from PyPI, use `nexus` instead of `python -m nexus.cli.main`.
+
+## Optional Capabilities
+
+- Full dev/test environment: `uv sync --extra dev --extra test`
+- txtai/FAISS semantic search stack: `uv sync --extra semantic-search`
+- Optional Rust BLAKE3 acceleration: `maturin develop --release -m rust/nexus_pyo3/Cargo.toml`
+- Rust metastore / federation extensions: `maturin develop --release -m rust/nexus_raft/Cargo.toml --features python` or `--features full`
+
+## Troubleshooting
+
+- `ModuleNotFoundError: No module named 'nexus'`: you are in a source checkout without installing the package into the active interpreter. Use the `uv` setup above or install `nexus-ai-fs` from PyPI.
+- `maturin develop --release` fails at the repo root: the root [Cargo.toml](./Cargo.toml) is a workspace manifest. Point `maturin` at a crate manifest under `rust/`.
+- `Rust BLAKE3 extension not available`: this is an optional performance path. The default quickstart uses the Python `blake3` package.
+- `faiss-cpu` resolution fails: stay on the default source quickstart above, or opt into `semantic-search` only on a platform with compatible `txtai`/`faiss-cpu` wheels.
 
 For the full walkthrough, see the [quickstart page](https://nexi-lab.github.io/nexus/getting-started/quickstart/).
 
@@ -147,11 +169,14 @@ See [Kernel Architecture](https://nexi-lab.github.io/nexus/architecture/kernel-a
 ```bash
 git clone https://github.com/nexi-lab/nexus.git
 cd nexus
-pip install -e ".[dev]"
-pre-commit install
-pytest tests/
+uv python install 3.14
+uv sync --extra dev --extra test
+uv run pre-commit install
+uv run pytest tests/
 ```
+
+If you are working on the txtai search stack, add `--extra semantic-search`.
 
 ## License
 
-© 2025 Nexi Labs, Inc. Licensed under Apache License 2.0 — see [LICENSE](https://github.com/nexi-lab/nexus/blob/main/LICENSE) for details.
+© 2026 Nexi Labs, Inc. Licensed under Apache License 2.0 — see [LICENSE](https://github.com/nexi-lab/nexus/blob/main/LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -7,133 +7,75 @@
   [![Lint](https://github.com/nexi-lab/nexus/actions/workflows/lint.yml/badge.svg)](https://github.com/nexi-lab/nexus/actions/workflows/lint.yml)
 
   [![PyPI version](https://badge.fury.io/py/nexus-ai-fs.svg)](https://badge.fury.io/py/nexus-ai-fs)
-  [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-  [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
+  [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/nexi-lab/nexus/blob/main/LICENSE)
+  [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 
-  [Architecture](docs/architecture/KERNEL-ARCHITECTURE.md) • [PyPI](https://pypi.org/project/nexus-ai-fs/) • [Examples](examples/)
+  [Docs](https://nexi-lab.github.io/nexus/) • [Quickstart](https://nexi-lab.github.io/nexus/getting-started/quickstart/) • [PyPI](https://pypi.org/project/nexus-ai-fs/) • [Examples](https://github.com/nexi-lab/nexus/tree/main/examples)
 </div>
 
-An operating system for AI agents.
+Nexus = filesystem/context plane.
 
-⚠️ **Beta**: Nexus is under active development. APIs may change.
+⚠️ **Beta**: Nexus is under active development. APIs and deployment defaults may change.
 
-## What is Nexus?
+## What Nexus Does
 
-Nexus is an operating system for AI agents. Like Linux provides processes with a unified interface to hardware (files, sockets, devices), Nexus provides agents with a unified interface to data (files, databases, APIs, SaaS tools) — through syscalls, a virtual filesystem, permissions, and loadable services.
-
-**Why an OS, not a framework?**
-- **Kernel** with VFS, syscall dispatch, and inode-like metadata — not an application-layer wrapper
-- **Drivers** swapped at config-time via dependency injection (redb, S3, PostgreSQL) — like compiled-in kernel drivers
-- **Services** loaded/unloaded at runtime following the Linux Loadable Kernel Module pattern — not plugins
-- **Deployment profiles** that select which services to include from the same codebase — like Linux distros (Ubuntu, Alpine, BusyBox) built from the same kernel
-- **Zones** as the fundamental isolation and consensus unit (1 zone = 1 Raft group) — like cgroups/namespaces for data
+Nexus gives agents one place to read, write, search, and carry context across files, services, and runs. The core abstraction is a VFS-style interface that can start local in-process and grow into a daemon-backed deployment when you need remote access, permissions, or multi-tenant control.
 
 ## Quick Start
 
-### Python SDK
+This is the local SDK path verified against this repo with `PYTHONPATH=src`
+and Python 3.13. If you installed from PyPI, drop `PYTHONPATH=src`.
 
 ```bash
-pip install nexus-ai-fs
-```
+PYTHONPATH=src python3.13 - <<'PY'
+from nexus.sdk import connect
 
-```python
-import nexus
+nx = connect(
+    config={
+        "profile": "minimal",
+        "data_dir": "./nexus-data",
+    }
+)
 
-nx = nexus.connect(config={
-    "mode": "remote",
-    "url": "http://localhost:2026",
-    "api_key": "nxk_..."
-})
-
-# File operations
-nx.sys_write("/workspace/hello.txt", b"Hello, Nexus!")
-print(nx.sys_read("/workspace/hello.txt").decode())
-
-# Search across all backends
-results = nx.grep("TODO", "/workspace")
-
-# Agent memory
-nx.memory.store("User prefers detailed explanations", memory_type="preference")
-context = nx.memory.query("What does the user prefer?")
+nx.sys_write("/hello.txt", b"Hello, Nexus!")
+print(nx.sys_read("/hello.txt").decode())
 
 nx.close()
+PY
 ```
 
-### Agent Engine (Embedded)
+Expected output:
 
-Run an AI agent directly against a local NexusFS — no server required:
-
-```python
-import asyncio
-from pathlib import Path
-from pydantic import SecretStr
-
-from nexus.backends.local import LocalBackend
-from nexus.core.config import PermissionConfig
-from nexus.factory import create_nexus_fs
-from nexus.storage.raft_metadata_store import RaftMetadataStore
-from nexus.storage.record_store import SQLAlchemyRecordStore
-
-from nexus.bricks.llm.config import LLMConfig
-from nexus.bricks.llm.provider import LiteLLMProvider
-from nexus.system_services.agent_runtime.process_manager import ProcessManager
-from nexus.system_services.agent_runtime.types import AgentProcessConfig, TextDelta
-from nexus.contracts.llm_types import Message, MessageRole
-
-
-async def main():
-    # 1. Bootstrap NexusFS (local storage, no server)
-    data = Path("/tmp/nexus-agent")
-    data.mkdir(exist_ok=True)
-    nx = create_nexus_fs(
-        backend=LocalBackend(root_path=str(data / "files")),
-        metadata_store=RaftMetadataStore.embedded(str(data / "raft")),
-        record_store=SQLAlchemyRecordStore(),
-        permissions=PermissionConfig(enforce=False),
-    )
-
-    # 2. Create LLM provider
-    llm = LiteLLMProvider(LLMConfig(
-        model="claude-haiku-4-5-20251001",
-        api_key=SecretStr("sk-ant-..."),  # your API key
-    ))
-
-    # 3. Spawn agent and chat
-    pm = ProcessManager(vfs=nx, llm_provider=llm)
-    proc = await pm.spawn("user1", "default", config=AgentProcessConfig(
-        name="my-agent",
-        tools=("read_file", "write_file", "grep", "glob"),
-    ))
-
-    async for event in pm.resume(
-        proc.pid,
-        Message(role=MessageRole.USER, content="List the files in /default"),
-    ):
-        if isinstance(event, TextDelta):
-            print(event.text, end="", flush=True)
-    print()
-
-    # Cleanup
-    await pm.terminate(proc.pid)
-    await llm.cleanup()
-    nx.close()
-
-asyncio.run(main())
+```text
+Hello, Nexus!
 ```
 
-### CLI
+Local CLI path from a source checkout:
 
 ```bash
-pip install nexus-ai-fs
+PYTHONPATH=src python3.13 -m nexus.cli.main init .nexus-cli-demo
+export NEXUS_DATA_DIR="$PWD/.nexus-cli-demo/nexus-data"
 
-export NEXUS_URL="http://localhost:2026"
-export NEXUS_API_KEY="nxk_..."
-
-nexus write /workspace/hello.txt "Hello, Nexus!"
-nexus cat /workspace/hello.txt
-nexus grep "TODO" /workspace
-nexus memory store "Important fact" --type fact
+PYTHONPATH=src python3.13 -m nexus.cli.main write /workspace/hello.txt "hello from cli"
+PYTHONPATH=src python3.13 -m nexus.cli.main cat /workspace/hello.txt
+PYTHONPATH=src python3.13 -m nexus.cli.main ls /workspace
 ```
+
+If you installed from PyPI, use `nexus` instead of `python3.13 -m nexus.cli.main`.
+
+For the full walkthrough, see the [quickstart page](https://nexi-lab.github.io/nexus/getting-started/quickstart/).
+
+## Three Landing Paths
+
+- **Local SDK**: Start local, keep the filesystem/context plane inside your process, and integrate from Python. Docs: [Local SDK path](https://nexi-lab.github.io/nexus/paths/embedded-sdk/)
+- **Shared daemon**: Run `nexusd` when you need a long-lived service, remote clients, or operational controls. Docs: [Shared daemon path](https://nexi-lab.github.io/nexus/paths/daemon-and-remote/)
+- **Architecture**: Read the kernel, storage, and proposal docs before changing the system model. Docs: [Architecture path](https://nexi-lab.github.io/nexus/paths/architecture/)
+
+## Trust Boundaries
+
+- The quickstart above is a local path. It is intentionally smaller than a production deployment.
+- Remote SDK access uses the `remote` profile and depends on a running `nexusd` plus a configured gRPC port.
+- Permissions, memory, and federation are deployment capabilities, not implied by the basic local write/read example.
 
 ## Architecture
 
@@ -187,18 +129,18 @@ Same kernel, different service sets — like Linux distros:
 | **cloud** | Ubuntu Server | k8s, serverless | 22 (all) |
 | **remote** | NFS client | Client-side proxy | 0 |
 
-See [Kernel Architecture](docs/architecture/KERNEL-ARCHITECTURE.md) for the full design.
+See [Kernel Architecture](https://nexi-lab.github.io/nexus/architecture/kernel-architecture/) for the full design.
 
 ## Examples
 
 | Framework | Description | Location |
 |-----------|-------------|----------|
-| CrewAI | Multi-agent collaboration | [examples/crewai/](examples/crewai/) |
-| LangGraph | Permission-based workflows | [examples/langgraph_integration/](examples/langgraph_integration/) |
-| Claude SDK | ReAct agent pattern | [examples/claude_agent_sdk/](examples/claude_agent_sdk/) |
-| OpenAI Agents | Multi-tenant with memory | [examples/openai_agents/](examples/openai_agents/) |
-| Google ADK | Agent Development Kit | [examples/google_adk/](examples/google_adk/) |
-| CLI | 40+ shell demos | [examples/cli/](examples/cli/) |
+| CrewAI | Multi-agent collaboration | [examples/crewai/](https://github.com/nexi-lab/nexus/tree/main/examples/crewai) |
+| LangGraph | Permission-based workflows | [examples/langgraph_integration/](https://github.com/nexi-lab/nexus/tree/main/examples/langgraph_integration) |
+| Claude SDK | ReAct agent pattern | [examples/claude_agent_sdk/](https://github.com/nexi-lab/nexus/tree/main/examples/claude_agent_sdk) |
+| OpenAI Agents | Multi-tenant with memory | [examples/openai_agents/](https://github.com/nexi-lab/nexus/tree/main/examples/openai_agents) |
+| Google ADK | Agent Development Kit | [examples/google_adk/](https://github.com/nexi-lab/nexus/tree/main/examples/google_adk) |
+| CLI | 40+ shell demos | [examples/cli/](https://github.com/nexi-lab/nexus/tree/main/examples/cli) |
 
 ## Contributing
 
@@ -212,4 +154,4 @@ pytest tests/
 
 ## License
 
-© 2025 Nexi Labs, Inc. Licensed under Apache License 2.0 — see [LICENSE](LICENSE) for details.
+© 2025 Nexi Labs, Inc. Licensed under Apache License 2.0 — see [LICENSE](https://github.com/nexi-lab/nexus/blob/main/LICENSE) for details.

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -118,7 +118,7 @@ entry point for all Nexus users. It auto-detects deployment mode
 ```python
 from nexus.sdk import connect
 nx = connect()                    # auto-detect from env/config
-nx = connect(config={"mode": "remote", "url": "http://..."})
+nx = connect(config={"profile": "remote", "url": "http://..."})
 ```
 
 Linux analogue: the boot sequence that selects rootfs and mounts it

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,19 +2,35 @@
 
 Nexus = filesystem/context plane.
 
-This page documents the local SDK path verified against this repository on March 11, 2026 using Python 3.13. The package metadata supports Python 3.12+.
+This page documents the local SDK path re-verified against this repository on
+March 11, 2026 using `uv` and Python 3.14. The package metadata supports
+Python 3.12+.
 
 ## Prerequisites
 
+- `uv`
 - Python 3.12 or newer
 - A writable local directory for Nexus state
+
+## Set Up A Source Environment
+
+From a checkout:
+
+```bash
+uv venv --python 3.14
+source .venv/bin/activate
+uv pip install -r requirements-minimal.txt
+uv pip install -e . --no-deps
+```
+
+The remaining commands assume the same activated `.venv`.
 
 ## Run A Verified Example
 
 From a checkout:
 
 ```bash
-PYTHONPATH=src python3.13 - <<'PY'
+python - <<'PY'
 from nexus.sdk import connect
 
 nx = connect(
@@ -26,13 +42,12 @@ nx = connect(
 
 nx.sys_write("/hello.txt", b"Hello, Nexus!")
 print(nx.sys_read("/hello.txt").decode())
-
 nx.close()
 PY
 ```
 
-From PyPI, install `nexus-ai-fs` first and run the same snippet without
-`PYTHONPATH=src`.
+From PyPI, install `nexus-ai-fs` first and run the same snippet without the
+source-checkout setup.
 
 Expected output:
 
@@ -47,15 +62,15 @@ This standalone CLI path was also verified in this repository on March 11, 2026.
 From a checkout:
 
 ```bash
-PYTHONPATH=src python3.13 -m nexus.cli.main init .nexus-cli-demo
+python -m nexus.cli.main init .nexus-cli-demo
 export NEXUS_DATA_DIR="$PWD/.nexus-cli-demo/nexus-data"
 
-PYTHONPATH=src python3.13 -m nexus.cli.main write /workspace/hello.txt "hello from cli"
-PYTHONPATH=src python3.13 -m nexus.cli.main cat /workspace/hello.txt
-PYTHONPATH=src python3.13 -m nexus.cli.main ls /workspace
+python -m nexus.cli.main write /workspace/hello.txt "hello from cli"
+python -m nexus.cli.main cat /workspace/hello.txt
+python -m nexus.cli.main ls /workspace
 ```
 
-If you installed from PyPI, use `nexus` instead of `python3.13 -m nexus.cli.main`.
+If you installed from PyPI, use `nexus` instead of `python -m nexus.cli.main`.
 
 Expected result:
 
@@ -63,11 +78,26 @@ Expected result:
 - `cat` returns `hello from cli`.
 - `ls` shows `/workspace/hello.txt`.
 
+## Optional Capabilities
+
+- Full dev/test environment: `uv sync --extra dev --extra test`
+- txtai/FAISS semantic search stack: `uv sync --extra semantic-search`
+- Optional Rust hashing: `maturin develop --release -m rust/nexus_pyo3/Cargo.toml`
+- Rust metastore / federation extensions: `maturin develop --release -m rust/nexus_raft/Cargo.toml --features python` or `--features full`
+
+## Common First-Run Fixes
+
+- `ModuleNotFoundError: No module named 'nexus'`: you skipped the editable install step or are using the wrong interpreter.
+- `maturin develop --release` fails at the repo root: point `maturin` at a crate manifest under `rust/`, not the workspace root.
+- `Rust BLAKE3 extension not available`: this is an optional performance message, not a quickstart failure.
+- `faiss-cpu` resolution fails: the default quickstart above avoids the optional semantic-search stack; only opt into `semantic-search` on platforms with compatible `txtai` and `faiss-cpu` wheels.
+
 ## Why This Quickstart
 
 - It does not require `nexusd`.
 - It does not require API keys.
 - It does not require the full federation build.
+- It keeps federation-by-default intact while letting local fallback happen automatically when Rust extensions are absent.
 - It exercises the real local `connect()` path used by the SDK and CLI.
 
 ## Next Steps

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,78 @@
+# Quickstart
+
+Nexus = filesystem/context plane.
+
+This page documents the local SDK path verified against this repository on March 11, 2026 using Python 3.13. The package metadata supports Python 3.12+.
+
+## Prerequisites
+
+- Python 3.12 or newer
+- A writable local directory for Nexus state
+
+## Run A Verified Example
+
+From a checkout:
+
+```bash
+PYTHONPATH=src python3.13 - <<'PY'
+from nexus.sdk import connect
+
+nx = connect(
+    config={
+        "profile": "minimal",
+        "data_dir": "./nexus-data",
+    }
+)
+
+nx.sys_write("/hello.txt", b"Hello, Nexus!")
+print(nx.sys_read("/hello.txt").decode())
+
+nx.close()
+PY
+```
+
+From PyPI, install `nexus-ai-fs` first and run the same snippet without
+`PYTHONPATH=src`.
+
+Expected output:
+
+```text
+Hello, Nexus!
+```
+
+## Local CLI Quickstart
+
+This standalone CLI path was also verified in this repository on March 11, 2026.
+
+From a checkout:
+
+```bash
+PYTHONPATH=src python3.13 -m nexus.cli.main init .nexus-cli-demo
+export NEXUS_DATA_DIR="$PWD/.nexus-cli-demo/nexus-data"
+
+PYTHONPATH=src python3.13 -m nexus.cli.main write /workspace/hello.txt "hello from cli"
+PYTHONPATH=src python3.13 -m nexus.cli.main cat /workspace/hello.txt
+PYTHONPATH=src python3.13 -m nexus.cli.main ls /workspace
+```
+
+If you installed from PyPI, use `nexus` instead of `python3.13 -m nexus.cli.main`.
+
+Expected result:
+
+- `write` succeeds against the workspace-scoped data dir.
+- `cat` returns `hello from cli`.
+- `ls` shows `/workspace/hello.txt`.
+
+## Why This Quickstart
+
+- It does not require `nexusd`.
+- It does not require API keys.
+- It does not require the full federation build.
+- It exercises the real local `connect()` path used by the SDK and CLI.
+
+## Next Steps
+
+- Stay local and keep building from the [Local SDK path](../paths/embedded-sdk.md).
+- Move to a service deployment with the [Shared daemon path](../paths/daemon-and-remote.md).
+- Read the system model in [Architecture](../paths/architecture.md).
+- Read the [trust boundary guide](trust-boundary.md).

--- a/docs/getting-started/trust-boundary.md
+++ b/docs/getting-started/trust-boundary.md
@@ -1,0 +1,25 @@
+# Trust Boundary
+
+Nexus = filesystem/context plane.
+
+The local quickstart, the shared daemon, and a production auth deployment are
+not the same trust model.
+
+## Modes
+
+| Mode | Boundary | Identity model | Use it for |
+| --- | --- | --- | --- |
+| Local SDK with `profile="minimal"` | One local process | Implicit local user/process | Prototyping, notebooks, tests |
+| Shared daemon with one `--api-key` | One shared service | One shared key | Internal tools, simple shared setups |
+| Shared daemon with real auth | One shared service | Per-user or per-agent identity | Multi-user systems, audit, policy |
+
+## Rules
+
+- Do not treat the local quickstart as a multi-user secure deployment.
+- Do not use one shared key when you need per-user trust or audit trails.
+- Use `profile="remote"` for clients talking to a daemon.
+
+## Next
+
+- [Quickstart](quickstart.md)
+- [Shared daemon path](../paths/daemon-and-remote.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Nexus gives agents a stable place to read, write, search, and carry context acro
 
 ### 1. Local SDK
 
-Use Nexus inside a Python process with a local data directory. This is the shortest verified path and the best place to start.
+Use Nexus inside a Python process with a local data directory. This is the shortest verified path and the best place to start, using the `uv`-based quickstart from a source checkout or PyPI install.
 
 - Docs: [Local SDK](paths/embedded-sdk.md)
 - Verified guide: [Quickstart](getting-started/quickstart.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,39 @@
+# Nexus
+
+Nexus = filesystem/context plane.
+
+Nexus gives agents a stable place to read, write, search, and carry context across files, services, and runs. Start with the smallest path that matches your use case, then move up to daemon-backed deployments or architecture docs when you need them.
+
+## Start Here
+
+### 1. Local SDK
+
+Use Nexus inside a Python process with a local data directory. This is the shortest verified path and the best place to start.
+
+- Docs: [Local SDK](paths/embedded-sdk.md)
+- Verified guide: [Quickstart](getting-started/quickstart.md)
+
+### 2. Shared Daemon
+
+Run `nexusd` when you need a long-lived service, remote clients, or operational controls. The remote SDK path depends on a configured gRPC port in addition to the HTTP URL.
+
+- Docs: [Shared Daemon](paths/daemon-and-remote.md)
+
+### 3. Architecture
+
+Read the design docs before changing the storage model, service boundaries, or deployment assumptions.
+
+- Docs: [Architecture](paths/architecture.md)
+- Deep dive: [Kernel Architecture](architecture/KERNEL-ARCHITECTURE.md)
+
+## What To Trust
+
+- The quickstart in this docsite is a local embedded path that was verified against this repository.
+- Remote SDK access is a separate path. It requires `nexusd` and a configured gRPC port.
+- Permissions, memory, and federation are deployment capabilities, not implied by the basic local write/read example.
+
+## Links
+
+- GitHub: <https://github.com/nexi-lab/nexus>
+- PyPI: <https://pypi.org/project/nexus-ai-fs/>
+- Examples: <https://github.com/nexi-lab/nexus/tree/main/examples>

--- a/docs/paths/architecture.md
+++ b/docs/paths/architecture.md
@@ -1,0 +1,22 @@
+# Architecture
+
+Nexus = filesystem/context plane.
+
+Choose this path when you need to understand how the kernel, storage pillars, services, and deployment profiles fit together.
+
+## Read These First
+
+- [Kernel Architecture](../architecture/KERNEL-ARCHITECTURE.md)
+- [Backend Architecture](../architecture/backend-architecture.md)
+- [CLI Design](../architecture/cli-design.md)
+
+## For Deeper Context
+
+- [CLI Experience Design Research](../research/cli-experience-design-research.md)
+- [CLI Architecture Proposal](../proposals/cli-architecture-proposal.md)
+- [CLI Issues](../proposals/cli-issues.md)
+- [Grove Async Agent Graph](../proposals/grove-async-agent-graph.md)
+
+## Why This Path Exists
+
+Nexus has several layers: storage pillars, a VFS-style kernel, system services, and optional bricks. If you are changing those boundaries or explaining the product externally, read the design docs before editing behavior or docs copy.

--- a/docs/paths/daemon-and-remote.md
+++ b/docs/paths/daemon-and-remote.md
@@ -1,0 +1,42 @@
+# Shared Daemon
+
+Nexus = filesystem/context plane.
+
+Choose this path when Nexus needs to run as a service instead of as an in-process library.
+
+## What Changes
+
+- You start `nexusd` as the server process.
+- Remote SDK clients use the `remote` profile.
+- The remote SDK path depends on gRPC as well as the HTTP server URL.
+
+## Server
+
+In a clean install, a minimal daemon setup looks like this:
+
+```bash
+export NEXUS_GRPC_PORT=2126
+nexusd --profile minimal --host 127.0.0.1 --port 2026 --data-dir ./nexus-data --api-key dev-key
+```
+
+## Client
+
+```python
+from nexus.sdk import connect
+
+nx = connect(
+    config={
+        "profile": "remote",
+        "url": "http://127.0.0.1:2026",
+        "api_key": "dev-key",
+    }
+)
+```
+
+Set `NEXUS_GRPC_PORT` in the client environment if the server is not using the default gRPC port expected by the SDK.
+
+## Trust Notes
+
+- The HTTP port alone is not enough for the current remote SDK path.
+- Documented remote access should always mention the gRPC requirement explicitly.
+- If you only need local development, start with the [Local SDK path](embedded-sdk.md).

--- a/docs/paths/embedded-sdk.md
+++ b/docs/paths/embedded-sdk.md
@@ -1,0 +1,45 @@
+# Local SDK
+
+Nexus = filesystem/context plane.
+
+Choose this path when you want the shortest working integration: one process, one local data directory, no daemon.
+
+## Best For
+
+- Local agent prototypes
+- CLI tools and developer workflows
+- Tests and notebooks
+- Applications that want Nexus as an in-process dependency
+
+## Starting Point
+
+```python
+from nexus.sdk import connect
+
+nx = connect(
+    config={
+        "profile": "minimal",
+        "data_dir": "./nexus-data",
+    }
+)
+```
+
+From there you can use the filesystem API directly:
+
+```python
+nx.sys_write("/notes/today.txt", b"hello")
+content = nx.sys_read("/notes/today.txt")
+```
+
+## What You Get
+
+- A local VFS-style API
+- Persistent state under your chosen data directory
+- A path that works without remote infrastructure
+
+## When To Leave This Path
+
+Move to the daemon path when you need remote clients, long-lived processes, or operational controls around a shared Nexus instance.
+
+- Next: [Shared daemon](daemon-and-remote.md)
+- Verified walkthrough: [Quickstart](../getting-started/quickstart.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Nexus
-site_description: The AI-Native Distributed Filesystem - Build production AI agents with enterprise-grade context, permissions, and multi-tenancy
+site_description: Nexus = filesystem/context plane.
 site_author: Nexus Team
 site_url: https://nexi-lab.github.io/nexus/
 
@@ -186,55 +186,20 @@ extra_javascript:
 
 # Navigation structure
 nav:
-  - Home:
-    - index.md
-    - Getting Started:
-      - getting-started/index.md
-      - Installation: getting-started/installation.md
-      - Quick Start: getting-started/quickstart.md
-      - Configuration: getting-started/configuration.md
-      - Deployment Modes: getting-started/deployment-modes.md
-    - Core Concepts:
-      - What is Nexus?: concepts/what-is-nexus.md
-      - Memory System: concepts/memory-system.md
-      - Sandbox Management: concepts/sandbox-management.md
-      - Agent Permissions: concepts/agent-permissions.md
-      - ReBAC Explained: concepts/rebac-explained.md
-      - Content-Addressable Storage: concepts/content-addressable-storage.md
-      - Learning Loops: concepts/learning-loops.md
-      - Workflows vs Triggers: concepts/workflows-vs-triggers.md
-      - Plugin System: concepts/plugin-system.md
-      - Mounts & Backends: concepts/mounts-and-backends.md
-      - Skills System: concepts/skills-system.md
-      - Multi-Tenancy: concepts/multi-tenancy.md
-      - When to Use What: concepts/when-to-use-what.md
-      - Architecture: architecture/KERNEL-ARCHITECTURE.md
-      - Core Tenets: CORE_TENETS.md
-
-  - Examples:
-    - examples/index.md
-    - File Operations: examples/file-operations.md
-    - Directory Operations: examples/directory-operations.md
-    - Permission Management: examples/permissions.md
-    - Workspace & Sessions: examples/workspace-session.md
-    - DeepAgents Integration: examples/deepagents.md
-    - LangGraph Integration: examples/langgraph.md
-    - "📘 LangGraph Migration Tutorial": examples/langgraph-migration.md
-    - CrewAI Integration: examples/crewai.md
-    - Claude Agent SDK: examples/claude-agent-sdk.md
-    - OpenAI Agents SDK: examples/openai-agents.md
-    - Google ADK Integration: examples/google-adk.md
-    - Skill Seekers: examples/skill-seekers.md
-
-  - Learning Paths:
-    - Simple File Storage: learning-paths/simple-file-storage.md
-    - Document Q&A System: learning-paths/document-qa.md
-    - AI Agent Memory: learning-paths/ai-agent-memory.md
-    - Workflow Automation: learning-paths/workflow-automation.md
-    - Team Collaboration: learning-paths/team-collaboration.md
-    - Multi-Tenant SaaS: learning-paths/multi-tenant-saas.md
-    - Multi-Backend Storage: learning-paths/multi-backend-storage.md
-    - Administration & Operations: learning-paths/administration-operations.md
-    - Building Plugins: learning-paths/building-plugins.md
-
-  - Glossary: glossary.md
+  - Home: index.md
+  - Quickstart: getting-started/quickstart.md
+  - Landing Paths:
+    - Local SDK: paths/embedded-sdk.md
+    - Shared Daemon: paths/daemon-and-remote.md
+    - Architecture: paths/architecture.md
+  - Trust Boundary: getting-started/trust-boundary.md
+  - Architecture:
+    - Kernel Architecture: architecture/KERNEL-ARCHITECTURE.md
+    - Backend Architecture: architecture/backend-architecture.md
+    - CLI Design: architecture/cli-design.md
+  - Research:
+    - CLI Experience Design Research: research/cli-experience-design-research.md
+  - Proposals:
+    - CLI Architecture Proposal: proposals/cli-architecture-proposal.md
+    - CLI Issues: proposals/cli-issues.md
+    - Grove Async Agent Graph: proposals/grove-async-agent-graph.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 [project]
 name = "nexus-ai-fs"
 version = "0.9.0"
-description = "AI-Native Distributed Filesystem Architecture"
+description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 authors = [
     {name = "Nexus Team", email = "team@nexus.example.com"}
 ]
@@ -14,6 +14,7 @@ maintainers = [
 ]
 keywords = [
     "filesystem",
+    "context",
     "ai",
     "agents",
     "storage",
@@ -25,7 +26,7 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
@@ -103,10 +104,6 @@ dependencies = [
     "fastcdc>=1.5.0",
     # BM25S for 500x faster ranked text search (Issue #796)
     "bm25s>=0.2.0",
-    # txtai unified search: hybrid BM25+dense, pgvector backend, semantic graph (Issue #2663)
-    # NOTE: txtai → torch has no macOS x86_64 wheel (torch 2.10+). Exclude that platform.
-    "txtai[database,graph]>=9.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
-    "faiss-cpu>=1.11.0; platform_machine=='x86_64' or platform_machine=='aarch64' or platform_machine=='arm64'",
     # Rapidfuzz for fast fuzzy string matching in edit engine (Issue #800)
     # 10-100x faster than difflib (Rust-backed)
     "rapidfuzz>=3.0.0",
@@ -238,6 +235,11 @@ cloud-sql = [
 ]
 
 semantic-search = [
+    # txtai unified search: hybrid BM25+dense, semantic graph (Issue #2663)
+    # NOTE: txtai depends on faiss-cpu and large ML wheels; keep this opt-in.
+    # torch still has no supported macOS x86_64 path for this stack.
+    "txtai[database,graph]>=9.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "faiss-cpu>=1.11.0; platform_machine=='x86_64' or platform_machine=='aarch64' or platform_machine=='arm64'",
     # Keyword search support - uses existing SQLite/PostgreSQL FTS
     # BM25S is now in core dependencies (Issue #796)
     # Vector database extensions for semantic/hybrid search:
@@ -293,6 +295,8 @@ all = [
     # Excludes: sentence-transformers (too heavy ~2GB), voyageai (specialized use case)
     # Note: fusepy removed - Rust nexus-fuse binary is bundled in the package
     # Note: bm25s is now in core dependencies (Issue #796)
+    "txtai[database,graph]>=9.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "faiss-cpu>=1.11.0; platform_machine=='x86_64' or platform_machine=='aarch64' or platform_machine=='arm64'",
     "psycopg2-binary>=2.9.9",
     "sqlite-vec>=0.1.0",
     "pgvector>=0.3.0",
@@ -302,7 +306,7 @@ all = [
 
 [project.urls]
 Homepage = "https://github.com/nexi-lab/nexus"
-Documentation = "https://github.com/nexi-lab/nexus/blob/main/README.md"
+Documentation = "https://nexi-lab.github.io/nexus/"
 Repository = "https://github.com/nexi-lab/nexus"
 Issues = "https://github.com/nexi-lab/nexus/issues"
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,4 +1,4 @@
-# Minimal dependencies for NEXUS_PROFILE=minimal (standalone server).
+# Minimal dependencies for the verified local quickstart and NEXUS_PROFILE=minimal.
 # Subset of pyproject.toml for a lightweight Nexus server with storage only.
 # No cloud connectors, no LLM/ML packages, no Zoekt, no sandbox providers.
 

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -1,12 +1,11 @@
 """
-Nexus: AI-Native Distributed Filesystem Architecture
+Nexus = filesystem/context plane.
 
-Nexus is a complete AI agent infrastructure platform that combines distributed
-unified filesystem, self-evolving agent memory, intelligent document processing,
-and seamless deployment across deployment profiles.
+Nexus combines a VFS-style filesystem interface with deployment-aware context,
+storage, and service composition for agent systems.
 
 Deployment profiles control which bricks are enabled:
-- kernel: Bare VFS, storage only
+- minimal: Bare VFS, storage only
 - embedded: Storage + eventlog
 - lite: Core services
 - full: All bricks (default)
@@ -19,7 +18,7 @@ For programmatic access (building tools, libraries, integrations), use the SDK:
 
     from nexus.sdk import connect
 
-    nx = connect()
+    nx = connect(config={"profile": "minimal", "data_dir": "./nexus-data"})
     nx.sys_write("/workspace/data.txt", b"Hello World")
     content = nx.sys_read("/workspace/data.txt")
 
@@ -351,9 +350,9 @@ def connect(
                     path, zone_id = pair.strip().split("=", 1)
                     mounts[path.strip()] = zone_id.strip()
             zone_mgr.bootstrap_static(zones=zones, peers=peers, mounts=mounts)
-
         metadata_store = FederatedMetadataProxy.from_zone_manager(zone_mgr)
     except ImportError:
+        zone_mgr = None
         # Raft extensions not available — single-node embedded Raft, with fallback
         try:
             from nexus.storage.raft_metadata_store import RaftMetadataStore
@@ -362,12 +361,36 @@ def connect(
         except (RuntimeError, ImportError):
             from nexus.storage.dict_metastore import DictMetastore
 
+            dict_metastore_path = Path(metadata_path).with_suffix(".json")
             logger.warning(
-                "Rust metastore not available — using in-memory DictMetastore. "
-                "Data will not persist across restarts. "
-                "For durable storage, build with: maturin develop -m rust/nexus_raft/Cargo.toml"
+                "Rust metastore not available — using Python DictMetastore fallback at %s. "
+                "Build with maturin develop -m rust/nexus_raft/Cargo.toml for the durable Rust metastore.",
+                dict_metastore_path,
             )
-            metadata_store = DictMetastore()
+            metadata_store = DictMetastore(dict_metastore_path)
+    except RuntimeError as exc:
+        if "ZoneManager requires PyO3 build with --features full" not in str(exc):
+            raise
+
+        zone_mgr = None
+        logger.info(
+            "Federation extensions unavailable for local connect(); "
+            "falling back to single-node metadata store"
+        )
+        try:
+            from nexus.storage.raft_metadata_store import RaftMetadataStore
+
+            metadata_store = RaftMetadataStore.embedded(metadata_path)
+        except (RuntimeError, ImportError):
+            from nexus.storage.dict_metastore import DictMetastore
+
+            dict_metastore_path = Path(metadata_path).with_suffix(".json")
+            logger.warning(
+                "Rust metastore not available — using Python DictMetastore fallback at %s. "
+                "Build with maturin develop -m rust/nexus_raft/Cargo.toml for the durable Rust metastore.",
+                dict_metastore_path,
+            )
+            metadata_store = DictMetastore(dict_metastore_path)
 
     # Permission defaults: standalone without explicit config → permissive
     enforce_permissions = cfg.enforce_permissions

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -362,9 +362,10 @@ def connect(
             from nexus.storage.dict_metastore import DictMetastore
 
             dict_metastore_path = Path(metadata_path).with_suffix(".json")
-            logger.warning(
-                "Rust metastore not available — using Python DictMetastore fallback at %s. "
-                "Build with maturin develop -m rust/nexus_raft/Cargo.toml for the durable Rust metastore.",
+            logger.info(
+                "Rust metastore not available; using JSON-backed DictMetastore fallback at %s. "
+                "Build rust/nexus_raft with maturin develop -m rust/nexus_raft/Cargo.toml "
+                "--features python for the durable metastore.",
                 dict_metastore_path,
             )
             metadata_store = DictMetastore(dict_metastore_path)
@@ -385,9 +386,10 @@ def connect(
             from nexus.storage.dict_metastore import DictMetastore
 
             dict_metastore_path = Path(metadata_path).with_suffix(".json")
-            logger.warning(
-                "Rust metastore not available — using Python DictMetastore fallback at %s. "
-                "Build with maturin develop -m rust/nexus_raft/Cargo.toml for the durable Rust metastore.",
+            logger.info(
+                "Rust metastore not available; using JSON-backed DictMetastore fallback at %s. "
+                "Build rust/nexus_raft with maturin develop -m rust/nexus_raft/Cargo.toml "
+                "--features python for the durable metastore.",
                 dict_metastore_path,
             )
             metadata_store = DictMetastore(dict_metastore_path)

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -65,7 +65,7 @@ def _init_bloom(cas_root: Path, capacity: int, fp_rate: float) -> Any:
                 logger.info("CAS Bloom filter populated with %d entries", len(keys))
         return bloom
     except ImportError:
-        logger.warning("nexus_fast not available, CAS Bloom filter disabled")
+        logger.debug("nexus_fast not available, CAS Bloom filter disabled")
         return None
     except Exception as e:
         logger.warning("Failed to initialize CAS Bloom filter: %s", e)

--- a/src/nexus/backends/wrappers/cache_mixin.py
+++ b/src/nexus/backends/wrappers/cache_mixin.py
@@ -97,7 +97,7 @@ class CacheConnectorMixin:
                     cls._l1_default_ttl,
                 )
             except ImportError:
-                logger.warning("[CACHE] nexus_fast not available, L1 cache disabled")
+                logger.debug("[CACHE] nexus_fast not available, L1 cache disabled")
                 return None
         return cls._l1_cache
 

--- a/src/nexus/bricks/mount/mount_persist_service.py
+++ b/src/nexus/bricks/mount/mount_persist_service.py
@@ -204,7 +204,7 @@ class MountPersistService:
             - errors: List of error messages
         """
         if not self._manager:
-            logger.warning("Mount manager not available, skipping mount restoration")
+            logger.debug("Mount manager not available, skipping mount restoration")
             return {"loaded": 0, "synced": 0, "failed": 0, "errors": []}
 
         saved_mounts = self._manager.list_mounts()

--- a/src/nexus/bricks/sandbox/sandbox_monty_provider.py
+++ b/src/nexus/bricks/sandbox/sandbox_monty_provider.py
@@ -20,7 +20,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 from nexus.bricks.sandbox.sandbox_provider import (
     CodeExecutionResult,
@@ -513,24 +513,25 @@ class MontySandboxProvider(SandboxProvider):
                     f"{instance.sandbox_id}."
                 )
             if isinstance(progress, MontySnapshot):
-                fn_name = progress.function_name
-                fn_args = progress.args
-                fn_kwargs = progress.kwargs
+                snapshot = cast(Any, progress)
+                fn_name = snapshot.function_name
+                fn_args = snapshot.args
+                fn_kwargs = snapshot.kwargs
 
                 handler = instance.host_functions.get(fn_name)
                 if handler is None:
                     # Unknown function — resume with NameError
-                    progress = progress.resume(
+                    progress = snapshot.resume(
                         exception=NameError(f"Host function '{fn_name}' is not registered")
                     )
                     continue
 
                 try:
                     result = handler(*fn_args, **fn_kwargs)
-                    progress = progress.resume(return_value=result)
+                    progress = snapshot.resume(return_value=result)
                 except Exception as exc:
                     # Propagate host function errors back to Monty code
-                    progress = progress.resume(exception=exc)
+                    progress = snapshot.resume(exception=exc)
             else:
                 # Unexpected state — should not happen in non-async mode
                 raise SandboxProviderError(

--- a/src/nexus/cli/__init__.py
+++ b/src/nexus/cli/__init__.py
@@ -1,56 +1,40 @@
-"""
-Nexus CLI - Command-line interface for Nexus filesystem operations.
+"""Nexus CLI package.
 
-This module contains CLI-specific code for the nexus command-line tool.
-For programmatic access, use the nexus.sdk module instead.
-
-Architecture:
-    - utils.py: Common utilities (decorators, helpers)
-    - formatters.py: Rich output formatting utilities
-    - context.py: Global context management
-    - main.py: Main CLI entry point
-    - commands/: Modular command structure
-        - file_ops.py: File operations (init, cat, write, cp, mv, sync, rm)
-        - directory.py: Directory operations (ls, mkdir, rmdir, tree)
-        - search.py: Discovery commands (glob, grep, semantic search)
-        - permissions.py: Permission commands (chmod, chown, chgrp, getfacl, setfacl)
-        - rebac.py: Relationship-based access control
-        - versions.py: Version tracking commands
-        - plugins.py: Plugin management commands
-        - mounts.py: Connector mount management
-        - inspect.py: File inspection (info, version, size)
-
-Usage:
-    From command line:
-        $ nexus ls /workspace
-        $ nexus write /file.txt "content"
-
-    For programmatic access, use the SDK:
-        >>> from nexus.sdk import connect
-        >>> nx = connect()
-        >>> nx.sys_write("/file.txt", b"content")
+The package keeps its public re-exports lazy so submodules like
+``nexus.cli.exit_codes`` do not eagerly import the full CLI stack.
 """
 
-__all__ = ["main"]
+from __future__ import annotations
 
-# Import the main CLI entry point from main module
-from nexus.cli.main import main
-
-# Re-export utilities for internal CLI use
-from nexus.cli.utils import (
-    add_backend_options,
-    console,
-    get_filesystem,
-    handle_error,
-    open_filesystem,
-)
+import importlib
+from typing import Any
 
 __all__ = [
     "main",
-    # Utilities (for internal CLI use only)
     "console",
     "get_filesystem",
     "open_filesystem",
     "handle_error",
     "add_backend_options",
 ]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "main": ("nexus.cli.main", "main"),
+    "console": ("nexus.cli.utils", "console"),
+    "get_filesystem": ("nexus.cli.utils", "get_filesystem"),
+    "open_filesystem": ("nexus.cli.utils", "open_filesystem"),
+    "handle_error": ("nexus.cli.utils", "handle_error"),
+    "add_backend_options": ("nexus.cli.utils", "add_backend_options"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Load CLI exports on demand."""
+    if name not in _LAZY_IMPORTS:
+        raise AttributeError(f"module 'nexus.cli' has no attribute {name!r}")
+
+    module_name, attr_name = _LAZY_IMPORTS[name]
+    module = importlib.import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/src/nexus/cli/commands/directory.py
+++ b/src/nexus/cli/commands/directory.py
@@ -89,7 +89,14 @@ def list_files(
     timing = CommandTiming()
 
     try:
-        with timing.phase("connect"), open_filesystem(remote_url, remote_api_key) as nx:
+        with (
+            timing.phase("connect"),
+            open_filesystem(
+                remote_url,
+                remote_api_key,
+                allow_local_default=True,
+            ) as nx,
+        ):
             if at_operation:
                 _ls_time_travel(nx, path, at_operation, recursive, long, output_opts, timing)
                 return
@@ -164,7 +171,7 @@ def _ls_time_travel(
     timing: CommandTiming,
 ) -> None:
     """Handle time-travel ls (--at-operation)."""
-    time_travel = nx.service("time_travel")
+    time_travel = getattr(nx, "time_travel_service", None)
     if time_travel is None:
         console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
         return
@@ -235,7 +242,11 @@ def mkdir(
             render_dry_run(preview)
             return
 
-        with open_filesystem(remote_url, remote_api_key) as nx:
+        with open_filesystem(
+            remote_url,
+            remote_api_key,
+            allow_local_default=True,
+        ) as nx:
             if if_not_exists:
                 with contextlib.suppress(FileExistsError):
                     nx.sys_mkdir(path, parents=parents, exist_ok=True)
@@ -278,7 +289,11 @@ def rmdir(
             render_dry_run(preview)
             return
 
-        with open_filesystem(remote_url, remote_api_key) as nx:
+        with open_filesystem(
+            remote_url,
+            remote_api_key,
+            allow_local_default=True,
+        ) as nx:
             if not force and not click.confirm(f"Remove directory {path}?"):
                 console.print("[yellow]Cancelled[/yellow]")
                 return
@@ -315,7 +330,11 @@ def tree(
     try:
         with (
             timing.phase("connect"),
-            open_filesystem(remote_url, remote_api_key) as nx,
+            open_filesystem(
+                remote_url,
+                remote_api_key,
+                allow_local_default=True,
+            ) as nx,
             timing.phase("server"),
         ):
             files_raw = nx.sys_readdir(path, recursive=True, details=True)

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -7,13 +7,13 @@ from typing import Any, cast
 import click
 from rich.syntax import Syntax
 
-import nexus
 from nexus.cli.dry_run import add_dry_run_option, dry_run_preview, render_dry_run
 from nexus.cli.output import OutputOptions, add_output_options, render_error, render_output
 from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     add_backend_options,
     add_context_options,
+    connect_local_workspace,
     console,
     get_filesystem,
     handle_error,
@@ -58,7 +58,7 @@ def init(path: str) -> None:
         data_dir.mkdir(parents=True, exist_ok=True)
 
         # Initialize Nexus
-        nx = nexus.connect(config={"profile": "minimal", "data_dir": str(data_dir)})
+        nx = connect_local_workspace(str(data_dir))
 
         # Create default directories
         nx.sys_mkdir("/workspace", exist_ok=True)

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -58,7 +58,7 @@ def init(path: str) -> None:
         data_dir.mkdir(parents=True, exist_ok=True)
 
         # Initialize Nexus
-        nx = nexus.connect(config={"data_dir": str(data_dir)})
+        nx = nexus.connect(config={"profile": "minimal", "data_dir": str(data_dir)})
 
         # Create default directories
         nx.sys_mkdir("/workspace", exist_ok=True)
@@ -112,7 +112,14 @@ def cat(
     timing = CommandTiming()
 
     try:
-        with timing.phase("connect"), open_filesystem(remote_url, remote_api_key) as nx:
+        with (
+            timing.phase("connect"),
+            open_filesystem(
+                remote_url,
+                remote_api_key,
+                allow_local_default=True,
+            ) as nx,
+        ):
             if at_operation:
                 _cat_time_travel(nx, path, at_operation, metadata, output_opts, timing)
                 return
@@ -143,10 +150,7 @@ def cat(
                             file_size = 0
 
                     if file_size > STREAM_THRESHOLD:
-                        print(
-                            f"Streaming large file ({file_size:,} bytes)...",
-                            file=sys.stderr,
-                        )
+                        console.print(f"[dim]Streaming large file ({file_size:,} bytes)...[/dim]")
                         for chunk in nx.stream(  # type: ignore[attr-defined]
                             path, chunk_size=65536, context=operation_context
                         ):
@@ -209,10 +213,10 @@ def _cat_time_travel(
     timing: CommandTiming,
 ) -> None:
     """Handle time-travel cat (--at-operation)."""
-    time_travel = nx.service("time_travel")
+    time_travel = getattr(nx, "time_travel_service", None)
     if time_travel is None:
         console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
-        sys.exit(1)
+        return
 
     with timing.phase("server"):
         state = time_travel.get_file_at_operation(path, at_operation)
@@ -347,7 +351,11 @@ def write(
             render_dry_run(preview)
             return
 
-        with open_filesystem(remote_url, remote_api_key) as nx:
+        with open_filesystem(
+            remote_url,
+            remote_api_key,
+            allow_local_default=True,
+        ) as nx:
             # OCC: use lib/occ helper if CAS params present (Issue #1323).
             ctx = cast(Any, operation_context)
             if (if_match or if_none_match) and not force:
@@ -422,7 +430,11 @@ def append(
     try:
         file_content = resolve_content(content, input_file)
 
-        with open_filesystem(remote_url, remote_api_key) as nx:
+        with open_filesystem(
+            remote_url,
+            remote_api_key,
+            allow_local_default=True,
+        ) as nx:
             # Append with OCC parameters and context.
             # CAS params (if_match, force) are NexusFS-specific (transitional, see #1323).
             result = cast(Any, nx).append(
@@ -520,7 +532,7 @@ def write_batch(
             TimeElapsedColumn,
         )
 
-        nx = get_filesystem(remote_url, remote_api_key)
+        nx = get_filesystem(remote_url, remote_api_key, allow_local_default=True)
         source_path = Path(source_dir)
 
         # Ensure dest_prefix starts with /
@@ -637,7 +649,7 @@ def cp(
             render_dry_run(preview)
             return
 
-        nx = get_filesystem(remote_url, remote_api_key)
+        nx = get_filesystem(remote_url, remote_api_key, allow_local_default=True)
 
         # Read source
         content = nx.sys_read(source)
@@ -696,7 +708,7 @@ def copy_cmd(
     try:
         from nexus.sync import copy_file, copy_recursive, is_local_path
 
-        nx = get_filesystem(remote_url, remote_api_key)
+        nx = get_filesystem(remote_url, remote_api_key, allow_local_default=True)
 
         # Handle --no-checksum flag
         use_checksum = checksum and not no_checksum
@@ -773,7 +785,7 @@ def move_cmd(
 
         from nexus.sync import move_file
 
-        nx = get_filesystem(remote_url, remote_api_key)
+        nx = get_filesystem(remote_url, remote_api_key, allow_local_default=True)
 
         # Confirm unless --force
         if not force and not click.confirm(f"Move {source} to {dest}?"):
@@ -835,7 +847,7 @@ def sync_cmd(
     try:
         from nexus.sync import sync_directories
 
-        nx = get_filesystem(remote_url, remote_api_key)
+        nx = get_filesystem(remote_url, remote_api_key, allow_local_default=True)
 
         use_checksum = not no_checksum
 
@@ -906,7 +918,7 @@ def rm(
             render_dry_run(preview)
             return
 
-        nx = get_filesystem(remote_url, remote_api_key)
+        nx = get_filesystem(remote_url, remote_api_key, allow_local_default=True)
 
         # Check if file exists
         if not nx.sys_access(path):

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -31,7 +31,7 @@ setup_uvloop()
 )
 @click.pass_context
 def main(ctx: click.Context, profile: str | None) -> None:
-    """Nexus - AI-Native Distributed Filesystem.
+    """Nexus - filesystem/context plane.
 
     Beautiful command-line interface for file operations, discovery, and management.
 

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -142,25 +142,33 @@ def get_filesystem(
         NexusFilesystem instance.
     """
     try:
+        from click.core import ParameterSource
+
         from nexus.cli.config import resolve_connection
 
-        explicit_remote_url = remote_url.strip() if remote_url is not None else None
         explicit_local_data_dir = os.environ.get("NEXUS_DATA_DIR")
-
-        # Source-checkout quickstart: if a local data dir is explicitly set and
-        # no remote URL was provided, prefer the local workspace over any active
-        # CLI profile stored in ~/.nexus/config.yaml.
-        if allow_local_default and explicit_local_data_dir and not explicit_remote_url:
-            return nexus.connect(config={"profile": "minimal", "data_dir": explicit_local_data_dir})
+        remote_url_source = None
 
         # Get profile name from Click context if available
         profile_name = None
         try:
             ctx = click.get_current_context(silent=True)
-            if ctx and ctx.obj:
-                profile_name = ctx.obj.get("profile")
+            if ctx:
+                if ctx.obj:
+                    profile_name = ctx.obj.get("profile")
+                remote_url_source = ctx.get_parameter_source("remote_url")
         except RuntimeError:
             pass
+
+        # Source-checkout quickstart: if a local data dir is explicitly set and
+        # the user did not explicitly pass --remote-url, prefer the local
+        # workspace over any ambient NEXUS_URL or saved CLI profile.
+        if (
+            allow_local_default
+            and explicit_local_data_dir
+            and remote_url_source is not ParameterSource.COMMANDLINE
+        ):
+            return nexus.connect(config={"profile": "minimal", "data_dir": explicit_local_data_dir})
 
         resolved = resolve_connection(
             remote_url=remote_url,

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -144,6 +144,15 @@ def get_filesystem(
     try:
         from nexus.cli.config import resolve_connection
 
+        explicit_remote_url = remote_url.strip() if remote_url is not None else None
+        explicit_local_data_dir = os.environ.get("NEXUS_DATA_DIR")
+
+        # Source-checkout quickstart: if a local data dir is explicitly set and
+        # no remote URL was provided, prefer the local workspace over any active
+        # CLI profile stored in ~/.nexus/config.yaml.
+        if allow_local_default and explicit_local_data_dir and not explicit_remote_url:
+            return nexus.connect(config={"profile": "minimal", "data_dir": explicit_local_data_dir})
+
         # Get profile name from Click context if available
         profile_name = None
         try:

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -530,3 +530,30 @@ def get_service_client(
     from nexus.cli.client import NexusServiceClient
 
     return NexusServiceClient(url=remote_url, api_key=remote_api_key)
+
+
+def rpc_call(
+    remote_url: str | None,
+    remote_api_key: str | None,
+    rpc_method: str,
+    **kwargs: Any,
+) -> Any:
+    """Backward-compatible wrapper over ``NexusServiceClient`` methods.
+
+    A few CLI commands still call the older ``rpc_call(...)`` helper. Keep it
+    as a thin adapter until those commands are migrated to the newer client
+    wrappers.
+    """
+    method_aliases = {
+        "federation_list_zones": "federation_zones",
+    }
+    client_method_name = method_aliases.get(rpc_method, rpc_method)
+
+    with get_service_client(remote_url, remote_api_key) as client:
+        client_method = getattr(client, client_method_name, None)
+        if client_method is None or not callable(client_method):
+            raise AttributeError(
+                f"NexusServiceClient has no method {client_method_name!r} "
+                f"(requested via legacy rpc_call name {rpc_method!r})"
+            )
+        return client_method(**kwargs)

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -6,6 +6,7 @@ import os
 import sys
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
@@ -98,21 +99,47 @@ def add_backend_options(func: Any) -> Any:
     return wrapper
 
 
+def _apply_common_config(
+    config: dict[str, Any],
+    *,
+    enforce_permissions: bool | None,
+    allow_admin_bypass: bool | None,
+    enforce_zone_isolation: bool | None,
+    enable_memory_paging: bool,
+    memory_main_capacity: int,
+    memory_recall_max_age_hours: float,
+) -> None:
+    """Apply common configuration options to a config dict (mutates in place)."""
+    if enforce_permissions is not None:
+        config["enforce_permissions"] = enforce_permissions
+    if allow_admin_bypass is not None:
+        config["allow_admin_bypass"] = allow_admin_bypass
+    if enforce_zone_isolation is not None:
+        config["enforce_zone_isolation"] = enforce_zone_isolation
+    config["enable_memory_paging"] = enable_memory_paging
+    config["memory_main_capacity"] = memory_main_capacity
+    config["memory_recall_max_age_hours"] = memory_recall_max_age_hours
+
+
 def get_filesystem(
     remote_url: str | None = None,
     remote_api_key: str | None = None,
+    *,
+    allow_local_default: bool = False,
 ) -> NexusFilesystem:
-    """Get a remote NexusFilesystem instance.
+    """Get a NexusFilesystem instance.
 
     Uses resolve_connection() to determine the effective connection target
-    when no explicit --remote-url, --config, or --backend=gcs is provided.
+    when no explicit ``--remote-url`` is provided.
 
     Args:
         remote_url: Nexus server URL (falls back to NEXUS_URL env var).
         remote_api_key: API key (falls back to NEXUS_API_KEY env var).
+        allow_local_default: When True, fall back to a verified local minimal
+            profile using ``NEXUS_DATA_DIR`` or ``~/.nexus/data``.
 
     Returns:
-        NexusFilesystem instance connected to the remote server.
+        NexusFilesystem instance.
     """
     try:
         from nexus.cli.config import resolve_connection
@@ -133,6 +160,13 @@ def get_filesystem(
         )
 
         if not resolved.is_remote:
+            if allow_local_default:
+                data_dir = os.environ.get(
+                    "NEXUS_DATA_DIR",
+                    str(Path(nexus.NEXUS_STATE_DIR) / "data"),
+                )
+                return nexus.connect(config={"profile": "minimal", "data_dir": data_dir})
+
             console.print("[red]Error:[/red] NEXUS_URL or --remote-url is required")
             console.print(
                 "[yellow]Hint:[/yellow] export NEXUS_URL=http://your-nexus-server:2026"
@@ -415,7 +449,8 @@ def resolve_content(content: str | None, input_file: Any) -> bytes:
         SystemExit: If no content source is provided.
     """
     if input_file:
-        return bytes(input_file.read())
+        data = input_file.read()
+        return data if isinstance(data, bytes) else data.encode("utf-8")
     if content == "-":
         return sys.stdin.buffer.read()
     if content:
@@ -428,6 +463,7 @@ def resolve_content(content: str | None, input_file: Any) -> bytes:
 def open_filesystem(
     remote_url: str | None = None,
     remote_api_key: str | None = None,
+    **kwargs: Any,
 ) -> Generator[NexusFilesystem, None, None]:
     """Context manager that opens and auto-closes a NexusFilesystem.
 
@@ -437,7 +473,7 @@ def open_filesystem(
             result = nx.sys_readdir(path)
         # nx.close() is called automatically, even on exception.
     """
-    nx = get_filesystem(remote_url, remote_api_key)
+    nx = get_filesystem(remote_url, remote_api_key, **kwargs)
     try:
         yield nx
     finally:
@@ -471,29 +507,26 @@ def output_result(data: Any, json_output: bool, rich_fn: Any) -> None:
         rich_fn(data)
 
 
-def rpc_call(
-    remote_url: str | None,
-    remote_api_key: str | None,
-    rpc_method: str,
-    **kwargs: Any,
+def get_service_client(
+    remote_url: str | None = None,
+    remote_api_key: str | None = None,
 ) -> Any:
-    """Call a server RPC method via gRPC transport.
-
-    Opens a remote NexusFilesystem, grabs any wired service proxy, and
-    dispatches the method through ``RemoteServiceProxy.__getattr__`` →
-    ``_call_rpc`` → gRPC ``Call`` RPC → server-side ``dispatch_method()``.
+    """Create a NexusServiceClient from URL/API key, with validation.
 
     Args:
         remote_url: Server URL (from --remote-url or NEXUS_URL env var)
         remote_api_key: API key (from --remote-api-key or NEXUS_API_KEY env var)
-        rpc_method: RPC method name (e.g. ``"federation_list_zones"``)
-        **kwargs: Method parameters
 
     Returns:
-        Result dict from the server.
+        NexusServiceClient instance
+
+    Raises:
+        SystemExit: If URL is not provided
     """
-    with open_filesystem(remote_url, remote_api_key) as nx:
-        svc = nx.service("version")  # any wired proxy works — they all share _call_rpc
-        if svc is None:
-            raise RuntimeError("Cannot reach server — no service proxy available")
-        return getattr(svc, rpc_method)(**kwargs)
+    if not remote_url:
+        console.print("[red]Error:[/red] Server URL required. Set NEXUS_URL or use --remote-url")
+        sys.exit(ExitCode.CONFIG_ERROR)
+
+    from nexus.cli.client import NexusServiceClient
+
+    return NexusServiceClient(url=remote_url, api_key=remote_api_key)

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -22,6 +22,26 @@ if TYPE_CHECKING:
 
 console = Console()
 
+_LOCAL_WORKSPACE_ENV_KEYS = (
+    "NEXUS_URL",
+    "NEXUS_API_KEY",
+    "NEXUS_PROFILE",
+    "NEXUS_BACKEND",
+    "NEXUS_GCS_BUCKET_NAME",
+    "NEXUS_GCS_PROJECT_ID",
+    "NEXUS_GCS_CREDENTIALS_PATH",
+    "NEXUS_DB_PATH",
+    "NEXUS_METASTORE_PATH",
+    "NEXUS_RECORD_STORE_PATH",
+    "NEXUS_DATABASE_URL",
+    "NEXUS_NODE_ID",
+    "NEXUS_BIND_ADDR",
+    "NEXUS_ADVERTISE_ADDR",
+    "NEXUS_PEERS",
+    "NEXUS_FEDERATION_ZONES",
+    "NEXUS_FEDERATION_MOUNTS",
+)
+
 # Global options
 REMOTE_URL_OPTION = click.option(
     "--remote-url",
@@ -121,6 +141,47 @@ def _apply_common_config(
     config["memory_recall_max_age_hours"] = memory_recall_max_age_hours
 
 
+@contextmanager
+def _isolated_local_workspace_env(data_dir: str) -> Generator[None, None, None]:
+    """Temporarily mask ambient Nexus connection env for local quickstart use."""
+    previous: dict[str, str | None] = {
+        key: os.environ.get(key) for key in _LOCAL_WORKSPACE_ENV_KEYS
+    }
+    previous_data_dir = os.environ.get("NEXUS_DATA_DIR")
+    try:
+        for key in _LOCAL_WORKSPACE_ENV_KEYS:
+            os.environ.pop(key, None)
+        os.environ["NEXUS_DATA_DIR"] = data_dir
+        yield
+    finally:
+        if previous_data_dir is None:
+            os.environ.pop("NEXUS_DATA_DIR", None)
+        else:
+            os.environ["NEXUS_DATA_DIR"] = previous_data_dir
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def connect_local_workspace(data_dir: str) -> NexusFilesystem:
+    """Connect to a self-contained local workspace without ambient env bleed."""
+    with _isolated_local_workspace_env(data_dir):
+        return nexus.connect(
+            config={
+                "profile": "minimal",
+                "backend": "local",
+                "data_dir": data_dir,
+                "db_path": None,
+                "metastore_path": None,
+                "record_store_path": None,
+                "url": None,
+                "api_key": None,
+            }
+        )
+
+
 def get_filesystem(
     remote_url: str | None = None,
     remote_api_key: str | None = None,
@@ -168,7 +229,7 @@ def get_filesystem(
             and explicit_local_data_dir
             and remote_url_source is not ParameterSource.COMMANDLINE
         ):
-            return nexus.connect(config={"profile": "minimal", "data_dir": explicit_local_data_dir})
+            return connect_local_workspace(explicit_local_data_dir)
 
         resolved = resolve_connection(
             remote_url=remote_url,

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -266,7 +266,7 @@ class NexusConfig(BaseModel):
 
     # Remote mode settings
     url: str | None = Field(
-        default=None, description="Nexus server URL (required for mode='remote')"
+        default=None, description="Nexus server URL (required for profile='remote')"
     )
     api_key: str | None = Field(default=None, description="API key for authentication")
     timeout: float = Field(default=30.0, description="Request timeout in seconds")

--- a/src/nexus/core/hash_fast.py
+++ b/src/nexus/core/hash_fast.py
@@ -41,9 +41,10 @@ try:
     _RUST_AVAILABLE = True
     logger.debug("Using Rust BLAKE3 acceleration")
 except (ImportError, AttributeError):
-    logger.warning(
-        "Rust BLAKE3 extension not available — falling back to Python blake3. "
-        "Install with: pip install nexus-ai-fs[rust] or maturin develop --release"
+    logger.info(
+        "Optional Rust BLAKE3 extension not available; using Python blake3. "
+        "For local development, build rust/nexus_pyo3 with: "
+        "maturin develop --release -m rust/nexus_pyo3/Cargo.toml"
     )
 
 # Priority 2: Python blake3 package (Issue #582, #833)

--- a/src/nexus/factory/_remote.py
+++ b/src/nexus/factory/_remote.py
@@ -1,7 +1,8 @@
 """Boot helper for REMOTE deployment profile — the ``mount -t nfs`` command.
 
-Fills ServiceRegistry with RemoteServiceProxy instances, forwarding all
-method calls to the server via the transport-agnostic ``call_rpc`` callback.
+Fills NexusFS kernel service slots with RemoteServiceProxy instances,
+forwarding all method calls to the server via the transport-agnostic
+``call_rpc`` callback.
 
 The kernel runs its natural VFS pipeline (permission → route → backend →
 metadata) identically to standalone/federation modes.  RemoteMetastore and
@@ -26,14 +27,43 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# All fields accepted by bind_wired_services() (dict path).
+# Derived from nexus.factory.service_routing.bind_wired_services.
+_WIRED_FIELDS: list[str] = [
+    # Services
+    "rebac_service",
+    "mount_service",
+    "gateway",
+    "mount_core_service",
+    "sync_service",
+    "sync_job_service",
+    "mount_persist_service",
+    "mcp_service",
+    "llm_service",
+    "oauth_service",
+    "search_service",
+    "share_link_service",
+    "events_service",
+    "workspace_rpc_service",
+    "agent_rpc_service",
+    "user_provisioning_service",
+    "sandbox_rpc_service",
+    "metadata_export_service",
+    "descendant_checker",
+    "memory_provider",
+    # Versioning services (Issue #882)
+    "time_travel_service",
+    "operations_service",
+]
+
 
 def _boot_remote_services(nfs: "NexusFS", call_rpc: Callable[..., Any]) -> None:
-    """Wire RemoteServiceProxy instances into ServiceRegistry.
+    """Wire RemoteServiceProxy instances as all service attributes.
 
-    Like ``mount -t nfs``: fills ServiceRegistry with RPC forwarders
+    Like ``mount -t nfs``: fills VFS service slots with RPC forwarders
     instead of local service implementations.
 
-    Called by ``connect(profile=REMOTE)`` after NexusFS construction.
+    Called by ``connect(profile="remote")`` after NexusFS construction.
 
     Args:
         nfs: The NexusFS instance to wire services onto.
@@ -43,15 +73,17 @@ def _boot_remote_services(nfs: "NexusFS", call_rpc: Callable[..., Any]) -> None:
 
     proxy = RemoteServiceProxy(call_rpc, service_name="universal")
 
-    from nexus.factory.service_routing import _CANONICAL_NAMES, populate_service_registry
+    # Fill all wired service slots via bind_wired_services (dict path)
+    from nexus.factory.service_routing import bind_wired_services, populate_service_registry
 
-    wired_dict: dict[str, Any] = dict.fromkeys(_CANONICAL_NAMES.keys(), proxy)
-    count = populate_service_registry(nfs._service_registry, wired_dict, is_remote=True)
+    wired_dict: dict[str, Any] = dict.fromkeys(_WIRED_FIELDS, proxy)
+    bind_wired_services(nfs, wired_dict)
+    populate_service_registry(nfs._service_registry, wired_dict, is_remote=True)
 
     # BrickServices field not covered by WiredServices
     nfs.version_service = proxy
 
     logger.info(
-        "REMOTE profile: registered %d services with RPC forwarders (kernel runs naturally)",
-        count + 1,
+        "REMOTE profile: wired %d service slots with RPC forwarders (kernel runs naturally)",
+        len(_WIRED_FIELDS) + 1,
     )

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -1,8 +1,8 @@
-"""Service wiring — registers DI-resolved service instances into ServiceRegistry.
+"""Service wiring — binds DI services and populates ``ServiceRegistry``.
 
-Issue #1452 Phase 2c: ``bind_wired_services()`` deleted — all callers migrated
-to ``nx.service("xxx")`` via ServiceRegistry.  ``populate_service_registry()``
-is now the sole registration path.
+``bind_wired_services()`` is still kept as a compatibility shim because
+``_remote.py`` and a few tests still exercise the older attribute-wiring path
+while the codebase completes the ServiceRegistry migration.
 """
 
 from __future__ import annotations
@@ -12,6 +12,44 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from nexus.core.config import WiredServices
     from nexus.core.service_registry import ServiceRegistry
+
+
+def bind_wired_services(target: object, wired: "WiredServices | dict[str, Any]") -> None:
+    """Bind wired service instances onto *target* object.
+
+    This preserves the historical ``setattr`` wiring path used by remote boot
+    code while callers migrate to ``nx.service(...)`` lookups.
+    """
+    slot_map: dict[str, str] = {
+        "rebac_service": "rebac_service",
+        "mount_service": "mount_service",
+        "gateway": "_gateway",
+        "mount_core_service": "_mount_core_service",
+        "sync_service": "_sync_service",
+        "sync_job_service": "_sync_job_service",
+        "mount_persist_service": "_mount_persist_service",
+        "mcp_service": "mcp_service",
+        "llm_service": "llm_service",
+        "oauth_service": "oauth_service",
+        "search_service": "search_service",
+        "share_link_service": "share_link_service",
+        "events_service": "events_service",
+        "workspace_rpc_service": "_workspace_rpc_service",
+        "agent_rpc_service": "_agent_rpc_service",
+        "user_provisioning_service": "_user_provisioning_service",
+        "sandbox_rpc_service": "_sandbox_rpc_service",
+        "metadata_export_service": "_metadata_export_service",
+        "descendant_checker": "_descendant_checker",
+        "memory_provider": "_memory_provider",
+        "time_travel_service": "time_travel_service",
+        "operations_service": "operations_service",
+    }
+    if isinstance(wired, dict):
+        for src_key, target_attr in slot_map.items():
+            setattr(target, target_attr, wired.get(src_key))
+        return
+    for src_key, target_attr in slot_map.items():
+        setattr(target, target_attr, getattr(wired, src_key))
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/sdk/__init__.py
+++ b/src/nexus/sdk/__init__.py
@@ -93,7 +93,6 @@ __all__ = [
     "ReBACTuple",
     "Entity",
     "WILDCARD_SUBJECT",
-    "ConsistencyLevel",
     "CheckResult",
     "GraphLimitExceeded",
 ]
@@ -110,7 +109,6 @@ from nexus.bricks.rebac.domain import WILDCARD_SUBJECT, Entity, ReBACTuple
 from nexus.bricks.rebac.enforcer import PermissionEnforcer
 from nexus.bricks.rebac.manager import (
     CheckResult,
-    ConsistencyLevel,
     GraphLimitExceeded,
     ReBACManager,
 )

--- a/src/nexus/sdk/__init__.py
+++ b/src/nexus/sdk/__init__.py
@@ -1,5 +1,7 @@
 """
-Nexus SDK - Clean programmatic interface for third-party tools.
+Nexus = filesystem/context plane.
+
+Nexus SDK - clean programmatic interface for third-party tools.
 
 This module provides a clean, stable API for building custom tools and interfaces
 on top of Nexus, without any CLI dependencies. Use this SDK to build:
@@ -11,14 +13,23 @@ on top of Nexus, without any CLI dependencies. Use this SDK to build:
 
 The SDK interface is stable and semantic-versioned separately from CLI changes.
 
-Quick Start (Server Mode - Recommended):
+Quick Start (Local - Verified):
     >>> from nexus.sdk import connect
     >>>
-    >>> # Start server first: nexusd --host 0.0.0.0 --port 2026
+    >>> nx = connect(config={"profile": "minimal", "data_dir": "./nexus-data"})
+    >>> nx.sys_write("/workspace/file.txt", b"Hello World")
+    >>> content = nx.sys_read("/workspace/file.txt")
+
+Quick Start (Remote):
+    >>> from nexus.sdk import connect
+    >>>
+    >>> # Start server first:
+    >>> #   export NEXUS_GRPC_PORT=2126
+    >>> #   nexusd --host 0.0.0.0 --port 2026
     >>> # Set environment: export NEXUS_URL=http://localhost:2026
     >>>
-    >>> # Connect to Nexus server (thin HTTP client)
-    >>> nx = connect()
+    >>> # Connect to Nexus server (thin remote client)
+    >>> nx = connect(config={"profile": "remote", "url": "http://localhost:2026"})
     >>>
     >>> # File operations
     >>> nx.sys_write("/workspace/file.txt", b"Hello World")
@@ -30,24 +41,21 @@ Quick Start (Server Mode - Recommended):
     >>> python_files = nx.glob("**/*.py")
     >>> todos = nx.grep("TODO", file_pattern="**/*.py")
 
-Quick Start (Local - Development Only):
-    >>> # No server required, but less suitable for production
-    >>> nx = connect(config={"data_dir": "./nexus-data"})
-    >>> nx.sys_write("/workspace/file.txt", b"Hello World")
-
 Configuration:
-    >>> # Server mode with auto-discovery (recommended)
+    >>> # Remote mode with auto-discovery
     >>> # Checks NEXUS_URL and NEXUS_API_KEY environment variables
-    >>> nx = connect()
+    >>> nx = connect(config={"profile": "remote"})
     >>>
     >>> # Server mode with explicit config
     >>> nx = connect(config={
+    ...     "profile": "remote",
     ...     "url": "http://localhost:2026",
     ...     "api_key": "your-api-key"
     ... })
     >>>
-    >>> # Local mode (development/testing only)
+    >>> # Local mode
     >>> nx = connect(config={
+    ...     "profile": "minimal",
     ...     "data_dir": "./nexus-data"
     ... })
     >>>
@@ -85,6 +93,7 @@ __all__ = [
     "ReBACTuple",
     "Entity",
     "WILDCARD_SUBJECT",
+    "ConsistencyLevel",
     "CheckResult",
     "GraphLimitExceeded",
 ]
@@ -101,6 +110,7 @@ from nexus.bricks.rebac.domain import WILDCARD_SUBJECT, Entity, ReBACTuple
 from nexus.bricks.rebac.enforcer import PermissionEnforcer
 from nexus.bricks.rebac.manager import (
     CheckResult,
+    ConsistencyLevel,
     GraphLimitExceeded,
     ReBACManager,
 )

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -278,7 +278,11 @@ def create_app(
     # Kept for backward compatibility with handlers not yet migrated.
     if _record_store is not None:
         app.state.session_factory = _record_store.session_factory
-    elif hasattr(nexus_fs, "SessionLocal") and nexus_fs.SessionLocal is not None:
+    elif (
+        nexus_fs is not None
+        and hasattr(nexus_fs, "SessionLocal")
+        and nexus_fs.SessionLocal is not None
+    ):
         app.state.session_factory = nexus_fs.SessionLocal
     else:
         app.state.session_factory = None
@@ -312,55 +316,59 @@ def create_app(
 
     # Discover exposed methods — includes brick services (Issue #2035, Follow-up 1)
     # Services with @rpc_expose override kernel stubs (later sources win).
-    _brick_sources: list[Any] = []
-    for _svc_name in (
-        "mcp",
-        "llm",
-        "oauth",
-        "mount",
-        "search",
-        "share_link",
-        "rebac",
-    ):
-        _brick_svc = nexus_fs.service(_svc_name)
-        if _brick_svc is not None:
-            _brick_sources.append(_brick_svc)
-    # version_service is on BrickServices, not in ServiceRegistry
-    _version_svc = getattr(nexus_fs, "version_service", None)
-    if _version_svc is not None:
-        _brick_sources.append(_version_svc)
-    # AgentRPCService
-    _agent_rpc = nexus_fs.service("agent_rpc")
-    if _agent_rpc is not None:
-        _brick_sources.append(_agent_rpc)
-    # WorkspaceRPCService
-    _workspace_rpc = nexus_fs.service("workspace_rpc")
-    if _workspace_rpc is not None:
-        _brick_sources.append(_workspace_rpc)
-    # Issue #12: MemoryService lives outside kernel — created by factory, not on NexusFS
-    try:
-        from nexus.factory import create_memory_service
+    if nexus_fs is not None:
+        _brick_sources: list[Any] = []
+        for _svc_name in (
+            "mcp",
+            "llm",
+            "oauth",
+            "mount",
+            "search",
+            "share_link",
+            "rebac",
+        ):
+            _brick_svc = nexus_fs.service(_svc_name)
+            if _brick_svc is not None:
+                _brick_sources.append(_brick_svc)
+        # version_service is on BrickServices, not in ServiceRegistry
+        _version_svc = getattr(nexus_fs, "version_service", None)
+        if _version_svc is not None:
+            _brick_sources.append(_version_svc)
+        # AgentRPCService
+        _agent_rpc = nexus_fs.service("agent_rpc")
+        if _agent_rpc is not None:
+            _brick_sources.append(_agent_rpc)
+        # WorkspaceRPCService
+        _workspace_rpc = nexus_fs.service("workspace_rpc")
+        if _workspace_rpc is not None:
+            _brick_sources.append(_workspace_rpc)
+        # Issue #12: MemoryService lives outside kernel — created by factory, not on NexusFS
+        try:
+            from nexus.factory import create_memory_service
 
-        _memory_svc = create_memory_service(nexus_fs)
-        if _memory_svc is not None:
-            _brick_sources.append(_memory_svc)
-            app.state.memory_service = _memory_svc  # for cleanup in lifespan
-    except Exception as _exc:
-        logger.debug("MemoryService unavailable: %s", _exc)
-    # Issue #841: MetadataExportService lives outside kernel
-    try:
-        from nexus.factory import create_metadata_export_service
+            _memory_svc = create_memory_service(nexus_fs)
+            if _memory_svc is not None:
+                _brick_sources.append(_memory_svc)
+                app.state.memory_service = _memory_svc  # for cleanup in lifespan
+        except Exception as _exc:
+            logger.debug("MemoryService unavailable: %s", _exc)
+        # Issue #841: MetadataExportService lives outside kernel
+        try:
+            from nexus.factory import create_metadata_export_service
 
-        _meta_export_svc = create_metadata_export_service(nexus_fs)
-        if _meta_export_svc is not None:
-            _brick_sources.append(_meta_export_svc)
-    except Exception as _exc:
-        logger.debug("MetadataExportService unavailable: %s", _exc)
-    # Issue #1410: VersionService @rpc_expose methods (moved from NexusFS)
-    _version_svc = getattr(nexus_fs, "version_service", None)
-    if _version_svc is not None:
-        _brick_sources.append(_version_svc)
-    app.state.exposed_methods = _discover_exposed_methods(nexus_fs, *_brick_sources)
+            _meta_export_svc = create_metadata_export_service(nexus_fs)
+            if _meta_export_svc is not None:
+                _brick_sources.append(_meta_export_svc)
+        except Exception as _exc:
+            logger.debug("MetadataExportService unavailable: %s", _exc)
+        # Issue #1410: VersionService @rpc_expose methods (moved from NexusFS)
+        _version_svc = getattr(nexus_fs, "version_service", None)
+        if _version_svc is not None:
+            _brick_sources.append(_version_svc)
+        app.state.exposed_methods = _discover_exposed_methods(nexus_fs, *_brick_sources)
+    else:
+        logger.info("create_app() started without NexusFS; service discovery disabled")
+        app.state.exposed_methods = {}
 
     # Defaults for optional services are set by init_app_state() above (Issue #2135)
 
@@ -376,7 +384,7 @@ def create_app(
 
     # Initialize subscription manager if we have a metadata store
     try:
-        if hasattr(nexus_fs, "SessionLocal"):
+        if nexus_fs is not None and hasattr(nexus_fs, "SessionLocal"):
             from nexus.server.subscriptions import (
                 SubscriptionManager,
                 set_subscription_manager,
@@ -511,10 +519,11 @@ def create_app(
     # Register NexusFS instance for zone routes, migration, and user provisioning.
     # This must happen unconditionally (not only when OAuth is configured).
     try:
-        from nexus.server.auth.auth_routes import set_nexus_instance
+        if nexus_fs is not None:
+            from nexus.server.auth.auth_routes import set_nexus_instance
 
-        set_nexus_instance(nexus_fs)
-        logger.info("NexusFS instance registered for zone management")
+            set_nexus_instance(nexus_fs)
+            logger.info("NexusFS instance registered for zone management")
     except Exception as e:
         logger.warning(f"Failed to register NexusFS instance: {e}")
 

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -182,7 +182,7 @@ def create_app(
     # Create app first so we can store state on it
     app = FastAPI(
         title="Nexus RPC Server",
-        description="AI-Native Distributed Filesystem API",
+        description="Nexus = filesystem/context plane.",
         version="1.0.0",
         lifespan=_modular_lifespan,
     )
@@ -313,29 +313,28 @@ def create_app(
     # Discover exposed methods — includes brick services (Issue #2035, Follow-up 1)
     # Services with @rpc_expose override kernel stubs (later sources win).
     _brick_sources: list[Any] = []
-    if nexus_fs is not None:
-        for _svc_name in (
-            "mcp",
-            "llm",
-            "oauth",
-            "mount",
-            "search",
-            "share_link",
-            "rebac",
-        ):
-            _brick_svc = nexus_fs.service(_svc_name)
-            if _brick_svc is not None:
-                _brick_sources.append(_brick_svc)
+    for _svc_name in (
+        "mcp",
+        "llm",
+        "oauth",
+        "mount",
+        "search",
+        "share_link",
+        "rebac",
+    ):
+        _brick_svc = nexus_fs.service(_svc_name)
+        if _brick_svc is not None:
+            _brick_sources.append(_brick_svc)
     # version_service is on BrickServices, not in ServiceRegistry
     _version_svc = getattr(nexus_fs, "version_service", None)
     if _version_svc is not None:
         _brick_sources.append(_version_svc)
     # AgentRPCService
-    _agent_rpc = nexus_fs.service("agent_rpc") if nexus_fs is not None else None
+    _agent_rpc = nexus_fs.service("agent_rpc")
     if _agent_rpc is not None:
         _brick_sources.append(_agent_rpc)
     # WorkspaceRPCService
-    _workspace_rpc = nexus_fs.service("workspace_rpc") if nexus_fs is not None else None
+    _workspace_rpc = nexus_fs.service("workspace_rpc")
     if _workspace_rpc is not None:
         _brick_sources.append(_workspace_rpc)
     # Issue #12: MemoryService lives outside kernel — created by factory, not on NexusFS
@@ -361,49 +360,7 @@ def create_app(
     _version_svc = getattr(nexus_fs, "version_service", None)
     if _version_svc is not None:
         _brick_sources.append(_version_svc)
-    # --- Service RPC surfaces (Issue #1520) ---
-    _zone_mgr = getattr(app.state, "zone_manager", None)
-    if _zone_mgr is not None:
-        from nexus.server.rpc.services.federation_rpc import FederationRPCService
-
-        _brick_sources.append(
-            FederationRPCService(_zone_mgr, getattr(app.state, "federation", None))
-        )
-    _credits = getattr(app.state, "credits_service", None)
-    if _credits is not None:
-        from nexus.server.rpc.services.pay_rpc import PayRPCService
-
-        _brick_sources.append(PayRPCService(_credits))
-    _audit_logger = getattr(app.state, "exchange_audit_logger", None)
-    if _audit_logger is not None:
-        from nexus.server.rpc.services.audit_rpc import AuditRPCService
-
-        _brick_sources.append(AuditRPCService(_audit_logger))
-    _lock_mgr = getattr(nexus_fs, "_lock_manager", None)
-    if _lock_mgr is not None:
-        from nexus.server.rpc.services.locks_rpc import LocksRPCService
-
-        _brick_sources.append(LocksRPCService(_lock_mgr))
-    _gov_anomaly = getattr(app.state, "governance_anomaly_service", None)
-    _gov_collusion = getattr(app.state, "governance_collusion_service", None)
-    if _gov_anomaly is not None or _gov_collusion is not None:
-        from nexus.server.rpc.services.governance_rpc import GovernanceRPCService
-
-        _brick_sources.append(GovernanceRPCService(_gov_anomaly, _gov_collusion))
-    _replay_svc = getattr(app.state, "replay_service", None)
-    if _replay_svc is not None:
-        from nexus.server.rpc.services.events_rpc import EventsRPCService
-
-        _brick_sources.append(EventsRPCService(_replay_svc))
-    _snapshot_svc = getattr(nexus_fs, "_snapshot_service", None)
-    if _snapshot_svc is not None:
-        from nexus.server.rpc.services.snapshots_rpc import SnapshotsRPCService
-
-        _brick_sources.append(SnapshotsRPCService(_snapshot_svc))
-    if nexus_fs is not None:
-        app.state.exposed_methods = _discover_exposed_methods(nexus_fs, *_brick_sources)
-    else:
-        app.state.exposed_methods = {}
+    app.state.exposed_methods = _discover_exposed_methods(nexus_fs, *_brick_sources)
 
     # Defaults for optional services are set by init_app_state() above (Issue #2135)
 
@@ -437,9 +394,7 @@ def create_app(
             # Issue #914: Inject getter into delivery worker (fixes services→server import)
             from nexus.server.subscriptions import get_subscription_manager
 
-            _dw = (
-                nexus_fs.exposed_services().get("delivery_worker") if nexus_fs is not None else None
-            )
+            _dw = nexus_fs.exposed_services().get("delivery_worker")
             if _dw is not None:
                 _dw._subscription_manager_getter = get_subscription_manager
             logger.info("Subscription manager initialized and injected into NexusFS")

--- a/src/nexus/storage/dict_metastore.py
+++ b/src/nexus/storage/dict_metastore.py
@@ -11,14 +11,17 @@ build the Rust extensions: ``maturin develop -m rust/nexus_raft/Cargo.toml``.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from nexus.contracts.metadata import FileMetadata
 from nexus.core.metastore import MetastoreABC
 from nexus.core.pagination import PaginatedResult
+from nexus.storage._metadata_mapper_generated import MetadataMapper
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +41,46 @@ class DictMetastore(MetastoreABC):
     Thread-safe under Python GIL.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, storage_path: str | Path | None = None) -> None:
         self._store: dict[str, FileMetadata] = {}
         self._file_metadata: dict[str, dict[str, Any]] = {}
+        self._storage_path = Path(storage_path) if storage_path is not None else None
+        if self._storage_path is not None:
+            self._load()
+
+    def _load(self) -> None:
+        if self._storage_path is None or not self._storage_path.exists():
+            return
+        with self._storage_path.open() as fh:
+            payload = json.load(fh)
+
+        raw_store = payload.get("store", {})
+        raw_file_metadata = payload.get("file_metadata", {})
+
+        if isinstance(raw_store, dict):
+            self._store = {
+                path: MetadataMapper.from_json(meta)
+                for path, meta in raw_store.items()
+                if isinstance(meta, dict)
+            }
+        if isinstance(raw_file_metadata, dict):
+            self._file_metadata = {
+                path: meta for path, meta in raw_file_metadata.items() if isinstance(meta, dict)
+            }
+
+    def _flush(self) -> None:
+        if self._storage_path is None:
+            return
+
+        self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "store": {path: MetadataMapper.to_json(meta) for path, meta in self._store.items()},
+            "file_metadata": self._file_metadata,
+        }
+        tmp_path = self._storage_path.with_suffix(f"{self._storage_path.suffix}.tmp")
+        with tmp_path.open("w") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+        tmp_path.replace(self._storage_path)
 
     # -- abstract methods --------------------------------------------------
 
@@ -50,6 +90,7 @@ class DictMetastore(MetastoreABC):
     def put(self, metadata: FileMetadata, *, consistency: str = "sc") -> int | None:
         del consistency
         self._store[metadata.path] = metadata
+        self._flush()
         return None
 
     def put_if_version(
@@ -65,6 +106,7 @@ class DictMetastore(MetastoreABC):
         if current_ver != expected_version:
             return _CasResult(success=False, current_version=current_ver)
         self._store[metadata.path] = metadata
+        self._flush()
         return _CasResult(success=True, current_version=metadata.version)
 
     def delete(self, path: str, *, consistency: str = "sc") -> dict[str, Any] | None:
@@ -72,6 +114,7 @@ class DictMetastore(MetastoreABC):
         if path in self._store:
             del self._store[path]
             self._file_metadata.pop(path, None)
+            self._flush()
             return {"deleted": path}
         return None
 
@@ -86,6 +129,7 @@ class DictMetastore(MetastoreABC):
         return results
 
     def close(self) -> None:
+        self._flush()
         self._store.clear()
         self._file_metadata.clear()
 
@@ -124,10 +168,12 @@ class DictMetastore(MetastoreABC):
         for p in paths:
             self._store.pop(p, None)
             self._file_metadata.pop(p, None)
+        self._flush()
 
     def put_batch(self, metadata_list: Sequence[FileMetadata]) -> None:
         for m in metadata_list:
             self._store[m.path] = m
+        self._flush()
 
     def batch_get_content_ids(self, paths: Sequence[str]) -> dict[str, str | None]:
         return {p: (m.etag if (m := self._store.get(p)) else None) for p in paths}
@@ -140,11 +186,13 @@ class DictMetastore(MetastoreABC):
             self._store[new_path] = replace(meta, path=new_path)
             if old_path in self._file_metadata:
                 self._file_metadata[new_path] = self._file_metadata.pop(old_path)
+            self._flush()
 
     def set_file_metadata(self, path: str, key: str, value: Any) -> None:
         if path not in self._file_metadata:
             self._file_metadata[path] = {}
         self._file_metadata[path][key] = value
+        self._flush()
 
     def get_file_metadata(self, path: str, key: str) -> Any:
         return self._file_metadata.get(path, {}).get(key)

--- a/src/nexus/storage/dict_metastore.py
+++ b/src/nexus/storage/dict_metastore.py
@@ -22,12 +22,8 @@ from typing import Any
 
 from nexus.contracts.metadata import FileMetadata
 from nexus.core.metastore import MetastoreABC
+from nexus.core.pagination import PaginatedResult
 from nexus.storage._metadata_mapper_generated import MetadataMapper
-
-try:
-    from nexus.lib.pagination import PaginatedResult
-except ImportError:  # Backward compatibility for branches that still expose core.pagination
-    from nexus.core.pagination import PaginatedResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/storage/dict_metastore.py
+++ b/src/nexus/storage/dict_metastore.py
@@ -1,12 +1,14 @@
-"""Dict-backed MetastoreABC for environments without Rust extensions.
+"""JSON-backed MetastoreABC fallback for environments without Rust extensions.
 
-Lightweight in-memory metastore used as automatic fallback when the Raft
-metastore (Rust/PyO3) is not available.  This enables ``nexusd``
-to work out of the box after a plain ``pip install nexus``
-without requiring ``maturin develop``.
+Lightweight single-file metastore used as automatic fallback when the Raft
+metastore (Rust/PyO3) is not available. This keeps the local SDK and CLI
+quickstart paths working from a plain source checkout without requiring a Rust
+build.
 
-All data is stored in-memory and lost on process exit.  For durable storage,
-build the Rust extensions: ``maturin develop -m rust/nexus_raft/Cargo.toml``.
+State persists to a JSON file for local restarts, but this backend is still
+meant for single-process development and quickstarts. For the durable Rust
+metastore, build ``maturin develop -m rust/nexus_raft/Cargo.toml --features
+python``.
 """
 
 from __future__ import annotations
@@ -20,8 +22,12 @@ from typing import Any
 
 from nexus.contracts.metadata import FileMetadata
 from nexus.core.metastore import MetastoreABC
-from nexus.core.pagination import PaginatedResult
 from nexus.storage._metadata_mapper_generated import MetadataMapper
+
+try:
+    from nexus.lib.pagination import PaginatedResult
+except ImportError:  # Backward compatibility for branches that still expose core.pagination
+    from nexus.core.pagination import PaginatedResult
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +41,10 @@ class _CasResult:
 
 
 class DictMetastore(MetastoreABC):
-    """Dict-backed metastore — in-memory, no Rust required.
+    """JSON-backed metastore fallback with no Rust requirement.
 
-    All operations are O(1) for point lookups, O(n) for scans.
-    Thread-safe under Python GIL.
+    All operations are O(1) for point lookups and O(n) for scans. Suitable for
+    local development, tests, and quickstarts.
     """
 
     def __init__(self, storage_path: str | Path | None = None) -> None:
@@ -51,7 +57,7 @@ class DictMetastore(MetastoreABC):
     def _load(self) -> None:
         if self._storage_path is None or not self._storage_path.exists():
             return
-        with self._storage_path.open() as fh:
+        with self._storage_path.open(encoding="utf-8") as fh:
             payload = json.load(fh)
 
         raw_store = payload.get("store", {})
@@ -78,7 +84,7 @@ class DictMetastore(MetastoreABC):
             "file_metadata": self._file_metadata,
         }
         tmp_path = self._storage_path.with_suffix(f"{self._storage_path.suffix}.tmp")
-        with tmp_path.open("w") as fh:
+        with tmp_path.open("w", encoding="utf-8") as fh:
             json.dump(payload, fh, indent=2, sort_keys=True)
         tmp_path.replace(self._storage_path)
 
@@ -153,7 +159,7 @@ class DictMetastore(MetastoreABC):
         start = int(cursor) if cursor else 0
         page = all_items[start : start + limit]
         has_more = start + limit < len(all_items)
-        next_cursor = page[-1].path if has_more and page else None
+        next_cursor = str(start + limit) if has_more and page else None
         return PaginatedResult(
             items=page,
             next_cursor=next_cursor,

--- a/src/nexus/storage/file_cache.py
+++ b/src/nexus/storage/file_cache.py
@@ -103,7 +103,7 @@ class FileContentCache:
                 f"fp_rate={self._bloom_fp_rate}, memory={self._bloom.memory_bytes} bytes"
             )
         except ImportError:
-            logger.warning("nexus_fast not available, Bloom filter disabled")
+            logger.debug("nexus_fast not available, Bloom filter disabled")
             self._bloom = None
         except Exception as e:
             logger.warning(f"Failed to initialize Bloom filter: {e}")

--- a/src/nexus/storage/local_disk_cache.py
+++ b/src/nexus/storage/local_disk_cache.py
@@ -180,7 +180,7 @@ class LocalDiskCache:
                 f"fp_rate={self._bloom_fp_rate}"
             )
         except ImportError:
-            logger.warning("nexus_fast not available, Bloom filter disabled")
+            logger.debug("nexus_fast not available, Bloom filter disabled")
             self._bloom = None
 
     def _make_cache_key(self, content_hash: str, zone_id: str | None = None) -> str:

--- a/tests/unit/cli/test_cli_quickstart.py
+++ b/tests/unit/cli/test_cli_quickstart.py
@@ -46,6 +46,9 @@ def test_local_cli_quickstart_persists_across_invocations(
         "HOME": str(home_dir),
         "NEXUS_DATA_DIR": str(workspace / "nexus-data"),
         "NEXUS_URL": "http://127.0.0.1:65535",
+        "NEXUS_DATABASE_URL": "sqlite:///" + str(tmp_path / "ambient.db"),
+        "NEXUS_METASTORE_PATH": str(tmp_path / "ambient-metastore"),
+        "NEXUS_RECORD_STORE_PATH": str(tmp_path / "ambient-record-store.db"),
     }
 
     init_result = runner.invoke(main, ["init", str(workspace)], env=env)

--- a/tests/unit/cli/test_cli_quickstart.py
+++ b/tests/unit/cli/test_cli_quickstart.py
@@ -1,0 +1,58 @@
+"""Regression tests for the documented local CLI quickstart."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from nexus.cli.main import main
+from nexus.raft import zone_manager
+
+
+def test_local_cli_quickstart_persists_across_invocations(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """The local CLI quickstart should work from a source checkout."""
+
+    def _raise_missing_full_build(*args, **kwargs):
+        raise RuntimeError(
+            "ZoneManager requires PyO3 build with --features full. "
+            "Build with: maturin develop -m rust/nexus_raft/Cargo.toml --features full"
+        )
+
+    monkeypatch.setattr(zone_manager, "ZoneManager", _raise_missing_full_build)
+
+    runner = CliRunner()
+    workspace = tmp_path / "cli-demo"
+    env = {"NEXUS_DATA_DIR": str(workspace / "nexus-data")}
+
+    init_result = runner.invoke(main, ["init", str(workspace)])
+    assert init_result.exit_code == 0, init_result.output
+
+    write_result = runner.invoke(
+        main,
+        ["write", "/workspace/hello.txt", "hello from cli"],
+        env=env,
+    )
+    assert write_result.exit_code == 0, write_result.output
+
+    cat_result = runner.invoke(main, ["cat", "/workspace/hello.txt", "--json"], env=env)
+    assert cat_result.exit_code == 0, cat_result.output
+    assert "hello from cli" in cat_result.output
+
+    ls_result = runner.invoke(main, ["ls", "/workspace", "--json"], env=env)
+    assert ls_result.exit_code == 0, ls_result.output
+    assert "/workspace/hello.txt" in ls_result.output
+
+
+def test_cli_help_registers_local_quickstart_commands() -> None:
+    """Quickstart commands should be present in the top-level CLI help."""
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    for command_name in ("init", "write", "cat", "ls"):
+        assert command_name in result.output

--- a/tests/unit/cli/test_cli_quickstart.py
+++ b/tests/unit/cli/test_cli_quickstart.py
@@ -45,6 +45,7 @@ def test_local_cli_quickstart_persists_across_invocations(
     env = {
         "HOME": str(home_dir),
         "NEXUS_DATA_DIR": str(workspace / "nexus-data"),
+        "NEXUS_URL": "http://127.0.0.1:65535",
     }
 
     init_result = runner.invoke(main, ["init", str(workspace)], env=env)

--- a/tests/unit/cli/test_cli_quickstart.py
+++ b/tests/unit/cli/test_cli_quickstart.py
@@ -26,9 +26,28 @@ def test_local_cli_quickstart_persists_across_invocations(
 
     runner = CliRunner()
     workspace = tmp_path / "cli-demo"
-    env = {"NEXUS_DATA_DIR": str(workspace / "nexus-data")}
+    home_dir = tmp_path / "home"
+    config_dir = home_dir / ".nexus"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.yaml").write_text(
+        "\n".join(
+            [
+                "current-profile: ci-remote",
+                "profiles:",
+                "  ci-remote:",
+                "    url: http://127.0.0.1:65535",
+                "    api-key: test-key",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env = {
+        "HOME": str(home_dir),
+        "NEXUS_DATA_DIR": str(workspace / "nexus-data"),
+    }
 
-    init_result = runner.invoke(main, ["init", str(workspace)])
+    init_result = runner.invoke(main, ["init", str(workspace)], env=env)
     assert init_result.exit_code == 0, init_result.output
 
     write_result = runner.invoke(

--- a/tests/unit/storage/test_dict_metastore.py
+++ b/tests/unit/storage/test_dict_metastore.py
@@ -1,0 +1,44 @@
+"""Tests for the JSON-backed DictMetastore fallback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nexus.contracts.metadata import FileMetadata
+from nexus.storage.dict_metastore import DictMetastore
+
+
+def _metadata(path: str) -> FileMetadata:
+    return FileMetadata(
+        path=path,
+        backend_name="local",
+        physical_path=f"cas:{path}",
+        size=1,
+    )
+
+
+def test_dict_metastore_persists_and_supports_numeric_pagination_cursor(
+    tmp_path: Path,
+) -> None:
+    storage_path = tmp_path / "metastore.json"
+
+    store = DictMetastore(storage_path)
+    store.put(_metadata("/workspace/a.txt"))
+    store.put(_metadata("/workspace/b.txt"))
+    store.close()
+
+    reopened = DictMetastore(storage_path)
+    first_page = reopened.list_paginated(prefix="/workspace", limit=1)
+
+    assert [item.path for item in first_page.items] == ["/workspace/a.txt"]
+    assert first_page.next_cursor == "1"
+
+    second_page = reopened.list_paginated(
+        prefix="/workspace",
+        limit=1,
+        cursor=first_page.next_cursor,
+    )
+
+    assert [item.path for item in second_page.items] == ["/workspace/b.txt"]
+    assert second_page.next_cursor is None
+    reopened.close()

--- a/tests/unit/test_connect_quickstart.py
+++ b/tests/unit/test_connect_quickstart.py
@@ -1,0 +1,35 @@
+"""Regression tests for the documented local quickstart path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import nexus
+from nexus.raft import zone_manager
+
+
+def test_local_connect_falls_back_when_full_federation_build_is_unavailable(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A source checkout should still support the local SDK quickstart."""
+
+    def _raise_missing_full_build(*args, **kwargs):
+        raise RuntimeError(
+            "ZoneManager requires PyO3 build with --features full. "
+            "Build with: maturin develop -m rust/nexus_raft/Cargo.toml --features full"
+        )
+
+    monkeypatch.setattr(zone_manager, "ZoneManager", _raise_missing_full_build)
+
+    nx = nexus.connect(
+        config={
+            "profile": "minimal",
+            "data_dir": str(tmp_path / "nexus-data"),
+        }
+    )
+    try:
+        nx.sys_write("/hello.txt", b"hello")
+        assert nx.sys_read("/hello.txt") == b"hello"
+    finally:
+        nx.close()

--- a/tests/unit/test_packaging_metadata.py
+++ b/tests/unit/test_packaging_metadata.py
@@ -1,0 +1,19 @@
+"""Regression tests for packaging metadata used by the source quickstart."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_semantic_search_stack_is_not_in_base_dependencies() -> None:
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    payload = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    base_dependencies = payload["project"]["dependencies"]
+    semantic_search = payload["project"]["optional-dependencies"]["semantic-search"]
+
+    assert not any(dep.startswith("txtai[database,graph]") for dep in base_dependencies)
+    assert not any(dep.startswith("faiss-cpu") for dep in base_dependencies)
+    assert any(dep.startswith("txtai[database,graph]") for dep in semantic_search)
+    assert any(dep.startswith("faiss-cpu") for dep in semantic_search)

--- a/uv.lock
+++ b/uv.lock
@@ -3446,7 +3446,7 @@ wheels = [
 
 [[package]]
 name = "nexus-ai-fs"
-version = "0.7.2.dev0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -3465,7 +3465,6 @@ dependencies = [
     { name = "click" },
     { name = "cryptography" },
     { name = "dotenv" },
-    { name = "faiss-cpu", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "fastapi" },
     { name = "fastcdc" },
     { name = "fastmcp" },
@@ -3514,7 +3513,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "tiktoken" },
     { name = "tqdm" },
-    { name = "txtai", extra = ["database", "graph"], marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
     { name = "watchfiles" },
@@ -3523,10 +3521,12 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "e2b-code-interpreter" },
+    { name = "faiss-cpu", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "openai" },
     { name = "pgvector" },
     { name = "psycopg2-binary" },
     { name = "sqlite-vec" },
+    { name = "txtai", extra = ["database", "graph"], marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 cloud-sql = [
     { name = "cloud-sql-python-connector", extra = ["asyncpg"] },
@@ -3600,8 +3600,10 @@ sandbox-monty = [
     { name = "pydantic-monty" },
 ]
 semantic-search = [
+    { name = "faiss-cpu", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "pgvector" },
     { name = "sqlite-vec" },
+    { name = "txtai", extra = ["database", "graph"], marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 semantic-search-remote = [
     { name = "openai" },
@@ -3663,7 +3665,8 @@ requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "e2b-code-interpreter", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=1.0.0" },
-    { name = "faiss-cpu", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'x86_64'", specifier = ">=1.11.0" },
+    { name = "faiss-cpu", marker = "(platform_machine == 'aarch64' and extra == 'all') or (platform_machine == 'arm64' and extra == 'all') or (platform_machine == 'x86_64' and extra == 'all')", specifier = ">=1.11.0" },
+    { name = "faiss-cpu", marker = "(platform_machine == 'aarch64' and extra == 'semantic-search') or (platform_machine == 'arm64' and extra == 'semantic-search') or (platform_machine == 'x86_64' and extra == 'semantic-search')", specifier = ">=1.11.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "fastcdc", specifier = ">=1.5.0" },
     { name = "fastembed", marker = "extra == 'performance'", specifier = ">=0.4.0" },
@@ -3763,7 +3766,8 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "tiktoken", specifier = ">=0.12" },
     { name = "tqdm", specifier = ">=4.66.0" },
-    { name = "txtai", extras = ["database", "graph"], marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=9.0" },
+    { name = "txtai", extras = ["database", "graph"], marker = "(platform_machine != 'x86_64' and extra == 'all') or (sys_platform != 'darwin' and extra == 'all')", specifier = ">=9.0" },
+    { name = "txtai", extras = ["database", "graph"], marker = "(platform_machine != 'x86_64' and extra == 'semantic-search') or (sys_platform != 'darwin' and extra == 'semantic-search')", specifier = ">=9.0" },
     { name = "types-cachetools", marker = "extra == 'dev'", specifier = ">=5.3.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
@@ -6273,6 +6277,11 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
     { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
     { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },


### PR DESCRIPTION
## Summary
- align the public repo/docs/PyPI positioning around "Nexus = filesystem/context plane."
- add three landing paths plus an explicit trust-boundary quickstart flow in the docs
- fix the standalone local CLI quickstart path and add persistence/regression coverage for SDK and CLI

## Verification
- `PYTHONPATH=src /opt/homebrew/bin/python3.13 -m pytest tests/unit/cli/test_cli_quickstart.py tests/unit/test_connect_quickstart.py -q`
- `PYTHONPATH=src /opt/homebrew/bin/python3.13 -m nexus.cli.main --help`
- manual local CLI flow with `init`, `write`, `cat`, and `ls` using `NEXUS_DATA_DIR`
