### PR TITLE
fix: resolve bind-mount permission crash in Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,12 +104,14 @@ ENV USE_CHINA_MIRROR=${USE_CHINA_MIRROR}
 
 # ---------- Runtime dependencies ----------
 # libgomp1: OpenMP runtime required by txtai, scikit-learn, numpy (Issue #2946)
+# gosu: privilege drop in entrypoint for bind-mount permission fix
 RUN set -eux; \
     apt-get update && apt-get install -y --no-install-recommends \
         curl \
         netcat-openbsd \
         ca-certificates \
         libgomp1 \
+        gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # ---------- Copy Python packages + Rust extensions ----------
@@ -167,7 +169,10 @@ RUN useradd -r -m -u 1000 -s /bin/bash nexus
 RUN usermod -aG root nexus
 RUN mkdir -p /app/data && chown -R nexus:nexus /app
 
-USER nexus
+# NOTE: No USER directive here — the entrypoint starts as root to fix
+# bind-mount ownership, then drops to nexus via gosu.  When compose
+# sets `user: root` or the image is run with `docker run` (default root),
+# the entrypoint handles both cases.
 
 # ---------- Environment variables ----------
 # Prevent faiss SVE auto-detection crash on aarch64 in Docker containers

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -39,6 +39,26 @@ SERVER_PID=""
 ZOEKT_PID=""
 
 # -----------------------------------------------------------------------------
+# Bind-mount directory init + privilege drop
+# -----------------------------------------------------------------------------
+# When a host directory is bind-mounted over /app/data, the image's
+# pre-created subdirectories (skills/, .zoekt-index/) disappear and the
+# mount may be owned by a different uid.  If we're root, fix that now
+# and re-exec as the nexus user.
+fix_data_dir_and_drop_privileges() {
+    if [ "$(id -u)" = "0" ]; then
+        # Create required subdirectories inside the (possibly bind-mounted) data dir
+        mkdir -p /app/data/skills /app/data/.zoekt-index
+        chown -R nexus:nexus /app/data
+
+        # Re-exec the entrypoint as the nexus user
+        exec gosu nexus "$0" "$@"
+    fi
+}
+
+fix_data_dir_and_drop_privileges "$@"
+
+# -----------------------------------------------------------------------------
 # Functions
 # -----------------------------------------------------------------------------
 print_banner() {

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -307,10 +307,8 @@ build_serve_cmd() {
         if [ -n "${NEXUS_PROFILE:-}" ]; then
             cmd="$cmd --profile ${NEXUS_PROFILE}"
         fi
-        if [ "${NEXUS_BACKEND:-}" = "gcs" ]; then
-            cmd="$cmd --backend gcs --gcs-bucket ${NEXUS_GCS_BUCKET:-}"
-            [ -n "${NEXUS_GCS_PROJECT:-}" ] && cmd="$cmd --gcs-project ${NEXUS_GCS_PROJECT}"
-        fi
+        # GCS/S3 backends are configured via env vars (NEXUS_GCS_BUCKET_NAME,
+        # NEXUS_GCS_PROJECT_ID) read by the config loader, not CLI flags.
         echo "$cmd"
     fi
 }


### PR DESCRIPTION
## Summary

- Fix crash-loop when host directory is bind-mounted over `/app/data` — the container user `nexus(uid=1000)` cannot `mkdir` inside the host-owned mount, causing `Permission denied` on startup
- Install `gosu`, remove `USER nexus` from Dockerfile, add privilege-drop block to entrypoint that creates required subdirs as root then re-execs as `nexus`
- Sync Dockerfile and entrypoint with develop (nexusd, txtai/faiss, FAISS ARM64 workarounds, cluster join, stale PID cleanup)

## Root cause

The Dockerfile creates `/app/data/skills` at build time owned by `nexus:nexus`. But when compose bind-mounts `./nexus-data:/app/data`, the image's `/app/data` is replaced with an empty host directory owned by the host user. The entrypoint's `ensure_skills_directory()` then fails with `mkdir: cannot create directory '/app/data/skills': Permission denied`.

## Fix

Standard Docker entrypoint pattern (used by postgres, redis, etc.):
1. **Dockerfile**: add `gosu` to runtime deps, remove `USER nexus`
2. **Entrypoint**: `fix_data_dir_and_drop_privileges()` runs first — if root, creates `/app/data/skills` and `/app/data/.zoekt-index`, chowns `/app/data`, then `exec gosu nexus "$0" "$@"`

This covers both edge and stable/latest images since they share the same Dockerfile.

## Test plan

- [ ] `docker run --rm -v /tmp/empty:/app/data ghcr.io/nexi-lab/nexus:edge` no longer crashes on `mkdir`
- [ ] Container starts as root, drops to `nexus` user (verify with `docker exec <cid> whoami`)
- [ ] `docker compose up` with `./nexus-data:/app/data` bind mount starts successfully
- [ ] Existing `user: root` in compose files remains harmless (entrypoint handles both cases)