### PR TITLE
fix(cli): wrap all async Click commands with asyncio.run()

### DIFF
--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -1017,7 +1017,7 @@ def demo() -> None:
 @click.option(
     "--skip-semantic", is_flag=True, default=False, help="Skip semantic search corpus seeding."
 )
-async def demo_init(reset: bool, skip_semantic: bool) -> None:
+def demo_init(reset: bool, skip_semantic: bool) -> None:
     """Seed demo data into a running Nexus instance.
 
     Idempotent by default — safe to run multiple times.
@@ -1028,6 +1028,12 @@ async def demo_init(reset: bool, skip_semantic: bool) -> None:
         nexus demo init --reset        # clean slate re-seed
         nexus demo init --skip-semantic
     """
+    import asyncio
+
+    asyncio.run(_async_demo_init(reset, skip_semantic))
+
+
+async def _async_demo_init(reset: bool, skip_semantic: bool) -> None:
     config = _load_project_config()
     data_dir = config.get("data_dir", "./nexus-data")
 
@@ -1182,7 +1188,7 @@ async def demo_init(reset: bool, skip_semantic: bool) -> None:
 
 
 @demo.command(name="reset")
-async def demo_reset() -> None:
+def demo_reset() -> None:
     """Remove all demo data and the manifest.
 
     This is a destructive operation — demo files, users, and agents
@@ -1191,6 +1197,12 @@ async def demo_reset() -> None:
     Example:
         nexus demo reset
     """
+    import asyncio
+
+    asyncio.run(_async_demo_reset())
+
+
+async def _async_demo_reset() -> None:
     config = _load_project_config()
     data_dir = config.get("data_dir", "./nexus-data")
 

--- a/src/nexus/cli/commands/inspect.py
+++ b/src/nexus/cli/commands/inspect.py
@@ -26,7 +26,7 @@ from nexus.cli.utils import (
 @click.argument("path", type=str)
 @add_output_options
 @add_backend_options
-async def info(
+def info(
     path: str,
     output_opts: OutputOptions,
     remote_url: str | None,
@@ -39,6 +39,17 @@ async def info(
         nexus info /workspace/data.txt --json
         nexus info /workspace/data.txt --json --fields path,size,etag
     """
+    import asyncio
+
+    asyncio.run(_async_info(path, output_opts, remote_url, remote_api_key))
+
+
+async def _async_info(
+    path: str,
+    output_opts: OutputOptions,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     timing = CommandTiming()
 
     try:
@@ -114,7 +125,7 @@ def version() -> None:
 @click.option("--human", "-h", is_flag=True, help="Human-readable output")
 @click.option("--details", is_flag=True, help="Show per-file breakdown")
 @add_backend_options
-async def size(
+def size(
     path: str,
     human: bool,
     details: bool,
@@ -130,6 +141,18 @@ async def size(
         nexus size /workspace --human
         nexus size /workspace --details
     """
+    import asyncio
+
+    asyncio.run(_async_size(path, human, details, remote_url, remote_api_key))
+
+
+async def _async_size(
+    path: str,
+    human: bool,
+    details: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 

--- a/src/nexus/cli/commands/mcp.py
+++ b/src/nexus/cli/commands/mcp.py
@@ -172,7 +172,7 @@ def mcp() -> None:
     envvar="NEXUS_API_KEY",
 )
 @add_backend_options
-async def serve(
+def serve(
     transport: str,
     host: str,
     port: int,
@@ -223,6 +223,19 @@ async def serve(
         # Or via environment:
         NEXUS_URL=http://localhost:2026 NEXUS_API_KEY=YOUR_KEY nexus mcp serve
     """
+    import asyncio
+
+    asyncio.run(_async_serve(transport, host, port, api_key, remote_url, remote_api_key))
+
+
+async def _async_serve(
+    transport: str,
+    host: str,
+    port: int,
+    api_key: str | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         # Check if fastmcp is installed
         try:

--- a/src/nexus/cli/commands/migrate.py
+++ b/src/nexus/cli/commands/migrate.py
@@ -486,7 +486,7 @@ def restore(backup_path: str, dry_run: bool, data_dir: str | None) -> None:
 @click.option("--overwrite", is_flag=True, help="Overwrite existing files")
 @click.option("--dry-run", is_flag=True, help="Simulate without making changes")
 @add_backend_options
-async def import_s3(
+def import_s3(
     bucket: str,
     prefix: str,
     target: str,
@@ -503,6 +503,22 @@ async def import_s3(
         nexus migrate import-s3 --bucket my-bucket --prefix /data/ --target /workspace/
         nexus migrate import-s3 --bucket my-bucket --target /imports/ --dry-run
     """
+    import asyncio
+
+    asyncio.run(
+        _async_import_s3(bucket, prefix, target, overwrite, dry_run, remote_url, remote_api_key)
+    )
+
+
+async def _async_import_s3(
+    bucket: str,
+    prefix: str,
+    target: str,
+    overwrite: bool,
+    dry_run: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         from nexus.cli.utils import get_filesystem
         from nexus.migrations.data_migrator import DataMigrator, ImportOptions
@@ -552,7 +568,7 @@ async def import_s3(
 @click.option("--dry-run", is_flag=True, help="Simulate without making changes")
 @click.option("--credentials", default=None, help="Path to service account credentials JSON")
 @add_backend_options
-async def import_gcs(
+def import_gcs(
     bucket: str,
     prefix: str,
     target: str,
@@ -570,6 +586,25 @@ async def import_gcs(
         nexus migrate import-gcs --bucket my-bucket --prefix /data/ --target /workspace/
         nexus migrate import-gcs --bucket my-bucket --target /imports/ --credentials creds.json
     """
+    import asyncio
+
+    asyncio.run(
+        _async_import_gcs(
+            bucket, prefix, target, overwrite, dry_run, credentials, remote_url, remote_api_key
+        )
+    )
+
+
+async def _async_import_gcs(
+    bucket: str,
+    prefix: str,
+    target: str,
+    overwrite: bool,
+    dry_run: bool,
+    credentials: str | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         from nexus.cli.utils import get_filesystem
         from nexus.migrations.data_migrator import DataMigrator, ImportOptions
@@ -618,7 +653,7 @@ async def import_gcs(
 @click.option("--overwrite", is_flag=True, help="Overwrite existing files")
 @click.option("--dry-run", is_flag=True, help="Simulate without making changes")
 @add_backend_options
-async def import_fs(
+def import_fs(
     source: str,
     target: str,
     overwrite: bool,
@@ -632,6 +667,19 @@ async def import_fs(
         nexus migrate import-fs --source /local/data --target /workspace/
         nexus migrate import-fs --source ./docs --target /docs/ --dry-run
     """
+    import asyncio
+
+    asyncio.run(_async_import_fs(source, target, overwrite, dry_run, remote_url, remote_api_key))
+
+
+async def _async_import_fs(
+    source: str,
+    target: str,
+    overwrite: bool,
+    dry_run: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         from nexus.cli.utils import get_filesystem
         from nexus.migrations.data_migrator import DataMigrator, ImportOptions
@@ -676,7 +724,7 @@ async def import_fs(
 @click.option("--check-integrity", is_flag=True, help="Run full integrity checks")
 @click.option("--sample-size", default=100, help="Number of files to sample for content validation")
 @add_backend_options
-async def validate(
+def validate(
     check_integrity: bool,
     sample_size: int,  # noqa: ARG001 - Reserved for future use
     remote_url: str | None,
@@ -691,6 +739,16 @@ async def validate(
         nexus migrate validate --check-integrity
         nexus migrate validate --check-integrity --sample-size 500
     """
+    import asyncio
+
+    asyncio.run(_async_validate(check_integrity, remote_url, remote_api_key))
+
+
+async def _async_validate(
+    check_integrity: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         from nexus.cli.utils import get_filesystem
         from nexus.migrations.validators import IntegrityValidator

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -69,7 +69,7 @@ def mounts_group() -> None:
 @click.option("--owner", type=str, default=None, help="Owner user ID")
 @click.option("--zone", type=str, default=None, help="Zone ID")
 @add_backend_options
-async def add_mount(
+def add_mount(
     mount_point: str,
     backend_type: str,
     config_json: str,
@@ -101,6 +101,34 @@ async def add_mount(
         nexus mounts add /personal/alice google_drive '{"access_token":"..."}' \\
             --owner "google:alice123" --zone "acme"
     """
+    import asyncio
+
+    asyncio.run(
+        _async_add_mount(
+            mount_point,
+            backend_type,
+            config_json,
+            readonly,
+            io_profile,
+            owner,
+            zone,
+            remote_url,
+            remote_api_key,
+        )
+    )
+
+
+async def _async_add_mount(
+    mount_point: str,
+    backend_type: str,
+    config_json: str,
+    readonly: bool,
+    io_profile: str,
+    owner: str | None,
+    zone: str | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         # Parse backend config JSON
         try:
@@ -153,9 +181,7 @@ async def add_mount(
 @mounts_group.command(name="remove")
 @click.argument("mount_point", type=str)
 @add_backend_options
-async def remove_mount(
-    mount_point: str, remote_url: str | None, remote_api_key: str | None
-) -> None:
+def remove_mount(mount_point: str, remote_url: str | None, remote_api_key: str | None) -> None:
     """Remove a backend mount.
 
     Removes mount configuration from database. The mount will be unmounted
@@ -165,6 +191,14 @@ async def remove_mount(
         nexus mounts remove /personal/alice
         nexus mounts remove /cloud/bucket
     """
+    import asyncio
+
+    asyncio.run(_async_remove_mount(mount_point, remote_url, remote_api_key))
+
+
+async def _async_remove_mount(
+    mount_point: str, remote_url: str | None, remote_api_key: str | None
+) -> None:
     try:
         # Get filesystem (works with both local and remote)
         nx = await get_filesystem(remote_url, remote_api_key)
@@ -195,7 +229,7 @@ async def remove_mount(
 @click.option("--zone", type=str, default=None, help="Filter by zone ID")
 @add_output_options
 @add_backend_options
-async def list_mounts(
+def list_mounts(
     owner: str | None,
     zone: str | None,
     output_opts: OutputOptions,
@@ -220,6 +254,18 @@ async def list_mounts(
         # Output as JSON
         nexus mounts list --json
     """
+    import asyncio
+
+    asyncio.run(_async_list_mounts(owner, zone, output_opts, remote_url, remote_api_key))
+
+
+async def _async_list_mounts(
+    owner: str | None,
+    zone: str | None,
+    output_opts: OutputOptions,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     timing = CommandTiming()
     try:
         # Get filesystem (works with both local and remote)
@@ -284,7 +330,7 @@ async def list_mounts(
     "--show-config", is_flag=True, help="Show backend configuration (may contain secrets)"
 )
 @add_backend_options
-async def mount_info(
+def mount_info(
     mount_point: str, show_config: bool, remote_url: str | None, remote_api_key: str | None
 ) -> None:
     """Show detailed information about a mount.
@@ -293,6 +339,14 @@ async def mount_info(
         nexus mounts info /personal/alice
         nexus mounts info /cloud/bucket --show-config
     """
+    import asyncio
+
+    asyncio.run(_async_mount_info(mount_point, show_config, remote_url, remote_api_key))
+
+
+async def _async_mount_info(
+    mount_point: str, show_config: bool, remote_url: str | None, remote_api_key: str | None
+) -> None:
     try:
         # Get filesystem (works with both local and remote)
         nx = await get_filesystem(remote_url, remote_api_key)
@@ -350,7 +404,7 @@ async def mount_info(
 @click.option("--async", "run_async", is_flag=True, help="Run sync in background (returns job ID)")
 @add_output_options
 @add_backend_options
-async def sync_mount(
+def sync_mount(
     mount_point: str | None,
     path: str | None,
     no_cache: bool,
@@ -396,6 +450,38 @@ async def sync_mount(
         # Run sync in background (async)
         nexus mounts sync /mnt/gmail --async
     """
+    import asyncio
+
+    asyncio.run(
+        _async_sync_mount(
+            mount_point,
+            path,
+            no_cache,
+            include,
+            exclude,
+            embeddings,
+            dry_run,
+            run_async,
+            output_opts,
+            remote_url,
+            remote_api_key,
+        )
+    )
+
+
+async def _async_sync_mount(
+    mount_point: str | None,
+    path: str | None,
+    no_cache: bool,
+    include: tuple[str, ...],
+    exclude: tuple[str, ...],
+    embeddings: bool,
+    dry_run: bool,
+    run_async: bool,
+    output_opts: OutputOptions,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     timing = CommandTiming()
     try:
         # Get filesystem (works with both local and remote)
@@ -545,7 +631,7 @@ async def sync_mount(
 @click.option("--watch", is_flag=True, help="Watch progress until completion")
 @add_output_options
 @add_backend_options
-async def sync_status(
+def sync_status(
     job_id: str | None,
     watch: bool,
     output_opts: OutputOptions,
@@ -567,6 +653,18 @@ async def sync_status(
         # List recent running jobs
         nexus mounts sync-status
     """
+    import asyncio
+
+    asyncio.run(_async_sync_status(job_id, watch, output_opts, remote_url, remote_api_key))
+
+
+async def _async_sync_status(
+    job_id: str | None,
+    watch: bool,
+    output_opts: OutputOptions,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     import asyncio
 
     timing = CommandTiming()
@@ -702,7 +800,7 @@ def _display_job_status(job: dict[str, Any]) -> None:
 @click.argument("job_id", type=str)
 @add_output_options
 @add_backend_options
-async def sync_cancel(
+def sync_cancel(
     job_id: str,
     output_opts: OutputOptions,
     remote_url: str | None,
@@ -713,6 +811,17 @@ async def sync_cancel(
     Examples:
         nexus mounts sync-cancel abc123
     """
+    import asyncio
+
+    asyncio.run(_async_sync_cancel(job_id, output_opts, remote_url, remote_api_key))
+
+
+async def _async_sync_cancel(
+    job_id: str,
+    output_opts: OutputOptions,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     timing = CommandTiming()
     try:
         nx: Any = await get_filesystem(remote_url, remote_api_key)
@@ -754,7 +863,7 @@ async def sync_cancel(
 @click.option("--limit", type=int, default=20, help="Maximum jobs to show")
 @add_output_options
 @add_backend_options
-async def sync_jobs(
+def sync_jobs(
     mount: str | None,
     status: str | None,
     limit: int,
@@ -774,6 +883,19 @@ async def sync_jobs(
         # List only failed jobs
         nexus mounts sync-jobs --status failed
     """
+    import asyncio
+
+    asyncio.run(_async_sync_jobs(mount, status, limit, output_opts, remote_url, remote_api_key))
+
+
+async def _async_sync_jobs(
+    mount: str | None,
+    status: str | None,
+    limit: int,
+    output_opts: OutputOptions,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     timing = CommandTiming()
     try:
         nx: Any = await get_filesystem(remote_url, remote_api_key)

--- a/src/nexus/cli/commands/operations.py
+++ b/src/nexus/cli/commands/operations.py
@@ -45,7 +45,7 @@ def ops_group() -> None:
 @click.argument("operation_2", type=str)
 @click.option("--show-content", is_flag=True, help="Show content diff (for text files)")
 @add_backend_options
-async def ops_diff(
+def ops_diff(
     path: str,
     operation_1: str,
     operation_2: str,
@@ -62,6 +62,21 @@ async def ops_diff(
         nexus ops diff /workspace/data.txt op_abc123 op_def456
         nexus ops diff /workspace/code.py op_abc123 op_def456 --show-content
     """
+    import asyncio
+
+    asyncio.run(
+        _async_ops_diff(path, operation_1, operation_2, show_content, remote_url, remote_api_key)
+    )
+
+
+async def _async_ops_diff(
+    path: str,
+    operation_1: str,
+    operation_2: str,
+    show_content: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 
@@ -167,7 +182,7 @@ async def ops_diff(
 @click.option("--status", "-s", type=click.Choice(["success", "failure"]), help="Filter by status")
 @click.option("--limit", "-l", type=int, default=50, help="Maximum number of operations to show")
 @add_backend_options
-async def ops_log(
+def ops_log(
     agent: str | None,
     zone: str | None,
     op_type: str | None,
@@ -187,6 +202,23 @@ async def ops_log(
         nexus ops log --type write --path /workspace/data.txt
         nexus ops log --status failure
     """
+    import asyncio
+
+    asyncio.run(
+        _async_ops_log(agent, zone, op_type, path, status, limit, remote_url, remote_api_key)
+    )
+
+
+async def _async_ops_log(
+    agent: str | None,
+    zone: str | None,
+    op_type: str | None,
+    path: str | None,
+    status: str | None,
+    limit: int,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 
@@ -325,9 +357,7 @@ def ops_replay(
 @click.option("--agent", "-a", help="Filter by agent ID (undo last operation by this agent)")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
 @add_backend_options
-async def undo(
-    agent: str | None, yes: bool, remote_url: str | None, remote_api_key: str | None
-) -> None:
+def undo(agent: str | None, yes: bool, remote_url: str | None, remote_api_key: str | None) -> None:
     """Undo the last successful operation.
 
     Reverts the most recent filesystem operation.
@@ -337,6 +367,14 @@ async def undo(
         nexus undo --agent my-agent
         nexus undo --yes
     """
+    import asyncio
+
+    asyncio.run(_async_undo(agent, yes, remote_url, remote_api_key))
+
+
+async def _async_undo(
+    agent: str | None, yes: bool, remote_url: str | None, remote_api_key: str | None
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 

--- a/src/nexus/cli/commands/rebac.py
+++ b/src/nexus/cli/commands/rebac.py
@@ -62,7 +62,7 @@ def rebac() -> None:
 )
 @add_backend_options
 @add_context_options
-async def rebac_create(
+def rebac_create(
     subject_type: str,
     subject_id: str,
     relation: str,
@@ -105,6 +105,40 @@ async def rebac_create(
         # Dynamic viewer with column-level permissions (CSV only)
         nexus rebac create agent alice dynamic_viewer file /data/users.csv --column-config '{"hidden_columns":["password"],"aggregations":{"age":"mean"},"visible_columns":["name","email"]}'
     """
+    import asyncio
+
+    asyncio.run(
+        _async_rebac_create(
+            subject_type,
+            subject_id,
+            relation,
+            object_type,
+            object_id,
+            expires,
+            subject_relation,
+            wildcard,
+            column_config,
+            remote_url,
+            remote_api_key,
+            operation_context,
+        )
+    )
+
+
+async def _async_rebac_create(
+    subject_type: str,
+    subject_id: str,
+    relation: str,
+    object_type: str,
+    object_id: str,
+    expires: str | None,
+    subject_relation: str | None,
+    wildcard: bool,
+    column_config: str | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+    operation_context: dict[str, Any],
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 
@@ -217,7 +251,7 @@ async def rebac_create(
 )
 @click.option("--limit", type=int, help="Limit number of results")
 @add_backend_options
-async def rebac_list_cmd(
+def rebac_list_cmd(
     subject_type: str | None,
     subject_id: str | None,
     object_type: str | None,
@@ -249,6 +283,34 @@ async def rebac_list_cmd(
         # JSON output
         nexus rebac list --format json
     """
+    import asyncio
+
+    asyncio.run(
+        _async_rebac_list_cmd(
+            subject_type,
+            subject_id,
+            object_type,
+            object_id,
+            relation,
+            output_format,
+            limit,
+            remote_url,
+            remote_api_key,
+        )
+    )
+
+
+async def _async_rebac_list_cmd(
+    subject_type: str | None,
+    subject_id: str | None,
+    object_type: str | None,
+    object_id: str | None,
+    relation: str | None,
+    output_format: str,
+    limit: int | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         import json
 
@@ -332,7 +394,7 @@ async def rebac_list_cmd(
 @rebac.command(name="delete")
 @click.argument("tuple_id", type=str)
 @add_backend_options
-async def rebac_delete_cmd(
+def rebac_delete_cmd(
     tuple_id: str,
     remote_url: str | None,
     remote_api_key: str | None,
@@ -342,6 +404,16 @@ async def rebac_delete_cmd(
     Examples:
         nexus rebac delete 550e8400-e29b-41d4-a716-446655440000
     """
+    import asyncio
+
+    asyncio.run(_async_rebac_delete_cmd(tuple_id, remote_url, remote_api_key))
+
+
+async def _async_rebac_delete_cmd(
+    tuple_id: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 
@@ -368,7 +440,7 @@ async def rebac_delete_cmd(
 @click.argument("object_id", type=str)
 @add_backend_options
 @add_context_options
-async def rebac_check_cmd(
+def rebac_check_cmd(
     subject_type: str,
     subject_id: str,
     permission: str,
@@ -392,6 +464,32 @@ async def rebac_check_cmd(
         # Does eng-team have owner permission on project?
         nexus rebac check group eng-team owner file project-folder
     """
+    import asyncio
+
+    asyncio.run(
+        _async_rebac_check_cmd(
+            subject_type,
+            subject_id,
+            permission,
+            object_type,
+            object_id,
+            remote_url,
+            remote_api_key,
+            operation_context,
+        )
+    )
+
+
+async def _async_rebac_check_cmd(
+    subject_type: str,
+    subject_id: str,
+    permission: str,
+    object_type: str,
+    object_id: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+    operation_context: dict[str, Any],
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 
@@ -430,7 +528,7 @@ async def rebac_check_cmd(
 @click.argument("object_id", type=str)
 @add_backend_options
 @add_context_options
-async def rebac_expand_cmd(
+def rebac_expand_cmd(
     permission: str,
     object_type: str,
     object_id: str,
@@ -452,6 +550,28 @@ async def rebac_expand_cmd(
         # Who owns the project folder?
         nexus rebac expand owner file project-folder
     """
+    import asyncio
+
+    asyncio.run(
+        _async_rebac_expand_cmd(
+            permission,
+            object_type,
+            object_id,
+            remote_url,
+            remote_api_key,
+            operation_context,
+        )
+    )
+
+
+async def _async_rebac_expand_cmd(
+    permission: str,
+    object_type: str,
+    object_id: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+    operation_context: dict[str, Any],
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 
@@ -506,7 +626,7 @@ async def rebac_expand_cmd(
     help="Zone ID for multi-zone isolation (e.g., 'org_acme'). Can also be set via NEXUS_ZONE_ID env var.",
 )
 @add_backend_options
-async def rebac_explain_cmd(
+def rebac_explain_cmd(
     subject_type: str,
     subject_id: str,
     permission: str,
@@ -535,6 +655,34 @@ async def rebac_explain_cmd(
         # Explain within a specific zone
         nexus rebac explain agent alice read file file123 --zone-id org_acme
     """
+    import asyncio
+
+    asyncio.run(
+        _async_rebac_explain_cmd(
+            subject_type,
+            subject_id,
+            permission,
+            object_type,
+            object_id,
+            verbose,
+            zone_id,
+            remote_url,
+            remote_api_key,
+        )
+    )
+
+
+async def _async_rebac_explain_cmd(
+    subject_type: str,
+    subject_id: str,
+    permission: str,
+    object_type: str,
+    object_id: str,
+    verbose: bool,
+    zone_id: str | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         import json
         import os
@@ -743,7 +891,7 @@ def _display_proof_tree(path: dict, depth: int = 0, step_number: list[int] | Non
     help="Output format",
 )
 @add_backend_options
-async def rebac_check_batch_cmd(
+def rebac_check_batch_cmd(
     checks_file: str,
     output_format: str,
     remote_url: str | None,
@@ -776,6 +924,19 @@ async def rebac_check_batch_cmd(
         # Summary only
         nexus rebac check-batch checks.json --format summary
     """
+    import asyncio
+
+    asyncio.run(
+        _async_rebac_check_batch_cmd(checks_file, output_format, remote_url, remote_api_key)
+    )
+
+
+async def _async_rebac_check_batch_cmd(
+    checks_file: str,
+    output_format: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         import json
 
@@ -886,7 +1047,7 @@ async def rebac_check_batch_cmd(
     help="Add permission mapping (format: perm:rel1,rel2,rel3)",
 )
 @add_backend_options
-async def namespace_create(
+def namespace_create(
     object_type: str,
     config_file: str | None,
     relations: tuple[str, ...],
@@ -920,6 +1081,23 @@ async def namespace_create(
           }
         }
     """
+    import asyncio
+
+    asyncio.run(
+        _async_namespace_create(
+            object_type, config_file, relations, permission, remote_url, remote_api_key
+        )
+    )
+
+
+async def _async_namespace_create(
+    object_type: str,
+    config_file: str | None,
+    relations: tuple[str, ...],
+    permission: tuple[str, ...],
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         import json
 
@@ -977,7 +1155,7 @@ async def namespace_create(
     help="Output format",
 )
 @add_backend_options
-async def namespace_list(
+def namespace_list(
     output_format: str,
     remote_url: str | None,
     remote_api_key: str | None,
@@ -991,6 +1169,16 @@ async def namespace_list(
         # JSON output
         nexus rebac namespace-list --format json
     """
+    import asyncio
+
+    asyncio.run(_async_namespace_list(output_format, remote_url, remote_api_key))
+
+
+async def _async_namespace_list(
+    output_format: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
 
@@ -1045,7 +1233,7 @@ async def namespace_list(
     help="Output format",
 )
 @add_backend_options
-async def namespace_get(
+def namespace_get(
     object_type: str,
     output_format: str,
     remote_url: str | None,
@@ -1060,6 +1248,17 @@ async def namespace_get(
         # JSON output
         nexus rebac namespace-get group --format json
     """
+    import asyncio
+
+    asyncio.run(_async_namespace_get(object_type, output_format, remote_url, remote_api_key))
+
+
+async def _async_namespace_get(
+    object_type: str,
+    output_format: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         import json
 
@@ -1088,7 +1287,7 @@ async def namespace_get(
 @click.argument("object_type", type=str)
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt")
 @add_backend_options
-async def namespace_delete(
+def namespace_delete(
     object_type: str,
     yes: bool,
     remote_url: str | None,
@@ -1105,6 +1304,17 @@ async def namespace_delete(
         # Skip confirmation
         nexus rebac namespace-delete document --yes
     """
+    import asyncio
+
+    asyncio.run(_async_namespace_delete(object_type, yes, remote_url, remote_api_key))
+
+
+async def _async_namespace_delete(
+    object_type: str,
+    yes: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
     try:
         if not yes:
             confirm = input(f"Delete namespace '{object_type}'? (y/N): ")

--- a/src/nexus/cli/commands/versions.py
+++ b/src/nexus/cli/commands/versions.py
@@ -47,7 +47,7 @@ def version_group() -> None:
 @click.argument("path")
 @click.option("--limit", type=int, default=None, help="Limit number of versions shown")
 @add_backend_options
-async def version_history(
+def version_history(
     path: str, limit: int | None, remote_url: str | None, remote_api_key: str | None
 ) -> None:
     """Show version history for a file.
@@ -58,7 +58,14 @@ async def version_history(
         nexus version history /workspace/SKILL.md
         nexus version history /workspace/data.txt --limit 10
     """
+    import asyncio
 
+    asyncio.run(_async_version_history(path, limit, remote_url, remote_api_key))
+
+
+async def _async_version_history(
+    path: str, limit: int | None, remote_url: str | None, remote_api_key: str | None
+) -> None:
     def format_size(size: int) -> str:
         """Format size in human-readable format."""
         size_float = float(size)
@@ -117,7 +124,7 @@ async def version_history(
 @click.option("--version", "-v", type=int, required=True, help="Version number to retrieve")
 @click.option("--output", "-o", help="Output file path (default: stdout)")
 @add_backend_options
-async def version_get(
+def version_get(
     path: str, version: int, output: str | None, remote_url: str | None, remote_api_key: str | None
 ) -> None:
     """Get a specific version of a file.
@@ -128,6 +135,14 @@ async def version_get(
         nexus version get /workspace/file.txt --version 2
         nexus version get /workspace/file.txt -v 1 -o old_version.txt
     """
+    import asyncio
+
+    asyncio.run(_async_version_get(path, version, output, remote_url, remote_api_key))
+
+
+async def _async_version_get(
+    path: str, version: int, output: str | None, remote_url: str | None, remote_api_key: str | None
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
         _nx: Any = nx
@@ -159,7 +174,7 @@ async def version_get(
     "--mode", type=click.Choice(["metadata", "content"]), default="content", help="Diff mode"
 )
 @add_backend_options
-async def version_diff(
+def version_diff(
     path: str, v1: int, v2: int, mode: str, remote_url: str | None, remote_api_key: str | None
 ) -> None:
     """Compare two versions of a file.
@@ -170,7 +185,14 @@ async def version_diff(
         nexus version diff /workspace/file.txt --v1 1 --v2 3
         nexus version diff /workspace/file.txt --v1 1 --v2 2 --mode metadata
     """
+    import asyncio
 
+    asyncio.run(_async_version_diff(path, v1, v2, mode, remote_url, remote_api_key))
+
+
+async def _async_version_diff(
+    path: str, v1: int, v2: int, mode: str, remote_url: str | None, remote_api_key: str | None
+) -> None:
     def format_size(size: int) -> str:
         """Format size in human-readable format."""
         size_float = float(abs(size))
@@ -243,7 +265,7 @@ async def version_diff(
 @click.option("--version", "-v", type=int, required=True, help="Version to rollback to")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
 @add_backend_options
-async def version_rollback(
+def version_rollback(
     path: str, version: int, yes: bool, remote_url: str | None, remote_api_key: str | None
 ) -> None:
     """Rollback file to a previous version.
@@ -254,6 +276,14 @@ async def version_rollback(
         nexus version rollback /workspace/file.txt --version 2
         nexus version rollback /workspace/file.txt -v 1 --yes
     """
+    import asyncio
+
+    asyncio.run(_async_version_rollback(path, version, yes, remote_url, remote_api_key))
+
+
+async def _async_version_rollback(
+    path: str, version: int, yes: bool, remote_url: str | None, remote_api_key: str | None
+) -> None:
     try:
         nx = await get_filesystem(remote_url, remote_api_key)
         _nx: Any = nx


### PR DESCRIPTION
## Summary
- Click doesn't support `async def` command handlers — calling one returns an unawaited coroutine instead of executing the function
- This caused silent failures (`RuntimeWarning: coroutine 'X' was never awaited`) for 35 CLI commands across 8 files
- Applied the same sync-wrapper pattern already used in `file_ops.py`, `search.py`, `oauth.py`: sync Click handler calls `asyncio.run(_async_impl(...))`

## Files changed
| File | Commands fixed |
|---|---|
| `demo.py` | `demo_init`, `demo_reset` |
| `inspect.py` | `info`, `size` |
| `mcp.py` | `serve` |
| `migrate.py` | `import_s3`, `import_gcs`, `import_fs`, `validate` |
| `mounts.py` | `add_mount`, `remove_mount`, `list_mounts`, `mount_info`, `sync_mount`, `sync_status`, `sync_cancel`, `sync_jobs` |
| `operations.py` | `ops_diff`, `ops_log`, `undo` |
| `rebac.py` | `rebac_create`, `rebac_list_cmd`, `rebac_delete_cmd`, `rebac_check_cmd`, `rebac_expand_cmd`, `rebac_explain_cmd`, `rebac_check_batch_cmd`, `namespace_create`, `namespace_list`, `namespace_get`, `namespace_delete` |
| `versions.py` | `version_history`, `version_get`, `version_diff`, `version_rollback` |

## Test plan
- [x] All 8 files pass `python3 -m py_compile`
- [x] No remaining top-level `async def` Click commands (`grep` verified)
- [x] `nexus demo init` no longer emits `RuntimeWarning: coroutine 'demo_init' was never awaited`