### PR TITLE
fix(versioning): skip phantom 0-byte version on FUSE file create

### DIFF
--- a/src/nexus/storage/version_recorder.py
+++ b/src/nexus/storage/version_recorder.py
@@ -109,6 +109,14 @@ class VersionRecorder:
         from nexus.storage._metadata_mapper_generated import MetadataMapper
 
         values = MetadataMapper.to_file_path_values(metadata)
+
+        # Skip version history for empty-content creates (e.g. FUSE create()
+        # writes b"" as a placeholder before the real write() populates content).
+        # Set current_version=0 so the first real write becomes version 1.
+        has_content = metadata.etag is not None and (metadata.size or 0) > 0
+        if not has_content:
+            values["current_version"] = 0
+
         file_path = FilePathModel(
             path_id=str(uuid.uuid4()),
             **values,
@@ -116,7 +124,7 @@ class VersionRecorder:
         self.session.add(file_path)
         self.session.flush()
 
-        if metadata.etag is not None:
+        if has_content:
             version_entry = VersionHistoryModel(
                 version_id=str(uuid.uuid4()),
                 resource_type="file",


### PR DESCRIPTION
## Summary

FUSE `create()` handler calls `sys_write(path, b"")` as a placeholder before the OS issues the real `write()` with actual content. This recorded a phantom version 1 (0 bytes) for every FUSE-created file, followed by version 2 with the real content.

### Fix

In `VersionRecorder._record_create`, skip `VersionHistoryModel` creation when content is empty (`size=0`) and set `current_version=0` on `FilePathModel`. The first real `write()` then increments to version 1 with actual content.

**Before:**
```
Version 1: 0 bytes (phantom from FUSE create)
Version 2: N bytes (actual content from write)
```

**After:**
```
Version 1: N bytes (actual content — clean history)
```

The `FilePathModel` is still created on `create()` (needed for `getattr()` between create and write), just without a phantom version entry.

## Test plan
- [ ] FUSE-created files show only one version (the real content)
- [ ] CLI-created files (`nexus write`) still get version 1 correctly
- [ ] `_record_update` still increments from 0→1 correctly for FUSE files
- [ ] Legitimate 0-byte file updates via `_record_update` still get versioned