### PR TITLE
feat(#3102): TUI rendering & data-fetching performance

### DIFF
--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -14,19 +14,21 @@
  *   - "visual"  → visual mode for range selection (not an input mode)
  *
  * @see Issue #3101 — filter/search, bulk ops, move/copy
+ * @see Issue #3102 — TUI rendering & data-fetching performance
  */
 
 import React, { useState, useCallback, useEffect, useMemo } from "react";
 import {
   useFilesStore,
   type FileItem,
+  type TreeNode,
   getEffectiveSelection,
 } from "../../stores/files-store.js";
 import { useShareLinkStore } from "../../stores/share-link-store.js";
 import { useUploadStore } from "../../stores/upload-store.js";
 import { Breadcrumb } from "../../shared/components/breadcrumb.js";
 import { ConfirmDialog } from "../../shared/components/confirm-dialog.js";
-import { FileTree } from "./file-tree.js";
+import { FileTree, flattenVisibleNodes, LOAD_MORE_SENTINEL } from "./file-tree.js";
 import { FilePreview } from "./file-preview.js";
 import { FileMetadata } from "./file-metadata.js";
 import { FileAspects } from "./file-aspects.js";
@@ -76,6 +78,8 @@ interface BindingContext {
   readonly cachedFiles: readonly FileItem[];
   readonly selectedIndex: number;
   readonly selectedItem: FileItem | null;
+  readonly selectedNode: TreeNode | null;
+  readonly isSentinel: boolean;
   readonly visibleNodeCount: number;
   readonly currentPath: string;
   readonly client: ReturnType<typeof useApi>;
@@ -140,12 +144,13 @@ function getTabNavBindings(ctx: BindingContext): Record<string, () => void> {
           setIndex: ctx.setSelectedIndex,
           getLength: () => ctx.visibleNodeCount,
           onSelect: (index) => {
-            const item = ctx.cachedFiles[index];
-            if (item && ctx.client) {
-              if (item.isDirectory) {
-                ctx.toggleNode(item.path, ctx.client);
+            // Sentinel nodes are handled by FileTree's auto-load effect
+            if (ctx.isSentinel) return;
+            if (ctx.selectedNode && ctx.client) {
+              if (ctx.selectedNode.isDirectory) {
+                ctx.toggleNode(ctx.selectedNode.path, ctx.client);
               } else {
-                ctx.fetchPreview(item.path, ctx.client);
+                ctx.fetchPreview(ctx.selectedNode.path, ctx.client);
               }
             }
           },
@@ -192,12 +197,12 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
   return {
     // Tree navigation
     l: () => {
-      const item = ctx.cachedFiles[ctx.selectedIndex];
-      if (item?.isDirectory && ctx.client) ctx.toggleNode(item.path, ctx.client);
+      if (ctx.isSentinel) return;
+      if (ctx.selectedNode?.isDirectory && ctx.client) ctx.toggleNode(ctx.selectedNode.path, ctx.client);
     },
     h: () => {
-      const item = ctx.cachedFiles[ctx.selectedIndex];
-      if (item?.isDirectory) ctx.collapseNode(item.path);
+      if (ctx.isSentinel) return;
+      if (ctx.selectedNode?.isDirectory) ctx.collapseNode(ctx.selectedNode.path);
     },
     // Metadata tabs
     m: () => ctx.setMetadataTab("metadata"),
@@ -207,6 +212,7 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
     } : {}),
     // File operations — bulk delete if selection active, otherwise single item
     d: () => {
+      if (ctx.isSentinel) return;
       const effective = getEffectiveSelection(
         ctx.selectedPaths, ctx.visualModeAnchor, ctx.selectedIndex,
         ctx.cachedFiles.map((f) => f.path),
@@ -217,15 +223,20 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
     },
     N: () => { ctx.setInputMode("mkdir"); ctx.setInputBuffer(""); },
     R: () => {
+      if (ctx.isSentinel) return;
       if (ctx.selectedItem) {
         ctx.setInputMode("rename");
         ctx.setInputBuffer(ctx.selectedItem.name);
       }
     },
     // Copy path to system clipboard
-    y: () => { if (ctx.selectedItem) ctx.copy(ctx.selectedItem.path); },
+    y: () => {
+      if (ctx.isSentinel) return;
+      if (ctx.selectedItem) ctx.copy(ctx.selectedItem.path);
+    },
     // Selection
     space: () => {
+      if (ctx.isSentinel) return;
       const item = ctx.cachedFiles[ctx.selectedIndex];
       if (item) ctx.toggleSelect(item.path);
     },
@@ -484,12 +495,20 @@ export default function FileExplorerPanel(): React.ReactNode {
   // Files store
   const currentPath = useFilesStore((s) => s.currentPath);
   const setCurrentPath = useFilesStore((s) => s.setCurrentPath);
-  const fileCache = useFilesStore((s) => s.fileCache);
+  const treeNodes = useFilesStore((s) => s.treeNodes);
+  const fileCacheRevision = useFilesStore((s) => s.fileCacheRevision);
+  const getCachedFiles = useFilesStore((s) => s.getCachedFiles);
+  const abortAll = useFilesStore((s) => s.abortAllInFlight);
   const selectedIndex = useFilesStore((s) => s.selectedIndex);
   const toggleNode = useFilesStore((s) => s.toggleNode);
   const collapseNode = useFilesStore((s) => s.collapseNode);
   const setSelectedIndex = useFilesStore((s) => s.setSelectedIndex);
   const fetchPreview = useFilesStore((s) => s.fetchPreview);
+
+  // Cancel all in-flight file requests when panel unmounts (Issue #3102)
+  useEffect(() => {
+    return () => { abortAll(); };
+  }, [abortAll]);
 
   // Selection & clipboard store
   const selectedPaths = useFilesStore((s) => s.selectedPaths);
@@ -534,10 +553,26 @@ export default function FileExplorerPanel(): React.ReactNode {
     }
   }, [catalogAvailable, metadataTab]);
 
-  // Derived values
-  const cachedFiles = fileCache.get(currentPath)?.data ?? [];
-  const selectedItem: FileItem | null = cachedFiles[selectedIndex] ?? null;
-  const visibleNodeCount = cachedFiles.length;
+  // Flattened visible tree nodes — the source of truth for explorer navigation.
+  const visibleNodes = useMemo(
+    () => flattenVisibleNodes(currentPath, treeNodes),
+    [currentPath, treeNodes],
+  );
+
+  const selectedNode = visibleNodes[selectedIndex] ?? null;
+  const isSentinel = selectedNode?.path.endsWith(LOAD_MORE_SENTINEL) ?? false;
+
+  // For metadata/actions, look up the FileItem from the node's parent directory cache.
+  const selectedItem: FileItem | null = useMemo(() => {
+    if (!selectedNode || isSentinel) return null;
+    const parentDir = selectedNode.path.split("/").slice(0, -1).join("/") || "/";
+    const parentFiles = getCachedFiles(parentDir);
+    return parentFiles?.find((f) => f.path === selectedNode.path) ?? null;
+  }, [selectedNode, isSentinel, getCachedFiles, fileCacheRevision]);
+
+  const visibleNodeCount = visibleNodes.length;
+  // Keep cachedFiles for backward compat with BindingContext (selection uses it)
+  const cachedFiles = fileCacheRevision >= 0 ? (getCachedFiles(currentPath) ?? []) : [];
 
   // Aspect count badge
   const aspectsCache = useKnowledgeStore((s) => s.aspectsCache);
@@ -636,8 +671,8 @@ export default function FileExplorerPanel(): React.ReactNode {
 
   // Build binding context
   const ctx: BindingContext = {
-    activeTab, cachedFiles, selectedIndex, selectedItem, visibleNodeCount,
-    currentPath, client, setSelectedIndex, toggleNode, collapseNode,
+    activeTab, cachedFiles, selectedIndex, selectedItem, selectedNode, isSentinel,
+    visibleNodeCount, currentPath, client, setSelectedIndex, toggleNode, collapseNode,
     fetchPreview, setMetadataTab, catalogAvailable,
     shareLinks, selectedLinkIndex, setSelectedLinkIndex, revokeLink, fetchLinks,
     uploadSessions, selectedSessionIndex, setSelectedSessionIndex,

--- a/packages/nexus-tui/src/panels/files/file-list-item.tsx
+++ b/packages/nexus-tui/src/panels/files/file-list-item.tsx
@@ -1,23 +1,20 @@
 /**
  * Single row in the file list: icon + name + size + modified date.
+ *
+ * Wrapped with React.memo — re-renders only when item or selected changes.
+ * @see Issue #3102, Decisions 4A + 5A
  */
 
 import React from "react";
 import type { FileItem } from "../../stores/files-store.js";
+import { formatSize } from "../../shared/utils/format-size.js";
 
 interface FileListItemProps {
   readonly item: FileItem;
   readonly selected: boolean;
 }
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}K`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}M`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}G`;
-}
-
-export function FileListItem({ item, selected }: FileListItemProps): React.ReactNode {
+export const FileListItem = React.memo(function FileListItem({ item, selected }: FileListItemProps): React.ReactNode {
   const icon = item.isDirectory ? "📁" : "📄";
   const prefix = selected ? "▸ " : "  ";
   const size = item.isDirectory ? "<DIR>" : formatSize(item.size);
@@ -28,4 +25,4 @@ export function FileListItem({ item, selected }: FileListItemProps): React.React
       <text>{`  ${size}`}</text>
     </box>
   );
-}
+});

--- a/packages/nexus-tui/src/panels/files/file-tree-node.tsx
+++ b/packages/nexus-tui/src/panels/files/file-tree-node.tsx
@@ -1,12 +1,14 @@
 /**
  * Single tree node row: indent + expand/collapse icon + file/folder icon + name + size.
  *
- * Wrapped in React.memo to avoid unnecessary re-renders during filtering (Decision 13A).
+ * Wrapped with React.memo — re-renders only when node, selected, or marked changes.
  * Shows selection checkmark for multi-select (Decision 3A).
+ * @see Issue #3102, Decisions 4A + 5A
  */
 
 import React from "react";
 import type { TreeNode } from "../../stores/files-store.js";
+import { formatSize } from "../../shared/utils/format-size.js";
 
 interface FileTreeNodeProps {
   readonly node: TreeNode;
@@ -15,13 +17,7 @@ interface FileTreeNodeProps {
   readonly marked: boolean;
 }
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function FileTreeNodeInner({ node, selected, marked }: FileTreeNodeProps): React.ReactNode {
+export const FileTreeNode = React.memo(function FileTreeNode({ node, selected, marked }: FileTreeNodeProps): React.ReactNode {
   const indent = "  ".repeat(node.depth);
   const cursor = selected ? "▸ " : "  ";
   const check = marked ? "✓ " : "  ";
@@ -45,6 +41,4 @@ function FileTreeNodeInner({ node, selected, marked }: FileTreeNodeProps): React
       <text>{`${cursor}${check}${indent}${expandIcon}${fileIcon} ${node.name}${sizeSuffix}`}</text>
     </box>
   );
-}
-
-export const FileTreeNode = React.memo(FileTreeNodeInner);
+});

--- a/packages/nexus-tui/src/panels/files/file-tree.tsx
+++ b/packages/nexus-tui/src/panels/files/file-tree.tsx
@@ -1,17 +1,43 @@
 /**
  * Recursive file tree with lazy-expand for directories.
- * Flattens the visible tree for virtual scrolling.
+ * Flattens the visible tree, then uses VirtualList for windowed rendering.
+ * Auto-loads more children when the user scrolls near the end of a paginated directory.
  *
  * Supports client-side fuzzy filtering (Decision 4A, 13A)
  * and rendering multi-selection state (Decision 3A).
+ *
+ * @see Issue #3102, Decisions 1A (virtualization) + 4A (React.memo on children)
  */
 
-import React, { useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { useFilesStore, type TreeNode } from "../../stores/files-store.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { FileTreeNode } from "./file-tree-node.js";
 import { Spinner } from "../../shared/components/spinner.js";
 import { ScrollIndicator } from "../../shared/components/scroll-indicator.js";
+import { VirtualList } from "../../shared/components/virtual-list.js";
+
+const VIEWPORT_HEIGHT = 20;
+
+/** Sentinel value used to mark "load more" placeholder nodes in the flattened list. */
+export const LOAD_MORE_SENTINEL = "__load_more__";
+
+/** A synthetic TreeNode representing a "load more" placeholder. */
+export function makeLoadMoreNode(parentPath: string, depth: number, loading: boolean): TreeNode {
+  return {
+    path: `${parentPath}/${LOAD_MORE_SENTINEL}`,
+    name: loading ? "Loading more..." : "▼ Load more...",
+    isDirectory: false,
+    expanded: false,
+    children: [],
+    loading: false,
+    depth,
+    size: 0,
+    nextCursor: null,
+    hasMore: false,
+    loadingMore: false,
+  };
+}
 
 interface FileTreeProps {
   /** Client-side fuzzy filter query. Empty string = no filter. */
@@ -26,6 +52,7 @@ export function FileTree({ filterQuery = "", effectiveSelection }: FileTreeProps
   const currentPath = useFilesStore((s) => s.currentPath);
   const selectedIndex = useFilesStore((s) => s.selectedIndex);
   const expandNode = useFilesStore((s) => s.expandNode);
+  const loadMoreChildren = useFilesStore((s) => s.loadMoreChildren);
 
   // Initialize root on mount
   useEffect(() => {
@@ -34,13 +61,41 @@ export function FileTree({ filterQuery = "", effectiveSelection }: FileTreeProps
     }
   }, [client, currentPath, treeNodes, expandNode]);
 
-  // Flatten visible tree nodes, then apply filter (Decision 13A)
+  // Flatten visible tree nodes, then apply filter (Decision 13A).
+  // Inserts "load more" sentinel nodes at the end of paginated directories.
   const visibleNodes = useMemo(() => {
     const all = flattenVisibleNodes(currentPath, treeNodes);
     if (!filterQuery) return all;
     const lowerQuery = filterQuery.toLowerCase();
     return all.filter((node) => fuzzyMatch(node.name.toLowerCase(), lowerQuery));
   }, [currentPath, treeNodes, filterQuery]);
+
+  // Auto-load more: when the selected node is a "load more" sentinel, trigger fetch
+  useEffect(() => {
+    if (!client) return;
+    const selectedNode = visibleNodes[selectedIndex];
+    if (!selectedNode || !selectedNode.path.endsWith(LOAD_MORE_SENTINEL)) return;
+
+    // Extract the parent path from the sentinel node
+    const parentPath = selectedNode.path.slice(0, -(LOAD_MORE_SENTINEL.length + 1));
+    const parentNode = treeNodes.get(parentPath);
+    if (parentNode?.hasMore && !parentNode.loadingMore) {
+      loadMoreChildren(parentPath, client);
+    }
+  }, [client, selectedIndex, visibleNodes, treeNodes, loadMoreChildren]);
+
+  // Stable render callback for VirtualList (avoids inline closure per-render)
+  const renderNode = useCallback(
+    (node: TreeNode, index: number) => (
+      <FileTreeNode
+        key={node.path}
+        node={node}
+        selected={index === selectedIndex}
+        marked={effectiveSelection?.has(node.path) ?? false}
+      />
+    ),
+    [selectedIndex, effectiveSelection],
+  );
 
   if (!client) {
     return <text>No connection configured</text>;
@@ -55,17 +110,14 @@ export function FileTree({ filterQuery = "", effectiveSelection }: FileTreeProps
   }
 
   return (
-    <ScrollIndicator selectedIndex={selectedIndex} totalItems={visibleNodes.length} visibleItems={20}>
-      <scrollbox height="100%" width="100%">
-        {visibleNodes.map((node, index) => (
-          <FileTreeNode
-            key={node.path}
-            node={node}
-            selected={index === selectedIndex}
-            marked={effectiveSelection?.has(node.path) ?? false}
-          />
-        ))}
-      </scrollbox>
+    <ScrollIndicator selectedIndex={selectedIndex} totalItems={visibleNodes.length} visibleItems={VIEWPORT_HEIGHT}>
+      <VirtualList
+        items={visibleNodes}
+        renderItem={renderNode}
+        viewportHeight={VIEWPORT_HEIGHT}
+        selectedIndex={selectedIndex}
+        overscan={5}
+      />
     </ScrollIndicator>
   );
 }
@@ -79,8 +131,11 @@ function fuzzyMatch(target: string, query: string): boolean {
   return qi === query.length;
 }
 
-/** Flatten tree into ordered list of visible nodes (expanded directories show children). */
-function flattenVisibleNodes(
+/**
+ * Flatten tree into ordered list of visible nodes (expanded directories show children).
+ * Appends a synthetic "load more" node after the last child of any directory with hasMore.
+ */
+export function flattenVisibleNodes(
   rootPath: string,
   nodes: ReadonlyMap<string, TreeNode>,
 ): readonly TreeNode[] {
@@ -100,6 +155,11 @@ function flattenVisibleNodes(
     if (node.expanded) {
       for (const childPath of node.children) {
         walk(childPath);
+      }
+
+      // If this directory has more pages, show a "load more" placeholder
+      if (node.hasMore) {
+        result.push(makeLoadMoreNode(nodePath, node.depth + 1, node.loadingMore));
       }
     }
   }

--- a/packages/nexus-tui/src/panels/search/memory-list.tsx
+++ b/packages/nexus-tui/src/panels/search/memory-list.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 import type { Memory, MemoryHistory, MemoryDiff } from "../../stores/search-store.js";
+import { truncateText } from "../../shared/utils/format-text.js";
 
 interface MemoryListProps {
   readonly memories: readonly Memory[];
@@ -16,11 +17,6 @@ interface MemoryListProps {
   readonly memoryHistoryLoading: boolean;
   readonly memoryDiff: MemoryDiff | null;
   readonly memoryDiffLoading: boolean;
-}
-
-function truncateText(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  return `${text.slice(0, maxLen - 3)}...`;
 }
 
 function shortId(id: unknown): string {

--- a/packages/nexus-tui/src/panels/search/playbook-list.tsx
+++ b/packages/nexus-tui/src/panels/search/playbook-list.tsx
@@ -4,16 +4,12 @@
 
 import React from "react";
 import type { PlaybookRecord } from "../../stores/search-store.js";
+import { truncateText } from "../../shared/utils/format-text.js";
 
 interface PlaybookListProps {
   readonly playbooks: readonly PlaybookRecord[];
   readonly selectedIndex: number;
   readonly loading: boolean;
-}
-
-function truncateText(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  return `${text.slice(0, maxLen - 3)}...`;
 }
 
 function formatRate(rate: number | null): string {

--- a/packages/nexus-tui/src/panels/search/search-results.tsx
+++ b/packages/nexus-tui/src/panels/search/search-results.tsx
@@ -6,17 +6,13 @@ import React from "react";
 import type { SearchResult } from "../../stores/search-store.js";
 import { statusColor } from "../../shared/theme.js";
 import { EmptyState } from "../../shared/components/empty-state.js";
+import { truncateText } from "../../shared/utils/format-text.js";
 
 interface SearchResultsProps {
   readonly results: readonly SearchResult[];
   readonly total: number;
   readonly selectedIndex: number;
   readonly loading: boolean;
-}
-
-function truncateText(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  return `${text.slice(0, maxLen - 3)}...`;
 }
 
 function formatScore(score: number): string {

--- a/packages/nexus-tui/src/panels/zones/cache-tab.tsx
+++ b/packages/nexus-tui/src/panels/zones/cache-tab.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { formatSize } from "../../shared/utils/format-size.js";
 
 interface CacheStats {
   readonly total_entries?: number;
@@ -23,16 +24,6 @@ interface CacheTabProps {
   readonly stats: unknown | null;
   readonly hotFiles: readonly unknown[];
   readonly loading: boolean;
-}
-
-function formatSize(bytes: number): string {
-  if (bytes >= 1024 * 1024) {
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  }
-  if (bytes >= 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-  return `${bytes} B`;
 }
 
 function hitRateColor(rate: number): string | undefined {

--- a/packages/nexus-tui/src/shared/components/virtual-list.tsx
+++ b/packages/nexus-tui/src/shared/components/virtual-list.tsx
@@ -1,0 +1,93 @@
+/**
+ * Windowed list rendering for terminal UIs.
+ *
+ * Only renders the visible rows plus an overscan buffer, instead of
+ * materializing all items. This keeps the terminal responsive even for
+ * 10k+ item lists.
+ *
+ * @see Issue #3102, Decision 1A
+ */
+
+import React, { useMemo } from "react";
+
+export interface VirtualListProps<T> {
+  /** Full (flat) list of items. */
+  readonly items: readonly T[];
+  /** Render callback for a single item row. */
+  readonly renderItem: (item: T, index: number) => React.ReactNode;
+  /** Height of each item in terminal rows. Default: 1 */
+  readonly itemHeight?: number;
+  /** Maximum number of visible rows in the viewport. */
+  readonly viewportHeight: number;
+  /** Currently selected/focused index (drives scroll position). */
+  readonly selectedIndex: number;
+  /** Extra rows rendered above and below the viewport. Default: 5 */
+  readonly overscan?: number;
+}
+
+/**
+ * Calculate the visible window for the given parameters.
+ *
+ * Exported for unit testing the pure math separately from React rendering.
+ */
+export function calculateWindow(
+  totalItems: number,
+  viewportHeight: number,
+  selectedIndex: number,
+  overscan: number,
+): { startIndex: number; endIndex: number; scrollOffset: number } {
+  if (totalItems === 0) {
+    return { startIndex: 0, endIndex: 0, scrollOffset: 0 };
+  }
+
+  // Determine the scroll offset so the selected item is visible.
+  // We keep a "follow" strategy: if selectedIndex would be outside the
+  // current viewport, we shift the scroll offset to bring it into view.
+  let scrollOffset = 0;
+
+  if (totalItems <= viewportHeight) {
+    // Everything fits — no scrolling needed
+    scrollOffset = 0;
+  } else {
+    // Center the selected item in the viewport, clamped to valid range
+    scrollOffset = Math.max(0, selectedIndex - Math.floor(viewportHeight / 2));
+    const maxOffset = totalItems - viewportHeight;
+    scrollOffset = Math.min(scrollOffset, maxOffset);
+  }
+
+  // Apply overscan to render a buffer above/below
+  const startIndex = Math.max(0, scrollOffset - overscan);
+  const endIndex = Math.min(totalItems, scrollOffset + viewportHeight + overscan);
+
+  return { startIndex, endIndex, scrollOffset };
+}
+
+export function VirtualList<T>({
+  items,
+  renderItem,
+  itemHeight = 1,
+  viewportHeight,
+  selectedIndex,
+  overscan = 5,
+}: VirtualListProps<T>): React.ReactNode {
+  const { startIndex, endIndex } = useMemo(
+    () => calculateWindow(items.length, viewportHeight, selectedIndex, overscan),
+    [items.length, viewportHeight, selectedIndex, overscan],
+  );
+
+  // Slice the items to only the visible window
+  const visibleItems = useMemo(
+    () => items.slice(startIndex, endIndex),
+    [items, startIndex, endIndex],
+  );
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <box flexDirection="column" height={viewportHeight * itemHeight} width="100%">
+      {visibleItems.map((item, i) => renderItem(item, startIndex + i))}
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/shared/hooks/use-swr.ts
+++ b/packages/nexus-tui/src/shared/hooks/use-swr.ts
@@ -4,9 +4,11 @@
  * - Immediately returns cached data if available (even if stale)
  * - Triggers background revalidation if data is stale
  * - Reports loading/error states
+ * - Aborts in-flight requests on key change or unmount (Issue #3102)
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { LruCache } from "../utils/lru-cache.js";
 
 interface SwrOptions {
   /** Time in ms before cached data is considered stale. Default: 30000 */
@@ -23,75 +25,23 @@ interface SwrResult<T> {
   readonly mutate: () => void;
 }
 
-interface CacheEntry<T> {
-  data: T;
-  fetchedAt: number;
-}
-
 // =============================================================================
-// LRU cache with eviction (Decision 16A)
+// Module-level cache shared across hook instances (Decision 7A)
 // =============================================================================
 
-const MAX_CACHE_SIZE = 200;
-
-let accessCounter = 0;
-
-class LruCache {
-  private readonly _map = new Map<string, { entry: CacheEntry<unknown>; accessOrder: number }>();
-
-  get(key: string): CacheEntry<unknown> | undefined {
-    const item = this._map.get(key);
-    if (!item) return undefined;
-    // Update access order for LRU tracking (monotonic counter avoids Date.now() ties)
-    item.accessOrder = ++accessCounter;
-    return item.entry;
-  }
-
-  set(key: string, entry: CacheEntry<unknown>): void {
-    this._map.set(key, { entry, accessOrder: ++accessCounter });
-    this._evictIfNeeded();
-  }
-
-  delete(key: string): void {
-    this._map.delete(key);
-  }
-
-  clear(): void {
-    this._map.clear();
-  }
-
-  private _evictIfNeeded(): void {
-    if (this._map.size <= MAX_CACHE_SIZE) return;
-
-    // Find and remove least-recently-accessed entries
-    const entries = [...this._map.entries()].sort(
-      (a, b) => a[1].accessOrder - b[1].accessOrder,
-    );
-
-    const toRemove = this._map.size - MAX_CACHE_SIZE;
-    for (let i = 0; i < toRemove; i++) {
-      this._map.delete(entries[i]![0]);
-    }
-  }
-}
-
-// Module-level cache shared across hook instances
 /** @internal Exported for testing LRU behavior */
-export const swrCache = new LruCache();
-
-// Keep backward-compatible local alias
-const cache = swrCache;
+export const swrCache = new LruCache(200);
 
 export function useSwr<T>(
   key: string,
-  fetcher: () => Promise<T>,
+  fetcher: (signal: AbortSignal) => Promise<T>,
   options?: SwrOptions,
 ): SwrResult<T> {
   const ttlMs = options?.ttlMs ?? 30_000;
   const enabled = options?.enabled ?? true;
 
   const [data, setData] = useState<T | undefined>(() => {
-    const cached = cache.get(key) as CacheEntry<T> | undefined;
+    const cached = swrCache.get(key) as { data: T; fetchedAt: number } | undefined;
     return cached?.data;
   });
   const [error, setError] = useState<Error | undefined>();
@@ -99,33 +49,44 @@ export function useSwr<T>(
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
 
-  // Track the active key so in-flight fetches for stale keys are discarded (Bug 2)
+  // Track the active key so in-flight fetches for stale keys are discarded
   const activeKeyRef = useRef(key);
   activeKeyRef.current = key;
 
-  // Reset data to cached value (or undefined) when key changes (Bug 3)
+  // Track the active AbortController for cancellation (Issue #3102, Decision 3A)
+  const controllerRef = useRef<AbortController | null>(null);
+
+  // Reset data to cached value (or undefined) when key changes
   useEffect(() => {
-    const cached = cache.get(key) as CacheEntry<T> | undefined;
+    const cached = swrCache.get(key) as { data: T; fetchedAt: number } | undefined;
     setData(cached?.data);
   }, [key]);
 
   const isStale = (() => {
-    const cached = cache.get(key);
+    const cached = swrCache.get(key);
     if (!cached) return true;
     return Date.now() - cached.fetchedAt > ttlMs;
   })();
 
   const doFetch = useCallback(async () => {
     const fetchKey = key; // capture for closure
+
+    // Abort any previous in-flight fetch
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
     setIsLoading(true);
     setError(undefined);
     try {
-      const result = await fetcherRef.current();
+      const result = await fetcherRef.current(controller.signal);
       // Only update if this key is still the active one
       if (activeKeyRef.current !== fetchKey) return;
-      cache.set(key, { data: result, fetchedAt: Date.now() });
+      swrCache.set(key, { data: result, fetchedAt: Date.now() });
       setData(result);
     } catch (err) {
+      // Suppress AbortError — it's expected when we cancel
+      if (err instanceof DOMException && err.name === "AbortError") return;
       if (activeKeyRef.current !== fetchKey) return;
       setError(err instanceof Error ? err : new Error(String(err)));
     } finally {
@@ -140,10 +101,15 @@ export function useSwr<T>(
     if (isStale) {
       doFetch();
     }
+
+    // Abort in-flight request on unmount or key change
+    return () => {
+      controllerRef.current?.abort();
+    };
   }, [key, enabled, isStale, doFetch]);
 
   const mutate = useCallback(() => {
-    cache.delete(key);
+    swrCache.delete(key);
     doFetch();
   }, [key, doFetch]);
 

--- a/packages/nexus-tui/src/shared/utils/format-size.ts
+++ b/packages/nexus-tui/src/shared/utils/format-size.ts
@@ -1,0 +1,20 @@
+/**
+ * Consistent byte-size formatting across all panels.
+ *
+ * Output: "0 B", "1.5 KB", "2.3 MB", "1.1 GB"
+ * - Space before unit, standard suffixes
+ * - Supports up to GB
+ *
+ * @see Issue #3102, Decision 5A
+ */
+
+const KB = 1024;
+const MB = KB * 1024;
+const GB = MB * 1024;
+
+export function formatSize(bytes: number): string {
+  if (bytes < KB) return `${bytes} B`;
+  if (bytes < MB) return `${(bytes / KB).toFixed(1)} KB`;
+  if (bytes < GB) return `${(bytes / MB).toFixed(1)} MB`;
+  return `${(bytes / GB).toFixed(1)} GB`;
+}

--- a/packages/nexus-tui/src/shared/utils/format-text.ts
+++ b/packages/nexus-tui/src/shared/utils/format-text.ts
@@ -1,0 +1,10 @@
+/**
+ * Text truncation utility for terminal column alignment.
+ *
+ * @see Issue #3102, Decision 8A
+ */
+
+export function truncateText(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return `${text.slice(0, maxLen - 3)}...`;
+}

--- a/packages/nexus-tui/src/shared/utils/lru-cache.ts
+++ b/packages/nexus-tui/src/shared/utils/lru-cache.ts
@@ -1,0 +1,75 @@
+/**
+ * Generic LRU cache with O(n) eviction.
+ *
+ * Uses a monotonic access counter for LRU ordering.
+ * Eviction finds the minimum-access-order entry in a single pass (O(n))
+ * instead of sorting (O(n log n)).
+ *
+ * @see Issue #3102, Decisions 7A + 16A
+ */
+
+interface CacheEntry<T> {
+  data: T;
+  fetchedAt: number;
+}
+
+let accessCounter = 0;
+
+export class LruCache<T = unknown> {
+  private readonly _map = new Map<string, { entry: CacheEntry<T>; accessOrder: number }>();
+  private readonly _maxSize: number;
+
+  constructor(maxSize: number = 200) {
+    this._maxSize = maxSize;
+  }
+
+  get(key: string): CacheEntry<T> | undefined {
+    const item = this._map.get(key);
+    if (!item) return undefined;
+    // Update access order for LRU tracking (monotonic counter avoids Date.now() ties)
+    item.accessOrder = ++accessCounter;
+    return item.entry;
+  }
+
+  set(key: string, entry: CacheEntry<T>): void {
+    this._map.set(key, { entry, accessOrder: ++accessCounter });
+    this._evictIfNeeded();
+  }
+
+  has(key: string): boolean {
+    return this._map.has(key);
+  }
+
+  delete(key: string): void {
+    this._map.delete(key);
+  }
+
+  clear(): void {
+    this._map.clear();
+  }
+
+  get size(): number {
+    return this._map.size;
+  }
+
+  private _evictIfNeeded(): void {
+    while (this._map.size > this._maxSize) {
+      // O(n) min-scan: find the least-recently-accessed entry
+      let minKey: string | undefined;
+      let minOrder = Infinity;
+
+      for (const [key, item] of this._map) {
+        if (item.accessOrder < minOrder) {
+          minOrder = item.accessOrder;
+          minKey = key;
+        }
+      }
+
+      if (minKey !== undefined) {
+        this._map.delete(minKey);
+      } else {
+        break;
+      }
+    }
+  }
+}

--- a/packages/nexus-tui/src/stores/files-store.ts
+++ b/packages/nexus-tui/src/stores/files-store.ts
@@ -1,11 +1,15 @@
 /**
  * File data store with SWR caching, tree state, and preview state.
+ *
+ * @see Issue #3102 — LRU cache (Decision 7A), AbortController (Decisions 3A/14A),
+ *      sortFileItems helper (Decision 6A), cursor pagination + infinite scroll.
  */
 
 import { create } from "zustand";
 import type { FetchClient } from "@nexus/api-client";
 import { categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
+import { LruCache } from "../shared/utils/lru-cache.js";
 
 // =============================================================================
 // Types
@@ -34,24 +38,77 @@ export interface TreeNode {
   readonly loading: boolean;
   readonly depth: number;
   readonly size: number;
+  /** Opaque cursor for fetching the next page of children. */
+  readonly nextCursor: string | null;
+  /** Whether more children are available beyond what's loaded. */
+  readonly hasMore: boolean;
+  /** Whether a "load more" fetch is currently in flight. */
+  readonly loadingMore: boolean;
 }
 
-interface CachedEntry<T> {
-  readonly data: T;
-  readonly fetchedAt: number;
+/** Paginated list response from the server. */
+interface PaginatedListResponse {
+  readonly items: readonly FileItem[];
+  readonly has_more: boolean;
+  readonly next_cursor: string | null;
 }
+
+// =============================================================================
+// Helpers (Decision 6A: extract sort)
+// =============================================================================
+
+/** Sort file items: directories first, then alphabetical by name. */
+function sortFileItems(items: readonly FileItem[]): FileItem[] {
+  return [...items].sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+// =============================================================================
+// LRU cache for file listings (Decision 7A: reuse shared LruCache)
+// =============================================================================
 
 const CACHE_TTL_MS = 30_000;
+const fileCache = new LruCache<readonly FileItem[]>(200);
+
+// =============================================================================
+// Per-path AbortController tracking (Decisions 3A + 14A)
+// =============================================================================
+
+const inFlightControllers = new Map<string, AbortController>();
+
+function abortForPath(path: string): void {
+  inFlightControllers.get(path)?.abort();
+  inFlightControllers.delete(path);
+}
+
+function controllerForPath(path: string): AbortController {
+  abortForPath(path);
+  const controller = new AbortController();
+  inFlightControllers.set(path, controller);
+  return controller;
+}
+
+/** Abort all in-flight requests (called on panel unmount). */
+function abortAllInFlight(): void {
+  for (const controller of inFlightControllers.values()) {
+    controller.abort();
+  }
+  inFlightControllers.clear();
+}
 
 // =============================================================================
 // Store
 // =============================================================================
 
 export interface FilesState {
-  // File list cache
-  readonly fileCache: ReadonlyMap<string, CachedEntry<readonly FileItem[]>>;
+  // File list cache (external LruCache — store only exposes current path data)
   readonly currentPath: string;
   readonly selectedIndex: number;
+
+  // Revision counter — bumped whenever fileCache changes, so selectors re-fire
+  readonly fileCacheRevision: number;
 
   // Tree state
   readonly treeNodes: ReadonlyMap<string, TreeNode>;
@@ -84,11 +141,14 @@ export interface FilesState {
   readonly expandNode: (path: string, client: FetchClient) => Promise<void>;
   readonly collapseNode: (path: string) => void;
   readonly toggleNode: (path: string, client: FetchClient) => Promise<void>;
+  readonly loadMoreChildren: (path: string, client: FetchClient) => Promise<void>;
   readonly invalidate: (path: string) => void;
   readonly writeFile: (path: string, content: string, client: FetchClient) => Promise<void>;
   readonly deleteFile: (path: string, client: FetchClient) => Promise<void>;
   readonly mkdirFile: (path: string, client: FetchClient) => Promise<void>;
   readonly renameFile: (oldPath: string, newPath: string, client: FetchClient) => Promise<void>;
+  readonly getCachedFiles: (path: string) => readonly FileItem[] | undefined;
+  readonly abortAllInFlight: () => void;
 
   // Selection actions
   readonly toggleSelect: (path: string) => void;
@@ -134,10 +194,13 @@ export function getEffectiveSelection(
   return result;
 }
 
+/** Expose fileCache for external access (e.g. getCachedFiles selector). */
+export { fileCache as _fileCache };
+
 export const useFilesStore = create<FilesState>((set, get) => ({
-  fileCache: new Map(),
   currentPath: "/",
   selectedIndex: 0,
+  fileCacheRevision: 0,
   treeNodes: new Map(),
   focusPane: "tree",
   previewPath: null,
@@ -155,49 +218,55 @@ export const useFilesStore = create<FilesState>((set, get) => ({
 
   setFocusPane: (pane) => set({ focusPane: pane }),
 
+  getCachedFiles: (path) => {
+    const entry = fileCache.get(path);
+    if (!entry) return undefined;
+    if (Date.now() - entry.fetchedAt > CACHE_TTL_MS) return undefined;
+    return entry.data;
+  },
+
+  abortAllInFlight,
+
   fetchFiles: async (path, client) => {
     // Check SWR cache
-    const cached = get().fileCache.get(path);
+    const cached = fileCache.get(path);
     if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
       return;
     }
 
+    const controller = controllerForPath(`list:${path}`);
     try {
-      const response = await client.get<{ items: readonly FileItem[] }>(
-        `/api/v2/files/list?path=${encodeURIComponent(path)}`,
+      const response = await client.get<PaginatedListResponse>(
+        `/api/v2/files/list?path=${encodeURIComponent(path)}&limit=200`,
+        { signal: controller.signal },
       );
 
       const items = response.items ?? [];
-      const sorted = [...items].sort((a, b) => {
-        // Directories first, then alphabetical
-        if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
-        return a.name.localeCompare(b.name);
-      });
-
-      const newCache = new Map(get().fileCache);
-      newCache.set(path, { data: sorted, fetchedAt: Date.now() });
-      // Evict oldest entries if cache exceeds 200 paths
-      if (newCache.size > 200) {
-        const oldest = newCache.keys().next().value;
-        if (oldest !== undefined) newCache.delete(oldest);
-      }
-      set({ fileCache: newCache, error: null });
+      const sorted = sortFileItems(items);
+      fileCache.set(path, { data: sorted, fetchedAt: Date.now() });
+      set({ fileCacheRevision: get().fileCacheRevision + 1, error: null });
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       const message = err instanceof Error ? err.message : "Failed to fetch files";
       set({ error: message });
       useErrorStore.getState().pushError({ message, category: categorizeError(message), source: SOURCE });
+    } finally {
+      inFlightControllers.delete(`list:${path}`);
     }
   },
 
   fetchPreview: async (path, client) => {
     set({ previewPath: path, previewLoading: true, previewContent: null });
 
+    const controller = controllerForPath(`preview:${path}`);
     try {
       const response = await client.get<{ content: string }>(
         `/api/v2/files/read?path=${encodeURIComponent(path)}`,
+        { signal: controller.signal },
       );
       set({ previewContent: response.content ?? "", previewLoading: false });
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       const message = err instanceof Error ? err.message : "Failed to fetch preview";
       set({
         previewContent: null,
@@ -205,6 +274,8 @@ export const useFilesStore = create<FilesState>((set, get) => ({
         error: message,
       });
       useErrorStore.getState().pushError({ message, category: categorizeError(message), source: SOURCE });
+    } finally {
+      inFlightControllers.delete(`preview:${path}`);
     }
   },
 
@@ -214,35 +285,42 @@ export const useFilesStore = create<FilesState>((set, get) => ({
 
     if (existing?.expanded) return;
 
+    // Abort any in-flight expand for this path (Decision 14A)
+    const controller = controllerForPath(`expand:${path}`);
+
     // Mark as loading
     const loadingNodes = new Map(nodes);
     loadingNodes.set(path, {
-      ...(existing ?? { path, name: path.split("/").pop() ?? path, isDirectory: true, children: [], depth: 0, size: 0 }),
+      ...(existing ?? {
+        path, name: path.split("/").pop() ?? path, isDirectory: true,
+        children: [], depth: 0, size: 0, nextCursor: null, hasMore: false, loadingMore: false,
+      }),
       expanded: true,
       loading: true,
     });
     set({ treeNodes: loadingNodes });
 
     try {
-      const response = await client.get<{ items: readonly FileItem[] }>(
-        `/api/v2/files/list?path=${encodeURIComponent(path)}`,
+      const response = await client.get<PaginatedListResponse>(
+        `/api/v2/files/list?path=${encodeURIComponent(path)}&limit=200`,
+        { signal: controller.signal },
       );
 
       const items = response.items ?? [];
-      const sorted = [...items].sort((a, b) => {
-        if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
-        return a.name.localeCompare(b.name);
-      });
+      const sorted = sortFileItems(items);
 
       const parentDepth = existing?.depth ?? 0;
       const updatedNodes = new Map(get().treeNodes);
 
-      // Update parent node
+      // Update parent node with pagination state
       updatedNodes.set(path, {
         ...updatedNodes.get(path)!,
         expanded: true,
         loading: false,
         children: sorted.map((item) => item.path),
+        nextCursor: response.next_cursor ?? null,
+        hasMore: response.has_more ?? false,
+        loadingMore: false,
       });
 
       // Add child nodes
@@ -257,12 +335,16 @@ export const useFilesStore = create<FilesState>((set, get) => ({
             loading: false,
             depth: parentDepth + 1,
             size: item.size,
+            nextCursor: null,
+            hasMore: false,
+            loadingMore: false,
           });
         }
       }
 
       set({ treeNodes: updatedNodes, error: null });
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       // Revert loading state
       const revertNodes = new Map(get().treeNodes);
       const node = revertNodes.get(path);
@@ -275,10 +357,90 @@ export const useFilesStore = create<FilesState>((set, get) => ({
         error: message,
       });
       useErrorStore.getState().pushError({ message, category: categorizeError(message), source: SOURCE });
+    } finally {
+      inFlightControllers.delete(`expand:${path}`);
+    }
+  },
+
+  loadMoreChildren: async (path, client) => {
+    const nodes = get().treeNodes;
+    const parentNode = nodes.get(path);
+
+    if (!parentNode || !parentNode.hasMore || !parentNode.nextCursor || parentNode.loadingMore) {
+      return;
+    }
+
+    const controller = controllerForPath(`more:${path}`);
+
+    // Mark as loading more
+    const loadingNodes = new Map(nodes);
+    loadingNodes.set(path, { ...parentNode, loadingMore: true });
+    set({ treeNodes: loadingNodes });
+
+    try {
+      const response = await client.get<PaginatedListResponse>(
+        `/api/v2/files/list?path=${encodeURIComponent(path)}&limit=200&cursor=${encodeURIComponent(parentNode.nextCursor)}`,
+        { signal: controller.signal },
+      );
+
+      const items = response.items ?? [];
+      const sorted = sortFileItems(items);
+
+      const updatedNodes = new Map(get().treeNodes);
+      const currentParent = updatedNodes.get(path);
+      if (!currentParent) return;
+
+      // Append new children to existing children
+      const newChildPaths = sorted.map((item) => item.path);
+      updatedNodes.set(path, {
+        ...currentParent,
+        children: [...currentParent.children, ...newChildPaths],
+        nextCursor: response.next_cursor ?? null,
+        hasMore: response.has_more ?? false,
+        loadingMore: false,
+      });
+
+      // Add new child nodes
+      for (const item of sorted) {
+        if (!updatedNodes.has(item.path)) {
+          updatedNodes.set(item.path, {
+            path: item.path,
+            name: item.name,
+            isDirectory: item.isDirectory,
+            expanded: false,
+            children: [],
+            loading: false,
+            depth: currentParent.depth + 1,
+            size: item.size,
+            nextCursor: null,
+            hasMore: false,
+            loadingMore: false,
+          });
+        }
+      }
+
+      set({ treeNodes: updatedNodes, error: null });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      // Revert loadingMore state
+      const revertNodes = new Map(get().treeNodes);
+      const node = revertNodes.get(path);
+      if (node) {
+        revertNodes.set(path, { ...node, loadingMore: false });
+      }
+      const message = err instanceof Error ? err.message : "Failed to load more files";
+      set({ treeNodes: revertNodes, error: message });
+      useErrorStore.getState().pushError({ message, category: categorizeError(message), source: SOURCE });
+    } finally {
+      inFlightControllers.delete(`more:${path}`);
     }
   },
 
   collapseNode: (path) => {
+    // Abort any in-flight expand/loadMore for this path (Decision 14A)
+    abortForPath(`expand:${path}`);
+    abortForPath(`more:${path}`);
+
     const nodes = new Map(get().treeNodes);
     const node = nodes.get(path);
     if (node) {
@@ -297,9 +459,8 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   },
 
   invalidate: (path) => {
-    const newCache = new Map(get().fileCache);
-    newCache.delete(path);
-    set({ fileCache: newCache });
+    fileCache.delete(path);
+    set({ fileCacheRevision: get().fileCacheRevision + 1 });
   },
 
   writeFile: async (path, content, client) => {

--- a/packages/nexus-tui/tests/shared/format-size.test.ts
+++ b/packages/nexus-tui/tests/shared/format-size.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for shared formatSize utility.
+ * @see Issue #3102, Decision 5A
+ */
+
+import { describe, it, expect } from "bun:test";
+import { formatSize } from "../../src/shared/utils/format-size.js";
+
+describe("formatSize", () => {
+  it("formats bytes", () => {
+    expect(formatSize(0)).toBe("0 B");
+    expect(formatSize(1)).toBe("1 B");
+    expect(formatSize(512)).toBe("512 B");
+    expect(formatSize(1023)).toBe("1023 B");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatSize(1024)).toBe("1.0 KB");
+    expect(formatSize(1536)).toBe("1.5 KB");
+    expect(formatSize(10240)).toBe("10.0 KB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatSize(1024 * 1024)).toBe("1.0 MB");
+    expect(formatSize(1024 * 1024 * 2.5)).toBe("2.5 MB");
+  });
+
+  it("formats gigabytes", () => {
+    expect(formatSize(1024 * 1024 * 1024)).toBe("1.0 GB");
+    expect(formatSize(1024 * 1024 * 1024 * 3.7)).toBe("3.7 GB");
+  });
+
+  it("handles boundary values", () => {
+    // Just below KB threshold
+    expect(formatSize(1023)).toBe("1023 B");
+    // Exactly at KB threshold
+    expect(formatSize(1024)).toBe("1.0 KB");
+    // Just below MB threshold
+    expect(formatSize(1024 * 1024 - 1)).toBe("1024.0 KB");
+    // Exactly at MB threshold
+    expect(formatSize(1024 * 1024)).toBe("1.0 MB");
+  });
+});

--- a/packages/nexus-tui/tests/shared/format-text.test.ts
+++ b/packages/nexus-tui/tests/shared/format-text.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Tests for shared truncateText utility.
+ * @see Issue #3102, Decision 8A
+ */
+
+import { describe, it, expect } from "bun:test";
+import { truncateText } from "../../src/shared/utils/format-text.js";
+
+describe("truncateText", () => {
+  it("returns text unchanged when within limit", () => {
+    expect(truncateText("hello", 10)).toBe("hello");
+    expect(truncateText("abc", 3)).toBe("abc");
+    expect(truncateText("", 5)).toBe("");
+  });
+
+  it("truncates with ellipsis when exceeding limit", () => {
+    expect(truncateText("hello world", 8)).toBe("hello...");
+    expect(truncateText("abcdefghij", 7)).toBe("abcd...");
+  });
+
+  it("handles exact boundary", () => {
+    expect(truncateText("12345", 5)).toBe("12345");
+    expect(truncateText("123456", 5)).toBe("12...");
+  });
+
+  it("handles small maxLen", () => {
+    expect(truncateText("hello", 3)).toBe("...");
+    expect(truncateText("hello", 4)).toBe("h...");
+  });
+});

--- a/packages/nexus-tui/tests/shared/lru-cache.test.ts
+++ b/packages/nexus-tui/tests/shared/lru-cache.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the shared LruCache with O(n) eviction.
+ *
+ * Extends the original swr-lru tests to cover the extracted shared module.
+ * @see Issue #3102, Decisions 7A + 16A
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { LruCache } from "../../src/shared/utils/lru-cache.js";
+
+describe("LruCache", () => {
+  let cache: LruCache;
+
+  beforeEach(() => {
+    cache = new LruCache(5);
+  });
+
+  it("stores and retrieves entries", () => {
+    cache.set("a", { data: 1, fetchedAt: 100 });
+    expect(cache.get("a")?.data).toBe(1);
+  });
+
+  it("returns undefined for missing keys", () => {
+    expect(cache.get("missing")).toBeUndefined();
+  });
+
+  it("reports has() correctly", () => {
+    cache.set("a", { data: 1, fetchedAt: 100 });
+    expect(cache.has("a")).toBe(true);
+    expect(cache.has("b")).toBe(false);
+  });
+
+  it("deletes entries", () => {
+    cache.set("a", { data: 1, fetchedAt: 100 });
+    cache.delete("a");
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.has("a")).toBe(false);
+  });
+
+  it("clears all entries", () => {
+    cache.set("a", { data: 1, fetchedAt: 100 });
+    cache.set("b", { data: 2, fetchedAt: 100 });
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.get("a")).toBeUndefined();
+  });
+
+  it("reports size correctly", () => {
+    expect(cache.size).toBe(0);
+    cache.set("a", { data: 1, fetchedAt: 100 });
+    expect(cache.size).toBe(1);
+    cache.set("b", { data: 2, fetchedAt: 100 });
+    expect(cache.size).toBe(2);
+  });
+
+  it("evicts least-recently-used entry when exceeding maxSize", () => {
+    // Fill to capacity (5)
+    for (let i = 0; i < 5; i++) {
+      cache.set(`key-${i}`, { data: i, fetchedAt: 100 });
+    }
+    expect(cache.size).toBe(5);
+
+    // Adding one more should evict key-0 (oldest)
+    cache.set("key-5", { data: 5, fetchedAt: 100 });
+    expect(cache.size).toBe(5);
+    expect(cache.get("key-0")).toBeUndefined();
+    expect(cache.get("key-5")?.data).toBe(5);
+  });
+
+  it("promotes accessed entries (LRU behavior)", () => {
+    // Fill to capacity
+    for (let i = 0; i < 5; i++) {
+      cache.set(`key-${i}`, { data: i, fetchedAt: 100 });
+    }
+
+    // Access key-0 to promote it
+    cache.get("key-0");
+
+    // Add a new entry — key-1 should be evicted (oldest non-accessed)
+    cache.set("key-5", { data: 5, fetchedAt: 100 });
+    expect(cache.get("key-0")?.data).toBe(0); // survived (was accessed)
+    expect(cache.get("key-1")).toBeUndefined(); // evicted
+  });
+
+  it("evicts multiple entries when multiple are added past capacity", () => {
+    for (let i = 0; i < 5; i++) {
+      cache.set(`key-${i}`, { data: i, fetchedAt: 100 });
+    }
+
+    // Add 3 more — should evict 3 oldest
+    cache.set("key-5", { data: 5, fetchedAt: 100 });
+    cache.set("key-6", { data: 6, fetchedAt: 100 });
+    cache.set("key-7", { data: 7, fetchedAt: 100 });
+
+    expect(cache.get("key-0")).toBeUndefined();
+    expect(cache.get("key-1")).toBeUndefined();
+    expect(cache.get("key-2")).toBeUndefined();
+    expect(cache.get("key-3")?.data).toBe(3);
+    expect(cache.get("key-7")?.data).toBe(7);
+  });
+
+  it("overwrites existing entry without increasing size", () => {
+    cache.set("a", { data: 1, fetchedAt: 100 });
+    cache.set("a", { data: 2, fetchedAt: 200 });
+    expect(cache.size).toBe(1);
+    expect(cache.get("a")?.data).toBe(2);
+    expect(cache.get("a")?.fetchedAt).toBe(200);
+  });
+
+  it("uses default maxSize of 200 when not specified", () => {
+    const defaultCache = new LruCache();
+    for (let i = 0; i < 205; i++) {
+      defaultCache.set(`key-${i}`, { data: i, fetchedAt: 100 });
+    }
+    // Oldest 5 entries should be evicted
+    expect(defaultCache.get("key-0")).toBeUndefined();
+    expect(defaultCache.get("key-4")).toBeUndefined();
+    expect(defaultCache.get("key-5")).toBeDefined();
+    expect(defaultCache.get("key-204")?.data).toBe(204);
+  });
+});

--- a/packages/nexus-tui/tests/shared/use-swr.test.ts
+++ b/packages/nexus-tui/tests/shared/use-swr.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the useSwr hook — cache integration and fetcher contract.
+ *
+ * These tests exercise the module-level swrCache and the fetcher/AbortSignal
+ * contract without rendering the React hook (no DOM needed).
+ *
+ * LRU eviction behavior is covered in swr-lru.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { swrCache } from "../../src/shared/hooks/use-swr.js";
+
+describe("useSwr cache integration", () => {
+  beforeEach(() => {
+    swrCache.clear();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. Cache starts empty for unknown key
+  // ---------------------------------------------------------------------------
+  it("returns undefined for an unknown key", () => {
+    expect(swrCache.get("unknown-key")).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Cache set populates data and fetchedAt
+  // ---------------------------------------------------------------------------
+  it("stores data and fetchedAt via set", () => {
+    const now = Date.now();
+    swrCache.set("users", { data: [{ id: 1 }], fetchedAt: now });
+
+    const entry = swrCache.get("users");
+    expect(entry).toBeDefined();
+    expect(entry!.data).toEqual([{ id: 1 }]);
+    expect(entry!.fetchedAt).toBe(now);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Cache entry is fresh within TTL (default 30s)
+  // ---------------------------------------------------------------------------
+  it("entry is fresh when fetchedAt is within the default 30s TTL", () => {
+    const defaultTtlMs = 30_000;
+    const fetchedAt = Date.now() - (defaultTtlMs - 1_000); // 1s before expiry
+    swrCache.set("fresh-key", { data: "fresh", fetchedAt });
+
+    const entry = swrCache.get("fresh-key")!;
+    const age = Date.now() - entry.fetchedAt;
+    expect(age).toBeLessThan(defaultTtlMs);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Cache entry is stale past TTL
+  // ---------------------------------------------------------------------------
+  it("entry is stale when fetchedAt exceeds the default 30s TTL", () => {
+    const defaultTtlMs = 30_000;
+    const fetchedAt = Date.now() - (defaultTtlMs + 1_000); // 1s past expiry
+    swrCache.set("stale-key", { data: "stale", fetchedAt });
+
+    const entry = swrCache.get("stale-key")!;
+    const age = Date.now() - entry.fetchedAt;
+    expect(age).toBeGreaterThan(defaultTtlMs);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Fetcher receives an AbortSignal argument
+  // ---------------------------------------------------------------------------
+  it("fetcher receives an AbortSignal when called with AbortController", async () => {
+    const fetcher = mock(async (signal: AbortSignal) => {
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal.aborted).toBe(false);
+      return "result";
+    });
+
+    const controller = new AbortController();
+    const result = await fetcher(controller.signal);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result).toBe("result");
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. AbortController.abort() causes AbortError
+  // ---------------------------------------------------------------------------
+  it("AbortController.abort() causes fetch-like operations to throw AbortError", async () => {
+    const controller = new AbortController();
+
+    const fetcher = async (signal: AbortSignal): Promise<string> => {
+      // Simulate an async operation that respects the signal
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    };
+
+    const promise = fetcher(controller.signal);
+    controller.abort();
+
+    try {
+      await promise;
+      // Should not reach here
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(DOMException);
+      expect((err as DOMException).name).toBe("AbortError");
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // 7. swrCache.delete removes entry
+  // ---------------------------------------------------------------------------
+  it("delete removes a cache entry (simulates mutate clearing cache)", () => {
+    swrCache.set("to-delete", { data: "bye", fetchedAt: Date.now() });
+    expect(swrCache.get("to-delete")).toBeDefined();
+
+    swrCache.delete("to-delete");
+    expect(swrCache.get("to-delete")).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 8. swrCache respects LRU eviction (integration sanity check)
+  // ---------------------------------------------------------------------------
+  it("evicts least-recently-used entries when capacity is exceeded", () => {
+    // swrCache has maxSize 200
+    for (let i = 0; i < 201; i++) {
+      swrCache.set(`k-${i}`, { data: i, fetchedAt: Date.now() });
+    }
+
+    // The very first entry (k-0) should have been evicted
+    expect(swrCache.get("k-0")).toBeUndefined();
+
+    // The most recent entry should still be present
+    expect(swrCache.get("k-200")?.data).toBe(200);
+  });
+});

--- a/packages/nexus-tui/tests/shared/virtual-list.test.ts
+++ b/packages/nexus-tui/tests/shared/virtual-list.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the calculateWindow pure function used by VirtualList.
+ *
+ * Validates scroll offset calculation, viewport windowing, and overscan
+ * buffer clamping without involving React rendering.
+ *
+ * @see Issue #3102, Decision 1A
+ */
+
+import { describe, it, expect } from "bun:test";
+import { calculateWindow } from "../../src/shared/components/virtual-list.js";
+
+describe("calculateWindow", () => {
+  it("returns zeros for an empty list", () => {
+    const result = calculateWindow(0, 10, 0, 2);
+    expect(result).toEqual({ startIndex: 0, endIndex: 0, scrollOffset: 0 });
+  });
+
+  it("handles a single item", () => {
+    const result = calculateWindow(1, 10, 0, 2);
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(1);
+    expect(result.scrollOffset).toBe(0);
+  });
+
+  it("shows all items when count equals viewport height", () => {
+    // totalItems=10, viewportHeight=10 => everything fits, no scroll
+    const result = calculateWindow(10, 10, 5, 2);
+    expect(result.scrollOffset).toBe(0);
+    expect(result.startIndex).toBe(0);
+    // endIndex = min(10, 0 + 10 + 2) = 10
+    expect(result.endIndex).toBe(10);
+  });
+
+  it("shows all items when count is less than viewport height", () => {
+    const result = calculateWindow(5, 10, 3, 2);
+    expect(result.scrollOffset).toBe(0);
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(5);
+  });
+
+  it("clamps scroll offset to 0 when selectedIndex is at top", () => {
+    // 100 items, viewport 20, selected at 0 => offset centers to max(0, 0-10) = 0
+    const result = calculateWindow(100, 20, 0, 3);
+    expect(result.scrollOffset).toBe(0);
+    // startIndex = max(0, 0-3) = 0
+    expect(result.startIndex).toBe(0);
+    // endIndex = min(100, 0+20+3) = 23
+    expect(result.endIndex).toBe(23);
+  });
+
+  it("centers selectedIndex in the viewport for a large list", () => {
+    // 100 items, viewport 20, selected at 50
+    // scrollOffset = max(0, 50 - floor(20/2)) = 50 - 10 = 40
+    // maxOffset = 100 - 20 = 80, so 40 is within range
+    const result = calculateWindow(100, 20, 50, 3);
+    expect(result.scrollOffset).toBe(40);
+    // startIndex = max(0, 40-3) = 37
+    expect(result.startIndex).toBe(37);
+    // endIndex = min(100, 40+20+3) = 63
+    expect(result.endIndex).toBe(63);
+  });
+
+  it("clamps scroll offset to maxOffset when selectedIndex is at the end", () => {
+    // 100 items, viewport 20, selected at 99
+    // scrollOffset = max(0, 99 - 10) = 89, but maxOffset = 100-20 = 80
+    // so scrollOffset = 80
+    const result = calculateWindow(100, 20, 99, 3);
+    expect(result.scrollOffset).toBe(80);
+    // startIndex = max(0, 80-3) = 77
+    expect(result.startIndex).toBe(77);
+    // endIndex = min(100, 80+20+3) = 100
+    expect(result.endIndex).toBe(100);
+  });
+
+  it("clamps overscan at the top edge so startIndex never goes negative", () => {
+    // 50 items, viewport 10, selected at 2, overscan 8
+    // scrollOffset = max(0, 2 - 5) = 0
+    // startIndex = max(0, 0 - 8) = 0 (not -8)
+    const result = calculateWindow(50, 10, 2, 8);
+    expect(result.scrollOffset).toBe(0);
+    expect(result.startIndex).toBe(0);
+    // endIndex = min(50, 0+10+8) = 18
+    expect(result.endIndex).toBe(18);
+  });
+
+  it("clamps overscan at the bottom edge so endIndex never exceeds totalItems", () => {
+    // 50 items, viewport 10, selected at 47, overscan 8
+    // scrollOffset = max(0, 47 - 5) = 42, maxOffset = 50-10 = 40 => 40
+    // endIndex = min(50, 40+10+8) = min(50, 58) = 50
+    const result = calculateWindow(50, 10, 47, 8);
+    expect(result.scrollOffset).toBe(40);
+    expect(result.endIndex).toBe(50);
+    // startIndex = max(0, 40-8) = 32
+    expect(result.startIndex).toBe(32);
+  });
+
+  it("handles overscan larger than totalItems", () => {
+    // 5 items, viewport 3, selected at 2, overscan 100
+    // scrollOffset = max(0, 2 - 1) = 1, maxOffset = 5-3 = 2 => 1
+    // startIndex = max(0, 1 - 100) = 0
+    // endIndex = min(5, 1 + 3 + 100) = 5
+    const result = calculateWindow(5, 3, 2, 100);
+    expect(result.scrollOffset).toBe(1);
+    expect(result.startIndex).toBe(0);
+    expect(result.endIndex).toBe(5);
+  });
+});

--- a/packages/nexus-tui/tests/stores/files-store.test.ts
+++ b/packages/nexus-tui/tests/stores/files-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
-import { useFilesStore, getEffectiveSelection } from "../../src/stores/files-store.js";
+import { useFilesStore, getEffectiveSelection, _fileCache } from "../../src/stores/files-store.js";
 import type { FetchClient } from "@nexus/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
@@ -27,10 +27,11 @@ function mockClient(responses: Record<string, unknown>): FetchClient {
 
 describe("FilesStore", () => {
   beforeEach(() => {
+    _fileCache.clear();
     useFilesStore.setState({
-      fileCache: new Map(),
       currentPath: "/",
       selectedIndex: 0,
+      fileCacheRevision: 0,
       treeNodes: new Map(),
       focusPane: "tree",
       previewPath: null,
@@ -72,21 +73,23 @@ describe("FilesStore", () => {
             { name: "a_dir", path: "/a_dir", isDirectory: true, size: 0, modifiedAt: null, etag: null, mimeType: null },
             { name: "b.txt", path: "/b.txt", isDirectory: false, size: 200, modifiedAt: null, etag: null, mimeType: null },
           ],
+          has_more: false,
+          next_cursor: null,
         },
       });
 
       await useFilesStore.getState().fetchFiles("/", client);
-      const cached = useFilesStore.getState().fileCache.get("/");
+      const cached = useFilesStore.getState().getCachedFiles("/");
       expect(cached).toBeDefined();
-      expect(cached!.data[0]!.name).toBe("a_dir");
-      expect(cached!.data[0]!.isDirectory).toBe(true);
-      expect(cached!.data[1]!.name).toBe("b.txt");
-      expect(cached!.data[2]!.name).toBe("z.txt");
+      expect(cached![0]!.name).toBe("a_dir");
+      expect(cached![0]!.isDirectory).toBe(true);
+      expect(cached![1]!.name).toBe("b.txt");
+      expect(cached![2]!.name).toBe("z.txt");
     });
 
     it("uses SWR cache (doesn't re-fetch within TTL)", async () => {
       const client = mockClient({
-        "/api/v2/files/list": { items: [] },
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
       });
 
       await useFilesStore.getState().fetchFiles("/", client);
@@ -103,18 +106,28 @@ describe("FilesStore", () => {
       await useFilesStore.getState().fetchFiles("/", client);
       expect(useFilesStore.getState().error).toBe("Network error");
     });
+
+    it("increments fileCacheRevision on successful fetch", async () => {
+      const client = mockClient({
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
+      });
+
+      const revBefore = useFilesStore.getState().fileCacheRevision;
+      await useFilesStore.getState().fetchFiles("/", client);
+      expect(useFilesStore.getState().fileCacheRevision).toBe(revBefore + 1);
+    });
   });
 
   describe("invalidate", () => {
     it("removes path from cache", async () => {
       const client = mockClient({
-        "/api/v2/files/list": { items: [] },
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
       });
       await useFilesStore.getState().fetchFiles("/", client);
-      expect(useFilesStore.getState().fileCache.has("/")).toBe(true);
+      expect(useFilesStore.getState().getCachedFiles("/")).toBeDefined();
 
       useFilesStore.getState().invalidate("/");
-      expect(useFilesStore.getState().fileCache.has("/")).toBe(false);
+      expect(_fileCache.has("/")).toBe(false);
     });
   });
 
@@ -126,6 +139,8 @@ describe("FilesStore", () => {
             { name: "child.txt", path: "/child.txt", isDirectory: false, size: 100, modifiedAt: null, etag: null, mimeType: null },
             { name: "subdir", path: "/subdir", isDirectory: true, size: 0, modifiedAt: null, etag: null, mimeType: null },
           ],
+          has_more: false,
+          next_cursor: null,
         },
       });
 
@@ -146,9 +161,27 @@ describe("FilesStore", () => {
       expect(subdir!.depth).toBe(1);
     });
 
+    it("expandNode stores pagination state", async () => {
+      const client = mockClient({
+        "/api/v2/files/list": {
+          items: [
+            { name: "file1.txt", path: "/file1.txt", isDirectory: false, size: 50, modifiedAt: null, etag: null, mimeType: null },
+          ],
+          has_more: true,
+          next_cursor: "abc123",
+        },
+      });
+
+      await useFilesStore.getState().expandNode("/", client);
+      const root = useFilesStore.getState().treeNodes.get("/")!;
+      expect(root.hasMore).toBe(true);
+      expect(root.nextCursor).toBe("abc123");
+      expect(root.loadingMore).toBe(false);
+    });
+
     it("collapseNode sets expanded to false", async () => {
       const client = mockClient({
-        "/api/v2/files/list": { items: [] },
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
       });
 
       await useFilesStore.getState().expandNode("/", client);
@@ -156,6 +189,77 @@ describe("FilesStore", () => {
 
       useFilesStore.getState().collapseNode("/");
       expect(useFilesStore.getState().treeNodes.get("/")!.expanded).toBe(false);
+    });
+
+    it("expandNode sorts directories first", async () => {
+      const client = mockClient({
+        "/api/v2/files/list": {
+          items: [
+            { name: "z.txt", path: "/z.txt", isDirectory: false, size: 100, modifiedAt: null, etag: null, mimeType: null },
+            { name: "a_dir", path: "/a_dir", isDirectory: true, size: 0, modifiedAt: null, etag: null, mimeType: null },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      });
+
+      await useFilesStore.getState().expandNode("/", client);
+      const root = useFilesStore.getState().treeNodes.get("/")!;
+      expect(root.children[0]).toBe("/a_dir");
+      expect(root.children[1]).toBe("/z.txt");
+    });
+  });
+
+  describe("loadMoreChildren", () => {
+    it("appends next page to existing children", async () => {
+      // First page
+      const getMock = mock(async (path: string) => {
+        if (path.includes("cursor=")) {
+          return {
+            items: [
+              { name: "file3.txt", path: "/file3.txt", isDirectory: false, size: 300, modifiedAt: null, etag: null, mimeType: null },
+            ],
+            has_more: false,
+            next_cursor: null,
+          };
+        }
+        return {
+          items: [
+            { name: "file1.txt", path: "/file1.txt", isDirectory: false, size: 100, modifiedAt: null, etag: null, mimeType: null },
+            { name: "file2.txt", path: "/file2.txt", isDirectory: false, size: 200, modifiedAt: null, etag: null, mimeType: null },
+          ],
+          has_more: true,
+          next_cursor: "cursor_abc",
+        };
+      });
+      const client = { get: getMock } as unknown as FetchClient;
+
+      // Expand first
+      await useFilesStore.getState().expandNode("/", client);
+      const rootBefore = useFilesStore.getState().treeNodes.get("/")!;
+      expect(rootBefore.children.length).toBe(2);
+      expect(rootBefore.hasMore).toBe(true);
+
+      // Load more
+      await useFilesStore.getState().loadMoreChildren("/", client);
+      const rootAfter = useFilesStore.getState().treeNodes.get("/")!;
+      expect(rootAfter.children.length).toBe(3);
+      expect(rootAfter.children).toContain("/file3.txt");
+      expect(rootAfter.hasMore).toBe(false);
+      expect(rootAfter.nextCursor).toBeNull();
+    });
+
+    it("does nothing when hasMore is false", async () => {
+      const client = mockClient({
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
+      });
+
+      await useFilesStore.getState().expandNode("/", client);
+      const callsBefore = (client.get as ReturnType<typeof mock>).mock.calls.length;
+
+      await useFilesStore.getState().loadMoreChildren("/", client);
+      // No additional call should be made
+      expect((client.get as ReturnType<typeof mock>).mock.calls.length).toBe(callsBefore);
     });
   });
 
@@ -190,12 +294,12 @@ describe("FilesStore", () => {
   describe("deleteFile", () => {
     it("calls DELETE API and invalidates parent cache", async () => {
       const client = mockClient({
-        "/api/v2/files/list": { items: [] },
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
       });
 
       // Pre-populate cache for parent
       await useFilesStore.getState().fetchFiles("/", client);
-      expect(useFilesStore.getState().fileCache.has("/")).toBe(true);
+      expect(useFilesStore.getState().getCachedFiles("/")).toBeDefined();
 
       await useFilesStore.getState().deleteFile("/test.txt", client);
 
@@ -220,7 +324,7 @@ describe("FilesStore", () => {
   describe("mkdirFile", () => {
     it("calls POST mkdir API and invalidates parent cache", async () => {
       const client = mockClient({
-        "/api/v2/files/list": { items: [] },
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
       });
 
       await useFilesStore.getState().mkdirFile("/newdir", client);
@@ -244,7 +348,7 @@ describe("FilesStore", () => {
   describe("renameFile", () => {
     it("calls rename API and invalidates parent cache", async () => {
       const client = mockClient({
-        "/api/v2/files/list": { items: [] },
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
         "/api/v2/files/rename": { success: true },
       });
 
@@ -406,7 +510,7 @@ describe("FilesStore", () => {
   describe("pasteFiles", () => {
     it("copies files and tracks progress", async () => {
       const client = mockClient({
-        "/api/v2/files/list": { items: [] },
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
       });
 
       useFilesStore.getState().yankToClipboard(["/a.txt", "/b.txt"]);
@@ -422,7 +526,7 @@ describe("FilesStore", () => {
 
     it("uses rename endpoint for cut operations", async () => {
       const client = mockClient({
-        "/api/v2/files/list": { items: [] },
+        "/api/v2/files/list": { items: [], has_more: false, next_cursor: null },
       });
 
       useFilesStore.getState().cutToClipboard(["/x.txt"]);
@@ -504,6 +608,32 @@ describe("FilesStore", () => {
       // anchor=5, cursor=10 with only 7 items → clamp cursor to 6
       const result = getEffectiveSelection(new Set(), 5, 10, nodes);
       expect(result).toEqual(new Set(["/f", "/g"]));
+    });
+  });
+
+  // ===========================================================================
+  // getCachedFiles (#3102)
+  // ===========================================================================
+
+  describe("getCachedFiles", () => {
+    it("returns cached data within TTL", async () => {
+      const client = mockClient({
+        "/api/v2/files/list": {
+          items: [{ name: "test.txt", path: "/test.txt", isDirectory: false, size: 50, modifiedAt: null, etag: null, mimeType: null }],
+          has_more: false,
+          next_cursor: null,
+        },
+      });
+
+      await useFilesStore.getState().fetchFiles("/", client);
+      const files = useFilesStore.getState().getCachedFiles("/");
+      expect(files).toBeDefined();
+      expect(files!.length).toBe(1);
+      expect(files![0]!.name).toBe("test.txt");
+    });
+
+    it("returns undefined for uncached path", () => {
+      expect(useFilesStore.getState().getCachedFiles("/unknown")).toBeUndefined();
     });
   });
 });

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -43,6 +43,37 @@ from nexus.contracts.exceptions import (
 
 logger = logging.getLogger(__name__)
 
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _to_file_item(entry: dict[str, Any], prefix: str) -> "FileItemResponse":
+    """Convert a sys_readdir details dict to a FileItemResponse.
+
+    sys_readdir(details=True) returns dicts with path, size, etag.
+    We derive name and is_directory from the path.
+    """
+    raw_path: str = entry.get("path", "")
+    is_dir = raw_path.endswith("/")
+    clean_path = raw_path.rstrip("/")
+    name = (
+        clean_path[len(prefix) :]
+        if clean_path.startswith(prefix)
+        else clean_path.rsplit("/", 1)[-1]
+    )
+
+    return FileItemResponse(
+        name=name,
+        path=clean_path,
+        is_directory=is_dir,
+        size=entry.get("size", 0) if not is_dir else 0,
+        modified_at=None,
+        etag=entry.get("etag"),
+    )
+
+
 # =============================================================================
 # Request/Response Models
 # =============================================================================
@@ -90,10 +121,34 @@ class ExistsResponse(BaseModel):
     exists: bool
 
 
-class ListResponse(BaseModel):
-    """Response model for list directory."""
+class FileItemResponse(BaseModel):
+    """Single file/directory entry with metadata.
 
-    items: list[str]
+    Uses serialization_alias so JSON output matches the TUI's camelCase convention.
+    """
+
+    name: str
+    path: str
+    is_directory: bool = Field(default=False, serialization_alias="isDirectory")
+    size: int = 0
+    modified_at: str | None = Field(None, serialization_alias="modifiedAt")
+    etag: str | None = None
+    mime_type: str | None = Field(None, serialization_alias="mimeType")
+    version: int | None = None
+    owner: str | None = None
+    permissions: str | None = None
+    zone_id: str | None = Field(None, serialization_alias="zoneId")
+
+
+class ListResponse(BaseModel):
+    """Response model for list directory — supports cursor pagination.
+
+    @see Issue #3102, Decision 2A
+    """
+
+    items: list[FileItemResponse]
+    has_more: bool = False
+    next_cursor: str | None = None
 
 
 class MkdirRequest(BaseModel):
@@ -505,26 +560,70 @@ def create_async_files_router(
     # List Directory Endpoint
     # =============================================================================
 
-    @router.get("/list", response_model=ListResponse)
+    @router.get("/list", response_model=ListResponse, response_model_by_alias=True)
     async def list_directory(
         path: str = Query(..., description="Directory path to list"),
+        limit: int | None = Query(
+            None, ge=1, le=1000, description="Max items per page (default: all)"
+        ),
+        cursor: str | None = Query(
+            None, description="Opaque cursor from previous response's next_cursor"
+        ),
         context: Any = Depends(get_context),
     ) -> ListResponse:
-        """List directory contents."""
+        """List directory contents with optional cursor pagination.
+
+        When ``limit`` is provided, returns at most ``limit`` items plus
+        ``has_more`` / ``next_cursor`` for fetching the next page.  Without
+        ``limit``, all entries are returned in a single response (backward
+        compatible).
+
+        @see Issue #3102, Decision 2A
+        """
         try:
             fs = await _get_fs()
 
-            # NexusFS.list() returns full paths; strip prefix to get names
-            full_paths = await asyncio.to_thread(
-                fs.sys_readdir, path, recursive=False, context=context
-            )
-            prefix = path.rstrip("/") + "/"
-            items = [
-                fp[len(prefix) :] if fp.startswith(prefix) else fp.rsplit("/", 1)[-1]
-                for fp in full_paths
-            ]
-            return ListResponse(items=items)
+            # Decode opaque cursor (base64-encoded path)
+            cursor_path: str | None = None
+            if cursor is not None:
+                try:
+                    cursor_path = base64.b64decode(cursor).decode("utf-8")
+                except Exception:
+                    raise HTTPException(status_code=400, detail="Invalid cursor") from None
 
+            # sys_readdir already supports limit/cursor/details natively
+            result = await asyncio.to_thread(
+                fs.sys_readdir,
+                path,
+                recursive=False,
+                details=True,
+                context=context,
+                limit=limit,
+                cursor=cursor_path,
+            )
+
+            prefix = path.rstrip("/") + "/"
+
+            # Paginated path: result is a PaginatedResult
+            if limit is not None:
+                file_items = [_to_file_item(entry, prefix) for entry in result.items]
+                next_cursor = (
+                    base64.b64encode(result.next_cursor.encode("utf-8")).decode("ascii")
+                    if result.next_cursor
+                    else None
+                )
+                return ListResponse(
+                    items=file_items,
+                    has_more=result.has_more,
+                    next_cursor=next_cursor,
+                )
+
+            # Non-paginated path (backward compat): result is list[dict]
+            file_items = [_to_file_item(entry, prefix) for entry in result]
+            return ListResponse(items=file_items, has_more=False)
+
+        except HTTPException:
+            raise
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -71,6 +71,8 @@ def _to_file_item(entry: dict[str, Any], prefix: str) -> "FileItemResponse":
         size=entry.get("size", 0) if not is_dir else 0,
         modified_at=None,
         etag=entry.get("etag"),
+        mime_type=None,
+        zone_id=None,
     )
 
 

--- a/tests/unit/server/api/v2/routers/test_async_files_pagination.py
+++ b/tests/unit/server/api/v2/routers/test_async_files_pagination.py
@@ -1,0 +1,192 @@
+"""Tests for paginated /list endpoint (Issue #3102, Decision 2A)."""
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.core.pagination import PaginatedResult
+from nexus.server.api.v2.routers.async_files import create_async_files_router
+from nexus.server.dependencies import get_auth_result
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(path: str, size: int = 100, etag: str = "etag1") -> dict:
+    """Build a details dict as returned by sys_readdir(details=True)."""
+    return {"path": path, "size": size, "etag": etag}
+
+
+def _encode_cursor(path: str) -> str:
+    return base64.b64encode(path.encode()).decode()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_fs() -> MagicMock:
+    """Create a mock NexusFS."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(mock_fs: MagicMock) -> TestClient:
+    """Create a TestClient with mock FS and bypassed auth."""
+    app = FastAPI()
+    router = create_async_files_router(nexus_fs=mock_fs)
+    app.include_router(router)
+
+    app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "test-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": False,
+    }
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestListPagination:
+    """Cursor-based pagination on GET /list."""
+
+    def test_list_without_limit_returns_all_items(
+        self, client: TestClient, mock_fs: MagicMock
+    ) -> None:
+        """Without limit, sys_readdir returns a plain list (backward compat)."""
+        mock_fs.sys_readdir.return_value = [
+            _make_entry("/data/a.txt", size=10, etag="e1"),
+            _make_entry("/data/b.txt", size=20, etag="e2"),
+            _make_entry("/data/sub/", size=0, etag="e3"),
+        ]
+
+        resp = client.get("/list", params={"path": "/data"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["items"]) == 3
+        assert body["has_more"] is False
+        assert body["next_cursor"] is None
+        # Verify names derived from path
+        assert body["items"][0]["name"] == "a.txt"
+        assert body["items"][2]["name"] == "sub"
+        assert body["items"][2]["isDirectory"] is True
+
+    def test_list_with_limit_returns_first_page(
+        self, client: TestClient, mock_fs: MagicMock
+    ) -> None:
+        """With limit=2, returns first 2 items, has_more=True, next_cursor set."""
+        next_cursor_path = "/data/b.txt"
+        mock_fs.sys_readdir.return_value = PaginatedResult(
+            items=[
+                _make_entry("/data/a.txt", size=10, etag="e1"),
+                _make_entry("/data/b.txt", size=20, etag="e2"),
+            ],
+            next_cursor=next_cursor_path,
+            has_more=True,
+        )
+
+        resp = client.get("/list", params={"path": "/data", "limit": 2})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["items"]) == 2
+        assert body["has_more"] is True
+        assert body["next_cursor"] == _encode_cursor(next_cursor_path)
+        # Verify sys_readdir called with limit and cursor=None
+        call_kwargs = mock_fs.sys_readdir.call_args[1]
+        assert call_kwargs["limit"] == 2
+        assert call_kwargs["cursor"] is None
+
+    def test_list_with_limit_and_cursor_returns_next_page(
+        self, client: TestClient, mock_fs: MagicMock
+    ) -> None:
+        """Passing cursor from previous response fetches the next page."""
+        cursor_path = "/data/b.txt"
+        encoded_cursor = _encode_cursor(cursor_path)
+
+        mock_fs.sys_readdir.return_value = PaginatedResult(
+            items=[
+                _make_entry("/data/c.txt", size=30, etag="e3"),
+                _make_entry("/data/d.txt", size=40, etag="e4"),
+            ],
+            next_cursor="/data/d.txt",
+            has_more=True,
+        )
+
+        resp = client.get(
+            "/list",
+            params={"path": "/data", "limit": 2, "cursor": encoded_cursor},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["items"]) == 2
+        assert body["items"][0]["name"] == "c.txt"
+        # Verify decoded cursor was forwarded to sys_readdir
+        call_kwargs = mock_fs.sys_readdir.call_args[1]
+        assert call_kwargs["cursor"] == cursor_path
+
+    def test_last_page_has_no_more(self, client: TestClient, mock_fs: MagicMock) -> None:
+        """Last page: has_more=False, next_cursor=None."""
+        mock_fs.sys_readdir.return_value = PaginatedResult(
+            items=[
+                _make_entry("/data/e.txt", size=50, etag="e5"),
+            ],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        resp = client.get("/list", params={"path": "/data", "limit": 2})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["items"]) == 1
+        assert body["has_more"] is False
+        assert body["next_cursor"] is None
+
+    def test_empty_directory(self, client: TestClient, mock_fs: MagicMock) -> None:
+        """Empty directory returns empty items, has_more=False."""
+        mock_fs.sys_readdir.return_value = PaginatedResult(
+            items=[],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        resp = client.get("/list", params={"path": "/empty", "limit": 10})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["items"] == []
+        assert body["has_more"] is False
+        assert body["next_cursor"] is None
+
+    def test_invalid_cursor_returns_400(self, client: TestClient, mock_fs: MagicMock) -> None:
+        """A cursor that is not valid base64 returns 400."""
+        resp = client.get(
+            "/list",
+            params={"path": "/data", "limit": 10, "cursor": "%%%not-base64%%%"},
+        )
+
+        assert resp.status_code == 400
+        assert "Invalid cursor" in resp.json()["detail"]
+        # sys_readdir should never be called
+        mock_fs.sys_readdir.assert_not_called()
+
+    def test_limit_exceeds_max_returns_422(self, client: TestClient) -> None:
+        """limit=1001 exceeds the max (1000) and triggers validation error."""
+        resp = client.get("/list", params={"path": "/data", "limit": 1001})
+
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Closes #3102

Full implementation of the 4 performance optimizations for the TUI file explorer:

- **React.memo** on `FileTreeNode` and `FileListItem` — prevents O(n) re-renders when store updates
- **AbortController** in `use-swr.ts` + `files-store.ts` — cancels stale requests on key change, path change, panel unmount
- **VirtualList** shared component — windowed rendering (only visible rows + overscan buffer), integrated into FileTree
- **Cursor pagination** on `GET /api/v2/files/list` — server-side limit/cursor using existing `sys_readdir` pagination, client-side infinite scroll with "load more" sentinels

### DRY / code quality
- Extract `formatSize` to `shared/utils/format-size.ts` (was 3 inconsistent copies)
- Extract `truncateText` to `shared/utils/format-text.ts` (was 3 identical copies)
- Extract `sortFileItems` helper in `files-store.ts`
- Extract generic `LruCache` to `shared/utils/lru-cache.ts` with O(n) min-scan eviction
- Replace FIFO file cache with shared LruCache

### Files changed (22)
- 12 modified, 10 new
- +1400 / -179 lines

## Test plan
- [x] `bun test` — 644 pass, 0 new failures (5 pre-existing module resolution errors)
- [x] `pytest test_async_files_pagination.py` — 7 pass (cursor pagination edge cases)
- [x] `pytest test_async_files_write_mode.py` — 5 pass (no regression)
- [x] New test suites: VirtualList (10), LruCache (10), formatSize (5), truncateText (4), useSwr (8), files-store loadMore (3), server pagination (7) = **47 new tests**
- [ ] Manual: expand a large directory, verify only ~20 rows render
- [ ] Manual: rapid panel switching, confirm no stale state
- [ ] Manual: scroll to bottom of 200+ item directory, confirm "load more" triggers