### PR TITLE
refactor(#1710): migrate federation resolvers to coordinator.enlist()

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -548,7 +548,7 @@ async def connect(
 
         # Register federation content resolver (PRE-DISPATCH, Issue #163)
         # Registered LAST so Pipe/Memory/VirtualView resolvers get priority.
-        _register_federation_resolver(nx_fs, zone_mgr)
+        await _register_federation_resolver(nx_fs, zone_mgr)
 
     # Restore saved mounts (application-layer startup I/O)
     await _restore_mounts(nx_fs)
@@ -556,15 +556,20 @@ async def connect(
     return nx_fs
 
 
-def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any) -> None:
-    """Register federation resolvers for remote IPC and content (#163, #1625).
+async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any) -> None:
+    """Register federation resolvers via coordinator.enlist() (#163, #1625, #1710).
 
     Registration order matters — IPC resolver is registered FIRST so remote
     DT_PIPE/DT_STREAM are intercepted before the content resolver.  Content
     resolver is registered LAST as a generic fallback for CAS-backed content.
+
+    Both resolvers implement HotSwappable and are enlisted via the unified
+    coordinator.enlist() entry point (#1710).
     """
     from nexus.raft.federation_content_resolver import FederationContentResolver
     from nexus.raft.federation_ipc_resolver import FederationIPCResolver
+
+    _coordinator = getattr(nx_fs, "_service_coordinator", None)
 
     # IPC resolver — remote DT_PIPE/DT_STREAM (#1625)
     ipc_resolver = FederationIPCResolver(
@@ -572,7 +577,10 @@ def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any) -> None:
         self_address=zone_mgr.advertise_addr,
         tls_config=zone_mgr.tls_config,
     )
-    nx_fs._dispatch.register_resolver(ipc_resolver)
+    if _coordinator is not None:
+        await _coordinator.enlist("federation_ipc", ipc_resolver)
+    else:
+        nx_fs._dispatch.register_resolver(ipc_resolver)
 
     # Content resolver — remote CAS content (#163)
     content_resolver = FederationContentResolver(
@@ -580,7 +588,10 @@ def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any) -> None:
         self_address=zone_mgr.advertise_addr,
         tls_config=zone_mgr.tls_config,
     )
-    nx_fs._dispatch.register_resolver(content_resolver)
+    if _coordinator is not None:
+        await _coordinator.enlist("federation_content", content_resolver)
+    else:
+        nx_fs._dispatch.register_resolver(content_resolver)
 
     logger.info("Federation resolvers registered: IPC + Content (self=%s)", zone_mgr.advertise_addr)
 

--- a/src/nexus/raft/federation_content_resolver.py
+++ b/src/nexus/raft/federation_content_resolver.py
@@ -23,6 +23,7 @@ from nexus.contracts.backend_address import BackendAddress
 from nexus.contracts.exceptions import NexusFileNotFoundError
 
 if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.core.metastore import MetastoreABC
     from nexus.security.tls.config import ZoneTlsConfig
 
@@ -66,6 +67,21 @@ class FederationContentResolver:
         self._self_address = self_address
         self._tls_config = tls_config
         self._timeout = timeout
+
+    # ------------------------------------------------------------------
+    # HotSwappable protocol (#1710) — enables coordinator.enlist()
+    # ------------------------------------------------------------------
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(resolvers=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     # ------------------------------------------------------------------
     # VFSPathResolver single-call try_* protocol (#1665)

--- a/src/nexus/raft/federation_ipc_resolver.py
+++ b/src/nexus/raft/federation_ipc_resolver.py
@@ -28,6 +28,7 @@ from nexus.contracts.backend_address import BackendAddress
 from nexus.contracts.exceptions import NexusFileNotFoundError
 
 if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.core.metastore import MetastoreABC
     from nexus.security.tls.config import ZoneTlsConfig
 
@@ -61,6 +62,21 @@ class FederationIPCResolver:
         self._self_address = self_address
         self._tls_config = tls_config
         self._timeout = timeout
+
+    # ------------------------------------------------------------------
+    # HotSwappable protocol (#1710) — enables coordinator.enlist()
+    # ------------------------------------------------------------------
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(resolvers=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     # ------------------------------------------------------------------
     # VFSPathResolver single-call try_* protocol (#1665)


### PR DESCRIPTION
## Summary
- Add HotSwappable protocol (`hook_spec()`, `drain()`, `activate()`) to `FederationIPCResolver` and `FederationContentResolver`
- Replace direct `dispatch.register_resolver()` calls with `coordinator.enlist()` in `_register_federation_resolver()`
- Fallback to direct dispatch when coordinator is unavailable (unit tests)

## Details
This eliminates the last direct dispatch registration path for federation resolvers. Both resolvers now go through the unified `coordinator.enlist()` entry point, which auto-detects HotSwappable and handles dispatch registration + lifecycle management.

## Test plan
- [x] 10698 unit tests pass locally
- [x] Lint + mypy + all pre-commit hooks pass
- [ ] CI green on all 24 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)