### PR TITLE
Fix semantic-search init bootstrap script

### DIFF
--- a/scripts/init_semantic_search.py
+++ b/scripts/init_semantic_search.py
@@ -26,9 +26,7 @@ script_dir = Path(__file__).parent
 src_dir = script_dir.parent / "src"
 sys.path.insert(0, str(src_dir))
 
-from nexus.backends.storage.cas_local import CASLocalBackend  # noqa: E402
-from nexus.core.nexus_fs import NexusFS  # noqa: E402
-from nexus.storage.raft_metadata_store import RaftMetadataStore  # noqa: E402
+from nexus import connect  # noqa: E402
 
 
 async def init_semantic_search() -> bool:
@@ -46,9 +44,25 @@ async def init_semantic_search() -> bool:
             print("ERROR: NEXUS_DATABASE_URL is required", file=sys.stderr)
             return False
 
-        backend = CASLocalBackend(data_dir)
-        metadata_store = RaftMetadataStore.embedded(str(database_url).replace(".db", ""))
-        nx = NexusFS(backend, metadata_store=metadata_store)
+        config_file = os.getenv("NEXUS_CONFIG_FILE")
+        if config_file and Path(config_file).exists():
+            nx = connect(config=config_file)
+        else:
+            nx = connect(
+                config={
+                    "profile": "full",
+                    "backend": "local",
+                    "data_dir": data_dir,
+                    "database": {"url": database_url},
+                    "features": {"search": True},
+                }
+            )
+
+        search = nx.service("search")
+        if search is None:
+            print("ERROR: Search service is not available", file=sys.stderr)
+            nx.close()
+            return False
 
         # Check if explicitly requested to use vector embeddings
         # Default: keyword-only mode (safer, more stable)
@@ -58,7 +72,9 @@ async def init_semantic_search() -> bool:
             # Only use embeddings if explicitly requested
             openai_api_key = os.getenv("OPENAI_API_KEY")
             if openai_api_key and openai_api_key != "your-openai-api-key":
-                await nx.initialize_semantic_search(
+                await search.ainitialize_semantic_search(
+                    nx=nx,
+                    record_store_engine=None,
                     embedding_provider="openai",
                     api_key=openai_api_key,
                     chunk_size=512,
@@ -74,7 +90,9 @@ async def init_semantic_search() -> bool:
                     file=sys.stderr,
                 )
                 print("Falling back to keyword-only mode", file=sys.stderr)
-                await nx.initialize_semantic_search(
+                await search.ainitialize_semantic_search(
+                    nx=nx,
+                    record_store_engine=None,
                     embedding_provider=None,
                     chunk_size=512,
                     chunk_strategy="semantic",
@@ -82,7 +100,9 @@ async def init_semantic_search() -> bool:
                 print("✓ Semantic search initialized (keyword-only mode)", file=sys.stderr)
         else:
             # Default: keyword-only mode (PostgreSQL FTS)
-            await nx.initialize_semantic_search(
+            await search.ainitialize_semantic_search(
+                nx=nx,
+                record_store_engine=None,
                 embedding_provider=None,
                 chunk_size=512,
                 chunk_strategy="semantic",

--- a/scripts/init_semantic_search.py
+++ b/scripts/init_semantic_search.py
@@ -53,7 +53,6 @@ async def init_semantic_search() -> bool:
                     "profile": "full",
                     "backend": "local",
                     "data_dir": data_dir,
-                    "database": {"url": database_url},
                     "features": {"search": True},
                 }
             )

--- a/tests/unit/scripts/test_init_semantic_search.py
+++ b/tests/unit/scripts/test_init_semantic_search.py
@@ -73,3 +73,30 @@ def test_init_semantic_search_fails_when_search_service_missing(monkeypatch) -> 
 
     assert asyncio.run(module.init_semantic_search()) is False
     assert fake_nx.closed is True
+
+
+def test_init_semantic_search_inline_config_relies_on_env_database_url(monkeypatch) -> None:
+    module = _load_module()
+    fake_search = _FakeSearch()
+    fake_nx = _FakeNx(fake_search)
+    captured: dict[str, object] = {}
+
+    def fake_connect(*, config=None):
+        captured["config"] = config
+        return fake_nx
+
+    monkeypatch.setattr(module, "connect", fake_connect)
+    monkeypatch.setenv("NEXUS_DATABASE_URL", "postgresql://skillhub:skillhub@db:5432/nexus")
+    monkeypatch.setenv("NEXUS_DATA_DIR", "/tmp/nexus-data")
+    monkeypatch.delenv("NEXUS_CONFIG_FILE", raising=False)
+
+    assert asyncio.run(module.init_semantic_search()) is True
+    assert captured["config"] == {
+        "profile": "full",
+        "backend": "local",
+        "data_dir": "/tmp/nexus-data",
+        "features": {"search": True},
+    }
+    assert fake_search.calls[0]["nx"] is fake_nx
+    assert fake_search.calls[0]["record_store_engine"] is None
+    assert fake_nx.closed is True

--- a/tests/unit/scripts/test_init_semantic_search.py
+++ b/tests/unit/scripts/test_init_semantic_search.py
@@ -1,0 +1,75 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[3] / "scripts" / "init_semantic_search.py"
+    spec = importlib.util.spec_from_file_location("init_semantic_search_script", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeSearch:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def ainitialize_semantic_search(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class _FakeNx:
+    def __init__(self, search) -> None:
+        self._search = search
+        self.closed = False
+
+    def service(self, name: str):
+        if name == "search":
+            return self._search
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_init_semantic_search_uses_configured_connect(monkeypatch, tmp_path) -> None:
+    module = _load_module()
+    fake_search = _FakeSearch()
+    fake_nx = _FakeNx(fake_search)
+    captured: dict[str, object] = {}
+
+    def fake_connect(*, config=None):
+        captured["config"] = config
+        return fake_nx
+
+    config_file = tmp_path / "nexus.yaml"
+    config_file.write_text("profile: full\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "connect", fake_connect)
+    monkeypatch.setenv("NEXUS_DATABASE_URL", "postgresql://skillhub:skillhub@db:5432/nexus")
+    monkeypatch.setenv("NEXUS_DATA_DIR", "/tmp/nexus-data")
+    monkeypatch.setenv("NEXUS_CONFIG_FILE", str(config_file))
+
+    assert asyncio.run(module.init_semantic_search()) is True
+    assert captured["config"] == str(config_file)
+    assert fake_search.calls[0]["nx"] is fake_nx
+    assert fake_search.calls[0]["record_store_engine"] is None
+    assert fake_search.calls[0]["embedding_provider"] is None
+    assert fake_nx.closed is True
+
+
+def test_init_semantic_search_fails_when_search_service_missing(monkeypatch) -> None:
+    module = _load_module()
+    fake_nx = _FakeNx(search=None)
+
+    def fake_connect(*, config=None):
+        return fake_nx
+
+    monkeypatch.setattr(module, "connect", fake_connect)
+    monkeypatch.setenv("NEXUS_DATABASE_URL", "postgresql://skillhub:skillhub@db:5432/nexus")
+    monkeypatch.delenv("NEXUS_CONFIG_FILE", raising=False)
+
+    assert asyncio.run(module.init_semantic_search()) is False
+    assert fake_nx.closed is True


### PR DESCRIPTION
## Summary
- replace the stale manual `NexusFS` bootstrap path in `scripts/init_semantic_search.py`
- initialize semantic search through `nexus.connect(...)` and `nx.service("search")`
- add a regression test for both the config-file path and missing-search-service failure mode

## Problem
`scripts/init_semantic_search.py` still manually constructs `NexusFS` with `CASLocalBackend` and `RaftMetadataStore`, then calls the old initialization path. On current `develop`, source-backed deployments can fail startup with:

```text
NexusFS.__init__() got multiple values for argument metadata_store
```

That leaves semantic-search initialization broken during container entrypoint boot.

## Fix
- respect `NEXUS_CONFIG_FILE` when present
- otherwise bootstrap Nexus through `connect(config=...)`
- resolve the search service via `nx.service("search")`
- call `search.ainitialize_semantic_search(...)` using the supported service API

## Testing
```bash
uv run pytest -o addopts= tests/unit/scripts/test_init_semantic_search.py tests/unit/core/test_deployment_profile.py -q
```

Closes #2970
