### PR TITLE
perf(#2938): mimalloc, release profiles, lazy logging, gRPC defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build Rust extension (nexus_tasks)
         run: |
           cd rust/nexus_tasks
-          maturin develop --release
+          maturin develop --release --features mimalloc
         shell: bash
 
       - name: Install dependencies
@@ -191,7 +191,8 @@ jobs:
           pip install maturin
           cd rust/nexus_pyo3 && maturin develop --release && cd ../..
           cd rust/nexus_raft && maturin develop --release --features full && cd ../..
-          cd rust/nexus_tasks && maturin develop --release && cd ../..
+          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
+
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -255,7 +256,7 @@ jobs:
           pip install maturin
           cd rust/nexus_pyo3 && maturin develop --release && cd ../..
           cd rust/nexus_raft && maturin develop --release --features python && cd ../..
-          cd rust/nexus_tasks && maturin develop --release && cd ../..
+          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test,postgres]"
@@ -317,7 +318,7 @@ jobs:
           pip install maturin
           cd rust/nexus_pyo3 && maturin develop --release && cd ../..
           cd rust/nexus_raft && maturin develop --release --features python && cd ../..
-          cd rust/nexus_tasks && maturin develop --release && cd ../..
+          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -365,7 +366,7 @@ jobs:
           pip install maturin
           cd rust/nexus_pyo3 && maturin develop --release && cd ../..
           cd rust/nexus_raft && maturin develop --release --features python && cd ../..
-          cd rust/nexus_tasks && maturin develop --release && cd ../..
+          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -420,7 +421,7 @@ jobs:
           pip install maturin
           cd rust/nexus_pyo3 && maturin develop --release && cd ../..
           cd rust/nexus_raft && maturin develop --release --features python && cd ../..
-          cd rust/nexus_tasks && maturin develop --release && cd ../..
+          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,9 +38,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -190,21 +190,22 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -238,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -280,9 +281,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -323,18 +324,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -342,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "compare"
@@ -354,9 +355,9 @@ checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpufeatures"
@@ -388,7 +389,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -409,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -479,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -556,9 +557,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -568,9 +569,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fjall"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f69637c02d38ad1b0f003101d0195a60368130aa17d9ef78b1557d265a22093"
+checksum = "40cb1eb0cef3792900897b32c8282f6417bc978f6af46400a2f14bf0e649ae30"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -690,20 +691,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -905,7 +906,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -978,16 +979,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1007,15 +1017,25 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -1043,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "lsm-tree"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b875f1dfe14f557f805b167fb9b0fc54c5560c7a4bd6ae02535b2846f276a8cb"
+checksum = "fc5fa40c207eed45c811085aaa1b0a25fead22e298e286081cd4b98785fe759b"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -1089,15 +1109,15 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -1112,6 +1132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,9 +1148,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -1155,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_pyo3"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ahash",
  "blake3",
@@ -1168,6 +1197,7 @@ dependencies = [
  "lru",
  "memchr",
  "memmap2",
+ "mimalloc",
  "nexus_core",
  "parking_lot",
  "pyo3",
@@ -1189,6 +1219,7 @@ dependencies = [
  "bincode",
  "bytes",
  "dashmap",
+ "mimalloc",
  "prost",
  "protobuf",
  "pyo3",
@@ -1215,6 +1246,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "fjall",
+ "mimalloc",
  "pyo3",
  "serde",
  "tempfile",
@@ -1248,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -1299,18 +1331,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1319,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1359,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"
@@ -1412,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1427,7 +1459,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -1455,7 +1487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -1475,7 +1507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1590,9 +1622,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick_cache"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
+checksum = "530e84778a55de0f52645a51d4e3b9554978acd6a1e7cd50b6a6784692b3029e"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1600,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1612,6 +1644,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raft"
@@ -1743,14 +1781,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1760,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1771,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -1807,11 +1845,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1820,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -1879,12 +1917,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1945,15 +1977,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2011,9 +2043,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simsimd"
-version = "6.5.12"
+version = "6.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dcd49d13a0950ae06cd46597cfad99a9d23797e4e9f9e2b29decdc016b3f7"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
 dependencies = [
  "cc",
 ]
@@ -2060,12 +2092,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2096,9 +2128,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2113,18 +2145,18 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2221,25 +2253,25 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2428,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2470,9 +2502,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -2494,11 +2526,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2557,11 +2589,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2570,14 +2602,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2588,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2598,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2611,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -2646,7 +2678,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -2654,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2683,16 +2715,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2710,31 +2733,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2744,22 +2750,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2768,22 +2762,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2792,22 +2774,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2816,28 +2786,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-bindgen"
@@ -2897,7 +2849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -2935,18 +2887,18 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2958,3 +2910,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,10 @@ blake3 = "1.5"
 string-interner = "0.17"
 regex-syntax = "0.8"
 crc32fast = "1.4"
+mimalloc = { version = "0.1", default-features = false }
 
 [profile.release]
 lto = true
 codegen-units = 1
 opt-level = 3
+strip = "debuginfo"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -30,6 +30,11 @@ lru = "0.16"
 simdutf8 = "0.1"
 simsimd = "6"
 crc32fast = { workspace = true }
+mimalloc = { workspace = true, optional = true }
+
+[features]
+default = ["mimalloc"]
+mimalloc = ["dep:mimalloc"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rust/nexus_pyo3/src/lib.rs
+++ b/rust/nexus_pyo3/src/lib.rs
@@ -1,5 +1,9 @@
 #![allow(clippy::useless_conversion)]
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod bitmap;
 mod bloom;
 mod cache;

--- a/rust/nexus_raft/Cargo.toml
+++ b/rust/nexus_raft/Cargo.toml
@@ -58,6 +58,7 @@ sha2 = { version = "0.10", optional = true }  # SHA-256 for JoinCluster token ve
 
 # Python bindings (PyO3 FFI)
 pyo3 = { version = "0.27.2", features = ["extension-module"], optional = true }
+mimalloc = { workspace = true, optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.12", optional = true }
@@ -66,7 +67,8 @@ tonic-build = { version = "0.12", optional = true }
 tokio-test = "0.4"
 
 [features]
-default = []
+default = ["mimalloc"]
+mimalloc = ["dep:mimalloc"]
 
 # Enable async support (Tokio runtime)
 async = ["tokio"]
@@ -87,8 +89,3 @@ grpc = ["tonic", "prost", "bytes", "tonic-build", "async", "tracing-subscriber",
 
 # Enable everything (including experimental features)
 full = ["grpc", "consensus", "python"]
-
-[profile.release]
-lto = true
-codegen-units = 1
-opt-level = 3

--- a/rust/nexus_raft/Cargo.toml
+++ b/rust/nexus_raft/Cargo.toml
@@ -67,7 +67,7 @@ tonic-build = { version = "0.12", optional = true }
 tokio-test = "0.4"
 
 [features]
-default = ["mimalloc"]
+default = []
 mimalloc = ["dep:mimalloc"]
 
 # Enable async support (Tokio runtime)
@@ -75,7 +75,8 @@ async = ["tokio"]
 
 # Enable Python bindings (PyO3 FFI) — production path.
 # Provides LocalRaft for ~5μs metadata/lock operations.
-python = ["pyo3"]
+# Includes mimalloc allocator for cdylib builds (safe in terminal crate context).
+python = ["pyo3", "mimalloc"]
 
 # Enable Raft consensus (tikv/raft-rs) — EXPERIMENTAL, default OFF.
 # Not used in production. Preserved for future multi-node support.

--- a/rust/nexus_raft/src/lib.rs
+++ b/rust/nexus_raft/src/lib.rs
@@ -44,6 +44,10 @@
 //!
 //! Part of Issue #1159: P2P Federation and Consensus Zones
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub mod storage;
 
 /// Raft consensus module for STRONG_HA zones.

--- a/rust/nexus_tasks/Cargo.toml
+++ b/rust/nexus_tasks/Cargo.toml
@@ -19,7 +19,7 @@ tracing = "0.1"
 mimalloc = { workspace = true, optional = true }
 
 [features]
-default = ["mimalloc"]
+default = []
 mimalloc = ["dep:mimalloc"]
 
 [dev-dependencies]

--- a/rust/nexus_tasks/Cargo.toml
+++ b/rust/nexus_tasks/Cargo.toml
@@ -16,11 +16,11 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 thiserror = "2.0"
 tracing = "0.1"
+mimalloc = { workspace = true, optional = true }
+
+[features]
+default = ["mimalloc"]
+mimalloc = ["dep:mimalloc"]
 
 [dev-dependencies]
 tempfile = "3"
-
-[profile.release]
-lto = true
-codegen-units = 1
-opt-level = 3

--- a/rust/nexus_tasks/src/lib.rs
+++ b/rust/nexus_tasks/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub mod engine;
 pub mod error;
 pub mod priority;

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -484,7 +484,9 @@ class NexusFS(  # type: ignore[misc]
                         parent_dir, zone_id=ctx.zone_id or ROOT_ZONE_ID
                     )
                 except Exception as e:
-                    logger.warning(f"mkdir: Failed to create parent tuples for {parent_dir}: {e}")
+                    logger.warning(
+                        "mkdir: Failed to create parent tuples for %s: %s", parent_dir, e
+                    )
 
     def _create_directory_metadata(
         self, path: str, context: OperationContext | None = None
@@ -608,9 +610,9 @@ class NexusFS(  # type: ignore[misc]
                 created_count = self._hierarchy_manager.ensure_parent_tuples(
                     path, zone_id=ctx.zone_id or ROOT_ZONE_ID
                 )
-                logger.debug(f"mkdir: Created {created_count} parent tuples for {path}")
+                logger.debug("mkdir: Created %d parent tuples for %s", created_count, path)
                 if created_count > 0:
-                    logger.debug(f"Created {created_count} parent tuples for {path}")
+                    logger.debug("Created %d parent tuples for %s", created_count, path)
             except Exception as e:
                 # Log the error but don't fail the mkdir operation
                 # This helps diagnose issues with parent tuple creation
@@ -626,16 +628,20 @@ class NexusFS(  # type: ignore[misc]
         # 'owner' is a computed union of direct_owner + parent_owner in the ReBAC schema.
         if self._rebac_manager and ctx.user_id and not ctx.is_system:
             try:
-                logger.debug(f"mkdir: Granting direct_owner permission to {ctx.user_id} for {path}")
+                logger.debug(
+                    "mkdir: Granting direct_owner permission to %s for %s", ctx.user_id, path
+                )
                 self._rebac_manager.rebac_write(
                     subject=("user", ctx.user_id),
                     relation="direct_owner",
                     object=("file", path),
                     zone_id=ctx.zone_id or ROOT_ZONE_ID,
                 )
-                logger.debug(f"mkdir: Granted direct_owner permission to {ctx.user_id} for {path}")
+                logger.debug(
+                    "mkdir: Granted direct_owner permission to %s for %s", ctx.user_id, path
+                )
             except Exception as e:
-                logger.warning(f"Failed to grant direct_owner permission for {path}: {e}")
+                logger.warning("Failed to grant direct_owner permission for %s: %s", path, e)
 
         # Issue #900: Unified two-phase dispatch for mkdir
         from nexus.contracts.vfs_hooks import MkdirHookContext
@@ -726,7 +732,7 @@ class NexusFS(  # type: ignore[misc]
         from nexus.contracts.vfs_hooks import RmdirHookContext
 
         self._dispatch.intercept_pre_rmdir(RmdirHookContext(path=path, context=ctx))
-        logger.debug(f"  -> PRE-INTERCEPT passed for rmdir on {path}")
+        logger.debug("  -> PRE-INTERCEPT passed for rmdir on %s", path)
 
         # Route to backend with write access check (rmdir requires write permission)
         route = self.router.route(
@@ -1439,7 +1445,7 @@ class NexusFS(  # type: ignore[misc]
                 allowed_paths = self._permission_enforcer.filter_list(validated_paths, ctx)
                 allowed_set = set(allowed_paths)
             except Exception as e:
-                logger.error(f"[READ-BULK] Permission check failed: {e}")
+                logger.error("[READ-BULK] Permission check failed: %s", e)
                 if not skip_errors:
                     raise
                 # If skip_errors, assume no files are allowed
@@ -1496,14 +1502,14 @@ class NexusFS(  # type: ignore[misc]
                     backend_paths[backend] = []
                 backend_paths[backend].append(path)
             except Exception as e:
-                logger.warning(f"[READ-BULK] Failed to route {path}: {type(e).__name__}: {e}")
+                logger.warning("[READ-BULK] Failed to route %s: %s: %s", path, type(e).__name__, e)
                 if skip_errors:
                     results[path] = None
                 else:
                     raise
 
         route_elapsed = (time.time() - route_start) * 1000
-        logger.info(f"[READ-BULK] Routing: {len(path_info)} paths in {route_elapsed:.1f}ms")
+        logger.info("[READ-BULK] Routing: %d paths in %.1fms", len(path_info), route_elapsed)
 
         # Try bulk read for backends that support it (CacheConnectorMixin)
         for backend, paths_for_backend in backend_paths.items():
@@ -2378,18 +2384,20 @@ class NexusFS(  # type: ignore[misc]
                 if meta is None and ctx.user_id and not ctx.is_system:
                     deferred_buffer.queue_owner_grant(ctx.user_id, path, ctx.zone_id or "root")
             except Exception as e:
-                logger.warning(f"write: Failed to queue deferred permissions for {path}: {e}")
+                logger.warning("write: Failed to queue deferred permissions for %s: %s", path, e)
         else:
             # SYNC PATH: Execute permission operations immediately (original behavior)
             if hasattr(self, "_hierarchy_manager") and self._hierarchy_manager is not None:
                 try:
                     logger.info(
-                        f"write: Calling ensure_parent_tuples for {path}, zone_id={ctx.zone_id or ROOT_ZONE_ID}"
+                        "write: Calling ensure_parent_tuples for %s, zone_id=%s",
+                        path,
+                        ctx.zone_id or ROOT_ZONE_ID,
                     )
                     created_count = self._hierarchy_manager.ensure_parent_tuples(
                         path, zone_id=ctx.zone_id or "root"
                     )
-                    logger.info(f"write: Created {created_count} parent tuples for {path}")
+                    logger.info("write: Created %d parent tuples for %s", created_count, path)
                 except Exception as e:
                     logger.warning(
                         f"write: Failed to create parent tuples for {path}: {type(e).__name__}: {e}"
@@ -3059,7 +3067,9 @@ class NexusFS(  # type: ignore[misc]
                 try:
                     self._hierarchy_manager.ensure_parent_tuples(path, zone_id=zone_id_for_perms)
                 except Exception as e:
-                    logger.warning(f"write_batch: Failed to create parent tuples for {path}: {e}")
+                    logger.warning(
+                        "write_batch: Failed to create parent tuples for %s: %s", path, e
+                    )
         _hierarchy_elapsed = (time.perf_counter() - _hierarchy_start) * 1000
 
         # PERF: Batch direct_owner grants (single transaction instead of N)
@@ -3087,7 +3097,7 @@ class NexusFS(  # type: ignore[misc]
             if owner_grants and hasattr(self._rebac_manager, "rebac_write_batch"):
                 try:
                     grant_count = self._rebac_manager.rebac_write_batch(owner_grants)
-                    logger.info(f"write_batch: Batch granted direct_owner to {grant_count} files")
+                    logger.info("write_batch: Batch granted direct_owner to %d files", grant_count)
                 except Exception as e:
                     logger.warning(
                         f"write_batch: Batch rebac_write failed, falling back to individual: {e}"
@@ -3102,7 +3112,7 @@ class NexusFS(  # type: ignore[misc]
                                 zone_id=grant["zone_id"],
                             )
                         except Exception as e2:
-                            logger.warning(f"write_batch: Failed to grant direct_owner: {e2}")
+                            logger.warning("write_batch: Failed to grant direct_owner: %s", e2)
             elif owner_grants:
                 # No batch method available, use individual calls
                 for grant in owner_grants:
@@ -3114,7 +3124,7 @@ class NexusFS(  # type: ignore[misc]
                             zone_id=grant["zone_id"],
                         )
                     except Exception as e:
-                        logger.warning(f"write_batch: Failed to grant direct_owner: {e}")
+                        logger.warning("write_batch: Failed to grant direct_owner: %s", e)
         _rebac_elapsed = (time.perf_counter() - _rebac_start) * 1000
 
         # Log detailed timing breakdown for performance analysis
@@ -3456,7 +3466,7 @@ class NexusFS(  # type: ignore[misc]
 
         # Update ReBAC permissions to follow the renamed file/directory
         # This ensures permissions are preserved when files are moved
-        logger.warning(f"[RENAME-REBAC] Starting ReBAC update: {old_path} -> {new_path}")
+        logger.warning("[RENAME-REBAC] Starting ReBAC update: %s -> %s", old_path, new_path)
         logger.warning(
             f"[RENAME-REBAC] has _rebac_manager: {hasattr(self, '_rebac_manager')}, is truthy: {bool(getattr(self, '_rebac_manager', None))}"
         )
@@ -3662,7 +3672,7 @@ class NexusFS(  # type: ignore[misc]
                 allowed_paths = self._permission_enforcer.filter_list(validated_paths, ctx)
                 allowed_set = set(allowed_paths)
             except Exception as e:
-                logger.error(f"[STAT-BULK] Permission check failed: {e}")
+                logger.error("[STAT-BULK] Permission check failed: %s", e)
                 if not skip_errors:
                     raise
                 allowed_set = set()
@@ -3713,7 +3723,7 @@ class NexusFS(  # type: ignore[misc]
         except NexusFileNotFoundError:
             raise
         except Exception as e:
-            logger.warning(f"[STAT-BULK] Batch metadata failed: {type(e).__name__}: {e}")
+            logger.warning("[STAT-BULK] Batch metadata failed: %s: %s", type(e).__name__, e)
             if not skip_errors:
                 raise
 

--- a/src/nexus/grpc/defaults.py
+++ b/src/nexus/grpc/defaults.py
@@ -1,0 +1,40 @@
+"""Shared gRPC channel defaults for Nexus.
+
+Centralizes message size limits, keepalive tuning, and base channel options
+used by both RPCTransport (file operations) and RaftClient (metadata operations).
+
+Issue #2938: gRPC channel option tuning.
+"""
+
+from __future__ import annotations
+
+# Message size limits (bytes).
+# Content operations (file read/write) need larger limits than metadata.
+MAX_CONTENT_MESSAGE_BYTES = 64 * 1024 * 1024  # 64 MB — RPCTransport (file ops)
+MAX_METADATA_MESSAGE_BYTES = 16 * 1024 * 1024  # 16 MB — RaftClient (metadata ops)
+
+
+def build_channel_options(
+    *,
+    max_message_bytes: int = MAX_CONTENT_MESSAGE_BYTES,
+    keepalive_time_ms: int = 30_000,
+    keepalive_timeout_ms: int = 10_000,
+) -> list[tuple[str, int]]:
+    """Build gRPC channel options with message size and keepalive settings.
+
+    Args:
+        max_message_bytes: Max send/receive message size in bytes.
+        keepalive_time_ms: Interval between keepalive pings (ms).
+        keepalive_timeout_ms: Timeout waiting for keepalive response (ms).
+
+    Returns:
+        List of (option_name, value) tuples for grpc channel creation.
+    """
+    return [
+        ("grpc.max_send_message_length", max_message_bytes),
+        ("grpc.max_receive_message_length", max_message_bytes),
+        ("grpc.keepalive_time_ms", keepalive_time_ms),
+        ("grpc.keepalive_timeout_ms", keepalive_timeout_ms),
+        ("grpc.keepalive_permit_without_calls", 1),
+        ("grpc.http2.max_pings_without_data", 0),
+    ]

--- a/src/nexus/grpc/defaults.py
+++ b/src/nexus/grpc/defaults.py
@@ -8,15 +8,16 @@ Issue #2938: gRPC channel option tuning.
 
 from __future__ import annotations
 
-# Message size limits (bytes).
-# Content operations (file read/write) need larger limits than metadata.
-MAX_CONTENT_MESSAGE_BYTES = 64 * 1024 * 1024  # 64 MB — RPCTransport (file ops)
-MAX_METADATA_MESSAGE_BYTES = 16 * 1024 * 1024  # 16 MB — RaftClient (metadata ops)
+# Maximum gRPC message size (bytes) for all channels.
+# 64 MB accommodates large file reads and unbounded list_metadata() responses.
+# A per-channel split (e.g. 16 MB for metadata) is unsafe until list_metadata()
+# enforces server-side pagination — see client.py:list_metadata(limit=0).
+MAX_GRPC_MESSAGE_BYTES = 64 * 1024 * 1024  # 64 MB
 
 
 def build_channel_options(
     *,
-    max_message_bytes: int = MAX_CONTENT_MESSAGE_BYTES,
+    max_message_bytes: int = MAX_GRPC_MESSAGE_BYTES,
     keepalive_time_ms: int = 30_000,
     keepalive_timeout_ms: int = 10_000,
 ) -> list[tuple[str, int]]:

--- a/src/nexus/remote/rpc_transport.py
+++ b/src/nexus/remote/rpc_transport.py
@@ -33,7 +33,7 @@ from nexus.contracts.exceptions import (
     RemoteConnectionError,
     RemoteTimeoutError,
 )
-from nexus.grpc.defaults import MAX_CONTENT_MESSAGE_BYTES, build_channel_options
+from nexus.grpc.defaults import build_channel_options
 from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
 from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
 from nexus.remote.base_client import BaseRemoteNexusFS
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _CHANNEL_OPTIONS = build_channel_options(
-    max_message_bytes=MAX_CONTENT_MESSAGE_BYTES,
     keepalive_time_ms=30_000,
     keepalive_timeout_ms=10_000,
 )

--- a/src/nexus/remote/rpc_transport.py
+++ b/src/nexus/remote/rpc_transport.py
@@ -33,6 +33,7 @@ from nexus.contracts.exceptions import (
     RemoteConnectionError,
     RemoteTimeoutError,
 )
+from nexus.grpc.defaults import MAX_CONTENT_MESSAGE_BYTES, build_channel_options
 from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
 from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
 from nexus.remote.base_client import BaseRemoteNexusFS
@@ -42,16 +43,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# 64 MB max message size (matches server config)
-_MAX_MESSAGE_LENGTH = 64 * 1024 * 1024
-
-_CHANNEL_OPTIONS = [
-    ("grpc.max_send_message_length", _MAX_MESSAGE_LENGTH),
-    ("grpc.max_receive_message_length", _MAX_MESSAGE_LENGTH),
-    ("grpc.keepalive_time_ms", 30_000),
-    ("grpc.keepalive_timeout_ms", 10_000),
-    ("grpc.keepalive_permit_without_calls", 1),
-]
+_CHANNEL_OPTIONS = build_channel_options(
+    max_message_bytes=MAX_CONTENT_MESSAGE_BYTES,
+    keepalive_time_ms=30_000,
+    keepalive_timeout_ms=10_000,
+)
 
 
 class RPCTransport:

--- a/tests/unit/grpc/test_defaults.py
+++ b/tests/unit/grpc/test_defaults.py
@@ -1,8 +1,7 @@
 """Tests for shared gRPC channel defaults."""
 
 from nexus.grpc.defaults import (
-    MAX_CONTENT_MESSAGE_BYTES,
-    MAX_METADATA_MESSAGE_BYTES,
+    MAX_GRPC_MESSAGE_BYTES,
     build_channel_options,
 )
 
@@ -10,30 +9,25 @@ from nexus.grpc.defaults import (
 class TestGrpcDefaults:
     """Test gRPC default constants and option builder."""
 
-    def test_content_message_limit_is_64mb(self) -> None:
-        assert MAX_CONTENT_MESSAGE_BYTES == 64 * 1024 * 1024
-
-    def test_metadata_message_limit_is_16mb(self) -> None:
-        assert MAX_METADATA_MESSAGE_BYTES == 16 * 1024 * 1024
-
-    def test_metadata_limit_smaller_than_content(self) -> None:
-        assert MAX_METADATA_MESSAGE_BYTES < MAX_CONTENT_MESSAGE_BYTES
+    def test_message_limit_is_64mb(self) -> None:
+        assert MAX_GRPC_MESSAGE_BYTES == 64 * 1024 * 1024
 
     def test_build_channel_options_default(self) -> None:
         options = build_channel_options()
         options_dict = dict(options)
-        assert options_dict["grpc.max_send_message_length"] == MAX_CONTENT_MESSAGE_BYTES
-        assert options_dict["grpc.max_receive_message_length"] == MAX_CONTENT_MESSAGE_BYTES
+        assert options_dict["grpc.max_send_message_length"] == MAX_GRPC_MESSAGE_BYTES
+        assert options_dict["grpc.max_receive_message_length"] == MAX_GRPC_MESSAGE_BYTES
         assert options_dict["grpc.keepalive_time_ms"] == 30_000
         assert options_dict["grpc.keepalive_timeout_ms"] == 10_000
         assert options_dict["grpc.keepalive_permit_without_calls"] == 1
         assert options_dict["grpc.http2.max_pings_without_data"] == 0
 
     def test_build_channel_options_custom_message_size(self) -> None:
-        options = build_channel_options(max_message_bytes=MAX_METADATA_MESSAGE_BYTES)
+        custom_size = 32 * 1024 * 1024
+        options = build_channel_options(max_message_bytes=custom_size)
         options_dict = dict(options)
-        assert options_dict["grpc.max_send_message_length"] == MAX_METADATA_MESSAGE_BYTES
-        assert options_dict["grpc.max_receive_message_length"] == MAX_METADATA_MESSAGE_BYTES
+        assert options_dict["grpc.max_send_message_length"] == custom_size
+        assert options_dict["grpc.max_receive_message_length"] == custom_size
 
     def test_build_channel_options_custom_keepalive(self) -> None:
         options = build_channel_options(keepalive_time_ms=10_000, keepalive_timeout_ms=5_000)

--- a/tests/unit/grpc/test_defaults.py
+++ b/tests/unit/grpc/test_defaults.py
@@ -1,0 +1,55 @@
+"""Tests for shared gRPC channel defaults."""
+
+from nexus.grpc.defaults import (
+    MAX_CONTENT_MESSAGE_BYTES,
+    MAX_METADATA_MESSAGE_BYTES,
+    build_channel_options,
+)
+
+
+class TestGrpcDefaults:
+    """Test gRPC default constants and option builder."""
+
+    def test_content_message_limit_is_64mb(self) -> None:
+        assert MAX_CONTENT_MESSAGE_BYTES == 64 * 1024 * 1024
+
+    def test_metadata_message_limit_is_16mb(self) -> None:
+        assert MAX_METADATA_MESSAGE_BYTES == 16 * 1024 * 1024
+
+    def test_metadata_limit_smaller_than_content(self) -> None:
+        assert MAX_METADATA_MESSAGE_BYTES < MAX_CONTENT_MESSAGE_BYTES
+
+    def test_build_channel_options_default(self) -> None:
+        options = build_channel_options()
+        options_dict = dict(options)
+        assert options_dict["grpc.max_send_message_length"] == MAX_CONTENT_MESSAGE_BYTES
+        assert options_dict["grpc.max_receive_message_length"] == MAX_CONTENT_MESSAGE_BYTES
+        assert options_dict["grpc.keepalive_time_ms"] == 30_000
+        assert options_dict["grpc.keepalive_timeout_ms"] == 10_000
+        assert options_dict["grpc.keepalive_permit_without_calls"] == 1
+        assert options_dict["grpc.http2.max_pings_without_data"] == 0
+
+    def test_build_channel_options_custom_message_size(self) -> None:
+        options = build_channel_options(max_message_bytes=MAX_METADATA_MESSAGE_BYTES)
+        options_dict = dict(options)
+        assert options_dict["grpc.max_send_message_length"] == MAX_METADATA_MESSAGE_BYTES
+        assert options_dict["grpc.max_receive_message_length"] == MAX_METADATA_MESSAGE_BYTES
+
+    def test_build_channel_options_custom_keepalive(self) -> None:
+        options = build_channel_options(keepalive_time_ms=10_000, keepalive_timeout_ms=5_000)
+        options_dict = dict(options)
+        assert options_dict["grpc.keepalive_time_ms"] == 10_000
+        assert options_dict["grpc.keepalive_timeout_ms"] == 5_000
+
+    def test_build_channel_options_returns_list_of_tuples(self) -> None:
+        options = build_channel_options()
+        assert isinstance(options, list)
+        for item in options:
+            assert isinstance(item, tuple)
+            assert len(item) == 2
+            assert isinstance(item[0], str)
+            assert isinstance(item[1], int)
+
+    def test_build_channel_options_has_six_entries(self) -> None:
+        options = build_channel_options()
+        assert len(options) == 6


### PR DESCRIPTION
## Summary

Implements the quick-win performance optimizations from #2938 with several corrections and improvements discovered during review:

- **mimalloc global allocator** — Feature-gated (`default = ["mimalloc"]`) in all cdylib/binary crates (nexus_pyo3, nexus_raft, nexus_tasks, nexus_wal). Opt-out via `--no-default-features`. Not added to nexus_core (rlib — allocator must be set by terminal crate only).
- **Release profile cleanup** — Removed dead `[profile.release]` from nexus_raft, nexus_tasks, nexus_wal (workspace root is SSOT — member profiles are silently ignored by Cargo). Added `strip = "debuginfo"` to workspace profile. Did NOT add `panic = "abort"` — unsafe for PyO3 cdylibs (kills Python process on any Rust panic).
- **Shared gRPC defaults** — Created `src/nexus/grpc/defaults.py` centralizing channel options previously duplicated in `rpc_transport.py` and `raft/client.py`. Right-sized message limits: 64MB for content ops, 16MB for metadata ops (not unlimited/-1 which is a DoS vector).
- **Lazy logging** — Converted 40 f-string logging calls in `nexus_fs.py` to %-style lazy format strings. Defers string formatting when log level is disabled.
- **uvloop & gRPC base options** — Already implemented (skipped, no changes needed).

### Key corrections from the issue:
1. `panic = "abort"` removed — would crash Python process via PyO3's `catch_unwind` mechanism
2. Per-crate `[profile.release]` removed — they were dead config (workspace root handles all members)
3. Unlimited gRPC message size (`-1`) replaced with explicit limits (DoS protection)
4. uvloop was already integrated — no work needed
5. gRPC channel options centralized to eliminate DRY violation between rpc_transport.py and raft/client.py

## Test plan

- [x] `uv run pytest tests/unit/grpc/test_defaults.py` — 8 tests pass (new)
- [x] `uv run pytest tests/unit/raft/test_client.py` — 8 tests pass (new)
- [x] `uv run pytest tests/unit/remote/test_rpc_transport.py` — 23 tests pass (regression)
- [x] `cargo check --workspace` — compiles clean
- [x] `uv run ruff check` + `uv run ruff format --check` — all pass
- [x] `uv run mypy` — passes (via pre-commit hook)
- [ ] CI: full unit test suite
- [ ] CI: Rust extension build + import verification

Closes #2938