### PR TITLE
refactor(#1665): VFSPathResolver — eliminate matches() + match_ctx

### DIFF
--- a/src/nexus/bricks/parsers/virtual_view_resolver.py
+++ b/src/nexus/bricks/parsers/virtual_view_resolver.py
@@ -28,11 +28,10 @@ logger = logging.getLogger(__name__)
 class VirtualViewResolver(VFSPathResolver):
     """PRE-DISPATCH resolver for virtual parsed view paths.
 
-    Implements ``VFSPathResolver`` protocol:
-    - ``matches(path)`` — routing predicate
-    - ``read(path, ...)`` — read original file + parse to markdown
-    - ``write(path, content)`` — always raises (read-only)
-    - ``delete(path, ...)`` — always raises (read-only)
+    Implements ``VFSPathResolver`` single-call ``try_*`` protocol (#1665):
+    - ``try_read(path, ...)`` — check if virtual view, read + parse to markdown
+    - ``try_write(path, content)`` — raises if virtual view, else returns None
+    - ``try_delete(path, ...)`` — raises if virtual view, else returns None
 
     Dependencies injected via constructor:
     - metadata: MetastoreABC (file existence + metadata lookup)
@@ -78,38 +77,20 @@ class VirtualViewResolver(VFSPathResolver):
         self._read_tracker_fn = read_tracker_fn
 
     # ------------------------------------------------------------------
-    # VFSPathResolver protocol
+    # VFSPathResolver single-call try_* protocol (#1665)
     # ------------------------------------------------------------------
 
-    def matches(self, path: str) -> Any:
-        """Return parsed path context if *path* is a virtual parsed view, None otherwise."""
-        from nexus.lib.virtual_views import parse_virtual_path
-
-        original_path, view_type = parse_virtual_path(path, self._metadata.exists)
-        if view_type == "md":
-            return (original_path, view_type)
-        return None
-
-    def read(
-        self,
-        path: str,
-        *,
-        match_ctx: Any = None,
-        return_metadata: bool = False,
-        context: Any = None,
-    ) -> bytes | dict[str, Any]:
-        """Read virtual parsed view."""
+    def try_read(
+        self, path: str, *, return_metadata: bool = False, context: Any = None
+    ) -> bytes | dict[str, Any] | None:
+        """Read virtual parsed view, or return None if not a virtual view."""
         from nexus.lib.virtual_views import get_parsed_content, parse_virtual_path
 
-        if match_ctx is not None:
-            original_path, view_type = match_ctx
-        else:
-            original_path, view_type = parse_virtual_path(path, self._metadata.exists)
+        original_path, view_type = parse_virtual_path(path, self._metadata.exists)
         if view_type != "md":
-            raise NexusFileNotFoundError(f"Not a virtual view: {path}")
+            return None
 
         # Permission check — resolver owns its permission semantics.
-        # The checker resolves virtual paths to the original file internally.
         self._permission_checker.check(path, Permission.READ, context)
 
         logger.info("read: Virtual view detected, reading original file: %s", original_path)
@@ -152,12 +133,23 @@ class VirtualViewResolver(VFSPathResolver):
             }
         return content
 
-    def write(self, path: str, content: bytes, *, match_ctx: Any = None) -> dict[str, Any]:
-        """Virtual views are read-only."""
-        _ = match_ctx  # Protocol-required; virtual views are read-only
-        raise NexusFileNotFoundError(f"Cannot write to virtual view: {path} ({len(content)} bytes)")
+    def try_write(self, path: str, content: bytes) -> dict[str, Any] | None:
+        """Virtual views are read-only — raise if virtual view, else return None."""
+        from nexus.lib.virtual_views import parse_virtual_path
 
-    def delete(self, path: str, *, match_ctx: Any = None, context: Any = None) -> None:
-        """Virtual views are read-only."""
-        _ = (match_ctx, context)  # Protocol-required; virtual views are read-only
-        raise NexusFileNotFoundError(f"Cannot delete virtual view: {path}")
+        _, view_type = parse_virtual_path(path, self._metadata.exists)
+        if view_type == "md":
+            raise NexusFileNotFoundError(
+                f"Cannot write to virtual view: {path} ({len(content)} bytes)"
+            )
+        return None
+
+    def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None:
+        """Virtual views are read-only — raise if virtual view, else return None."""
+        from nexus.lib.virtual_views import parse_virtual_path
+
+        _ = context
+        _, view_type = parse_virtual_path(path, self._metadata.exists)
+        if view_type == "md":
+            raise NexusFileNotFoundError(f"Cannot delete virtual view: {path}")
+        return None

--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -245,36 +245,24 @@ class VFSObserver(Protocol):
 
 @runtime_checkable
 class VFSPathResolver(Protocol):
-    """PRE-DISPATCH resolver for virtual paths (Issue #889).
+    """PRE-DISPATCH resolver for virtual paths (Issue #889, #1665).
 
     Linux analogue: virtual filesystem dispatch (procfs, sysfs, devtmpfs).
-    When read()/write()/delete() is called on a path claimed by a resolver,
-    the resolver handles the entire operation — the normal VFS pipeline is
-    skipped.  Each resolver owns its own permission semantics.
+    When a path is claimed by a resolver, the resolver handles the entire
+    operation — the normal VFS pipeline is skipped.  Each resolver owns
+    its own permission semantics.
+
+    Single-call ``try_*`` pattern: each method returns ``None`` when the
+    resolver does not claim the path ("not my path"), or the operation
+    result when it does.  This eliminates the old two-phase
+    ``matches()`` + ``read/write/delete()`` dispatch.
 
     Registered at boot via factory into KernelDispatch.  Empty resolver
     chain = no-op = zero overhead when no resolvers registered.
-
-    Two-phase dispatch:
-        1. ``matches(path)`` — returns truthy match context (e.g. metadata)
-           or ``None``.  The match context is passed to the subsequent
-           operation to avoid redundant lookups.
-        2. ``read/write/delete(path, match_ctx=...)`` — executes using
-           the cached match context from ``matches()``.
-
-    Note: ``matches()`` is never called standalone — always paired with
-    an operation.  Future cleanup (#1665) will merge match+op into a
-    single-call pattern.
     """
 
-    def matches(self, path: str) -> Any: ...
-    def read(
-        self,
-        path: str,
-        *,
-        match_ctx: Any = None,
-        return_metadata: bool = False,
-        context: Any = None,
-    ) -> bytes | dict: ...
-    def write(self, path: str, content: bytes, *, match_ctx: Any = None) -> dict[str, Any]: ...
-    def delete(self, path: str, *, match_ctx: Any = None, context: Any = None) -> None: ...
+    def try_read(
+        self, path: str, *, return_metadata: bool = False, context: Any = None
+    ) -> bytes | dict | None: ...
+    def try_write(self, path: str, content: bytes) -> dict[str, Any] | None: ...
+    def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None: ...

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -6,7 +6,7 @@ through three ordered phases:
 
     PRE-DISPATCH  (first-match short-circuit)
     └── Registered VFSPathResolver chain.
-        First resolver whose ``matches(path)`` returns True handles
+        First resolver whose ``try_*(path)`` returns non-None handles
         the entire operation — normal VFS pipeline is skipped.
         Each resolver owns its own permission semantics.
 
@@ -34,7 +34,7 @@ Lifecycle:
     then ``notify()``.
     Empty lists = no-op dispatch = zero overhead when no services.
 
-Issue #900, #889.
+Issue #900, #889, #1665.
 """
 
 import logging
@@ -78,7 +78,7 @@ class KernelDispatch:
         dispatch.register_observe(some_observer)
 
     Dispatch (kernel VFS call sites):
-        dispatch.resolve_read(path)          # phase 0: PRE-DISPATCH
+        dispatch.resolve_read(path)          # phase 0: PRE-DISPATCH (try_read)
         dispatch.intercept_pre_read(ctx)     # phase 1a: INTERCEPT (pre)
         ...actual VFS operation...
         dispatch.intercept_post_read(ctx)    # phase 1b: INTERCEPT (post)
@@ -126,51 +126,43 @@ class KernelDispatch:
         return_metadata: bool = False,
         context: Any = None,
     ) -> tuple[bool, Any]:
-        """PRE-DISPATCH: first-match resolver for read.
+        """PRE-DISPATCH: first-match resolver for read (#1665).
 
         Returns (handled, result):
-            handled=True,  result=content  — resolver handled the read.
-            handled=False, result=hint     — resolver passed a prefetched hint.
-            handled=False, result=None     — no resolver matched.
+            handled=True,  result=content — resolver handled the read.
+            handled=False, result=None    — no resolver matched.
 
-        Two-phase: ``matches(path)`` returns truthy match context (e.g.
-        metadata) which is passed to ``read()`` as ``match_ctx`` to avoid
-        redundant lookups.
+        Each resolver's ``try_read()`` returns the result directly, or
+        ``None`` when it does not claim the path.
         """
         for r in self._resolvers:
-            match_ctx = r.matches(path)
-            if match_ctx is not None:
-                return True, r.read(
-                    path, match_ctx=match_ctx, return_metadata=return_metadata, context=context
-                )
+            result = r.try_read(path, return_metadata=return_metadata, context=context)
+            if result is not None:
+                return True, result
         return False, None
 
     def resolve_write(self, path: str, content: bytes) -> tuple[bool, Any]:
-        """PRE-DISPATCH: first-match resolver for write.
-
-        Returns (handled, result):
-            handled=True,  result=dict   — resolver handled the write.
-            handled=False, result=None   — no resolver matched.
-        """
+        """PRE-DISPATCH: first-match resolver for write (#1665)."""
         for r in self._resolvers:
-            match_ctx = r.matches(path)
-            if match_ctx is not None:
-                return True, r.write(path, content, match_ctx=match_ctx)
+            result = r.try_write(path, content)
+            if result is not None:
+                return True, result
         return False, None
 
     def resolve_delete(self, path: str, *, context: Any = None) -> tuple[bool, Any]:
-        """PRE-DISPATCH: first-match resolver for delete.
+        """PRE-DISPATCH: first-match resolver for delete (#1665).
 
         Returns (handled, result):
-            handled=True,  result={}       — resolver handled the delete.
-            handled=False, result=hint     — resolver passed a prefetched hint.
-            handled=False, result=None     — no resolver matched.
+            handled=True,  result={}    — resolver handled the delete.
+            handled=False, result=None  — no resolver matched.
+
+        Each resolver's ``try_delete()`` returns the result directly, or
+        ``None`` when it does not claim the path.
         """
         for r in self._resolvers:
-            match_ctx = r.matches(path)
-            if match_ctx is not None:
-                r.delete(path, match_ctx=match_ctx, context=context)
-                return True, {}
+            result = r.try_delete(path, context=context)
+            if result is not None:
+                return True, result
         return False, None
 
     @property

--- a/src/nexus/raft/federation_content_resolver.py
+++ b/src/nexus/raft/federation_content_resolver.py
@@ -1,11 +1,9 @@
-"""FederationContentResolver — PRE-DISPATCH resolver for remote content (#163).
+"""FederationContentResolver — PRE-DISPATCH resolver for remote content (#163, #1665).
 
-Registered as a VFSPathResolver in KernelDispatch.  On every read/delete,
-``matches()`` looks up metadata and checks locality:
-
-    - Remote origin → returns metadata as match context → read/delete handle
-      the operation via gRPC RPC to the origin peer.
-    - Local origin  → returns None → kernel handles normally.
+Registered as a VFSPathResolver in KernelDispatch.  Each ``try_*`` method
+looks up metadata once, decides local vs remote, and either handles the
+operation (remote → returns result) or declines (local/unknown → returns
+``None``).
 
 Zero kernel coupling: the kernel sees a standard VFSPathResolver.
 Federation topology, gRPC channels, and progressive replication are
@@ -43,9 +41,10 @@ class FederationContentResolver:
     FederatedMetadataProxy (DI), which enriches ``backend_name`` with the
     writer node's address so future reads can locate content.
 
-    ``matches()`` returns metadata for remote content only (truthy match
-    context), ``None`` for local or non-existent content.  Writes always
-    pass through (matches returns None) since content writes are local.
+    Implements the single-call ``try_*`` protocol (#1665):
+    each method looks up metadata, decides local vs remote, and either
+    handles the operation (remote → returns result) or declines
+    (local/unknown → returns ``None``).
 
     Args:
         metastore: MetastoreABC for metadata lookup.
@@ -69,16 +68,23 @@ class FederationContentResolver:
         self._timeout = timeout
 
     # ------------------------------------------------------------------
-    # VFSPathResolver protocol
+    # VFSPathResolver single-call try_* protocol (#1665)
     # ------------------------------------------------------------------
 
-    def matches(self, path: str) -> Any:
-        """Check if path refers to remote content.
+    def try_read(
+        self,
+        path: str,
+        *,
+        return_metadata: bool = False,
+        context: Any = None,
+    ) -> bytes | dict | None:
+        """Single-call resolve: metadata lookup + local/remote decision.
 
-        Returns metadata (truthy) for remote content, None otherwise.
-        The metadata is passed as ``match_ctx`` to read/delete to avoid
-        redundant metastore lookups.
+        Returns:
+            bytes or dict — handled: content fetched from remote peer.
+            None          — not handled: local content or no metadata.
         """
+        _ = context  # unused, present for protocol conformance
         meta = self._metastore.get(path)
         if meta is None or not meta.backend_name:
             return None
@@ -87,25 +93,8 @@ class FederationContentResolver:
         if not addr.has_origin or addr.origin == self._self_address:
             return None  # local content — kernel handles
 
-        return meta  # remote content — resolver handles
-
-    def read(
-        self,
-        path: str,
-        *,
-        match_ctx: Any = None,
-        return_metadata: bool = False,
-        context: Any = None,
-    ) -> bytes | dict[str, Any]:
-        """Fetch content from remote origin peer via gRPC.
-
-        ``match_ctx`` is the FileMetadata returned by ``matches()``.
-        """
-        _ = context  # Protocol-required; not used for federation content
-        meta = match_ctx
-        addr = BackendAddress.parse(meta.backend_name)
-        assert addr.origin is not None
-
+        # Remote content — fetch from origin peer
+        assert addr.origin is not None  # guaranteed by has_origin check above
         file_size = meta.size or 0
         use_streaming = file_size > _STREAMING_THRESHOLD
         logger.info(
@@ -132,20 +121,36 @@ class FederationContentResolver:
             }
         return content
 
-    def write(self, path: str, content: bytes, *, match_ctx: Any = None) -> dict[str, Any]:
-        """Content writes are always local — this should never be called.
+    def try_write(self, _path: str, _content: bytes) -> dict[str, Any] | None:
+        """Content writes are always local — return None to pass through."""
+        return None
 
-        matches() returns None for writes, so KernelDispatch never reaches here.
+    def try_delete(
+        self,
+        path: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any] | None:
+        """Single-call resolve: metadata lookup + local/remote decision for delete.
+
+        Symmetric with ``try_read``. If content origin is remote, delegates
+        the full ``sys_unlink`` to the origin peer via gRPC Delete RPC.
+
+        Returns:
+            dict — handled: remote peer deleted file.
+            None — not handled: local content or no metadata.
         """
-        raise NotImplementedError("FederationContentResolver does not handle writes")
+        _ = context  # unused, present for protocol conformance
+        meta = self._metastore.get(path)
+        if meta is None or not meta.backend_name:
+            return None
 
-    def delete(self, path: str, *, match_ctx: Any = None, context: Any = None) -> None:
-        """Delete remote content via gRPC Delete RPC to origin peer."""
-        _ = context  # Protocol-required; not used for federation content
-        meta = match_ctx
         addr = BackendAddress.parse(meta.backend_name)
-        assert addr.origin is not None
+        if not addr.has_origin or addr.origin == self._self_address:
+            return None  # local content — kernel handles
 
+        # Remote content — delegate full sys_unlink to origin peer
+        assert addr.origin is not None
         logger.info(
             "Federation delete: %s -> %s (etag=%s)",
             path,
@@ -153,6 +158,7 @@ class FederationContentResolver:
             (meta.etag or "")[:12],
         )
         self._delete_on_peer(addr.origin, path)
+        return {}
 
     # === gRPC Remote Operations ===
 

--- a/tests/unit/raft/test_federation_content_resolver.py
+++ b/tests/unit/raft/test_federation_content_resolver.py
@@ -1,8 +1,11 @@
-"""Unit tests for FederationContentResolver (#163).
+"""Unit tests for FederationContentResolver (#163, #1665).
 
 Tests the PRE-DISPATCH resolver for remote content reads and deletes
 using mocks for metastore, backend, and gRPC stubs (no real network
 or Raft needed).
+
+After #1665: try_read/try_write/try_delete return result or None
+(single-call pattern, no matches() or match_ctx).
 """
 
 from unittest.mock import MagicMock, patch
@@ -35,8 +38,8 @@ def _make_resolver(**kwargs):
     )
 
 
-class TestMatchesLocalContent:
-    """matches() returns None for local content (not handled)."""
+class TestTryReadLocalContent:
+    """try_read returns None for local content (not handled)."""
 
     def test_local_origin_returns_none(self):
         meta = _make_meta(f"local@{SELF_ADDR}")
@@ -44,7 +47,9 @@ class TestMatchesLocalContent:
         metastore.get.return_value = meta
 
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/test/file.txt") is None
+        result = resolver.try_read("/test/file.txt")
+
+        assert result is None
 
     def test_no_origin_returns_none(self):
         """Legacy backend_name without origin → treated as local."""
@@ -53,14 +58,18 @@ class TestMatchesLocalContent:
         metastore.get.return_value = meta
 
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/test/file.txt") is None
+        result = resolver.try_read("/test/file.txt")
+
+        assert result is None
 
     def test_no_metadata_returns_none(self):
         metastore = MagicMock()
         metastore.get.return_value = None
 
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/nonexistent.txt") is None
+        result = resolver.try_read("/nonexistent.txt")
+
+        assert result is None
 
     def test_empty_backend_name_returns_none(self):
         meta = MagicMock()
@@ -69,32 +78,23 @@ class TestMatchesLocalContent:
         metastore.get.return_value = meta
 
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/test/file.txt") is None
+        result = resolver.try_read("/test/file.txt")
+
+        assert result is None
 
 
-class TestMatchesRemoteContent:
-    """matches() returns metadata (truthy) for remote content."""
+class TestTryReadRemoteContent:
+    """try_read returns content for remote content."""
 
-    def test_remote_origin_returns_metadata(self):
-        meta = _make_meta(f"local@{REMOTE_ADDR}")
+    @patch.object(FederationContentResolver, "_fetch_from_peer")
+    def test_remote_origin_fetches_content(self, mock_fetch):
+        mock_fetch.return_value = b"remote content"
+        meta = _make_meta(f"local@{REMOTE_ADDR}", size=100)
         metastore = MagicMock()
         metastore.get.return_value = meta
 
         resolver = _make_resolver(metastore=metastore)
-        result = resolver.matches("/test/file.txt")
-        assert result is meta
-
-
-class TestReadRemoteContent:
-    """read() fetches content from remote peer using match_ctx."""
-
-    @patch.object(FederationContentResolver, "_fetch_from_peer")
-    def test_remote_read_uses_match_ctx(self, mock_fetch):
-        mock_fetch.return_value = b"remote content"
-        meta = _make_meta(f"local@{REMOTE_ADDR}", size=100)
-
-        resolver = _make_resolver()
-        result = resolver.read("/test/file.txt", match_ctx=meta)
+        result = resolver.try_read("/test/file.txt")
 
         assert result == b"remote content"
         mock_fetch.assert_called_once_with(REMOTE_ADDR, "/test/file.txt")
@@ -103,9 +103,11 @@ class TestReadRemoteContent:
     def test_remote_with_metadata(self, mock_fetch):
         mock_fetch.return_value = b"data"
         meta = _make_meta(f"local@{REMOTE_ADDR}", etag="xyz789", version=3, size=4)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
-        result = resolver.read("/test/file.txt", match_ctx=meta, return_metadata=True)
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_read("/test/file.txt", return_metadata=True)
 
         assert result["content"] == b"data"
         assert result["etag"] == "xyz789"
@@ -117,9 +119,11 @@ class TestReadRemoteContent:
         """Files > _STREAMING_THRESHOLD use StreamRead instead of unary Read."""
         mock_stream.return_value = b"streamed content"
         meta = _make_meta(f"local@{REMOTE_ADDR}", size=2_000_000)  # 2MB > 1MB threshold
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
-        result = resolver.read("/test/large.bin", match_ctx=meta)
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_read("/test/large.bin")
 
         assert result == b"streamed content"
         mock_stream.assert_called_once_with(REMOTE_ADDR, "/test/large.bin")
@@ -129,38 +133,117 @@ class TestReadRemoteContent:
         """Files <= _STREAMING_THRESHOLD use unary Read RPC."""
         mock_fetch.return_value = b"small"
         meta = _make_meta(f"local@{REMOTE_ADDR}", size=500_000)  # 500KB < 1MB threshold
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
-        result = resolver.read("/test/small.txt", match_ctx=meta)
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_read("/test/small.txt")
 
         assert result == b"small"
         mock_fetch.assert_called_once_with(REMOTE_ADDR, "/test/small.txt")
 
 
-class TestDeleteRemoteContent:
-    """delete() delegates to remote peer using match_ctx."""
+class TestTryWritePassthrough:
+    """try_write always returns None (content writes are local)."""
+
+    def test_try_write_returns_none(self):
+        resolver = _make_resolver()
+        result = resolver.try_write("/any/path", b"data")
+
+        assert result is None
+
+
+class TestTryDeleteLocalContent:
+    """try_delete returns None for local content (not handled)."""
+
+    def test_local_origin_returns_none(self):
+        meta = _make_meta(f"local@{SELF_ADDR}")
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_delete("/test/file.txt")
+
+        assert result is None
+
+    def test_no_origin_returns_none(self):
+        meta = _make_meta("local")
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_delete("/test/file.txt")
+
+        assert result is None
+
+    def test_no_metadata_returns_none(self):
+        metastore = MagicMock()
+        metastore.get.return_value = None
+
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_delete("/nonexistent.txt")
+
+        assert result is None
+
+    def test_empty_backend_name_returns_none(self):
+        meta = MagicMock()
+        meta.backend_name = ""
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_delete("/test/file.txt")
+
+        assert result is None
+
+
+class TestTryDeleteRemoteContent:
+    """try_delete returns {} for remote content."""
 
     @patch.object(FederationContentResolver, "_delete_on_peer")
-    def test_remote_delete_delegates_to_peer(self, mock_delete):
+    def test_remote_origin_delegates_to_peer(self, mock_delete):
         meta = _make_meta(f"local@{REMOTE_ADDR}")
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
-        resolver.delete("/test/file.txt", match_ctx=meta)
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_delete("/test/file.txt")
 
+        assert result == {}
         mock_delete.assert_called_once_with(REMOTE_ADDR, "/test/file.txt")
 
     @patch.object(FederationContentResolver, "_delete_on_peer")
     def test_remote_delete_failure_propagates(self, mock_delete):
+        """gRPC failure during remote delete propagates to caller."""
         mock_delete.side_effect = Exception("network error")
         meta = _make_meta(f"local@{REMOTE_ADDR}")
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
+        resolver = _make_resolver(metastore=metastore)
         with pytest.raises(Exception, match="network error"):
-            resolver.delete("/test/file.txt", match_ctx=meta)
+            resolver.try_delete("/test/file.txt")
 
 
 class TestKernelDispatchIntegration:
-    """Verify FederationContentResolver works with new KernelDispatch matches() protocol."""
+    """Verify FederationContentResolver works with KernelDispatch."""
+
+    @patch.object(FederationContentResolver, "_fetch_from_peer")
+    def test_resolve_read_remote_returns_handled(self, mock_fetch):
+        from nexus.core.kernel_dispatch import KernelDispatch
+
+        mock_fetch.return_value = b"remote"
+        meta = _make_meta(f"local@{REMOTE_ADDR}", size=100)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+
+        resolver = _make_resolver(metastore=metastore)
+        dispatch = KernelDispatch()
+        dispatch.register_resolver(resolver)
+
+        handled, result = dispatch.resolve_read("/test/file.txt")
+        assert handled is True
+        assert result == b"remote"
 
     def test_resolve_read_local_passes_through(self):
         from nexus.core.kernel_dispatch import KernelDispatch
@@ -175,7 +258,7 @@ class TestKernelDispatchIntegration:
 
         handled, result = dispatch.resolve_read("/test/file.txt")
         assert handled is False
-        assert result is None  # local content: matches() returns None
+        assert result is None
 
     def test_resolve_read_no_metadata_passes_through(self):
         from nexus.core.kernel_dispatch import KernelDispatch
@@ -191,22 +274,16 @@ class TestKernelDispatchIntegration:
         assert handled is False
         assert result is None
 
-    @patch.object(FederationContentResolver, "_fetch_from_peer")
-    def test_resolve_read_remote_is_handled(self, mock_fetch):
+    def test_resolve_write_passes_through(self):
         from nexus.core.kernel_dispatch import KernelDispatch
 
-        mock_fetch.return_value = b"remote data"
-        meta = _make_meta(f"local@{REMOTE_ADDR}", size=100)
-        metastore = MagicMock()
-        metastore.get.return_value = meta
-
-        resolver = _make_resolver(metastore=metastore)
+        resolver = _make_resolver()
         dispatch = KernelDispatch()
         dispatch.register_resolver(resolver)
 
-        handled, result = dispatch.resolve_read("/test/file.txt")
-        assert handled is True
-        assert result == b"remote data"
+        handled, result = dispatch.resolve_write("/test/file.txt", b"data")
+        assert handled is False
+        assert result is None
 
     def test_resolve_delete_local_passes_through(self):
         from nexus.core.kernel_dispatch import KernelDispatch


### PR DESCRIPTION
## Summary
- Replace two-phase `matches()` + `read/write/delete(match_ctx=...)` dispatch with single-call `try_read/try_write/try_delete` returning `None` for "not my path"
- Simplify `KernelDispatch.resolve_*()` — no more `getattr` fallback or `match_ctx` threading
- Update all 3 resolver implementations: `FederationContentResolver`, `VirtualViewResolver`, and protocol definition

## Files changed
- `src/nexus/contracts/vfs_hooks.py` — VFSPathResolver protocol: `try_read/try_write/try_delete`
- `src/nexus/core/kernel_dispatch.py` — Simplified resolve methods
- `src/nexus/raft/federation_content_resolver.py` — Merged match+op, added `try_write`
- `src/nexus/bricks/parsers/virtual_view_resolver.py` — Merged match+op into `try_*`
- `tests/unit/raft/test_federation_content_resolver.py` — Updated for new API

## Test plan
- [x] `ruff check` passes on all modified files
- [x] `pytest tests/unit/raft/test_federation_content_resolver.py` — 22 tests pass
- [x] `resolve_*()` return type unchanged — zero nexus_fs.py changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)