### PR TITLE
feat(#1666): unify pre-bootstrap to enlist() — auto-start PersistentService

### DIFF
--- a/src/nexus/bricks/rebac/deferred_permission_buffer.py
+++ b/src/nexus/bricks/rebac/deferred_permission_buffer.py
@@ -75,8 +75,16 @@ class DeferredPermissionBuffer:
         self._total_grants_flushed = 0
         self._flush_count = 0
 
-    def start(self) -> None:
-        """Start the background flush worker thread."""
+    async def start(self) -> None:
+        """Start the background flush worker thread (PersistentService protocol)."""
+        self._start_sync()
+
+    async def stop(self) -> None:
+        """Stop the buffer and flush remaining items (PersistentService protocol)."""
+        self._stop_sync()
+
+    def _start_sync(self) -> None:
+        """Sync start — spawns background flush thread."""
         if self._started:
             return
 
@@ -93,12 +101,8 @@ class DeferredPermissionBuffer:
             f"max_batch={self._max_batch_size})"
         )
 
-    def stop(self, timeout: float = 5.0) -> None:
-        """Stop the buffer and flush remaining items.
-
-        Args:
-            timeout: Maximum time to wait for final flush
-        """
+    def _stop_sync(self, timeout: float = 5.0) -> None:
+        """Sync stop — joins thread and flushes remaining items."""
         if not self._started:
             return
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4964,9 +4964,11 @@ class NexusFS(  # type: ignore[misc]
         if hasattr(self, "_process_table") and self._process_table is not None:
             self._process_table.close_all()
 
-        # Stop DeferredPermissionBuffer first to flush pending permissions
+        # Stop DeferredPermissionBuffer first to flush pending permissions.
+        # Uses _stop_sync() because close() is sync; async stop() is handled
+        # by coordinator.stop_persistent_services() in aclose().
         if hasattr(self, "_deferred_permission_buffer") and self._deferred_permission_buffer:
-            self._deferred_permission_buffer.stop()
+            self._deferred_permission_buffer._stop_sync()
 
         # Flush write observer pre-buffer (CLI mode: events buffered in memory
         # because PipeManager was never injected). Must happen before

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -108,6 +108,15 @@ async def _do_link(
         coordinator = ServiceLifecycleCoordinator(nx._service_registry, _blm, nx._dispatch)
         nx._service_coordinator = coordinator
         populate_service_registry(coordinator, _wired)
+
+        # Issue #1666: Register system-tier PersistentService instances so
+        # start_persistent_services() auto-discovers them at bootstrap.
+        _dpb = getattr(nx, "_deferred_permission_buffer", None)
+        if _dpb is not None:
+            coordinator.register_service("deferred_permission_buffer", _dpb, exports=())
+        _dw = getattr(nx._system_services, "delivery_worker", None)
+        if _dw is not None:
+            coordinator.register_service("delivery_worker", _dw, exports=())
     else:
         populate_service_registry(nx._service_registry, _wired)
 
@@ -167,24 +176,10 @@ def _do_initialize(nx: Any) -> None:
     # --- Register background services as bootstrap callbacks ---
     # TL directive: initialize() prepares resources but stays static.
     # bootstrap() is the only phase allowed to spawn active threads/async loops.
-
-    _dpb = nx._deferred_permission_buffer
-    if _dpb is not None and hasattr(_dpb, "start"):
-
-        async def _start_dpb() -> None:
-            _dpb.start()
-            logger.debug("[LIFECYCLE] DeferredPermissionBuffer started (bootstrap)")
-
-        nx._bootstrap_callbacks.append(_start_dpb)
-
-    _dw = getattr(nx._system_services, "delivery_worker", None)
-    if _dw is not None and hasattr(_dw, "start"):
-
-        async def _start_dw() -> None:
-            _dw.start()
-            logger.debug("[LIFECYCLE] EventDeliveryWorker started (bootstrap)")
-
-        nx._bootstrap_callbacks.append(_start_dw)
+    #
+    # Issue #1666: DeferredPermissionBuffer and EventDeliveryWorker now
+    # implement PersistentService and are auto-started by the coordinator's
+    # start_persistent_services() at bootstrap.  Manual callbacks deleted.
 
     _zl = nx._zone_lifecycle
     if _zl is not None and hasattr(_zl, "load_terminating_zones"):

--- a/src/nexus/system_services/event_log/delivery.py
+++ b/src/nexus/system_services/event_log/delivery.py
@@ -121,8 +121,8 @@ class EventDeliveryWorker:
 
     # ---- Lifecycle -----------------------------------------------------------
 
-    def start(self) -> None:
-        """Start background polling thread."""
+    async def start(self) -> None:
+        """Start background polling thread (PersistentService protocol)."""
         if self._thread is not None and self._thread.is_alive():
             logger.warning("EventDeliveryWorker already running")
             return
@@ -141,8 +141,8 @@ class EventDeliveryWorker:
             self._exporter_registry.exporter_names if self._exporter_registry else "none",
         )
 
-    def stop(self, timeout: float = 5.0) -> None:
-        """Graceful shutdown: signal stop, then wait for in-flight work."""
+    async def stop(self, timeout: float = 5.0) -> None:
+        """Graceful shutdown: signal stop, then wait for in-flight work (PersistentService protocol)."""
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join(timeout=timeout)

--- a/tests/e2e/self_contained/test_transactional_event_log.py
+++ b/tests/e2e/self_contained/test_transactional_event_log.py
@@ -9,6 +9,7 @@ End-to-end flow:
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
 import time
 from collections.abc import Generator
@@ -239,7 +240,7 @@ class TestTransactionalOutboxIntegration:
             event_bus=mock_bus,
             poll_interval_ms=50,
         )
-        worker.start()
+        asyncio.run(worker.start())
 
         try:
             # Write file while worker is running
@@ -263,4 +264,4 @@ class TestTransactionalOutboxIntegration:
 
             assert delivered, "Background worker did not deliver event"
         finally:
-            worker.stop(timeout=3.0)
+            asyncio.run(worker.stop(timeout=3.0))

--- a/tests/unit/services/permissions/test_deferred_permission_buffer.py
+++ b/tests/unit/services/permissions/test_deferred_permission_buffer.py
@@ -83,29 +83,29 @@ class TestLifecycle:
         """Test that start() creates a daemon background thread."""
         buffer = DeferredPermissionBuffer()
 
-        buffer.start()
+        buffer._start_sync()
 
         assert buffer._started is True
         assert buffer._flush_thread is not None
         assert buffer._flush_thread.is_alive()
         assert buffer._flush_thread.daemon is True
 
-        buffer.stop()
+        buffer._stop_sync()
 
     def test_start_is_idempotent(self) -> None:
         """Test that calling start() twice doesn't create a second thread."""
         buffer = DeferredPermissionBuffer()
 
-        buffer.start()
+        buffer._start_sync()
         first_thread = buffer._flush_thread
 
-        buffer.start()
+        buffer._start_sync()
         second_thread = buffer._flush_thread
 
         assert first_thread is second_thread
         assert threading.active_count() >= 1
 
-        buffer.stop()
+        buffer._stop_sync()
 
     def test_stop_flushes_remaining_items(self) -> None:
         """Test that stop() flushes all pending items."""
@@ -116,10 +116,10 @@ class TestLifecycle:
             hierarchy_manager=hierarchy,
         )
 
-        buffer.start()
+        buffer._start_sync()
         buffer.queue_hierarchy("/test/path", "zone1")
         buffer.queue_owner_grant("user1", "/test/file", "zone1")
-        buffer.stop()
+        buffer._stop_sync()
 
         # Verify both managers were called
         hierarchy.ensure_parent_tuples_batch.assert_called_once()
@@ -134,12 +134,12 @@ class TestLifecycle:
         """Test that calling stop() multiple times is safe."""
         buffer = DeferredPermissionBuffer()
 
-        buffer.start()
-        buffer.stop()
+        buffer._start_sync()
+        buffer._stop_sync()
         assert buffer._started is False
 
         # Second stop should be no-op
-        buffer.stop()
+        buffer._stop_sync()
         assert buffer._started is False
 
     def test_stop_without_start_is_noop(self) -> None:
@@ -147,7 +147,7 @@ class TestLifecycle:
         buffer = DeferredPermissionBuffer()
 
         # Should not raise
-        buffer.stop()
+        buffer._stop_sync()
         assert buffer._started is False
 
 
@@ -435,7 +435,7 @@ class TestErrorHandling:
             flush_interval_sec=0.05,
         )
 
-        buffer.start()
+        buffer._start_sync()
         buffer.queue_owner_grant("user1", "/file1", "zone1")
 
         # Wait for first flush attempt (will fail) — generous margin for slow CI
@@ -447,7 +447,7 @@ class TestErrorHandling:
         # Wait for second flush attempt (should succeed)
         time.sleep(0.3)
 
-        buffer.stop()
+        buffer._stop_sync()
 
         # Should have attempted flush at least twice
         assert rebac.rebac_write_batch.call_count >= 2

--- a/tests/unit/services/test_event_delivery_worker.py
+++ b/tests/unit/services/test_event_delivery_worker.py
@@ -367,41 +367,41 @@ class TestBackoff:
 class TestLifecycle:
     """Test start() and stop() lifecycle."""
 
-    def test_start_creates_daemon_thread(self, record_store: SQLAlchemyRecordStore) -> None:
+    async def test_start_creates_daemon_thread(self, record_store: SQLAlchemyRecordStore) -> None:
         from nexus.system_services.event_log.delivery import EventDeliveryWorker
 
         worker = EventDeliveryWorker(record_store, poll_interval_ms=50)
-        worker.start()
+        await worker.start()
 
         try:
             assert worker._thread is not None
             assert worker._thread.is_alive()
             assert worker._thread.daemon is True
         finally:
-            worker.stop(timeout=2.0)
+            await worker.stop(timeout=2.0)
 
-    def test_stop_joins_thread(self, record_store: SQLAlchemyRecordStore) -> None:
+    async def test_stop_joins_thread(self, record_store: SQLAlchemyRecordStore) -> None:
         from nexus.system_services.event_log.delivery import EventDeliveryWorker
 
         worker = EventDeliveryWorker(record_store, poll_interval_ms=50)
-        worker.start()
-        worker.stop(timeout=2.0)
+        await worker.start()
+        await worker.stop(timeout=2.0)
 
         assert worker._thread is None
 
-    def test_double_start_is_noop(self, record_store: SQLAlchemyRecordStore) -> None:
+    async def test_double_start_is_noop(self, record_store: SQLAlchemyRecordStore) -> None:
         from nexus.system_services.event_log.delivery import EventDeliveryWorker
 
         worker = EventDeliveryWorker(record_store, poll_interval_ms=50)
-        worker.start()
+        await worker.start()
         thread1 = worker._thread
 
-        worker.start()  # Should not create a new thread
+        await worker.start()  # Should not create a new thread
         assert worker._thread is thread1
 
-        worker.stop(timeout=2.0)
+        await worker.stop(timeout=2.0)
 
-    def test_worker_processes_during_run(self, record_store: SQLAlchemyRecordStore) -> None:
+    async def test_worker_processes_during_run(self, record_store: SQLAlchemyRecordStore) -> None:
         """Worker should process events while running."""
         from nexus.system_services.event_log.delivery import EventDeliveryWorker
 
@@ -415,7 +415,7 @@ class TestLifecycle:
             event_bus=mock_bus,
             poll_interval_ms=50,
         )
-        worker.start()
+        await worker.start()
 
         # Wait for worker to pick up the event
         deadline = time.monotonic() + 5.0
@@ -428,7 +428,7 @@ class TestLifecycle:
                     break
             time.sleep(0.1)
 
-        worker.stop(timeout=2.0)
+        await worker.stop(timeout=2.0)
         assert delivered, "Worker did not deliver event within timeout"
 
 


### PR DESCRIPTION
## Summary
- Make `DeferredPermissionBuffer` and `EventDeliveryWorker` implement `PersistentService` protocol (async `start()`/`stop()`)
- Register both as services in `ServiceLifecycleCoordinator` during `_do_link()`
- Delete manual bootstrap callbacks in `_do_initialize()` — coordinator's `start_persistent_services()` auto-discovers and starts them at bootstrap
- DeferredPermissionBuffer uses split pattern (`_start_sync()`/`_stop_sync()`) to preserve sync `close()` path in NexusFS

## Test plan
- [x] 56 targeted tests pass (test_event_delivery_worker + test_deferred_permission_buffer)
- [x] Ruff lint clean
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>