### PR TITLE
fix: correctness bugs across nexus_raft, nexus_tasks, nexus-fuse (#3029)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_pyo3"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "ahash",
  "blake3",
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -2214,29 +2214,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/nexus-fuse/src/fs.rs
+++ b/nexus-fuse/src/fs.rs
@@ -6,7 +6,7 @@ use fuser::{
     FileAttr, FileType, Filesystem, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry, ReplyWrite,
     Request, FUSE_ROOT_ID,
 };
-use libc::{ENOENT, ENOTDIR, ENOTEMPTY, EISDIR, EIO};
+use libc::{EIO, EISDIR, ENOENT, ENOTDIR, ENOTEMPTY};
 use log::{debug, error};
 use lru::LruCache;
 use std::ffi::OsStr;
@@ -41,7 +41,7 @@ impl InodeTable {
         let mut inode_to_path = LruCache::new(cap);
         let mut path_to_inode = LruCache::new(cap);
 
-        // Root inode
+        // Root inode — always present, re-pinned after eviction-prone operations.
         inode_to_path.put(FUSE_ROOT_ID, "/".to_string());
         path_to_inode.put("/".to_string(), FUSE_ROOT_ID);
 
@@ -49,6 +49,17 @@ impl InodeTable {
             inode_to_path,
             path_to_inode,
             next_inode: FUSE_ROOT_ID + 1,
+        }
+    }
+
+    /// Ensure root inode is present in both maps (Issue #3029 / Bug 4).
+    /// Called after operations that could trigger LRU eviction.
+    fn ensure_root_pinned(&mut self) {
+        if self.inode_to_path.peek(&FUSE_ROOT_ID).is_none() {
+            self.inode_to_path.put(FUSE_ROOT_ID, "/".to_string());
+        }
+        if self.path_to_inode.peek("/").is_none() {
+            self.path_to_inode.put("/".to_string(), FUSE_ROOT_ID);
         }
     }
 
@@ -62,8 +73,23 @@ impl InodeTable {
         let inode = self.next_inode;
         self.next_inode += 1;
 
-        self.path_to_inode.put(path.to_string(), inode);
-        self.inode_to_path.put(inode, path.to_string());
+        // Insert into both maps, synchronizing evictions (Issue #3029 / Bug 4).
+        // `push` returns the evicted (key, value) if the cache was at capacity.
+        if let Some((_evicted_path, evicted_inode)) =
+            self.path_to_inode.push(path.to_string(), inode)
+        {
+            // path_to_inode evicted an entry; remove the stale reverse mapping.
+            self.inode_to_path.pop(&evicted_inode);
+        }
+        if let Some((_evicted_inode, evicted_path)) =
+            self.inode_to_path.push(inode, path.to_string())
+        {
+            // inode_to_path evicted an entry; remove the stale reverse mapping.
+            self.path_to_inode.pop(&evicted_path);
+        }
+
+        // Re-pin root after potential evictions
+        self.ensure_root_pinned();
 
         inode
     }
@@ -92,9 +118,15 @@ impl InodeTable {
         }
     }
 
-    /// Get inode for a path (for cache lookups, doesn't promote in LRU).
+    /// Get inode for a path (promotes in LRU).
     fn get_inode(&mut self, path: &str) -> Option<u64> {
         self.path_to_inode.get(path).copied()
+    }
+
+    /// Peek inode for a path without promoting in LRU (Issue #3029 / Issue 8).
+    /// Used for speculative lookups where promotion is undesirable.
+    fn peek_inode(&self, path: &str) -> Option<u64> {
+        self.path_to_inode.peek(path).copied()
     }
 }
 
@@ -150,7 +182,14 @@ impl NexusFs {
     }
 
     /// Create FileAttr from metadata.
-    fn make_attr(&self, inode: u64, entry_type: &str, size: u64, created: Option<&String>, updated: Option<&String>) -> FileAttr {
+    fn make_attr(
+        &self,
+        inode: u64,
+        entry_type: &str,
+        size: u64,
+        created: Option<&String>,
+        updated: Option<&String>,
+    ) -> FileAttr {
         let kind = if entry_type == "directory" {
             FileType::Directory
         } else {
@@ -163,7 +202,11 @@ impl NexusFs {
 
         let nlink = if kind == FileType::Directory { 2 } else { 1 };
         // Use permissive permissions - access control is done by Nexus API key
-        let perm = if kind == FileType::Directory { 0o777 } else { 0o666 };
+        let perm = if kind == FileType::Directory {
+            0o777
+        } else {
+            0o666
+        };
 
         FileAttr {
             ino: inode,
@@ -195,7 +238,7 @@ impl NexusFs {
         // Fast path: check attr_cache for existing info
         {
             let inodes = self.inodes.lock().unwrap();
-            if let Some(&inode) = inodes.path_to_inode.peek(path) {
+            if let Some(inode) = inodes.peek_inode(path) {
                 let mut cache = self.attr_cache.lock().unwrap();
                 if let Some((attr, cached_at)) = cache.get(&inode) {
                     if cached_at.elapsed().unwrap_or(Duration::MAX) < ATTR_TTL {
@@ -235,7 +278,11 @@ impl NexusFs {
         // Use stat() for single API call
         match self.client.stat(path) {
             Ok(meta) => {
-                let entry_type = if meta.is_directory { "directory" } else { "file" };
+                let entry_type = if meta.is_directory {
+                    "directory"
+                } else {
+                    "file"
+                };
                 let attr = self.make_attr(
                     inode,
                     entry_type,
@@ -276,11 +323,15 @@ impl NexusFs {
         // Extract inode info while holding inodes lock, then release
         let (inode, parent_inode) = {
             let inodes = self.inodes.lock().unwrap();
-            let inode = inodes.get_inode(path);
+            let inode = inodes.peek_inode(path);
             let parent_inode = if let Some(parent) = std::path::Path::new(path).parent() {
                 let parent_path = parent.to_string_lossy().to_string();
-                let parent_path = if parent_path.is_empty() { "/".to_string() } else { parent_path };
-                inodes.get_inode(&parent_path)
+                let parent_path = if parent_path.is_empty() {
+                    "/".to_string()
+                } else {
+                    parent_path
+                };
+                inodes.peek_inode(&parent_path)
             } else {
                 None
             };
@@ -420,18 +471,18 @@ impl Filesystem for NexusFs {
             let mut cache = self.dir_cache.lock().unwrap();
             if let Some((entries, cached_at)) = cache.get(&ino) {
                 if cached_at.elapsed().unwrap_or(Duration::MAX) < ATTR_TTL {
-                    Some(entries.clone())  // Cache hit (may be empty dir)
+                    Some(entries.clone()) // Cache hit (may be empty dir)
                 } else {
                     cache.pop(&ino);
-                    None  // Cache expired
+                    None // Cache expired
                 }
             } else {
-                None  // Cache miss
+                None // Cache miss
             }
         };
 
         let entries = match cached_entries {
-            Some(entries) => entries,  // Cache hit - use cached (even if empty)
+            Some(entries) => entries, // Cache hit - use cached (even if empty)
             None => {
                 // Cache miss - fetch from server
                 match self.client.list(&path) {
@@ -472,7 +523,11 @@ impl Filesystem for NexusFs {
 
             // Pre-populate attr_cache from list() response to avoid N stat() calls
             // when kernel calls lookup()/getattr() for each entry
-            let entry_type = if entry.entry_type == "directory" { "directory" } else { "file" };
+            let entry_type = if entry.entry_type == "directory" {
+                "directory"
+            } else {
+                "file"
+            };
             let attr = self.make_attr(
                 child_inode,
                 entry_type,
@@ -480,7 +535,10 @@ impl Filesystem for NexusFs {
                 entry.created_at.as_ref(),
                 entry.updated_at.as_ref(),
             );
-            self.attr_cache.lock().unwrap().put(child_inode, (attr, SystemTime::now()));
+            self.attr_cache
+                .lock()
+                .unwrap()
+                .put(child_inode, (attr, SystemTime::now()));
 
             all_entries.push((child_inode, kind, entry.name.clone()));
         }
@@ -755,13 +813,19 @@ impl Filesystem for NexusFs {
         // Only log if RENAME_NOREPLACE (flag bit 0) is set — the server should
         // handle this, but we note it for debugging.
         if flags & 1 != 0 {
-            debug!("rename: RENAME_NOREPLACE flag set for {} -> {}", old_path, new_path);
+            debug!(
+                "rename: RENAME_NOREPLACE flag set for {} -> {}",
+                old_path, new_path
+            );
         }
 
         match self.client.rename(&old_path, &new_path) {
             Ok(_) => {
                 // Update inode mappings atomically (single lock)
-                self.inodes.lock().unwrap().rename_path(&old_path, &new_path);
+                self.inodes
+                    .lock()
+                    .unwrap()
+                    .rename_path(&old_path, &new_path);
                 self.invalidate_path(&old_path);
                 self.invalidate_path(&new_path);
                 reply.ok();
@@ -893,7 +957,14 @@ impl Filesystem for NexusFs {
         }
     }
 
-    fn flush(&mut self, _req: &Request, _ino: u64, _fh: u64, _lock_owner: u64, reply: fuser::ReplyEmpty) {
+    fn flush(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        reply: fuser::ReplyEmpty,
+    ) {
         reply.ok();
     }
 
@@ -910,7 +981,14 @@ impl Filesystem for NexusFs {
         reply.ok();
     }
 
-    fn releasedir(&mut self, _req: &Request, _ino: u64, _fh: u64, _flags: i32, reply: fuser::ReplyEmpty) {
+    fn releasedir(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _flags: i32,
+        reply: fuser::ReplyEmpty,
+    ) {
         reply.ok();
     }
 
@@ -924,5 +1002,141 @@ impl Filesystem for NexusFs {
         } else {
             reply.error(ENOENT);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_or_create_idempotent() {
+        let mut table = InodeTable::new();
+        let inode1 = table.get_or_create("/foo/bar");
+        let inode2 = table.get_or_create("/foo/bar");
+        assert_eq!(inode1, inode2, "Same path must return same inode");
+    }
+
+    #[test]
+    fn test_get_or_create_unique() {
+        let mut table = InodeTable::new();
+        let a = table.get_or_create("/a");
+        let b = table.get_or_create("/b");
+        assert_ne!(a, b, "Different paths must get different inodes");
+    }
+
+    #[test]
+    fn test_get_path_roundtrip() {
+        let mut table = InodeTable::new();
+        let inode = table.get_or_create("/foo");
+        let path = table.get_path(inode);
+        assert_eq!(path.as_deref(), Some("/foo"));
+    }
+
+    #[test]
+    fn test_root_inode_accessible() {
+        let mut table = InodeTable::new();
+        assert_eq!(table.get_path(FUSE_ROOT_ID), Some("/".to_string()));
+        assert_eq!(table.get_inode("/"), Some(FUSE_ROOT_ID));
+        assert_eq!(table.peek_inode("/"), Some(FUSE_ROOT_ID));
+    }
+
+    /// Root inode must survive even when MAX_INODE_ENTRIES are inserted
+    /// (Issue #3029 / Bug 4 regression test).
+    #[test]
+    fn test_root_inode_survives_eviction() {
+        // Use a small capacity to make the test fast
+        let cap = NonZeroUsize::new(100).unwrap();
+        let mut table = InodeTable {
+            inode_to_path: LruCache::new(cap),
+            path_to_inode: LruCache::new(cap),
+            next_inode: FUSE_ROOT_ID + 1,
+        };
+        // Manually insert root
+        table.inode_to_path.put(FUSE_ROOT_ID, "/".to_string());
+        table.path_to_inode.put("/".to_string(), FUSE_ROOT_ID);
+
+        // Insert more entries than capacity — should evict old entries but not root
+        for i in 0..200 {
+            table.get_or_create(&format!("/deep/path/entry-{}", i));
+        }
+
+        // Root must still be accessible
+        assert_eq!(
+            table.get_path(FUSE_ROOT_ID),
+            Some("/".to_string()),
+            "Root inode was evicted from inode_to_path"
+        );
+        assert_eq!(
+            table.peek_inode("/"),
+            Some(FUSE_ROOT_ID),
+            "Root inode was evicted from path_to_inode"
+        );
+    }
+
+    /// After eviction, both maps must agree — no stale reverse mappings
+    /// (Issue #3029 / Bug 4 regression test).
+    #[test]
+    fn test_eviction_sync() {
+        let cap = NonZeroUsize::new(10).unwrap();
+        let mut table = InodeTable {
+            inode_to_path: LruCache::new(cap),
+            path_to_inode: LruCache::new(cap),
+            next_inode: FUSE_ROOT_ID + 1,
+        };
+        table.inode_to_path.put(FUSE_ROOT_ID, "/".to_string());
+        table.path_to_inode.put("/".to_string(), FUSE_ROOT_ID);
+
+        // Record first batch of inodes
+        let mut first_inodes = Vec::new();
+        for i in 0..9 {
+            let inode = table.get_or_create(&format!("/file-{}", i));
+            first_inodes.push((inode, format!("/file-{}", i)));
+        }
+
+        // Now insert enough to trigger evictions of the first batch
+        for i in 0..20 {
+            table.get_or_create(&format!("/new-{}", i));
+        }
+
+        // For any inode in inode_to_path, path_to_inode must agree (and vice versa)
+        // Check: if get_path returns a path, peek_inode on that path must return the same inode
+        for inode_val in 1..table.next_inode {
+            if let Some(path) = table.inode_to_path.peek(&inode_val).cloned() {
+                let reverse = table.path_to_inode.peek(&path).copied();
+                assert_eq!(
+                    reverse,
+                    Some(inode_val),
+                    "Desync: inode {} -> path {:?} but path -> inode {:?}",
+                    inode_val,
+                    path,
+                    reverse,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_rename_path() {
+        let mut table = InodeTable::new();
+        let inode = table.get_or_create("/old/name");
+        table.rename_path("/old/name", "/new/name");
+
+        // Old path should not resolve
+        assert_eq!(table.peek_inode("/old/name"), None);
+        // New path should resolve to same inode
+        assert_eq!(table.peek_inode("/new/name"), Some(inode));
+        // Inode should map to new path
+        assert_eq!(table.get_path(inode), Some("/new/name".to_string()));
+    }
+
+    #[test]
+    fn test_remove_path() {
+        let mut table = InodeTable::new();
+        let inode = table.get_or_create("/to-delete");
+        let removed = table.remove_path("/to-delete");
+        assert_eq!(removed, Some(inode));
+        assert_eq!(table.peek_inode("/to-delete"), None);
+        assert_eq!(table.get_path(inode), None);
     }
 }

--- a/nexus-fuse/src/fs.rs
+++ b/nexus-fuse/src/fs.rs
@@ -111,10 +111,24 @@ impl InodeTable {
     }
 
     /// Update path for an existing inode (rename).
+    /// Uses `push` for synchronized eviction and re-pins root (Issue #3029 / Bug 4).
     fn rename_path(&mut self, old_path: &str, new_path: &str) {
         if let Some(inode) = self.path_to_inode.pop(old_path) {
-            self.inode_to_path.put(inode, new_path.to_string());
-            self.path_to_inode.put(new_path.to_string(), inode);
+            self.inode_to_path.pop(&inode);
+
+            // Re-insert with synchronized eviction (same pattern as get_or_create)
+            if let Some((_evicted_path, evicted_inode)) =
+                self.path_to_inode.push(new_path.to_string(), inode)
+            {
+                self.inode_to_path.pop(&evicted_inode);
+            }
+            if let Some((_evicted_inode, evicted_path)) =
+                self.inode_to_path.push(inode, new_path.to_string())
+            {
+                self.path_to_inode.pop(&evicted_path);
+            }
+
+            self.ensure_root_pinned();
         }
     }
 

--- a/rust/nexus_raft/src/pyo3_bindings.rs
+++ b/rust/nexus_raft/src/pyo3_bindings.rs
@@ -421,6 +421,7 @@ impl PyMetastore {
             max_holders,
             ttl_secs,
             holder_info: holder_info.to_string(),
+            now_secs: crate::prelude::FullStateMachine::now(),
         };
 
         let result = self.apply_command_raw(cmd)?;
@@ -465,6 +466,7 @@ impl PyMetastore {
             path: path.to_string(),
             lock_id: lock_id.to_string(),
             new_ttl_secs,
+            now_secs: crate::prelude::FullStateMachine::now(),
         };
         let result = self.apply_command_raw(cmd)?;
         match result {
@@ -1104,6 +1106,7 @@ impl PyZoneHandle {
             max_holders,
             ttl_secs,
             holder_info: holder_info.to_string(),
+            now_secs: crate::prelude::FullStateMachine::now(),
         };
         let result = self.propose_command_raw(py, cmd)?;
         match result {
@@ -1134,6 +1137,7 @@ impl PyZoneHandle {
             path: path.to_string(),
             lock_id: lock_id.to_string(),
             new_ttl_secs,
+            now_secs: crate::prelude::FullStateMachine::now(),
         };
         let result = self.propose_command_raw(py, cmd)?;
         Ok(matches!(result, CommandResult::Success))

--- a/rust/nexus_raft/src/raft/state_machine.rs
+++ b/rust/nexus_raft/src/raft/state_machine.rs
@@ -49,6 +49,10 @@ pub enum Command {
         ttl_secs: u32,
         /// Information about the holder (e.g., "agent:xxx").
         holder_info: String,
+        /// Wall-clock timestamp captured at proposal time (Unix secs).
+        /// All replicas use this value instead of local clocks to ensure
+        /// deterministic state machine application (Issue #3029 / Bug 1).
+        now_secs: u64,
     },
 
     /// Release a distributed lock.
@@ -67,6 +71,10 @@ pub enum Command {
         lock_id: String,
         /// New TTL in seconds (from now).
         new_ttl_secs: u32,
+        /// Wall-clock timestamp captured at proposal time (Unix secs).
+        /// All replicas use this value instead of local clocks to ensure
+        /// deterministic state machine application (Issue #3029 / Bug 1).
+        now_secs: u64,
     },
 
     /// Compare-and-swap metadata: write only if current version matches.
@@ -146,7 +154,7 @@ pub struct HolderInfo {
 }
 
 /// Lock entry stored in the state machine.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LockInfo {
     /// Resource path.
     pub path: String,
@@ -520,8 +528,9 @@ impl FullStateMachine {
         })
     }
 
-    /// Get current Unix timestamp.
-    fn now() -> u64 {
+    /// Get current Unix timestamp. Public so proposal sites can capture
+    /// the timestamp before it enters the replicated command.
+    pub fn now() -> u64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -684,6 +693,9 @@ impl FullStateMachine {
     }
 
     /// Apply AcquireLock command.
+    ///
+    /// `now` is the wall-clock timestamp from the replicated command, ensuring
+    /// all replicas compute identical lock state (Issue #3029 / Bug 1).
     fn apply_acquire_lock(
         &self,
         path: &str,
@@ -691,8 +703,8 @@ impl FullStateMachine {
         max_holders: u32,
         ttl_secs: u32,
         holder_info: &str,
+        now: u64,
     ) -> Result<CommandResult> {
-        let now = Self::now();
         let expires_at = now + ttl_secs as u64;
 
         let new_holder = HolderInfo {
@@ -777,13 +789,16 @@ impl FullStateMachine {
     }
 
     /// Apply ExtendLock command.
+    ///
+    /// `now` is the wall-clock timestamp from the replicated command, ensuring
+    /// all replicas compute identical lock state (Issue #3029 / Bug 1).
     fn apply_extend_lock(
         &self,
         path: &str,
         lock_id: &str,
         new_ttl_secs: u32,
+        now: u64,
     ) -> Result<CommandResult> {
-        let now = Self::now();
         let new_expires_at = now + new_ttl_secs as u64;
 
         let mut lock_info: LockInfo = match self.locks.get(path.as_bytes())? {
@@ -908,13 +923,22 @@ impl FullStateMachine {
                 max_holders,
                 ttl_secs,
                 holder_info,
-            } => self.apply_acquire_lock(path, lock_id, *max_holders, *ttl_secs, holder_info),
+                now_secs,
+            } => self.apply_acquire_lock(
+                path,
+                lock_id,
+                *max_holders,
+                *ttl_secs,
+                holder_info,
+                *now_secs,
+            ),
             Command::ReleaseLock { path, lock_id } => self.apply_release_lock(path, lock_id),
             Command::ExtendLock {
                 path,
                 lock_id,
                 new_ttl_secs,
-            } => self.apply_extend_lock(path, lock_id, *new_ttl_secs),
+                now_secs,
+            } => self.apply_extend_lock(path, lock_id, *new_ttl_secs, *now_secs),
             Command::AdjustCounter { key, delta } => self.apply_adjust_counter(key, *delta),
             Command::Noop => Ok(CommandResult::Success),
         }
@@ -1090,6 +1114,7 @@ mod tests {
             max_holders: 3,
             ttl_secs: 30,
             holder_info: "agent:test".into(),
+            now_secs: 1000,
         };
 
         let serialized = bincode::serialize(&cmd).unwrap();
@@ -1102,15 +1127,106 @@ mod tests {
                 max_holders,
                 ttl_secs,
                 holder_info,
+                now_secs,
             } => {
                 assert_eq!(path, "/data/test.txt");
                 assert_eq!(lock_id, "uuid-123");
                 assert_eq!(max_holders, 3);
                 assert_eq!(ttl_secs, 30);
                 assert_eq!(holder_info, "agent:test");
+                assert_eq!(now_secs, 1000);
             }
             _ => panic!("wrong command type"),
         }
+    }
+
+    /// Determinism regression test (Issue #3029 / Bug 1):
+    /// Two state machines applying the same commands must produce byte-identical snapshots.
+    #[test]
+    fn test_state_machine_determinism() {
+        let store1 = RedbStore::open_temporary().unwrap();
+        let store2 = RedbStore::open_temporary().unwrap();
+        let mut sm1 = FullStateMachine::new(&store1).unwrap();
+        let mut sm2 = FullStateMachine::new(&store2).unwrap();
+
+        // Build a sequence of commands with explicit timestamps
+        let commands: Vec<(u64, Command)> = vec![
+            (
+                1,
+                Command::SetMetadata {
+                    key: "/file1".into(),
+                    value: b"data1".to_vec(),
+                },
+            ),
+            (
+                2,
+                Command::AcquireLock {
+                    path: "/file1".into(),
+                    lock_id: "lock-1".into(),
+                    max_holders: 1,
+                    ttl_secs: 60,
+                    holder_info: "agent:a".into(),
+                    now_secs: 1000,
+                },
+            ),
+            (
+                3,
+                Command::AcquireLock {
+                    path: "/file2".into(),
+                    lock_id: "lock-2".into(),
+                    max_holders: 3,
+                    ttl_secs: 30,
+                    holder_info: "agent:b".into(),
+                    now_secs: 1001,
+                },
+            ),
+            (
+                4,
+                Command::ExtendLock {
+                    path: "/file1".into(),
+                    lock_id: "lock-1".into(),
+                    new_ttl_secs: 120,
+                    now_secs: 1010,
+                },
+            ),
+            (
+                5,
+                Command::ReleaseLock {
+                    path: "/file2".into(),
+                    lock_id: "lock-2".into(),
+                },
+            ),
+            // Acquire after TTL-based expiry cleanup
+            (
+                6,
+                Command::AcquireLock {
+                    path: "/file2".into(),
+                    lock_id: "lock-3".into(),
+                    max_holders: 1,
+                    ttl_secs: 60,
+                    holder_info: "agent:c".into(),
+                    now_secs: 2000, // well past lock-2's 30s TTL
+                },
+            ),
+        ];
+
+        // Apply identical commands to both state machines
+        for (idx, cmd) in &commands {
+            sm1.apply(*idx, cmd).unwrap();
+            sm2.apply(*idx, cmd).unwrap();
+        }
+
+        // Snapshots must be logically identical (HashMap serialization order may vary)
+        let snap1 = sm1.snapshot().unwrap();
+        let snap2 = sm2.snapshot().unwrap();
+        let decoded1: Snapshot = bincode::deserialize(&snap1).unwrap();
+        let decoded2: Snapshot = bincode::deserialize(&snap2).unwrap();
+        assert_eq!(decoded1.metadata, decoded2.metadata, "Metadata diverged");
+        assert_eq!(decoded1.locks, decoded2.locks, "Locks diverged");
+        assert_eq!(
+            decoded1.last_applied, decoded2.last_applied,
+            "last_applied diverged"
+        );
     }
 
     #[test]
@@ -1153,6 +1269,7 @@ mod tests {
             max_holders: 1,
             ttl_secs: 30,
             holder_info: "agent:test1".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(1, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1169,6 +1286,7 @@ mod tests {
             max_holders: 1,
             ttl_secs: 30,
             holder_info: "agent:test2".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(2, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1193,6 +1311,7 @@ mod tests {
             max_holders: 1,
             ttl_secs: 30,
             holder_info: "agent:test2".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(4, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1214,6 +1333,7 @@ mod tests {
             max_holders: 3,
             ttl_secs: 30,
             holder_info: "agent:test1".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(1, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1231,6 +1351,7 @@ mod tests {
             max_holders: 3,
             ttl_secs: 30,
             holder_info: "agent:test2".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(2, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1247,6 +1368,7 @@ mod tests {
             max_holders: 3,
             ttl_secs: 30,
             holder_info: "agent:test3".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(3, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1263,6 +1385,7 @@ mod tests {
             max_holders: 3,
             ttl_secs: 30,
             holder_info: "agent:test4".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(4, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1286,6 +1409,7 @@ mod tests {
             max_holders: 3,
             ttl_secs: 30,
             holder_info: "agent:test4".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(6, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1326,6 +1450,7 @@ mod tests {
                 max_holders: 1,
                 ttl_secs: 3600,
                 holder_info: "agent:test".into(),
+                now_secs: 1000,
             },
         )
         .unwrap();
@@ -1357,6 +1482,7 @@ mod tests {
             max_holders: 1,
             ttl_secs: 30,
             holder_info: "agent:test1".into(),
+            now_secs: 1000,
         };
         sm.apply(1, &cmd).unwrap();
 
@@ -1376,13 +1502,14 @@ mod tests {
         let store = RedbStore::open_temporary().unwrap();
         let mut sm = FullStateMachine::new(&store).unwrap();
 
-        // Acquire a lock with 1-second TTL
+        // Acquire a lock with 1-second TTL at time 1000
         let cmd = Command::AcquireLock {
             path: "/test/expire".into(),
             lock_id: "holder-1".into(),
             max_holders: 1,
             ttl_secs: 1,
             holder_info: "agent:test1".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(1, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1391,16 +1518,15 @@ mod tests {
             panic!("Expected LockResult");
         }
 
-        // Wait for TTL to expire
-        std::thread::sleep(std::time::Duration::from_secs(2));
-
-        // Another holder should be able to acquire because the first expired
+        // Another holder acquires at time 1002 (after the 1s TTL expired)
+        // No sleep needed — deterministic timestamps from the command.
         let cmd2 = Command::AcquireLock {
             path: "/test/expire".into(),
             lock_id: "holder-2".into(),
             max_holders: 1,
             ttl_secs: 30,
             holder_info: "agent:test2".into(),
+            now_secs: 1002,
         };
         let result = sm.apply(2, &cmd2).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1426,6 +1552,7 @@ mod tests {
             max_holders: 3,
             ttl_secs: 30,
             holder_info: "agent:test1".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(1, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1441,6 +1568,7 @@ mod tests {
             max_holders: 1, // Mismatch: 1 != 3
             ttl_secs: 30,
             holder_info: "agent:test2".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(2, &cmd2).unwrap();
         if let CommandResult::LockResult(state) = result {
@@ -1456,21 +1584,19 @@ mod tests {
         let store = RedbStore::open_temporary().unwrap();
         let mut sm = FullStateMachine::new(&store).unwrap();
 
-        // Acquire a lock with 1-second TTL
+        // Acquire a lock with 1-second TTL at time 1000 (expires at 1001)
         let cmd = Command::AcquireLock {
             path: "/test/snap-expire".into(),
             lock_id: "holder-1".into(),
             max_holders: 1,
             ttl_secs: 1,
             holder_info: "agent:test1".into(),
+            now_secs: 1000,
         };
         sm.apply(1, &cmd).unwrap();
 
-        // Wait for TTL to expire
-        std::thread::sleep(std::time::Duration::from_secs(2));
-
         // Take snapshot — should still include the expired holder
-        // (cleanup happens during acquire, not snapshot)
+        // (cleanup happens during acquire, not snapshot; the lock expired at 1001)
         let snapshot_data = sm.snapshot().unwrap();
 
         // Restore to a new state machine
@@ -1499,6 +1625,7 @@ mod tests {
             max_holders: u32::MAX,
             ttl_secs: 30,
             holder_info: "agent:test1".into(),
+            now_secs: 1000,
         };
         let result = sm.apply(1, &cmd).unwrap();
         if let CommandResult::LockResult(state) = result {

--- a/rust/nexus_raft/src/raft/zone_registry.rs
+++ b/rust/nexus_raft/src/raft/zone_registry.rs
@@ -92,10 +92,7 @@ impl ZoneRaftRegistry {
     /// * `zone_id` — Unique zone identifier.
     /// * `peers` — Peer nodes in this zone's Raft group.
     /// * `runtime_handle` — Tokio runtime handle for spawning the transport loop.
-    #[expect(
-        clippy::result_large_err,
-        reason = "TransportError contains tonic types; will Box in transport refactor"
-    )]
+    #[allow(clippy::result_large_err)]
     pub fn create_zone(
         &self,
         zone_id: &str,
@@ -119,10 +116,7 @@ impl ZoneRaftRegistry {
     /// The leader's snapshot will bring the correct voter set after ConfChange commit.
     ///
     /// After calling this, send a JoinZone RPC to the leader.
-    #[expect(
-        clippy::result_large_err,
-        reason = "TransportError contains tonic types; will Box in transport refactor"
-    )]
+    #[allow(clippy::result_large_err)]
     pub fn join_zone(
         &self,
         zone_id: &str,
@@ -143,10 +137,7 @@ impl ZoneRaftRegistry {
     }
 
     /// Internal: open sled, create ZoneConsensus + driver, spawn transport loop, register zone.
-    #[expect(
-        clippy::result_large_err,
-        reason = "TransportError contains tonic types; will Box in transport refactor"
-    )]
+    #[allow(clippy::result_large_err)]
     fn setup_zone(
         &self,
         zone_id: &str,
@@ -273,10 +264,7 @@ impl ZoneRaftRegistry {
     }
 
     /// Remove a zone, shutting down its transport loop.
-    #[expect(
-        clippy::result_large_err,
-        reason = "TransportError contains tonic types; will Box in transport refactor"
-    )]
+    #[allow(clippy::result_large_err)]
     pub fn remove_zone(&self, zone_id: &str) -> Result<(), TransportError> {
         match self.zones.remove(zone_id) {
             Some((_, entry)) => {

--- a/rust/nexus_raft/src/transport/mod.rs
+++ b/rust/nexus_raft/src/transport/mod.rs
@@ -166,19 +166,13 @@ impl NodeAddress {
     }
 
     /// Parse from "id@host:port" format.
-    #[expect(
-        clippy::result_large_err,
-        reason = "TransportError contains tonic types; will Box in transport refactor"
-    )]
+    #[allow(clippy::result_large_err)]
     pub fn parse(s: &str) -> Result<Self> {
         Self::parse_with_tls(s, false)
     }
 
     /// Parse from "id@host:port" format, using `https://` scheme when TLS is active.
-    #[expect(
-        clippy::result_large_err,
-        reason = "TransportError contains tonic types; will Box in transport refactor"
-    )]
+    #[allow(clippy::result_large_err)]
     pub fn parse_with_tls(s: &str, use_tls: bool) -> Result<Self> {
         let parts: Vec<&str> = s.splitn(2, '@').collect();
         if parts.len() != 2 {

--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -4,12 +4,6 @@
 //! `ZoneRaftRegistry`. There is no separate "single-zone" code path —
 //! a single-zone deployment is simply a registry with one zone.
 
-// TransportError contains tonic types that are large; will Box in future refactor.
-#![expect(
-    clippy::result_large_err,
-    reason = "TransportError contains tonic types; will Box large variants in transport refactor"
-)]
-
 use super::proto::nexus::raft::{
     raft_command::Command as ProtoCommandVariant,
     raft_query::Query as ProtoQueryVariant,
@@ -253,6 +247,7 @@ fn proto_command_to_internal(proto: RaftCommand) -> Option<Command> {
             max_holders: 1, // Default to mutex
             ttl_secs: (al.ttl_ms / 1000) as u32,
             holder_info: al.holder_id,
+            now_secs: crate::prelude::FullStateMachine::now(),
         }),
         ProtoCommandVariant::ReleaseLock(rl) => Some(Command::ReleaseLock {
             path: rl.lock_id.clone(),
@@ -262,6 +257,7 @@ fn proto_command_to_internal(proto: RaftCommand) -> Option<Command> {
             path: el.lock_id.clone(),
             lock_id: el.holder_id,
             new_ttl_secs: (el.ttl_ms / 1000) as u32,
+            now_secs: crate::prelude::FullStateMachine::now(),
         }),
     }
 }

--- a/rust/nexus_tasks/src/store.rs
+++ b/rust/nexus_tasks/src/store.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 
 use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
 
@@ -9,56 +10,65 @@ use crate::priority::{
 };
 use crate::task::{TaskRecord, TaskStatus};
 
-/// Fjall-backed task storage with 4 keyspaces (column families).
+/// Fjall-backed task storage with 5 keyspaces (column families).
 ///
 /// Keyspaces:
-/// - `tasks`:       task_id (u64 BE)          -> TaskRecord (bincode)
-/// - `pending_idx`: composite priority key     -> () (empty value)
-/// - `running_idx`: [lease_expires][task_id]   -> () (empty value)
-/// - `dead_letter`: task_id (u64 BE)           -> TaskRecord (bincode)
+/// - `tasks`:            task_id (u64 BE)          -> TaskRecord (bincode)
+/// - `pending_idx`:      composite priority key     -> () (empty value)
+/// - `running_idx`:      [lease_expires][task_id]   -> () (empty value)
+/// - `running_task_key`: task_id (u64 BE)           -> running_idx key bytes
+/// - `dead_letter`:      task_id (u64 BE)           -> TaskRecord (bincode)
 pub struct TaskStore {
     db: Database,
     tasks: Keyspace,
     pending_idx: Keyspace,
     running_idx: Keyspace,
+    /// Reverse lookup: task_id -> running_idx key, for O(1) removal.
+    running_task_key: Keyspace,
     dead_letter: Keyspace,
     id_counter: AtomicU64,
-    /// Cached pending count — updated atomically on submit/claim/requeue.
-    /// Avoids O(n) scan on every admission control check.
+    /// Prevents concurrent claim_next races (Issue #3029 / Bug 2).
+    claim_lock: Mutex<()>,
+    // Atomic status counters — O(1) stats instead of full-table scans.
     pending_count: AtomicU64,
+    running_count: AtomicU64,
+    completed_count: AtomicU64,
+    cancelled_count: AtomicU64,
+    dead_letter_count: AtomicU64,
 }
 
 impl TaskStore {
     /// Open or create the task store at the given path.
     pub fn open(path: &str) -> Result<Self> {
-        let db = Database::builder(Path::new(path))
-            .open()
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
+        let db = Database::builder(Path::new(path)).open()?;
 
-        let tasks = db
-            .keyspace("tasks", KeyspaceCreateOptions::default)
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
-        let pending_idx = db
-            .keyspace("pending_idx", KeyspaceCreateOptions::default)
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
-        let running_idx = db
-            .keyspace("running_idx", KeyspaceCreateOptions::default)
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
-        let dead_letter = db
-            .keyspace("dead_letter", KeyspaceCreateOptions::default)
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
+        let tasks = db.keyspace("tasks", KeyspaceCreateOptions::default)?;
+        let pending_idx = db.keyspace("pending_idx", KeyspaceCreateOptions::default)?;
+        let running_idx = db.keyspace("running_idx", KeyspaceCreateOptions::default)?;
+        let running_task_key = db.keyspace("running_task_key", KeyspaceCreateOptions::default)?;
+        let dead_letter = db.keyspace("dead_letter", KeyspaceCreateOptions::default)?;
 
         // Initialize counter from existing max task_id
         let max_id = Self::find_max_task_id(&tasks);
+
+        // Scan once to initialize all status counters and populate running_task_key
+        let (pending, running, completed, cancelled, dead_letter_n) =
+            Self::count_all_statuses(&tasks);
 
         Ok(Self {
             db,
             tasks,
             pending_idx,
             running_idx,
+            running_task_key,
             dead_letter,
             id_counter: AtomicU64::new(max_id + 1),
-            pending_count: AtomicU64::new(0), // Will be initialized by first count_pending call
+            claim_lock: Mutex::new(()),
+            pending_count: AtomicU64::new(pending),
+            running_count: AtomicU64::new(running),
+            completed_count: AtomicU64::new(completed),
+            cancelled_count: AtomicU64::new(cancelled),
+            dead_letter_count: AtomicU64::new(dead_letter_n),
         })
     }
 
@@ -81,6 +91,32 @@ impl TaskStore {
         max_id
     }
 
+    /// Scan all tasks to count by status. Used once at startup.
+    fn count_all_statuses(tasks: &Keyspace) -> (u64, u64, u64, u64, u64) {
+        let mut pending = 0u64;
+        let mut running = 0u64;
+        let mut completed = 0u64;
+        let mut cancelled = 0u64;
+        let mut dead_letter = 0u64;
+
+        for guard in tasks.iter() {
+            if let Ok((_, value)) = guard.into_inner() {
+                if let Ok(record) = bincode::deserialize::<TaskRecord>(value.as_ref()) {
+                    match record.status {
+                        TaskStatus::Pending => pending += 1,
+                        TaskStatus::Running => running += 1,
+                        TaskStatus::Completed => completed += 1,
+                        TaskStatus::Cancelled => cancelled += 1,
+                        TaskStatus::DeadLetter => dead_letter += 1,
+                        TaskStatus::Failed => {} // transient, not counted
+                    }
+                }
+            }
+        }
+
+        (pending, running, completed, cancelled, dead_letter)
+    }
+
     /// Generate a monotonically increasing task ID.
     pub fn generate_id(&self) -> u64 {
         self.id_counter.fetch_add(1, Ordering::Relaxed)
@@ -95,21 +131,15 @@ impl TaskStore {
         let mut batch = self.db.batch();
         batch.insert(&self.tasks, task_key, task_value);
         batch.insert(&self.pending_idx, pending_key, vec![]);
-        batch
-            .commit()
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
-        self.pending_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        batch.commit()?;
+        self.pending_count.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
     /// Get a task by ID from the primary store.
     pub fn get_task(&self, task_id: u64) -> Result<Option<TaskRecord>> {
         let key = task_id.to_be_bytes();
-        match self
-            .tasks
-            .get(key)
-            .map_err(|e| TaskError::Storage(e.to_string()))?
-        {
+        match self.tasks.get(key)? {
             Some(bytes) => {
                 let record: TaskRecord = bincode::deserialize(bytes.as_ref())?;
                 Ok(Some(record))
@@ -122,14 +152,24 @@ impl TaskStore {
     pub fn update_task(&self, task: &TaskRecord) -> Result<()> {
         let key = task.task_id.to_be_bytes();
         let value = bincode::serialize(task)?;
-        self.tasks
-            .insert(key, value)
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
+        self.tasks.insert(key, value)?;
         Ok(())
+    }
+
+    /// Look up the running_idx key for a task via the reverse-lookup keyspace.
+    /// Returns O(1) instead of scanning the running index.
+    fn find_running_key(&self, task_id: u64) -> Result<Option<Vec<u8>>> {
+        match self.running_task_key.get(task_id.to_be_bytes())? {
+            Some(val) => Ok(Some(val.as_ref().to_vec())),
+            None => Ok(None),
+        }
     }
 
     /// Claim the next pending task. Atomically moves from pending_idx to running_idx.
     /// Returns None if no eligible tasks are available.
+    ///
+    /// Protected by a process-local mutex to prevent concurrent claim races
+    /// (Issue #3029 / Bug 2).
     pub fn claim_next(
         &self,
         worker_id: &str,
@@ -137,6 +177,8 @@ impl TaskStore {
         now: u64,
         max_wait_secs: u64,
     ) -> Result<Option<TaskRecord>> {
+        let _guard = self.claim_lock.lock().unwrap();
+
         // Check for anti-starvation: if the oldest low-priority task has waited too long, promote it
         let mut target_key = None;
 
@@ -184,9 +226,7 @@ impl TaskStore {
         // Load the task record
         let Some(mut task) = self.get_task(task_id)? else {
             // Stale index entry — remove and return None
-            self.pending_idx
-                .remove(&key_bytes)
-                .map_err(|e| TaskError::Storage(e.to_string()))?;
+            self.pending_idx.remove(&key_bytes)?;
             return Ok(None);
         };
 
@@ -206,20 +246,22 @@ impl TaskStore {
         let task_value = bincode::serialize(&task)?;
         let running_key = encode_running_key(lease_expires, task_id);
 
-        // Atomic: remove from pending, add to running, update task
+        // Atomic: remove from pending, add to running + reverse lookup, update task
         let mut batch = self.db.batch();
         batch.remove(&self.pending_idx, &key_bytes);
-        batch.insert(&self.running_idx, running_key, vec![]);
+        batch.insert(&self.running_idx, &running_key, vec![]);
+        batch.insert(&self.running_task_key, task_id.to_be_bytes(), &running_key);
         batch.insert(&self.tasks, task_id.to_be_bytes(), task_value);
-        batch
-            .commit()
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
-        self.pending_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        batch.commit()?;
+        self.pending_count.fetch_sub(1, Ordering::Relaxed);
+        self.running_count.fetch_add(1, Ordering::Relaxed);
 
         Ok(Some(task))
     }
 
-    /// Move a running task to completed state. Removes from running_idx.
+    /// Move a running task to completed state. Atomically removes from running_idx
+    /// and updates the task record in a single batch (Issue #3029 / Bug 3).
+    ///
     /// Verifies that `worker_id` matches the current owner to prevent stale workers
     /// from overwriting a re-claimed task after lease expiry.
     pub fn complete_task(
@@ -248,18 +290,31 @@ impl TaskStore {
             });
         }
 
-        // Find and remove running index entry
-        self.remove_from_running_idx(task_id)?;
+        let running_key = self.find_running_key(task_id)?;
 
         task.status = TaskStatus::Completed;
         task.result = Some(result.to_vec());
         task.completed_at = Some(now);
+        let task_value = bincode::serialize(&task)?;
 
-        self.update_task(&task)?;
+        let mut batch = self.db.batch();
+        if let Some(ref rk) = running_key {
+            batch.remove(&self.running_idx, rk);
+        }
+        batch.remove(&self.running_task_key, task_id.to_be_bytes());
+        batch.insert(&self.tasks, task_id.to_be_bytes(), task_value);
+        batch.commit()?;
+
+        self.running_count.fetch_sub(1, Ordering::Relaxed);
+        self.completed_count.fetch_add(1, Ordering::Relaxed);
+
         Ok(task)
     }
 
     /// Fail a running task. If retries remain, re-queue to pending; otherwise dead-letter.
+    /// All index updates and task writes are in a single atomic batch
+    /// (Issue #3029 / Bug 3 + Bug 5).
+    ///
     /// Verifies that `worker_id` matches the current owner to prevent stale workers
     /// from overwriting a re-claimed task after lease expiry.
     pub fn fail_task(
@@ -288,64 +343,71 @@ impl TaskStore {
             });
         }
 
-        // Remove from running index
-        self.remove_from_running_idx(task_id)?;
-
+        let running_key = self.find_running_key(task_id)?;
         task.error_message = Some(error_message.to_string());
 
         let dead_lettered = crate::retry::should_dead_letter(task.attempt, task.max_retries);
 
+        let mut batch = self.db.batch();
+
+        // Remove from running index (atomically in batch)
+        if let Some(ref rk) = running_key {
+            batch.remove(&self.running_idx, rk);
+        }
+        batch.remove(&self.running_task_key, task_id.to_be_bytes());
+
         if dead_lettered {
-            // Move to dead letter
             task.status = TaskStatus::DeadLetter;
             task.completed_at = Some(now);
             let task_value = bincode::serialize(&task)?;
-
-            let mut batch = self.db.batch();
             batch.insert(&self.tasks, task_id.to_be_bytes(), task_value.clone());
             batch.insert(&self.dead_letter, task_id.to_be_bytes(), task_value);
-            batch
-                .commit()
-                .map_err(|e| TaskError::Storage(e.to_string()))?;
         } else {
-            // Re-queue with backoff delay
             let delay = crate::retry::backoff_secs(task.attempt, task_id);
             task.status = TaskStatus::Pending;
             task.run_at = now + delay;
             task.claimed_at = None;
             task.claimed_by = None;
-
             let task_value = bincode::serialize(&task)?;
             let pending_key = encode_pending_key(task.priority, task.run_at, task_id);
-
-            let mut batch = self.db.batch();
             batch.insert(&self.tasks, task_id.to_be_bytes(), task_value);
             batch.insert(&self.pending_idx, pending_key, vec![]);
-            batch
-                .commit()
-                .map_err(|e| TaskError::Storage(e.to_string()))?;
+        }
+
+        batch.commit()?;
+
+        self.running_count.fetch_sub(1, Ordering::Relaxed);
+        if dead_lettered {
+            self.dead_letter_count.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.pending_count.fetch_add(1, Ordering::Relaxed);
         }
 
         Ok((task, dead_lettered))
     }
 
     /// Cancel a task. Works for both pending and running tasks.
+    /// All index updates and task writes are in a single atomic batch
+    /// (Issue #3029 / Bug 3).
     pub fn cancel_task(&self, task_id: u64, now: u64) -> Result<TaskRecord> {
         let mut task = self
             .get_task(task_id)?
             .ok_or(TaskError::NotFound(task_id))?;
 
-        match task.status {
+        let prev_status = task.status;
+
+        let mut batch = self.db.batch();
+
+        match prev_status {
             TaskStatus::Pending => {
-                // Remove from pending index
                 let pending_key = encode_pending_key(task.priority, task.run_at, task_id);
-                self.pending_idx
-                    .remove(pending_key)
-                    .map_err(|e| TaskError::Storage(e.to_string()))?;
+                batch.remove(&self.pending_idx, pending_key);
             }
             TaskStatus::Running => {
-                // Remove from running index
-                self.remove_from_running_idx(task_id)?;
+                if let Some(rk) = self.find_running_key(task_id)? {
+                    batch.remove(&self.running_idx, &rk);
+                }
+                batch.remove(&self.running_task_key, task_id.to_be_bytes());
             }
             _ => {
                 return Err(TaskError::InvalidTransition {
@@ -358,13 +420,27 @@ impl TaskStore {
 
         task.status = TaskStatus::Cancelled;
         task.completed_at = Some(now);
-        self.update_task(&task)?;
+        let task_value = bincode::serialize(&task)?;
+        batch.insert(&self.tasks, task_id.to_be_bytes(), task_value);
+        batch.commit()?;
+
+        match prev_status {
+            TaskStatus::Pending => {
+                self.pending_count.fetch_sub(1, Ordering::Relaxed);
+            }
+            TaskStatus::Running => {
+                self.running_count.fetch_sub(1, Ordering::Relaxed);
+            }
+            _ => {}
+        }
+        self.cancelled_count.fetch_add(1, Ordering::Relaxed);
+
         Ok(task)
     }
 
     /// Requeue tasks whose leases have expired. Returns count of requeued tasks.
+    /// All mutations are committed in a single batch (Issue #3029 / Issue 15).
     pub fn requeue_abandoned(&self, now: u64) -> Result<u32> {
-        let mut count = 0u32;
         let upper_bound = encode_running_key(now, u64::MAX);
 
         // Collect expired entries first (avoid holding iterator across writes)
@@ -379,19 +455,24 @@ impl TaskStore {
             })
             .collect();
 
-        for (running_key, task_id) in expired {
-            let Some(mut task) = self.get_task(task_id)? else {
-                // Stale index entry — just clean it up
-                self.running_idx
-                    .remove(&running_key)
-                    .map_err(|e| TaskError::Storage(e.to_string()))?;
+        if expired.is_empty() {
+            return Ok(0);
+        }
+
+        let mut batch = self.db.batch();
+        let mut requeued = 0u32;
+
+        for (running_key, task_id) in &expired {
+            let Some(mut task) = self.get_task(*task_id)? else {
+                // Stale index entry — clean up
+                batch.remove(&self.running_idx, running_key);
+                batch.remove(&self.running_task_key, task_id.to_be_bytes());
                 continue;
             };
 
             if task.status != TaskStatus::Running {
-                self.running_idx
-                    .remove(&running_key)
-                    .map_err(|e| TaskError::Storage(e.to_string()))?;
+                batch.remove(&self.running_idx, running_key);
+                batch.remove(&self.running_task_key, task_id.to_be_bytes());
                 continue;
             }
 
@@ -402,29 +483,34 @@ impl TaskStore {
             task.error_message = Some("lease expired (abandoned)".to_string());
 
             let task_value = bincode::serialize(&task)?;
-            let pending_key = encode_pending_key(task.priority, task.run_at, task_id);
+            let pending_key = encode_pending_key(task.priority, task.run_at, *task_id);
 
-            let mut batch = self.db.batch();
-            batch.remove(&self.running_idx, &running_key);
+            batch.remove(&self.running_idx, running_key);
+            batch.remove(&self.running_task_key, task_id.to_be_bytes());
             batch.insert(&self.pending_idx, pending_key, vec![]);
             batch.insert(&self.tasks, task_id.to_be_bytes(), task_value);
-            batch
-                .commit()
-                .map_err(|e| TaskError::Storage(e.to_string()))?;
 
-            count += 1;
+            requeued += 1;
         }
 
-        Ok(count)
+        batch.commit()?;
+
+        // Update counters for requeued tasks (Running → Pending)
+        self.running_count
+            .fetch_sub(requeued as u64, Ordering::Relaxed);
+        self.pending_count
+            .fetch_add(requeued as u64, Ordering::Relaxed);
+
+        Ok(requeued)
     }
 
     /// Remove completed/failed tasks older than max_age_secs. Returns count of cleaned tasks.
+    /// All removals are committed in a single batch (Issue #3029 / Issue 15).
     pub fn cleanup(&self, max_age_secs: u64, now: u64) -> Result<u32> {
         let cutoff = now.saturating_sub(max_age_secs);
-        let mut count = 0u32;
 
         // Scan all tasks and collect IDs of old terminal tasks
-        let to_remove: Vec<(u64, bool)> = self
+        let to_remove: Vec<(u64, bool, TaskStatus)> = self
             .tasks
             .iter()
             .filter_map(|guard| {
@@ -433,8 +519,11 @@ impl TaskStore {
                 if record.status.is_terminal() {
                     if let Some(completed_at) = record.completed_at {
                         if completed_at < cutoff {
-                            let is_dead_letter = record.status == TaskStatus::DeadLetter;
-                            return Some((record.task_id, is_dead_letter));
+                            return Some((
+                                record.task_id,
+                                record.status == TaskStatus::DeadLetter,
+                                record.status,
+                            ));
                         }
                     }
                 }
@@ -442,47 +531,55 @@ impl TaskStore {
             })
             .collect();
 
-        for (task_id, is_dead_letter) in to_remove {
-            let mut batch = self.db.batch();
+        if to_remove.is_empty() {
+            return Ok(0);
+        }
+
+        let mut batch = self.db.batch();
+        for &(task_id, is_dead_letter, _) in &to_remove {
             batch.remove(&self.tasks, task_id.to_be_bytes());
             if is_dead_letter {
                 batch.remove(&self.dead_letter, task_id.to_be_bytes());
             }
-            batch
-                .commit()
-                .map_err(|e| TaskError::Storage(e.to_string()))?;
-            count += 1;
         }
+        batch.commit()?;
 
-        Ok(count)
-    }
-
-    /// Count tasks in each status for stats.
-    pub fn count_by_status(&self) -> Result<crate::task::QueueStats> {
-        let mut stats = crate::task::QueueStats::default();
-
-        for guard in self.tasks.iter() {
-            let (_, value) = guard
-                .into_inner()
-                .map_err(|e| TaskError::Storage(e.to_string()))?;
-            let record: TaskRecord = bincode::deserialize(value.as_ref())?;
-            match record.status {
-                TaskStatus::Pending => stats.pending += 1,
-                TaskStatus::Running => stats.running += 1,
-                TaskStatus::Completed => stats.completed += 1,
-                TaskStatus::Failed => stats.failed += 1,
-                TaskStatus::DeadLetter => stats.dead_letter += 1,
-                TaskStatus::Cancelled => stats.cancelled += 1,
+        // Update counters
+        for &(_, _, status) in &to_remove {
+            match status {
+                TaskStatus::Completed => {
+                    self.completed_count.fetch_sub(1, Ordering::Relaxed);
+                }
+                TaskStatus::DeadLetter => {
+                    self.dead_letter_count.fetch_sub(1, Ordering::Relaxed);
+                }
+                TaskStatus::Cancelled => {
+                    self.cancelled_count.fetch_sub(1, Ordering::Relaxed);
+                }
+                _ => {}
             }
         }
 
-        Ok(stats)
+        Ok(to_remove.len() as u32)
+    }
+
+    /// Count tasks in each status. Uses atomic counters for O(1) performance
+    /// (Issue #3029 / Issue 14).
+    pub fn count_by_status(&self) -> Result<crate::task::QueueStats> {
+        Ok(crate::task::QueueStats {
+            pending: self.pending_count.load(Ordering::Relaxed) as usize,
+            running: self.running_count.load(Ordering::Relaxed) as usize,
+            completed: self.completed_count.load(Ordering::Relaxed) as usize,
+            failed: 0, // Failed is a transient state (→ Pending or DeadLetter)
+            dead_letter: self.dead_letter_count.load(Ordering::Relaxed) as usize,
+            cancelled: self.cancelled_count.load(Ordering::Relaxed) as usize,
+        })
     }
 
     /// Count pending tasks (for admission control).
     /// Uses cached atomic counter for O(1) performance instead of scanning the index.
     pub fn count_pending(&self) -> Result<usize> {
-        Ok(self.pending_count.load(std::sync::atomic::Ordering::Relaxed) as usize)
+        Ok(self.pending_count.load(Ordering::Relaxed) as usize)
     }
 
     /// List tasks with optional filters.
@@ -537,18 +634,7 @@ impl TaskStore {
         new_lease_expires: u64,
         task: &TaskRecord,
     ) -> Result<()> {
-        // Find old running_idx entry
-        let mut old_key: Option<Vec<u8>> = None;
-        for guard in self.running_idx.iter() {
-            if let Ok((key, _)) = guard.into_inner() {
-                if let Some((_, tid)) = decode_running_key(key.as_ref()) {
-                    if tid == task_id {
-                        old_key = Some(key.as_ref().to_vec());
-                        break;
-                    }
-                }
-            }
-        }
+        let old_key = self.find_running_key(task_id)?;
 
         let new_running_key = encode_running_key(new_lease_expires, task_id);
         let task_value = bincode::serialize(task)?;
@@ -557,37 +643,21 @@ impl TaskStore {
         if let Some(ref old) = old_key {
             batch.remove(&self.running_idx, old);
         }
-        batch.insert(&self.running_idx, new_running_key, vec![]);
+        batch.insert(&self.running_idx, &new_running_key, vec![]);
+        batch.insert(
+            &self.running_task_key,
+            task_id.to_be_bytes(),
+            &new_running_key,
+        );
         batch.insert(&self.tasks, task_id.to_be_bytes(), task_value);
-        batch
-            .commit()
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
+        batch.commit()?;
 
-        Ok(())
-    }
-
-    /// Remove a task from the running index by scanning for its task_id.
-    fn remove_from_running_idx(&self, task_id: u64) -> Result<()> {
-        for guard in self.running_idx.iter() {
-            if let Ok((key, _)) = guard.into_inner() {
-                if let Some((_, tid)) = decode_running_key(key.as_ref()) {
-                    if tid == task_id {
-                        self.running_idx
-                            .remove(key.as_ref())
-                            .map_err(|e| TaskError::Storage(e.to_string()))?;
-                        return Ok(());
-                    }
-                }
-            }
-        }
         Ok(())
     }
 
     /// Persist all in-memory data to disk.
     pub fn flush(&self) -> Result<()> {
-        self.db
-            .persist(PersistMode::SyncAll)
-            .map_err(|e| TaskError::Storage(e.to_string()))?;
+        self.db.persist(PersistMode::SyncAll)?;
         Ok(())
     }
 }
@@ -596,6 +666,8 @@ impl TaskStore {
 mod tests {
     use super::*;
     use crate::task::{TaskPriority, TaskStatus};
+    use std::collections::HashSet;
+    use std::sync::Arc;
     use tempfile::TempDir;
 
     fn test_store() -> (TaskStore, TempDir) {
@@ -627,6 +699,92 @@ mod tests {
         }
     }
 
+    /// Verify that all indexes are consistent with task records.
+    /// Every task in pending_idx must be Pending in the tasks keyspace,
+    /// every task in running_idx must be Running, and vice versa.
+    fn verify_index_consistency(store: &TaskStore) {
+        // Collect all task IDs from pending_idx
+        let mut pending_ids: HashSet<u64> = HashSet::new();
+        for guard in store.pending_idx.iter() {
+            if let Ok((key, _)) = guard.into_inner() {
+                if let Some((_, _, task_id)) = decode_pending_key(key.as_ref()) {
+                    pending_ids.insert(task_id);
+                }
+            }
+        }
+
+        // Collect all task IDs from running_idx
+        let mut running_ids: HashSet<u64> = HashSet::new();
+        for guard in store.running_idx.iter() {
+            if let Ok((key, _)) = guard.into_inner() {
+                if let Some((_, task_id)) = decode_running_key(key.as_ref()) {
+                    running_ids.insert(task_id);
+                }
+            }
+        }
+
+        // Verify each pending task in the index is actually Pending
+        for &task_id in &pending_ids {
+            let task = store
+                .get_task(task_id)
+                .unwrap()
+                .expect("pending index references nonexistent task");
+            assert_eq!(
+                task.status,
+                TaskStatus::Pending,
+                "task {} in pending_idx has status {:?}",
+                task_id,
+                task.status
+            );
+        }
+
+        // Verify each running task in the index is actually Running
+        for &task_id in &running_ids {
+            let task = store
+                .get_task(task_id)
+                .unwrap()
+                .expect("running index references nonexistent task");
+            assert_eq!(
+                task.status,
+                TaskStatus::Running,
+                "task {} in running_idx has status {:?}",
+                task_id,
+                task.status
+            );
+        }
+
+        // Verify running_task_key reverse lookup is consistent with running_idx
+        for &task_id in &running_ids {
+            assert!(
+                store.find_running_key(task_id).unwrap().is_some(),
+                "task {} in running_idx has no reverse-lookup entry",
+                task_id
+            );
+        }
+
+        // Verify no Pending tasks are missing from pending_idx
+        for guard in store.tasks.iter() {
+            if let Ok((_, value)) = guard.into_inner() {
+                if let Ok(record) = bincode::deserialize::<TaskRecord>(value.as_ref()) {
+                    if record.status == TaskStatus::Pending && record.run_at == 0 {
+                        assert!(
+                            pending_ids.contains(&record.task_id),
+                            "task {} is Pending but not in pending_idx",
+                            record.task_id
+                        );
+                    }
+                    if record.status == TaskStatus::Running {
+                        assert!(
+                            running_ids.contains(&record.task_id),
+                            "task {} is Running but not in running_idx",
+                            record.task_id
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_open_and_generate_id() {
         let (store, _dir) = test_store();
@@ -646,6 +804,7 @@ mod tests {
         assert_eq!(loaded.task_id, task_id);
         assert_eq!(loaded.task_type, "test.echo");
         assert_eq!(loaded.status, TaskStatus::Pending);
+        verify_index_consistency(&store);
     }
 
     #[test]
@@ -691,6 +850,8 @@ mod tests {
             .claim_next("w-0", 300, 1700000000, 0)
             .unwrap()
             .is_none());
+
+        verify_index_consistency(&store);
     }
 
     #[test]
@@ -706,6 +867,7 @@ mod tests {
             .unwrap();
         assert_eq!(claimed.status, TaskStatus::Running);
         assert_eq!(claimed.attempt, 1);
+        verify_index_consistency(&store);
 
         let completed = store
             .complete_task(task_id, b"done", 1700000001, "w-0")
@@ -715,6 +877,7 @@ mod tests {
 
         let loaded = store.get_task(task_id).unwrap().unwrap();
         assert_eq!(loaded.status, TaskStatus::Completed);
+        verify_index_consistency(&store);
     }
 
     #[test]
@@ -727,12 +890,11 @@ mod tests {
 
         // Claim and fail — should re-queue (attempt 1 < max_retries 3)
         store.claim_next("w-0", 300, 1700000000, 0).unwrap();
-        let (failed, dead) = store
-            .fail_task(task_id, "oops", 1700000001, "w-0")
-            .unwrap();
+        let (failed, dead) = store.fail_task(task_id, "oops", 1700000001, "w-0").unwrap();
         assert!(!dead);
         assert_eq!(failed.status, TaskStatus::Pending);
         assert!(failed.run_at > 1700000001); // backoff applied
+        verify_index_consistency(&store);
     }
 
     #[test]
@@ -750,6 +912,7 @@ mod tests {
             .unwrap();
         assert!(dead);
         assert_eq!(failed.status, TaskStatus::DeadLetter);
+        verify_index_consistency(&store);
     }
 
     #[test]
@@ -767,6 +930,7 @@ mod tests {
             .claim_next("w-0", 300, 1700000000, 0)
             .unwrap()
             .is_none());
+        verify_index_consistency(&store);
     }
 
     #[test]
@@ -790,6 +954,7 @@ mod tests {
         // Task is pending again
         let loaded = store.get_task(task_id).unwrap().unwrap();
         assert_eq!(loaded.status, TaskStatus::Pending);
+        verify_index_consistency(&store);
     }
 
     #[test]
@@ -861,6 +1026,136 @@ mod tests {
             let store = TaskStore::open(path).unwrap();
             let loaded = store.get_task(task_id).unwrap().unwrap();
             assert_eq!(loaded.task_type, "persist");
+
+            // Verify counters are initialized correctly on reopen
+            let stats = store.count_by_status().unwrap();
+            assert_eq!(stats.pending, 1);
         }
+    }
+
+    /// Test that concurrent claim_next calls never produce duplicate claims
+    /// (Issue #3029 / Bug 2 regression test).
+    #[test]
+    fn test_concurrent_claim_no_duplicates() {
+        let dir = TempDir::new().unwrap();
+        let store = Arc::new(TaskStore::open(dir.path().to_str().unwrap()).unwrap());
+
+        let num_tasks = 50;
+        let num_workers = 8;
+
+        // Insert tasks
+        for i in 0..num_tasks {
+            let mut task = make_task(&store, &format!("task-{}", i), TaskPriority::Normal);
+            task.run_at = 0;
+            store.insert_task(&task).unwrap();
+        }
+
+        // Spawn workers that race to claim
+        let claimed: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+        let mut handles = Vec::new();
+
+        for w in 0..num_workers {
+            let store = Arc::clone(&store);
+            let claimed = Arc::clone(&claimed);
+            handles.push(std::thread::spawn(move || {
+                let worker_id = format!("worker-{}", w);
+                loop {
+                    match store.claim_next(&worker_id, 300, 1700000000, 0).unwrap() {
+                        Some(task) => {
+                            claimed.lock().unwrap().push(task.task_id);
+                        }
+                        None => break,
+                    }
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let claimed = claimed.lock().unwrap();
+        let unique: HashSet<u64> = claimed.iter().copied().collect();
+
+        // Every task claimed exactly once: no duplicates, no losses
+        assert_eq!(
+            claimed.len(),
+            num_tasks,
+            "expected {} claims, got {}",
+            num_tasks,
+            claimed.len()
+        );
+        assert_eq!(unique.len(), num_tasks, "duplicate claims detected");
+
+        verify_index_consistency(&store);
+    }
+
+    /// Test that complete_task, cancel_task, fail_task maintain index consistency
+    /// (Issue #3029 / Bug 3 regression test).
+    #[test]
+    fn test_index_consistency_across_transitions() {
+        let (store, _dir) = test_store();
+
+        // Create tasks for each transition path
+        let t_complete = make_task(&store, "complete", TaskPriority::Normal);
+        let t_cancel_pending = make_task(&store, "cancel_p", TaskPriority::Normal);
+        let t_cancel_running = make_task(&store, "cancel_r", TaskPriority::Normal);
+        let t_fail_retry = make_task(&store, "fail_retry", TaskPriority::Normal);
+        let mut t_fail_dl = make_task(&store, "fail_dl", TaskPriority::Normal);
+        t_fail_dl.max_retries = 1;
+
+        let id_complete = t_complete.task_id;
+        let id_cancel_p = t_cancel_pending.task_id;
+        let id_cancel_r = t_cancel_running.task_id;
+        let id_fail_retry = t_fail_retry.task_id;
+        let id_fail_dl = t_fail_dl.task_id;
+
+        store.insert_task(&t_complete).unwrap();
+        store.insert_task(&t_cancel_pending).unwrap();
+        store.insert_task(&t_cancel_running).unwrap();
+        store.insert_task(&t_fail_retry).unwrap();
+        store.insert_task(&t_fail_dl).unwrap();
+        verify_index_consistency(&store);
+
+        // Cancel a pending task
+        store.cancel_task(id_cancel_p, 1700000001).unwrap();
+        verify_index_consistency(&store);
+
+        // Claim remaining tasks
+        store.claim_next("w-0", 300, 1700000000, 0).unwrap(); // complete
+        store.claim_next("w-0", 300, 1700000000, 0).unwrap(); // cancel_r
+        store.claim_next("w-0", 300, 1700000000, 0).unwrap(); // fail_retry
+        store.claim_next("w-0", 300, 1700000000, 0).unwrap(); // fail_dl
+        verify_index_consistency(&store);
+
+        // Complete
+        store
+            .complete_task(id_complete, b"ok", 1700000001, "w-0")
+            .unwrap();
+        verify_index_consistency(&store);
+
+        // Cancel running
+        store.cancel_task(id_cancel_r, 1700000001).unwrap();
+        verify_index_consistency(&store);
+
+        // Fail with retry
+        store
+            .fail_task(id_fail_retry, "oops", 1700000001, "w-0")
+            .unwrap();
+        verify_index_consistency(&store);
+
+        // Fail to dead letter
+        store
+            .fail_task(id_fail_dl, "fatal", 1700000001, "w-0")
+            .unwrap();
+        verify_index_consistency(&store);
+
+        // Verify final status counts
+        let stats = store.count_by_status().unwrap();
+        assert_eq!(stats.completed, 1);
+        assert_eq!(stats.cancelled, 2);
+        assert_eq!(stats.dead_letter, 1);
+        assert_eq!(stats.pending, 1); // fail_retry was re-queued
+        assert_eq!(stats.running, 0);
     }
 }

--- a/rust/nexus_tasks/src/store.rs
+++ b/rust/nexus_tasks/src/store.rs
@@ -51,9 +51,14 @@ impl TaskStore {
         // Initialize counter from existing max task_id
         let max_id = Self::find_max_task_id(&tasks);
 
-        // Scan once to initialize all status counters and populate running_task_key
+        // Scan once to initialize all status counters
         let (pending, running, completed, cancelled, dead_letter_n) =
             Self::count_all_statuses(&tasks);
+
+        // Rebuild running_task_key reverse-lookup index from running_idx.
+        // This is necessary after restart/upgrade since running_task_key is
+        // an auxiliary index that may not have existed before this version.
+        Self::rebuild_running_task_key(&running_idx, &running_task_key)?;
 
         Ok(Self {
             db,
@@ -115,6 +120,21 @@ impl TaskStore {
         }
 
         (pending, running, completed, cancelled, dead_letter)
+    }
+
+    /// Rebuild the running_task_key reverse-lookup index by scanning running_idx.
+    /// Ensures that after restart or upgrade from a version without this index,
+    /// all running tasks have their reverse-lookup entry populated.
+    fn rebuild_running_task_key(running_idx: &Keyspace, running_task_key: &Keyspace) -> Result<()> {
+        for guard in running_idx.iter() {
+            if let Ok((key, _)) = guard.into_inner() {
+                if let Some((_, task_id)) = decode_running_key(key.as_ref()) {
+                    let running_key_bytes = key.as_ref().to_vec();
+                    running_task_key.insert(task_id.to_be_bytes(), running_key_bytes)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Generate a monotonically increasing task ID.


### PR DESCRIPTION
## Summary

Fixes the 4 confirmed open correctness bugs from #3029, plus performance improvements and comprehensive regression tests.

### Bug Fixes

- **Bug 1 — Raft state machine non-determinism** (`nexus_raft`): `apply_acquire_lock()` and `apply_extend_lock()` called `SystemTime::now()` during state machine apply, meaning leader and followers computed different lock timestamps from the same replicated command. Fixed by embedding `now_secs` in the `Command::AcquireLock` and `Command::ExtendLock` variants at proposal time. All replicas now use the identical timestamp from the log entry.

- **Bug 2 — `claim_next` race condition** (`nexus_tasks`): Two concurrent workers could select and claim the same pending task before either batch committed. Fixed by adding a process-local `Mutex<()>` guard around `claim_next`.

- **Bug 3+5 — Non-atomic `complete_task`/`cancel_task`/`fail_task`** (`nexus_tasks`): These methods performed index removal and task record update as separate I/O operations. A crash between them would leave inconsistent state. Fixed by batching all mutations into a single Fjall batch commit (following the pattern already established by `renew_lease`). Note: `fail_task` had the same bug but wasn't called out in the original issue.

- **Bug 4 — FUSE inode eviction unsafe** (`nexus-fuse`): Two independent LRU caches could desynchronize during eviction, and the root inode could be evicted. Fixed by synchronizing evictions across both maps (using `LruCache::push` return values) and re-pinning root after eviction-prone operations.

### Performance Improvements

- **O(1) running index removal**: Added `running_task_key` reverse-lookup keyspace (`task_id → running_key`), replacing the O(n) scan in `remove_from_running_idx` and `renew_lease`.
- **O(1) queue stats**: Added atomic counters for all task statuses (extending the existing `pending_count` pattern), replacing the full-table-scan `count_by_status`.
- **Batch cleanup/requeue**: `cleanup()` and `requeue_abandoned()` now commit all mutations in a single batch instead of per-item.
- **Counter initialization on restart**: All status counters are now correctly initialized from a scan on `TaskStore::open()` (the existing `pending_count` was incorrectly initialized to 0 on restart).

### Code Quality

- Replaced ~12 redundant `map_err(|e| TaskError::Storage(e.to_string()))` closures with `?` (the `From<fjall::Error>` impl already existed in `error.rs`).
- Added `peek_inode()` method to `InodeTable` for non-promoting lookups, fixing an encapsulation break where `check_is_directory` accessed internal fields directly.
- Downgraded `time` crate to 0.3.36 for rustc 1.86 compatibility; replaced unfulfilled `#[expect]` lint attrs with `#[allow]`.

### New Tests

- **Raft determinism test**: Two state machines apply identical commands and assert logically-identical snapshots.
- **Concurrent claim contention test**: 8 threads race to claim 50 tasks; asserts every task claimed exactly once (no duplicates, no losses).
- **Index consistency helper**: `verify_index_consistency()` validates that pending_idx, running_idx, running_task_key, and task records are all mutually consistent. Added to all lifecycle tests.
- **InodeTable unit tests**: Root survival after eviction, eviction synchronization, get_or_create idempotency, rename, remove.

## Test plan

- [x] All 46 `nexus_raft` tests pass (including new determinism test)
- [x] All pre-commit hooks pass (format, clippy)
- [ ] Run `nexus_tasks` tests (blocked by rustc 1.86 < fjall 3.1's minimum 1.90 in CI)
- [ ] Run `nexus-fuse` tests (standalone crate, excluded from workspace)
- [ ] Integration test with 3-node Raft cluster
- [ ] Manual smoke test of lock acquire/release/extend cycle

Closes #3029