### PR TITLE
fix(lint): ruff format fix for permissions.py

### DIFF
--- a/src/nexus/storage/models/permissions.py
+++ b/src/nexus/storage/models/permissions.py
@@ -233,6 +233,7 @@ class ReBACVersionSequenceModel(Base):
 
     __table_args__: tuple = ()
 
+
 class TigerResourceMapModel(Base):
     """Maps resource UUIDs to int64 IDs for Roaring Bitmap compatibility."""
 


### PR DESCRIPTION
## Summary
- Add missing blank line before class definition in `permissions.py`
- Required by ruff 0.15.6 (CI version), not flagged by older local versions

## Test plan
- [x] `ruff format --check` passes locally with 0.15.6