### PR TITLE
feat(#1704,#1705): move _hierarchy_manager and _rebac_manager to _do_link()

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -154,9 +154,7 @@ class NexusFS(  # type: ignore[misc]
         # =====================================================================
         # Hot-path service attrs — kept on kernel for perf (Issue #1682)
         # =====================================================================
-        self._rebac_manager = sys_svc.rebac_manager
         self._permission_enforcer = sys_svc.permission_enforcer
-        self._hierarchy_manager = sys_svc.hierarchy_manager
         # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
         self._overlay_resolver = None
         # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)
@@ -606,7 +604,12 @@ class NexusFS(  # type: ignore[misc]
         # Grant direct_owner permission to the user who created the directory
         # Note: Use 'direct_owner' (not 'owner') as the base relation.
         # 'owner' is a computed union of direct_owner + parent_owner in the ReBAC schema.
-        if self._rebac_manager and ctx.user_id and not ctx.is_system:
+        if (
+            hasattr(self, "_rebac_manager")
+            and self._rebac_manager
+            and ctx.user_id
+            and not ctx.is_system
+        ):
             try:
                 logger.debug(
                     "mkdir: Granting direct_owner permission to %s for %s", ctx.user_id, path

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -48,6 +48,8 @@ async def _do_link(
     nx._async_namespace_manager = _sys.async_namespace_manager
     nx._context_branch_service = _sys.context_branch_service
     nx._dir_visibility_cache = _sys.dir_visibility_cache  # Issue #1703: facade, not kernel
+    nx._hierarchy_manager = _sys.hierarchy_manager  # Issue #1704: facade, not kernel
+    nx._rebac_manager = _sys.rebac_manager  # Issue #1705: facade, not kernel
     nx._event_bus = _brk.event_bus
     nx._wallet_provisioner = _brk.wallet_provisioner
     nx._api_key_creator = _brk.api_key_creator


### PR DESCRIPTION
## Summary
- Move `_hierarchy_manager` and `_rebac_manager` from kernel `__init__` to factory `_do_link()` as facade attrs
- Continues Constructor DI deprecation (#1682) after `_dir_visibility_cache` (#1703, merged in PR #3106)
- Fixed unguarded `self._rebac_manager` access in `sys_mkdir` by adding `hasattr` guard
- After this, only `_permission_enforcer` remains in `__init__` (8 unguarded call sites — tracked by #1706)

## Changes
| Attr | Issue | Call sites | Guard pattern |
|------|-------|-----------|--------------|
| `_hierarchy_manager` | #1704 | 5 sites (mkdir/write/write_batch) | All `hasattr` guarded |
| `_rebac_manager` | #1705 | 9 sites (mkdir/write/write_batch/rename/close) | Fixed 1 unguarded site |

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, etc.)
- [x] 2375 core tests pass
- [x] All `hasattr` guards handle missing attrs correctly (degraded mode when `link()` not called)

🤖 Generated with [Claude Code](https://claude.com/claude-code)