### PR TITLE
refactor(#1509): delete PM.resume() + spawn in RUNNING state

### DIFF
--- a/src/nexus/contracts/protocols/process_manager.py
+++ b/src/nexus/contracts/protocols/process_manager.py
@@ -1,6 +1,6 @@
 """ProcessManager protocol — agent process lifecycle contract.
 
-Defines the kernel contract for agent process creation, resumption,
+Defines the kernel contract for agent process creation,
 signaling, and termination. Modeled after Linux kernel/fork.c,
 kernel/exit.c, and kernel/signal.c.
 
@@ -9,13 +9,10 @@ Design doc: docs/design/AGENT-PROCESS-ARCHITECTURE.md §5.2.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from nexus.contracts.llm_types import Message
     from nexus.system_services.agent_runtime.types import (
-        AgentEvent,
         AgentProcess,
         AgentProcessConfig,
         AgentSignal,
@@ -28,8 +25,8 @@ class ProcessManagerProtocol(Protocol):
 
     Linux analogue: kernel/fork.c + kernel/exit.c + kernel/signal.c.
 
-    Manages agent processes: creation (fork/exec), message handling
-    (resume), termination (exit), and signaling (steering messages).
+    Manages agent processes: creation (fork/exec), termination (exit),
+    and signaling (steering messages).
     """
 
     async def spawn(
@@ -43,21 +40,8 @@ class ProcessManagerProtocol(Protocol):
         """Create a new agent process (fork+exec).
 
         Allocates PID, creates home directory in NexusFS, writes
-        SYSTEM.md and settings.json, registers with AgentRegistry,
-        and stores process in the in-memory process table.
-        """
-        ...
-
-    async def resume(
-        self,
-        pid: str,
-        message: Message,
-    ) -> AsyncIterator[AgentEvent]:
-        """Send a message to an agent process and run the agent loop.
-
-        Loads process state, builds AgentContext (system prompt +
-        memory + conversation history), runs the agent loop, saves
-        checkpoint, and yields AgentEvents as they arrive.
+        SYSTEM.md and settings.json, and stores process in the
+        in-memory process table.
         """
         ...
 
@@ -88,7 +72,7 @@ class ProcessManagerProtocol(Protocol):
         """Send a signal to an agent process.
 
         SIGSTOP -> suspend (transition to STOPPED)
-        SIGCONT -> resume (transition to SLEEPING)
+        SIGCONT -> continue (transition to SLEEPING)
         SIGTERM -> graceful shutdown
         SIGKILL -> immediate termination
         SIGUSR1 -> steering message injection

--- a/src/nexus/core/process_table.py
+++ b/src/nexus/core/process_table.py
@@ -169,7 +169,7 @@ class ProcessTable:
             owner_id=owner_id,
             zone_id=zone_id,
             kind=kind,
-            state=ProcessState.CREATED,
+            state=ProcessState.RUNNING,
             cwd=cwd,
             external_info=external_info,
             labels=labels or {},

--- a/src/nexus/system_services/agent_runtime/process_manager.py
+++ b/src/nexus/system_services/agent_runtime/process_manager.py
@@ -1,6 +1,6 @@
 """ProcessManager — agent process lifecycle orchestrator.
 
-Manages agent processes: spawn, resume, terminate, signal.
+Manages agent processes: spawn, terminate, signal, list.
 In-memory process table for Phase 1 (single-node).
 
 Design doc: docs/design/AGENT-PROCESS-ARCHITECTURE.md §5.2, §10.
@@ -9,26 +9,18 @@ Design doc: docs/design/AGENT-PROCESS-ARCHITECTURE.md §5.2, §10.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import uuid
-from collections.abc import AsyncIterator
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from nexus.contracts.llm_types import Message
-from nexus.system_services.agent_runtime.loop import agent_loop
 from nexus.system_services.agent_runtime.session_store import SessionStore
-from nexus.system_services.agent_runtime.tool_dispatcher import ToolDispatcher
 from nexus.system_services.agent_runtime.types import (
-    AgentContext,
-    AgentEvent,
     AgentProcess,
     AgentProcessConfig,
     AgentProcessState,
     AgentSignal,
-    Error,
 )
 
 if TYPE_CHECKING:
@@ -46,7 +38,7 @@ _DEFAULT_SYSTEM_PROMPT = (
 
 
 class ProcessManager:
-    """Manages agent process lifecycle: spawn, resume, terminate.
+    """Manages agent process lifecycle: spawn, terminate, signal.
 
     In-memory process table (single-node Phase 1).
     """
@@ -67,7 +59,6 @@ class ProcessManager:
         self._scheduler = scheduler
         self._session_store = SessionStore(vfs)
         self._processes: dict[str, AgentProcess] = {}
-        self._dispatchers: dict[str, ToolDispatcher] = {}  # cached per process
         self._tasks: dict[str, asyncio.Task[None]] = {}  # running loop tasks per PID
 
     # ------------------------------------------------------------------
@@ -162,156 +153,6 @@ class ProcessManager:
         return process
 
     # ------------------------------------------------------------------
-    # resume
-    # ------------------------------------------------------------------
-
-    async def resume(
-        self,
-        pid: str,
-        message: Message,
-    ) -> AsyncIterator[AgentEvent]:
-        """Send a message to an agent process and run the agent loop.
-
-        1. Load AgentProcess from table.
-        2. Build OperationContext.
-        3. Read SYSTEM.md + MEMORY.md from VFS.
-        4. Load checkpoint (conversation history) from CAS.
-        5. Build AgentContext.
-        6. Transition SLEEPING->RUNNING.
-        7. Run agent_loop() with event callback.
-        8. Save checkpoint to CAS.
-        9. Transition RUNNING->SLEEPING.
-        10. Yield AgentEvents.
-        """
-        process = self._processes.get(pid)
-        if process is None:
-            yield Error(error=f"Process not found: {pid}")
-            return
-
-        if process.state == AgentProcessState.RUNNING:
-            yield Error(error=f"Process {pid} is already running")
-            return
-
-        config = process.config
-        if config is None:
-            yield Error(error=f"Process {pid} has no config")
-            return
-
-        ctx = _make_system_context(process.owner_id, process.zone_id)
-
-        # Transition to RUNNING
-        process = replace(
-            process,
-            state=AgentProcessState.RUNNING,
-            last_scheduled=datetime.now(UTC),
-        )
-        self._processes[pid] = process
-
-        # Load system prompt from VFS
-        system_prompt = _DEFAULT_SYSTEM_PROMPT
-        if process.system_prompt_path:
-            try:
-                raw = await self._vfs.sys_read(process.system_prompt_path, context=ctx)
-                if isinstance(raw, dict):
-                    raw = raw.get("content", b"")
-                if isinstance(raw, bytes):
-                    system_prompt = raw.decode("utf-8", errors="replace")
-            except Exception as exc:
-                logger.warning("Failed to read SYSTEM.md for %s: %s", pid, exc)
-
-        # Load MEMORY.md if it exists
-        memory_path = f"{process.cwd}/MEMORY.md"
-        memory_content = ""
-        try:
-            if await self._vfs.sys_access(memory_path, context=ctx):
-                raw = await self._vfs.sys_read(memory_path, context=ctx)
-                if isinstance(raw, dict):
-                    raw = raw.get("content", b"")
-                if isinstance(raw, bytes):
-                    memory_content = raw.decode("utf-8", errors="replace")
-        except Exception:
-            pass  # MEMORY.md is optional
-
-        if memory_content:
-            system_prompt += f"\n\n## Working Memory\n\n{memory_content}"
-
-        # Load checkpoint (previous conversation)
-        prev_messages = await self._session_store.load(pid, ctx, cwd=process.cwd)
-
-        # Build message list: previous + new user message
-        messages = list(prev_messages)
-        messages.append(message)
-
-        # Get or create cached ToolDispatcher for this process
-        dispatcher = self._dispatchers.get(pid)
-        if dispatcher is None:
-            dispatcher = ToolDispatcher(
-                self._vfs,
-                self._sandbox,
-                default_cwd=process.cwd,
-            )
-            self._dispatchers[pid] = dispatcher
-        tools = dispatcher.get_tool_definitions(config.tools)
-
-        # Build context
-        agent_context = AgentContext(
-            system_prompt=system_prompt,
-            messages=tuple(messages),
-            tools=tuple(tools),
-        )
-
-        # Queue-based streaming: events arrive as they happen
-        queue: asyncio.Queue[AgentEvent | None] = asyncio.Queue(maxsize=256)
-        agent_cwd = process.cwd  # capture before closure
-
-        async def _on_event(event: AgentEvent) -> None:
-            await queue.put(event)
-
-        async def _on_checkpoint(messages: list[Message]) -> None:
-            await self._session_store.save(pid, messages, ctx, cwd=agent_cwd)
-
-        async def _run_loop() -> None:
-            try:
-                result_messages = await agent_loop(
-                    llm=self._llm,
-                    dispatcher=dispatcher,
-                    context=agent_context,
-                    config=config,
-                    ctx=ctx,
-                    on_event=_on_event,
-                    on_checkpoint=_on_checkpoint,
-                    cwd=agent_cwd,
-                    sandbox_id=config.sandbox_id,
-                )
-                # Final save (captures the last assistant message / Completed)
-                await self._session_store.save(pid, result_messages, ctx, cwd=agent_cwd)
-            except Exception as exc:
-                error_msg = f"Agent loop failed for {pid}: {exc}"
-                logger.error(error_msg)
-                await queue.put(Error(error=error_msg))
-            finally:
-                self._tasks.pop(pid, None)
-                await queue.put(None)  # sentinel
-
-        task = asyncio.create_task(_run_loop())
-        self._tasks[pid] = task
-        try:
-            while True:
-                event = await queue.get()
-                if event is None:
-                    break
-                yield event
-        finally:
-            if not task.done():
-                task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-            self._tasks.pop(pid, None)
-            # Transition to SLEEPING
-            process = replace(process, state=AgentProcessState.SLEEPING)
-            self._processes[pid] = process
-
-    # ------------------------------------------------------------------
     # get_process
     # ------------------------------------------------------------------
 
@@ -358,7 +199,6 @@ class ProcessManager:
 
         # Remove from process table + caches
         self._processes.pop(pid, None)
-        self._dispatchers.pop(pid, None)
         self._session_store.clear_cache(pid)
 
         logger.info(

--- a/src/nexus/system_services/agent_runtime/types.py
+++ b/src/nexus/system_services/agent_runtime/types.py
@@ -137,7 +137,7 @@ class ToolDefinition:
 
 @dataclass(frozen=True, slots=True)
 class AgentContext:
-    """Execution context built by ProcessManager.resume().
+    """Execution context for an agent process.
 
     Contains everything the agent loop needs to run:
     system prompt, conversation history, and tool schemas.

--- a/tests/unit/core/test_process_table.py
+++ b/tests/unit/core/test_process_table.py
@@ -49,7 +49,7 @@ class TestSpawn:
         assert desc.name == "agent-1"
         assert desc.owner_id == OWNER
         assert desc.zone_id == ZONE
-        assert desc.state == ProcessState.CREATED
+        assert desc.state == ProcessState.RUNNING
         assert desc.kind == ProcessKind.MANAGED
         assert len(desc.pid) == 12
 
@@ -120,10 +120,10 @@ class TestSpawn:
         pt = _make_table()
         pt.spawn("a1", OWNER, ZONE)
         desc = pt.spawn("a2", OWNER, ZONE)
-        # Transition a2 to RUNNING
-        pt._transition(desc, ProcessState.RUNNING)
-        assert len(pt.list_processes(state=ProcessState.CREATED)) == 1
+        # Transition a2 to SLEEPING
+        pt._transition(desc, ProcessState.SLEEPING)
         assert len(pt.list_processes(state=ProcessState.RUNNING)) == 1
+        assert len(pt.list_processes(state=ProcessState.SLEEPING)) == 1
 
     def test_spawn_persists_to_metastore(self) -> None:
         ms = DictMetastore()

--- a/tests/unit/core/test_process_table.py
+++ b/tests/unit/core/test_process_table.py
@@ -138,35 +138,32 @@ class TestSpawn:
 
 
 # ---------------------------------------------------------------------------
-# State Transitions
+# State Transitions (spawn creates processes in RUNNING state)
 # ---------------------------------------------------------------------------
 
 
 class TestTransitions:
-    def test_created_to_running(self) -> None:
+    def test_spawn_starts_running(self) -> None:
+        """spawn() creates processes directly in RUNNING state."""
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        updated = pt._transition(desc, ProcessState.RUNNING)
-        assert updated.state == ProcessState.RUNNING
+        assert desc.state == ProcessState.RUNNING
 
     def test_running_to_sleeping(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         updated = pt._transition(desc, ProcessState.SLEEPING)
         assert updated.state == ProcessState.SLEEPING
 
     def test_running_to_stopped(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         updated = pt._transition(desc, ProcessState.STOPPED)
         assert updated.state == ProcessState.STOPPED
 
     def test_stopped_to_sleeping(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         desc = pt._transition(desc, ProcessState.STOPPED)
         updated = pt._transition(desc, ProcessState.SLEEPING)
         assert updated.state == ProcessState.SLEEPING
@@ -174,13 +171,13 @@ class TestTransitions:
     def test_invalid_transition_raises(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
+        # RUNNING→CREATED is invalid
         with pytest.raises(InvalidTransitionError):
-            pt._transition(desc, ProcessState.SLEEPING)  # CREATED→SLEEPING invalid
+            pt._transition(desc, ProcessState.CREATED)
 
     def test_zombie_is_terminal(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         desc = pt._transition(desc, ProcessState.ZOMBIE)
         with pytest.raises(InvalidTransitionError):
             pt._transition(desc, ProcessState.RUNNING)
@@ -192,7 +189,7 @@ class TestTransitions:
 
 
 # ---------------------------------------------------------------------------
-# Signals
+# Signals (spawn creates in RUNNING — no extra transition needed)
 # ---------------------------------------------------------------------------
 
 
@@ -200,14 +197,12 @@ class TestSignals:
     def test_sigstop(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         updated = pt.signal(desc.pid, ProcessSignal.SIGSTOP)
         assert updated.state == ProcessState.STOPPED
 
     def test_sigcont(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         desc = pt.signal(desc.pid, ProcessSignal.SIGSTOP)
         updated = pt.signal(desc.pid, ProcessSignal.SIGCONT)
         assert updated.state == ProcessState.SLEEPING
@@ -215,14 +210,12 @@ class TestSignals:
     def test_sigterm(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         updated = pt.signal(desc.pid, ProcessSignal.SIGTERM)
         assert updated.state == ProcessState.ZOMBIE
 
     def test_sigkill(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         pt.signal(desc.pid, ProcessSignal.SIGKILL)
         # SIGKILL reaps immediately
         assert pt.get(desc.pid) is None
@@ -249,7 +242,6 @@ class TestKillReap:
     def test_kill_orphan_auto_reaps(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.RUNNING)
         pt.kill(desc.pid)
         assert pt.get(desc.pid) is None  # reaped
 
@@ -257,7 +249,6 @@ class TestKillReap:
         pt = _make_table()
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
-        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
         pt.kill(child.pid)
         # Not reaped — parent can wait()
         zombie = pt.get(child.pid)
@@ -273,7 +264,6 @@ class TestKillReap:
         pt = _make_table()
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
-        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
         pt.kill(child.pid)
         # Kill again — should be idempotent
         result = pt.kill(child.pid)
@@ -283,7 +273,6 @@ class TestKillReap:
         pt = _make_table()
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
-        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
         # SIGKILL forces immediate reap
         pt.signal(child.pid, ProcessSignal.SIGKILL)
         updated_parent = pt.get(parent.pid)
@@ -302,7 +291,6 @@ class TestWait:
         pt = _make_table()
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
-        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
         pt.kill(child.pid)  # ZOMBIE (not reaped — has parent)
         result = await pt.wait(child.pid)
         assert result is not None
@@ -313,7 +301,6 @@ class TestWait:
         pt = _make_table()
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
-        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
 
         async def _killer() -> None:
             await asyncio.sleep(0.05)
@@ -342,7 +329,6 @@ class TestWait:
     async def test_wait_custom_target_states(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        pt._transition(desc, ProcessState.RUNNING)
 
         async def _stopper() -> None:
             await asyncio.sleep(0.05)
@@ -363,7 +349,6 @@ class TestWait:
         pt = _make_table()
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
-        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
 
         results: list[ProcessDescriptor | None] = []
 
@@ -418,7 +403,6 @@ class TestExternalProcesses:
     def test_unregister_external(self) -> None:
         pt = _make_table()
         desc = pt.register_external("agent", OWNER, ZONE, connection_id="c1")
-        pt._transition(pt.get(desc.pid), ProcessState.RUNNING)
         pt.unregister_external(desc.pid)
         assert pt.get(desc.pid) is None  # reaped
 
@@ -432,16 +416,16 @@ class TestRecovery:
     def test_recover_running_becomes_zombie(self) -> None:
         ms = DictMetastore()
         pt = ProcessTable(ms, zone_id=ZONE)
-        desc = pt.spawn("a", OWNER, ZONE)
-        pt._transition(desc, ProcessState.RUNNING)
+        pt.spawn("a", OWNER, ZONE)  # RUNNING
 
         # New ProcessTable on same metastore
         pt2 = ProcessTable(ms, zone_id=ZONE)
         recovered = pt2.recover()
         assert recovered == 1
-        result = pt2.get(desc.pid)
-        assert result is not None
-        assert result.state == ProcessState.ZOMBIE
+        # Find the recovered process
+        procs = pt2.list_processes()
+        assert len(procs) == 1
+        assert procs[0].state == ProcessState.ZOMBIE
 
     def test_recover_external_deleted(self) -> None:
         ms = DictMetastore()
@@ -458,7 +442,6 @@ class TestRecovery:
         pt = ProcessTable(ms, zone_id=ZONE)
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
-        pt._transition(pt.get(child.pid), ProcessState.RUNNING)
         pt.kill(child.pid)  # ZOMBIE
 
         pt2 = ProcessTable(ms, zone_id=ZONE)
@@ -469,8 +452,7 @@ class TestRecovery:
     def test_close_all(self) -> None:
         pt = _make_table()
         pt.spawn("a", OWNER, ZONE)
-        desc = pt.spawn("b", OWNER, ZONE)
-        pt._transition(desc, ProcessState.RUNNING)
+        pt.spawn("b", OWNER, ZONE)
         pt.close_all()
         assert len(pt.list_processes()) == 0
 


### PR DESCRIPTION
## Summary
- Delete `ProcessManager.resume()` — 0 callers, dead code from Phase 1 in-process agent_loop design. Removes unused imports (agent_loop, ToolDispatcher, AgentContext, AgentEvent, Error, Message).
- Remove `resume()` from `ProcessManagerProtocol` contract.
- Change `ProcessTable.spawn()` initial state from CREATED → RUNNING. CREATED→RUNNING was the only valid transition from CREATED, making the two-step spawn+start unnecessary.

## Test plan
- [x] mypy passes on all changed files
- [x] ruff check + format passes
- [x] All pre-commit hooks pass
- [ ] CI green on ProcessTable unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)