### PR TITLE
feat(#1510): kernel primitives for subprocess-per-agent runtime

### DIFF
--- a/src/nexus/contracts/process_types.py
+++ b/src/nexus/contracts/process_types.py
@@ -8,7 +8,7 @@ on kernel/services/bricks — only stdlib + contracts.
 Defines:
     ProcessState     — finite state machine (CREATED → RUNNING → … → ZOMBIE)
     ProcessSignal    — POSIX-like signals (SIGTERM, SIGSTOP, SIGCONT, SIGKILL, SIGUSR1)
-    ProcessKind      — INTERNAL (async coroutine) vs EXTERNAL (OS process via gRPC)
+    ProcessKind      — MANAGED (nexusd-spawned) vs UNMANAGED (self-managed via gRPC)
     ProcessDescriptor — frozen PCB (Process Control Block)
     ExternalProcessInfo — connection metadata for external agents
 
@@ -62,10 +62,10 @@ class ProcessSignal(StrEnum):
 
 
 class ProcessKind(StrEnum):
-    """Process kind — determines lifecycle depth."""
+    """Process kind — who controls the lifecycle."""
 
-    INTERNAL = "internal"  # async coroutine inside nexusd
-    EXTERNAL = "external"  # separate OS process via gRPC/MCP
+    MANAGED = "managed"  # nexusd spawns + owns lifecycle (spawn/kill/signal)
+    UNMANAGED = "unmanaged"  # external agent connects, self-managed (register/heartbeat)
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/contracts/protocols/process_table.py
+++ b/src/nexus/contracts/protocols/process_table.py
@@ -31,6 +31,7 @@ class ProcessTableProtocol(Protocol):
         zone_id: str,
         *,
         kind: ProcessKind = ...,
+        pid: str | None = None,
         parent_pid: str | None = None,
         cwd: str = "/",
         external_info: ExternalProcessInfo | None = None,

--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -24,8 +24,11 @@ byte-capacity tracking. Data plane in Rust (nexus_fast.RingBufferCore) for
 See: federation-memo.md §7j
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
+from typing import Protocol, runtime_checkable
 
 from nexus_fast import RingBufferCore
 
@@ -54,6 +57,39 @@ class PipeClosedError(PipeError):
 
 class PipeNotFoundError(PipeError):
     """No pipe registered at the given path."""
+
+
+# ---------------------------------------------------------------------------
+# PipeBackend protocol — pluggable transport tier
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class PipeBackend(Protocol):
+    """Protocol for pipe data transport backends.
+
+    Pluggable transport tier for DT_PIPE (KERNEL-ARCHITECTURE.md §4.2).
+    PipeManager stores ``dict[str, PipeBackend]`` — all backends share
+    this interface so PipeManager is transport-agnostic.
+
+    Implementations:
+        RingBuffer              — in-process SPSC ring buffer (Rust, ~0.5μs)
+        [Future] SharedMemoryPipeBackend — mmap'd ring buffer (~1–5μs)
+    """
+
+    async def write(self, data: bytes, *, blocking: bool = True) -> int: ...
+    async def read(self, *, blocking: bool = True) -> bytes: ...
+    def write_nowait(self, data: bytes) -> int: ...
+    def read_nowait(self) -> bytes: ...
+    async def wait_writable(self) -> None: ...
+    async def wait_readable(self) -> None: ...
+    def close(self) -> None: ...
+
+    @property
+    def closed(self) -> bool: ...
+
+    @property
+    def stats(self) -> dict: ...
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/core/pipe_manager.py
+++ b/src/nexus/core/pipe_manager.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.pipe import (
+    PipeBackend,
     PipeClosedError,
     PipeEmptyError,
     PipeError,
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 # Re-export exceptions so callers can import from either module
 __all__ = [
     "PipeManager",
+    "PipeBackend",
     "PipeError",
     "PipeFullError",
     "PipeEmptyError",
@@ -72,7 +74,7 @@ class PipeManager:
         self._metastore = metastore
         self._zone_id = zone_id
         self._self_address = self_address
-        self._buffers: dict[str, RingBuffer] = {}
+        self._buffers: dict[str, PipeBackend] = {}
         self._locks: dict[str, asyncio.Lock] = {}
 
     @property
@@ -134,7 +136,7 @@ class PipeManager:
         logger.debug("pipe created: %s (capacity=%d)", path, capacity)
         return buf
 
-    def open(self, path: str, *, capacity: int = 65_536) -> RingBuffer:
+    def open(self, path: str, *, capacity: int = 65_536) -> PipeBackend:
         """Open an existing pipe, or recover its buffer after restart.
 
         If the buffer is already in memory, returns it. If a DT_PIPE inode
@@ -168,6 +170,58 @@ class PipeManager:
 
         logger.debug("pipe opened (recovered): %s", path)
         return buf
+
+    def create_from_backend(
+        self,
+        path: str,
+        backend: PipeBackend,
+        *,
+        owner_id: str | None = None,
+    ) -> PipeBackend:
+        """Create a named pipe backed by an external PipeBackend.
+
+        Unlike ``create()`` which always uses an in-process RingBuffer,
+        this method accepts any PipeBackend implementation (e.g., a future
+        SharedMemoryPipeBackend for inter-process IPC).
+
+        The DT_PIPE inode is still registered in MetastoreABC for VFS
+        visibility and ReBAC.
+
+        Args:
+            path: VFS path. Must start with "/".
+            backend: The PipeBackend instance to use for data transport.
+            owner_id: Owner for ReBAC permission checks.
+
+        Returns:
+            The registered PipeBackend (same object passed in).
+
+        Raises:
+            PipeError: Pipe already exists at this path.
+        """
+        from nexus.contracts.metadata import DT_PIPE, FileMetadata
+
+        if path in self._buffers:
+            raise PipeError(f"pipe already exists: {path}")
+
+        existing = self._metastore.get(path)
+        if existing is not None:
+            raise PipeError(f"path already exists: {path}")
+
+        pipe_backend_name = f"pipe@{self._self_address}" if self._self_address else "pipe"
+        metadata = FileMetadata(
+            path=path,
+            backend_name=pipe_backend_name,
+            physical_path="mem://",
+            size=0,
+            entry_type=DT_PIPE,
+            zone_id=self._zone_id,
+            owner_id=owner_id,
+        )
+        self._metastore.put(metadata)
+
+        self._buffers[path] = backend
+        logger.debug("pipe created (custom backend): %s", path)
+        return backend
 
     def signal_close(self, path: str) -> None:
         """Signal a pipe closed without removing from registry.
@@ -221,7 +275,7 @@ class PipeManager:
         self._metastore.delete(path)
         logger.debug("pipe destroyed: %s", path)
 
-    def _get_buffer(self, path: str) -> RingBuffer:
+    def _get_buffer(self, path: str) -> PipeBackend:
         """Get buffer or raise PipeNotFoundError."""
         buf = self._buffers.get(path)
         if buf is None:
@@ -289,12 +343,24 @@ class PipeManager:
     # ------------------------------------------------------------------
 
     def pipe_peek(self, path: str) -> bytes | None:
-        """Peek at next message in a named pipe."""
-        return self._get_buffer(path).peek()
+        """Peek at next message in a named pipe.
+
+        Only supported for RingBuffer backends. Returns None for other backends.
+        """
+        buf = self._get_buffer(path)
+        if isinstance(buf, RingBuffer):
+            return buf.peek()
+        return None
 
     def pipe_peek_all(self, path: str) -> list[bytes]:
-        """Peek at all messages in a named pipe."""
-        return self._get_buffer(path).peek_all()
+        """Peek at all messages in a named pipe.
+
+        Only supported for RingBuffer backends. Returns empty list for others.
+        """
+        buf = self._get_buffer(path)
+        if isinstance(buf, RingBuffer):
+            return buf.peek_all()
+        return []
 
     def list_pipes(self) -> dict[str, dict]:
         """List all active pipes with their stats."""

--- a/src/nexus/core/process_table.py
+++ b/src/nexus/core/process_table.py
@@ -145,7 +145,8 @@ class ProcessTable:
         owner_id: str,
         zone_id: str,
         *,
-        kind: ProcessKind = ProcessKind.INTERNAL,
+        kind: ProcessKind = ProcessKind.MANAGED,
+        pid: str | None = None,
         parent_pid: str | None = None,
         cwd: str = "/",
         external_info: ExternalProcessInfo | None = None,
@@ -158,7 +159,7 @@ class ProcessTable:
             if parent is None:
                 raise ProcessNotFoundError(f"parent not found: {parent_pid}")
 
-        pid = self._alloc_pid()
+        pid = pid or self._alloc_pid()
         now = datetime.now(UTC)
 
         desc = ProcessDescriptor(
@@ -351,7 +352,7 @@ class ProcessTable:
             name,
             owner_id,
             zone_id,
-            kind=ProcessKind.EXTERNAL,
+            kind=ProcessKind.UNMANAGED,
             parent_pid=parent_pid,
             external_info=ext_info,
             labels=labels,
@@ -362,8 +363,8 @@ class ProcessTable:
         desc = self._processes.get(pid)
         if desc is None:
             raise ProcessNotFoundError(f"process not found: {pid}")
-        if desc.kind != ProcessKind.EXTERNAL:
-            raise ProcessError(f"heartbeat only for external processes: {pid}")
+        if desc.kind != ProcessKind.UNMANAGED:
+            raise ProcessError(f"heartbeat only for unmanaged processes: {pid}")
         if desc.external_info is None:
             raise ProcessError(f"missing external_info: {pid}")
 
@@ -379,8 +380,8 @@ class ProcessTable:
         desc = self._processes.get(pid)
         if desc is None:
             raise ProcessNotFoundError(f"process not found: {pid}")
-        if desc.kind != ProcessKind.EXTERNAL:
-            raise ProcessError(f"unregister_external only for external processes: {pid}")
+        if desc.kind != ProcessKind.UNMANAGED:
+            raise ProcessError(f"unregister_external only for unmanaged processes: {pid}")
 
         if desc.state != ProcessState.ZOMBIE:
             desc = self._transition(desc, ProcessState.ZOMBIE)
@@ -421,7 +422,7 @@ class ProcessTable:
 
         - RUNNING/SLEEPING/STOPPED/CREATED → ZOMBIE (crashed)
         - ZOMBIE → kept as-is (waiting for wait())
-        - EXTERNAL → deleted entirely (must reconnect)
+        - UNMANAGED → deleted entirely (must reconnect)
 
         Returns number of recovered processes.
         """
@@ -441,9 +442,9 @@ class ProcessTable:
                 continue
 
             # External processes: clean slate on restart
-            if desc.kind == ProcessKind.EXTERNAL:
+            if desc.kind == ProcessKind.UNMANAGED:
                 self._metastore.delete(entry.path)
-                logger.debug("removed stale external process: pid=%s", desc.pid)
+                logger.debug("removed stale unmanaged process: pid=%s", desc.pid)
                 continue
 
             # Non-terminal processes: mark as crashed (ZOMBIE)

--- a/src/nexus/core/stream.py
+++ b/src/nexus/core/stream.py
@@ -21,8 +21,11 @@ Storage model (KERNEL-ARCHITECTURE.md):
 Data plane backed by Rust ``nexus_fast.StreamBufferCore``.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
+from typing import Protocol, runtime_checkable
 
 try:
     from nexus_fast import StreamBufferCore
@@ -54,6 +57,44 @@ class StreamClosedError(StreamError):
 
 class StreamNotFoundError(StreamError):
     """No stream registered at the given path."""
+
+
+# ---------------------------------------------------------------------------
+# StreamBackend protocol — pluggable transport tier
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class StreamBackend(Protocol):
+    """Protocol for stream data transport backends.
+
+    Pluggable transport tier for DT_STREAM (KERNEL-ARCHITECTURE.md §4.2).
+    StreamManager stores ``dict[str, StreamBackend]`` — all backends share
+    this interface so StreamManager is transport-agnostic.
+
+    Implementations:
+        StreamBuffer            — in-process append-only buffer (Rust, ~0.5μs)
+        [Future] SharedMemoryStreamBackend — mmap'd linear buffer (~1–5μs)
+    """
+
+    async def write(self, data: bytes, *, blocking: bool = True) -> int: ...
+    def write_nowait(self, data: bytes) -> int: ...
+    def read_at(self, byte_offset: int = 0) -> tuple[bytes, int]: ...
+    async def read(self, byte_offset: int = 0, *, blocking: bool = True) -> tuple[bytes, int]: ...
+    def read_batch(self, byte_offset: int = 0, count: int = 10) -> tuple[list[bytes], int]: ...
+    async def read_batch_blocking(
+        self, byte_offset: int = 0, count: int = 10, *, blocking: bool = True
+    ) -> tuple[list[bytes], int]: ...
+    def close(self) -> None: ...
+
+    @property
+    def closed(self) -> bool: ...
+
+    @property
+    def stats(self) -> dict: ...
+
+    @property
+    def tail(self) -> int: ...
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/core/stream_manager.py
+++ b/src/nexus/core/stream_manager.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.stream import (
+    StreamBackend,
     StreamBuffer,
     StreamClosedError,
     StreamEmptyError,
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 # Re-export exceptions so callers can import from either module
 __all__ = [
     "StreamManager",
+    "StreamBackend",
     "StreamError",
     "StreamFullError",
     "StreamEmptyError",
@@ -65,7 +67,7 @@ class StreamManager:
         self._metastore = metastore
         self._zone_id = zone_id
         self._self_address = self_address
-        self._buffers: dict[str, StreamBuffer] = {}
+        self._buffers: dict[str, StreamBackend] = {}
         self._locks: dict[str, asyncio.Lock] = {}
 
     @property
@@ -127,7 +129,7 @@ class StreamManager:
         logger.debug("stream created: %s (capacity=%d)", path, capacity)
         return buf
 
-    def open(self, path: str, *, capacity: int = 65_536) -> StreamBuffer:
+    def open(self, path: str, *, capacity: int = 65_536) -> StreamBackend:
         """Open an existing stream, or recover its buffer after restart.
 
         If the buffer is already in memory, returns it. If a DT_STREAM inode
@@ -161,6 +163,58 @@ class StreamManager:
 
         logger.debug("stream opened (recovered): %s", path)
         return buf
+
+    def create_from_backend(
+        self,
+        path: str,
+        backend: StreamBackend,
+        *,
+        owner_id: str | None = None,
+    ) -> StreamBackend:
+        """Create a named stream backed by an external StreamBackend.
+
+        Unlike ``create()`` which always uses an in-process StreamBuffer,
+        this method accepts any StreamBackend implementation (e.g., a future
+        SharedMemoryStreamBackend for inter-process IPC).
+
+        The DT_STREAM inode is still registered in MetastoreABC for VFS
+        visibility and ReBAC.
+
+        Args:
+            path: VFS path. Must start with "/".
+            backend: The StreamBackend instance to use for data transport.
+            owner_id: Owner for ReBAC permission checks.
+
+        Returns:
+            The registered StreamBackend (same object passed in).
+
+        Raises:
+            StreamError: Stream already exists at this path.
+        """
+        from nexus.contracts.metadata import DT_STREAM, FileMetadata
+
+        if path in self._buffers:
+            raise StreamError(f"stream already exists: {path}")
+
+        existing = self._metastore.get(path)
+        if existing is not None:
+            raise StreamError(f"path already exists: {path}")
+
+        stream_backend_name = f"stream@{self._self_address}" if self._self_address else "stream"
+        metadata = FileMetadata(
+            path=path,
+            backend_name=stream_backend_name,
+            physical_path="mem://",
+            size=0,
+            entry_type=DT_STREAM,
+            zone_id=self._zone_id,
+            owner_id=owner_id,
+        )
+        self._metastore.put(metadata)
+
+        self._buffers[path] = backend
+        logger.debug("stream created (custom backend): %s", path)
+        return backend
 
     def signal_close(self, path: str) -> None:
         """Signal a stream closed without removing from registry.
@@ -210,7 +264,7 @@ class StreamManager:
         self._metastore.delete(path)
         logger.debug("stream destroyed: %s", path)
 
-    def _get_buffer(self, path: str) -> StreamBuffer:
+    def _get_buffer(self, path: str) -> StreamBackend:
         """Get buffer or raise StreamNotFoundError."""
         buf = self._buffers.get(path)
         if buf is None:

--- a/src/nexus/system_services/agent_runtime/ipc.py
+++ b/src/nexus/system_services/agent_runtime/ipc.py
@@ -1,0 +1,96 @@
+"""JSON-lines IPC protocol for agent worker subprocess communication.
+
+Defines the wire format between nexusd (ProcessManager) and the worker
+subprocess (worker.py).  Each message is a single JSON object terminated
+by ``\\n`` — the same JSON-lines convention used by ACP (PR #3060) and
+task dispatch (PR #3059).
+
+Transport: subprocess stdin (nexusd → worker) and stdout (worker → nexusd).
+Both sides see the same VFS fd/0 (stdin) and fd/1 (stdout) DT_STREAMs.
+
+Philosophy: **everything is a file**.  The worker is a user-space process
+that makes "syscalls" to nexusd for all I/O:
+  - LLM inference → ``llm_request`` / ``llm_response`` (VFS SudoRouter)
+  - Tool dispatch → ``tool_calls`` / ``tool_results``  (VFS operations)
+  - State save    → ``checkpoint`` / ``turn_complete``  (VFS session store)
+
+Direction: nexusd → worker (stdin / fd/0)
+    init           — once at spawn: config, tools
+    user_message   — each send(): user message + system prompt + history
+    llm_response   — inner loop: LLM inference result (content, tool_calls)
+    tool_results   — inner loop: dispatched tool call results
+    cancel         — terminate(): request graceful exit
+
+Direction: worker → nexusd (stdout / fd/1)
+    ready          — after init processed, worker is alive
+    llm_request    — inner loop: request LLM inference (messages, tools)
+    tool_calls     — inner loop: tool calls for nexusd to dispatch
+    checkpoint     — after each tool round: save conversation state
+    turn_complete  — inner loop done: final messages + back to SLEEPING
+    error          — unrecoverable error
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Message type constants
+# ---------------------------------------------------------------------------
+
+# nexusd → worker (stdin / fd/0)
+MSG_INIT = "init"
+MSG_USER_MESSAGE = "user_message"
+MSG_LLM_RESPONSE = "llm_response"
+MSG_TOOL_RESULTS = "tool_results"
+MSG_CANCEL = "cancel"
+
+# worker → nexusd (stdout / fd/1)
+MSG_READY = "ready"
+MSG_LLM_REQUEST = "llm_request"
+MSG_TOOL_CALLS = "tool_calls"
+MSG_CHECKPOINT = "checkpoint"
+MSG_TURN_COMPLETE = "turn_complete"
+MSG_ERROR = "error"
+
+
+# ---------------------------------------------------------------------------
+# Codec — JSON-lines (one JSON object per \n-terminated line)
+# ---------------------------------------------------------------------------
+
+
+def encode(msg: dict[str, Any]) -> bytes:
+    """Encode a message dict to a JSON-line (compact, newline-terminated)."""
+    return json.dumps(msg, separators=(",", ":")).encode() + b"\n"
+
+
+def decode(line: bytes) -> dict[str, Any]:
+    """Decode a JSON-line back to a message dict."""
+    result: dict[str, Any] = json.loads(line.strip())
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Async I/O helpers — read/write on asyncio streams
+# ---------------------------------------------------------------------------
+
+
+async def read_message(reader: asyncio.StreamReader) -> dict[str, Any] | None:
+    """Read one JSON-line message from an async stream.
+
+    Returns None on EOF (subprocess exited or stdin closed).
+    """
+    line = await reader.readline()
+    if not line:
+        return None
+    return decode(line)
+
+
+def write_message(writer: asyncio.StreamWriter, msg: dict[str, Any]) -> None:
+    """Write one JSON-line message to an async stream (non-draining).
+
+    Caller must ``await writer.drain()`` when appropriate.
+    """
+    writer.write(encode(msg))

--- a/tests/unit/core/test_process_table.py
+++ b/tests/unit/core/test_process_table.py
@@ -50,7 +50,7 @@ class TestSpawn:
         assert desc.owner_id == OWNER
         assert desc.zone_id == ZONE
         assert desc.state == ProcessState.CREATED
-        assert desc.kind == ProcessKind.INTERNAL
+        assert desc.kind == ProcessKind.MANAGED
         assert len(desc.pid) == 12
 
     def test_spawn_unique_pids(self) -> None:
@@ -112,9 +112,9 @@ class TestSpawn:
 
     def test_list_filter_kind(self) -> None:
         pt = _make_table()
-        pt.spawn("internal", OWNER, ZONE, kind=ProcessKind.INTERNAL)
-        pt.spawn("external", OWNER, ZONE, kind=ProcessKind.EXTERNAL)
-        assert len(pt.list_processes(kind=ProcessKind.INTERNAL)) == 1
+        pt.spawn("managed-agent", OWNER, ZONE, kind=ProcessKind.MANAGED)
+        pt.spawn("unmanaged-agent", OWNER, ZONE, kind=ProcessKind.UNMANAGED)
+        assert len(pt.list_processes(kind=ProcessKind.MANAGED)) == 1
 
     def test_list_filter_state(self) -> None:
         pt = _make_table()
@@ -397,7 +397,7 @@ class TestExternalProcesses:
             host_pid=12345,
             remote_addr="127.0.0.1:50051",
         )
-        assert desc.kind == ProcessKind.EXTERNAL
+        assert desc.kind == ProcessKind.UNMANAGED
         assert desc.external_info is not None
         assert desc.external_info.connection_id == "conn-1"
         assert desc.external_info.host_pid == 12345
@@ -409,10 +409,10 @@ class TestExternalProcesses:
         updated = pt.heartbeat(desc.pid)
         assert updated.external_info.last_heartbeat >= before
 
-    def test_heartbeat_on_internal_raises(self) -> None:
+    def test_heartbeat_on_managed_raises(self) -> None:
         pt = _make_table()
-        desc = pt.spawn("internal", OWNER, ZONE)
-        with pytest.raises(ProcessError, match="heartbeat only for external"):
+        desc = pt.spawn("managed", OWNER, ZONE)
+        with pytest.raises(ProcessError, match="heartbeat only for unmanaged"):
             pt.heartbeat(desc.pid)
 
     def test_unregister_external(self) -> None:
@@ -489,7 +489,7 @@ class TestSerialization:
             name="test",
             owner_id=OWNER,
             zone_id=ZONE,
-            kind=ProcessKind.INTERNAL,
+            kind=ProcessKind.MANAGED,
             state=ProcessState.RUNNING,
             exit_code=None,
             cwd="/workspace",
@@ -514,7 +514,7 @@ class TestSerialization:
             name="external",
             owner_id=OWNER,
             zone_id=ZONE,
-            kind=ProcessKind.EXTERNAL,
+            kind=ProcessKind.UNMANAGED,
             state=ProcessState.CREATED,
             created_at=now,
             updated_at=now,


### PR DESCRIPTION
## Summary
- **ProcessKind**: rename `INTERNAL/EXTERNAL` → `MANAGED/UNMANAGED`, removing the Phase 1 asyncio-task hack
- **ProcessTable.spawn(pid=)**: accept optional OS PID so subprocess-based agents use real PIDs
- **PipeBackend/StreamBackend protocols**: pluggable transport tier ABCs in `core/pipe.py` and `core/stream.py`
- **PipeManager/StreamManager.create_from_backend()**: register any backend implementation (future: SharedMemory mmap)
- **ipc.py**: thin JSON-lines codec for worker ↔ nexusd IPC protocol (same convention as ACP PR #3060)

## Context
Kernel-layer foundations for the subprocess-per-agent model (#1510). This PR only adds kernel primitives — the actual worker subprocess, ProcessManager rewrite, and bridge architecture will follow in subsequent PRs.

The Backend protocols enable a clean upgrade path:
1. **Current**: in-process RingBuffer/StreamBuffer (~0.5μs)
2. **Next PR**: SharedMemory mmap'd backend (~1-5μs) — drop-in via same protocol
3. **Existing**: remote gRPC proxy via FederationIPCResolver (~1-10ms) — unchanged

## Test plan
- [x] 48/48 ProcessTable unit tests pass
- [x] ruff + mypy + all pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)