### PR TITLE
feat(#1589): OpenAI-compatible LLM backend (sync MVP)

### DIFF
--- a/src/nexus/backends/compute/__init__.py
+++ b/src/nexus/backends/compute/__init__.py
@@ -1,0 +1,5 @@
+"""Compute backends — LLM and inference providers.
+
+Backends in this category expose AI/ML compute resources
+(LLM APIs, inference engines) through the VFS syscall path.
+"""

--- a/src/nexus/backends/compute/llm_blob_transport.py
+++ b/src/nexus/backends/compute/llm_blob_transport.py
@@ -1,0 +1,110 @@
+"""In-memory BlobTransport for LLM backends.
+
+Stores CAS blobs in process memory. LLM conversations are ephemeral
+during a session — persistence is handled by CAS flush to durable
+backends (local/GCS/S3) in Step 2 (DT_STREAM + CAS flush).
+
+Satisfies the 6-method CASBackend subset of BlobTransport:
+    put_blob, get_blob, delete_blob, blob_exists, get_blob_size, stream_blob.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+
+from nexus.contracts.exceptions import NexusFileNotFoundError
+
+
+class LLMBlobTransport:
+    """In-memory blob transport for LLM request/response storage.
+
+    Thread-safe via a threading.Lock on the internal dict. Suitable for
+    concurrent CAS operations from multiple async tasks writing to the
+    same conversation store.
+
+    Not a subclass of BlobTransport (Protocol-based structural typing).
+    """
+
+    transport_name: str = "llm_memory"
+
+    __slots__ = ("_store", "_lock")
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+        self._lock = threading.Lock()
+
+    def put_blob(self, key: str, data: bytes, content_type: str = "") -> str | None:
+        """Store blob in memory. Returns None (no versioning)."""
+        with self._lock:
+            self._store[key] = bytes(data) if isinstance(data, memoryview) else data
+        return None
+
+    def get_blob(self, key: str, version_id: str | None = None) -> tuple[bytes, str | None]:
+        """Retrieve blob from memory."""
+        with self._lock:
+            data = self._store.get(key)
+        if data is None:
+            raise NexusFileNotFoundError(path=key, message=f"Blob not found: {key}")
+        return data, None
+
+    def delete_blob(self, key: str) -> None:
+        """Delete blob from memory."""
+        with self._lock:
+            if key not in self._store:
+                raise NexusFileNotFoundError(path=key, message=f"Blob not found: {key}")
+            del self._store[key]
+
+    def blob_exists(self, key: str) -> bool:
+        """Check if blob exists in memory."""
+        with self._lock:
+            return key in self._store
+
+    def get_blob_size(self, key: str) -> int:
+        """Return blob size in bytes."""
+        with self._lock:
+            data = self._store.get(key)
+        if data is None:
+            raise NexusFileNotFoundError(path=key, message=f"Blob not found: {key}")
+        return len(data)
+
+    def list_blobs(self, prefix: str, delimiter: str = "/") -> tuple[list[str], list[str]]:
+        """List blobs under prefix."""
+        with self._lock:
+            keys = list(self._store.keys())
+        blobs = []
+        prefixes: set[str] = set()
+        for k in keys:
+            if not k.startswith(prefix):
+                continue
+            remainder = k[len(prefix) :]
+            if delimiter and delimiter in remainder:
+                pfx = prefix + remainder[: remainder.index(delimiter) + len(delimiter)]
+                prefixes.add(pfx)
+            else:
+                blobs.append(k)
+        return sorted(blobs), sorted(prefixes)
+
+    def copy_blob(self, src_key: str, dst_key: str) -> None:
+        """Copy blob from src to dst."""
+        with self._lock:
+            data = self._store.get(src_key)
+            if data is None:
+                raise NexusFileNotFoundError(path=src_key, message=f"Blob not found: {src_key}")
+            self._store[dst_key] = data
+
+    def create_directory_marker(self, key: str) -> None:
+        """Create empty directory marker."""
+        with self._lock:
+            self._store[key] = b""
+
+    def stream_blob(
+        self,
+        key: str,
+        chunk_size: int = 8192,
+        version_id: str | None = None,
+    ) -> Iterator[bytes]:
+        """Stream blob in chunks."""
+        data, _ = self.get_blob(key, version_id)
+        for i in range(0, len(data), chunk_size):
+            yield data[i : i + chunk_size]

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -1,0 +1,264 @@
+"""OpenAI-compatible LLM backend — CAS addressing over any OpenAI API.
+
+Composes CASBackend (addressing) + LLMBlobTransport (in-memory I/O)
+to expose LLM inference as a VFS-mountable backend.
+
+    nexus mount /zone/llm/openai --backend=openai_compatible \
+        --config='{"base_url":"https://api.sudorouter.ai","api_key":"sk-..."}'
+    nexus mount /zone/llm/local  --backend=openai_compatible \
+        --config='{"base_url":"http://localhost:11434/v1"}'
+
+Write path (sync MVP):
+    1. Agent writes request JSON via sys_write
+    2. Backend calls OpenAI chat.completions.create (sync)
+    3. Response stored in CAS
+    4. Returns WriteResult(hash(request+response), size)
+
+Read path: Standard CAS — read_content(hash) returns stored data.
+
+Streaming (Step 2, DT_STREAM) will add async token-by-token delivery.
+
+References:
+    - Task #1589: LLM backend driver design
+    - Plan: curious-gliding-orbit.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from nexus.backends.base.cas_backend import CASBackend
+from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
+from nexus.backends.compute.llm_blob_transport import LLMBlobTransport
+from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.exceptions import BackendError
+from nexus.core.object_store import WriteResult
+
+if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
+
+logger = logging.getLogger(__name__)
+
+
+def _build_openai_client(base_url: str, api_key: str, timeout: float) -> Any:
+    """Create OpenAI client. Import deferred to avoid hard dependency."""
+    try:
+        from openai import OpenAI
+
+        return OpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            timeout=timeout,
+        )
+    except ImportError:
+        raise BackendError(
+            "openai package not installed. Install with: pip install 'nexus-ai-fs[all]'",
+            backend="openai_compatible",
+        ) from None
+
+
+@register_connector(
+    "openai_compatible",
+    description="OpenAI-compatible LLM API (OpenAI, SudoRouter, OpenRouter, Ollama)",
+    category="compute",
+    requires=["openai"],
+)
+class OpenAICompatibleBackend(CASBackend):
+    """CAS addressing + OpenAI-compatible LLM transport.
+
+    Sync MVP: write_content stores request + calls LLM + stores response.
+    All data lives in CAS (in-memory transport, flushed to durable store later).
+
+    Usage::
+
+        backend = OpenAICompatibleBackend(
+            base_url="https://api.sudorouter.ai",
+            api_key="sk-...",
+            default_model="gpt-4o",
+        )
+        # Write request → triggers LLM call
+        result = backend.write_content(json.dumps({
+            "messages": [{"role": "user", "content": "Hello"}]
+        }).encode())
+        # Read response
+        data = backend.read_content(result.content_hash)
+    """
+
+    CONNECTION_ARGS: dict[str, ConnectionArg] = {
+        "base_url": ConnectionArg(
+            type=ArgType.STRING,
+            description="API base URL (e.g. https://api.openai.com/v1)",
+            required=True,
+        ),
+        "api_key": ConnectionArg(
+            type=ArgType.SECRET,
+            description="API key",
+            required=False,
+            secret=True,
+            env_var="OPENAI_API_KEY",
+        ),
+        "default_model": ConnectionArg(
+            type=ArgType.STRING,
+            description="Default model (e.g. gpt-4o, claude-3-opus)",
+            required=False,
+            default="gpt-4o",
+        ),
+    }
+
+    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = frozenset(
+        {
+            ConnectorCapability.CAS,
+            ConnectorCapability.STREAMING,
+            ConnectorCapability.BATCH_CONTENT,
+        }
+    )
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str = "",
+        default_model: str = "gpt-4o",
+        timeout: float = 120.0,
+    ) -> None:
+        self._base_url = base_url
+        self._api_key = api_key
+        self._default_model = default_model
+
+        # Build OpenAI client (lazy import)
+        self._client = _build_openai_client(base_url, api_key, timeout)
+
+        # In-memory transport for CAS blobs
+        transport = LLMBlobTransport()
+
+        super().__init__(transport, backend_name="openai_compatible")
+
+    @property
+    def name(self) -> str:
+        return "openai_compatible"
+
+    # === LLM-specific write ===
+
+    def write_content(
+        self, content: bytes, context: "OperationContext | None" = None
+    ) -> WriteResult:
+        """Write request JSON, call LLM, store both request and response in CAS.
+
+        The request is parsed as JSON with at minimum a ``messages`` field.
+        The LLM response is stored as a separate CAS entry. A "session"
+        envelope containing both request hash and response hash is the
+        returned WriteResult.
+
+        Args:
+            content: JSON-encoded request (``{"messages": [...], "model": "...", ...}``)
+            context: Operation context (optional)
+
+        Returns:
+            WriteResult with content_hash of the session envelope.
+        """
+        # Store the raw request in CAS first
+        request_result = super().write_content(content, context=context)
+
+        # Parse request
+        try:
+            request = json.loads(content)
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            raise BackendError(
+                f"Invalid request JSON: {e}",
+                backend="openai_compatible",
+            ) from e
+
+        if "messages" not in request:
+            raise BackendError(
+                "Request must contain 'messages' field",
+                backend="openai_compatible",
+            )
+
+        # Call LLM
+        model = request.pop("model", self._default_model)
+        messages = request.pop("messages")
+        extra_params = request  # remaining keys passed through
+
+        start_time = time.perf_counter()
+        try:
+            completion = self._client.chat.completions.create(
+                model=model,
+                messages=messages,
+                stream=False,
+                **extra_params,
+            )
+        except Exception as e:
+            raise BackendError(
+                f"LLM API call failed: {e}",
+                backend="openai_compatible",
+            ) from e
+
+        elapsed_ms = (time.perf_counter() - start_time) * 1000
+
+        # Extract response
+        choice = completion.choices[0] if completion.choices else None
+        response_content = choice.message.content if choice and choice.message else ""
+        finish_reason = choice.finish_reason if choice else "unknown"
+
+        # Build response payload
+        response_payload = {
+            "model": completion.model,
+            "content": response_content,
+            "finish_reason": finish_reason,
+            "usage": {
+                "prompt_tokens": completion.usage.prompt_tokens if completion.usage else 0,
+                "completion_tokens": completion.usage.completion_tokens if completion.usage else 0,
+                "total_tokens": completion.usage.total_tokens if completion.usage else 0,
+            },
+            "latency_ms": round(elapsed_ms, 1),
+        }
+        response_bytes = json.dumps(response_payload, separators=(",", ":")).encode("utf-8")
+
+        # Store response in CAS
+        response_result = super().write_content(response_bytes, context=context)
+
+        # Build session envelope (links request + response)
+        session = {
+            "type": "llm_session_v1",
+            "request_hash": request_result.content_hash,
+            "response_hash": response_result.content_hash,
+            "model": completion.model,
+            "latency_ms": round(elapsed_ms, 1),
+        }
+        session_bytes = json.dumps(session, separators=(",", ":")).encode("utf-8")
+
+        # Store session envelope in CAS
+        session_result = super().write_content(session_bytes, context=context)
+
+        logger.info(
+            "LLM call completed: model=%s tokens=%d latency=%.1fms session=%s",
+            completion.model,
+            completion.usage.total_tokens if completion.usage else 0,
+            elapsed_ms,
+            session_result.content_hash[:16],
+        )
+
+        return session_result
+
+    # === Directory operations (minimal, compute backends don't need dirs) ===
+
+    def mkdir(
+        self,
+        path: str,
+        parents: bool = False,
+        exist_ok: bool = False,
+        context: "OperationContext | None" = None,
+    ) -> None:
+        """No-op for compute backends."""
+        pass
+
+    def rmdir(
+        self,
+        path: str,
+        recursive: bool = False,
+        context: "OperationContext | None" = None,
+    ) -> None:
+        """No-op for compute backends."""
+        pass

--- a/tests/unit/backends/test_openai_compat.py
+++ b/tests/unit/backends/test_openai_compat.py
@@ -1,0 +1,313 @@
+"""Tests for OpenAI-compatible LLM backend (sync MVP).
+
+Tests cover:
+- LLMBlobTransport: in-memory blob operations
+- OpenAICompatibleBackend: CAS write → LLM call → session envelope
+- Error handling: invalid JSON, missing messages, API failure
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.backends.compute.llm_blob_transport import LLMBlobTransport
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+
+# =============================================================================
+# LLMBlobTransport tests
+# =============================================================================
+
+
+class TestLLMBlobTransport:
+    """Test in-memory blob transport."""
+
+    def test_put_and_get(self) -> None:
+        t = LLMBlobTransport()
+        t.put_blob("key1", b"hello")
+        data, version = t.get_blob("key1")
+        assert data == b"hello"
+        assert version is None
+
+    def test_get_missing_raises(self) -> None:
+        t = LLMBlobTransport()
+        with pytest.raises(NexusFileNotFoundError):
+            t.get_blob("missing")
+
+    def test_delete(self) -> None:
+        t = LLMBlobTransport()
+        t.put_blob("key1", b"data")
+        t.delete_blob("key1")
+        assert not t.blob_exists("key1")
+
+    def test_delete_missing_raises(self) -> None:
+        t = LLMBlobTransport()
+        with pytest.raises(NexusFileNotFoundError):
+            t.delete_blob("missing")
+
+    def test_blob_exists(self) -> None:
+        t = LLMBlobTransport()
+        assert not t.blob_exists("key1")
+        t.put_blob("key1", b"data")
+        assert t.blob_exists("key1")
+
+    def test_get_blob_size(self) -> None:
+        t = LLMBlobTransport()
+        t.put_blob("key1", b"hello")
+        assert t.get_blob_size("key1") == 5
+
+    def test_get_blob_size_missing_raises(self) -> None:
+        t = LLMBlobTransport()
+        with pytest.raises(NexusFileNotFoundError):
+            t.get_blob_size("missing")
+
+    def test_list_blobs(self) -> None:
+        t = LLMBlobTransport()
+        t.put_blob("cas/ab/cd/hash1", b"data1")
+        t.put_blob("cas/ab/cd/hash2", b"data2")
+        t.put_blob("cas/ef/gh/hash3", b"data3")
+        blobs, prefixes = t.list_blobs("cas/ab/")
+        assert len(prefixes) == 1  # cas/ab/cd/
+        assert "cas/ab/cd/" in prefixes
+
+    def test_copy_blob(self) -> None:
+        t = LLMBlobTransport()
+        t.put_blob("src", b"content")
+        t.copy_blob("src", "dst")
+        data, _ = t.get_blob("dst")
+        assert data == b"content"
+
+    def test_copy_missing_raises(self) -> None:
+        t = LLMBlobTransport()
+        with pytest.raises(NexusFileNotFoundError):
+            t.copy_blob("missing", "dst")
+
+    def test_stream_blob(self) -> None:
+        t = LLMBlobTransport()
+        t.put_blob("key1", b"abcdefghij")
+        chunks = list(t.stream_blob("key1", chunk_size=4))
+        assert chunks == [b"abcd", b"efgh", b"ij"]
+
+    def test_create_directory_marker(self) -> None:
+        t = LLMBlobTransport()
+        t.create_directory_marker("dirs/mydir/")
+        assert t.blob_exists("dirs/mydir/")
+        data, _ = t.get_blob("dirs/mydir/")
+        assert data == b""
+
+    def test_transport_name(self) -> None:
+        t = LLMBlobTransport()
+        assert t.transport_name == "llm_memory"
+
+    def test_overwrite(self) -> None:
+        t = LLMBlobTransport()
+        t.put_blob("key1", b"old")
+        t.put_blob("key1", b"new")
+        data, _ = t.get_blob("key1")
+        assert data == b"new"
+
+
+# =============================================================================
+# OpenAICompatibleBackend tests
+# =============================================================================
+
+
+def _mock_completion(
+    content: str = "Hello! I'm an AI assistant.",
+    model: str = "gpt-4o",
+    prompt_tokens: int = 10,
+    completion_tokens: int = 20,
+    finish_reason: str = "stop",
+) -> MagicMock:
+    """Build a mock OpenAI ChatCompletion response."""
+    usage = MagicMock()
+    usage.prompt_tokens = prompt_tokens
+    usage.completion_tokens = completion_tokens
+    usage.total_tokens = prompt_tokens + completion_tokens
+
+    message = MagicMock()
+    message.content = content
+
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = finish_reason
+
+    completion = MagicMock()
+    completion.choices = [choice]
+    completion.model = model
+    completion.usage = usage
+    return completion
+
+
+class TestOpenAICompatibleBackend:
+    """Test OpenAI-compatible backend with mocked API."""
+
+    def _make_backend(self, mock_client: MagicMock | None = None) -> Any:
+        """Create backend with mocked OpenAI client."""
+        from nexus.backends.compute.openai_compatible import OpenAICompatibleBackend
+
+        with patch("nexus.backends.compute.openai_compatible._build_openai_client") as mock_build:
+            client = mock_client or MagicMock()
+            mock_build.return_value = client
+            backend = OpenAICompatibleBackend(
+                base_url="https://api.test.com/v1",
+                api_key="sk-test",
+                default_model="gpt-4o",
+            )
+        return backend, client
+
+    def test_name(self) -> None:
+        backend, _ = self._make_backend()
+        assert backend.name == "openai_compatible"
+
+    def test_write_and_read_session(self) -> None:
+        """Write request → LLM call → read session envelope."""
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion()
+        backend, _ = self._make_backend(client)
+
+        request = {"messages": [{"role": "user", "content": "Hello"}]}
+        request_bytes = json.dumps(request).encode()
+
+        result = backend.write_content(request_bytes)
+        assert result.content_hash
+        assert result.size > 0
+
+        # Read session envelope
+        session_bytes = backend.read_content(result.content_hash)
+        session = json.loads(session_bytes)
+        assert session["type"] == "llm_session_v1"
+        assert "request_hash" in session
+        assert "response_hash" in session
+        assert session["model"] == "gpt-4o"
+
+    def test_read_request_and_response(self) -> None:
+        """Verify request and response are readable from CAS."""
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion(content="The answer is 42.")
+        backend, _ = self._make_backend(client)
+
+        request = {"messages": [{"role": "user", "content": "What is the answer?"}]}
+        result = backend.write_content(json.dumps(request).encode())
+
+        session = json.loads(backend.read_content(result.content_hash))
+
+        # Read request
+        req_data = json.loads(backend.read_content(session["request_hash"]))
+        assert req_data["messages"][0]["content"] == "What is the answer?"
+
+        # Read response
+        resp_data = json.loads(backend.read_content(session["response_hash"]))
+        assert resp_data["content"] == "The answer is 42."
+        assert resp_data["usage"]["total_tokens"] == 30
+
+    def test_custom_model(self) -> None:
+        """Model from request overrides default."""
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion(model="claude-3-opus")
+        backend, _ = self._make_backend(client)
+
+        request = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "claude-3-opus",
+        }
+        result = backend.write_content(json.dumps(request).encode())
+
+        # Verify the API was called with the custom model
+        call_kwargs = client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["model"] == "claude-3-opus"
+
+        session = json.loads(backend.read_content(result.content_hash))
+        assert session["model"] == "claude-3-opus"
+
+    def test_extra_params_passed_through(self) -> None:
+        """Extra parameters (temperature, etc.) are passed to the API."""
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion()
+        backend, _ = self._make_backend(client)
+
+        request = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "temperature": 0.7,
+            "max_tokens": 100,
+        }
+        backend.write_content(json.dumps(request).encode())
+
+        call_kwargs = client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["temperature"] == 0.7
+        assert call_kwargs["max_tokens"] == 100
+
+    def test_invalid_json_raises(self) -> None:
+        backend, _ = self._make_backend()
+        with pytest.raises(BackendError, match="Invalid request JSON"):
+            backend.write_content(b"not json {{{")
+
+    def test_missing_messages_raises(self) -> None:
+        backend, _ = self._make_backend()
+        with pytest.raises(BackendError, match="must contain 'messages'"):
+            backend.write_content(json.dumps({"model": "gpt-4o"}).encode())
+
+    def test_api_failure_raises(self) -> None:
+        client = MagicMock()
+        client.chat.completions.create.side_effect = Exception("Connection timeout")
+        backend, _ = self._make_backend(client)
+
+        request = {"messages": [{"role": "user", "content": "Hi"}]}
+        with pytest.raises(BackendError, match="LLM API call failed"):
+            backend.write_content(json.dumps(request).encode())
+
+    def test_capabilities(self) -> None:
+        from nexus.contracts.capabilities import ConnectorCapability
+
+        backend, _ = self._make_backend()
+        assert backend.has_capability(ConnectorCapability.CAS)
+        assert backend.has_capability(ConnectorCapability.STREAMING)
+        assert not backend.has_capability(ConnectorCapability.ROOT_PATH)
+
+    def test_mkdir_rmdir_noop(self) -> None:
+        """Directory ops are no-ops for compute backends."""
+        backend, _ = self._make_backend()
+        backend.mkdir("/some/path")  # Should not raise
+        backend.rmdir("/some/path")  # Should not raise
+
+    def test_delete_content(self) -> None:
+        """Verify content can be deleted."""
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion()
+        backend, _ = self._make_backend(client)
+
+        request = {"messages": [{"role": "user", "content": "Hi"}]}
+        result = backend.write_content(json.dumps(request).encode())
+
+        # Should not raise
+        backend.delete_content(result.content_hash)
+
+        # Now reading should fail
+        with pytest.raises(NexusFileNotFoundError):
+            backend.read_content(result.content_hash)
+
+    def test_content_exists(self) -> None:
+        """Verify content_exists works via CASBackend."""
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion()
+        backend, _ = self._make_backend(client)
+
+        request = {"messages": [{"role": "user", "content": "Hi"}]}
+        result = backend.write_content(json.dumps(request).encode())
+        assert backend.content_exists(result.content_hash)
+
+    def test_get_content_size(self) -> None:
+        """Verify get_content_size returns correct size."""
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion()
+        backend, _ = self._make_backend(client)
+
+        request = {"messages": [{"role": "user", "content": "Hi"}]}
+        result = backend.write_content(json.dumps(request).encode())
+
+        size = backend.get_content_size(result.content_hash)
+        # Session envelope is a small JSON
+        assert size > 0


### PR DESCRIPTION
## Summary
- **LLMBlobTransport**: Thread-safe in-memory BlobTransport for CAS blob storage (satisfies BlobTransport Protocol)
- **OpenAICompatibleBackend**: CASBackend subclass registered as `"openai_compatible"` connector (category=`"compute"`)
  - `write_content()` stores request JSON in CAS, calls LLM API, stores response, returns session envelope hash
  - Session envelope links `request_hash` + `response_hash` (all CAS-addressed)
  - OpenAI SDK as universal transport (SudoRouter, OpenRouter, Ollama, local LLMs)
- 27 unit tests with fully mocked OpenAI API

## Design
Step 1 of the LLM backend driver plan (Task #1589):
1. ~~Step 0: CDC Promotion (#1681)~~ — merged via PR #3086
2. **Step 1: Sync MVP** — this PR
3. Step 2: DT_STREAM Streaming + CAS Flush (next)
4. Step 3: MessageBoundaryStrategy (chunking)
5. Step 4: AgentService Integration

## Usage
```python
# Mount at any VFS path
nexus mount /zone/llm/openai --backend=openai_compatible \
    --config='{"base_url":"https://api.sudorouter.ai","api_key":"sk-..."}'

# Or programmatically
backend = OpenAICompatibleBackend(
    base_url="https://api.openai.com/v1",
    api_key="sk-...",
    default_model="gpt-4o",
)
result = backend.write_content(json.dumps({
    "messages": [{"role": "user", "content": "Hello"}]
}).encode())
session = json.loads(backend.read_content(result.content_hash))
response = json.loads(backend.read_content(session["response_hash"]))
```

## Test plan
- [x] LLMBlobTransport: put/get/delete/exists/size/list/copy/stream/overwrite (14 tests)
- [x] OpenAICompatibleBackend: write+read session, request/response CAS, custom model, extra params, error handling (13 tests)
- [x] ruff lint + format clean
- [x] mypy passes
- [x] All pre-commit hooks green
- [x] 820 existing backend tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)