### PR TITLE
fix(daemon): await async nexus.connect() in nexusd startup

### DIFF
--- a/src/nexus/daemon/main.py
+++ b/src/nexus/daemon/main.py
@@ -275,6 +275,8 @@ def main(
 
         # --- Create local NexusFS -------------------------------------------
         try:
+            import asyncio
+
             import nexus
 
             connect_config: dict[str, object] = {"profile": deployment_profile}
@@ -294,9 +296,9 @@ def main(
                 from nexus.config import load_config
 
                 config_obj = load_config(Path(config_path))
-                nx = nexus.connect(config=config_obj)
+                nx = asyncio.run(nexus.connect(config=config_obj))
             else:
-                nx = nexus.connect(config=connect_config)
+                nx = asyncio.run(nexus.connect(config=connect_config))
 
         except Exception as e:
             click.echo(f"Error: Failed to initialize NexusFS: {e}", err=True)


### PR DESCRIPTION
## Summary
- `nexus.connect()` was changed from sync to `async def` but `daemon/main.py` still called it synchronously
- This caused `nx` to be a coroutine object instead of `NexusFS`, crashing at startup with `'coroutine' object has no attribute 'service'`
- Wrapped both `nexus.connect()` calls in `asyncio.run()` to properly resolve the coroutine

## Test plan
- [x] `nexus up --build` — nexus service starts and becomes healthy
- [x] All 4 services (nexus, postgres, dragonfly, zoekt) report healthy