### PR TITLE
fix: use sk- prefix for generated admin API keys in nexus init

### DIFF
--- a/src/nexus/cli/commands/init_cmd.py
+++ b/src/nexus/cli/commands/init_cmd.py
@@ -175,7 +175,7 @@ def _build_config(
         # to write .admin-api-key (portable image runs nexusd directly).
         import secrets
 
-        config["api_key"] = f"nx_admin_{secrets.token_urlsafe(32)}"
+        config["api_key"] = f"sk-{secrets.token_urlsafe(32)}"
 
         # Compose file: CLI override → search CWD + ancestors → bundled copy
         if compose_file_override:


### PR DESCRIPTION
## Summary
- `nexus init` generated API keys with `nx_admin_` prefix, but the auth system (`server/dependencies.py`, `server/token_utils.py`) only recognizes `sk-` prefixed tokens
- This caused auth rejection when the CLI tried to authenticate against the stack using the generated key
- Fix: change prefix from `nx_admin_` to `sk-` in `init_cmd.py:178`

## Test plan
- [ ] Run `nexus init` and verify the generated API key in config starts with `sk-`
- [ ] Verify the generated key is accepted by the auth layer