### PR TITLE
feat(#1706): migrate _permission_enforcer to _do_link()

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -151,10 +151,9 @@ class NexusFS(  # type: ignore[misc]
             admin_capabilities=set(),
         )
 
-        # =====================================================================
-        # Hot-path service attrs — kept on kernel for perf (Issue #1682)
-        # =====================================================================
-        self._permission_enforcer = sys_svc.permission_enforcer
+        # Issue #1706: sentinel — real value wired by factory._do_link().
+        # Kept as sentinel (not deleted) because 8 kernel methods access without hasattr guard.
+        self._permission_enforcer: Any = None
         # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
         self._overlay_resolver = None
         # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -50,6 +50,7 @@ async def _do_link(
     nx._dir_visibility_cache = _sys.dir_visibility_cache  # Issue #1703: facade, not kernel
     nx._hierarchy_manager = _sys.hierarchy_manager  # Issue #1704: facade, not kernel
     nx._rebac_manager = _sys.rebac_manager  # Issue #1705: facade, not kernel
+    nx._permission_enforcer = _sys.permission_enforcer  # Issue #1706: override sentinel
     nx._event_bus = _brk.event_bus
     nx._wallet_provisioner = _brk.wallet_provisioner
     nx._api_key_creator = _brk.api_key_creator


### PR DESCRIPTION
## Summary
- Migrates `_permission_enforcer` from `NexusFS.__init__()` constructor DI to factory `_do_link()` facade attr wiring
- Uses `None` sentinel in `__init__` (can't delete because 8 kernel methods access without `hasattr` guard), overridden with real value in `_do_link()` before any syscall runs
- Part of Issue #1570 constructor DI deprecation path (#1703→#1704→#1705→**#1706**)

## Test plan
- [x] `ruff check` passes on both changed files
- [x] 85 targeted unit tests pass (write_observer, minimal_boot, rename, write_batch)
- [x] 2857/2858 full unit tests pass (1 pre-existing flaky: `test_client_class_parameter`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)