### PR TITLE
Speed up remote CLI startup

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -234,12 +234,15 @@ def connect(
 
         # Build a lightweight NexusFS directly — no factory, no bricks.
         # Server is SSOT; client just proxies calls via HTTP.
+        from nexus.bricks.parsers.providers.registry import ProviderRegistry as _ProviderRegistry
+        from nexus.bricks.parsers.registry import ParserRegistry as _ParserRegistry
+        from nexus.core.config import BrickServices as _BrickServices
         from nexus.core.config import PermissionConfig as _PermissionConfig
         from nexus.core.nexus_fs import NexusFS as _RemoteNexusFS
         from nexus.core.router import PathRouter as _PathRouter
 
         _router = _PathRouter(remote_metastore)
-        _router.add_mount("/", remote_backend)
+        _router.add_runtime_mount("/", remote_backend)
 
         from nexus.core.config import KernelServices as _KernelServices
 
@@ -247,6 +250,13 @@ def connect(
             metadata_store=remote_metastore,
             permissions=_PermissionConfig(enforce=False),
             kernel_services=_KernelServices(router=_router),
+            brick_services=_BrickServices(
+                # Remote clients delegate parsing to the server. Supplying
+                # empty registries avoids parser auto-discovery and heavy
+                # optional imports during one-shot CLI startup.
+                parser_registry=_ParserRegistry(),
+                provider_registry=_ProviderRegistry(),
+            ),
         )
 
         # Wire service proxies for REMOTE profile (Issue #1171).

--- a/src/nexus/cli/commands/__init__.py
+++ b/src/nexus/cli/commands/__init__.py
@@ -1,19 +1,8 @@
-"""Nexus CLI Commands - Modular command structure.
-
-This package contains all CLI commands organized by functionality:
-- file_ops: File operations (init, cat, write, cp, mv, sync, rm)
-- directory: Directory operations (ls, mkdir, rmdir, tree)
-- search: Search and discovery (glob, grep, find-duplicates)
-- permissions: Permission management (chmod, chown, chgrp, getfacl, setfacl)
-- rebac: Relationship-based access control
-- versions: Version tracking and rollback
-- inspect: File inspection (info, version, size)
-- mounts: Connector mount management
-- plugins: Plugin management
-- workflows: Workflow automation system
-"""
+"""Nexus CLI Commands - modular command structure with lazy top-level loading."""
 
 import importlib
+from dataclasses import dataclass
+from typing import Any
 
 import click
 
@@ -24,35 +13,45 @@ import click
 # ---------------------------------------------------------------------------
 
 # Modules that expose register_commands(cli)
-_REGISTER_COMMANDS = [
-    "file_ops",
-    "directory",
-    "search",
-    "rebac",
-    "versions",
-    "workspace",
-    "inspect",
-    "plugins",
-    "operations",
-    "workflows",
-    "mounts",
-    "connectors",
-    "llm",
-    "mcp",
-    "cache",
-    "migrate",
-    "context",
-    "network",
-    "tls",
-    "cluster",
-    "skills",
-    "status",  # status [--watch] [--json]
-    "doctor",  # doctor [--json] [--fix]
+_REGISTER_COMMANDS: dict[str, tuple[str, ...]] = {
+    "file_ops": (
+        "init",
+        "cat",
+        "write",
+        "append",
+        "write-batch",
+        "cp",
+        "copy",
+        "move",
+        "sync",
+        "rm",
+    ),
+    "directory": ("ls", "mkdir", "rmdir", "tree"),
+    "search": ("glob", "grep", "search"),
+    "rebac": ("rebac",),
+    "versions": ("versions",),
+    "workspace": ("workspace",),
+    "inspect": ("info", "version", "size"),
+    "plugins": ("plugins",),
+    "operations": ("ops", "undo"),
+    "workflows": ("workflows",),
+    "mounts": ("mounts",),
+    "connectors": ("connectors",),
+    "llm": ("llm",),
+    "mcp": ("mcp",),
+    "cache": ("cache",),
+    "migrate": ("migrate",),
+    "context": ("context",),
+    "network": ("network",),
+    "tls": ("tls",),
+    "cluster": ("join",),
+    "status": ("status",),  # status [--watch] [--json]
+    "doctor": ("doctor",),  # doctor [--json] [--fix]
     # Issue #2809: Profile management
-    "profile",  # profile list/add/use/delete/show/rename
-    "connect_cmd",  # Interactive connection setup
-    "config_cmd",  # Config show/set/get/reset
-]
+    "profile": ("profile",),  # profile list/add/use/delete/show/rename
+    "connect_cmd": ("connect",),  # Interactive connection setup
+    "config_cmd": ("config",),  # Config show/set/get/reset
+}
 
 # Modules that expose a single Click command/group to add via cli.add_command
 _ADD_COMMAND: dict[str, str] = {
@@ -87,6 +86,63 @@ _ADD_COMMAND: dict[str, str] = {
 }
 
 
+@dataclass(frozen=True)
+class _LazyCommandSpec:
+    module_name: str
+    attr_name: str | None = None
+
+
+class LazyCommandGroup(click.Group):
+    """Click group that imports only the requested top-level command module."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._lazy_commands: dict[str, _LazyCommandSpec] = {}
+        self._loaded_modules: set[str] = set()
+
+    def add_lazy_module(self, module_name: str, command_names: tuple[str, ...]) -> None:
+        """Register a module that exposes register_commands(cli)."""
+        spec = _LazyCommandSpec(module_name=module_name)
+        for command_name in command_names:
+            self._lazy_commands[command_name] = spec
+
+    def add_lazy_command_attr(self, module_name: str, command_name: str, attr_name: str) -> None:
+        """Register a module that exposes a single Click command/group attribute."""
+        self._lazy_commands[command_name] = _LazyCommandSpec(
+            module_name=module_name,
+            attr_name=attr_name,
+        )
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        names = set(super().list_commands(ctx))
+        names.update(self._lazy_commands)
+        return sorted(names)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        command = super().get_command(ctx, cmd_name)
+        if command is not None:
+            return command
+
+        self._load_command_module(cmd_name)
+        return super().get_command(ctx, cmd_name)
+
+    def _load_command_module(self, cmd_name: str) -> None:
+        spec = self._lazy_commands.get(cmd_name)
+        if spec is None or spec.module_name in self._loaded_modules:
+            return
+
+        try:
+            mod = importlib.import_module(f"nexus.cli.commands.{spec.module_name}")
+            if spec.attr_name is None:
+                mod.register_commands(self)
+            else:
+                self.add_command(getattr(mod, spec.attr_name))
+        except (ImportError, Exception):
+            return
+
+        self._loaded_modules.add(spec.module_name)
+
+
 def register_all_commands(cli: click.Group) -> None:
     """Register all commands from all modules to the main CLI group.
 
@@ -96,9 +152,16 @@ def register_all_commands(cli: click.Group) -> None:
     Args:
         cli: The main Click group to register commands to
     """
-    for name in _REGISTER_COMMANDS:
+    if isinstance(cli, LazyCommandGroup):
+        for module_name, command_names in _REGISTER_COMMANDS.items():
+            cli.add_lazy_module(module_name, command_names)
+        for module_name, command_name in _ADD_COMMAND.items():
+            cli.add_lazy_command_attr(module_name, command_name, command_name)
+        return
+
+    for module_name in _REGISTER_COMMANDS:
         try:
-            mod = importlib.import_module(f"nexus.cli.commands.{name}")
+            mod = importlib.import_module(f"nexus.cli.commands.{module_name}")
             mod.register_commands(cli)
         except (ImportError, Exception):
             pass
@@ -112,5 +175,6 @@ def register_all_commands(cli: click.Group) -> None:
 
 
 __all__ = [
+    "LazyCommandGroup",
     "register_all_commands",
 ]

--- a/src/nexus/cli/commands/directory.py
+++ b/src/nexus/cli/commands/directory.py
@@ -89,14 +89,15 @@ def list_files(
     timing = CommandTiming()
 
     try:
-        with (
-            timing.phase("connect"),
-            open_filesystem(
-                remote_url,
-                remote_api_key,
-                allow_local_default=True,
-            ) as nx,
-        ):
+        with contextlib.ExitStack() as stack:
+            with timing.phase("connect"):
+                nx = stack.enter_context(
+                    open_filesystem(
+                        remote_url,
+                        remote_api_key,
+                        allow_local_default=True,
+                    )
+                )
             if at_operation:
                 _ls_time_travel(nx, path, at_operation, recursive, long, output_opts, timing)
                 return
@@ -328,16 +329,17 @@ def tree(
     timing = CommandTiming()
 
     try:
-        with (
-            timing.phase("connect"),
-            open_filesystem(
-                remote_url,
-                remote_api_key,
-                allow_local_default=True,
-            ) as nx,
-            timing.phase("server"),
-        ):
-            files_raw = nx.sys_readdir(path, recursive=True, details=True)
+        with contextlib.ExitStack() as stack:
+            with timing.phase("connect"):
+                nx = stack.enter_context(
+                    open_filesystem(
+                        remote_url,
+                        remote_api_key,
+                        allow_local_default=True,
+                    )
+                )
+            with timing.phase("server"):
+                files_raw = nx.sys_readdir(path, recursive=True, details=True)
 
         files = _normalize_readdir(files_raw)
         if not files:

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -1,5 +1,6 @@
 """File operation commands - read, write, cat, cp, mv, rm, sync."""
 
+import contextlib
 import sys
 from pathlib import Path
 from typing import Any, cast
@@ -112,14 +113,15 @@ def cat(
     timing = CommandTiming()
 
     try:
-        with (
-            timing.phase("connect"),
-            open_filesystem(
-                remote_url,
-                remote_api_key,
-                allow_local_default=True,
-            ) as nx,
-        ):
+        with contextlib.ExitStack() as stack:
+            with timing.phase("connect"):
+                nx = stack.enter_context(
+                    open_filesystem(
+                        remote_url,
+                        remote_api_key,
+                        allow_local_default=True,
+                    )
+                )
             if at_operation:
                 _cat_time_travel(nx, path, at_operation, metadata, output_opts, timing)
                 return

--- a/src/nexus/cli/commands/inspect.py
+++ b/src/nexus/cli/commands/inspect.py
@@ -3,6 +3,7 @@
 Commands for viewing file information, version, and calculating sizes.
 """
 
+import contextlib
 import sys
 from typing import Any, cast
 
@@ -42,7 +43,9 @@ def info(
     timing = CommandTiming()
 
     try:
-        with timing.phase("connect"), open_filesystem(remote_url, remote_api_key) as nx:
+        with contextlib.ExitStack() as stack:
+            with timing.phase("connect"):
+                nx = stack.enter_context(open_filesystem(remote_url, remote_api_key))
             # Check if file exists first
             if not nx.sys_access(path):
                 render_output(

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -1,5 +1,6 @@
 """Search and discovery commands - glob, grep, semantic search."""
 
+import contextlib
 from collections import defaultdict
 from typing import Any, cast
 
@@ -59,7 +60,9 @@ def glob(
     timing = CommandTiming()
 
     try:
-        with timing.phase("connect"), open_filesystem(remote_url, remote_api_key) as nx:
+        with contextlib.ExitStack() as stack:
+            with timing.phase("connect"):
+                nx = stack.enter_context(open_filesystem(remote_url, remote_api_key))
             with timing.phase("server"):
                 result = nx.service("search").glob(pattern, path)
                 matches = (
@@ -216,19 +219,18 @@ def grep(
     timing = CommandTiming()
 
     try:
-        with (
-            timing.phase("connect"),
-            open_filesystem(remote_url, remote_api_key) as nx,
-            timing.phase("server"),
-        ):
-            result = nx.service("search").grep(
-                pattern,
-                path=path,
-                file_pattern=file_pattern,
-                ignore_case=ignore_case,
-                max_results=max_results,
-                search_mode=search_mode,
-            )
+        with contextlib.ExitStack() as stack:
+            with timing.phase("connect"):
+                nx = stack.enter_context(open_filesystem(remote_url, remote_api_key))
+            with timing.phase("server"):
+                result = nx.service("search").grep(
+                    pattern,
+                    path=path,
+                    file_pattern=file_pattern,
+                    ignore_case=ignore_case,
+                    max_results=max_results,
+                    search_mode=search_mode,
+                )
 
         # Normalize result format
         if isinstance(result, dict) and "results" in result:

--- a/src/nexus/cli/export_tools.py
+++ b/src/nexus/cli/export_tools.py
@@ -157,9 +157,12 @@ def walk_click_tree(
 ) -> list[dict[str, Any]]:
     """Walk a Click group recursively, collecting MCP tool definitions for leaf commands."""
     tools: list[dict[str, Any]] = []
+    ctx = click.Context(group)
 
-    for name in sorted(group.commands):
-        cmd = group.commands[name]
+    for name in group.list_commands(ctx):
+        cmd = group.get_command(ctx, name)
+        if cmd is None:
+            continue
         # Normalize group name for prefix
         normalized = name.replace("-", "_")
 

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -9,7 +9,7 @@ import warnings
 import click
 
 import nexus
-from nexus.cli.commands import register_all_commands
+from nexus.cli.commands import LazyCommandGroup, register_all_commands
 from nexus.core import setup_uvloop
 
 # Suppress pydub warning about missing ffmpeg/avconv
@@ -21,7 +21,7 @@ warnings.filterwarnings("ignore", message="Couldn't find ffmpeg or avconv", cate
 setup_uvloop()
 
 
-@click.group()
+@click.group(cls=LazyCommandGroup)
 @click.version_option(version=nexus.__version__, prog_name="nexus")
 @click.option(
     "--profile",

--- a/src/nexus/core/router.py
+++ b/src/nexus/core/router.py
@@ -130,8 +130,47 @@ class PathRouter:
             entry_type=DT_MOUNT,
         )
         self._metastore.put(meta)
+        self._register_mount_entry(
+            mount_point,
+            backend,
+            readonly=readonly,
+            admin_only=admin_only,
+            io_profile=io_profile,
+        )
 
-        # Register runtime backend (Python objects, not a cache)
+    def add_runtime_mount(
+        self,
+        mount_point: str,
+        backend: "ObjectStoreABC",
+        *,
+        readonly: bool = False,
+        admin_only: bool = False,
+        io_profile: str = "balanced",
+    ) -> None:
+        """Register an in-memory mount without persisting metadata.
+
+        Used for ephemeral runtime mounts where the metastore is not the
+        source of truth, such as the REMOTE client-side root mount.
+        """
+        mount_point = self._normalize_path(mount_point)
+        self._register_mount_entry(
+            mount_point,
+            backend,
+            readonly=readonly,
+            admin_only=admin_only,
+            io_profile=io_profile,
+        )
+
+    def _register_mount_entry(
+        self,
+        mount_point: str,
+        backend: "ObjectStoreABC",
+        *,
+        readonly: bool,
+        admin_only: bool,
+        io_profile: str,
+    ) -> None:
+        """Register the runtime mount entry for path routing."""
         self._backends[mount_point] = _MountEntry(
             backend=backend,
             readonly=readonly,

--- a/src/nexus/storage/remote_metastore.py
+++ b/src/nexus/storage/remote_metastore.py
@@ -91,7 +91,8 @@ class RemoteMetastore(MetastoreABC):
 
     def list(self, prefix: str = "", recursive: bool = True, **kwargs: Any) -> list[FileMetadata]:
         """List files by proxying ``list`` to the server."""
-        params: dict[str, Any] = {"path": prefix, "recursive": recursive}
+        rpc_path = prefix or "/"
+        params: dict[str, Any] = {"path": rpc_path, "recursive": recursive}
         if kwargs:
             params.update(kwargs)
         result = self._call_rpc("sys_readdir", params)
@@ -101,8 +102,11 @@ class RemoteMetastore(MetastoreABC):
         items: list[Any] = []
         if isinstance(result, list):
             items = result
-        elif isinstance(result, dict) and "items" in result:
-            items = result["items"]
+        elif isinstance(result, dict):
+            if "files" in result:
+                items = result["files"]
+            elif "items" in result:
+                items = result["items"]
 
         metadata_list: list[FileMetadata] = []
         for item in items:

--- a/tests/unit/cli/test_cli_quickstart.py
+++ b/tests/unit/cli/test_cli_quickstart.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import click
 from click.testing import CliRunner
 
+from nexus.cli.commands import LazyCommandGroup, register_all_commands
 from nexus.cli.main import main
 from nexus.raft import zone_manager
 
@@ -79,3 +81,25 @@ def test_cli_help_registers_local_quickstart_commands() -> None:
     assert result.exit_code == 0, result.output
     for command_name in ("init", "write", "cat", "ls"):
         assert command_name in result.output
+
+
+def test_lazy_registration_defers_command_module_import(monkeypatch) -> None:
+    """Top-level CLI registration should not import every command eagerly."""
+    imported: list[str] = []
+    real_import = __import__("importlib").import_module
+
+    def _spy(name: str, package: str | None = None):
+        imported.append(name)
+        return real_import(name, package)
+
+    monkeypatch.setattr("nexus.cli.commands.importlib.import_module", _spy)
+
+    cli = LazyCommandGroup(name="nexus")
+    register_all_commands(cli)
+    assert imported == []
+
+    command = cli.get_command(click.Context(cli), "ls")
+
+    assert command is not None
+    assert "nexus.cli.commands.directory" in imported
+    assert "nexus.cli.commands.oauth" not in imported

--- a/tests/unit/core/test_router.py
+++ b/tests/unit/core/test_router.py
@@ -39,6 +39,16 @@ def test_add_mount(router: PathRouter, temp_backend: CASLocalBackend) -> None:
     assert router._backends["/workspace"].backend == temp_backend
 
 
+def test_add_runtime_mount_does_not_persist_metadata(
+    router: PathRouter, metastore: DictMetastore, temp_backend: CASLocalBackend
+) -> None:
+    """Runtime mounts should only populate the in-memory mount table."""
+    router.add_runtime_mount("/workspace", temp_backend)
+
+    assert "/workspace" in router._backends
+    assert metastore.get("/workspace") is None
+
+
 def test_add_mount_normalizes_path(router: PathRouter, temp_backend: CASLocalBackend) -> None:
     """Test that mount points are normalized."""
     router.add_mount("/workspace/", temp_backend)  # Trailing slash
@@ -135,6 +145,19 @@ def test_route_prefix_match(router: PathRouter, temp_backend: CASLocalBackend) -
 def test_route_root_mount(router: PathRouter, temp_backend: CASLocalBackend) -> None:
     """Test routing with root mount."""
     router.add_mount("/", temp_backend)
+
+    result = router.route("/anything/goes/here.txt")
+
+    assert result.backend == temp_backend
+    assert result.backend_path == "anything/goes/here.txt"
+    assert result.mount_point == "/"
+
+
+def test_route_runtime_mount_without_metastore_entry(
+    router: PathRouter, temp_backend: CASLocalBackend
+) -> None:
+    """Route fallback should work for ephemeral runtime mounts."""
+    router.add_runtime_mount("/", temp_backend)
 
     result = router.route("/anything/goes/here.txt")
 

--- a/tests/unit/storage/test_remote_metastore.py
+++ b/tests/unit/storage/test_remote_metastore.py
@@ -176,6 +176,21 @@ class TestRemoteMetastoreRPC:
             assert all(isinstance(m, FileMetadata) for m in result)
             assert result[0].path == "/a.txt"
 
+    def test_list_normalizes_empty_prefix_to_root(self, metastore: RemoteMetastore) -> None:
+        """list('') should call sys_readdir('/') because the server requires absolute paths."""
+        with patch.object(
+            metastore,
+            "_call_rpc",
+            return_value=[],
+        ) as mock_rpc:
+            result = metastore.list("", recursive=True)
+
+            mock_rpc.assert_called_once_with(
+                "sys_readdir",
+                {"path": "/", "recursive": True},
+            )
+            assert result == []
+
     def test_list_returns_empty_on_none(self, metastore: RemoteMetastore) -> None:
         """list() should return empty list when server returns None."""
         with patch.object(metastore, "_call_rpc", return_value=None):
@@ -202,6 +217,23 @@ class TestRemoteMetastoreRPC:
                 "items": [
                     {"path": "/x.txt", "backend_name": "r", "physical_path": "/x", "size": 5},
                 ]
+            },
+        ):
+            result = metastore.list("/")
+            assert len(result) == 1
+            assert result[0].path == "/x.txt"
+
+    def test_list_handles_dict_with_files(self, metastore: RemoteMetastore) -> None:
+        """list() should handle the server's 'files' response envelope."""
+        with patch.object(
+            metastore,
+            "_call_rpc",
+            return_value={
+                "files": [
+                    {"path": "/x.txt", "backend_name": "r", "physical_path": "/x", "size": 5},
+                ],
+                "has_more": False,
+                "next_cursor": None,
             },
         ):
             result = metastore.list("/")

--- a/tests/unit/test_connect_quickstart.py
+++ b/tests/unit/test_connect_quickstart.py
@@ -33,3 +33,31 @@ def test_local_connect_falls_back_when_full_federation_build_is_unavailable(
         assert nx.sys_read("/hello.txt") == b"hello"
     finally:
         nx.close()
+
+
+def test_remote_connect_skips_mount_persistence_and_parser_autodiscovery(
+    monkeypatch,
+) -> None:
+    """Remote clients should avoid local parser bootstrap and mount writes."""
+    from nexus.bricks.parsers.providers.registry import ProviderRegistry
+    from nexus.bricks.parsers.registry import ParserRegistry
+    from nexus.storage.remote_metastore import RemoteMetastore
+
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("remote connect should not perform this bootstrap step")
+
+    monkeypatch.setattr(RemoteMetastore, "put", _unexpected)
+    monkeypatch.setattr(ParserRegistry, "register", _unexpected)
+    monkeypatch.setattr(ProviderRegistry, "auto_discover", _unexpected)
+
+    nx = nexus.connect(
+        config={
+            "profile": "remote",
+            "url": "http://127.0.0.1:2027",
+        }
+    )
+    try:
+        assert nx.parser_registry.get_parsers() == []
+        assert nx.provider_registry.get_all_providers() == []
+    finally:
+        nx.close()


### PR DESCRIPTION
## Summary
- lazy-load top-level CLI command modules instead of importing the full command surface at startup
- slim the remote client bootstrap by avoiding mount persistence writes and parser/provider auto-discovery on connect
- keep the remote root listing and timing regression coverage in place

## Root Cause
Simple commands like `nexus ls /` were slow for two separate reasons:
1. `nexus.cli.main` eagerly imported most command modules before dispatching `ls`.
2. `nexus.connect(profile="remote")` booted parser/provider discovery and wrote a root mount entry back to the server on every connect.

## Benchmarks
Benchmarks were run against a local auth-enabled server. The tool shell does not have an API key, so the live `ls` benchmark fails fast at auth, but it still exercises the same startup/connect path.

- `import nexus.cli.main`: 492.0 ms -> 190.9 ms
- direct remote `connect()`: 814.8 ms -> 114.7 ms
- live `nexus ls /` connect phase: ~817.7 ms -> ~114.1 ms
- end-to-end wall clock for `nexus ls /`: ~1.64 s -> ~0.39 s

## Testing
- `/Users/taofeng/nexus/.venv/bin/pytest tests/unit/cli/test_cli_quickstart.py tests/unit/test_connect_quickstart.py tests/unit/core/test_router.py tests/unit/storage/test_remote_metastore.py tests/unit/cli/test_commands_smoke.py`
- `76 passed`
