### PR TITLE
feat(#1580): kernel auto-manages service lifecycle — four-quadrant one-click

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -76,7 +76,7 @@ Follows Linux's monolithic kernel model, not microkernel:
 |------|-----------|-------|----------------|
 | Static kernel | Never | MetastoreABC, VFS `route()`, syscall dispatch | vmlinuz core (scheduler, mm, VFS) |
 | Drivers | Config-time (DI at startup) | redb, S3, PostgreSQL, Dragonfly, SearchBrick | compiled-in drivers (`=y`) |
-| Services | Init-time DI (Phase 1); runtime hot-swap planned (Phase 2) | 40+ protocols (ReBAC, Mount, Auth, Agents, Search, Skills, ...) | loadable kernel modules (`insmod`/`rmmod`) |
+| Services | Init-time DI + runtime hot-swap | 40+ protocols (ReBAC, Mount, Auth, Agents, Search, Skills, ...) | loadable kernel modules (`insmod`/`rmmod`) |
 
 **Invariant:** Services depend on kernel interfaces, never the reverse.
 The kernel operates with zero services loaded.
@@ -86,10 +86,9 @@ The kernel operates with zero services loaded.
 
 ### Service Lifecycle
 
-**Phase 1 — Init-time DI (current).** `factory/` acts as the init system
-(like systemd): creates selected services and injects them via DI.
-Different distros select different service sets at startup — `nexus-server`
-loads all 22+, `nexus-embedded` loads zero.
+`factory/` acts as the init system (like systemd): creates selected services
+and injects them via DI. Different distros select different service sets at
+startup — `nexus-server` loads all 22+, `nexus-embedded` loads zero.
 
 Factory boot sequence (3 tiers, strictly ordered):
 
@@ -103,10 +102,35 @@ Services needing kernel syscalls declare `KERNEL_DEPS` in `brick_factory.py`;
 `ServiceRegistry` resolves via kernel symbol table (`EXPORT_SYMBOL()` pattern).
 `DeploymentProfile` gates which bricks are constructed (see §7).
 
-**Phase 2 — Runtime hot-swap (planned).** `ServiceRegistry` will manage services
-following the Loadable Kernel Module pattern: lifecycle protocol
-(`init`→`start`→`stop`→`cleanup`), dependency graph enforcement, reference
-counting, and hook auto-registration/unregistration at load/unload time.
+#### Service Lifecycle Protocols
+
+Two `@runtime_checkable` protocols classify services into a 2×2 matrix.
+Services satisfy the contract by implementing the methods — no inheritance
+required (structural typing).
+
+```
+                  Invocation-only          Persistent-required
+             ┌─────────────────────┬─────────────────────────┐
+  Static     │ Q1: register only   │ Q3: auto start()/stop() │
+             │ (SearchService)     │ (EventDeliveryWorker)   │
+             ├─────────────────────┼─────────────────────────┤
+  HotSwap    │ Q2: auto hooks +   │ Q4: hooks + activate +  │
+             │     activate()      │     start()/stop()      │
+             │ (ReBACService)      │ (future)                │
+             └─────────────────────┴─────────────────────────┘
+```
+
+| Protocol | Methods | Kernel auto-manages |
+|----------|---------|---------------------|
+| `HotSwappable` | `hook_spec()`, `drain()`, `activate()` | Hook registration into KernelDispatch + activate on bootstrap; drain + unregister on shutdown |
+| `PersistentService` | `start()`, `stop()` | `start()` on bootstrap (dependency order); `stop()` on shutdown (reverse order) |
+
+One-click contract: implement protocol → `coordinator.register_service()` →
+kernel handles the rest. `ServiceLifecycleCoordinator` (optional, injected by
+factory) scans the registry and auto-calls the appropriate methods during
+`NexusFS.bootstrap()` / `NexusFS.aclose()`.
+
+**Source of truth:** `contracts/protocols/service_lifecycle.py`
 
 ### Entry Point: `connect()`
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -302,6 +302,11 @@ class NexusFS(  # type: ignore[misc]
             self.initialize()
         for cb in self._bootstrap_callbacks:
             await cb()
+        # Auto-lifecycle: activate HotSwappable hooks, start PersistentService (Issue #1580)
+        coord = self.service_coordinator
+        if coord is not None:
+            await coord.activate_hot_swappable_services()
+            await coord.start_persistent_services()
         self._bootstrapped = True
 
     # -- Service registry accessors (Issue #1452) ---------------------------
@@ -4178,6 +4183,19 @@ class NexusFS(  # type: ignore[misc]
             raise BackendError(str(exc)) from exc
 
         return {"path": path, "capacity": capacity}
+
+    async def aclose(self) -> None:
+        """Async shutdown: stop PersistentService + deactivate HotSwappable, then close.
+
+        Preferred over close() when an event loop is available.
+        Calls coordinator lifecycle methods first (async), then
+        delegates to close() for sync resource cleanup.
+        """
+        coord = self.service_coordinator
+        if coord is not None:
+            await coord.stop_persistent_services()
+            await coord.deactivate_hot_swappable_services()
+        self.close()
 
     def close(self) -> None:
         """Close the filesystem and release resources."""

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -229,9 +229,12 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
     await shutdown_services(app, svc)
     await shutdown_realtime(app, svc)
 
-    # Close NexusFS kernel
-    if app.state.nexus_fs and hasattr(app.state.nexus_fs, "close"):
-        app.state.nexus_fs.close()
+    # Close NexusFS kernel (async shutdown for PersistentService + HotSwappable)
+    if app.state.nexus_fs:
+        if hasattr(app.state.nexus_fs, "aclose"):
+            await app.state.nexus_fs.aclose()
+        elif hasattr(app.state.nexus_fs, "close"):
+            app.state.nexus_fs.close()
 
     # Shutdown CacheBrick (Issue #1524)
     if app.state.cache_brick:

--- a/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
+++ b/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
@@ -305,6 +305,144 @@ class ServiceLifecycleCoordinator:
         return hot, static
 
     # ------------------------------------------------------------------
+    # Auto-lifecycle — four-quadrant "one-click" management (Issue #1580)
+    # ------------------------------------------------------------------
+
+    async def start_persistent_services(self, *, timeout: float = 30.0) -> list[str]:
+        """Auto-start all PersistentService instances in dependency order.
+
+        Scans ServiceRegistry for services implementing PersistentService,
+        calls start() in BLM dependency order.  Services only need to
+        implement the protocol — kernel handles the rest.
+
+        Idempotent — PersistentService.start() is idempotent by contract.
+
+        Returns list of started service names.
+        """
+        started: list[str] = []
+        for name in self._ordered_names():
+            info = self._registry.service_info(name)
+            if info is None:
+                continue
+            if not isinstance(info.instance, PersistentService):
+                continue
+            try:
+                await asyncio.wait_for(info.instance.start(), timeout=timeout)
+                started.append(name)
+                logger.info("[COORDINATOR] auto-started persistent service %r", name)
+            except TimeoutError:
+                logger.error("[COORDINATOR] timeout starting %r after %.1fs", name, timeout)
+            except Exception as exc:
+                logger.error("[COORDINATOR] failed to start %r: %s", name, exc)
+        if started:
+            logger.info("[COORDINATOR] started %d persistent services: %s", len(started), started)
+        return started
+
+    async def stop_persistent_services(self, *, timeout: float = 10.0) -> list[str]:
+        """Auto-stop all PersistentService instances in reverse dependency order.
+
+        Called during shutdown.  Mirrors start_persistent_services().
+        """
+        stopped: list[str] = []
+        for name in self._ordered_names(reverse=True):
+            info = self._registry.service_info(name)
+            if info is None:
+                continue
+            if not isinstance(info.instance, PersistentService):
+                continue
+            try:
+                await asyncio.wait_for(info.instance.stop(), timeout=timeout)
+                stopped.append(name)
+                logger.info("[COORDINATOR] auto-stopped persistent service %r", name)
+            except TimeoutError:
+                logger.error("[COORDINATOR] timeout stopping %r after %.1fs", name, timeout)
+            except Exception as exc:
+                logger.error("[COORDINATOR] failed to stop %r: %s", name, exc)
+        if stopped:
+            logger.info("[COORDINATOR] stopped %d persistent services: %s", len(stopped), stopped)
+        return stopped
+
+    async def activate_hot_swappable_services(self) -> list[str]:
+        """Auto-activate all HotSwappable services: register hooks + activate().
+
+        Scans ServiceRegistry for HotSwappable instances, registers their
+        hook_spec() into KernelDispatch, then calls activate().  Services
+        only need to implement the protocol — kernel handles the rest.
+
+        Idempotent — activate() is idempotent by contract.
+
+        Returns list of activated service names.
+        """
+        activated: list[str] = []
+        for name in self._ordered_names():
+            info = self._registry.service_info(name)
+            if info is None:
+                continue
+            if not isinstance(info.instance, HotSwappable):
+                continue
+            try:
+                # Auto-capture hook_spec from protocol if not already set
+                spec = self._hook_specs.get(name)
+                if spec is None:
+                    spec = info.instance.hook_spec()
+                    if spec is not None and not spec.is_empty:
+                        self._hook_specs[name] = spec
+                # Register hooks into dispatch
+                self._register_hooks(name)
+                # Activate service
+                await info.instance.activate()
+                activated.append(name)
+                logger.info("[COORDINATOR] auto-activated hot-swappable service %r", name)
+            except Exception as exc:
+                logger.error("[COORDINATOR] failed to activate %r: %s", name, exc)
+        if activated:
+            logger.info(
+                "[COORDINATOR] activated %d hot-swappable services: %s",
+                len(activated),
+                activated,
+            )
+        return activated
+
+    async def deactivate_hot_swappable_services(self) -> list[str]:
+        """Auto-deactivate all HotSwappable services: drain + unregister hooks.
+
+        Called during shutdown.  Mirrors activate_hot_swappable_services().
+        """
+        deactivated: list[str] = []
+        for name in self._ordered_names(reverse=True):
+            info = self._registry.service_info(name)
+            if info is None:
+                continue
+            if not isinstance(info.instance, HotSwappable):
+                continue
+            try:
+                await info.instance.drain()
+                self._unregister_hooks(name)
+                deactivated.append(name)
+                logger.info("[COORDINATOR] auto-deactivated hot-swappable service %r", name)
+            except Exception as exc:
+                logger.error("[COORDINATOR] failed to deactivate %r: %s", name, exc)
+        if deactivated:
+            logger.info(
+                "[COORDINATOR] deactivated %d hot-swappable services: %s",
+                len(deactivated),
+                deactivated,
+            )
+        return deactivated
+
+    def _ordered_names(self, *, reverse: bool = False) -> list[str]:
+        """Return service names in BLM dependency order (or reverse for shutdown)."""
+        try:
+            if reverse:
+                levels = self._blm.compute_shutdown_order()
+            else:
+                levels = self._blm.compute_startup_order()
+            return [name for level in levels for name in level]
+        except Exception:
+            # Fallback: no ordering guarantee
+            return [info.name for info in self._registry.list_all()]
+
+    # ------------------------------------------------------------------
     # Hook spec management (retroactive spec capture for existing services)
     # ------------------------------------------------------------------
 

--- a/tests/unit/services/test_service_lifecycle_coordinator.py
+++ b/tests/unit/services/test_service_lifecycle_coordinator.py
@@ -115,6 +115,32 @@ class _PersistentFakeService:
         return "working"
 
 
+class _BothProtocolsService:
+    """Q4: HotSwappable + PersistentService — satisfies both protocols."""
+
+    def __init__(self, hook_spec_value: HookSpec | None = None) -> None:
+        self._hook_spec = hook_spec_value or HookSpec()
+        self.drained = False
+        self.activated = False
+        self.started = False
+        self.stopped = False
+
+    def hook_spec(self) -> HookSpec:
+        return self._hook_spec
+
+    async def drain(self) -> None:
+        self.drained = True
+
+    async def activate(self) -> None:
+        self.activated = True
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
 # ---------------------------------------------------------------------------
 # insmod — register_service
 # ---------------------------------------------------------------------------
@@ -584,3 +610,286 @@ class TestDistroClassification:
         assert "rebac" in hot
         assert "search" in static
         assert "worker" in static  # persistent but not hot-swappable
+
+
+# ---------------------------------------------------------------------------
+# Auto-lifecycle — four-quadrant "one-click" management (Issue #1580)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoLifecyclePersistentService:
+    """Auto start/stop for PersistentService (Q3 + Q4)."""
+
+    @pytest.mark.asyncio()
+    async def test_start_calls_start_on_persistent(
+        self, coordinator: ServiceLifecycleCoordinator
+    ) -> None:
+        svc = _PersistentFakeService()
+        coordinator.register_service("worker", svc)
+        started = await coordinator.start_persistent_services()
+        assert started == ["worker"]
+        assert svc.started is True
+
+    @pytest.mark.asyncio()
+    async def test_start_skips_non_persistent(
+        self, coordinator: ServiceLifecycleCoordinator
+    ) -> None:
+        coordinator.register_service("search", _FakeService())
+        started = await coordinator.start_persistent_services()
+        assert started == []
+
+    @pytest.mark.asyncio()
+    async def test_stop_calls_stop_on_persistent(
+        self, coordinator: ServiceLifecycleCoordinator
+    ) -> None:
+        svc = _PersistentFakeService()
+        coordinator.register_service("worker", svc)
+        stopped = await coordinator.stop_persistent_services()
+        assert stopped == ["worker"]
+        assert svc.stopped is True
+
+    @pytest.mark.asyncio()
+    async def test_start_handles_exception(self, coordinator: ServiceLifecycleCoordinator) -> None:
+        """Exception during start() logs error, continues to next service."""
+
+        class _FailStart:
+            async def start(self) -> None:
+                raise RuntimeError("boom")
+
+            async def stop(self) -> None:
+                pass
+
+        ok_svc = _PersistentFakeService()
+        coordinator.register_service("fail", _FailStart())
+        coordinator.register_service("ok", ok_svc)
+        started = await coordinator.start_persistent_services()
+        assert "ok" in started
+        assert "fail" not in started
+        assert ok_svc.started is True
+
+    @pytest.mark.asyncio()
+    async def test_stop_handles_exception(self, coordinator: ServiceLifecycleCoordinator) -> None:
+        """Exception during stop() logs error, continues."""
+
+        class _FailStop:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                raise RuntimeError("boom")
+
+        ok_svc = _PersistentFakeService()
+        coordinator.register_service("fail", _FailStop())
+        coordinator.register_service("ok", ok_svc)
+        stopped = await coordinator.stop_persistent_services()
+        assert "ok" in stopped
+        assert "fail" not in stopped
+        assert ok_svc.stopped is True
+
+    @pytest.mark.asyncio()
+    async def test_start_handles_timeout(self, coordinator: ServiceLifecycleCoordinator) -> None:
+        """Timeout during start() logs error, continues."""
+
+        class _SlowStart:
+            async def start(self) -> None:
+                await asyncio.sleep(10)
+
+            async def stop(self) -> None:
+                pass
+
+        ok_svc = _PersistentFakeService()
+        coordinator.register_service("slow", _SlowStart())
+        coordinator.register_service("ok", ok_svc)
+        started = await coordinator.start_persistent_services(timeout=0.01)
+        assert "ok" in started
+        assert "slow" not in started
+
+    @pytest.mark.asyncio()
+    async def test_start_stop_idempotent(self, coordinator: ServiceLifecycleCoordinator) -> None:
+        svc = _PersistentFakeService()
+        coordinator.register_service("worker", svc)
+        await coordinator.start_persistent_services()
+        await coordinator.start_persistent_services()
+        assert svc.started is True
+        await coordinator.stop_persistent_services()
+        await coordinator.stop_persistent_services()
+        assert svc.stopped is True
+
+
+class TestAutoLifecycleHotSwappable:
+    """Auto activate/deactivate for HotSwappable (Q2 + Q4)."""
+
+    @pytest.mark.asyncio()
+    async def test_activate_registers_hooks_and_calls_activate(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        dispatch: KernelDispatch,
+    ) -> None:
+        hook = MagicMock()
+        spec = HookSpec(read_hooks=(hook,))
+        svc = _HotSwappableService(hook_spec_value=spec)
+        coordinator.register_service("rebac", svc)
+        activated = await coordinator.activate_hot_swappable_services()
+        assert activated == ["rebac"]
+        assert svc.activated is True
+        assert dispatch.read_hook_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_activate_auto_captures_hook_spec_from_protocol(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        dispatch: KernelDispatch,
+    ) -> None:
+        """hook_spec is auto-detected from HotSwappable.hook_spec() if not set explicitly."""
+        hook = MagicMock()
+        spec = HookSpec(read_hooks=(hook,))
+        svc = _HotSwappableService(hook_spec_value=spec)
+        # Register WITHOUT explicit hook_spec — should auto-capture
+        coordinator.register_service("rebac", svc)
+        assert coordinator.get_hook_spec("rebac") is None
+        await coordinator.activate_hot_swappable_services()
+        assert coordinator.get_hook_spec("rebac") is spec
+        assert dispatch.read_hook_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_activate_skips_non_hot_swappable(
+        self, coordinator: ServiceLifecycleCoordinator
+    ) -> None:
+        coordinator.register_service("search", _FakeService())
+        activated = await coordinator.activate_hot_swappable_services()
+        assert activated == []
+
+    @pytest.mark.asyncio()
+    async def test_deactivate_drains_and_unregisters_hooks(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        dispatch: KernelDispatch,
+    ) -> None:
+        hook = MagicMock()
+        spec = HookSpec(read_hooks=(hook,))
+        svc = _HotSwappableService(hook_spec_value=spec)
+        coordinator.register_service("rebac", svc, hook_spec=spec)
+        await coordinator.activate_hot_swappable_services()
+        assert dispatch.read_hook_count == 1
+
+        deactivated = await coordinator.deactivate_hot_swappable_services()
+        assert deactivated == ["rebac"]
+        assert svc.drained is True
+        assert dispatch.read_hook_count == 0
+
+    @pytest.mark.asyncio()
+    async def test_activate_handles_exception(
+        self, coordinator: ServiceLifecycleCoordinator
+    ) -> None:
+        class _FailActivate:
+            def hook_spec(self) -> HookSpec:
+                return HookSpec()
+
+            async def drain(self) -> None:
+                pass
+
+            async def activate(self) -> None:
+                raise RuntimeError("boom")
+
+        ok_svc = _HotSwappableService()
+        coordinator.register_service("fail", _FailActivate())
+        coordinator.register_service("ok", ok_svc)
+        activated = await coordinator.activate_hot_swappable_services()
+        assert "ok" in activated
+        assert "fail" not in activated
+
+
+class TestAutoLifecycleQ4BothProtocols:
+    """Q4: HotSwappable + PersistentService — both protocols auto-managed."""
+
+    @pytest.mark.asyncio()
+    async def test_q4_activate_and_start(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        dispatch: KernelDispatch,
+    ) -> None:
+        hook = MagicMock()
+        spec = HookSpec(read_hooks=(hook,))
+        svc = _BothProtocolsService(hook_spec_value=spec)
+        coordinator.register_service("q4svc", svc)
+
+        activated = await coordinator.activate_hot_swappable_services()
+        started = await coordinator.start_persistent_services()
+
+        assert activated == ["q4svc"]
+        assert started == ["q4svc"]
+        assert svc.activated is True
+        assert svc.started is True
+        assert dispatch.read_hook_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_q4_stop_and_deactivate(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        dispatch: KernelDispatch,
+    ) -> None:
+        hook = MagicMock()
+        spec = HookSpec(read_hooks=(hook,))
+        svc = _BothProtocolsService(hook_spec_value=spec)
+        coordinator.register_service("q4svc", svc)
+        await coordinator.activate_hot_swappable_services()
+        await coordinator.start_persistent_services()
+
+        stopped = await coordinator.stop_persistent_services()
+        deactivated = await coordinator.deactivate_hot_swappable_services()
+
+        assert stopped == ["q4svc"]
+        assert deactivated == ["q4svc"]
+        assert svc.stopped is True
+        assert svc.drained is True
+        assert dispatch.read_hook_count == 0
+
+    @pytest.mark.asyncio()
+    async def test_q4_mixed_with_other_quadrants(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        dispatch: KernelDispatch,
+    ) -> None:
+        """All four quadrants coexist — each gets its appropriate lifecycle."""
+        # Q1: static + invocation
+        q1 = _FakeService()
+        coordinator.register_service("q1_search", q1)
+
+        # Q2: hot-swappable + invocation
+        q2_hook = MagicMock()
+        q2 = _HotSwappableService(hook_spec_value=HookSpec(read_hooks=(q2_hook,)))
+        coordinator.register_service("q2_rebac", q2)
+
+        # Q3: static + persistent
+        q3 = _PersistentFakeService()
+        coordinator.register_service("q3_worker", q3)
+
+        # Q4: both
+        q4_hook = MagicMock()
+        q4 = _BothProtocolsService(hook_spec_value=HookSpec(observers=(q4_hook,)))
+        coordinator.register_service("q4_full", q4)
+
+        # --- Bootstrap ---
+        activated = await coordinator.activate_hot_swappable_services()
+        started = await coordinator.start_persistent_services()
+
+        assert sorted(activated) == ["q2_rebac", "q4_full"]
+        assert sorted(started) == ["q3_worker", "q4_full"]
+        assert q2.activated is True
+        assert q3.started is True
+        assert q4.activated is True
+        assert q4.started is True
+        assert dispatch.read_hook_count == 1  # q2
+        assert dispatch.observer_count == 1  # q4
+
+        # --- Shutdown ---
+        stopped = await coordinator.stop_persistent_services()
+        deactivated = await coordinator.deactivate_hot_swappable_services()
+
+        assert sorted(stopped) == ["q3_worker", "q4_full"]
+        assert sorted(deactivated) == ["q2_rebac", "q4_full"]
+        assert q3.stopped is True
+        assert q4.stopped is True
+        assert q4.drained is True
+        assert dispatch.read_hook_count == 0
+        assert dispatch.observer_count == 0


### PR DESCRIPTION
## Summary
- **ServiceLifecycleCoordinator** gains 4 auto-lifecycle methods covering all protocol quadrants:
  - `activate_hot_swappable_services()` / `deactivate_hot_swappable_services()` — Q2+Q4: auto hook registration + activate/drain
  - `start_persistent_services()` / `stop_persistent_services()` — Q3+Q4: auto start/stop in dependency order
- **NexusFS.bootstrap()** calls activate+start; new **`aclose()`** calls stop+deactivate+close
- **Lifespan** shutdown uses `aclose()` instead of `close()`
- **KERNEL-ARCHITECTURE.md** updated: removed Phase 1/2 dev markers, added four-quadrant lifecycle contract docs

## Four-Quadrant Matrix

```
                  Invocation-only          Persistent-required
             ┌─────────────────────┬─────────────────────────┐
  Static     │ Q1: register only   │ Q3: auto start()/stop() │
             ├─────────────────────┼─────────────────────────┤
  HotSwap    │ Q2: auto hooks +   │ Q4: hooks + activate +  │
             │     activate()      │     start()/stop()      │
             └─────────────────────┴─────────────────────────┘
```

Implement protocol → `register_service()` → kernel handles the rest.

## Test plan
- [x] 15 new unit tests covering all four quadrants
- [x] Error handling, timeout, idempotent cases
- [x] Q4 mixed-quadrant coexistence test
- [x] Regression: 45 coordinator tests pass, 44 factory tests pass
- [x] Lint: ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)