### PR TITLE
feat(#1667): nexusd --innovation mode

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -10,6 +10,7 @@ Deployment profiles control which bricks are enabled:
 - lite: Core services
 - full: All bricks (default)
 - cloud: All bricks + federation
+- innovation: All bricks + startup validation (experimental)
 - remote: Thin gRPC client (RemoteBackend + RemoteServiceProxy)
 
 SDK vs CLI:

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -349,9 +349,9 @@ class NexusConfig(BaseModel):
     def validate_profile(cls, v: str) -> str:
         """Validate deployment profile.
 
-        Valid profiles: minimal, embedded, lite, full, cloud, remote, auto
+        Valid profiles: minimal, embedded, lite, full, cloud, innovation, remote, auto
         """
-        allowed = ["minimal", "embedded", "lite", "full", "cloud", "remote", "auto"]
+        allowed = ["minimal", "embedded", "lite", "full", "cloud", "innovation", "remote", "auto"]
         if v not in allowed:
             raise ValueError(f"profile must be one of {allowed}, got '{v}'")
         return v

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -11,7 +11,10 @@ The profile sets the *defaults*; explicit overrides always win.
 Lego Architecture reference: Part 10 — Edge Deployment.
 
 Profile hierarchy (superset relationship):
-    minimal ⊂ embedded ⊂ lite ⊂ full ⊆ cloud
+    minimal ⊂ embedded ⊂ lite ⊂ full ⊆ cloud ⊆ innovation
+
+INNOVATION extends CLOUD with all bricks enabled + experimental validation.
+Requires explicit opt-in (``nexusd --innovation`` or ``--profile innovation``).
 
 REMOTE is orthogonal — zero local bricks, all operations proxy via RemoteBackend:
     remote  (no local bricks — NFS-client model)
@@ -124,6 +127,7 @@ class DeploymentProfile(StrEnum):
     - lite: Pi, Jetson, mobile (512 MB–4 GB) — core services, no LLM/Pay
     - full: Desktop, laptop (4–32 GB) — all bricks, local inference
     - cloud: k8s, serverless (unlimited) — all + federation + multi-tenant
+    - innovation: Experimental tier — cloud + all bricks, startup validation (Issue #1667)
     - remote: Client-side proxy — zero local bricks, NFS-client model (Issue #844)
     """
 
@@ -132,6 +136,7 @@ class DeploymentProfile(StrEnum):
     LITE = "lite"
     FULL = "full"
     CLOUD = "cloud"
+    INNOVATION = "innovation"
     REMOTE = "remote"
 
     def default_bricks(self) -> frozenset[str]:
@@ -213,6 +218,10 @@ _CLOUD_BRICKS: frozenset[str] = _FULL_BRICKS | frozenset(
     }
 )
 
+_INNOVATION_BRICKS: frozenset[str] = (
+    _CLOUD_BRICKS  # same as cloud; future experimental bricks added here
+)
+
 _REMOTE_BRICKS: frozenset[str] = frozenset()  # no local bricks — NFS-client model
 
 _PROFILE_BRICKS: dict[DeploymentProfile, frozenset[str]] = {
@@ -221,6 +230,7 @@ _PROFILE_BRICKS: dict[DeploymentProfile, frozenset[str]] = {
     DeploymentProfile.LITE: _LITE_BRICKS,
     DeploymentProfile.FULL: _FULL_BRICKS,
     DeploymentProfile.CLOUD: _CLOUD_BRICKS,
+    DeploymentProfile.INNOVATION: _INNOVATION_BRICKS,
     DeploymentProfile.REMOTE: _REMOTE_BRICKS,
 }
 

--- a/src/nexus/daemon/main.py
+++ b/src/nexus/daemon/main.py
@@ -111,6 +111,39 @@ def _redact_url(url: str) -> str:
     return url
 
 
+def _run_innovation_validation(nx: Any) -> None:
+    """Startup validation for innovation mode (Issue #1667).
+
+    Reports service quadrant classification and lifecycle readiness.
+    Logs warnings for services that failed to load but does not abort.
+    """
+    try:
+        coordinator = getattr(nx, "_lifecycle_coordinator", None)
+        if coordinator is None:
+            click.echo("  [validation] lifecycle coordinator not available — skipping")
+            return
+
+        quadrants = coordinator.classify_all()
+        by_q: dict[str, list[str]] = {}
+        for name, q in sorted(quadrants.items()):
+            by_q.setdefault(q.label, []).append(name)
+
+        click.echo("  [validation] Service quadrant report:")
+        for label in sorted(by_q):
+            names = ", ".join(by_q[label])
+            click.echo(f"    {label}: {names}")
+
+        # Count persistent + hot-swappable
+        n_persistent = sum(1 for q in quadrants.values() if q.is_persistent)
+        n_hot = sum(1 for q in quadrants.values() if q.is_hot_swappable)
+        click.echo(
+            f"  [validation] {len(quadrants)} services: "
+            f"{n_hot} hot-swappable, {n_persistent} persistent"
+        )
+    except Exception as exc:
+        logger.warning("Innovation validation failed: %s", exc)
+
+
 # ---------------------------------------------------------------------------
 # CLI group — bare ``nexusd`` starts the daemon, subcommands are node-local ops
 # ---------------------------------------------------------------------------
@@ -152,7 +185,7 @@ def _redact_url(url: str) -> str:
     "deployment_profile",
     default=None,
     envvar="NEXUS_PROFILE",
-    help="Deployment profile: full, lite, embedded, kernel, cloud, auto (default: auto).",
+    help="Deployment profile: full, lite, embedded, cloud, innovation, auto (default: auto).",
 )
 @click.option(
     "--api-key",
@@ -193,6 +226,13 @@ def _redact_url(url: str) -> str:
     envvar="NEXUS_WORKERS",
     help="Number of uvicorn workers (default: 1).",
 )
+@click.option(
+    "--innovation",
+    is_flag=True,
+    default=False,
+    envvar="NEXUS_INNOVATION_MODE",
+    help="Enable innovation mode (all bricks + startup validation).",
+)
 @click.version_option(package_name="nexus-ai-fs", prog_name="nexusd")
 @click.pass_context
 def main(
@@ -208,6 +248,7 @@ def main(
     log_level: str | None,
     log_format: str,
     workers: int | None,
+    innovation: bool,
 ) -> None:
     """Nexus node daemon.
 
@@ -230,6 +271,10 @@ def main(
     host = host or "0.0.0.0"
     port = port or 2026
     log_level = log_level or "info"
+
+    # --innovation flag overrides profile (explicit --profile wins over --innovation)
+    if innovation and deployment_profile is None:
+        deployment_profile = "innovation"
     deployment_profile = deployment_profile or "auto"
 
     # Configure logging early
@@ -271,6 +316,13 @@ def main(
             click.echo(f"  Config:  {config_path}")
         if database_url:
             click.echo(f"  DB:      {_redact_url(database_url)}")
+
+        if deployment_profile == "innovation":
+            click.echo("")
+            click.echo("  ** INNOVATION MODE **")
+            click.echo("  All bricks enabled. Experimental features active.")
+            click.echo("  Not recommended for production workloads.")
+
         click.echo("")
 
         # --- Create local NexusFS -------------------------------------------
@@ -304,6 +356,10 @@ def main(
             click.echo(f"Error: Failed to initialize NexusFS: {e}", err=True)
             logger.exception("NexusFS initialization failed")
             sys.exit(ExitCode.INTERNAL_ERROR)
+
+        # --- Innovation mode: startup validation ----------------------------
+        if deployment_profile == "innovation":
+            _run_innovation_validation(nx)
 
         # --- Resolve auth ---------------------------------------------------
         auth_provider = None

--- a/src/nexus/lib/device_capabilities.py
+++ b/src/nexus/lib/device_capabilities.py
@@ -262,6 +262,7 @@ _PROFILE_INDEX: dict[str, int] = {
     "lite": 1,
     "full": 2,
     "cloud": 3,
+    "innovation": 4,
 }
 
 

--- a/src/nexus/lib/performance_tuning.py
+++ b/src/nexus/lib/performance_tuning.py
@@ -696,6 +696,7 @@ def _get_profile_tuning_map() -> dict[str, ProfileTuning]:
         DeploymentProfile.LITE: _LITE_TUNING,
         DeploymentProfile.FULL: _FULL_TUNING,
         DeploymentProfile.CLOUD: _CLOUD_TUNING,
+        DeploymentProfile.INNOVATION: _CLOUD_TUNING,  # INNOVATION reuses CLOUD tuning
         DeploymentProfile.REMOTE: _MINIMAL_TUNING,  # REMOTE reuses MINIMAL tuning
     }
 

--- a/tests/unit/core/test_deployment_profile.py
+++ b/tests/unit/core/test_deployment_profile.py
@@ -41,6 +41,7 @@ class TestDeploymentProfileEnum:
         assert DeploymentProfile.LITE == "lite"
         assert DeploymentProfile.FULL == "full"
         assert DeploymentProfile.CLOUD == "cloud"
+        assert DeploymentProfile.INNOVATION == "innovation"
         assert DeploymentProfile.REMOTE == "remote"
 
     def test_enum_from_string(self) -> None:
@@ -112,13 +113,14 @@ class TestDefaultBrickSets:
         assert embedded.issubset(lite)
 
     def test_hierarchy_chain(self) -> None:
-        """embedded ⊂ lite ⊂ full ⊆ cloud."""
+        """embedded ⊂ lite ⊂ full ⊆ cloud ⊆ innovation."""
         embedded = DeploymentProfile.EMBEDDED.default_bricks()
         lite = DeploymentProfile.LITE.default_bricks()
         full = DeploymentProfile.FULL.default_bricks()
         cloud = DeploymentProfile.CLOUD.default_bricks()
+        innovation = DeploymentProfile.INNOVATION.default_bricks()
 
-        assert embedded < lite < full <= cloud
+        assert embedded < lite < full <= cloud <= innovation
 
     def test_is_brick_enabled(self) -> None:
         assert DeploymentProfile.FULL.is_brick_enabled(BRICK_SEARCH)
@@ -246,7 +248,7 @@ class TestNexusConfigProfile:
     def test_valid_profiles(self) -> None:
         from nexus.config import NexusConfig
 
-        for p in ["minimal", "embedded", "lite", "full", "cloud"]:
+        for p in ["minimal", "embedded", "lite", "full", "cloud", "innovation"]:
             cfg = NexusConfig(profile=p)
             assert cfg.profile == p
         # "remote" requires url
@@ -265,3 +267,41 @@ class TestNexusConfigProfile:
         cfg = NexusConfig(features={"semantic_search": True, "search": True})
         assert cfg.features.semantic_search is True
         assert cfg.features.search is True
+
+
+class TestInnovationProfile:
+    """Tests for the INNOVATION deployment profile (Issue #1667)."""
+
+    def test_innovation_enum_value(self) -> None:
+        assert DeploymentProfile("innovation") is DeploymentProfile.INNOVATION
+
+    def test_innovation_is_superset_of_cloud(self) -> None:
+        cloud = DeploymentProfile.CLOUD.default_bricks()
+        innovation = DeploymentProfile.INNOVATION.default_bricks()
+        assert cloud.issubset(innovation)
+
+    def test_innovation_includes_federation(self) -> None:
+        bricks = DeploymentProfile.INNOVATION.default_bricks()
+        assert BRICK_FEDERATION in bricks
+
+    def test_innovation_includes_all_full_bricks(self) -> None:
+        full = DeploymentProfile.FULL.default_bricks()
+        innovation = DeploymentProfile.INNOVATION.default_bricks()
+        assert full.issubset(innovation)
+
+    def test_innovation_config_accepted(self) -> None:
+        from nexus.config import NexusConfig
+
+        cfg = NexusConfig(profile="innovation")
+        assert cfg.profile == "innovation"
+
+    def test_innovation_overrides_work(self) -> None:
+        result = resolve_enabled_bricks(
+            DeploymentProfile.INNOVATION,
+            overrides={BRICK_SEARCH: False},
+        )
+        assert BRICK_SEARCH not in result
+
+    def test_innovation_tuning_resolves(self) -> None:
+        tuning = DeploymentProfile.INNOVATION.tuning()
+        assert tuning is not None

--- a/tests/unit/daemon/test_main.py
+++ b/tests/unit/daemon/test_main.py
@@ -322,3 +322,70 @@ class TestMainCli:
         call_kwargs = mock_run_server.call_args
         assert call_kwargs.kwargs["host"] == "127.0.0.1"
         assert call_kwargs.kwargs["port"] == 9999
+
+    def test_main_innovation_flag_sets_profile(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """``--innovation`` flag sets profile to 'innovation'."""
+        import sys
+        import types
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        mock_nx = MagicMock()
+        mock_connect = AsyncMock(return_value=mock_nx)
+
+        mock_app = MagicMock()
+        mock_create_app = MagicMock(return_value=mock_app)
+        mock_run_server = MagicMock()
+
+        fake_mod = types.ModuleType("nexus.server.fastapi_server")
+        fake_mod.create_app = mock_create_app
+        fake_mod.run_server = mock_run_server
+        monkeypatch.setitem(sys.modules, "nexus.server.fastapi_server", fake_mod)
+
+        with patch("nexus.connect", mock_connect):
+            runner = CliRunner()
+            result = runner.invoke(main, ["--innovation"])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        assert "INNOVATION MODE" in result.output
+        # Profile should be "innovation" in the connect config
+        call_args = mock_connect.call_args
+        config = call_args.kwargs.get("config") or call_args.args[0]
+        assert config["profile"] == "innovation"
+
+    def test_main_innovation_flag_overridden_by_explicit_profile(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """Explicit --profile wins over --innovation flag."""
+        import sys
+        import types
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        mock_nx = MagicMock()
+        mock_connect = AsyncMock(return_value=mock_nx)
+
+        mock_app = MagicMock()
+        mock_create_app = MagicMock(return_value=mock_app)
+        mock_run_server = MagicMock()
+
+        fake_mod = types.ModuleType("nexus.server.fastapi_server")
+        fake_mod.create_app = mock_create_app
+        fake_mod.run_server = mock_run_server
+        monkeypatch.setitem(sys.modules, "nexus.server.fastapi_server", fake_mod)
+
+        with patch("nexus.connect", mock_connect):
+            runner = CliRunner()
+            result = runner.invoke(main, ["--innovation", "--profile", "full"])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        assert "INNOVATION MODE" not in result.output
+        call_args = mock_connect.call_args
+        config = call_args.kwargs.get("config") or call_args.args[0]
+        assert config["profile"] == "full"


### PR DESCRIPTION
## Summary
- Add `INNOVATION` deployment profile — superset of CLOUD, all bricks enabled
- Add `--innovation` CLI flag to nexusd (shorthand for `--profile innovation`)
- Startup validation prints service quadrant report (Q1/Q2/Q3/Q4 classification)
- Banner warns "Not recommended for production workloads"
- Profile hierarchy: `minimal < embedded < lite < full <= cloud <= innovation`

### Files changed
- `deployment_profile.py` — INNOVATION enum + brick mapping
- `daemon/main.py` — `--innovation` flag + `_run_innovation_validation()`
- `config.py` — accept "innovation" in profile validator
- `performance_tuning.py` — INNOVATION reuses CLOUD tuning
- `device_capabilities.py` — profile index for tier comparison
- `__init__.py` — docstring update

## Test plan
- [x] `tests/unit/core/test_deployment_profile.py` — 38 pass (+7 new)
- [x] `tests/unit/daemon/test_main.py` — 21 pass (+2 new)
- [x] ruff + mypy + pre-commit clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>