### PR TITLE
fix: bump pyproject.toml to 0.9.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.5"
+version = "0.9.6"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
The release/v0.9.6 commit missed pyproject.toml (still 0.9.5). Fixes version-verify failure.