### PR TITLE
fix(ci): skip merge commit check for develop→main PRs

### DIFF
--- a/.github/workflows/no-merge-commits.yml
+++ b/.github/workflows/no-merge-commits.yml
@@ -17,14 +17,24 @@ jobs:
 
       - name: Reject merge commits in PR branch
         run: |
-          # For merge_group events, skip (queue handles rebase)
+          # For merge_group events, skip (queue handles merge)
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "✅ Merge queue event — skipping merge commit check"
             exit 0
           fi
 
-          HEAD_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+          HEAD_REF="${{ github.head_ref }}"
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
           BASE_REF=${{ github.event.pull_request.base.ref }}
+
+          # develop→main merges naturally contain merge commits from merged PRs.
+          # Only skip for the canonical repo — not forks with a branch also named "develop".
+          if [ "$HEAD_REF" = "develop" ] && [ "$BASE_REF" = "main" ] && [ "$HEAD_REPO" = "${{ github.repository }}" ]; then
+            echo "✅ develop → main merge (same repo) — skipping merge commit check"
+            exit 0
+          fi
+
+          HEAD_SHA=${{ github.event.pull_request.head.sha || github.sha }}
 
           # Compute merge-base dynamically from the base branch ref.
           # Using base.sha is unreliable — it's a frozen snapshot that doesn't

--- a/tests/unit/daemon/test_main.py
+++ b/tests/unit/daemon/test_main.py
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -293,7 +293,7 @@ class TestMainCli:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
         mock_nx = MagicMock()
-        mock_connect = MagicMock(return_value=mock_nx)
+        mock_connect = AsyncMock(return_value=mock_nx)
 
         mock_app = MagicMock()
         mock_create_app = MagicMock(return_value=mock_app)


### PR DESCRIPTION
## Summary
- Skip the no-merge-commits check when source is `develop` and target is `main`
- `develop` naturally accumulates merge commits from merged feature PRs — this check is only relevant for feature branches
- Also verifies `head.repo == github.repository` to prevent fork bypass (Codex review feedback)

## Test plan
- [ ] CI passes
- [ ] After merge, re-run CI on develop→main PR #3038