### PR TITLE
fix(raft): migrate FederationIPCResolver to try_* protocol (#1665)

### DIFF
--- a/src/nexus/raft/federation_ipc_resolver.py
+++ b/src/nexus/raft/federation_ipc_resolver.py
@@ -1,18 +1,13 @@
-"""FederationIPCResolver — PRE-DISPATCH resolver for remote DT_PIPE/DT_STREAM (#1625).
+"""FederationIPCResolver — PRE-DISPATCH resolver for remote DT_PIPE/DT_STREAM (#1625, #1665).
 
-Registered as a VFSPathResolver in KernelDispatch.  On every read/write/delete,
-``matches()`` looks up metadata and checks:
+Registered as a VFSPathResolver in KernelDispatch.  Each ``try_*`` method
+looks up metadata once, decides local vs remote, and either handles the
+operation (remote → returns result) or declines (local/unknown → returns
+``None``).
 
-    1. Is this a DT_PIPE or DT_STREAM inode? (entry_type check)
-    2. Is the pipe/stream hosted on a remote node? (locality check via backend_name)
-
-If both are true, the resolver handles the operation entirely via gRPC Call/Delete
-RPCs to the origin peer.  Local pipes/streams return None from matches() and fall
-through to the kernel's normal IPC dispatch.
-
-This extracts ~200 lines of federation remote proxy from NexusFS (kernel) to the
-service layer, per federation-memo.md §6.6: "Federation is optional DI subsystem,
-NOT kernel."
+For remote IPC, operations are dispatched via gRPC Call/Delete RPCs to the
+origin peer.  Local pipes/streams return None and fall through to the
+kernel's PipeManager/StreamManager.
 
 Design reference:
     - FederationContentResolver: same pattern for CAS content
@@ -63,14 +58,13 @@ class FederationIPCResolver:
         self._timeout = timeout
 
     # ------------------------------------------------------------------
-    # VFSPathResolver protocol
+    # VFSPathResolver single-call try_* protocol (#1665)
     # ------------------------------------------------------------------
 
-    def matches(self, path: str) -> Any:
-        """Check if path refers to a remote DT_PIPE or DT_STREAM.
+    def _resolve_remote(self, path: str) -> tuple[Any, str] | None:
+        """Shared metadata lookup + locality check for try_* methods.
 
-        Returns metadata (truthy) for remote IPC, None otherwise.
-        The metadata is passed as ``match_ctx`` to read/write/delete.
+        Returns (metadata, origin_address) for remote IPC, None for local.
         """
         meta = self._metastore.get(path)
         if meta is None or not meta.backend_name:
@@ -87,44 +81,63 @@ class FederationIPCResolver:
         if addr.origin == self._self_address:
             return None  # origin is self → local
 
-        return meta  # remote IPC — resolver handles
+        assert addr.origin is not None
+        return meta, addr.origin
 
-    def read(
+    def try_read(
         self,
         path: str,
         *,
-        match_ctx: Any = None,
         return_metadata: bool = False,
         context: Any = None,
-    ) -> bytes | dict[str, Any]:
-        """Read from remote DT_PIPE/DT_STREAM via gRPC Call RPC."""
-        _ = (return_metadata, context)  # Protocol-required; not used for IPC federation
-        meta = match_ctx
-        addr = BackendAddress.parse(meta.backend_name)
-        assert addr.origin is not None
+    ) -> bytes | dict | None:
+        """Single-call resolve: read from remote DT_PIPE/DT_STREAM.
 
-        return self._read_remote(addr.origin, path)
+        Returns:
+            bytes — handled: content read from remote peer.
+            None  — not handled: local IPC or not a pipe/stream.
+        """
+        _ = (return_metadata, context)  # not used for IPC federation
+        resolved = self._resolve_remote(path)
+        if resolved is None:
+            return None
 
-    def write(self, path: str, content: bytes, *, match_ctx: Any = None) -> dict[str, Any]:
-        """Write to remote DT_PIPE/DT_STREAM via gRPC Call RPC."""
-        meta = match_ctx
-        addr = BackendAddress.parse(meta.backend_name)
-        assert addr.origin is not None
+        _meta, origin = resolved
+        return self._read_remote(origin, path)
 
-        result = self._write_remote(addr.origin, path, content)
+    def try_write(self, path: str, content: bytes) -> dict[str, Any] | None:
+        """Single-call resolve: write to remote DT_PIPE/DT_STREAM.
+
+        Returns:
+            dict  — handled: written to remote peer.
+            None  — not handled: local IPC or not a pipe/stream.
+        """
+        resolved = self._resolve_remote(path)
+        if resolved is None:
+            return None
+
+        meta, origin = resolved
+        result = self._write_remote(origin, path, content)
         # For streams, result may contain offset info
         if meta.is_stream:
             return {"offset": result}
         return {}
 
-    def delete(self, path: str, *, match_ctx: Any = None, context: Any = None) -> None:
-        """Delete remote DT_PIPE/DT_STREAM via gRPC Delete RPC."""
-        _ = context  # Protocol-required; not used for IPC federation
-        meta = match_ctx
-        addr = BackendAddress.parse(meta.backend_name)
-        assert addr.origin is not None
+    def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None:
+        """Single-call resolve: delete remote DT_PIPE/DT_STREAM.
 
-        self._delete_remote(addr.origin, path)
+        Returns:
+            dict  — handled: deleted on remote peer.
+            None  — not handled: local IPC or not a pipe/stream.
+        """
+        _ = context  # not used for IPC federation
+        resolved = self._resolve_remote(path)
+        if resolved is None:
+            return None
+
+        _meta, origin = resolved
+        self._delete_remote(origin, path)
+        return {}
 
     # ------------------------------------------------------------------
     # gRPC remote operations

--- a/tests/unit/raft/test_federation_ipc_resolver.py
+++ b/tests/unit/raft/test_federation_ipc_resolver.py
@@ -1,4 +1,4 @@
-"""Unit tests for FederationIPCResolver (#1625).
+"""Unit tests for FederationIPCResolver (#1625, #1665).
 
 Tests the PRE-DISPATCH resolver for remote DT_PIPE/DT_STREAM using mocks
 for metastore and gRPC stubs (no real network or Raft needed).
@@ -36,21 +36,21 @@ def _make_resolver(**kwargs):
     )
 
 
-class TestMatchesNonIPC:
-    """matches() returns None for non-IPC paths."""
+class TestTryReadNonIPC:
+    """try_read() returns None for non-IPC paths."""
 
     def test_no_metadata_returns_none(self):
         metastore = MagicMock()
         metastore.get.return_value = None
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/test/file.txt") is None
+        assert resolver.try_read("/test/file.txt") is None
 
     def test_regular_file_returns_none(self):
         meta = _make_meta(f"cas_local@{REMOTE_ADDR}", is_pipe=False, is_stream=False)
         metastore = MagicMock()
         metastore.get.return_value = meta
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/test/file.txt") is None
+        assert resolver.try_read("/test/file.txt") is None
 
     def test_empty_backend_name_returns_none(self):
         meta = MagicMock()
@@ -58,103 +58,89 @@ class TestMatchesNonIPC:
         metastore = MagicMock()
         metastore.get.return_value = meta
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/test/file.txt") is None
+        assert resolver.try_read("/test/file.txt") is None
 
 
-class TestMatchesLocalPipe:
-    """matches() returns None for local pipes."""
+class TestTryReadLocalPipe:
+    """try_read() returns None for local pipes."""
 
     def test_local_pipe_returns_none(self):
         meta = _make_meta(f"pipe@{SELF_ADDR}", is_pipe=True)
         metastore = MagicMock()
         metastore.get.return_value = meta
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/ipc/my-pipe") is None
+        assert resolver.try_read("/ipc/my-pipe") is None
 
     def test_legacy_pipe_no_origin_returns_none(self):
         meta = _make_meta("pipe", is_pipe=True)
         metastore = MagicMock()
         metastore.get.return_value = meta
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/ipc/my-pipe") is None
+        assert resolver.try_read("/ipc/my-pipe") is None
 
 
-class TestMatchesLocalStream:
-    """matches() returns None for local streams."""
+class TestTryReadLocalStream:
+    """try_read() returns None for local streams."""
 
     def test_local_stream_returns_none(self):
         meta = _make_meta(f"stream@{SELF_ADDR}", is_stream=True)
         metastore = MagicMock()
         metastore.get.return_value = meta
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/ipc/my-stream") is None
+        assert resolver.try_read("/ipc/my-stream") is None
 
     def test_legacy_stream_no_origin_returns_none(self):
         meta = _make_meta("stream", is_stream=True)
         metastore = MagicMock()
         metastore.get.return_value = meta
         resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/ipc/my-stream") is None
+        assert resolver.try_read("/ipc/my-stream") is None
 
 
-class TestMatchesRemotePipe:
-    """matches() returns metadata for remote pipes."""
-
-    def test_remote_pipe_returns_metadata(self):
-        meta = _make_meta(f"pipe@{REMOTE_ADDR}", is_pipe=True)
-        metastore = MagicMock()
-        metastore.get.return_value = meta
-        resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/ipc/remote-pipe") is meta
-
-
-class TestMatchesRemoteStream:
-    """matches() returns metadata for remote streams."""
-
-    def test_remote_stream_returns_metadata(self):
-        meta = _make_meta(f"stream@{REMOTE_ADDR}", is_stream=True)
-        metastore = MagicMock()
-        metastore.get.return_value = meta
-        resolver = _make_resolver(metastore=metastore)
-        assert resolver.matches("/ipc/remote-stream") is meta
-
-
-class TestReadRemote:
-    """read() fetches from remote peer via gRPC Call RPC."""
+class TestTryReadRemotePipe:
+    """try_read() returns data for remote pipes."""
 
     @patch.object(FederationIPCResolver, "_read_remote")
-    def test_read_remote_pipe(self, mock_read):
+    def test_remote_pipe_returns_data(self, mock_read):
         mock_read.return_value = b"pipe data"
         meta = _make_meta(f"pipe@{REMOTE_ADDR}", is_pipe=True)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+        resolver = _make_resolver(metastore=metastore)
 
-        resolver = _make_resolver()
-        result = resolver.read("/ipc/remote-pipe", match_ctx=meta)
-
+        result = resolver.try_read("/ipc/remote-pipe")
         assert result == b"pipe data"
         mock_read.assert_called_once_with(REMOTE_ADDR, "/ipc/remote-pipe")
 
+
+class TestTryReadRemoteStream:
+    """try_read() returns data for remote streams."""
+
     @patch.object(FederationIPCResolver, "_read_remote")
-    def test_read_remote_stream(self, mock_read):
+    def test_remote_stream_returns_data(self, mock_read):
         mock_read.return_value = b"stream data"
         meta = _make_meta(f"stream@{REMOTE_ADDR}", is_stream=True)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+        resolver = _make_resolver(metastore=metastore)
 
-        resolver = _make_resolver()
-        result = resolver.read("/ipc/remote-stream", match_ctx=meta)
-
+        result = resolver.try_read("/ipc/remote-stream")
         assert result == b"stream data"
         mock_read.assert_called_once_with(REMOTE_ADDR, "/ipc/remote-stream")
 
 
-class TestWriteRemote:
-    """write() sends to remote peer via gRPC Call RPC."""
+class TestTryWriteRemote:
+    """try_write() sends to remote peer via gRPC Call RPC."""
 
     @patch.object(FederationIPCResolver, "_write_remote")
     def test_write_remote_pipe(self, mock_write):
         mock_write.return_value = 5
         meta = _make_meta(f"pipe@{REMOTE_ADDR}", is_pipe=True)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
-        result = resolver.write("/ipc/remote-pipe", b"hello", match_ctx=meta)
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_write("/ipc/remote-pipe", b"hello")
 
         assert result == {}
         mock_write.assert_called_once_with(REMOTE_ADDR, "/ipc/remote-pipe", b"hello")
@@ -163,34 +149,56 @@ class TestWriteRemote:
     def test_write_remote_stream_returns_offset(self, mock_write):
         mock_write.return_value = 42
         meta = _make_meta(f"stream@{REMOTE_ADDR}", is_stream=True)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
-        result = resolver.write("/ipc/remote-stream", b"data", match_ctx=meta)
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_write("/ipc/remote-stream", b"data")
 
         assert result == {"offset": 42}
         mock_write.assert_called_once_with(REMOTE_ADDR, "/ipc/remote-stream", b"data")
 
+    def test_write_local_pipe_returns_none(self):
+        meta = _make_meta(f"pipe@{SELF_ADDR}", is_pipe=True)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+        resolver = _make_resolver(metastore=metastore)
+        assert resolver.try_write("/ipc/my-pipe", b"data") is None
 
-class TestDeleteRemote:
-    """delete() destroys remote pipe/stream via gRPC Delete RPC."""
+
+class TestTryDeleteRemote:
+    """try_delete() destroys remote pipe/stream via gRPC Delete RPC."""
 
     @patch.object(FederationIPCResolver, "_delete_remote")
     def test_delete_remote_pipe(self, mock_delete):
         meta = _make_meta(f"pipe@{REMOTE_ADDR}", is_pipe=True)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
-        resolver.delete("/ipc/remote-pipe", match_ctx=meta)
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_delete("/ipc/remote-pipe")
 
+        assert result == {}
         mock_delete.assert_called_once_with(REMOTE_ADDR, "/ipc/remote-pipe")
 
     @patch.object(FederationIPCResolver, "_delete_remote")
     def test_delete_remote_stream(self, mock_delete):
         meta = _make_meta(f"stream@{REMOTE_ADDR}", is_stream=True)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
 
-        resolver = _make_resolver()
-        resolver.delete("/ipc/remote-stream", match_ctx=meta)
+        resolver = _make_resolver(metastore=metastore)
+        result = resolver.try_delete("/ipc/remote-stream")
 
+        assert result == {}
         mock_delete.assert_called_once_with(REMOTE_ADDR, "/ipc/remote-stream")
+
+    def test_delete_local_returns_none(self):
+        meta = _make_meta(f"pipe@{SELF_ADDR}", is_pipe=True)
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+        resolver = _make_resolver(metastore=metastore)
+        assert resolver.try_delete("/ipc/my-pipe") is None
 
 
 class TestKernelDispatchIntegration:


### PR DESCRIPTION
## Summary

`FederationIPCResolver` was missed in PR #3094's refactor that replaced the two-phase `matches()` + `read/write/delete()` pattern with single-call `try_read/try_write/try_delete` methods.

This caused `AttributeError: 'FederationIPCResolver' object has no attribute 'try_read'` on **any** file read/write/delete when the federation IPC resolver was registered — breaking `nexus cat`, `nexus write`, and all file operations.

### Changes
- Replaces `matches()` + `read/write/delete(match_ctx=...)` with `try_read/try_write/try_delete`
- Adds `_resolve_remote()` helper for shared metadata lookup + locality check
- Updates all unit tests to use the new API (20 tests, all passing)

Follows the exact same pattern as `FederationContentResolver` (updated in #3094).

## Test plan
- [x] `python -m pytest tests/unit/raft/test_federation_ipc_resolver.py` — 20/20 pass
- [x] `nexus cat /workspace/demo/README.md` — works (was: AttributeError crash)
- [x] `nexus write /hello.txt "hello world"` — works (was: AttributeError crash)
- [x] Full demo flow verified end-to-end