### PR TITLE
chore: add .mailmap to unify contributor identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+# Canonical author mappings — merges contributor identities
+# Format: Canonical Name <canonical@email> Name-in-commit <email-in-commit>
+
+# Ethan Song (elfenlieds7 / songym)
+Ethan Song <elfenliedsp@gmail.com> elfenlieds7 <elfenliedsp@gmail.com>
+Ethan Song <elfenliedsp@gmail.com> elfenlieds7 <songym@sudoprivacy.com>
+Ethan Song <elfenliedsp@gmail.com> songym <songym@sudoprivacy.com>
+Ethan Song <elfenliedsp@gmail.com> songym <songym@users.noreply.github.com>
+Ethan Song <elfenliedsp@gmail.com> Ethan Song <songym@sudoprivacy.com>
+Ethan Song <elfenliedsp@gmail.com> Ethan Song <songym@EthandeMacBook-Pro.local>


### PR DESCRIPTION
## Summary
- Adds `.mailmap` to merge elfenlieds7/songym/Ethan Song contributor variants into a single canonical identity (`Ethan Song <elfenliedsp@gmail.com>`)
- GitHub Contributors page will show one unified profile instead of multiple

## Test plan
- [x] `git log --format='%aN <%aE>' | sort -u` confirms all variants map to one identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)