### PR TITLE
fix(#2916): pgvector-backed txtai search 500 — wrong config key for ANN URL

### DIFF
--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -165,7 +165,7 @@ class TxtaiBackend:
 
             if _has_pgvector:
                 config["backend"] = "pgvector"
-                config["database"] = self._database_url
+                config["pgvector"] = {"url": self._database_url}
                 use_pgvector = True
             else:
                 logger.warning(

--- a/tests/unit/bricks/search/test_txtai_backend.py
+++ b/tests/unit/bricks/search/test_txtai_backend.py
@@ -143,7 +143,7 @@ class TestTxtaiBackendLifecycle:
                 database_url="postgresql://u:p@localhost:5432/nexus",
                 model="test-model",
             )
-            asyncio.get_event_loop().run_until_complete(backend.startup())
+            asyncio.run(backend.startup())
 
         assert len(captured_configs) >= 1
         cfg = captured_configs[0]

--- a/tests/unit/bricks/search/test_txtai_backend.py
+++ b/tests/unit/bricks/search/test_txtai_backend.py
@@ -115,8 +115,8 @@ class TestTxtaiBackendLifecycle:
 
         mock_embeddings_cls = MagicMock()
         captured_configs: list[dict] = []
-        mock_embeddings_cls.side_effect = (
-            lambda cfg: captured_configs.append(dict(cfg)) or MagicMock()
+        mock_embeddings_cls.side_effect = lambda cfg: (
+            captured_configs.append(dict(cfg)) or MagicMock()
         )
 
         # Build mock torch module tree

--- a/tests/unit/bricks/search/test_txtai_backend.py
+++ b/tests/unit/bricks/search/test_txtai_backend.py
@@ -9,7 +9,7 @@ Mocked unit tests verifying:
 - Graph search methods
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -101,6 +101,55 @@ class TestTxtaiBackendLifecycle:
         assert backend._embeddings is None
         backend._embeddings = MagicMock()
         assert backend._embeddings is not None
+
+    def test_startup_pgvector_config_uses_pgvector_url_key(self) -> None:
+        """Regression test for #2916: pgvector URL must be under config['pgvector']['url'].
+
+        txtai's PGVector ANN resolves the database URL via self.setting('url'),
+        which looks up config[config['backend']]['url'].  Previously the URL was
+        placed under config['database'] (the content-DB key), leaving the ANN's
+        database session uninitialised and causing ``AttributeError: 'NoneType'
+        object has no attribute 'query'`` at search time.
+        """
+        import asyncio
+
+        mock_embeddings_cls = MagicMock()
+        captured_configs: list[dict] = []
+        mock_embeddings_cls.side_effect = (
+            lambda cfg: captured_configs.append(dict(cfg)) or MagicMock()
+        )
+
+        # Build mock torch module tree
+        mock_mps = MagicMock()
+        mock_mps.is_available.return_value = False
+        mock_backends = MagicMock()
+        mock_backends.mps = mock_mps
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends = mock_backends
+
+        # Patch txtai + torch imports so startup() doesn't need real packages
+        with patch.dict(
+            "sys.modules",
+            {
+                "txtai": MagicMock(Embeddings=mock_embeddings_cls),
+                "txtai.ann": MagicMock(),
+                "txtai.ann.dense": MagicMock(),
+                "txtai.ann.dense.pgvector": MagicMock(),
+                "torch": mock_torch,
+            },
+        ):
+            backend = TxtaiBackend(
+                database_url="postgresql://u:p@localhost:5432/nexus",
+                model="test-model",
+            )
+            asyncio.get_event_loop().run_until_complete(backend.startup())
+
+        assert len(captured_configs) >= 1
+        cfg = captured_configs[0]
+        assert cfg["backend"] == "pgvector"
+        assert cfg["pgvector"] == {"url": "postgresql://u:p@localhost:5432/nexus"}
+        assert "database" not in cfg, "URL must not go under 'database' — that's the content-DB key"
 
     @pytest.mark.asyncio
     async def test_shutdown_when_not_started(self) -> None:


### PR DESCRIPTION
## Summary

- Fix pgvector database URL placement in txtai Embeddings config: `config["database"]` → `config["pgvector"]["url"]`
- Add regression test verifying the config structure passed to txtai `Embeddings()`

## Root Cause

txtai's `PGVector` ANN backend resolves its database connection via `self.setting("url")`, which looks up `config[config["backend"]]["url"]` — i.e. `config["pgvector"]["url"]`. The code introduced in #2913 placed the URL under `config["database"]`, which is the **content-storage** key (SQLAlchemy content DB), not the ANN backend key. This left `PGVector.database` as `None`, causing:

```
AttributeError: 'NoneType' object has no attribute 'query'
```

on every search call, and:

```
Expected string or URL object, got None
```

on upsert attempts.

## Test plan

- [x] New regression test `test_startup_pgvector_config_uses_pgvector_url_key` passes
- [x] All existing txtai backend unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy, format)
- [ ] Manual verification with pgvector-enabled PostgreSQL instance

Closes #2916