### PR TITLE
fix(#182,#190): delete dead ContentChunkModel and FileSystemVersionSequenceModel

### DIFF
--- a/src/nexus/storage/__init__.py
+++ b/src/nexus/storage/__init__.py
@@ -13,7 +13,6 @@ _LAZY_STORAGE: dict[str, tuple[str, str]] = {
     "FileContentCache": ("nexus.storage.file_cache", "FileContentCache"),
     "FilePathModel": ("nexus.storage.models", "FilePathModel"),
     "FileMetadataModel": ("nexus.storage.models", "FileMetadataModel"),
-    "ContentChunkModel": ("nexus.storage.models", "ContentChunkModel"),
     "UserModel": ("nexus.storage.models", "UserModel"),
     "UserOAuthAccountModel": ("nexus.storage.models", "UserOAuthAccountModel"),
     "ZoneModel": ("nexus.storage.models", "ZoneModel"),
@@ -35,7 +34,6 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "FilePathModel",
     "FileMetadataModel",
-    "ContentChunkModel",
     "UserModel",
     "UserOAuthAccountModel",
     "ZoneModel",

--- a/src/nexus/storage/models/__init__.py
+++ b/src/nexus/storage/models/__init__.py
@@ -63,7 +63,6 @@ from nexus.storage.models.exchange_audit_log import ExchangeAuditLogModel as Exc
 from nexus.storage.models.file_path import FilePathModel as FilePathModel
 
 # Domain: Filesystem
-from nexus.storage.models.filesystem import ContentChunkModel as ContentChunkModel
 from nexus.storage.models.filesystem import DirectoryEntryModel as DirectoryEntryModel
 from nexus.storage.models.filesystem import DocumentChunkModel as DocumentChunkModel
 from nexus.storage.models.filesystem import FileMetadataModel as FileMetadataModel
@@ -101,9 +100,6 @@ from nexus.storage.models.payments import UsageEvent as UsageEvent
 
 # Domain: Permissions (ReBAC + Tiger Cache)
 from nexus.storage.models.permissions import AdminBypassAuditModel as AdminBypassAuditModel
-from nexus.storage.models.permissions import (
-    FileSystemVersionSequenceModel as FileSystemVersionSequenceModel,
-)
 from nexus.storage.models.permissions import ReBACChangelogModel as ReBACChangelogModel
 from nexus.storage.models.permissions import ReBACCheckCacheModel as ReBACCheckCacheModel
 from nexus.storage.models.permissions import ReBACGroupClosureModel as ReBACGroupClosureModel

--- a/src/nexus/storage/models/filesystem.py
+++ b/src/nexus/storage/models/filesystem.py
@@ -125,57 +125,6 @@ class FileMetadataModel(Base):
             )
 
 
-class ContentChunkModel(Base):
-    """Content chunks for deduplication.
-
-    Stores unique content chunks identified by hash, with reference counting
-    for garbage collection.
-    """
-
-    __tablename__ = "content_chunks"
-
-    chunk_id: Mapped[str] = uuid_pk()
-
-    content_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
-    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    storage_path: Mapped[str] = mapped_column(Text, nullable=False)
-
-    ref_count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
-
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=lambda: datetime.now(UTC)
-    )
-    last_accessed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    protected_until: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-
-    __table_args__ = (
-        Index("idx_content_chunks_ref_count", "ref_count"),
-        Index("idx_content_chunks_last_accessed", "last_accessed_at"),
-    )
-
-    def __repr__(self) -> str:
-        return f"<ContentChunkModel(chunk_id={self.chunk_id}, content_hash={self.content_hash}, ref_count={self.ref_count})>"
-
-    def validate(self) -> None:
-        """Validate content chunk model before database operations."""
-        if not self.content_hash:
-            raise ValidationError("content_hash is required")
-        if len(self.content_hash) != 64:
-            raise ValidationError(
-                f"content_hash must be 64 characters (SHA-256), got {len(self.content_hash)}"
-            )
-        try:
-            int(self.content_hash, 16)
-        except ValueError:
-            raise ValidationError("content_hash must contain only hexadecimal characters") from None
-        if self.size_bytes < 0:
-            raise ValidationError(f"size_bytes cannot be negative, got {self.size_bytes}")
-        if not self.storage_path:
-            raise ValidationError("storage_path is required")
-        if self.ref_count is not None and self.ref_count < 0:
-            raise ValidationError(f"ref_count cannot be negative, got {self.ref_count}")
-
-
 class WorkspaceSnapshotModel(Base):
     """Workspace snapshot tracking for registered workspaces.
 

--- a/src/nexus/storage/models/permissions.py
+++ b/src/nexus/storage/models/permissions.py
@@ -234,20 +234,6 @@ class ReBACVersionSequenceModel(Base):
     __table_args__: tuple = ()
 
 
-class FileSystemVersionSequenceModel(Base):
-    """Per-zone version sequence for filesystem consistency tokens (Issue #1187)."""
-
-    __tablename__ = "filesystem_version_sequences"
-
-    zone_id: Mapped[str] = mapped_column(String(255), primary_key=True)
-    current_revision: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
-    )
-
-    __table_args__: tuple = ()
-
-
 class ReBACCheckCacheModel(Base):
     """Cache for ReBAC permission check results."""
 

--- a/src/nexus/storage/views.py
+++ b/src/nexus/storage/views.py
@@ -437,48 +437,6 @@ LIMIT 1000;
 """)
 
 
-def get_orphaned_content_view(db_type: str = "sqlite", _zone_id: str | None = None) -> TextClause:
-    """SQL View: orphaned_content_objects - content chunks with no references (GC targets).
-
-    Note: zone_id is accepted for signature consistency with other view generators
-    but is not used (this view queries content_chunks, not file_paths).
-    """
-    create_stmt = (
-        "CREATE OR REPLACE VIEW" if db_type == "postgresql" else "CREATE VIEW IF NOT EXISTS"
-    )
-
-    if db_type == "postgresql":
-        days_since_access = (
-            "CAST(EXTRACT(EPOCH FROM (NOW() - cc.last_accessed_at)) / 86400 AS INTEGER)"
-        )
-        now_expr = _now(db_type)
-        seven_days_ago = _interval_ago("7 days", db_type)
-    else:
-        days_since_access = "CAST(julianday('now') - julianday(cc.last_accessed_at) AS INTEGER)"
-        now_expr = "datetime('now')"
-        seven_days_ago = "datetime('now', '-7 days')"
-
-    return text(f"""
-{create_stmt} orphaned_content_objects AS
-SELECT
-    cc.chunk_id,
-    cc.content_hash,
-    cc.size_bytes,
-    cc.storage_path,
-    cc.ref_count,
-    cc.created_at,
-    cc.last_accessed_at,
-    cc.protected_until,
-    -- Days since last access
-    {days_since_access} as days_since_access
-FROM content_chunks cc
-WHERE cc.ref_count = 0
-  AND (cc.protected_until IS NULL OR cc.protected_until < {now_expr})
-  AND (cc.last_accessed_at IS NULL OR cc.last_accessed_at < {seven_days_ago})
-ORDER BY cc.last_accessed_at ASC NULLS FIRST;
-""")
-
-
 # List of view names and their generator functions
 VIEW_GENERATORS = [
     ("ready_work_items", get_ready_work_view),
@@ -488,7 +446,6 @@ VIEW_GENERATORS = [
     ("in_progress_work", get_in_progress_work_view),
     ("ready_for_indexing", get_ready_for_indexing_view),
     ("hot_tier_eviction_candidates", get_hot_tier_eviction_view),
-    ("orphaned_content_objects", get_orphaned_content_view),
 ]
 
 # SQL to drop all views

--- a/tests/unit/core/test_validation.py
+++ b/tests/unit/core/test_validation.py
@@ -4,7 +4,6 @@ Tests the validation methods on all domain types:
 - FileMetadata
 - FilePathModel
 - FileMetadataModel
-- ContentChunkModel
 """
 
 from datetime import UTC, datetime
@@ -13,7 +12,7 @@ import pytest
 
 from nexus.contracts.exceptions import ValidationError
 from nexus.contracts.metadata import FileMetadata
-from nexus.storage.models import ContentChunkModel, FileMetadataModel, FilePathModel
+from nexus.storage.models import FileMetadataModel, FilePathModel
 
 
 class TestFileMetadataValidation:
@@ -232,87 +231,6 @@ class TestFileMetadataModelValidation:
             metadata.validate()
 
 
-class TestContentChunkModelValidation:
-    """Test suite for ContentChunkModel validation."""
-
-    def test_valid_content_chunk_model(self):
-        """Test that valid ContentChunkModel passes validation."""
-        chunk = ContentChunkModel(
-            content_hash="a" * 64,
-            size_bytes=1024,
-            storage_path="/storage/chunks/abc",
-            ref_count=1,
-        )
-        # Should not raise
-        chunk.validate()
-
-    def test_content_hash_required(self):
-        """Test that content_hash is required."""
-        chunk = ContentChunkModel(
-            content_hash="",
-            size_bytes=1024,
-            storage_path="/storage/chunks/abc",
-            ref_count=1,
-        )
-        with pytest.raises(ValidationError, match="content_hash is required"):
-            chunk.validate()
-
-    def test_content_hash_length(self):
-        """Test that content_hash must be 64 characters."""
-        chunk = ContentChunkModel(
-            content_hash="tooshort",
-            size_bytes=1024,
-            storage_path="/storage/chunks/abc",
-            ref_count=1,
-        )
-        with pytest.raises(ValidationError, match="content_hash must be 64 characters"):
-            chunk.validate()
-
-    def test_content_hash_hex_only(self):
-        """Test that content_hash must contain only hex characters."""
-        chunk = ContentChunkModel(
-            content_hash="z" * 64,  # Invalid hex
-            size_bytes=1024,
-            storage_path="/storage/chunks/abc",
-            ref_count=1,
-        )
-        with pytest.raises(ValidationError, match="content_hash must contain only hexadecimal"):
-            chunk.validate()
-
-    def test_size_bytes_cannot_be_negative(self):
-        """Test that size_bytes cannot be negative."""
-        chunk = ContentChunkModel(
-            content_hash="a" * 64,
-            size_bytes=-100,
-            storage_path="/storage/chunks/abc",
-            ref_count=1,
-        )
-        with pytest.raises(ValidationError, match="size_bytes cannot be negative"):
-            chunk.validate()
-
-    def test_storage_path_required(self):
-        """Test that storage_path is required."""
-        chunk = ContentChunkModel(
-            content_hash="a" * 64,
-            size_bytes=1024,
-            storage_path="",
-            ref_count=1,
-        )
-        with pytest.raises(ValidationError, match="storage_path is required"):
-            chunk.validate()
-
-    def test_ref_count_cannot_be_negative(self):
-        """Test that ref_count cannot be negative."""
-        chunk = ContentChunkModel(
-            content_hash="a" * 64,
-            size_bytes=1024,
-            storage_path="/storage/chunks/abc",
-            ref_count=-1,
-        )
-        with pytest.raises(ValidationError, match="ref_count cannot be negative"):
-            chunk.validate()
-
-
 class TestTableDrivenValidation:
     """Table-driven validation tests for comprehensive coverage."""
 
@@ -347,40 +265,3 @@ class TestTableDrivenValidation:
         else:
             # Should not raise
             metadata.validate()
-
-    @pytest.mark.parametrize(
-        "content_hash,size_bytes,ref_count,should_fail,error_match",
-        [
-            # Valid cases
-            ("a" * 64, 0, 0, False, None),
-            ("0" * 64, 1024, 1, False, None),
-            ("f" * 64, 9999, 100, False, None),
-            # Invalid hash length
-            ("tooshort", 100, 1, True, "content_hash must be 64 characters"),
-            ("a" * 63, 100, 1, True, "content_hash must be 64 characters"),
-            ("a" * 65, 100, 1, True, "content_hash must be 64 characters"),
-            # Invalid hash characters
-            ("z" * 64, 100, 1, True, "content_hash must contain only hexadecimal"),
-            ("x" * 64, 100, 1, True, "content_hash must contain only hexadecimal"),
-            # Invalid sizes and counts
-            ("a" * 64, -1, 1, True, "size_bytes cannot be negative"),
-            ("a" * 64, 100, -1, True, "ref_count cannot be negative"),
-        ],
-    )
-    def test_content_chunk_validation_table(
-        self, content_hash, size_bytes, ref_count, should_fail, error_match
-    ):
-        """Table-driven test for ContentChunkModel validation."""
-        chunk = ContentChunkModel(
-            content_hash=content_hash,
-            size_bytes=size_bytes,
-            storage_path="/storage/chunks/test",
-            ref_count=ref_count,
-        )
-
-        if should_fail:
-            with pytest.raises(ValidationError, match=error_match):
-                chunk.validate()
-        else:
-            # Should not raise
-            chunk.validate()

--- a/tests/unit/storage/test_domain_models.py
+++ b/tests/unit/storage/test_domain_models.py
@@ -443,41 +443,6 @@ class TestDirectoryEntryModelValidate:
             e.validate()
 
 
-class TestContentChunkModelValidate:
-    """Tests for ContentChunkModel.validate()."""
-
-    def test_valid_chunk(self) -> None:
-        from nexus.storage.models.filesystem import ContentChunkModel
-
-        c = ContentChunkModel(
-            content_hash="a" * 64,
-            size_bytes=100,
-            storage_path="/data/chunks/a",
-        )
-        c.validate()
-
-    def test_invalid_hash_length(self) -> None:
-        from nexus.storage.models.filesystem import ContentChunkModel
-
-        c = ContentChunkModel(content_hash="abc", size_bytes=100, storage_path="/data/chunks/a")
-        with pytest.raises(Exception, match="content_hash must be 64 characters"):
-            c.validate()
-
-    def test_invalid_hash_chars(self) -> None:
-        from nexus.storage.models.filesystem import ContentChunkModel
-
-        c = ContentChunkModel(content_hash="z" * 64, size_bytes=100, storage_path="/data/chunks/a")
-        with pytest.raises(Exception, match="hexadecimal"):
-            c.validate()
-
-    def test_negative_size(self) -> None:
-        from nexus.storage.models.filesystem import ContentChunkModel
-
-        c = ContentChunkModel(content_hash="a" * 64, size_bytes=-1, storage_path="/data/chunks/a")
-        with pytest.raises(Exception, match="size_bytes cannot be negative"):
-            c.validate()
-
-
 class TestEntityRegistryModelValidate:
     """Tests for EntityRegistryModel.validate()."""
 

--- a/tests/unit/storage/test_model_imports.py
+++ b/tests/unit/storage/test_model_imports.py
@@ -18,7 +18,6 @@ EXPECTED_MODELS = [
     # Filesystem
     "DirectoryEntryModel",
     "FileMetadataModel",
-    "ContentChunkModel",
     "WorkspaceSnapshotModel",
     "DocumentChunkModel",
     # Permissions
@@ -27,7 +26,6 @@ EXPECTED_MODELS = [
     "ReBACGroupClosureModel",
     "ReBACChangelogModel",
     "ReBACVersionSequenceModel",
-    "FileSystemVersionSequenceModel",
     "ReBACCheckCacheModel",
     "TigerResourceMapModel",
     "TigerCacheModel",

--- a/tests/unit/storage/test_models.py
+++ b/tests/unit/storage/test_models.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
-from nexus.storage.models import Base, ContentChunkModel, FileMetadataModel, FilePathModel
+from nexus.storage.models import Base, FileMetadataModel, FilePathModel
 
 
 @pytest.fixture
@@ -177,86 +177,6 @@ class TestFileMetadataModel:
         assert len(file_path.metadata_entries) == 2
 
 
-class TestContentChunkModel:
-    """Test suite for ContentChunkModel."""
-
-    def test_create_content_chunk(self, session):
-        """Test creating a content chunk record."""
-        chunk = ContentChunkModel(
-            content_hash="abc123def456",
-            size_bytes=4096,
-            storage_path="/chunks/abc123def456",
-            ref_count=1,
-        )
-        session.add(chunk)
-        session.commit()
-
-        assert chunk.chunk_id is not None
-        assert chunk.content_hash == "abc123def456"
-        assert chunk.size_bytes == 4096
-        assert chunk.ref_count == 1
-        assert chunk.created_at is not None
-
-    def test_unique_content_hash(self, session):
-        """Test that content_hash must be unique."""
-        chunk1 = ContentChunkModel(
-            content_hash="abc123",
-            size_bytes=4096,
-            storage_path="/chunks/abc123-1",
-            ref_count=1,
-        )
-        session.add(chunk1)
-        session.commit()
-
-        # Try to create duplicate
-        chunk2 = ContentChunkModel(
-            content_hash="abc123",
-            size_bytes=8192,
-            storage_path="/chunks/abc123-2",
-            ref_count=2,
-        )
-        session.add(chunk2)
-
-        with pytest.raises(IntegrityError):
-            session.commit()
-
-    def test_ref_count_increment(self, session):
-        """Test incrementing reference count."""
-        chunk = ContentChunkModel(
-            content_hash="abc123",
-            size_bytes=4096,
-            storage_path="/chunks/abc123",
-            ref_count=1,
-        )
-        session.add(chunk)
-        session.commit()
-
-        # Increment ref count
-        chunk.ref_count += 1
-        session.commit()
-
-        assert chunk.ref_count == 2
-
-    def test_last_accessed_at(self, session):
-        """Test updating last accessed timestamp."""
-        chunk = ContentChunkModel(
-            content_hash="abc123",
-            size_bytes=4096,
-            storage_path="/chunks/abc123",
-            ref_count=1,
-        )
-        session.add(chunk)
-        session.commit()
-
-        assert chunk.last_accessed_at is None
-
-        # Update last accessed
-        chunk.last_accessed_at = datetime.now(UTC)
-        session.commit()
-
-        assert chunk.last_accessed_at is not None
-
-
 class TestModelIndexes:
     """Test that indexes are created correctly."""
 
@@ -279,9 +199,3 @@ class TestModelIndexes:
         index_names = [idx["name"] for idx in file_metadata_indexes]
         assert "idx_file_metadata_path_id" in index_names
         assert "idx_file_metadata_key" in index_names
-
-        # Check content_chunks indexes
-        content_chunks_indexes = inspector.get_indexes("content_chunks")
-        index_names = [idx["name"] for idx in content_chunks_indexes]
-        # Note: idx_content_chunks_hash was removed - content_hash lookups use unique constraint
-        assert "idx_content_chunks_ref_count" in index_names

--- a/tests/unit/storage/test_views.py
+++ b/tests/unit/storage/test_views.py
@@ -178,27 +178,6 @@ class TestAdditionalViews:
         assert "select" in sql.lower()
         assert "extract" in sql.lower()
 
-    def test_get_orphaned_content_view_sqlite(self):
-        """Test orphaned content view for SQLite."""
-        from nexus.storage.views import get_orphaned_content_view
-
-        view = get_orphaned_content_view("sqlite")
-        assert view is not None
-        sql = str(view)
-        assert "select" in sql.lower()
-        assert "days_since_access" in sql.lower()
-        assert "content_chunks" in sql.lower()
-
-    def test_get_orphaned_content_view_postgresql(self):
-        """Test orphaned content view for PostgreSQL."""
-        from nexus.storage.views import get_orphaned_content_view
-
-        view = get_orphaned_content_view("postgresql")
-        assert view is not None
-        sql = str(view)
-        assert "select" in sql.lower()
-        assert "extract" in sql.lower()
-
 
 class TestViewUtilities:
     """Test view utility functions."""


### PR DESCRIPTION
## Summary
- Delete `ContentChunkModel` (zero runtime references — dead code)
- Delete `FileSystemVersionSequenceModel` (zero runtime references — dead code)
- Delete `get_orphaned_content_view` (referenced dead `content_chunks` table)
- Clean up all re-exports, lazy imports, and test references (10 files, -379 lines)

## Context
Part of data pillar migration batch (tasks #179-#193, tracked by #1636).
Both models were identified as having zero runtime callers during the merge analysis.

## Test plan
- [x] `ruff check` passes on all changed files
- [x] All 121 affected unit tests pass
- [x] Zero remaining references to `ContentChunkModel` or `FileSystemVersionSequenceModel` in src/ and tests/
- [x] Pre-commit hooks (ruff-format, mypy, end-of-file) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)