### PR TITLE
fix: cross-platform Docker stack — native arm64 + amd64 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -123,3 +123,18 @@ jobs:
           build-args: TORCH_VARIANT=${{ matrix.variant }}
           cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-${{ matrix.variant }}
           cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-${{ matrix.variant }},mode=max,ignore-error=true
+
+      # ---- Zoekt sidecar image (multi-arch, CPU-only variant only) ----
+      - name: Build and push Zoekt sidecar
+        if: matrix.variant == 'cpu'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./dockerfiles
+          file: dockerfiles/Dockerfile.zoekt
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          sbom: false
+          tags: ghcr.io/nexi-lab/nexus-zoekt:sha-${{ github.sha }},ghcr.io/nexi-lab/nexus-zoekt:edge
+          cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus-zoekt:buildcache
+          cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus-zoekt:buildcache,mode=max,ignore-error=true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,6 +56,7 @@ jobs:
           # Branch pushes only get channel tags (edge/sha-*), never semver.
           # Semver tags (0.9.2, latest) are owned exclusively by release.yml
           # to prevent mutable version tags appearing before atomic release.
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
           echo "tags=ghcr.io/nexi-lab/nexus:sha-${SHA}${SUFFIX},ghcr.io/nexi-lab/nexus:edge${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       # ---- Build locally for smoke testing (Issue #2946) ----
@@ -135,6 +136,6 @@ jobs:
           push: true
           provenance: false
           sbom: false
-          tags: ghcr.io/nexi-lab/nexus-zoekt:sha-${{ github.sha }},ghcr.io/nexi-lab/nexus-zoekt:edge
+          tags: ghcr.io/nexi-lab/nexus-zoekt:sha-${{ steps.meta.outputs.sha }},ghcr.io/nexi-lab/nexus-zoekt:edge
           cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus-zoekt:buildcache
           cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus-zoekt:buildcache,mode=max,ignore-error=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,6 +276,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           SUFFIX="${{ matrix.suffix }}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tags=ghcr.io/nexi-lab/nexus:${VERSION}${SUFFIX},ghcr.io/nexi-lab/nexus:stable${SUFFIX},ghcr.io/nexi-lab/nexus:latest${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Build image (local load for smoke tests)
@@ -344,7 +345,7 @@ jobs:
           push: true
           provenance: false
           sbom: false
-          tags: ghcr.io/nexi-lab/nexus-zoekt:${{ github.ref_name }},ghcr.io/nexi-lab/nexus-zoekt:stable,ghcr.io/nexi-lab/nexus-zoekt:latest
+          tags: ghcr.io/nexi-lab/nexus-zoekt:${{ steps.meta.outputs.version }},ghcr.io/nexi-lab/nexus-zoekt:stable,ghcr.io/nexi-lab/nexus-zoekt:latest
           cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus-zoekt:buildcache
           cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus-zoekt:buildcache,mode=max,ignore-error=true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,6 +333,21 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }}
           cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }},mode=max,ignore-error=true
 
+      # Zoekt sidecar — publish stable + versioned tags on release (CPU only)
+      - name: Build and push Zoekt sidecar
+        if: matrix.variant == 'cpu'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./dockerfiles
+          file: dockerfiles/Dockerfile.zoekt
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          sbom: false
+          tags: ghcr.io/nexi-lab/nexus-zoekt:${{ github.ref_name }},ghcr.io/nexi-lab/nexus-zoekt:stable,ghcr.io/nexi-lab/nexus-zoekt:latest
+          cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus-zoekt:buildcache
+          cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus-zoekt:buildcache,mode=max,ignore-error=true
+
   # GitHub Release is created ONLY after both PyPI and Docker succeed.
   # This is the user-visible "released" signal — without it, the version
   # doesn't appear on the releases page or trigger notifications.

--- a/dockerfiles/Dockerfile.zoekt
+++ b/dockerfiles/Dockerfile.zoekt
@@ -1,0 +1,13 @@
+# Zoekt search server — multi-arch (amd64 + arm64)
+# Replaces sourcegraph/zoekt-webserver which is amd64-only.
+# Builds native Go binaries for the target platform.
+FROM golang:1.24-alpine AS builder
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest
+
+FROM alpine:3.21
+RUN apk add --no-cache wget
+COPY --from=builder /go/bin/zoekt-webserver /usr/local/bin/zoekt-webserver
+EXPOSE 6070
+ENTRYPOINT ["zoekt-webserver"]

--- a/dockerfiles/Dockerfile.zoekt
+++ b/dockerfiles/Dockerfile.zoekt
@@ -1,13 +1,15 @@
-# Zoekt search server — multi-arch (amd64 + arm64)
+# Zoekt search server + indexer — multi-arch (amd64 + arm64)
 # Replaces sourcegraph/zoekt-webserver which is amd64-only.
 # Builds native Go binaries for the target platform.
 FROM golang:1.24-alpine AS builder
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest
+    CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest && \
+    CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-index@latest
 
 FROM alpine:3.21
 RUN apk add --no-cache wget
 COPY --from=builder /go/bin/zoekt-webserver /usr/local/bin/zoekt-webserver
+COPY --from=builder /go/bin/zoekt-index /usr/local/bin/zoekt-index
 EXPOSE 6070
 ENTRYPOINT ["zoekt-webserver"]

--- a/dockerfiles/compose.yaml
+++ b/dockerfiles/compose.yaml
@@ -404,7 +404,7 @@ services:
   #   docker compose --profile zoekt-index up   # Build/rebuild index
   # ============================================
   zoekt:
-    image: sourcegraph/zoekt-webserver:latest
+    image: ${ZOEKT_IMAGE_REF:-ghcr.io/nexi-lab/nexus-zoekt:stable}
     container_name: nexus-zoekt
     restart: unless-stopped
     profiles:
@@ -442,7 +442,7 @@ services:
   # Zoekt indexer - runs once to build/update index
   # Uses zoekt-webserver image which includes zoekt-index binary
   zoekt-indexer:
-    image: sourcegraph/zoekt-webserver:latest
+    image: ${ZOEKT_IMAGE_REF:-ghcr.io/nexi-lab/nexus-zoekt:stable}
     container_name: nexus-zoekt-indexer
     profiles:
       - zoekt-index  # docker compose --profile zoekt-index run zoekt-indexer

--- a/dockerfiles/docker-compose.cross-platform-test.yml
+++ b/dockerfiles/docker-compose.cross-platform-test.yml
@@ -510,7 +510,7 @@ services:
   #   docker compose --profile zoekt -f dockerfiles/docker-compose.cross-platform-test.yml up -d
   # ==========================================================================
   zoekt:
-    image: sourcegraph/zoekt-webserver:latest
+    image: ${ZOEKT_IMAGE_REF:-ghcr.io/nexi-lab/nexus-zoekt:stable}
     container_name: nexus-zoekt
     restart: unless-stopped
     profiles:
@@ -538,7 +538,7 @@ services:
         max-file: "3"
 
   zoekt-indexer:
-    image: sourcegraph/zoekt-webserver:latest
+    image: ${ZOEKT_IMAGE_REF:-ghcr.io/nexi-lab/nexus-zoekt:stable}
     container_name: nexus-zoekt-indexer
     profiles:
       - zoekt-index

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -49,7 +49,11 @@ fix_data_dir_and_drop_privileges() {
     if [ "$(id -u)" = "0" ]; then
         # Create required subdirectories inside the (possibly bind-mounted) data dir
         mkdir -p /app/data/skills /app/data/.zoekt-index
-        chown -R nexus:nexus /app/data
+        # chown may fail on macOS Docker Desktop (VirtioFS/gRPC FUSE does not
+        # support ownership changes on bind-mounted host directories).  This is
+        # safe to ignore — macOS maps all container access through the host uid
+        # regardless of in-container ownership.
+        chown -R nexus:nexus /app/data 2>/dev/null || true
 
         # Re-exec the entrypoint as the nexus user
         exec gosu nexus "$0" "$@"

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -49,11 +49,21 @@ fix_data_dir_and_drop_privileges() {
     if [ "$(id -u)" = "0" ]; then
         # Create required subdirectories inside the (possibly bind-mounted) data dir
         mkdir -p /app/data/skills /app/data/.zoekt-index
-        # chown may fail on macOS Docker Desktop (VirtioFS/gRPC FUSE does not
-        # support ownership changes on bind-mounted host directories).  This is
-        # safe to ignore — macOS maps all container access through the host uid
-        # regardless of in-container ownership.
-        chown -R nexus:nexus /app/data 2>/dev/null || true
+
+        if ! chown -R nexus:nexus /app/data 2>/dev/null; then
+            # chown fails on macOS Docker Desktop (VirtioFS/gRPC FUSE does not
+            # support ownership changes on bind-mounted host directories).
+            # Verify the nexus user can still write — on macOS, Docker maps all
+            # container access through the host uid regardless of in-container
+            # ownership, so writes succeed despite the chown failure.
+            if gosu nexus touch /app/data/.entrypoint-write-test 2>/dev/null; then
+                rm -f /app/data/.entrypoint-write-test
+            else
+                echo -e "${RED:-}ERROR: chown failed and /app/data is not writable by nexus user.${NC:-}"
+                echo "  Check bind-mount permissions on the host directory."
+                exit 1
+            fi
+        fi
 
         # Re-exec the entrypoint as the nexus user
         exec gosu nexus "$0" "$@"

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -181,10 +181,18 @@ services:
   # Zoekt — Fast Code Search
   # ============================================================================
   zoekt:
-    image: sourcegraph/zoekt-webserver:latest
+    # Build from Go source for native multi-arch support (amd64 + arm64).
+    # sourcegraph/zoekt-webserver only publishes amd64 images, which forces
+    # slow QEMU emulation on Apple Silicon. Building from source produces
+    # a native binary on any platform.
+    build:
+      context: ./dockerfiles
+      dockerfile: Dockerfile.zoekt
+    image: ${ZOEKT_IMAGE_REF:-ghcr.io/nexi-lab/nexus-zoekt:latest}
     restart: unless-stopped
     profiles:
       - search
+    command: ["-index", "/index", "-listen", ":6070"]
     environment:
       ZOEKT_INDEX_DIR: /index
       ZOEKT_DATA_DIR: /data

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -188,7 +188,7 @@ services:
     build:
       context: ./dockerfiles
       dockerfile: Dockerfile.zoekt
-    image: ${ZOEKT_IMAGE_REF:-ghcr.io/nexi-lab/nexus-zoekt:latest}
+    image: ${ZOEKT_IMAGE_REF:-ghcr.io/nexi-lab/nexus-zoekt:stable}
     restart: unless-stopped
     profiles:
       - search

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -146,10 +146,13 @@ services:
   # Zoekt — Fast Code Search
   # ============================================================================
   zoekt:
-    image: sourcegraph/zoekt-webserver:latest
+    # Multi-arch image (amd64 + arm64) — replaces sourcegraph/zoekt-webserver
+    # which is amd64-only and requires slow QEMU emulation on Apple Silicon.
+    image: ${ZOEKT_IMAGE_REF:-ghcr.io/nexi-lab/nexus-zoekt:stable}
     restart: unless-stopped
     profiles:
       - search
+    command: ["-index", "/index", "-listen", ":6070"]
     environment:
       ZOEKT_INDEX_DIR: /index
       ZOEKT_DATA_DIR: /data


### PR DESCRIPTION
## Summary

`nexus init --preset demo && nexus up` was broken on Apple Silicon (and unreliable on ARM Linux) due to three issues:

### 1. Zoekt image is amd64-only
`sourcegraph/zoekt-webserver:latest` only publishes amd64 images. On arm64 hosts, Docker runs it under QEMU emulation — slow, flaky, and logs a noisy platform mismatch warning.

**Fix:** New `dockerfiles/Dockerfile.zoekt` builds zoekt-webserver from Go source, producing native binaries on any platform. CI publishes it as `ghcr.io/nexi-lab/nexus-zoekt` (amd64 + arm64) in both `docker-publish.yml` and `release.yml`.

### 2. Entrypoint chown crashes on macOS
`chown -R nexus:nexus /app/data` fails with "Permission denied" on macOS Docker Desktop (VirtioFS doesn't support ownership changes on bind mounts). With `set -e`, this kills the entrypoint before the server starts → infinite crash loop → health timeout after 124s.

**Fix:** `chown ... 2>/dev/null || true` — the ownership change is best-effort. On macOS, Docker maps access through the host uid regardless.

### 3. Bundled compose template out of sync
The pip-installed copy (`src/nexus/cli/data/nexus-stack.yml`) still referenced the amd64-only zoekt image.

**Fix:** Updated to use `ghcr.io/nexi-lab/nexus-zoekt:stable`.

### Platform audit — all images now multi-arch

| Service | Image | amd64 | arm64 |
|---|---|---|---|
| nexus | `ghcr.io/nexi-lab/nexus` | ✓ | ✓ |
| postgres | `pgvector/pgvector:pg16` | ✓ | ✓ |
| dragonfly | `dragonflydb/dragonfly` | ✓ | ✓ |
| zoekt | `ghcr.io/nexi-lab/nexus-zoekt` **(NEW)** | ✓ | ✓ |
| nats | `nats:2.10-alpine` | ✓ | ✓ |

## Test plan
- [ ] `nexus init --preset demo && nexus up` on macOS Apple Silicon — all services healthy
- [ ] `nexus init --preset shared && nexus up` on Linux amd64 — no regression
- [ ] `nexus up --build` — zoekt builds from Dockerfile.zoekt natively
- [ ] CI: `docker-publish.yml` pushes `nexus-zoekt:edge` for both platforms
- [ ] Verify `nexus logs` shows no chown errors on macOS

Supersedes #3035 and #3037.