### PR TITLE
Keep txtai content store on Postgres when configured

### DIFF
--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -142,9 +142,14 @@ class TxtaiBackend:
         except Exception:
             pass
 
+        # txtai treats ``content=True`` as "store content in SQLite". When Nexus
+        # has a database URL, keep both ANN vectors and content/object storage on
+        # the same client-server database instead of silently creating a local
+        # SQLite sidecar that can crash under concurrent indexing/search.
+        content_store: bool | str = self._database_url or True
         config: dict[str, Any] = {
             "path": self._model,
-            "content": True,
+            "content": content_store,
             "hybrid": self._hybrid,
             "objects": True,
         }
@@ -193,7 +198,7 @@ class TxtaiBackend:
             try:
                 bm25_config: dict[str, Any] = {
                     "keyword": True,
-                    "content": True,
+                    "content": content_store,
                     "objects": True,
                 }
                 self._embeddings = Embeddings(bm25_config)

--- a/tests/unit/bricks/search/test_txtai_backend.py
+++ b/tests/unit/bricks/search/test_txtai_backend.py
@@ -151,7 +151,51 @@ class TestTxtaiBackendLifecycle:
         cfg = captured_configs[0]
         assert cfg["backend"] == "pgvector"
         assert cfg["pgvector"] == {"url": "postgresql://u:p@localhost:5432/nexus"}
+        assert cfg["content"] == "postgresql://u:p@localhost:5432/nexus"
         assert "database" not in cfg, "URL must not go under 'database' — that's the content-DB key"
+
+    def test_startup_with_database_url_does_not_default_content_to_sqlite(self) -> None:
+        """Regression test for SQLite sidecar crashes during txtai indexing.
+
+        txtai treats ``content=True`` as "use SQLite". When Nexus already has a
+        PostgreSQL database URL, the content/object store must use that same URL
+        so the backend stays fully Postgres/pgvector-backed.
+        """
+        import asyncio
+
+        mock_embeddings_cls = MagicMock()
+        captured_configs: list[dict] = []
+        mock_embeddings_cls.side_effect = lambda cfg: (
+            captured_configs.append(dict(cfg)) or MagicMock()
+        )
+
+        mock_mps = MagicMock()
+        mock_mps.is_available.return_value = False
+        mock_backends = MagicMock()
+        mock_backends.mps = mock_mps
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends = mock_backends
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "txtai": MagicMock(Embeddings=mock_embeddings_cls),
+                "txtai.ann": MagicMock(),
+                "txtai.ann.dense": MagicMock(),
+                "txtai.ann.dense.pgvector": MagicMock(),
+                "torch": mock_torch,
+            },
+        ):
+            backend = TxtaiBackend(
+                database_url="postgresql://u:p@localhost:5432/nexus",
+                model="test-model",
+            )
+            asyncio.run(backend.startup())
+
+        cfg = captured_configs[0]
+        assert cfg["content"] == "postgresql://u:p@localhost:5432/nexus"
+        assert cfg["content"] is not True
 
     @pytest.mark.asyncio
     async def test_shutdown_when_not_started(self) -> None:


### PR DESCRIPTION
## Problem
Bulk skill uploads could make the semantic-search stack unstable even when Nexus was configured with PostgreSQL + pgvector. On the affected deployment, the host kernel showed native crashes in `_sqlite3.cpython-313-*.so` during indexing/search activity.

## Root Cause
Nexus already passes the main `database_url` into the txtai backend and correctly configures the ANN backend as `pgvector`. But the wrapper also set `content=True`. In txtai, `content=True` means "store content in a local SQLite database". So the runtime ended up split across two stores:

- vectors: PostgreSQL/pgvector
- content/object store: local SQLite sidecar

That made the search path not truly PostgreSQL-backed and explains the observed `_sqlite3` segfaults during concurrent indexing/search.

## Fix
When Nexus has a `database_url`, pass that same URL into txtai `content` storage instead of `True`. This keeps the txtai content/object store on the same client-server database and avoids silently creating a SQLite sidecar. The BM25 fallback path now does the same.

## Testing
- `uv run pytest -o addopts='' tests/unit/bricks/search/test_txtai_backend.py tests/unit/bricks/search/test_txtai_reranker.py`
- Added regression assertions that `content` is the PostgreSQL URL rather than `True` when `database_url` is set