### PR TITLE
feat(#1681): promote CDC to CASBackend Feature DI + ChunkingStrategy protocol

### DIFF
--- a/src/nexus/backends/base/cas_backend.py
+++ b/src/nexus/backends/base/cas_backend.py
@@ -13,12 +13,13 @@ The transport is INTERNAL — callers never see BlobTransport.  They see Backend
 Thin subclasses exist for: registration, CONNECTION_ARGS, connector-specific
 features (batch reads, signed URLs, versioning).
 
-Feature DI (optional, local-only optimizations):
+Feature DI (optional optimizations):
     bloom_filter  — Bloom pre-check for fast content_exists() miss
     content_cache — In-memory cache for read_content() hot path
     meta_cache    — LRU cache for _read_meta() hot path (e.g. cachetools.LRUCache)
     stripe_lock   — Per-hash threading.Lock for metadata read-modify-write
     on_write_callback — Write notification (e.g. Zoekt reindex)
+    cdc_engine    — ChunkingStrategy for large file chunking (CDC)
 
 Storage layout (in transport key-space):
     cas/<hash[0:2]>/<hash[2:4]>/<hash>       # Content blob
@@ -46,6 +47,7 @@ from nexus.core.hash_fast import create_hasher, hash_content
 from nexus.core.object_store import WriteResult
 
 if TYPE_CHECKING:
+    from nexus.backends.engines.cdc import ChunkingStrategy
     from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
@@ -80,12 +82,13 @@ class CASBackend(Backend):
         transport: BlobTransport,
         *,
         backend_name: str | None = None,
-        # Feature DI — local-only optimizations, all None-safe
+        # Feature DI — optional optimizations, all None-safe
         bloom_filter: Any | None = None,
         content_cache: Any | None = None,
         meta_cache: Any | None = None,
         stripe_lock: Any | None = None,
         on_write_callback: Any | None = None,
+        cdc_engine: "ChunkingStrategy | None" = None,
     ) -> None:
         self._transport = transport
         self._backend_name = backend_name or f"cas-{transport.transport_name}"
@@ -97,6 +100,7 @@ class CASBackend(Backend):
         self._meta_cache_misses = 0
         self._stripe_lock = stripe_lock  # stripe_lock._StripeLock
         self._on_write_callback = on_write_callback
+        self._cdc: ChunkingStrategy | None = cdc_engine
 
     @property
     def name(self) -> str:
@@ -212,6 +216,18 @@ class CASBackend(Backend):
     def write_content(
         self, content: bytes, context: "OperationContext | None" = None
     ) -> WriteResult:
+        # Feature DI: CDC routing for large files
+        if self._cdc is not None and self._cdc.should_chunk(content):
+            content_hash = self._cdc.write_chunked(content, context)
+
+            # Feature DI: Bloom filter + content cache
+            if self._bloom is not None:
+                self._bloom.add(content_hash)
+            if self._cache is not None:
+                self._cache.put(content_hash, content)
+
+            return WriteResult(content_hash=content_hash, size=len(content))
+
         content_hash = hash_content(content)
         key = self._blob_key(content_hash)
 
@@ -259,6 +275,13 @@ class CASBackend(Backend):
             if cached is not None:
                 return cached
 
+        # Feature DI: CDC chunked content
+        if self._cdc is not None and self._cdc.is_chunked(content_hash):
+            chunked_content: bytes = self._cdc.read_chunked(content_hash, context)
+            if self._cache is not None:
+                self._cache.put(content_hash, chunked_content)
+            return chunked_content
+
         key = self._blob_key(content_hash)
 
         try:
@@ -293,6 +316,11 @@ class CASBackend(Backend):
             ) from e
 
     def delete_content(self, content_hash: str, context: "OperationContext | None" = None) -> None:
+        # Feature DI: CDC chunked content
+        if self._cdc is not None and self._cdc.is_chunked(content_hash):
+            self._cdc.delete_chunked(content_hash, context)
+            return
+
         key = self._blob_key(content_hash)
 
         try:
@@ -345,6 +373,11 @@ class CASBackend(Backend):
             return False
 
     def get_content_size(self, content_hash: str, context: "OperationContext | None" = None) -> int:
+        # Feature DI: CDC chunked content
+        if self._cdc is not None and self._cdc.is_chunked(content_hash):
+            size: int = self._cdc.get_size(content_hash)
+            return size
+
         key = self._blob_key(content_hash)
 
         try:
@@ -357,6 +390,35 @@ class CASBackend(Backend):
                 backend=self.name,
                 path=content_hash,
             ) from e
+
+    def read_content_range(
+        self,
+        content_hash: str,
+        start: int,
+        end: int,
+        context: "OperationContext | None" = None,
+    ) -> bytes:
+        """Read a byte range [start, end) from stored content.
+
+        Optimised path when CDC is enabled:
+        - Content cache hit: slice cached content.
+        - Chunked content: delegate to CDCEngine.read_chunked_range().
+        - Single blob: read full content, verify hash, then slice.
+        """
+        # Feature DI: content cache hit → slice
+        if self._cache is not None:
+            cached: bytes | None = self._cache.get(content_hash)
+            if cached is not None:
+                return cached[start:end]
+
+        # Feature DI: CDC chunked content → range-aware chunk read
+        if self._cdc is not None and self._cdc.is_chunked(content_hash):
+            range_data: bytes = self._cdc.read_chunked_range(content_hash, start, end, context)
+            return range_data
+
+        # Single blob: read, verify integrity, then slice
+        content = self.read_content(content_hash, context=context)
+        return content[start:end]
 
     def get_ref_count(self, content_hash: str, context: "OperationContext | None" = None) -> int:
         if not self.content_exists(content_hash, context=context):

--- a/src/nexus/backends/engines/cdc.py
+++ b/src/nexus/backends/engines/cdc.py
@@ -1,17 +1,17 @@
 """Content-Defined Chunking (CDC) for large files (Issue #1074).
 
-CDCEngine provides chunking for any CASBackend subclass via composition:
+CDCEngine provides chunking for any CASBackend subclass via Feature DI:
 
-    class CASLocalBackend(CASBackend):
-        def __init__(self, ...):
-            super().__init__(transport, ...)
-            self._cdc = CDCEngine(self)
+    class CASBackend(Backend):
+        def __init__(self, transport, ..., cdc_engine=None):
+            self._cdc = cdc_engine  # Optional, None-safe
 
-        def write_content(self, content, context=None):
-            if self._cdc.should_chunk(content):
-                hash = self._cdc.write_chunked(content)
-                return WriteResult(content_hash=hash, size=len(content))
-            return super().write_content(content, context)
+CDC routing is handled by CASBackend base class — subclasses do NOT
+need to override write_content/read_content for CDC.
+
+ChunkingStrategy protocol allows pluggable chunking algorithms:
+    - FastCDCStrategy (default): Rabin fingerprint content-defined chunking
+    - Custom strategies: message-boundary chunking for LLM conversations, etc.
 
 Storage structure:
     cas/
@@ -30,7 +30,7 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from nexus.core.hash_fast import hash_content
 
@@ -46,6 +46,57 @@ CDC_MIN_CHUNK_SIZE = 256 * 1024  # 256KB
 CDC_AVG_CHUNK_SIZE = 1 * 1024 * 1024  # 1MB
 CDC_MAX_CHUNK_SIZE = 4 * 1024 * 1024  # 4MB
 CDC_PARALLEL_WORKERS = 8
+
+
+# =============================================================================
+# ChunkingStrategy Protocol
+# =============================================================================
+
+
+@runtime_checkable
+class ChunkingStrategy(Protocol):
+    """Pluggable chunking strategy for CAS content.
+
+    Allows custom chunking algorithms beyond fastcdc:
+    - Default: ``CDCEngine`` (Rabin fingerprint, 16MB threshold)
+    - Custom: message-boundary chunking for LLM conversations, etc.
+
+    All methods receive the parent ``CASBackend`` instance for transport access.
+    """
+
+    def should_chunk(self, content: bytes) -> bool:
+        """Return True if content should be stored as chunks."""
+        ...
+
+    def write_chunked(self, content: bytes, context: "OperationContext | None" = None) -> str:
+        """Write content as chunks + manifest. Returns manifest hash."""
+        ...
+
+    def read_chunked(self, content_hash: str, context: "OperationContext | None" = None) -> bytes:
+        """Reassemble chunked content from manifest + chunks."""
+        ...
+
+    def read_chunked_range(
+        self,
+        content_hash: str,
+        start: int,
+        end: int,
+        context: "OperationContext | None" = None,
+    ) -> bytes:
+        """Read a byte range [start, end) from chunked content."""
+        ...
+
+    def is_chunked(self, content_hash: str) -> bool:
+        """Check if content_hash refers to a chunked manifest."""
+        ...
+
+    def get_size(self, content_hash: str) -> int:
+        """Get original file size from manifest metadata."""
+        ...
+
+    def delete_chunked(self, content_hash: str, context: "OperationContext | None" = None) -> None:
+        """Delete chunked content, handling chunk reference counts."""
+        ...
 
 
 # =============================================================================

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -1,13 +1,15 @@
 """CAS + Local transport backend — full-featured local storage.
 
 Composes CASBackend (addressing) + LocalBlobTransport (I/O) +
-CDCEngine (chunking) + MultipartUpload (resumable uploads)
-using Feature DI for Bloom filter, content cache, and stripe lock.
+MultipartUpload (resumable uploads) using Feature DI for Bloom filter,
+content cache, stripe lock, and CDCEngine (chunking).
 
     CASLocalBackend = CASBackend(LocalBlobTransport)
-                    + CDCEngine           (CDC for large files, composed)
                     + MultipartUpload     (resumable uploads, ABC)
-                    + Feature DI          (Bloom, cache, stripe lock)
+                    + Feature DI          (Bloom, cache, stripe lock, CDC)
+
+CDC routing is handled by CASBackend base class via Feature DI —
+CASLocalBackend only instantiates and passes CDCEngine.
 
 Naming convention: {addressing}_{transport} per Section 5.2 of
 docs/architecture/backend-architecture.md.
@@ -33,11 +35,8 @@ from nexus.backends.transports.local_transport import LocalBlobTransport
 from nexus.contracts.capabilities import ConnectorCapability
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
-from nexus.core.object_store import WriteResult
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
@@ -80,7 +79,8 @@ def _init_bloom(cas_root: Path, capacity: int, fp_rate: float) -> Any:
 class CASLocalBackend(CASBackend, MultipartUpload):
     """CAS addressing + local filesystem transport.
 
-    Uses CDCEngine via composition (not inheritance) for large file chunking.
+    CDCEngine is injected via CASBackend Feature DI (``self._cdc``).
+    CDC routing (write/read/delete) is handled by CASBackend base class.
     """
 
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
@@ -133,7 +133,9 @@ class CASLocalBackend(CASBackend, MultipartUpload):
 
         meta_cache: Any = cachetools.LRUCache(maxsize=10_000)
 
-        # Initialize CASBackend with Feature DI
+        # Initialize CASBackend with Feature DI (including CDC)
+        # CDCEngine requires a reference to the backend, so we create a
+        # temporary instance and wire it after super().__init__().
         super().__init__(
             transport,
             backend_name="local",
@@ -144,7 +146,7 @@ class CASLocalBackend(CASBackend, MultipartUpload):
             on_write_callback=on_write_callback,
         )
 
-        # CDCEngine via composition — accesses CASBackend internals
+        # CDCEngine needs self (CASBackend internals) — wire after init
         self._cdc = CDCEngine(self)
 
     @property
@@ -165,136 +167,13 @@ class CASLocalBackend(CASBackend, MultipartUpload):
 
     def _is_chunked_content(self, content_hash: str) -> bool:
         """Check if content was stored as CDC chunks."""
-        return self._cdc.is_chunked(content_hash)
+        if self._cdc is None:
+            return False
+        return bool(self._cdc.is_chunked(content_hash))
 
-    # === Content Operations (override CASBackend for CDC routing) ===
-
-    def write_content(
-        self, content: bytes, context: "OperationContext | None" = None
-    ) -> WriteResult:
-        # Route large files to CDCEngine
-        if self._cdc.should_chunk(content):
-            content_hash = self._cdc.write_chunked(content, context)
-
-            # Feature DI: Bloom, cache, callback
-            if self._bloom is not None:
-                self._bloom.add(content_hash)
-            if self._cache is not None:
-                self._cache.put(content_hash, content)
-
-            return WriteResult(content_hash=content_hash, size=len(content))
-
-        # Small files: delegate to CASBackend (has Feature DI wiring)
-        return super().write_content(content, context=context)
-
-    def read_content(self, content_hash: str, context: "OperationContext | None" = None) -> bytes:
-        # Check cache first
-        if self._cache is not None:
-            cached: bytes | None = self._cache.get(content_hash)
-            if cached is not None:
-                return cached
-
-        # Check if chunked
-        if self._cdc.is_chunked(content_hash):
-            try:
-                content = self._cdc.read_chunked(content_hash, context)
-                if self._cache is not None:
-                    self._cache.put(content_hash, content)
-                return content
-            except FileNotFoundError:
-                raise NexusFileNotFoundError(
-                    path=content_hash,
-                    message=f"Chunked content not found: {content_hash}",
-                ) from None
-
-        # Single blob: delegate to CASBackend (has cache wiring)
-        return super().read_content(content_hash, context=context)
-
-    def read_content_range(
-        self,
-        content_hash: str,
-        start: int,
-        end: int,
-        context: "OperationContext | None" = None,
-    ) -> bytes:
-        """Read a byte range [start, end) without loading the full file.
-
-        Optimised path for CASLocalBackend:
-        - Content cache hit: slice cached content.
-        - Chunked content: delegate to CDCEngine.read_chunked_range().
-        - Single blob: read full content, verify hash, then slice.
-        """
-        # Feature DI: content cache hit → slice
-        if self._cache is not None:
-            cached: bytes | None = self._cache.get(content_hash)
-            if cached is not None:
-                return cached[start:end]
-
-        # Chunked content → range-aware chunk read
-        if self._cdc.is_chunked(content_hash):
-            return self._cdc.read_chunked_range(content_hash, start, end)
-
-        # Single blob: read, verify integrity, then slice
-        key = self._blob_key(content_hash)
-        try:
-            data, _ = self._transport.get_blob(key)
-
-            actual_hash = hash_content(data)
-            if actual_hash != content_hash:
-                raise BackendError(
-                    f"Content hash mismatch: expected {content_hash}, got {actual_hash}",
-                    backend=self.name,
-                    path=content_hash,
-                )
-
-            content = bytes(data)
-
-            # Populate content cache on miss
-            if self._cache is not None:
-                self._cache.put(content_hash, content)
-
-            return content[start:end]
-
-        except NexusFileNotFoundError:
-            raise
-        except BackendError:
-            raise
-        except Exception as e:
-            raise BackendError(
-                f"Failed to read content range: {e}",
-                backend=self.name,
-                path=content_hash,
-            ) from e
-
-    def delete_content(self, content_hash: str, context: "OperationContext | None" = None) -> None:
-        # Check if chunked
-        if self._cdc.is_chunked(content_hash):
-            self._cdc.delete_chunked(content_hash, context)
-            return
-
-        # Single blob: delegate to CASBackend
-        super().delete_content(content_hash, context=context)
-
-    def get_content_size(self, content_hash: str, context: "OperationContext | None" = None) -> int:
-        key = self._blob_key(content_hash)
-        if not self._transport.blob_exists(key):
-            raise NexusFileNotFoundError(
-                path=content_hash,
-                message=f"CAS content not found: {content_hash}",
-            )
-        if self._cdc.is_chunked(content_hash):
-            return self._cdc.get_size(content_hash)
-        return self._transport.get_blob_size(key)
-
-    def write_stream(
-        self,
-        chunks: "Iterator[bytes]",
-        context: "OperationContext | None" = None,
-    ) -> WriteResult:
-        # Delegate to CASBackend's streaming write (temp file + incremental hash).
-        # CDC routing is not applied here — CDC is triggered by write_content
-        # only for large payloads already in memory.
-        return super().write_stream(chunks, context=context)
+    # Content operations (write_content, read_content, delete_content,
+    # get_content_size, read_content_range) — all inherited from CASBackend
+    # which handles CDC routing via Feature DI (self._cdc).
 
     # === Directory Operations (local FS native, not blob markers) ===
 


### PR DESCRIPTION
## Summary
- **Promote CDC from CASLocalBackend to CASBackend base class** — CDC is a CAS addressing concern, not transport-specific
- **Add `ChunkingStrategy` protocol** — pluggable chunking algorithms (fastcdc default, message-boundary for LLM, etc.)
- **Add `cdc_engine` Feature DI** to `CASBackend.__init__()` — same pattern as bloom_filter, content_cache, stripe_lock
- **Move CDC routing** from CASLocalBackend overrides into CASBackend base methods (write/read/delete/get_size)
- **Add `read_content_range()`** to CASBackend base (was CASLocalBackend-only)
- **Simplify CASLocalBackend** — remove ~100 LOC of CDC routing overrides, now just instantiates CDCEngine

All 107 existing backend tests pass unchanged. CASGCSBackend and future backends can now opt into CDC.

Prerequisite for #1589 (LLM backend driver).

## Test plan
- [x] All 107 existing backend tests pass (test_chunked_storage, test_local_cas_backend, test_local_backend)
- [x] Ruff lint clean
- [x] Mypy clean
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)