### PR TITLE
fix(#3030): Rust correctness and performance fixes across 4 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_pyo3"
-version = "0.9.4"
+version = "0.9.6"
 dependencies = [
  "ahash",
  "blake3",

--- a/nexus-fuse/src/client.rs
+++ b/nexus-fuse/src/client.rs
@@ -167,7 +167,9 @@ impl NexusClient {
         let rpc_resp: JsonRpcResponse<T> = resp.json()?;
 
         if let Some(err) = rpc_resp.error {
-            if err.message.contains("not found") || err.message.contains("Not Found") {
+            // Classify by structured error code (rpc_types.py RPCErrorCode),
+            // not message text. -32000 = FILE_NOT_FOUND per server contract.
+            if err.code == -32000 {
                 return Err(NexusClientError::NotFound(err.message));
             }
             return Err(NexusClientError::InvalidResponse(format!(
@@ -327,9 +329,6 @@ impl NexusClient {
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().unwrap_or_default();
-            if status.as_u16() == 404 || text.contains("not found") || text.contains("Not Found") {
-                return Err(NexusClientError::NotFound("not found".to_string()));
-            }
             return Err(Self::status_to_error(status, text));
         }
 
@@ -357,8 +356,7 @@ impl NexusClient {
         let rpc_resp: JsonRpcReadResponse = resp.json()?;
 
         if let Some(err) = rpc_resp.error {
-            if err.message.contains("not found") || err.message.contains("Not Found")
-                || err.message.contains("CAS content not found") {
+            if err.code == -32000 {
                 return Err(NexusClientError::NotFound(err.message));
             }
             return Err(NexusClientError::InvalidResponse(format!(

--- a/nexus-fuse/src/fs.rs
+++ b/nexus-fuse/src/fs.rs
@@ -309,8 +309,7 @@ impl NexusFs {
                 Ok(attr)
             }
             Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("not found") {
+                if e.is_not_found() {
                     Err(ENOENT)
                 } else {
                     error!("get_attr error for {}: {}", path, e);
@@ -507,8 +506,7 @@ impl Filesystem for NexusFs {
                         entries
                     }
                     Err(e) => {
-                        let msg = e.to_string();
-                        if msg.contains("not found") {
+                        if e.is_not_found() {
                             reply.error(ENOENT);
                         } else {
                             error!("readdir error for {}: {}", path, e);
@@ -586,8 +584,9 @@ impl Filesystem for NexusFs {
         let content = match self.read_cached(&path) {
             Ok((data, _etag)) => data,
             Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("not found") {
+                if e.downcast_ref::<crate::error::NexusClientError>()
+                    .map_or(false, |ne| ne.is_not_found())
+                {
                     reply.error(ENOENT);
                 } else {
                     error!("read error for {}: {}", path, e);
@@ -629,7 +628,11 @@ impl Filesystem for NexusFs {
             // Read existing content first (use cache if available)
             let existing = match self.read_cached(&path) {
                 Ok((data, _)) => data,
-                Err(_) => Vec::new(),
+                Err(e) => {
+                    error!("partial write: read failed for {}: {}", path, e);
+                    reply.error(EIO);
+                    return;
+                }
             };
 
             let mut new_content = existing;
@@ -748,8 +751,7 @@ impl Filesystem for NexusFs {
                 reply.ok();
             }
             Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("not found") {
+                if e.is_not_found() {
                     reply.error(ENOENT);
                 } else {
                     error!("unlink error for {}: {}", path, e);
@@ -774,8 +776,7 @@ impl Filesystem for NexusFs {
                 return;
             }
             Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("not found") {
+                if e.is_not_found() {
                     reply.error(ENOENT);
                 } else {
                     error!("rmdir list error for {}: {}", path, e);
@@ -845,8 +846,7 @@ impl Filesystem for NexusFs {
                 reply.ok();
             }
             Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("not found") {
+                if e.is_not_found() {
                     reply.error(ENOENT);
                 } else {
                     error!("rename error: {} -> {}: {}", old_path, new_path, e);

--- a/nexus-fuse/tests/error_handling_test.rs
+++ b/nexus-fuse/tests/error_handling_test.rs
@@ -106,10 +106,11 @@ fn test_connection_refused_is_transient() {
 }
 
 #[test]
-fn test_rpc_not_found_in_body() {
+fn test_rpc_file_not_found_code_maps_to_enoent() {
     let mut server = Server::new();
 
-    // Server returns 200 but the RPC body indicates "not found"
+    // Server returns RPC error with code -32000 (RPCErrorCode.FILE_NOT_FOUND).
+    // This is the server's canonical "file not found" signal and must map to ENOENT.
     let _m = server
         .mock("POST", "/api/nfs/read")
         .with_status(200)
@@ -122,7 +123,7 @@ fn test_rpc_not_found_in_body() {
 
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(err.is_not_found());
+    assert!(err.is_not_found(), "RPC code -32000 must map to NotFound");
     assert_eq!(err.to_errno(), libc::ENOENT);
 }
 
@@ -334,4 +335,91 @@ fn test_list_directory() {
     assert_eq!(entries[0].name, "hello.txt");
     assert_eq!(entries[0].entry_type, "file");
     assert_eq!(entries[0].size, 5);
+}
+
+#[test]
+fn test_rpc_non_32000_code_with_not_found_message_is_not_enoent() {
+    let mut server = Server::new();
+
+    // RPC errors are classified by error code, not message text.
+    // Code -1 is NOT -32000 (FILE_NOT_FOUND), so even though the message
+    // says "Not Found", this must map to InvalidResponse, not NotFound.
+    let _m = server
+        .mock("POST", "/api/nfs/stat")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"Not Found: /missing"}}"#)
+        .create();
+
+    let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+    let result = client.stat("/test");
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(!err.is_not_found(), "RPC errors should not map to NotFound");
+    assert_eq!(err.to_errno(), libc::EPROTO);
+    assert!(!err.is_transient());
+}
+
+#[test]
+fn test_rpc_error_permission_denied_maps_to_invalid_response() {
+    let mut server = Server::new();
+
+    let _m = server
+        .mock("POST", "/api/nfs/stat")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"Permission denied"}}"#)
+        .create();
+
+    let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+    let result = client.stat("/test");
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(!err.is_not_found());
+    assert_eq!(err.to_errno(), libc::EPROTO);
+    assert!(!err.is_transient());
+}
+
+#[test]
+fn test_http_404_maps_to_not_found() {
+    let mut server = Server::new();
+
+    // HTTP 404 should map to NotFound/ENOENT (alongside RPC code -32000).
+    let _m = server
+        .mock("POST", "/api/nfs/stat")
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body("Not Found")
+        .create();
+
+    let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+    let result = client.stat("/test");
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.is_not_found(), "HTTP 404 should map to NotFound");
+    assert_eq!(err.to_errno(), libc::ENOENT);
+    assert!(!err.is_transient());
+}
+
+#[test]
+fn test_rpc_internal_error_not_misclassified() {
+    let mut server = Server::new();
+
+    // Internal errors with "not found" substring must NOT become ENOENT
+    let _m = server
+        .mock("POST", "/api/nfs/stat")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"Key not found in distributed hash table"}}"#)
+        .create();
+
+    let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+    let result = client.stat("/test");
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(!err.is_not_found(), "Internal errors must not be misclassified as NotFound");
 }

--- a/rust/nexus_core/src/rebac/mod.rs
+++ b/rust/nexus_core/src/rebac/mod.rs
@@ -26,6 +26,10 @@ pub struct ReBACGraph {
     /// Enables tupleToUserset resolution which needs "find subjects with relation on object".
     pub reverse_adjacency: AHashMap<AdjacencyKey, Vec<Entity>>,
     pub userset_index: AHashMap<UsersetKey, Vec<UsersetEntry>>,
+    /// Direct-only reverse adjacency: (object_type, object_id, relation) → [subjects].
+    /// Built only from tuples WITHOUT subject_relation (direct relations).
+    /// Used by add_direct_subjects() to avoid conflating userset subjects with direct ones.
+    pub direct_reverse: AHashMap<AdjacencyKey, Vec<Entity>>,
 }
 
 impl ReBACGraph {
@@ -35,6 +39,7 @@ impl ReBACGraph {
         let mut adjacency_list: AHashMap<AdjacencyKey, Vec<Entity>> = AHashMap::new();
         let mut reverse_adjacency: AHashMap<AdjacencyKey, Vec<Entity>> = AHashMap::new();
         let mut userset_index: AHashMap<UsersetKey, Vec<UsersetEntry>> = AHashMap::new();
+        let mut direct_reverse: AHashMap<AdjacencyKey, Vec<Entity>> = AHashMap::new();
 
         for tuple in tuples {
             if let Some(ref subject_relation) = tuple.subject_relation {
@@ -60,6 +65,19 @@ impl ReBACGraph {
                     tuple.subject_id.clone(),
                 );
                 tuple_index.insert(tuple_key);
+
+                let direct_rev_key = (
+                    tuple.object_type.clone(),
+                    tuple.object_id.clone(),
+                    tuple.relation.clone(),
+                );
+                direct_reverse
+                    .entry(direct_rev_key)
+                    .or_default()
+                    .push(Entity {
+                        entity_type: tuple.subject_type.clone(),
+                        entity_id: tuple.subject_id.clone(),
+                    });
             }
 
             // Forward adjacency: subject → objects
@@ -90,6 +108,7 @@ impl ReBACGraph {
             adjacency_list,
             reverse_adjacency,
             userset_index,
+            direct_reverse,
         }
     }
 
@@ -142,6 +161,15 @@ impl ReBACGraph {
             .get(&rev_key)
             .cloned()
             .unwrap_or_default()
+    }
+
+    pub fn find_direct_subjects_for_object(&self, object: &Entity, relation: &str) -> Vec<Entity> {
+        let key = (
+            object.entity_type.clone(),
+            object.entity_id.clone(),
+            relation.to_string(),
+        );
+        self.direct_reverse.get(&key).cloned().unwrap_or_default()
     }
 
     /// Get usersets that grant a relation on an object.
@@ -469,11 +497,8 @@ fn add_direct_subjects(
     graph: &ReBACGraph,
     subjects: &mut AHashSet<(String, String)>,
 ) {
-    for key in graph.tuple_index.iter() {
-        let (obj_type, obj_id, rel, subj_type, subj_id) = key;
-        if obj_type == &object.entity_type && obj_id == &object.entity_id && rel == relation {
-            subjects.insert((subj_type.clone(), subj_id.clone()));
-        }
+    for entity in graph.find_direct_subjects_for_object(object, relation) {
+        subjects.insert((entity.entity_type, entity.entity_id));
     }
 
     for userset in graph.get_usersets(object, relation) {

--- a/rust/nexus_pyo3/src/io.rs
+++ b/rust/nexus_pyo3/src/io.rs
@@ -41,46 +41,28 @@ pub fn read_file(py: Python<'_>, path: &str) -> PyResult<Option<Py<PyBytes>>> {
 /// Read multiple files using memory-mapped I/O in parallel.
 #[pyfunction]
 pub fn read_files_bulk(py: Python<'_>, paths: Vec<String>) -> PyResult<Bound<'_, PyDict>> {
-    const PARALLEL_THRESHOLD: usize = 10;
-
-    let results: Vec<(String, Vec<u8>)> = if paths.len() < PARALLEL_THRESHOLD {
+    let mmaps: Vec<(String, Option<Mmap>)> = py.detach(|| {
         paths
-            .into_iter()
+            .into_par_iter()
             .filter_map(|path| {
                 let file = File::open(&path).ok()?;
                 let metadata = file.metadata().ok()?;
-
                 if metadata.len() == 0 {
-                    return Some((path, Vec::new()));
+                    return Some((path, None));
                 }
-
                 let mmap = unsafe { Mmap::map(&file).ok()? };
-                Some((path, mmap.to_vec()))
+                Some((path, Some(mmap)))
             })
             .collect()
-    } else {
-        py.detach(|| {
-            paths
-                .into_par_iter()
-                .filter_map(|path| {
-                    let file = File::open(&path).ok()?;
-                    let metadata = file.metadata().ok()?;
-
-                    if metadata.len() == 0 {
-                        return Some((path, Vec::new()));
-                    }
-
-                    let mmap = unsafe { Mmap::map(&file).ok()? };
-                    Some((path, mmap.to_vec()))
-                })
-                .collect()
-        })
-    };
+    });
 
     let py_dict = PyDict::new(py);
-    for (path, content) in results {
-        py_dict.set_item(path, PyBytes::new(py, &content))?;
+    for (path, mmap) in &mmaps {
+        let bytes = match mmap {
+            Some(m) => PyBytes::new(py, m),
+            None => PyBytes::new(py, &[]),
+        };
+        py_dict.set_item(path, bytes)?;
     }
-
     Ok(py_dict)
 }

--- a/rust/nexus_pyo3/src/lib.rs
+++ b/rust/nexus_pyo3/src/lib.rs
@@ -13,11 +13,11 @@ mod io;
 mod lock;
 mod pipe;
 mod prefix;
-mod stream;
-mod semaphore;
 mod rebac;
 mod search;
+mod semaphore;
 mod simd;
+mod stream;
 mod trigram;
 
 use pyo3::prelude::*;

--- a/rust/nexus_pyo3/src/lock.rs
+++ b/rust/nexus_pyo3/src/lock.rs
@@ -169,7 +169,11 @@ impl VFSLockManager {
     /// where `upper` replaces the trailing '/' (0x2F) with '0' (0x30, the next
     /// ASCII codepoint). Since '/' and '0' are adjacent in ASCII, no valid path
     /// character falls between them.
-    fn descendant_conflict(locks: &BTreeMap<String, LockEntry>, path: &str, mode: LockMode) -> bool {
+    fn descendant_conflict(
+        locks: &BTreeMap<String, LockEntry>,
+        path: &str,
+        mode: LockMode,
+    ) -> bool {
         let prefix = if path.ends_with('/') {
             path.to_string()
         } else {
@@ -847,7 +851,7 @@ mod tests {
         let mgr = make();
         let _w1 = acquire(&mgr, "/a/bc", LockMode::Write).unwrap(); // sibling
         let _w2 = acquire(&mgr, "/a/b/child", LockMode::Write).unwrap(); // descendant
-        // "/a/b" should fail due to descendant "/a/b/child".
+                                                                         // "/a/b" should fail due to descendant "/a/b/child".
         assert!(acquire(&mgr, "/a/b", LockMode::Write).is_none());
     }
 }

--- a/rust/nexus_pyo3/src/pipe.rs
+++ b/rust/nexus_pyo3/src/pipe.rs
@@ -112,8 +112,7 @@ impl RingBufferCore {
         // Write frame: [4B len][payload]
         let header = (payload_len as u32).to_le_bytes();
         ring[write_idx..write_idx + HEADER_SIZE].copy_from_slice(&header);
-        ring[write_idx + HEADER_SIZE..write_idx + HEADER_SIZE + payload_len]
-            .copy_from_slice(data);
+        ring[write_idx + HEADER_SIZE..write_idx + HEADER_SIZE + payload_len].copy_from_slice(data);
 
         // Update tail
         let current_tail = self.tail.load(Ordering::Relaxed);
@@ -208,9 +207,9 @@ impl RingBufferCore {
     fn push(&self, _py: Python<'_>, data: &[u8]) -> PyResult<usize> {
         match self.push_inner(data) {
             Ok(n) => Ok(n),
-            Err(RingError::Closed(msg)) => Err(pyo3::exceptions::PyRuntimeError::new_err(
-                format!("PipeClosed:{msg}"),
-            )),
+            Err(RingError::Closed(msg)) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "PipeClosed:{msg}"
+            ))),
             Err(RingError::Full(used, cap)) => Err(pyo3::exceptions::PyRuntimeError::new_err(
                 format!("PipeFull:buffer full ({used}/{cap} bytes)"),
             )),
@@ -248,9 +247,9 @@ impl RingBufferCore {
     fn push_u64(&self, _py: Python<'_>, val: u64) -> PyResult<()> {
         match self.push_inner(&val.to_le_bytes()) {
             Ok(_) => Ok(()),
-            Err(RingError::Closed(msg)) => Err(pyo3::exceptions::PyRuntimeError::new_err(
-                format!("PipeClosed:{msg}"),
-            )),
+            Err(RingError::Closed(msg)) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "PipeClosed:{msg}"
+            ))),
             Err(RingError::Full(used, cap)) => Err(pyo3::exceptions::PyRuntimeError::new_err(
                 format!("PipeFull:buffer full ({used}/{cap} bytes)"),
             )),

--- a/rust/nexus_pyo3/src/search.rs
+++ b/rust/nexus_pyo3/src/search.rs
@@ -172,7 +172,7 @@ pub fn grep_bulk<'py>(
         }
     } else {
         let regex = get_or_compile_regex(pattern, ignore_case)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+            .map_err(pyo3::exceptions::PyValueError::new_err)?;
         SearchMode::Regex(regex)
     };
 
@@ -274,7 +274,7 @@ pub fn grep_files_mmap<'py>(
     let regex_opt: Option<regex::bytes::Regex> = if !is_literal {
         Some(
             get_or_compile_regex(pattern, ignore_case)
-                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?,
+                .map_err(pyo3::exceptions::PyValueError::new_err)?,
         )
     } else {
         None
@@ -555,7 +555,10 @@ mod tests {
         // Should hit cache.
         let re2 = get_or_compile_regex("test_pattern_123", false).unwrap();
         // Both should produce the same match results.
-        assert_eq!(re1.is_match(b"test_pattern_123"), re2.is_match(b"test_pattern_123"));
+        assert_eq!(
+            re1.is_match(b"test_pattern_123"),
+            re2.is_match(b"test_pattern_123")
+        );
     }
 
     #[test]
@@ -628,8 +631,7 @@ mod tests {
     #[test]
     fn test_grep_mmap_literal_case_sensitive() {
         let (_f, path) = write_temp_file("Hello World\nhello world\nHELLO WORLD\n");
-        let results =
-            grep_single_file_mmap(&path, "hello", "", true, false, None, 100).unwrap();
+        let results = grep_single_file_mmap(&path, "hello", "", true, false, None, 100).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].line, 2);
         assert_eq!(results[0].match_text, "hello");
@@ -649,12 +651,9 @@ mod tests {
     #[test]
     fn test_grep_mmap_regex() {
         let (_f, path) = write_temp_file("fn main() {}\nlet x = 42;\nfn helper() {}\n");
-        let regex = RegexBuilder::new(r"fn \w+")
-            .build()
-            .unwrap();
+        let regex = RegexBuilder::new(r"fn \w+").build().unwrap();
         let results =
-            grep_single_file_mmap(&path, r"fn \w+", "", false, false, Some(&regex), 100)
-                .unwrap();
+            grep_single_file_mmap(&path, r"fn \w+", "", false, false, Some(&regex), 100).unwrap();
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].match_text, "fn main");
         assert_eq!(results[1].match_text, "fn helper");
@@ -663,24 +662,21 @@ mod tests {
     #[test]
     fn test_grep_mmap_max_results() {
         let (_f, path) = write_temp_file("aaa\naaa\naaa\naaa\naaa\n");
-        let results =
-            grep_single_file_mmap(&path, "aaa", "", true, false, None, 2).unwrap();
+        let results = grep_single_file_mmap(&path, "aaa", "", true, false, None, 2).unwrap();
         assert_eq!(results.len(), 2);
     }
 
     #[test]
     fn test_grep_mmap_empty_file() {
         let (_f, path) = write_temp_file("");
-        let results =
-            grep_single_file_mmap(&path, "test", "", true, false, None, 100).unwrap();
+        let results = grep_single_file_mmap(&path, "test", "", true, false, None, 100).unwrap();
         assert!(results.is_empty());
     }
 
     #[test]
     fn test_grep_mmap_no_match() {
         let (_f, path) = write_temp_file("Hello World\n");
-        let results =
-            grep_single_file_mmap(&path, "xyz", "", true, false, None, 100).unwrap();
+        let results = grep_single_file_mmap(&path, "xyz", "", true, false, None, 100).unwrap();
         assert!(results.is_empty());
     }
 

--- a/rust/nexus_pyo3/src/simd.rs
+++ b/rust/nexus_pyo3/src/simd.rs
@@ -108,10 +108,7 @@ fn top_k_by_similarity<T: Sync>(
         }
     }
 
-    let mut result: Vec<(usize, f64)> = heap
-        .into_iter()
-        .map(|e| (e.index, e.score.0))
-        .collect();
+    let mut result: Vec<(usize, f64)> = heap.into_iter().map(|e| (e.index, e.score.0)).collect();
     result.sort_by(|a, b| TotalF64(b.1).cmp(&TotalF64(a.1)));
     result
 }
@@ -184,7 +181,11 @@ pub fn euclidean_sq_f32(a: Vec<f32>, b: Vec<f32>) -> PyResult<f64> {
 
 /// Batch cosine similarity: compute similarity of query vs all vectors.
 #[pyfunction]
-pub fn batch_cosine_similarity_f32(query: Vec<f32>, vectors: Vec<Vec<f32>>) -> PyResult<Vec<f64>> {
+pub fn batch_cosine_similarity_f32(
+    py: Python<'_>,
+    query: Vec<f32>,
+    vectors: Vec<Vec<f32>>,
+) -> PyResult<Vec<f64>> {
     if vectors.is_empty() {
         return Ok(vec![]);
     }
@@ -201,34 +202,35 @@ pub fn batch_cosine_similarity_f32(query: Vec<f32>, vectors: Vec<Vec<f32>>) -> P
         }
     }
 
-    const PARALLEL_THRESHOLD: usize = 100;
+    Ok(py.detach(|| {
+        const PARALLEL_THRESHOLD: usize = 100;
 
-    let similarities: Vec<f64> = if vectors.len() > PARALLEL_THRESHOLD {
-        vectors
-            .par_iter()
-            .map(|v| {
-                <f32 as SpatialSimilarity>::cos(&query, v)
-                    .map(|dist| 1.0 - dist)
-                    .unwrap_or(0.0)
-            })
-            .collect()
-    } else {
-        vectors
-            .iter()
-            .map(|v| {
-                <f32 as SpatialSimilarity>::cos(&query, v)
-                    .map(|dist| 1.0 - dist)
-                    .unwrap_or(0.0)
-            })
-            .collect()
-    };
-
-    Ok(similarities)
+        if vectors.len() > PARALLEL_THRESHOLD {
+            vectors
+                .par_iter()
+                .map(|v| {
+                    <f32 as SpatialSimilarity>::cos(&query, v)
+                        .map(|dist| 1.0 - dist)
+                        .unwrap_or(0.0)
+                })
+                .collect()
+        } else {
+            vectors
+                .iter()
+                .map(|v| {
+                    <f32 as SpatialSimilarity>::cos(&query, v)
+                        .map(|dist| 1.0 - dist)
+                        .unwrap_or(0.0)
+                })
+                .collect()
+        }
+    }))
 }
 
 /// Top-K similarity search using SIMD (f32).
 #[pyfunction]
 pub fn top_k_similar_f32(
+    py: Python<'_>,
     query: Vec<f32>,
     vectors: Vec<Vec<f32>>,
     k: usize,
@@ -249,7 +251,7 @@ pub fn top_k_similar_f32(
         }
     }
 
-    Ok(top_k_by_similarity(&query, &vectors, k, cosine_sim_f32))
+    Ok(py.detach(|| top_k_by_similarity(&query, &vectors, k, cosine_sim_f32)))
 }
 
 // ---------------------------------------------------------------------------
@@ -274,7 +276,11 @@ pub fn cosine_similarity_i8(a: Vec<i8>, b: Vec<i8>) -> PyResult<f64> {
 
 /// Batch cosine similarity for int8 quantized vectors.
 #[pyfunction]
-pub fn batch_cosine_similarity_i8(query: Vec<i8>, vectors: Vec<Vec<i8>>) -> PyResult<Vec<f64>> {
+pub fn batch_cosine_similarity_i8(
+    py: Python<'_>,
+    query: Vec<i8>,
+    vectors: Vec<Vec<i8>>,
+) -> PyResult<Vec<f64>> {
     if vectors.is_empty() {
         return Ok(vec![]);
     }
@@ -291,34 +297,35 @@ pub fn batch_cosine_similarity_i8(query: Vec<i8>, vectors: Vec<Vec<i8>>) -> PyRe
         }
     }
 
-    const PARALLEL_THRESHOLD: usize = 100;
+    Ok(py.detach(|| {
+        const PARALLEL_THRESHOLD: usize = 100;
 
-    let similarities: Vec<f64> = if vectors.len() > PARALLEL_THRESHOLD {
-        vectors
-            .par_iter()
-            .map(|v| {
-                <i8 as SpatialSimilarity>::cos(&query, v)
-                    .map(|dist| 1.0 - dist)
-                    .unwrap_or(0.0)
-            })
-            .collect()
-    } else {
-        vectors
-            .iter()
-            .map(|v| {
-                <i8 as SpatialSimilarity>::cos(&query, v)
-                    .map(|dist| 1.0 - dist)
-                    .unwrap_or(0.0)
-            })
-            .collect()
-    };
-
-    Ok(similarities)
+        if vectors.len() > PARALLEL_THRESHOLD {
+            vectors
+                .par_iter()
+                .map(|v| {
+                    <i8 as SpatialSimilarity>::cos(&query, v)
+                        .map(|dist| 1.0 - dist)
+                        .unwrap_or(0.0)
+                })
+                .collect()
+        } else {
+            vectors
+                .iter()
+                .map(|v| {
+                    <i8 as SpatialSimilarity>::cos(&query, v)
+                        .map(|dist| 1.0 - dist)
+                        .unwrap_or(0.0)
+                })
+                .collect()
+        }
+    }))
 }
 
 /// Top-K similarity search for int8 quantized vectors.
 #[pyfunction]
 pub fn top_k_similar_i8(
+    py: Python<'_>,
     query: Vec<i8>,
     vectors: Vec<Vec<i8>>,
     k: usize,
@@ -339,7 +346,7 @@ pub fn top_k_similar_i8(
         }
     }
 
-    Ok(top_k_by_similarity(&query, &vectors, k, cosine_sim_i8))
+    Ok(py.detach(|| top_k_by_similarity(&query, &vectors, k, cosine_sim_i8)))
 }
 
 // ---------------------------------------------------------------------------
@@ -415,13 +422,7 @@ mod tests {
     #[test]
     fn test_top_k_returns_descending_order() {
         let query = vec![1.0f32];
-        let vectors = vec![
-            vec![3.0],
-            vec![1.0],
-            vec![5.0],
-            vec![2.0],
-            vec![4.0],
-        ];
+        let vectors = vec![vec![3.0], vec![1.0], vec![5.0], vec![2.0], vec![4.0]];
         let result = top_k_by_similarity(&query, &vectors, 5, dummy_sim);
         for i in 1..result.len() {
             assert!(
@@ -474,9 +475,11 @@ mod tests {
             vec![1.0, 0.0, 0.0], // valid
             vec![0.5, 0.5, 0.0], // valid
         ];
-        let result = top_k_similar_f32(query, vectors, 5).unwrap();
-        // Should always return all vectors (2), not fewer.
-        assert_eq!(result.len(), 2);
+        Python::with_gil(|py| {
+            let result = top_k_similar_f32(py, query, vectors, 5).unwrap();
+            // Should always return all vectors (2), not fewer.
+            assert_eq!(result.len(), 2);
+        });
     }
 
     #[test]
@@ -545,15 +548,17 @@ mod tests {
         // Normalized vectors for meaningful cosine similarity.
         let query = vec![1.0f32, 0.0, 0.0];
         let vectors = vec![
-            vec![1.0, 0.0, 0.0],  // identical → similarity ≈ 1.0
-            vec![0.0, 1.0, 0.0],  // orthogonal → similarity ≈ 0.0
+            vec![1.0, 0.0, 0.0],       // identical → similarity ≈ 1.0
+            vec![0.0, 1.0, 0.0],       // orthogonal → similarity ≈ 0.0
             vec![0.7071, 0.7071, 0.0], // 45 degrees → similarity ≈ 0.7071
         ];
-        let result = top_k_similar_f32(query, vectors, 2).unwrap();
-        assert_eq!(result.len(), 2);
-        // First result should be the identical vector.
-        assert_eq!(result[0].0, 0);
-        assert!(result[0].1 > 0.99);
+        Python::with_gil(|py| {
+            let result = top_k_similar_f32(py, query, vectors, 2).unwrap();
+            assert_eq!(result.len(), 2);
+            // First result should be the identical vector.
+            assert_eq!(result[0].0, 0);
+            assert!(result[0].1 > 0.99);
+        });
     }
 
     // -- Integration: top_k_similar_i8 uses the generic ---------------------
@@ -562,12 +567,14 @@ mod tests {
     fn test_top_k_similar_i8_basic() {
         let query = vec![100i8, 0, 0];
         let vectors = vec![
-            vec![100, 0, 0],  // identical
-            vec![0, 100, 0],  // orthogonal
-            vec![70, 70, 0],  // ~45 degrees
+            vec![100, 0, 0], // identical
+            vec![0, 100, 0], // orthogonal
+            vec![70, 70, 0], // ~45 degrees
         ];
-        let result = top_k_similar_i8(query, vectors, 2).unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].0, 0);
+        Python::with_gil(|py| {
+            let result = top_k_similar_i8(py, query, vectors, 2).unwrap();
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0].0, 0);
+        });
     }
 }

--- a/rust/nexus_pyo3/src/stream.rs
+++ b/rust/nexus_pyo3/src/stream.rs
@@ -178,7 +178,9 @@ impl StreamBufferCore {
                     "message size {msg_len} exceeds buffer capacity {cap}"
                 )))
             }
-            Err(StreamError::Empty | StreamError::ClosedEmpty | StreamError::InvalidOffset(_, _)) => {
+            Err(
+                StreamError::Empty | StreamError::ClosedEmpty | StreamError::InvalidOffset(_, _),
+            ) => {
                 unreachable!()
             }
         }
@@ -207,7 +209,9 @@ impl StreamBufferCore {
                     "invalid offset {off} (tail={tail})"
                 )))
             }
-            Err(StreamError::Closed(_) | StreamError::Full(_, _) | StreamError::Oversized(_, _)) => {
+            Err(
+                StreamError::Closed(_) | StreamError::Full(_, _) | StreamError::Oversized(_, _),
+            ) => {
                 unreachable!()
             }
         }
@@ -274,7 +278,9 @@ impl StreamBufferCore {
                     "message size {msg_len} exceeds buffer capacity {cap}"
                 )))
             }
-            Err(StreamError::Empty | StreamError::ClosedEmpty | StreamError::InvalidOffset(_, _)) => {
+            Err(
+                StreamError::Empty | StreamError::ClosedEmpty | StreamError::InvalidOffset(_, _),
+            ) => {
                 unreachable!()
             }
         }

--- a/rust/nexus_raft/src/raft/node.rs
+++ b/rust/nexus_raft/src/raft/node.rs
@@ -779,14 +779,15 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
             messages.extend(ready.take_persisted_messages());
         }
 
-        // Handle committed entries — NO lock drop needed, we own raw_node
-        let committed = ready.take_committed_entries();
-        if !committed.is_empty() {
-            tracing::debug!(count = committed.len(), "raft.apply");
-            self.apply_entries(committed).await?;
-        }
+        // Ordering invariant (per raft-rs five_mem_node example / Raft paper §3):
+        //   1. Apply snapshot first — apply_snapshot() clears log entries,
+        //      so it must run before appending new entries.
+        //   2. Persist entries and hard state — durable BEFORE side-effects.
+        //   3. Apply committed entries to state machine — safe only after
+        //      the log is durable; committed_entries were persisted in a
+        //      prior round, so re-apply on crash is idempotent via last_applied.
 
-        // Handle snapshot (received from leader during catch-up / join)
+        // 1. Handle snapshot (received from leader during catch-up / join)
         if !ready.snapshot().is_empty() {
             let snapshot = ready.snapshot();
             tracing::info!(
@@ -808,7 +809,7 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
             }
         }
 
-        // Persist entries and hard state
+        // 2. Persist entries and hard state
         if !ready.entries().is_empty() {
             self.raw_node
                 .mut_store()
@@ -821,6 +822,13 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                 .mut_store()
                 .set_hard_state(hs)
                 .map_err(|e| RaftError::Storage(e.to_string()))?;
+        }
+
+        // 3. Apply committed entries — NO lock drop needed, we own raw_node
+        let committed = ready.take_committed_entries();
+        if !committed.is_empty() {
+            tracing::debug!(count = committed.len(), "raft.apply");
+            self.apply_entries(committed).await?;
         }
 
         // Advance the ready — NO TOCTOU: we never dropped ownership

--- a/rust/nexus_raft/src/raft/state_machine.rs
+++ b/rust/nexus_raft/src/raft/state_machine.rs
@@ -1004,18 +1004,38 @@ impl StateMachine for FullStateMachine {
     }
 
     fn apply(&mut self, index: u64, command: &Command) -> Result<CommandResult> {
-        // Skip if already applied (idempotent)
         if index <= self.last_applied {
             return Ok(CommandResult::Success);
         }
 
-        let result = self.execute(command);
+        // Execute the command. Storage errors during apply of committed entries
+        // are non-deterministic and unrecoverable — if this replica fails but
+        // others succeed, state has diverged. Following etcd/CockroachDB:
+        // panic to prevent silent divergence (node must be restored from snapshot).
+        let result = match self.execute(command) {
+            Ok(result) => result,
+            Err(e) => {
+                panic!(
+                    "Fatal: storage error applying committed entry at index {}: {}. \
+                     Node must be restored from snapshot to recover.",
+                    index, e
+                );
+            }
+        };
 
-        // Update last_applied
+        // Update last_applied only on success. Panic on failure here too:
+        // execute() already mutated state, so failing to persist the progress
+        // marker would cause replay-after-restart (same divergence risk).
         self.last_applied = index;
-        self.save_last_applied(index)?;
+        if let Err(e) = self.save_last_applied(index) {
+            panic!(
+                "Fatal: failed to persist last_applied after applying index {}: {}. \
+                 Node must be restored from snapshot to recover.",
+                index, e
+            );
+        }
 
-        result
+        Ok(result)
     }
 
     fn snapshot(&self) -> Result<Vec<u8>> {
@@ -1052,24 +1072,59 @@ impl StateMachine for FullStateMachine {
     fn restore_snapshot(&mut self, data: &[u8]) -> Result<()> {
         let snapshot: Snapshot = bincode::deserialize(data)?;
 
-        // Clear existing data
-        self.metadata.clear()?;
-        self.locks.clear()?;
+        // Atomic restore: all clears + inserts in a single redb transaction.
+        // If any step fails, the transaction rolls back and old state is preserved.
+        let db = self.metadata.raw_db();
+        let meta_def = redb::TableDefinition::<&[u8], &[u8]>::new(self.metadata.name());
+        let locks_def = redb::TableDefinition::<&[u8], &[u8]>::new(self.locks.name());
 
-        // Restore metadata
-        for (path, value) in snapshot.metadata {
-            self.metadata.set(path.as_bytes(), &value)?;
+        let write_txn = db.begin_write().map_err(|e| {
+            super::RaftError::Storage(format!("begin_write for snapshot restore: {e}"))
+        })?;
+
+        {
+            // Clear and repopulate metadata table
+            write_txn
+                .delete_table(meta_def)
+                .map_err(|e| super::RaftError::Storage(format!("delete metadata table: {e}")))?;
+            let mut meta_table = write_txn
+                .open_table(meta_def)
+                .map_err(|e| super::RaftError::Storage(format!("open metadata table: {e}")))?;
+            for (path, value) in &snapshot.metadata {
+                meta_table
+                    .insert(path.as_bytes(), value.as_slice())
+                    .map_err(|e| super::RaftError::Storage(format!("insert metadata: {e}")))?;
+            }
+            // Persist last_applied inside the same transaction
+            meta_table
+                .insert(
+                    KEY_LAST_APPLIED,
+                    snapshot.last_applied.to_be_bytes().as_slice(),
+                )
+                .map_err(|e| super::RaftError::Storage(format!("insert last_applied: {e}")))?;
+
+            // Clear and repopulate locks table
+            drop(meta_table);
+            write_txn
+                .delete_table(locks_def)
+                .map_err(|e| super::RaftError::Storage(format!("delete locks table: {e}")))?;
+            let mut locks_table = write_txn
+                .open_table(locks_def)
+                .map_err(|e| super::RaftError::Storage(format!("open locks table: {e}")))?;
+            for (path, lock_info) in &snapshot.locks {
+                let serialized = bincode::serialize(lock_info)?;
+                locks_table
+                    .insert(path.as_bytes(), serialized.as_slice())
+                    .map_err(|e| super::RaftError::Storage(format!("insert lock: {e}")))?;
+            }
         }
 
-        // Restore locks
-        for (path, lock_info) in snapshot.locks {
-            let serialized = bincode::serialize(&lock_info)?;
-            self.locks.set(path.as_bytes(), &serialized)?;
-        }
+        write_txn
+            .commit()
+            .map_err(|e| super::RaftError::Storage(format!("commit snapshot restore: {e}")))?;
 
-        // Restore last_applied
+        // Update in-memory state only after successful commit
         self.last_applied = snapshot.last_applied;
-        self.save_last_applied(snapshot.last_applied)?;
 
         Ok(())
     }
@@ -1885,5 +1940,172 @@ mod tests {
         } else {
             panic!("Expected Value result");
         }
+    }
+
+    #[test]
+    fn test_apply_idempotency_guard() {
+        let store = RedbStore::open_temporary().unwrap();
+        let mut sm = FullStateMachine::new(&store).unwrap();
+        let cmd = Command::SetMetadata {
+            key: "/test".into(),
+            value: b"data".to_vec(),
+        };
+        sm.apply(1, &cmd).unwrap();
+        assert_eq!(sm.last_applied_index(), 1);
+        let result = sm
+            .apply(
+                1,
+                &Command::DeleteMetadata {
+                    key: "/test".into(),
+                },
+            )
+            .unwrap();
+        assert!(matches!(result, CommandResult::Success));
+        assert_eq!(sm.get_metadata("/test").unwrap(), Some(b"data".to_vec()));
+        assert_eq!(sm.last_applied_index(), 1);
+        let result = sm.apply(0, &Command::Noop).unwrap();
+        assert!(matches!(result, CommandResult::Success));
+        assert_eq!(sm.last_applied_index(), 1);
+    }
+
+    #[test]
+    fn test_apply_advances_last_applied_sequentially() {
+        let store = RedbStore::open_temporary().unwrap();
+        let mut sm = FullStateMachine::new(&store).unwrap();
+        for i in 1..=5 {
+            sm.apply(i, &Command::Noop).unwrap();
+            assert_eq!(sm.last_applied_index(), i);
+        }
+        let sm2 = FullStateMachine::new(&store).unwrap();
+        assert_eq!(sm2.last_applied_index(), 5);
+    }
+
+    #[test]
+    fn test_apply_skips_gaps_correctly() {
+        let store = RedbStore::open_temporary().unwrap();
+        let mut sm = FullStateMachine::new(&store).unwrap();
+        sm.apply(1, &Command::Noop).unwrap();
+        sm.apply(
+            5,
+            &Command::SetMetadata {
+                key: "/test".into(),
+                value: b"data".to_vec(),
+            },
+        )
+        .unwrap();
+        assert_eq!(sm.last_applied_index(), 5);
+        assert_eq!(sm.get_metadata("/test").unwrap(), Some(b"data".to_vec()));
+    }
+
+    #[test]
+    fn test_restore_snapshot_corrupt_data_preserves_state() {
+        let store = RedbStore::open_temporary().unwrap();
+        let mut sm = FullStateMachine::new(&store).unwrap();
+        sm.apply(
+            1,
+            &Command::SetMetadata {
+                key: "/existing".into(),
+                value: b"original".to_vec(),
+            },
+        )
+        .unwrap();
+        assert_eq!(sm.last_applied_index(), 1);
+        let result = sm.restore_snapshot(b"this is not valid bincode");
+        assert!(result.is_err(), "corrupt snapshot should return error");
+        assert_eq!(
+            sm.get_metadata("/existing").unwrap(),
+            Some(b"original".to_vec())
+        );
+        assert_eq!(sm.last_applied_index(), 1);
+    }
+
+    #[test]
+    fn test_restore_snapshot_empty_data() {
+        let store = RedbStore::open_temporary().unwrap();
+        let mut sm = FullStateMachine::new(&store).unwrap();
+        let result = sm.restore_snapshot(b"");
+        assert!(result.is_err(), "empty snapshot should return error");
+    }
+
+    #[test]
+    fn test_restore_snapshot_overwrites_existing_data() {
+        let store = RedbStore::open_temporary().unwrap();
+        let mut sm = FullStateMachine::new(&store).unwrap();
+        sm.apply(
+            1,
+            &Command::SetMetadata {
+                key: "/old_file".into(),
+                value: b"old_data".to_vec(),
+            },
+        )
+        .unwrap();
+        sm.apply(
+            2,
+            &Command::AcquireLock {
+                path: "/old_file".into(),
+                lock_id: "lock-old".into(),
+                max_holders: 1,
+                ttl_secs: 3600,
+                holder_info: "agent:old".into(),
+                now_secs: 1000,
+            },
+        )
+        .unwrap();
+        let store2 = RedbStore::open_temporary().unwrap();
+        let mut sm2 = FullStateMachine::new(&store2).unwrap();
+        sm2.apply(
+            1,
+            &Command::SetMetadata {
+                key: "/new_file".into(),
+                value: b"new_data".to_vec(),
+            },
+        )
+        .unwrap();
+        let snapshot_data = sm2.snapshot().unwrap();
+        sm.restore_snapshot(&snapshot_data).unwrap();
+        assert!(sm.get_metadata("/old_file").unwrap().is_none());
+        assert!(sm.get_lock("/old_file").unwrap().is_none());
+        assert_eq!(
+            sm.get_metadata("/new_file").unwrap(),
+            Some(b"new_data".to_vec())
+        );
+        assert_eq!(sm.last_applied_index(), 1);
+    }
+
+    #[test]
+    fn test_restore_snapshot_persists_atomically() {
+        let store = RedbStore::open_temporary().unwrap();
+        let mut sm = FullStateMachine::new(&store).unwrap();
+        let store2 = RedbStore::open_temporary().unwrap();
+        let mut sm2 = FullStateMachine::new(&store2).unwrap();
+        sm2.apply(
+            1,
+            &Command::SetMetadata {
+                key: "/persisted".into(),
+                value: b"value".to_vec(),
+            },
+        )
+        .unwrap();
+        sm2.apply(
+            2,
+            &Command::AcquireLock {
+                path: "/persisted".into(),
+                lock_id: "lock-1".into(),
+                max_holders: 1,
+                ttl_secs: 3600,
+                holder_info: "agent:test".into(),
+                now_secs: 1000,
+            },
+        )
+        .unwrap();
+        let snapshot_data = sm2.snapshot().unwrap();
+        sm.restore_snapshot(&snapshot_data).unwrap();
+        let sm3 = FullStateMachine::new(&store).unwrap();
+        assert_eq!(
+            sm3.get_metadata("/persisted").unwrap(),
+            Some(b"value".to_vec())
+        );
+        assert!(sm3.get_lock("/persisted").unwrap().is_some());
+        assert_eq!(sm3.last_applied_index(), 2);
     }
 }

--- a/rust/nexus_raft/src/transport/mod.rs
+++ b/rust/nexus_raft/src/transport/mod.rs
@@ -104,6 +104,7 @@ pub mod proto {
 
 /// Transport error types.
 #[derive(Debug, thiserror::Error)]
+#[allow(clippy::result_large_err)]
 pub enum TransportError {
     /// Connection failed.
     #[error("connection error: {0}")]

--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -263,6 +263,7 @@ fn proto_command_to_internal(proto: RaftCommand) -> Option<Command> {
 }
 
 /// Look up a zone's ZoneConsensus from the registry, or return a gRPC error.
+#[allow(clippy::result_large_err)]
 fn get_zone_node(
     registry: &ZoneRaftRegistry,
     zone_id: &str,
@@ -329,6 +330,7 @@ fn command_result_to_proto(result: &CommandResult) -> RaftResponse {
 /// request is allowed.  This prevents rogue nodes from injecting Raft messages
 /// for zones they don't belong to (CockroachDB/etcd pattern: zone auth at app
 /// layer, node identity at TLS layer).
+#[allow(clippy::result_large_err)]
 fn check_zone_membership(
     registry: &ZoneRaftRegistry,
     zone_id: &str,
@@ -1010,6 +1012,7 @@ impl WitnessZoneRegistry {
     ///
     /// Opens zone-specific storage at `{base_path}/{zone_id}/`, creates a
     /// `ZoneConsensus<WitnessStateMachine>`, and spawns a `TransportLoop` task.
+    #[allow(clippy::result_large_err)]
     pub fn create_zone(
         &self,
         zone_id: &str,

--- a/tests/unit/daemon/test_main.py
+++ b/tests/unit/daemon/test_main.py
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -293,7 +293,7 @@ class TestMainCli:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
 
         mock_nx = MagicMock()
-        mock_connect = MagicMock(return_value=mock_nx)
+        mock_connect = AsyncMock(return_value=mock_nx)
 
         mock_app = MagicMock()
         mock_create_app = MagicMock(return_value=mock_app)


### PR DESCRIPTION
## Summary

Fixes 8 high-priority correctness and performance issues across `nexus_raft`, `nexus-fuse`, `nexus_pyo3`, and `nexus_core`. Includes 12 new tests.

### Raft safety (critical)
- **Snapshot-first ordering**: Reorder `advance()` to snapshot→persist→apply (apply_snapshot clears log, so it must precede entry append)
- **Panic on storage error**: `apply()` now panics on non-deterministic storage errors during committed-entry apply, matching etcd/CockroachDB
- **Atomic snapshot restore**: `restore_snapshot()` uses a single redb write transaction — crash mid-restore rolls back

### FUSE correctness
- **Partial write data corruption**: Return `EIO` when read fails during read-modify-write instead of silently zeroing content
- **Typed error classification**: Replace 6 fragile `contains("not found")` string matches with `is_not_found()`

### Performance
- **GIL release**: `py.detach()` for SIMD batch/top-k operations (unblocks Python threads)
- **Zero-copy bulk reads**: Collect `Mmap` objects in parallel, create `PyBytes` directly (eliminates intermediate Vec copy)
- **ReBAC O(1) lookup**: New `direct_reverse` index for `add_direct_subjects()` — direct-only to avoid userset overgrant

### New tests (+12)
- 7 Raft: apply idempotency, sequential advancement, gap handling, snapshot corrupt/empty/overwrite/atomicity
- 5 FUSE: mockito-based RPC error classification tests

## Test plan
- [x] `cargo test -p nexus_core` — 103 passed
- [x] `cargo test -p nexus_raft` — 53 passed
- [x] `cargo check --workspace` — clean
- [ ] CI: Python 3.13 tests on ubuntu/macos
- [ ] Manual smoke test of FUSE mount + partial writes

Closes #3030