### PR TITLE
fix(#1625): fix pre-existing CI failures — re-export model + update rebac cache test

### DIFF
--- a/src/nexus/storage/models/__init__.py
+++ b/src/nexus/storage/models/__init__.py
@@ -104,6 +104,7 @@ from nexus.storage.models.permissions import ReBACChangelogModel as ReBACChangel
 from nexus.storage.models.permissions import ReBACGroupClosureModel as ReBACGroupClosureModel
 from nexus.storage.models.permissions import ReBACNamespaceModel as ReBACNamespaceModel
 from nexus.storage.models.permissions import ReBACTupleModel as ReBACTupleModel
+from nexus.storage.models.permissions import ReBACVersionSequenceModel as ReBACVersionSequenceModel
 from nexus.storage.models.permissions import TigerCacheModel as TigerCacheModel
 from nexus.storage.models.permissions import TigerCacheQueueModel as TigerCacheQueueModel
 from nexus.storage.models.permissions import TigerDirectoryGrantsModel as TigerDirectoryGrantsModel

--- a/tests/unit/core/test_rebac.py
+++ b/tests/unit/core/test_rebac.py
@@ -530,28 +530,14 @@ def test_expand_api_with_union(rebac_manager):
 
 
 def test_cleanup_expired_cache(rebac_manager_fast_cache):
-    """Test cleanup of expired cache entries."""
-    with freeze_time("2025-01-01 12:00:00") as frozen_time:
-        # Create a relationship
-        rebac_manager_fast_cache.rebac_write(
-            subject=("agent", "alice"),
-            relation="member-of",
-            object=("group", "eng-team"),
-        )
+    """Test cleanup of expired cache entries.
 
-        # Check to create cache entry
-        rebac_manager_fast_cache.rebac_check(
-            subject=("agent", "alice"),
-            permission="member-of",
-            object=("group", "eng-team"),
-        )
-
-        # Advance time by 2 seconds to expire the cache (TTL is 1 second)
-        frozen_time.tick(delta=timedelta(seconds=2))
-
-        # Cleanup expired cache
-        removed = rebac_manager_fast_cache.cleanup_expired_cache()
-        assert removed > 0
+    Note: L2 SQL cache (rebac_check_cache) was removed — cleanup_expired_cache()
+    now always returns 0.  This test verifies the method is callable and returns
+    a non-negative integer.
+    """
+    removed = rebac_manager_fast_cache.cleanup_expired_cache()
+    assert removed >= 0
 
 
 def test_delete_nonexistent_tuple(rebac_manager):


### PR DESCRIPTION
## Summary
- Add missing `ReBACVersionSequenceModel` re-export from `storage.models.__init__`
- Update `test_cleanup_expired_cache`: L2 SQL cache was removed, method now returns 0 — assert `>= 0` instead of `> 0`

## Test plan
- [ ] CI unit tests pass on both Ubuntu and macOS
- [ ] `test_model_importable[ReBACVersionSequenceModel]` passes
- [ ] `test_cleanup_expired_cache` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)