### PR TITLE
fix(#1280): add nexus.security to tier-neutral layer in import-linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -905,18 +905,19 @@ ignore_imports = [
 unmatched_ignore_imports_alerting = "warn"
 
 # Contract 2: Five-tier layered architecture
-# contracts (include/linux) < lib (lib/) < kernel (core) < system_services < bricks
+# contracts (include/linux) < lib+security (lib/) < kernel (core) < system_services < bricks
 # contracts is the type-definition base — everyone can depend on it.
-# lib provides utilities that may use contract types, like Linux lib/ includes include/linux/.
+# lib and security provide utilities that may use contract types, like Linux lib/ includes include/linux/.
+# security is tier-neutral (TLS, TOFU, prompt sanitizer) — zero kernel/service/brick deps.
 [[tool.importlinter.contracts]]
 id = "four-tier-layers"
-name = "Five-tier architecture: contracts < lib < kernel < system_services < bricks"
+name = "Five-tier architecture: contracts < lib+security < kernel < system_services < bricks"
 type = "layers"
 layers = [
     "nexus.bricks",
     "nexus.system_services",
     "nexus.core",
-    "nexus.lib",
+    "nexus.lib | nexus.security",
     "nexus.contracts",
 ]
 # Ratchet baseline — known violations. Remove entries as fixes land.


### PR DESCRIPTION
## Summary
- Audit confirms `nexus.security` (TLS certgen, TOFU trust store, join tokens, prompt sanitizer) has **zero imports** from kernel/services/bricks — qualifies as lib-style tier-neutral
- Add `nexus.security` to five-tier-layers contract at the `nexus.lib` level using pipe notation
- Supersedes PR #2455 which was based on outdated config structure

## Audit Findings
| File | Imports | Implementation | Verdict |
|------|---------|---------------|---------|
| `tls/certgen.py` | stdlib + cryptography only | Pure cert generation functions | COMPLIANT |
| `tls/config.py` | stdlib only | Frozen dataclass | COMPLIANT |
| `tls/join_token.py` | stdlib + cryptography + internal | Token codec functions | COMPLIANT |
| `tls/trust_store.py` | stdlib + cryptography + internal | TOFU verification class | COMPLIANT |

All files import only from stdlib, third-party (`cryptography`), or sibling modules. **Zero** imports from `nexus.core`, `nexus.services`, `nexus.bricks`, or `nexus.system_services`.

## Test plan
- [x] `lint-imports --contract four-tier-layers` — passes
- [x] Pre-commit hooks green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)