### PR TITLE
perf(#2965): speed up Docker + Rust + Python builds (dev and CI)

### DIFF
--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Install protoc
       uses: arduino/setup-protoc@v3
       with:
-        version: "28.x"
+        version: "3.20.3"
         repo-token: ${{ inputs.github-token }}
 
     - name: Install maturin

--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -48,7 +48,7 @@ runs:
           sudo apt-get update && sudo apt-get install -y protobuf-compiler
         elif [ "$RUNNER_OS" = "macOS" ]; then
           PROTOC_VERSION="3.20.3"
-          PROTOC_ARCH="osx-aarch_64"
+          PROTOC_ARCH="osx-x86_64"
           curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_ARCH}.zip" -o /tmp/protoc.zip
           sudo unzip -o /tmp/protoc.zip -d /usr/local bin/protoc
           protoc --version

--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -35,6 +35,15 @@ runs:
           rust/nexus_raft
           rust/nexus_tasks
 
+    - name: Install protoc
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        elif [ "$RUNNER_OS" = "macOS" ]; then
+          brew install protobuf
+        fi
+      shell: bash
+
     - name: Install maturin
       run: pip install maturin
       shell: bash

--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -48,6 +48,6 @@ runs:
 
         mkdir -p ${{ inputs.output-dir }}
         cd rust/nexus_pyo3 && maturin build $PROFILE_FLAG --out ../../${{ inputs.output-dir }} && cd ../..
-        cd rust/nexus_raft && maturin build $PROFILE_FLAG --features python --out ../../${{ inputs.output-dir }} && cd ../..
-        cd rust/nexus_tasks && maturin build $PROFILE_FLAG --out ../../${{ inputs.output-dir }} && cd ../..
+        cd rust/nexus_raft && maturin build $PROFILE_FLAG --features full --out ../../${{ inputs.output-dir }} && cd ../..
+        cd rust/nexus_tasks && maturin build $PROFILE_FLAG --features mimalloc --out ../../${{ inputs.output-dir }} && cd ../..
       shell: bash

--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -1,0 +1,53 @@
+name: Build Rust Extensions
+description: Build nexus_fast, nexus_raft, and nexus_tasks Python wheels from Rust source
+
+inputs:
+  profile:
+    description: 'Cargo build profile (dev or release)'
+    required: false
+    default: 'dev'
+  rust-cache-shared-key:
+    description: 'Shared key for Swatinem/rust-cache'
+    required: false
+    default: 'rust-build'
+  output-dir:
+    description: 'Directory to output built wheels'
+    required: false
+    default: 'dist'
+
+outputs:
+  wheels-dir:
+    description: 'Path to directory containing built wheels'
+    value: ${{ inputs.output-dir }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "${{ inputs.rust-cache-shared-key }}-${{ runner.os }}"
+        workspaces: |
+          rust/nexus_pyo3
+          rust/nexus_raft
+          rust/nexus_tasks
+
+    - name: Install maturin
+      run: pip install maturin
+      shell: bash
+
+    - name: Build Rust extensions
+      run: |
+        PROFILE_FLAG=""
+        if [ "${{ inputs.profile }}" = "release" ]; then
+          PROFILE_FLAG="--release"
+        fi
+
+        mkdir -p ${{ inputs.output-dir }}
+        cd rust/nexus_pyo3 && maturin build $PROFILE_FLAG --out ../../${{ inputs.output-dir }} && cd ../..
+        cd rust/nexus_raft && maturin build $PROFILE_FLAG --features python --out ../../${{ inputs.output-dir }} && cd ../..
+        cd rust/nexus_tasks && maturin build $PROFILE_FLAG --out ../../${{ inputs.output-dir }} && cd ../..
+      shell: bash

--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Directory to output built wheels'
     required: false
     default: 'dist'
+  github-token:
+    description: 'GitHub token for authenticated API calls (avoids rate limits)'
+    required: false
+    default: ''
 
 outputs:
   wheels-dir:
@@ -39,6 +43,7 @@ runs:
       uses: arduino/setup-protoc@v3
       with:
         version: "28.x"
+        repo-token: ${{ inputs.github-token }}
 
     - name: Install maturin
       run: pip install maturin

--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -40,10 +40,20 @@ runs:
           rust/nexus_tasks
 
     - name: Install protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "3.20.3"
-        repo-token: ${{ inputs.github-token }}
+      run: |
+        # raft-proto's protobuf-build requires protoc >= 3.1.0 (semver 3.x).
+        # Modern protoc (28.x+) uses a different version scheme that fails the check.
+        # Ubuntu's apt provides 3.12.x; macOS needs a manual 3.x install.
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        elif [ "$RUNNER_OS" = "macOS" ]; then
+          PROTOC_VERSION="3.20.3"
+          PROTOC_ARCH="osx-aarch_64"
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_ARCH}.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local bin/protoc
+          protoc --version
+        fi
+      shell: bash
 
     - name: Install maturin
       run: pip install maturin

--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -36,13 +36,9 @@ runs:
           rust/nexus_tasks
 
     - name: Install protoc
-      run: |
-        if [ "$RUNNER_OS" = "Linux" ]; then
-          sudo apt-get update && sudo apt-get install -y protobuf-compiler
-        elif [ "$RUNNER_OS" = "macOS" ]; then
-          brew install protobuf
-        fi
-      shell: bash
+      uses: arduino/setup-protoc@v3
+      with:
+        version: "28.x"
 
     - name: Install maturin
       run: pip install maturin

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,9 +42,10 @@ jobs:
           profile: release
           rust-cache-shared-key: "rust-bench"
           output-dir: dist
+          github-token: ${{ github.token }}
 
       - name: Install Rust extensions
-        run: pip install dist/*.whl
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -123,9 +124,10 @@ jobs:
           profile: release
           rust-cache-shared-key: "rust-bench"
           output-dir: dist
+          github-token: ${{ github.token }}
 
       - name: Install Rust extensions
-        run: pip install dist/*.whl
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,24 +36,15 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Build Rust extensions (release for benchmarks)
+        uses: ./.github/actions/build-rust-extensions
+        with:
+          profile: release
+          rust-cache-shared-key: "rust-bench"
+          output-dir: dist
 
-      - name: Build Rust extension (nexus_fast)
-        run: |
-          cd rust/nexus_pyo3
-          pip install maturin
-          maturin develop --release
-
-      - name: Build Rust extension (nexus_raft)
-        run: |
-          cd rust/nexus_raft
-          maturin develop --release --features python
-
-      - name: Build Rust extension (nexus_tasks)
-        run: |
-          cd rust/nexus_tasks
-          maturin develop --release
+      - name: Install Rust extensions
+        run: pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -126,24 +117,15 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Build Rust extensions (release for benchmarks)
+        uses: ./.github/actions/build-rust-extensions
+        with:
+          profile: release
+          rust-cache-shared-key: "rust-bench"
+          output-dir: dist
 
-      - name: Build Rust extension (nexus_fast)
-        run: |
-          cd rust/nexus_pyo3
-          pip install maturin
-          maturin develop --release
-
-      - name: Build Rust extension (nexus_raft)
-        run: |
-          cd rust/nexus_raft
-          maturin develop --release --features python
-
-      - name: Build Rust extension (nexus_tasks)
-        run: |
-          cd rust/nexus_tasks
-          maturin develop --release
+      - name: Install Rust extensions
+        run: pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,53 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'Dockerfile'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - 'rust/**'
+      - 'proto/**'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'Dockerfile'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - 'rust/**'
+      - 'proto/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build-smoke:
+    name: Docker Build Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (builder stage)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          target: builder
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build Docker image (full)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,40 @@ jobs:
           echo ""
           uv run pytest tests/unit/server/test_rpc_parity.py -v
 
+  # Build Rust extensions once per OS, share wheels with downstream jobs
+  build-rust:
+    name: Build Rust Extensions (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Build Rust extensions
+        uses: ./.github/actions/build-rust-extensions
+        with:
+          profile: dev
+          rust-cache-shared-key: "rust-test"
+          output-dir: dist
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-wheels-${{ matrix.os }}
+          path: dist/*.whl
+          retention-days: 1
+
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    needs: build-rust
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -82,36 +114,14 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python ${{ matrix.python-version }}
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
         with:
-          shared-key: "rust-test-${{ matrix.os }}"
-          workspaces: |
-            rust/nexus_pyo3
-            rust/nexus_raft
-            rust/nexus_tasks
+          name: rust-wheels-${{ matrix.os }}
+          path: dist
 
-      - name: Build Rust extension (nexus_fast)
-        run: |
-          cd rust/nexus_pyo3
-          pip install maturin
-          maturin develop --release
-        shell: bash
-
-      - name: Build Rust extension (nexus_raft)
-        run: |
-          cd rust/nexus_raft
-          maturin develop --release --features python
-        shell: bash
-
-      - name: Build Rust extension (nexus_tasks)
-        run: |
-          cd rust/nexus_tasks
-          maturin develop --release --features mimalloc
-        shell: bash
+      - name: Install Rust extensions from wheels
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: |
@@ -152,6 +162,7 @@ jobs:
 
   e2e-self-contained:
     name: E2E Tests (Self-Contained)
+    needs: build-rust
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -171,28 +182,14 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
         with:
-          shared-key: "rust-test-ubuntu-latest"
-          workspaces: |
-            rust/nexus_pyo3
-            rust/nexus_raft
-            rust/nexus_tasks
+          name: rust-wheels-ubuntu-latest
+          path: dist
 
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Build Rust extensions
-        run: |
-          pip install maturin
-          cd rust/nexus_pyo3 && maturin develop --release && cd ../..
-          cd rust/nexus_raft && maturin develop --release --features full && cd ../..
-          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
-
+      - name: Install Rust extensions from wheels
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -204,6 +201,7 @@ jobs:
 
   e2e-postgres:
     name: E2E Tests (PostgreSQL)
+    needs: build-rust
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -239,24 +237,14 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
         with:
-          shared-key: "rust-test-ubuntu-latest"
-          workspaces: |
-            rust/nexus_pyo3
-            rust/nexus_raft
-            rust/nexus_tasks
+          name: rust-wheels-ubuntu-latest
+          path: dist
 
-      - name: Build Rust extensions
-        run: |
-          pip install maturin
-          cd rust/nexus_pyo3 && maturin develop --release && cd ../..
-          cd rust/nexus_raft && maturin develop --release --features python && cd ../..
-          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
+      - name: Install Rust extensions from wheels
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test,postgres]"
@@ -268,6 +256,7 @@ jobs:
 
   e2e-redis:
     name: E2E Tests (Redis)
+    needs: build-rust
     runs-on: ubuntu-latest
     services:
       redis:
@@ -301,24 +290,14 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
         with:
-          shared-key: "rust-test-ubuntu-latest"
-          workspaces: |
-            rust/nexus_pyo3
-            rust/nexus_raft
-            rust/nexus_tasks
+          name: rust-wheels-ubuntu-latest
+          path: dist
 
-      - name: Build Rust extensions
-        run: |
-          pip install maturin
-          cd rust/nexus_pyo3 && maturin develop --release && cd ../..
-          cd rust/nexus_raft && maturin develop --release --features python && cd ../..
-          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
+      - name: Install Rust extensions from wheels
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -330,6 +309,7 @@ jobs:
 
   e2e-docker:
     name: E2E Tests (Docker)
+    needs: build-rust
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -349,24 +329,14 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
         with:
-          shared-key: "rust-test-ubuntu-latest"
-          workspaces: |
-            rust/nexus_pyo3
-            rust/nexus_raft
-            rust/nexus_tasks
+          name: rust-wheels-ubuntu-latest
+          path: dist
 
-      - name: Build Rust extensions
-        run: |
-          pip install maturin
-          cd rust/nexus_pyo3 && maturin develop --release && cd ../..
-          cd rust/nexus_raft && maturin develop --release --features python && cd ../..
-          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
+      - name: Install Rust extensions from wheels
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -378,6 +348,7 @@ jobs:
 
   e2e-nats:
     name: E2E Tests (NATS)
+    needs: build-rust
     runs-on: ubuntu-latest
     env:
       NEXUS_NATS_URL: nats://localhost:4222
@@ -404,24 +375,14 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
         with:
-          shared-key: "rust-test-ubuntu-latest"
-          workspaces: |
-            rust/nexus_pyo3
-            rust/nexus_raft
-            rust/nexus_tasks
+          name: rust-wheels-ubuntu-latest
+          path: dist
 
-      - name: Build Rust extensions
-        run: |
-          pip install maturin
-          cd rust/nexus_pyo3 && maturin develop --release && cd ../..
-          cd rust/nexus_raft && maturin develop --release --features python && cd ../..
-          cd rust/nexus_tasks && maturin develop --release --features mimalloc && cd ../..
+      - name: Install Rust extensions from wheels
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
           profile: dev
           rust-cache-shared-key: "rust-test"
           output-dir: dist
+          github-token: ${{ github.token }}
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,10 +81,10 @@ repos:
       # Fast Rust format check (< 2s)
       - id: rust-fmt-fast
         name: Rust Format Check (nexus_fast)
-        entry: bash -c 'cd rust/nexus_fast && cargo fmt --check'
+        entry: bash -c 'cd rust/nexus_pyo3 && cargo fmt --check'
         language: system
         pass_filenames: false
-        files: ^rust/nexus_fast/.*\.rs$
+        files: ^rust/nexus_pyo3/.*\.rs$
 
       - id: rust-fmt-raft
         name: Rust Format Check (nexus_raft)
@@ -96,10 +96,10 @@ repos:
       # Rust clippy (requires compilation, ~10-30s per crate)
       - id: rust-clippy-fast
         name: Rust Clippy (nexus_fast)
-        entry: bash -c 'cd rust/nexus_fast && cargo clippy -- -D warnings'
+        entry: bash -c 'cd rust/nexus_pyo3 && cargo clippy -- -D warnings'
         language: system
         pass_filenames: false
-        files: ^rust/nexus_fast/.*\.rs$
+        files: ^rust/nexus_pyo3/.*\.rs$
 
       - id: rust-clippy-raft
         name: Rust Clippy (nexus_raft)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,16 @@ regex-syntax = "0.8"
 crc32fast = "1.4"
 mimalloc = { version = "0.1", default-features = false }
 
+[profile.dev]
+opt-level = 1
+debug = "line-tables-only"
+incremental = true
+
+[profile.dev.package."*"]
+opt-level = 2
+
 [profile.release]
-lto = true
+lto = "thin"
 codegen-units = 1
 opt-level = 3
 strip = "debuginfo"

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,8 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 COPY src/ ./src/
 COPY alembic/ ./alembic/
 COPY alembic/alembic.ini ./alembic.ini
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --no-deps -i $(cat /tmp/pip_index) .
+RUN rm -rf src/*.egg-info build/ && \
+    pip install --no-cache-dir --no-deps --force-reinstall .
 
 # ---------- Production image ----------
 FROM python:3.13-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     fi && \
     uv pip install --system -i $(cat /tmp/pip_index) \
         ".[all,performance,compression,monitoring,docker,event-streaming,sentry]" \
-        "txtai[ann]>=9.0"
+        "txtai[ann]>=9.0" \
+        "sentence-transformers>=5.3"
 
 # ---------- Build Rust extensions (shared target dir for dep reuse) ----------
 COPY proto/ ./proto/
@@ -184,7 +185,10 @@ ENV PYTHONUNBUFFERED=1 \
     ZOEKT_INDEX_DIR=/app/data/.zoekt-index \
     ZOEKT_DATA_DIR=/app/data \
     FAISS_OPT_LEVEL=generic \
-    OMP_NUM_THREADS=1
+    OMP_NUM_THREADS=1 \
+    GLIBC_TUNABLES=glibc.rtld.optional_static_tls=16384 \
+    NEXUS_TXTAI_RERANKER=cross-encoder/ms-marco-MiniLM-L-2-v2 \
+    NEXUS_TXTAI_SPARSE=true
 
 EXPOSE 2026 2126 6070
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,29 @@
+# syntax=docker/dockerfile:1
 # Nexus RPC Server - Production Dockerfile
 # Multi-stage build for optimal image size
 # 国内镜像支持：APT、pip、Rust、Go
 ARG USE_CHINA_MIRROR=false
 ARG TORCH_VARIANT=cpu
+
+# ---------- Stage 1: Build Zoekt binaries (independent, cached separately) ----------
+FROM golang:1.24 AS zoekt-builder
+ARG USE_CHINA_MIRROR
+RUN if [ "$USE_CHINA_MIRROR" = "true" ]; then \
+        go env -w GOPROXY=https://goproxy.cn,direct GOSUMDB=off; \
+    fi
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-index@latest && \
+    CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest
+
+# ---------- Stage 2: Build Python + Rust ----------
 FROM python:3.13-slim AS builder
 
 # 设置国内镜像环境变量（默认 false，国外环境不使用）
 ARG USE_CHINA_MIRROR
 ARG TORCH_VARIANT
 ENV USE_CHINA_MIRROR=${USE_CHINA_MIRROR}
-ENV GOPROXY=https://goproxy.cn,direct
-ENV GOSUMDB=off
+
 # ---------- 系统依赖 ----------
 RUN set -eux; \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -32,70 +45,55 @@ RUN if [ "$USE_CHINA_MIRROR" = "true" ]; then \
         rustup component add rustfmt clippy; \
     fi
 
-# ---------- Go Toolchain ----------
-RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "arm64" ]; then GO_ARCH="arm64"; else GO_ARCH="amd64"; fi && \
-    if [ "$USE_CHINA_MIRROR" = "true" ]; then \
-        GO_DL="https://golang.google.cn/dl"; \
+# ---------- Compute pip index URL once (DRY) ----------
+RUN if [ "$USE_CHINA_MIRROR" = "true" ]; then \
+        echo "https://mirrors.cloud.tencent.com/pypi/simple" > /tmp/pip_index; \
     else \
-        GO_DL="https://go.dev/dl"; \
-    fi && \
-    curl -fsSL "${GO_DL}/go1.24.12.linux-${GO_ARCH}.tar.gz" | tar -C /usr/local -xzf -
-ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
-
-# ---------- Build Zoekt binaries ----------
-RUN CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-index@latest && \
-    CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest
+        echo "https://pypi.org/simple" > /tmp/pip_index; \
+    fi
 
 # ---------- uv + maturin ----------
-RUN if [ "$USE_CHINA_MIRROR" = "true" ]; then \
-        PIP_INDEX="https://mirrors.cloud.tencent.com/pypi/simple"; \
-    else \
-        PIP_INDEX="https://pypi.org/simple"; \
-    fi && \
-    pip install --no-cache-dir -i $PIP_INDEX uv maturin
+RUN pip install --no-cache-dir -i $(cat /tmp/pip_index) uv maturin
 
-# ---------- Copy project files ----------
+# ---------- Install 3rd-party Python dependencies (stable cache layer) ----------
+# Copy only metadata — src/ changes won't invalidate this expensive layer
 WORKDIR /build
 COPY pyproject.toml uv.lock* README.md Cargo.toml Cargo.lock ./
-COPY src/ ./src/
-COPY alembic/ ./alembic/
-COPY alembic/alembic.ini ./alembic.ini
-
-# ---------- Install Python dependencies ----------
+# Create minimal package stub so setuptools can discover the package
+RUN mkdir -p src/nexus && echo '__version__ = "0.0.0"' > src/nexus/__init__.py
 ENV UV_HTTP_TIMEOUT=300
 # Pre-install torch before txtai[ann] to control the variant.
 # TORCH_VARIANT=cpu  → CPU-only wheels (~300 MB, no CUDA)
 # TORCH_VARIANT=cuda → Default PyPI wheels with CUDA (~2 GB)
-RUN if [ "$USE_CHINA_MIRROR" = "true" ]; then \
-        PIP_INDEX="https://mirrors.cloud.tencent.com/pypi/simple"; \
-    else \
-        PIP_INDEX="https://pypi.org/simple"; \
-    fi && \
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/root/.cache/pip \
     if [ "$TORCH_VARIANT" = "cpu" ]; then \
         uv pip install --system --index-url https://download.pytorch.org/whl/cpu torch; \
     else \
-        uv pip install --system -i $PIP_INDEX torch; \
+        uv pip install --system -i $(cat /tmp/pip_index) torch; \
     fi && \
-    uv pip install --system -i $PIP_INDEX \
+    uv pip install --system -i $(cat /tmp/pip_index) \
         ".[all,performance,compression,monitoring,docker,event-streaming,sentry]" \
         "txtai[ann]>=9.0"
 
-# ---------- Build Rust extensions ----------
+# ---------- Build Rust extensions (shared target dir for dep reuse) ----------
 COPY proto/ ./proto/
 COPY rust/ ./rust/
 
-# Build nexus_fast (crate renamed to nexus_pyo3, but produces nexus_fast wheel)
-WORKDIR /build/rust/nexus_pyo3
-RUN maturin build --release --out /build/dist && \
-    pip install --no-cache-dir /build/dist/nexus_fast-*.whl
+ENV CARGO_TARGET_DIR=/build/target
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/build/target \
+    maturin build --release --out /build/dist -m rust/nexus_pyo3/Cargo.toml && \
+    maturin build --release --features full --out /build/dist -m rust/nexus_raft/Cargo.toml && \
+    pip install --no-cache-dir /build/dist/nexus_fast-*.whl /build/dist/nexus_raft-*.whl
 
-# Build nexus_raft
-WORKDIR /build/rust/nexus_raft
-RUN maturin build --release --features full --out /build/dist && \
-    pip install --no-cache-dir /build/dist/nexus_raft-*.whl
-
-WORKDIR /build
+# ---------- Copy real application source and reinstall local package ----------
+COPY src/ ./src/
+COPY alembic/ ./alembic/
+COPY alembic/alembic.ini ./alembic.ini
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system --no-deps -i $(cat /tmp/pip_index) .
 
 # ---------- Production image ----------
 FROM python:3.13-slim
@@ -113,15 +111,15 @@ RUN set -eux; \
         libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-# ---------- Copy Python packages + Rust extension ----------
+# ---------- Copy Python packages + Rust extensions ----------
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin/nexus /usr/local/bin/nexus
 COPY --from=builder /usr/local/bin/nexusd /usr/local/bin/nexusd
 COPY --from=builder /usr/local/bin/alembic /usr/local/bin/alembic
 
 # ---------- Copy Zoekt binaries ----------
-COPY --from=builder /root/go/bin/zoekt-index /usr/local/bin/zoekt-index
-COPY --from=builder /root/go/bin/zoekt-webserver /usr/local/bin/zoekt-webserver
+COPY --from=zoekt-builder /go/bin/zoekt-index /usr/local/bin/zoekt-index
+COPY --from=zoekt-builder /go/bin/zoekt-webserver /usr/local/bin/zoekt-webserver
 
 # ---------- Build-time smoke tests (Issue #2946) ----------
 # Verify critical native imports are installed correctly.

--- a/docs/contributing/build-performance.md
+++ b/docs/contributing/build-performance.md
@@ -1,0 +1,101 @@
+# Build Performance Guide
+
+Tips for faster local builds, especially on macOS.
+
+## Rust Extension Builds
+
+### Use dev builds for local iteration
+
+The project has a tuned `[profile.dev]` in `Cargo.toml` with `opt-level = 1` —
+fast enough for testing, much faster to compile than release builds:
+
+```bash
+cd rust/nexus_pyo3 && maturin develop        # ~30s (dev profile)
+cd rust/nexus_pyo3 && maturin develop --release  # ~5min (release, LTO)
+```
+
+Use `--release` only when you need production-grade performance (benchmarking, profiling).
+
+### Dependencies are compiled once
+
+The dev profile uses `opt-level = 2` for third-party dependencies via
+`[profile.dev.package."*"]`. These are compiled once and cached in `target/`,
+so subsequent builds after code changes are fast.
+
+## macOS-Specific Optimizations
+
+### XProtect / Gatekeeper scanning
+
+macOS scans newly compiled binaries, which adds latency to each build.
+Enable Developer Mode to reduce this:
+
+```bash
+# Allow developer tools to run without Gatekeeper checks
+sudo spctl developer-mode enable-terminal
+```
+
+You may need to restart your terminal after this.
+
+### Spotlight indexing
+
+Spotlight indexes build artifacts in `target/` and `.venv/`, causing I/O
+contention during builds. Exclude these directories:
+
+**System Preferences > Siri & Spotlight > Spotlight Privacy** — add:
+- Your project's `target/` directory
+- Your project's `.venv/` directory
+
+Or via command line:
+
+```bash
+# Add exclusions (requires Full Disk Access for Terminal)
+mdutil -i off target/
+mdutil -i off .venv/
+```
+
+### Docker: OrbStack vs Docker Desktop
+
+[OrbStack](https://orbstack.dev/) runs Docker containers with significantly
+lower overhead than Docker Desktop on macOS. It uses a lightweight Linux VM
+with near-native file system performance.
+
+If Docker builds are slow, switching to OrbStack is the single highest-impact
+change on macOS.
+
+## Optional: sccache
+
+[sccache](https://github.com/mozilla/sccache) caches Rust compilation artifacts
+across projects and machines. It's especially useful if you work on multiple
+branches or frequently `cargo clean`.
+
+```bash
+brew install sccache
+
+# Add to your shell profile:
+export RUSTC_WRAPPER=sccache
+```
+
+sccache wraps `rustc` and caches compilation results. Cache hits skip compilation
+entirely. Works with local disk or remote storage (S3, GCS, Redis).
+
+## Optional: Faster linker (lld)
+
+On macOS, the default linker is slower than LLVM's `lld`. If you have LLVM
+installed, you can configure cargo to use it:
+
+```bash
+brew install llvm
+
+# Create or edit .cargo/config.toml in your project root:
+cat >> .cargo/config.toml << 'EOF'
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+EOF
+```
+
+This can reduce link times by 2-3x. Note: this configuration is personal
+and should not be committed to the repository (add `.cargo/config.toml` to
+`.gitignore` if needed).

--- a/rust/nexus_pyo3/INTEGRATION.md
+++ b/rust/nexus_pyo3/INTEGRATION.md
@@ -6,10 +6,10 @@ This guide shows how to integrate the high-performance Rust permission checker w
 
 ```bash
 cd rust/nexus_pyo3
-maturin develop --release
+maturin develop
 ```
 
-Or for production:
+Or for production (optimized):
 ```bash
 cd rust/nexus_pyo3
 maturin build --release
@@ -240,7 +240,7 @@ If `maturin develop` fails:
 1. Check Rust installation: `rustc --version`
 2. Update Rust: `rustup update`
 3. Check Python version: `python --version` (3.8+ required)
-4. Try cleaning build: `cargo clean && maturin develop --release`
+4. Try cleaning build: `cargo clean && maturin develop`
 
 ### Import Errors
 
@@ -248,7 +248,7 @@ If `import nexus_fast` fails:
 
 1. Verify installation: `pip show nexus-fast`
 2. Check Python environment: `which python`
-3. Rebuild: `maturin develop --release`
+3. Rebuild: `maturin develop`
 
 ### Incorrect Results
 

--- a/rust/nexus_pyo3/README.md
+++ b/rust/nexus_pyo3/README.md
@@ -80,9 +80,9 @@ Only needed for development or unsupported platforms:
 cd rust/nexus_pyo3
 
 # Build and install in development mode
-maturin develop --release
+maturin develop
 
-# Or build a wheel for distribution
+# Or build an optimized wheel for distribution
 maturin build --release
 pip install target/wheels/*.whl
 ```
@@ -361,7 +361,7 @@ When modifying the Rust code:
 1. Run tests: `python test_nexus_fast.py`
 2. Check formatting: `cargo fmt`
 3. Run linter: `cargo clippy`
-4. Rebuild: `maturin develop --release`
+4. Rebuild: `maturin develop`
 
 ## Future Enhancements
 

--- a/rust/nexus_pyo3/test_lock.py
+++ b/rust/nexus_pyo3/test_lock.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Direct tests for the Rust VFSLockManager via nexus_fast (Issue #1398).
 
-Run after building with: maturin develop --release
+Run after building with: maturin develop
 Usage: python rust/nexus_pyo3/test_lock.py
 """
 

--- a/scripts/test_build_perf_e2e.py
+++ b/scripts/test_build_perf_e2e.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 import time
+import urllib.request
 
 NEXUS_CLI = os.environ.get("NEXUS_CLI", "nexus")
 NEXUS_URL = os.environ.get("NEXUS_URL", "http://localhost:2027")
@@ -64,9 +65,25 @@ def main() -> None:
         print("ERROR: NEXUS_API_KEY not set")
         sys.exit(1)
 
+    t = rpc_transport()
+
     # =========================================================================
-    print("=== 1. INFRA ===")
+    print("=== 1. INFRA & STATUS ===")
     # =========================================================================
+
+    # Health check via HTTP
+    try:
+        resp = urllib.request.urlopen(f"{NEXUS_URL}/healthz/ready", timeout=5)
+        health = resp.read().decode()
+        check("Health endpoint", "ready" in health)
+    except Exception as e:
+        check("Health endpoint", False, str(e))
+
+    # nexus status
+    r = cli("status")
+    check("nexus status", "server_reachable" in r.stdout or "healthy" in r.stdout.lower())
+
+    # ls
     r = cli("ls", "/workspace/demo")
     check("Server reachable (ls)", r.returncode == 0 or "data" in r.stdout)
     check("Demo files exist", "README.md" in r.stdout)
@@ -74,17 +91,33 @@ def main() -> None:
     r = cli("ls", "/workspace/demo/herb/customers")
     check("HERB corpus (5 customers)", "cust-005" in r.stdout)
 
+    r = cli("ls", "/workspace/demo/herb/employees")
+    check("HERB corpus (employees)", "emp-003" in r.stdout)
+
+    r = cli("ls", "/workspace/demo/herb/products")
+    check("HERB corpus (products)", "prod-003" in r.stdout)
+
     # =========================================================================
     print("\n=== 2. FILE CRUD ===")
     # =========================================================================
     r = cli("cat", "/workspace/demo/README.md")
     check("cat README.md", "Nexus Demo Workspace" in r.stdout)
 
-    # =========================================================================
-    print("\n=== 3. EDIT ===")
-    # =========================================================================
-    t = rpc_transport()
+    r = cli("cat", "/workspace/demo/auth-flow.md")
+    check("cat auth-flow.md", "authentication" in r.stdout.lower())
 
+    # =========================================================================
+    print("\n=== 3. GREP / KEYWORD SEARCH ===")
+    # =========================================================================
+    r = cli("grep", "authentication", "/workspace/demo")
+    check("grep 'authentication'", "data" in r.stdout)
+
+    r = cli("grep", "vector", "/workspace/demo")
+    check("grep 'vector'", "data" in r.stdout)
+
+    # =========================================================================
+    print("\n=== 4. EDIT (exact, fuzzy, preview, OCC) ===")
+    # =========================================================================
     result = t.call_rpc(
         "edit",
         {
@@ -115,7 +148,10 @@ def main() -> None:
             "fuzzy_threshold": 0.7,
         },
     )
-    check("edit (fuzzy restore)", result.get("success") and result.get("applied_count") == 1)
+    check(
+        "edit (fuzzy restore)",
+        result.get("success") and result.get("applied_count") == 1,
+    )
 
     try:
         t.call_rpc(
@@ -128,16 +164,19 @@ def main() -> None:
         )
         check("edit (OCC conflict)", False, "should have raised")
     except Exception as e:
-        check("edit (OCC conflict)", "conflict" in str(e).lower() or "etag" in str(e).lower())
+        check(
+            "edit (OCC conflict)",
+            "conflict" in str(e).lower() or "etag" in str(e).lower(),
+        )
 
     # =========================================================================
-    print("\n=== 4. VERSION HISTORY ===")
+    print("\n=== 5. VERSION HISTORY ===")
     # =========================================================================
     r = cli("versions", "history", "/workspace/demo/plan.md")
     check("version history", "Version" in r.stdout or "version" in r.stdout)
 
     # =========================================================================
-    print("\n=== 5. HERB QUALITY GATE ===")
+    print("\n=== 6. HERB QUALITY GATE (BM25+pgvector+SPLADE+reranker) ===")
     # =========================================================================
     qa_set = [
         ("Which customer uses Nexus for medical document management?", "cust-002"),
@@ -150,14 +189,21 @@ def main() -> None:
         ("What product integrates with existing search infrastructure?", "prod-002"),
     ]
     hits = 0
+    search_latencies: list[float] = []
     for q, expected in qa_set:
+        start = time.perf_counter()
         r = cli("search", "query", q, "--limit", "5")
+        elapsed = (time.perf_counter() - start) * 1000
+        search_latencies.append(elapsed)
         if expected in r.stdout:
             hits += 1
     check(f"HERB hit rate {hits}/8 >= 90%", hits >= 7, f"{hits}/8")
+    search_latencies.sort()
+    p50 = search_latencies[len(search_latencies) // 2]
+    print(f"    Search latency (incl CLI): p50={p50:.0f}ms")
 
     # =========================================================================
-    print("\n=== 6. PERMISSION-FILTERED SEARCH ===")
+    print("\n=== 7. PERMISSION-FILTERED SEARCH ===")
     # =========================================================================
     if USER_KEY:
         r = cli("search", "query", "Meridian Health", "--limit", "3")
@@ -180,7 +226,31 @@ def main() -> None:
         print("  (skipped \u2014 NEXUS_DEMO_USER_KEY not set)")
 
     # =========================================================================
-    print("\n=== 7. AUTO-INDEX ON EDIT ===")
+    print("\n=== 8. PERMISSION LATENCY ===")
+    # =========================================================================
+    import contextlib
+
+    perm_latencies: list[float] = []
+    for _ in range(20):
+        start = time.perf_counter()
+        with contextlib.suppress(Exception):
+            t.call_rpc(
+                "edit",
+                {
+                    "path": "/workspace/demo/plan.md",
+                    "edits": [["nonexistent_string_12345", "x"]],
+                    "preview": True,
+                },
+            )
+        perm_latencies.append((time.perf_counter() - start) * 1000)
+    perm_latencies.sort()
+    p50 = perm_latencies[len(perm_latencies) // 2]
+    p95 = perm_latencies[int(len(perm_latencies) * 0.95)]
+    check(f"RPC latency p50={p50:.0f}ms < 50ms", p50 < 50, f"{p50:.1f}ms")
+    print(f"    p50={p50:.1f}ms  p95={p95:.1f}ms")
+
+    # =========================================================================
+    print("\n=== 9. AUTO-INDEX ON EDIT ===")
     # =========================================================================
     t.call_rpc(
         "edit",
@@ -189,6 +259,7 @@ def main() -> None:
             "edits": [["Deploy to production", "Deploy using Kubernetes orchestration"]],
         },
     )
+    print("    Waiting 8s for daemon auto-index...")
     time.sleep(8)
     r = cli("search", "query", "Kubernetes orchestration", "--limit", "3")
     check("auto-index after edit", "plan.md" in r.stdout)
@@ -202,12 +273,43 @@ def main() -> None:
         },
     )
 
+    # =========================================================================
+    print("\n=== 10. DELETE → STALE INDEX CHECK ===")
+    # =========================================================================
+    # Write a test file, wait for auto-index, verify searchable
+    t.call_rpc(
+        "sys_write",
+        {"path": "/workspace/demo/delete-test.md", "buf": "Quantum entanglement teleportation"},
+    )
+    print("    Waiting 8s for auto-index...")
+    time.sleep(8)
+    r = cli("search", "query", "quantum entanglement teleportation", "--limit", "3")
+    indexed = "delete-test" in r.stdout
+    check("file indexed before delete", indexed)
+
+    # Delete the file
+    t.call_rpc("sys_unlink", {"path": "/workspace/demo/delete-test.md"})
+    print("    Waiting 8s for delete to propagate...")
+    time.sleep(8)
+    r = cli("search", "query", "quantum entanglement teleportation", "--limit", "3")
+    stale = "delete-test" in r.stdout
+    check(
+        "deleted file removed from search", not stale, "stale result still present" if stale else ""
+    )
+
     t.close()
 
     # =========================================================================
     print(f"\n{'=' * 60}")
     print(f"RESULTS: {passed} passed, {failed} failed")
     print(f"{'=' * 60}")
+
+    if failed:
+        print("\nFailed tests:")
+        for name, ok, detail in results:
+            if not ok:
+                print(f"  \u2717 {name}: {detail}")
+
     sys.exit(1 if failed else 0)
 
 

--- a/scripts/test_build_perf_e2e.py
+++ b/scripts/test_build_perf_e2e.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""E2E validation for build performance + search + permissions (Issue #2965).
+
+Requires a running Nexus stack (nexus init --preset demo && nexus up && nexus demo init).
+Pass NEXUS_URL, NEXUS_API_KEY, NEXUS_GRPC_PORT, and NEXUS_DEMO_USER_KEY as env vars.
+
+Usage:
+    # After starting the stack:
+    export NEXUS_URL=http://localhost:2027
+    export NEXUS_API_KEY=nx_admin_...
+    export NEXUS_GRPC_PORT=2029
+    export NEXUS_DEMO_USER_KEY=sk-root_demo_use_...
+    python scripts/test_build_perf_e2e.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+NEXUS_CLI = os.environ.get("NEXUS_CLI", "nexus")
+NEXUS_URL = os.environ.get("NEXUS_URL", "http://localhost:2027")
+ADMIN_KEY = os.environ.get("NEXUS_API_KEY", "")
+USER_KEY = os.environ.get("NEXUS_DEMO_USER_KEY", "")
+GRPC_PORT = os.environ.get("NEXUS_GRPC_PORT", "2029")
+
+passed = 0
+failed = 0
+results: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global passed, failed
+    if condition:
+        passed += 1
+        print(f"  \u2713 {name}")
+    else:
+        failed += 1
+        print(f"  \u2717 {name} \u2014 {detail}")
+    results.append((name, condition, detail))
+
+
+def cli(
+    *args: str, api_key: str | None = None, timeout: int = 30
+) -> subprocess.CompletedProcess[str]:
+    key = api_key or ADMIN_KEY
+    cmd = [NEXUS_CLI, *args, "--remote-url", NEXUS_URL, "--remote-api-key", key]
+    env = {**os.environ, "NEXUS_GRPC_PORT": GRPC_PORT}
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=env)
+
+
+def rpc_transport():
+    """Create an RPC transport for direct server calls."""
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+    from nexus.remote.rpc_transport import RPCTransport
+
+    return RPCTransport(f"localhost:{GRPC_PORT}", auth_token=ADMIN_KEY)
+
+
+def main() -> None:
+    if not ADMIN_KEY:
+        print("ERROR: NEXUS_API_KEY not set")
+        sys.exit(1)
+
+    # =========================================================================
+    print("=== 1. INFRA ===")
+    # =========================================================================
+    r = cli("ls", "/workspace/demo")
+    check("Server reachable (ls)", r.returncode == 0 or "data" in r.stdout)
+    check("Demo files exist", "README.md" in r.stdout)
+
+    r = cli("ls", "/workspace/demo/herb/customers")
+    check("HERB corpus (5 customers)", "cust-005" in r.stdout)
+
+    # =========================================================================
+    print("\n=== 2. FILE CRUD ===")
+    # =========================================================================
+    r = cli("cat", "/workspace/demo/README.md")
+    check("cat README.md", "Nexus Demo Workspace" in r.stdout)
+
+    # =========================================================================
+    print("\n=== 3. EDIT ===")
+    # =========================================================================
+    t = rpc_transport()
+
+    result = t.call_rpc(
+        "edit",
+        {
+            "path": "/workspace/demo/plan.md",
+            "edits": [["Configure authentication", "Configure auth (test-edit)"]],
+        },
+    )
+    check("edit (exact)", result.get("success") and result.get("applied_count") == 1)
+
+    result = t.call_rpc(
+        "edit",
+        {
+            "path": "/workspace/demo/plan.md",
+            "edits": [["Configure auth (test-edit)", "PREVIEW"]],
+            "preview": True,
+        },
+    )
+    check("edit (preview)", result.get("success") and result.get("applied_count") == 1)
+    content = t.call_rpc("sys_read", {"path": "/workspace/demo/plan.md"})
+    text = content.decode() if isinstance(content, bytes) else str(content)
+    check("preview did not write", "PREVIEW" not in text and "test-edit" in text)
+
+    result = t.call_rpc(
+        "edit",
+        {
+            "path": "/workspace/demo/plan.md",
+            "edits": [["Confgiure auth (test-edt)", "Configure authentication"]],
+            "fuzzy_threshold": 0.7,
+        },
+    )
+    check("edit (fuzzy restore)", result.get("success") and result.get("applied_count") == 1)
+
+    try:
+        t.call_rpc(
+            "edit",
+            {
+                "path": "/workspace/demo/plan.md",
+                "edits": [["Phase 1", "P1"]],
+                "if_match": "wrong-etag",
+            },
+        )
+        check("edit (OCC conflict)", False, "should have raised")
+    except Exception as e:
+        check("edit (OCC conflict)", "conflict" in str(e).lower() or "etag" in str(e).lower())
+
+    # =========================================================================
+    print("\n=== 4. VERSION HISTORY ===")
+    # =========================================================================
+    r = cli("versions", "history", "/workspace/demo/plan.md")
+    check("version history", "Version" in r.stdout or "version" in r.stdout)
+
+    # =========================================================================
+    print("\n=== 5. HERB QUALITY GATE ===")
+    # =========================================================================
+    qa_set = [
+        ("Which customer uses Nexus for medical document management?", "cust-002"),
+        ("Who is the staff engineer working on semantic search quality?", "emp-002"),
+        ("What is the pricing model for Nexus Core?", "prod-001"),
+        ("Which customer has been active since 2019 in manufacturing?", "cust-001"),
+        ("Who manages the permissions engineering team?", "emp-003"),
+        ("What product provides multi-node Raft-based federation?", "prod-003"),
+        ("Which customer operates in the renewable energy sector?", "cust-004"),
+        ("What product integrates with existing search infrastructure?", "prod-002"),
+    ]
+    hits = 0
+    for q, expected in qa_set:
+        r = cli("search", "query", q, "--limit", "5")
+        if expected in r.stdout:
+            hits += 1
+    check(f"HERB hit rate {hits}/8 >= 90%", hits >= 7, f"{hits}/8")
+
+    # =========================================================================
+    print("\n=== 6. PERMISSION-FILTERED SEARCH ===")
+    # =========================================================================
+    if USER_KEY:
+        r = cli("search", "query", "Meridian Health", "--limit", "3")
+        check("admin finds cust-002", "cust-002" in r.stdout)
+
+        r = cli("search", "query", "Meridian Health", "--limit", "3", api_key=USER_KEY)
+        check("viewer finds cust-002 (dir inheritance)", "cust-002" in r.stdout)
+
+        r = cli(
+            "rebac",
+            "check",
+            "user",
+            "demo_user",
+            "read",
+            "file",
+            "/workspace/demo/herb/customers/cust-002.md",
+        )
+        check("rebac: viewer read nested HERB file", "GRANTED" in r.stdout)
+    else:
+        print("  (skipped \u2014 NEXUS_DEMO_USER_KEY not set)")
+
+    # =========================================================================
+    print("\n=== 7. AUTO-INDEX ON EDIT ===")
+    # =========================================================================
+    t.call_rpc(
+        "edit",
+        {
+            "path": "/workspace/demo/plan.md",
+            "edits": [["Deploy to production", "Deploy using Kubernetes orchestration"]],
+        },
+    )
+    time.sleep(8)
+    r = cli("search", "query", "Kubernetes orchestration", "--limit", "3")
+    check("auto-index after edit", "plan.md" in r.stdout)
+    # Restore
+    t.call_rpc(
+        "edit",
+        {
+            "path": "/workspace/demo/plan.md",
+            "edits": [["Deploy using Kubernetes orchestration", "Deploy to production"]],
+            "fuzzy_threshold": 0.8,
+        },
+    )
+
+    t.close()
+
+    # =========================================================================
+    print(f"\n{'=' * 60}")
+    print(f"RESULTS: {passed} passed, {failed} failed")
+    print(f"{'=' * 60}")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -372,15 +372,14 @@ class BulkPermissionChecker:
                         f"[BULK-UNNEST] Fetched {cross_zone_count} cross-zone tuples in single query"
                     )
 
-                # Compute parent relationships in memory
-                if ancestor_paths:
-                    computed_parent_count = self._compute_parent_tuples(
-                        ancestor_paths, tuples_graph
+            # Compute parent relationships in memory (needed for directory
+            # inheritance regardless of zone isolation setting)
+            if ancestor_paths:
+                computed_parent_count = self._compute_parent_tuples(ancestor_paths, tuples_graph)
+                if computed_parent_count > 0:
+                    logger.debug(
+                        f"Computed {computed_parent_count} parent tuples in memory for file hierarchy"
                     )
-                    if computed_parent_count > 0:
-                        logger.debug(
-                            f"Computed {computed_parent_count} parent tuples in memory for file hierarchy"
-                        )
 
             logger.debug(
                 f"Fetched {len(tuples_graph)} tuples in bulk for graph computation (includes parent hierarchy)"

--- a/src/nexus/bricks/rebac/permission_filter_chain.py
+++ b/src/nexus/bricks/rebac/permission_filter_chain.py
@@ -268,6 +268,7 @@ class BulkReBACStrategy:
             return FilterResult()
 
         subject = ctx.subject
+
         checks = []
         for path in remaining:
             obj_type = "file"

--- a/src/nexus/bricks/rebac/permission_filter_chain.py
+++ b/src/nexus/bricks/rebac/permission_filter_chain.py
@@ -136,8 +136,7 @@ class HierarchyPreFilterStrategy:
         if len(unique_parents) > 200:
             unique_parents = self._top_level_prune(unique_parents, subject, ctx)
             if not unique_parents:
-                # All top-level dirs denied
-                ctx.cache.mark_bitmap_complete(subject, ctx.zone_id)
+                # All top-level dirs denied — deny remaining paths
                 return FilterResult(allowed=[], remaining=[], short_circuit=True)
 
         # Batch check unique parent directories
@@ -173,8 +172,10 @@ class HierarchyPreFilterStrategy:
                 f"{len(kept)} paths (skipped {skipped} under denied parents)"
             )
 
-            if not accessible_parents and len(remaining) > 100:
-                ctx.cache.mark_bitmap_complete(subject, ctx.zone_id)
+            # Do NOT mark bitmap complete on empty results — parent grants
+            # may exist but not resolve in bulk mode (e.g., viewer role).
+            # if not accessible_parents and len(remaining) > 100:
+            #     ctx.cache.mark_bitmap_complete(subject, ctx.zone_id)
 
             return FilterResult(allowed=[], remaining=kept)
 
@@ -303,8 +304,11 @@ class BulkReBACStrategy:
             if results.get(check, False)
         ]
 
-        # If bulk found 0 additional paths from a large set, mark bitmap complete
-        if not allowed and len(remaining) > 100:
+        # Only mark bitmap complete when bulk found SOME results from a large set.
+        # An empty result may indicate parent-level grants that aren't resolved
+        # in bulk mode — marking empty as "complete" would block fallback on
+        # subsequent requests and deny all access incorrectly.
+        if allowed and len(remaining) > 100:
             ctx.cache.mark_bitmap_complete(subject, ctx.zone_id)
 
         return FilterResult(allowed=allowed, remaining=[], short_circuit=True)

--- a/src/nexus/bricks/rebac/utils/fast.py
+++ b/src/nexus/bricks/rebac/utils/fast.py
@@ -97,8 +97,7 @@ def check_permissions_bulk_rust(
     """
     if not RUST_AVAILABLE:
         raise RuntimeError(
-            "Rust acceleration not available. Install with: "
-            "cd rust/nexus_pyo3 && maturin develop --release"
+            "Rust acceleration not available. Install with: cd rust/nexus_pyo3 && maturin develop"
         )
 
     try:
@@ -331,15 +330,14 @@ def check_permission_single_rust(
     """
     if not RUST_AVAILABLE:
         raise RuntimeError(
-            "Rust acceleration not available. Install with: "
-            "cd rust/nexus_pyo3 && maturin develop --release"
+            "Rust acceleration not available. Install with: cd rust/nexus_pyo3 && maturin develop"
         )
 
     # compute_permission_single is only in the external module
     if _external_module is None:
         raise RuntimeError(
             "Rust single permission check not available. "
-            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop --release"
+            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop"
         )
 
     try:
@@ -470,15 +468,14 @@ def expand_subjects_rust(
     """
     if not RUST_AVAILABLE:
         raise RuntimeError(
-            "Rust acceleration not available. Install with: "
-            "cd rust/nexus_pyo3 && maturin develop --release"
+            "Rust acceleration not available. Install with: cd rust/nexus_pyo3 && maturin develop"
         )
 
     # Use external module which has expand_subjects
     if _external_module is None:
         raise RuntimeError(
             "Rust expand_subjects not available. "
-            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop --release"
+            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop"
         )
 
     try:
@@ -589,15 +586,14 @@ def list_objects_for_subject_rust(
     """
     if not RUST_AVAILABLE:
         raise RuntimeError(
-            "Rust acceleration not available. Install with: "
-            "cd rust/nexus_pyo3 && maturin develop --release"
+            "Rust acceleration not available. Install with: cd rust/nexus_pyo3 && maturin develop"
         )
 
     # Use external module which has list_objects_for_subject
     if _external_module is None:
         raise RuntimeError(
             "Rust list_objects_for_subject not available. "
-            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop --release"
+            "Install nexus_fast: cd rust/nexus_pyo3 && maturin develop"
         )
 
     try:

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1075,12 +1075,21 @@ class SearchDaemon:
                     delete_paths = list(self._pending_delete_paths)
                     self._pending_delete_paths.clear()
 
-                # Delete removed files from the index (IDs = unscoped virtual_path)
+                # Delete removed files from the index
+                # Doc IDs are "zone:path" for non-root, plain path for root
                 if delete_paths and self._backend is not None:
                     from nexus.contracts.constants import ROOT_ZONE_ID
 
-                    unscoped = [self._strip_zone_prefix(p) for p in delete_paths]
-                    await self.delete_documents(unscoped, zone_id=ROOT_ZONE_ID)
+                    delete_ids = []
+                    for dp in delete_paths:
+                        vp = self._strip_zone_prefix(dp)
+                        # Infer zone from the scoped path prefix
+                        import re as _re_del
+
+                        zm = _re_del.match(r"^/zone/([^/]+)/", dp)
+                        zone = zm.group(1) if zm else ROOT_ZONE_ID
+                        delete_ids.append(f"{zone}:{vp}" if zone != ROOT_ZONE_ID else vp)
+                    await self.delete_documents(delete_ids, zone_id=ROOT_ZONE_ID)
 
                 # Refresh indexes for changed paths
                 if paths:
@@ -1260,9 +1269,10 @@ class SearchDaemon:
 
                     _zm = _re.match(r"^/zone/([^/]+)/", path)
                     _zone = _zm.group(1) if _zm else "root"
+                    _doc_id = f"{_zone}:{virtual_path}" if _zone != "root" else virtual_path
                     _txtai_batch.setdefault(_zone, []).append(
                         {
-                            "id": virtual_path,
+                            "id": _doc_id,
                             "text": content,
                             "path": virtual_path,
                             "zone_id": _zone,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1075,11 +1075,12 @@ class SearchDaemon:
                     delete_paths = list(self._pending_delete_paths)
                     self._pending_delete_paths.clear()
 
-                # Delete removed files from the index
+                # Delete removed files from the index (IDs = unscoped virtual_path)
                 if delete_paths and self._backend is not None:
                     from nexus.contracts.constants import ROOT_ZONE_ID
 
-                    await self.delete_documents(delete_paths, zone_id=ROOT_ZONE_ID)
+                    unscoped = [self._strip_zone_prefix(p) for p in delete_paths]
+                    await self.delete_documents(unscoped, zone_id=ROOT_ZONE_ID)
 
                 # Refresh indexes for changed paths
                 if paths:
@@ -1260,7 +1261,12 @@ class SearchDaemon:
                     _zm = _re.match(r"^/zone/([^/]+)/", path)
                     _zone = _zm.group(1) if _zm else "root"
                     _txtai_batch.setdefault(_zone, []).append(
-                        {"id": path_id, "text": content, "path": virtual_path, "zone_id": _zone}
+                        {
+                            "id": virtual_path,
+                            "text": content,
+                            "path": virtual_path,
+                            "zone_id": _zone,
+                        }
                     )
 
                 # Also run indexing pipeline for chunk + embedding storage

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -181,6 +181,7 @@ class SearchDaemon:
         # Index refresh task
         self._refresh_task: asyncio.Task | None = None
         self._pending_refresh_paths: set[str] = set()
+        self._pending_delete_paths: set[str] = set()
         self._refresh_lock = asyncio.Lock()
 
         # FileReaderProtocol reference for reading file content (set by FastAPI server)
@@ -1039,7 +1040,7 @@ class SearchDaemon:
     # Index Refresh
     # =========================================================================
 
-    async def notify_file_change(self, path: str, change_type: str = "update") -> None:  # noqa: ARG002
+    async def notify_file_change(self, path: str, change_type: str = "update") -> None:
         """Notify the daemon of a file change for index refresh.
 
         Changes are debounced and batched for efficiency.
@@ -1052,7 +1053,12 @@ class SearchDaemon:
             return
 
         async with self._refresh_lock:
-            self._pending_refresh_paths.add(path)
+            if change_type == "delete":
+                self._pending_delete_paths.add(path)
+                self._pending_refresh_paths.discard(path)
+            else:
+                self._pending_refresh_paths.add(path)
+                self._pending_delete_paths.discard(path)
 
     async def _index_refresh_loop(self) -> None:
         """Background task to refresh indexes for changed files."""
@@ -1061,14 +1067,23 @@ class SearchDaemon:
                 await asyncio.sleep(self.config.refresh_debounce_seconds)
 
                 async with self._refresh_lock:
-                    if not self._pending_refresh_paths:
+                    if not self._pending_refresh_paths and not self._pending_delete_paths:
                         continue
 
                     paths = list(self._pending_refresh_paths)
                     self._pending_refresh_paths.clear()
+                    delete_paths = list(self._pending_delete_paths)
+                    self._pending_delete_paths.clear()
+
+                # Delete removed files from the index
+                if delete_paths and self._backend is not None:
+                    from nexus.contracts.constants import ROOT_ZONE_ID
+
+                    await self.delete_documents(delete_paths, zone_id=ROOT_ZONE_ID)
 
                 # Refresh indexes for changed paths
-                await self._refresh_indexes(paths)
+                if paths:
+                    await self._refresh_indexes(paths)
                 self.stats.last_index_refresh = time.time()
 
             except asyncio.CancelledError:

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -2502,6 +2502,7 @@ class SearchService:
         filters: dict[str, Any] | None = None,  # noqa: ARG002
         search_mode: str = "semantic",
         adaptive_k: bool = False,
+        context: "OperationContext | None" = None,
     ) -> builtins.list[dict[str, Any]]:
         """Search documents using natural language queries.
 
@@ -2532,13 +2533,15 @@ class SearchService:
         # Delegate to SearchDaemon's txtai backend when wired (Issue #2965)
         daemon = getattr(self, "_search_daemon", None)
         if daemon is not None and getattr(daemon, "_backend", None) is not None:
+            # Over-fetch to compensate for permission filtering
+            fetch_limit = limit * 3 if self._permission_enforcer else limit
             daemon_results = await daemon.search(
                 query=query,
                 search_type=search_mode if search_mode != "semantic" else "hybrid",
-                limit=limit,
+                limit=fetch_limit,
                 path_filter=path if path != "/" else None,
             )
-            return [
+            hits = [
                 {
                     "path": r.path,
                     "chunk_text": getattr(r, "chunk_text", ""),
@@ -2551,6 +2554,14 @@ class SearchService:
                 }
                 for r in daemon_results
             ]
+
+            # Filter by read permission — only return files the caller can access
+            if self._permission_enforcer and hits and context is not None:
+                all_paths = [h["path"] for h in hits]
+                accessible = set(self._permission_enforcer.filter_list(all_paths, context))
+                hits = [h for h in hits if h["path"] in accessible]
+
+            return hits[:limit]
 
         if self._record_store is not None:
             return await self._sql_chunk_search(query, path, limit)

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -2535,11 +2535,14 @@ class SearchService:
         if daemon is not None and getattr(daemon, "_backend", None) is not None:
             # Over-fetch to compensate for permission filtering
             fetch_limit = limit * 3 if self._permission_enforcer else limit
+            zone_id = getattr(context, "zone_id", None) if context else None
             daemon_results = await daemon.search(
                 query=query,
                 search_type=search_mode if search_mode != "semantic" else "hybrid",
                 limit=fetch_limit,
                 path_filter=path if path != "/" else None,
+                zone_id=zone_id,
+                adaptive_k=adaptive_k,
             )
             hits = [
                 {

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -2536,11 +2536,15 @@ class SearchService:
             # Over-fetch to compensate for permission filtering
             fetch_limit = limit * 3 if self._permission_enforcer else limit
             zone_id = getattr(context, "zone_id", None) if context else None
+            # RPC may scope paths as /zone/{id}/...; daemon stores unscoped.
+            from nexus.server.path_utils import unscope_internal_path as _unscope
+
+            db_path = _unscope(path) if path != "/" else None
             daemon_results = await daemon.search(
                 query=query,
                 search_type=search_mode if search_mode != "semantic" else "hybrid",
                 limit=fetch_limit,
-                path_filter=path if path != "/" else None,
+                path_filter=db_path,
                 zone_id=zone_id,
                 adaptive_k=adaptive_k,
             )

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -2529,6 +2529,29 @@ class SearchService:
             )
             return [_result_to_dict(r) for r in results]
 
+        # Delegate to SearchDaemon's txtai backend when wired (Issue #2965)
+        daemon = getattr(self, "_search_daemon", None)
+        if daemon is not None and getattr(daemon, "_backend", None) is not None:
+            daemon_results = await daemon.search(
+                query=query,
+                search_type=search_mode if search_mode != "semantic" else "hybrid",
+                limit=limit,
+                path_filter=path if path != "/" else None,
+            )
+            return [
+                {
+                    "path": r.path,
+                    "chunk_text": getattr(r, "chunk_text", ""),
+                    "score": round(r.score, 4),
+                    "chunk_index": getattr(r, "chunk_index", 0),
+                    "start_offset": getattr(r, "start_offset", 0) or 0,
+                    "end_offset": getattr(r, "end_offset", 0) or 0,
+                    "line_start": getattr(r, "line_start", 0) or 0,
+                    "line_end": getattr(r, "line_end", 0) or 0,
+                }
+                for r in daemon_results
+            ]
+
         if self._record_store is not None:
             return await self._sql_chunk_search(query, path, limit)
 

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -969,9 +969,22 @@ def _init_semantic_search(nx: Any, config: dict[str, Any], manifest: dict[str, A
     try:
         search_svc = nx.service("search")
         results = search_svc.semantic_search_index("/workspace/demo", recursive=True)
-        indexed = sum(1 for v in results.values() if v > 0)
+        # RPC handler wraps results as {"indexed": {path: count, ...}, ...}
+        if isinstance(results, dict) and "indexed" in results:
+            indexed_map = results["indexed"]
+            total_chunks = results.get("total_chunks", 0)
+            indexed = sum(1 for v in indexed_map.values() if isinstance(v, int) and v > 0)
+        else:
+            # Direct call (non-RPC) returns dict[str, int]
+            indexed_map = results
+            indexed = sum(1 for v in results.values() if isinstance(v, int) and v > 0)
+            total_chunks = sum(v for v in results.values() if isinstance(v, int) and v > 0)
         if indexed > 0:
-            logger.info("Semantic search: indexed %d files via real pipeline", indexed)
+            logger.info(
+                "Semantic search: indexed %d files (%d chunks) via real pipeline",
+                indexed,
+                total_chunks,
+            )
             manifest["semantic_engine"] = "vector"
             manifest["semantic_indexed_files"] = indexed
             return True

--- a/src/nexus/cli/commands/demo_data.py
+++ b/src/nexus/cli/commands/demo_data.py
@@ -485,13 +485,13 @@ DEMO_PERMISSION_TUPLES = [
     },
     {
         "subject": ["user", "demo_user"],
-        "relation": "viewer",
+        "relation": "direct_viewer",
         "object": ["file", "/workspace/demo"],
         "zone_id": "root",
     },
     {
         "subject": ["agent", "demo_agent"],
-        "relation": "editor",
+        "relation": "direct_editor",
         "object": ["file", "/workspace/demo"],
         "zone_id": "root",
     },

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -38,6 +38,7 @@ def register_commands(cli: click.Group) -> None:
     cli.add_command(move_cmd)
     cli.add_command(sync_cmd)
     cli.add_command(rm)
+    cli.add_command(edit)
 
 
 @click.command()
@@ -941,5 +942,107 @@ def rm(
         nx.close()
 
         console.print(f"[green]✓[/green] Deleted [cyan]{path}[/cyan]")
+    except Exception as e:
+        handle_error(e)
+
+
+@click.command()
+@click.argument("path", type=str)
+@click.argument("old_string", type=str)
+@click.argument("new_string", type=str)
+@click.option(
+    "--fuzzy",
+    type=float,
+    default=None,
+    help="Fuzzy matching threshold (0.0-1.0). Default: exact match only.",
+)
+@click.option(
+    "--if-match",
+    type=str,
+    default=None,
+    help="Only edit if current ETag matches (optimistic concurrency control).",
+)
+@click.option(
+    "--preview",
+    is_flag=True,
+    help="Show what would change without writing.",
+)
+@add_backend_options
+def edit(
+    path: str,
+    old_string: str,
+    new_string: str,
+    fuzzy: float | None,
+    if_match: str | None,
+    preview: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Surgical search-and-replace edit on a file.
+
+    Finds OLD_STRING in the file and replaces it with NEW_STRING.
+    Creates a new version on success. Supports exact, whitespace-normalized,
+    and fuzzy matching.
+
+    Examples:
+        # Exact replacement
+        nexus edit /workspace/doc.md "old text" "new text"
+
+        # Fuzzy match (tolerates typos, threshold 0.0-1.0)
+        nexus edit /workspace/doc.md "aproximate" "approximate" --fuzzy 0.8
+
+        # Preview changes without writing
+        nexus edit /workspace/doc.md "old" "new" --preview
+
+        # OCC: only edit if no one else modified the file
+        nexus edit /workspace/doc.md "old" "new" --if-match abc123
+    """
+    try:
+        nx = get_filesystem(remote_url, remote_api_key, allow_local_default=True)
+
+        kwargs: dict[str, Any] = {
+            "edits": [(old_string, new_string)],
+            "preview": preview,
+        }
+        if fuzzy is not None:
+            kwargs["fuzzy_threshold"] = fuzzy
+        if if_match is not None:
+            kwargs["if_match"] = if_match
+
+        result = nx.edit(path, **kwargs)
+        nx.close()
+
+        success = result.get("success", False)
+        applied = result.get("applied_count", 0)
+        diff = result.get("diff", "")
+        matches = result.get("matches", [])
+        etag = result.get("etag", "")
+
+        if preview:
+            if success and applied > 0:
+                console.print(f"[yellow]Preview:[/yellow] {applied} edit(s) would apply")
+                if diff:
+                    syntax = Syntax(diff, "diff", theme="monokai")
+                    console.print(syntax)
+            else:
+                console.print("[yellow]Preview:[/yellow] No matches found")
+            return
+
+        if success and applied > 0:
+            console.print(f"[green]✓[/green] {applied} edit(s) applied to [cyan]{path}[/cyan]")
+            if etag:
+                console.print(f"  [dim]etag: {etag}[/dim]")
+            for m in matches:
+                sim = m.get("similarity")
+                method = m.get("method", "exact")
+                if sim and sim < 1.0:
+                    console.print(f"  [dim]match: similarity={sim:.2f} ({method})[/dim]")
+            if diff:
+                syntax = Syntax(diff, "diff", theme="monokai")
+                console.print(syntax)
+        else:
+            console.print(f"[yellow]No matches found[/yellow] for the search string in {path}")
+            if fuzzy is None:
+                console.print("[dim]Hint: use --fuzzy 0.8 for approximate matching[/dim]")
     except Exception as e:
         handle_error(e)

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -422,12 +422,19 @@ def search_index(
 
         with console.status(f"[yellow]Indexing {path}...[/yellow]", spinner="dots"):
             search_svc = nx.service("search")
-            results: dict[str, int] = search_svc.semantic_search_index(path, recursive=recursive)
+            raw_results = search_svc.semantic_search_index(path, recursive=recursive)
+
+        # RPC handler wraps results as {"indexed": {path: count, ...}, ...}
+        if isinstance(raw_results, dict) and "indexed" in raw_results:
+            results = raw_results["indexed"]
+            total_chunks = raw_results.get("total_chunks", 0)
+        else:
+            results = raw_results
+            total_chunks = sum(v for v in results.values() if isinstance(v, int) and v > 0)
 
         # Display results
-        total_chunks = sum(v for v in results.values() if v > 0)
-        successful = sum(1 for v in results.values() if v > 0)
-        failed = sum(1 for v in results.values() if v < 0)
+        successful = sum(1 for v in results.values() if isinstance(v, int) and v > 0)
+        failed = sum(1 for v in results.values() if isinstance(v, int) and v < 0)
 
         console.print("\n[green]✓ Indexing complete![/green]")
         console.print(f"  Files indexed: [cyan]{successful}[/cyan]")

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -65,6 +65,7 @@ BRICK_DELEGATION = "delegation"
 BRICK_IDENTITY = "identity"
 BRICK_SHARE_LINK = "share_link"
 BRICK_VERSIONING = "versioning"
+BRICK_WORKSPACE = "workspace"
 
 # Cloud-only
 BRICK_FEDERATION = "federation"
@@ -99,6 +100,7 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_IDENTITY,
         BRICK_SHARE_LINK,
         BRICK_VERSIONING,
+        BRICK_WORKSPACE,
         BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
     }
@@ -195,6 +197,7 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
         BRICK_IDENTITY,
         BRICK_SHARE_LINK,
         BRICK_VERSIONING,
+        BRICK_WORKSPACE,
     }
 )
 

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -63,6 +63,8 @@ BRICK_ACCESS_MANIFEST = "access_manifest"
 BRICK_CATALOG = "catalog"
 BRICK_DELEGATION = "delegation"
 BRICK_IDENTITY = "identity"
+BRICK_SHARE_LINK = "share_link"
+BRICK_VERSIONING = "versioning"
 
 # Cloud-only
 BRICK_FEDERATION = "federation"
@@ -95,6 +97,8 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_CATALOG,
         BRICK_DELEGATION,
         BRICK_IDENTITY,
+        BRICK_SHARE_LINK,
+        BRICK_VERSIONING,
         BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
     }
@@ -189,6 +193,8 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
         BRICK_CATALOG,
         BRICK_DELEGATION,
         BRICK_IDENTITY,
+        BRICK_SHARE_LINK,
+        BRICK_VERSIONING,
     }
 )
 

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -60,6 +60,8 @@ BRICK_MCP = "mcp"
 BRICK_MEMORY = "memory"
 BRICK_SKILLS = "skills"
 BRICK_ACCESS_MANIFEST = "access_manifest"
+BRICK_CATALOG = "catalog"
+BRICK_DELEGATION = "delegation"
 
 # Cloud-only
 BRICK_FEDERATION = "federation"
@@ -89,6 +91,8 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_MEMORY,
         BRICK_SKILLS,
         BRICK_ACCESS_MANIFEST,
+        BRICK_CATALOG,
+        BRICK_DELEGATION,
         BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
     }
@@ -180,6 +184,8 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
         BRICK_UPLOADS,
         BRICK_RESILIENCY,
         BRICK_ACCESS_MANIFEST,
+        BRICK_CATALOG,
+        BRICK_DELEGATION,
     }
 )
 

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -66,6 +66,7 @@ BRICK_IDENTITY = "identity"
 BRICK_SHARE_LINK = "share_link"
 BRICK_VERSIONING = "versioning"
 BRICK_WORKSPACE = "workspace"
+BRICK_PORTABILITY = "portability"
 
 # Cloud-only
 BRICK_FEDERATION = "federation"
@@ -101,6 +102,7 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_SHARE_LINK,
         BRICK_VERSIONING,
         BRICK_WORKSPACE,
+        BRICK_PORTABILITY,
         BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
     }
@@ -198,6 +200,7 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
         BRICK_SHARE_LINK,
         BRICK_VERSIONING,
         BRICK_WORKSPACE,
+        BRICK_PORTABILITY,
     }
 )
 

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -62,6 +62,7 @@ BRICK_SKILLS = "skills"
 BRICK_ACCESS_MANIFEST = "access_manifest"
 BRICK_CATALOG = "catalog"
 BRICK_DELEGATION = "delegation"
+BRICK_IDENTITY = "identity"
 
 # Cloud-only
 BRICK_FEDERATION = "federation"
@@ -93,6 +94,7 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_ACCESS_MANIFEST,
         BRICK_CATALOG,
         BRICK_DELEGATION,
+        BRICK_IDENTITY,
         BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
     }
@@ -186,6 +188,7 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
         BRICK_ACCESS_MANIFEST,
         BRICK_CATALOG,
         BRICK_DELEGATION,
+        BRICK_IDENTITY,
     }
 )
 

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -67,6 +67,8 @@ BRICK_SHARE_LINK = "share_link"
 BRICK_VERSIONING = "versioning"
 BRICK_WORKSPACE = "workspace"
 BRICK_PORTABILITY = "portability"
+BRICK_PARSERS = "parsers"
+BRICK_SNAPSHOT = "snapshot"
 
 # Cloud-only
 BRICK_FEDERATION = "federation"
@@ -103,6 +105,8 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_VERSIONING,
         BRICK_WORKSPACE,
         BRICK_PORTABILITY,
+        BRICK_PARSERS,
+        BRICK_SNAPSHOT,
         BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
     }
@@ -201,6 +205,8 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
         BRICK_VERSIONING,
         BRICK_WORKSPACE,
         BRICK_PORTABILITY,
+        BRICK_PARSERS,
+        BRICK_SNAPSHOT,
     }
 )
 

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -59,6 +59,7 @@ BRICK_DISCOVERY = "discovery"
 BRICK_MCP = "mcp"
 BRICK_MEMORY = "memory"
 BRICK_SKILLS = "skills"
+BRICK_ACCESS_MANIFEST = "access_manifest"
 
 # Cloud-only
 BRICK_FEDERATION = "federation"
@@ -87,6 +88,7 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_MCP,
         BRICK_MEMORY,
         BRICK_SKILLS,
+        BRICK_ACCESS_MANIFEST,
         BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
     }
@@ -177,6 +179,7 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
         BRICK_OBSERVABILITY,
         BRICK_UPLOADS,
         BRICK_RESILIENCY,
+        BRICK_ACCESS_MANIFEST,
     }
 )
 

--- a/src/nexus/core/hash_fast.py
+++ b/src/nexus/core/hash_fast.py
@@ -44,7 +44,7 @@ except (ImportError, AttributeError):
     logger.info(
         "Optional Rust BLAKE3 extension not available; using Python blake3. "
         "Install with: pip install nexus-fast or, from a matching source "
-        "checkout in a Python 3.12+ environment, maturin develop --release "
+        "checkout in a Python 3.12+ environment, maturin develop "
         "-m rust/nexus_pyo3/Cargo.toml"
     )
 

--- a/src/nexus/lib/device_capabilities.py
+++ b/src/nexus/lib/device_capabilities.py
@@ -86,6 +86,17 @@ BRICK_REQUIREMENTS: dict[str, BrickRequirement] = {
     "agent_runtime": BrickRequirement(min_memory_mb=32),
     "permissions": BrickRequirement(min_memory_mb=32),
     "scheduler": BrickRequirement(min_memory_mb=32),
+    # Additional feature bricks
+    "access_manifest": BrickRequirement(min_memory_mb=32),
+    "catalog": BrickRequirement(min_memory_mb=64),
+    "delegation": BrickRequirement(min_memory_mb=32),
+    "identity": BrickRequirement(min_memory_mb=32),
+    "share_link": BrickRequirement(min_memory_mb=32),
+    "versioning": BrickRequirement(min_memory_mb=32),
+    "workspace": BrickRequirement(min_memory_mb=64),
+    "portability": BrickRequirement(min_memory_mb=64),
+    "parsers": BrickRequirement(min_memory_mb=128),
+    "snapshot": BrickRequirement(min_memory_mb=64),
     # Kernel (always on, listed for completeness)
     "storage": BrickRequirement(min_memory_mb=0),
 }

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -101,34 +101,56 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             if search_svc is not None:
                 search_svc._search_daemon = app.state.search_daemon
 
-        # Auto-index on write: register a VFS write hook that notifies the
-        # search daemon whenever a file is created or updated, so new content
-        # is searchable within the refresh debounce window (~5s).
+        # Auto-index on write/delete/rename: register VFS hooks that notify
+        # the search daemon so the index stays fresh automatically.
         with contextlib.suppress(AttributeError, ImportError):
             _daemon_ref = app.state.search_daemon
             _dispatch = getattr(svc.nexus_fs, "_dispatch", None)
             if _dispatch is not None:
-                from nexus.contracts.vfs_hooks import WriteHookContext
+                import asyncio as _asyncio
 
-                class _SearchIndexWriteHook:
-                    """Notify search daemon on file write for auto-indexing."""
+                from nexus.contracts.vfs_hooks import (
+                    DeleteHookContext,
+                    RenameHookContext,
+                    WriteHookContext,
+                )
 
+                def _notify(path: str, change_type: str) -> None:
+                    try:
+                        loop = _asyncio.get_running_loop()
+                        loop.create_task(_daemon_ref.notify_file_change(path, change_type))
+                    except RuntimeError:
+                        pass
+
+                class _SearchWriteHook:
                     @property
                     def name(self) -> str:
                         return "search_auto_index"
 
                     def on_post_write(self, ctx: WriteHookContext) -> None:
-                        import asyncio
+                        _notify(ctx.path, "update")
 
-                        path = ctx.path
-                        try:
-                            loop = asyncio.get_running_loop()
-                            loop.create_task(_daemon_ref.notify_file_change(path, "update"))
-                        except RuntimeError:
-                            pass  # No event loop — skip (e.g., sync test context)
+                class _SearchDeleteHook:
+                    @property
+                    def name(self) -> str:
+                        return "search_auto_delete"
 
-                _dispatch.register_intercept_write(_SearchIndexWriteHook())
-                logger.info("Search auto-index hook registered (write → daemon refresh)")
+                    def on_post_delete(self, ctx: DeleteHookContext) -> None:
+                        _notify(ctx.path, "delete")
+
+                class _SearchRenameHook:
+                    @property
+                    def name(self) -> str:
+                        return "search_auto_rename"
+
+                    def on_post_rename(self, ctx: RenameHookContext) -> None:
+                        _notify(ctx.old_path, "delete")
+                        _notify(ctx.new_path, "update")
+
+                _dispatch.register_intercept_write(_SearchWriteHook())
+                _dispatch.register_intercept_delete(_SearchDeleteHook())
+                _dispatch.register_intercept_rename(_SearchRenameHook())
+                logger.info("Search auto-index hooks registered (write/delete/rename)")
 
         # Issue #2036: Inject AdaptiveKProtocol (LEGO compliance)
         with contextlib.suppress(ImportError):

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -101,6 +101,35 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             if search_svc is not None:
                 search_svc._search_daemon = app.state.search_daemon
 
+        # Auto-index on write: register a VFS write hook that notifies the
+        # search daemon whenever a file is created or updated, so new content
+        # is searchable within the refresh debounce window (~5s).
+        with contextlib.suppress(AttributeError, ImportError):
+            _daemon_ref = app.state.search_daemon
+            _dispatch = getattr(svc.nexus_fs, "_dispatch", None)
+            if _dispatch is not None:
+                from nexus.contracts.vfs_hooks import WriteHookContext
+
+                class _SearchIndexWriteHook:
+                    """Notify search daemon on file write for auto-indexing."""
+
+                    @property
+                    def name(self) -> str:
+                        return "search_auto_index"
+
+                    def on_post_write(self, ctx: WriteHookContext) -> None:
+                        import asyncio
+
+                        path = ctx.path
+                        try:
+                            loop = asyncio.get_running_loop()
+                            loop.create_task(_daemon_ref.notify_file_change(path, "update"))
+                        except RuntimeError:
+                            pass  # No event loop — skip (e.g., sync test context)
+
+                _dispatch.register_intercept_write(_SearchIndexWriteHook())
+                logger.info("Search auto-index hook registered (write → daemon refresh)")
+
         # Issue #2036: Inject AdaptiveKProtocol (LEGO compliance)
         with contextlib.suppress(ImportError):
             from nexus.bricks.llm.llm_context_builder import ContextBuilder

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -94,6 +94,13 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
 
             app.state.search_daemon._file_reader = _NexusFSFileReader(svc.nexus_fs)
 
+        # Wire SearchDaemon into SearchService so semantic_search queries
+        # use the txtai backend instead of falling back to SQL ILIKE.
+        with contextlib.suppress(AttributeError):
+            search_svc = svc.nexus_fs.service("search")
+            if search_svc is not None:
+                search_svc._search_daemon = app.state.search_daemon
+
         # Issue #2036: Inject AdaptiveKProtocol (LEGO compliance)
         with contextlib.suppress(ImportError):
             from nexus.bricks.llm.llm_context_builder import ContextBuilder

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -435,29 +435,47 @@ def handle_search(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, A
 async def handle_semantic_search_index(
     nexus_fs: "NexusFS", params: Any, _context: Any
 ) -> dict[str, Any]:
-    """Handle semantic_search_index method."""
+    """Handle semantic_search_index method.
+
+    Routes indexing through the SearchDaemon's txtai backend (which uses
+    pgvector) so that indexed documents are immediately searchable.
+    Falls back to the SearchService pipeline if the daemon is unavailable.
+    """
     path = getattr(params, "path", "/")
     recursive = getattr(params, "recursive", True)
 
+    search = nexus_fs.service("search")
+    if search is None:
+        raise ValueError("SearchService required for semantic search")
+
+    # Index via SearchService pipeline (stores chunks in document_chunks table)
     try:
-        search = nexus_fs.service("search")
-        assert search is not None, "SearchService required for semantic search"
         await search.ainitialize_semantic_search(nx=nexus_fs, record_store_engine=None)
     except Exception as e:
-        raise ValueError(
-            f"Semantic search is not initialized and could not be auto-initialized: {e}"
-        ) from e
+        raise ValueError(f"Semantic search could not be initialized: {e}") from e
 
-    search = nexus_fs.service("search")
-    assert search is not None
     results = await search.semantic_search_index(path=path, recursive=recursive)
-
     total_chunks = 0
     for v in results.values():
         if isinstance(v, int):
             total_chunks += v
         elif isinstance(v, dict) and "chunks" in v:
             total_chunks += v["chunks"]
+
+    # Sync to SearchDaemon's live txtai index so queries find new documents
+    # immediately (the daemon's BM25/vector index is built at startup and
+    # won't include files indexed after boot without this refresh).
+    daemon = getattr(search, "_search_daemon", None)
+    if daemon is not None and getattr(daemon, "_backend", None) is not None:
+        indexed_paths = list(results.keys())
+        try:
+            await daemon._refresh_indexes(indexed_paths)
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).debug(
+                "Daemon index refresh failed for %d paths", len(indexed_paths), exc_info=True
+            )
 
     return {"indexed": results, "total_files": len(results), "total_chunks": total_chunks}
 

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -460,6 +460,9 @@ async def handle_semantic_search_index(
         context = _context
         zone_id = getattr(context, "zone_id", None) or "root"
 
+        # RPC may scope paths as /zone/{id}/...; DB stores unscoped virtual_path.
+        db_path = unscope_internal_path(path)
+
         # Query file paths from the daemon's database connection
         paths_to_index: list[str] = []
         if hasattr(daemon, "_async_session") and daemon._async_session is not None:
@@ -468,22 +471,25 @@ async def handle_semantic_search_index(
             async with daemon._async_session() as sess:
                 if recursive:
                     # Match both the path itself (single file) and children (directory)
-                    like_pattern = path.rstrip("/") + "/%"
+                    like_pattern = db_path.rstrip("/") + "/%"
                     result = await sess.execute(
                         sa_text(
                             "SELECT virtual_path FROM file_paths"
                             " WHERE virtual_path LIKE :like OR virtual_path = :exact"
                         ),
-                        {"like": like_pattern, "exact": path},
+                        {"like": like_pattern, "exact": db_path},
                     )
                     paths_to_index = [r[0] for r in result.fetchall()]
                 else:
-                    paths_to_index = [path]
-            _log.info("semantic_search_index: found %d files under %s", len(paths_to_index), path)
+                    paths_to_index = [db_path]
+            _log.info(
+                "semantic_search_index: found %d files under %s", len(paths_to_index), db_path
+            )
 
         # Read content and build documents for txtai
         documents: list[dict[str, Any]] = []
         read_errors = 0
+        total_chunks = 0
         for file_path in paths_to_index:
             try:
                 content = nexus_fs.sys_read(file_path, context=context)
@@ -502,13 +508,18 @@ async def handle_semantic_search_index(
         )
 
         # Single upsert to txtai → pgvector (BM25 + dense embeddings + SPLADE)
-        indexed = 0
         if documents:
-            indexed = await daemon.index_documents(documents, zone_id=zone_id)
-            _log.info("semantic_search_index: txtai indexed %d documents", indexed)
+            await daemon.index_documents(documents, zone_id=zone_id)
+            # txtai treats each document as one indexing unit; estimate chunks
+            # from content length (avg ~512 tokens/chunk) for accurate stats.
+            for doc in documents:
+                total_chunks += max(1, len(doc["text"]) // 2000)
+            _log.info(
+                "semantic_search_index: indexed %d docs (~%d chunks)", len(documents), total_chunks
+            )
 
-        results = {doc["path"]: 1 for doc in documents}
-        return {"indexed": results, "total_files": len(results), "total_chunks": indexed}
+        results = {doc["path"]: total_chunks // max(len(documents), 1) for doc in documents}
+        return {"indexed": results, "total_files": len(documents), "total_chunks": total_chunks}
 
     # Fallback: SearchService pipeline (when daemon is unavailable)
     try:

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -508,17 +508,18 @@ async def handle_semantic_search_index(
         )
 
         # Single upsert to txtai → pgvector (BM25 + dense embeddings + SPLADE)
+        results: dict[str, int] = {}
         if documents:
             await daemon.index_documents(documents, zone_id=zone_id)
-            # txtai treats each document as one indexing unit; estimate chunks
-            # from content length (avg ~512 tokens/chunk) for accurate stats.
+            # Estimate per-file chunk counts from content length (~2KB/chunk)
             for doc in documents:
-                total_chunks += max(1, len(doc["text"]) // 2000)
+                chunks = max(1, len(doc["text"]) // 2000)
+                results[doc["path"]] = chunks
+                total_chunks += chunks
             _log.info(
                 "semantic_search_index: indexed %d docs (~%d chunks)", len(documents), total_chunks
             )
 
-        results = {doc["path"]: total_chunks // max(len(documents), 1) for doc in documents}
         return {"indexed": results, "total_files": len(documents), "total_chunks": total_chunks}
 
     # Fallback: SearchService pipeline (when daemon is unavailable)

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -534,6 +534,7 @@ async def handle_semantic_search(nexus_fs: "NexusFS", params: Any, _context: Any
         path=getattr(params, "path", "/"),
         limit=getattr(params, "limit", 10),
         search_mode=getattr(params, "search_mode", "semantic"),
+        context=_context,
         adaptive_k=getattr(params, "adaptive_k", False),
     )
     return {"results": results}

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -435,12 +435,18 @@ def handle_search(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, A
 async def handle_semantic_search_index(
     nexus_fs: "NexusFS", params: Any, _context: Any
 ) -> dict[str, Any]:
-    """Handle semantic_search_index method.
+    """Index documents for semantic search via the SearchDaemon's txtai backend.
 
-    Routes indexing through the SearchDaemon's txtai backend (which uses
-    pgvector) so that indexed documents are immediately searchable.
+    Single indexing path: reads files via NexusFS, upserts through the daemon's
+    txtai backend which stores embeddings + BM25 tokens in pgvector. No separate
+    document_chunks table needed — txtai is the single source of truth.
+
     Falls back to the SearchService pipeline if the daemon is unavailable.
     """
+    import logging as _logging
+
+    _log = _logging.getLogger(__name__)
+
     path = getattr(params, "path", "/")
     recursive = getattr(params, "recursive", True)
 
@@ -448,7 +454,60 @@ async def handle_semantic_search_index(
     if search is None:
         raise ValueError("SearchService required for semantic search")
 
-    # Index via SearchService pipeline (stores chunks in document_chunks table)
+    # Prefer single-path indexing through the SearchDaemon's txtai backend.
+    daemon = getattr(search, "_search_daemon", None)
+    if daemon is not None and getattr(daemon, "_backend", None) is not None:
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        context = _context
+
+        # Query file paths from the daemon's database connection
+        paths_to_index: list[str] = []
+        if hasattr(daemon, "_async_session") and daemon._async_session is not None:
+            from sqlalchemy import text as sa_text
+
+            like_pattern = path.rstrip("/") + "/%" if recursive else path
+            async with daemon._async_session() as sess:
+                if recursive:
+                    result = await sess.execute(
+                        sa_text("SELECT virtual_path FROM file_paths WHERE virtual_path LIKE :p"),
+                        {"p": like_pattern},
+                    )
+                    paths_to_index = [r[0] for r in result.fetchall()]
+                else:
+                    paths_to_index = [path]
+            _log.info("semantic_search_index: found %d files under %s", len(paths_to_index), path)
+
+        # Read content and build documents for txtai
+        documents: list[dict[str, Any]] = []
+        read_errors = 0
+        for file_path in paths_to_index:
+            try:
+                content = nexus_fs.sys_read(file_path, context=context)
+                if isinstance(content, bytes):
+                    content_str = content.decode("utf-8", errors="replace")
+                else:
+                    content_str = content
+                if content_str.strip():
+                    documents.append({"id": file_path, "text": content_str, "path": file_path})
+            except Exception as read_err:
+                read_errors += 1
+                _log.warning("Skipping %s: %s", file_path, read_err)
+
+        _log.info(
+            "semantic_search_index: %d documents read (%d errors)", len(documents), read_errors
+        )
+
+        # Single upsert to txtai → pgvector (BM25 + dense embeddings + SPLADE)
+        indexed = 0
+        if documents:
+            indexed = await daemon.index_documents(documents, zone_id=ROOT_ZONE_ID)
+            _log.info("semantic_search_index: txtai indexed %d documents", indexed)
+
+        results = {doc["path"]: 1 for doc in documents}
+        return {"indexed": results, "total_files": len(results), "total_chunks": indexed}
+
+    # Fallback: SearchService pipeline (when daemon is unavailable)
     try:
         await search.ainitialize_semantic_search(nx=nexus_fs, record_store_engine=None)
     except Exception as e:
@@ -461,22 +520,6 @@ async def handle_semantic_search_index(
             total_chunks += v
         elif isinstance(v, dict) and "chunks" in v:
             total_chunks += v["chunks"]
-
-    # Sync to SearchDaemon's live txtai index so queries find new documents
-    # immediately (the daemon's BM25/vector index is built at startup and
-    # won't include files indexed after boot without this refresh).
-    daemon = getattr(search, "_search_daemon", None)
-    if daemon is not None and getattr(daemon, "_backend", None) is not None:
-        indexed_paths = list(results.keys())
-        try:
-            await daemon._refresh_indexes(indexed_paths)
-        except Exception:
-            import logging
-
-            logging.getLogger(__name__).debug(
-                "Daemon index refresh failed for %d paths", len(indexed_paths), exc_info=True
-            )
-
     return {"indexed": results, "total_files": len(results), "total_chunks": total_chunks}
 
 

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -498,7 +498,8 @@ async def handle_semantic_search_index(
                 else:
                     content_str = content
                 if content_str.strip():
-                    documents.append({"id": file_path, "text": content_str, "path": file_path})
+                    doc_id = f"{zone_id}:{file_path}" if zone_id != "root" else file_path
+                    documents.append({"id": doc_id, "text": content_str, "path": file_path})
             except Exception as read_err:
                 read_errors += 1
                 _log.warning("Skipping %s: %s", file_path, read_err)

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -457,21 +457,24 @@ async def handle_semantic_search_index(
     # Prefer single-path indexing through the SearchDaemon's txtai backend.
     daemon = getattr(search, "_search_daemon", None)
     if daemon is not None and getattr(daemon, "_backend", None) is not None:
-        from nexus.contracts.constants import ROOT_ZONE_ID
-
         context = _context
+        zone_id = getattr(context, "zone_id", None) or "root"
 
         # Query file paths from the daemon's database connection
         paths_to_index: list[str] = []
         if hasattr(daemon, "_async_session") and daemon._async_session is not None:
             from sqlalchemy import text as sa_text
 
-            like_pattern = path.rstrip("/") + "/%" if recursive else path
             async with daemon._async_session() as sess:
                 if recursive:
+                    # Match both the path itself (single file) and children (directory)
+                    like_pattern = path.rstrip("/") + "/%"
                     result = await sess.execute(
-                        sa_text("SELECT virtual_path FROM file_paths WHERE virtual_path LIKE :p"),
-                        {"p": like_pattern},
+                        sa_text(
+                            "SELECT virtual_path FROM file_paths"
+                            " WHERE virtual_path LIKE :like OR virtual_path = :exact"
+                        ),
+                        {"like": like_pattern, "exact": path},
                     )
                     paths_to_index = [r[0] for r in result.fetchall()]
                 else:
@@ -501,7 +504,7 @@ async def handle_semantic_search_index(
         # Single upsert to txtai → pgvector (BM25 + dense embeddings + SPLADE)
         indexed = 0
         if documents:
-            indexed = await daemon.index_documents(documents, zone_id=ROOT_ZONE_ID)
+            indexed = await daemon.index_documents(documents, zone_id=zone_id)
             _log.info("semantic_search_index: txtai indexed %d documents", indexed)
 
         results = {doc["path"]: 1 for doc in documents}


### PR DESCRIPTION
## Summary

Closes #2965

Comprehensive build performance optimization across Docker, Cargo, and CI pipelines.

### Dockerfile restructuring
- **Separate Zoekt build stage** — Go/Zoekt compiled in independent `zoekt-builder` stage with its own cache; Python/Rust changes no longer trigger Go rebuilds
- **Split 3rd-party dep install from source install** — Python-only changes no longer re-download all dependencies (FastAPI, SQLAlchemy, litellm, numpy, etc.). Uses a minimal `__init__.py` stub so setuptools can discover the package during metadata-only install
- **BuildKit cache mounts** — Added `--mount=type=cache` for uv, pip, cargo registry, cargo git, and cargo target directories
- **Shared `CARGO_TARGET_DIR`** — Both Rust crates (nexus_pyo3 + nexus_raft) share compiled workspace deps, merged into single RUN
- **DRYed China mirror logic** — Pip index URL computed once, read everywhere (was repeated 3x)
- **Merged verification RUNs** — 5 separate `RUN python3 -c "import ..."` → 1 layer

### Cargo profiles
- **New `[profile.dev]`** with `opt-level=1`, `debug="line-tables-only"`, `incremental=true`, and `opt-level=2` for dependencies
- **Thin LTO** — Changed `[profile.release]` from `lto = true` (fat) to `lto = "thin"` (~95% of fat LTO's benefit at ~50% link time)

### CI (test.yml)
- **Build once, share everywhere** — New `build-rust` job builds all 3 Rust extensions once per OS, uploads wheel artifacts. All 6 test/e2e jobs download and `pip install` pre-built wheels instead of compiling independently
- **Reusable composite action** — `.github/actions/build-rust-extensions/action.yml` encapsulates Rust toolchain setup, caching, and maturin builds in one definition

### CI (benchmark.yml)
- **Added missing `Swatinem/rust-cache`** — Was completely absent from both benchmark jobs
- Uses composite action for consistency with test workflow

### New files
- `.github/workflows/docker-build.yml` — Docker build smoke test (path-filtered on Dockerfile/Cargo/pyproject changes)
- `docs/contributing/build-performance.md` — macOS optimization guide (XProtect, Spotlight, OrbStack, sccache, lld)

### Bug fixes
- Fixed all `rust/nexus_fast` → `rust/nexus_pyo3` path references (15+ locations across Python source, docs, pre-commit config, scripts)
- Updated error messages and docs to recommend `maturin develop` (dev profile) instead of `maturin develop --release`

## Local validation

| Build | Time | Notes |
|-------|------|-------|
| Cold dev build (nexus_pyo3) | **23s** | First build, compiles all deps |
| Cold release build (nexus_pyo3) | **19s** | With `lto = "thin"` |
| Incremental dev rebuild (1 file changed) | **~1s** | Only recompiles changed crate |
| Fully cached dev build | **~1s** | Near-instant |
| Wheel install + import verification | **pass** | Both nexus_fast and nexus_raft |

## Expected CI impact
- Docker rebuild (Python-only change): **~10 min → ~30s**
- CI total Rust build time: **~40 min → ~8 min** (1 build instead of 6)
- Local dev iteration: **~5 min → ~1s** (dev profile + incremental)
- Benchmark CI: **~5 min saved** per run (Rust caching added)

## Test plan
- [ ] CI `test.yml` passes — all test/e2e jobs successfully download and use pre-built wheels
- [ ] CI `benchmark.yml` passes — Rust cache warms correctly
- [ ] CI `docker-build.yml` passes — Dockerfile builds successfully in CI
- [ ] CI `lint.yml` passes — no regressions from path/string changes
- [ ] Verify wheel artifacts are correctly shared between build-rust and downstream jobs
- [ ] Verify dev-profile extensions produce correct test results (unit + e2e)