### PR TITLE
fix(task-manager): rewrite dispatch to VFS syscalls, DT_STREAM SSE

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: .venv/bin/python -m mypy
+        entry: bash -c 'if [ -x .venv/bin/python ]; then exec .venv/bin/python -m mypy "$@"; else exec .venv/Scripts/python -m mypy "$@"; fi' --
         language: system
         types: [python]
         exclude: ^(tests/|alembic/|examples/|benchmarks/|\.claude/|scripts/|nexus-plugin-)|_pb2(_grpc)?\.py$

--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -107,6 +107,8 @@ KNOWN_CORE_EXCEPTIONS: dict[str, list[str]] = {
     # search_service moved from services/ — needs core.metastore, core.router, core.path_utils,
     # and services.gateway (TYPE_CHECKING + lazy imports)
     "nexus.bricks.search.search_service": ["nexus.core", "nexus.services"],
+    # dispatch_consumer needs core.pipe + core.pipe_manager for DT_PIPE lifecycle
+    "nexus.bricks.task_manager.dispatch_consumer": ["nexus.core"],
 }
 
 # Lines matching these patterns are not actual imports (comments, strings, etc.)

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -504,6 +504,16 @@ def connect(
     overrides = cfg.features.to_overrides() if cfg.features else {}
     enabled_bricks = resolve_enabled_bricks(resolved_profile, overrides=overrides)
 
+    # Audit strict mode: env var override (default True for compliance)
+    from nexus.contracts.types import AuditConfig
+
+    _audit_strict = os.environ.get("NEXUS_AUDIT_STRICT_MODE", "true").lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+    audit_cfg = AuditConfig(strict_mode=_audit_strict)
+
     # Create NexusFS via factory
     from nexus.factory import create_nexus_fs
 
@@ -517,6 +527,7 @@ def connect(
         distributed=dist_cfg,
         parsing=parse_cfg,
         enabled_bricks=enabled_bricks,
+        audit=audit_cfg,
     )
 
     # Set memory config for Memory API

--- a/src/nexus/bricks/task_manager/__init__.py
+++ b/src/nexus/bricks/task_manager/__init__.py
@@ -1,0 +1,19 @@
+"""Task Manager brick — NexusFS-backed task and mission management."""
+
+from nexus.bricks.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
+from nexus.bricks.task_manager.events import (
+    TaskCreatedEvent,
+    TaskEventHandler,
+    TaskUpdatedEvent,
+)
+from nexus.bricks.task_manager.service import TaskManagerService
+from nexus.bricks.task_manager.write_hook import TaskWriteHook
+
+__all__ = [
+    "TaskCreatedEvent",
+    "TaskDispatchPipeConsumer",
+    "TaskEventHandler",
+    "TaskManagerService",
+    "TaskUpdatedEvent",
+    "TaskWriteHook",
+]

--- a/src/nexus/bricks/task_manager/__init__.py
+++ b/src/nexus/bricks/task_manager/__init__.py
@@ -1,19 +1,13 @@
 """Task Manager brick — NexusFS-backed task and mission management."""
 
 from nexus.bricks.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
-from nexus.bricks.task_manager.events import (
-    TaskCreatedEvent,
-    TaskEventHandler,
-    TaskUpdatedEvent,
-)
+from nexus.bricks.task_manager.events import TaskSignalHandler
 from nexus.bricks.task_manager.service import TaskManagerService
 from nexus.bricks.task_manager.write_hook import TaskWriteHook
 
 __all__ = [
-    "TaskCreatedEvent",
     "TaskDispatchPipeConsumer",
-    "TaskEventHandler",
     "TaskManagerService",
-    "TaskUpdatedEvent",
+    "TaskSignalHandler",
     "TaskWriteHook",
 ]

--- a/src/nexus/bricks/task_manager/dispatch_consumer.py
+++ b/src/nexus/bricks/task_manager/dispatch_consumer.py
@@ -1,0 +1,424 @@
+"""DT_PIPE-backed dispatch consumer for task lifecycle events.
+
+Produces task signals into a kernel ring buffer pipe and consumes them
+in a background asyncio task, following the same pattern as
+``WorkflowDispatchService`` and ``ZoektPipeConsumer``.
+
+Flow::
+
+    TaskWriteHook.on_post_write() [sync, kernel dispatch]
+      → TaskDispatchPipeConsumer.on_task_created/updated() [TaskEventHandler]
+        → JSON → pipe_write_nowait("/nexus/pipes/task-dispatch")
+
+    Background _consume() [asyncio.Task]
+      → pipe_read() → JSON → _dispatch()
+        → "task_created" → log (placeholder: worker starts)
+        → "task_updated" + status="in_review" → log (placeholder: copilot reviews)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import subprocess
+from dataclasses import asdict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from nexus.bricks.task_manager.events import (
+    TaskCreatedEvent,
+    TaskUpdatedEvent,
+)
+
+if TYPE_CHECKING:
+    from nexus.core.pipe_manager import PipeManager
+
+logger = logging.getLogger(__name__)
+
+_TASK_DISPATCH_PIPE_PATH = "/nexus/pipes/task-dispatch"
+_TASK_DISPATCH_PIPE_CAPACITY = 65_536  # 64KB
+
+
+class TaskDispatchPipeConsumer:
+    """Produces and consumes task dispatch signals via DT_PIPE.
+
+    Implements ``TaskEventHandler`` so it can be registered with
+    :class:`TaskWriteHook`.  The producer side serialises events to JSON
+    and writes them into the kernel pipe.  The consumer side runs a
+    background ``asyncio.Task`` that reads from the pipe and routes
+    signals via ``_dispatch()``.
+
+    Lifecycle (deferred injection)::
+
+        consumer = TaskDispatchPipeConsumer()
+        task_write_hook.register_handler(consumer)
+        consumer.set_pipe_manager(pipe_manager)
+        await consumer.start()
+        ...
+        await consumer.stop()
+    """
+
+    def __init__(self) -> None:
+        self._pipe_manager: PipeManager | None = None
+        self._pipe_ready = False
+        self._consumer_task: asyncio.Task[None] | None = None
+
+    # ------------------------------------------------------------------
+    # Deferred injection
+    # ------------------------------------------------------------------
+
+    def set_pipe_manager(self, pipe_manager: PipeManager) -> None:
+        """Inject PipeManager after server lifespan initialization."""
+        self._pipe_manager = pipe_manager
+
+    # ------------------------------------------------------------------
+    # TaskEventHandler (producer side)
+    # ------------------------------------------------------------------
+
+    def on_task_created(self, event: TaskCreatedEvent) -> None:
+        """Serialize task_created event and write to pipe."""
+        self._fire("task_created", asdict(event))
+
+    def on_task_updated(self, event: TaskUpdatedEvent) -> None:
+        """Serialize task_updated event and write to pipe."""
+        self._fire("task_updated", asdict(event))
+
+    def _fire(self, signal_type: str, payload: dict[str, Any]) -> None:
+        """Encode signal as JSON and push into the pipe (non-blocking)."""
+        if self._pipe_manager is None or not self._pipe_ready:
+            # Pipe not ready yet — drop the signal (dispatch hints, not audit)
+            return
+
+        from nexus.core.pipe import PipeClosedError, PipeFullError
+
+        try:
+            data = json.dumps({"type": signal_type, "payload": payload}).encode()
+            self._pipe_manager.pipe_write_nowait(_TASK_DISPATCH_PIPE_PATH, data)
+        except (PipeClosedError, PipeFullError):
+            logger.warning("[TASK-DISPATCH] pipe full/closed, dropping signal: %s", signal_type)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Create the dispatch pipe and start the background consumer."""
+        if self._pipe_ready:
+            return
+
+        if self._pipe_manager is None:
+            return
+
+        from nexus.core.pipe import PipeError
+
+        try:
+            self._pipe_manager.create(
+                _TASK_DISPATCH_PIPE_PATH,
+                capacity=_TASK_DISPATCH_PIPE_CAPACITY,
+                owner_id="kernel",
+            )
+        except PipeError:
+            self._pipe_manager.open(_TASK_DISPATCH_PIPE_PATH, capacity=_TASK_DISPATCH_PIPE_CAPACITY)
+
+        self._pipe_ready = True
+        self._consumer_task = asyncio.create_task(self._consume())
+        logger.info("[TASK-DISPATCH] pipe consumer started")
+
+    async def stop(self) -> None:
+        """Graceful shutdown: signal pipe closed, drain, then cancel."""
+        if self._consumer_task is not None and not self._consumer_task.done():
+            if self._pipe_manager is not None and self._pipe_ready:
+                with contextlib.suppress(Exception):
+                    self._pipe_manager.signal_close(_TASK_DISPATCH_PIPE_PATH)
+
+            try:
+                await asyncio.wait_for(asyncio.shield(self._consumer_task), timeout=5.0)
+            except (TimeoutError, asyncio.CancelledError):
+                self._consumer_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._consumer_task
+
+            self._consumer_task = None
+
+        self._pipe_ready = False
+        logger.info("[TASK-DISPATCH] pipe consumer stopped")
+
+    # ------------------------------------------------------------------
+    # Consumer loop
+    # ------------------------------------------------------------------
+
+    async def _consume(self) -> None:
+        """Background loop: read from pipe, deserialize, dispatch."""
+        from nexus.core.pipe import PipeClosedError, PipeNotFoundError
+
+        assert self._pipe_manager is not None
+        pipe_mgr = self._pipe_manager
+
+        while True:
+            try:
+                data = await pipe_mgr.pipe_read(_TASK_DISPATCH_PIPE_PATH)
+            except (PipeClosedError, PipeNotFoundError):
+                logger.debug("[TASK-DISPATCH] pipe closed, consumer exiting")
+                break
+
+            try:
+                msg = json.loads(data)
+                await self._dispatch(msg)
+            except Exception as e:
+                logger.error("[TASK-DISPATCH] event processing failed: %s", e)
+
+    # ------------------------------------------------------------------
+    # Dispatch routing
+    # ------------------------------------------------------------------
+
+    _LOG_FILE = "/tmp/nexus-log"
+    _API_BASE = "http://localhost:2026/api/v2"
+
+    async def _dispatch(self, msg: dict[str, Any]) -> None:
+        """Route a deserialized pipe message by signal type."""
+        signal_type = msg.get("type")
+        payload = msg.get("payload", {})
+        ts = datetime.now(UTC).isoformat()
+
+        if signal_type == "task_created":
+            task_id = payload.get("task_id", "?")
+            mission_id = payload.get("mission_id", "?")
+            await self._api_audit(task_id, "task_created", detail="task created")
+
+            # Check if task is blocked
+            blocked_by = payload.get("blocked_by") or []
+            if blocked_by:
+                self._shell_log(
+                    f"[{ts}] task_created task_id={task_id} "
+                    f"mission_id={mission_id} → blocked by {blocked_by}"
+                )
+                return
+
+            self._shell_log(
+                f"[{ts}] task_created task_id={task_id} "
+                f"mission_id={mission_id} → worker starts work"
+            )
+            await self._start_worker(task_id)
+
+        elif signal_type == "task_updated":
+            task_id = payload.get("task_id", "?")
+            status = payload.get("status", "?")
+            if status == "in_review":
+                self._shell_log(
+                    f"[{ts}] task_updated task_id={task_id} status={status} → copilot reviews"
+                )
+                try:
+                    worker_comment = await self._api_get_last_comment(task_id)
+                    review = await self._llm_prompt(
+                        f"Review this worker output and give brief feedback:\n\n{worker_comment}"
+                    )
+                    await self._api_comment(task_id, "copilot", review)
+                    await self._api_patch_status(task_id, "completed")
+                    await self._api_audit(
+                        task_id,
+                        "status_changed",
+                        actor="copilot",
+                        detail="task completed by copilot",
+                    )
+                except Exception as e:
+                    self._shell_log(f"  copilot failed: {e}")
+                    await self._api_comment(task_id, "copilot", f"Review failed: {e}")
+                    await self._api_patch_status(task_id, "failed")
+                    await self._api_audit(
+                        task_id, "status_changed", actor="copilot", detail=f"review failed: {e}"
+                    )
+            elif status in ("completed", "failed", "cancelled"):
+                self._shell_log(
+                    f"[{ts}] task_updated task_id={task_id} status={status} "
+                    f"→ checking for unblocked tasks"
+                )
+                await self._dispatch_unblocked_tasks()
+            else:
+                self._shell_log(f"[{ts}] task_updated task_id={task_id} status={status}")
+        else:
+            self._shell_log(f"[{ts}] unknown signal type: {signal_type}")
+
+    async def _start_worker(self, task_id: str) -> None:
+        """Run the worker phase: fetch instruction → LLM → comment → in_review."""
+        try:
+            instruction = await self._api_get_instruction(task_id)
+            await self._api_patch_status(task_id, "running")
+            await self._api_audit(
+                task_id, "status_changed", actor="worker", detail="task started by worker"
+            )
+            worker_response = await self._llm_prompt(instruction)
+            await self._api_comment(task_id, "worker", worker_response)
+            await self._api_patch_status(task_id, "in_review")
+            await self._api_audit(
+                task_id, "status_changed", actor="worker", detail="status changed to in_review"
+            )
+        except Exception as e:
+            self._shell_log(f"  worker failed: {e}")
+            await self._api_comment(task_id, "worker", f"Worker failed: {e}")
+            await self._api_patch_status(task_id, "failed")
+            await self._api_audit(
+                task_id, "status_changed", actor="worker", detail=f"task failed: {e}"
+            )
+
+    async def _dispatch_unblocked_tasks(self) -> None:
+        """Check for dispatchable tasks (created + unblocked) and start them."""
+        proc = await asyncio.create_subprocess_exec(
+            "curl",
+            "-s",
+            f"{self._API_BASE}/tasks",
+            "-H",
+            "Content-Type: application/json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        try:
+            tasks = json.loads(stdout.decode())
+        except Exception:
+            return
+        for t in tasks:
+            tid = t.get("id", "?")
+            self._shell_log(f"  unblocked: dispatching task {tid}")
+            await self._start_worker(tid)
+
+    async def _api_comment(self, task_id: str, author: str, content: str) -> None:
+        """Add a comment to a task via REST API."""
+        data = json.dumps({"task_id": task_id, "author": author, "content": content})
+        proc = await asyncio.create_subprocess_exec(
+            "curl",
+            "-s",
+            "-X",
+            "POST",
+            f"{self._API_BASE}/comments",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            data,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        self._shell_log(f"  comment({author}): {stdout.decode().strip()}")
+
+    async def _api_patch_status(self, task_id: str, status: str) -> None:
+        """Transition a task's status via REST API."""
+        data = json.dumps({"status": status})
+        proc = await asyncio.create_subprocess_exec(
+            "curl",
+            "-s",
+            "-X",
+            "PATCH",
+            f"{self._API_BASE}/tasks/{task_id}",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            data,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        self._shell_log(f"  patch({status}): {stdout.decode().strip()}")
+
+    async def _llm_prompt(self, prompt: str) -> str:
+        """Run `gemini -p <prompt>` and return stdout."""
+        proc = await asyncio.create_subprocess_exec(
+            "gemini",
+            "-p",
+            prompt,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        result = stdout.decode().strip()
+        # gemini may prefix MCP/tool warnings — strip lines before actual content
+        clean_lines = []
+        for line in result.splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("MCP ", "Run /mcp", "[MCP")):
+                continue
+            clean_lines.append(line)
+        result = "\n".join(clean_lines).strip()
+        if not result:
+            result = "(no response)"
+        self._shell_log(f"  gemini: {result[:120]}...")
+        return result
+
+    async def _api_get_instruction(self, task_id: str) -> str:
+        """Fetch task instruction via REST API."""
+        proc = await asyncio.create_subprocess_exec(
+            "curl",
+            "-s",
+            f"{self._API_BASE}/tasks/{task_id}",
+            "-H",
+            "Content-Type: application/json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        try:
+            return json.loads(stdout.decode()).get("instruction", "do the task")
+        except Exception:
+            return "do the task"
+
+    async def _api_get_last_comment(self, task_id: str) -> str:
+        """Fetch the last comment content for a task."""
+        proc = await asyncio.create_subprocess_exec(
+            "curl",
+            "-s",
+            f"{self._API_BASE}/comments?task_id={task_id}",
+            "-H",
+            "Content-Type: application/json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        try:
+            comments = json.loads(stdout.decode())
+            if comments:
+                return comments[-1].get("content", "")
+        except Exception:
+            pass
+        return "(no worker comment found)"
+
+    async def _api_audit(
+        self,
+        task_id: str,
+        action: str,
+        *,
+        actor: str | None = None,
+        detail: str | None = None,
+    ) -> None:
+        """Create an audit trail entry via REST API."""
+        payload: dict[str, Any] = {"action": action}
+        if actor is not None:
+            payload["actor"] = actor
+        if detail is not None:
+            payload["detail"] = detail
+        data = json.dumps(payload)
+        proc = await asyncio.create_subprocess_exec(
+            "curl",
+            "-s",
+            "-X",
+            "POST",
+            f"{self._API_BASE}/tasks/{task_id}/audit",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            data,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        self._shell_log(f"  audit({action}): {stdout.decode().strip()}")
+
+    def _shell_log(self, line: str) -> None:
+        """Append a line to /tmp/nexus-log via bash."""
+        try:
+            subprocess.run(
+                ["bash", "-c", f"echo {line!r} >> {self._LOG_FILE}"],
+                timeout=2,
+            )
+        except Exception as e:
+            logger.warning("[TASK-DISPATCH] shell_log failed: %s", e)

--- a/src/nexus/bricks/task_manager/dispatch_consumer.py
+++ b/src/nexus/bricks/task_manager/dispatch_consumer.py
@@ -1,4 +1,4 @@
-"""DT_PIPE-backed dispatch consumer for task lifecycle events.
+"""DT_PIPE-backed dispatch consumer for task lifecycle signals.
 
 Produces task signals into a kernel ring buffer pipe and consumes them
 in a background asyncio task, following the same pattern as
@@ -7,13 +7,16 @@ in a background asyncio task, following the same pattern as
 Flow::
 
     TaskWriteHook.on_post_write() [sync, kernel dispatch]
-      → TaskDispatchPipeConsumer.on_task_created/updated() [TaskEventHandler]
+      → TaskDispatchPipeConsumer.on_task_signal(signal_type, payload)
         → JSON → pipe_write_nowait("/nexus/pipes/task-dispatch")
 
     Background _consume() [asyncio.Task]
       → pipe_read() → JSON → _dispatch()
-        → "task_created" → log (placeholder: worker starts)
-        → "task_updated" + status="in_review" → log (placeholder: copilot reviews)
+        → "task_created" → start worker via VFS syscalls
+        → "task_updated" + status="in_review" → copilot review via VFS
+
+All state mutations use TaskManagerService (VFS-backed) directly —
+no HTTP loopback, no subprocess calls.
 """
 
 from __future__ import annotations
@@ -22,17 +25,11 @@ import asyncio
 import contextlib
 import json
 import logging
-import subprocess
-from dataclasses import asdict
-from datetime import UTC, datetime
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
-from nexus.bricks.task_manager.events import (
-    TaskCreatedEvent,
-    TaskUpdatedEvent,
-)
-
 if TYPE_CHECKING:
+    from nexus.bricks.task_manager.service import TaskManagerService
     from nexus.core.pipe_manager import PipeManager
 
 logger = logging.getLogger(__name__)
@@ -40,28 +37,43 @@ logger = logging.getLogger(__name__)
 _TASK_DISPATCH_PIPE_PATH = "/nexus/pipes/task-dispatch"
 _TASK_DISPATCH_PIPE_CAPACITY = 65_536  # 64KB
 
+# Type alias for injectable LLM provider
+LLMCallable = Callable[[str], Awaitable[str]]
+
+
+async def _no_llm(_prompt: str) -> str:
+    """Placeholder LLM provider — returns a stub until VFS-routed LLM is wired."""
+    return "(LLM provider not configured — VFS-routed LLM pending)"
+
 
 class TaskDispatchPipeConsumer:
     """Produces and consumes task dispatch signals via DT_PIPE.
 
-    Implements ``TaskEventHandler`` so it can be registered with
-    :class:`TaskWriteHook`.  The producer side serialises events to JSON
+    Implements ``TaskSignalHandler`` so it can be registered with
+    :class:`TaskWriteHook`.  The producer side serialises signals to JSON
     and writes them into the kernel pipe.  The consumer side runs a
     background ``asyncio.Task`` that reads from the pipe and routes
     signals via ``_dispatch()``.
+
+    All state mutations go through ``TaskManagerService`` which uses
+    NexusFS ``sys_read``/``sys_write`` — getting file events, permissions,
+    and audit trail for free.
 
     Lifecycle (deferred injection)::
 
         consumer = TaskDispatchPipeConsumer()
         task_write_hook.register_handler(consumer)
         consumer.set_pipe_manager(pipe_manager)
+        consumer.set_task_service(task_manager_service)
         await consumer.start()
         ...
         await consumer.stop()
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, llm_fn: LLMCallable | None = None) -> None:
         self._pipe_manager: PipeManager | None = None
+        self._task_svc: TaskManagerService | None = None
+        self._llm_fn: LLMCallable = llm_fn or _no_llm
         self._pipe_ready = False
         self._consumer_task: asyncio.Task[None] | None = None
 
@@ -73,22 +85,17 @@ class TaskDispatchPipeConsumer:
         """Inject PipeManager after server lifespan initialization."""
         self._pipe_manager = pipe_manager
 
+    def set_task_service(self, task_svc: TaskManagerService) -> None:
+        """Inject TaskManagerService for direct VFS-backed operations."""
+        self._task_svc = task_svc
+
     # ------------------------------------------------------------------
-    # TaskEventHandler (producer side)
+    # TaskSignalHandler (producer side)
     # ------------------------------------------------------------------
 
-    def on_task_created(self, event: TaskCreatedEvent) -> None:
-        """Serialize task_created event and write to pipe."""
-        self._fire("task_created", asdict(event))
-
-    def on_task_updated(self, event: TaskUpdatedEvent) -> None:
-        """Serialize task_updated event and write to pipe."""
-        self._fire("task_updated", asdict(event))
-
-    def _fire(self, signal_type: str, payload: dict[str, Any]) -> None:
-        """Encode signal as JSON and push into the pipe (non-blocking)."""
+    def on_task_signal(self, signal_type: str, payload: dict[str, Any]) -> None:
+        """Serialize signal and write to pipe (non-blocking)."""
         if self._pipe_manager is None or not self._pipe_ready:
-            # Pipe not ready yet — drop the signal (dispatch hints, not audit)
             return
 
         from nexus.core.pipe import PipeClosedError, PipeFullError
@@ -170,255 +177,139 @@ class TaskDispatchPipeConsumer:
                 logger.error("[TASK-DISPATCH] event processing failed: %s", e)
 
     # ------------------------------------------------------------------
-    # Dispatch routing
+    # Dispatch routing — all ops via VFS-backed TaskManagerService
     # ------------------------------------------------------------------
-
-    _LOG_FILE = "/tmp/nexus-log"
-    _API_BASE = "http://localhost:2026/api/v2"
 
     async def _dispatch(self, msg: dict[str, Any]) -> None:
         """Route a deserialized pipe message by signal type."""
+        if self._task_svc is None:
+            logger.warning("[TASK-DISPATCH] no TaskManagerService — dropping signal")
+            return
+
         signal_type = msg.get("type")
         payload = msg.get("payload", {})
-        ts = datetime.now(UTC).isoformat()
 
         if signal_type == "task_created":
             task_id = payload.get("task_id", "?")
             mission_id = payload.get("mission_id", "?")
-            await self._api_audit(task_id, "task_created", detail="task created")
+
+            # Record audit via VFS
+            self._task_svc.create_audit_entry(task_id, "task_created", detail="task created")
 
             # Check if task is blocked
             blocked_by = payload.get("blocked_by") or []
             if blocked_by:
-                self._shell_log(
-                    f"[{ts}] task_created task_id={task_id} "
-                    f"mission_id={mission_id} → blocked by {blocked_by}"
+                logger.info(
+                    "[TASK-DISPATCH] task_created task_id=%s mission_id=%s blocked_by=%s",
+                    task_id,
+                    mission_id,
+                    blocked_by,
                 )
                 return
 
-            self._shell_log(
-                f"[{ts}] task_created task_id={task_id} "
-                f"mission_id={mission_id} → worker starts work"
+            logger.info(
+                "[TASK-DISPATCH] task_created task_id=%s mission_id=%s → starting worker",
+                task_id,
+                mission_id,
             )
             await self._start_worker(task_id)
 
         elif signal_type == "task_updated":
             task_id = payload.get("task_id", "?")
             status = payload.get("status", "?")
+
             if status == "in_review":
-                self._shell_log(
-                    f"[{ts}] task_updated task_id={task_id} status={status} → copilot reviews"
-                )
-                try:
-                    worker_comment = await self._api_get_last_comment(task_id)
-                    review = await self._llm_prompt(
-                        f"Review this worker output and give brief feedback:\n\n{worker_comment}"
-                    )
-                    await self._api_comment(task_id, "copilot", review)
-                    await self._api_patch_status(task_id, "completed")
-                    await self._api_audit(
-                        task_id,
-                        "status_changed",
-                        actor="copilot",
-                        detail="task completed by copilot",
-                    )
-                except Exception as e:
-                    self._shell_log(f"  copilot failed: {e}")
-                    await self._api_comment(task_id, "copilot", f"Review failed: {e}")
-                    await self._api_patch_status(task_id, "failed")
-                    await self._api_audit(
-                        task_id, "status_changed", actor="copilot", detail=f"review failed: {e}"
-                    )
+                logger.info("[TASK-DISPATCH] task_id=%s in_review → copilot review", task_id)
+                await self._copilot_review(task_id)
             elif status in ("completed", "failed", "cancelled"):
-                self._shell_log(
-                    f"[{ts}] task_updated task_id={task_id} status={status} "
-                    f"→ checking for unblocked tasks"
+                logger.info(
+                    "[TASK-DISPATCH] task_id=%s %s → checking unblocked tasks",
+                    task_id,
+                    status,
                 )
-                await self._dispatch_unblocked_tasks()
+                self._dispatch_unblocked_tasks()
             else:
-                self._shell_log(f"[{ts}] task_updated task_id={task_id} status={status}")
+                logger.debug("[TASK-DISPATCH] task_id=%s status=%s (no action)", task_id, status)
         else:
-            self._shell_log(f"[{ts}] unknown signal type: {signal_type}")
+            logger.warning("[TASK-DISPATCH] unknown signal type: %s", signal_type)
 
     async def _start_worker(self, task_id: str) -> None:
         """Run the worker phase: fetch instruction → LLM → comment → in_review."""
+        assert self._task_svc is not None
+        svc = self._task_svc
+
         try:
-            instruction = await self._api_get_instruction(task_id)
-            await self._api_patch_status(task_id, "running")
-            await self._api_audit(
+            task = svc.get_task(task_id)
+            instruction = task.get("instruction", "do the task")
+
+            svc.update_task(task_id, status="running")
+            svc.create_audit_entry(
                 task_id, "status_changed", actor="worker", detail="task started by worker"
             )
-            worker_response = await self._llm_prompt(instruction)
-            await self._api_comment(task_id, "worker", worker_response)
-            await self._api_patch_status(task_id, "in_review")
-            await self._api_audit(
-                task_id, "status_changed", actor="worker", detail="status changed to in_review"
+
+            worker_response = await self._llm_fn(instruction)
+
+            svc.create_comment(task_id, "worker", worker_response)
+            svc.update_task(task_id, status="in_review")
+            svc.create_audit_entry(
+                task_id, "status_changed", actor="worker", detail="submitted for review"
             )
         except Exception as e:
-            self._shell_log(f"  worker failed: {e}")
-            await self._api_comment(task_id, "worker", f"Worker failed: {e}")
-            await self._api_patch_status(task_id, "failed")
-            await self._api_audit(
-                task_id, "status_changed", actor="worker", detail=f"task failed: {e}"
+            logger.error("[TASK-DISPATCH] worker failed for task %s: %s", task_id, e)
+            try:
+                svc.create_comment(task_id, "worker", f"Worker failed: {e}")
+                svc.update_task(task_id, status="failed")
+                svc.create_audit_entry(
+                    task_id, "status_changed", actor="worker", detail=f"task failed: {e}"
+                )
+            except Exception:
+                logger.error(
+                    "[TASK-DISPATCH] cleanup after worker failure also failed", exc_info=True
+                )
+
+    async def _copilot_review(self, task_id: str) -> None:
+        """Copilot reviews the worker output and completes or fails the task."""
+        assert self._task_svc is not None
+        svc = self._task_svc
+
+        try:
+            comments = svc.get_comments(task_id)
+            last_content = comments[-1].get("content", "") if comments else "(no worker comment)"
+
+            review = await self._llm_fn(
+                f"Review this worker output and give brief feedback:\n\n{last_content}"
             )
 
-    async def _dispatch_unblocked_tasks(self) -> None:
+            svc.create_comment(task_id, "copilot", review)
+            svc.update_task(task_id, status="completed")
+            svc.create_audit_entry(
+                task_id, "status_changed", actor="copilot", detail="task completed by copilot"
+            )
+        except Exception as e:
+            logger.error("[TASK-DISPATCH] copilot review failed for task %s: %s", task_id, e)
+            try:
+                svc.create_comment(task_id, "copilot", f"Review failed: {e}")
+                svc.update_task(task_id, status="failed")
+                svc.create_audit_entry(
+                    task_id, "status_changed", actor="copilot", detail=f"review failed: {e}"
+                )
+            except Exception:
+                logger.error(
+                    "[TASK-DISPATCH] cleanup after copilot failure also failed", exc_info=True
+                )
+
+    def _dispatch_unblocked_tasks(self) -> None:
         """Check for dispatchable tasks (created + unblocked) and start them."""
-        proc = await asyncio.create_subprocess_exec(
-            "curl",
-            "-s",
-            f"{self._API_BASE}/tasks",
-            "-H",
-            "Content-Type: application/json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
+        assert self._task_svc is not None
+
         try:
-            tasks = json.loads(stdout.decode())
+            dispatchable = self._task_svc.list_dispatchable_tasks()
         except Exception:
+            logger.warning("[TASK-DISPATCH] failed to list dispatchable tasks", exc_info=True)
             return
-        for t in tasks:
-            tid = t.get("id", "?")
-            self._shell_log(f"  unblocked: dispatching task {tid}")
-            await self._start_worker(tid)
 
-    async def _api_comment(self, task_id: str, author: str, content: str) -> None:
-        """Add a comment to a task via REST API."""
-        data = json.dumps({"task_id": task_id, "author": author, "content": content})
-        proc = await asyncio.create_subprocess_exec(
-            "curl",
-            "-s",
-            "-X",
-            "POST",
-            f"{self._API_BASE}/comments",
-            "-H",
-            "Content-Type: application/json",
-            "-d",
-            data,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        self._shell_log(f"  comment({author}): {stdout.decode().strip()}")
-
-    async def _api_patch_status(self, task_id: str, status: str) -> None:
-        """Transition a task's status via REST API."""
-        data = json.dumps({"status": status})
-        proc = await asyncio.create_subprocess_exec(
-            "curl",
-            "-s",
-            "-X",
-            "PATCH",
-            f"{self._API_BASE}/tasks/{task_id}",
-            "-H",
-            "Content-Type: application/json",
-            "-d",
-            data,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        self._shell_log(f"  patch({status}): {stdout.decode().strip()}")
-
-    async def _llm_prompt(self, prompt: str) -> str:
-        """Run `gemini -p <prompt>` and return stdout."""
-        proc = await asyncio.create_subprocess_exec(
-            "gemini",
-            "-p",
-            prompt,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        result = stdout.decode().strip()
-        # gemini may prefix MCP/tool warnings — strip lines before actual content
-        clean_lines = []
-        for line in result.splitlines():
-            stripped = line.strip()
-            if stripped.startswith(("MCP ", "Run /mcp", "[MCP")):
-                continue
-            clean_lines.append(line)
-        result = "\n".join(clean_lines).strip()
-        if not result:
-            result = "(no response)"
-        self._shell_log(f"  gemini: {result[:120]}...")
-        return result
-
-    async def _api_get_instruction(self, task_id: str) -> str:
-        """Fetch task instruction via REST API."""
-        proc = await asyncio.create_subprocess_exec(
-            "curl",
-            "-s",
-            f"{self._API_BASE}/tasks/{task_id}",
-            "-H",
-            "Content-Type: application/json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        try:
-            return json.loads(stdout.decode()).get("instruction", "do the task")
-        except Exception:
-            return "do the task"
-
-    async def _api_get_last_comment(self, task_id: str) -> str:
-        """Fetch the last comment content for a task."""
-        proc = await asyncio.create_subprocess_exec(
-            "curl",
-            "-s",
-            f"{self._API_BASE}/comments?task_id={task_id}",
-            "-H",
-            "Content-Type: application/json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        try:
-            comments = json.loads(stdout.decode())
-            if comments:
-                return comments[-1].get("content", "")
-        except Exception:
-            pass
-        return "(no worker comment found)"
-
-    async def _api_audit(
-        self,
-        task_id: str,
-        action: str,
-        *,
-        actor: str | None = None,
-        detail: str | None = None,
-    ) -> None:
-        """Create an audit trail entry via REST API."""
-        payload: dict[str, Any] = {"action": action}
-        if actor is not None:
-            payload["actor"] = actor
-        if detail is not None:
-            payload["detail"] = detail
-        data = json.dumps(payload)
-        proc = await asyncio.create_subprocess_exec(
-            "curl",
-            "-s",
-            "-X",
-            "POST",
-            f"{self._API_BASE}/tasks/{task_id}/audit",
-            "-H",
-            "Content-Type: application/json",
-            "-d",
-            data,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        self._shell_log(f"  audit({action}): {stdout.decode().strip()}")
-
-    def _shell_log(self, line: str) -> None:
-        """Append a line to /tmp/nexus-log via bash."""
-        try:
-            subprocess.run(
-                ["bash", "-c", f"echo {line!r} >> {self._LOG_FILE}"],
-                timeout=2,
-            )
-        except Exception as e:
-            logger.warning("[TASK-DISPATCH] shell_log failed: %s", e)
+        for task in dispatchable:
+            tid = task.get("id", "?")
+            logger.info("[TASK-DISPATCH] unblocked: dispatching task %s", tid)
+            # Schedule worker start as a separate task to avoid blocking the consumer
+            asyncio.create_task(self._start_worker(tid))

--- a/src/nexus/bricks/task_manager/events.py
+++ b/src/nexus/bricks/task_manager/events.py
@@ -1,0 +1,41 @@
+"""Task Manager event dataclasses and handler protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class TaskCreatedEvent:
+    """Emitted when a new task file is written for the first time."""
+
+    task_id: str
+    mission_id: str
+    instruction: str
+    worker_type: str | None
+    blocked_by: list[str]
+    input_refs: list[str]
+    label: str | None
+    created_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class TaskUpdatedEvent:
+    """Emitted when an existing task file is overwritten."""
+
+    task_id: str
+    mission_id: str
+    status: str
+    worker_type: str | None
+    label: str | None
+    started_at: str | None
+    completed_at: str | None
+    timestamp: str  # when the hook fired
+
+
+class TaskEventHandler(Protocol):
+    """Protocol for objects that react to task lifecycle events."""
+
+    def on_task_created(self, event: TaskCreatedEvent) -> None: ...
+    def on_task_updated(self, event: TaskUpdatedEvent) -> None: ...

--- a/src/nexus/bricks/task_manager/events.py
+++ b/src/nexus/bricks/task_manager/events.py
@@ -1,41 +1,16 @@
-"""Task Manager event dataclasses and handler protocol."""
+"""Task Manager event handler protocol.
+
+The write hook parses task JSON and delivers signal dicts directly to
+DT_PIPE.  No custom event dataclasses — the kernel FileEvent already
+records the mutation; dispatch signals carry only the parsed payload.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 
-@dataclass(frozen=True, slots=True)
-class TaskCreatedEvent:
-    """Emitted when a new task file is written for the first time."""
+class TaskSignalHandler(Protocol):
+    """Protocol for objects that react to task lifecycle signals."""
 
-    task_id: str
-    mission_id: str
-    instruction: str
-    worker_type: str | None
-    blocked_by: list[str]
-    input_refs: list[str]
-    label: str | None
-    created_at: str
-
-
-@dataclass(frozen=True, slots=True)
-class TaskUpdatedEvent:
-    """Emitted when an existing task file is overwritten."""
-
-    task_id: str
-    mission_id: str
-    status: str
-    worker_type: str | None
-    label: str | None
-    started_at: str | None
-    completed_at: str | None
-    timestamp: str  # when the hook fired
-
-
-class TaskEventHandler(Protocol):
-    """Protocol for objects that react to task lifecycle events."""
-
-    def on_task_created(self, event: TaskCreatedEvent) -> None: ...
-    def on_task_updated(self, event: TaskUpdatedEvent) -> None: ...
+    def on_task_signal(self, signal_type: str, payload: dict[str, Any]) -> None: ...

--- a/src/nexus/bricks/task_manager/service.py
+++ b/src/nexus/bricks/task_manager/service.py
@@ -99,7 +99,8 @@ class TaskManagerService:
 
     def _read_json(self, path: str) -> dict[str, Any]:
         raw = self._fs.sys_read(path)
-        return json.loads(raw)
+        result: dict[str, Any] = json.loads(raw)
+        return result
 
     def _write_json(self, path: str, data: dict[str, Any]) -> None:
         self._fs.sys_write(path, json.dumps(data, default=str))

--- a/src/nexus/bricks/task_manager/service.py
+++ b/src/nexus/bricks/task_manager/service.py
@@ -1,0 +1,555 @@
+"""TaskManagerService — NexusFS-backed task and mission management.
+
+All data is stored as JSON files under ``/.tasks/`` in NexusFS.  This
+dogfoods the platform and gets file events, permissions, and CAS
+deduplication for free — no migrations, no new DB tables.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# State machine
+# ---------------------------------------------------------------------------
+
+# Maps (current_status) -> set of valid next statuses
+_TASK_TRANSITIONS: dict[str, set[str]] = {
+    "created": {"running", "failed", "cancelled"},
+    "running": {"in_review", "completed", "failed", "cancelled"},
+    "in_review": {"running", "completed", "failed", "cancelled"},
+    "completed": {"cancelled"},
+    "failed": {"cancelled"},
+    "cancelled": set(),
+}
+
+_VALID_TASK_STATUSES = frozenset(_TASK_TRANSITIONS.keys())
+
+_VALID_MISSION_STATUSES = frozenset({"running", "partial_complete", "completed", "cancelled"})
+
+_VALID_ARTIFACT_TYPES = frozenset(
+    {
+        "document",
+        "code",
+        "folder",
+        "pr",
+        "image",
+        "data",
+        "spreadsheet",
+        "presentation",
+        "other",
+    }
+)
+
+
+class ValidationError(Exception):
+    """Raised when a state-machine transition or input is invalid."""
+
+
+class NotFoundError(Exception):
+    """Raised when the requested entity does not exist."""
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class TaskManagerService:
+    """Core brick for task/mission management, backed by NexusFS JSON files."""
+
+    def __init__(self, nexus_fs: Any) -> None:
+        self._fs = nexus_fs
+        self._ensure_dirs()
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _mission_path(mission_id: str) -> str:
+        return f"/.tasks/missions/{mission_id}.json"
+
+    @staticmethod
+    def _task_path(task_id: str) -> str:
+        return f"/.tasks/tasks/{task_id}.json"
+
+    @staticmethod
+    def _comment_dir(task_id: str) -> str:
+        return f"/.tasks/comments/{task_id}"
+
+    @staticmethod
+    def _comment_path(task_id: str, comment_id: str) -> str:
+        return f"/.tasks/comments/{task_id}/{comment_id}.json"
+
+    @staticmethod
+    def _artifact_path(artifact_id: str) -> str:
+        return f"/.tasks/artifacts/{artifact_id}.json"
+
+    # ------------------------------------------------------------------
+    # I/O helpers
+    # ------------------------------------------------------------------
+
+    def _read_json(self, path: str) -> dict[str, Any]:
+        raw = self._fs.sys_read(path)
+        return json.loads(raw)
+
+    def _write_json(self, path: str, data: dict[str, Any]) -> None:
+        self._fs.sys_write(path, json.dumps(data, default=str))
+
+    @staticmethod
+    def _audit_dir(task_id: str) -> str:
+        return f"/.tasks/audit/{task_id}"
+
+    @staticmethod
+    def _audit_path(task_id: str, entry_id: str) -> str:
+        return f"/.tasks/audit/{task_id}/{entry_id}.json"
+
+    def _ensure_dirs(self) -> None:
+        for d in (
+            "/.tasks",
+            "/.tasks/missions",
+            "/.tasks/tasks",
+            "/.tasks/artifacts",
+            "/.tasks/comments",
+            "/.tasks/audit",
+        ):
+            self._fs.sys_mkdir(d, parents=True, exist_ok=True)
+
+    def _now(self) -> str:
+        return datetime.now(UTC).isoformat()
+
+    # ------------------------------------------------------------------
+    # Copilot methods
+    # ------------------------------------------------------------------
+
+    def create_mission(
+        self,
+        title: str,
+        context_summary: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new mission."""
+        mission_id = uuid.uuid4().hex
+        now = self._now()
+        doc: dict[str, Any] = {
+            "id": mission_id,
+            "title": title,
+            "status": "running",
+            "context_summary": context_summary,
+            "conclusion": None,
+            "archived": False,
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._write_json(self._mission_path(mission_id), doc)
+        return doc
+
+    def update_mission(self, mission_id: str, **fields: Any) -> dict[str, Any]:
+        """Update mission fields (status, conclusion, archived)."""
+        path = self._mission_path(mission_id)
+        try:
+            doc = self._read_json(path)
+        except Exception as exc:
+            raise NotFoundError(f"Mission {mission_id} not found") from exc
+
+        allowed = {"status", "conclusion", "archived", "title", "context_summary"}
+        for key, value in fields.items():
+            if key not in allowed:
+                raise ValidationError(f"Cannot update field '{key}' on mission")
+            if key == "status" and value not in _VALID_MISSION_STATUSES:
+                raise ValidationError(
+                    f"Invalid mission status '{value}'. "
+                    f"Must be one of: {sorted(_VALID_MISSION_STATUSES)}"
+                )
+            doc[key] = value
+
+        doc["updated_at"] = self._now()
+        self._write_json(path, doc)
+        return doc
+
+    def create_task(
+        self,
+        mission_id: str,
+        instruction: str,
+        *,
+        worker_type: str | None = None,
+        input_refs: list[str] | None = None,
+        blocked_by: list[str] | None = None,
+        deadline: str | None = None,
+        estimated_duration: int | None = None,
+        label: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new task within a mission."""
+        # Verify mission exists; reopen if completed
+        try:
+            mission = self._read_json(self._mission_path(mission_id))
+        except Exception as exc:
+            raise NotFoundError(f"Mission {mission_id} not found") from exc
+
+        if mission.get("status") in ("completed", "partial_complete"):
+            mission["status"] = "running"
+            mission["updated_at"] = self._now()
+            self._write_json(self._mission_path(mission_id), mission)
+            logger.info("[TASK-MGR] Mission %s reopened (new task added)", mission_id)
+
+        task_id = uuid.uuid4().hex
+        now = self._now()
+        doc: dict[str, Any] = {
+            "id": task_id,
+            "mission_id": mission_id,
+            "instruction": instruction,
+            "status": "created",
+            "worker_type": worker_type,
+            "input_refs": input_refs or [],
+            "output_refs": [],
+            "blocked_by": blocked_by or [],
+            "label": label,
+            "deadline": deadline,
+            "estimated_duration": estimated_duration,
+            "created_at": now,
+            "started_at": None,
+            "completed_at": None,
+        }
+        self._write_json(self._task_path(task_id), doc)
+        return doc
+
+    def update_task(self, task_id: str, **fields: Any) -> dict[str, Any]:
+        """Update task fields — enforces state machine for status changes."""
+        allowed = {"status", "output_refs"}
+        for key in fields:
+            if key not in allowed:
+                raise ValidationError(f"Cannot update field '{key}' on task")
+
+        path = self._task_path(task_id)
+        try:
+            doc = self._read_json(path)
+        except Exception as exc:
+            raise NotFoundError(f"Task {task_id} not found") from exc
+
+        if "status" in fields:
+            new_status = fields["status"]
+            current = doc["status"]
+            valid_next = _TASK_TRANSITIONS.get(current, set())
+            if new_status not in valid_next:
+                raise ValidationError(
+                    f"Invalid transition: {current} → {new_status}. Allowed: {sorted(valid_next)}"
+                )
+            doc["status"] = new_status
+
+            # Auto-set timestamps
+            if new_status == "running" and doc["started_at"] is None:
+                doc["started_at"] = self._now()
+            if new_status in ("completed", "failed", "cancelled"):
+                doc["completed_at"] = self._now()
+
+        if "output_refs" in fields:
+            doc["output_refs"] = fields["output_refs"]
+
+        self._write_json(path, doc)
+
+        # Auto-complete mission when all its tasks are terminal
+        if "status" in fields and fields["status"] in ("completed", "failed", "cancelled"):
+            self._maybe_complete_mission(doc.get("mission_id"))
+
+        return doc
+
+    def get_task(self, task_id: str) -> dict[str, Any]:
+        """Get a single task by ID."""
+        try:
+            return self._read_json(self._task_path(task_id))
+        except Exception as exc:
+            raise NotFoundError(f"Task {task_id} not found") from exc
+
+    def create_comment(
+        self,
+        task_id: str,
+        author: str,
+        content: str,
+        artifact_refs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a comment on a task."""
+        if author not in ("copilot", "worker"):
+            raise ValidationError(f"Invalid author '{author}'. Must be 'copilot' or 'worker'.")
+
+        # Verify task exists
+        self.get_task(task_id)
+
+        # Ensure per-task comment directory
+        self._fs.sys_mkdir(self._comment_dir(task_id), parents=True, exist_ok=True)
+
+        comment_id = uuid.uuid4().hex
+        doc: dict[str, Any] = {
+            "id": comment_id,
+            "task_id": task_id,
+            "author": author,
+            "content": content,
+            "artifact_refs": artifact_refs or [],
+            "created_at": self._now(),
+        }
+        self._write_json(self._comment_path(task_id, comment_id), doc)
+        return doc
+
+    def get_comments(self, task_id: str) -> list[dict[str, Any]]:
+        """Get all comments for a task, ordered by created_at."""
+        comment_dir = self._comment_dir(task_id)
+        if not self._fs.sys_is_directory(comment_dir):
+            return []
+
+        paths = self._fs.sys_readdir(comment_dir, recursive=False)
+        comments = []
+        for p in paths:
+            if p.endswith(".json"):
+                try:
+                    comments.append(self._read_json(p))
+                except Exception:
+                    logger.warning("Failed to read comment at %s", p)
+        comments.sort(key=lambda c: c.get("created_at", ""))
+        return comments
+
+    def create_artifact(
+        self,
+        type: str,
+        uri: str,
+        title: str,
+        *,
+        mime_type: str | None = None,
+        size_bytes: int | None = None,
+    ) -> dict[str, Any]:
+        """Create an artifact reference."""
+        if type not in _VALID_ARTIFACT_TYPES:
+            raise ValidationError(
+                f"Invalid artifact type '{type}'. Must be one of: {sorted(_VALID_ARTIFACT_TYPES)}"
+            )
+
+        artifact_id = uuid.uuid4().hex
+        doc: dict[str, Any] = {
+            "id": artifact_id,
+            "type": type,
+            "uri": uri,
+            "title": title,
+            "mime_type": mime_type,
+            "size_bytes": size_bytes,
+            "created_at": self._now(),
+        }
+        self._write_json(self._artifact_path(artifact_id), doc)
+        return doc
+
+    # ------------------------------------------------------------------
+    # Dispatcher methods
+    # ------------------------------------------------------------------
+
+    def list_dispatchable_tasks(self, worker_type: str | None = None) -> list[dict[str, Any]]:
+        """List tasks with status=created whose blocked_by are all completed."""
+        all_tasks = self._list_all_tasks()
+
+        # Build a lookup of task statuses for blocked_by resolution
+        status_by_id = {t["id"]: t["status"] for t in all_tasks}
+
+        result = []
+        for t in all_tasks:
+            if t["status"] != "created":
+                continue
+            if worker_type and t.get("worker_type") != worker_type:
+                continue
+            # Check all blockers are completed
+            blocked_by = t.get("blocked_by", [])
+            if all(status_by_id.get(b) == "completed" for b in blocked_by):
+                result.append(t)
+        return result
+
+    def start_task(self, task_id: str) -> dict[str, Any]:
+        """Dispatcher: created → running."""
+        return self.update_task(task_id, status="running")
+
+    def complete_task(self, task_id: str, output_refs: list[str] | None = None) -> dict[str, Any]:
+        """Worker: running → completed."""
+        fields: dict[str, Any] = {"status": "completed"}
+        if output_refs is not None:
+            fields["output_refs"] = output_refs
+        return self.update_task(task_id, **fields)
+
+    def fail_task(self, task_id: str) -> dict[str, Any]:
+        """Worker: running → failed."""
+        return self.update_task(task_id, status="failed")
+
+    # ------------------------------------------------------------------
+    # User methods (read-only)
+    # ------------------------------------------------------------------
+
+    def list_missions(
+        self,
+        *,
+        archived: bool = False,
+        status: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        """List missions with optional filters and pagination."""
+        missions_dir = "/.tasks/missions"
+        if not self._fs.sys_is_directory(missions_dir):
+            return {"items": [], "total": 0, "page": page, "limit": limit}
+
+        paths = self._fs.sys_readdir(missions_dir, recursive=False)
+        missions = []
+        for p in paths:
+            if p.endswith(".json"):
+                try:
+                    m = self._read_json(p)
+                    if m.get("archived", False) != archived:
+                        continue
+                    if status and m.get("status") != status:
+                        continue
+                    missions.append(m)
+                except Exception:
+                    logger.warning("Failed to read mission at %s", p)
+
+        missions.sort(key=lambda m: m.get("created_at", ""), reverse=True)
+        total = len(missions)
+        start = (page - 1) * limit
+        items = missions[start : start + limit]
+        return {"items": items, "total": total, "page": page, "limit": limit}
+
+    def get_mission(self, mission_id: str) -> dict[str, Any]:
+        """Get mission detail with its task list."""
+        try:
+            mission = self._read_json(self._mission_path(mission_id))
+        except Exception as exc:
+            raise NotFoundError(f"Mission {mission_id} not found") from exc
+
+        # Collect tasks for this mission
+        all_tasks = self._list_all_tasks()
+        tasks = [t for t in all_tasks if t.get("mission_id") == mission_id]
+        tasks.sort(key=lambda t: t.get("created_at", ""))
+        mission["tasks"] = tasks
+        return mission
+
+    def get_task_detail(self, task_id: str) -> dict[str, Any]:
+        """Get task detail with comments, artifacts, and history."""
+        task = self.get_task(task_id)
+        task["comments"] = self.get_comments(task_id)
+        task["history"] = self.get_task_history(task_id)
+
+        # Resolve artifact references
+        all_refs = set(task.get("input_refs", []) + task.get("output_refs", []))
+        for comment in task["comments"]:
+            all_refs.update(comment.get("artifact_refs", []))
+
+        artifacts = []
+        for ref_id in all_refs:
+            with contextlib.suppress(Exception):
+                artifacts.append(self._read_json(self._artifact_path(ref_id)))
+        task["artifacts"] = artifacts
+        return task
+
+    # ------------------------------------------------------------------
+    # Audit trail
+    # ------------------------------------------------------------------
+
+    def create_audit_entry(
+        self,
+        task_id: str,
+        action: str,
+        *,
+        actor: str | None = None,
+        detail: str | None = None,
+    ) -> dict[str, Any]:
+        """Create an audit trail entry for a task."""
+        # Verify task exists
+        self.get_task(task_id)
+
+        # Ensure per-task audit directory
+        self._fs.sys_mkdir(self._audit_dir(task_id), parents=True, exist_ok=True)
+
+        entry_id = uuid.uuid4().hex
+        doc: dict[str, Any] = {
+            "id": entry_id,
+            "task_id": task_id,
+            "action": action,
+            "actor": actor,
+            "detail": detail,
+            "created_at": self._now(),
+        }
+        self._write_json(self._audit_path(task_id, entry_id), doc)
+        return doc
+
+    def get_audit_trail(self, task_id: str) -> list[dict[str, Any]]:
+        """Get all audit entries for a task, ordered by created_at."""
+        audit_dir = self._audit_dir(task_id)
+        if not self._fs.sys_is_directory(audit_dir):
+            return []
+
+        paths = self._fs.sys_readdir(audit_dir, recursive=False)
+        entries = []
+        for p in paths:
+            if p.endswith(".json"):
+                try:
+                    entries.append(self._read_json(p))
+                except Exception:
+                    logger.warning("Failed to read audit entry at %s", p)
+        entries.sort(key=lambda e: e.get("created_at", ""))
+        return entries
+
+    def get_task_history(self, task_id: str) -> list[dict[str, Any]]:
+        """Get unified timeline merging audit entries and comments."""
+        # Verify task exists
+        self.get_task(task_id)
+
+        history: list[dict[str, Any]] = []
+
+        for entry in self.get_audit_trail(task_id):
+            history.append({"type": "audit", **entry})
+
+        for comment in self.get_comments(task_id):
+            history.append({"type": "comment", **comment})
+
+        history.sort(key=lambda h: h.get("created_at", ""))
+        return history
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    _TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+
+    def _maybe_complete_mission(self, mission_id: str | None) -> None:
+        """Auto-complete the mission if all its tasks have reached a terminal status."""
+        if not mission_id:
+            return
+        try:
+            mission = self._read_json(self._mission_path(mission_id))
+        except Exception:
+            return
+        if mission.get("status") != "running":
+            return
+
+        tasks = [t for t in self._list_all_tasks() if t.get("mission_id") == mission_id]
+        if not tasks:
+            return
+        if all(t.get("status") in self._TERMINAL_STATUSES for t in tasks):
+            mission["status"] = "completed"
+            mission["updated_at"] = self._now()
+            self._write_json(self._mission_path(mission_id), mission)
+            logger.info("[TASK-MGR] Mission %s auto-completed (all tasks terminal)", mission_id)
+
+    def _list_all_tasks(self) -> list[dict[str, Any]]:
+        """Read all task JSON files from NexusFS."""
+        tasks_dir = "/.tasks/tasks"
+        if not self._fs.sys_is_directory(tasks_dir):
+            return []
+
+        paths = self._fs.sys_readdir(tasks_dir, recursive=False)
+        tasks = []
+        for p in paths:
+            if p.endswith(".json"):
+                try:
+                    tasks.append(self._read_json(p))
+                except Exception:
+                    logger.warning("Failed to read task at %s", p)
+        return tasks

--- a/src/nexus/bricks/task_manager/write_hook.py
+++ b/src/nexus/bricks/task_manager/write_hook.py
@@ -1,4 +1,10 @@
-"""VFS write hook that emits task lifecycle events."""
+"""VFS write hook that emits task lifecycle signals to DT_PIPE.
+
+Intercepts writes to ``/.tasks/tasks/*.json``, parses the JSON content,
+and pushes a signal dict into the task-dispatch pipe.  No intermediate
+event dataclasses — the kernel FileEvent already provides the audit
+trail; this hook only produces dispatch hints for the consumer.
+"""
 
 from __future__ import annotations
 
@@ -6,15 +12,10 @@ import json
 import logging
 from datetime import UTC, datetime
 from fnmatch import fnmatch
-from typing import TYPE_CHECKING
-
-from nexus.bricks.task_manager.events import (
-    TaskCreatedEvent,
-    TaskEventHandler,
-    TaskUpdatedEvent,
-)
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from nexus.bricks.task_manager.events import TaskSignalHandler
     from nexus.contracts.vfs_hooks import WriteHookContext
 
 logger = logging.getLogger(__name__)
@@ -23,23 +24,22 @@ _TASK_PATTERN = "/.tasks/tasks/*.json"
 
 
 class TaskWriteHook:
-    """Post-write hook that emits task lifecycle events.
+    """Post-write hook that pushes task signals to registered handlers.
 
-    Intercepts writes to ``/.tasks/tasks/*.json`` and fires
-    :class:`TaskCreatedEvent` or :class:`TaskUpdatedEvent` to registered
-    handlers.  No in-memory cache — all state comes from the written content
-    and ``ctx.is_new_file``.
+    Intercepts writes to ``/.tasks/tasks/*.json`` and fires signal dicts
+    to registered :class:`TaskSignalHandler` implementations.  No in-memory
+    cache — all state comes from the written content and ``ctx.is_new_file``.
     """
 
     def __init__(self) -> None:
-        self._handlers: list[TaskEventHandler] = []
+        self._handlers: list[TaskSignalHandler] = []
 
     @property
     def name(self) -> str:
         return "task_manager_write"
 
-    def register_handler(self, handler: TaskEventHandler) -> None:
-        """Subscribe a handler to task lifecycle events."""
+    def register_handler(self, handler: TaskSignalHandler) -> None:
+        """Subscribe a handler to task lifecycle signals."""
         self._handlers.append(handler)
 
     # ── VFSWriteHook protocol ──────────────────────────────────────────
@@ -54,53 +54,35 @@ class TaskWriteHook:
             logger.warning("[TASK-HOOK] failed to parse task JSON at %s", ctx.path)
             return
 
-        if ctx.is_new_file:
-            event = TaskCreatedEvent(
-                task_id=doc.get("id", ""),
-                mission_id=doc.get("mission_id", ""),
-                instruction=doc.get("instruction", ""),
-                worker_type=doc.get("worker_type"),
-                blocked_by=doc.get("blocked_by", []),
-                input_refs=doc.get("input_refs", []),
-                label=doc.get("label"),
-                created_at=doc.get("created_at", ""),
-            )
-            logger.info(
-                "[TASK-HOOK] task_created task_id=%s mission_id=%s",
-                event.task_id,
-                event.mission_id,
-            )
-            for handler in self._handlers:
-                try:
-                    handler.on_task_created(event)
-                except Exception:
-                    logger.warning(
-                        "[TASK-HOOK] handler %r failed on task_created",
-                        handler,
-                        exc_info=True,
-                    )
-        else:
-            event = TaskUpdatedEvent(
-                task_id=doc.get("id", ""),
-                mission_id=doc.get("mission_id", ""),
-                status=doc.get("status", ""),
-                worker_type=doc.get("worker_type"),
-                label=doc.get("label"),
-                started_at=doc.get("started_at"),
-                completed_at=doc.get("completed_at"),
-                timestamp=datetime.now(UTC).isoformat(),
-            )
-            logger.info(
-                "[TASK-HOOK] task_updated task_id=%s status=%s",
-                event.task_id,
-                event.status,
-            )
-            for handler in self._handlers:
-                try:
-                    handler.on_task_updated(event)
-                except Exception:
-                    logger.warning(
-                        "[TASK-HOOK] handler %r failed on task_updated",
-                        handler,
-                        exc_info=True,
-                    )
+        signal_type = "task_created" if ctx.is_new_file else "task_updated"
+        payload: dict[str, Any] = {
+            "task_id": doc.get("id", ""),
+            "mission_id": doc.get("mission_id", ""),
+            "status": doc.get("status", ""),
+            "instruction": doc.get("instruction", ""),
+            "worker_type": doc.get("worker_type"),
+            "blocked_by": doc.get("blocked_by", []),
+            "input_refs": doc.get("input_refs", []),
+            "label": doc.get("label"),
+            "started_at": doc.get("started_at"),
+            "completed_at": doc.get("completed_at"),
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+
+        logger.info(
+            "[TASK-HOOK] %s task_id=%s status=%s",
+            signal_type,
+            payload["task_id"],
+            payload["status"],
+        )
+
+        for handler in self._handlers:
+            try:
+                handler.on_task_signal(signal_type, payload)
+            except Exception:
+                logger.warning(
+                    "[TASK-HOOK] handler %r failed on %s",
+                    handler,
+                    signal_type,
+                    exc_info=True,
+                )

--- a/src/nexus/bricks/task_manager/write_hook.py
+++ b/src/nexus/bricks/task_manager/write_hook.py
@@ -1,0 +1,106 @@
+"""VFS write hook that emits task lifecycle events."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from fnmatch import fnmatch
+from typing import TYPE_CHECKING
+
+from nexus.bricks.task_manager.events import (
+    TaskCreatedEvent,
+    TaskEventHandler,
+    TaskUpdatedEvent,
+)
+
+if TYPE_CHECKING:
+    from nexus.contracts.vfs_hooks import WriteHookContext
+
+logger = logging.getLogger(__name__)
+
+_TASK_PATTERN = "/.tasks/tasks/*.json"
+
+
+class TaskWriteHook:
+    """Post-write hook that emits task lifecycle events.
+
+    Intercepts writes to ``/.tasks/tasks/*.json`` and fires
+    :class:`TaskCreatedEvent` or :class:`TaskUpdatedEvent` to registered
+    handlers.  No in-memory cache — all state comes from the written content
+    and ``ctx.is_new_file``.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: list[TaskEventHandler] = []
+
+    @property
+    def name(self) -> str:
+        return "task_manager_write"
+
+    def register_handler(self, handler: TaskEventHandler) -> None:
+        """Subscribe a handler to task lifecycle events."""
+        self._handlers.append(handler)
+
+    # ── VFSWriteHook protocol ──────────────────────────────────────────
+
+    def on_post_write(self, ctx: WriteHookContext) -> None:
+        if not fnmatch(ctx.path, _TASK_PATTERN):
+            return
+
+        try:
+            doc = json.loads(ctx.content)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            logger.warning("[TASK-HOOK] failed to parse task JSON at %s", ctx.path)
+            return
+
+        if ctx.is_new_file:
+            event = TaskCreatedEvent(
+                task_id=doc.get("id", ""),
+                mission_id=doc.get("mission_id", ""),
+                instruction=doc.get("instruction", ""),
+                worker_type=doc.get("worker_type"),
+                blocked_by=doc.get("blocked_by", []),
+                input_refs=doc.get("input_refs", []),
+                label=doc.get("label"),
+                created_at=doc.get("created_at", ""),
+            )
+            logger.info(
+                "[TASK-HOOK] task_created task_id=%s mission_id=%s",
+                event.task_id,
+                event.mission_id,
+            )
+            for handler in self._handlers:
+                try:
+                    handler.on_task_created(event)
+                except Exception:
+                    logger.warning(
+                        "[TASK-HOOK] handler %r failed on task_created",
+                        handler,
+                        exc_info=True,
+                    )
+        else:
+            event = TaskUpdatedEvent(
+                task_id=doc.get("id", ""),
+                mission_id=doc.get("mission_id", ""),
+                status=doc.get("status", ""),
+                worker_type=doc.get("worker_type"),
+                label=doc.get("label"),
+                started_at=doc.get("started_at"),
+                completed_at=doc.get("completed_at"),
+                timestamp=datetime.now(UTC).isoformat(),
+            )
+            logger.info(
+                "[TASK-HOOK] task_updated task_id=%s status=%s",
+                event.task_id,
+                event.status,
+            )
+            for handler in self._handlers:
+                try:
+                    handler.on_task_updated(event)
+                except Exception:
+                    logger.warning(
+                        "[TASK-HOOK] handler %r failed on task_updated",
+                        handler,
+                        exc_info=True,
+                    )

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -85,6 +85,9 @@ def _do_link(
     def _brick_on(name: str) -> bool:
         return name in _resolved_bricks
 
+    # Stash on kernel so _do_initialize() can pass it to _register_vfs_hooks()
+    nx._brick_on = _brick_on
+
     # --- Boot wired services → register into ServiceRegistry ---
     _wired = _boot_wired_services(
         nx,
@@ -133,6 +136,7 @@ def _do_initialize(nx: Any) -> None:
         nx,
         permission_checker=nx._permission_checker,
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
+        brick_on=getattr(nx, "_brick_on", None),
     )
 
     # --- BLM registration for late bricks (Issue #1704, #2991) ---

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -243,6 +243,7 @@ def create_nexus_fs(
     is_admin: bool = False,
     cache: "CacheConfig | None" = None,
     permissions: "PermissionConfig | None" = None,
+    audit: "AuditConfig | None" = None,
     distributed: "DistributedConfig | None" = None,
     memory: Any = None,
     parsing: Any = None,
@@ -335,6 +336,7 @@ def create_nexus_fs(
             backend=backend,
             router=router,
             permissions=permissions,
+            audit=audit,
             cache=cache,
             distributed=distributed,
             zone_id=zone_id,
@@ -532,6 +534,14 @@ def _register_vfs_hooks(
     )
     dispatch.register_resolver(_vview_resolver)
     hook_refs["vview_resolver"] = _vview_resolver
+
+    # ── TaskWriteHook (post-write: emit task lifecycle events) ─────────
+    from nexus.bricks.task_manager.write_hook import TaskWriteHook
+
+    _task_write_hook = TaskWriteHook()
+    dispatch.register_intercept_write(_task_write_hook)
+    hook_refs["task_write_hook"] = _task_write_hook
+    nx._task_write_hook = _task_write_hook
 
     # ── OBSERVE observers (Issue #900, #922) ──────────────────────────
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -6,6 +6,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from nexus.backends.base.backend import Backend
     from nexus.bricks.workflows.protocol import WorkflowProtocol
     from nexus.contracts.types import AuditConfig
@@ -387,7 +389,11 @@ def create_nexus_fs(
 
 
 def _register_vfs_hooks(
-    nx: "NexusFS", *, permission_checker: Any = None, auto_parse: bool = True
+    nx: "NexusFS",
+    *,
+    permission_checker: Any = None,
+    auto_parse: bool = True,
+    brick_on: "Callable[[str], bool] | None" = None,
 ) -> dict[str, Any]:
     """Register hooks + observers into kernel-owned dispatch (Issue #900).
 
@@ -402,6 +408,10 @@ def _register_vfs_hooks(
     construction (Issue #1452 Phase 3).
     """
     dispatch = nx._dispatch
+
+    from nexus.factory._helpers import _make_gate
+
+    _on = _make_gate(brick_on)
 
     # Hook references for retroactive HookSpec (Issue #1452 Phase 3).
     # Factory code uses raw instances (not ServiceRef) so hooks can be
@@ -536,12 +546,15 @@ def _register_vfs_hooks(
     hook_refs["vview_resolver"] = _vview_resolver
 
     # ── TaskWriteHook (post-write: emit task lifecycle events) ─────────
-    from nexus.bricks.task_manager.write_hook import TaskWriteHook
+    if _on("task_manager"):
+        from nexus.bricks.task_manager.write_hook import TaskWriteHook
 
-    _task_write_hook = TaskWriteHook()
-    dispatch.register_intercept_write(_task_write_hook)
-    hook_refs["task_write_hook"] = _task_write_hook
-    nx._task_write_hook = _task_write_hook
+        _task_write_hook = TaskWriteHook()
+        dispatch.register_intercept_write(_task_write_hook)
+        hook_refs["task_write_hook"] = _task_write_hook
+        nx._task_write_hook = _task_write_hook
+    else:
+        logger.debug("[BOOT:BRICK] TaskWriteHook disabled by profile")
 
     # ── OBSERVE observers (Issue #900, #922) ──────────────────────────
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).

--- a/src/nexus/security/secret_file.py
+++ b/src/nexus/security/secret_file.py
@@ -6,6 +6,7 @@ world-readable.
 """
 
 import os
+import sys
 from pathlib import Path
 
 
@@ -26,7 +27,8 @@ def write_secret_file(path: Path, data: str | bytes, *, mode: int = 0o600) -> No
     try:
         # Enforce mode even when overwriting an existing file — os.open only
         # applies mode on create; O_TRUNC preserves old permission bits.
-        os.fchmod(fd, mode)
+        if sys.platform != "win32":
+            os.fchmod(fd, mode)
         if isinstance(data, str):
             os.write(fd, data.encode())
         else:

--- a/src/nexus/server/api/v2/routers/task_manager.py
+++ b/src/nexus/server/api/v2/routers/task_manager.py
@@ -1,0 +1,533 @@
+"""Task Manager REST API endpoints.
+
+Provides endpoints for mission and task management:
+- POST   /api/v2/missions              - Create mission
+- GET    /api/v2/missions              - List missions
+- GET    /api/v2/missions/{id}         - Mission detail + tasks
+- PATCH  /api/v2/missions/{id}         - Update mission
+- POST   /api/v2/tasks                 - Create task
+- GET    /api/v2/tasks                 - List dispatchable tasks
+- GET    /api/v2/tasks/{id}            - Task detail + comments + artifacts
+- PATCH  /api/v2/tasks/{id}            - Update task status
+- GET    /api/v2/tasks/events           - SSE stream of task mutations
+- POST   /api/v2/tasks/{id}/audit      - Create audit entry
+- GET    /api/v2/tasks/{id}/history    - Unified timeline (audit + comments)
+- POST   /api/v2/comments              - Create comment
+- GET    /api/v2/comments              - List comments by task_id
+- POST   /api/v2/artifacts             - Create artifact
+"""
+
+import asyncio
+import contextlib
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+from starlette.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["task_manager"])
+
+# =============================================================================
+# Pydantic Models
+# =============================================================================
+
+
+# -- Mission --
+
+
+class CreateMissionRequest(BaseModel):
+    title: str = Field(..., min_length=1, description="Mission title")
+    context_summary: str | None = Field(default=None, description="Optional context")
+
+
+class UpdateMissionRequest(BaseModel):
+    title: str | None = Field(default=None, description="New title")
+    status: str | None = Field(
+        default=None, description="running|partial_complete|completed|cancelled"
+    )
+    conclusion: str | None = Field(default=None, description="Conclusion text")
+    archived: bool | None = Field(default=None, description="Archive flag")
+    context_summary: str | None = Field(default=None, description="Updated context")
+
+
+class MissionResponse(BaseModel):
+    id: str
+    title: str
+    status: str
+    context_summary: str | None = None
+    conclusion: str | None = None
+    archived: bool = False
+    created_at: str
+    updated_at: str
+    tasks: list[dict[str, Any]] | None = None
+
+
+class MissionListResponse(BaseModel):
+    items: list[MissionResponse]
+    total: int
+    page: int
+    limit: int
+
+
+# -- Task --
+
+
+class CreateTaskRequest(BaseModel):
+    mission_id: str = Field(..., description="Parent mission ID")
+    instruction: str = Field(..., min_length=1, description="Task instruction")
+    worker_type: str | None = Field(default=None, description="Worker type")
+    input_refs: list[str] | None = Field(default=None, description="Input artifact IDs")
+    blocked_by: list[str] | None = Field(default=None, description="Blocking task IDs")
+    deadline: str | None = Field(default=None, description="ISO 8601 deadline")
+    estimated_duration: int | None = Field(default=None, description="Estimated seconds")
+    label: str | None = Field(default=None, description="Optional label")
+
+
+class UpdateTaskRequest(BaseModel):
+    status: str | None = Field(default=None, description="New status")
+    output_refs: list[str] | None = Field(default=None, description="Output artifact IDs")
+
+
+class TaskResponse(BaseModel):
+    id: str
+    mission_id: str
+    instruction: str
+    status: str
+    worker_type: str | None = None
+    input_refs: list[str] = Field(default_factory=list)
+    output_refs: list[str] = Field(default_factory=list)
+    blocked_by: list[str] = Field(default_factory=list)
+    label: str | None = None
+    deadline: str | None = None
+    estimated_duration: int | None = None
+    created_at: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    comments: list[dict[str, Any]] | None = None
+    artifacts: list[dict[str, Any]] | None = None
+    history: list[dict[str, Any]] | None = None
+
+
+# -- Comment --
+
+
+class CreateCommentRequest(BaseModel):
+    task_id: str = Field(..., description="Parent task ID")
+    author: str = Field(..., description="copilot|worker")
+    content: str = Field(..., min_length=1, description="Comment text")
+    artifact_refs: list[str] | None = Field(default=None, description="Artifact IDs")
+
+
+class CommentResponse(BaseModel):
+    id: str
+    task_id: str
+    author: str
+    content: str
+    artifact_refs: list[str] = Field(default_factory=list)
+    created_at: str
+
+
+# -- Artifact --
+
+
+class CreateArtifactRequest(BaseModel):
+    type: str = Field(
+        ..., description="document|code|folder|pr|image|data|spreadsheet|presentation|other"
+    )
+    uri: str = Field(..., description="Resource URI")
+    title: str = Field(..., min_length=1, description="Artifact title")
+    mime_type: str | None = Field(default=None, description="MIME type")
+    size_bytes: int | None = Field(default=None, description="File size")
+
+
+class ArtifactResponse(BaseModel):
+    id: str
+    type: str
+    uri: str
+    title: str
+    mime_type: str | None = None
+    size_bytes: int | None = None
+    created_at: str
+
+
+# -- Audit --
+
+
+class CreateAuditEntryRequest(BaseModel):
+    action: str = Field(..., min_length=1, description="Audit action (e.g. task_created)")
+    actor: str | None = Field(default=None, description="Actor (e.g. worker, copilot)")
+    detail: str | None = Field(default=None, description="Additional detail")
+
+
+class AuditEntryResponse(BaseModel):
+    id: str
+    task_id: str
+    action: str
+    actor: str | None = None
+    detail: str | None = None
+    created_at: str
+
+
+# -- History --
+
+
+class HistoryEntryResponse(BaseModel):
+    type: str = Field(..., description="audit|comment")
+    id: str
+    task_id: str
+    created_at: str
+    # Audit fields
+    action: str | None = None
+    actor: str | None = None
+    detail: str | None = None
+    # Comment fields
+    author: str | None = None
+    content: str | None = None
+    artifact_refs: list[str] = Field(default_factory=list)
+
+
+# =============================================================================
+# Dependencies
+# =============================================================================
+
+
+def _get_require_auth() -> Any:
+    """Lazy import to avoid circular imports."""
+    from nexus.server.dependencies import require_auth
+
+    return require_auth
+
+
+def get_task_manager_service(request: Request) -> Any:
+    """Get TaskManagerService from app state."""
+    service = getattr(request.app.state, "task_manager_service", None)
+    if not service:
+        raise HTTPException(status_code=503, detail="Task manager service not available")
+    return service
+
+
+# =============================================================================
+# SSE broadcaster (task change notifications)
+# =============================================================================
+
+
+class _TaskEventBroadcaster:
+    """In-process SSE fan-out for task mutations."""
+
+    def __init__(self) -> None:
+        self._subscribers: set[asyncio.Queue[str]] = set()
+
+    def subscribe(self) -> asyncio.Queue[str]:
+        q: asyncio.Queue[str] = asyncio.Queue(maxsize=256)
+        self._subscribers.add(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[str]) -> None:
+        self._subscribers.discard(q)
+
+    def notify(self, event: str, task_id: str) -> None:
+        data = json.dumps({"event": event, "task_id": task_id})
+        for q in list(self._subscribers):
+            with contextlib.suppress(asyncio.QueueFull):
+                q.put_nowait(data)
+
+
+_broadcaster = _TaskEventBroadcaster()
+
+
+@router.get("/api/v2/tasks/events")
+async def task_events(request: Request) -> StreamingResponse:
+    """SSE stream of task mutation notifications."""
+    q = _broadcaster.subscribe()
+
+    async def _stream():
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    data = await asyncio.wait_for(q.get(), timeout=25)
+                    yield f"data: {data}\n\n"
+                except TimeoutError:
+                    yield ": keepalive\n\n"
+        finally:
+            _broadcaster.unsubscribe(q)
+
+    return StreamingResponse(
+        _stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+# =============================================================================
+# Mission endpoints
+# =============================================================================
+
+
+@router.post("/api/v2/missions", response_model=MissionResponse, status_code=201)
+async def create_mission(
+    request: CreateMissionRequest,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> MissionResponse:
+    """Create a new mission."""
+    doc = svc.create_mission(
+        title=request.title,
+        context_summary=request.context_summary,
+    )
+    return MissionResponse(**doc)
+
+
+@router.get("/api/v2/missions", response_model=MissionListResponse)
+async def list_missions(
+    status: str | None = Query(default=None),
+    archived: bool = Query(default=False),
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=20, ge=1, le=100),
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> MissionListResponse:
+    """List missions with optional filters."""
+    result = svc.list_missions(archived=archived, status=status, page=page, limit=limit)
+    return MissionListResponse(**result)
+
+
+@router.get("/api/v2/missions/{mission_id}", response_model=MissionResponse)
+async def get_mission(
+    mission_id: str,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> MissionResponse:
+    """Get mission detail with task list."""
+    from nexus.bricks.task_manager.service import NotFoundError
+
+    try:
+        doc = svc.get_mission(mission_id)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return MissionResponse(**doc)
+
+
+@router.patch("/api/v2/missions/{mission_id}", response_model=MissionResponse)
+async def update_mission(
+    mission_id: str,
+    request: UpdateMissionRequest,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> MissionResponse:
+    """Update mission fields."""
+    from nexus.bricks.task_manager.service import NotFoundError, ValidationError
+
+    fields = request.model_dump(exclude_unset=True)
+    if not fields:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    try:
+        doc = svc.update_mission(mission_id, **fields)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return MissionResponse(**doc)
+
+
+# =============================================================================
+# Task endpoints
+# =============================================================================
+
+
+@router.post("/api/v2/tasks", response_model=TaskResponse, status_code=201)
+async def create_task(
+    request: CreateTaskRequest,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> TaskResponse:
+    """Create a new task within a mission."""
+    from nexus.bricks.task_manager.service import NotFoundError
+
+    try:
+        doc = svc.create_task(
+            mission_id=request.mission_id,
+            instruction=request.instruction,
+            worker_type=request.worker_type,
+            input_refs=request.input_refs,
+            blocked_by=request.blocked_by,
+            deadline=request.deadline,
+            estimated_duration=request.estimated_duration,
+            label=request.label,
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _broadcaster.notify("task_created", doc["id"])
+    return TaskResponse(**doc)
+
+
+@router.get("/api/v2/tasks", response_model=list[TaskResponse])
+async def list_tasks(
+    worker_type: str | None = Query(default=None),
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> list[TaskResponse]:
+    """List dispatchable tasks (status=created, unblocked)."""
+    tasks = svc.list_dispatchable_tasks(worker_type=worker_type)
+    return [TaskResponse(**t) for t in tasks]
+
+
+@router.get("/api/v2/tasks/{task_id}", response_model=TaskResponse)
+async def get_task_detail(
+    task_id: str,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> TaskResponse:
+    """Get task detail with comments and artifacts."""
+    from nexus.bricks.task_manager.service import NotFoundError
+
+    try:
+        doc = svc.get_task_detail(task_id)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return TaskResponse(**doc)
+
+
+@router.patch("/api/v2/tasks/{task_id}", response_model=TaskResponse)
+async def update_task(
+    task_id: str,
+    request: UpdateTaskRequest,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> TaskResponse:
+    """Update task status and/or output_refs."""
+    from nexus.bricks.task_manager.service import NotFoundError, ValidationError
+
+    fields: dict[str, Any] = {}
+    if request.status is not None:
+        fields["status"] = request.status
+    if request.output_refs is not None:
+        fields["output_refs"] = request.output_refs
+    if not fields:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    try:
+        doc = svc.update_task(task_id, **fields)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _broadcaster.notify("task_updated", task_id)
+    return TaskResponse(**doc)
+
+
+# =============================================================================
+# Audit / History endpoints
+# =============================================================================
+
+
+@router.post("/api/v2/tasks/{task_id}/audit", response_model=AuditEntryResponse, status_code=201)
+async def create_audit_entry(
+    task_id: str,
+    request: CreateAuditEntryRequest,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> AuditEntryResponse:
+    """Create an audit trail entry for a task."""
+    from nexus.bricks.task_manager.service import NotFoundError
+
+    try:
+        doc = svc.create_audit_entry(
+            task_id,
+            request.action,
+            actor=request.actor,
+            detail=request.detail,
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _broadcaster.notify("audit_created", task_id)
+    return AuditEntryResponse(**doc)
+
+
+@router.get("/api/v2/tasks/{task_id}/history", response_model=list[HistoryEntryResponse])
+async def get_task_history(
+    task_id: str,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> list[HistoryEntryResponse]:
+    """Get unified timeline of audit entries and comments for a task."""
+    from nexus.bricks.task_manager.service import NotFoundError
+
+    try:
+        history = svc.get_task_history(task_id)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return [HistoryEntryResponse(**h) for h in history]
+
+
+# =============================================================================
+# Comment endpoints
+# =============================================================================
+
+
+@router.post("/api/v2/comments", response_model=CommentResponse, status_code=201)
+async def create_comment(
+    request: CreateCommentRequest,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> CommentResponse:
+    """Create a comment on a task."""
+    from nexus.bricks.task_manager.service import NotFoundError, ValidationError
+
+    try:
+        doc = svc.create_comment(
+            task_id=request.task_id,
+            author=request.author,
+            content=request.content,
+            artifact_refs=request.artifact_refs,
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _broadcaster.notify("comment_created", request.task_id)
+    return CommentResponse(**doc)
+
+
+@router.get("/api/v2/comments", response_model=list[CommentResponse])
+async def list_comments(
+    task_id: str = Query(..., description="Task ID to list comments for"),
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> list[CommentResponse]:
+    """List comments for a task."""
+    comments = svc.get_comments(task_id)
+    return [CommentResponse(**c) for c in comments]
+
+
+# =============================================================================
+# Artifact endpoints
+# =============================================================================
+
+
+@router.post("/api/v2/artifacts", response_model=ArtifactResponse, status_code=201)
+async def create_artifact(
+    request: CreateArtifactRequest,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
+    svc: Any = Depends(get_task_manager_service),
+) -> ArtifactResponse:
+    """Create an artifact reference."""
+    from nexus.bricks.task_manager.service import ValidationError
+
+    try:
+        doc = svc.create_artifact(
+            type=request.type,
+            uri=request.uri,
+            title=request.title,
+            mime_type=request.mime_type,
+            size_bytes=request.size_bytes,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ArtifactResponse(**doc)

--- a/src/nexus/server/api/v2/routers/task_manager.py
+++ b/src/nexus/server/api/v2/routers/task_manager.py
@@ -18,9 +18,9 @@ Provides endpoints for mission and task management:
 """
 
 import asyncio
-import contextlib
 import json
 import logging
+from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -211,51 +211,55 @@ def get_task_manager_service(request: Request) -> Any:
 
 
 # =============================================================================
-# SSE broadcaster (task change notifications)
+# SSE via DT_STREAM (task change notifications)
 # =============================================================================
 
-
-class _TaskEventBroadcaster:
-    """In-process SSE fan-out for task mutations."""
-
-    def __init__(self) -> None:
-        self._subscribers: set[asyncio.Queue[str]] = set()
-
-    def subscribe(self) -> asyncio.Queue[str]:
-        q: asyncio.Queue[str] = asyncio.Queue(maxsize=256)
-        self._subscribers.add(q)
-        return q
-
-    def unsubscribe(self, q: asyncio.Queue[str]) -> None:
-        self._subscribers.discard(q)
-
-    def notify(self, event: str, task_id: str) -> None:
-        data = json.dumps({"event": event, "task_id": task_id})
-        for q in list(self._subscribers):
-            with contextlib.suppress(asyncio.QueueFull):
-                q.put_nowait(data)
+_TASK_SSE_STREAM_PATH = "/nexus/streams/task-events"
 
 
-_broadcaster = _TaskEventBroadcaster()
+def _get_stream_manager(request: Request) -> Any:
+    """Get StreamManager from app state (optional — SSE degrades gracefully)."""
+    return getattr(request.app.state, "task_stream_manager", None)
+
+
+def _notify_stream(request: Request, event: str, task_id: str) -> None:
+    """Write a task event notification to the DT_STREAM (best-effort)."""
+    sm = _get_stream_manager(request)
+    if sm is None:
+        return
+    try:
+        data = json.dumps({"event": event, "task_id": task_id}).encode()
+        sm.stream_write_nowait(_TASK_SSE_STREAM_PATH, data)
+    except Exception:
+        logger.debug("[TASK-SSE] stream write failed (non-fatal)")
 
 
 @router.get("/api/v2/tasks/events")
 async def task_events(request: Request) -> StreamingResponse:
-    """SSE stream of task mutation notifications."""
-    q = _broadcaster.subscribe()
+    """SSE stream of task mutation notifications via DT_STREAM.
 
-    async def _stream():
-        try:
-            while True:
-                if await request.is_disconnected():
-                    break
-                try:
-                    data = await asyncio.wait_for(q.get(), timeout=25)
-                    yield f"data: {data}\n\n"
-                except TimeoutError:
-                    yield ": keepalive\n\n"
-        finally:
-            _broadcaster.unsubscribe(q)
+    Each SSE client maintains its own byte offset into the stream,
+    providing true fan-out without destructive reads (unlike DT_PIPE).
+    """
+    sm = _get_stream_manager(request)
+
+    async def _stream() -> AsyncGenerator[str, None]:
+        if sm is None:
+            yield ": stream manager not available\n\n"
+            return
+
+        offset = 0
+        while True:
+            if await request.is_disconnected():
+                break
+            try:
+                data, next_offset = sm.stream_read_at(_TASK_SSE_STREAM_PATH, offset)
+                offset = next_offset
+                yield f"data: {data.decode()}\n\n"
+            except Exception:
+                # StreamEmptyError or StreamNotFoundError — wait and send keepalive
+                await asyncio.sleep(25)
+                yield ": keepalive\n\n"
 
     return StreamingResponse(
         _stream(),
@@ -343,7 +347,8 @@ async def update_mission(
 
 @router.post("/api/v2/tasks", response_model=TaskResponse, status_code=201)
 async def create_task(
-    request: CreateTaskRequest,
+    raw_request: Request,
+    body: CreateTaskRequest,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
     svc: Any = Depends(get_task_manager_service),
 ) -> TaskResponse:
@@ -352,18 +357,18 @@ async def create_task(
 
     try:
         doc = svc.create_task(
-            mission_id=request.mission_id,
-            instruction=request.instruction,
-            worker_type=request.worker_type,
-            input_refs=request.input_refs,
-            blocked_by=request.blocked_by,
-            deadline=request.deadline,
-            estimated_duration=request.estimated_duration,
-            label=request.label,
+            mission_id=body.mission_id,
+            instruction=body.instruction,
+            worker_type=body.worker_type,
+            input_refs=body.input_refs,
+            blocked_by=body.blocked_by,
+            deadline=body.deadline,
+            estimated_duration=body.estimated_duration,
+            label=body.label,
         )
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    _broadcaster.notify("task_created", doc["id"])
+    _notify_stream(raw_request, "task_created", doc["id"])
     return TaskResponse(**doc)
 
 
@@ -396,8 +401,9 @@ async def get_task_detail(
 
 @router.patch("/api/v2/tasks/{task_id}", response_model=TaskResponse)
 async def update_task(
+    raw_request: Request,
     task_id: str,
-    request: UpdateTaskRequest,
+    body: UpdateTaskRequest,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
     svc: Any = Depends(get_task_manager_service),
 ) -> TaskResponse:
@@ -405,10 +411,10 @@ async def update_task(
     from nexus.bricks.task_manager.service import NotFoundError, ValidationError
 
     fields: dict[str, Any] = {}
-    if request.status is not None:
-        fields["status"] = request.status
-    if request.output_refs is not None:
-        fields["output_refs"] = request.output_refs
+    if body.status is not None:
+        fields["status"] = body.status
+    if body.output_refs is not None:
+        fields["output_refs"] = body.output_refs
     if not fields:
         raise HTTPException(status_code=400, detail="No fields to update")
 
@@ -418,7 +424,7 @@ async def update_task(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    _broadcaster.notify("task_updated", task_id)
+    _notify_stream(raw_request, "task_updated", task_id)
     return TaskResponse(**doc)
 
 
@@ -429,8 +435,9 @@ async def update_task(
 
 @router.post("/api/v2/tasks/{task_id}/audit", response_model=AuditEntryResponse, status_code=201)
 async def create_audit_entry(
+    raw_request: Request,
     task_id: str,
-    request: CreateAuditEntryRequest,
+    body: CreateAuditEntryRequest,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
     svc: Any = Depends(get_task_manager_service),
 ) -> AuditEntryResponse:
@@ -440,13 +447,13 @@ async def create_audit_entry(
     try:
         doc = svc.create_audit_entry(
             task_id,
-            request.action,
-            actor=request.actor,
-            detail=request.detail,
+            body.action,
+            actor=body.actor,
+            detail=body.detail,
         )
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    _broadcaster.notify("audit_created", task_id)
+    _notify_stream(raw_request, "audit_created", task_id)
     return AuditEntryResponse(**doc)
 
 
@@ -473,7 +480,8 @@ async def get_task_history(
 
 @router.post("/api/v2/comments", response_model=CommentResponse, status_code=201)
 async def create_comment(
-    request: CreateCommentRequest,
+    raw_request: Request,
+    body: CreateCommentRequest,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),  # noqa: ARG001
     svc: Any = Depends(get_task_manager_service),
 ) -> CommentResponse:
@@ -482,16 +490,16 @@ async def create_comment(
 
     try:
         doc = svc.create_comment(
-            task_id=request.task_id,
-            author=request.author,
-            content=request.content,
-            artifact_refs=request.artifact_refs,
+            task_id=body.task_id,
+            author=body.author,
+            content=body.content,
+            artifact_refs=body.artifact_refs,
         )
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    _broadcaster.notify("comment_created", request.task_id)
+    _notify_stream(raw_request, "comment_created", body.task_id)
     return CommentResponse(**doc)
 
 

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -263,6 +263,16 @@ def build_v2_registry(
     except ImportError as e:
         logger.warning("Failed to import Replay routes: %s", e)
 
+    # ---- Task Manager router ----
+    try:
+        from nexus.server.api.v2.routers.task_manager import router as task_manager_router
+
+        registry.add(
+            RouterEntry(router=task_manager_router, name="task_manager", endpoint_count=14)
+        )
+    except ImportError as e:
+        logger.warning("Failed to import Task manager routes: %s", e)
+
     # ---- Batch operations router (Issue #1242) ----
     try:
         from nexus.server.api.v2.routers.batch import create_batch_router

--- a/src/nexus/server/app_state.py
+++ b/src/nexus/server/app_state.py
@@ -80,6 +80,9 @@ class NexusAppState:
     credential_service: Any = None
     scheduler_service: Any = None
     task_runner: Any = None
+    task_manager_service: Any = None
+    task_write_hook: Any = None
+    task_dispatch_consumer: Any = None
     workflow_engine: Any = None
     workflow_dispatch: Any = None
     sandbox_auth_service: Any = None

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -631,7 +631,7 @@ def _register_routes(app: FastAPI) -> None:
     from fastapi.responses import HTMLResponse
 
     @app.get("/dashboard/tasks", response_class=HTMLResponse, include_in_schema=False)
-    async def task_manager_dashboard():
+    async def task_manager_dashboard() -> HTMLResponse:
         html_path = Path(__file__).parent / "static" / "task_manager.html"
         return HTMLResponse(html_path.read_text())
 

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -625,6 +625,16 @@ def _register_routes(app: FastAPI) -> None:
     app.add_middleware(VersionHeaderMiddleware)
     app.add_middleware(DeprecationMiddleware, registry=v2_registry)
 
+    # Dashboard: Task Manager UI (self-contained HTML)
+    from pathlib import Path
+
+    from fastapi.responses import HTMLResponse
+
+    @app.get("/dashboard/tasks", response_class=HTMLResponse, include_in_schema=False)
+    async def task_manager_dashboard():
+        html_path = Path(__file__).parent / "static" / "task_manager.html"
+        return HTMLResponse(html_path.read_text())
+
     # Request correlation middleware (Issue #1002).
     # MUST be the last add_middleware call — Starlette applies in reverse order,
     # so last-added = outermost = first to execute on each request.

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -569,7 +569,8 @@ def _startup_task_manager(app: "FastAPI", svc: "LifespanServices") -> None:
     try:
         from nexus.bricks.task_manager.service import TaskManagerService
 
-        app.state.task_manager_service = TaskManagerService(nexus_fs=svc.nexus_fs)
+        task_svc = TaskManagerService(nexus_fs=svc.nexus_fs)
+        app.state.task_manager_service = task_svc
         logger.info("[TASK-MGR] TaskManagerService initialized")
 
         task_write_hook = getattr(svc.nexus_fs, "_task_write_hook", None)
@@ -580,8 +581,22 @@ def _startup_task_manager(app: "FastAPI", svc: "LifespanServices") -> None:
             from nexus.bricks.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
 
             dispatch_consumer = TaskDispatchPipeConsumer()
+            dispatch_consumer.set_task_service(task_svc)
             task_write_hook.register_handler(dispatch_consumer)
             app.state.task_dispatch_consumer = dispatch_consumer
+
+        # Set up DT_STREAM for SSE notifications
+        stream_manager = getattr(svc.nexus_fs, "_stream_manager", None)
+        if stream_manager is not None:
+            from nexus.core.stream import StreamError
+
+            _SSE_STREAM_PATH = "/nexus/streams/task-events"
+            try:
+                stream_manager.create(_SSE_STREAM_PATH, capacity=65_536, owner_id="kernel")
+            except StreamError:
+                stream_manager.open(_SSE_STREAM_PATH, capacity=65_536)
+            app.state.task_stream_manager = stream_manager
+            logger.info("[TASK-MGR] DT_STREAM for SSE initialized at %s", _SSE_STREAM_PATH)
     except Exception as e:
         logger.warning("[TASK-MGR] Failed to initialize TaskManagerService: %s", e, exc_info=True)
         app.state.task_manager_service = None

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -40,6 +40,8 @@ async def startup_services(app: "FastAPI", svc: "LifespanServices") -> list[asyn
     agent_tasks = await _startup_agent_tasks(app, svc)
     bg_tasks.extend(agent_tasks)
 
+    _startup_task_manager(app, svc)
+
     await _startup_scheduler(app, svc)
     await _startup_workflow_engine(app, svc)
     await _startup_pipe_consumers(app, svc)
@@ -558,6 +560,33 @@ async def _startup_agent_tasks(app: "FastAPI", svc: "LifespanServices") -> list[
     return tasks
 
 
+def _startup_task_manager(app: "FastAPI", svc: "LifespanServices") -> None:
+    """Initialize TaskManagerService backed by NexusFS."""
+    if svc.nexus_fs is None:
+        app.state.task_manager_service = None
+        return
+
+    try:
+        from nexus.bricks.task_manager.service import TaskManagerService
+
+        app.state.task_manager_service = TaskManagerService(nexus_fs=svc.nexus_fs)
+        logger.info("[TASK-MGR] TaskManagerService initialized")
+
+        task_write_hook = getattr(svc.nexus_fs, "_task_write_hook", None)
+        if task_write_hook is not None:
+            app.state.task_write_hook = task_write_hook
+
+            # Wire up DT_PIPE dispatch consumer for task signals
+            from nexus.bricks.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
+
+            dispatch_consumer = TaskDispatchPipeConsumer()
+            task_write_hook.register_handler(dispatch_consumer)
+            app.state.task_dispatch_consumer = dispatch_consumer
+    except Exception as e:
+        logger.warning("[TASK-MGR] Failed to initialize TaskManagerService: %s", e, exc_info=True)
+        app.state.task_manager_service = None
+
+
 async def _startup_scheduler(app: "FastAPI", svc: "LifespanServices") -> None:
     """Initialize factory-created SchedulerService with async pool (Issue #2195, #2360).
 
@@ -704,5 +733,15 @@ async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> No
             logger.info("[PIPE] ZoektPipeConsumer started")
         except Exception as e:
             logger.warning("[PIPE] ZoektPipeConsumer start failed: %s", e, exc_info=True)
+
+    # TaskDispatchPipeConsumer
+    tdc = getattr(app.state, "task_dispatch_consumer", None)
+    if tdc is not None and hasattr(tdc, "set_pipe_manager"):
+        try:
+            tdc.set_pipe_manager(pipe_manager)
+            await tdc.start()
+            logger.info("[PIPE] TaskDispatchPipeConsumer started")
+        except Exception as e:
+            logger.warning("[PIPE] TaskDispatchPipeConsumer start failed: %s", e, exc_info=True)
 
     # write_observer (Q3), zoekt_pipe_consumer (Q3) — stopped by coordinator via aclose()

--- a/src/nexus/server/static/task_manager.html
+++ b/src/nexus/server/static/task_manager.html
@@ -1,0 +1,714 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nexus Task Manager</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f0f2f5; color: #1a1a2e; height: 100vh; display: flex; flex-direction: column; }
+
+/* Header */
+.header { background: #1a1a2e; color: #fff; padding: 8px 16px; display: flex; align-items: center; gap: 16px; flex-shrink: 0; }
+.header h1 { font-size: 16px; font-weight: 600; white-space: nowrap; }
+.header input { background: #2a2a4e; border: 1px solid #3a3a5e; color: #fff; padding: 4px 8px; border-radius: 4px; font-size: 13px; }
+.header #apiKey { width: 260px; }
+.header label { font-size: 12px; color: #aaa; white-space: nowrap; }
+.header .spacer { flex: 1; }
+.header .dispatch-count { font-size: 12px; color: #8f8; background: #2a4a2e; padding: 2px 8px; border-radius: 10px; }
+
+/* Layout */
+.container { display: flex; flex: 1; overflow: hidden; }
+.panel { overflow-y: auto; padding: 12px; }
+.left { width: 280px; min-width: 220px; background: #fff; border-right: 1px solid #ddd; }
+.center { flex: 1; background: #f8f9fa; }
+.right { width: 360px; min-width: 300px; background: #fff; border-left: 1px solid #ddd; }
+
+/* Section headers */
+.section-hdr { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.section-hdr h2 { font-size: 14px; font-weight: 600; }
+
+/* Buttons */
+button { cursor: pointer; border: none; border-radius: 4px; padding: 4px 10px; font-size: 12px; font-weight: 500; }
+.btn-primary { background: #4361ee; color: #fff; }
+.btn-primary:hover { background: #3a56d4; }
+.btn-sm { padding: 2px 8px; font-size: 11px; }
+.btn-danger { background: #e74c3c; color: #fff; }
+.btn-danger:hover { background: #c0392b; }
+.btn-success { background: #27ae60; color: #fff; }
+.btn-success:hover { background: #219a52; }
+.btn-warning { background: #f39c12; color: #fff; }
+.btn-warning:hover { background: #d68910; }
+.btn-secondary { background: #95a5a6; color: #fff; }
+.btn-secondary:hover { background: #7f8c8d; }
+.btn-info { background: #3498db; color: #fff; }
+.btn-info:hover { background: #2980b9; }
+
+/* Status badges */
+.badge { display: inline-block; padding: 1px 7px; border-radius: 10px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; }
+.badge-created { background: #e8f4fd; color: #2980b9; }
+.badge-running { background: #fef3e2; color: #e67e22; }
+.badge-in_review { background: #f3e8fd; color: #8e44ad; }
+.badge-completed { background: #e8fde8; color: #27ae60; }
+.badge-failed { background: #fde8e8; color: #e74c3c; }
+.badge-cancelled { background: #f0f0f0; color: #7f8c8d; }
+.badge-partial_complete { background: #fef9e7; color: #d4ac0d; }
+
+/* Mission list */
+.mission-item { padding: 8px 10px; border: 1px solid #e8e8e8; border-radius: 6px; margin-bottom: 6px; cursor: pointer; transition: background 0.15s; }
+.mission-item:hover { background: #f0f4ff; }
+.mission-item.selected { background: #e8f0ff; border-color: #4361ee; }
+.mission-item .mission-title { font-size: 13px; font-weight: 500; margin-bottom: 3px; word-break: break-word; }
+.mission-item .mission-meta { font-size: 11px; color: #888; }
+
+/* Task cards */
+.task-card { background: #fff; border: 1px solid #e0e0e0; border-radius: 8px; padding: 10px 12px; margin-bottom: 8px; }
+.task-card .task-instruction { font-size: 13px; margin-bottom: 6px; word-break: break-word; }
+.task-card .task-meta { font-size: 11px; color: #888; margin-bottom: 6px; }
+.task-card .task-blocked { font-size: 11px; color: #e74c3c; margin-bottom: 6px; }
+.task-card .task-actions { display: flex; gap: 4px; flex-wrap: wrap; }
+.task-card.selected-task { border-color: #4361ee; box-shadow: 0 0 0 2px rgba(67,97,238,0.15); }
+
+/* Detail panel */
+.detail-section { margin-bottom: 16px; }
+.detail-section h3 { font-size: 13px; font-weight: 600; margin-bottom: 6px; border-bottom: 1px solid #eee; padding-bottom: 4px; }
+.detail-field { font-size: 12px; margin-bottom: 4px; }
+.detail-field strong { color: #555; }
+
+/* Comments */
+.comment { padding: 6px 8px; border-radius: 6px; margin-bottom: 6px; font-size: 12px; }
+.comment-copilot { background: #e8f4fd; border-left: 3px solid #3498db; }
+.comment-worker { background: #fef3e2; border-left: 3px solid #e67e22; }
+.comment .comment-author { font-weight: 600; font-size: 11px; text-transform: uppercase; }
+.comment .comment-time { font-size: 10px; color: #999; }
+.comment .comment-text { margin-top: 3px; word-break: break-word; }
+
+/* Audit entries */
+.audit-entry { padding: 4px 8px; border-radius: 6px; margin-bottom: 6px; font-size: 12px; background: #f0f0f5; border-left: 3px solid #95a5a6; }
+.audit-entry .audit-action { font-weight: 600; font-size: 11px; color: #555; }
+.audit-entry .audit-time { font-size: 10px; color: #999; }
+.audit-entry .audit-detail { margin-top: 2px; color: #666; }
+
+/* Artifacts */
+.artifact-item { font-size: 12px; padding: 4px 8px; background: #f8f9fa; border-radius: 4px; margin-bottom: 4px; }
+.artifact-item .artifact-type { font-weight: 600; text-transform: uppercase; font-size: 10px; color: #666; }
+
+/* Forms */
+.form-group { margin-bottom: 8px; }
+.form-group label { display: block; font-size: 11px; font-weight: 600; color: #555; margin-bottom: 2px; }
+.form-group input, .form-group textarea, .form-group select { width: 100%; padding: 5px 8px; border: 1px solid #ddd; border-radius: 4px; font-size: 12px; font-family: inherit; }
+.form-group textarea { resize: vertical; min-height: 50px; }
+
+/* Modal overlay */
+.modal-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.4); z-index: 100; align-items: center; justify-content: center; }
+.modal-overlay.active { display: flex; }
+.modal { background: #fff; border-radius: 10px; padding: 20px; min-width: 380px; max-width: 500px; box-shadow: 0 8px 32px rgba(0,0,0,0.2); }
+.modal h3 { margin-bottom: 12px; }
+.modal .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
+
+/* Empty state */
+.empty-state { text-align: center; color: #aaa; padding: 40px 20px; font-size: 13px; }
+
+/* Toast */
+.toast { position: fixed; bottom: 20px; right: 20px; padding: 10px 16px; border-radius: 8px; color: #fff; font-size: 13px; z-index: 200; animation: fadeIn 0.3s; max-width: 400px; word-break: break-word; }
+.toast-error { background: #e74c3c; }
+.toast-success { background: #27ae60; }
+@keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+
+/* Loading */
+.loading { text-align: center; color: #aaa; padding: 20px; font-size: 12px; }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Nexus Task Manager</h1>
+  <div class="spacer"></div>
+  <label>API Key:</label>
+  <input type="password" id="apiKey" placeholder="Enter API key..." />
+  <span class="dispatch-count" id="dispatchCount" title="Dispatchable tasks">Dispatch: --</span>
+</div>
+
+<div class="container">
+  <!-- Left: Mission List -->
+  <div class="panel left" id="missionPanel">
+    <div class="section-hdr">
+      <h2>Missions</h2>
+      <button class="btn-primary btn-sm" onclick="openNewMissionModal()">+ New</button>
+    </div>
+    <div>
+      <select id="missionStatusFilter" style="width:100%;margin-bottom:8px;padding:3px 6px;font-size:12px;border:1px solid #ddd;border-radius:4px;">
+        <option value="">All statuses</option>
+        <option value="running">Running</option>
+        <option value="partial_complete">Partial Complete</option>
+        <option value="completed">Completed</option>
+        <option value="cancelled">Cancelled</option>
+      </select>
+    </div>
+    <div id="missionList"><div class="loading">Loading...</div></div>
+  </div>
+
+  <!-- Center: Task Board -->
+  <div class="panel center" id="taskPanel">
+    <div class="section-hdr">
+      <h2 id="taskPanelTitle">Tasks</h2>
+      <button class="btn-primary btn-sm" id="newTaskBtn" onclick="openNewTaskModal()" style="display:none;">+ New Task</button>
+    </div>
+    <div id="missionActions" style="display:none;margin-bottom:8px;"></div>
+    <div id="taskList"><div class="empty-state">Select a mission to view tasks</div></div>
+  </div>
+
+  <!-- Right: Task Detail -->
+  <div class="panel right" id="detailPanel">
+    <div id="taskDetail"><div class="empty-state">Select a task to view details</div></div>
+  </div>
+</div>
+
+<!-- New Mission Modal -->
+<div class="modal-overlay" id="newMissionModal">
+  <div class="modal">
+    <h3>New Mission</h3>
+    <div class="form-group">
+      <label>Title *</label>
+      <input type="text" id="newMissionTitle" />
+    </div>
+    <div class="form-group">
+      <label>Context Summary</label>
+      <textarea id="newMissionContext" rows="3"></textarea>
+    </div>
+    <div class="modal-actions">
+      <button class="btn-secondary" onclick="closeModal('newMissionModal')">Cancel</button>
+      <button class="btn-primary" onclick="createMission()">Create</button>
+    </div>
+  </div>
+</div>
+
+<!-- New Task Modal -->
+<div class="modal-overlay" id="newTaskModal">
+  <div class="modal">
+    <h3>New Task</h3>
+    <div class="form-group">
+      <label>Instruction *</label>
+      <textarea id="newTaskInstruction" rows="3"></textarea>
+    </div>
+    <div class="form-group">
+      <label>Worker Type</label>
+      <input type="text" id="newTaskWorkerType" placeholder="e.g. copilot, worker" />
+    </div>
+    <div class="form-group">
+      <label>Label</label>
+      <input type="text" id="newTaskLabel" />
+    </div>
+    <div class="form-group">
+      <label>Blocked By (comma-separated task IDs)</label>
+      <input type="text" id="newTaskBlockedBy" placeholder="task-id-1, task-id-2" />
+    </div>
+    <div class="form-group">
+      <label>Deadline (ISO 8601)</label>
+      <input type="text" id="newTaskDeadline" placeholder="2025-12-31T23:59:59Z" />
+    </div>
+    <div class="modal-actions">
+      <button class="btn-secondary" onclick="closeModal('newTaskModal')">Cancel</button>
+      <button class="btn-primary" onclick="createTask()">Create</button>
+    </div>
+  </div>
+</div>
+
+<!-- New Comment Modal -->
+<div class="modal-overlay" id="newCommentModal">
+  <div class="modal">
+    <h3>Add Comment</h3>
+    <div class="form-group">
+      <label>Author *</label>
+      <select id="newCommentAuthor">
+        <option value="copilot">copilot</option>
+        <option value="worker">worker</option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label>Content *</label>
+      <textarea id="newCommentContent" rows="4"></textarea>
+    </div>
+    <div class="modal-actions">
+      <button class="btn-secondary" onclick="closeModal('newCommentModal')">Cancel</button>
+      <button class="btn-primary" onclick="createComment()">Add</button>
+    </div>
+  </div>
+</div>
+
+<!-- New Artifact Modal -->
+<div class="modal-overlay" id="newArtifactModal">
+  <div class="modal">
+    <h3>Create Artifact</h3>
+    <div class="form-group">
+      <label>Title *</label>
+      <input type="text" id="newArtifactTitle" />
+    </div>
+    <div class="form-group">
+      <label>Type *</label>
+      <select id="newArtifactType">
+        <option value="document">document</option>
+        <option value="code">code</option>
+        <option value="folder">folder</option>
+        <option value="pr">pr</option>
+        <option value="image">image</option>
+        <option value="data">data</option>
+        <option value="spreadsheet">spreadsheet</option>
+        <option value="presentation">presentation</option>
+        <option value="other">other</option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label>URI *</label>
+      <input type="text" id="newArtifactUri" placeholder="nexus://path/to/file" />
+    </div>
+    <div class="form-group">
+      <label>MIME Type</label>
+      <input type="text" id="newArtifactMime" placeholder="text/plain" />
+    </div>
+    <div class="modal-actions">
+      <button class="btn-secondary" onclick="closeModal('newArtifactModal')">Cancel</button>
+      <button class="btn-primary" onclick="createArtifact()">Create</button>
+    </div>
+  </div>
+</div>
+
+<script>
+// ---- State ----
+let selectedMissionId = null;
+let selectedTaskId = null;
+let currentMission = null;
+
+// ---- Config ----
+const BASE_URL = window.location.origin;
+
+function getApiKey() {
+  return document.getElementById('apiKey').value.trim();
+}
+
+function headers() {
+  const h = { 'Content-Type': 'application/json' };
+  const key = getApiKey();
+  if (key) h['Authorization'] = 'Bearer ' + key;
+  return h;
+}
+
+// ---- Persistence ----
+document.getElementById('apiKey').value = localStorage.getItem('nexus_api_key') || '';
+document.getElementById('apiKey').addEventListener('input', function() {
+  localStorage.setItem('nexus_api_key', this.value);
+  loadMissions();
+  refreshDispatch();
+});
+
+// ---- API helpers ----
+async function api(method, path, body) {
+  const opts = { method, headers: headers() };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(BASE_URL + path, opts);
+  if (!res.ok) {
+    let msg = res.statusText;
+    try { const j = await res.json(); msg = j.detail || JSON.stringify(j); } catch {}
+    throw new Error(`${res.status}: ${msg}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+// ---- Toast ----
+function toast(msg, type) {
+  const el = document.createElement('div');
+  el.className = 'toast toast-' + type;
+  el.textContent = msg;
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), 4000);
+}
+
+// ---- Modal helpers ----
+function openModal(id) { document.getElementById(id).classList.add('active'); }
+function closeModal(id) { document.getElementById(id).classList.remove('active'); }
+
+// ---- Badge helper ----
+function badge(status) {
+  return `<span class="badge badge-${status}">${status.replace('_', ' ')}</span>`;
+}
+
+// ---- Format time ----
+function fmtTime(iso) {
+  if (!iso) return '--';
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, { month:'short', day:'numeric', hour:'2-digit', minute:'2-digit' });
+}
+
+// ---- Missions ----
+async function loadMissions() {
+  const statusFilter = document.getElementById('missionStatusFilter').value;
+  let path = '/api/v2/missions?limit=100';
+  if (statusFilter) path += '&status=' + statusFilter;
+  try {
+    const data = await api('GET', path);
+    renderMissions(data.items || []);
+  } catch (e) {
+    document.getElementById('missionList').innerHTML = '<div class="empty-state">Error loading missions: ' + escHtml(e.message) + '</div>';
+  }
+}
+
+function renderMissions(missions) {
+  const container = document.getElementById('missionList');
+  if (!missions.length) {
+    container.innerHTML = '<div class="empty-state">No missions yet</div>';
+    return;
+  }
+  container.innerHTML = missions.map(m => `
+    <div class="mission-item ${m.id === selectedMissionId ? 'selected' : ''}" onclick="selectMission('${m.id}')">
+      <div class="mission-title">${escHtml(m.title)}</div>
+      <div class="mission-meta">${badge(m.status)} &middot; ${fmtTime(m.created_at)}</div>
+    </div>
+  `).join('');
+}
+
+async function selectMission(id) {
+  selectedMissionId = id;
+  selectedTaskId = null;
+  document.getElementById('taskDetail').innerHTML = '<div class="empty-state">Select a task to view details</div>';
+  document.querySelectorAll('.mission-item').forEach(el => el.classList.remove('selected'));
+  try {
+    currentMission = await api('GET', '/api/v2/missions/' + id);
+    document.getElementById('taskPanelTitle').textContent = 'Tasks: ' + currentMission.title;
+    document.getElementById('newTaskBtn').style.display = '';
+    renderMissionActions(currentMission);
+    renderTasks(currentMission.tasks || []);
+    // Highlight in list
+    document.querySelectorAll('.mission-item').forEach(el => {
+      if (el.onclick && el.onclick.toString().includes(id)) el.classList.add('selected');
+    });
+    loadMissions(); // refresh list to update selection highlight
+  } catch (e) {
+    toast('Failed to load mission: ' + e.message, 'error');
+  }
+}
+
+function renderMissionActions(mission) {
+  const container = document.getElementById('missionActions');
+  container.style.display = '';
+  const statusButtons = {
+    running: [
+      { label: 'Complete', status: 'completed', cls: 'btn-success' },
+      { label: 'Partial Complete', status: 'partial_complete', cls: 'btn-warning' },
+      { label: 'Cancel', status: 'cancelled', cls: 'btn-danger' },
+    ],
+    partial_complete: [
+      { label: 'Complete', status: 'completed', cls: 'btn-success' },
+      { label: 'Cancel', status: 'cancelled', cls: 'btn-danger' },
+    ],
+    completed: [],
+    cancelled: [],
+  };
+  const actions = statusButtons[mission.status] || [];
+  container.innerHTML = '<span style="font-size:12px;color:#888;">Mission: </span>' + badge(mission.status) + ' ' +
+    actions.map(a => `<button class="${a.cls} btn-sm" onclick="updateMissionStatus('${a.status}')" style="margin-left:4px;">${a.label}</button>`).join('');
+}
+
+async function updateMissionStatus(status) {
+  try {
+    const body = { status };
+    if (status === 'completed' || status === 'partial_complete') {
+      const conclusion = prompt('Conclusion (optional):');
+      if (conclusion) body.conclusion = conclusion;
+    }
+    await api('PATCH', '/api/v2/missions/' + selectedMissionId, body);
+    toast('Mission updated', 'success');
+    selectMission(selectedMissionId);
+    loadMissions();
+  } catch (e) {
+    toast('Error: ' + e.message, 'error');
+  }
+}
+
+function openNewMissionModal() { openModal('newMissionModal'); document.getElementById('newMissionTitle').focus(); }
+
+async function createMission() {
+  const title = document.getElementById('newMissionTitle').value.trim();
+  if (!title) { toast('Title is required', 'error'); return; }
+  const body = { title };
+  const ctx = document.getElementById('newMissionContext').value.trim();
+  if (ctx) body.context_summary = ctx;
+  try {
+    const m = await api('POST', '/api/v2/missions', body);
+    closeModal('newMissionModal');
+    document.getElementById('newMissionTitle').value = '';
+    document.getElementById('newMissionContext').value = '';
+    toast('Mission created', 'success');
+    loadMissions();
+    selectMission(m.id);
+  } catch (e) {
+    toast('Error: ' + e.message, 'error');
+  }
+}
+
+document.getElementById('missionStatusFilter').addEventListener('change', loadMissions);
+
+// ---- Tasks ----
+function renderTasks(tasks) {
+  const container = document.getElementById('taskList');
+  if (!tasks.length) {
+    container.innerHTML = '<div class="empty-state">No tasks in this mission</div>';
+    return;
+  }
+  container.innerHTML = tasks.map(t => {
+    const transitions = getTransitions(t.status);
+    return `
+      <div class="task-card ${t.id === selectedTaskId ? 'selected-task' : ''}" onclick="selectTask('${t.id}')">
+        <div class="task-instruction">${escHtml(t.instruction)}</div>
+        <div class="task-meta">
+          ${badge(t.status)}
+          ${t.label ? ' &middot; <strong>' + escHtml(t.label) + '</strong>' : ''}
+          ${t.worker_type ? ' &middot; ' + escHtml(t.worker_type) : ''}
+          &middot; ${fmtTime(t.created_at)}
+        </div>
+        ${t.blocked_by && t.blocked_by.length ? '<div class="task-blocked">Blocked by: ' + t.blocked_by.map(id => id.substring(0,8) + '...').join(', ') + '</div>' : ''}
+        <div class="task-actions" onclick="event.stopPropagation()">
+          ${transitions.map(tr => `<button class="${tr.cls} btn-sm" onclick="transitionTask('${t.id}','${tr.status}')">${tr.label}</button>`).join('')}
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
+function getTransitions(status) {
+  const map = {
+    created:   [{ label:'Start', status:'running', cls:'btn-primary' }, { label:'Cancel', status:'cancelled', cls:'btn-danger' }],
+    running:   [{ label:'Complete', status:'completed', cls:'btn-success' }, { label:'Fail', status:'failed', cls:'btn-danger' }, { label:'Review', status:'in_review', cls:'btn-info' }, { label:'Cancel', status:'cancelled', cls:'btn-secondary' }],
+    in_review: [{ label:'Approve', status:'completed', cls:'btn-success' }, { label:'Send Back', status:'running', cls:'btn-warning' }, { label:'Cancel', status:'cancelled', cls:'btn-danger' }],
+    completed: [{ label:'Cancel', status:'cancelled', cls:'btn-danger' }],
+    failed:    [{ label:'Cancel', status:'cancelled', cls:'btn-danger' }],
+    cancelled: [],
+  };
+  return map[status] || [];
+}
+
+async function transitionTask(taskId, newStatus) {
+  try {
+    await api('PATCH', '/api/v2/tasks/' + taskId, { status: newStatus });
+    toast('Task updated', 'success');
+    selectMission(selectedMissionId);
+    if (taskId === selectedTaskId) selectTask(taskId);
+    refreshDispatch();
+  } catch (e) {
+    toast('Error: ' + e.message, 'error');
+  }
+}
+
+async function selectTask(id) {
+  selectedTaskId = id;
+  // Highlight card
+  document.querySelectorAll('.task-card').forEach(el => el.classList.remove('selected-task'));
+  try {
+    const t = await api('GET', '/api/v2/tasks/' + id);
+    renderTaskDetail(t);
+  } catch (e) {
+    toast('Failed to load task: ' + e.message, 'error');
+  }
+}
+
+function renderTaskDetail(t) {
+  const transitions = getTransitions(t.status);
+  const comments = t.comments || [];
+  const artifacts = t.artifacts || [];
+
+  document.getElementById('taskDetail').innerHTML = `
+    <div class="detail-section">
+      <h3>Task Detail</h3>
+      <div class="detail-field"><strong>ID:</strong> ${t.id}</div>
+      <div class="detail-field"><strong>Status:</strong> ${badge(t.status)}</div>
+      <div class="detail-field"><strong>Instruction:</strong> ${escHtml(t.instruction)}</div>
+      ${t.worker_type ? `<div class="detail-field"><strong>Worker:</strong> ${escHtml(t.worker_type)}</div>` : ''}
+      ${t.label ? `<div class="detail-field"><strong>Label:</strong> ${escHtml(t.label)}</div>` : ''}
+      ${t.deadline ? `<div class="detail-field"><strong>Deadline:</strong> ${fmtTime(t.deadline)}</div>` : ''}
+      <div class="detail-field"><strong>Created:</strong> ${fmtTime(t.created_at)}</div>
+      ${t.started_at ? `<div class="detail-field"><strong>Started:</strong> ${fmtTime(t.started_at)}</div>` : ''}
+      ${t.completed_at ? `<div class="detail-field"><strong>Completed:</strong> ${fmtTime(t.completed_at)}</div>` : ''}
+      ${t.blocked_by && t.blocked_by.length ? `<div class="detail-field"><strong>Blocked by:</strong> ${t.blocked_by.join(', ')}</div>` : ''}
+      ${t.output_refs && t.output_refs.length ? `<div class="detail-field"><strong>Output refs:</strong> ${t.output_refs.join(', ')}</div>` : ''}
+      <div style="margin-top:8px;display:flex;gap:4px;flex-wrap:wrap;">
+        ${transitions.map(tr => `<button class="${tr.cls} btn-sm" onclick="transitionTask('${t.id}','${tr.status}')">${tr.label}</button>`).join('')}
+      </div>
+    </div>
+
+    <div class="detail-section">
+      <div class="section-hdr">
+        <h3>History (${(t.history || []).length})</h3>
+        <button class="btn-primary btn-sm" onclick="openCommentModal()">+ Comment</button>
+      </div>
+      ${(t.history || []).length ? (t.history || []).map(h => {
+        if (h.type === 'comment') {
+          return `
+            <div class="comment comment-${h.author}">
+              <span class="comment-author">${escHtml(h.author)}</span>
+              <span class="comment-time">${fmtTime(h.created_at)}</span>
+              <div class="comment-text">${escHtml(h.content)}</div>
+              ${h.artifact_refs && h.artifact_refs.length ? `<div style="font-size:10px;color:#888;margin-top:2px;">Refs: ${h.artifact_refs.join(', ')}</div>` : ''}
+            </div>`;
+        } else {
+          return `
+            <div class="audit-entry">
+              <span class="audit-action">${escHtml(h.action)}</span>
+              ${h.actor ? `<span style="font-size:10px;color:#888;"> by ${escHtml(h.actor)}</span>` : ''}
+              <span class="audit-time">${fmtTime(h.created_at)}</span>
+              ${h.detail ? `<div class="audit-detail">${escHtml(h.detail)}</div>` : ''}
+            </div>`;
+        }
+      }).join('') : '<div class="empty-state" style="padding:10px;">No history yet</div>'}
+    </div>
+
+    <div class="detail-section">
+      <div class="section-hdr">
+        <h3>Artifacts (${artifacts.length})</h3>
+        <button class="btn-primary btn-sm" onclick="openArtifactModal()">+ Add</button>
+      </div>
+      ${artifacts.length ? artifacts.map(a => `
+        <div class="artifact-item">
+          <span class="artifact-type">${a.type}</span>
+          <strong>${escHtml(a.title)}</strong>
+          <div style="font-size:11px;color:#888;">${escHtml(a.uri)}${a.mime_type ? ' &middot; ' + a.mime_type : ''}</div>
+        </div>
+      `).join('') : '<div class="empty-state" style="padding:10px;">No artifacts</div>'}
+    </div>
+  `;
+}
+
+// ---- New Task ----
+function openNewTaskModal() { openModal('newTaskModal'); document.getElementById('newTaskInstruction').focus(); }
+
+async function createTask() {
+  const instruction = document.getElementById('newTaskInstruction').value.trim();
+  if (!instruction) { toast('Instruction is required', 'error'); return; }
+  const body = { mission_id: selectedMissionId, instruction };
+  const wt = document.getElementById('newTaskWorkerType').value.trim();
+  if (wt) body.worker_type = wt;
+  const label = document.getElementById('newTaskLabel').value.trim();
+  if (label) body.label = label;
+  const bb = document.getElementById('newTaskBlockedBy').value.trim();
+  if (bb) body.blocked_by = bb.split(',').map(s => s.trim()).filter(Boolean);
+  const dl = document.getElementById('newTaskDeadline').value.trim();
+  if (dl) body.deadline = dl;
+  try {
+    await api('POST', '/api/v2/tasks', body);
+    closeModal('newTaskModal');
+    document.getElementById('newTaskInstruction').value = '';
+    document.getElementById('newTaskWorkerType').value = '';
+    document.getElementById('newTaskLabel').value = '';
+    document.getElementById('newTaskBlockedBy').value = '';
+    document.getElementById('newTaskDeadline').value = '';
+    toast('Task created', 'success');
+    selectMission(selectedMissionId);
+    refreshDispatch();
+  } catch (e) {
+    toast('Error: ' + e.message, 'error');
+  }
+}
+
+// ---- Comments ----
+function openCommentModal() { openModal('newCommentModal'); document.getElementById('newCommentContent').focus(); }
+
+async function createComment() {
+  const content = document.getElementById('newCommentContent').value.trim();
+  if (!content) { toast('Content is required', 'error'); return; }
+  const body = {
+    task_id: selectedTaskId,
+    author: document.getElementById('newCommentAuthor').value,
+    content,
+  };
+  try {
+    await api('POST', '/api/v2/comments', body);
+    closeModal('newCommentModal');
+    document.getElementById('newCommentContent').value = '';
+    toast('Comment added', 'success');
+    selectTask(selectedTaskId);
+  } catch (e) {
+    toast('Error: ' + e.message, 'error');
+  }
+}
+
+// ---- Artifacts ----
+function openArtifactModal() { openModal('newArtifactModal'); document.getElementById('newArtifactTitle').focus(); }
+
+async function createArtifact() {
+  const title = document.getElementById('newArtifactTitle').value.trim();
+  const uri = document.getElementById('newArtifactUri').value.trim();
+  if (!title || !uri) { toast('Title and URI are required', 'error'); return; }
+  const body = {
+    type: document.getElementById('newArtifactType').value,
+    uri,
+    title,
+  };
+  const mime = document.getElementById('newArtifactMime').value.trim();
+  if (mime) body.mime_type = mime;
+  try {
+    const artifact = await api('POST', '/api/v2/artifacts', body);
+    closeModal('newArtifactModal');
+    document.getElementById('newArtifactTitle').value = '';
+    document.getElementById('newArtifactUri').value = '';
+    document.getElementById('newArtifactMime').value = '';
+    toast('Artifact created (ID: ' + artifact.id + ')', 'success');
+    if (selectedTaskId) selectTask(selectedTaskId);
+  } catch (e) {
+    toast('Error: ' + e.message, 'error');
+  }
+}
+
+// ---- Dispatch count ----
+async function refreshDispatch() {
+  try {
+    const tasks = await api('GET', '/api/v2/tasks');
+    document.getElementById('dispatchCount').textContent = 'Dispatch: ' + (tasks.length || 0);
+  } catch {
+    document.getElementById('dispatchCount').textContent = 'Dispatch: --';
+  }
+}
+
+// ---- Utility ----
+function escHtml(str) {
+  if (!str) return '';
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+// ---- SSE live updates ----
+let _evtSource = null;
+
+function connectSSE() {
+  if (_evtSource) _evtSource.close();
+  _evtSource = new EventSource(BASE_URL + '/api/v2/tasks/events');
+
+  _evtSource.onmessage = function(e) {
+    try {
+      const msg = JSON.parse(e.data);
+      // Refresh task detail if we're looking at the changed task
+      if (selectedTaskId && msg.task_id === selectedTaskId) {
+        selectTask(selectedTaskId);
+      }
+      // Refresh mission task list if a mission is selected
+      if (selectedMissionId) {
+        selectMission(selectedMissionId);
+      }
+      refreshDispatch();
+    } catch {}
+  };
+
+  _evtSource.onerror = function() {
+    // Reconnect after a brief delay (browser auto-reconnects SSE,
+    // but we reset state just in case)
+    setTimeout(connectSSE, 5000);
+  };
+}
+
+// ---- Init ----
+loadMissions();
+refreshDispatch();
+connectSSE();
+setInterval(refreshDispatch, 30000);
+</script>
+</body>
+</html>

--- a/tests/e2e/server/test_task_manager_e2e.py
+++ b/tests/e2e/server/test_task_manager_e2e.py
@@ -1,0 +1,445 @@
+"""E2E tests for Task Manager API.
+
+Three user-journey tests using httpx.Client against a real server:
+1. Full mission lifecycle
+2. Multi-round review loop
+3. Task dependency chain
+
+Uses the shared nexus_server fixture from conftest.py (SQLite backend).
+
+Run with:
+    pytest tests/e2e/server/test_task_manager_e2e.py -v --override-ini="addopts="
+"""
+
+import httpx
+import pytest
+
+AUTH_HEADERS = {"Authorization": "Bearer test-e2e-api-key-12345"}
+
+
+@pytest.mark.e2e
+class TestDashboardEndpoint:
+    """Journey 0: Dashboard HTML is served at /dashboard/tasks."""
+
+    def test_dashboard_serves_html(self, test_app: httpx.Client) -> None:
+        r = test_app.get("/dashboard/tasks")
+        assert r.status_code == 200, r.text
+        assert "text/html" in r.headers.get("content-type", "")
+        assert "Nexus Task Manager" in r.text
+        assert "/api/v2/missions" in r.text
+
+
+@pytest.mark.e2e
+class TestMissionLifecycle:
+    """Journey 1: Full mission lifecycle — create, dispatch, complete."""
+
+    def test_full_mission_lifecycle(self, test_app: httpx.Client) -> None:
+        # 1. Create mission
+        r = test_app.post(
+            "/api/v2/missions",
+            headers=AUTH_HEADERS,
+            json={"title": "Q1 Analysis", "context_summary": "Quarterly review"},
+        )
+        assert r.status_code == 201, r.text
+        mission = r.json()
+        mission_id = mission["id"]
+        assert mission["status"] == "running"
+
+        # 2. Create input artifact
+        r = test_app.post(
+            "/api/v2/artifacts",
+            headers=AUTH_HEADERS,
+            json={
+                "type": "data",
+                "uri": "/datasets/q1.csv",
+                "title": "Q1 Data",
+                "mime_type": "text/csv",
+                "size_bytes": 1024,
+            },
+        )
+        assert r.status_code == 201, r.text
+        artifact = r.json()
+        artifact_id = artifact["id"]
+
+        # 3. Create task A with input_refs
+        r = test_app.post(
+            "/api/v2/tasks",
+            headers=AUTH_HEADERS,
+            json={
+                "mission_id": mission_id,
+                "instruction": "Analyze Q1 data",
+                "input_refs": [artifact_id],
+            },
+        )
+        assert r.status_code == 201, r.text
+        task_a = r.json()
+        task_a_id = task_a["id"]
+        assert task_a["status"] == "created"
+        assert task_a["input_refs"] == [artifact_id]
+
+        # 4. Create task B
+        r = test_app.post(
+            "/api/v2/tasks",
+            headers=AUTH_HEADERS,
+            json={
+                "mission_id": mission_id,
+                "instruction": "Generate report",
+            },
+        )
+        assert r.status_code == 201, r.text
+        task_b = r.json()
+        task_b_id = task_b["id"]
+
+        # 5. List dispatchable tasks — both should be dispatchable
+        r = test_app.get("/api/v2/tasks", headers=AUTH_HEADERS)
+        assert r.status_code == 200, r.text
+        dispatchable = r.json()
+        dispatchable_ids = {t["id"] for t in dispatchable}
+        assert task_a_id in dispatchable_ids
+        assert task_b_id in dispatchable_ids
+
+        # 6. Dispatcher picks up task A: created → running
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_a_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "running"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "running"
+        assert r.json()["started_at"] is not None
+
+        # 7. Worker reports progress via comment
+        r = test_app.post(
+            "/api/v2/comments",
+            headers=AUTH_HEADERS,
+            json={
+                "task_id": task_a_id,
+                "author": "worker",
+                "content": "Processing data, 50% done",
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        # 8. Complete task A with output artifact
+        r = test_app.post(
+            "/api/v2/artifacts",
+            headers=AUTH_HEADERS,
+            json={
+                "type": "document",
+                "uri": "/reports/q1_analysis.pdf",
+                "title": "Q1 Analysis Report",
+            },
+        )
+        assert r.status_code == 201, r.text
+        output_artifact_id = r.json()["id"]
+
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_a_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "completed", "output_refs": [output_artifact_id]},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "completed"
+        assert r.json()["completed_at"] is not None
+
+        # 9. Complete task B: running → completed
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_b_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "running"},
+        )
+        assert r.status_code == 200, r.text
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_b_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "completed"},
+        )
+        assert r.status_code == 200, r.text
+
+        # 10. Complete mission
+        r = test_app.patch(
+            f"/api/v2/missions/{mission_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "completed", "conclusion": "Q1 looks great"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "completed"
+        assert r.json()["conclusion"] == "Q1 looks great"
+
+        # 11. Verify mission detail shows both tasks completed
+        r = test_app.get(f"/api/v2/missions/{mission_id}", headers=AUTH_HEADERS)
+        assert r.status_code == 200, r.text
+        detail = r.json()
+        assert detail["status"] == "completed"
+        assert len(detail["tasks"]) == 2
+        assert all(t["status"] == "completed" for t in detail["tasks"])
+
+        # 12. Verify mission appears in list
+        r = test_app.get("/api/v2/missions", headers=AUTH_HEADERS)
+        assert r.status_code == 200, r.text
+        mission_list = r.json()
+        assert any(m["id"] == mission_id for m in mission_list["items"])
+
+
+@pytest.mark.e2e
+class TestReviewLoop:
+    """Journey 2: Multi-round review loop — worker submits, copilot reviews."""
+
+    def test_multi_round_review(self, test_app: httpx.Client) -> None:
+        # Create mission + task
+        r = test_app.post(
+            "/api/v2/missions",
+            headers=AUTH_HEADERS,
+            json={"title": "Review Loop Test"},
+        )
+        assert r.status_code == 201, r.text
+        mission_id = r.json()["id"]
+
+        r = test_app.post(
+            "/api/v2/tasks",
+            headers=AUTH_HEADERS,
+            json={
+                "mission_id": mission_id,
+                "instruction": "Write draft report",
+            },
+        )
+        assert r.status_code == 201, r.text
+        task_id = r.json()["id"]
+
+        # Start task: created → running
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "running"},
+        )
+        assert r.status_code == 200, r.text
+
+        # Worker submits partial result with artifact
+        r = test_app.post(
+            "/api/v2/artifacts",
+            headers=AUTH_HEADERS,
+            json={
+                "type": "document",
+                "uri": "/drafts/v1.md",
+                "title": "Draft v1",
+            },
+        )
+        assert r.status_code == 201, r.text
+        draft_v1_id = r.json()["id"]
+
+        r = test_app.post(
+            "/api/v2/comments",
+            headers=AUTH_HEADERS,
+            json={
+                "task_id": task_id,
+                "author": "worker",
+                "content": "Draft v1 ready for review",
+                "artifact_refs": [draft_v1_id],
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        # Worker moves to in_review
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "in_review"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "in_review"
+
+        # Copilot gives feedback
+        r = test_app.post(
+            "/api/v2/comments",
+            headers=AUTH_HEADERS,
+            json={
+                "task_id": task_id,
+                "author": "copilot",
+                "content": "Needs more detail in section 2",
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        # Copilot sends back: in_review → running
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "running"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "running"
+
+        # Worker submits updated result
+        r = test_app.post(
+            "/api/v2/comments",
+            headers=AUTH_HEADERS,
+            json={
+                "task_id": task_id,
+                "author": "worker",
+                "content": "Updated draft with more detail",
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        # Worker moves to in_review again
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "in_review"},
+        )
+        assert r.status_code == 200, r.text
+
+        # Copilot approves: in_review → completed
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "completed"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "completed"
+
+        # Verify all 3 comments in order
+        r = test_app.get(
+            f"/api/v2/comments?task_id={task_id}",
+            headers=AUTH_HEADERS,
+        )
+        assert r.status_code == 200, r.text
+        comments = r.json()
+        assert len(comments) == 3
+        assert comments[0]["author"] == "worker"
+        assert comments[1]["author"] == "copilot"
+        assert comments[2]["author"] == "worker"
+
+        # Verify full task detail with comment history
+        r = test_app.get(f"/api/v2/tasks/{task_id}", headers=AUTH_HEADERS)
+        assert r.status_code == 200, r.text
+        detail = r.json()
+        assert detail["status"] == "completed"
+        assert len(detail["comments"]) == 3
+        # Artifact from first comment should be in artifacts list
+        assert any(a["id"] == draft_v1_id for a in detail["artifacts"])
+
+
+@pytest.mark.e2e
+class TestDependencyChain:
+    """Journey 3: Task dependency chain — blocked_by enforcement."""
+
+    def test_task_dependency_chain(self, test_app: httpx.Client) -> None:
+        # Create mission
+        r = test_app.post(
+            "/api/v2/missions",
+            headers=AUTH_HEADERS,
+            json={"title": "Dependency Chain Test"},
+        )
+        assert r.status_code == 201, r.text
+        mission_id = r.json()["id"]
+
+        # Create task A (no blocked_by)
+        r = test_app.post(
+            "/api/v2/tasks",
+            headers=AUTH_HEADERS,
+            json={
+                "mission_id": mission_id,
+                "instruction": "Step A",
+            },
+        )
+        assert r.status_code == 201, r.text
+        task_a_id = r.json()["id"]
+
+        # Create task B (blocked_by=[A])
+        r = test_app.post(
+            "/api/v2/tasks",
+            headers=AUTH_HEADERS,
+            json={
+                "mission_id": mission_id,
+                "instruction": "Step B",
+                "blocked_by": [task_a_id],
+            },
+        )
+        assert r.status_code == 201, r.text
+        task_b_id = r.json()["id"]
+
+        # Create task C (blocked_by=[B])
+        r = test_app.post(
+            "/api/v2/tasks",
+            headers=AUTH_HEADERS,
+            json={
+                "mission_id": mission_id,
+                "instruction": "Step C",
+                "blocked_by": [task_b_id],
+            },
+        )
+        assert r.status_code == 201, r.text
+        task_c_id = r.json()["id"]
+
+        # Only A is dispatchable
+        r = test_app.get("/api/v2/tasks", headers=AUTH_HEADERS)
+        assert r.status_code == 200, r.text
+        dispatchable = r.json()
+        dispatchable_ids = {t["id"] for t in dispatchable}
+        assert task_a_id in dispatchable_ids
+        assert task_b_id not in dispatchable_ids
+        assert task_c_id not in dispatchable_ids
+
+        # Complete A: created → running → completed
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_a_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "running"},
+        )
+        assert r.status_code == 200, r.text
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_a_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "completed"},
+        )
+        assert r.status_code == 200, r.text
+
+        # Now B is dispatchable, C still blocked
+        r = test_app.get("/api/v2/tasks", headers=AUTH_HEADERS)
+        assert r.status_code == 200, r.text
+        dispatchable = r.json()
+        dispatchable_ids = {t["id"] for t in dispatchable}
+        assert task_b_id in dispatchable_ids
+        assert task_c_id not in dispatchable_ids
+
+        # Complete B
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_b_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "running"},
+        )
+        assert r.status_code == 200, r.text
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_b_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "completed"},
+        )
+        assert r.status_code == 200, r.text
+
+        # Now C is dispatchable
+        r = test_app.get("/api/v2/tasks", headers=AUTH_HEADERS)
+        assert r.status_code == 200, r.text
+        dispatchable = r.json()
+        dispatchable_ids = {t["id"] for t in dispatchable}
+        assert task_c_id in dispatchable_ids
+
+        # Complete C
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_c_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "running"},
+        )
+        assert r.status_code == 200, r.text
+        r = test_app.patch(
+            f"/api/v2/tasks/{task_c_id}",
+            headers=AUTH_HEADERS,
+            json={"status": "completed"},
+        )
+        assert r.status_code == 200, r.text
+
+        # Verify all 3 tasks completed
+        for tid in (task_a_id, task_b_id, task_c_id):
+            r = test_app.get(f"/api/v2/tasks/{tid}", headers=AUTH_HEADERS)
+            assert r.status_code == 200, r.text
+            assert r.json()["status"] == "completed"


### PR DESCRIPTION
## Summary

Comprehensive rewrite of the task-manager brick to align with NexusFS kernel architecture:

- **VFS-native dispatch**: Remove all `curl`/`subprocess` calls from `dispatch_consumer.py`; use `TaskManagerService` (VFS-backed `sys_read`/`sys_write`) directly for all state mutations
- **Unified signal protocol**: Replace custom `TaskCreatedEvent`/`TaskUpdatedEvent` dataclasses with a single `TaskSignalHandler` protocol + signal dicts — matches kernel `FileEvent` philosophy
- **DT_STREAM SSE**: Replace in-process `_TaskEventBroadcaster` with kernel's `DT_STREAM` primitive for true fan-out SSE (non-destructive, offset-based reads)
- **DT_PIPE dispatch**: Task lifecycle signals flow through kernel pipe (`/nexus/pipes/task-dispatch`) using `PipeManager` ring buffer
- **Deployment profile gating**: Gate `TaskWriteHook` registration behind `_brick_on("task_manager")`
- **Injectable LLM**: Add `LLMCallable` type for worker/copilot phases (placeholder until VFS-routed LLM sudorouter lands)
- **Cross-platform pre-commit**: Fix mypy hook to work on both Unix and Windows

Supersedes #3001 (closed).

## Files changed (12)
- `src/nexus/bricks/task_manager/dispatch_consumer.py` — full rewrite
- `src/nexus/bricks/task_manager/events.py` — simplified to protocol
- `src/nexus/bricks/task_manager/write_hook.py` — signal dict approach
- `src/nexus/bricks/task_manager/__init__.py` — updated exports
- `src/nexus/bricks/task_manager/service.py` — mypy fix
- `src/nexus/server/api/v2/routers/task_manager.py` — DT_STREAM SSE
- `src/nexus/server/lifespan/services.py` — DT_STREAM setup
- `src/nexus/factory/orchestrator.py` — brick_on gate + TYPE_CHECKING import
- `src/nexus/factory/_lifecycle.py` — brick_on scoping fix
- `.pre-commit-config.yaml` — cross-platform mypy
- `src/nexus/security/secret_file.py` — platform guard for fchmod
- `src/nexus/server/fastapi_server.py` — mypy return type

## Test plan
- [ ] CI lint (ruff + mypy) passes
- [ ] CI tests pass
- [ ] Manual: task create/update lifecycle via API
- [ ] Manual: SSE endpoint delivers events to multiple clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)