### PR TITLE
feat(#1673): ServiceQuadrant enum + quadrant guards for swap/activate/deactivate

### DIFF
--- a/src/nexus/contracts/protocols/service_lifecycle.py
+++ b/src/nexus/contracts/protocols/service_lifecycle.py
@@ -54,10 +54,73 @@ References:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+import enum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from nexus.contracts.protocols.service_hooks import HookSpec
+
+
+# ---------------------------------------------------------------------------
+# ServiceQuadrant — first-class quadrant classification (Issue #1673)
+# ---------------------------------------------------------------------------
+
+
+class ServiceQuadrant(enum.Enum):
+    """Four-quadrant classification based on protocol conformance.
+
+    Constraint lattice (Q1 = fewest constraints, Q4 = most)::
+
+              Q4 (both) ← most constrained
+             /        \\
+           Q2          Q3
+             \\        /
+              Q1 (static) ← least constrained
+
+    Q2 and Q3 are independent constraint dimensions:
+    - Q2 adds hot-swap capability (service must implement drain/activate/hook_spec)
+    - Q3 adds persistent requirement (environment must support long-running process)
+    - Q4 is their union — both constraints apply
+    """
+
+    Q1_STATIC = "Q1"
+    Q2_HOT_SWAPPABLE = "Q2"
+    Q3_PERSISTENT = "Q3"
+    Q4_BOTH = "Q4"
+
+    @staticmethod
+    def of(instance: Any) -> ServiceQuadrant:
+        """Classify a service instance into its quadrant."""
+        is_hot = isinstance(instance, HotSwappable)
+        is_persistent = isinstance(instance, PersistentService)
+        if is_hot and is_persistent:
+            return ServiceQuadrant.Q4_BOTH
+        if is_hot:
+            return ServiceQuadrant.Q2_HOT_SWAPPABLE
+        if is_persistent:
+            return ServiceQuadrant.Q3_PERSISTENT
+        return ServiceQuadrant.Q1_STATIC
+
+    @property
+    def is_hot_swappable(self) -> bool:
+        """True if this quadrant includes HotSwappable capability (Q2/Q4)."""
+        return self in (ServiceQuadrant.Q2_HOT_SWAPPABLE, ServiceQuadrant.Q4_BOTH)
+
+    @property
+    def is_persistent(self) -> bool:
+        """True if this quadrant requires persistent process (Q3/Q4)."""
+        return self in (ServiceQuadrant.Q3_PERSISTENT, ServiceQuadrant.Q4_BOTH)
+
+    @property
+    def label(self) -> str:
+        """Human-readable label for error messages and CLI output."""
+        labels = {
+            ServiceQuadrant.Q1_STATIC: "Q1 (static)",
+            ServiceQuadrant.Q2_HOT_SWAPPABLE: "Q2 (HotSwappable)",
+            ServiceQuadrant.Q3_PERSISTENT: "Q3 (PersistentService)",
+            ServiceQuadrant.Q4_BOTH: "Q4 (HotSwappable + PersistentService)",
+        }
+        return labels[self]
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
+++ b/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
@@ -35,7 +35,11 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.protocols.service_hooks import HookSpec
-from nexus.contracts.protocols.service_lifecycle import HotSwappable, PersistentService
+from nexus.contracts.protocols.service_lifecycle import (
+    HotSwappable,
+    PersistentService,
+    ServiceQuadrant,
+)
 
 if TYPE_CHECKING:
     from nexus.core.kernel_dispatch import KernelDispatch
@@ -253,10 +257,12 @@ class ServiceLifecycleCoordinator:
         old_instance = old_info.instance
 
         # --- Guard: only HotSwappable services can be swapped ---
-        if not isinstance(old_instance, HotSwappable):
+        quadrant = ServiceQuadrant.of(old_instance)
+        if not quadrant.is_hot_swappable:
             raise TypeError(
-                f"swap_service: {name!r} ({type(old_instance).__name__}) is not HotSwappable. "
-                f"Static services cannot be hot-swapped — use full restart instead."
+                f"swap_service: {name!r} is {quadrant.label} — cannot hot-swap. "
+                f"Only Q2/Q4 services (HotSwappable) support runtime swap. "
+                f"Use full restart instead."
             )
 
         # Snapshot old state
@@ -328,6 +334,70 @@ class ServiceLifecycleCoordinator:
     # Distro classification — persistent vs invocation-compatible
     # ------------------------------------------------------------------
 
+    def classify_service(self, name: str) -> ServiceQuadrant:
+        """Return the quadrant classification for a registered service.
+
+        Raises:
+            KeyError: If service is not registered.
+        """
+        info = self._registry.service_info(name)
+        if info is None:
+            raise KeyError(f"classify_service: {name!r} not registered")
+        return ServiceQuadrant.of(info.instance)
+
+    def classify_all(self) -> dict[str, ServiceQuadrant]:
+        """Return quadrant classification for all registered services."""
+        return {info.name: ServiceQuadrant.of(info.instance) for info in self._registry.list_all()}
+
+    # ------------------------------------------------------------------
+    # Single-service activate / deactivate (with quadrant guard)
+    # ------------------------------------------------------------------
+
+    async def activate_service(self, name: str) -> None:
+        """Activate a single HotSwappable service: register hooks + activate().
+
+        Raises:
+            KeyError: If service is not registered.
+            TypeError: If service is not HotSwappable (Q1/Q3).
+        """
+        info = self._registry.service_info(name)
+        if info is None:
+            raise KeyError(f"activate_service: {name!r} not registered")
+        quadrant = ServiceQuadrant.of(info.instance)
+        if not quadrant.is_hot_swappable:
+            raise TypeError(
+                f"activate_service: {name!r} is {quadrant.label} — cannot activate. "
+                f"Only Q2/Q4 services (HotSwappable) support activate/drain."
+            )
+        spec = self._hook_specs.get(name)
+        if spec is None:
+            spec = info.instance.hook_spec()
+            if spec is not None and not spec.is_empty:
+                self._hook_specs[name] = spec
+        self._register_hooks(name)
+        await info.instance.activate()
+        logger.info("[COORDINATOR] activate_service %r — done (%s)", name, quadrant.label)
+
+    async def deactivate_service(self, name: str) -> None:
+        """Deactivate a single HotSwappable service: drain + unregister hooks.
+
+        Raises:
+            KeyError: If service is not registered.
+            TypeError: If service is not HotSwappable (Q1/Q3).
+        """
+        info = self._registry.service_info(name)
+        if info is None:
+            raise KeyError(f"deactivate_service: {name!r} not registered")
+        quadrant = ServiceQuadrant.of(info.instance)
+        if not quadrant.is_hot_swappable:
+            raise TypeError(
+                f"deactivate_service: {name!r} is {quadrant.label} — cannot deactivate. "
+                f"Only Q2/Q4 services (HotSwappable) support activate/drain."
+            )
+        await info.instance.drain()
+        self._unregister_hooks(name)
+        logger.info("[COORDINATOR] deactivate_service %r — done (%s)", name, quadrant.label)
+
     def classify_distro(self) -> tuple[bool, list[str]]:
         """Determine whether this distro requires a persistent process.
 
@@ -351,7 +421,7 @@ class ServiceLifecycleCoordinator:
         hot: list[str] = []
         static: list[str] = []
         for info in self._registry.list_all():
-            if isinstance(info.instance, HotSwappable):
+            if ServiceQuadrant.of(info.instance).is_hot_swappable:
                 hot.append(info.name)
             else:
                 static.append(info.name)

--- a/tests/unit/services/test_service_lifecycle_coordinator.py
+++ b/tests/unit/services/test_service_lifecycle_coordinator.py
@@ -322,7 +322,7 @@ class TestSwapService:
         await coordinator.mount_service("search")
 
         svc2 = _FakeServiceV2()
-        with pytest.raises(TypeError, match="not HotSwappable"):
+        with pytest.raises(TypeError, match="cannot hot-swap"):
             await coordinator.swap_service("search", svc2, exports=("glob",))
 
     @pytest.mark.asyncio()
@@ -985,3 +985,239 @@ class TestEnlist:
         spec = blm.get_spec("child")
         assert spec is not None
         assert "dep" in spec.depends_on
+
+
+# ---------------------------------------------------------------------------
+# ServiceQuadrant — classification and guards (Issue #1673)
+# ---------------------------------------------------------------------------
+
+
+class TestServiceQuadrant:
+    """Tests for ServiceQuadrant enum and classify_service()."""
+
+    def test_classify_q1_static(self) -> None:
+        from nexus.contracts.protocols.service_lifecycle import ServiceQuadrant
+
+        q = ServiceQuadrant.of(_FakeService())
+        assert q == ServiceQuadrant.Q1_STATIC
+        assert not q.is_hot_swappable
+        assert not q.is_persistent
+        assert "Q1" in q.label
+
+    def test_classify_q2_hot_swappable(self) -> None:
+        from nexus.contracts.protocols.service_lifecycle import ServiceQuadrant
+
+        q = ServiceQuadrant.of(_HotSwappableService())
+        assert q == ServiceQuadrant.Q2_HOT_SWAPPABLE
+        assert q.is_hot_swappable
+        assert not q.is_persistent
+
+    def test_classify_q3_persistent(self) -> None:
+        from nexus.contracts.protocols.service_lifecycle import ServiceQuadrant
+
+        q = ServiceQuadrant.of(_PersistentFakeService())
+        assert q == ServiceQuadrant.Q3_PERSISTENT
+        assert not q.is_hot_swappable
+        assert q.is_persistent
+
+    def test_classify_q4_both(self) -> None:
+        from nexus.contracts.protocols.service_lifecycle import ServiceQuadrant
+
+        q = ServiceQuadrant.of(_BothProtocolsService())
+        assert q == ServiceQuadrant.Q4_BOTH
+        assert q.is_hot_swappable
+        assert q.is_persistent
+
+    def test_coordinator_classify_service(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        from nexus.contracts.protocols.service_lifecycle import ServiceQuadrant
+
+        coordinator.register_service("q1", _FakeService())
+        coordinator.register_service("q2", _HotSwappableService())
+        coordinator.register_service("q3", _PersistentFakeService())
+        coordinator.register_service("q4", _BothProtocolsService())
+
+        assert coordinator.classify_service("q1") == ServiceQuadrant.Q1_STATIC
+        assert coordinator.classify_service("q2") == ServiceQuadrant.Q2_HOT_SWAPPABLE
+        assert coordinator.classify_service("q3") == ServiceQuadrant.Q3_PERSISTENT
+        assert coordinator.classify_service("q4") == ServiceQuadrant.Q4_BOTH
+
+    def test_coordinator_classify_service_not_found(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        with pytest.raises(KeyError, match="not registered"):
+            coordinator.classify_service("nonexistent")
+
+    def test_coordinator_classify_all(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        from nexus.contracts.protocols.service_lifecycle import ServiceQuadrant
+
+        coordinator.register_service("q1", _FakeService())
+        coordinator.register_service("q2", _HotSwappableService())
+        coordinator.register_service("q3", _PersistentFakeService())
+
+        result = coordinator.classify_all()
+        assert result == {
+            "q1": ServiceQuadrant.Q1_STATIC,
+            "q2": ServiceQuadrant.Q2_HOT_SWAPPABLE,
+            "q3": ServiceQuadrant.Q3_PERSISTENT,
+        }
+
+
+class TestQuadrantGuards:
+    """Tests for quadrant-enforced guards on swap/activate/deactivate."""
+
+    @pytest.mark.asyncio
+    async def test_swap_rejects_q1_with_quadrant_in_error(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """Swapping Q1 service includes quadrant label in error."""
+        coordinator.register_service("svc", _FakeService())
+        await coordinator.mount_service("svc")
+
+        with pytest.raises(TypeError, match="Q1.*static.*cannot hot-swap"):
+            await coordinator.swap_service("svc", _FakeServiceV2())
+
+    @pytest.mark.asyncio
+    async def test_swap_rejects_q3_with_quadrant_in_error(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """Swapping Q3 (PersistentService) includes quadrant label in error."""
+        coordinator.register_service("svc", _PersistentFakeService())
+        await coordinator.mount_service("svc")
+
+        with pytest.raises(TypeError, match="Q3.*PersistentService.*cannot hot-swap"):
+            await coordinator.swap_service("svc", _PersistentFakeService())
+
+    @pytest.mark.asyncio
+    async def test_swap_allows_q2(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        registry: ServiceRegistry,
+    ) -> None:
+        """Q2 service can be swapped."""
+        svc1 = _HotSwappableService()
+        coordinator.register_service("svc", svc1)
+        await coordinator.mount_service("svc")
+
+        svc2 = _HotSwappableServiceV2()
+        await coordinator.swap_service("svc", svc2)
+
+        ref = registry.service("svc")
+        assert ref is not None
+        assert ref._service_instance is svc2
+
+    @pytest.mark.asyncio
+    async def test_swap_allows_q4(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        registry: ServiceRegistry,
+    ) -> None:
+        """Q4 service can be swapped."""
+        svc1 = _BothProtocolsService()
+        coordinator.register_service("svc", svc1)
+        await coordinator.mount_service("svc")
+
+        svc2 = _BothProtocolsService()
+        await coordinator.swap_service("svc", svc2)
+
+        ref = registry.service("svc")
+        assert ref is not None
+        assert ref._service_instance is svc2
+
+    @pytest.mark.asyncio
+    async def test_activate_rejects_q1(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """activate_service on Q1 raises TypeError with quadrant info."""
+        coordinator.register_service("svc", _FakeService())
+        with pytest.raises(TypeError, match="Q1.*static.*cannot activate"):
+            await coordinator.activate_service("svc")
+
+    @pytest.mark.asyncio
+    async def test_activate_rejects_q3(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """activate_service on Q3 raises TypeError with quadrant info."""
+        coordinator.register_service("svc", _PersistentFakeService())
+        with pytest.raises(TypeError, match="Q3.*PersistentService.*cannot activate"):
+            await coordinator.activate_service("svc")
+
+    @pytest.mark.asyncio
+    async def test_activate_allows_q2(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """activate_service on Q2 succeeds."""
+        svc = _HotSwappableService()
+        coordinator.register_service("svc", svc)
+        await coordinator.activate_service("svc")
+        assert svc.activated is True
+
+    @pytest.mark.asyncio
+    async def test_activate_allows_q4(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """activate_service on Q4 succeeds."""
+        svc = _BothProtocolsService()
+        coordinator.register_service("svc", svc)
+        await coordinator.activate_service("svc")
+        assert svc.activated is True
+
+    @pytest.mark.asyncio
+    async def test_deactivate_rejects_q1(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """deactivate_service on Q1 raises TypeError."""
+        coordinator.register_service("svc", _FakeService())
+        with pytest.raises(TypeError, match="Q1.*static.*cannot deactivate"):
+            await coordinator.deactivate_service("svc")
+
+    @pytest.mark.asyncio
+    async def test_deactivate_rejects_q3(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """deactivate_service on Q3 raises TypeError."""
+        coordinator.register_service("svc", _PersistentFakeService())
+        with pytest.raises(TypeError, match="Q3.*PersistentService.*cannot deactivate"):
+            await coordinator.deactivate_service("svc")
+
+    @pytest.mark.asyncio
+    async def test_deactivate_allows_q2(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        """deactivate_service on Q2 succeeds — calls drain + unregister hooks."""
+        svc = _HotSwappableService()
+        coordinator.register_service("svc", svc)
+        await coordinator.activate_service("svc")
+        await coordinator.deactivate_service("svc")
+        assert svc.drained is True
+
+    @pytest.mark.asyncio
+    async def test_activate_not_found(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        with pytest.raises(KeyError, match="not registered"):
+            await coordinator.activate_service("ghost")
+
+    @pytest.mark.asyncio
+    async def test_deactivate_not_found(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+    ) -> None:
+        with pytest.raises(KeyError, match="not registered"):
+            await coordinator.deactivate_service("ghost")


### PR DESCRIPTION
## Summary
- Add `ServiceQuadrant` enum (Q1–Q4) to `service_lifecycle.py` — first-class quadrant classification with constraint lattice semantics
- Add `classify_service()`, `classify_all()`, `activate_service()`, `deactivate_service()` to coordinator
- Improve `swap_service()` error to include quadrant label (e.g. "Q1 (static) — cannot hot-swap")
- 70 tests pass (+2 new test classes: `TestServiceQuadrant`, `TestQuadrantGuards`)

## Test plan
- [x] `uv run pytest tests/unit/services/test_service_lifecycle_coordinator.py -x` — 70 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>