### PR TITLE
fix(ci): resolve GHCR 403 on Docker image push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-and-push:
@@ -62,6 +64,8 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
+          sbom: false
           tags: ${{ steps.meta.outputs.tags }}
           build-args: TORCH_VARIANT=${{ matrix.variant }}
           cache-from: type=gha,scope=${{ matrix.variant }}


### PR DESCRIPTION
## Summary
- Fixes 403 Forbidden error when pushing Docker images to GHCR ([failed run](https://github.com/nexi-lab/nexus/actions/runs/23043373282/job/66926531250))
- `docker/build-push-action@v6` enables provenance attestations by default, generating additional OCI manifests that trigger 403 on GHCR with restrictive org permissions
- Disables `provenance` and `sbom` to eliminate attestation push failures
- Adds `id-token: write` and `attestations: write` permissions for future re-enablement

## Test plan
- [ ] Re-run the Docker publish workflow on develop after merge
- [ ] Verify both cpu and cuda variants push successfully to GHCR