### PR TITLE
fix(shm_pipe): revert incorrect gRPC-style fixes on shared-memory pipe

### DIFF
--- a/src/nexus/core/shm_pipe.py
+++ b/src/nexus/core/shm_pipe.py
@@ -160,8 +160,6 @@ class SharedRingBuffer:
             raise
         except ValueError:
             raise
-        # Wake up any blocked reader (e.g. PipedRecordStoreWriteObserver consumer)
-        self._not_empty.set()
         return int(n)
 
     def read_nowait(self) -> bytes:
@@ -180,16 +178,9 @@ class SharedRingBuffer:
             await self._not_full.wait()
 
     async def wait_readable(self) -> None:
-        import asyncio as _asyncio
-
         while self._core.is_empty() and not self._core.closed:
-            # Poll with short sleep instead of relying on Event.set() alone,
-            # because producers may run on a different event loop (e.g. gRPC
-            # async server vs. FastAPI/uvicorn loop). Event.set() from a
-            # different loop doesn't wake asyncio.Event.wait() reliably.
             self._not_empty.clear()
-            with contextlib.suppress(TimeoutError):
-                await _asyncio.wait_for(self._not_empty.wait(), timeout=0.1)
+            await self._not_empty.wait()
 
     # -- lifecycle ------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Reverts the two `shm_pipe.py` changes from PR #3093 that incorrectly applied intra-process event-loop workarounds to the cross-process shared-memory pipe.

`SharedRingBuffer` is for **inter-process** IPC via mmap + OS pipe fd notifications — it does **not** use cross-loop `asyncio.Event` signaling. The gRPC vs FastAPI event-loop concern from #3093 does not apply here.

### What's reverted

| Change | Why it's wrong |
|--------|----------------|
| `write_nowait()`: added `self._not_empty.set()` | Writer and reader are in **different processes** with separate Event objects. Rust core already notifies via OS pipe write-end → `_on_data_available()` callback |
| `wait_readable()`: 0.1s polling timeout | `_on_data_available()` runs on the **same event loop** as `wait_readable()` (registered via `loop.add_reader(fd)`). OS pipe fd notification is reliable. Polling added up to 100ms latency per message |

### Context: Three transport tiers

| Scenario | Module | Notification |
|----------|--------|-------------|
| Intra-process | `core/pipe.py` | `asyncio.Event` (same loop) |
| **Inter-process** | **`core/shm_pipe.py`** | **OS pipe fd + `loop.add_reader()`** |
| Cross-machine | gRPC | gRPC streaming |

The other two fixes in #3093 (`search/daemon.py` missing `await`, `piped_record_store_write_observer.py` session flush) are correct and untouched.

## Test plan
- [ ] Existing `tests/unit/core/test_shm_pipe.py` passes (requires nexus_fast build with SharedRingBufferCore)
- [ ] Cross-process pipe test: `tests/integration/core/test_shm_crossprocess.py`
- [ ] CI mypy + ruff pass