### PR TITLE
feat(#3078): unified CLI/TUI entry point with embedded command runner

### DIFF
--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -2,6 +2,7 @@
  * Root application component.
  *
  * Lazy-loads panels on first navigation for fast startup.
+ * Shows PreConnectionScreen when the server is unavailable (Decision 3A).
  */
 
 import React, { lazy, Suspense, useState, useCallback, useEffect } from "react";
@@ -17,7 +18,10 @@ import { IdentitySwitcher } from "./shared/components/identity-switcher.js";
 import { AppConfirmDialog } from "./shared/components/app-confirm-dialog.js";
 import { HelpOverlay } from "./shared/components/help-overlay.js";
 import { WelcomeScreen } from "./shared/components/welcome-screen.js";
+import { PreConnectionScreen } from "./shared/components/pre-connection-screen.js";
 import { useFreshServer } from "./shared/hooks/use-fresh-server.js";
+import { detectConnectionState } from "./shared/hooks/use-connection-state.js";
+import { killAllProcesses } from "./services/command-runner.js";
 
 // Lazy-loaded panels
 const FileExplorerPanel = lazy(() => import("./panels/files/file-explorer-panel.js"));
@@ -77,9 +81,20 @@ function PanelRouter(): React.ReactNode {
   }
 }
 
+/**
+ * Graceful shutdown: kill child processes then exit (Decision 6A).
+ */
+function shutdown(): void {
+  killAllProcesses();
+  process.exit(0);
+}
+
 export function App(): React.ReactNode {
   const activePanel = useGlobalStore((s) => s.activePanel);
   const setActivePanel = useGlobalStore((s) => s.setActivePanel);
+  const connectionStatus = useGlobalStore((s) => s.connectionStatus);
+  const connectionError = useGlobalStore((s) => s.connectionError);
+  const config = useGlobalStore((s) => s.config);
   const toggleZoom = useUiStore((s) => s.toggleZoom);
   const zoomedPanel = useUiStore((s) => s.zoomedPanel);
   const [identitySwitcherOpen, setIdentitySwitcherOpen] = useState(false);
@@ -87,6 +102,10 @@ export function App(): React.ReactNode {
   const { isFresh } = useFreshServer();
   const [welcomeDismissed, setWelcomeDismissed] = useState(false);
   const showWelcome = isFresh === true && !welcomeDismissed;
+
+  // Determine if we should show the pre-connection screen (Decision 3A)
+  const connState = detectConnectionState(connectionStatus, connectionError, config);
+  const showPreConnection = connState !== "ready" && connState !== "connecting";
 
   const setOverlayActive = useUiStore((s) => s.setOverlayActive);
   useEffect(() => {
@@ -102,7 +121,12 @@ export function App(): React.ReactNode {
   }, []);
 
   useKeyboard(
-    identitySwitcherOpen || helpOpen || showWelcome
+    showPreConnection
+      ? {
+          // Pre-connection screen handles its own keybindings
+          "q": shutdown,
+        }
+      : identitySwitcherOpen || helpOpen || showWelcome
       ? {
           // When an overlay is open, only its dismiss key works from app level.
           "ctrl+i": toggleIdentitySwitcher,
@@ -121,9 +145,19 @@ export function App(): React.ReactNode {
           "ctrl+i": toggleIdentitySwitcher,
           "z": () => toggleZoom(activePanel),
           "?": () => setHelpOpen(true),
-          "q": () => process.exit(0),
+          "q": shutdown,
         },
   );
+
+  // Pre-connection screen (Decision 3A): shown when server is unavailable
+  if (showPreConnection) {
+    return (
+      <box height="100%" width="100%" flexDirection="column">
+        <PreConnectionScreen />
+        <StatusBar />
+      </box>
+    );
+  }
 
   return (
     <box height="100%" width="100%" flexDirection="column">

--- a/packages/nexus-tui/src/index.tsx
+++ b/packages/nexus-tui/src/index.tsx
@@ -94,41 +94,9 @@ async function main(): Promise<void> {
     transformKeys: false,
   });
 
-  // Initialize global store
+  // Initialize global store — testConnection() is called automatically by initConfig()
+  // when a client is available (consolidates health + features + auth check, Decision 5A)
   useGlobalStore.getState().initConfig(config);
-
-  // Test connection + fetch features in background (non-blocking — TUI renders immediately)
-  const client = useGlobalStore.getState().client;
-  if (client) {
-    useGlobalStore.getState().setConnectionStatus("connecting");
-
-    const healthPromise = client
-      .get<{ version?: string; zone_id?: string; uptime_seconds?: number }>(
-        "/api/v2/bricks/health",
-      );
-
-    const featuresPromise = client
-      .get<{ profile: string; mode: string; enabled_bricks: string[]; disabled_bricks: string[]; version: string | null; rate_limit_enabled: boolean }>(
-        "/api/v2/features",
-      );
-
-    Promise.all([healthPromise, featuresPromise.catch(() => null)])
-      .then(([health, features]) => {
-        const store = useGlobalStore.getState();
-        store.setConnectionStatus("connected");
-        store.setServerInfo({
-          version: health.version,
-          zoneId: health.zone_id,
-          uptime: health.uptime_seconds,
-        });
-        if (features) {
-          store.setFeatures(features);
-        }
-      })
-      .catch(() => {
-        useGlobalStore.getState().setConnectionStatus("error", "Failed to connect to server");
-      });
-  }
 
   // Create OpenTUI renderer and mount the React tree
   const renderer = await createCliRenderer({

--- a/packages/nexus-tui/src/panels/agents/agents-panel.tsx
+++ b/packages/nexus-tui/src/panels/agents/agents-panel.tsx
@@ -43,6 +43,9 @@ export default function AgentsPanel(): React.ReactNode {
   const confirm = useConfirmStore((s) => s.confirm);
   const visibleTabs = useVisibleTabs(ALL_TABS);
 
+  // Reactive subscription to command runner status (Codex finding 2)
+  const commandRunnerStatus = useCommandRunnerStore((s) => s.status);
+
   // Zone ID for fetchAgents
   const configZoneId = useGlobalStore((s) => s.config.zoneId);
   const serverZoneId = useGlobalStore((s) => s.zoneId);
@@ -413,7 +416,7 @@ export default function AgentsPanel(): React.ReactNode {
       </box>
 
       {/* Command runner output (when agent spawn is running) */}
-      {useCommandRunnerStore.getState().status !== "idle" && (
+      {commandRunnerStatus !== "idle" && (
         <box borderStyle="single" height={6} width="100%">
           <CommandOutput />
         </box>

--- a/packages/nexus-tui/src/panels/agents/agents-panel.tsx
+++ b/packages/nexus-tui/src/panels/agents/agents-panel.tsx
@@ -19,6 +19,8 @@ import { TrajectoriesTab } from "./trajectories-tab.js";
 import { EmptyState } from "../../shared/components/empty-state.js";
 import { StyledText } from "../../shared/components/styled-text.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { CommandOutput } from "../../shared/components/command-output.js";
+import { useCommandRunnerStore, executeLocalCommand } from "../../services/command-runner.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { focusColor } from "../../shared/theme.js";
 import { ScrollIndicator } from "../../shared/components/scroll-indicator.js";
@@ -302,6 +304,11 @@ export default function AgentsPanel(): React.ReactNode {
         copy(selectedAgentId);
       }
     },
+    // Issue #3078: spawn new agent via local CLI command
+    n: () => {
+      useCommandRunnerStore.getState().reset();
+      executeLocalCommand("agent", ["spawn"]);
+    },
   });
 
   return (
@@ -405,12 +412,19 @@ export default function AgentsPanel(): React.ReactNode {
         </box>
       </box>
 
+      {/* Command runner output (when agent spawn is running) */}
+      {useCommandRunnerStore.getState().status !== "idle" && (
+        <box borderStyle="single" height={6} width="100%">
+          <CommandOutput />
+        </box>
+      )}
+
       {/* Help bar */}
       <box height={1} width="100%">
         {copied
           ? <text foregroundColor="green">Copied!</text>
           : <text>
-          {"j/k:navigate  Tab:switch tab  r:refresh  Enter:detail  d:revoke  Shift+W:warmup  Shift+E:evict  Shift+V:verify  y:copy  q:quit"}
+          {"j/k:navigate  Tab:switch tab  r:refresh  n:spawn agent  Enter:detail  d:revoke  Shift+W:warmup  Shift+E:evict  y:copy  q:quit"}
         </text>}
       </box>
     </box>

--- a/packages/nexus-tui/src/panels/api-console/api-console-panel.tsx
+++ b/packages/nexus-tui/src/panels/api-console/api-console-panel.tsx
@@ -21,6 +21,8 @@ import { Tooltip } from "../../shared/components/tooltip.js";
 
 export default function ApiConsolePanel(): React.ReactNode {
   const client = useApi();
+  // Reactive subscription to command runner status (Codex finding 2)
+  const commandRunnerStatus = useCommandRunnerStore((s) => s.status);
   const endpoints = useApiConsoleStore((s) => s.endpoints);
   const filteredEndpoints = useApiConsoleStore((s) => s.filteredEndpoints);
   const selectedEndpoint = useApiConsoleStore((s) => s.selectedEndpoint);
@@ -192,7 +194,7 @@ export default function ApiConsolePanel(): React.ReactNode {
         </box>
 
         {/* Local command output (when running via !command or Shift+B) */}
-        {useCommandRunnerStore.getState().status !== "idle" && (
+        {commandRunnerStatus !== "idle" && (
           <box borderStyle="single" height={8} width="100%">
             <CommandOutput />
           </box>

--- a/packages/nexus-tui/src/panels/api-console/api-console-panel.tsx
+++ b/packages/nexus-tui/src/panels/api-console/api-console-panel.tsx
@@ -13,6 +13,8 @@ import { useApiConsoleStore } from "../../stores/api-console-store.js";
 import { EndpointList } from "./endpoint-list.js";
 import { RequestBuilder } from "./request-builder.js";
 import { ResponseViewer } from "./response-viewer.js";
+import { CommandOutput } from "../../shared/components/command-output.js";
+import { useCommandRunnerStore, executeLocalCommand } from "../../services/command-runner.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { focusColor } from "../../shared/theme.js";
 import { Tooltip } from "../../shared/components/tooltip.js";
@@ -147,6 +149,11 @@ export default function ApiConsolePanel(): React.ReactNode {
           ":": () => {
             setCommandInputMode(true);
           },
+          // Issue #3078: Shift+B to run nexus build from Console
+          "shift+b": () => {
+            useCommandRunnerStore.getState().reset();
+            executeLocalCommand("build", []);
+          },
           tab: () => toggleFocus("console"),
         },
     overlayActive ? undefined : handleUnhandledKey,
@@ -180,9 +187,16 @@ export default function ApiConsolePanel(): React.ReactNode {
           <text>
             {commandInputMode
               ? `> ${commandInputBuffer}█`
-              : `Press ":" for command input | history: ${commandHistory.length}`}
+              : `Press ":" for command input | "!" prefix for local commands | Shift+B:build | history: ${commandHistory.length}`}
           </text>
         </box>
+
+        {/* Local command output (when running via !command or Shift+B) */}
+        {useCommandRunnerStore.getState().status !== "idle" && (
+          <box borderStyle="single" height={8} width="100%">
+            <CommandOutput />
+          </box>
+        )}
 
         {/* Request builder (top 40%) */}
         <box flexGrow={4} borderStyle="single">

--- a/packages/nexus-tui/src/services/command-runner.ts
+++ b/packages/nexus-tui/src/services/command-runner.ts
@@ -23,7 +23,7 @@ const MAX_OUTPUT_LINES = 200;
 const THROTTLE_MS = 100;
 
 /** Defense-in-depth: re-validate the subcommand even though parseCommand already checks. */
-const ALLOWED_COMMANDS = new Set(["init", "build", "demo", "brick", "agent"]);
+const ALLOWED_COMMANDS = new Set(["init", "build", "demo", "brick", "agent", "up"]);
 
 // =============================================================================
 // Types

--- a/packages/nexus-tui/src/services/command-runner.ts
+++ b/packages/nexus-tui/src/services/command-runner.ts
@@ -1,0 +1,243 @@
+/**
+ * CommandRunner — executes local `nexus` CLI subcommands via Bun.spawn().
+ *
+ * Decisions implemented:
+ *   2A: Shell out to the Python `nexus` binary
+ *   4A: Strict allowlist (validated in parseCommand, enforced here as defense-in-depth)
+ *   6A: Process lifecycle management with cleanup on shutdown
+ *   7A: Accumulator buffer for streaming output
+ *   13A+C: Windowed rendering (last MAX_OUTPUT_LINES) + throttled state updates
+ *   15A: Show spinner immediately (handled by consumer component)
+ */
+
+import { create } from "zustand";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Maximum lines retained in the output buffer (Decision 13A). */
+const MAX_OUTPUT_LINES = 200;
+
+/** Minimum interval between state updates in ms (Decision 13C). */
+const THROTTLE_MS = 100;
+
+/** Defense-in-depth: re-validate the subcommand even though parseCommand already checks. */
+const ALLOWED_COMMANDS = new Set(["init", "build", "demo", "brick", "agent"]);
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type CommandStatus = "idle" | "running" | "success" | "error";
+
+export interface CommandRunnerState {
+  /** Current command status. */
+  readonly status: CommandStatus;
+  /** Output lines (windowed to last MAX_OUTPUT_LINES). */
+  readonly outputLines: readonly string[];
+  /** Exit code of the last command (null while running). */
+  readonly exitCode: number | null;
+  /** The command string being/was executed. */
+  readonly commandLabel: string;
+  /** Error message if the command failed to spawn. */
+  readonly spawnError: string | null;
+}
+
+export interface CommandRunnerStore extends CommandRunnerState {
+  readonly appendOutput: (chunk: string) => void;
+  readonly setStatus: (status: CommandStatus, exitCode?: number | null) => void;
+  readonly setSpawnError: (error: string) => void;
+  readonly reset: () => void;
+}
+
+// =============================================================================
+// Store
+// =============================================================================
+
+const INITIAL_STATE: CommandRunnerState = {
+  status: "idle",
+  outputLines: [],
+  exitCode: null,
+  commandLabel: "",
+  spawnError: null,
+};
+
+export const useCommandRunnerStore = create<CommandRunnerStore>((set) => ({
+  ...INITIAL_STATE,
+
+  appendOutput: (chunk) => {
+    set((state) => {
+      // Split chunk into lines, preserving partial last line
+      const newLines = chunk.split("\n");
+      const combined = [...state.outputLines];
+
+      // Append first fragment to the last existing line (handles partial lines)
+      if (combined.length > 0 && newLines.length > 0) {
+        combined[combined.length - 1] = combined[combined.length - 1]! + newLines[0]!;
+        newLines.shift();
+      }
+
+      combined.push(...newLines);
+
+      // Window to last MAX_OUTPUT_LINES (Decision 13A)
+      const windowed = combined.length > MAX_OUTPUT_LINES
+        ? combined.slice(-MAX_OUTPUT_LINES)
+        : combined;
+
+      return { outputLines: windowed };
+    });
+  },
+
+  setStatus: (status, exitCode) => {
+    set({ status, exitCode: exitCode ?? null });
+  },
+
+  setSpawnError: (error) => {
+    set({ status: "error", spawnError: error });
+  },
+
+  reset: () => {
+    set(INITIAL_STATE);
+  },
+}));
+
+// =============================================================================
+// Process management (Decision 6A)
+// =============================================================================
+
+/** Set of currently running child processes for cleanup on shutdown. */
+const activeProcesses = new Set<{ kill(): void }>();
+
+/**
+ * Kill all running child processes. Called from the shutdown handler.
+ */
+export function killAllProcesses(): void {
+  for (const proc of activeProcesses) {
+    try {
+      proc.kill();
+    } catch {
+      // Process may have already exited
+    }
+  }
+  activeProcesses.clear();
+}
+
+// =============================================================================
+// Execute local command
+// =============================================================================
+
+/**
+ * Execute a local nexus subcommand via Bun.spawn().
+ *
+ * Output is streamed into the CommandRunnerStore for rendering by CommandOutput.
+ */
+export function executeLocalCommand(command: string, args: readonly string[]): void {
+  // Defense-in-depth: re-validate allowlist (already checked in parseCommand)
+  if (!ALLOWED_COMMANDS.has(command)) {
+    useCommandRunnerStore.getState().setSpawnError(
+      `Command "${command}" is not in the allowlist. Allowed: ${[...ALLOWED_COMMANDS].join(", ")}`,
+    );
+    return;
+  }
+
+  const store = useCommandRunnerStore.getState();
+
+  // Don't start a new command if one is already running
+  if (store.status === "running") {
+    return;
+  }
+
+  // Reset state
+  useCommandRunnerStore.setState({
+    ...INITIAL_STATE,
+    status: "running",
+    commandLabel: `nexus ${command} ${args.join(" ")}`.trim(),
+  });
+
+  const fullArgs = ["nexus", command, ...args];
+
+  try {
+    const proc = Bun.spawn(fullArgs, {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    activeProcesses.add(proc);
+
+    // Throttled output flushing (Decision 13C)
+    let pendingChunks = "";
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function flushOutput(): void {
+      if (pendingChunks) {
+        useCommandRunnerStore.getState().appendOutput(pendingChunks);
+        pendingChunks = "";
+      }
+      flushTimer = null;
+    }
+
+    function bufferChunk(text: string): void {
+      pendingChunks += text;
+      if (!flushTimer) {
+        flushTimer = setTimeout(flushOutput, THROTTLE_MS);
+      }
+    }
+
+    // Stream stdout
+    (async () => {
+      try {
+        const reader = proc.stdout.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          bufferChunk(decoder.decode(value, { stream: true }));
+        }
+      } catch {
+        // Stream closed
+      }
+    })();
+
+    // Stream stderr (interleaved with stdout)
+    (async () => {
+      try {
+        const reader = proc.stderr.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          bufferChunk(decoder.decode(value, { stream: true }));
+        }
+      } catch {
+        // Stream closed
+      }
+    })();
+
+    // Wait for process to complete
+    proc.exited.then((exitCode) => {
+      activeProcesses.delete(proc);
+      // Flush any remaining buffered output
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+      }
+      flushOutput();
+
+      useCommandRunnerStore.getState().setStatus(
+        exitCode === 0 ? "success" : "error",
+        exitCode,
+      );
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to spawn command";
+
+    // Common case: `nexus` binary not found
+    if (message.includes("ENOENT") || message.includes("not found")) {
+      useCommandRunnerStore.getState().setSpawnError(
+        `"nexus" command not found on PATH. Install the Nexus CLI: pip install nexus`,
+      );
+    } else {
+      useCommandRunnerStore.getState().setSpawnError(message);
+    }
+  }
+}

--- a/packages/nexus-tui/src/shared/components/command-output.tsx
+++ b/packages/nexus-tui/src/shared/components/command-output.tsx
@@ -1,0 +1,66 @@
+/**
+ * CommandOutput — renders streaming output from local nexus CLI commands.
+ *
+ * Uses StyledText for ANSI rendering and the CommandRunnerStore for state.
+ * Shows a spinner while running (Decision 15A).
+ */
+
+import React from "react";
+import { useCommandRunnerStore } from "../../services/command-runner.js";
+import { StyledText } from "./styled-text.js";
+import { Spinner } from "./spinner.js";
+import { statusColor } from "../theme.js";
+
+export function CommandOutput(): React.ReactNode {
+  const status = useCommandRunnerStore((s) => s.status);
+  const outputLines = useCommandRunnerStore((s) => s.outputLines);
+  const commandLabel = useCommandRunnerStore((s) => s.commandLabel);
+  const exitCode = useCommandRunnerStore((s) => s.exitCode);
+  const spawnError = useCommandRunnerStore((s) => s.spawnError);
+
+  if (status === "idle") {
+    return null;
+  }
+
+  const output = outputLines.join("\n");
+
+  return (
+    <box flexDirection="column" width="100%">
+      {/* Header */}
+      <box height={1} width="100%">
+        <text>
+          <text dimColor>{"$ "}</text>
+          <text bold>{commandLabel}</text>
+        </text>
+      </box>
+
+      {/* Output */}
+      {output ? (
+        <box width="100%">
+          <StyledText>{output}</StyledText>
+        </box>
+      ) : status === "running" ? (
+        <Spinner label="Running..." />
+      ) : null}
+
+      {/* Spawn error */}
+      {spawnError && (
+        <box height={1} width="100%">
+          <text foregroundColor={statusColor.error}>{"Error: "}{spawnError}</text>
+        </box>
+      )}
+
+      {/* Status footer */}
+      {status === "success" && (
+        <box height={1} width="100%">
+          <text foregroundColor={statusColor.success}>{"Command completed successfully"}</text>
+        </box>
+      )}
+      {status === "error" && exitCode !== null && (
+        <box height={1} width="100%">
+          <text foregroundColor={statusColor.error}>{`Command failed with exit code ${exitCode}`}</text>
+        </box>
+      )}
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -1,0 +1,162 @@
+/**
+ * PreConnectionScreen — shown when the server is not available (Decision 3A).
+ *
+ * Guides users through setup: init, start server, configure URL.
+ * Supports manual retry + opt-in auto-poll (Decision 14A).
+ */
+
+import React, { useState, useEffect, useCallback } from "react";
+import { useKeyboard } from "../hooks/use-keyboard.js";
+import { useGlobalStore } from "../../stores/global-store.js";
+import { detectConnectionState, type ConnectionState } from "../hooks/use-connection-state.js";
+import { executeLocalCommand, useCommandRunnerStore } from "../../services/command-runner.js";
+import { CommandOutput } from "./command-output.js";
+import { Spinner } from "./spinner.js";
+import { statusColor } from "../theme.js";
+
+const AUTO_POLL_INTERVAL = 5_000; // 5 seconds (Decision 14A)
+
+export function PreConnectionScreen(): React.ReactNode {
+  const connectionStatus = useGlobalStore((s) => s.connectionStatus);
+  const connectionError = useGlobalStore((s) => s.connectionError);
+  const config = useGlobalStore((s) => s.config);
+  const testConnection = useGlobalStore((s) => s.testConnection);
+
+  const commandStatus = useCommandRunnerStore((s) => s.status);
+
+  const connState = detectConnectionState(connectionStatus, connectionError, config);
+
+  const [autoPoll, setAutoPoll] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
+
+  // Manual retry
+  const handleRetry = useCallback(() => {
+    setRetryCount((c) => c + 1);
+    testConnection();
+  }, [testConnection]);
+
+  // Auto-poll (Decision 14A: opt-in after first manual retry)
+  useEffect(() => {
+    if (!autoPoll || connState === "ready") return;
+
+    const timer = setInterval(() => {
+      testConnection();
+    }, AUTO_POLL_INTERVAL);
+
+    return () => clearInterval(timer);
+  }, [autoPoll, connState, testConnection]);
+
+  // Stop auto-poll when connected
+  useEffect(() => {
+    if (connState === "ready") {
+      setAutoPoll(false);
+    }
+  }, [connState]);
+
+  const isCommandRunning = commandStatus === "running";
+
+  useKeyboard(
+    isCommandRunning
+      ? {}
+      : {
+          r: handleRetry,
+          a: () => setAutoPoll((prev) => !prev),
+          i: () => {
+            useCommandRunnerStore.getState().reset();
+            executeLocalCommand("init", []);
+          },
+          s: () => {
+            useCommandRunnerStore.getState().reset();
+            executeLocalCommand("init", ["--preset", "shared"]);
+          },
+        },
+  );
+
+  return (
+    <box height="100%" width="100%" justifyContent="center" alignItems="center">
+      <box
+        flexDirection="column"
+        borderStyle="double"
+        width={64}
+        padding={1}
+      >
+        <text bold foregroundColor={statusColor.info}>
+          {"    \u2554\u2557\u2554\u250C\u2500\u2510\u2500\u2510 \u2510\u252C\u2510 \u252C\u250C\u2500\u2510"}
+        </text>
+        <text bold foregroundColor={statusColor.info}>
+          {"    \u2551\u2551\u2551\u251C\u2524 \u250C\u2524 \u2502 \u2502\u2502\u2514\u2500\u2510"}
+        </text>
+        <text bold foregroundColor={statusColor.info}>
+          {"    \u255D\u255A\u255D\u2514\u2500\u2518\u2518\u2514 \u2514\u2500\u2518\u2514\u2500\u2518"}
+        </text>
+        <text>{""}</text>
+
+        {/* Status-specific message */}
+        {connState === "no-config" && (
+          <>
+            <text foregroundColor={statusColor.warning}>{"  No API key configured"}</text>
+            <text>{""}</text>
+            <text dimColor>{"  Set NEXUS_API_KEY or add api_key to ~/.nexus/config.yaml"}</text>
+            <text dimColor>{"  Or run nexus init to create a new project."}</text>
+          </>
+        )}
+
+        {connState === "no-server" && (
+          <>
+            <text foregroundColor={statusColor.error}>{"  Cannot connect to server"}</text>
+            <text>{""}</text>
+            <text dimColor>{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
+            {connectionError && (
+              <text dimColor>{`  Error: ${connectionError}`}</text>
+            )}
+          </>
+        )}
+
+        {connState === "auth-failed" && (
+          <>
+            <text foregroundColor={statusColor.error}>{"  Authentication failed"}</text>
+            <text>{""}</text>
+            <text dimColor>{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
+            <text dimColor>{"  Check your API key or credentials."}</text>
+          </>
+        )}
+
+        {connState === "connecting" && (
+          <Spinner label="  Connecting..." />
+        )}
+
+        <text>{""}</text>
+
+        {/* Actions */}
+        {connState !== "connecting" && !isCommandRunning && (
+          <>
+            <text>
+              <text foregroundColor={statusColor.info}>{"  [I]"}</text>
+              <text>{" Initialize local project (nexus init)"}</text>
+            </text>
+            <text>
+              <text foregroundColor={statusColor.info}>{"  [S]"}</text>
+              <text>{" Initialize shared project (nexus init --preset shared)"}</text>
+            </text>
+            <text>
+              <text foregroundColor={statusColor.info}>{"  [R]"}</text>
+              <text>{` Retry connection${retryCount > 0 ? ` (${retryCount})` : ""}`}</text>
+            </text>
+            <text>
+              <text foregroundColor={autoPoll ? statusColor.success : statusColor.dim}>{"  [A]"}</text>
+              <text>{autoPoll ? " Auto-check: ON (every 5s)" : " Enable auto-check (every 5s)"}</text>
+            </text>
+          </>
+        )}
+
+        {/* Command output (when running nexus init etc.) */}
+        {commandStatus !== "idle" && (
+          <>
+            <text>{""}</text>
+            <CommandOutput />
+          </>
+        )}
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -128,7 +128,7 @@ export function PreConnectionScreen(): React.ReactNode {
           u: () => {
             // Start server (nexus up)
             useCommandRunnerStore.getState().reset();
-            executeLocalCommand("init", ["--preset", "shared"]);
+            executeLocalCommand("up", []);
           },
           c: () => {
             // Connect to a different URL
@@ -216,6 +216,10 @@ export function PreConnectionScreen(): React.ReactNode {
             <text>
               <text foregroundColor={statusColor.info}>{"  [S]"}</text>
               <text>{" Initialize shared project (nexus init --preset shared)"}</text>
+            </text>
+            <text>
+              <text foregroundColor={statusColor.info}>{"  [U]"}</text>
+              <text>{" Start server (nexus up)"}</text>
             </text>
             <text>
               <text foregroundColor={statusColor.info}>{"  [C]"}</text>

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -3,12 +3,16 @@
  *
  * Guides users through setup: init, start server, configure URL.
  * Supports manual retry + opt-in auto-poll (Decision 14A).
+ *
+ * Fix (Codex review finding 1): Retry now calls initConfig() instead of
+ * testConnection() so config is re-read from disk after nexus init creates
+ * nexus.yaml.  Also auto-reloads config when a local command completes.
  */
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useKeyboard } from "../hooks/use-keyboard.js";
 import { useGlobalStore } from "../../stores/global-store.js";
-import { detectConnectionState, type ConnectionState } from "../hooks/use-connection-state.js";
+import { detectConnectionState } from "../hooks/use-connection-state.js";
 import { executeLocalCommand, useCommandRunnerStore } from "../../services/command-runner.js";
 import { CommandOutput } from "./command-output.js";
 import { Spinner } from "./spinner.js";
@@ -20,7 +24,7 @@ export function PreConnectionScreen(): React.ReactNode {
   const connectionStatus = useGlobalStore((s) => s.connectionStatus);
   const connectionError = useGlobalStore((s) => s.connectionError);
   const config = useGlobalStore((s) => s.config);
-  const testConnection = useGlobalStore((s) => s.testConnection);
+  const initConfig = useGlobalStore((s) => s.initConfig);
 
   const commandStatus = useCommandRunnerStore((s) => s.status);
 
@@ -28,23 +32,48 @@ export function PreConnectionScreen(): React.ReactNode {
 
   const [autoPoll, setAutoPoll] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
+  const [urlInput, setUrlInput] = useState("");
+  const [editingUrl, setEditingUrl] = useState(false);
 
-  // Manual retry
+  // Track previous commandStatus to detect completion
+  const prevCommandStatus = useRef(commandStatus);
+
+  // When a local command finishes (success or error), re-read config from disk
+  // so that `nexus init` creating nexus.yaml is picked up automatically.
+  useEffect(() => {
+    const prev = prevCommandStatus.current;
+    prevCommandStatus.current = commandStatus;
+
+    if (
+      (prev === "running") &&
+      (commandStatus === "success" || commandStatus === "error")
+    ) {
+      // Re-read config from disk — initConfig() calls resolveConfig() which
+      // searches ./nexus.yaml → ~/.nexus/config.yaml, then creates a new
+      // FetchClient if an API key is now present.
+      initConfig();
+    }
+  }, [commandStatus, initConfig]);
+
+  // Manual retry: re-read config from disk + test connection.
+  // This is critical for the no-config → init → retry flow: after nexus init
+  // writes nexus.yaml, we must call initConfig() (not just testConnection())
+  // because testConnection() returns immediately when client=null.
   const handleRetry = useCallback(() => {
     setRetryCount((c) => c + 1);
-    testConnection();
-  }, [testConnection]);
+    initConfig();
+  }, [initConfig]);
 
-  // Auto-poll (Decision 14A: opt-in after first manual retry)
+  // Auto-poll: also uses initConfig() so it picks up new config from disk
   useEffect(() => {
     if (!autoPoll || connState === "ready") return;
 
     const timer = setInterval(() => {
-      testConnection();
+      initConfig();
     }, AUTO_POLL_INTERVAL);
 
     return () => clearInterval(timer);
-  }, [autoPoll, connState, testConnection]);
+  }, [autoPoll, connState, initConfig]);
 
   // Stop auto-poll when connected
   useEffect(() => {
@@ -53,11 +82,38 @@ export function PreConnectionScreen(): React.ReactNode {
     }
   }, [connState]);
 
+  // Connect to a different URL
+  const handleConnectUrl = useCallback(() => {
+    const url = urlInput.trim();
+    if (!url) return;
+    setEditingUrl(false);
+    initConfig({ baseUrl: url });
+  }, [urlInput, initConfig]);
+
   const isCommandRunning = commandStatus === "running";
+
+  // Handle printable chars when editing URL
+  const handleUnhandledKey = useCallback(
+    (keyName: string) => {
+      if (!editingUrl) return;
+      if (keyName.length === 1) {
+        setUrlInput((u) => u + keyName);
+      } else if (keyName === "space") {
+        setUrlInput((u) => u + " ");
+      }
+    },
+    [editingUrl],
+  );
 
   useKeyboard(
     isCommandRunning
       ? {}
+      : editingUrl
+      ? {
+          return: handleConnectUrl,
+          escape: () => { setEditingUrl(false); setUrlInput(""); },
+          backspace: () => setUrlInput((u) => u.slice(0, -1)),
+        }
       : {
           r: handleRetry,
           a: () => setAutoPoll((prev) => !prev),
@@ -69,7 +125,18 @@ export function PreConnectionScreen(): React.ReactNode {
             useCommandRunnerStore.getState().reset();
             executeLocalCommand("init", ["--preset", "shared"]);
           },
+          u: () => {
+            // Start server (nexus up)
+            useCommandRunnerStore.getState().reset();
+            executeLocalCommand("init", ["--preset", "shared"]);
+          },
+          c: () => {
+            // Connect to a different URL
+            setEditingUrl(true);
+            setUrlInput(config.baseUrl ?? "http://localhost:2026");
+          },
         },
+    isCommandRunning ? undefined : editingUrl ? handleUnhandledKey : undefined,
   );
 
   return (
@@ -97,7 +164,7 @@ export function PreConnectionScreen(): React.ReactNode {
             <text foregroundColor={statusColor.warning}>{"  No API key configured"}</text>
             <text>{""}</text>
             <text dimColor>{"  Set NEXUS_API_KEY or add api_key to ~/.nexus/config.yaml"}</text>
-            <text dimColor>{"  Or run nexus init to create a new project."}</text>
+            <text dimColor>{"  Or press [I] to initialize a new project."}</text>
           </>
         )}
 
@@ -127,8 +194,20 @@ export function PreConnectionScreen(): React.ReactNode {
 
         <text>{""}</text>
 
+        {/* URL editor */}
+        {editingUrl && (
+          <>
+            <text>{"  Enter server URL:"}</text>
+            <box height={1} width="100%">
+              <text>{`  > ${urlInput}\u2588`}</text>
+            </box>
+            <text dimColor>{"  Enter to connect, Esc to cancel"}</text>
+            <text>{""}</text>
+          </>
+        )}
+
         {/* Actions */}
-        {connState !== "connecting" && !isCommandRunning && (
+        {connState !== "connecting" && !isCommandRunning && !editingUrl && (
           <>
             <text>
               <text foregroundColor={statusColor.info}>{"  [I]"}</text>
@@ -137,6 +216,10 @@ export function PreConnectionScreen(): React.ReactNode {
             <text>
               <text foregroundColor={statusColor.info}>{"  [S]"}</text>
               <text>{" Initialize shared project (nexus init --preset shared)"}</text>
+            </text>
+            <text>
+              <text foregroundColor={statusColor.info}>{"  [C]"}</text>
+              <text>{" Connect to a different URL"}</text>
             </text>
             <text>
               <text foregroundColor={statusColor.info}>{"  [R]"}</text>

--- a/packages/nexus-tui/src/shared/hooks/use-connection-state.ts
+++ b/packages/nexus-tui/src/shared/hooks/use-connection-state.ts
@@ -1,0 +1,67 @@
+/**
+ * Connection state detection for the PreConnectionScreen (Decision 12A).
+ *
+ * Pure function exported for testing — follows the detectFreshServer pattern.
+ */
+
+import type { ConnectionStatus } from "../../stores/global-store.js";
+import type { NexusClientOptions } from "@nexus/api-client";
+
+/**
+ * Describes why the TUI cannot connect, guiding the PreConnectionScreen UI.
+ *
+ *   "no-config"  — No API key configured (client is null)
+ *   "no-server"  — Server unreachable (connection error)
+ *   "auth-failed" — Server reachable but authentication failed
+ *   "connecting" — Still trying to connect
+ *   "ready"      — Connected and authenticated
+ */
+export type ConnectionState =
+  | "no-config"
+  | "no-server"
+  | "auth-failed"
+  | "connecting"
+  | "ready";
+
+/**
+ * Derive a high-level connection state from store values.
+ * Pure function — no side effects, fully testable.
+ */
+export function detectConnectionState(
+  connectionStatus: ConnectionStatus,
+  connectionError: string | null,
+  config: NexusClientOptions,
+): ConnectionState {
+  // No API key → client was never created
+  if (!config.apiKey) {
+    return "no-config";
+  }
+
+  switch (connectionStatus) {
+    case "connected":
+      return "ready";
+
+    case "connecting":
+    case "disconnected":
+      return "connecting";
+
+    case "error": {
+      if (!connectionError) return "no-server";
+
+      // Distinguish auth failures from network failures
+      const lower = connectionError.toLowerCase();
+      if (
+        lower.includes("unauthorized") ||
+        lower.includes("forbidden") ||
+        lower.includes("401") ||
+        lower.includes("403")
+      ) {
+        return "auth-failed";
+      }
+      return "no-server";
+    }
+
+    default:
+      return "connecting";
+  }
+}

--- a/packages/nexus-tui/src/stores/api-console-store.ts
+++ b/packages/nexus-tui/src/stores/api-console-store.ts
@@ -101,7 +101,7 @@ const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "
  * Each entry is the first token after `nexus` — compound commands like `demo init`
  * are validated by checking the first token only (the CLI handles the rest).
  */
-const ALLOWED_LOCAL_COMMANDS = new Set(["init", "build", "demo", "brick", "agent"]);
+const ALLOWED_LOCAL_COMMANDS = new Set(["init", "build", "demo", "brick", "agent", "up"]);
 
 /**
  * Parse a command string into an HTTP command or local command.

--- a/packages/nexus-tui/src/stores/api-console-store.ts
+++ b/packages/nexus-tui/src/stores/api-console-store.ts
@@ -60,14 +60,25 @@ const MAX_HISTORY = 50;
 const MAX_COMMAND_HISTORY = 100;
 
 // =============================================================================
-// CLI-like command parsing
+// CLI-like command parsing (Decision 8A: discriminated union)
 // =============================================================================
 
-export interface ParsedCommand {
+/** An HTTP API request (CLI shorthand or raw HTTP method). */
+export interface HttpCommand {
+  readonly type: "http";
   readonly method: string;
   readonly path: string;
   readonly body: string;
 }
+
+/** A local nexus CLI command to execute via Bun.spawn() (Decision 4A: allowlist). */
+export interface LocalCommand {
+  readonly type: "local";
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+export type ParsedCommand = HttpCommand | LocalCommand;
 
 const CLI_COMMANDS: Readonly<
   Record<string, { readonly method: string; readonly pathFn: (arg: string) => string; readonly bodyFn?: (arg: string) => string }>
@@ -86,12 +97,44 @@ const CLI_COMMANDS: Readonly<
 const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
 
 /**
- * Parse a CLI-like command string into method, path, and optional body.
+ * Allowlist of nexus subcommands that can be run locally from the TUI (Decision 4A).
+ * Each entry is the first token after `nexus` — compound commands like `demo init`
+ * are validated by checking the first token only (the CLI handles the rest).
+ */
+const ALLOWED_LOCAL_COMMANDS = new Set(["init", "build", "demo", "brick", "agent"]);
+
+/**
+ * Parse a command string into an HTTP command or local command.
+ *
+ * Input formats:
+ *   - CLI shorthand: `ls /path`, `cat /file`, `stat /file`, `rm /file`, `mkdir /dir`
+ *   - Raw HTTP: `GET /api/v2/health`, `POST /api/v2/files/write {"body": true}`
+ *   - Local command: `!init --preset shared`, `!build`, `!demo init`
+ *
  * Returns `null` if the input cannot be parsed.
  */
 export function parseCommand(input: string): ParsedCommand | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
+
+  // Local command: starts with "!" prefix (Decision 4A)
+  if (trimmed.startsWith("!")) {
+    const cmdStr = trimmed.slice(1).trim();
+    if (!cmdStr) return null;
+
+    const parts = cmdStr.split(/\s+/);
+    const subcommand = parts[0]!;
+
+    if (!ALLOWED_LOCAL_COMMANDS.has(subcommand)) {
+      return null; // Not in allowlist
+    }
+
+    return {
+      type: "local",
+      command: subcommand,
+      args: parts.slice(1),
+    };
+  }
 
   // Split on first space
   const spaceIdx = trimmed.indexOf(" ");
@@ -104,6 +147,7 @@ export function parseCommand(input: string): ParsedCommand | null {
   const cmd = CLI_COMMANDS[firstWord];
   if (cmd) {
     return {
+      type: "http",
       method: cmd.method,
       path: cmd.pathFn(rest),
       body: cmd.bodyFn ? cmd.bodyFn(rest) : "",
@@ -116,9 +160,9 @@ export function parseCommand(input: string): ParsedCommand | null {
     // Check if rest has a JSON body after the path
     const bodyMatch = rest.match(/^(\S+)\s+(\{[\s\S]*\})$/);
     if (bodyMatch) {
-      return { method, path: bodyMatch[1] ?? "", body: bodyMatch[2] ?? "" };
+      return { type: "http", method, path: bodyMatch[1] ?? "", body: bodyMatch[2] ?? "" };
     }
-    return { method, path: rest, body: "" };
+    return { type: "http", method, path: rest, body: "" };
   }
 
   return null;
@@ -338,6 +382,14 @@ export const useApiConsoleStore = create<ApiConsoleState>((set, get) => ({
     const parsed = parseCommand(input);
     if (!parsed) return;
 
+    if (parsed.type === "local") {
+      // Local command — dispatch to CommandRunner (Phase 2)
+      const { executeLocalCommand } = await import("../services/command-runner.js");
+      executeLocalCommand(parsed.command, parsed.args);
+      return;
+    }
+
+    // HTTP command — existing flow
     get().updateRequest({
       method: parsed.method,
       path: parsed.path,

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -116,7 +116,26 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
     set({ connectionStatus: "connecting", connectionError: null });
 
     try {
-      const userInfo = await client.get<UserInfo>("/auth/me");
+      // Consolidated connection check (Decision 5A): health + features + auth in one flow
+      const [health, features, userInfo] = await Promise.all([
+        client.get<{ version?: string; zone_id?: string; uptime_seconds?: number }>(
+          "/api/v2/bricks/health",
+        ).catch(() => null),
+        client.get<FeaturesResponse>("/api/v2/features").catch(() => null),
+        client.get<UserInfo>("/auth/me"),
+      ]);
+
+      if (health) {
+        set({
+          serverVersion: health.version ?? get().serverVersion,
+          zoneId: health.zone_id ?? get().zoneId,
+          uptime: health.uptime_seconds ?? get().uptime,
+        });
+      }
+      if (features) {
+        get().setFeatures(features);
+      }
+
       set({ connectionStatus: "connected", connectionError: null, userInfo });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Connection test failed";

--- a/packages/nexus-tui/tests/services/command-runner.test.ts
+++ b/packages/nexus-tui/tests/services/command-runner.test.ts
@@ -132,6 +132,11 @@ describe("CommandRunner", () => {
       executeLocalCommand("agent", ["spawn"]);
       expect(useCommandRunnerStore.getState().spawnError).toBeNull();
     });
+
+    it("accepts allowed commands (up)", () => {
+      executeLocalCommand("up", []);
+      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+    });
   });
 
   // =========================================================================

--- a/packages/nexus-tui/tests/services/command-runner.test.ts
+++ b/packages/nexus-tui/tests/services/command-runner.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for CommandRunner — Issues #11A+B.
+ *
+ * Unit tests for allowlist, store operations, and output buffer.
+ * Light integration tests with real Bun.spawn.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  useCommandRunnerStore,
+  executeLocalCommand,
+  killAllProcesses,
+} from "../../src/services/command-runner.js";
+
+describe("CommandRunner", () => {
+  beforeEach(() => {
+    useCommandRunnerStore.getState().reset();
+  });
+
+  // =========================================================================
+  // Store unit tests
+  // =========================================================================
+  describe("store", () => {
+    it("starts in idle state", () => {
+      const state = useCommandRunnerStore.getState();
+      expect(state.status).toBe("idle");
+      expect(state.outputLines).toEqual([]);
+      expect(state.exitCode).toBeNull();
+      expect(state.commandLabel).toBe("");
+      expect(state.spawnError).toBeNull();
+    });
+
+    it("appendOutput splits chunks into lines", () => {
+      const { appendOutput } = useCommandRunnerStore.getState();
+      appendOutput("line 1\nline 2\nline 3");
+      const lines = useCommandRunnerStore.getState().outputLines;
+      expect(lines).toEqual(["line 1", "line 2", "line 3"]);
+    });
+
+    it("appendOutput joins partial lines across chunks", () => {
+      const { appendOutput } = useCommandRunnerStore.getState();
+      appendOutput("hello ");
+      appendOutput("world\ndone");
+      const lines = useCommandRunnerStore.getState().outputLines;
+      expect(lines).toEqual(["hello world", "done"]);
+    });
+
+    it("appendOutput windows to MAX_OUTPUT_LINES (200)", () => {
+      const { appendOutput } = useCommandRunnerStore.getState();
+      const bigChunk = Array.from({ length: 300 }, (_, i) => `line ${i}`).join("\n");
+      appendOutput(bigChunk);
+      const lines = useCommandRunnerStore.getState().outputLines;
+      expect(lines.length).toBe(200);
+      expect(lines[0]).toBe("line 100");
+      expect(lines[199]).toBe("line 299");
+    });
+
+    it("setStatus updates status and exit code", () => {
+      const { setStatus } = useCommandRunnerStore.getState();
+      setStatus("running");
+      expect(useCommandRunnerStore.getState().status).toBe("running");
+      expect(useCommandRunnerStore.getState().exitCode).toBeNull();
+
+      setStatus("success", 0);
+      expect(useCommandRunnerStore.getState().status).toBe("success");
+      expect(useCommandRunnerStore.getState().exitCode).toBe(0);
+    });
+
+    it("setSpawnError sets error status", () => {
+      const { setSpawnError } = useCommandRunnerStore.getState();
+      setSpawnError("nexus not found");
+      const state = useCommandRunnerStore.getState();
+      expect(state.status).toBe("error");
+      expect(state.spawnError).toBe("nexus not found");
+    });
+
+    it("reset returns to initial state", () => {
+      const store = useCommandRunnerStore.getState();
+      store.appendOutput("some output");
+      store.setStatus("success", 0);
+      store.reset();
+
+      const state = useCommandRunnerStore.getState();
+      expect(state.status).toBe("idle");
+      expect(state.outputLines).toEqual([]);
+      expect(state.exitCode).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Allowlist enforcement (defense-in-depth)
+  // =========================================================================
+  describe("allowlist", () => {
+    it("rejects commands not in allowlist", () => {
+      executeLocalCommand("rm", ["/important"]);
+      const state = useCommandRunnerStore.getState();
+      expect(state.status).toBe("error");
+      expect(state.spawnError).toContain("not in the allowlist");
+    });
+
+    it("rejects migrate command", () => {
+      executeLocalCommand("migrate", ["--destructive"]);
+      expect(useCommandRunnerStore.getState().spawnError).toContain("not in the allowlist");
+    });
+
+    it("accepts allowed commands (init)", () => {
+      // This will actually try to spawn `nexus init` which may fail,
+      // but the point is it doesn't get rejected by the allowlist
+      executeLocalCommand("init", ["--help"]);
+      const state = useCommandRunnerStore.getState();
+      expect(state.spawnError).toBeNull();
+      // Status should be "running" (or "error" if nexus is not installed, but NOT allowlist error)
+      expect(state.status).not.toBe("idle");
+    });
+
+    it("accepts allowed commands (build)", () => {
+      executeLocalCommand("build", []);
+      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+    });
+
+    it("accepts allowed commands (demo)", () => {
+      executeLocalCommand("demo", ["init"]);
+      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+    });
+
+    it("accepts allowed commands (brick)", () => {
+      executeLocalCommand("brick", ["mount", "test"]);
+      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+    });
+
+    it("accepts allowed commands (agent)", () => {
+      executeLocalCommand("agent", ["spawn"]);
+      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Process management
+  // =========================================================================
+  describe("process management", () => {
+    it("prevents concurrent commands", () => {
+      // Set status to running manually
+      useCommandRunnerStore.setState({ status: "running", commandLabel: "nexus init" });
+
+      executeLocalCommand("build", []);
+
+      // Should still be the original command
+      expect(useCommandRunnerStore.getState().commandLabel).toBe("nexus init");
+    });
+
+    it("killAllProcesses does not throw when no processes running", () => {
+      expect(() => killAllProcesses()).not.toThrow();
+    });
+  });
+
+  // =========================================================================
+  // Integration tests (11B): real Bun.spawn
+  // =========================================================================
+  describe("integration: real process spawn", () => {
+    it("captures output from a real command", async () => {
+      // Use echo which is guaranteed to exist
+      const proc = Bun.spawn(["echo", "hello world"], { stdout: "pipe" });
+      const output = await new Response(proc.stdout).text();
+      expect(output.trim()).toBe("hello world");
+      await proc.exited;
+    });
+
+    it("captures exit code from failing command", async () => {
+      const proc = Bun.spawn(["false"], { stdout: "pipe", stderr: "pipe" });
+      const exitCode = await proc.exited;
+      expect(exitCode).not.toBe(0);
+    });
+
+    it("streams output incrementally", async () => {
+      // Spawn a process that produces output over time
+      const proc = Bun.spawn(["printf", "line1\\nline2\\nline3\\n"], {
+        stdout: "pipe",
+      });
+
+      const chunks: string[] = [];
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(decoder.decode(value, { stream: true }));
+      }
+
+      await proc.exited;
+      const fullOutput = chunks.join("");
+      expect(fullOutput).toContain("line1");
+      expect(fullOutput).toContain("line2");
+      expect(fullOutput).toContain("line3");
+    });
+  });
+});

--- a/packages/nexus-tui/tests/services/command-runner.test.ts
+++ b/packages/nexus-tui/tests/services/command-runner.test.ts
@@ -103,39 +103,47 @@ describe("CommandRunner", () => {
       expect(useCommandRunnerStore.getState().spawnError).toContain("not in the allowlist");
     });
 
+    // These tests verify the allowlist does NOT reject these commands.
+    // On CI, `nexus` may not be on PATH, so Bun.spawn may fail with ENOENT.
+    // We assert the error (if any) is NOT an allowlist rejection.
     it("accepts allowed commands (init)", () => {
-      // This will actually try to spawn `nexus init` which may fail,
-      // but the point is it doesn't get rejected by the allowlist
       executeLocalCommand("init", ["--help"]);
       const state = useCommandRunnerStore.getState();
-      expect(state.spawnError).toBeNull();
-      // Status should be "running" (or "error" if nexus is not installed, but NOT allowlist error)
+      // Should not be rejected by allowlist — may fail with ENOENT on CI
+      if (state.spawnError) {
+        expect(state.spawnError).not.toContain("not in the allowlist");
+      }
       expect(state.status).not.toBe("idle");
     });
 
     it("accepts allowed commands (build)", () => {
       executeLocalCommand("build", []);
-      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+      const { spawnError } = useCommandRunnerStore.getState();
+      if (spawnError) expect(spawnError).not.toContain("not in the allowlist");
     });
 
     it("accepts allowed commands (demo)", () => {
       executeLocalCommand("demo", ["init"]);
-      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+      const { spawnError } = useCommandRunnerStore.getState();
+      if (spawnError) expect(spawnError).not.toContain("not in the allowlist");
     });
 
     it("accepts allowed commands (brick)", () => {
       executeLocalCommand("brick", ["mount", "test"]);
-      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+      const { spawnError } = useCommandRunnerStore.getState();
+      if (spawnError) expect(spawnError).not.toContain("not in the allowlist");
     });
 
     it("accepts allowed commands (agent)", () => {
       executeLocalCommand("agent", ["spawn"]);
-      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+      const { spawnError } = useCommandRunnerStore.getState();
+      if (spawnError) expect(spawnError).not.toContain("not in the allowlist");
     });
 
     it("accepts allowed commands (up)", () => {
       executeLocalCommand("up", []);
-      expect(useCommandRunnerStore.getState().spawnError).toBeNull();
+      const { spawnError } = useCommandRunnerStore.getState();
+      if (spawnError) expect(spawnError).not.toContain("not in the allowlist");
     });
   });
 

--- a/packages/nexus-tui/tests/shared/connection-state.test.ts
+++ b/packages/nexus-tui/tests/shared/connection-state.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for detectConnectionState() — Issue #12A.
+ *
+ * Pure function tests following the detectFreshServer pattern.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { detectConnectionState } from "../../src/shared/hooks/use-connection-state.js";
+import type { NexusClientOptions } from "@nexus/api-client";
+
+const baseConfig: NexusClientOptions = {
+  baseUrl: "http://localhost:2026",
+  apiKey: "sk-test-key",
+};
+
+const noKeyConfig: NexusClientOptions = {
+  baseUrl: "http://localhost:2026",
+  apiKey: "",
+};
+
+describe("detectConnectionState", () => {
+  // =========================================================================
+  // Happy path
+  // =========================================================================
+  it("returns 'ready' when connected", () => {
+    expect(detectConnectionState("connected", null, baseConfig)).toBe("ready");
+  });
+
+  // =========================================================================
+  // No config
+  // =========================================================================
+  it("returns 'no-config' when no API key (empty string)", () => {
+    expect(detectConnectionState("disconnected", null, noKeyConfig)).toBe("no-config");
+  });
+
+  it("returns 'no-config' when no API key (undefined)", () => {
+    expect(detectConnectionState("disconnected", null, {
+      baseUrl: "http://localhost:2026",
+    } as NexusClientOptions)).toBe("no-config");
+  });
+
+  it("returns 'no-config' even when error state but no key", () => {
+    expect(detectConnectionState("error", "some error", noKeyConfig)).toBe("no-config");
+  });
+
+  // =========================================================================
+  // Connecting
+  // =========================================================================
+  it("returns 'connecting' when status is connecting", () => {
+    expect(detectConnectionState("connecting", null, baseConfig)).toBe("connecting");
+  });
+
+  it("returns 'connecting' when status is disconnected (initial state)", () => {
+    expect(detectConnectionState("disconnected", null, baseConfig)).toBe("connecting");
+  });
+
+  // =========================================================================
+  // Server unreachable
+  // =========================================================================
+  it("returns 'no-server' for ECONNREFUSED", () => {
+    expect(detectConnectionState("error", "ECONNREFUSED", baseConfig)).toBe("no-server");
+  });
+
+  it("returns 'no-server' for timeout", () => {
+    expect(detectConnectionState("error", "Request timed out", baseConfig)).toBe("no-server");
+  });
+
+  it("returns 'no-server' for generic network error", () => {
+    expect(detectConnectionState("error", "Network error", baseConfig)).toBe("no-server");
+  });
+
+  it("returns 'no-server' for null error message", () => {
+    expect(detectConnectionState("error", null, baseConfig)).toBe("no-server");
+  });
+
+  it("returns 'no-server' for 500 server error", () => {
+    expect(detectConnectionState("error", "Internal Server Error (500)", baseConfig)).toBe("no-server");
+  });
+
+  // =========================================================================
+  // Auth failures
+  // =========================================================================
+  it("returns 'auth-failed' for 401", () => {
+    expect(detectConnectionState("error", "Unauthorized (401)", baseConfig)).toBe("auth-failed");
+  });
+
+  it("returns 'auth-failed' for 403", () => {
+    expect(detectConnectionState("error", "Forbidden (403)", baseConfig)).toBe("auth-failed");
+  });
+
+  it("returns 'auth-failed' for lowercase unauthorized", () => {
+    expect(detectConnectionState("error", "request unauthorized", baseConfig)).toBe("auth-failed");
+  });
+
+  it("returns 'auth-failed' for error containing 401", () => {
+    expect(detectConnectionState("error", "HTTP 401: Invalid API key", baseConfig)).toBe("auth-failed");
+  });
+
+  it("returns 'auth-failed' for error containing 403", () => {
+    expect(detectConnectionState("error", "HTTP 403: Access denied", baseConfig)).toBe("auth-failed");
+  });
+});

--- a/packages/nexus-tui/tests/stores/command-history.test.ts
+++ b/packages/nexus-tui/tests/stores/command-history.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for command history navigation and input mode — Phase 0, Issue #9A.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { useApiConsoleStore } from "../../src/stores/api-console-store.js";
+
+describe("ApiConsoleStore — command history", () => {
+  beforeEach(() => {
+    useApiConsoleStore.setState({
+      commandHistory: [],
+      historyIndex: -1,
+      commandInputMode: false,
+      commandInputBuffer: "",
+    });
+  });
+
+  describe("setCommandInputMode", () => {
+    it("enables command input mode and clears buffer", () => {
+      useApiConsoleStore.getState().setCommandInputBuffer("leftover");
+      useApiConsoleStore.getState().setCommandInputMode(true);
+      const state = useApiConsoleStore.getState();
+      expect(state.commandInputMode).toBe(true);
+      expect(state.commandInputBuffer).toBe("");
+      expect(state.historyIndex).toBe(-1);
+    });
+
+    it("disables command input mode", () => {
+      useApiConsoleStore.getState().setCommandInputMode(true);
+      useApiConsoleStore.getState().setCommandInputMode(false);
+      expect(useApiConsoleStore.getState().commandInputMode).toBe(false);
+    });
+  });
+
+  describe("setCommandInputBuffer", () => {
+    it("sets the buffer", () => {
+      useApiConsoleStore.getState().setCommandInputBuffer("GET /api");
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("GET /api");
+    });
+  });
+
+  describe("navigateHistory", () => {
+    it("does nothing with empty history", () => {
+      useApiConsoleStore.getState().navigateHistory("up");
+      expect(useApiConsoleStore.getState().historyIndex).toBe(-1);
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("");
+    });
+
+    it("navigates up to most recent entry", () => {
+      useApiConsoleStore.setState({
+        commandHistory: ["GET /health", "POST /files"],
+      });
+      useApiConsoleStore.getState().navigateHistory("up");
+      const state = useApiConsoleStore.getState();
+      expect(state.historyIndex).toBe(1); // last entry
+      expect(state.commandInputBuffer).toBe("POST /files");
+    });
+
+    it("navigates up through full history", () => {
+      useApiConsoleStore.setState({
+        commandHistory: ["first", "second", "third"],
+      });
+      useApiConsoleStore.getState().navigateHistory("up");
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("third");
+
+      useApiConsoleStore.getState().navigateHistory("up");
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("second");
+
+      useApiConsoleStore.getState().navigateHistory("up");
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("first");
+    });
+
+    it("stops at oldest entry", () => {
+      useApiConsoleStore.setState({
+        commandHistory: ["first", "second"],
+      });
+      useApiConsoleStore.getState().navigateHistory("up");
+      useApiConsoleStore.getState().navigateHistory("up");
+      useApiConsoleStore.getState().navigateHistory("up"); // should stay at 0
+      expect(useApiConsoleStore.getState().historyIndex).toBe(0);
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("first");
+    });
+
+    it("navigates down back toward newest", () => {
+      useApiConsoleStore.setState({
+        commandHistory: ["first", "second", "third"],
+      });
+      // Go to oldest
+      useApiConsoleStore.getState().navigateHistory("up");
+      useApiConsoleStore.getState().navigateHistory("up");
+      useApiConsoleStore.getState().navigateHistory("up");
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("first");
+
+      // Go back down
+      useApiConsoleStore.getState().navigateHistory("down");
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("second");
+    });
+
+    it("clears buffer when navigating past newest entry", () => {
+      useApiConsoleStore.setState({
+        commandHistory: ["first"],
+      });
+      useApiConsoleStore.getState().navigateHistory("up");
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("first");
+
+      useApiConsoleStore.getState().navigateHistory("down");
+      expect(useApiConsoleStore.getState().historyIndex).toBe(-1);
+      expect(useApiConsoleStore.getState().commandInputBuffer).toBe("");
+    });
+
+    it("down does nothing when already at newest (index -1)", () => {
+      useApiConsoleStore.setState({
+        commandHistory: ["first"],
+        historyIndex: -1,
+      });
+      useApiConsoleStore.getState().navigateHistory("down");
+      expect(useApiConsoleStore.getState().historyIndex).toBe(-1);
+    });
+  });
+});

--- a/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
+++ b/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for connection lifecycle transitions — Phase 0, Issue #10A.
+ *
+ * Tests the full initConfig → testConnection flow with mocked FetchClient,
+ * covering happy path + all error modes. These tests validate the signals
+ * that the PreConnectionScreen will rely on.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { useGlobalStore } from "../../src/stores/global-store.js";
+import type { FetchClient } from "@nexus/api-client";
+
+function createMockClient(overrides: {
+  health?: () => Promise<unknown>;
+  features?: () => Promise<unknown>;
+  authMe?: () => Promise<unknown>;
+} = {}): FetchClient {
+  const defaultUserInfo = {
+    user_id: "user-1",
+    email: "test@example.com",
+    username: "testuser",
+    display_name: "Test User",
+    avatar_url: null,
+    is_global_admin: false,
+    primary_auth_method: "api_key",
+  };
+
+  const defaultHealth = { version: "0.9.0", zone_id: "default", uptime_seconds: 100 };
+  const defaultFeatures = {
+    profile: "full",
+    mode: "standalone",
+    enabled_bricks: ["search", "catalog"],
+    disabled_bricks: [],
+    version: "0.9.0",
+    rate_limit_enabled: false,
+  };
+
+  return {
+    get: mock(async (url: string) => {
+      if (url === "/auth/me") {
+        return overrides.authMe ? overrides.authMe() : defaultUserInfo;
+      }
+      if (url === "/api/v2/bricks/health") {
+        return overrides.health ? overrides.health() : defaultHealth;
+      }
+      if (url === "/api/v2/features") {
+        return overrides.features ? overrides.features() : defaultFeatures;
+      }
+      throw new Error(`Unmocked URL: ${url}`);
+    }),
+    rawRequest: mock(async () => new Response("{}", { status: 200 })),
+  } as unknown as FetchClient;
+}
+
+describe("Connection Lifecycle", () => {
+  beforeEach(() => {
+    useGlobalStore.setState({
+      connectionStatus: "disconnected",
+      connectionError: null,
+      client: null,
+      serverVersion: null,
+      zoneId: null,
+      uptime: null,
+      userInfo: null,
+      enabledBricks: [],
+      profile: null,
+      mode: null,
+      featuresLoaded: false,
+      featuresLastFetched: 0,
+    });
+  });
+
+  describe("happy path: disconnected → connecting → connected", () => {
+    it("testConnection sets connected + userInfo on success", async () => {
+      const client = createMockClient();
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("connected");
+      expect(state.connectionError).toBeNull();
+      expect(state.userInfo).not.toBeNull();
+      expect(state.userInfo!.email).toBe("test@example.com");
+    });
+
+    it("transitions through connecting state", async () => {
+      const states: string[] = [];
+      const unsubscribe = useGlobalStore.subscribe((s) => {
+        states.push(s.connectionStatus);
+      });
+
+      const client = createMockClient();
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+      unsubscribe();
+
+      // Should have gone through connecting → connected
+      expect(states).toContain("connecting");
+      expect(states[states.length - 1]).toBe("connected");
+    });
+  });
+
+  describe("server unreachable → error", () => {
+    it("network error sets error status", async () => {
+      const client = createMockClient({
+        authMe: async () => { throw new Error("ECONNREFUSED"); },
+      });
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("error");
+      expect(state.connectionError).toBe("ECONNREFUSED");
+      expect(state.userInfo).toBeNull();
+    });
+
+    it("timeout sets error status", async () => {
+      const client = createMockClient({
+        authMe: async () => { throw new Error("Request timed out"); },
+      });
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("error");
+      expect(state.connectionError).toBe("Request timed out");
+    });
+  });
+
+  describe("auth failures", () => {
+    it("401 unauthorized sets error", async () => {
+      const client = createMockClient({
+        authMe: async () => { throw new Error("Unauthorized (401)"); },
+      });
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("error");
+      expect(state.connectionError).toContain("Unauthorized");
+    });
+
+    it("403 forbidden sets error", async () => {
+      const client = createMockClient({
+        authMe: async () => { throw new Error("Forbidden (403)"); },
+      });
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("error");
+      expect(state.connectionError).toContain("Forbidden");
+    });
+  });
+
+  describe("no client → disconnected", () => {
+    it("testConnection with null client stays disconnected", async () => {
+      useGlobalStore.setState({ client: null });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("disconnected");
+      expect(state.connectionError).toBeNull();
+      expect(state.userInfo).toBeNull();
+    });
+  });
+
+  describe("reconnection", () => {
+    it("can recover from error to connected", async () => {
+      // First: fail
+      const failClient = createMockClient({
+        authMe: async () => { throw new Error("Connection refused"); },
+      });
+      useGlobalStore.setState({ client: failClient });
+      await useGlobalStore.getState().testConnection();
+      expect(useGlobalStore.getState().connectionStatus).toBe("error");
+
+      // Second: succeed
+      const okClient = createMockClient();
+      useGlobalStore.setState({ client: okClient });
+      await useGlobalStore.getState().testConnection();
+      expect(useGlobalStore.getState().connectionStatus).toBe("connected");
+      expect(useGlobalStore.getState().userInfo).not.toBeNull();
+      expect(useGlobalStore.getState().connectionError).toBeNull();
+    });
+  });
+
+  describe("non-Error thrown objects", () => {
+    it("handles string throws", async () => {
+      const client = createMockClient({
+        authMe: async () => { throw "raw string error"; },
+      });
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("error");
+      expect(state.connectionError).toBe("Connection test failed");
+    });
+  });
+
+  describe("server error (500)", () => {
+    it("server error sets error status", async () => {
+      const client = createMockClient({
+        authMe: async () => { throw new Error("Internal Server Error (500)"); },
+      });
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("error");
+      expect(state.connectionError).toContain("500");
+    });
+  });
+});

--- a/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
+++ b/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
@@ -221,4 +221,31 @@ describe("Connection Lifecycle", () => {
       expect(state.connectionError).toContain("500");
     });
   });
+
+  describe("testConnection with null client (Codex finding 1)", () => {
+    it("testConnection returns immediately when client is null", async () => {
+      // This validates the bug Codex found: calling testConnection() when
+      // client is null does NOT attempt connection — it just stays disconnected.
+      // The fix is that PreConnectionScreen must call initConfig() instead.
+      useGlobalStore.setState({ client: null, connectionStatus: "disconnected" });
+
+      await useGlobalStore.getState().testConnection();
+
+      const state = useGlobalStore.getState();
+      expect(state.connectionStatus).toBe("disconnected");
+      expect(state.connectionError).toBeNull();
+    });
+
+    it("initConfig re-reads config and can create a new client", () => {
+      // Verify that initConfig() with overrides creates a new client
+      useGlobalStore.setState({ client: null, connectionStatus: "disconnected" });
+
+      useGlobalStore.getState().initConfig({ apiKey: "sk-new-key", baseUrl: "http://localhost:2026" });
+
+      // Should now have a client and be in connecting state
+      const state = useGlobalStore.getState();
+      expect(state.client).not.toBeNull();
+      expect(state.connectionStatus).toBe("connecting");
+    });
+  });
 });

--- a/packages/nexus-tui/tests/stores/parse-command.test.ts
+++ b/packages/nexus-tui/tests/stores/parse-command.test.ts
@@ -211,6 +211,12 @@ describe("parseCommand", () => {
       expect(result.args).toEqual(["spawn"]);
     });
 
+    it("!up", () => {
+      const result = expectLocal("!up");
+      expect(result.command).toBe("up");
+      expect(result.args).toEqual([]);
+    });
+
     it("handles leading whitespace after !", () => {
       const result = expectLocal("!  init --preset demo");
       expect(result.command).toBe("init");

--- a/packages/nexus-tui/tests/stores/parse-command.test.ts
+++ b/packages/nexus-tui/tests/stores/parse-command.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for parseCommand() — Issues #9A, #8A.
+ *
+ * Covers the discriminated union (HttpCommand | LocalCommand) parser.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { parseCommand, type HttpCommand, type LocalCommand } from "../../src/stores/api-console-store.js";
+
+/** Type-narrowing helper for HTTP commands. */
+function expectHttp(input: string): HttpCommand {
+  const result = parseCommand(input);
+  expect(result).not.toBeNull();
+  expect(result!.type).toBe("http");
+  return result as HttpCommand;
+}
+
+/** Type-narrowing helper for local commands. */
+function expectLocal(input: string): LocalCommand {
+  const result = parseCommand(input);
+  expect(result).not.toBeNull();
+  expect(result!.type).toBe("local");
+  return result as LocalCommand;
+}
+
+describe("parseCommand", () => {
+  // =========================================================================
+  // Edge cases: empty / whitespace / unparseable
+  // =========================================================================
+  describe("returns null for invalid input", () => {
+    it("empty string", () => {
+      expect(parseCommand("")).toBeNull();
+    });
+
+    it("whitespace only", () => {
+      expect(parseCommand("   ")).toBeNull();
+    });
+
+    it("single word (no space)", () => {
+      expect(parseCommand("hello")).toBeNull();
+    });
+
+    it("unknown command", () => {
+      expect(parseCommand("foobar /path")).toBeNull();
+    });
+
+    it("just a slash", () => {
+      expect(parseCommand("/ something")).toBeNull();
+    });
+
+    it("! with no command", () => {
+      expect(parseCommand("!")).toBeNull();
+    });
+
+    it("! with only whitespace", () => {
+      expect(parseCommand("!   ")).toBeNull();
+    });
+
+    it("! with disallowed command", () => {
+      expect(parseCommand("!rm /important")).toBeNull();
+    });
+
+    it("! with disallowed command (migrate)", () => {
+      expect(parseCommand("!migrate --destructive")).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // CLI shortcuts: ls, cat, stat, rm, mkdir → HttpCommand
+  // =========================================================================
+  describe("CLI shortcuts (type: http)", () => {
+    it("ls /workspace", () => {
+      const result = expectHttp("ls /workspace");
+      expect(result.method).toBe("GET");
+      expect(result.path).toBe("/api/v2/files/list?path=%2Fworkspace");
+      expect(result.body).toBe("");
+    });
+
+    it("ls with path containing spaces", () => {
+      const result = expectHttp("ls /my folder/file");
+      expect(result.path).toContain(encodeURIComponent("/my folder/file"));
+    });
+
+    it("cat /file.txt", () => {
+      const result = expectHttp("cat /file.txt");
+      expect(result.method).toBe("GET");
+      expect(result.path).toBe("/api/v2/files/read?path=%2Ffile.txt");
+      expect(result.body).toBe("");
+    });
+
+    it("stat /file.txt", () => {
+      const result = expectHttp("stat /file.txt");
+      expect(result.method).toBe("GET");
+      expect(result.path).toBe("/api/v2/files/metadata?path=%2Ffile.txt");
+    });
+
+    it("rm /file.txt", () => {
+      const result = expectHttp("rm /file.txt");
+      expect(result.method).toBe("DELETE");
+      expect(result.path).toBe("/api/v2/files?path=%2Ffile.txt");
+    });
+
+    it("mkdir /new-dir", () => {
+      const result = expectHttp("mkdir /new-dir");
+      expect(result.method).toBe("POST");
+      expect(result.path).toBe("/api/v2/files/mkdir");
+      expect(result.body).toBe(JSON.stringify({ path: "/new-dir" }));
+    });
+
+    it("handles leading/trailing whitespace", () => {
+      const result = expectHttp("  ls /workspace  ");
+      expect(result.method).toBe("GET");
+    });
+  });
+
+  // =========================================================================
+  // Raw HTTP methods → HttpCommand
+  // =========================================================================
+  describe("raw HTTP methods (type: http)", () => {
+    it("GET /api/v2/health", () => {
+      const result = expectHttp("GET /api/v2/health");
+      expect(result.method).toBe("GET");
+      expect(result.path).toBe("/api/v2/health");
+      expect(result.body).toBe("");
+    });
+
+    it("POST with JSON body", () => {
+      const result = expectHttp('POST /api/v2/files/write {"path": "/test.txt", "content": "hello"}');
+      expect(result.method).toBe("POST");
+      expect(result.path).toBe("/api/v2/files/write");
+      expect(result.body).toBe('{"path": "/test.txt", "content": "hello"}');
+    });
+
+    it("PUT without body", () => {
+      const result = expectHttp("PUT /api/v2/files/touch");
+      expect(result.method).toBe("PUT");
+      expect(result.path).toBe("/api/v2/files/touch");
+      expect(result.body).toBe("");
+    });
+
+    it("PATCH with body", () => {
+      const result = expectHttp('PATCH /api/v2/agents/1 {"name": "updated"}');
+      expect(result.method).toBe("PATCH");
+      expect(result.body).toBe('{"name": "updated"}');
+    });
+
+    it("DELETE path", () => {
+      const result = expectHttp("DELETE /api/v2/files?path=/test.txt");
+      expect(result.method).toBe("DELETE");
+      expect(result.path).toBe("/api/v2/files?path=/test.txt");
+    });
+
+    it("HEAD request", () => {
+      const result = expectHttp("HEAD /api/v2/health");
+      expect(result.method).toBe("HEAD");
+    });
+
+    it("OPTIONS request", () => {
+      const result = expectHttp("OPTIONS /api/v2/files");
+      expect(result.method).toBe("OPTIONS");
+    });
+
+    it("case-insensitive method", () => {
+      const result = expectHttp("get /api/v2/health");
+      expect(result.method).toBe("GET");
+    });
+
+    it("mixed case method", () => {
+      const result = expectHttp("Post /api/v2/files/write");
+      expect(result.method).toBe("POST");
+    });
+  });
+
+  // =========================================================================
+  // Local commands (! prefix) → LocalCommand (Decision 4A: allowlist)
+  // =========================================================================
+  describe("local commands (type: local)", () => {
+    it("!init", () => {
+      const result = expectLocal("!init");
+      expect(result.command).toBe("init");
+      expect(result.args).toEqual([]);
+    });
+
+    it("!init --preset shared", () => {
+      const result = expectLocal("!init --preset shared");
+      expect(result.command).toBe("init");
+      expect(result.args).toEqual(["--preset", "shared"]);
+    });
+
+    it("!build", () => {
+      const result = expectLocal("!build");
+      expect(result.command).toBe("build");
+      expect(result.args).toEqual([]);
+    });
+
+    it("!demo init", () => {
+      const result = expectLocal("!demo init");
+      expect(result.command).toBe("demo");
+      expect(result.args).toEqual(["init"]);
+    });
+
+    it("!brick mount my-brick", () => {
+      const result = expectLocal("!brick mount my-brick");
+      expect(result.command).toBe("brick");
+      expect(result.args).toEqual(["mount", "my-brick"]);
+    });
+
+    it("!agent spawn", () => {
+      const result = expectLocal("!agent spawn");
+      expect(result.command).toBe("agent");
+      expect(result.args).toEqual(["spawn"]);
+    });
+
+    it("handles leading whitespace after !", () => {
+      const result = expectLocal("!  init --preset demo");
+      expect(result.command).toBe("init");
+      expect(result.args).toEqual(["--preset", "demo"]);
+    });
+
+    it("handles leading whitespace before !", () => {
+      const result = expectLocal("  !init");
+      expect(result.command).toBe("init");
+    });
+
+    it("rejects commands not in allowlist", () => {
+      expect(parseCommand("!rm /important")).toBeNull();
+      expect(parseCommand("!migrate --force")).toBeNull();
+      expect(parseCommand("!cat /etc/passwd")).toBeNull();
+      expect(parseCommand("!status")).toBeNull();
+    });
+  });
+});

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -2,8 +2,13 @@
 
 This module provides the main CLI entry point for the Nexus command-line tool.
 It creates the main command group and registers all commands from the modular structure.
+
+When invoked with no subcommand, ``nexus`` execs into the TUI (``nexus-tui``).
 """
 
+import os
+import shutil
+import sys
 import warnings
 
 import click
@@ -21,7 +26,47 @@ warnings.filterwarnings("ignore", message="Couldn't find ffmpeg or avconv", cate
 setup_uvloop()
 
 
-@click.group(cls=LazyCommandGroup)
+# ---------------------------------------------------------------------------
+# TUI launcher helpers
+# ---------------------------------------------------------------------------
+
+
+def _exec_tui(extra_args: list[str] | None = None) -> None:
+    """Replace the current process with the TUI.
+
+    Prefers a locally-installed ``nexus-tui`` binary (faster startup) and
+    falls back to ``bunx nexus-tui``.  If neither is available, prints a
+    helpful error and exits with code 1.
+    """
+    args = extra_args or []
+
+    # Fast path: nexus-tui already on PATH
+    nexus_tui = shutil.which("nexus-tui")
+    if nexus_tui is not None:
+        os.execvp(nexus_tui, ["nexus-tui", *args])
+        # execvp does not return
+
+    # Fallback: use bunx (Bun's npx equivalent)
+    bunx = shutil.which("bunx")
+    if bunx is not None:
+        os.execvp(bunx, ["bunx", "nexus-tui", *args])
+        # execvp does not return
+
+    # Neither found – give the user actionable guidance.
+    click.secho("Error: could not find nexus-tui or bunx on PATH.", fg="red", err=True)
+    click.echo(
+        "Install the TUI with:\n  npm install -g nexus-tui   # or\n  bun install -g nexus-tui\n",
+        err=True,
+    )
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Main CLI group
+# ---------------------------------------------------------------------------
+
+
+@click.group(cls=LazyCommandGroup, invoke_without_command=True)
 @click.version_option(version=nexus.__version__, prog_name="nexus")
 @click.option(
     "--profile",
@@ -35,7 +80,12 @@ def main(ctx: click.Context, profile: str | None) -> None:
 
     Beautiful command-line interface for file operations, discovery, and management.
 
+    When invoked without a subcommand the interactive TUI is launched.
+
     Examples:
+        # Launch the TUI
+        nexus
+
         # Initialize a workspace
         nexus init ./my-workspace
 
@@ -71,6 +121,43 @@ def main(ctx: click.Context, profile: str | None) -> None:
     """
     ctx.ensure_object(dict)
     ctx.obj["profile"] = profile
+
+    # When no subcommand is supplied, launch the TUI.
+    if ctx.invoked_subcommand is None:
+        _exec_tui()
+
+
+# ---------------------------------------------------------------------------
+# Explicit ``nexus tui`` subcommand (convenience / backward-compat alias)
+# ---------------------------------------------------------------------------
+
+
+@main.command("tui")
+@click.option("--url", default=None, help="Nexus server URL.")
+@click.option("--api-key", default=None, help="API key for authentication.")
+@click.option("--agent-id", default=None, help="Agent ID to connect as.")
+@click.option("--subject", default=None, help="Subject (user) identity.")
+@click.option("--zone-id", default=None, help="Zone ID to target.")
+def tui_cmd(
+    url: str | None,
+    api_key: str | None,
+    agent_id: str | None,
+    subject: str | None,
+    zone_id: str | None,
+) -> None:
+    """Launch the Nexus interactive TUI."""
+    args: list[str] = []
+    if url is not None:
+        args.extend(["--url", url])
+    if api_key is not None:
+        args.extend(["--api-key", api_key])
+    if agent_id is not None:
+        args.extend(["--agent-id", agent_id])
+    if subject is not None:
+        args.extend(["--subject", subject])
+    if zone_id is not None:
+        args.extend(["--zone-id", zone_id])
+    _exec_tui(args)
 
 
 # Register all commands from the modular structure


### PR DESCRIPTION
## Summary

Closes #3078

Unify the CLI and TUI into a single entry point so users can do everything from the TUI — including local operations like `nexus init`, `nexus build`, and `nexus demo` that currently require leaving the TUI.

- **`nexus` with no args** now launches the TUI (execs `nexus-tui` via `os.execvp()`)
- **`!` prefix** in Console `:` command mode runs local nexus subcommands (strict allowlist: init, build, demo, brick, agent)
- **Pre-connection screen** guides setup when server is unavailable (init, retry, auto-poll)
- **`Shift+B`** in Console panel runs `nexus build`; **`n`** in Agents panel spawns agent
- **89 new tests** covering parser, command runner, connection lifecycle, and detection logic

## Changes

### Python CLI (`main.py`)
- `nexus` with no subcommand execs into `nexus-tui` via `os.execvp()`
- Added `nexus tui` subcommand with `--url`, `--api-key`, `--agent-id`, `--subject`, `--zone-id`

### Command Runner (new `services/command-runner.ts`)
- `Bun.spawn()` wrapper with strict allowlist for defense-in-depth
- Streaming output: windowed buffer (200 lines) + throttled re-renders (100ms)
- Process lifecycle with `killAllProcesses()` for clean shutdown

### Pre-Connection Screen (new component)
- Shown when server is unavailable instead of error in status bar
- Offers `nexus init` (local/shared), manual retry, opt-in auto-poll (5s)
- Pure `detectConnectionState()` function (testable, follows `detectFreshServer` pattern)

### Console Panel
- `!` prefix in `:` command mode for local nexus subcommands
- Discriminated union `ParsedCommand` (`HttpCommand | LocalCommand`)
- `Shift+B` keybinding for `nexus build`

### Code Quality
- Consolidated dual connection-checking into global store (eliminated DRY violation)
- Replaced `process.exit(0)` with proper `shutdown()` + `killAllProcesses()`
- Removed 30 lines of duplicate connection logic from `index.tsx`

## Test plan

- [x] 89 new tests (674 total, all passing)
  - `parseCommand`: 31 tests (CLI shortcuts, HTTP methods, local commands, allowlist)
  - Command history: 10 tests (navigation, input mode)
  - Connection lifecycle: 10 tests (happy path, errors, auth failures, reconnection)
  - Connection state detection: 16 tests (all 5 states)
  - Command runner: 22 tests (store ops, allowlist enforcement, process mgmt, real `Bun.spawn()` integration)
- [ ] Manual: run `nexus` with no args → TUI launches
- [ ] Manual: run `nexus init` → CLI mode works
- [ ] Manual: in TUI Console, type `:!init --help` → local command output rendered
- [ ] Manual: disconnect server → PreConnectionScreen shown with init/retry options
- [ ] Manual: `Shift+B` in Console → build command runs
- [ ] Manual: `n` in Agents panel → agent spawn runs