### PR TITLE
feat(#1590): async blocking reads for DT_PIPE and DT_STREAM

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1326,15 +1326,15 @@ class NexusFS(  # type: ignore[misc]
         zone_id, agent_id, is_admin = self._get_routing_params(context)
         route = self.router.route(path, is_admin=is_admin, check_write=False)
 
-        # DT_PIPE / DT_STREAM bypass
+        # DT_PIPE / DT_STREAM bypass (sync — range reads not applicable)
         from nexus.core.router import PipeRouteResult, StreamRouteResult
 
         if isinstance(route, PipeRouteResult | StreamRouteResult):
-            # Not applicable for range reads; return sentinel
+            # Range reads not applicable; use sync non-blocking path
             if isinstance(route, PipeRouteResult):
-                content = self._pipe_read(path, count=None, offset=0)
+                content = self._pipe_manager._get_buffer(path).read_nowait()
             else:
-                content = self._stream_read(path, count=None, offset=0)
+                content, _ = self._stream_manager.stream_read_at(path, 0)
             return (content, None, route, zone_id, agent_id)
 
         from dataclasses import replace
@@ -1479,9 +1479,9 @@ class NexusFS(  # type: ignore[misc]
         from nexus.core.router import PipeRouteResult, StreamRouteResult
 
         if isinstance(route, PipeRouteResult):
-            return self._pipe_read(path, count=count, offset=offset)
+            return await self._pipe_read(path, count=count, offset=offset)
         if isinstance(route, StreamRouteResult):
-            return self._stream_read(path, count=count, offset=offset)
+            return await self._stream_read(path, count=count, offset=offset)
 
         # Add backend_path to context for path-based connectors
         from dataclasses import replace
@@ -4442,9 +4442,9 @@ class NexusFS(  # type: ignore[misc]
             return None  # origin is self → local
         return addr.origin
 
-    def _pipe_read(self, path: str, *, count: int | None = None, offset: int = 0) -> bytes:
-        """Read from DT_PIPE — non-blocking, raises PipeEmptyError if empty."""
-        from nexus.core.pipe import PipeClosedError, PipeEmptyError, PipeNotFoundError
+    async def _pipe_read(self, path: str, *, count: int | None = None, offset: int = 0) -> bytes:
+        """Read from DT_PIPE — async blocking, waits until data is available."""
+        from nexus.core.pipe import PipeClosedError, PipeNotFoundError
 
         if self._pipe_manager is None:
             raise NexusFileNotFoundError(path, "PipeManager not available")
@@ -4455,16 +4455,9 @@ class NexusFS(  # type: ignore[misc]
             return self._pipe_read_remote(remote_origin, path, count=count, offset=offset)
 
         try:
-            buf = self._pipe_manager._get_buffer(path)
+            data = await self._pipe_manager.pipe_read(path, blocking=True)
         except PipeNotFoundError:
-            try:
-                buf = self._pipe_manager.open(path)
-            except PipeNotFoundError:
-                raise NexusFileNotFoundError(path, f"Pipe not found: {path}") from None
-        try:
-            data = buf.read_nowait()
-        except PipeEmptyError:
-            raise PipeEmptyError(f"pipe empty: {path}") from None
+            raise NexusFileNotFoundError(path, f"Pipe not found: {path}") from None
         except PipeClosedError:
             raise NexusFileNotFoundError(path, f"Pipe closed: {path}") from None
         if offset or count is not None:
@@ -4630,25 +4623,23 @@ class NexusFS(  # type: ignore[misc]
             return None
         return addr.origin
 
-    def _stream_read(self, path: str, *, count: int | None = None, offset: int = 0) -> bytes:
-        """Read from DT_STREAM — non-destructive, offset-based."""
-        from nexus.core.stream import StreamClosedError, StreamEmptyError, StreamNotFoundError
+    async def _stream_read(self, path: str, *, count: int | None = None, offset: int = 0) -> bytes:
+        """Read from DT_STREAM — async blocking, waits until data at offset is available."""
+        from nexus.core.stream import StreamClosedError, StreamNotFoundError
 
         # TODO: remote proxy (like _pipe_read_remote) when federation is wired
         try:
             if count is not None and count > 1:
-                items, _ = self._stream_manager.stream_read_batch(path, offset, count)
+                items, _ = await self._stream_manager.stream_read_batch_blocking(
+                    path, offset, count, blocking=True
+                )
                 return b"".join(items)
-            data, _ = self._stream_manager.stream_read_at(path, offset)
+            data, _ = await self._stream_manager.stream_read(path, offset, blocking=True)
             return data
         except StreamNotFoundError:
             raise NexusFileNotFoundError(path, f"Stream not found: {path}") from None
         except StreamClosedError:
             raise NexusFileNotFoundError(path, f"Stream closed: {path}") from None
-        except StreamEmptyError:
-            from nexus.core.stream import StreamEmptyError as _SE
-
-            raise _SE(f"stream empty at offset {offset}: {path}") from None
 
     def _stream_write(self, path: str, data: bytes) -> int:
         """Write to DT_STREAM — non-blocking append, returns byte offset."""

--- a/src/nexus/core/stream.py
+++ b/src/nexus/core/stream.py
@@ -72,7 +72,7 @@ class StreamBuffer:
     Python provides asyncio.Event coordination for blocked writers.
     """
 
-    __slots__ = ("_core", "_not_full")
+    __slots__ = ("_core", "_not_empty", "_not_full")
 
     def __init__(self, capacity: int = 65_536) -> None:
         if StreamBufferCore is None:
@@ -83,6 +83,8 @@ class StreamBuffer:
         if capacity <= 0:
             raise ValueError(f"capacity must be > 0, got {capacity}")
         self._core = StreamBufferCore(capacity)
+        self._not_empty = asyncio.Event()
+        # _not_empty starts unset — no data yet
         self._not_full = asyncio.Event()
         self._not_full.set()  # initially not full
 
@@ -97,12 +99,15 @@ class StreamBuffer:
             ValueError: Message larger than total capacity.
         """
         try:
-            return int(self._core.push(data))
+            offset = int(self._core.push(data))
         except RuntimeError as exc:
             _translate_rust_error(exc)
             raise
         except ValueError:
             raise
+        # Wake blocked readers — new data is available
+        self._not_empty.set()
+        return offset
 
     async def write(self, data: bytes, *, blocking: bool = True) -> int:
         """Async append. If blocking=True, waits for close (only way to unblock)."""
@@ -151,11 +156,68 @@ class StreamBuffer:
             _translate_rust_error(exc)
             raise
 
+    # -- async blocking reads -----------------------------------------------
+
+    async def read(self, byte_offset: int = 0, *, blocking: bool = True) -> tuple[bytes, int]:
+        """Async read one message at byte_offset. Blocks until data is available.
+
+        If blocking=True and no data at offset, waits for a push() or close().
+        Non-destructive — same offset can be re-read.
+
+        Returns (data, next_offset).
+
+        Raises:
+            StreamEmptyError: Non-blocking and no data at offset.
+            StreamClosedError: Stream closed and no data at offset.
+        """
+        while True:
+            try:
+                return self.read_at(byte_offset)
+            except StreamEmptyError:
+                if not blocking:
+                    raise
+                if self._core.closed:
+                    raise StreamClosedError(
+                        f"stream closed, no data at offset {byte_offset}"
+                    ) from None
+                self._not_empty.clear()
+                # Re-check before sleeping (avoid lost-wakeup race)
+                try:
+                    return self.read_at(byte_offset)
+                except StreamEmptyError:
+                    pass
+                await self._not_empty.wait()
+
+    async def read_batch_blocking(
+        self, byte_offset: int = 0, count: int = 10, *, blocking: bool = True
+    ) -> tuple[list[bytes], int]:
+        """Async read up to `count` messages. Blocks until at least one available.
+
+        Returns (list_of_bytes, next_offset).
+        """
+        while True:
+            try:
+                return self.read_batch(byte_offset, count)
+            except StreamEmptyError:
+                if not blocking:
+                    raise
+                if self._core.closed:
+                    raise StreamClosedError(
+                        f"stream closed, no data at offset {byte_offset}"
+                    ) from None
+                self._not_empty.clear()
+                try:
+                    return self.read_batch(byte_offset, count)
+                except StreamEmptyError:
+                    pass
+                await self._not_empty.wait()
+
     # -- lifecycle -----------------------------------------------------------
 
     def close(self) -> None:
-        """Close the buffer. Wakes blocked writers."""
+        """Close the buffer. Wakes blocked readers and writers."""
         self._core.close()
+        self._not_empty.set()  # wake blocked readers (so they see closed)
         self._not_full.set()  # wake blocked writers (so they see closed)
 
     @property

--- a/src/nexus/core/stream_manager.py
+++ b/src/nexus/core/stream_manager.py
@@ -253,6 +253,16 @@ class StreamManager:
         """
         return self._get_buffer(path).read_at(byte_offset)
 
+    async def stream_read(
+        self, path: str, byte_offset: int = 0, *, blocking: bool = True
+    ) -> tuple[bytes, int]:
+        """Async read one message. Blocks until data at offset is available.
+
+        No lock needed — reads are non-destructive and lock-free.
+        Returns (data, next_offset).
+        """
+        return await self._get_buffer(path).read(byte_offset, blocking=blocking)
+
     def stream_read_batch(
         self, path: str, byte_offset: int = 0, count: int = 10
     ) -> tuple[list[bytes], int]:
@@ -261,6 +271,17 @@ class StreamManager:
         Returns (list_of_bytes, next_offset).
         """
         return self._get_buffer(path).read_batch(byte_offset, count)
+
+    async def stream_read_batch_blocking(
+        self, path: str, byte_offset: int = 0, count: int = 10, *, blocking: bool = True
+    ) -> tuple[list[bytes], int]:
+        """Async read up to `count` messages. Blocks until at least one available.
+
+        Returns (list_of_bytes, next_offset).
+        """
+        return await self._get_buffer(path).read_batch_blocking(
+            byte_offset, count, blocking=blocking
+        )
 
     # ------------------------------------------------------------------
     # Observability

--- a/tests/unit/core/test_stream.py
+++ b/tests/unit/core/test_stream.py
@@ -349,3 +349,168 @@ class TestStreamManagerFederation:
 
         meta = store["/s/test"]
         assert meta.backend_name == "stream@node1:5050"
+
+
+# ---------------------------------------------------------------------------
+# StreamBuffer — async blocking reads
+# ---------------------------------------------------------------------------
+
+
+class TestStreamBufferBlockingRead:
+    """Async blocking read waits for data, unblocks on push or close."""
+
+    async def test_blocking_read_with_existing_data(self):
+        """Blocking read returns immediately when data exists."""
+        buf = StreamBuffer(capacity=1024)
+        buf.write_nowait(b"hello")
+        data, next_off = await buf.read(0, blocking=True)
+        assert data == b"hello"
+        assert next_off > 0
+
+    async def test_blocking_read_waits_for_push(self):
+        """Blocking read blocks until producer pushes data."""
+        import asyncio
+
+        buf = StreamBuffer(capacity=1024)
+        results = []
+
+        async def consumer():
+            data, _ = await buf.read(0, blocking=True)
+            results.append(data)
+
+        async def producer():
+            await asyncio.sleep(0.01)
+            buf.write_nowait(b"delayed")
+
+        await asyncio.gather(consumer(), producer())
+        assert results == [b"delayed"]
+
+    async def test_blocking_read_unblocks_on_close(self):
+        """Blocking read raises StreamClosedError when buffer is closed."""
+        import asyncio
+
+        buf = StreamBuffer(capacity=1024)
+
+        async def consumer():
+            with pytest.raises(StreamClosedError):
+                await buf.read(0, blocking=True)
+
+        async def closer():
+            await asyncio.sleep(0.01)
+            buf.close()
+
+        await asyncio.gather(consumer(), closer())
+
+    async def test_non_blocking_read_raises_empty(self):
+        """Non-blocking read raises StreamEmptyError immediately."""
+        buf = StreamBuffer(capacity=1024)
+        with pytest.raises(StreamEmptyError):
+            await buf.read(0, blocking=False)
+
+    async def test_blocking_batch_waits_for_push(self):
+        """Blocking batch read waits until data is available."""
+        import asyncio
+
+        buf = StreamBuffer(capacity=1024)
+        results = []
+
+        async def consumer():
+            items, _ = await buf.read_batch_blocking(0, count=5, blocking=True)
+            results.extend(items)
+
+        async def producer():
+            await asyncio.sleep(0.01)
+            buf.write_nowait(b"a")
+            buf.write_nowait(b"b")
+
+        await asyncio.gather(consumer(), producer())
+        assert len(results) >= 1  # at least one message
+
+    async def test_multi_reader_blocking(self):
+        """Multiple async readers unblock independently."""
+        import asyncio
+
+        buf = StreamBuffer(capacity=1024)
+        r1_result = []
+        r2_result = []
+
+        async def reader1():
+            data, _ = await buf.read(0, blocking=True)
+            r1_result.append(data)
+
+        async def reader2():
+            data, _ = await buf.read(0, blocking=True)
+            r2_result.append(data)
+
+        async def producer():
+            await asyncio.sleep(0.01)
+            buf.write_nowait(b"shared")
+
+        await asyncio.gather(reader1(), reader2(), producer())
+        # Both readers see same data (non-destructive)
+        assert r1_result == [b"shared"]
+        assert r2_result == [b"shared"]
+
+
+# ---------------------------------------------------------------------------
+# StreamManager — async blocking reads
+# ---------------------------------------------------------------------------
+
+
+class TestStreamManagerBlockingRead:
+    """StreamManager async blocking read API."""
+
+    @pytest.fixture()
+    def manager(self):
+        from unittest.mock import MagicMock
+
+        from nexus.contracts.metadata import FileMetadata
+
+        store: dict[str, FileMetadata] = {}
+        mock = MagicMock()
+        mock.get = lambda p: store.get(p)
+        mock.put = lambda m: store.__setitem__(m.path, m)
+        mock.delete = lambda p: store.pop(p, None)
+
+        from nexus.core.stream_manager import StreamManager
+
+        return StreamManager(mock, zone_id="root")
+
+    async def test_stream_read_blocking(self, manager):
+        """stream_read() blocks until data arrives."""
+        import asyncio
+
+        manager.create("/s/test", capacity=1024)
+        results = []
+
+        async def consumer():
+            data, _ = await manager.stream_read("/s/test", 0, blocking=True)
+            results.append(data)
+
+        async def producer():
+            await asyncio.sleep(0.01)
+            manager.stream_write_nowait("/s/test", b"token1")
+
+        await asyncio.gather(consumer(), producer())
+        assert results == [b"token1"]
+
+    async def test_stream_read_batch_blocking(self, manager):
+        """stream_read_batch_blocking() blocks until data arrives."""
+        import asyncio
+
+        manager.create("/s/test", capacity=1024)
+        results = []
+
+        async def consumer():
+            items, _ = await manager.stream_read_batch_blocking(
+                "/s/test", 0, count=10, blocking=True
+            )
+            results.extend(items)
+
+        async def producer():
+            await asyncio.sleep(0.01)
+            manager.stream_write_nowait("/s/test", b"a")
+            manager.stream_write_nowait("/s/test", b"b")
+
+        await asyncio.gather(consumer(), producer())
+        assert len(results) >= 1


### PR DESCRIPTION
## Summary
- Add `asyncio.Event` (`_not_empty`) to `StreamBuffer` for async blocking reads — consumers `await buf.read(offset, blocking=True)` instead of polling with `sleep(0.01)`
- Add `stream_read()` and `stream_read_batch_blocking()` async methods to `StreamManager`
- Wire `sys_read` dispatch through async `pipe_read(blocking=True)` and `stream_read(blocking=True)` — data arrives via event wakeup, not sync poll

## Test plan
- [x] 8 new async blocking read tests in `test_stream.py` (buffer + manager level)
- [x] All 36 stream tests pass
- [x] All 103 nexus_fs core tests pass
- [x] Lint clean (ruff + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)