### PR TITLE
feat(#1574): DT_STREAM — append-only log with offset-based non-destructive reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_pyo3"
-version = "0.1.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "blake3",

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -375,6 +375,7 @@ with them indirectly through syscalls. See §2.2 matrix for per-syscall usage.
 | **VFSLockManager** | `core.lock_fast` | per-inode `i_rwsem` | Per-path read/write lock with hierarchy-aware conflict detection. Details in §4.1 |
 | **KernelDispatch** | `core.kernel_dispatch` | `security_hook_heads` + `fsnotify` | Three-phase callback mechanism implementing §2.4. Per-op callback lists; empty = zero overhead. Hook contracts (§2.4) and registration API (§2.5) are User Contract; this is the plumbing |
 | **PipeManager + RingBuffer** | `system_services` + `core.pipe` | `pipe(2)` + `fs/pipe.c` | VFS named pipes — inode in MetastoreABC, data in heap ring buffer. Details in §4.2 |
+| **StreamManager + StreamBuffer** | `system_services` + `core.stream` | append-only log | VFS named streams — inode in MetastoreABC, data in heap linear buffer. Non-destructive offset-based reads, multi-reader fan-out. Details in §4.2 |
 | **PathValidator** | `core.nexus_fs` (to extract) | `fs/namei.c` path validation | Path format validation on every syscall entry. Rejects malformed paths before routing or HAL access |
 | **ZoneAccessGuard** | `core.nexus_fs` (to extract) | `fs/namespace.c` mount readonly | Zone write permission check on every mutating syscall. Rejects writes to read-only zones before routing |
 | **FileEvent** | `core.file_events` | `fsnotify_event` | Immutable mutation records. Details in §4.3 |
@@ -391,16 +392,32 @@ with them indirectly through syscalls. See §2.2 matrix for per-syscall usage.
 
 **Advisory locks** are a separate concern — see `lock-architecture.md` §4.
 
-### 4.2 PipeManager + RingBuffer — Named Pipes
+### 4.2 IPC Primitives — Named Pipes & Streams
 
-Two-layer architecture: VFS metadata (inode) in MetastoreABC, data (bytes) in
-process heap ring buffer (like Linux `kmalloc`'d pipe buffer).
+Two-layer architecture for both: VFS metadata (inode) in MetastoreABC, data
+(bytes) in process heap buffer (like Linux `kmalloc`'d pipe buffer).
 
-- **PipeManager** — VFS named pipe lifecycle (created via `sys_setattr` upsert,
-  read/write via `sys_read`/`sys_write`, destroyed via `sys_unlink`),
-  per-pipe lock for MPMC safety
-- **RingBuffer** — Lock-free SPSC kernel primitive (`kfifo` analogue), GIL-atomic.
-  PipeManager wraps with `asyncio.Lock` for MPMC
+| Primitive  | Linux Analogue    | Buffer         | Read          |
+|------------|-------------------|----------------|---------------|
+| DT_PIPE    | `kfifo` ring      | RingBuffer     | Destructive   |
+| DT_STREAM  | append-only log   | StreamBuffer   | Non-destructive (offset-based) |
+
+**DT_PIPE (PipeManager + RingBuffer):**
+
+- **PipeManager (mkpipe)** — VFS named pipe lifecycle (created via `sys_setattr`
+  upsert, read/write via `sys_read`/`sys_write`, destroyed via `sys_unlink`),
+  per-pipe lock for MPMC safety. Reads are destructive (consumed on read).
+- **RingBuffer (kpipe)** — Lock-free SPSC kernel primitive (`kfifo` analogue),
+  GIL-atomic. PipeManager wraps with `asyncio.Lock` for MPMC.
+
+**DT_STREAM (StreamManager + StreamBuffer):**
+
+- **StreamManager (mkstream)** — VFS named stream lifecycle (same syscall
+  surface as mkpipe). Per-stream lock for concurrent writers. Reads are
+  non-destructive — multiple readers maintain independent byte offsets (fan-out).
+- **StreamBuffer (kstream)** — Linear append-only buffer. Monotonic tail, no
+  wrap-around. Primary use case: LLM streaming I/O (realtime first consumer +
+  replay for later consumers).
 
 See `federation-memo.md` §7j for design rationale.
 
@@ -534,13 +551,14 @@ Same kernel binary, different driver injection. See §1 `connect()`.
 
 ## 8. Communication
 
-Kernel-adjacent services built on kernel primitives (PipeManager §4.2,
-FileEvent §4.3). Not kernel-owned, but bottom-layer infrastructure.
+Kernel-adjacent services built on kernel primitives (§4.2 IPC, §4.3
+FileEvent). Not kernel-owned, but bottom-layer infrastructure.
 
 | Tier | Nexus | Built on | Topology |
 |------|-------|----------|----------|
-| **Kernel** | Native Pipe (§4.2) | RingBuffer (kernel primitive) | Local or distributed (transparent) |
-| **System** | gRPC + IPC | PipeManager, consensus proto | Point-to-point |
+| **Kernel** | DT_PIPE (§4.2) | RingBuffer — destructive FIFO | Local or distributed (transparent) |
+| **Kernel** | DT_STREAM (§4.2) | StreamBuffer — append-only log | Local or distributed (transparent) |
+| **System** | gRPC + IPC | PipeManager/StreamManager, consensus proto | Point-to-point |
 | **User Space** | EventBus | CacheStoreABC pub/sub + FileEvent (§4.3) | Fan-out (1:N) |
 
 See `federation-memo.md` §2–§5 for gRPC/consensus details.
@@ -557,4 +575,4 @@ See `federation-memo.md` §2–§5 for gRPC/consensus details.
 | VFS lock design + advisory locks | `lock-architecture.md` §4 |
 | Zone model, DT_MOUNT, federation | `federation-memo.md` §5–§6 |
 | Raft, gRPC, write flows | `federation-memo.md` §2–§5 |
-| Pipe design rationale | `federation-memo.md` §7j |
+| Pipe + Stream design rationale | `federation-memo.md` §7j |

--- a/docs/architecture/federation-memo.md
+++ b/docs/architecture/federation-memo.md
@@ -233,7 +233,7 @@ Documented in `document-ai/notes/` discussions; brief summary for reference:
 - **Memory/Cache tiering**: L0 kernel (redb ~50ns), L1 Dragonfly (~1ms), L2 PostgreSQL (~5ms). L0 stays in kernel; L1/L2 hot-pluggable.
 - **Identity: PCB-based binding**: Immutable identity at process spawn. Progressive isolation: Host Process → Docker → Wasm.
 - **Auth: Verify/Sign split**: Kernel = `verify_token()` ~50ns. Driver = `login()` ~50-500ms (DB + OAuth).
-- **Nexus native IPC**: `DT_PIPE` inode, ring buffer at `/nexus/pipes/{name}`. Observable, Raft-replicated metadata, local or distributed data (see §7j).
+- **Nexus native IPC**: `DT_PIPE` (destructive FIFO) and `DT_STREAM` (non-destructive append-only log with offset-based reads). VFS inodes, heap buffers. Observable, Raft-replicated metadata, local or distributed data (see §7j).
 - **Container I/O monopoly**: `--network none`, single mount `/mnt/nexus`, `--read-only`.
 - **Runtime hot-swapping**: Linux `modprobe`/`rmmod` semantics for drivers. Phases: Constructor DI → DriverRegistry → state migration.
 
@@ -331,10 +331,12 @@ Single-node GC is straightforward (scan local ObjectStore vs local Metastore).
 Federation GC requires node-level reconciliation: each node scans its local ObjectStore
 against the Raft-replicated Metastore to find locally-held orphans.
 
-### 7j. DT_PIPE Federation Design
+### 7j. DT_PIPE / DT_STREAM Federation Design
 
-DT_PIPE inodes have Raft-replicated metadata but in-process heap data (RingBuffer).
-Federation extends pipe I/O transparently via origin-aware routing.
+Both IPC primitives have Raft-replicated metadata but in-process heap data
+(RingBuffer for DT_PIPE, StreamBuffer for DT_STREAM). Federation extends
+IPC I/O transparently via origin-aware routing. DT_STREAM uses the same
+`stream@host:port` pattern as DT_PIPE's `pipe@host:port`.
 
 #### Metadata: `backend_name` Encoding
 
@@ -342,8 +344,8 @@ PipeManager embeds the creator node's advertise address in `backend_name`:
 
 | Mode | `backend_name` | Meaning |
 |------|---------------|---------|
-| Single-node | `pipe` | No origin, always local |
-| Federated | `pipe@host:port` | Origin node address for remote proxy |
+| Single-node | `pipe` / `stream` | No origin, always local |
+| Federated | `pipe@host:port` / `stream@host:port` | Origin node address for remote proxy |
 
 #### Read/Write Routing
 

--- a/proto/nexus/core/metadata.proto
+++ b/proto/nexus/core/metadata.proto
@@ -14,8 +14,9 @@ package nexus.core;
 enum DirEntryType {
   DT_REG = 0;     // Regular file (proto3 default)
   DT_DIR = 1;     // Directory
-  DT_MOUNT = 2;   // Mount point to another zone
+  DT_MOUNT = 2;   // Mount point (VFS namespace composition)
   DT_PIPE = 3;    // Kernel IPC ring buffer (same-node, SPSC)
+  DT_STREAM = 4;  // Append-only log with offset-based non-destructive reads
 }
 
 // FileMetadata represents the metadata for a single file or directory in Nexus.
@@ -59,8 +60,8 @@ message FileMetadata {
   // Owner ID for O(1) permission checks (posix_uid).
   string owner_id = 12;
 
-  // Entry type: DT_REG (0), DT_DIR (1), or DT_MOUNT (2).
-  // SSOT for file/directory/mount distinction.
+  // Entry type: DT_REG (0), DT_DIR (1), DT_MOUNT (2), DT_PIPE (3), DT_STREAM (4).
+  // SSOT for file/directory/mount/ipc distinction.
   DirEntryType entry_type = 13;
 
   // Target zone ID for DT_MOUNT entries. Only set when entry_type == DT_MOUNT.

--- a/rust/nexus_pyo3/src/lib.rs
+++ b/rust/nexus_pyo3/src/lib.rs
@@ -9,6 +9,7 @@ mod io;
 mod lock;
 mod pipe;
 mod prefix;
+mod stream;
 mod semaphore;
 mod rebac;
 mod search;
@@ -81,6 +82,7 @@ fn nexus_fast(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<cache::L1MetadataCache>()?;
     m.add_class::<lock::VFSLockManager>()?;
     m.add_class::<pipe::RingBufferCore>()?;
+    m.add_class::<stream::StreamBufferCore>()?;
     m.add_class::<semaphore::VFSSemaphore>()?;
     Ok(())
 }

--- a/rust/nexus_pyo3/src/stream.rs
+++ b/rust/nexus_pyo3/src/stream.rs
@@ -1,0 +1,512 @@
+//! Linear append-only buffer for DT_STREAM kernel IPC (Task #1574).
+//!
+//! Unlike `pipe.rs` (circular ring, destructive pop), StreamBufferCore is a
+//! linear append-only buffer where reads are non-destructive and offset-based.
+//! Multiple readers maintain independent cursors (fan-out).
+//!
+//! Message framing: `[4B u32 LE length][N bytes payload]`.
+//! No sentinel, no wrap-around — fundamentally simpler than the ring buffer.
+//!
+//! Error encoding: Rust raises `RuntimeError("StreamFull:…")` etc. Python
+//! translates to the matching exception class.
+
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyList};
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Frame header size: 4-byte u32 LE length prefix.
+const HEADER_SIZE: usize = 4;
+
+// ---------------------------------------------------------------------------
+// StreamBufferCore
+// ---------------------------------------------------------------------------
+
+/// Linear append-only buffer for DT_STREAM.
+///
+/// Pre-allocated linear buffer with monotonic tail. Reads are non-destructive
+/// and offset-based — each reader supplies its own byte offset.
+/// Python wrapper provides asyncio.Event coordination for blocked writers.
+#[pyclass]
+pub struct StreamBufferCore {
+    buf: UnsafeCell<Vec<u8>>,
+    capacity: usize,
+    tail: AtomicUsize,
+    closed: AtomicBool,
+    push_count: AtomicU64,
+    msg_count: AtomicUsize,
+}
+
+// SAFETY: Append-only buffer. Writes extend [tail..new_tail], reads access
+// [offset..offset+len] which is already committed. Python GIL serializes
+// all PyO3 method calls.
+unsafe impl Send for StreamBufferCore {}
+unsafe impl Sync for StreamBufferCore {}
+
+// ---------------------------------------------------------------------------
+// Internal error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+enum StreamError {
+    Closed(&'static str),
+    Full(usize, usize),
+    Empty,
+    ClosedEmpty,
+    Oversized(usize, usize),
+    InvalidOffset(usize, usize),
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+impl StreamBufferCore {
+    /// Push raw bytes into the buffer. Returns byte offset where message starts.
+    fn push_inner(&self, data: &[u8]) -> Result<usize, StreamError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(StreamError::Closed("write to closed stream"));
+        }
+        let payload_len = data.len();
+        if payload_len == 0 {
+            return Ok(self.tail.load(Ordering::Relaxed));
+        }
+        if payload_len > self.capacity {
+            return Err(StreamError::Oversized(payload_len, self.capacity));
+        }
+
+        let frame_len = HEADER_SIZE + payload_len;
+        let tail = self.tail.load(Ordering::Relaxed);
+
+        if tail + frame_len > self.capacity {
+            return Err(StreamError::Full(tail, self.capacity));
+        }
+
+        let buf = unsafe { &mut *self.buf.get() };
+
+        // Write frame: [4B len][payload]
+        let header = (payload_len as u32).to_le_bytes();
+        buf[tail..tail + HEADER_SIZE].copy_from_slice(&header);
+        buf[tail + HEADER_SIZE..tail + HEADER_SIZE + payload_len].copy_from_slice(data);
+
+        // Record the start offset before advancing tail
+        let msg_offset = tail;
+
+        // Update tail
+        self.tail.store(tail + frame_len, Ordering::Release);
+
+        // Update counters
+        self.msg_count.fetch_add(1, Ordering::Relaxed);
+        self.push_count.fetch_add(1, Ordering::Relaxed);
+
+        Ok(msg_offset)
+    }
+
+    /// Read one message at the given byte offset. Returns (payload, next_offset).
+    fn read_at_inner(&self, byte_offset: usize) -> Result<(usize, usize, usize), StreamError> {
+        let tail = self.tail.load(Ordering::Acquire);
+
+        if byte_offset >= tail {
+            return if self.closed.load(Ordering::Acquire) {
+                Err(StreamError::ClosedEmpty)
+            } else {
+                Err(StreamError::Empty)
+            };
+        }
+
+        if byte_offset + HEADER_SIZE > tail {
+            return Err(StreamError::InvalidOffset(byte_offset, tail));
+        }
+
+        let buf = unsafe { &*self.buf.get() };
+
+        // Read header
+        let mut hdr = [0u8; HEADER_SIZE];
+        hdr.copy_from_slice(&buf[byte_offset..byte_offset + HEADER_SIZE]);
+        let payload_len = u32::from_le_bytes(hdr) as usize;
+
+        let payload_start = byte_offset + HEADER_SIZE;
+        let next_offset = payload_start + payload_len;
+
+        if next_offset > tail {
+            return Err(StreamError::InvalidOffset(byte_offset, tail));
+        }
+
+        Ok((payload_start, payload_len, next_offset))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyO3 methods
+// ---------------------------------------------------------------------------
+
+#[pymethods]
+impl StreamBufferCore {
+    #[new]
+    fn new(capacity: usize) -> PyResult<Self> {
+        if capacity == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "capacity must be > 0, got 0",
+            ));
+        }
+        Ok(Self {
+            buf: UnsafeCell::new(vec![0u8; capacity]),
+            capacity,
+            tail: AtomicUsize::new(0),
+            closed: AtomicBool::new(false),
+            push_count: AtomicU64::new(0),
+            msg_count: AtomicUsize::new(0),
+        })
+    }
+
+    /// Push a message. Returns byte offset where the message starts.
+    fn push(&self, _py: Python<'_>, data: &[u8]) -> PyResult<usize> {
+        match self.push_inner(data) {
+            Ok(offset) => Ok(offset),
+            Err(StreamError::Closed(msg)) => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                format!("StreamClosed:{msg}"),
+            )),
+            Err(StreamError::Full(used, cap)) => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                format!("StreamFull:buffer full ({used}/{cap} bytes)"),
+            )),
+            Err(StreamError::Oversized(msg_len, cap)) => {
+                Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "message size {msg_len} exceeds buffer capacity {cap}"
+                )))
+            }
+            Err(StreamError::Empty | StreamError::ClosedEmpty | StreamError::InvalidOffset(_, _)) => {
+                unreachable!()
+            }
+        }
+    }
+
+    /// Read one message at the given byte offset. Returns (data, next_offset).
+    fn read_at<'py>(
+        &self,
+        py: Python<'py>,
+        byte_offset: usize,
+    ) -> PyResult<(Bound<'py, PyBytes>, usize)> {
+        match self.read_at_inner(byte_offset) {
+            Ok((start, len, next)) => {
+                let buf = unsafe { &*self.buf.get() };
+                let data = PyBytes::new(py, &buf[start..start + len]);
+                Ok((data, next))
+            }
+            Err(StreamError::ClosedEmpty) => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "StreamClosed:read from closed empty stream",
+            )),
+            Err(StreamError::Empty) => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "StreamEmpty:no data at offset",
+            )),
+            Err(StreamError::InvalidOffset(off, tail)) => {
+                Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid offset {off} (tail={tail})"
+                )))
+            }
+            Err(StreamError::Closed(_) | StreamError::Full(_, _) | StreamError::Oversized(_, _)) => {
+                unreachable!()
+            }
+        }
+    }
+
+    /// Read up to `count` messages starting at byte_offset.
+    /// Returns (list_of_bytes, next_offset).
+    fn read_batch<'py>(
+        &self,
+        py: Python<'py>,
+        byte_offset: usize,
+        count: usize,
+    ) -> PyResult<(Bound<'py, PyList>, usize)> {
+        let list = PyList::empty(py);
+        let buf = unsafe { &*self.buf.get() };
+        let tail = self.tail.load(Ordering::Acquire);
+        let mut pos = byte_offset;
+        let mut read = 0;
+
+        while read < count && pos < tail {
+            if pos + HEADER_SIZE > tail {
+                break;
+            }
+            let mut hdr = [0u8; HEADER_SIZE];
+            hdr.copy_from_slice(&buf[pos..pos + HEADER_SIZE]);
+            let payload_len = u32::from_le_bytes(hdr) as usize;
+            let payload_start = pos + HEADER_SIZE;
+            let next = payload_start + payload_len;
+            if next > tail {
+                break;
+            }
+            let item = PyBytes::new(py, &buf[payload_start..payload_start + payload_len]);
+            list.append(item).expect("append to list");
+            pos = next;
+            read += 1;
+        }
+
+        if read == 0 && byte_offset >= tail {
+            if self.closed.load(Ordering::Acquire) {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "StreamClosed:read from closed empty stream",
+                ));
+            }
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "StreamEmpty:no data at offset",
+            ));
+        }
+
+        Ok((list, pos))
+    }
+
+    /// Push a u64 value. Returns byte offset where the message starts.
+    fn push_u64(&self, _py: Python<'_>, val: u64) -> PyResult<usize> {
+        match self.push_inner(&val.to_le_bytes()) {
+            Ok(offset) => Ok(offset),
+            Err(StreamError::Closed(msg)) => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                format!("StreamClosed:{msg}"),
+            )),
+            Err(StreamError::Full(used, cap)) => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                format!("StreamFull:buffer full ({used}/{cap} bytes)"),
+            )),
+            Err(StreamError::Oversized(msg_len, cap)) => {
+                Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "message size {msg_len} exceeds buffer capacity {cap}"
+                )))
+            }
+            Err(StreamError::Empty | StreamError::ClosedEmpty | StreamError::InvalidOffset(_, _)) => {
+                unreachable!()
+            }
+        }
+    }
+
+    /// Close the buffer. Idempotent.
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+    }
+
+    /// Buffer statistics as a dict.
+    fn stats(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let dict = PyDict::new(py);
+        dict.set_item("tail", self.tail.load(Ordering::Relaxed))?;
+        dict.set_item("capacity", self.capacity)?;
+        dict.set_item("msg_count", self.msg_count.load(Ordering::Relaxed))?;
+        dict.set_item("closed", self.closed.load(Ordering::Acquire))?;
+        dict.set_item("push_count", self.push_count.load(Ordering::Relaxed))?;
+        Ok(dict.into())
+    }
+
+    #[getter]
+    fn closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    #[getter]
+    fn size(&self) -> usize {
+        self.tail.load(Ordering::Relaxed)
+    }
+
+    #[getter]
+    fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    #[getter]
+    fn msg_count(&self) -> usize {
+        self.msg_count.load(Ordering::Relaxed)
+    }
+
+    #[getter]
+    fn tail(&self) -> usize {
+        self.tail.load(Ordering::Relaxed)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make(cap: usize) -> StreamBufferCore {
+        StreamBufferCore::new(cap).unwrap()
+    }
+
+    fn push(core: &StreamBufferCore, data: &[u8]) -> usize {
+        core.push_inner(data).expect("push failed")
+    }
+
+    fn read_at(core: &StreamBufferCore, offset: usize) -> (Vec<u8>, usize) {
+        let (start, len, next) = core.read_at_inner(offset).expect("read_at failed");
+        let buf = unsafe { &*core.buf.get() };
+        (buf[start..start + len].to_vec(), next)
+    }
+
+    #[test]
+    fn test_zero_capacity_rejected() {
+        assert!(StreamBufferCore::new(0).is_err());
+    }
+
+    #[test]
+    fn test_push_read_roundtrip() {
+        let core = make(1024);
+        let offset = push(&core, b"hello");
+        assert_eq!(offset, 0);
+        let (data, next) = read_at(&core, offset);
+        assert_eq!(data, b"hello");
+        assert_eq!(next, HEADER_SIZE + 5);
+    }
+
+    #[test]
+    fn test_ordering() {
+        let core = make(1024);
+        let o1 = push(&core, b"first");
+        let o2 = push(&core, b"second");
+        assert!(o2 > o1);
+        let (d1, n1) = read_at(&core, o1);
+        let (d2, _n2) = read_at(&core, n1);
+        assert_eq!(d1, b"first");
+        assert_eq!(d2, b"second");
+    }
+
+    #[test]
+    fn test_non_destructive_replay() {
+        let core = make(1024);
+        let offset = push(&core, b"replay");
+        let (d1, _) = read_at(&core, offset);
+        let (d2, _) = read_at(&core, offset);
+        assert_eq!(d1, d2);
+        assert_eq!(d1, b"replay");
+    }
+
+    #[test]
+    fn test_multi_reader() {
+        let core = make(1024);
+        push(&core, b"msg1");
+        push(&core, b"msg2");
+        push(&core, b"msg3");
+
+        // Reader A starts at 0, reads all
+        let (d1, n1) = read_at(&core, 0);
+        let (d2, n2) = read_at(&core, n1);
+        let (d3, _) = read_at(&core, n2);
+        assert_eq!(d1, b"msg1");
+        assert_eq!(d2, b"msg2");
+        assert_eq!(d3, b"msg3");
+
+        // Reader B starts at 0, same result
+        let (d1b, _) = read_at(&core, 0);
+        assert_eq!(d1b, b"msg1");
+    }
+
+    #[test]
+    fn test_stats() {
+        let core = make(100);
+        push(&core, b"abcde");
+        assert_eq!(core.msg_count(), 1);
+        assert_eq!(core.tail(), HEADER_SIZE + 5);
+        push(&core, b"xyz");
+        assert_eq!(core.msg_count(), 2);
+    }
+
+    #[test]
+    fn test_close() {
+        let core = make(1024);
+        assert!(!core.closed());
+        core.close();
+        assert!(core.closed());
+    }
+
+    #[test]
+    fn test_push_closed_rejected() {
+        let core = make(1024);
+        core.close();
+        assert!(core.push_inner(b"data").is_err());
+    }
+
+    #[test]
+    fn test_oversized_rejected() {
+        let core = make(10);
+        match core.push_inner(&[0u8; 11]) {
+            Err(StreamError::Oversized(11, 10)) => {}
+            other => panic!("expected Oversized, got {:?}", other.is_ok()),
+        }
+    }
+
+    #[test]
+    fn test_full_rejected() {
+        let core = make(20);
+        // Push 12 bytes payload = 16 bytes frame. Remaining: 4 bytes.
+        push(&core, &[0u8; 12]);
+        // Next push of 1 byte needs 5 bytes frame, only 4 available.
+        match core.push_inner(b"x") {
+            Err(StreamError::Full(_, _)) => {}
+            other => panic!("expected Full, got {:?}", other.is_ok()),
+        }
+    }
+
+    #[test]
+    fn test_empty_push_is_noop() {
+        let core = make(1024);
+        let offset = push(&core, b"");
+        assert_eq!(offset, 0);
+        assert_eq!(core.msg_count(), 0);
+    }
+
+    #[test]
+    fn test_read_empty_error() {
+        let core = make(1024);
+        assert!(core.read_at_inner(0).is_err());
+    }
+
+    #[test]
+    fn test_read_closed_empty_error() {
+        let core = make(1024);
+        core.close();
+        match core.read_at_inner(0) {
+            Err(StreamError::ClosedEmpty) => {}
+            _ => panic!("expected ClosedEmpty"),
+        }
+    }
+
+    #[test]
+    fn test_drain_before_closed() {
+        let core = make(1024);
+        let offset = push(&core, b"last");
+        core.close();
+        let (data, next) = read_at(&core, offset);
+        assert_eq!(data, b"last");
+        match core.read_at_inner(next) {
+            Err(StreamError::ClosedEmpty) => {}
+            _ => panic!("expected ClosedEmpty"),
+        }
+    }
+
+    #[test]
+    fn test_exact_capacity() {
+        // capacity=12: one frame of 8 bytes payload = 4+8 = 12 bytes exactly
+        let core = make(12);
+        let offset = push(&core, &[0xAA; 8]);
+        assert_eq!(offset, 0);
+        let (data, _) = read_at(&core, 0);
+        assert_eq!(data, vec![0xAA; 8]);
+        // Buffer is now full
+        match core.push_inner(b"x") {
+            Err(StreamError::Full(_, _)) => {}
+            other => panic!("expected Full, got {:?}", other.is_ok()),
+        }
+    }
+
+    #[test]
+    fn test_u64_push_read() {
+        let core = make(1024);
+        let o1 = core.push_inner(&42u64.to_le_bytes()).unwrap();
+        let o2 = core.push_inner(&u64::MAX.to_le_bytes()).unwrap();
+        let (d1, _) = read_at(&core, o1);
+        let (d2, _) = read_at(&core, o2);
+        assert_eq!(u64::from_le_bytes(d1.try_into().unwrap()), 42);
+        assert_eq!(u64::from_le_bytes(d2.try_into().unwrap()), u64::MAX);
+    }
+}

--- a/scripts/gen_metadata.py
+++ b/scripts/gen_metadata.py
@@ -37,6 +37,7 @@ GENERATED_NAMES: dict[str, set[str]] = {
         "DT_DIR",
         "DT_MOUNT",
         "DT_PIPE",
+        "DT_STREAM",
     },
     "metastore": {
         "MetastoreABC",
@@ -336,7 +337,7 @@ To modify FileMetadata:
 
 Contains:
   - FileMetadata: Core file metadata dataclass
-  - DT_REG, DT_DIR, DT_MOUNT, DT_PIPE: Directory entry type constants
+  - DT_REG, DT_DIR, DT_MOUNT, DT_PIPE, DT_STREAM: Directory entry type constants
 """
 
 from __future__ import annotations
@@ -404,8 +405,8 @@ class FileMetadata:
         if "\\x00" in self.path:
             raise ValidationError("path contains null bytes", path=self.path)
 
-        # DT_PIPE inodes: in-memory ring buffer, no backend storage required
-        if self.entry_type == 3:  # DT_PIPE
+        # DT_PIPE/DT_STREAM inodes: in-memory buffers, no backend storage required
+        if self.entry_type in (3, 4):  # DT_PIPE, DT_STREAM
             return
 
         if not self.backend_name:

--- a/src/nexus/contracts/metadata.py
+++ b/src/nexus/contracts/metadata.py
@@ -10,7 +10,7 @@ To modify FileMetadata:
 
 Contains:
   - FileMetadata: Core file metadata dataclass
-  - DT_REG, DT_DIR, DT_MOUNT, DT_PIPE: Directory entry type constants
+  - DT_REG, DT_DIR, DT_MOUNT, DT_PIPE, DT_STREAM: Directory entry type constants
 """
 
 from __future__ import annotations
@@ -30,6 +30,7 @@ DT_REG = 0
 DT_DIR = 1
 DT_MOUNT = 2
 DT_PIPE = 3
+DT_STREAM = 4
 
 
 @dataclass(slots=True)
@@ -69,6 +70,10 @@ class FileMetadata:
     @property
     def is_pipe(self) -> bool:
         return self.entry_type == 3
+
+    @property
+    def is_stream(self) -> bool:
+        return self.entry_type == 4
 
     @property
     def backend_address(self) -> BackendAddress:
@@ -127,8 +132,8 @@ class FileMetadata:
         if "\x00" in self.path:
             raise ValidationError("path contains null bytes", path=self.path)
 
-        # DT_PIPE inodes: in-memory ring buffer, no backend storage required
-        if self.entry_type == 3:  # DT_PIPE
+        # DT_PIPE/DT_STREAM inodes: in-memory buffers, no backend storage required
+        if self.entry_type in (3, 4):  # DT_PIPE, DT_STREAM
             return
 
         if not self.backend_name:

--- a/src/nexus/core/_compact_generated.py
+++ b/src/nexus/core/_compact_generated.py
@@ -15,7 +15,6 @@ and timezone information across serialization boundaries.
 
 from __future__ import annotations
 
-import threading
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -26,12 +25,10 @@ if TYPE_CHECKING:
 # --- String interning ---
 # Single global pool: string -> int ID, and reverse lookup.
 # All string fields share one pool for simplicity.
-# Protected by _POOL_LOCK against concurrent first-seen collisions.
 
 _STRING_POOL: dict[str, int] = {}
 _STRING_POOL_REVERSE: dict[int, str] = {}
 _NEXT_ID: int = 0
-_POOL_LOCK = threading.Lock()
 
 
 def _intern(s: str | None) -> int:
@@ -39,18 +36,11 @@ def _intern(s: str | None) -> int:
     global _NEXT_ID
     if s is None:
         return -1
-    # Fast path: already interned (read-only, safe without lock)
-    existing = _STRING_POOL.get(s)
-    if existing is not None:
-        return existing
-    with _POOL_LOCK:
-        # Re-check under lock (another thread may have inserted)
-        if s in _STRING_POOL:
-            return _STRING_POOL[s]
+    if s not in _STRING_POOL:
         _STRING_POOL[s] = _NEXT_ID
         _STRING_POOL_REVERSE[_NEXT_ID] = s
         _NEXT_ID += 1
-        return _NEXT_ID - 1
+    return _STRING_POOL[s]
 
 
 def _resolve(id: int) -> str | None:
@@ -146,7 +136,6 @@ def get_intern_pool_stats() -> dict[str, int]:
 def clear_intern_pool() -> None:
     """Clear the intern pool. Use only for testing."""
     global _NEXT_ID
-    with _POOL_LOCK:
-        _STRING_POOL.clear()
-        _STRING_POOL_REVERSE.clear()
-        _NEXT_ID = 0
+    _STRING_POOL.clear()
+    _STRING_POOL_REVERSE.clear()
+    _NEXT_ID = 0

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -255,8 +255,8 @@ class SystemServices:
     # Zone lifecycle — ordered zone deprovisioning (Issue #2061)
     zone_lifecycle: Any = None
 
-    # DT_PIPE manager — VFS named-pipe IPC (Issue #809)
-    pipe_manager: Any = None
+    # (PipeManager + StreamManager are kernel-internal primitives,
+    # constructed in NexusFS.__init__ — not injected via SystemServices.)
 
     # Process lifecycle — kernel process table (Issue #1509)
     process_table: Any = None

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -172,8 +172,7 @@ class NexusFS(  # type: ignore[misc]
         self._context_branch_service = sys_svc.context_branch_service
         # Zone lifecycle — write gating during deprovisioning (Issue #2061)
         self._zone_lifecycle = getattr(sys_svc, "zone_lifecycle", None)
-        # DT_PIPE manager — kernel primitive (§4.2), None when unavailable (CLI mode)
-        self._pipe_manager = sys_svc.pipe_manager
+        # (PipeManager + StreamManager constructed above as kernel-internal primitives)
         # Process lifecycle — kernel process table (Issue #1509)
         self._process_table = sys_svc.process_table
 
@@ -208,6 +207,30 @@ class NexusFS(  # type: ignore[misc]
         from nexus.core.kernel_dispatch import KernelDispatch
 
         self._dispatch: KernelDispatch = KernelDispatch()
+
+        # IPC primitives — kernel-internal, NOT injected via DI.
+        # Like VFSLockManager: always present, created by kernel at init.
+        # Both use ROOT_ZONE_ID (zone_id is a federation concept, not kernel).
+        import os as _os_ipc
+
+        from nexus.core.pipe_manager import PipeManager
+        from nexus.core.stream_manager import StreamManager
+
+        _ipc_self_addr = _os_ipc.environ.get("NEXUS_ADVERTISE_ADDR")
+        self._pipe_manager = PipeManager(
+            metadata_store,
+            zone_id=ROOT_ZONE_ID,
+            self_address=_ipc_self_addr,
+        )
+        self._stream_manager = StreamManager(
+            metadata_store,
+            zone_id=ROOT_ZONE_ID,
+            self_address=_ipc_self_addr,
+        )
+        logger.info(
+            "IPC primitives initialized: PipeManager + StreamManager (self_address=%s)",
+            _ipc_self_addr or "none/single-node",
+        )
 
         # Service registry — /proc/modules of Nexus (Issue #1452).
         # Populated by factory via populate_service_registry() at link().
@@ -985,18 +1008,26 @@ class NexusFS(  # type: ignore[misc]
 
     def _setattr_create(self, path: str, entry_type: int, attrs: dict[str, Any]) -> dict[str, Any]:
         """Create an inode via sys_setattr upsert — dispatches by entry_type."""
-        from nexus.contracts.metadata import DT_PIPE
+        from nexus.contracts.metadata import DT_PIPE, DT_STREAM
+
+        capacity = attrs.get("capacity", 65_536)
+        owner_id = attrs.get("owner_id")
 
         if entry_type == DT_PIPE:
-            capacity = attrs.get("capacity", 65_536)
-            owner_id = attrs.get("owner_id")
-            if self._pipe_manager is None:
-                raise BackendError("PipeManager not available")
             from nexus.core.pipe import PipeError
 
             try:
                 self._pipe_manager.create(path, capacity=capacity, owner_id=owner_id)
             except PipeError as exc:
+                raise BackendError(str(exc)) from exc
+            return {"path": path, "created": True, "entry_type": entry_type, "capacity": capacity}
+
+        if entry_type == DT_STREAM:
+            from nexus.core.stream import StreamError
+
+            try:
+                self._stream_manager.create(path, capacity=capacity, owner_id=owner_id)
+            except StreamError as exc:
                 raise BackendError(str(exc)) from exc
             return {"path": path, "created": True, "entry_type": entry_type, "capacity": capacity}
 
@@ -1228,11 +1259,13 @@ class NexusFS(  # type: ignore[misc]
             check_write=False,
         )
 
-        # DT_PIPE: kernel-native pipe dispatch (§4.2)
-        from nexus.core.router import PipeRouteResult
+        # DT_PIPE / DT_STREAM: kernel-native IPC dispatch (§4.2)
+        from nexus.core.router import PipeRouteResult, StreamRouteResult
 
         if isinstance(route, PipeRouteResult):
             return self._pipe_read(path, count=count, offset=offset)
+        if isinstance(route, StreamRouteResult):
+            return self._stream_read(path, count=count, offset=offset)
 
         # Add backend_path to context for path-based connectors
         from dataclasses import replace
@@ -2040,11 +2073,14 @@ class NexusFS(  # type: ignore[misc]
         if _handled:
             return {"path": path, "bytes_written": len(buf), "created": False}
 
-        # DT_PIPE: kernel-native pipe dispatch (§4.2)
+        # DT_PIPE / DT_STREAM: kernel-native IPC dispatch (§4.2)
         _meta = self.metadata.get(path)
         if _meta is not None and _meta.is_pipe:
             n = self._pipe_write(path, buf)
             return {"path": path, "bytes_written": n, "created": False}
+        if _meta is not None and _meta.is_stream:
+            offset = self._stream_write(path, buf)
+            return {"path": path, "bytes_written": len(buf), "created": False, "offset": offset}
 
         self._write_internal(path=path, content=buf, context=context)
         return {"path": path, "bytes_written": len(buf), "created": _meta is None}
@@ -3112,10 +3148,12 @@ class NexusFS(  # type: ignore[misc]
         if _handled:
             return _result
 
-        # DT_PIPE: kernel-native pipe destroy (§4.2)
-        _pipe_meta = self.metadata.get(path)
-        if _pipe_meta is not None and _pipe_meta.is_pipe:
+        # DT_PIPE / DT_STREAM: kernel-native IPC destroy (§4.2)
+        _ipc_meta = self.metadata.get(path)
+        if _ipc_meta is not None and _ipc_meta.is_pipe:
             return self._pipe_destroy(path)
+        if _ipc_meta is not None and _ipc_meta.is_stream:
+            return self._stream_destroy(path)
 
         # Route to backend with write access check FIRST (to check zone/agent isolation)
         # This must happen before permission check so AccessDeniedError is raised before PermissionError
@@ -4337,6 +4375,70 @@ class NexusFS(  # type: ignore[misc]
         finally:
             channel.close()
 
+    # ------------------------------------------------------------------
+    # DT_STREAM kernel primitives (§4.2)
+    # ------------------------------------------------------------------
+
+    def _stream_is_remote(self, path: str) -> str | None:
+        """Check if a DT_STREAM is hosted on a remote node.
+
+        Returns the remote origin address if remote, None if local.
+        """
+        from nexus.contracts.backend_address import BackendAddress
+
+        meta = self.metadata.get(path)
+        if meta is None or not meta.backend_name:
+            return None
+        addr = BackendAddress.parse(meta.backend_name)
+        if not addr.has_origin:
+            return None
+        if addr.origin == self._stream_manager.self_address:
+            return None
+        return addr.origin
+
+    def _stream_read(self, path: str, *, count: int | None = None, offset: int = 0) -> bytes:
+        """Read from DT_STREAM — non-destructive, offset-based."""
+        from nexus.core.stream import StreamClosedError, StreamEmptyError, StreamNotFoundError
+
+        # TODO: remote proxy (like _pipe_read_remote) when federation is wired
+        try:
+            if count is not None and count > 1:
+                items, _ = self._stream_manager.stream_read_batch(path, offset, count)
+                return b"".join(items)
+            data, _ = self._stream_manager.stream_read_at(path, offset)
+            return data
+        except StreamNotFoundError:
+            raise NexusFileNotFoundError(path, f"Stream not found: {path}") from None
+        except StreamClosedError:
+            raise NexusFileNotFoundError(path, f"Stream closed: {path}") from None
+        except StreamEmptyError:
+            from nexus.core.stream import StreamEmptyError as _SE
+
+            raise _SE(f"stream empty at offset {offset}: {path}") from None
+
+    def _stream_write(self, path: str, data: bytes) -> int:
+        """Write to DT_STREAM — non-blocking append, returns byte offset."""
+        from nexus.core.stream import StreamClosedError, StreamNotFoundError
+
+        # TODO: remote proxy when federation is wired
+        try:
+            return self._stream_manager.stream_write_nowait(path, data)
+        except StreamNotFoundError:
+            raise NexusFileNotFoundError(path, f"Stream not found: {path}") from None
+        except StreamClosedError:
+            raise NexusFileNotFoundError(path, f"Stream closed: {path}") from None
+
+    def _stream_destroy(self, path: str) -> dict[str, Any]:
+        """Destroy DT_STREAM — close buffer + delete inode."""
+        from nexus.core.stream import StreamNotFoundError
+
+        # TODO: remote proxy when federation is wired
+        try:
+            self._stream_manager.destroy(path)
+        except StreamNotFoundError:
+            raise NexusFileNotFoundError(path, f"Stream not found: {path}") from None
+        return {}
+
     async def aclose(self) -> None:
         """Async shutdown: stop PersistentService + deactivate HotSwappable, then close.
 
@@ -4352,6 +4454,12 @@ class NexusFS(  # type: ignore[misc]
 
     def close(self) -> None:
         """Close the filesystem and release resources."""
+        # Close IPC primitives — kernel-internal (§4.2)
+        if hasattr(self, "_pipe_manager"):
+            self._pipe_manager.close_all()
+        if hasattr(self, "_stream_manager"):
+            self._stream_manager.close_all()
+
         # Close ProcessTable — kill all processes, clear state
         if hasattr(self, "_process_table") and self._process_table is not None:
             self._process_table.close_all()

--- a/src/nexus/core/router.py
+++ b/src/nexus/core/router.py
@@ -69,6 +69,17 @@ class PipeRouteResult:
     path: str
 
 
+@dataclass(frozen=True, slots=True)
+class StreamRouteResult:
+    """Route result for DT_STREAM — kernel dispatches to StreamManager.
+
+    Like ``PipeRouteResult`` but for append-only streams with
+    non-destructive offset-based reads.
+    """
+
+    path: str
+
+
 class PathRouter:
     """Route virtual paths to storage backends using mount table.
 
@@ -184,16 +195,17 @@ class PathRouter:
         *,
         is_admin: bool = False,
         check_write: bool = False,
-    ) -> RouteResult | PipeRouteResult:
+    ) -> RouteResult | PipeRouteResult | StreamRouteResult:
         """Route virtual path to backend with mount-level access control.
 
         Algorithm: walk path components from deepest to shallowest, checking
         metastore for DT_MOUNT at each level (longest prefix match).  Each
         metastore.get() is ~5 μs with redb's Rust in-memory cache.
 
-        DT_PIPE inodes are detected at the exact target path (first iteration)
-        and short-circuit to ``PipeRouteResult`` — like Linux VFS dispatching
-        to ``fifo_fops`` when the inode is ``S_ISFIFO``.
+        DT_PIPE / DT_STREAM inodes are detected at the exact target path
+        (first iteration) and short-circuit to ``PipeRouteResult`` /
+        ``StreamRouteResult`` — like Linux VFS dispatching to special
+        ``fops`` when the inode type matches.
 
         Args:
             virtual_path: Virtual path to route.
@@ -201,7 +213,8 @@ class PathRouter:
             check_write: Whether to check write permissions.
 
         Returns:
-            RouteResult for regular files, PipeRouteResult for DT_PIPE.
+            RouteResult for regular files, PipeRouteResult for DT_PIPE,
+            StreamRouteResult for DT_STREAM.
 
         Raises:
             PathNotMountedError: No mount found for path.
@@ -215,11 +228,14 @@ class PathRouter:
         while True:
             meta = self._metastore.get(current)
 
-            # DT_PIPE: kernel-native pipe dispatch at exact target path.
-            # Pipes are endpoint inodes (not prefixes), so only match on
-            # the first iteration (current == virtual_path).
-            if meta is not None and meta.is_pipe and current == virtual_path:
-                return PipeRouteResult(path=virtual_path)
+            # DT_PIPE / DT_STREAM: kernel-native IPC dispatch at exact
+            # target path. IPC inodes are endpoints (not prefixes), so
+            # only match on the first iteration (current == virtual_path).
+            if meta is not None and current == virtual_path:
+                if meta.is_pipe:
+                    return PipeRouteResult(path=virtual_path)
+                if meta.is_stream:
+                    return StreamRouteResult(path=virtual_path)
 
             # Primary: metastore DT_MOUNT (persistent, cross-session).
             # Fallback: _backends registry (in-memory, current session).

--- a/src/nexus/core/stream.py
+++ b/src/nexus/core/stream.py
@@ -1,0 +1,182 @@
+"""DT_STREAM kernel IPC primitive — append-only log with offset-based reads.
+
+Complements DT_PIPE (FIFO, destructive reads) as the second kernel messaging
+primitive from KERNEL-ARCHITECTURE.md §4.2:
+
+    | Primitive  | Linux Analogue   | Nexus                | Read      |
+    |------------|------------------|----------------------|-----------|
+    | DT_PIPE    | kfifo ring buffer| RingBuffer (pipe.py) | Destructive|
+    | DT_STREAM  | append-only log  | StreamBuffer         | Non-destructive|
+
+Multiple readers maintain independent cursors (fan-out). Primary use case:
+LLM streaming I/O — realtime first consumer + replay for later consumers.
+
+    stream.py           = kernel-internal buffer (kfifo equivalent)
+    core/stream_manager.py = VFS named stream (fs/pipe.c equivalent)
+
+Storage model (KERNEL-ARCHITECTURE.md):
+    - Stream **inode** (FileMetadata, entry_type=DT_STREAM) → MetastoreABC
+    - Stream **data** (bytes in linear buffer) → process heap (not in any pillar)
+
+Data plane backed by Rust ``nexus_fast.StreamBufferCore``.
+"""
+
+import asyncio
+import logging
+
+from nexus_fast import StreamBufferCore
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class StreamError(Exception):
+    """Base exception for stream operations."""
+
+
+class StreamFullError(StreamError):
+    """Non-blocking write on a full buffer."""
+
+
+class StreamEmptyError(StreamError):
+    """Read at offset with no data available."""
+
+
+class StreamClosedError(StreamError):
+    """Operation on a closed stream."""
+
+
+class StreamNotFoundError(StreamError):
+    """No stream registered at the given path."""
+
+
+# ---------------------------------------------------------------------------
+# StreamBuffer — append-only log (kernel-internal, no VFS)
+# ---------------------------------------------------------------------------
+
+
+class StreamBuffer:
+    """Append-only log buffer with offset-based non-destructive reads.
+
+    Unlike RingBuffer (SPSC destructive FIFO), StreamBuffer is a linear
+    append-only buffer where reads never consume data. Multiple readers
+    maintain independent byte offsets (cursors).
+
+    Data plane backed by Rust ``nexus_fast.StreamBufferCore``.
+    Python provides asyncio.Event coordination for blocked writers.
+    """
+
+    __slots__ = ("_core", "_not_full")
+
+    def __init__(self, capacity: int = 65_536) -> None:
+        if capacity <= 0:
+            raise ValueError(f"capacity must be > 0, got {capacity}")
+        self._core = StreamBufferCore(capacity)
+        self._not_full = asyncio.Event()
+        self._not_full.set()  # initially not full
+
+    # -- write (append) -----------------------------------------------------
+
+    def write_nowait(self, data: bytes) -> int:
+        """Synchronous non-blocking append. Returns byte offset of the message.
+
+        Raises:
+            StreamFullError: Buffer is full (linear — never reclaims space).
+            StreamClosedError: Buffer is closed.
+            ValueError: Message larger than total capacity.
+        """
+        try:
+            return int(self._core.push(data))
+        except RuntimeError as exc:
+            _translate_rust_error(exc)
+            raise
+        except ValueError:
+            raise
+
+    async def write(self, data: bytes, *, blocking: bool = True) -> int:
+        """Async append. If blocking=True, waits for close (only way to unblock)."""
+        while True:
+            try:
+                return self.write_nowait(data)
+            except StreamFullError:
+                if not blocking:
+                    raise
+                self._not_full.clear()
+                await self._not_full.wait()
+                if self._core.closed:
+                    raise StreamClosedError("write to closed stream") from None
+
+    # -- read (non-destructive, offset-based) --------------------------------
+
+    def read_at(self, byte_offset: int = 0) -> tuple[bytes, int]:
+        """Read one message at byte_offset. Returns (data, next_offset).
+
+        Non-destructive — the same offset can be re-read by any reader.
+
+        Raises:
+            StreamEmptyError: No data at this offset.
+            StreamClosedError: Stream closed and no data at offset.
+        """
+        try:
+            data, next_offset = self._core.read_at(byte_offset)
+            return bytes(data), next_offset
+        except RuntimeError as exc:
+            _translate_rust_error(exc)
+            raise
+
+    def read_batch(self, byte_offset: int = 0, count: int = 10) -> tuple[list[bytes], int]:
+        """Read up to `count` messages starting at byte_offset.
+
+        Returns (list_of_bytes, next_offset).
+
+        Raises:
+            StreamEmptyError: No data at this offset.
+            StreamClosedError: Stream closed and no data at offset.
+        """
+        try:
+            items, next_offset = self._core.read_batch(byte_offset, count)
+            return [bytes(b) for b in items], next_offset
+        except RuntimeError as exc:
+            _translate_rust_error(exc)
+            raise
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def close(self) -> None:
+        """Close the buffer. Wakes blocked writers."""
+        self._core.close()
+        self._not_full.set()  # wake blocked writers (so they see closed)
+
+    @property
+    def closed(self) -> bool:
+        return bool(self._core.closed)
+
+    @property
+    def stats(self) -> dict:
+        """Buffer statistics for observability."""
+        return dict(self._core.stats())
+
+    @property
+    def tail(self) -> int:
+        """Current write position (monotonic byte offset)."""
+        return int(self._core.tail)
+
+
+# ---------------------------------------------------------------------------
+# Error translation
+# ---------------------------------------------------------------------------
+
+
+def _translate_rust_error(exc: RuntimeError) -> None:
+    """Translate Rust RuntimeError tags to Python exception classes."""
+    msg = str(exc)
+    if msg.startswith("StreamClosed:"):
+        raise StreamClosedError(msg.split(":", 1)[1]) from None
+    if msg.startswith("StreamFull:"):
+        raise StreamFullError(msg.split(":", 1)[1]) from None
+    if msg.startswith("StreamEmpty:"):
+        raise StreamEmptyError(msg.split(":", 1)[1]) from None
+    raise exc

--- a/src/nexus/core/stream_manager.py
+++ b/src/nexus/core/stream_manager.py
@@ -1,0 +1,283 @@
+"""StreamManager — VFS named stream manager (mkstream equivalent).
+
+Kernel primitive (§4.2) managing DT_STREAM lifecycle and buffer registry
+with per-stream locking for concurrent writers.
+
+    core/stream.py         = kstream  (linear append-only buffer)
+    core/stream_manager.py = mkstream (VFS named stream with per-stream lock)
+
+Concurrency model:
+  - StreamBuffer (kstream) is single-writer internally (linear append).
+  - StreamManager (mkstream) adds per-stream asyncio.Lock for concurrent
+    writers. Reads are lock-free (non-destructive, offset-based).
+
+See: core/stream.py for StreamBuffer, federation-memo.md §7j
+"""
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.core.stream import (
+    StreamBuffer,
+    StreamClosedError,
+    StreamEmptyError,
+    StreamError,
+    StreamFullError,
+    StreamNotFoundError,
+)
+
+if TYPE_CHECKING:
+    from nexus.core.metastore import MetastoreABC
+
+logger = logging.getLogger(__name__)
+
+# Re-export exceptions so callers can import from either module
+__all__ = [
+    "StreamManager",
+    "StreamError",
+    "StreamFullError",
+    "StreamEmptyError",
+    "StreamClosedError",
+    "StreamNotFoundError",
+]
+
+
+class StreamManager:
+    """Manages DT_STREAM lifecycle and buffer registry.
+
+    Analogous to PipeManager but for append-only streams. Each stream has
+    a FileMetadata inode in MetastoreABC (entry_type=DT_STREAM) and a
+    StreamBuffer in process memory.
+
+    Key difference from PipeManager: reads are non-destructive and lock-free.
+    Multiple readers maintain independent byte offsets (fan-out). Writers
+    use a per-stream lock for MPMC safety.
+    """
+
+    def __init__(
+        self,
+        metastore: "MetastoreABC",
+        zone_id: str = ROOT_ZONE_ID,
+        self_address: str | None = None,
+    ) -> None:
+        self._metastore = metastore
+        self._zone_id = zone_id
+        self._self_address = self_address
+        self._buffers: dict[str, StreamBuffer] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    @property
+    def self_address(self) -> str | None:
+        """This node's advertise address, or None for single-node mode."""
+        return self._self_address
+
+    def create(
+        self,
+        path: str,
+        *,
+        capacity: int = 65_536,
+        owner_id: str | None = None,
+    ) -> StreamBuffer:
+        """Create a new named stream at the given VFS path.
+
+        Creates a DT_STREAM inode in MetastoreABC and a StreamBuffer in memory.
+
+        Args:
+            path: VFS path (e.g., "/nexus/streams/my-stream"). Must start with "/".
+            capacity: Linear buffer byte capacity. Default 64KB.
+            owner_id: Owner for ReBAC permission checks.
+
+        Returns:
+            The created StreamBuffer.
+
+        Raises:
+            StreamError: Stream already exists at this path.
+        """
+        from nexus.contracts.metadata import DT_STREAM, FileMetadata
+
+        if path in self._buffers:
+            raise StreamError(f"stream already exists: {path}")
+
+        # Check if inode already exists in metastore
+        existing = self._metastore.get(path)
+        if existing is not None:
+            raise StreamError(f"path already exists: {path}")
+
+        # Create DT_STREAM inode in MetastoreABC.
+        # Embed origin address so remote nodes can proxy stream I/O.
+        # "stream" (no origin) = single-node mode, "stream@host:port" = federated.
+        stream_backend = f"stream@{self._self_address}" if self._self_address else "stream"
+        metadata = FileMetadata(
+            path=path,
+            backend_name=stream_backend,
+            physical_path="mem://",
+            size=capacity,
+            entry_type=DT_STREAM,
+            zone_id=self._zone_id,
+            owner_id=owner_id,
+        )
+        self._metastore.put(metadata)
+
+        # Create in-memory linear buffer
+        buf = StreamBuffer(capacity=capacity)
+        self._buffers[path] = buf
+
+        logger.debug("stream created: %s (capacity=%d)", path, capacity)
+        return buf
+
+    def open(self, path: str, *, capacity: int = 65_536) -> StreamBuffer:
+        """Open an existing stream, or recover its buffer after restart.
+
+        If the buffer is already in memory, returns it. If a DT_STREAM inode
+        exists but the buffer was lost (process restart), creates a new
+        buffer for the existing inode.
+
+        Args:
+            path: VFS path of the stream.
+            capacity: Buffer capacity (used only if recreating after restart).
+
+        Returns:
+            The StreamBuffer for this stream.
+
+        Raises:
+            StreamNotFoundError: No stream inode at this path.
+        """
+        from nexus.contracts.metadata import DT_STREAM
+
+        # Return existing buffer if available
+        if path in self._buffers and not self._buffers[path].closed:
+            return self._buffers[path]
+
+        # Check metastore for inode
+        metadata = self._metastore.get(path)
+        if metadata is None or metadata.entry_type != DT_STREAM:
+            raise StreamNotFoundError(f"no stream at: {path}")
+
+        # Recreate buffer (restart recovery)
+        buf = StreamBuffer(capacity=capacity)
+        self._buffers[path] = buf
+
+        logger.debug("stream opened (recovered): %s", path)
+        return buf
+
+    def signal_close(self, path: str) -> None:
+        """Signal a stream closed without removing from registry.
+
+        Closes the StreamBuffer (wakes blocked writers) but keeps it in
+        ``_buffers`` so readers can still read existing data at their offsets.
+
+        Raises:
+            StreamNotFoundError: No buffer at this path.
+        """
+        buf = self._buffers.get(path)
+        if buf is None:
+            raise StreamNotFoundError(f"no stream at: {path}")
+        buf.close()
+        logger.debug("stream signal_close: %s", path)
+
+    def close(self, path: str) -> None:
+        """Close a stream's buffer and remove from registry. Inode stays in MetastoreABC.
+
+        Raises:
+            StreamNotFoundError: No buffer at this path.
+        """
+        buf = self._buffers.pop(path, None)
+        if buf is None:
+            raise StreamNotFoundError(f"no stream at: {path}")
+        buf.close()
+        self._locks.pop(path, None)
+        logger.debug("stream closed: %s", path)
+
+    def destroy(self, path: str) -> None:
+        """Close buffer AND delete inode from MetastoreABC.
+
+        Raises:
+            StreamNotFoundError: No stream at this path.
+        """
+        buf = self._buffers.pop(path, None)
+        if buf is not None:
+            buf.close()
+        self._locks.pop(path, None)
+
+        metadata = self._metastore.get(path)
+        if metadata is None:
+            if buf is None:
+                raise StreamNotFoundError(f"no stream at: {path}")
+            return
+
+        self._metastore.delete(path)
+        logger.debug("stream destroyed: %s", path)
+
+    def _get_buffer(self, path: str) -> StreamBuffer:
+        """Get buffer or raise StreamNotFoundError."""
+        buf = self._buffers.get(path)
+        if buf is None:
+            raise StreamNotFoundError(f"no stream at: {path}")
+        return buf
+
+    def _get_lock(self, path: str) -> asyncio.Lock:
+        """Get or create per-stream lock for concurrent writer safety."""
+        lock = self._locks.get(path)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[path] = lock
+        return lock
+
+    # ------------------------------------------------------------------
+    # Data path — writes locked, reads lock-free
+    # ------------------------------------------------------------------
+
+    async def stream_write(self, path: str, data: bytes, *, blocking: bool = True) -> int:
+        """Write to a named stream. MPMC-safe (per-stream asyncio.Lock).
+
+        Returns the byte offset where the message was appended.
+        """
+        buf = self._get_buffer(path)
+        lock = self._get_lock(path)
+        async with lock:
+            return await buf.write(data, blocking=blocking)
+
+    def stream_write_nowait(self, path: str, data: bytes) -> int:
+        """Synchronous non-blocking write to a named stream.
+
+        Atomic under asyncio event loop (no await points = no preemption).
+        """
+        return self._get_buffer(path).write_nowait(data)
+
+    def stream_read_at(self, path: str, byte_offset: int = 0) -> tuple[bytes, int]:
+        """Read one message at byte_offset. Lock-free (non-destructive).
+
+        Returns (data, next_offset).
+        """
+        return self._get_buffer(path).read_at(byte_offset)
+
+    def stream_read_batch(
+        self, path: str, byte_offset: int = 0, count: int = 10
+    ) -> tuple[list[bytes], int]:
+        """Read up to `count` messages starting at byte_offset. Lock-free.
+
+        Returns (list_of_bytes, next_offset).
+        """
+        return self._get_buffer(path).read_batch(byte_offset, count)
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    def list_streams(self) -> dict[str, dict]:
+        """List all active streams with their stats."""
+        return {path: buf.stats for path, buf in self._buffers.items()}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close_all(self) -> None:
+        """Close all stream buffers. Called on kernel shutdown."""
+        for path, buf in self._buffers.items():
+            buf.close()
+            logger.debug("stream closed (shutdown): %s", path)
+        self._buffers.clear()
+        self._locks.clear()

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -488,27 +488,8 @@ def _boot_system_services(
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] SchedulerService unavailable: %s", exc)
 
-    # --- PipeManager (Issue #809: DT_PIPE kernel IPC for write observer + zoekt) ---
-    # self_address enables federated DT_PIPE: remote nodes can proxy pipe
-    # I/O to the origin via gRPC Call RPC (Issue #1576).
-    pipe_manager: Any = None
-    try:
-        import os
-
-        from nexus.core.pipe_manager import PipeManager
-
-        _pipe_self_addr = os.environ.get("NEXUS_ADVERTISE_ADDR")
-        pipe_manager = PipeManager(
-            ctx.metadata_store,
-            zone_id=ctx.zone_id or ROOT_ZONE_ID,
-            self_address=_pipe_self_addr,
-        )
-        logger.debug(
-            "[BOOT:SYSTEM] PipeManager created (self_address=%s)",
-            _pipe_self_addr or "none/single-node",
-        )
-    except Exception as exc:
-        logger.warning("[BOOT:SYSTEM] PipeManager unavailable: %s", exc)
+    # (PipeManager + StreamManager are kernel-internal primitives,
+    # constructed in NexusFS.__init__ — not booted here.)
 
     # --- ProcessTable (Issue #1509: kernel process lifecycle) ---
     process_table: Any = None
@@ -557,7 +538,6 @@ def _boot_system_services(
         "entity_registry": entity_registry,
         "permission_enforcer": permission_enforcer,
         "write_observer": write_observer,
-        "pipe_manager": pipe_manager,
         "process_table": process_table,
         # Former-kernel degradable
         "dir_visibility_cache": dir_visibility_cache,

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -196,8 +196,8 @@ def create_nexus_services(
         resiliency_manager=system_dict["resiliency_manager"],
         eviction_manager=system_dict.get("eviction_manager"),
         zone_lifecycle=system_dict.get("zone_lifecycle"),
-        # DT_PIPE manager (Issue #809)
-        pipe_manager=system_dict.get("pipe_manager"),
+        # (PipeManager + StreamManager are kernel-internal primitives §4.2,
+        # constructed in NexusFS.__init__ — not injected via SystemServices.)
         # Scheduler (Issue #2195)
         scheduler_service=system_dict.get("scheduler_service"),
     )

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -54,7 +54,7 @@ class LifespanServices:
     eviction_manager: Any = None
     write_observer: Any = None
     zone_lifecycle: Any = None
-    pipe_manager: Any = None  # DT_PIPE manager (Issue #809)
+    pipe_manager: Any = None  # DT_PIPE manager — kernel-internal primitive (§4.2)
 
     # --- Issue #2195, #2360: Scheduler (from SystemServices) ----
     scheduler_service: "SchedulerProtocol | None" = None
@@ -116,7 +116,7 @@ class LifespanServices:
             eviction_manager=(getattr(_sys, "eviction_manager", None) if _sys else None),
             write_observer=(getattr(_sys, "write_observer", None) if _sys else None),
             zone_lifecycle=(getattr(_sys, "zone_lifecycle", None) if _sys else None),
-            pipe_manager=(getattr(_sys, "pipe_manager", None) if _sys else None),
+            pipe_manager=(getattr(nx, "_pipe_manager", None) if nx else None),
             # Issue #810: DT_PIPE Zoekt consumer
             zoekt_pipe_consumer=(getattr(_brk, "zoekt_pipe_consumer", None) if _brk else None),
             # Issue #2195: Scheduler

--- a/src/nexus/system_services/sync/sync_service.py
+++ b/src/nexus/system_services/sync/sync_service.py
@@ -197,6 +197,10 @@ class SyncService:
         route = self._gw.router.route(ctx.mount_point)
         if isinstance(route, PipeRouteResult):
             raise ValueError(f"Cannot sync pipe path: {ctx.mount_point}")
+        from nexus.core.router import StreamRouteResult
+
+        if isinstance(route, StreamRouteResult):
+            raise ValueError(f"Cannot sync stream path: {ctx.mount_point}")
         backend = route.backend
         backend_name = type(backend).__name__
 

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -72,7 +72,6 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "brick_lifecycle_manager",
         "brick_reconciler",
         "zone_lifecycle",
-        "pipe_manager",
         "process_table",
         "scheduler_service",
         "agent_runtime",
@@ -227,7 +226,6 @@ class TestBootSystemServices:
             "delivery_worker",
             "observability_subsystem",
             "workspace_registry",  # degradable — None with mock session_factory
-            "pipe_manager",  # degradable — None if PipeManager unavailable
             "scheduler_service",  # degradable — None if SchedulerService unavailable
             "agent_runtime",  # degradable — None if AgentRuntime unavailable
         }

--- a/tests/unit/core/test_kernel_config.py
+++ b/tests/unit/core/test_kernel_config.py
@@ -275,8 +275,7 @@ class TestSystemServices:
         assert ss.delivery_worker is None
         assert ss.observability_subsystem is None
         assert ss.resiliency_manager is None
-        # DT_PIPE manager (Issue #809)
-        assert ss.pipe_manager is None
+        # (PipeManager is kernel-internal §4.2, not in SystemServices)
 
     def test_frozen(self) -> None:
         ss = SystemServices()
@@ -329,7 +328,6 @@ class TestSystemServices:
             "observability_subsystem",
             "resiliency_manager",
             "zone_lifecycle",
-            "pipe_manager",
             "process_table",
             "scheduler_service",
         }

--- a/tests/unit/core/test_stream.py
+++ b/tests/unit/core/test_stream.py
@@ -1,0 +1,339 @@
+"""Tests for DT_STREAM — append-only log with offset-based non-destructive reads.
+
+Tests StreamBuffer (kstream) and StreamManager (mkstream).
+"""
+
+import pytest
+
+from nexus.core.stream import (
+    StreamBuffer,
+    StreamClosedError,
+    StreamEmptyError,
+    StreamFullError,
+)
+
+# ---------------------------------------------------------------------------
+# StreamBuffer (kstream) — basic operations
+# ---------------------------------------------------------------------------
+
+
+class TestStreamBufferBasic:
+    """Write / read_at roundtrip, ordering, stats."""
+
+    def test_write_read_roundtrip(self):
+        buf = StreamBuffer(capacity=1024)
+        offset = buf.write_nowait(b"hello")
+        data, next_offset = buf.read_at(offset)
+        assert data == b"hello"
+        assert next_offset > offset
+
+    def test_write_multiple_read_in_order(self):
+        buf = StreamBuffer(capacity=1024)
+        o1 = buf.write_nowait(b"aaa")
+        o2 = buf.write_nowait(b"bbb")
+        o3 = buf.write_nowait(b"ccc")
+
+        d1, n1 = buf.read_at(o1)
+        d2, n2 = buf.read_at(n1)
+        d3, _ = buf.read_at(n2)
+
+        assert d1 == b"aaa"
+        assert d2 == b"bbb"
+        assert d3 == b"ccc"
+        assert o1 < o2 < o3
+
+    def test_stats(self):
+        buf = StreamBuffer(capacity=1024)
+        buf.write_nowait(b"x")
+        buf.write_nowait(b"y")
+        s = buf.stats
+        assert s["msg_count"] == 2
+        assert s["push_count"] == 2
+
+    def test_tail_monotonic(self):
+        buf = StreamBuffer(capacity=1024)
+        assert buf.tail == 0
+        buf.write_nowait(b"data")
+        t1 = buf.tail
+        buf.write_nowait(b"more")
+        t2 = buf.tail
+        assert t2 > t1 > 0
+
+
+# ---------------------------------------------------------------------------
+# StreamBuffer — replay / multi-reader
+# ---------------------------------------------------------------------------
+
+
+class TestStreamBufferReplay:
+    """read_at(0) replays from start, same offset re-readable."""
+
+    def test_replay_from_start(self):
+        buf = StreamBuffer(capacity=1024)
+        buf.write_nowait(b"first")
+        buf.write_nowait(b"second")
+
+        # Read from 0 twice — same result (non-destructive)
+        d1, n1 = buf.read_at(0)
+        d2, n2 = buf.read_at(0)
+        assert d1 == d2 == b"first"
+        assert n1 == n2
+
+    def test_same_offset_re_readable(self):
+        buf = StreamBuffer(capacity=1024)
+        offset = buf.write_nowait(b"hello")
+        for _ in range(5):
+            data, _ = buf.read_at(offset)
+            assert data == b"hello"
+
+
+class TestStreamBufferMultiReader:
+    """Two readers at different offsets."""
+
+    def test_independent_cursors(self):
+        buf = StreamBuffer(capacity=1024)
+        buf.write_nowait(b"msg1")
+        buf.write_nowait(b"msg2")
+        buf.write_nowait(b"msg3")
+
+        # Reader A reads from start
+        da, na = buf.read_at(0)
+        assert da == b"msg1"
+
+        # Reader B reads further ahead
+        _, nb = buf.read_at(na)
+        db, _ = buf.read_at(nb)
+        assert db == b"msg3"
+
+        # Reader A still at msg1 offset — can re-read
+        da2, _ = buf.read_at(0)
+        assert da2 == b"msg1"
+
+
+# ---------------------------------------------------------------------------
+# StreamBuffer — batch reads
+# ---------------------------------------------------------------------------
+
+
+class TestStreamBufferBatch:
+    """read_batch with various counts."""
+
+    def test_batch_all(self):
+        buf = StreamBuffer(capacity=1024)
+        buf.write_nowait(b"a")
+        buf.write_nowait(b"b")
+        buf.write_nowait(b"c")
+
+        items, next_off = buf.read_batch(0, count=10)
+        assert len(items) == 3
+        assert items == [b"a", b"b", b"c"]
+
+    def test_batch_partial(self):
+        buf = StreamBuffer(capacity=1024)
+        buf.write_nowait(b"a")
+        buf.write_nowait(b"b")
+        buf.write_nowait(b"c")
+
+        items, next_off = buf.read_batch(0, count=2)
+        assert len(items) == 2
+        assert items == [b"a", b"b"]
+
+        # Continue from next_off
+        items2, _ = buf.read_batch(next_off, count=10)
+        assert items2 == [b"c"]
+
+    def test_batch_count_one(self):
+        buf = StreamBuffer(capacity=1024)
+        buf.write_nowait(b"only")
+
+        items, _ = buf.read_batch(0, count=1)
+        assert items == [b"only"]
+
+
+# ---------------------------------------------------------------------------
+# StreamBuffer — capacity and errors
+# ---------------------------------------------------------------------------
+
+
+class TestStreamBufferCapacity:
+    """Oversized, exact capacity, full error."""
+
+    def test_oversized_message(self):
+        buf = StreamBuffer(capacity=64)
+        with pytest.raises(ValueError):
+            buf.write_nowait(b"x" * 1000)
+
+    def test_full_error(self):
+        buf = StreamBuffer(capacity=64)
+        # Fill the buffer
+        while True:
+            try:
+                buf.write_nowait(b"xxxx")
+            except (StreamFullError, ValueError):
+                break
+
+    def test_capacity_must_be_positive(self):
+        with pytest.raises(ValueError):
+            StreamBuffer(capacity=0)
+        with pytest.raises(ValueError):
+            StreamBuffer(capacity=-1)
+
+    def test_empty_read(self):
+        buf = StreamBuffer(capacity=1024)
+        with pytest.raises(StreamEmptyError):
+            buf.read_at(0)
+
+
+# ---------------------------------------------------------------------------
+# StreamBuffer — close semantics
+# ---------------------------------------------------------------------------
+
+
+class TestStreamBufferClose:
+    """Write after close, close semantics."""
+
+    def test_write_after_close(self):
+        buf = StreamBuffer(capacity=1024)
+        buf.write_nowait(b"before")
+        buf.close()
+        with pytest.raises(StreamClosedError):
+            buf.write_nowait(b"after")
+
+    def test_read_existing_after_close(self):
+        buf = StreamBuffer(capacity=1024)
+        offset = buf.write_nowait(b"data")
+        buf.close()
+        # Existing data still readable after close
+        data, _ = buf.read_at(offset)
+        assert data == b"data"
+
+    def test_closed_property(self):
+        buf = StreamBuffer(capacity=1024)
+        assert not buf.closed
+        buf.close()
+        assert buf.closed
+
+
+# ---------------------------------------------------------------------------
+# StreamManager (mkstream) — lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestStreamManager:
+    """create, open, destroy, list, close_all."""
+
+    @pytest.fixture()
+    def manager(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from nexus.contracts.metadata import FileMetadata
+
+        # Simple in-memory metastore mock
+        store: dict[str, FileMetadata] = {}
+
+        mock = MagicMock()
+        mock.get = lambda p: store.get(p)
+        mock.put = lambda m: store.__setitem__(m.path, m)
+        mock.delete = lambda p: store.pop(p, None)
+
+        from nexus.core.stream_manager import StreamManager
+
+        return StreamManager(mock, zone_id="root", self_address=None)
+
+    def test_create_and_read(self, manager):
+        buf = manager.create("/streams/test", capacity=1024)
+        offset = buf.write_nowait(b"hello")
+
+        data, _ = manager.stream_read_at("/streams/test", offset)
+        assert data == b"hello"
+
+    def test_create_duplicate_raises(self, manager):
+        manager.create("/streams/test")
+        from nexus.core.stream import StreamError
+
+        with pytest.raises(StreamError, match="already exists"):
+            manager.create("/streams/test")
+
+    def test_open_existing(self, manager):
+        manager.create("/streams/test")
+        buf = manager.open("/streams/test")
+        assert not buf.closed
+
+    def test_open_not_found(self, manager):
+        from nexus.core.stream import StreamNotFoundError
+
+        with pytest.raises(StreamNotFoundError):
+            manager.open("/streams/nonexistent")
+
+    def test_destroy(self, manager):
+        manager.create("/streams/test")
+        manager.destroy("/streams/test")
+
+        from nexus.core.stream import StreamNotFoundError
+
+        with pytest.raises(StreamNotFoundError):
+            manager.stream_read_at("/streams/test", 0)
+
+    def test_list_streams(self, manager):
+        manager.create("/streams/a")
+        manager.create("/streams/b")
+
+        streams = manager.list_streams()
+        assert "/streams/a" in streams
+        assert "/streams/b" in streams
+
+    def test_close_all(self, manager):
+        buf_a = manager.create("/streams/a")
+        buf_b = manager.create("/streams/b")
+
+        manager.close_all()
+        assert buf_a.closed
+        assert buf_b.closed
+
+    def test_signal_close(self, manager):
+        buf = manager.create("/streams/test")
+        manager.signal_close("/streams/test")
+        assert buf.closed
+        # Buffer still in registry — can still read existing data
+
+    def test_write_nowait(self, manager):
+        manager.create("/streams/test")
+        offset = manager.stream_write_nowait("/streams/test", b"sync_data")
+        data, _ = manager.stream_read_at("/streams/test", offset)
+        assert data == b"sync_data"
+
+
+class TestStreamManagerFederation:
+    """self_address and backend_name encoding."""
+
+    def test_no_self_address(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        store: dict = {}
+        mock = MagicMock()
+        mock.get = lambda p: store.get(p)
+        mock.put = lambda m: store.__setitem__(m.path, m)
+
+        from nexus.core.stream_manager import StreamManager
+
+        mgr = StreamManager(mock, self_address=None)
+        mgr.create("/s/test")
+
+        meta = store["/s/test"]
+        assert meta.backend_name == "stream"
+
+    def test_with_self_address(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        store: dict = {}
+        mock = MagicMock()
+        mock.get = lambda p: store.get(p)
+        mock.put = lambda m: store.__setitem__(m.path, m)
+
+        from nexus.core.stream_manager import StreamManager
+
+        mgr = StreamManager(mock, self_address="node1:5050")
+        mgr.create("/s/test")
+
+        meta = store["/s/test"]
+        assert meta.backend_name == "stream@node1:5050"

--- a/tests/unit/server/lifespan/test_lifespan_services.py
+++ b/tests/unit/server/lifespan/test_lifespan_services.py
@@ -132,9 +132,8 @@ class TestFromAppSystemServices:
             eviction_manager="em",
             write_observer="write_obs",
             zone_lifecycle="zl",
-            pipe_manager="pipe_mgr",
         )
-        nx = _make_nexus_fs(_system_services=sys_svc)
+        nx = _make_nexus_fs(_system_services=sys_svc, _pipe_manager="pipe_mgr")
         app = _make_app(nexus_fs=nx)
         svc = LifespanServices.from_app(app)
 

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -183,8 +183,7 @@ class TestBootSystemServices:
             "brick_lifecycle_manager",
             "brick_reconciler",
             "zone_lifecycle",
-            # DT_PIPE manager (Issue #809)
-            "pipe_manager",
+            # (PipeManager is kernel-internal §4.2, not in SystemServices)
             # Process lifecycle (Issue #1509)
             "process_table",
             "scheduler_service",


### PR DESCRIPTION
## Summary

- **New kernel primitive DT_STREAM** (§4.2): append-only log with non-destructive, offset-based reads and independent reader cursors (fan-out). Primary use case: LLM streaming I/O (realtime first consumer + replay for later consumers).
- **Rust `StreamBufferCore`**: linear append buffer with `push`/`read_at`/`read_batch` — fundamentally simpler than `RingBufferCore` (no wrap-around, no head pointer).
- **Python `StreamBuffer` (kstream)** + **`StreamManager` (mkstream)**: exception hierarchy, lifecycle management, per-stream locking for concurrent writers, lock-free reads.
- **`DT_STREAM = 4`** entry type in proto/metadata with full generated code.
- **NexusFS syscall dispatch**: `StreamRouteResult` routing + `_stream_read`/`_stream_write`/`_stream_destroy` methods.
- **PipeManager relocated** from `SystemServices` to kernel-internal construction in `NexusFS.__init__` — fixes §4.2 classification violation (kernel primitives must always exist, not degradable).
- **Design docs updated**: KERNEL-ARCHITECTURE.md §4.2 (IPC Primitives comparison table), §8 (Communication table), federation-memo.md §7e/§7j.
- **28 unit tests** covering buffer ops, replay, multi-reader, batch reads, capacity, close semantics, manager lifecycle, and federation backend_name encoding.

## Test plan

- [x] `pytest tests/unit/core/test_stream.py -v` — 28 tests pass
- [x] `pytest tests/unit/core/test_pipe.py -v` — 81 tests pass (no regression from PipeManager relocation)
- [x] `ruff check` — all clean
- [x] `mypy` — passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)