### PR TITLE
feat(#2980): dynamic brick mount/unmount lifecycle in TUI

### DIFF
--- a/packages/nexus-tui/src/index.tsx
+++ b/packages/nexus-tui/src/index.tsx
@@ -97,21 +97,33 @@ async function main(): Promise<void> {
   // Initialize global store
   useGlobalStore.getState().initConfig(config);
 
-  // Test connection in background (non-blocking — TUI renders immediately)
+  // Test connection + fetch features in background (non-blocking — TUI renders immediately)
   const client = useGlobalStore.getState().client;
   if (client) {
     useGlobalStore.getState().setConnectionStatus("connecting");
-    client
+
+    const healthPromise = client
       .get<{ version?: string; zone_id?: string; uptime_seconds?: number }>(
         "/api/v2/bricks/health",
-      )
-      .then((info) => {
-        useGlobalStore.getState().setConnectionStatus("connected");
-        useGlobalStore.getState().setServerInfo({
-          version: info.version,
-          zoneId: info.zone_id,
-          uptime: info.uptime_seconds,
+      );
+
+    const featuresPromise = client
+      .get<{ profile: string; mode: string; enabled_bricks: string[]; disabled_bricks: string[]; version: string | null; rate_limit_enabled: boolean }>(
+        "/api/v2/features",
+      );
+
+    Promise.all([healthPromise, featuresPromise.catch(() => null)])
+      .then(([health, features]) => {
+        const store = useGlobalStore.getState();
+        store.setConnectionStatus("connected");
+        store.setServerInfo({
+          version: health.version,
+          zoneId: health.zone_id,
+          uptime: health.uptime_seconds,
         });
+        if (features) {
+          store.setFeatures(features);
+        }
       })
       .catch(() => {
         useGlobalStore.getState().setConnectionStatus("error", "Failed to connect to server");

--- a/packages/nexus-tui/src/panels/zones/brick-detail.tsx
+++ b/packages/nexus-tui/src/panels/zones/brick-detail.tsx
@@ -119,7 +119,7 @@ export function BrickDetail({ brick, loading }: BrickDetailProps): React.ReactNo
       ) : (
         brick.transitions.map((t, i) => (
           <box key={i} height={1} width="100%">
-            <text>{`  ${t.from_state} → ${t.to_state}  (${t.event})`}</text>
+            <text>{`  ${formatEpoch(t.timestamp)}  ${t.from_state} → ${t.to_state}  (${t.event})`}</text>
           </box>
         ))
       )}

--- a/packages/nexus-tui/src/panels/zones/brick-detail.tsx
+++ b/packages/nexus-tui/src/panels/zones/brick-detail.tsx
@@ -1,14 +1,16 @@
 /**
  * Brick detail view: shows individual brick info from GET /api/v2/bricks/{name}.
  *
- * Displays: name, state, protocol_name, error, started_at, stopped_at, unmounted_at.
+ * Displays: name, state, protocol, error, dependency graph, config (spec),
+ * state history (timestamps), and available actions.
  */
 
 import React from "react";
-import type { BrickStatusResponse } from "../../stores/zones-store.js";
+import type { BrickDetailResponse } from "../../stores/zones-store.js";
+import { stateIndicator, allowedActionsForState } from "../../shared/brick-states.js";
 
 interface BrickDetailProps {
-  readonly brick: BrickStatusResponse | null;
+  readonly brick: BrickDetailResponse | null;
   readonly loading: boolean;
 }
 
@@ -20,6 +22,14 @@ function formatEpoch(epoch: number | null): string {
     return String(epoch);
   }
 }
+
+const ACTION_KEYS: Readonly<Record<string, string>> = {
+  mount: "M (shift)",
+  unmount: "U",
+  unregister: "D",
+  remount: "m",
+  reset: "x",
+};
 
 export function BrickDetail({ brick, loading }: BrickDetailProps): React.ReactNode {
   if (loading) {
@@ -38,13 +48,34 @@ export function BrickDetail({ brick, loading }: BrickDetailProps): React.ReactNo
     );
   }
 
+  const allowed = allowedActionsForState(brick.state);
+  const actionHints = Array.from(allowed)
+    .map((action) => {
+      const key = ACTION_KEYS[action] ?? action;
+      return `${key}:${action}`;
+    })
+    .join("  ");
+
+  // Build state history from available timestamps (chronological order)
+  const history: { label: string; time: string }[] = [];
+  if (brick.started_at !== null) {
+    history.push({ label: "Started", time: formatEpoch(brick.started_at) });
+  }
+  if (brick.stopped_at !== null) {
+    history.push({ label: "Stopped", time: formatEpoch(brick.stopped_at) });
+  }
+  if (brick.unmounted_at !== null) {
+    history.push({ label: "Unmounted", time: formatEpoch(brick.unmounted_at) });
+  }
+
   return (
     <scrollbox height="100%" width="100%">
+      {/* Identity */}
       <box height={1} width="100%">
         <text>{`Name:         ${brick.name}`}</text>
       </box>
       <box height={1} width="100%">
-        <text>{`State:        ${brick.state}`}</text>
+        <text>{`State:        ${stateIndicator(brick.state)} ${brick.state}`}</text>
       </box>
       <box height={1} width="100%">
         <text>{`Protocol:     ${brick.protocol_name}`}</text>
@@ -53,17 +84,47 @@ export function BrickDetail({ brick, loading }: BrickDetailProps): React.ReactNo
         <text>{`Error:        ${brick.error ?? "none"}`}</text>
       </box>
 
+      {/* Config (spec data) */}
       <box height={1} width="100%" marginTop={1}>
-        <text>--- Timestamps ---</text>
+        <text>--- Configuration ---</text>
       </box>
       <box height={1} width="100%">
-        <text>{`Started at:   ${formatEpoch(brick.started_at)}`}</text>
+        <text>{`Enabled:      ${brick.enabled ? "yes" : "no"}`}</text>
+      </box>
+
+      {/* Dependency graph */}
+      <box height={1} width="100%" marginTop={1}>
+        <text>--- Dependencies ---</text>
       </box>
       <box height={1} width="100%">
-        <text>{`Stopped at:   ${formatEpoch(brick.stopped_at)}`}</text>
+        <text>{`Depends on:   ${brick.depends_on.length > 0 ? brick.depends_on.join(", ") : "(none)"}`}</text>
       </box>
       <box height={1} width="100%">
-        <text>{`Unmounted at: ${formatEpoch(brick.unmounted_at)}`}</text>
+        <text>{`Depended by:  ${brick.depended_by.length > 0 ? brick.depended_by.join(", ") : "(none)"}`}</text>
+      </box>
+
+      {/* State history */}
+      <box height={1} width="100%" marginTop={1}>
+        <text>--- State History ---</text>
+      </box>
+      {history.length > 0 ? (
+        history.map((entry) => (
+          <box key={entry.label} height={1} width="100%">
+            <text>{`${entry.label.padEnd(12)} ${entry.time}`}</text>
+          </box>
+        ))
+      ) : (
+        <box height={1} width="100%">
+          <text>(no transitions recorded)</text>
+        </box>
+      )}
+
+      {/* Available actions */}
+      <box height={1} width="100%" marginTop={1}>
+        <text>--- Available Actions ---</text>
+      </box>
+      <box height={1} width="100%">
+        <text>{actionHints || "(none \u2014 brick is in a transient state)"}</text>
       </box>
     </scrollbox>
   );

--- a/packages/nexus-tui/src/panels/zones/brick-detail.tsx
+++ b/packages/nexus-tui/src/panels/zones/brick-detail.tsx
@@ -2,7 +2,7 @@
  * Brick detail view: shows individual brick info from GET /api/v2/bricks/{name}.
  *
  * Displays: name, state, protocol, error, dependency graph, config (spec),
- * state history (timestamps), and available actions.
+ * real FSM transition history, and available actions.
  */
 
 import React from "react";
@@ -56,18 +56,6 @@ export function BrickDetail({ brick, loading }: BrickDetailProps): React.ReactNo
     })
     .join("  ");
 
-  // Build state history from available timestamps (chronological order)
-  const history: { label: string; time: string }[] = [];
-  if (brick.started_at !== null) {
-    history.push({ label: "Started", time: formatEpoch(brick.started_at) });
-  }
-  if (brick.stopped_at !== null) {
-    history.push({ label: "Stopped", time: formatEpoch(brick.stopped_at) });
-  }
-  if (brick.unmounted_at !== null) {
-    history.push({ label: "Unmounted", time: formatEpoch(brick.unmounted_at) });
-  }
-
   return (
     <scrollbox height="100%" width="100%">
       {/* Identity */}
@@ -91,6 +79,9 @@ export function BrickDetail({ brick, loading }: BrickDetailProps): React.ReactNo
       <box height={1} width="100%">
         <text>{`Enabled:      ${brick.enabled ? "yes" : "no"}`}</text>
       </box>
+      <box height={1} width="100%">
+        <text>{`Retry count:  ${brick.retry_count}`}</text>
+      </box>
 
       {/* Dependency graph */}
       <box height={1} width="100%" marginTop={1}>
@@ -103,20 +94,34 @@ export function BrickDetail({ brick, loading }: BrickDetailProps): React.ReactNo
         <text>{`Depended by:  ${brick.depended_by.length > 0 ? brick.depended_by.join(", ") : "(none)"}`}</text>
       </box>
 
-      {/* State history */}
+      {/* Timestamps */}
+      <box height={1} width="100%" marginTop={1}>
+        <text>--- Timestamps ---</text>
+      </box>
+      <box height={1} width="100%">
+        <text>{`Started at:   ${formatEpoch(brick.started_at)}`}</text>
+      </box>
+      <box height={1} width="100%">
+        <text>{`Stopped at:   ${formatEpoch(brick.stopped_at)}`}</text>
+      </box>
+      <box height={1} width="100%">
+        <text>{`Unmounted at: ${formatEpoch(brick.unmounted_at)}`}</text>
+      </box>
+
+      {/* State history (real FSM transitions) */}
       <box height={1} width="100%" marginTop={1}>
         <text>--- State History ---</text>
       </box>
-      {history.length > 0 ? (
-        history.map((entry) => (
-          <box key={entry.label} height={1} width="100%">
-            <text>{`${entry.label.padEnd(12)} ${entry.time}`}</text>
+      {brick.transitions.length === 0 ? (
+        <box height={1} width="100%">
+          <text>  No transitions recorded</text>
+        </box>
+      ) : (
+        brick.transitions.map((t, i) => (
+          <box key={i} height={1} width="100%">
+            <text>{`  ${t.from_state} → ${t.to_state}  (${t.event})`}</text>
           </box>
         ))
-      ) : (
-        <box height={1} width="100%">
-          <text>(no transitions recorded)</text>
-        </box>
       )}
 
       {/* Available actions */}
@@ -124,7 +129,7 @@ export function BrickDetail({ brick, loading }: BrickDetailProps): React.ReactNo
         <text>--- Available Actions ---</text>
       </box>
       <box height={1} width="100%">
-        <text>{actionHints || "(none \u2014 brick is in a transient state)"}</text>
+        <text>{actionHints || "(none — brick is in a transient state)"}</text>
       </box>
     </scrollbox>
   );

--- a/packages/nexus-tui/src/panels/zones/brick-list.tsx
+++ b/packages/nexus-tui/src/panels/zones/brick-list.tsx
@@ -4,28 +4,12 @@
 
 import React from "react";
 import type { BrickStatusResponse } from "../../stores/zones-store.js";
+import { stateIndicator } from "../../shared/brick-states.js";
 
 interface BrickListProps {
   readonly bricks: readonly BrickStatusResponse[];
   readonly selectedIndex: number;
   readonly loading: boolean;
-}
-
-function stateIndicator(state: string): string {
-  switch (state) {
-    case "running":
-      return "[ON]";
-    case "stopped":
-      return "[--]";
-    case "failed":
-      return "[!!]";
-    case "mounted":
-      return "[MT]";
-    case "unmounted":
-      return "[UM]";
-    default:
-      return "[??]";
-  }
 }
 
 export function BrickList({

--- a/packages/nexus-tui/src/panels/zones/zones-panel.tsx
+++ b/packages/nexus-tui/src/panels/zones/zones-panel.tsx
@@ -1,8 +1,11 @@
 /**
  * Zones panel: tabbed layout with Zones list, Bricks health, and Drift report.
+ *
+ * Keybindings are context-aware — only actions valid for the selected brick's
+ * current state are active and displayed in the help bar.
  */
 
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useZonesStore } from "../../stores/zones-store.js";
 import type { ZoneTab } from "../../stores/zones-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
@@ -12,6 +15,8 @@ import { BrickList } from "./brick-list.js";
 import { BrickDetail } from "./brick-detail.js";
 import { DriftView } from "./drift-view.js";
 import { ReindexStatus } from "./reindex-status.js";
+import { ConfirmDialog } from "../../shared/components/confirm-dialog.js";
+import { allowedActionsForState } from "../../shared/brick-states.js";
 
 const TAB_ORDER: readonly ZoneTab[] = ["zones", "bricks", "drift", "reindex"];
 const TAB_LABELS: Readonly<Record<ZoneTab, string>> = {
@@ -41,13 +46,28 @@ export default function ZonesPanel(): React.ReactNode {
   const fetchBricks = useZonesStore((s) => s.fetchBricks);
   const fetchBrickDetail = useZonesStore((s) => s.fetchBrickDetail);
   const fetchDrift = useZonesStore((s) => s.fetchDrift);
+  const mountBrick = useZonesStore((s) => s.mountBrick);
+  const unmountBrick = useZonesStore((s) => s.unmountBrick);
+  const unregisterBrick = useZonesStore((s) => s.unregisterBrick);
   const remountBrick = useZonesStore((s) => s.remountBrick);
   const resetBrick = useZonesStore((s) => s.resetBrick);
   const setSelectedIndex = useZonesStore((s) => s.setSelectedIndex);
   const setActiveTab = useZonesStore((s) => s.setActiveTab);
 
+  // Confirmation dialog state for destructive unregister action
+  const [confirmUnregister, setConfirmUnregister] = useState(false);
+
+  // Currently selected brick (if on bricks tab)
+  const selectedBrick = activeTab === "bricks" ? bricks[selectedIndex] ?? null : null;
+
+  // Allowed actions for the selected brick's current state
+  const allowed = useMemo(
+    () => (selectedBrick ? allowedActionsForState(selectedBrick.state) : new Set<string>()),
+    [selectedBrick?.state],
+  );
+
   // Refresh data for the current tab
-  const refreshActiveTab = (): void => {
+  const refreshActiveTab = useCallback((): void => {
     if (!client) return;
 
     if (activeTab === "zones") {
@@ -57,13 +77,12 @@ export default function ZonesPanel(): React.ReactNode {
     } else if (activeTab === "drift") {
       fetchDrift(client);
     }
-  };
+  }, [activeTab, client, fetchZones, fetchBricks, fetchDrift]);
 
   // Auto-fetch data on mount and when tab changes
   useEffect(() => {
     refreshActiveTab();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTab, client]);
+  }, [refreshActiveTab]);
 
   // Fetch brick detail when selection changes in bricks tab
   useEffect(() => {
@@ -75,47 +94,87 @@ export default function ZonesPanel(): React.ReactNode {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedIndex, bricks, activeTab, client]);
 
-  useKeyboard({
-    j: () => {
-      const maxLen = activeTab === "zones" ? zones.length : bricks.length;
-      setSelectedIndex(Math.min(selectedIndex + 1, maxLen - 1));
-    },
-    down: () => {
-      const maxLen = activeTab === "zones" ? zones.length : bricks.length;
-      setSelectedIndex(Math.min(selectedIndex + 1, maxLen - 1));
-    },
-    k: () => {
-      setSelectedIndex(Math.max(selectedIndex - 1, 0));
-    },
-    up: () => {
-      setSelectedIndex(Math.max(selectedIndex - 1, 0));
-    },
-    tab: () => {
-      const currentIdx = TAB_ORDER.indexOf(activeTab);
-      const nextIdx = (currentIdx + 1) % TAB_ORDER.length;
-      const nextTab = TAB_ORDER[nextIdx];
-      if (nextTab) {
-        setActiveTab(nextTab);
-      }
-    },
-    m: () => {
-      if (!client || activeTab !== "bricks") return;
-      const brick = bricks[selectedIndex];
-      if (brick) {
-        remountBrick(brick.name, client);
-      }
-    },
-    x: () => {
-      if (!client || activeTab !== "bricks") return;
-      const brick = bricks[selectedIndex];
-      if (brick) {
-        resetBrick(brick.name, client);
-      }
-    },
-    r: () => {
-      refreshActiveTab();
-    },
-  });
+  // Confirmation handlers
+  const handleConfirmUnregister = useCallback(() => {
+    if (!client || !selectedBrick) return;
+    unregisterBrick(selectedBrick.name, client);
+    setConfirmUnregister(false);
+  }, [client, selectedBrick, unregisterBrick]);
+
+  const handleCancelUnregister = useCallback(() => {
+    setConfirmUnregister(false);
+  }, []);
+
+  // Build context-aware help text for the bricks tab
+  const brickHelpText = useMemo(() => {
+    const parts: string[] = ["j/k:navigate", "Tab:switch tab"];
+    if (allowed.has("mount")) parts.push("M:mount");
+    if (allowed.has("remount")) parts.push("m:remount");
+    if (allowed.has("unmount")) parts.push("U:unmount");
+    if (allowed.has("unregister")) parts.push("D:unregister");
+    if (allowed.has("reset")) parts.push("x:reset");
+    parts.push("r:refresh", "q:quit");
+    return parts.join("  ");
+  }, [allowed]);
+
+  useKeyboard(
+    confirmUnregister
+      ? {} // ConfirmDialog handles its own keys when visible
+      : {
+          j: () => {
+            const maxLen = activeTab === "zones" ? zones.length : bricks.length;
+            setSelectedIndex(Math.min(selectedIndex + 1, maxLen - 1));
+          },
+          down: () => {
+            const maxLen = activeTab === "zones" ? zones.length : bricks.length;
+            setSelectedIndex(Math.min(selectedIndex + 1, maxLen - 1));
+          },
+          k: () => {
+            setSelectedIndex(Math.max(selectedIndex - 1, 0));
+          },
+          up: () => {
+            setSelectedIndex(Math.max(selectedIndex - 1, 0));
+          },
+          tab: () => {
+            const currentIdx = TAB_ORDER.indexOf(activeTab);
+            const nextIdx = (currentIdx + 1) % TAB_ORDER.length;
+            const nextTab = TAB_ORDER[nextIdx];
+            if (nextTab) {
+              setActiveTab(nextTab);
+            }
+          },
+          // M (shift+m): Mount — valid for registered/unmounted
+          "shift+m": () => {
+            if (!client || !selectedBrick || !allowed.has("mount")) return;
+            mountBrick(selectedBrick.name, client);
+          },
+          // U: Unmount — valid for active
+          "shift+u": () => {
+            if (!client || !selectedBrick || !allowed.has("unmount")) return;
+            unmountBrick(selectedBrick.name, client);
+          },
+          // D: Unregister — valid for unmounted (with confirmation)
+          "shift+d": () => {
+            if (!client || !selectedBrick || !allowed.has("unregister")) return;
+            setConfirmUnregister(true);
+          },
+          // m: Remount (existing) — valid for unmounted only
+          m: () => {
+            if (!client || !selectedBrick || !allowed.has("remount")) return;
+            remountBrick(selectedBrick.name, client);
+          },
+          // x: Reset (existing) — valid for failed
+          x: () => {
+            if (!client || !selectedBrick || !allowed.has("reset")) return;
+            resetBrick(selectedBrick.name, client);
+          },
+          r: () => {
+            refreshActiveTab();
+          },
+        },
+  );
+
+  const defaultHelp = "j/k:navigate  Tab:switch tab  r:refresh  q:quit";
 
   return (
     <box height="100%" width="100%" flexDirection="column">
@@ -179,12 +238,21 @@ export default function ZonesPanel(): React.ReactNode {
         {activeTab === "reindex" && <ReindexStatus />}
       </box>
 
-      {/* Help bar */}
+      {/* Context-aware help bar */}
       <box height={1} width="100%">
         <text>
-          {"j/k:navigate  Tab:switch tab  m:remount  x:reset  r:refresh  q:quit"}
+          {activeTab === "bricks" ? brickHelpText : defaultHelp}
         </text>
       </box>
+
+      {/* Unregister confirmation dialog */}
+      <ConfirmDialog
+        visible={confirmUnregister}
+        title="Unregister Brick"
+        message={`Permanently unregister "${selectedBrick?.name ?? ""}"? This cannot be undone.`}
+        onConfirm={handleConfirmUnregister}
+        onCancel={handleCancelUnregister}
+      />
     </box>
   );
 }

--- a/packages/nexus-tui/src/shared/brick-states.ts
+++ b/packages/nexus-tui/src/shared/brick-states.ts
@@ -1,0 +1,81 @@
+/**
+ * Brick FSM state constants and state-aware action logic.
+ *
+ * Single source of truth for brick lifecycle states — matches the backend
+ * BrickState enum values exactly (see brick_lifecycle.py).
+ */
+
+// ---------------------------------------------------------------------------
+// State constants (match backend BrickState enum values)
+// ---------------------------------------------------------------------------
+
+export const BRICK_STATE = {
+  REGISTERED: "registered",
+  STARTING: "starting",
+  ACTIVE: "active",
+  STOPPING: "stopping",
+  UNMOUNTED: "unmounted",
+  UNREGISTERED: "unregistered",
+  FAILED: "failed",
+} as const;
+
+export type BrickStateValue = (typeof BRICK_STATE)[keyof typeof BRICK_STATE];
+
+// ---------------------------------------------------------------------------
+// Actions the TUI can trigger
+// ---------------------------------------------------------------------------
+
+export type BrickAction = "mount" | "unmount" | "remount" | "reset" | "unregister";
+
+// ---------------------------------------------------------------------------
+// State → allowed actions mapping
+// ---------------------------------------------------------------------------
+
+const STATE_ACTIONS: Readonly<Record<string, readonly BrickAction[]>> = {
+  [BRICK_STATE.REGISTERED]: ["mount"],
+  [BRICK_STATE.STARTING]: [],
+  [BRICK_STATE.ACTIVE]: ["unmount"],
+  [BRICK_STATE.STOPPING]: [],
+  [BRICK_STATE.UNMOUNTED]: ["mount", "remount", "unregister"],
+  [BRICK_STATE.UNREGISTERED]: [],
+  [BRICK_STATE.FAILED]: ["reset"],
+};
+
+/**
+ * Returns the set of lifecycle actions valid for a given brick state.
+ *
+ * Pure function — safe to call from render and easy to test exhaustively.
+ */
+export function allowedActionsForState(state: string): ReadonlySet<BrickAction> {
+  const actions = STATE_ACTIONS[state];
+  return new Set(actions ?? []);
+}
+
+// ---------------------------------------------------------------------------
+// State → display indicator
+// ---------------------------------------------------------------------------
+
+/**
+ * Short state indicator for the brick list sidebar.
+ * Matches all 7 backend FSM states.
+ */
+export function stateIndicator(state: string): string {
+  switch (state) {
+    case BRICK_STATE.REGISTERED:
+      return "[RG]";
+    case BRICK_STATE.STARTING:
+      return "[..]";
+    case BRICK_STATE.ACTIVE:
+      return "[ON]";
+    case BRICK_STATE.STOPPING:
+      return "[..]";
+    case BRICK_STATE.UNMOUNTED:
+      return "[UM]";
+    case BRICK_STATE.UNREGISTERED:
+      return "[--]";
+    case BRICK_STATE.FAILED:
+      return "[!!]";
+    default:
+      return "[??]";
+  }
+}

--- a/packages/nexus-tui/src/shared/components/confirm-dialog.tsx
+++ b/packages/nexus-tui/src/shared/components/confirm-dialog.tsx
@@ -1,0 +1,61 @@
+/**
+ * Reusable confirmation dialog for destructive actions.
+ *
+ * Renders a centered modal overlay with a message and Y/N keybindings.
+ * Follows the same overlay pattern as IdentitySwitcher.
+ */
+
+import React from "react";
+import { useKeyboard } from "../hooks/use-keyboard.js";
+
+interface ConfirmDialogProps {
+  readonly visible: boolean;
+  readonly title: string;
+  readonly message: string;
+  readonly onConfirm: () => void;
+  readonly onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  visible,
+  title,
+  message,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps): React.ReactNode {
+  useKeyboard(
+    visible
+      ? {
+          y: onConfirm,
+          return: onConfirm,
+          n: onCancel,
+          escape: onCancel,
+        }
+      : {},
+  );
+
+  if (!visible) return null;
+
+  return (
+    <box
+      height="100%"
+      width="100%"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <box
+        flexDirection="column"
+        borderStyle="double"
+        width={50}
+        height={7}
+        padding={1}
+      >
+        <text>{title}</text>
+        <text>{""}</text>
+        <text>{message}</text>
+        <text>{""}</text>
+        <text>{"Y:confirm  N/Esc:cancel"}</text>
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -20,6 +20,16 @@ export type PanelId =
   | "infrastructure"
   | "console";
 
+/** Response from GET /api/v2/features */
+export interface FeaturesResponse {
+  readonly profile: string;
+  readonly mode: string;
+  readonly enabled_bricks: readonly string[];
+  readonly disabled_bricks: readonly string[];
+  readonly version: string | null;
+  readonly rate_limit_enabled: boolean;
+}
+
 /** Response from GET /auth/me */
 export interface UserInfo {
   readonly user_id: string;
@@ -48,6 +58,11 @@ export interface GlobalState {
   readonly uptime: number | null;
   readonly userInfo: UserInfo | null;
 
+  // Features (from GET /api/v2/features)
+  readonly enabledBricks: readonly string[];
+  readonly profile: string | null;
+  readonly mode: string | null;
+
   // Actions
   readonly initConfig: (overrides?: Partial<NexusClientOptions>) => void;
   readonly testConnection: () => Promise<void>;
@@ -55,6 +70,7 @@ export interface GlobalState {
   readonly setConnectionStatus: (status: ConnectionStatus, error?: string) => void;
   readonly setServerInfo: (info: { version?: string; zoneId?: string; uptime?: number }) => void;
   readonly setIdentity: (identity: { agentId?: string; subject?: string; zoneId?: string }) => void;
+  readonly setFeatures: (features: FeaturesResponse) => void;
 }
 
 export const useGlobalStore = create<GlobalState>((set, get) => ({
@@ -69,6 +85,9 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
   zoneId: null,
   uptime: null,
   userInfo: null,
+  enabledBricks: [],
+  profile: null,
+  mode: null,
 
   initConfig: (overrides) => {
     const config = resolveConfig(overrides);
@@ -133,5 +152,13 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
     };
     const client = config.apiKey ? new FetchClient(config) : null;
     set({ config, client });
+  },
+
+  setFeatures: (features) => {
+    set({
+      enabledBricks: features.enabled_bricks ?? [],
+      profile: features.profile ?? null,
+      mode: features.mode ?? null,
+    });
   },
 }));

--- a/packages/nexus-tui/src/stores/zones-store.ts
+++ b/packages/nexus-tui/src/stores/zones-store.ts
@@ -247,6 +247,10 @@ export const useZonesStore = create<ZonesState>((set, get) => ({
         {},
       );
       await get().fetchBricks(client);
+      // Clamp selectedIndex and clear stale detail after brick removal
+      const { bricks, selectedIndex } = get();
+      const clamped = Math.min(selectedIndex, Math.max(0, bricks.length - 1));
+      set({ selectedIndex: clamped, brickDetail: null });
     } catch (err) {
       set({
         error: err instanceof Error ? err.message : "Failed to unregister brick",

--- a/packages/nexus-tui/src/stores/zones-store.ts
+++ b/packages/nexus-tui/src/stores/zones-store.ts
@@ -22,6 +22,12 @@ export interface BrickStatusResponse {
   readonly unmounted_at: number | null;
 }
 
+export interface BrickDetailResponse extends BrickStatusResponse {
+  readonly enabled: boolean;
+  readonly depends_on: readonly string[];
+  readonly depended_by: readonly string[];
+}
+
 export interface DriftReportItem {
   readonly brick_name: string;
   readonly spec_state: string;
@@ -90,8 +96,8 @@ export interface ZonesState {
   // Active tab
   readonly activeTab: ZoneTab;
 
-  // Brick detail
-  readonly brickDetail: BrickStatusResponse | null;
+  // Brick detail (extended with spec/dependency info)
+  readonly brickDetail: BrickDetailResponse | null;
   readonly detailLoading: boolean;
 
   // Drift report (global, not per-brick)
@@ -103,6 +109,9 @@ export interface ZonesState {
   readonly fetchBricks: (client: FetchClient) => Promise<void>;
   readonly fetchBrickDetail: (name: string, client: FetchClient) => Promise<void>;
   readonly fetchDrift: (client: FetchClient) => Promise<void>;
+  readonly mountBrick: (name: string, client: FetchClient) => Promise<void>;
+  readonly unmountBrick: (name: string, client: FetchClient) => Promise<void>;
+  readonly unregisterBrick: (name: string, client: FetchClient) => Promise<void>;
   readonly remountBrick: (name: string, client: FetchClient) => Promise<void>;
   readonly resetBrick: (name: string, client: FetchClient) => Promise<void>;
   readonly setSelectedIndex: (index: number) => void;
@@ -158,7 +167,7 @@ export const useZonesStore = create<ZonesState>((set, get) => ({
     set({ detailLoading: true, error: null });
 
     try {
-      const detail = await client.get<BrickStatusResponse>(
+      const detail = await client.get<BrickDetailResponse>(
         `/api/v2/bricks/${encodeURIComponent(name)}`,
       );
       set({ brickDetail: detail, detailLoading: false });
@@ -184,6 +193,54 @@ export const useZonesStore = create<ZonesState>((set, get) => ({
         driftReport: null,
         driftLoading: false,
         error: err instanceof Error ? err.message : "Failed to fetch drift report",
+      });
+    }
+  },
+
+  mountBrick: async (name, client) => {
+    set({ error: null });
+
+    try {
+      await client.post<void>(
+        `/api/v2/bricks/${encodeURIComponent(name)}/mount`,
+        {},
+      );
+      await get().fetchBricks(client);
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : "Failed to mount brick",
+      });
+    }
+  },
+
+  unmountBrick: async (name, client) => {
+    set({ error: null });
+
+    try {
+      await client.post<void>(
+        `/api/v2/bricks/${encodeURIComponent(name)}/unmount`,
+        {},
+      );
+      await get().fetchBricks(client);
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : "Failed to unmount brick",
+      });
+    }
+  },
+
+  unregisterBrick: async (name, client) => {
+    set({ error: null });
+
+    try {
+      await client.post<void>(
+        `/api/v2/bricks/${encodeURIComponent(name)}/unregister`,
+        {},
+      );
+      await get().fetchBricks(client);
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : "Failed to unregister brick",
       });
     }
   },

--- a/packages/nexus-tui/src/stores/zones-store.ts
+++ b/packages/nexus-tui/src/stores/zones-store.ts
@@ -22,10 +22,19 @@ export interface BrickStatusResponse {
   readonly unmounted_at: number | null;
 }
 
+export interface BrickTransitionItem {
+  readonly timestamp: number;
+  readonly event: string;
+  readonly from_state: string;
+  readonly to_state: string;
+}
+
 export interface BrickDetailResponse extends BrickStatusResponse {
   readonly enabled: boolean;
   readonly depends_on: readonly string[];
   readonly depended_by: readonly string[];
+  readonly retry_count: number;
+  readonly transitions: readonly BrickTransitionItem[];
 }
 
 export interface DriftReportItem {

--- a/packages/nexus-tui/tests/shared/brick-states.test.ts
+++ b/packages/nexus-tui/tests/shared/brick-states.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Exhaustive truth table for brick state → allowed actions mapping.
+ *
+ * Tests all 7 FSM states × 5 possible actions = 35 cases.
+ * This is the highest-risk logic in the TUI — a wrong guard means
+ * the operator can trigger an invalid transition.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  allowedActionsForState,
+  stateIndicator,
+  BRICK_STATE,
+  type BrickAction,
+} from "../../src/shared/brick-states.js";
+
+// ---------------------------------------------------------------------------
+// allowedActionsForState — exhaustive truth table
+// ---------------------------------------------------------------------------
+
+describe("allowedActionsForState", () => {
+  // Truth table: [state, expected allowed actions]
+  const TRUTH_TABLE: readonly [string, readonly BrickAction[]][] = [
+    [BRICK_STATE.REGISTERED, ["mount"]],
+    [BRICK_STATE.STARTING, []],
+    [BRICK_STATE.ACTIVE, ["unmount"]],
+    [BRICK_STATE.STOPPING, []],
+    [BRICK_STATE.UNMOUNTED, ["mount", "remount", "unregister"]],
+    [BRICK_STATE.UNREGISTERED, []],
+    [BRICK_STATE.FAILED, ["reset"]],
+  ];
+
+  for (const [state, expectedActions] of TRUTH_TABLE) {
+    it(`${state} → [${expectedActions.join(", ") || "none"}]`, () => {
+      const allowed = allowedActionsForState(state);
+      expect(allowed.size).toBe(expectedActions.length);
+      for (const action of expectedActions) {
+        expect(allowed.has(action)).toBe(true);
+      }
+    });
+  }
+
+  // Verify disallowed actions explicitly for each state
+  const ALL_ACTIONS: readonly BrickAction[] = ["mount", "unmount", "remount", "reset", "unregister"];
+
+  it("registered disallows unmount, remount, reset, unregister", () => {
+    const allowed = allowedActionsForState(BRICK_STATE.REGISTERED);
+    expect(allowed.has("unmount")).toBe(false);
+    expect(allowed.has("remount")).toBe(false);
+    expect(allowed.has("reset")).toBe(false);
+    expect(allowed.has("unregister")).toBe(false);
+  });
+
+  it("active disallows mount, remount, reset, unregister", () => {
+    const allowed = allowedActionsForState(BRICK_STATE.ACTIVE);
+    expect(allowed.has("mount")).toBe(false);
+    expect(allowed.has("remount")).toBe(false);
+    expect(allowed.has("reset")).toBe(false);
+    expect(allowed.has("unregister")).toBe(false);
+  });
+
+  it("unmounted disallows unmount and reset", () => {
+    const allowed = allowedActionsForState(BRICK_STATE.UNMOUNTED);
+    expect(allowed.has("unmount")).toBe(false);
+    expect(allowed.has("reset")).toBe(false);
+  });
+
+  it("unmounted allows mount, remount, and unregister", () => {
+    const allowed = allowedActionsForState(BRICK_STATE.UNMOUNTED);
+    expect(allowed.has("mount")).toBe(true);
+    expect(allowed.has("remount")).toBe(true);
+    expect(allowed.has("unregister")).toBe(true);
+  });
+
+  it("failed disallows mount, unmount, remount, unregister", () => {
+    const allowed = allowedActionsForState(BRICK_STATE.FAILED);
+    expect(allowed.has("mount")).toBe(false);
+    expect(allowed.has("unmount")).toBe(false);
+    expect(allowed.has("remount")).toBe(false);
+    expect(allowed.has("unregister")).toBe(false);
+  });
+
+  it("transient states (starting, stopping) disallow all actions", () => {
+    for (const state of [BRICK_STATE.STARTING, BRICK_STATE.STOPPING]) {
+      const allowed = allowedActionsForState(state);
+      for (const action of ALL_ACTIONS) {
+        expect(allowed.has(action)).toBe(false);
+      }
+    }
+  });
+
+  it("terminal state (unregistered) disallows all actions", () => {
+    const allowed = allowedActionsForState(BRICK_STATE.UNREGISTERED);
+    for (const action of ALL_ACTIONS) {
+      expect(allowed.has(action)).toBe(false);
+    }
+  });
+
+  it("unknown state returns empty set", () => {
+    const allowed = allowedActionsForState("bogus_state");
+    expect(allowed.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stateIndicator — display mapping
+// ---------------------------------------------------------------------------
+
+describe("stateIndicator", () => {
+  it("maps all 7 backend states to indicators", () => {
+    expect(stateIndicator(BRICK_STATE.REGISTERED)).toBe("[RG]");
+    expect(stateIndicator(BRICK_STATE.STARTING)).toBe("[..]");
+    expect(stateIndicator(BRICK_STATE.ACTIVE)).toBe("[ON]");
+    expect(stateIndicator(BRICK_STATE.STOPPING)).toBe("[..]");
+    expect(stateIndicator(BRICK_STATE.UNMOUNTED)).toBe("[UM]");
+    expect(stateIndicator(BRICK_STATE.UNREGISTERED)).toBe("[--]");
+    expect(stateIndicator(BRICK_STATE.FAILED)).toBe("[!!]");
+  });
+
+  it("returns [??] for unknown states", () => {
+    expect(stateIndicator("bogus")).toBe("[??]");
+    expect(stateIndicator("")).toBe("[??]");
+  });
+});

--- a/packages/nexus-tui/tests/stores/zones-store.test.ts
+++ b/packages/nexus-tui/tests/stores/zones-store.test.ts
@@ -208,7 +208,7 @@ describe("ZonesStore", () => {
   });
 
   describe("fetchBrickDetail", () => {
-    it("fetches and stores individual brick detail", async () => {
+    it("fetches and stores individual brick detail with extended fields", async () => {
       const brickData = {
         name: "brick-alpha",
         state: "running",
@@ -217,6 +217,9 @@ describe("ZonesStore", () => {
         started_at: 1717243200,
         stopped_at: null,
         unmounted_at: null,
+        enabled: true,
+        depends_on: ["brick-gamma"],
+        depended_by: ["brick-beta"],
       };
 
       const client = mockClient({
@@ -232,6 +235,9 @@ describe("ZonesStore", () => {
       expect(state.brickDetail!.protocol_name).toBe("grpc");
       expect(state.brickDetail!.error).toBeNull();
       expect(state.brickDetail!.started_at).toBe(1717243200);
+      expect(state.brickDetail!.enabled).toBe(true);
+      expect(state.brickDetail!.depends_on).toEqual(["brick-gamma"]);
+      expect(state.brickDetail!.depended_by).toEqual(["brick-beta"]);
       expect(state.detailLoading).toBe(false);
     });
 
@@ -457,6 +463,112 @@ describe("ZonesStore", () => {
 
       await useZonesStore.getState().fetchBricks(client);
       expect(useZonesStore.getState().error).toBe("Failed to fetch bricks");
+    });
+  });
+
+  describe("mountBrick", () => {
+    it("calls POST mount and refreshes bricks list", async () => {
+      const client = mockClient({
+        "/api/v2/bricks/brick-alpha/mount": undefined,
+        "/api/v2/bricks/health": SAMPLE_BRICKS_HEALTH,
+      });
+
+      await useZonesStore.getState().mountBrick("brick-alpha", client);
+      const state = useZonesStore.getState();
+
+      expect(state.error).toBeNull();
+      expect(state.bricks).toHaveLength(3);
+      expect((client.post as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    });
+
+    it("sets error on mount failure", async () => {
+      const client = {
+        get: mock(async () => ({ total: 0, active: 0, failed: 0, bricks: [] })),
+        post: mock(async () => { throw new Error("Invalid state transition"); }),
+      } as unknown as FetchClient;
+
+      await useZonesStore.getState().mountBrick("brick-alpha", client);
+      const state = useZonesStore.getState();
+
+      expect(state.error).toBe("Invalid state transition");
+    });
+
+    it("clears previous error before mount", async () => {
+      useZonesStore.setState({ error: "old error" });
+
+      const client = mockClient({
+        "/api/v2/bricks/brick-alpha/mount": undefined,
+        "/api/v2/bricks/health": { total: 0, active: 0, failed: 0, bricks: [] },
+      });
+
+      await useZonesStore.getState().mountBrick("brick-alpha", client);
+      expect(useZonesStore.getState().error).toBeNull();
+    });
+  });
+
+  describe("unmountBrick", () => {
+    it("calls POST unmount and refreshes bricks list", async () => {
+      const client = mockClient({
+        "/api/v2/bricks/brick-alpha/unmount": undefined,
+        "/api/v2/bricks/health": SAMPLE_BRICKS_HEALTH,
+      });
+
+      await useZonesStore.getState().unmountBrick("brick-alpha", client);
+      const state = useZonesStore.getState();
+
+      expect(state.error).toBeNull();
+      expect(state.bricks).toHaveLength(3);
+      expect((client.post as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    });
+
+    it("sets error on unmount failure", async () => {
+      const client = {
+        get: mock(async () => ({ total: 0, active: 0, failed: 0, bricks: [] })),
+        post: mock(async () => { throw new Error("Brick is not active"); }),
+      } as unknown as FetchClient;
+
+      await useZonesStore.getState().unmountBrick("brick-alpha", client);
+      const state = useZonesStore.getState();
+
+      expect(state.error).toBe("Brick is not active");
+    });
+  });
+
+  describe("unregisterBrick", () => {
+    it("calls POST unregister and refreshes bricks list", async () => {
+      const client = mockClient({
+        "/api/v2/bricks/brick-gamma/unregister": undefined,
+        "/api/v2/bricks/health": SAMPLE_BRICKS_HEALTH,
+      });
+
+      await useZonesStore.getState().unregisterBrick("brick-gamma", client);
+      const state = useZonesStore.getState();
+
+      expect(state.error).toBeNull();
+      expect(state.bricks).toHaveLength(3);
+      expect((client.post as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    });
+
+    it("sets error on unregister failure", async () => {
+      const client = {
+        get: mock(async () => ({ total: 0, active: 0, failed: 0, bricks: [] })),
+        post: mock(async () => { throw new Error("Brick must be unmounted"); }),
+      } as unknown as FetchClient;
+
+      await useZonesStore.getState().unregisterBrick("brick-gamma", client);
+      const state = useZonesStore.getState();
+
+      expect(state.error).toBe("Brick must be unmounted");
+    });
+
+    it("non-Error exceptions produce fallback message", async () => {
+      const client = {
+        get: mock(async () => ({ total: 0, active: 0, failed: 0, bricks: [] })),
+        post: mock(async () => { throw 42; }),
+      } as unknown as FetchClient;
+
+      await useZonesStore.getState().unregisterBrick("brick-gamma", client);
+      expect(useZonesStore.getState().error).toBe("Failed to unregister brick");
     });
   });
 });

--- a/packages/nexus-tui/tests/stores/zones-store.test.ts
+++ b/packages/nexus-tui/tests/stores/zones-store.test.ts
@@ -220,6 +220,11 @@ describe("ZonesStore", () => {
         enabled: true,
         depends_on: ["brick-gamma"],
         depended_by: ["brick-beta"],
+        retry_count: 2,
+        transitions: [
+          { timestamp: 1000.0, event: "mount", from_state: "REGISTERED", to_state: "STARTING" },
+          { timestamp: 1001.0, event: "started", from_state: "STARTING", to_state: "ACTIVE" },
+        ],
       };
 
       const client = mockClient({
@@ -238,6 +243,11 @@ describe("ZonesStore", () => {
       expect(state.brickDetail!.enabled).toBe(true);
       expect(state.brickDetail!.depends_on).toEqual(["brick-gamma"]);
       expect(state.brickDetail!.depended_by).toEqual(["brick-beta"]);
+      expect(state.brickDetail!.retry_count).toBe(2);
+      expect(state.brickDetail!.transitions).toHaveLength(2);
+      expect(state.brickDetail!.transitions[0]!.event).toBe("mount");
+      expect(state.brickDetail!.transitions[0]!.from_state).toBe("REGISTERED");
+      expect(state.brickDetail!.transitions[1]!.to_state).toBe("ACTIVE");
       expect(state.detailLoading).toBe(false);
     });
 

--- a/packages/nexus-tui/tests/stores/zones-store.test.ts
+++ b/packages/nexus-tui/tests/stores/zones-store.test.ts
@@ -580,5 +580,27 @@ describe("ZonesStore", () => {
       await useZonesStore.getState().unregisterBrick("brick-gamma", client);
       expect(useZonesStore.getState().error).toBe("Failed to unregister brick");
     });
+
+    it("clears stale detail and clamps selectedIndex after unregister", async () => {
+      // Set up: select last brick (index 2), with stale detail loaded
+      useZonesStore.setState({
+        bricks: SAMPLE_BRICKS,
+        selectedIndex: 2,
+        brickDetail: SAMPLE_BRICKS[2]! as any,
+      });
+
+      // After unregister, health returns only 2 bricks
+      const twoRemainingBricks = SAMPLE_BRICKS.slice(0, 2);
+      const client = mockClient({
+        "/api/v2/bricks/brick-gamma/unregister": undefined,
+        "/api/v2/bricks/health": { total: 2, active: 1, failed: 1, bricks: twoRemainingBricks },
+      });
+
+      await useZonesStore.getState().unregisterBrick("brick-gamma", client);
+      const state = useZonesStore.getState();
+
+      expect(state.brickDetail).toBeNull();
+      expect(state.selectedIndex).toBeLessThanOrEqual(1);
+    });
   });
 });

--- a/src/nexus/server/api/v2/routers/bricks.py
+++ b/src/nexus/server/api/v2/routers/bricks.py
@@ -45,12 +45,23 @@ class BrickStatusResponse(BaseModel):
     unmounted_at: float | None = None
 
 
+class BrickTransitionItem(BaseModel):
+    """Single FSM state transition entry."""
+
+    timestamp: float
+    event: str
+    from_state: str
+    to_state: str
+
+
 class BrickDetailResponse(BrickStatusResponse):
-    """Extended brick detail with spec and dependency info (Issue #2980)."""
+    """Extended brick detail with spec, dependency info, and transition history."""
 
     enabled: bool = True
     depends_on: list[str] = []
     depended_by: list[str] = []
+    retry_count: int = 0
+    transitions: list[BrickTransitionItem] = []
 
 
 class BrickHealthResponse(BaseModel):
@@ -238,7 +249,7 @@ async def brick_status(
     name: str,
     manager: Any = Depends(_get_lifecycle_manager),
 ) -> BrickDetailResponse:
-    """Individual brick lifecycle status with spec and dependency info."""
+    """Individual brick lifecycle status with spec, dependency, and transition info."""
     status = manager.get_status(name)
     if status is None:
         raise HTTPException(status_code=404, detail=f"Brick {name!r} not found")
@@ -255,6 +266,14 @@ async def brick_status(
         if name in other_spec.depends_on:
             depended_by.append(other_name)
 
+    # Transition history and retry count
+    retry_count = manager.get_retry_count(name)
+    raw_transitions = manager.get_transitions(name)
+    transitions = [
+        BrickTransitionItem(timestamp=ts, event=evt, from_state=frm, to_state=to)
+        for ts, evt, frm, to in raw_transitions
+    ]
+
     return BrickDetailResponse(
         name=status.name,
         state=status.state.value,
@@ -266,6 +285,8 @@ async def brick_status(
         enabled=enabled,
         depends_on=depends_on,
         depended_by=sorted(depended_by),
+        retry_count=retry_count,
+        transitions=transitions,
     )
 
 

--- a/src/nexus/server/api/v2/routers/bricks.py
+++ b/src/nexus/server/api/v2/routers/bricks.py
@@ -45,6 +45,14 @@ class BrickStatusResponse(BaseModel):
     unmounted_at: float | None = None
 
 
+class BrickDetailResponse(BrickStatusResponse):
+    """Extended brick detail with spec and dependency info (Issue #2980)."""
+
+    enabled: bool = True
+    depends_on: list[str] = []
+    depended_by: list[str] = []
+
+
 class BrickHealthResponse(BaseModel):
     """Aggregated brick health report."""
 
@@ -225,16 +233,29 @@ async def brick_health(
     )
 
 
-@router.get("/{name}", response_model=BrickStatusResponse)
+@router.get("/{name}", response_model=BrickDetailResponse)
 async def brick_status(
     name: str,
     manager: Any = Depends(_get_lifecycle_manager),
-) -> BrickStatusResponse:
-    """Individual brick lifecycle status."""
+) -> BrickDetailResponse:
+    """Individual brick lifecycle status with spec and dependency info."""
     status = manager.get_status(name)
     if status is None:
         raise HTTPException(status_code=404, detail=f"Brick {name!r} not found")
-    return BrickStatusResponse(
+
+    # Enrich with spec data (depends_on, enabled)
+    spec = manager.get_spec(name)
+    depends_on: list[str] = list(spec.depends_on) if spec else []
+    enabled: bool = spec.enabled if spec else True
+
+    # Compute reverse dependencies (which bricks depend on this one)
+    depended_by: list[str] = []
+    all_specs = manager.all_specs()
+    for other_name, other_spec in all_specs.items():
+        if name in other_spec.depends_on:
+            depended_by.append(other_name)
+
+    return BrickDetailResponse(
         name=status.name,
         state=status.state.value,
         protocol_name=status.protocol_name,
@@ -242,6 +263,9 @@ async def brick_status(
         started_at=status.started_at,
         stopped_at=status.stopped_at,
         unmounted_at=status.unmounted_at,
+        enabled=enabled,
+        depends_on=depends_on,
+        depended_by=sorted(depended_by),
     )
 
 

--- a/src/nexus/system_services/lifecycle/brick_lifecycle.py
+++ b/src/nexus/system_services/lifecycle/brick_lifecycle.py
@@ -23,6 +23,7 @@ References:
 import asyncio
 import logging
 import time
+from collections import deque
 from dataclasses import replace
 from graphlib import CycleError, TopologicalSorter
 from typing import Any
@@ -49,6 +50,9 @@ logger = logging.getLogger(__name__)
 
 # Default timeout for brick.start() in seconds
 DEFAULT_START_TIMEOUT: float = 5.0
+
+# Maximum number of state transitions to retain per brick
+MAX_TRANSITION_HISTORY: int = 50
 
 # ---------------------------------------------------------------------------
 # OTel tracing — zero-overhead when telemetry is not enabled
@@ -125,6 +129,7 @@ class _BrickEntry:
         "unmounted_at",
         "retry_count",
         "lock",
+        "transitions",
     )
 
     def __init__(
@@ -141,6 +146,7 @@ class _BrickEntry:
         self.unmounted_at: float | None = None
         self.retry_count: int = 0
         self.lock = asyncio.Lock()
+        self.transitions: deque[tuple[float, str, str, str]] = deque(maxlen=MAX_TRANSITION_HISTORY)
 
     # Convenience accessors (delegate to spec)
     @property
@@ -280,6 +286,7 @@ class BrickLifecycleManager:
 
         old_state = entry.state
         entry.state = new_state
+        entry.transitions.append((time.monotonic(), event, old_state.name, new_state.name))
         logger.debug("[LIFECYCLE] %s: %s + %s → %s", name, old_state.name, event, new_state.name)
         return new_state
 
@@ -288,7 +295,9 @@ class BrickLifecycleManager:
         entry = self._bricks.get(name)
         if entry is None:
             raise KeyError(f"Brick {name!r} not found")
+        old_state = entry.state
         entry.state = state
+        entry.transitions.append((time.monotonic(), "force", old_state.name, state.name))
 
     # ------------------------------------------------------------------
     # Status & health
@@ -367,6 +376,19 @@ class BrickLifecycleManager:
         if entry is None:
             raise KeyError(f"Brick {name!r} not found")
         return entry.retry_count
+
+    def get_transitions(self, name: str) -> list[tuple[float, str, str, str]]:
+        """Return transition history for a brick.
+
+        Each tuple is (timestamp, event, from_state, to_state).
+
+        Raises:
+            KeyError: If brick not found.
+        """
+        entry = self._bricks.get(name)
+        if entry is None:
+            raise KeyError(f"Brick {name!r} not found")
+        return list(entry.transitions)
 
     def update_spec(self, name: str, *, enabled: bool | None = None) -> BrickSpec:
         """Update a brick's spec fields. Returns the new spec.

--- a/tests/unit/server/api/v2/routers/test_bricks_router.py
+++ b/tests/unit/server/api/v2/routers/test_bricks_router.py
@@ -75,6 +75,10 @@ def _reset_mock() -> None:
     _mock_manager.get_status.side_effect = None
     _mock_manager.mount = AsyncMock()
     _mock_manager.unmount = AsyncMock()
+    _mock_manager.get_retry_count.return_value = 0
+    _mock_manager.get_transitions.return_value = []
+    _mock_manager.get_spec.return_value = None
+    _mock_manager.all_specs.return_value = {}
 
 
 def _make_status(
@@ -181,6 +185,26 @@ class TestBrickStatus:
         data = resp.json()
         assert data["state"] == "failed"
         assert data["error"] == "db down"
+
+    def test_detail_includes_retry_count_and_transitions(self) -> None:
+        status = _make_status("search", BrickState.ACTIVE, "SearchProtocol")
+        _mock_manager.get_status.return_value = status
+        _mock_manager.get_retry_count.return_value = 3
+        _mock_manager.get_transitions.return_value = [
+            (1000.0, "mount", "REGISTERED", "STARTING"),
+            (1001.0, "started", "STARTING", "ACTIVE"),
+        ]
+
+        resp = client.get("/api/v2/bricks/search")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["retry_count"] == 3
+        assert len(data["transitions"]) == 2
+        assert data["transitions"][0]["event"] == "mount"
+        assert data["transitions"][0]["from_state"] == "REGISTERED"
+        assert data["transitions"][0]["to_state"] == "STARTING"
+        assert data["transitions"][1]["event"] == "started"
+        assert data["transitions"][1]["timestamp"] == 1001.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_brick_lifecycle.py
+++ b/tests/unit/services/test_brick_lifecycle.py
@@ -24,6 +24,7 @@ from nexus.contracts.protocols.brick_lifecycle import (
     BrickState,
 )
 from nexus.system_services.lifecycle.brick_lifecycle import (
+    MAX_TRANSITION_HISTORY,
     BrickLifecycleManager,
     CyclicDependencyError,
     InvalidTransitionError,
@@ -936,3 +937,82 @@ class TestShutdown:
         assert status is not None
         assert status.unmounted_at is not None
         assert status.unmounted_at > 0
+
+
+# ---------------------------------------------------------------------------
+# Transition history tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionHistory:
+    """Test transition recording and get_transitions()."""
+
+    @pytest.fixture
+    def manager(self) -> BrickLifecycleManager:
+        return BrickLifecycleManager()
+
+    @pytest.mark.asyncio
+    async def test_mount_records_transitions(self, manager: BrickLifecycleManager) -> None:
+        """Mount should record REGISTERED→STARTING and STARTING→ACTIVE transitions."""
+        brick = _make_lifecycle_brick("search")
+        manager.register("search", brick, protocol_name="SearchProtocol")
+        await manager.mount("search")
+
+        transitions = manager.get_transitions("search")
+        assert len(transitions) == 2
+        # First: REGISTERED → STARTING (mount event)
+        _, event0, from0, to0 = transitions[0]
+        assert event0 == EVENT_MOUNT
+        assert from0 == "REGISTERED"
+        assert to0 == "STARTING"
+        # Second: STARTING → ACTIVE (started event)
+        _, event1, from1, to1 = transitions[1]
+        assert event1 == EVENT_STARTED
+        assert from1 == "STARTING"
+        assert to1 == "ACTIVE"
+
+    def test_cap_enforcement(self, manager: BrickLifecycleManager) -> None:
+        """More than MAX_TRANSITION_HISTORY transitions should keep only the last N."""
+        brick = _make_lifecycle_brick("search")
+        manager.register("search", brick, protocol_name="SearchProtocol")
+
+        # Force many transitions by alternating states
+        for _ in range(MAX_TRANSITION_HISTORY + 20):
+            manager._force_state("search", BrickState.REGISTERED)
+
+        transitions = manager.get_transitions("search")
+        assert len(transitions) == MAX_TRANSITION_HISTORY
+
+    def test_get_transitions_unknown_raises(self, manager: BrickLifecycleManager) -> None:
+        """get_transitions() should raise KeyError for unknown brick."""
+        with pytest.raises(KeyError, match="not found"):
+            manager.get_transitions("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_transitions_survive_reset(self, manager: BrickLifecycleManager) -> None:
+        """Transitions should NOT be cleared on reset()."""
+        brick = _make_lifecycle_brick("search")
+        brick.start = AsyncMock(side_effect=[RuntimeError("fail"), None])
+        manager.register("search", brick, protocol_name="SearchProtocol")
+
+        await manager.mount("search")  # REGISTERED→STARTING→FAILED
+        transitions_before = manager.get_transitions("search")
+        assert len(transitions_before) > 0
+
+        manager.reset("search")  # FAILED→REGISTERED
+        transitions_after = manager.get_transitions("search")
+        # Should have MORE transitions (the reset itself adds one)
+        assert len(transitions_after) > len(transitions_before)
+
+    def test_force_state_records_transition(self, manager: BrickLifecycleManager) -> None:
+        """_force_state() should record a transition with event='force'."""
+        brick = _make_lifecycle_brick("search")
+        manager.register("search", brick, protocol_name="SearchProtocol")
+        manager._force_state("search", BrickState.ACTIVE)
+
+        transitions = manager.get_transitions("search")
+        assert len(transitions) == 1
+        _, event, from_state, to_state = transitions[0]
+        assert event == "force"
+        assert from_state == "REGISTERED"
+        assert to_state == "ACTIVE"


### PR DESCRIPTION
## Summary

Closes #2980

- Wire three missing backend brick lifecycle APIs (`mount`, `unmount`, `unregister`) into the TUI's Zones > Bricks panel
- Add context-aware keybindings that only show/allow actions valid for the selected brick's FSM state
- Add confirmation dialog for destructive `D:unregister` action (terminal, irreversible)
- Enhance brick detail pane with dependency graph, config, and state history
- Consume `GET /api/v2/features` at startup for adaptive TUI layout
- Fix state mismatch bug: TUI was checking wrong state values (`running`/`stopped`/`mounted` instead of `active`/`unmounted`/`registered`)

## Changes

### Backend (Python)
- **`src/nexus/server/api/v2/routers/bricks.py`** — New `BrickDetailResponse` extending `BrickStatusResponse` with `depends_on`, `depended_by`, `enabled` fields. `GET /api/v2/bricks/{name}` now returns enriched detail using `get_spec()` and computed reverse deps.

### TUI (TypeScript/React)
- **NEW `src/shared/brick-states.ts`** — Single source of truth for FSM states, `allowedActionsForState()` pure function, `stateIndicator()` display mapping
- **NEW `src/shared/components/confirm-dialog.tsx`** — Reusable Y/N confirmation modal (follows IdentitySwitcher overlay pattern)
- **`src/stores/zones-store.ts`** — `mountBrick`, `unmountBrick`, `unregisterBrick` actions + `BrickDetailResponse` type
- **`src/stores/global-store.ts`** — `FeaturesResponse` type, `enabledBricks`/`profile`/`mode` state, `setFeatures()` action
- **`src/index.tsx`** — `Promise.all` parallel fetch of `bricks/health` + `features` at startup
- **`src/panels/zones/brick-list.tsx`** — Uses shared `stateIndicator()` (fixes state mismatch)
- **`src/panels/zones/brick-detail.tsx`** — Dependency graph, config, state history, available actions sections
- **`src/panels/zones/zones-panel.tsx`** — `M:mount`, `U:unmount`, `D:unregister` keybindings with FSM state guards, `ConfirmDialog` integration, dynamic help bar

### Tests
- **NEW `tests/shared/brick-states.test.ts`** — 17 tests: exhaustive truth table (7 states x 5 actions) + display mapping
- **`tests/stores/zones-store.test.ts`** — 10 new tests for mount/unmount/unregister (success, failure, error clearing)

## Test plan

- [x] All 47 TUI tests pass (30 existing + 17 new)
- [ ] Manual: navigate to Zones > Bricks tab, verify state indicators show correct FSM states
- [ ] Manual: select a `registered` brick, verify only `M:mount` appears in help bar
- [ ] Manual: select an `active` brick, verify only `U:unmount` appears
- [ ] Manual: select an `unmounted` brick, verify `M:mount`, `m:remount`, `D:unregister` appear
- [ ] Manual: select a `failed` brick, verify only `x:reset` appears
- [ ] Manual: press `D` on unmounted brick, verify confirmation dialog appears
- [ ] Manual: verify brick detail pane shows dependencies, config, state history
- [ ] Manual: verify features data loads at startup (check global store)