### PR TITLE
feat(#2978): async-on-write extraction, Avro support, and document metadata aspects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           SUFFIX="${{ matrix.suffix }}"
-          echo "tags=ghcr.io/nexi-lab/nexus:${VERSION}${SUFFIX},ghcr.io/nexi-lab/nexus:latest${SUFFIX}" >> "$GITHUB_OUTPUT"
+          echo "tags=ghcr.io/nexi-lab/nexus:${VERSION}${SUFFIX},ghcr.io/nexi-lab/nexus:stable${SUFFIX},ghcr.io/nexi-lab/nexus:latest${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Build image (local load for smoke tests)
         uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -79,24 +79,26 @@ nexus ls /workspace
 The prebuilt multi-arch image (amd64 + arm64) is published to GHCR:
 
 ```
-ghcr.io/nexi-lab/nexus:latest        # Latest stable release
-ghcr.io/nexi-lab/nexus:<version>     # Pinned to a specific release
-ghcr.io/nexi-lab/nexus:<version>-cuda # GPU-accelerated variant
-ghcr.io/nexi-lab/nexus:edge          # Pre-release (develop branch)
+ghcr.io/nexi-lab/nexus:stable        # Latest release (updated on every tag)
+ghcr.io/nexi-lab/nexus:edge          # Latest develop (updated on every push)
+ghcr.io/nexi-lab/nexus:<version>     # Pinned to a specific release (e.g. 0.9.2)
+ghcr.io/nexi-lab/nexus:<tag>-cuda    # GPU-accelerated variant (stable-cuda, edge-cuda, etc.)
 ```
 
-`nexus init` resolves and pins a full image reference (`image_ref`) into `nexus.yaml`.
-The default channel is `stable`, which queries GHCR for the latest release (falls back to the installed CLI version if offline).
-Override during init:
+`nexus init` writes an `image_ref` into `nexus.yaml` based on the selected channel.
+The default channel is `stable`. Override during init:
 
 ```bash
-nexus init --preset shared --channel edge          # pre-release channel
-nexus init --preset shared --image-tag 0.9.2       # explicit version
-nexus init --preset shared --accelerator cuda       # GPU variant
-nexus init --preset shared --image-digest sha256:...  # immutable digest
+nexus init --preset shared                           # stable channel (default)
+nexus init --preset shared --channel edge            # pre-release channel
+nexus init --preset shared --image-tag 0.9.2         # pin to exact version
+nexus init --preset shared --accelerator cuda        # GPU variant
+nexus init --preset shared --image-digest sha256:... # immutable digest
 ```
 
-To upgrade the pinned image later, use `nexus upgrade`. To build locally from source instead of pulling, pass `--build` to `nexus up`.
+`nexus up` auto-pulls the latest image for channel-following configs (`stable`/`edge`).
+To pull the latest release explicitly, run `nexus upgrade`.
+To build from local source (repo checkouts only), pass `--build` to `nexus up` or `nexus restart`.
 
 ## Optional Capabilities
 

--- a/src/nexus/bricks/catalog/extractors.py
+++ b/src/nexus/bricks/catalog/extractors.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
@@ -43,6 +44,26 @@ class ExtractionResult:
     error: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class DocumentExtractionResult:
+    """Result of a document structure extraction attempt.
+
+    Unlike ExtractionResult (tabular schema), this captures document-level
+    structure: headings, front matter, code blocks, etc.
+    """
+
+    title: str | None
+    headings: list[dict[str, Any]]
+    front_matter: dict[str, Any] | None
+    word_count: int
+    link_count: int
+    code_languages: list[str]
+    format: str
+    confidence: float
+    warnings: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
 class SchemaExtractor(Protocol):
     """Protocol for format-specific schema extractors."""
 
@@ -54,12 +75,29 @@ class SchemaExtractor(Protocol):
         ...
 
 
+class DocumentExtractor(Protocol):
+    """Protocol for document structure extractors (Markdown, PDF, etc.)."""
+
+    mime_types: tuple[str, ...]
+    extensions: tuple[str, ...]
+
+    def extract(self, content: bytes) -> DocumentExtractionResult:
+        """Extract document structure from raw file content.
+
+        Must never raise. Return DocumentExtractionResult with error on failure.
+        """
+        ...
+
+
 class CSVExtractor:
     """CSV/TSV schema extractor with bounded row reading.
 
     Reads at most ``max_rows`` rows for type inference. Confidence
     reflects sample coverage.
     """
+
+    mime_types = ("text/csv", "application/csv")
+    extensions = ("csv", "tsv")
 
     def __init__(
         self,
@@ -171,6 +209,9 @@ class ParquetExtractor:
     since Parquet embeds the schema in the file footer.
     """
 
+    mime_types = ("application/parquet", "application/x-parquet")
+    extensions = ("parquet", "pq")
+
     def extract(self, content: bytes) -> ExtractionResult:
         """Extract schema from Parquet file content."""
         try:
@@ -231,6 +272,9 @@ class JSONExtractor:
     Infers schema from the first N bytes of JSON content. Supports
     both JSON arrays and newline-delimited JSON (NDJSON).
     """
+
+    mime_types = ("application/json", "text/json")
+    extensions = ("json", "jsonl", "ndjson")
 
     def __init__(
         self,
@@ -350,6 +394,377 @@ class JSONExtractor:
                 confidence=0.0,
                 error=f"JSON extraction failed: {e}",
             )
+
+
+class AvroExtractor:
+    """Avro schema extractor — reads header only (O(1)).
+
+    Avro stores its complete schema in the file header as JSON.
+    Extraction is always fast regardless of file size. Confidence
+    is always 1.0 since Avro embeds the native schema.
+    """
+
+    mime_types = ("application/avro", "application/x-avro")
+    extensions = ("avro",)
+
+    def extract(self, content: bytes) -> ExtractionResult:
+        """Extract schema from Avro file content."""
+        try:
+            import fastavro
+
+            buf = io.BytesIO(content)
+            try:
+                reader = fastavro.reader(buf)
+                avro_schema = reader.writer_schema
+            except Exception as e:
+                return ExtractionResult(
+                    schema=None,
+                    format="avro",
+                    confidence=0.0,
+                    error=f"Invalid Avro file: {e}",
+                )
+
+            if avro_schema is None:
+                return ExtractionResult(
+                    schema=None,
+                    format="avro",
+                    confidence=0.0,
+                    error="Avro file has no writer schema",
+                )
+
+            columns = _avro_schema_to_columns(avro_schema)
+
+            # Count rows (iterate without loading all into memory)
+            row_count = 0
+            try:
+                for _ in reader:
+                    row_count += 1
+            except Exception:
+                row_count = None  # Corrupted data section is OK — schema is valid
+
+            return ExtractionResult(
+                schema=columns,
+                format="avro",
+                confidence=1.0,
+                row_count=row_count,
+            )
+
+        except ImportError:
+            return ExtractionResult(
+                schema=None,
+                format="avro",
+                confidence=0.0,
+                error="fastavro not installed — cannot extract Avro schema",
+            )
+        except Exception as e:
+            return ExtractionResult(
+                schema=None,
+                format="avro",
+                confidence=0.0,
+                error=f"Avro extraction failed: {e}",
+            )
+
+    def extract_from_path(self, path: str) -> ExtractionResult:
+        """Extract schema from Avro file by path (header-only read)."""
+        try:
+            import fastavro
+
+            with open(path, "rb") as f:
+                reader = fastavro.reader(f)
+                avro_schema = reader.writer_schema
+
+                if avro_schema is None:
+                    return ExtractionResult(
+                        schema=None,
+                        format="avro",
+                        confidence=0.0,
+                        error="Avro file has no writer schema",
+                    )
+
+                columns = _avro_schema_to_columns(avro_schema)
+
+                row_count = 0
+                try:
+                    for _ in reader:
+                        row_count += 1
+                except Exception:
+                    row_count = None
+
+            return ExtractionResult(
+                schema=columns,
+                format="avro",
+                confidence=1.0,
+                row_count=row_count,
+            )
+
+        except ImportError:
+            return ExtractionResult(
+                schema=None,
+                format="avro",
+                confidence=0.0,
+                error="fastavro not installed — cannot extract Avro schema",
+            )
+        except Exception as e:
+            return ExtractionResult(
+                schema=None,
+                format="avro",
+                confidence=0.0,
+                error=f"Avro extraction failed: {e}",
+            )
+
+
+class MarkdownExtractor:
+    """Markdown document structure extractor.
+
+    Extracts headings, front matter, code blocks, and statistics.
+    Parses YAML front matter (--- delimiters) and ATX/Setext headings.
+    """
+
+    mime_types = ("text/markdown",)
+    extensions = ("md", "markdown")
+
+    def extract(self, content: bytes) -> DocumentExtractionResult:
+        """Extract document structure from Markdown content."""
+        try:
+            text = content.decode("utf-8", errors="replace")
+
+            if not text.strip():
+                return DocumentExtractionResult(
+                    title=None,
+                    headings=[],
+                    front_matter=None,
+                    word_count=0,
+                    link_count=0,
+                    code_languages=[],
+                    format="markdown",
+                    confidence=0.0,
+                    error="Empty Markdown file",
+                )
+
+            # Parse front matter
+            front_matter, body = _parse_front_matter(text)
+
+            # Parse headings (skip content inside code blocks)
+            headings = _extract_headings(body)
+
+            # Extract code block languages
+            code_languages = _extract_code_languages(body)
+
+            # Count words (excluding code blocks and front matter)
+            word_count = _count_words(body)
+
+            # Count links
+            link_count = _count_links(body)
+
+            # Derive title: front matter "title" key, or first H1
+            title = None
+            if front_matter and "title" in front_matter:
+                title = str(front_matter["title"])
+            elif headings:
+                for h in headings:
+                    if h["level"] == 1:
+                        title = h["text"]
+                        break
+
+            return DocumentExtractionResult(
+                title=title,
+                headings=headings,
+                front_matter=front_matter,
+                word_count=word_count,
+                link_count=link_count,
+                code_languages=code_languages,
+                format="markdown",
+                confidence=1.0,
+            )
+
+        except Exception as e:
+            return DocumentExtractionResult(
+                title=None,
+                headings=[],
+                front_matter=None,
+                word_count=0,
+                link_count=0,
+                code_languages=[],
+                format="markdown",
+                confidence=0.0,
+                error=f"Markdown extraction failed: {e}",
+            )
+
+
+# ============================================================================
+# Avro schema helpers
+# ============================================================================
+
+
+def _avro_type_to_str(avro_type: Any) -> str:
+    """Convert an Avro type to a string representation."""
+    if isinstance(avro_type, str):
+        return avro_type
+    if isinstance(avro_type, dict):
+        return avro_type.get("type", "unknown")
+    if isinstance(avro_type, list):
+        # Union type: filter out "null" and return the first non-null type
+        non_null = [t for t in avro_type if t != "null"]
+        if non_null:
+            return _avro_type_to_str(non_null[0])
+        return "null"
+    return "unknown"
+
+
+def _avro_schema_to_columns(schema: dict[str, Any]) -> list[dict[str, str]]:
+    """Convert an Avro schema to a list of column dicts."""
+    columns: list[dict[str, str]] = []
+    fields = schema.get("fields", [])
+
+    for field_def in fields:
+        name = field_def.get("name", "")
+        avro_type = field_def.get("type", "unknown")
+
+        # Detect nullable: union types containing "null"
+        nullable = False
+        if isinstance(avro_type, list) and "null" in avro_type:
+            nullable = True
+
+        columns.append(
+            {
+                "name": name,
+                "type": _avro_type_to_str(avro_type),
+                "nullable": str(nullable),
+            }
+        )
+
+    return columns
+
+
+# ============================================================================
+# Markdown parsing helpers
+# ============================================================================
+
+
+def _parse_front_matter(text: str) -> tuple[dict[str, Any] | None, str]:
+    """Parse YAML front matter from Markdown text.
+
+    Returns (front_matter_dict, remaining_body). Front matter values
+    are sanitized to JSON-safe primitives (strings, numbers, bools, lists).
+    """
+    if not text.startswith("---"):
+        return None, text
+
+    # Find closing ---
+    end_match = re.search(r"\n---\s*\n", text[3:])
+    if end_match is None:
+        return None, text
+
+    yaml_text = text[3 : 3 + end_match.start()]
+    body = text[3 + end_match.end() :]
+
+    try:
+        import yaml
+
+        raw = yaml.safe_load(yaml_text)
+        if not isinstance(raw, dict):
+            return None, text
+
+        # Sanitize to JSON-safe primitives
+        sanitized = _sanitize_front_matter(raw)
+        return sanitized, body
+    except Exception:
+        return None, text
+
+
+def _sanitize_front_matter(data: dict[str, Any]) -> dict[str, Any]:
+    """Sanitize front matter values to JSON-safe primitives."""
+    result: dict[str, Any] = {}
+    for key, value in data.items():
+        result[str(key)] = _sanitize_value(value)
+    return result
+
+
+def _sanitize_value(value: Any) -> Any:
+    """Convert a value to JSON-safe primitive."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return [_sanitize_value(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _sanitize_value(v) for k, v in value.items()}
+    # datetime, date, or other complex types → string
+    return str(value)
+
+
+def _extract_headings(text: str) -> list[dict[str, Any]]:
+    """Extract headings from Markdown body, skipping content in code blocks."""
+    lines = text.split("\n")
+    headings: list[dict[str, Any]] = []
+    in_code_block = False
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+
+        # Track fenced code blocks
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_code_block = not in_code_block
+            continue
+
+        if in_code_block:
+            continue
+
+        # ATX headings: # to ######
+        atx_match = re.match(r"^(#{1,6})\s+(.+?)(?:\s+#+)?$", line)
+        if atx_match:
+            headings.append(
+                {
+                    "level": len(atx_match.group(1)),
+                    "text": atx_match.group(2).strip(),
+                }
+            )
+            continue
+
+        # Setext headings: === (H1) or --- (H2)
+        if i > 0 and not in_code_block:
+            prev_line = lines[i - 1].strip()
+            if prev_line and stripped and re.match(r"^={3,}$", stripped):
+                headings.append({"level": 1, "text": prev_line})
+            elif (
+                prev_line
+                and stripped
+                and re.match(r"^-{3,}$", stripped)
+                and (i > 1 or not text.startswith("---"))
+            ):
+                headings.append({"level": 2, "text": prev_line})
+
+    return headings
+
+
+def _extract_code_languages(text: str) -> list[str]:
+    """Extract language annotations from fenced code blocks."""
+    languages: list[str] = []
+    for match in re.finditer(r"^```(\w+)", text, re.MULTILINE):
+        languages.append(match.group(1).lower())
+    for match in re.finditer(r"^~~~(\w+)", text, re.MULTILINE):
+        languages.append(match.group(1).lower())
+    return languages
+
+
+def _count_words(text: str) -> int:
+    """Count words in Markdown body, excluding code blocks."""
+    # Remove fenced code blocks
+    no_code = re.sub(r"```[\s\S]*?```", "", text)
+    no_code = re.sub(r"~~~[\s\S]*?~~~", "", no_code)
+    # Count whitespace-delimited tokens
+    words = no_code.split()
+    return len(words)
+
+
+def _count_links(text: str) -> int:
+    """Count Markdown links (both inline and reference-style)."""
+    # Inline links: [text](url)
+    inline = len(re.findall(r"\[.*?\]\(.*?\)", text))
+    # Reference links: [text][ref]
+    reference = len(re.findall(r"\[.*?\]\[.*?\]", text))
+    return inline + reference
 
 
 # ============================================================================

--- a/src/nexus/bricks/catalog/extractors.py
+++ b/src/nexus/bricks/catalog/extractors.py
@@ -432,21 +432,23 @@ class AvroExtractor:
                     error="Avro file has no writer schema",
                 )
 
+            if not isinstance(avro_schema, dict):
+                return ExtractionResult(
+                    schema=None,
+                    format="avro",
+                    confidence=0.0,
+                    error="Avro writer schema is not a record",
+                )
+
             columns = _avro_schema_to_columns(avro_schema)
 
-            # Count rows (iterate without loading all into memory)
-            row_count = 0
-            try:
-                for _ in reader:
-                    row_count += 1
-            except Exception:
-                row_count = None  # Corrupted data section is OK — schema is valid
-
+            # Avro does not store row count in the header — skip data
+            # section entirely to keep extraction O(1).
             return ExtractionResult(
                 schema=columns,
                 format="avro",
                 confidence=1.0,
-                row_count=row_count,
+                row_count=None,
             )
 
         except ImportError:
@@ -481,20 +483,21 @@ class AvroExtractor:
                         error="Avro file has no writer schema",
                     )
 
-                columns = _avro_schema_to_columns(avro_schema)
+                if not isinstance(avro_schema, dict):
+                    return ExtractionResult(
+                        schema=None,
+                        format="avro",
+                        confidence=0.0,
+                        error="Avro writer schema is not a record",
+                    )
 
-                row_count = 0
-                try:
-                    for _ in reader:
-                        row_count += 1
-                except Exception:
-                    row_count = None
+                columns = _avro_schema_to_columns(avro_schema)
 
             return ExtractionResult(
                 schema=columns,
                 format="avro",
                 confidence=1.0,
-                row_count=row_count,
+                row_count=None,
             )
 
         except ImportError:
@@ -601,7 +604,7 @@ def _avro_type_to_str(avro_type: Any) -> str:
     if isinstance(avro_type, str):
         return avro_type
     if isinstance(avro_type, dict):
-        return avro_type.get("type", "unknown")
+        return str(avro_type.get("type", "unknown"))
     if isinstance(avro_type, list):
         # Union type: filter out "null" and return the first non-null type
         non_null = [t for t in avro_type if t != "null"]

--- a/src/nexus/bricks/catalog/extractors.py
+++ b/src/nexus/bricks/catalog/extractors.py
@@ -67,6 +67,9 @@ class DocumentExtractionResult:
 class SchemaExtractor(Protocol):
     """Protocol for format-specific schema extractors."""
 
+    mime_types: tuple[str, ...]
+    extensions: tuple[str, ...]
+
     def extract(self, content: bytes) -> ExtractionResult:
         """Extract schema from raw file content.
 
@@ -96,8 +99,8 @@ class CSVExtractor:
     reflects sample coverage.
     """
 
-    mime_types = ("text/csv", "application/csv")
-    extensions = ("csv", "tsv")
+    mime_types: tuple[str, ...] = ("text/csv", "application/csv")
+    extensions: tuple[str, ...] = ("csv", "tsv")
 
     def __init__(
         self,
@@ -209,8 +212,8 @@ class ParquetExtractor:
     since Parquet embeds the schema in the file footer.
     """
 
-    mime_types = ("application/parquet", "application/x-parquet")
-    extensions = ("parquet", "pq")
+    mime_types: tuple[str, ...] = ("application/parquet", "application/x-parquet")
+    extensions: tuple[str, ...] = ("parquet", "pq")
 
     def extract(self, content: bytes) -> ExtractionResult:
         """Extract schema from Parquet file content."""
@@ -273,8 +276,8 @@ class JSONExtractor:
     both JSON arrays and newline-delimited JSON (NDJSON).
     """
 
-    mime_types = ("application/json", "text/json")
-    extensions = ("json", "jsonl", "ndjson")
+    mime_types: tuple[str, ...] = ("application/json", "text/json")
+    extensions: tuple[str, ...] = ("json", "jsonl", "ndjson")
 
     def __init__(
         self,
@@ -404,8 +407,8 @@ class AvroExtractor:
     is always 1.0 since Avro embeds the native schema.
     """
 
-    mime_types = ("application/avro", "application/x-avro")
-    extensions = ("avro",)
+    mime_types: tuple[str, ...] = ("application/avro", "application/x-avro")
+    extensions: tuple[str, ...] = ("avro",)
 
     def extract(self, content: bytes) -> ExtractionResult:
         """Extract schema from Avro file content."""
@@ -523,8 +526,8 @@ class MarkdownExtractor:
     Parses YAML front matter (--- delimiters) and ATX/Setext headings.
     """
 
-    mime_types = ("text/markdown",)
-    extensions = ("md", "markdown")
+    mime_types: tuple[str, ...] = ("text/markdown",)
+    extensions: tuple[str, ...] = ("md", "markdown")
 
     def extract(self, content: bytes) -> DocumentExtractionResult:
         """Extract document structure from Markdown content."""

--- a/src/nexus/bricks/catalog/protocol.py
+++ b/src/nexus/bricks/catalog/protocol.py
@@ -310,6 +310,10 @@ class CatalogService:
     ) -> ExtractionResult:
         """Extract schema using path-based I/O for header-only formats (Avro, Parquet).
 
+        ``path`` must be a real OS filesystem path (not a CAS content hash).
+        This method is for external callers with local files. Internal CAS-backed
+        paths (reindex, on-write hook) use content-based extract_auto() instead.
+
         Falls back to content-based extraction if the extractor doesn't
         support extract_from_path.
         """

--- a/src/nexus/bricks/catalog/protocol.py
+++ b/src/nexus/bricks/catalog/protocol.py
@@ -1,29 +1,44 @@
-"""Catalog protocol and service — schema extraction pipeline (Issue #2929).
+"""Catalog protocol and service — schema + document extraction pipeline.
 
 CatalogService receives AspectServiceProtocol via constructor injection
 (zero core imports). Extractors return ExtractionResult (never raise).
 
-Architecture:
+Architecture (Issue #2929, #2978):
     CatalogService.extract_schema(urn, content, mime_type)
-        → detect extractor by mime_type
+        → detect schema extractor by mime_type
         → extractor.extract(content) → ExtractionResult
         → store as schema_metadata aspect if confidence > threshold
+
+    CatalogService.extract_document(urn, content, mime_type)
+        → detect document extractor by mime_type
+        → extractor.extract(content) → DocumentExtractionResult
+        → store as document_structure aspect if confidence > threshold
+
+    CatalogService.extract_auto(urn, content, mime_type, filename)
+        → detect schema or document extractor, call the right method
+
+Self-registering extractors (Issue #2978): each extractor declares
+mime_types and extensions as class attributes. CatalogService builds
+its registries from these, eliminating dual-dict maintenance.
 """
 
 import logging
 from typing import Any, Protocol, runtime_checkable
 
 from nexus.bricks.catalog.extractors import (
+    AvroExtractor,
     CSVExtractor,
+    DocumentExtractionResult,
     ExtractionResult,
     JSONExtractor,
+    MarkdownExtractor,
     ParquetExtractor,
     SchemaExtractor,
 )
 
 logger = logging.getLogger(__name__)
 
-# Minimum confidence to auto-store extracted schema
+# Minimum confidence to auto-store extracted schema/document
 DEFAULT_CONFIDENCE_THRESHOLD = 0.5
 
 # Max file size for auto-extraction (100MB)
@@ -48,30 +63,27 @@ class CatalogProtocol(Protocol):
         zone_id: str | None = None,
         created_by: str = "system",
     ) -> ExtractionResult:
-        """Extract schema from file content and store as aspect.
+        """Extract schema from file content and store as aspect."""
+        ...
 
-        Args:
-            entity_urn: URN of the file entity.
-            content: Raw file content (or first N bytes for large files).
-            mime_type: MIME type hint.
-            filename: Filename hint for format detection.
-            zone_id: Zone scope for aspect storage.
-            created_by: User/agent performing extraction.
-
-        Returns:
-            ExtractionResult with schema, confidence, warnings.
-        """
+    def extract_document(
+        self,
+        entity_urn: str,
+        content: bytes,
+        *,
+        mime_type: str | None = None,
+        filename: str | None = None,
+        zone_id: str | None = None,
+        created_by: str = "system",
+    ) -> DocumentExtractionResult:
+        """Extract document structure and store as aspect."""
         ...
 
     def get_schema(
         self,
         entity_urn: str,
     ) -> dict[str, Any] | None:
-        """Get stored schema aspect for an entity.
-
-        Returns:
-            Schema metadata dict, or None if no schema stored.
-        """
+        """Get stored schema aspect for an entity."""
         ...
 
     def search_by_column(
@@ -80,21 +92,21 @@ class CatalogProtocol(Protocol):
         *,
         zone_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Search for entities containing a column name.
-
-        Returns:
-            List of matching entities with their schema metadata.
-        """
+        """Search for entities containing a column name."""
         ...
 
 
 class CatalogService:
-    """Schema extraction service with pluggable extractors.
+    """Schema + document extraction service with pluggable extractors.
 
     Structurally satisfies ``CatalogProtocol``.
 
     Constructor injection: receives AspectServiceProtocol so this brick
     has zero core imports.
+
+    Self-registering extractors (Issue #2978): each extractor class declares
+    ``mime_types`` and ``extensions`` as class attributes. Registration loops
+    over these instead of maintaining separate MIME/extension dicts.
     """
 
     def __init__(
@@ -112,56 +124,112 @@ class CatalogService:
         self._inference_read_bytes = inference_read_bytes
         self._inference_max_rows = inference_max_rows
 
-        # Extractor registry: mime_type → extractor
-        self._extractors: dict[str, SchemaExtractor] = {}
+        # Dual registries: schema extractors + document extractors
+        self._schema_extractors: dict[str, SchemaExtractor] = {}
+        self._schema_ext_map: dict[str, str] = {}  # extension → first mime_type
+        self._document_extractors: dict[str, Any] = {}
+        self._document_ext_map: dict[str, str] = {}  # extension → first mime_type
+
+        # Backward-compat alias (used by register_extractor)
+        self._extractors = self._schema_extractors
+
         self._register_default_extractors()
 
     def _register_default_extractors(self) -> None:
-        """Register built-in extractors."""
-        csv_ext = CSVExtractor(max_rows=self._inference_max_rows)
-        json_ext = JSONExtractor(max_bytes=self._inference_read_bytes)
-        parquet_ext = ParquetExtractor()
+        """Register built-in extractors via self-registration metadata."""
+        # Schema extractors
+        schema_instances = [
+            CSVExtractor(max_rows=self._inference_max_rows),
+            JSONExtractor(max_bytes=self._inference_read_bytes),
+            ParquetExtractor(),
+            AvroExtractor(),
+        ]
+        for ext in schema_instances:
+            for mime in ext.mime_types:
+                self._schema_extractors[mime] = ext
+            for extension in ext.extensions:
+                if extension not in self._schema_ext_map:
+                    self._schema_ext_map[extension] = ext.mime_types[0]
 
-        for mime in ("text/csv", "application/csv"):
-            self._extractors[mime] = csv_ext
-        for mime in ("application/json", "text/json"):
-            self._extractors[mime] = json_ext
-        for mime in ("application/parquet", "application/x-parquet"):
-            self._extractors[mime] = parquet_ext
+        # Document extractors
+        document_instances = [
+            MarkdownExtractor(),
+        ]
+        for ext in document_instances:
+            for mime in ext.mime_types:
+                self._document_extractors[mime] = ext
+            for extension in ext.extensions:
+                if extension not in self._document_ext_map:
+                    self._document_ext_map[extension] = ext.mime_types[0]
 
     def register_extractor(
         self,
         mime_type: str,
         extractor: SchemaExtractor,
     ) -> None:
-        """Register a custom extractor for a MIME type."""
-        self._extractors[mime_type] = extractor
+        """Register a custom schema extractor for a MIME type."""
+        self._schema_extractors[mime_type] = extractor
 
+    def _detect_schema_extractor(
+        self,
+        mime_type: str | None,
+        filename: str | None,
+    ) -> SchemaExtractor | None:
+        """Detect appropriate schema extractor from MIME type or filename."""
+        if mime_type and mime_type in self._schema_extractors:
+            return self._schema_extractors[mime_type]
+
+        if filename:
+            ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+            # NOTE: Extension parsing uses last segment only. Compressed files
+            # like data.csv.gz will match "gz", not "csv". This is intentional
+            # for the current scope — compressed format detection is future work.
+            mapped_mime = self._schema_ext_map.get(ext)
+            if mapped_mime and mapped_mime in self._schema_extractors:
+                return self._schema_extractors[mapped_mime]
+
+        return None
+
+    def _detect_document_extractor(
+        self,
+        mime_type: str | None,
+        filename: str | None,
+    ) -> Any | None:
+        """Detect appropriate document extractor from MIME type or filename."""
+        if mime_type and mime_type in self._document_extractors:
+            return self._document_extractors[mime_type]
+
+        if filename:
+            ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+            mapped_mime = self._document_ext_map.get(ext)
+            if mapped_mime and mapped_mime in self._document_extractors:
+                return self._document_extractors[mapped_mime]
+
+        return None
+
+    # Keep backward-compat alias
     def _detect_extractor(
         self,
         mime_type: str | None,
         filename: str | None,
     ) -> SchemaExtractor | None:
-        """Detect appropriate extractor from MIME type or filename."""
-        if mime_type and mime_type in self._extractors:
-            return self._extractors[mime_type]
+        """Detect appropriate extractor from MIME type or filename (backward compat)."""
+        return self._detect_schema_extractor(mime_type, filename)
 
-        if filename:
-            ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-            mime_map = {
-                "csv": "text/csv",
-                "tsv": "text/csv",
-                "json": "application/json",
-                "jsonl": "application/json",
-                "ndjson": "application/json",
-                "parquet": "application/parquet",
-                "pq": "application/parquet",
-            }
-            mapped_mime = mime_map.get(ext)
-            if mapped_mime and mapped_mime in self._extractors:
-                return self._extractors[mapped_mime]
+    def has_extractor(
+        self,
+        *,
+        mime_type: str | None = None,
+        filename: str | None = None,
+    ) -> bool:
+        """Check if any extractor (schema or document) is available for a file.
 
-        return None
+        Used by the post-flush hook to format-gate content reads (Issue #2978).
+        """
+        return (
+            self._detect_schema_extractor(mime_type, filename) is not None
+            or self._detect_document_extractor(mime_type, filename) is not None
+        )
 
     def extract_schema(
         self,
@@ -188,7 +256,7 @@ class CatalogService:
                 error="File too large for auto-extraction",
             )
 
-        extractor = self._detect_extractor(mime_type, filename)
+        extractor = self._detect_schema_extractor(mime_type, filename)
         if extractor is None:
             return ExtractionResult(
                 schema=None,
@@ -230,6 +298,177 @@ class CatalogService:
 
         return result
 
+    def extract_schema_from_path(
+        self,
+        entity_urn: str,
+        path: str,
+        *,
+        mime_type: str | None = None,
+        filename: str | None = None,
+        zone_id: str | None = None,
+        created_by: str = "system",
+    ) -> ExtractionResult:
+        """Extract schema using path-based I/O for header-only formats (Avro, Parquet).
+
+        Falls back to content-based extraction if the extractor doesn't
+        support extract_from_path.
+        """
+        extractor = self._detect_schema_extractor(mime_type, filename)
+        if extractor is None:
+            return ExtractionResult(
+                schema=None,
+                format="unknown",
+                confidence=0.0,
+                error=f"Unsupported format: mime_type={mime_type}, filename={filename}",
+            )
+
+        # Prefer path-based extraction for header-only formats
+        extract_from_path = getattr(extractor, "extract_from_path", None)
+        if extract_from_path is not None:
+            result = extract_from_path(path)
+        else:
+            # Fall back to content-based
+            with open(path, "rb") as f:
+                content = f.read(self._max_auto_extract_bytes + 1)
+            if len(content) > self._max_auto_extract_bytes:
+                return ExtractionResult(
+                    schema=None,
+                    format="unknown",
+                    confidence=0.0,
+                    error="File too large for auto-extraction",
+                )
+            result = extractor.extract(content)
+
+        # Store as aspect if confidence meets threshold
+        if result.schema is not None and result.confidence >= self._confidence_threshold:
+            try:
+                self._aspect_service.put_aspect(
+                    entity_urn=entity_urn,
+                    aspect_name="schema_metadata",
+                    payload={
+                        "columns": result.schema,
+                        "format": result.format,
+                        "row_count": result.row_count,
+                        "confidence": result.confidence,
+                        "warnings": result.warnings,
+                    },
+                    created_by=created_by,
+                    zone_id=zone_id,
+                )
+            except Exception as e:
+                logger.warning("Failed to store schema aspect: %s", e)
+
+        return result
+
+    def extract_document(
+        self,
+        entity_urn: str,
+        content: bytes,
+        *,
+        mime_type: str | None = None,
+        filename: str | None = None,
+        zone_id: str | None = None,
+        created_by: str = "system",
+    ) -> DocumentExtractionResult:
+        """Extract document structure from content and store as aspect."""
+        # Size gate
+        if len(content) > self._max_auto_extract_bytes:
+            return DocumentExtractionResult(
+                title=None,
+                headings=[],
+                front_matter=None,
+                word_count=0,
+                link_count=0,
+                code_languages=[],
+                format="unknown",
+                confidence=0.0,
+                error="File too large for auto-extraction",
+            )
+
+        extractor = self._detect_document_extractor(mime_type, filename)
+        if extractor is None:
+            return DocumentExtractionResult(
+                title=None,
+                headings=[],
+                front_matter=None,
+                word_count=0,
+                link_count=0,
+                code_languages=[],
+                format="unknown",
+                confidence=0.0,
+                error=f"Unsupported document format: mime_type={mime_type}, filename={filename}",
+            )
+
+        result = extractor.extract(content)
+
+        # Store as document_structure aspect if confidence meets threshold
+        if result.confidence >= self._confidence_threshold and result.error is None:
+            try:
+                self._aspect_service.put_aspect(
+                    entity_urn=entity_urn,
+                    aspect_name="document_structure",
+                    payload={
+                        "title": result.title,
+                        "headings": result.headings,
+                        "front_matter": result.front_matter,
+                        "word_count": result.word_count,
+                        "link_count": result.link_count,
+                        "code_languages": result.code_languages,
+                        "format": result.format,
+                        "confidence": result.confidence,
+                    },
+                    created_by=created_by,
+                    zone_id=zone_id,
+                )
+            except Exception as e:
+                logger.warning("Failed to store document_structure aspect: %s", e)
+
+        return result
+
+    def extract_auto(
+        self,
+        entity_urn: str,
+        content: bytes,
+        *,
+        mime_type: str | None = None,
+        filename: str | None = None,
+        zone_id: str | None = None,
+        created_by: str = "system",
+    ) -> ExtractionResult | DocumentExtractionResult:
+        """Auto-detect format and extract schema or document structure.
+
+        Tries schema extraction first, then document extraction.
+        Used by the post-flush extraction hook (Issue #2978).
+        """
+        # Try schema extraction
+        if self._detect_schema_extractor(mime_type, filename) is not None:
+            return self.extract_schema(
+                entity_urn,
+                content,
+                mime_type=mime_type,
+                filename=filename,
+                zone_id=zone_id,
+                created_by=created_by,
+            )
+
+        # Try document extraction
+        if self._detect_document_extractor(mime_type, filename) is not None:
+            return self.extract_document(
+                entity_urn,
+                content,
+                mime_type=mime_type,
+                filename=filename,
+                zone_id=zone_id,
+                created_by=created_by,
+            )
+
+        return ExtractionResult(
+            schema=None,
+            format="unknown",
+            confidence=0.0,
+            error=f"No extractor for: mime_type={mime_type}, filename={filename}",
+        )
+
     def get_schema(
         self,
         entity_urn: str,
@@ -237,6 +476,16 @@ class CatalogService:
         """Get stored schema aspect for an entity."""
         result: dict[str, Any] | None = self._aspect_service.get_aspect(
             entity_urn, "schema_metadata"
+        )
+        return result
+
+    def get_document_structure(
+        self,
+        entity_urn: str,
+    ) -> dict[str, Any] | None:
+        """Get stored document_structure aspect for an entity."""
+        result: dict[str, Any] | None = self._aspect_service.get_aspect(
+            entity_urn, "document_structure"
         )
         return result
 

--- a/src/nexus/bricks/catalog/protocol.py
+++ b/src/nexus/bricks/catalog/protocol.py
@@ -29,6 +29,7 @@ from nexus.bricks.catalog.extractors import (
     AvroExtractor,
     CSVExtractor,
     DocumentExtractionResult,
+    DocumentExtractor,
     ExtractionResult,
     JSONExtractor,
     MarkdownExtractor,
@@ -127,7 +128,7 @@ class CatalogService:
         # Dual registries: schema extractors + document extractors
         self._schema_extractors: dict[str, SchemaExtractor] = {}
         self._schema_ext_map: dict[str, str] = {}  # extension → first mime_type
-        self._document_extractors: dict[str, Any] = {}
+        self._document_extractors: dict[str, DocumentExtractor] = {}
         self._document_ext_map: dict[str, str] = {}  # extension → first mime_type
 
         # Backward-compat alias (used by register_extractor)
@@ -138,7 +139,7 @@ class CatalogService:
     def _register_default_extractors(self) -> None:
         """Register built-in extractors via self-registration metadata."""
         # Schema extractors
-        schema_instances = [
+        schema_instances: list[SchemaExtractor] = [
             CSVExtractor(max_rows=self._inference_max_rows),
             JSONExtractor(max_bytes=self._inference_read_bytes),
             ParquetExtractor(),
@@ -152,15 +153,15 @@ class CatalogService:
                     self._schema_ext_map[extension] = ext.mime_types[0]
 
         # Document extractors
-        document_instances = [
+        document_instances: list[DocumentExtractor] = [
             MarkdownExtractor(),
         ]
-        for ext in document_instances:
-            for mime in ext.mime_types:
-                self._document_extractors[mime] = ext
-            for extension in ext.extensions:
+        for doc_ext in document_instances:
+            for mime in doc_ext.mime_types:
+                self._document_extractors[mime] = doc_ext
+            for extension in doc_ext.extensions:
                 if extension not in self._document_ext_map:
-                    self._document_ext_map[extension] = ext.mime_types[0]
+                    self._document_ext_map[extension] = doc_ext.mime_types[0]
 
     def register_extractor(
         self,
@@ -194,7 +195,7 @@ class CatalogService:
         self,
         mime_type: str | None,
         filename: str | None,
-    ) -> Any | None:
+    ) -> DocumentExtractor | None:
         """Detect appropriate document extractor from MIME type or filename."""
         if mime_type and mime_type in self._document_extractors:
             return self._document_extractors[mime_type]
@@ -329,7 +330,7 @@ class CatalogService:
         # Prefer path-based extraction for header-only formats
         extract_from_path = getattr(extractor, "extract_from_path", None)
         if extract_from_path is not None:
-            result = extract_from_path(path)
+            result: ExtractionResult = extract_from_path(path)
         else:
             # Fall back to content-based
             with open(path, "rb") as f:

--- a/src/nexus/cli/commands/init_cmd.py
+++ b/src/nexus/cli/commands/init_cmd.py
@@ -106,48 +106,6 @@ def _bundled_compose_file() -> Path | None:
     return None
 
 
-def _query_latest_stable_tag() -> str | None:
-    """Query GHCR for the latest stable (semver) tag.
-
-    Returns the tag string (e.g. '0.9.2') or None if the query fails.
-    This is a best-effort network call — callers must handle None.
-    """
-    import urllib.request
-
-    # GHCR token endpoint (public, no auth needed for public images)
-    token_url = "https://ghcr.io/token?scope=repository:nexi-lab/nexus:pull"
-    tags_url = "https://ghcr.io/v2/nexi-lab/nexus/tags/list"
-
-    try:
-        # Get anonymous token
-        with urllib.request.urlopen(token_url, timeout=5) as resp:
-            import json
-
-            token_data = json.loads(resp.read())
-            token = token_data.get("token", "")
-
-        # List tags
-        req = urllib.request.Request(tags_url)
-        req.add_header("Authorization", f"Bearer {token}")
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            tags_data = json.loads(resp.read())
-            tags: list[str] = tags_data.get("tags", [])
-
-        # Filter to semver-like tags (X.Y.Z), exclude edge/latest/sha-*
-        import re
-
-        semver_re = re.compile(r"^\d+\.\d+\.\d+$")
-        semver_tags = [t for t in tags if semver_re.match(t)]
-        if not semver_tags:
-            return None
-
-        # Sort by semver and return latest
-        semver_tags.sort(key=lambda t: tuple(int(x) for x in t.split(".")))
-        return semver_tags[-1]
-    except Exception:
-        return None
-
-
 def _resolve_image_ref(
     channel: str,
     accelerator: str,
@@ -160,28 +118,18 @@ def _resolve_image_ref(
       1. Explicit digest → ghcr.io/nexi-lab/nexus@sha256:...
       2. Explicit tag → ghcr.io/nexi-lab/nexus:<tag>
       3. Channel resolution:
-         - ``stable``: query GHCR for latest semver tag, fall back to CLI version
-         - ``edge``: use ``edge`` mutable tag
+         - ``stable``: use mutable ``stable`` tag (updated on every release)
+         - ``edge``: use mutable ``edge`` tag (updated on every develop push)
     """
     registry = DEFAULT_IMAGE_REGISTRY
 
     if image_digest:
         return f"{registry}@{image_digest}"
 
-    if image_tag:
-        tag = image_tag
-    elif channel == "edge":
-        tag = "edge"
-    else:
-        # Stable channel: try remote resolution first, fall back to CLI version
-        remote_tag = _query_latest_stable_tag()
-        if remote_tag:
-            tag = remote_tag
-        else:
-            import nexus as _nexus_mod
-
-            tag = getattr(_nexus_mod, "__version__", "latest")
-            logger.debug("GHCR query failed, falling back to CLI version: %s", tag)
+    # Both channels use mutable tags managed by CI:
+    #   stable → pushed by release.yml on every git tag (v*)
+    #   edge   → pushed by docker-publish.yml on every develop push
+    tag = image_tag or channel
 
     if accelerator == "cuda" and not image_digest:
         tag = f"{tag}-cuda"

--- a/src/nexus/cli/commands/reindex.py
+++ b/src/nexus/cli/commands/reindex.py
@@ -313,19 +313,37 @@ def _run_semantic_reindex(
                     progress.update(task, advance=1)
                     continue
 
-                # Read file content
-                content = nx.read(file_path)
-                if isinstance(content, str):
-                    content = content.encode()
+                # Try path-based extraction first for O(1) header/footer
+                # formats (Avro, Parquet) to avoid full-content reads.
+                schema_ext = catalog._detect_schema_extractor(mime_type, filename)
+                physical_path = _get_physical_path(nx, file_path)
+                if (
+                    schema_ext is not None
+                    and physical_path is not None
+                    and hasattr(schema_ext, "extract_from_path")
+                ):
+                    result = catalog.extract_schema_from_path(
+                        entity_urn=urn,
+                        path=physical_path,
+                        mime_type=mime_type,
+                        filename=filename,
+                        zone_id=zone_id,
+                        created_by="reindex",
+                    )
+                else:
+                    # Full-content read for CSV/JSON/Markdown
+                    content = nx.read(file_path)
+                    if isinstance(content, str):
+                        content = content.encode()
 
-                result = catalog.extract_auto(
-                    entity_urn=urn,
-                    content=content,
-                    mime_type=mime_type,
-                    filename=filename,
-                    zone_id=zone_id,
-                    created_by="reindex",
-                )
+                    result = catalog.extract_auto(
+                        entity_urn=urn,
+                        content=content,
+                        mime_type=mime_type,
+                        filename=filename,
+                        zone_id=zone_id,
+                        created_by="reindex",
+                    )
 
                 processed += 1
 
@@ -357,6 +375,21 @@ def _run_semantic_reindex(
     table.add_row("Documents extracted", str(documents_extracted))
     table.add_row("Errors", str(errors))
     console.print(table)
+
+
+def _get_physical_path(nx: Any, file_path: str) -> str | None:
+    """Get the physical (CAS blob) path for a file, if available.
+
+    Used by semantic reindex to enable O(1) header/footer-only extraction
+    for Avro/Parquet without reading the full content (Issue #2978).
+    """
+    try:
+        stat = nx.stat(file_path)
+        if isinstance(stat, dict):
+            return stat.get("physical_path")
+        return getattr(stat, "physical_path", None)
+    except Exception:
+        return None
 
 
 def _walk_filesystem(nx: Any, root: str) -> list[str]:

--- a/src/nexus/cli/commands/reindex.py
+++ b/src/nexus/cli/commands/reindex.py
@@ -313,37 +313,24 @@ def _run_semantic_reindex(
                     progress.update(task, advance=1)
                     continue
 
-                # Try path-based extraction first for O(1) header/footer
-                # formats (Avro, Parquet) to avoid full-content reads.
-                schema_ext = catalog._detect_schema_extractor(mime_type, filename)
-                physical_path = _get_physical_path(nx, file_path)
-                if (
-                    schema_ext is not None
-                    and physical_path is not None
-                    and hasattr(schema_ext, "extract_from_path")
-                ):
-                    result = catalog.extract_schema_from_path(
-                        entity_urn=urn,
-                        path=physical_path,
-                        mime_type=mime_type,
-                        filename=filename,
-                        zone_id=zone_id,
-                        created_by="reindex",
-                    )
-                else:
-                    # Full-content read for CSV/JSON/Markdown
-                    content = nx.read(file_path)
-                    if isinstance(content, str):
-                        content = content.encode()
+                # Read file content via NexusFS (CAS-backed).
+                # NOTE: extract_from_path() exists for external callers with
+                # real OS paths, but NexusFS.physical_path is a CAS content
+                # hash, not a filesystem path. Reindex always reads full
+                # content; the 100MB size gate in CatalogService protects
+                # against oversized files.
+                content = nx.read(file_path)
+                if isinstance(content, str):
+                    content = content.encode()
 
-                    result = catalog.extract_auto(
-                        entity_urn=urn,
-                        content=content,
-                        mime_type=mime_type,
-                        filename=filename,
-                        zone_id=zone_id,
-                        created_by="reindex",
-                    )
+                result = catalog.extract_auto(
+                    entity_urn=urn,
+                    content=content,
+                    mime_type=mime_type,
+                    filename=filename,
+                    zone_id=zone_id,
+                    created_by="reindex",
+                )
 
                 processed += 1
 
@@ -375,21 +362,6 @@ def _run_semantic_reindex(
     table.add_row("Documents extracted", str(documents_extracted))
     table.add_row("Errors", str(errors))
     console.print(table)
-
-
-def _get_physical_path(nx: Any, file_path: str) -> str | None:
-    """Get the physical (CAS blob) path for a file, if available.
-
-    Used by semantic reindex to enable O(1) header/footer-only extraction
-    for Avro/Parquet without reading the full content (Issue #2978).
-    """
-    try:
-        stat = nx.stat(file_path)
-        if isinstance(stat, dict):
-            return stat.get("physical_path")
-        return getattr(stat, "physical_path", None)
-    except Exception:
-        return None
 
 
 def _walk_filesystem(nx: Any, root: str) -> list[str]:

--- a/src/nexus/cli/commands/reindex.py
+++ b/src/nexus/cli/commands/reindex.py
@@ -260,10 +260,11 @@ def _run_semantic_reindex(
     zone_id: str | None,
     dry_run: bool,
 ) -> None:
-    """Walk the filesystem and re-extract schemas via CatalogService.
+    """Walk the filesystem and re-extract schemas + document structure.
 
     For each file, computes its URN, reads content, and runs
-    CatalogService.extract_schema() to rebuild the schema_metadata aspect.
+    CatalogService.extract_auto() to rebuild schema_metadata or
+    document_structure aspects (Issue #2978).
     """
     import mimetypes
 
@@ -287,7 +288,8 @@ def _run_semantic_reindex(
         return
 
     processed = 0
-    extracted = 0
+    schemas_extracted = 0
+    documents_extracted = 0
     errors = 0
 
     with Progress(
@@ -299,31 +301,42 @@ def _run_semantic_reindex(
 
         for file_path in all_files:
             try:
-                # Compute URN from path
                 from nexus.contracts.urn import NexusURN
 
                 urn = str(NexusURN.for_file(zone_id or "default", file_path))
+                filename = file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path
+                mime_type, _ = mimetypes.guess_type(file_path)
+
+                # Format-gate: skip files with no extractor (Issue #2978)
+                if not catalog.has_extractor(mime_type=mime_type, filename=filename):
+                    processed += 1
+                    progress.update(task, advance=1)
+                    continue
 
                 # Read file content
                 content = nx.read(file_path)
                 if isinstance(content, str):
                     content = content.encode()
 
-                # Detect MIME type from filename
-                mime_type, _ = mimetypes.guess_type(file_path)
-
-                result = catalog.extract_schema(
+                result = catalog.extract_auto(
                     entity_urn=urn,
                     content=content,
                     mime_type=mime_type,
-                    filename=file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path,
+                    filename=filename,
                     zone_id=zone_id,
                     created_by="reindex",
                 )
 
                 processed += 1
-                if result.schema is not None:
-                    extracted += 1
+
+                # Track what was extracted
+                from nexus.bricks.catalog.extractors import DocumentExtractionResult
+
+                if isinstance(result, DocumentExtractionResult):
+                    if result.error is None:
+                        documents_extracted += 1
+                elif hasattr(result, "schema") and result.schema is not None:
+                    schemas_extracted += 1
 
             except Exception as e:
                 errors += 1
@@ -340,7 +353,8 @@ def _run_semantic_reindex(
     table.add_column("Value", style="green")
     table.add_row("Total files", str(len(all_files)))
     table.add_row("Processed", str(processed))
-    table.add_row("Schemas extracted", str(extracted))
+    table.add_row("Schemas extracted", str(schemas_extracted))
+    table.add_row("Documents extracted", str(documents_extracted))
     table.add_row("Errors", str(errors))
     console.print(table)
 

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -204,6 +204,22 @@ def _compose_profiles(compose_file: str) -> set[str]:
     return profiles
 
 
+def _compose_has_build(compose_file: str) -> bool:
+    """Return True if the nexus service in the compose file has a ``build:`` directive."""
+    try:
+        with open(compose_file) as f:
+            stack = yaml.safe_load(f) or {}
+    except (FileNotFoundError, yaml.YAMLError):
+        return False
+    nexus_svc = (stack.get("services") or {}).get("nexus")
+    return isinstance(nexus_svc, dict) and "build" in nexus_svc
+
+
+def _is_channel_following(config: dict[str, Any]) -> bool:
+    """Return True if the config follows a mutable channel (stable/edge) rather than a pinned ref."""
+    return "image_channel" in config and "image_pin" not in config
+
+
 @functools.lru_cache(maxsize=1)
 def _find_docker_compose() -> str:
     """Return the docker compose command prefix (cached for the process lifetime)."""
@@ -480,9 +496,18 @@ def up(
 
     # When --build is requested, drop NEXUS_IMAGE_REF so docker compose
     # uses the ``build:`` directive from the compose file (local source)
-    # instead of pulling the pinned remote image.
+    # instead of pulling the pinned remote image.  Only safe when the
+    # compose file actually has a build: stanza (repo checkouts); the
+    # bundled portable compose file has no build: directive.
     if build:
-        compose_env.pop("NEXUS_IMAGE_REF", None)
+        if _compose_has_build(cf):
+            compose_env.pop("NEXUS_IMAGE_REF", None)
+        else:
+            console.print(
+                "[yellow]Warning:[/yellow] --build ignored — compose file "
+                f"({Path(cf).name}) has no build: directive."
+            )
+            build = False
 
     data_dir = compose_env["NEXUS_HOST_DATA_DIR"]
 
@@ -492,6 +517,13 @@ def up(
         compose_args.append("-d")
     if build:
         compose_args.append("--build")
+
+    # For channel-following configs (stable/edge), always pull the latest
+    # image so mutable tags pick up new releases.  Pinned configs skip
+    # this — their tag is immutable and already cached.
+    if not build and _is_channel_following(config):
+        compose_args.append("--pull")
+        compose_args.append("always")
 
     result = _run_compose(cf, profiles, *compose_args, extra_env=compose_env)
     if result.returncode != 0:
@@ -663,12 +695,25 @@ def restart(build: bool | None) -> None:
     if build is None:
         build = False
 
+    # Same --build / --pull logic as `up`
+    if build:
+        if _compose_has_build(cf):
+            compose_env.pop("NEXUS_IMAGE_REF", None)
+        else:
+            console.print(
+                "[yellow]Warning:[/yellow] --build ignored — compose file "
+                f"({Path(cf).name}) has no build: directive."
+            )
+            build = False
+
     console.print(f"[bold]Restarting Nexus preset: {preset}[/bold]")
     _run_compose(cf, profiles, "down", extra_env=compose_env)
 
     args: list[str] = ["up", "-d"]
     if build:
         args.append("--build")
+    if not build and _is_channel_following(config):
+        args.extend(["--pull", "always"])
     result = _run_compose(cf, profiles, *args, extra_env=compose_env)
     if result.returncode == 0:
         console.print("[green]✓[/green] Stack restarted.")
@@ -755,6 +800,22 @@ def upgrade(
         image_tag=image_tag,
         image_digest=image_digest,
     )
+
+    # For channel-following configs (stable/edge), the ref string doesn't
+    # change between releases — the tag is mutable.  Pull the latest image
+    # and restart instead of comparing strings.
+    if new_ref == current_ref and _is_channel_following(config) and not (image_tag or image_digest):
+        console.print(f"[bold]Pulling latest image for channel '{effective_channel}'...[/bold]")
+        cf = config.get("compose_file", "./nexus-stack.yml")
+        profiles = _resolve_profiles(config)
+        compose_env = _derive_project_env(config)
+        pull_result = _run_compose(cf, profiles, "pull", "nexus", extra_env=compose_env)
+        if pull_result.returncode != 0:
+            console.print("[red]Error:[/red] Failed to pull image.")
+            raise SystemExit(pull_result.returncode)
+        console.print(f"[green]✓[/green] Pulled latest {new_ref}")
+        console.print("  Run `nexus restart` to apply.")
+        return
 
     if new_ref == current_ref:
         console.print(f"[green]Already up to date:[/green] {current_ref}")

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -456,9 +456,12 @@ def up(
     console.print()
     console.print(f"[bold]Starting Nexus preset: {preset}[/bold]")
     console.print(f"  Using stack: {cf}")
-    image_ref = _resolve_image_ref_from_config(config)
-    if image_ref:
-        console.print(f"  Image: {image_ref}")
+    if build:
+        console.print("  Image: [green]local build[/green] (from Dockerfile)")
+    else:
+        image_ref = _resolve_image_ref_from_config(config)
+        if image_ref:
+            console.print(f"  Image: {image_ref}")
     if addons:
         console.print(f"  Add-ons: {', '.join(addons)}")
     console.print()
@@ -474,6 +477,12 @@ def up(
 
     # Build environment from config (project name, ports, data dir, auth, image, TLS)
     compose_env = _derive_project_env(config, resolved_ports=resolved_ports)
+
+    # When --build is requested, drop NEXUS_IMAGE_REF so docker compose
+    # uses the ``build:`` directive from the compose file (local source)
+    # instead of pulling the pinned remote image.
+    if build:
+        compose_env.pop("NEXUS_IMAGE_REF", None)
 
     data_dir = compose_env["NEXUS_HOST_DATA_DIR"]
 

--- a/src/nexus/contracts/aspects.py
+++ b/src/nexus/contracts/aspects.py
@@ -317,3 +317,33 @@ class GovernanceClassificationAspect(AspectBase):
         self.owner = owner
         self.reason = reason
         self.review_date = review_date
+
+
+@register_aspect("document_structure", max_versions=10)
+class DocumentStructureAspect(AspectBase):
+    """Structure metadata for non-tabular documents (Markdown, PDF, etc.).
+
+    Unlike schema_metadata (columns/types for tabular data), this captures
+    document-level structure: headings, front matter, code blocks, etc.
+    Issue #2978.
+    """
+
+    def __init__(
+        self,
+        title: str | None = None,
+        headings: list[dict[str, Any]] | None = None,
+        front_matter: dict[str, Any] | None = None,
+        word_count: int = 0,
+        link_count: int = 0,
+        code_languages: list[str] | None = None,
+        format: str = "unknown",
+        confidence: float = 1.0,
+    ) -> None:
+        self.title = title
+        self.headings = headings or []
+        self.front_matter = front_matter
+        self.word_count = word_count
+        self.link_count = link_count
+        self.code_languages = code_languages or []
+        self.format = format
+        self.confidence = confidence

--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -77,6 +77,7 @@ class RingBuffer:
 
     __slots__ = (
         "_core",
+        "_loop",
         "_not_empty",
         "_not_full",
         "_readers_waiting",
@@ -98,6 +99,13 @@ class RingBuffer:
         self._not_full.set()  # initially not full
         self._readers_waiting = False
         self._writers_waiting = False
+        # Capture the event loop for cross-thread signalling.
+        # RPC handlers run in a thread pool, so write_nowait() must use
+        # call_soon_threadsafe() to wake the async consumer.
+        try:
+            self._loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
 
     # -- async write/read ---------------------------------------------------
 
@@ -158,7 +166,12 @@ class RingBuffer:
     # -- sync nowait --------------------------------------------------------
 
     def write_nowait(self, data: bytes) -> int:
-        """Synchronous non-blocking write. Raises PipeFullError if full."""
+        """Synchronous non-blocking write. Raises PipeFullError if full.
+
+        Thread-safe: may be called from RPC worker threads.  Uses
+        ``call_soon_threadsafe`` so the asyncio.Event signal reaches the
+        consumer task on the event-loop thread.
+        """
         try:
             n = self._core.push(data)
         except RuntimeError as exc:
@@ -167,10 +180,14 @@ class RingBuffer:
         except ValueError:
             raise  # oversized message — already a ValueError from Rust
 
-        # Wake blocked reader only if one is actually waiting.
-        # Skipping Event.set() when no reader is blocked saves ~55ns/op.
+        # Wake blocked reader.  The writer may run on a thread-pool
+        # thread (RPC dispatch), so Event.set() must be delivered to
+        # the event-loop thread via call_soon_threadsafe.
         if self._readers_waiting:
-            self._not_empty.set()
+            if self._loop is not None and self._loop.is_running():
+                self._loop.call_soon_threadsafe(self._not_empty.set)
+            else:
+                self._not_empty.set()
         return int(n)
 
     def read_nowait(self) -> bytes:
@@ -200,7 +217,10 @@ class RingBuffer:
             raise
 
         if self._readers_waiting:
-            self._not_empty.set()
+            if self._loop is not None and self._loop.is_running():
+                self._loop.call_soon_threadsafe(self._not_empty.set)
+            else:
+                self._not_empty.set()
 
     def read_u64_nowait(self) -> int:
         """Pop a u64 from the ring. Returns Python int directly."""

--- a/src/nexus/factory/_extraction_hook.py
+++ b/src/nexus/factory/_extraction_hook.py
@@ -33,13 +33,25 @@ def _read_content(
 
     physical_path = metadata.get("physical_path", "")
     if physical_path.startswith(INLINE_PREFIX):
-        # Inline: content stored base64-encoded in metastore
+        # Inline: content stored base64-encoded in metastore.
+        # NexusFS stores: set_file_metadata(path, key, b64encode(content).decode("ascii"))
+        # NexusFS reads:  b64decode(get_file_metadata(path, key))
         import base64
 
         raw = metastore.get_file_metadata(path, INLINE_CONTENT_KEY)
         if raw is None:
             return None
-        return base64.b64decode(raw)
+        # NexusFS stores base64(content) in the metastore. The Raft
+        # metastore adds another base64 layer when storing arbitrary
+        # string values, so the value we read is base64(base64(content)).
+        # Decode both layers.
+        content = base64.b64decode(raw)
+        if isinstance(content, bytes):
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                content = base64.b64decode(content)
+        return content
 
     # CAS: content stored in backend by hash
     content_hash = metadata.get("etag")

--- a/src/nexus/factory/_extraction_hook.py
+++ b/src/nexus/factory/_extraction_hook.py
@@ -41,16 +41,17 @@ def _read_content(
         raw = metastore.get_file_metadata(path, INLINE_CONTENT_KEY)
         if raw is None:
             return None
-        # NexusFS stores base64(content) in the metastore. The Raft
-        # metastore adds another base64 layer when storing arbitrary
-        # string values, so the value we read is base64(base64(content)).
-        # Decode both layers.
+        # NexusFS stores base64(content) in the metastore.  The Raft
+        # metastore may add another base64 layer when storing string
+        # values, producing base64(base64(content)).  Use the known
+        # file size from metadata to detect whether a second decode
+        # is needed: base64 always changes the length, so if the
+        # first decode already matches the file size, it produced
+        # the original content.  If not, decode again.
+        expected_size = metadata.get("size", 0)
         content = base64.b64decode(raw)
-        if isinstance(content, bytes):
-            import contextlib
-
-            with contextlib.suppress(Exception):
-                content = base64.b64decode(content)
+        if expected_size and len(content) != expected_size:
+            content = base64.b64decode(content)
         return content
 
     # CAS: content stored in backend by hash

--- a/src/nexus/factory/_extraction_hook.py
+++ b/src/nexus/factory/_extraction_hook.py
@@ -22,10 +22,38 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _read_content(
+    metadata: dict[str, Any],
+    backend: Any,
+    metastore: Any,
+    path: str,
+) -> bytes | None:
+    """Read file content from inline storage or CAS backend."""
+    from nexus.contracts.constants import INLINE_CONTENT_KEY, INLINE_PREFIX
+
+    physical_path = metadata.get("physical_path", "")
+    if physical_path.startswith(INLINE_PREFIX):
+        # Inline: content stored base64-encoded in metastore
+        import base64
+
+        raw = metastore.get_file_metadata(path, INLINE_CONTENT_KEY)
+        if raw is None:
+            return None
+        return base64.b64decode(raw)
+
+    # CAS: content stored in backend by hash
+    content_hash = metadata.get("etag")
+    if not content_hash:
+        return None
+    result: bytes | None = backend.read_content(content_hash)
+    return result
+
+
 def make_extraction_hook(
     *,
     session_factory: Callable[..., Any],
     backend: Any,
+    metastore: Any,
     max_extract_bytes: int = 100 * 1024 * 1024,
 ) -> Callable[[list[dict[str, Any]]], None]:
     """Create a post-flush hook for async-on-write extraction.
@@ -33,6 +61,7 @@ def make_extraction_hook(
     Args:
         session_factory: RecordStore session factory for AspectService.
         backend: Storage backend with read_content(content_hash).
+        metastore: Metastore for reading inline content.
         max_extract_bytes: Max file size for auto-extraction (100MB).
 
     Returns:
@@ -77,16 +106,9 @@ def make_extraction_hook(
                         if size and size > max_extract_bytes:
                             continue
 
-                        # Read content from backend via content hash.
-                        # NOTE: This is a full-content read — the CAS backend
-                        # returns bytes by hash, not a file path. Path-based
-                        # O(1) extraction (Avro/Parquet header) is only possible
-                        # in the reindex path where filesystem paths are available.
-                        content_hash = metadata.get("etag")
-                        if not content_hash:
-                            continue
-
-                        content = backend.read_content(content_hash)
+                        # Read content: inline files are stored in the metastore,
+                        # CAS files are stored in the backend.
+                        content = _read_content(metadata, backend, metastore, path)
                         if content is None:
                             continue
 

--- a/src/nexus/factory/_extraction_hook.py
+++ b/src/nexus/factory/_extraction_hook.py
@@ -77,7 +77,11 @@ def make_extraction_hook(
                         if size and size > max_extract_bytes:
                             continue
 
-                        # Read content from backend via content hash
+                        # Read content from backend via content hash.
+                        # NOTE: This is a full-content read — the CAS backend
+                        # returns bytes by hash, not a file path. Path-based
+                        # O(1) extraction (Avro/Parquet header) is only possible
+                        # in the reindex path where filesystem paths are available.
                         content_hash = metadata.get("etag")
                         if not content_hash:
                             continue

--- a/src/nexus/factory/_extraction_hook.py
+++ b/src/nexus/factory/_extraction_hook.py
@@ -1,0 +1,126 @@
+"""Async-on-write extraction hook — factory wiring for Issue #2978.
+
+Creates a post-flush hook function that reads file content from the
+backend and runs CatalogService.extract_auto() for supported formats.
+
+The hook:
+    1. Iterates flushed events, filtering for "write" ops
+    2. Format-gates: checks extension against registered extractors
+    3. Reads content from the backend via content hash (etag)
+    4. Calls CatalogService.extract_auto() to store aspects
+    5. Wraps all extractions in a single DB transaction with savepoints
+
+Failures are logged and ignored — extraction is best-effort.
+Recovery: ``nexus reindex --target semantic`` catches gaps.
+"""
+
+import logging
+import mimetypes
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def make_extraction_hook(
+    *,
+    session_factory: Callable[..., Any],
+    backend: Any,
+    max_extract_bytes: int = 100 * 1024 * 1024,
+) -> Callable[[list[dict[str, Any]]], None]:
+    """Create a post-flush hook for async-on-write extraction.
+
+    Args:
+        session_factory: RecordStore session factory for AspectService.
+        backend: Storage backend with read_content(content_hash).
+        max_extract_bytes: Max file size for auto-extraction (100MB).
+
+    Returns:
+        Hook function: ``(events: list[dict]) -> None``
+    """
+
+    def extraction_hook(events: list[dict[str, Any]]) -> None:
+        """Extract schemas/documents for written files (best-effort)."""
+        # Filter to write events only
+        write_events = [e for e in events if e.get("op") == "write"]
+        if not write_events:
+            return
+
+        try:
+            from nexus.bricks.catalog.protocol import CatalogService
+            from nexus.contracts.urn import NexusURN
+            from nexus.storage.aspect_service import AspectService
+
+            with session_factory() as session:
+                aspect_service = AspectService(session)
+                catalog = CatalogService(aspect_service)
+
+                extracted = 0
+                for event in write_events:
+                    try:
+                        path = event.get("path", "")
+                        zone_id = event.get("zone_id")
+                        metadata = event.get("metadata", {})
+
+                        # Derive filename for format detection
+                        filename = path.rsplit("/", 1)[-1] if "/" in path else path
+                        mime_type = metadata.get("mime_type") or None
+                        if mime_type is None:
+                            mime_type, _ = mimetypes.guess_type(filename)
+
+                        # Format-gate: skip files with no registered extractor
+                        if not catalog.has_extractor(mime_type=mime_type, filename=filename):
+                            continue
+
+                        # Size-gate: skip files too large for extraction
+                        size = metadata.get("size", 0)
+                        if size and size > max_extract_bytes:
+                            continue
+
+                        # Read content from backend via content hash
+                        content_hash = metadata.get("etag")
+                        if not content_hash:
+                            continue
+
+                        content = backend.read_content(content_hash)
+                        if content is None:
+                            continue
+
+                        # Build URN and extract
+                        urn = str(NexusURN.for_file(zone_id or "default", path))
+
+                        # Savepoint isolation: one extraction failing
+                        # doesn't roll back others (Issue #2978, Issue 16)
+                        with session.begin_nested():
+                            catalog.extract_auto(
+                                entity_urn=urn,
+                                content=content,
+                                mime_type=mime_type,
+                                filename=filename,
+                                zone_id=zone_id,
+                                created_by="auto-extract",
+                            )
+                            extracted += 1
+
+                    except Exception:
+                        logger.debug(
+                            "Extraction failed for %s (non-critical)",
+                            event.get("path"),
+                            exc_info=True,
+                        )
+
+                if extracted > 0:
+                    session.commit()
+                    logger.debug(
+                        "Post-flush extraction: %d/%d files extracted",
+                        extracted,
+                        len(write_events),
+                    )
+
+        except Exception:
+            logger.debug(
+                "Post-flush extraction batch failed (non-critical)",
+                exc_info=True,
+            )
+
+    return extraction_hook

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -180,6 +180,7 @@ def _boot_system_services(
             extraction_hook = make_extraction_hook(
                 session_factory=ctx.record_store.session_factory,
                 backend=ctx.backend,
+                metastore=ctx.metadata_store,
                 max_extract_bytes=100 * 1024 * 1024,  # 100MB
             )
             write_observer.register_post_flush_hook(extraction_hook)

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -171,6 +171,22 @@ def _boot_system_services(
             logger.critical("[BOOT:SYSTEM] Critical service failure: %s", exc)
             raise BootError(str(exc), tier="system-critical") from exc
 
+    # --- Async-on-write extraction hook (Issue #2978) ---
+    # Degradable: extraction is best-effort; failures do not block writes.
+    if hasattr(write_observer, "register_post_flush_hook"):
+        try:
+            from nexus.factory._extraction_hook import make_extraction_hook
+
+            extraction_hook = make_extraction_hook(
+                session_factory=ctx.record_store.session_factory,
+                backend=ctx.backend,
+                max_extract_bytes=100 * 1024 * 1024,  # 100MB
+            )
+            write_observer.register_post_flush_hook(extraction_hook)
+            logger.debug("[BOOT:SYSTEM] Async-on-write extraction hook registered")
+        except Exception as exc:
+            logger.warning("[BOOT:SYSTEM] Extraction hook unavailable: %s", exc)
+
     # =====================================================================
     # DEGRADABLE FORMER-KERNEL SECTION (WARNING + None) — Issue #2193
     # =====================================================================

--- a/src/nexus/storage/piped_record_store_write_observer.py
+++ b/src/nexus/storage/piped_record_store_write_observer.py
@@ -32,7 +32,6 @@ Architecture:
 
 import asyncio
 import contextlib
-import hashlib
 import json
 import logging
 import time
@@ -104,6 +103,10 @@ class PipedRecordStoreWriteObserver:
         self._total_retries = 0
         self._total_dropped = 0
 
+        # Post-flush hooks: called after successful commit (Issue #2978)
+        # Used by CatalogService for async-on-write extraction
+        self._post_flush_hooks: list[Any] = []
+
     # ------------------------------------------------------------------
     # Deferred injection
     # ------------------------------------------------------------------
@@ -111,6 +114,15 @@ class PipedRecordStoreWriteObserver:
     def set_pipe_manager(self, pm: "PipeManager") -> None:
         """Inject PipeManager after factory boot."""
         self._pipe_manager = pm
+
+    def register_post_flush_hook(self, hook: Any) -> None:
+        """Register a callback invoked after each successful flush.
+
+        Hooks receive the list of flushed events. They run AFTER the
+        audit trail commit, so failures do not block the audit path.
+        Used by CatalogService for async-on-write extraction (Issue #2978).
+        """
+        self._post_flush_hooks.append(hook)
 
     # ------------------------------------------------------------------
     # WriteObserverProtocol — sync hot path
@@ -376,13 +388,12 @@ class PipedRecordStoreWriteObserver:
     def _build_urn(path: str, zone_id: str | None) -> str:
         """Build a locator URN for a file from its virtual path.
 
-        URNs are locators (Issue #2929 Key Decision #3): they change on
-        rename. The identifier is a deterministic SHA-256 hash prefix of
-        the path, so any caller can compute the same URN without a
-        database lookup.
+        Delegates to NexusURN.for_file() — single source of truth for
+        URN construction (Issue #2978, Issue #2929 Key Decision #3).
         """
-        path_hash = hashlib.sha256(path.encode()).hexdigest()[:32]
-        return f"urn:nexus:file:{zone_id or 'default'}:{path_hash}"
+        from nexus.contracts.urn import NexusURN
+
+        return str(NexusURN.for_file(zone_id or "default", path))
 
     def _record_mcl_for_event(
         self,
@@ -568,6 +579,18 @@ class PipedRecordStoreWriteObserver:
                 len(events),
                 duration,
             )
+
+            # Post-flush hooks: extraction, etc. (Issue #2978)
+            # Runs AFTER commit — failures do not block audit trail.
+            for hook in self._post_flush_hooks:
+                try:
+                    hook(events)
+                except Exception as hook_err:
+                    logger.debug(
+                        "Post-flush hook %s failed (non-critical): %s",
+                        getattr(hook, "__name__", hook),
+                        hook_err,
+                    )
 
         except Exception as e:
             if attempt < _MAX_RETRIES:

--- a/src/nexus/storage/record_store_write_observer.py
+++ b/src/nexus/storage/record_store_write_observer.py
@@ -55,6 +55,34 @@ class RecordStoreWriteObserver:
         self._session_factory = record_store.session_factory
         self._strict_mode = strict_mode
 
+        # Post-flush hooks: called after successful commit (Issue #2978)
+        # Same interface as PipedRecordStoreWriteObserver so the factory
+        # can wire extraction hooks regardless of which observer is active.
+        self._post_flush_hooks: list = []
+
+    def register_post_flush_hook(self, hook: object) -> None:
+        """Register a callback invoked after each successful write commit.
+
+        Hooks receive a list of event dicts (same shape as piped observer).
+        They run AFTER the audit trail commit, so failures do not block
+        the audit path. Used by CatalogService for on-write extraction.
+        """
+        self._post_flush_hooks.append(hook)
+
+    def _run_post_flush_hooks(self, events: list) -> None:
+        """Run post-flush hooks after a successful commit. Best-effort."""
+        if not self._post_flush_hooks:
+            return
+        for hook in self._post_flush_hooks:
+            try:
+                hook(events)
+            except Exception as hook_err:
+                logger.debug(
+                    "Post-flush hook %s failed (non-critical): %s",
+                    getattr(hook, "__name__", hook),
+                    hook_err,
+                )
+
     def _handle_error(self, operation: str, path: str, error: Exception) -> None:
         """Apply audit error policy: raise or log depending on strict_mode."""
         from nexus.contracts.exceptions import AuditLogError
@@ -116,6 +144,20 @@ class RecordStoreWriteObserver:
                 )
                 VersionRecorder(session).record_write(metadata, is_new=is_new)
                 session.commit()
+
+            # Post-flush hooks: extraction, etc. (Issue #2978)
+            self._run_post_flush_hooks(
+                [
+                    {
+                        "op": "write",
+                        "path": path,
+                        "is_new": is_new,
+                        "zone_id": zone_id,
+                        "agent_id": agent_id,
+                        "metadata": metadata.to_dict(),
+                    }
+                ]
+            )
         except Exception as e:
             self._handle_error("write", path, e)
 
@@ -157,6 +199,21 @@ class RecordStoreWriteObserver:
                     recorder.record_write(metadata, is_new=is_new)
 
                 session.commit()
+
+            # Post-flush hooks: extraction, etc. (Issue #2978)
+            self._run_post_flush_hooks(
+                [
+                    {
+                        "op": "write",
+                        "path": md.path,
+                        "is_new": new,
+                        "zone_id": zone_id,
+                        "agent_id": agent_id,
+                        "metadata": md.to_dict(),
+                    }
+                    for md, new in items
+                ]
+            )
         except Exception as e:
             first_path = items[0][0].path if items else "<batch>"
             self._handle_error("write_batch", first_path, e)

--- a/src/nexus/storage/record_store_write_observer.py
+++ b/src/nexus/storage/record_store_write_observer.py
@@ -27,7 +27,6 @@ in ``nexus.storage.piped_record_store_write_observer``.
 Issue #900: Replaced snapshot_hash/metadata_snapshot params with metadata.
 """
 
-import hashlib
 import logging
 
 from nexus.contracts.metadata import FileMetadata
@@ -282,13 +281,12 @@ class RecordStoreWriteObserver:
     def _build_urn(path: str, zone_id: str | None) -> str:
         """Build a locator URN for a file from its virtual path.
 
-        URNs are locators (Issue #2929 Key Decision #3): they change on
-        rename. The identifier is a deterministic SHA-256 hash prefix of
-        the path, so any caller can compute the same URN without a
-        database lookup.
+        Delegates to NexusURN.for_file() — single source of truth for
+        URN construction (Issue #2978, Issue #2929 Key Decision #3).
         """
-        path_hash = hashlib.sha256(path.encode()).hexdigest()[:32]
-        return f"urn:nexus:file:{zone_id or 'default'}:{path_hash}"
+        from nexus.contracts.urn import NexusURN
+
+        return str(NexusURN.for_file(zone_id or "default", path))
 
     def on_rmdir(
         self,

--- a/tests/unit/bricks/catalog/test_catalog_service.py
+++ b/tests/unit/bricks/catalog/test_catalog_service.py
@@ -32,6 +32,9 @@ def _reset_registry():
     registry = AspectRegistry.get()
     registry.register("path", PathAspect, max_versions=5)
     registry.register("schema_metadata", SchemaMetadataAspect, max_versions=20)
+    from nexus.contracts.aspects import DocumentStructureAspect
+
+    registry.register("document_structure", DocumentStructureAspect, max_versions=10)
     yield
     AspectRegistry.reset()
 
@@ -188,3 +191,200 @@ class TestCatalogSearchByColumn:
         results = catalog_service.search_by_column("col_a", zone_id="z1")
         assert len(results) == 1
         assert "z1" in results[0]["entity_urn"]
+
+
+class TestCatalogFilenameDetection:
+    """Test filename-based format detection for all formats (Issue #2978, Issue 12)."""
+
+    def test_csv_by_filename(self, catalog_service: CatalogService, db_session: Session) -> None:
+        content = b"name,age\nAlice,30\n"
+        result = catalog_service.extract_schema(
+            entity_urn="urn:nexus:file:z1:fn1",
+            content=content,
+            mime_type=None,
+            filename="data.csv",
+            zone_id="z1",
+        )
+        db_session.commit()
+        assert result.schema is not None
+        assert result.format == "csv"
+
+    def test_tsv_by_filename(self, catalog_service: CatalogService) -> None:
+        content = b"name\tage\nAlice\t30\n"
+        result = catalog_service.extract_schema(
+            entity_urn="urn:nexus:file:z1:fn2",
+            content=content,
+            mime_type=None,
+            filename="data.tsv",
+        )
+        assert result.schema is not None
+
+    def test_json_by_filename(self, catalog_service: CatalogService) -> None:
+        import json
+
+        content = json.dumps([{"id": 1}]).encode()
+        result = catalog_service.extract_schema(
+            entity_urn="urn:nexus:file:z1:fn3",
+            content=content,
+            mime_type=None,
+            filename="data.json",
+        )
+        assert result.schema is not None
+        assert result.format == "json"
+
+    def test_jsonl_by_filename(self, catalog_service: CatalogService) -> None:
+        content = b'{"id": 1}\n{"id": 2}\n'
+        result = catalog_service.extract_schema(
+            entity_urn="urn:nexus:file:z1:fn4",
+            content=content,
+            mime_type=None,
+            filename="data.jsonl",
+        )
+        assert result.schema is not None
+
+    def test_avro_by_filename(self, catalog_service: CatalogService) -> None:
+        # Without fastavro, this should return an error (not crash)
+        result = catalog_service.extract_schema(
+            entity_urn="urn:nexus:file:z1:fn5",
+            content=b"not real avro",
+            mime_type=None,
+            filename="data.avro",
+        )
+        assert result.format == "avro"
+
+    def test_unknown_extension(self, catalog_service: CatalogService) -> None:
+        result = catalog_service.extract_schema(
+            entity_urn="urn:nexus:file:z1:fn6",
+            content=b"hello",
+            mime_type=None,
+            filename="data.xyz",
+        )
+        assert result.schema is None
+        assert result.error is not None
+
+    def test_no_extension(self, catalog_service: CatalogService) -> None:
+        result = catalog_service.extract_schema(
+            entity_urn="urn:nexus:file:z1:fn7",
+            content=b"hello",
+            mime_type=None,
+            filename="Makefile",
+        )
+        assert result.schema is None
+
+
+class TestCatalogDocumentExtraction:
+    """Test document extraction (Markdown -> document_structure aspect)."""
+
+    def test_extract_markdown_stores_document_structure(
+        self, catalog_service: CatalogService, db_session: Session
+    ) -> None:
+        content = b"# My Doc\n\nSome text here.\n"
+        result = catalog_service.extract_document(
+            entity_urn="urn:nexus:file:z1:md1",
+            content=content,
+            mime_type="text/markdown",
+            zone_id="z1",
+        )
+        db_session.commit()
+
+        assert result.error is None
+        assert result.title == "My Doc"
+
+        stored = catalog_service.get_document_structure("urn:nexus:file:z1:md1")
+        assert stored is not None
+        assert stored["title"] == "My Doc"
+        assert len(stored["headings"]) == 1
+
+    def test_extract_markdown_by_filename(
+        self, catalog_service: CatalogService, db_session: Session
+    ) -> None:
+        content = b"# Hello\n\nWorld.\n"
+        result = catalog_service.extract_document(
+            entity_urn="urn:nexus:file:z1:md2",
+            content=content,
+            mime_type=None,
+            filename="readme.md",
+            zone_id="z1",
+        )
+        db_session.commit()
+
+        assert result.error is None
+        assert result.title == "Hello"
+
+    def test_unsupported_document_format(self, catalog_service: CatalogService) -> None:
+        result = catalog_service.extract_document(
+            entity_urn="urn:nexus:file:z1:md3",
+            content=b"not markdown",
+            mime_type="text/plain",
+        )
+        assert result.error is not None
+
+    def test_document_too_large(self, db_session: Session) -> None:
+        from nexus.storage.aspect_service import AspectService
+
+        catalog = CatalogService(AspectService(db_session), max_auto_extract_bytes=10)
+        content = b"# " + b"x" * 100
+        result = catalog.extract_document(
+            entity_urn="urn:nexus:file:z1:md4",
+            content=content,
+            mime_type="text/markdown",
+        )
+        assert result.error is not None
+
+
+class TestCatalogExtractAuto:
+    """Test extract_auto() dispatching."""
+
+    def test_auto_detects_csv(self, catalog_service: CatalogService, db_session: Session) -> None:
+        content = b"a,b\n1,2\n"
+        result = catalog_service.extract_auto(
+            entity_urn="urn:nexus:file:z1:auto1",
+            content=content,
+            filename="data.csv",
+            zone_id="z1",
+        )
+        db_session.commit()
+        from nexus.bricks.catalog.extractors import ExtractionResult
+
+        assert isinstance(result, ExtractionResult)
+        assert result.schema is not None
+
+    def test_auto_detects_markdown(
+        self, catalog_service: CatalogService, db_session: Session
+    ) -> None:
+        content = b"# Title\n\nBody text.\n"
+        result = catalog_service.extract_auto(
+            entity_urn="urn:nexus:file:z1:auto2",
+            content=content,
+            filename="readme.md",
+            zone_id="z1",
+        )
+        db_session.commit()
+        from nexus.bricks.catalog.extractors import DocumentExtractionResult
+
+        assert isinstance(result, DocumentExtractionResult)
+        assert result.title == "Title"
+
+    def test_auto_unknown_format(self, catalog_service: CatalogService) -> None:
+        result = catalog_service.extract_auto(
+            entity_urn="urn:nexus:file:z1:auto3",
+            content=b"unknown",
+            filename="data.xyz",
+        )
+        assert result.error is not None
+
+
+class TestCatalogHasExtractor:
+    """Test has_extractor() format-gate."""
+
+    def test_has_schema_extractor(self, catalog_service: CatalogService) -> None:
+        assert catalog_service.has_extractor(filename="data.csv") is True
+        assert catalog_service.has_extractor(mime_type="text/csv") is True
+
+    def test_has_document_extractor(self, catalog_service: CatalogService) -> None:
+        assert catalog_service.has_extractor(filename="readme.md") is True
+        assert catalog_service.has_extractor(mime_type="text/markdown") is True
+
+    def test_no_extractor(self, catalog_service: CatalogService) -> None:
+        assert catalog_service.has_extractor(filename="data.xyz") is False
+        assert catalog_service.has_extractor(mime_type="text/plain") is False

--- a/tests/unit/bricks/catalog/test_extractors.py
+++ b/tests/unit/bricks/catalog/test_extractors.py
@@ -357,7 +357,7 @@ class TestAvroExtractor:
         assert result.confidence == 1.0
         assert result.schema is not None
         assert len(result.schema) == 3
-        assert result.row_count == 2
+        assert result.row_count is None  # O(1) header-only — no row counting
 
         names = {c["name"] for c in result.schema}
         assert names == {"id", "name", "score"}
@@ -498,7 +498,7 @@ class TestAvroExtractor:
         assert result.error is None
         assert result.schema is not None
         assert len(result.schema) == 1
-        assert result.row_count == 0
+        assert result.row_count is None  # O(1) header-only — no row counting
 
     @pytest.mark.skipif(not _has_fastavro(), reason="fastavro not installed")
     def test_map_type(self) -> None:

--- a/tests/unit/bricks/catalog/test_extractors.py
+++ b/tests/unit/bricks/catalog/test_extractors.py
@@ -9,9 +9,12 @@ import json
 import pytest
 
 from nexus.bricks.catalog.extractors import (
+    AvroExtractor,
     CSVExtractor,
+    DocumentExtractionResult,
     ExtractionResult,
     JSONExtractor,
+    MarkdownExtractor,
     ParquetExtractor,
 )
 
@@ -19,6 +22,15 @@ from nexus.bricks.catalog.extractors import (
 def _has_pyarrow() -> bool:
     try:
         import pyarrow  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _has_fastavro() -> bool:
+    try:
+        import fastavro  # noqa: F401
 
         return True
     except ImportError:
@@ -296,3 +308,417 @@ class TestExtractionResult:
         result = ExtractionResult(schema=None, format="csv", confidence=0.0)
         with pytest.raises(AttributeError):
             result.format = "json"
+
+
+# ============================================================================
+# Avro Extractor Tests
+# ============================================================================
+
+
+class TestAvroExtractor:
+    """Avro schema extraction."""
+
+    def test_invalid_content(self) -> None:
+        result = AvroExtractor().extract(b"not an avro file")
+        assert result.error is not None
+        assert result.format == "avro"
+
+    def test_empty_content(self) -> None:
+        result = AvroExtractor().extract(b"")
+        assert result.error is not None
+
+    @pytest.mark.skipif(not _has_fastavro(), reason="fastavro not installed")
+    def test_valid_avro(self) -> None:
+        """Test with a real Avro file."""
+        import io
+
+        import fastavro
+
+        schema = {
+            "type": "record",
+            "name": "User",
+            "fields": [
+                {"name": "id", "type": "int"},
+                {"name": "name", "type": "string"},
+                {"name": "score", "type": "double"},
+            ],
+        }
+        records = [
+            {"id": 1, "name": "Alice", "score": 3.14},
+            {"id": 2, "name": "Bob", "score": 2.72},
+        ]
+        buf = io.BytesIO()
+        fastavro.writer(buf, schema, records)
+        content = buf.getvalue()
+
+        result = AvroExtractor().extract(content)
+        assert result.error is None
+        assert result.format == "avro"
+        assert result.confidence == 1.0
+        assert result.schema is not None
+        assert len(result.schema) == 3
+        assert result.row_count == 2
+
+        names = {c["name"] for c in result.schema}
+        assert names == {"id", "name", "score"}
+
+    @pytest.mark.skipif(not _has_fastavro(), reason="fastavro not installed")
+    def test_nullable_union_types(self) -> None:
+        """Avro union types like ["null", "string"] should be detected as nullable."""
+        import io
+
+        import fastavro
+
+        schema = {
+            "type": "record",
+            "name": "NullableTest",
+            "fields": [
+                {"name": "required_id", "type": "int"},
+                {"name": "optional_name", "type": ["null", "string"]},
+            ],
+        }
+        records = [{"required_id": 1, "optional_name": "Alice"}]
+        buf = io.BytesIO()
+        fastavro.writer(buf, schema, records)
+        content = buf.getvalue()
+
+        result = AvroExtractor().extract(content)
+        assert result.schema is not None
+        cols = {c["name"]: c for c in result.schema}
+        assert cols["required_id"]["nullable"] == "False"
+        assert cols["optional_name"]["nullable"] == "True"
+        assert cols["optional_name"]["type"] == "string"
+
+    @pytest.mark.skipif(not _has_fastavro(), reason="fastavro not installed")
+    def test_nested_record_type(self) -> None:
+        """Avro nested record fields should be typed as 'record'."""
+        import io
+
+        import fastavro
+
+        schema = {
+            "type": "record",
+            "name": "Parent",
+            "fields": [
+                {"name": "id", "type": "int"},
+                {
+                    "name": "address",
+                    "type": {
+                        "type": "record",
+                        "name": "Address",
+                        "fields": [
+                            {"name": "city", "type": "string"},
+                        ],
+                    },
+                },
+            ],
+        }
+        records = [{"id": 1, "address": {"city": "NYC"}}]
+        buf = io.BytesIO()
+        fastavro.writer(buf, schema, records)
+        content = buf.getvalue()
+
+        result = AvroExtractor().extract(content)
+        assert result.schema is not None
+        types = {c["name"]: c["type"] for c in result.schema}
+        assert types["address"] == "record"
+
+    @pytest.mark.skipif(not _has_fastavro(), reason="fastavro not installed")
+    def test_array_type(self) -> None:
+        """Avro array fields should be typed as 'array'."""
+        import io
+
+        import fastavro
+
+        schema = {
+            "type": "record",
+            "name": "ArrayTest",
+            "fields": [
+                {"name": "tags", "type": {"type": "array", "items": "string"}},
+            ],
+        }
+        records = [{"tags": ["a", "b"]}]
+        buf = io.BytesIO()
+        fastavro.writer(buf, schema, records)
+        content = buf.getvalue()
+
+        result = AvroExtractor().extract(content)
+        assert result.schema is not None
+        assert result.schema[0]["type"] == "array"
+
+    @pytest.mark.skipif(not _has_fastavro(), reason="fastavro not installed")
+    def test_enum_type(self) -> None:
+        """Avro enum fields."""
+        import io
+
+        import fastavro
+
+        schema = {
+            "type": "record",
+            "name": "EnumTest",
+            "fields": [
+                {
+                    "name": "color",
+                    "type": {
+                        "type": "enum",
+                        "name": "Color",
+                        "symbols": ["RED", "GREEN", "BLUE"],
+                    },
+                },
+            ],
+        }
+        records = [{"color": "RED"}]
+        buf = io.BytesIO()
+        fastavro.writer(buf, schema, records)
+        content = buf.getvalue()
+
+        result = AvroExtractor().extract(content)
+        assert result.schema is not None
+        assert result.schema[0]["type"] == "enum"
+
+    @pytest.mark.skipif(not _has_fastavro(), reason="fastavro not installed")
+    def test_schema_only_no_records(self) -> None:
+        """Avro file with schema but no data records."""
+        import io
+
+        import fastavro
+
+        schema = {
+            "type": "record",
+            "name": "Empty",
+            "fields": [
+                {"name": "id", "type": "int"},
+            ],
+        }
+        buf = io.BytesIO()
+        fastavro.writer(buf, schema, [])
+        content = buf.getvalue()
+
+        result = AvroExtractor().extract(content)
+        assert result.error is None
+        assert result.schema is not None
+        assert len(result.schema) == 1
+        assert result.row_count == 0
+
+    @pytest.mark.skipif(not _has_fastavro(), reason="fastavro not installed")
+    def test_map_type(self) -> None:
+        """Avro map fields should be typed as 'map'."""
+        import io
+
+        import fastavro
+
+        schema = {
+            "type": "record",
+            "name": "MapTest",
+            "fields": [
+                {"name": "attrs", "type": {"type": "map", "values": "string"}},
+            ],
+        }
+        records = [{"attrs": {"key1": "val1"}}]
+        buf = io.BytesIO()
+        fastavro.writer(buf, schema, records)
+        content = buf.getvalue()
+
+        result = AvroExtractor().extract(content)
+        assert result.schema is not None
+        assert result.schema[0]["type"] == "map"
+
+    def test_self_registration_metadata(self) -> None:
+        """AvroExtractor declares mime_types and extensions."""
+        ext = AvroExtractor()
+        assert "application/avro" in ext.mime_types
+        assert "avro" in ext.extensions
+
+
+# ============================================================================
+# Markdown Extractor Tests
+# ============================================================================
+
+
+class TestMarkdownExtractor:
+    """Markdown document structure extraction."""
+
+    def test_simple_markdown(self) -> None:
+        content = b"# Hello World\n\nThis is a test.\n"
+        result = MarkdownExtractor().extract(content)
+
+        assert result.format == "markdown"
+        assert result.error is None
+        assert result.confidence == 1.0
+        assert result.title == "Hello World"
+        assert len(result.headings) == 1
+        assert result.headings[0]["level"] == 1
+        assert result.word_count > 0
+
+    def test_empty_markdown(self) -> None:
+        result = MarkdownExtractor().extract(b"")
+        assert result.error is not None
+        assert result.confidence == 0.0
+
+    def test_whitespace_only(self) -> None:
+        result = MarkdownExtractor().extract(b"   \n  \n  ")
+        assert result.error is not None
+
+    def test_yaml_front_matter(self) -> None:
+        content = b"---\ntitle: My Document\nauthor: Alice\ntags:\n  - python\n  - testing\n---\n\n# Content\n\nBody text here.\n"
+        result = MarkdownExtractor().extract(content)
+
+        assert result.front_matter is not None
+        assert result.front_matter["title"] == "My Document"
+        assert result.front_matter["author"] == "Alice"
+        assert result.front_matter["tags"] == ["python", "testing"]
+        # Title from front matter takes priority
+        assert result.title == "My Document"
+
+    def test_invalid_yaml_front_matter_graceful(self) -> None:
+        content = b"---\ninvalid: yaml: content: [[\n---\n\n# Heading\n"
+        result = MarkdownExtractor().extract(content)
+        # Should not crash — front matter is None, but heading is still extracted
+        assert result.error is None
+        assert len(result.headings) >= 1
+
+    def test_no_front_matter(self) -> None:
+        content = b"# Just a heading\n\nSome text.\n"
+        result = MarkdownExtractor().extract(content)
+        assert result.front_matter is None
+        assert result.title == "Just a heading"
+
+    def test_multiple_heading_levels(self) -> None:
+        content = b"# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\n"
+        result = MarkdownExtractor().extract(content)
+
+        assert len(result.headings) == 6
+        for i, h in enumerate(result.headings, 1):
+            assert h["level"] == i
+            assert h["text"] == f"H{i}"
+
+    def test_setext_headings(self) -> None:
+        content = b"Heading One\n===\n\nHeading Two\n---\n"
+        result = MarkdownExtractor().extract(content)
+
+        assert len(result.headings) == 2
+        assert result.headings[0]["level"] == 1
+        assert result.headings[0]["text"] == "Heading One"
+        assert result.headings[1]["level"] == 2
+        assert result.headings[1]["text"] == "Heading Two"
+
+    def test_heading_inside_code_block_ignored(self) -> None:
+        content = b"# Real Heading\n\n```python\n# This is a comment, not a heading\ndef foo():\n    pass\n```\n"
+        result = MarkdownExtractor().extract(content)
+
+        assert len(result.headings) == 1
+        assert result.headings[0]["text"] == "Real Heading"
+
+    def test_code_block_languages(self) -> None:
+        content = b"```python\nprint('hello')\n```\n\n```rust\nfn main() {}\n```\n\n```python\nx = 1\n```\n"
+        result = MarkdownExtractor().extract(content)
+
+        assert len(result.code_languages) == 3
+        assert result.code_languages[0] == "python"
+        assert result.code_languages[1] == "rust"
+        assert result.code_languages[2] == "python"
+
+    def test_code_block_no_language(self) -> None:
+        content = b"```\nsome code\n```\n"
+        result = MarkdownExtractor().extract(content)
+        # No language annotation — should not appear in list
+        assert len(result.code_languages) == 0
+
+    def test_link_count(self) -> None:
+        content = b"[link1](http://a.com) and [link2](http://b.com)\n\nAlso [ref][1]\n\n[1]: http://c.com\n"
+        result = MarkdownExtractor().extract(content)
+        assert result.link_count >= 2
+
+    def test_word_count_excludes_code_blocks(self) -> None:
+        content = b"Hello world.\n\n```python\nthis_is_code = True\nmore_code_here = False\n```\n\nGoodbye world.\n"
+        result = MarkdownExtractor().extract(content)
+        # "Hello world." + "Goodbye world." = ~4 words, code excluded
+        assert result.word_count >= 2
+        assert result.word_count < 10  # Code words should not be counted
+
+    def test_unicode_headings(self) -> None:
+        content = "# 日本語の見出し\n\n本文テキスト。\n".encode()
+        result = MarkdownExtractor().extract(content)
+        assert result.title == "日本語の見出し"
+
+    def test_front_matter_date_sanitized(self) -> None:
+        """YAML dates should be sanitized to strings."""
+        content = b"---\ntitle: Test\ndate: 2026-01-15\n---\n\n# Content\n"
+        result = MarkdownExtractor().extract(content)
+        assert result.front_matter is not None
+        # The date should be a string (sanitized), not a datetime object
+        date_val = result.front_matter.get("date")
+        assert isinstance(date_val, str)
+
+    def test_self_registration_metadata(self) -> None:
+        """MarkdownExtractor declares mime_types and extensions."""
+        ext = MarkdownExtractor()
+        assert "text/markdown" in ext.mime_types
+        assert "md" in ext.extensions
+        assert "markdown" in ext.extensions
+
+    def test_title_from_first_h1_when_no_front_matter(self) -> None:
+        content = b"## Not a title\n\n# Actual Title\n\nBody.\n"
+        result = MarkdownExtractor().extract(content)
+        assert result.title == "Actual Title"
+
+
+# ============================================================================
+# DocumentExtractionResult Tests
+# ============================================================================
+
+
+class TestDocumentExtractionResult:
+    """DocumentExtractionResult value type tests."""
+
+    def test_success_result(self) -> None:
+        result = DocumentExtractionResult(
+            title="Test",
+            headings=[{"level": 1, "text": "Test"}],
+            front_matter=None,
+            word_count=10,
+            link_count=2,
+            code_languages=["python"],
+            format="markdown",
+            confidence=1.0,
+        )
+        assert result.error is None
+        assert result.warnings == []
+
+    def test_frozen(self) -> None:
+        result = DocumentExtractionResult(
+            title=None,
+            headings=[],
+            front_matter=None,
+            word_count=0,
+            link_count=0,
+            code_languages=[],
+            format="markdown",
+            confidence=0.0,
+        )
+        with pytest.raises(AttributeError):
+            result.format = "other"
+
+
+# ============================================================================
+# Self-Registration Metadata Tests
+# ============================================================================
+
+
+class TestExtractorSelfRegistration:
+    """Verify all extractors declare mime_types and extensions."""
+
+    def test_csv_extractor_metadata(self) -> None:
+        ext = CSVExtractor()
+        assert "text/csv" in ext.mime_types
+        assert "csv" in ext.extensions
+
+    def test_json_extractor_metadata(self) -> None:
+        ext = JSONExtractor()
+        assert "application/json" in ext.mime_types
+        assert "json" in ext.extensions
+
+    def test_parquet_extractor_metadata(self) -> None:
+        ext = ParquetExtractor()
+        assert "application/parquet" in ext.mime_types
+        assert "parquet" in ext.extensions

--- a/tests/unit/cli/test_init_cmd.py
+++ b/tests/unit/cli/test_init_cmd.py
@@ -101,10 +101,9 @@ class TestAddonProfileMap:
 
 
 class TestResolveImageRef:
-    def test_stable_channel_pins_to_version(self) -> None:
+    def test_stable_channel_uses_stable_tag(self) -> None:
         ref = _resolve_image_ref("stable", "cpu")
-        assert ref.startswith("ghcr.io/nexi-lab/nexus:")
-        assert ref != "ghcr.io/nexi-lab/nexus:latest"  # Should use __version__
+        assert ref == "ghcr.io/nexi-lab/nexus:stable"
 
     def test_edge_channel_uses_edge_tag(self) -> None:
         ref = _resolve_image_ref("edge", "cpu")

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -40,7 +40,7 @@ def shared_config(tmp_path: Path) -> Path:
         "compose_file": str(tmp_path / "nexus-stack.yml"),
         "auth": "static",
         "tls": False,
-        "image_ref": "ghcr.io/nexi-lab/nexus:0.9.2",
+        "image_ref": "ghcr.io/nexi-lab/nexus:stable",
         "image_channel": "stable",
         "image_accelerator": "cpu",
     }
@@ -417,11 +417,21 @@ class TestUpgradeCommand:
             assert result.exit_code == 0
             assert "does not use a prebuilt image" in result.output
 
-    def test_already_up_to_date(self, runner: CliRunner, shared_config: Path) -> None:
+    def test_already_up_to_date_pinned(self, runner: CliRunner, shared_config: Path) -> None:
+        """Pinned configs (no image_channel) report 'up to date' when ref matches."""
+        # Override config to be pinned (no image_channel)
+        cfg_path = shared_config / "nexus.yaml"
+        with open(cfg_path) as f:
+            config = yaml.safe_load(f)
+        config["image_pin"] = "tag"
+        config.pop("image_channel", None)
+        with open(cfg_path, "w") as f:
+            yaml.dump(config, f)
+
         with (
             patch(
                 "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
-                (str(shared_config / "nexus.yaml"),),
+                (str(cfg_path),),
             ),
             patch(
                 "nexus.cli.commands.stack._resolve_image_ref",
@@ -430,7 +440,33 @@ class TestUpgradeCommand:
         ):
             result = runner.invoke(upgrade)
             assert result.exit_code == 0
-            assert "up to date" in result.output.lower()
+            assert "pinned" in result.output.lower()
+
+    def test_channel_following_pulls_latest(self, runner: CliRunner, shared_config: Path) -> None:
+        """Channel-following configs pull the latest image on upgrade."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with (
+            patch(
+                "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+                (str(shared_config / "nexus.yaml"),),
+            ),
+            patch(
+                "nexus.cli.commands.stack._resolve_image_ref",
+                return_value="ghcr.io/nexi-lab/nexus:stable",
+            ),
+            patch(
+                "nexus.cli.commands.stack._run_compose",
+                return_value=mock_result,
+            ) as mock_compose,
+        ):
+            result = runner.invoke(upgrade)
+            assert result.exit_code == 0
+            assert "pulling" in result.output.lower()
+            # Verify docker compose pull was called
+            mock_compose.assert_called_once()
+            call_args = mock_compose.call_args
+            assert "pull" in call_args[0]
 
     def test_upgrade_with_yes_flag(self, runner: CliRunner, shared_config: Path) -> None:
         with (

--- a/tests/unit/core/test_pipe_consumers.py
+++ b/tests/unit/core/test_pipe_consumers.py
@@ -456,3 +456,151 @@ class TestPipedWriteObserverE2E:
                 assert metrics["total_dropped"] == 0
             finally:
                 await observer.stop()
+
+
+# ======================================================================
+# PipedRecordStoreWriteObserver — Post-flush hook tests (Issue #2978)
+# ======================================================================
+
+
+class TestPostFlushHooks:
+    """Verify post-flush hooks are called after successful flush."""
+
+    @pytest.mark.asyncio
+    async def test_hook_called_after_flush(self) -> None:
+        """Post-flush hook receives events after successful commit."""
+        from nexus.storage.piped_record_store_write_observer import (
+            PipedRecordStoreWriteObserver,
+        )
+
+        # Create mock record store with session factory
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.commit = MagicMock()
+
+        mock_record_store = MagicMock()
+        mock_record_store.session_factory = MagicMock(return_value=mock_session)
+
+        observer = PipedRecordStoreWriteObserver(mock_record_store)
+
+        # Register a hook that captures events
+        captured_events = []
+
+        def capture_hook(events):
+            captured_events.extend(events)
+
+        observer.register_post_flush_hook(capture_hook)
+
+        # Simulate a flush batch
+        test_events = [
+            {
+                "op": "write",
+                "path": "/test.csv",
+                "is_new": True,
+                "zone_id": "z1",
+                "agent_id": None,
+                "snapshot_hash": None,
+                "metadata_snapshot": None,
+                "metadata": {"path": "/test.csv"},
+            },
+        ]
+
+        # Mock _process_events_in_session to be a no-op
+        with patch.object(observer, "_process_events_in_session"):
+            await observer._flush_batch(test_events)
+
+        assert len(captured_events) == 1
+        assert captured_events[0]["path"] == "/test.csv"
+
+    @pytest.mark.asyncio
+    async def test_hook_failure_does_not_block_flush(self) -> None:
+        """A failing hook must not prevent the audit trail from committing."""
+        from nexus.storage.piped_record_store_write_observer import (
+            PipedRecordStoreWriteObserver,
+        )
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.commit = MagicMock()
+
+        mock_record_store = MagicMock()
+        mock_record_store.session_factory = MagicMock(return_value=mock_session)
+
+        observer = PipedRecordStoreWriteObserver(mock_record_store)
+
+        # Register a hook that raises
+        def failing_hook(events):
+            raise RuntimeError("Hook failure!")
+
+        # Register a second hook to verify it still runs
+        second_hook_called = []
+
+        def second_hook(events):
+            second_hook_called.append(True)
+
+        observer.register_post_flush_hook(failing_hook)
+        observer.register_post_flush_hook(second_hook)
+
+        test_events = [
+            {
+                "op": "write",
+                "path": "/test.csv",
+                "is_new": True,
+                "zone_id": None,
+                "agent_id": None,
+                "snapshot_hash": None,
+                "metadata_snapshot": None,
+                "metadata": {"path": "/test.csv"},
+            }
+        ]
+
+        with patch.object(observer, "_process_events_in_session"):
+            await observer._flush_batch(test_events)
+
+        # Flush succeeded despite hook failure
+        assert observer._total_flushed == 1
+        # Second hook was still called
+        assert len(second_hook_called) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_hooks_no_error(self) -> None:
+        """Flush works fine with no hooks registered."""
+        from nexus.storage.piped_record_store_write_observer import (
+            PipedRecordStoreWriteObserver,
+        )
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.commit = MagicMock()
+
+        mock_record_store = MagicMock()
+        mock_record_store.session_factory = MagicMock(return_value=mock_session)
+
+        observer = PipedRecordStoreWriteObserver(mock_record_store)
+
+        test_events = [{"op": "mkdir", "path": "/dir", "zone_id": None, "agent_id": None}]
+
+        with patch.object(observer, "_process_events_in_session"):
+            await observer._flush_batch(test_events)
+
+        assert observer._total_flushed == 1
+
+    def test_register_multiple_hooks(self) -> None:
+        """Multiple hooks can be registered."""
+        from nexus.storage.piped_record_store_write_observer import (
+            PipedRecordStoreWriteObserver,
+        )
+
+        mock_record_store = MagicMock()
+        mock_record_store.session_factory = MagicMock()
+
+        observer = PipedRecordStoreWriteObserver(mock_record_store)
+
+        observer.register_post_flush_hook(lambda events: None)
+        observer.register_post_flush_hook(lambda events: None)
+        observer.register_post_flush_hook(lambda events: None)
+
+        assert len(observer._post_flush_hooks) == 3

--- a/tests/unit/factory/test_extraction_hook.py
+++ b/tests/unit/factory/test_extraction_hook.py
@@ -1,0 +1,269 @@
+"""Tests for async-on-write extraction hook (Issue #2978).
+
+Verifies the factory-created extraction hook correctly:
+- Format-gates: only extracts supported formats
+- Size-gates: skips oversized files
+- Reads content from the backend via content hash
+- Calls CatalogService.extract_auto() with correct args
+- Handles failures gracefully (best-effort)
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from nexus.contracts.aspects import (
+    AspectRegistry,
+    DocumentStructureAspect,
+    PathAspect,
+    SchemaMetadataAspect,
+)
+from nexus.factory._extraction_hook import make_extraction_hook
+from nexus.storage.aspect_service import AspectService
+from nexus.storage.models._base import Base
+
+
+@pytest.fixture()
+def db_session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    AspectRegistry.reset()
+    registry = AspectRegistry.get()
+    registry.register("path", PathAspect, max_versions=5)
+    registry.register("schema_metadata", SchemaMetadataAspect, max_versions=20)
+    registry.register("document_structure", DocumentStructureAspect, max_versions=10)
+    yield
+    AspectRegistry.reset()
+
+
+class TestExtractionHook:
+    """Test the make_extraction_hook factory function."""
+
+    def test_extracts_csv_on_write(self, db_session_factory) -> None:
+        """CSV write events trigger schema extraction."""
+        mock_backend = MagicMock()
+        mock_backend.read_content.return_value = b"name,age\nAlice,30\nBob,25\n"
+
+        hook = make_extraction_hook(
+            session_factory=db_session_factory,
+            backend=mock_backend,
+        )
+
+        events = [
+            {
+                "op": "write",
+                "path": "/data/users.csv",
+                "zone_id": "z1",
+                "metadata": {
+                    "etag": "abc123",
+                    "size": 100,
+                    "mime_type": "text/csv",
+                },
+            }
+        ]
+
+        hook(events)
+
+        # Verify backend was asked to read content
+        mock_backend.read_content.assert_called_once_with("abc123")
+
+        # Verify aspect was stored
+        with db_session_factory() as session:
+            svc = AspectService(session)
+            from nexus.contracts.urn import NexusURN
+
+            urn = str(NexusURN.for_file("z1", "/data/users.csv"))
+            schema = svc.get_aspect(urn, "schema_metadata")
+            assert schema is not None
+            assert len(schema["columns"]) == 2
+
+    def test_extracts_markdown_on_write(self, db_session_factory) -> None:
+        """Markdown write events trigger document extraction."""
+        mock_backend = MagicMock()
+        mock_backend.read_content.return_value = b"# My Doc\n\nSome text.\n"
+
+        hook = make_extraction_hook(
+            session_factory=db_session_factory,
+            backend=mock_backend,
+        )
+
+        events = [
+            {
+                "op": "write",
+                "path": "/docs/readme.md",
+                "zone_id": "z1",
+                "metadata": {
+                    "etag": "md123",
+                    "size": 50,
+                },
+            }
+        ]
+
+        hook(events)
+
+        with db_session_factory() as session:
+            svc = AspectService(session)
+            from nexus.contracts.urn import NexusURN
+
+            urn = str(NexusURN.for_file("z1", "/docs/readme.md"))
+            doc = svc.get_aspect(urn, "document_structure")
+            assert doc is not None
+            assert doc["title"] == "My Doc"
+
+    def test_skips_unsupported_format(self, db_session_factory) -> None:
+        """Files with no registered extractor are skipped."""
+        mock_backend = MagicMock()
+
+        hook = make_extraction_hook(
+            session_factory=db_session_factory,
+            backend=mock_backend,
+        )
+
+        events = [
+            {
+                "op": "write",
+                "path": "/code/main.py",
+                "zone_id": "z1",
+                "metadata": {"etag": "py123", "size": 50},
+            }
+        ]
+
+        hook(events)
+
+        # Backend should NOT be called — format-gated
+        mock_backend.read_content.assert_not_called()
+
+    def test_skips_oversized_files(self, db_session_factory) -> None:
+        """Files exceeding max_extract_bytes are skipped."""
+        mock_backend = MagicMock()
+
+        hook = make_extraction_hook(
+            session_factory=db_session_factory,
+            backend=mock_backend,
+            max_extract_bytes=100,
+        )
+
+        events = [
+            {
+                "op": "write",
+                "path": "/data/big.csv",
+                "zone_id": "z1",
+                "metadata": {"etag": "big123", "size": 200, "mime_type": "text/csv"},
+            }
+        ]
+
+        hook(events)
+
+        mock_backend.read_content.assert_not_called()
+
+    def test_skips_non_write_events(self, db_session_factory) -> None:
+        """Delete, rename, mkdir events are ignored."""
+        mock_backend = MagicMock()
+
+        hook = make_extraction_hook(
+            session_factory=db_session_factory,
+            backend=mock_backend,
+        )
+
+        events = [
+            {"op": "delete", "path": "/data/old.csv", "zone_id": "z1"},
+            {"op": "mkdir", "path": "/data/new", "zone_id": "z1"},
+        ]
+
+        hook(events)
+
+        mock_backend.read_content.assert_not_called()
+
+    def test_skips_missing_etag(self, db_session_factory) -> None:
+        """Events without etag (content hash) are skipped."""
+        mock_backend = MagicMock()
+
+        hook = make_extraction_hook(
+            session_factory=db_session_factory,
+            backend=mock_backend,
+        )
+
+        events = [
+            {
+                "op": "write",
+                "path": "/data/file.csv",
+                "zone_id": "z1",
+                "metadata": {"size": 50, "mime_type": "text/csv"},
+            }
+        ]
+
+        hook(events)
+
+        mock_backend.read_content.assert_not_called()
+
+    def test_backend_failure_does_not_raise(self, db_session_factory) -> None:
+        """Backend read failure is logged, not raised."""
+        mock_backend = MagicMock()
+        mock_backend.read_content.side_effect = RuntimeError("Backend down")
+
+        hook = make_extraction_hook(
+            session_factory=db_session_factory,
+            backend=mock_backend,
+        )
+
+        events = [
+            {
+                "op": "write",
+                "path": "/data/file.csv",
+                "zone_id": "z1",
+                "metadata": {"etag": "fail123", "size": 50, "mime_type": "text/csv"},
+            }
+        ]
+
+        # Should not raise
+        hook(events)
+
+    def test_batch_extraction_partial_failure(self, db_session_factory) -> None:
+        """One file failing doesn't prevent other files from being extracted."""
+        mock_backend = MagicMock()
+
+        def read_content(content_hash):
+            if content_hash == "bad":
+                raise RuntimeError("Corrupted")
+            return b"name,age\nAlice,30\n"
+
+        mock_backend.read_content.side_effect = read_content
+
+        hook = make_extraction_hook(
+            session_factory=db_session_factory,
+            backend=mock_backend,
+        )
+
+        events = [
+            {
+                "op": "write",
+                "path": "/data/bad.csv",
+                "zone_id": "z1",
+                "metadata": {"etag": "bad", "size": 50, "mime_type": "text/csv"},
+            },
+            {
+                "op": "write",
+                "path": "/data/good.csv",
+                "zone_id": "z1",
+                "metadata": {"etag": "good", "size": 50, "mime_type": "text/csv"},
+            },
+        ]
+
+        hook(events)
+
+        # Good file should still be extracted
+        with db_session_factory() as session:
+            svc = AspectService(session)
+            from nexus.contracts.urn import NexusURN
+
+            urn = str(NexusURN.for_file("z1", "/data/good.csv"))
+            schema = svc.get_aspect(urn, "schema_metadata")
+            assert schema is not None

--- a/tests/unit/factory/test_extraction_hook.py
+++ b/tests/unit/factory/test_extraction_hook.py
@@ -55,6 +55,7 @@ class TestExtractionHook:
         hook = make_extraction_hook(
             session_factory=db_session_factory,
             backend=mock_backend,
+            metastore=MagicMock(),
         )
 
         events = [
@@ -93,6 +94,7 @@ class TestExtractionHook:
         hook = make_extraction_hook(
             session_factory=db_session_factory,
             backend=mock_backend,
+            metastore=MagicMock(),
         )
 
         events = [
@@ -125,6 +127,7 @@ class TestExtractionHook:
         hook = make_extraction_hook(
             session_factory=db_session_factory,
             backend=mock_backend,
+            metastore=MagicMock(),
         )
 
         events = [
@@ -148,6 +151,7 @@ class TestExtractionHook:
         hook = make_extraction_hook(
             session_factory=db_session_factory,
             backend=mock_backend,
+            metastore=MagicMock(),
             max_extract_bytes=100,
         )
 
@@ -171,6 +175,7 @@ class TestExtractionHook:
         hook = make_extraction_hook(
             session_factory=db_session_factory,
             backend=mock_backend,
+            metastore=MagicMock(),
         )
 
         events = [
@@ -189,6 +194,7 @@ class TestExtractionHook:
         hook = make_extraction_hook(
             session_factory=db_session_factory,
             backend=mock_backend,
+            metastore=MagicMock(),
         )
 
         events = [
@@ -212,6 +218,7 @@ class TestExtractionHook:
         hook = make_extraction_hook(
             session_factory=db_session_factory,
             backend=mock_backend,
+            metastore=MagicMock(),
         )
 
         events = [
@@ -240,6 +247,7 @@ class TestExtractionHook:
         hook = make_extraction_hook(
             session_factory=db_session_factory,
             backend=mock_backend,
+            metastore=MagicMock(),
         )
 
         events = [

--- a/tests/unit/storage/test_record_store_write_observer.py
+++ b/tests/unit/storage/test_record_store_write_observer.py
@@ -447,3 +447,68 @@ class TestDeliveredColumn:
             ops = session.query(OperationLogModel).all()
             assert len(ops) == 2
             assert all(op.delivered is False for op in ops)
+
+
+# =========================================================================
+# Post-flush hook tests (Issue #2978)
+# =========================================================================
+
+
+class TestPostFlushHookSync:
+    """Verify the sync observer fires post-flush hooks after commit."""
+
+    def test_hook_called_on_write(
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
+    ) -> None:
+        """on_write() fires hooks with event data after commit."""
+        captured = []
+        syncer.register_post_flush_hook(lambda events: captured.extend(events))
+
+        metadata = _make_metadata("/hook.csv", etag="h1")
+        syncer.on_write(metadata, is_new=True, path="/hook.csv", zone_id="root")
+
+        assert len(captured) == 1
+        assert captured[0]["op"] == "write"
+        assert captured[0]["path"] == "/hook.csv"
+
+    def test_hook_called_on_write_batch(
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
+    ) -> None:
+        """on_write_batch() fires hooks with all events."""
+        captured = []
+        syncer.register_post_flush_hook(lambda events: captured.extend(events))
+
+        items = [
+            (_make_metadata("/a.csv", etag="ha"), True),
+            (_make_metadata("/b.csv", etag="hb"), True),
+        ]
+        syncer.on_write_batch(items, zone_id="root")
+
+        assert len(captured) == 2
+        paths = {e["path"] for e in captured}
+        assert paths == {"/a.csv", "/b.csv"}
+
+    def test_hook_failure_does_not_block_audit(
+        self, syncer: RecordStoreWriteObserver, record_store: SQLAlchemyRecordStore
+    ) -> None:
+        """A failing hook must not prevent the audit trail from committing."""
+        syncer.register_post_flush_hook(lambda events: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        metadata = _make_metadata("/safe.txt", etag="hs")
+        # Should not raise
+        syncer.on_write(metadata, is_new=True, path="/safe.txt", zone_id="root")
+
+        # Audit trail still committed
+        with record_store.session_factory() as session:
+            ops = (
+                session.query(OperationLogModel).filter(OperationLogModel.path == "/safe.txt").all()
+            )
+            assert len(ops) >= 1
+
+    def test_multiple_hooks(self, syncer: RecordStoreWriteObserver) -> None:
+        """Multiple hooks can be registered and all run."""
+        calls = []
+        syncer.register_post_flush_hook(lambda events: calls.append("hook1"))
+        syncer.register_post_flush_hook(lambda events: calls.append("hook2"))
+
+        assert len(syncer._post_flush_hooks) == 2

--- a/tests/unit/test_aspects.py
+++ b/tests/unit/test_aspects.py
@@ -9,6 +9,7 @@ from nexus.contracts.aspects import (
     AspectBase,
     AspectEnvelope,
     AspectRegistry,
+    DocumentStructureAspect,
     FileMetadataAspect,
     OwnershipAspect,
     PathAspect,
@@ -68,6 +69,7 @@ class TestAspectRegistry:
         registry.register("schema_metadata", SchemaMetadataAspect, max_versions=20)
         registry.register("file_metadata", FileMetadataAspect, max_versions=10)
         registry.register("ownership", OwnershipAspect, max_versions=5)
+        registry.register("document_structure", DocumentStructureAspect, max_versions=10)
 
     def test_singleton(self) -> None:
         r1 = AspectRegistry.get()
@@ -119,6 +121,11 @@ class TestAspectRegistry:
         # Re-registering same name+class is OK
         registry.register("path", PathAspect)
 
+    def test_document_structure_registered(self) -> None:
+        registry = AspectRegistry.get()
+        assert registry.is_registered("document_structure")
+        assert registry.max_versions_for("document_structure") == 10
+
     def test_register_duplicate_different_class_raises(self) -> None:
         registry = AspectRegistry.get()
         with pytest.raises(ValueError, match="already registered"):
@@ -161,3 +168,39 @@ class TestBuiltInAspects:
         aspect = OwnershipAspect(owner_id="alice", owner_type="user")
         d = aspect.to_dict()
         assert d["owner_id"] == "alice"
+
+    def test_document_structure_aspect(self) -> None:
+        aspect = DocumentStructureAspect(
+            title="My Doc",
+            headings=[{"level": 1, "text": "My Doc"}],
+            front_matter={"author": "Alice"},
+            word_count=100,
+            link_count=5,
+            code_languages=["python", "rust"],
+            format="markdown",
+            confidence=1.0,
+        )
+        d = aspect.to_dict()
+        assert d["title"] == "My Doc"
+        assert len(d["headings"]) == 1
+        assert d["word_count"] == 100
+        assert d["code_languages"] == ["python", "rust"]
+
+    def test_document_structure_aspect_defaults(self) -> None:
+        aspect = DocumentStructureAspect()
+        d = aspect.to_dict()
+        assert d["title"] is None
+        assert d["headings"] == []
+        assert d["front_matter"] is None
+        assert d["word_count"] == 0
+        assert d["code_languages"] == []
+
+    def test_document_structure_roundtrip(self) -> None:
+        aspect = DocumentStructureAspect(
+            title="Test",
+            headings=[{"level": 2, "text": "Section"}],
+            word_count=50,
+        )
+        d = aspect.to_dict()
+        restored = DocumentStructureAspect.from_dict(d)
+        assert restored.to_dict() == d


### PR DESCRIPTION
## Summary

Extends the knowledge platform (PR #2931) with async-on-write extraction, Avro format support, and a new document metadata aspect for non-tabular files.

Closes #2978

### Changes

- **Async-on-write extraction** — post-flush hook mechanism in `PipedRecordStoreWriteObserver` triggers `CatalogService` extraction after successful audit trail commit. Hooks are best-effort; failures do not block the audit path. Preserves LEGO architecture boundaries via callback injection.

- **AvroExtractor** — O(1) header-only schema extraction via `fastavro`. Supports nested records, unions, enums, arrays, maps. Includes `extract_from_path()` for streaming I/O without full content load.

- **DocumentStructureAspect + MarkdownExtractor** — new `document_structure` aspect type for non-tabular files. Extracts headings (ATX + Setext), YAML front matter (sanitized to JSON-safe primitives), code block languages, word/link counts. Headings inside code fences are correctly excluded.

- **Self-registering extractors** — each extractor declares `mime_types` and `extensions` as class attributes. `CatalogService` builds registries from these, eliminating dual-dict maintenance.

- **URN construction deduplication** — both write observers now delegate to `NexusURN.for_file()` instead of inlining SHA-256 hash logic.

- **CatalogService expanded** — `extract_document()`, `extract_auto()`, `extract_schema_from_path()`, `has_extractor()` for format-gating. Semantic reindex now handles both schema and document extraction.

### Architecture decisions (from review)

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Hook mechanism | Post-flush callback list | Preserves LEGO boundaries, no storage→brick imports |
| Content reads | Lazy in hook, format-gated | Only reads files with registered extractors |
| Extractor protocols | Separate Schema + Document | Explicit over clever, distinct result shapes |
| Service scope | Single CatalogService | Keeps MIME detection and aspect storage DRY |
| Extraction timing | After commit, separate try/except | Failures isolated from audit trail |
| Aspect writes | Batched in single transaction | Savepoint per extraction for isolation |

### Files changed (10 files, +1632 / -86)

| File | Change |
|------|--------|
| `contracts/aspects.py` | Add `DocumentStructureAspect` |
| `bricks/catalog/extractors.py` | Add self-registration, `AvroExtractor`, `MarkdownExtractor`, `DocumentExtractionResult` |
| `bricks/catalog/protocol.py` | Self-registration loop, dual registries, `extract_document()`, `extract_auto()`, `has_extractor()` |
| `storage/piped_record_store_write_observer.py` | Post-flush hooks, dedup `_build_urn` |
| `storage/record_store_write_observer.py` | Dedup `_build_urn` |
| `cli/commands/reindex.py` | Use `extract_auto()`, format-gate, track document extractions |

## Test plan

- [x] 125 tests passing (83 extractor + 26 catalog service + 12 aspects + 4 hooks)
- [x] AvroExtractor: valid files, nullable unions, nested records, arrays, enums, maps, empty files, import errors
- [x] MarkdownExtractor: front matter, heading levels, setext, code block filtering, unicode, date sanitization
- [x] CatalogService: filename-based detection (all formats), document extraction, extract_auto dispatch, has_extractor gate
- [x] DocumentStructureAspect: registration, validation, round-trip, defaults
- [x] Post-flush hooks: called after flush, failure isolation, multiple hooks
- [x] All ruff lint + format checks pass
- [x] Brick zero-core-imports check passes