### PR TITLE
feat(#1578): expose lifecycle summary at nexusd startup

### DIFF
--- a/src/nexus/daemon/main.py
+++ b/src/nexus/daemon/main.py
@@ -111,11 +111,41 @@ def _redact_url(url: str) -> str:
     return url
 
 
-def _run_innovation_validation(nx: Any) -> None:
-    """Startup validation for innovation mode (Issue #1667).
+def _print_lifecycle_summary(nx: Any) -> None:
+    """Print one-line service lifecycle summary at startup (Issue #1578).
 
-    Reports service quadrant classification and lifecycle readiness.
-    Logs warnings for services that failed to load but does not abort.
+    Shown for every profile so operators know at a glance whether the
+    daemon has persistent workers and hot-swappable services.
+    """
+    try:
+        coordinator = getattr(nx, "_lifecycle_coordinator", None)
+        if coordinator is None:
+            return
+
+        quadrants = coordinator.classify_all()
+        if not quadrants:
+            return
+
+        n_persistent = sum(1 for q in quadrants.values() if q.is_persistent)
+        n_hot = sum(1 for q in quadrants.values() if q.is_hot_swappable)
+
+        parts: list[str] = [f"{len(quadrants)} services"]
+        if n_hot:
+            parts.append(f"{n_hot} hot-swappable")
+        if n_persistent:
+            parts.append(f"{n_persistent} persistent")
+        distro = "persistent" if n_persistent else "invocation-only"
+        parts.append(f"distro={distro}")
+
+        click.echo(f"  Lifecycle: {', '.join(parts)}")
+    except Exception:
+        pass  # best-effort — never block startup
+
+
+def _print_lifecycle_detail(nx: Any) -> None:
+    """Print detailed quadrant breakdown (innovation mode, Issue #1667).
+
+    Lists every registered service grouped by quadrant (Q1–Q4).
     """
     try:
         coordinator = getattr(nx, "_lifecycle_coordinator", None)
@@ -132,14 +162,6 @@ def _run_innovation_validation(nx: Any) -> None:
         for label in sorted(by_q):
             names = ", ".join(by_q[label])
             click.echo(f"    {label}: {names}")
-
-        # Count persistent + hot-swappable
-        n_persistent = sum(1 for q in quadrants.values() if q.is_persistent)
-        n_hot = sum(1 for q in quadrants.values() if q.is_hot_swappable)
-        click.echo(
-            f"  [validation] {len(quadrants)} services: "
-            f"{n_hot} hot-swappable, {n_persistent} persistent"
-        )
     except Exception as exc:
         logger.warning("Innovation validation failed: %s", exc)
 
@@ -357,9 +379,10 @@ def main(
             logger.exception("NexusFS initialization failed")
             sys.exit(ExitCode.INTERNAL_ERROR)
 
-        # --- Innovation mode: startup validation ----------------------------
+        # --- Service lifecycle summary (Issue #1578) -------------------------
+        _print_lifecycle_summary(nx)
         if deployment_profile == "innovation":
-            _run_innovation_validation(nx)
+            _print_lifecycle_detail(nx)
 
         # --- Resolve auth ---------------------------------------------------
         auth_provider = None

--- a/tests/unit/daemon/test_main.py
+++ b/tests/unit/daemon/test_main.py
@@ -22,6 +22,8 @@ from nexus.daemon.main import (
     _is_nexusd_process,
     _JsonLogFormatter,
     _manage_pid_file,
+    _print_lifecycle_detail,
+    _print_lifecycle_summary,
     _redact_url,
     main,
 )
@@ -389,3 +391,124 @@ class TestMainCli:
         call_args = mock_connect.call_args
         config = call_args.kwargs.get("config") or call_args.args[0]
         assert config["profile"] == "full"
+
+    def test_main_lifecycle_summary_shown(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """Lifecycle summary line appears for non-innovation profiles (Issue #1578)."""
+        import sys
+        import types
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        # Build mock with lifecycle coordinator
+        mock_q = MagicMock(is_persistent=True, is_hot_swappable=False)
+        mock_q2 = MagicMock(is_persistent=False, is_hot_swappable=True)
+        mock_coordinator = MagicMock()
+        mock_coordinator.classify_all.return_value = {"svc_a": mock_q, "svc_b": mock_q2}
+
+        mock_nx = MagicMock()
+        mock_nx._lifecycle_coordinator = mock_coordinator
+        mock_connect = AsyncMock(return_value=mock_nx)
+
+        mock_app = MagicMock()
+        mock_create_app = MagicMock(return_value=mock_app)
+        mock_run_server = MagicMock()
+
+        fake_mod = types.ModuleType("nexus.server.fastapi_server")
+        fake_mod.create_app = mock_create_app
+        fake_mod.run_server = mock_run_server
+        monkeypatch.setitem(sys.modules, "nexus.server.fastapi_server", fake_mod)
+
+        with patch("nexus.connect", mock_connect):
+            runner = CliRunner()
+            result = runner.invoke(main, ["--profile", "full"])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        assert "Lifecycle:" in result.output
+        assert "2 services" in result.output
+        assert "distro=persistent" in result.output
+        # Not innovation — no quadrant detail
+        assert "[validation]" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# _print_lifecycle_summary / _print_lifecycle_detail (Issue #1578)
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleReport:
+    """Unit tests for lifecycle summary and detail functions."""
+
+    def test_summary_with_coordinator(self, capsys) -> None:
+        mock_q1 = MagicMock(is_persistent=True, is_hot_swappable=True)
+        mock_q2 = MagicMock(is_persistent=False, is_hot_swappable=True)
+        mock_q3 = MagicMock(is_persistent=True, is_hot_swappable=False)
+        coordinator = MagicMock()
+        coordinator.classify_all.return_value = {
+            "a": mock_q1,
+            "b": mock_q2,
+            "c": mock_q3,
+        }
+        nx = MagicMock()
+        nx._lifecycle_coordinator = coordinator
+
+        _print_lifecycle_summary(nx)
+        out = capsys.readouterr().out
+
+        assert "Lifecycle:" in out
+        assert "3 services" in out
+        assert "2 hot-swappable" in out
+        assert "2 persistent" in out
+        assert "distro=persistent" in out
+
+    def test_summary_invocation_only(self, capsys) -> None:
+        mock_q = MagicMock(is_persistent=False, is_hot_swappable=False)
+        coordinator = MagicMock()
+        coordinator.classify_all.return_value = {"svc": mock_q}
+        nx = MagicMock()
+        nx._lifecycle_coordinator = coordinator
+
+        _print_lifecycle_summary(nx)
+        out = capsys.readouterr().out
+
+        assert "distro=invocation-only" in out
+
+    def test_summary_no_coordinator(self, capsys) -> None:
+        nx = MagicMock(spec=[])  # no attributes at all
+        _print_lifecycle_summary(nx)
+        out = capsys.readouterr().out
+        assert out == ""
+
+    def test_summary_exception_swallowed(self, capsys) -> None:
+        coordinator = MagicMock()
+        coordinator.classify_all.side_effect = RuntimeError("boom")
+        nx = MagicMock()
+        nx._lifecycle_coordinator = coordinator
+
+        _print_lifecycle_summary(nx)  # should not raise
+        out = capsys.readouterr().out
+        assert out == ""
+
+    def test_detail_shows_quadrants(self, capsys) -> None:
+        mock_q = MagicMock(label="Q1 (static)")
+        mock_q2 = MagicMock(label="Q3 (persistent)")
+        coordinator = MagicMock()
+        coordinator.classify_all.return_value = {"svc_a": mock_q, "svc_b": mock_q2}
+        nx = MagicMock()
+        nx._lifecycle_coordinator = coordinator
+
+        _print_lifecycle_detail(nx)
+        out = capsys.readouterr().out
+
+        assert "[validation] Service quadrant report:" in out
+        assert "Q1 (static): svc_a" in out
+        assert "Q3 (persistent): svc_b" in out
+
+    def test_detail_no_coordinator(self, capsys) -> None:
+        nx = MagicMock(spec=[])
+        _print_lifecycle_detail(nx)
+        out = capsys.readouterr().out
+        assert "not available" in out


### PR DESCRIPTION
## Summary
- Refactors `_run_innovation_validation()` into two focused functions:
  - `_print_lifecycle_summary(nx)` — one-line summary shown for **all profiles** (service count, hot-swappable, persistent, distro type)
  - `_print_lifecycle_detail(nx)` — quadrant breakdown shown only for **innovation mode**
- Operators now see lifecycle info at startup regardless of deployment profile
- 7 new unit tests covering summary, detail, edge cases (no coordinator, exceptions)

## Test plan
- [x] All 28 daemon tests pass (`tests/unit/daemon/test_main.py`)
- [x] Lint clean (ruff check + ruff format)
- [x] Pre-commit hooks pass (mypy, ruff, brick zero-core-imports)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)