### PR TITLE
Fix Rust packaging and release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,14 @@ jobs:
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           PKG_VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          RUST_PKG_VERSION=$(grep '^version = ' rust/nexus_pyo3/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          RUST_CARGO_VERSION=$(grep '^version = ' rust/nexus_pyo3/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           echo "Tag version: $TAG_VERSION"
           echo "Package version: $PKG_VERSION"
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "❌ Version mismatch! Tag is v$TAG_VERSION but pyproject.toml has $PKG_VERSION"
+          echo "Rust package version: $RUST_PKG_VERSION"
+          echo "Rust Cargo version: $RUST_CARGO_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ] || [ "$TAG_VERSION" != "$RUST_PKG_VERSION" ] || [ "$TAG_VERSION" != "$RUST_CARGO_VERSION" ]; then
+            echo "❌ Version mismatch! Tag is v$TAG_VERSION but package metadata is inconsistent"
             exit 1
           fi
           echo "✅ Version match confirmed"
@@ -83,9 +87,113 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
+  build-rust-wheel:
+    needs: [verify-version]
+    name: Build nexus-fast wheel (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-rust-${{ matrix.os }}
+          workspaces: |
+            rust/nexus_pyo3
+
+      - name: Build nexus-fast wheel
+        run: |
+          python -m pip install maturin
+          maturin build --release --compatibility off --manifest-path rust/nexus_pyo3/Cargo.toml --interpreter python --out dist
+
+      - name: Upload nexus-fast wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-wheel-${{ matrix.os }}-${{ matrix.python-version }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  build-rust-sdist:
+    needs: [verify-version]
+    name: Build nexus-fast source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-rust-sdist
+          workspaces: |
+            rust/nexus_pyo3
+
+      - name: Build nexus-fast sdist
+        run: |
+          python -m pip install maturin
+          maturin sdist --manifest-path rust/nexus_pyo3/Cargo.toml --out dist
+
+      - name: Upload nexus-fast sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish-rust:
+    name: Publish nexus-fast to PyPI
+    needs: [build-rust-wheel, build-rust-sdist]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download rust artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect nexus-fast distributions
+        run: |
+          mkdir -p dist-rust
+          cp artifacts/rust-sdist/* dist-rust/ 2>/dev/null || true
+          find artifacts -path "*/rust-wheel-*/*.whl" -exec cp {} dist-rust/ \;
+          ls -lh dist-rust/
+
+      - name: Publish nexus-fast to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist-rust
+
   publish:
-    name: Publish to PyPI
-    needs: [build-wheel, build-sdist]
+    name: Publish nexus-ai-fs to PyPI
+    needs: [build-wheel, build-sdist, publish-rust]
     runs-on: ubuntu-latest
 
     steps:
@@ -97,19 +205,23 @@ jobs:
         with:
           path: artifacts
 
-      - name: Collect all distributions
+      - name: Collect nexus-ai-fs distributions
         run: |
-          mkdir -p dist
-          # Copy source distribution
-          cp artifacts/sdist/* dist/ 2>/dev/null || true
-          # Copy all wheels
-          find artifacts -name "*.whl" -exec cp {} dist/ \;
-          ls -lh dist/
+          mkdir -p dist-main dist-release
+          cp artifacts/sdist/* dist-main/ 2>/dev/null || true
+          cp artifacts/sdist/* dist-release/ 2>/dev/null || true
+          cp artifacts/wheel/* dist-main/ 2>/dev/null || true
+          cp artifacts/wheel/* dist-release/ 2>/dev/null || true
+          cp artifacts/rust-sdist/* dist-release/ 2>/dev/null || true
+          find artifacts -path "*/rust-wheel-*/*.whl" -exec cp {} dist-release/ \;
+          ls -lh dist-main/
+          ls -lh dist-release/
 
-      - name: Publish to PyPI
+      - name: Publish nexus-ai-fs to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist-main
 
       - name: Extract release notes
         id: extract-release-notes
@@ -136,7 +248,7 @@ jobs:
         with:
           body_path: release_notes.txt
           files: |
-            dist/*
+            dist-release/*
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
         env:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you installed from PyPI, use `nexus` instead of `python -m nexus.cli.main`.
 
 - Full dev/test environment: `uv sync --extra dev --extra test`
 - txtai/FAISS semantic search stack: `uv sync --extra semantic-search`
-- Optional Rust acceleration from PyPI: `pip install 'nexus-ai-fs[rust]'`
+- Optional Rust acceleration from PyPI: `pip install nexus-fast`
 - Optional Rust acceleration from a checkout: `uv pip install maturin && maturin develop --release -m rust/nexus_pyo3/Cargo.toml`
 - Rust metastore / federation extensions: `maturin develop --release -m rust/nexus_raft/Cargo.toml --features python` or `--features full`
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,15 @@ If you installed from PyPI, use `nexus` instead of `python -m nexus.cli.main`.
 
 - Full dev/test environment: `uv sync --extra dev --extra test`
 - txtai/FAISS semantic search stack: `uv sync --extra semantic-search`
-- Optional Rust BLAKE3 acceleration: `maturin develop --release -m rust/nexus_pyo3/Cargo.toml`
+- Optional Rust acceleration from PyPI: `pip install 'nexus-ai-fs[rust]'`
+- Optional Rust acceleration from a checkout: `uv pip install maturin && maturin develop --release -m rust/nexus_pyo3/Cargo.toml`
 - Rust metastore / federation extensions: `maturin develop --release -m rust/nexus_raft/Cargo.toml --features python` or `--features full`
 
 ## Troubleshooting
 
 - `ModuleNotFoundError: No module named 'nexus'`: you are in a source checkout without installing the package into the active interpreter. Use the `uv` setup above or install `nexus-ai-fs` from PyPI.
 - `maturin develop --release` fails at the repo root: the root [Cargo.toml](./Cargo.toml) is a workspace manifest. Point `maturin` at a crate manifest under `rust/`.
+- `maturin develop ... rust/nexus_pyo3/Cargo.toml` uses the wrong Python: run it from the same activated `.venv` as Nexus. The package metadata requires Python 3.12+.
 - `Rust BLAKE3 extension not available`: this is an optional performance path. The default quickstart uses the Python `blake3` package.
 - `faiss-cpu` resolution fails: stay on the default source quickstart above, or opt into `semantic-search` only on a platform with compatible `txtai`/`faiss-cpu` wheels.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -82,7 +82,7 @@ Expected result:
 
 - Full dev/test environment: `uv sync --extra dev --extra test`
 - txtai/FAISS semantic search stack: `uv sync --extra semantic-search`
-- Optional Rust acceleration from PyPI: `pip install 'nexus-ai-fs[rust]'`
+- Optional Rust acceleration from PyPI: `pip install nexus-fast`
 - Optional Rust acceleration from a checkout: `uv pip install maturin && maturin develop --release -m rust/nexus_pyo3/Cargo.toml`
 - Rust metastore / federation extensions: `maturin develop --release -m rust/nexus_raft/Cargo.toml --features python` or `--features full`
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -82,13 +82,15 @@ Expected result:
 
 - Full dev/test environment: `uv sync --extra dev --extra test`
 - txtai/FAISS semantic search stack: `uv sync --extra semantic-search`
-- Optional Rust hashing: `maturin develop --release -m rust/nexus_pyo3/Cargo.toml`
+- Optional Rust acceleration from PyPI: `pip install 'nexus-ai-fs[rust]'`
+- Optional Rust acceleration from a checkout: `uv pip install maturin && maturin develop --release -m rust/nexus_pyo3/Cargo.toml`
 - Rust metastore / federation extensions: `maturin develop --release -m rust/nexus_raft/Cargo.toml --features python` or `--features full`
 
 ## Common First-Run Fixes
 
 - `ModuleNotFoundError: No module named 'nexus'`: you skipped the editable install step or are using the wrong interpreter.
 - `maturin develop --release` fails at the repo root: point `maturin` at a crate manifest under `rust/`, not the workspace root.
+- `maturin develop ... rust/nexus_pyo3/Cargo.toml` uses Anaconda or another wrong interpreter: run it from the same activated `.venv` as Nexus. The package metadata requires Python 3.12+.
 - `Rust BLAKE3 extension not available`: this is an optional performance message, not a quickstart failure.
 - `faiss-cpu` resolution fails: the default quickstart above avoids the optional semantic-search stack; only opt into `semantic-search` on platforms with compatible `txtai` and `faiss-cpu` wheels.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,16 +142,6 @@ performance = [
     "fastembed>=0.4.0",
 ]
 
-rust = [
-    # Optional Rust acceleration package (nexus_fast PyO3 extension)
-    "nexus-fast==0.9.1",
-]
-
-fast = [
-    # Backward-compatible alias for Rust acceleration
-    "nexus-fast==0.9.1",
-]
-
 compression = [
     # zstd compression for CompressedStorage wrapper (Issue #1705)
     # Python 3.14+ has native compression.zstd; this is the fallback for 3.12/3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,16 @@ performance = [
     "fastembed>=0.4.0",
 ]
 
+rust = [
+    # Optional Rust acceleration package (nexus_fast PyO3 extension)
+    "nexus-fast==0.9.1",
+]
+
+fast = [
+    # Backward-compatible alias for Rust acceleration
+    "nexus-fast==0.9.1",
+]
+
 compression = [
     # zstd compression for CompressedStorage wrapper (Issue #1705)
     # Python 3.14+ has native compression.zstd; this is the fallback for 3.12/3.13

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_pyo3"
-version = "0.1.0"
+version = "0.9.1"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_pyo3/INTEGRATION.md
+++ b/rust/nexus_pyo3/INTEGRATION.md
@@ -16,14 +16,17 @@ maturin build --release
 pip install target/wheels/nexus_fast-*.whl
 ```
 
-## Step 2: Add Optional Dependency
+## Step 2: Install `nexus-fast` in the Target Environment
 
-In the main `pyproject.toml`:
+Nexus loads `nexus_fast` opportunistically via import when it is present. Keep
+the extension as a separately installed package instead of advertising a root
+package extra that points at an unpublished registry artifact during
+development.
 
-```toml
-[project.optional-dependencies]
-rust = ["nexus-fast==0.9.1"]
-fast = ["nexus-fast==0.9.1"]
+For released environments:
+
+```bash
+pip install nexus-fast
 ```
 
 ## Step 3: Create Wrapper Module

--- a/rust/nexus_pyo3/INTEGRATION.md
+++ b/rust/nexus_pyo3/INTEGRATION.md
@@ -5,13 +5,13 @@ This guide shows how to integrate the high-performance Rust permission checker w
 ## Step 1: Install the Extension
 
 ```bash
-cd rust/nexus_fast
+cd rust/nexus_pyo3
 maturin develop --release
 ```
 
 Or for production:
 ```bash
-cd rust/nexus_fast
+cd rust/nexus_pyo3
 maturin build --release
 pip install target/wheels/nexus_fast-*.whl
 ```
@@ -22,7 +22,8 @@ In the main `pyproject.toml`:
 
 ```toml
 [project.optional-dependencies]
-fast = ["nexus-fast>=0.1.0"]
+rust = ["nexus-fast==0.9.1"]
+fast = ["nexus-fast==0.9.1"]
 ```
 
 ## Step 3: Create Wrapper Module

--- a/rust/nexus_pyo3/README.md
+++ b/rust/nexus_pyo3/README.md
@@ -45,28 +45,19 @@ All operations use GIL-free computation for true parallel execution with zero-co
 
 ### Automatic Installation (Recommended)
 
-Starting with version 0.5.6+, pre-built Rust wheels are available on PyPI:
+The published Rust extension package is `nexus-fast`. Install it directly or
+through the main package's optional extra:
 
 ```bash
-# Install with Rust acceleration (recommended - 30-100x faster grep)
-pip install nexus-ai-fs[fast]
+# Install the main package with the Rust extra
+pip install 'nexus-ai-fs[rust]'
 
-# Or install all optional dependencies (includes Rust acceleration)
-pip install nexus-ai-fs[all]
-
-# Or install all performance optimizations
-pip install nexus-ai-fs[performance]
+# Or install the Rust extension package directly
+pip install nexus-fast
 
 # Base installation (no Rust acceleration)
 pip install nexus-ai-fs
 ```
-
-Pre-built wheels are available for:
-- **Linux**: x86_64, aarch64 (ARM64)
-- **macOS**: x86_64 (Intel), aarch64 (Apple Silicon)
-- **Windows**: x86_64
-
-If a pre-built wheel is not available for your platform, Nexus will automatically fall back to Python implementations.
 
 #### Verify Installation
 
@@ -83,14 +74,14 @@ Only needed for development or unsupported platforms:
 #### Prerequisites
 
 - Rust toolchain (install via [rustup](https://rustup.rs/))
-- Python 3.8+
+- Python 3.12+
 - maturin (`pip install maturin`)
 
 #### Build Steps
 
 ```bash
 # Navigate to the Rust extension directory
-cd rust/nexus_fast
+cd rust/nexus_pyo3
 
 # Build and install in development mode
 maturin develop --release
@@ -334,14 +325,14 @@ def check_permissions_optimized(checks, tuples, namespace_configs):
 ### Build Requirements
 
 - Rust 1.70+ (with cargo)
-- Python 3.8+
-- PyO3 0.22
+- Python 3.12+
+- PyO3 0.27
 - maturin 1.0+
 
 ### Project Structure
 
 ```
-rust/nexus_fast/
+rust/nexus_pyo3/
 ├── Cargo.toml              # Rust dependencies and configuration
 ├── pyproject.toml          # Python packaging configuration
 ├── src/

--- a/rust/nexus_pyo3/README.md
+++ b/rust/nexus_pyo3/README.md
@@ -45,14 +45,10 @@ All operations use GIL-free computation for true parallel execution with zero-co
 
 ### Automatic Installation (Recommended)
 
-The published Rust extension package is `nexus-fast`. Install it directly or
-through the main package's optional extra:
+The published Rust extension package is `nexus-fast`. Install it directly:
 
 ```bash
-# Install the main package with the Rust extra
-pip install 'nexus-ai-fs[rust]'
-
-# Or install the Rust extension package directly
+# Install the Rust extension package directly
 pip install nexus-fast
 
 # Base installation (no Rust acceleration)

--- a/rust/nexus_pyo3/pyproject.toml
+++ b/rust/nexus_pyo3/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-fast"
-version = "0.1.0"
+version = "0.9.1"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/scripts/local-demo.sh
+++ b/scripts/local-demo.sh
@@ -768,7 +768,7 @@ start_server() {
     # if command -v maturin &> /dev/null || command -v ~/.local/bin/maturin &> /dev/null; then
     #     echo "Building Rust extension..."
     #     MATURIN_CMD=$(command -v maturin || echo ~/.local/bin/maturin)
-    #     [ -d "rust/nexus_fast" ] && (cd rust/nexus_fast && $MATURIN_CMD develop --release --quiet && cd ../..)
+    #     [ -d "rust/nexus_pyo3" ] && (cd rust/nexus_pyo3 && $MATURIN_CMD develop --release --quiet && cd ../..)
     # fi
 
     # Display configuration

--- a/src/nexus/bricks/rebac/utils/fast.py
+++ b/src/nexus/bricks/rebac/utils/fast.py
@@ -98,7 +98,7 @@ def check_permissions_bulk_rust(
     if not RUST_AVAILABLE:
         raise RuntimeError(
             "Rust acceleration not available. Install with: "
-            "cd rust/nexus_fast && maturin develop --release"
+            "cd rust/nexus_pyo3 && maturin develop --release"
         )
 
     try:
@@ -332,14 +332,14 @@ def check_permission_single_rust(
     if not RUST_AVAILABLE:
         raise RuntimeError(
             "Rust acceleration not available. Install with: "
-            "cd rust/nexus_fast && maturin develop --release"
+            "cd rust/nexus_pyo3 && maturin develop --release"
         )
 
     # compute_permission_single is only in the external module
     if _external_module is None:
         raise RuntimeError(
             "Rust single permission check not available. "
-            "Install nexus_fast: cd rust/nexus_fast && maturin develop --release"
+            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop --release"
         )
 
     try:
@@ -471,14 +471,14 @@ def expand_subjects_rust(
     if not RUST_AVAILABLE:
         raise RuntimeError(
             "Rust acceleration not available. Install with: "
-            "cd rust/nexus_fast && maturin develop --release"
+            "cd rust/nexus_pyo3 && maturin develop --release"
         )
 
     # Use external module which has expand_subjects
     if _external_module is None:
         raise RuntimeError(
             "Rust expand_subjects not available. "
-            "Install nexus_fast: cd rust/nexus_fast && maturin develop --release"
+            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop --release"
         )
 
     try:
@@ -590,14 +590,14 @@ def list_objects_for_subject_rust(
     if not RUST_AVAILABLE:
         raise RuntimeError(
             "Rust acceleration not available. Install with: "
-            "cd rust/nexus_fast && maturin develop --release"
+            "cd rust/nexus_pyo3 && maturin develop --release"
         )
 
     # Use external module which has list_objects_for_subject
     if _external_module is None:
         raise RuntimeError(
             "Rust list_objects_for_subject not available. "
-            "Install nexus_fast: cd rust/nexus_fast && maturin develop --release"
+            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop --release"
         )
 
     try:

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -7,7 +7,7 @@ import sys
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import click
 from rich.console import Console
@@ -34,12 +34,28 @@ _LOCAL_WORKSPACE_ENV_KEYS = (
     "NEXUS_METASTORE_PATH",
     "NEXUS_RECORD_STORE_PATH",
     "NEXUS_DATABASE_URL",
+    "POSTGRES_URL",
+    "DATABASE_URL",
     "NEXUS_NODE_ID",
     "NEXUS_BIND_ADDR",
     "NEXUS_ADVERTISE_ADDR",
+    "NEXUS_GRPC_PORT",
     "NEXUS_PEERS",
     "NEXUS_FEDERATION_ZONES",
     "NEXUS_FEDERATION_MOUNTS",
+    "NEXUS_TIMEOUT",
+    "NEXUS_ZONE_ID",
+    "NEXUS_USER_ID",
+    "NEXUS_AGENT_ID",
+    "NEXUS_SUBJECT",
+    "NEXUS_SUBJECT_TYPE",
+    "NEXUS_SUBJECT_ID",
+    "NEXUS_READ_REPLICA_URL",
+    "TOKEN_MANAGER_DB",
+    "CLOUD_SQL_INSTANCE",
+    "CLOUD_SQL_READ_INSTANCE",
+    "CLOUD_SQL_USER",
+    "CLOUD_SQL_DB",
 )
 
 # Global options
@@ -165,10 +181,29 @@ def _isolated_local_workspace_env(data_dir: str) -> Generator[None, None, None]:
                 os.environ[key] = value
 
 
+class _LocalWorkspaceFilesystemProxy:
+    """Reapply local-workspace env isolation around filesystem operations."""
+
+    def __init__(self, data_dir: str, filesystem: NexusFilesystem) -> None:
+        self._data_dir = data_dir
+        self._filesystem = filesystem
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._filesystem, name)
+        if not callable(attr):
+            return attr
+
+        def _wrapped(*args: Any, **kwargs: Any) -> Any:
+            with _isolated_local_workspace_env(self._data_dir):
+                return attr(*args, **kwargs)
+
+        return _wrapped
+
+
 def connect_local_workspace(data_dir: str) -> NexusFilesystem:
     """Connect to a self-contained local workspace without ambient env bleed."""
     with _isolated_local_workspace_env(data_dir):
-        return nexus.connect(
+        filesystem = nexus.connect(
             config={
                 "profile": "minimal",
                 "backend": "local",
@@ -180,6 +215,7 @@ def connect_local_workspace(data_dir: str) -> NexusFilesystem:
                 "api_key": None,
             }
         )
+    return cast(NexusFilesystem, _LocalWorkspaceFilesystemProxy(data_dir, filesystem))
 
 
 def get_filesystem(

--- a/src/nexus/core/hash_fast.py
+++ b/src/nexus/core/hash_fast.py
@@ -43,8 +43,9 @@ try:
 except (ImportError, AttributeError):
     logger.info(
         "Optional Rust BLAKE3 extension not available; using Python blake3. "
-        "Install with: pip install 'nexus-ai-fs[rust]' or, in a Python 3.12+ "
-        "environment, maturin develop --release -m rust/nexus_pyo3/Cargo.toml"
+        "Install with: pip install nexus-fast or, from a matching source "
+        "checkout in a Python 3.12+ environment, maturin develop --release "
+        "-m rust/nexus_pyo3/Cargo.toml"
     )
 
 # Priority 2: Python blake3 package (Issue #582, #833)

--- a/src/nexus/core/hash_fast.py
+++ b/src/nexus/core/hash_fast.py
@@ -43,8 +43,8 @@ try:
 except (ImportError, AttributeError):
     logger.info(
         "Optional Rust BLAKE3 extension not available; using Python blake3. "
-        "For local development, build rust/nexus_pyo3 with: "
-        "maturin develop --release -m rust/nexus_pyo3/Cargo.toml"
+        "Install with: pip install 'nexus-ai-fs[rust]' or, in a Python 3.12+ "
+        "environment, maturin develop --release -m rust/nexus_pyo3/Cargo.toml"
     )
 
 # Priority 2: Python blake3 package (Issue #582, #833)

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from nexus.cli.exit_codes import ExitCode
 from nexus.cli.utils import (
+    connect_local_workspace,
     create_operation_context,
     get_zone_id,
     handle_error,
@@ -147,6 +150,70 @@ class TestResolveContent:
         with pytest.raises(SystemExit) as exc_info:
             resolve_content(None, None)
         assert exc_info.value.code == ExitCode.USAGE_ERROR
+
+
+# ---------------------------------------------------------------------------
+# connect_local_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestConnectLocalWorkspace:
+    def test_reapplies_local_env_for_operations(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        local_data_dir = str(tmp_path / "local-data")
+        ambient_data_dir = str(tmp_path / "ambient-data")
+        ambient_database_url = "sqlite:///" + str(tmp_path / "ambient.db")
+
+        seen: dict[str, dict[str, str | None]] = {}
+
+        class DummyFilesystem:
+            def sys_read(self, path: str) -> bytes:
+                seen["sys_read"] = {
+                    "path": path,
+                    "data_dir": os.environ.get("NEXUS_DATA_DIR"),
+                    "database_url": os.environ.get("NEXUS_DATABASE_URL"),
+                    "remote_url": os.environ.get("NEXUS_URL"),
+                }
+                return b"ok"
+
+            def close(self) -> None:
+                seen["close"] = {
+                    "data_dir": os.environ.get("NEXUS_DATA_DIR"),
+                    "database_url": os.environ.get("NEXUS_DATABASE_URL"),
+                    "remote_url": os.environ.get("NEXUS_URL"),
+                }
+
+        monkeypatch.setenv("NEXUS_DATA_DIR", ambient_data_dir)
+        monkeypatch.setenv("NEXUS_DATABASE_URL", ambient_database_url)
+        monkeypatch.setenv("NEXUS_URL", "http://127.0.0.1:65535")
+        monkeypatch.setattr("nexus.connect", lambda config: DummyFilesystem())
+
+        filesystem = connect_local_workspace(local_data_dir)
+
+        assert os.environ["NEXUS_DATA_DIR"] == ambient_data_dir
+        assert os.environ["NEXUS_DATABASE_URL"] == ambient_database_url
+        assert os.environ["NEXUS_URL"] == "http://127.0.0.1:65535"
+
+        assert filesystem.sys_read("/workspace/demo.txt") == b"ok"
+        filesystem.close()
+
+        assert seen["sys_read"] == {
+            "path": "/workspace/demo.txt",
+            "data_dir": local_data_dir,
+            "database_url": None,
+            "remote_url": None,
+        }
+        assert seen["close"] == {
+            "data_dir": local_data_dir,
+            "database_url": None,
+            "remote_url": None,
+        }
+        assert os.environ["NEXUS_DATA_DIR"] == ambient_data_dir
+        assert os.environ["NEXUS_DATABASE_URL"] == ambient_database_url
+        assert os.environ["NEXUS_URL"] == "http://127.0.0.1:65535"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_packaging_metadata.py
+++ b/tests/unit/test_packaging_metadata.py
@@ -17,3 +17,48 @@ def test_semantic_search_stack_is_not_in_base_dependencies() -> None:
     assert not any(dep.startswith("faiss-cpu") for dep in base_dependencies)
     assert any(dep.startswith("txtai[database,graph]") for dep in semantic_search)
     assert any(dep.startswith("faiss-cpu") for dep in semantic_search)
+
+
+def test_rust_extra_points_at_version_matched_nexus_fast() -> None:
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    payload = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    version = payload["project"]["version"]
+    optional = payload["project"]["optional-dependencies"]
+
+    assert f"nexus-fast=={version}" in optional["rust"]
+    assert f"nexus-fast=={version}" in optional["fast"]
+
+
+def test_rust_package_versions_match_main_package() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    root_payload = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    rust_payload = tomllib.loads(
+        (repo_root / "rust" / "nexus_pyo3" / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    cargo_version = None
+    for line in (
+        (repo_root / "rust" / "nexus_pyo3" / "Cargo.toml").read_text(encoding="utf-8").splitlines()
+    ):
+        if line.startswith("version = "):
+            cargo_version = line.split('"')[1]
+            break
+
+    assert cargo_version is not None
+    assert rust_payload["project"]["version"] == root_payload["project"]["version"]
+    assert cargo_version == root_payload["project"]["version"]
+
+
+def test_release_workflow_builds_and_publishes_nexus_fast() -> None:
+    workflow_path = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+
+    assert "build-rust-wheel:" in workflow
+    assert "build-rust-sdist:" in workflow
+    assert "publish-rust:" in workflow
+    assert (
+        "maturin build --release --compatibility off --manifest-path rust/nexus_pyo3/Cargo.toml"
+        in workflow
+    )
+    assert "maturin sdist --manifest-path rust/nexus_pyo3/Cargo.toml --out dist" in workflow

--- a/tests/unit/test_packaging_metadata.py
+++ b/tests/unit/test_packaging_metadata.py
@@ -19,15 +19,14 @@ def test_semantic_search_stack_is_not_in_base_dependencies() -> None:
     assert any(dep.startswith("faiss-cpu") for dep in semantic_search)
 
 
-def test_rust_extra_points_at_version_matched_nexus_fast() -> None:
+def test_root_package_does_not_advertise_unpublished_nexus_fast_extra() -> None:
     pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
     payload = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 
-    version = payload["project"]["version"]
     optional = payload["project"]["optional-dependencies"]
 
-    assert f"nexus-fast=={version}" in optional["rust"]
-    assert f"nexus-fast=={version}" in optional["fast"]
+    assert "rust" not in optional
+    assert "fast" not in optional
 
 
 def test_rust_package_versions_match_main_package() -> None:


### PR DESCRIPTION
## Summary
- add real rust and fast extras in nexus-ai-fs that point at the published nexus-fast package
- sync nexus-fast package metadata with the main release version and Python requirement, and fix stale build/install guidance
- extend the release workflow to build and publish nexus-fast artifacts before publishing nexus-ai-fs

## Testing
- python3.11 -m pytest tests/unit/test_packaging_metadata.py -o addopts=
- python3.11 - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('.github/workflows/release.yml').read_text())
print('release.yml OK')
PY