### PR TITLE
Fix search lifecycle health drift and noisy legacy fallback warnings

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -680,7 +680,12 @@ class SearchDaemon:
             # Get query embedding
             embedding = await self._get_query_embedding(query)
             if not embedding:
-                logger.warning("Could not generate query embedding")
+                if self._embedding_provider is None:
+                    logger.debug(
+                        "Legacy semantic search unavailable: no embedding provider configured"
+                    )
+                else:
+                    logger.warning("Could not generate query embedding")
                 return []
 
             from sqlalchemy import text
@@ -1434,6 +1439,7 @@ class SearchDaemon:
         )
         return {
             "status": "healthy" if self._initialized else "starting",
+            "initialized": self._initialized,
             "daemon_initialized": self._initialized,
             "backend": "txtai" if self._backend is not None else "legacy",
             "bm25_index_loaded": keyword_ready,

--- a/src/nexus/bricks/search/lifecycle_adapter.py
+++ b/src/nexus/bricks/search/lifecycle_adapter.py
@@ -7,7 +7,7 @@ lifecycle-aware bricks.
 The adapter maps:
     - ``start()``        → ``SearchDaemon.startup()``
     - ``stop()``         → ``SearchDaemon.shutdown()``
-    - ``health_check()`` → ``SearchDaemon.get_health()["initialized"]``
+    - ``health_check()`` → ``SearchDaemon.get_health()``
 
 Zoekt lifecycle is an internal detail of the daemon and is NOT exposed
 to the lifecycle manager (Decision #3).
@@ -36,4 +36,7 @@ class SearchBrickLifecycleAdapter:
     async def health_check(self) -> bool:
         """Return True if the search daemon is healthy."""
         health: dict[str, Any] = self._daemon.get_health()
-        return bool(health.get("initialized", False))
+        # ``get_health`` uses ``daemon_initialized`` while older tests/mocks
+        # may still provide ``initialized``. Accept both to avoid false
+        # unhealthy reports that trigger unnecessary search remounts.
+        return bool(health.get("daemon_initialized", health.get("initialized", False)))

--- a/tests/unit/bricks/search/test_brick_compliance.py
+++ b/tests/unit/bricks/search/test_brick_compliance.py
@@ -51,16 +51,23 @@ class TestLifecycleAdapterSatisfiesLifecycleProtocol:
     @pytest.mark.asyncio
     async def test_adapter_health_check_true(self) -> None:
         mock_daemon = MagicMock()
-        mock_daemon.get_health.return_value = {"initialized": True}
+        mock_daemon.get_health.return_value = {"daemon_initialized": True}
         adapter = SearchBrickLifecycleAdapter(mock_daemon)
         assert await adapter.health_check() is True
 
     @pytest.mark.asyncio
     async def test_adapter_health_check_false(self) -> None:
         mock_daemon = MagicMock()
-        mock_daemon.get_health.return_value = {"initialized": False}
+        mock_daemon.get_health.return_value = {"daemon_initialized": False}
         adapter = SearchBrickLifecycleAdapter(mock_daemon)
         assert await adapter.health_check() is False
+
+    @pytest.mark.asyncio
+    async def test_adapter_health_check_legacy_key_compatibility(self) -> None:
+        mock_daemon = MagicMock()
+        mock_daemon.get_health.return_value = {"initialized": True}
+        adapter = SearchBrickLifecycleAdapter(mock_daemon)
+        assert await adapter.health_check() is True
 
 
 class TestNexusFSFileReaderSatisfiesProtocol:

--- a/tests/unit/bricks/search/test_error_paths.py
+++ b/tests/unit/bricks/search/test_error_paths.py
@@ -6,6 +6,8 @@ Validates error handling at brick boundaries:
 - SearchBrickManifest validation
 """
 
+import logging
+
 import pytest
 
 # =============================================================================
@@ -35,6 +37,24 @@ class TestSearchDaemonErrors:
         daemon = SearchDaemon()
         await daemon.shutdown()
         await daemon.shutdown()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_semantic_search_without_embedding_provider_logs_debug_not_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Missing legacy embedding provider should be treated as expected fallback."""
+        from nexus.bricks.search.daemon import SearchDaemon
+
+        daemon = SearchDaemon()
+        daemon._async_engine = object()
+        daemon._async_session = object()
+
+        with caplog.at_level(logging.DEBUG):
+            results = await daemon._semantic_search("test query", 5, None)
+
+        assert results == []
+        assert "Legacy semantic search unavailable: no embedding provider configured" in caplog.text
+        assert "Could not generate query embedding" not in caplog.text
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem
Two search issues remained after the txtai/Postgres fix:

1. `SearchDaemon already initialized` and `Self-healed brick "search"` kept appearing even on a healthy daemon.
2. Search logs still emitted `Could not generate query embedding` even when requests returned `200` and the txtai path was healthy.

## Root Cause
### 1. Lifecycle health key drift
`SearchDaemon.get_health()` reports `daemon_initialized`, but `SearchBrickLifecycleAdapter.health_check()` still only looked for `initialized`. That made the lifecycle manager treat a healthy search daemon as unhealthy and periodically remount it, which produced the repeated self-heal noise.

### 2. Legacy semantic fallback warning noise
The warning was not usually a txtai embedding failure. It came from the legacy semantic fallback path: when txtai returned no results, Nexus fell through to legacy search, which tried `_semantic_search()`. On deployments that do not configure the old embedding provider, `_get_query_embedding()` correctly returned `None`, but `_semantic_search()` still logged a warning. In practice that means the fallback semantic leg is unavailable, not that the live txtai backend failed.

## Fix
- Make the lifecycle adapter accept `daemon_initialized` and keep compatibility with the older `initialized` key.
- Add `initialized` as an alias in `SearchDaemon.get_health()` so old callers/tests keep working.
- Downgrade the legacy semantic fallback message to `debug` when no legacy embedding provider is configured, while preserving the warning for real provider-backed failures.

## Testing
- `uv run pytest -o addopts='' tests/unit/bricks/search/test_brick_compliance.py tests/unit/bricks/search/test_error_paths.py tests/unit/bricks/search/test_txtai_backend.py -q`

## Notes
This is a follow-up cleanup after the txtai/Postgres content-store fix in #2942. It does not change the txtai search path itself; it fixes lifecycle correctness and removes a misleading warning from the legacy fallback path.