### PR TITLE
fix(#1443): deduplicate _get_subject_from_context, delete legacy service routing

### DIFF
--- a/src/nexus/bricks/rebac/rebac_service.py
+++ b/src/nexus/bricks/rebac/rebac_service.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from nexus.bricks.rebac.share_mixin import ReBACShareMixin
 from nexus.contracts.exceptions import CircuitOpenError
+from nexus.lib.context_utils import get_subject_from_context
 from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
@@ -1555,61 +1556,6 @@ class ReBACService(ReBACShareMixin):
     # Helper Methods
     # =========================================================================
 
-    def _get_subject_from_context(self, context: Any) -> tuple[str, str] | None:
-        """Extract subject from operation context.
-
-        Args:
-            context: Operation context (OperationContext or dict)
-
-        Returns:
-            Subject tuple (type, id) or None if not found
-
-        Examples:
-            >>> context = {"subject": ("user", "alice")}
-            >>> self._get_subject_from_context(context)
-            ('user', 'alice')
-
-            >>> context = OperationContext(user_id="alice", groups=[])
-            >>> self._get_subject_from_context(context)
-            ('user', 'alice')
-        """
-        if not context:
-            return None
-
-        # Handle dict format (used by RPC server and tests)
-        if isinstance(context, dict):
-            subject = context.get("subject")
-            if subject and isinstance(subject, tuple) and len(subject) == 2:
-                return (str(subject[0]), str(subject[1]))
-
-            # Construct from subject_type + subject_id
-            subject_type = context.get("subject_type", "user")
-            subject_id = context.get("subject_id") or context.get("user_id")
-            if subject_id:
-                return (subject_type, subject_id)
-
-            return None
-
-        # Handle OperationContext format - use get_subject() method
-        if hasattr(context, "get_subject") and callable(context.get_subject):
-            result = context.get_subject()
-            if result is not None:
-                return (str(result[0]), str(result[1]))
-            return None
-
-        # Fallback: construct from attributes
-        if hasattr(context, "subject_type") and hasattr(context, "subject_id"):
-            subject_type = getattr(context, "subject_type", "user")
-            subject_id = getattr(context, "subject_id", None) or getattr(context, "user_id", None)
-            if subject_id:
-                return (subject_type, subject_id)
-
-        # Last resort: use user field
-        if hasattr(context, "user_id") and context.user_id:
-            return ("user", context.user_id)
-
-        return None
-
     def _check_share_permission(
         self,
         resource: tuple[str, str],
@@ -1686,7 +1632,7 @@ class ReBACService(ReBACShareMixin):
                     "ReBAC manager is not available. Ensure ReBACService is properly initialized."
                 )
             has_permission = self._rebac_manager.rebac_check(
-                subject=self._get_subject_from_context(context) or ("user", op_context.user_id),
+                subject=get_subject_from_context(context) or ("user", op_context.user_id),
                 permission="owner",  # Only owners can manage permissions
                 object=resource,
                 context=context,
@@ -1705,7 +1651,7 @@ class ReBACService(ReBACShareMixin):
             # If enforcer denied, also check direct ownership via ReBAC
             # (direct_owner relation may not imply execute in the permission graph)
             if not has_permission and self._rebac_manager:
-                subject = self._get_subject_from_context(context) or ("user", op_context.user_id)
+                subject = get_subject_from_context(context) or ("user", op_context.user_id)
                 has_permission = self._rebac_manager.rebac_check(
                     subject=subject,
                     permission="owner",

--- a/tests/unit/services/permissions/test_nexus_fs_rebac_behavior.py
+++ b/tests/unit/services/permissions/test_nexus_fs_rebac_behavior.py
@@ -57,11 +57,6 @@ class MockNexusFS:
             raise RuntimeError("ReBAC manager not available")
         return mgr
 
-    # --- Methods from context_utils (formerly bound from NexusFS) ---
-    @staticmethod
-    def _get_subject_from_context(context):
-        return get_subject_from_context(context)
-
     # --- Delegation to rebac_service (Issue #2440: methods deleted from NexusFS) ---
     def rebac_create(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         return self.rebac_service.rebac_create_sync(*args, **kwargs)
@@ -114,7 +109,7 @@ class MockNexusFS:
             resource_path = resource[1]
         else:
             has_permission = self.rebac_check(
-                subject=self._get_subject_from_context(context) or ("user", op_context.user_id),
+                subject=get_subject_from_context(context) or ("user", op_context.user_id),
                 permission="owner",
                 object=resource,
                 context=context,

--- a/tests/unit/services/test_rebac_service.py
+++ b/tests/unit/services/test_rebac_service.py
@@ -743,40 +743,50 @@ class TestRegisterNamespace:
 
 
 # =========================================================================
-# _get_subject_from_context Tests
+# get_subject_from_context Tests (canonical function in lib/context_utils)
 # =========================================================================
 
 
 class TestGetSubjectFromContext:
-    """Test the helper method that extracts subjects from various context formats."""
+    """Test the public get_subject_from_context function."""
 
-    def test_extract_from_dict_with_subject_tuple(self, service):
+    def test_extract_from_dict_with_subject_tuple(self):
         """Test extracting subject from dict with 'subject' key."""
+        from nexus.lib.context_utils import get_subject_from_context
+
         ctx = {"subject": ("user", "alice")}
-        result = service._get_subject_from_context(ctx)
+        result = get_subject_from_context(ctx)
         assert result == ("user", "alice")
 
-    def test_extract_from_dict_with_subject_type_and_id(self, service):
+    def test_extract_from_dict_with_subject_type_and_id(self):
         """Test extracting subject from dict with type and id keys."""
+        from nexus.lib.context_utils import get_subject_from_context
+
         ctx = {"subject_type": "user", "subject_id": "bob"}
-        result = service._get_subject_from_context(ctx)
+        result = get_subject_from_context(ctx)
         assert result == ("user", "bob")
 
-    def test_extract_from_dict_with_user_id_key(self, service):
+    def test_extract_from_dict_with_user_id_key(self):
         """Test extracting subject from dict with 'user_id' key."""
+        from nexus.lib.context_utils import get_subject_from_context
+
         ctx = {"user_id": "charlie"}
-        result = service._get_subject_from_context(ctx)
+        result = get_subject_from_context(ctx)
         assert result == ("user", "charlie")
 
-    def test_extract_from_operation_context(self, service, operation_context):
+    def test_extract_from_operation_context(self, operation_context):
         """Test extracting subject from OperationContext."""
-        result = service._get_subject_from_context(operation_context)
+        from nexus.lib.context_utils import get_subject_from_context
+
+        result = get_subject_from_context(operation_context)
         assert result is not None
         assert result[1] == "test_user"
 
-    def test_returns_none_for_none_context(self, service):
+    def test_returns_none_for_none_context(self):
         """Test that None context returns None."""
-        result = service._get_subject_from_context(None)
+        from nexus.lib.context_utils import get_subject_from_context
+
+        result = get_subject_from_context(None)
         assert result is None
 
 


### PR DESCRIPTION
## Summary
- Delete duplicate `_get_subject_from_context` method from ReBACService (55 lines)
- Callers now use the canonical `get_subject_from_context()` from `lib/context_utils`
- `_service_extras` was already deleted in Phase 5 PR1 (#1410) — no action needed
- Net **-49 lines** (26 added, 75 deleted)

## Changes
| File | Change |
|------|--------|
| `src/nexus/bricks/rebac/rebac_service.py` | Delete `_get_subject_from_context` method, import public function, update 2 call sites |
| `tests/unit/services/test_rebac_service.py` | Tests call public `get_subject_from_context()` directly |
| `tests/unit/services/permissions/test_nexus_fs_rebac_behavior.py` | Remove `_get_subject_from_context` static method, use public function |

## Test plan
- [x] `TestGetSubjectFromContext` — 5 tests pass
- [x] Ruff + mypy clean
- [x] Pre-commit hooks green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)