### PR TITLE
feat(#1610,#1612,#1613,#1616): HotSwappable for all 10 VFS hooks + delete _build_retroactive_hook_specs

### DIFF
--- a/src/nexus/bricks/parsers/auto_parse_hook.py
+++ b/src/nexus/bricks/parsers/auto_parse_hook.py
@@ -3,12 +3,17 @@
 Issue #625: Lives in parsers/ (service-layer, not kernel).
 """
 
+from __future__ import annotations
+
 import logging
 import threading
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.vfs_hooks import WriteHookContext
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +29,19 @@ class AutoParseWriteHook:
       - parse_fn:    (content: bytes, path: str) -> bytes | None
       - metadata:    MetastoreABC (optional, for cache invalidation)
     """
+
+    # ── HotSwappable protocol (Issue #1612) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(write_hooks=(self,))
+
+    async def drain(self) -> None:
+        self.shutdown()
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(
         self,

--- a/src/nexus/bricks/parsers/virtual_view_resolver.py
+++ b/src/nexus/bricks/parsers/virtual_view_resolver.py
@@ -13,11 +13,14 @@ the original file from the underlying filesystem and returns a parsed
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.contracts.types import Permission
 from nexus.contracts.vfs_hooks import VFSPathResolver
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +49,19 @@ class VirtualViewResolver(VFSPathResolver):
         "_parse_fn",
         "_read_tracker_fn",
     )
+
+    # ── HotSwappable protocol (Issue #1612) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(resolvers=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(
         self,

--- a/src/nexus/bricks/rebac/cache/tiger/rename_hook.py
+++ b/src/nexus/bricks/rebac/cache/tiger/rename_hook.py
@@ -3,12 +3,17 @@
 Issue #625: Lives in bricks/rebac/cache/tiger/ (service-layer, not kernel).
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.vfs_hooks import RenameHookContext
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +25,19 @@ class TigerCacheRenameHook:
       - tiger_cache:   The TigerCache instance (may be None)
       - metadata_list: (prefix, recursive, zone_id) -> Iterator[FileMetadata]
     """
+
+    # ── HotSwappable protocol (Issue #1610) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(rename_hooks=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(
         self,

--- a/src/nexus/bricks/rebac/cache/tiger/write_hook.py
+++ b/src/nexus/bricks/rebac/cache/tiger/write_hook.py
@@ -12,11 +12,16 @@ Same architectural pattern as TigerCacheRenameHook:
 Issue #2133: Leopard-style directory grants.
 """
 
+from __future__ import annotations
+
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.vfs_hooks import WriteHookContext
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +32,19 @@ class TigerCacheWriteHook:
     Dependencies injected at construction:
       - tiger_cache: The TigerCache instance (bitmap_cache)
     """
+
+    # ── HotSwappable protocol (Issue #1610) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(write_hooks=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(self, tiger_cache: Any) -> None:
         self._tiger_cache = tiger_cache

--- a/src/nexus/bricks/rebac/dynamic_viewer_hook.py
+++ b/src/nexus/bricks/rebac/dynamic_viewer_hook.py
@@ -3,11 +3,16 @@
 Issue #625: ReBAC brick hook for dynamic viewer grants.
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.vfs_hooks import ReadHookContext
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +27,19 @@ class DynamicViewerReadHook:
       - get_viewer_config:      (subject, file_path) -> dict | None
       - apply_filter:           (data, column_config, file_format) -> dict
     """
+
+    # ── HotSwappable protocol (Issue #1610) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(read_hooks=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(
         self,

--- a/src/nexus/bricks/rebac/permission_hook.py
+++ b/src/nexus/bricks/rebac/permission_hook.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.contracts.types import Permission
 
 if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.contracts.vfs_hooks import (
         DeleteHookContext,
         MkdirHookContext,
@@ -44,6 +45,26 @@ class PermissionCheckHook:
     """
 
     name = "permission_check"
+
+    # ── HotSwappable protocol (Issue #1610) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(
+            read_hooks=(self,),
+            write_hooks=(self,),
+            delete_hooks=(self,),
+            rename_hooks=(self,),
+            mkdir_hooks=(self,),
+            rmdir_hooks=(self,),
+        )
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(
         self,

--- a/src/nexus/bricks/task_manager/write_hook.py
+++ b/src/nexus/bricks/task_manager/write_hook.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from nexus.bricks.task_manager.events import TaskSignalHandler
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.contracts.vfs_hooks import WriteHookContext
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,19 @@ class TaskWriteHook:
     to registered :class:`TaskSignalHandler` implementations.  No in-memory
     cache — all state comes from the written content and ``ctx.is_new_file``.
     """
+
+    # ── HotSwappable protocol (Issue #1616) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(write_hooks=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(self) -> None:
         self._handlers: list[TaskSignalHandler] = []

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -143,9 +143,13 @@ def _do_initialize(nx: Any) -> None:
     _initialize_wired_ipc(nx, nx._brick_services)
 
     # --- Register VFS hooks (INTERCEPT + OBSERVE — Issue #900) ---
+    # Issue #1610/#1612/#1613/#1616: All hooks now implement HotSwappable.
+    # When coordinator exists, hooks are registered as services here and
+    # dispatch-registered at bootstrap via activate_hot_swappable_services().
+    # _build_retroactive_hook_specs() has been deleted — hooks self-describe.
     from nexus.factory.orchestrator import _register_vfs_hooks
 
-    _hook_refs = _register_vfs_hooks(
+    _register_vfs_hooks(
         nx,
         permission_checker=nx._permission_checker,
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
@@ -159,15 +163,6 @@ def _do_initialize(nx: Any) -> None:
 
         _cache_brick = getattr(nx._brick_services, "cache_brick", None)
         _register_late_bricks(_blm, {"cache": _cache_brick})
-
-    # --- Retroactive HookSpec capture (Issue #1452 Phase 3, #1615) ---
-    # Coordinator was created in _do_link() (Phase 1).  Reuse it here to
-    # bind retroactive hook specs for VFS hooks registered above.
-    coordinator = getattr(nx, "_service_coordinator", None)
-    if coordinator is not None:
-        from nexus.factory.orchestrator import _build_retroactive_hook_specs
-
-        _build_retroactive_hook_specs(coordinator, _hook_refs)
 
     # --- Register background services as bootstrap callbacks ---
     # TL directive: initialize() prepares resources but stays static.

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -394,7 +394,7 @@ def _register_vfs_hooks(
     permission_checker: Any = None,
     auto_parse: bool = True,
     brick_on: "Callable[[str], bool] | None" = None,
-) -> dict[str, Any]:
+) -> None:
     """Register hooks + observers into kernel-owned dispatch (Issue #900).
 
     Kernel creates KernelDispatch with empty callback lists at init.
@@ -404,8 +404,12 @@ def _register_vfs_hooks(
     Called by ``create_nexus_fs()`` after NexusFS construction + wired
     services binding, keeping the kernel free of service-layer imports.
 
-    Returns a dict of named hook references for retroactive HookSpec
-    construction (Issue #1452 Phase 3).
+    Issue #1610/#1612/#1613/#1616: All hook classes now implement
+    HotSwappable — they self-describe via ``hook_spec()``.  When a
+    ServiceLifecycleCoordinator is available, hooks are registered as
+    services and dispatch-registered at bootstrap via
+    ``activate_hot_swappable_services()``.  Without coordinator,
+    hooks are registered directly on dispatch (backward compat).
     """
     dispatch = nx._dispatch
 
@@ -413,14 +417,48 @@ def _register_vfs_hooks(
 
     _on = _make_gate(brick_on)
 
-    # Hook references for retroactive HookSpec (Issue #1452 Phase 3).
-    # Factory code uses raw instances (not ServiceRef) so hooks can be
-    # matched by identity for later unregistration.
-    _raw_svc = nx._service_registry.service_info
-    hook_refs: dict[str, Any] = {}
+    # Coordinator: when available, hooks are registered as services AND
+    # immediately on dispatch.  Pre-caching the spec in coordinator._hook_specs
+    # ensures activate_hot_swappable_services() at bootstrap skips re-registration
+    # (it only calls _register_hooks for services whose spec was NOT already cached).
+    _coordinator = getattr(nx, "_service_coordinator", None)
+
+    def _enlist_hook(name: str, hook: Any) -> None:
+        """Register hook on dispatch immediately + as service when coordinator available."""
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        spec: HookSpec = hook.hook_spec()
+
+        # Always register on dispatch — hooks must be active after initialize().
+        for h in spec.resolvers:
+            dispatch.register_resolver(h)
+        for h in spec.read_hooks:
+            dispatch.register_intercept_read(h)
+        for h in spec.write_hooks:
+            dispatch.register_intercept_write(h)
+        for h in spec.write_batch_hooks:
+            dispatch.register_intercept_write_batch(h)
+        for h in spec.delete_hooks:
+            dispatch.register_intercept_delete(h)
+        for h in spec.rename_hooks:
+            dispatch.register_intercept_rename(h)
+        for h in spec.mkdir_hooks:
+            dispatch.register_intercept_mkdir(h)
+        for h in spec.rmdir_hooks:
+            dispatch.register_intercept_rmdir(h)
+        for h in spec.observers:
+            dispatch.register_observe(h)
+
+        # Also register as service for lifecycle management (drain/activate/swap).
+        # Mark as pre-registered so activate_hot_swappable_services() skips
+        # _register_hooks() and avoids double dispatch registration.
+        if _coordinator is not None:
+            _coordinator.register_service(name, hook)
+            if not spec.is_empty:
+                _coordinator._hook_specs[name] = spec
+            _coordinator._hooks_on_dispatch.add(name)
 
     # ── Permission pre-intercept hook (Issue #899) ────────────────
-    _perm_hook = None
     if permission_checker is not None:
         from nexus.bricks.rebac.permission_hook import PermissionCheckHook
 
@@ -432,32 +470,19 @@ def _register_vfs_hooks(
             permission_enforcer=nx._permission_enforcer,
             descendant_checker=getattr(nx, "_descendant_checker", None),
         )
-        dispatch.register_intercept_read(_perm_hook)
-        dispatch.register_intercept_write(_perm_hook)
-        dispatch.register_intercept_delete(_perm_hook)
-        dispatch.register_intercept_rename(_perm_hook)
-        dispatch.register_intercept_mkdir(_perm_hook)
-        dispatch.register_intercept_rmdir(_perm_hook)
-    hook_refs["perm_hook"] = _perm_hook
+        _enlist_hook("permission", _perm_hook)
 
     # ── Audit write observer as interceptor (Issue #900) ──────────
     # Registered FIRST so it runs before other hooks (audit before side effects).
     write_observer = (
         getattr(nx._system_services, "write_observer", None) if nx._system_services else None
     )
-    audit = None
     if write_observer is not None:
         from nexus.storage.write_observer_hooks import AuditWriteInterceptor
 
         strict = getattr(write_observer, "_strict_mode", True)
         audit = AuditWriteInterceptor(write_observer, strict_mode=strict)
-        dispatch.register_intercept_write(audit)
-        dispatch.register_intercept_write_batch(audit)
-        dispatch.register_intercept_delete(audit)
-        dispatch.register_intercept_rename(audit)
-        dispatch.register_intercept_mkdir(audit)
-        dispatch.register_intercept_rmdir(audit)
-    hook_refs["audit"] = audit
+        _enlist_hook("audit", audit)
 
     # DynamicViewerReadHook (post-read: column-level CSV filtering)
     has_viewer = (
@@ -465,7 +490,6 @@ def _register_vfs_hooks(
         and hasattr(nx, "get_dynamic_viewer_config")
         and hasattr(nx, "apply_dynamic_viewer_filter")
     )
-    _viewer_hook = None
     if has_viewer:
         from nexus.bricks.rebac.dynamic_viewer_hook import DynamicViewerReadHook
         from nexus.lib.context_utils import get_subject_from_context
@@ -475,8 +499,7 @@ def _register_vfs_hooks(
             get_viewer_config=nx.get_dynamic_viewer_config,
             apply_filter=nx.apply_dynamic_viewer_filter,
         )
-        dispatch.register_intercept_read(_viewer_hook)
-    hook_refs["viewer_hook"] = _viewer_hook
+        _enlist_hook("viewer", _viewer_hook)
 
     # ContentParserEngine (on-demand parsed reads — Issue #1383)
     from nexus.bricks.parsers.engine import ContentParserEngine
@@ -489,7 +512,6 @@ def _register_vfs_hooks(
     # AutoParseWriteHook (post-write: background parsing + cache invalidation)
     parser_reg = nx._brick_services.parser_registry
     parse_fn = getattr(nx, "_virtual_view_parse_fn", None)
-    _auto_parse_hook = None
     if auto_parse and parser_reg is not None and parse_fn is not None:
         from nexus.bricks.parsers.auto_parse_hook import AutoParseWriteHook
 
@@ -498,14 +520,11 @@ def _register_vfs_hooks(
             parse_fn=parse_fn,
             metadata=nx.metadata,
         )
-        dispatch.register_intercept_write(_auto_parse_hook)
-    hook_refs["auto_parse_hook"] = _auto_parse_hook
+        _enlist_hook("auto_parse", _auto_parse_hook)
 
     # TigerCacheRenameHook (post-rename: bitmap updates)
     _rebac_mgr = getattr(nx, "_rebac_manager", None)
     tiger_cache = getattr(_rebac_mgr, "_tiger_cache", None) if _rebac_mgr else None
-    _tiger_rename_hook = None
-    _tiger_write_hook = None
     if tiger_cache is not None:
         from nexus.bricks.rebac.cache.tiger.rename_hook import TigerCacheRenameHook
 
@@ -520,16 +539,14 @@ def _register_vfs_hooks(
             tiger_cache=tiger_cache,
             metadata_list_iter=_metadata_list_iter,
         )
-        dispatch.register_intercept_rename(_tiger_rename_hook)
+        _enlist_hook("tiger_rename", _tiger_rename_hook)
 
     # TigerCacheWriteHook (post-write: add new files to ancestor directory grants)
     if tiger_cache is not None:
         from nexus.bricks.rebac.cache.tiger.write_hook import TigerCacheWriteHook
 
         _tiger_write_hook = TigerCacheWriteHook(tiger_cache=tiger_cache)
-        dispatch.register_intercept_write(_tiger_write_hook)
-    hook_refs["tiger_rename_hook"] = _tiger_rename_hook
-    hook_refs["tiger_write_hook"] = _tiger_write_hook
+        _enlist_hook("tiger_write", _tiger_write_hook)
 
     # ── PRE-DISPATCH: Virtual view resolver (Issue #332, #889) ────────
     from nexus.bricks.parsers.virtual_view_resolver import VirtualViewResolver
@@ -541,16 +558,14 @@ def _register_vfs_hooks(
         parse_fn=getattr(nx, "_virtual_view_parse_fn", None),
         read_tracker_fn=None,
     )
-    dispatch.register_resolver(_vview_resolver)
-    hook_refs["vview_resolver"] = _vview_resolver
+    _enlist_hook("virtual_view", _vview_resolver)
 
     # ── TaskWriteHook (post-write: emit task lifecycle events) ─────────
     if _on("task_manager"):
         from nexus.bricks.task_manager.write_hook import TaskWriteHook
 
         _task_write_hook = TaskWriteHook()
-        dispatch.register_intercept_write(_task_write_hook)
-        hook_refs["task_write_hook"] = _task_write_hook
+        _enlist_hook("task_write", _task_write_hook)
         nx._task_write_hook = _task_write_hook
     else:
         logger.debug("[BOOT:BRICK] TaskWriteHook disabled by profile")
@@ -564,12 +579,10 @@ def _register_vfs_hooks(
     from nexus.system_services.event_bus.observer import EventBusObserver
 
     _bus_observer = EventBusObserver(bus_provider=nx)
-    dispatch.register_observe(_bus_observer)
-    hook_refs["bus_observer"] = _bus_observer
+    _enlist_hook("event_bus_observer", _bus_observer)
 
-    # EventsService observer: now self-registered via HotSwappable.hook_spec()
+    # EventsService observer: self-registered via HotSwappable.hook_spec()
     # at bootstrap() → activate_hot_swappable_services() (Issue #1611).
-    # Removed from factory — EventsService owns its own observer hook.
 
     # RevisionTrackingObserver: feeds RevisionNotifier on versioned mutations.
     # Replaces the old kernel-internal _increment_vfs_revision() (Issue #1382).
@@ -578,9 +591,8 @@ def _register_vfs_hooks(
 
     _rev_notifier = RevisionNotifier()
     _rev_observer = RevisionTrackingObserver(revision_notifier=_rev_notifier)
-    dispatch.register_observe(_rev_observer)
+    _enlist_hook("revision_tracking", _rev_observer)
     nx._revision_notifier = _rev_notifier
-    hook_refs["rev_observer"] = _rev_observer
 
     # ── Test hooks (Issue #2) ────────────────────────────────────────
     # Only registered when NEXUS_TEST_HOOKS=true for E2E hook testing.
@@ -590,85 +602,3 @@ def _register_vfs_hooks(
         from nexus.core.test_hooks import register_test_hooks
 
         register_test_hooks(dispatch)
-
-    return hook_refs
-
-
-def _build_retroactive_hook_specs(coordinator: Any, hook_refs: dict[str, Any]) -> None:
-    """Build HookSpecs retroactively for hooks registered by _register_vfs_hooks().
-
-    Maps boot-time hook objects back to their owning service so the coordinator
-    can unregister them during hot-swap.  Covers all 11 hook groups from
-    ``_register_vfs_hooks()`` so ``swap_service()`` can cleanly unregister
-    any subsystem's hooks.
-    """
-    from nexus.contracts.protocols.service_hooks import HookSpec
-
-    # events service → now owns its hook via HotSwappable.hook_spec() (Issue #1611)
-
-    # permission → 6 dispatch channels
-    _perm = hook_refs.get("perm_hook")
-    if _perm is not None:
-        coordinator.set_hook_spec(
-            "permission",
-            HookSpec(
-                read_hooks=(_perm,),
-                write_hooks=(_perm,),
-                delete_hooks=(_perm,),
-                rename_hooks=(_perm,),
-                mkdir_hooks=(_perm,),
-                rmdir_hooks=(_perm,),
-            ),
-        )
-
-    # audit → 6 dispatch channels
-    _audit = hook_refs.get("audit")
-    if _audit is not None:
-        coordinator.set_hook_spec(
-            "audit",
-            HookSpec(
-                write_hooks=(_audit,),
-                write_batch_hooks=(_audit,),
-                delete_hooks=(_audit,),
-                rename_hooks=(_audit,),
-                mkdir_hooks=(_audit,),
-                rmdir_hooks=(_audit,),
-            ),
-        )
-
-    # viewer → read
-    _viewer = hook_refs.get("viewer_hook")
-    if _viewer is not None:
-        coordinator.set_hook_spec("viewer", HookSpec(read_hooks=(_viewer,)))
-
-    # auto_parse → write
-    _auto_parse = hook_refs.get("auto_parse_hook")
-    if _auto_parse is not None:
-        coordinator.set_hook_spec("auto_parse", HookSpec(write_hooks=(_auto_parse,)))
-
-    # tiger_cache → rename + write (combined into one spec)
-    _tiger_rename = hook_refs.get("tiger_rename_hook")
-    _tiger_write = hook_refs.get("tiger_write_hook")
-    if _tiger_rename is not None or _tiger_write is not None:
-        coordinator.set_hook_spec(
-            "tiger_cache",
-            HookSpec(
-                rename_hooks=(_tiger_rename,) if _tiger_rename else (),
-                write_hooks=(_tiger_write,) if _tiger_write else (),
-            ),
-        )
-
-    # virtual_view → resolver
-    _vview = hook_refs.get("vview_resolver")
-    if _vview is not None:
-        coordinator.set_hook_spec("virtual_view", HookSpec(resolvers=(_vview,)))
-
-    # event_bus → observer
-    _bus_obs = hook_refs.get("bus_observer")
-    if _bus_obs is not None:
-        coordinator.set_hook_spec("event_bus", HookSpec(observers=(_bus_obs,)))
-
-    # revision_tracking → observer
-    _rev_obs = hook_refs.get("rev_observer")
-    if _rev_obs is not None:
-        coordinator.set_hook_spec("revision_tracking", HookSpec(observers=(_rev_obs,)))

--- a/src/nexus/storage/write_observer_hooks.py
+++ b/src/nexus/storage/write_observer_hooks.py
@@ -14,6 +14,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.contracts.vfs_hooks import (
         DeleteHookContext,
         MkdirHookContext,
@@ -38,6 +39,26 @@ class AuditWriteInterceptor:
     name = "audit_write_observer"
 
     __slots__ = ("_observer", "_strict_mode")
+
+    # ── HotSwappable protocol (Issue #1613) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(
+            write_hooks=(self,),
+            write_batch_hooks=(self,),
+            delete_hooks=(self,),
+            rename_hooks=(self,),
+            mkdir_hooks=(self,),
+            rmdir_hooks=(self,),
+        )
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(self, observer: WriteObserverProtocol, *, strict_mode: bool = True) -> None:
         self._observer = observer

--- a/src/nexus/system_services/event_bus/observer.py
+++ b/src/nexus/system_services/event_bus/observer.py
@@ -17,6 +17,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.core.file_events import FileEvent
     from nexus.system_services.event_bus.protocol import EventBusProtocol
 
@@ -38,6 +39,19 @@ class EventBusObserver:
        so post-construction overrides (e.g. test fixtures injecting a
        shared Redis bus) are picked up automatically.
     """
+
+    # ── HotSwappable protocol (Issue #1616) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(observers=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(
         self,

--- a/src/nexus/system_services/lifecycle/revision_tracking_observer.py
+++ b/src/nexus/system_services/lifecycle/revision_tracking_observer.py
@@ -16,6 +16,7 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.core.file_events import FileEvent
     from nexus.lib.revision_notifier import RevisionNotifierBase
 
@@ -33,6 +34,19 @@ class RevisionTrackingObserver:
     """
 
     __slots__ = ("_notifier",)
+
+    # ── HotSwappable protocol (Issue #1616) ────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(observers=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def __init__(self, revision_notifier: RevisionNotifierBase) -> None:
         self._notifier = revision_notifier

--- a/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
+++ b/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
@@ -53,7 +53,7 @@ class ServiceLifecycleCoordinator:
     Kernel stays pure — this coordinator lives at system services tier.
     """
 
-    __slots__ = ("_registry", "_blm", "_dispatch", "_hook_specs")
+    __slots__ = ("_registry", "_blm", "_dispatch", "_hook_specs", "_hooks_on_dispatch")
 
     def __init__(
         self,
@@ -65,6 +65,10 @@ class ServiceLifecycleCoordinator:
         self._blm = lifecycle_manager
         self._dispatch = dispatch
         self._hook_specs: dict[str, HookSpec] = {}
+        # Tracks services whose hooks were pre-registered on dispatch at
+        # initialize() time by _enlist_hook().  activate_hot_swappable_services()
+        # skips _register_hooks() for these to avoid double registration.
+        self._hooks_on_dispatch: set[str] = set()
 
     # ------------------------------------------------------------------
     # insmod — register service in both Registry and BLM
@@ -436,8 +440,9 @@ class ServiceLifecycleCoordinator:
                     spec = info.instance.hook_spec()
                     if spec is not None and not spec.is_empty:
                         self._hook_specs[name] = spec
-                # Register hooks into dispatch
-                self._register_hooks(name)
+                # Register hooks into dispatch (skip if pre-registered by _enlist_hook)
+                if name not in self._hooks_on_dispatch:
+                    self._register_hooks(name)
                 # Activate service
                 await info.instance.activate()
                 activated.append(name)

--- a/tests/unit/factory/test_retroactive_hook_specs.py
+++ b/tests/unit/factory/test_retroactive_hook_specs.py
@@ -1,212 +1,310 @@
-"""Unit tests for _build_retroactive_hook_specs() (Issue #1452 Phase 4).
+"""Unit tests for VFS hook HotSwappable conformance (Issue #1610/#1612/#1613/#1616).
 
-Verifies that all retroactive hook groups from _register_vfs_hooks() are
-captured as HookSpecs so swap_service() can cleanly unregister them during
-hot-swap.  Services that implement HotSwappable.hook_spec() (e.g. EventsService)
-are NOT in this table — they self-register at bootstrap time.
+All VFS hooks now implement HotSwappable — they self-describe via hook_spec().
+_build_retroactive_hook_specs() has been deleted.  These tests verify that
+every hook class satisfies the HotSwappable structural protocol and returns
+the correct HookSpec.
 """
 
 from __future__ import annotations
 
-from unittest.mock import sentinel
+from unittest.mock import MagicMock
 
 import pytest
 
-from nexus.contracts.protocols.service_hooks import HookSpec
-from nexus.factory.orchestrator import _build_retroactive_hook_specs
-
-
-class _FakeCoordinator:
-    """Minimal coordinator stub — just stores set_hook_spec calls."""
-
-    def __init__(self) -> None:
-        self.specs: dict[str, HookSpec] = {}
-
-    def set_hook_spec(self, name: str, spec: HookSpec) -> None:
-        self.specs[name] = spec
-
-
-def _full_hook_refs() -> dict[str, object]:
-    """Return hook_refs dict with all retroactive hook objects present.
-
-    EventsService is excluded — it implements HotSwappable.hook_spec()
-    and self-registers at bootstrap time (Issue #1611).
-    """
-    return {
-        "perm_hook": sentinel.perm_hook,
-        "audit": sentinel.audit,
-        "viewer_hook": sentinel.viewer_hook,
-        "auto_parse_hook": sentinel.auto_parse_hook,
-        "tiger_rename_hook": sentinel.tiger_rename,
-        "tiger_write_hook": sentinel.tiger_write,
-        "vview_resolver": sentinel.vview_resolver,
-        "bus_observer": sentinel.bus_observer,
-        "rev_observer": sentinel.rev_observer,
-    }
-
+from nexus.contracts.protocols.service_lifecycle import HotSwappable
 
 # ---------------------------------------------------------------------------
-# All hooks captured
+# HotSwappable conformance — isinstance checks
 # ---------------------------------------------------------------------------
 
 
-class TestBuildRetroactiveHookSpecs:
-    def test_all_hooks_captured(self) -> None:
-        """Full boot — all retroactive hook groups result in specs."""
-        coord = _FakeCoordinator()
-        _build_retroactive_hook_specs(coord, _full_hook_refs())
+class TestHotSwappableConformance:
+    """Every VFS hook class satisfies HotSwappable protocol."""
 
-        expected_names = {
-            "permission",
-            "audit",
-            "viewer",
-            "auto_parse",
-            "tiger_cache",
-            "virtual_view",
-            "event_bus",
-            "revision_tracking",
-        }
-        assert set(coord.specs.keys()) == expected_names
+    def test_permission_hook(self) -> None:
+        from nexus.bricks.rebac.permission_hook import PermissionCheckHook
 
-    def test_partial_hooks_captured(self) -> None:
-        """Minimal boot — only bus_observer provided."""
-        coord = _FakeCoordinator()
-        hook_refs = dict.fromkeys(_full_hook_refs())
-        hook_refs["bus_observer"] = sentinel.bus_observer
+        hook = PermissionCheckHook(
+            checker=MagicMock(),
+            metadata_store=MagicMock(),
+            default_context=MagicMock(),
+        )
+        assert isinstance(hook, HotSwappable)
 
-        _build_retroactive_hook_specs(coord, hook_refs)
+    def test_audit_interceptor(self) -> None:
+        from nexus.storage.write_observer_hooks import AuditWriteInterceptor
 
-        assert set(coord.specs.keys()) == {"event_bus"}
+        hook = AuditWriteInterceptor(observer=MagicMock())
+        assert isinstance(hook, HotSwappable)
 
-    def test_none_hooks_skipped(self) -> None:
-        """All None — no specs set at all."""
-        coord = _FakeCoordinator()
-        hook_refs = dict.fromkeys(_full_hook_refs())
-        _build_retroactive_hook_specs(coord, hook_refs)
+    def test_dynamic_viewer_hook(self) -> None:
+        from nexus.bricks.rebac.dynamic_viewer_hook import DynamicViewerReadHook
 
-        assert coord.specs == {}
+        hook = DynamicViewerReadHook(
+            get_subject=MagicMock(),
+            get_viewer_config=MagicMock(),
+            apply_filter=MagicMock(),
+        )
+        assert isinstance(hook, HotSwappable)
 
-    def test_empty_hook_refs(self) -> None:
-        """Empty dict — no specs, no errors."""
-        coord = _FakeCoordinator()
-        _build_retroactive_hook_specs(coord, {})
-        assert coord.specs == {}
+    def test_tiger_rename_hook(self) -> None:
+        from nexus.bricks.rebac.cache.tiger.rename_hook import TigerCacheRenameHook
+
+        hook = TigerCacheRenameHook(tiger_cache=MagicMock())
+        assert isinstance(hook, HotSwappable)
+
+    def test_tiger_write_hook(self) -> None:
+        from nexus.bricks.rebac.cache.tiger.write_hook import TigerCacheWriteHook
+
+        hook = TigerCacheWriteHook(tiger_cache=MagicMock())
+        assert isinstance(hook, HotSwappable)
+
+    def test_virtual_view_resolver(self) -> None:
+        from nexus.bricks.parsers.virtual_view_resolver import VirtualViewResolver
+
+        hook = VirtualViewResolver(
+            metadata=MagicMock(),
+            path_router=MagicMock(),
+            permission_checker=MagicMock(),
+        )
+        assert isinstance(hook, HotSwappable)
+
+    def test_auto_parse_hook(self) -> None:
+        from nexus.bricks.parsers.auto_parse_hook import AutoParseWriteHook
+
+        hook = AutoParseWriteHook(
+            get_parser=MagicMock(),
+            parse_fn=MagicMock(),
+        )
+        assert isinstance(hook, HotSwappable)
+
+    def test_event_bus_observer(self) -> None:
+        from nexus.system_services.event_bus.observer import EventBusObserver
+
+        hook = EventBusObserver()
+        assert isinstance(hook, HotSwappable)
+
+    def test_revision_tracking_observer(self) -> None:
+        from nexus.system_services.lifecycle.revision_tracking_observer import (
+            RevisionTrackingObserver,
+        )
+
+        hook = RevisionTrackingObserver(revision_notifier=MagicMock())
+        assert isinstance(hook, HotSwappable)
+
+    def test_task_write_hook(self) -> None:
+        from nexus.bricks.task_manager.write_hook import TaskWriteHook
+
+        hook = TaskWriteHook()
+        assert isinstance(hook, HotSwappable)
 
 
 # ---------------------------------------------------------------------------
-# Permission hook — 6 channels
+# hook_spec() — correct channels declared
 # ---------------------------------------------------------------------------
 
 
-class TestPermissionHookSpec:
-    def test_permission_has_6_channels(self) -> None:
-        coord = _FakeCoordinator()
-        hook_refs = dict.fromkeys(_full_hook_refs())
-        hook_refs["perm_hook"] = sentinel.perm_hook
+class TestHookSpecDeclarations:
+    """Each hook declares the correct HookSpec channels."""
 
-        _build_retroactive_hook_specs(coord, hook_refs)
+    def test_permission_6_channels(self) -> None:
+        from nexus.bricks.rebac.permission_hook import PermissionCheckHook
 
-        spec = coord.specs["permission"]
-        assert spec.read_hooks == (sentinel.perm_hook,)
-        assert spec.write_hooks == (sentinel.perm_hook,)
-        assert spec.delete_hooks == (sentinel.perm_hook,)
-        assert spec.rename_hooks == (sentinel.perm_hook,)
-        assert spec.mkdir_hooks == (sentinel.perm_hook,)
-        assert spec.rmdir_hooks == (sentinel.perm_hook,)
+        hook = PermissionCheckHook(
+            checker=MagicMock(),
+            metadata_store=MagicMock(),
+            default_context=MagicMock(),
+        )
+        spec = hook.hook_spec()
+        assert spec.read_hooks == (hook,)
+        assert spec.write_hooks == (hook,)
+        assert spec.delete_hooks == (hook,)
+        assert spec.rename_hooks == (hook,)
+        assert spec.mkdir_hooks == (hook,)
+        assert spec.rmdir_hooks == (hook,)
         assert spec.total_hooks == 6
 
+    def test_audit_6_channels(self) -> None:
+        from nexus.storage.write_observer_hooks import AuditWriteInterceptor
 
-# ---------------------------------------------------------------------------
-# Audit hook — 6 channels
-# ---------------------------------------------------------------------------
-
-
-class TestAuditHookSpec:
-    def test_audit_has_6_channels(self) -> None:
-        coord = _FakeCoordinator()
-        hook_refs = dict.fromkeys(_full_hook_refs())
-        hook_refs["audit"] = sentinel.audit
-
-        _build_retroactive_hook_specs(coord, hook_refs)
-
-        spec = coord.specs["audit"]
-        assert spec.write_hooks == (sentinel.audit,)
-        assert spec.write_batch_hooks == (sentinel.audit,)
-        assert spec.delete_hooks == (sentinel.audit,)
-        assert spec.rename_hooks == (sentinel.audit,)
-        assert spec.mkdir_hooks == (sentinel.audit,)
-        assert spec.rmdir_hooks == (sentinel.audit,)
+        hook = AuditWriteInterceptor(observer=MagicMock())
+        spec = hook.hook_spec()
+        assert spec.write_hooks == (hook,)
+        assert spec.write_batch_hooks == (hook,)
+        assert spec.delete_hooks == (hook,)
+        assert spec.rename_hooks == (hook,)
+        assert spec.mkdir_hooks == (hook,)
+        assert spec.rmdir_hooks == (hook,)
         assert spec.total_hooks == 6
 
+    def test_viewer_1_channel(self) -> None:
+        from nexus.bricks.rebac.dynamic_viewer_hook import DynamicViewerReadHook
+
+        hook = DynamicViewerReadHook(
+            get_subject=MagicMock(),
+            get_viewer_config=MagicMock(),
+            apply_filter=MagicMock(),
+        )
+        spec = hook.hook_spec()
+        assert spec.read_hooks == (hook,)
+        assert spec.total_hooks == 1
+
+    def test_tiger_rename_1_channel(self) -> None:
+        from nexus.bricks.rebac.cache.tiger.rename_hook import TigerCacheRenameHook
+
+        hook = TigerCacheRenameHook(tiger_cache=MagicMock())
+        spec = hook.hook_spec()
+        assert spec.rename_hooks == (hook,)
+        assert spec.total_hooks == 1
+
+    def test_tiger_write_1_channel(self) -> None:
+        from nexus.bricks.rebac.cache.tiger.write_hook import TigerCacheWriteHook
+
+        hook = TigerCacheWriteHook(tiger_cache=MagicMock())
+        spec = hook.hook_spec()
+        assert spec.write_hooks == (hook,)
+        assert spec.total_hooks == 1
+
+    def test_virtual_view_1_resolver(self) -> None:
+        from nexus.bricks.parsers.virtual_view_resolver import VirtualViewResolver
+
+        hook = VirtualViewResolver(
+            metadata=MagicMock(),
+            path_router=MagicMock(),
+            permission_checker=MagicMock(),
+        )
+        spec = hook.hook_spec()
+        assert spec.resolvers == (hook,)
+        assert spec.total_hooks == 1
+
+    def test_auto_parse_1_channel(self) -> None:
+        from nexus.bricks.parsers.auto_parse_hook import AutoParseWriteHook
+
+        hook = AutoParseWriteHook(
+            get_parser=MagicMock(),
+            parse_fn=MagicMock(),
+        )
+        spec = hook.hook_spec()
+        assert spec.write_hooks == (hook,)
+        assert spec.total_hooks == 1
+
+    def test_event_bus_observer_1_channel(self) -> None:
+        from nexus.system_services.event_bus.observer import EventBusObserver
+
+        hook = EventBusObserver()
+        spec = hook.hook_spec()
+        assert spec.observers == (hook,)
+        assert spec.total_hooks == 1
+
+    def test_revision_observer_1_channel(self) -> None:
+        from nexus.system_services.lifecycle.revision_tracking_observer import (
+            RevisionTrackingObserver,
+        )
+
+        hook = RevisionTrackingObserver(revision_notifier=MagicMock())
+        spec = hook.hook_spec()
+        assert spec.observers == (hook,)
+        assert spec.total_hooks == 1
+
+    def test_task_write_1_channel(self) -> None:
+        from nexus.bricks.task_manager.write_hook import TaskWriteHook
+
+        hook = TaskWriteHook()
+        spec = hook.hook_spec()
+        assert spec.write_hooks == (hook,)
+        assert spec.total_hooks == 1
+
 
 # ---------------------------------------------------------------------------
-# Tiger cache — combined rename + write
+# drain() / activate() — lifecycle methods
 # ---------------------------------------------------------------------------
 
 
-class TestTigerCacheHookSpec:
-    def test_tiger_cache_combined(self) -> None:
-        """Both rename + write hooks present → combined into one spec."""
-        coord = _FakeCoordinator()
-        hook_refs = dict.fromkeys(_full_hook_refs())
-        hook_refs["tiger_rename_hook"] = sentinel.tiger_rename
-        hook_refs["tiger_write_hook"] = sentinel.tiger_write
+class TestDrainActivate:
+    """drain() and activate() are callable and don't raise."""
 
-        _build_retroactive_hook_specs(coord, hook_refs)
+    @pytest.mark.asyncio
+    async def test_permission_hook_lifecycle(self) -> None:
+        from nexus.bricks.rebac.permission_hook import PermissionCheckHook
 
-        spec = coord.specs["tiger_cache"]
-        assert spec.rename_hooks == (sentinel.tiger_rename,)
-        assert spec.write_hooks == (sentinel.tiger_write,)
-        assert spec.total_hooks == 2
+        hook = PermissionCheckHook(
+            checker=MagicMock(),
+            metadata_store=MagicMock(),
+            default_context=MagicMock(),
+        )
+        await hook.drain()
+        await hook.activate()
 
-    def test_tiger_rename_only(self) -> None:
-        """Only rename hook → write_hooks is empty tuple."""
-        coord = _FakeCoordinator()
-        hook_refs = dict.fromkeys(_full_hook_refs())
-        hook_refs["tiger_rename_hook"] = sentinel.tiger_rename
+    @pytest.mark.asyncio
+    async def test_audit_interceptor_lifecycle(self) -> None:
+        from nexus.storage.write_observer_hooks import AuditWriteInterceptor
 
-        _build_retroactive_hook_specs(coord, hook_refs)
+        hook = AuditWriteInterceptor(observer=MagicMock())
+        await hook.drain()
+        await hook.activate()
 
-        spec = coord.specs["tiger_cache"]
-        assert spec.rename_hooks == (sentinel.tiger_rename,)
-        assert spec.write_hooks == ()
+    @pytest.mark.asyncio
+    async def test_auto_parse_drain_calls_shutdown(self) -> None:
+        from nexus.bricks.parsers.auto_parse_hook import AutoParseWriteHook
 
-    def test_tiger_write_only(self) -> None:
-        """Only write hook → rename_hooks is empty tuple."""
-        coord = _FakeCoordinator()
-        hook_refs = dict.fromkeys(_full_hook_refs())
-        hook_refs["tiger_write_hook"] = sentinel.tiger_write
+        hook = AutoParseWriteHook(
+            get_parser=MagicMock(),
+            parse_fn=MagicMock(),
+        )
+        # drain() calls shutdown() which drains threads
+        await hook.drain()
+        await hook.activate()
 
-        _build_retroactive_hook_specs(coord, hook_refs)
+    @pytest.mark.asyncio
+    async def test_virtual_view_resolver_lifecycle(self) -> None:
+        from nexus.bricks.parsers.virtual_view_resolver import VirtualViewResolver
 
-        spec = coord.specs["tiger_cache"]
-        assert spec.rename_hooks == ()
-        assert spec.write_hooks == (sentinel.tiger_write,)
+        hook = VirtualViewResolver(
+            metadata=MagicMock(),
+            path_router=MagicMock(),
+            permission_checker=MagicMock(),
+        )
+        await hook.drain()
+        await hook.activate()
+
+    @pytest.mark.asyncio
+    async def test_event_bus_observer_lifecycle(self) -> None:
+        from nexus.system_services.event_bus.observer import EventBusObserver
+
+        hook = EventBusObserver()
+        await hook.drain()
+        await hook.activate()
+
+    @pytest.mark.asyncio
+    async def test_revision_observer_lifecycle(self) -> None:
+        from nexus.system_services.lifecycle.revision_tracking_observer import (
+            RevisionTrackingObserver,
+        )
+
+        hook = RevisionTrackingObserver(revision_notifier=MagicMock())
+        await hook.drain()
+        await hook.activate()
+
+    @pytest.mark.asyncio
+    async def test_task_write_hook_lifecycle(self) -> None:
+        from nexus.bricks.task_manager.write_hook import TaskWriteHook
+
+        hook = TaskWriteHook()
+        await hook.drain()
+        await hook.activate()
 
 
 # ---------------------------------------------------------------------------
-# Single-channel hook groups
+# _build_retroactive_hook_specs deleted — verify import removed
 # ---------------------------------------------------------------------------
 
 
-class TestSingleChannelHookSpecs:
-    @pytest.mark.parametrize(
-        ("ref_key", "spec_name", "field"),
-        [
-            ("viewer_hook", "viewer", "read_hooks"),
-            ("auto_parse_hook", "auto_parse", "write_hooks"),
-            ("vview_resolver", "virtual_view", "resolvers"),
-            ("bus_observer", "event_bus", "observers"),
-            ("rev_observer", "revision_tracking", "observers"),
-        ],
-    )
-    def test_single_channel(self, ref_key: str, spec_name: str, field: str) -> None:
-        coord = _FakeCoordinator()
-        hook_refs = dict.fromkeys(_full_hook_refs())
-        hook_refs[ref_key] = sentinel.hook_obj
+class TestRetroactiveHookSpecsDeleted:
+    """_build_retroactive_hook_specs() has been deleted (Issue #1616)."""
 
-        _build_retroactive_hook_specs(coord, hook_refs)
+    def test_function_no_longer_importable(self) -> None:
+        """The retroactive function should not exist in orchestrator."""
+        from nexus.factory import orchestrator
 
-        spec = coord.specs[spec_name]
-        assert getattr(spec, field) == (sentinel.hook_obj,)
-        assert not spec.is_empty
+        assert not hasattr(orchestrator, "_build_retroactive_hook_specs")


### PR DESCRIPTION
## Summary
- All 10 VFS hook classes now implement **HotSwappable** protocol (`hook_spec()`, `drain()`, `activate()`)
- `_register_vfs_hooks()` rewritten: always registers hooks on dispatch immediately + enlists as service via coordinator when available
- `_build_retroactive_hook_specs()` deleted — hooks self-describe via `hook_spec()`
- `activate_hot_swappable_services()` skips re-registration for pre-registered hooks (tracked via `_hooks_on_dispatch` set)

### Hook classes migrated (10 total):
| Hook | Channels | Brick |
|------|----------|-------|
| PermissionCheckHook | read, write, delete, rename, mkdir, rmdir (6) | rebac |
| AuditWriteInterceptor | write, write_batch, delete, rename, mkdir, rmdir (6) | storage |
| DynamicViewerReadHook | read (1) | rebac |
| TigerCacheRenameHook | rename (1) | rebac/cache |
| TigerCacheWriteHook | write (1) | rebac/cache |
| VirtualViewResolver | resolvers (1) | parsers |
| AutoParseWriteHook | write (1) | parsers |
| EventBusObserver | observers (1) | event_bus |
| RevisionTrackingObserver | observers (1) | lifecycle |
| TaskWriteHook | write (1) | task_manager |

### Key design decisions:
- Hooks are dispatch-registered at **initialize()** time (Phase 2), not deferred to bootstrap — tests that don't call `bootstrap()` still get working hooks
- `_hooks_on_dispatch` set prevents double registration when `activate_hot_swappable_services()` runs at bootstrap

## Test plan
- [x] 28 new tests: HotSwappable conformance (10), HookSpec declarations (10), drain/activate lifecycle (7), retroactive deletion verification (1)
- [x] Full unit suite: 10603 passed, 0 regressions (3 pre-existing LLM canary failures on develop)
- [x] Lint clean (ruff + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)