### PR TITLE
fix: rename docker-compose.demo.yml, add TTY detection to port conflict prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,10 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=nexus
 POSTGRES_PORT=5432
 POSTGRES_HOST=postgres
-# NOTE: Both local-demo.sh and docker-demo.sh share the same PostgreSQL container
+# NOTE: Both local-demo.sh and nexus-docker.sh share the same PostgreSQL container
 #   - For local-demo.sh: Add to /etc/hosts: 127.0.0.1 postgres
 #     Or use POSTGRES_HOST=localhost (will auto-fallback if 'postgres' not in /etc/hosts)
-#   - For docker-demo.sh: Uses 'postgres' directly (Docker internal networking)
+#   - For nexus-docker.sh: Uses 'postgres' directly (Docker internal networking)
 #   - Production: Set to actual database hostname or 'postgres' for Docker deployment
 
 # NOTE: TOKEN_MANAGER_DB is automatically constructed by docker-compose.yml

--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -20,7 +20,9 @@ on:
       # Docker-related files
       - 'Dockerfile'
       - 'docker-compose*.yml'
-      - 'scripts/docker-demo.sh'
+      - 'dockerfiles/compose.yaml'
+      - 'nexus-stack.yml'
+      - 'scripts/nexus-docker.sh'
       - 'docker-entrypoint.sh'
       - '.github/workflows/docker-integration.yml'
       # Core source files that affect Docker integration
@@ -86,7 +88,7 @@ jobs:
           echo '${{ secrets.NEXUS_GCS_CREDENTIALS }}' > gcs-credentials.json
 
           # Create .env file with config from GitHub secrets
-          # Note: docker-demo.sh looks for .env (not .env)
+          # Note: nexus-docker.sh looks for .env (not .env)
           cat > .env << 'EOF'
           # ============================================
           # PostgreSQL Database
@@ -208,15 +210,15 @@ jobs:
             exit 1
           fi
 
-      - name: Make docker-demo.sh executable
+      - name: Make nexus-docker.sh executable
         working-directory: nexus
-        run: chmod +x scripts/docker-demo.sh
+        run: chmod +x scripts/nexus-docker.sh
 
-      - name: Test docker-demo.sh --init --build
+      - name: Test nexus-docker.sh --init --build
         working-directory: nexus
         run: |
-          echo "🚀 Testing docker-demo.sh --init --build --yes..."
-          ./scripts/docker-demo.sh --init --build --rebuild --yes
+          echo "🚀 Testing nexus-docker.sh --init --build --yes..."
+          ./scripts/nexus-docker.sh --init --build --rebuild --yes
         timeout-minutes: 20
 
       - name: Wait for services to be healthy
@@ -317,7 +319,7 @@ jobs:
             echo "   Checking .env file..."
             grep "ANTHROPIC_API_KEY" .env || echo "   Not found in .env"
             echo "   Checking docker-compose environment..."
-            docker-compose -f docker-compose.demo.yml config | grep -A 5 "ANTHROPIC_API_KEY" || echo "   Not found in docker-compose config"
+            docker compose -f dockerfiles/compose.yaml config | grep -A 5 "ANTHROPIC_API_KEY" || echo "   Not found in docker-compose config"
             exit 1
           fi
 
@@ -1710,14 +1712,14 @@ jobs:
             exit 1
           fi
 
-      - name: Test docker-demo.sh --restart
+      - name: Test nexus-docker.sh --restart
         working-directory: nexus
         run: |
-          echo "🔄 Testing docker-demo.sh --restart..."
+          echo "🔄 Testing nexus-docker.sh --restart..."
           echo ""
 
           # Restart services
-          ./scripts/docker-demo.sh --restart
+          ./scripts/nexus-docker.sh --restart
 
           echo "⏳ Waiting for services to become healthy after restart..."
           MAX_WAIT=180  # 3 minutes
@@ -1788,14 +1790,14 @@ jobs:
           echo "🎉 Restart test completed successfully!"
           echo "   All services recovered and are fully functional."
 
-      - name: Test docker-demo.sh --status
+      - name: Test nexus-docker.sh --status
         working-directory: nexus
         run: |
-          echo "📊 Testing docker-demo.sh --status..."
+          echo "📊 Testing nexus-docker.sh --status..."
           echo ""
 
           # Run status command and capture output
-          STATUS_OUTPUT=$(./scripts/docker-demo.sh --status 2>&1)
+          STATUS_OUTPUT=$(./scripts/nexus-docker.sh --status 2>&1)
           EXIT_CODE=$?
 
           if [ $EXIT_CODE -ne 0 ]; then
@@ -1821,14 +1823,14 @@ jobs:
           echo ""
           echo "🎉 Status test completed successfully!"
 
-      - name: Test docker-demo.sh --logs
+      - name: Test nexus-docker.sh --logs
         working-directory: nexus
         run: |
-          echo "📝 Testing docker-demo.sh --logs..."
+          echo "📝 Testing nexus-docker.sh --logs..."
           echo ""
 
           # Run logs command in background and capture output for 5 seconds
-          timeout 5s ./scripts/docker-demo.sh --logs > /tmp/docker_logs_test.txt 2>&1 || true
+          timeout 5s ./scripts/nexus-docker.sh --logs > /tmp/docker_logs_test.txt 2>&1 || true
 
           # Verify log file has content
           if [ ! -s /tmp/docker_logs_test.txt ]; then
@@ -1849,10 +1851,10 @@ jobs:
           echo ""
           echo "🎉 Logs test completed successfully!"
 
-      - name: Test docker-demo.sh --stop
+      - name: Test nexus-docker.sh --stop
         working-directory: nexus
         run: |
-          echo "🛑 Testing docker-demo.sh --stop..."
+          echo "🛑 Testing nexus-docker.sh --stop..."
           echo ""
 
           # Record running containers before stop
@@ -1860,7 +1862,7 @@ jobs:
           echo "Containers running before stop: $CONTAINERS_BEFORE"
 
           # Run stop command
-          ./scripts/docker-demo.sh --stop
+          ./scripts/nexus-docker.sh --stop
           EXIT_CODE=$?
 
           if [ $EXIT_CODE -ne 0 ]; then
@@ -1918,5 +1920,5 @@ jobs:
         working-directory: nexus
         run: |
           echo "🧹 Cleaning up containers..."
-          ./scripts/docker-demo.sh --stop || true
+          ./scripts/nexus-docker.sh --stop || true
           docker system prune -af || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # ============================================================================
   # Nexus RPC Server (Backend for MCP server or direct API access)
@@ -32,7 +30,7 @@ services:
       # Tiger Cache - disabled by default for simpler debugging
       - NEXUS_ENABLE_TIGER_CACHE=${NEXUS_ENABLE_TIGER_CACHE:-false}
     volumes:
-      # Persistent data directory - use bind mount to match docker-compose.demo.yml
+      # Persistent data directory - use bind mount to match dockerfiles/compose.yaml
       - ./nexus-data:/app/data
       # Docker socket for sandbox container management
       - /var/run/docker.sock:/var/run/docker.sock

--- a/dockerfiles/build-templates.py
+++ b/dockerfiles/build-templates.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Build all Docker template images from config.demo.yaml.
 
-This script is called by docker-start.sh during initialization to pre-build
+This script is called by nexus-docker.sh during initialization to pre-build
 all template images with inline Dockerfile overrides.
 """
 

--- a/dockerfiles/compose.yaml
+++ b/dockerfiles/compose.yaml
@@ -12,15 +12,15 @@
 #   docker compose --profile full up          # Everything
 #
 # Or via the helper script:
-#   ./scripts/docker-demo.sh                    # Start with local environment
-#   ./scripts/docker-demo.sh --env=production   # Start with production environment
+#   ./scripts/nexus-docker.sh                    # Start with local environment
+#   ./scripts/nexus-docker.sh --env=production   # Start with production environment
 #
 # Direct compose commands:
-#   docker compose -f docker-compose.demo.yml --profile full up -d   # All services, background
-#   docker compose -f docker-compose.demo.yml down                   # Stop all
-#   docker compose -f docker-compose.demo.yml logs -f                # View logs
+#   docker compose -f dockerfiles/compose.yaml --profile full up -d   # All services, background
+#   docker compose -f dockerfiles/compose.yaml down                   # Stop all
+#   docker compose -f dockerfiles/compose.yaml logs -f                # View logs
 #
-# Environment Files (loaded by docker-demo.sh):
+# Environment Files (loaded by nexus-docker.sh):
 #   Local mode:      .env (or .env.example as fallback)
 #   Production mode: .env.production + .env.production.secrets
 #
@@ -222,7 +222,7 @@ services:
       # GCS credentials (auto-detected - see docker-gcs-setup.sh)
       # Automatically finds credentials from: gcloud, ./gcs-credentials.json, or GCS_CREDENTIALS_PATH
       - ../gcs-credentials.json:/app/gcs-credentials.json:ro
-      # AWS credentials (auto-detected - see docker-start.sh)
+      # AWS credentials (auto-detected - see nexus-docker.sh)
       # Automatically finds credentials from: ~/.aws/credentials or AWS_CREDENTIALS_PATH
       - ${AWS_CREDENTIALS_PATH:-../aws-credentials}:/app/aws-credentials:ro
       - ${AWS_CONFIG_PATH:-../aws-config}:/app/aws-config:ro
@@ -541,8 +541,8 @@ services:
   # Runs unit and integration tests to verify Linux-specific code (inotify)
   #
   # Usage:
-  #   docker compose -f docker-compose.demo.yml --profile test run --rm test
-  #   docker compose -f docker-compose.demo.yml --profile test run --rm test pytest tests/unit -v
+  #   docker compose -f dockerfiles/compose.yaml --profile test run --rm test
+  #   docker compose -f dockerfiles/compose.yaml --profile test run --rm test pytest tests/unit -v
   # ============================================
   test:
     image: python:3.13

--- a/dockerfiles/docker-compose.evaluation.yml
+++ b/dockerfiles/docker-compose.evaluation.yml
@@ -1,6 +1,6 @@
 # Nexus Evaluation Environment - Docker Compose
 # Complete stack for MCP evaluation testing with semantic search enabled
-# Based on docker-compose.demo.yml with config.evaluation.yaml
+# Based on dockerfiles/compose.yaml with config.evaluation.yaml
 #
 # Usage:
 #   docker compose -f docker-compose.evaluation.yml up          # Start all services
@@ -142,7 +142,7 @@ services:
       # GCS credentials (auto-detected - see docker-gcs-setup.sh)
       # Automatically finds credentials from: gcloud, ./gcs-credentials.json, or GCS_CREDENTIALS_PATH
       - ${GCS_CREDENTIALS_PATH:-./gcs-credentials.json}:/app/gcs-credentials.json:ro
-      # AWS credentials (auto-detected - see docker-demo.sh)
+      # AWS credentials (auto-detected - see nexus-docker.sh)
       # Automatically finds credentials from: ~/.aws/credentials or AWS_CREDENTIALS_PATH
       - ${AWS_CREDENTIALS_PATH:-./aws-credentials}:/app/aws-credentials:ro
       - ${AWS_CONFIG_PATH:-./aws-config}:/app/aws-config:ro

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -6,7 +6,7 @@ set -e  # Exit on error
 
 NEXUS_REPO="$HOME/nexus"
 FRONTEND_REPO="$HOME/nexus-frontend"
-COMPOSE_FILE="docker-compose.demo.yml"
+COMPOSE_FILE="dockerfiles/compose.yaml"
 
 echo "🚀 Starting production deployment..."
 
@@ -24,17 +24,17 @@ cd "$FRONTEND_REPO"
 git pull origin main
 echo "✅ Frontend repository updated"
 
-# Return to Nexus repo for docker-compose
+# Return to Nexus repo for docker compose
 cd "$NEXUS_REPO"
 
 # Rebuild and restart services
 echo ""
 echo "🔨 Rebuilding Docker images..."
-docker-compose -f "$COMPOSE_FILE" build --no-cache
+docker compose -f "$COMPOSE_FILE" build --no-cache
 
 echo ""
 echo "🔄 Restarting services..."
-docker-compose -f "$COMPOSE_FILE" up -d
+docker compose -f "$COMPOSE_FILE" up -d
 
 echo ""
 echo "⏳ Waiting for services to be healthy..."
@@ -43,7 +43,7 @@ sleep 10
 # Check service health
 echo ""
 echo "🏥 Checking service health..."
-docker-compose -f "$COMPOSE_FILE" ps
+docker compose -f "$COMPOSE_FILE" ps
 
 echo ""
 echo "✅ Deployment complete!"

--- a/scripts/local-demo.sh
+++ b/scripts/local-demo.sh
@@ -17,7 +17,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Load configuration from .env file (same as docker-demo.sh)
+# Load configuration from .env file (same as nexus-docker.sh)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 ENV_FILE="${PROJECT_ROOT}/.env"
@@ -377,7 +377,7 @@ ensure_docker_sandbox_image() {
     fi
 
     echo -e "${YELLOW}Docker image '${image}' not found.${NC}"
-    # Prefer dockerfiles/build.sh if present to build runtime image (matches docker-demo.sh)
+    # Prefer dockerfiles/build.sh if present to build runtime image (matches nexus-docker.sh)
     if [ -x "${PROJECT_ROOT}/dockerfiles/build.sh" ]; then
         echo -e "${YELLOW}Building sandbox runtime via dockerfiles/build.sh ...${NC}"
         if "${PROJECT_ROOT}/dockerfiles/build.sh"; then
@@ -424,7 +424,7 @@ check_port_2026_available() {
             echo ""
             echo "Stop the server first using one of these commands:"
             echo "   ./scripts/local-demo.sh --stop              # Stop local Nexus server"
-            echo "   ./scripts/docker-demo.sh --stop             # Stop Docker-based server"
+            echo "   ./scripts/nexus-docker.sh --stop             # Stop Docker-based server"
             echo ""
             echo "Or manually kill the process(es):"
             for PID in $PIDS; do
@@ -710,7 +710,7 @@ start_server() {
             echo ""
             echo "  Run: sudo bash -c 'echo \"127.0.0.1    postgres\" >> /etc/hosts'"
             echo ""
-            echo "  This allows the same .env config to work for both local-demo.sh and docker-demo.sh"
+            echo "  This allows the same .env config to work for both local-demo.sh and nexus-docker.sh"
             echo ""
 
             # Auto-fallback to localhost if postgres hostname not mapped

--- a/scripts/nexus-docker.sh
+++ b/scripts/nexus-docker.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-# docker-demo.sh - Start Nexus services using Docker Compose
+# nexus-docker.sh - Start Nexus services using Docker Compose
 #
 # Usage:
-#   ./scripts/docker-demo.sh                    # Start all services (detached)
-#   ./scripts/docker-demo.sh --build            # Rebuild images and start
-#   ./scripts/docker-demo.sh --stop             # Stop all services
-#   ./scripts/docker-demo.sh --restart          # Restart all services
-#   ./scripts/docker-demo.sh --logs             # View logs (follow mode)
-#   ./scripts/docker-demo.sh --status           # Check service status
-#   ./scripts/docker-demo.sh --clean            # Stop and remove all data (volumes)
-#   ./scripts/docker-demo.sh --init             # Initialize (clean + start; optional rebuild via --rebuild)
-#   ./scripts/docker-demo.sh --init --skip_permission  # Initialize with permissions disabled
-#   ./scripts/docker-demo.sh --init --rebuild   # Initialize + rebuild images (runtime + services)
-#   ./scripts/docker-demo.sh --init --yes       # Initialize without confirmation (CI)
-#   ./scripts/docker-demo.sh --env=production   # Use production environment files
+#   ./scripts/nexus-docker.sh                    # Start all services (detached)
+#   ./scripts/nexus-docker.sh --build            # Rebuild images and start
+#   ./scripts/nexus-docker.sh --stop             # Stop all services
+#   ./scripts/nexus-docker.sh --restart          # Restart all services
+#   ./scripts/nexus-docker.sh --logs             # View logs (follow mode)
+#   ./scripts/nexus-docker.sh --status           # Check service status
+#   ./scripts/nexus-docker.sh --clean            # Stop and remove all data (volumes)
+#   ./scripts/nexus-docker.sh --init             # Initialize (clean + start; optional rebuild via --rebuild)
+#   ./scripts/nexus-docker.sh --init --skip_permission  # Initialize with permissions disabled
+#   ./scripts/nexus-docker.sh --init --rebuild   # Initialize + rebuild images (runtime + services)
+#   ./scripts/nexus-docker.sh --init --yes       # Initialize without confirmation (CI)
+#   ./scripts/nexus-docker.sh --env=production   # Use production environment files
 #
 # Services:
 #   - postgres:    PostgreSQL database (port 5432)
@@ -27,7 +27,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$PROJECT_ROOT"
 
-COMPOSE_FILE="dockerfiles/docker-compose.demo.yml"
+COMPOSE_FILE="dockerfiles/compose.yaml"
 ENV_MODE="local"  # Default: local development
 SKIP_PERMISSIONS=false  # Default: set up permissions
 SKIP_CONFIRM=false  # Default: ask for confirmation on destructive operations
@@ -731,13 +731,13 @@ cmd_urls() {
 ║                      📚 Useful Commands                          ║
 ╚═══════════════════════════════════════════════════════════════════╝
 
-  View logs:         ./docker-start.sh --logs
-  Check status:      ./docker-start.sh --status
-  Restart:           ./docker-start.sh --restart
-  Stop:              ./docker-start.sh --stop
+  View logs:         ./scripts/nexus-docker.sh --logs
+  Check status:      ./scripts/nexus-docker.sh --status
+  Restart:           ./scripts/nexus-docker.sh --restart
+  Stop:              ./scripts/nexus-docker.sh --stop
 
   Docker commands:
-    All logs:        docker compose -f docker-compose.demo.yml logs -f
+    All logs:        docker compose -f dockerfiles/compose.yaml logs -f
     Nexus logs:      docker logs -f nexus-server
     Frontend logs:   docker logs -f nexus-frontend
     LangGraph logs:  docker logs -f nexus-langgraph
@@ -844,12 +844,12 @@ case "$COMMAND" in
         echo "  production      Use .env.production and .env.production.secrets"
         echo ""
         echo "Examples:"
-        echo "  ./docker-start.sh                    # Start with local env"
-        echo "  ./docker-start.sh --env=production   # Start with production env"
-        echo "  ./docker-start.sh --build --env=production  # Rebuild with production env"
-        echo "  ./docker-start.sh --init --skip_permission  # Initialize with permissions disabled"
-        echo "  ./docker-start.sh --init --rebuild   # Initialize and rebuild images"
-        echo "  ./docker-start.sh --init --yes       # Initialize without confirmation (CI)"
+        echo "  ./scripts/nexus-docker.sh                    # Start with local env"
+        echo "  ./scripts/nexus-docker.sh --env=production   # Start with production env"
+        echo "  ./scripts/nexus-docker.sh --build --env=production  # Rebuild with production env"
+        echo "  ./scripts/nexus-docker.sh --init --skip_permission  # Initialize with permissions disabled"
+        echo "  ./scripts/nexus-docker.sh --init --rebuild   # Initialize and rebuild images"
+        echo "  ./scripts/nexus-docker.sh --init --yes       # Initialize without confirmation (CI)"
         echo ""
         show_services
         ;;

--- a/scripts/run_share_link_e2e.sh
+++ b/scripts/run_share_link_e2e.sh
@@ -27,8 +27,8 @@ echo ""
 # Check if PostgreSQL is available
 echo "Checking PostgreSQL connection..."
 if ! pg_isready -h localhost -p 5432 -q 2>/dev/null; then
-    echo "PostgreSQL not running. Starting via docker-compose..."
-    docker-compose -f "$PROJECT_ROOT/docker-compose.demo.yml" up -d postgres
+    echo "PostgreSQL not running. Starting via docker compose..."
+    docker compose -f "$PROJECT_ROOT/dockerfiles/compose.yaml" up -d postgres
 
     # Wait for PostgreSQL to be ready
     echo "Waiting for PostgreSQL to be ready..."

--- a/scripts/test-revision-cache.sh
+++ b/scripts/test-revision-cache.sh
@@ -5,7 +5,7 @@
 # Uses Docker PostgreSQL for integration tests.
 #
 # Prerequisites:
-#   docker compose -f docker-compose.demo.yml up postgres -d
+#   docker compose -f dockerfiles/compose.yaml up postgres -d
 #
 # Usage:
 #   ./scripts/test-revision-cache.sh
@@ -36,7 +36,7 @@ POSTGRES_URL="${NEXUS_DATABASE_URL:-postgresql://postgres:nexus@localhost:5432/n
 
 if ! pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; then
     echo -e "${YELLOW}PostgreSQL not running. Starting...${NC}"
-    docker compose -f docker-compose.demo.yml up postgres -d
+    docker compose -f dockerfiles/compose.yaml up postgres -d
     echo "Waiting for PostgreSQL to be ready..."
     for i in {1..30}; do
         if pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; then

--- a/src/nexus/cli/port_utils.py
+++ b/src/nexus/cli/port_utils.py
@@ -150,9 +150,26 @@ def resolve_ports(
             sys.exit(1)
         elif strategy == "prompt":
             label = PORT_LABELS.get(service, service)
+            default_free = _find_free_unclaimed(port + 1, host, claimed)
+
+            # In non-interactive contexts (CI, piped stdin), fall back to
+            # "fail" behaviour instead of blocking on a prompt that nobody
+            # will answer.  Matches the Create-React-App / Next.js pattern.
+            if not sys.stdin.isatty():
+                from nexus.cli.utils import console
+
+                console.print(
+                    f"[red]Error:[/red] Port {port} ({label}) is already in use "
+                    f"(non-interactive terminal — cannot prompt)."
+                )
+                console.print(
+                    f"[yellow]Hint:[/yellow] Use --port-strategy auto to auto-select "
+                    f"a free port, or set the port explicitly (suggested: {default_free})."
+                )
+                sys.exit(1)
+
             import click
 
-            default_free = _find_free_unclaimed(port + 1, host, claimed)
             new_port = click.prompt(
                 f"Port {port} ({label}) is in use. Enter alternative port",
                 type=int,

--- a/tests/e2e/postgres/test_auth_postgres.py
+++ b/tests/e2e/postgres/test_auth_postgres.py
@@ -6,7 +6,7 @@ PostgreSQL's row-level locking behavior.
 
 Requirements:
     - PostgreSQL running at postgresql://postgres:nexus@localhost:5432/nexus
-    - Start with: docker compose -f docker-compose.demo.yml up postgres -d
+    - Start with: docker compose -f dockerfiles/compose.yaml up postgres -d
 
 Run tests with:
     pytest tests/integration/test_auth_postgres.py -v
@@ -77,7 +77,7 @@ def postgres_engine():
     Requires PostgreSQL running at:
         postgresql://postgres:nexus@localhost:5432/nexus
 
-    Start with: docker compose -f docker-compose.demo.yml up postgres -d
+    Start with: docker compose -f dockerfiles/compose.yaml up postgres -d
     """
     database_url = "postgresql://postgres:nexus@localhost:5432/nexus"
 

--- a/tests/e2e/postgres/test_postgres_cache.py
+++ b/tests/e2e/postgres/test_postgres_cache.py
@@ -6,7 +6,7 @@ and Protocol conformance.
 
 Requirements:
     - PostgreSQL running at postgresql://postgres:nexus@localhost:5432/nexus
-    - Start with: docker compose -f docker-compose.demo.yml up postgres -d
+    - Start with: docker compose -f dockerfiles/compose.yaml up postgres -d
 
 Run tests with:
     pytest tests/integration/test_postgres_cache.py -v
@@ -53,7 +53,7 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.skipif(
         not _pg_is_available(),
-        reason="PostgreSQL not available. Start with: docker compose -f docker-compose.demo.yml up postgres -d",
+        reason="PostgreSQL not available. Start with: docker compose -f dockerfiles/compose.yaml up postgres -d",
     ),
 ]
 

--- a/tests/evaluation/run_evaluation.py
+++ b/tests/evaluation/run_evaluation.py
@@ -409,7 +409,7 @@ async def run_evaluation_async(
     - These match the variables used by docker-compose.yml and MCP server
 
     **Before running evaluations**:
-    1. Start Docker containers: ./scripts/docker-demo.sh
+    1. Start Docker containers: ./scripts/nexus-docker.sh
     2. Verify MCP server: curl http://${MCP_HOST}:${MCP_PORT}/health
     3. Set NEXUS_API_KEY if authentication is enabled
     4. Override MCP_HOST/MCP_PORT for remote testing if needed

--- a/tests/unit/core/test_rebac_revision_cache.py
+++ b/tests/unit/core/test_rebac_revision_cache.py
@@ -9,7 +9,7 @@ Tests verify that:
 
 Requirements:
     - PostgreSQL running at postgresql://postgres:nexus@localhost:5432/nexus
-    - Start with: docker compose -f docker-compose.demo.yml up postgres -d
+    - Start with: docker compose -f dockerfiles/compose.yaml up postgres -d
     - Or set NEXUS_DATABASE_URL environment variable
 """
 


### PR DESCRIPTION
## Summary

- **Rename `dockerfiles/docker-compose.demo.yml`** → `dockerfiles/compose.yaml` — follows Docker's modern canonical naming (`compose.yaml` is the official standard), drops the misleading "demo" label that was being used for both dev and production
- **Rename `scripts/docker-demo.sh`** → `scripts/nexus-docker.sh` — consistent with project naming
- **Add TTY detection to `port_utils.py` prompt strategy** — when `--port-strategy prompt` is used in a non-interactive context (CI, piped stdin), falls back to "fail" with a clear error + suggested port instead of blocking forever. Matches CRA/Next.js best practice
- **Remove obsolete `version: '3.8'`** from root `docker-compose.yml` (deprecated per modern Compose spec)
- **Modernize `deploy-production.sh`** — `docker-compose` → `docker compose` (V2 syntax), point to new compose file path
- **Update all references** across 17 files (CI workflow, scripts, tests, docs, .env.example)

### What's NOT changed
- `nexus-stack.yml` (used by `nexus init` / `nexus up`) — untouched
- User journey (`nexus init --preset shared && nexus up --build`) — identical
- Port conflict resolution logic (auto/prompt/fail strategies) — only TTY guard added
- All service ports and profiles — same behavior

## Test plan
- [x] Unit tests pass: `pytest tests/unit/cli/test_port_utils.py` (18/18)
- [x] All pre-commit hooks pass (ruff, mypy, yaml, etc.)
- [x] Zero remaining `docker-compose.demo` / `docker-demo.sh` / `docker-start.sh` references (`grep` verified)
- [ ] Manual: `nexus init --preset shared && nexus up --build` starts postgres, dragonfly, zoekt, nexus
- [ ] Manual: `nexus up --port-strategy prompt` prompts interactively when port occupied
- [ ] Manual: `echo | nexus up --port-strategy prompt` fails gracefully (non-TTY)