### PR TITLE
Accept semantic_search in config features

### DIFF
--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -73,6 +73,10 @@ class FeaturesConfig(BaseModel):
 
     # Feature bricks
     search: bool | None = Field(default=None, description="Enable search brick")
+    semantic_search: bool | None = Field(
+        default=None,
+        description="Enable semantic search initialization/config wiring",
+    )
     pay: bool | None = Field(default=None, description="Enable payment brick")
     llm: bool | None = Field(default=None, description="Enable LLM brick")
     skills: bool | None = Field(default=None, description="Enable skills brick")
@@ -94,6 +98,8 @@ class FeaturesConfig(BaseModel):
         """
         overrides: dict[str, bool] = {}
         for field_name, value in self:
+            if field_name == "semantic_search":
+                continue
             if value is not None:
                 overrides[field_name] = value
         return overrides

--- a/tests/unit/core/test_deployment_profile.py
+++ b/tests/unit/core/test_deployment_profile.py
@@ -218,6 +218,13 @@ class TestFeaturesConfigOverrides:
         overrides = fc.to_overrides()
         assert overrides == {"search": True, "pay": False}
 
+    def test_semantic_search_is_config_only_not_brick_override(self) -> None:
+        from nexus.config import FeaturesConfig
+
+        fc = FeaturesConfig(search=True, semantic_search=True)
+        overrides = fc.to_overrides()
+        assert overrides == {"search": True}
+
     def test_overrides_integrate_with_resolve(self) -> None:
         from nexus.config import FeaturesConfig
 
@@ -253,3 +260,10 @@ class TestNexusConfigProfile:
 
         with pytest.raises(ValueError, match="profile must be one of"):
             NexusConfig(profile="invalid")
+
+    def test_semantic_search_feature_flag_is_accepted(self) -> None:
+        from nexus.config import NexusConfig
+
+        cfg = NexusConfig(features={"semantic_search": True, "search": True})
+        assert cfg.features.semantic_search is True
+        assert cfg.features.search is True


### PR DESCRIPTION
## Summary
- accept `features.semantic_search` in `NexusConfig`
- treat it as config-only wiring, not a brick override
- add regression coverage for config parsing and override behavior

## Problem
`dockerfiles/docker-entrypoint.sh` and bundled configs already use `features.semantic_search`, but `FeaturesConfig` rejected that field with `extra_forbidden`. That breaks source-backed deployments that explicitly enable semantic search in YAML.

## Changes
- add `semantic_search` to `FeaturesConfig`
- exclude it from `to_overrides()` so it does not flow into `resolve_enabled_bricks`
- add tests covering both config acceptance and override filtering

## Validation
```bash
uv run pytest -o addopts= tests/unit/core/test_deployment_profile.py -q
```

Closes #2968
