### PR TITLE
Implement explicit search daemon indexing helpers

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -634,6 +634,52 @@ class SearchDaemon:
             logger.warning(f"Search timeout after {self.config.query_timeout_seconds}s")
             return []
 
+    async def index_documents(
+        self,
+        documents: list[dict[str, Any]],
+        *,
+        zone_id: str | None = None,
+    ) -> int:
+        """Explicitly upsert documents into the active search backend.
+
+        This powers ``POST /api/v2/search/index`` for synthetic or externally
+        generated documents that do not rely on the file-refresh pipeline.
+        """
+        if not self._initialized:
+            raise RuntimeError("SearchDaemon not initialized. Call startup() first.")
+
+        if not documents or self._backend is None:
+            return 0
+
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        effective_zone_id = zone_id or ROOT_ZONE_ID
+        count = int(await self._backend.upsert(documents, zone_id=effective_zone_id))
+        if count:
+            self.stats.last_index_refresh = time.time()
+        return count
+
+    async def delete_documents(
+        self,
+        ids: list[str],
+        *,
+        zone_id: str | None = None,
+    ) -> int:
+        """Delete indexed documents from the active search backend."""
+        if not self._initialized:
+            raise RuntimeError("SearchDaemon not initialized. Call startup() first.")
+
+        if not ids or self._backend is None:
+            return 0
+
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        effective_zone_id = zone_id or ROOT_ZONE_ID
+        count = int(await self._backend.delete(ids, zone_id=effective_zone_id))
+        if count:
+            self.stats.last_index_refresh = time.time()
+        return count
+
     async def _keyword_search(
         self,
         query: str,

--- a/tests/unit/bricks/search/test_error_paths.py
+++ b/tests/unit/bricks/search/test_error_paths.py
@@ -7,6 +7,7 @@ Validates error handling at brick boundaries:
 """
 
 import logging
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -55,6 +56,40 @@ class TestSearchDaemonErrors:
         assert results == []
         assert "Legacy semantic search unavailable: no embedding provider configured" in caplog.text
         assert "Could not generate query embedding" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_index_documents_uses_backend_upsert(self) -> None:
+        """Explicit indexing should delegate to the active backend."""
+        from nexus.bricks.search.daemon import SearchDaemon
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        daemon = SearchDaemon()
+        daemon._initialized = True
+        daemon._backend = AsyncMock()
+        daemon._backend.upsert.return_value = 1
+
+        docs = [{"id": "doc-1", "text": "hello", "path": "/skill-hub/search/doc.md"}]
+        count = await daemon.index_documents(docs)
+
+        assert count == 1
+        daemon._backend.upsert.assert_awaited_once_with(docs, zone_id=ROOT_ZONE_ID)
+        assert daemon.stats.last_index_refresh is not None
+
+    @pytest.mark.asyncio
+    async def test_delete_documents_uses_backend_delete(self) -> None:
+        """Explicit deletion should delegate to the active backend."""
+        from nexus.bricks.search.daemon import SearchDaemon
+
+        daemon = SearchDaemon()
+        daemon._initialized = True
+        daemon._backend = AsyncMock()
+        daemon._backend.delete.return_value = 2
+
+        count = await daemon.delete_documents(["doc-1", "doc-2"], zone_id="corp")
+
+        assert count == 2
+        daemon._backend.delete.assert_awaited_once_with(["doc-1", "doc-2"], zone_id="corp")
+        assert daemon.stats.last_index_refresh is not None
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem
`POST /api/v2/search/index` is wired in the search router, but `SearchDaemon` does not actually implement the explicit indexing helpers that the router calls. On current `develop`, the endpoint returns a 500 with:

```text
AttributeError: 'SearchDaemon' object has no attribute 'index_documents'
```

That breaks explicit indexing for synthetic/external documents and blocks `skill-hub` from using the official search indexing API for generated package search docs.

Closes #2962.

## Fix
- add `SearchDaemon.index_documents()` that delegates to the active backend via `upsert`
- add `SearchDaemon.delete_documents()` that delegates to the active backend via `delete`
- stamp the effective zone id the same way `search()` already does
- update `last_index_refresh` when explicit index/delete operations succeed

## Testing
- `uv run pytest -o addopts='' tests/unit/bricks/search/test_error_paths.py tests/unit/bricks/search/test_txtai_backend.py tests/unit/bricks/search/test_brick_compliance.py -q`
