### PR TITLE
feat(#1615,#1611): coordinator-routed service registration + EventsService Q2

### DIFF
--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -93,7 +93,20 @@ def _do_link(
         nx._brick_services,
         _brick_on,
     )
-    populate_service_registry(nx._service_registry, _wired)
+
+    # Issue #1615: Create coordinator early so wired services are registered
+    # in both ServiceRegistry and BLM in one shot.
+    _blm = getattr(nx._system_services, "brick_lifecycle_manager", None)
+    if _blm is not None:
+        from nexus.system_services.lifecycle.service_lifecycle_coordinator import (
+            ServiceLifecycleCoordinator,
+        )
+
+        coordinator = ServiceLifecycleCoordinator(nx._service_registry, _blm, nx._dispatch)
+        nx._service_coordinator = coordinator
+        populate_service_registry(coordinator, _wired)
+    else:
+        populate_service_registry(nx._service_registry, _wired)
 
     # Kernel DI: _descendant_checker is a kernel component (like Linux LSM hook),
     # not an external service — inject directly onto the kernel instance.
@@ -143,16 +156,11 @@ def _do_initialize(nx: Any) -> None:
         _cache_brick = getattr(nx._brick_services, "cache_brick", None)
         _register_late_bricks(_blm, {"cache": _cache_brick})
 
-    # --- ServiceLifecycleCoordinator (Issue #1452 Phase 3) ---
-    if _blm is not None:
-        from nexus.system_services.lifecycle.service_lifecycle_coordinator import (
-            ServiceLifecycleCoordinator,
-        )
-
-        coordinator = ServiceLifecycleCoordinator(nx._service_registry, _blm, nx._dispatch)
-        nx._service_coordinator = coordinator
-
-        # Build retroactive HookSpecs for hooks registered above
+    # --- Retroactive HookSpec capture (Issue #1452 Phase 3, #1615) ---
+    # Coordinator was created in _do_link() (Phase 1).  Reuse it here to
+    # bind retroactive hook specs for VFS hooks registered above.
+    coordinator = getattr(nx, "_service_coordinator", None)
+    if coordinator is not None:
         from nexus.factory.orchestrator import _build_retroactive_hook_specs
 
         _build_retroactive_hook_specs(coordinator, _hook_refs)

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -412,14 +412,13 @@ def _register_vfs_hooks(
     if permission_checker is not None:
         from nexus.bricks.rebac.permission_hook import PermissionCheckHook
 
-        _dc_info = _raw_svc("descendant_checker")
         _perm_hook = PermissionCheckHook(
             checker=permission_checker,
             metadata_store=nx.metadata,
             default_context=nx._default_context,
             enforce_permissions=nx._enforce_permissions,
             permission_enforcer=nx._permission_enforcer,
-            descendant_checker=_dc_info.instance if _dc_info else None,
+            descendant_checker=getattr(nx, "_descendant_checker", None),
         )
         dispatch.register_intercept_read(_perm_hook)
         dispatch.register_intercept_write(_perm_hook)
@@ -545,15 +544,9 @@ def _register_vfs_hooks(
     dispatch.register_observe(_bus_observer)
     hook_refs["bus_observer"] = _bus_observer
 
-    # EventsService observer: receives FileEvents for wait_for_changes() internal path.
-    # Registered as VFSObserver so dispatch.notify() delivers events directly.
-    # Use raw instance (not ServiceRef) so identity-based unregister works.
-    _events_info = _raw_svc("events")
-    _events_instance = _events_info.instance if _events_info else None
-    if _events_instance is not None:
-        dispatch.register_observe(_events_instance)
-        _events_instance._observe_registered = True
-    hook_refs["events_observer"] = _events_instance
+    # EventsService observer: now self-registered via HotSwappable.hook_spec()
+    # at bootstrap() → activate_hot_swappable_services() (Issue #1611).
+    # Removed from factory — EventsService owns its own observer hook.
 
     # RevisionTrackingObserver: feeds RevisionNotifier on versioned mutations.
     # Replaces the old kernel-internal _increment_vfs_revision() (Issue #1382).
@@ -588,10 +581,7 @@ def _build_retroactive_hook_specs(coordinator: Any, hook_refs: dict[str, Any]) -
     """
     from nexus.contracts.protocols.service_hooks import HookSpec
 
-    # events service → observer
-    _events_obs = hook_refs.get("events_observer")
-    if _events_obs is not None:
-        coordinator.set_hook_spec("events", HookSpec(observers=(_events_obs,)))
+    # events service → now owns its hook via HotSwappable.hook_spec() (Issue #1611)
 
     # permission → 6 dispatch channels
     _perm = hook_refs.get("perm_hook")

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -3,6 +3,12 @@
 Issue #1502: ``bind_wired_services()`` and the setattr wiring path have been
 deleted.  All service access now goes through ``nx.service("name")``.
 The sole registration path is ``populate_service_registry()``.
+
+Issue #1615: ``populate_service_registry()`` accepts either a raw
+``ServiceRegistry`` or a ``ServiceLifecycleCoordinator`` — both expose
+``register_service(name, instance, *, exports, is_remote)``.  When a
+coordinator is provided, services are registered in both the Registry
+and BrickLifecycleManager in one shot.
 """
 
 from __future__ import annotations
@@ -12,6 +18,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from nexus.core.config import WiredServices
     from nexus.core.service_registry import ServiceRegistry
+    from nexus.system_services.lifecycle.service_lifecycle_coordinator import (
+        ServiceLifecycleCoordinator,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -68,15 +77,17 @@ _CANONICAL_NAMES: dict[str, str] = {
 
 
 def populate_service_registry(
-    registry: "ServiceRegistry",
+    registrar: "ServiceRegistry | ServiceLifecycleCoordinator",
     wired: "WiredServices | dict[str, Any]",
     *,
     is_remote: bool = False,
 ) -> int:
-    """Dual-write companion — populate ServiceRegistry from WiredServices.
+    """Populate ServiceRegistry (or coordinator) from WiredServices.
 
-    Sole registration path — extracts non-None service instances and registers
-    them under canonical short names (e.g. ``"search"`` instead of ``"search_service"``).
+    Accepts either a raw ``ServiceRegistry`` or a ``ServiceLifecycleCoordinator``.
+    Both duck-type on ``register_service(name, instance, *, exports, is_remote)``.
+    When a coordinator is provided, services are registered in both the
+    ServiceRegistry and BrickLifecycleManager in one shot (Issue #1615).
 
     Returns the number of services registered.
     """
@@ -86,7 +97,7 @@ def populate_service_registry(
         if val is None:
             continue
         exports = _CANONICAL_EXPORTS.get(canonical, ())
-        registry.register_service(
+        registrar.register_service(
             canonical,
             val,
             exports=exports,

--- a/src/nexus/system_services/lifecycle/events_service.py
+++ b/src/nexus/system_services/lifecycle/events_service.py
@@ -30,6 +30,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.protocols.service_hooks import HookSpec
 from nexus.core.path_utils import validate_path
 from nexus.lib.rpc_decorator import rpc_expose
 
@@ -82,6 +83,22 @@ class EventsService:
         self._observe_registered = False
 
         logger.info("[EventsService] Initialized")
+
+    # =========================================================================
+    # HotSwappable protocol (Q2 — Issue #1611)
+    # =========================================================================
+
+    def hook_spec(self) -> HookSpec:
+        """Declare VFS hooks: EventsService registers itself as an OBSERVE observer."""
+        return HookSpec(observers=(self,))
+
+    async def drain(self) -> None:
+        """Stop accepting new waiter registrations."""
+        self._observe_registered = False
+
+    async def activate(self) -> None:
+        """Resume accepting waiter registrations."""
+        self._observe_registered = True
 
     # =========================================================================
     # Infrastructure Detection

--- a/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
+++ b/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
@@ -77,6 +77,7 @@ class ServiceLifecycleCoordinator:
         *,
         dependencies: tuple[str, ...] = (),
         exports: tuple[str, ...] = (),
+        is_remote: bool = False,
         hook_spec: HookSpec | None = None,
         depends_on: tuple[str, ...] = (),
         protocol_name: str = "",
@@ -87,6 +88,7 @@ class ServiceLifecycleCoordinator:
             instance,
             dependencies=dependencies,
             exports=exports,
+            is_remote=is_remote,
         )
         self._blm.register(
             name,

--- a/tests/unit/core/test_stream.py
+++ b/tests/unit/core/test_stream.py
@@ -12,6 +12,18 @@ from nexus.core.stream import (
     StreamFullError,
 )
 
+try:
+    from nexus_fast import StreamBufferCore  # noqa: F401
+
+    _HAS_STREAM_CORE = True
+except ImportError:
+    _HAS_STREAM_CORE = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_STREAM_CORE,
+    reason="nexus_fast.StreamBufferCore not built — rebuild Rust extension",
+)
+
 # ---------------------------------------------------------------------------
 # StreamBuffer (kstream) — basic operations
 # ---------------------------------------------------------------------------

--- a/tests/unit/factory/test_retroactive_hook_specs.py
+++ b/tests/unit/factory/test_retroactive_hook_specs.py
@@ -1,7 +1,9 @@
 """Unit tests for _build_retroactive_hook_specs() (Issue #1452 Phase 4).
 
-Verifies that all 11 hook groups from _register_vfs_hooks() are captured
-as HookSpecs so swap_service() can cleanly unregister them during hot-swap.
+Verifies that all retroactive hook groups from _register_vfs_hooks() are
+captured as HookSpecs so swap_service() can cleanly unregister them during
+hot-swap.  Services that implement HotSwappable.hook_spec() (e.g. EventsService)
+are NOT in this table — they self-register at bootstrap time.
 """
 
 from __future__ import annotations
@@ -25,9 +27,12 @@ class _FakeCoordinator:
 
 
 def _full_hook_refs() -> dict[str, object]:
-    """Return hook_refs dict with all 10 hook objects present."""
+    """Return hook_refs dict with all retroactive hook objects present.
+
+    EventsService is excluded — it implements HotSwappable.hook_spec()
+    and self-registers at bootstrap time (Issue #1611).
+    """
     return {
-        "events_observer": sentinel.events_obs,
         "perm_hook": sentinel.perm_hook,
         "audit": sentinel.audit,
         "viewer_hook": sentinel.viewer_hook,
@@ -47,12 +52,11 @@ def _full_hook_refs() -> dict[str, object]:
 
 class TestBuildRetroactiveHookSpecs:
     def test_all_hooks_captured(self) -> None:
-        """Full boot — all 10 hook groups result in specs."""
+        """Full boot — all retroactive hook groups result in specs."""
         coord = _FakeCoordinator()
         _build_retroactive_hook_specs(coord, _full_hook_refs())
 
         expected_names = {
-            "events",
             "permission",
             "audit",
             "viewer",
@@ -65,14 +69,14 @@ class TestBuildRetroactiveHookSpecs:
         assert set(coord.specs.keys()) == expected_names
 
     def test_partial_hooks_captured(self) -> None:
-        """Minimal boot — only events provided."""
+        """Minimal boot — only bus_observer provided."""
         coord = _FakeCoordinator()
         hook_refs = dict.fromkeys(_full_hook_refs())
-        hook_refs["events_observer"] = sentinel.events_obs
+        hook_refs["bus_observer"] = sentinel.bus_observer
 
         _build_retroactive_hook_specs(coord, hook_refs)
 
-        assert set(coord.specs.keys()) == {"events"}
+        assert set(coord.specs.keys()) == {"event_bus"}
 
     def test_none_hooks_skipped(self) -> None:
         """All None — no specs set at all."""
@@ -194,7 +198,6 @@ class TestSingleChannelHookSpecs:
             ("vview_resolver", "virtual_view", "resolvers"),
             ("bus_observer", "event_bus", "observers"),
             ("rev_observer", "revision_tracking", "observers"),
-            ("events_observer", "events", "observers"),
         ],
     )
     def test_single_channel(self, ref_key: str, spec_name: str, field: str) -> None:

--- a/tests/unit/services/test_events_service.py
+++ b/tests/unit/services/test_events_service.py
@@ -88,6 +88,44 @@ class TestEventsServiceInit:
 
 
 # =============================================================================
+# HotSwappable protocol (Q2 — Issue #1611)
+# =============================================================================
+
+
+class TestHotSwappableProtocol:
+    """EventsService satisfies HotSwappable protocol."""
+
+    def test_isinstance_hot_swappable(self):
+        """isinstance check passes — coordinator auto-detects Q2."""
+        from nexus.contracts.protocols.service_lifecycle import HotSwappable
+
+        svc = EventsService()
+        assert isinstance(svc, HotSwappable)
+
+    def test_hook_spec_returns_observer(self):
+        """hook_spec() declares self as the sole observer."""
+        svc = EventsService()
+        spec = svc.hook_spec()
+        assert spec.observers == (svc,)
+        assert spec.total_hooks == 1
+
+    @pytest.mark.asyncio
+    async def test_drain_disables_observe(self):
+        """drain() sets _observe_registered = False."""
+        svc = EventsService()
+        svc._observe_registered = True
+        await svc.drain()
+        assert svc._observe_registered is False
+
+    @pytest.mark.asyncio
+    async def test_activate_enables_observe(self):
+        """activate() sets _observe_registered = True."""
+        svc = EventsService()
+        await svc.activate()
+        assert svc._observe_registered is True
+
+
+# =============================================================================
 # Infrastructure detection
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- **Wave 3 (#1615)**: `populate_service_registry()` now routes through `ServiceLifecycleCoordinator` when available, registering wired services in both ServiceRegistry and BLM in one shot. Coordinator created early in Phase 1 (`_do_link`) instead of Phase 2.
- **Wave 4 (#1611)**: EventsService implements `HotSwappable` protocol (Q2) — first service to own its VFS hooks via `hook_spec()`. Factory no longer manually registers the events observer; hooks self-register at bootstrap via `activate_hot_swappable_services()`.
- Fix: `descendant_checker` lookup in orchestrator uses kernel DI (`nx._descendant_checker`) instead of dead registry entry.
- Fix: Stream tests properly skipped when Rust extension not built.

## Test plan
- [x] 100 coordinator + events + retroactive tests pass
- [x] 10369 unit tests pass (2 known pre-existing failures excluded)
- [x] All pre-commit hooks pass (ruff, mypy, brick zero-core-imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)