### PR TITLE
fix(tui,server): OpenTUI compat, async file ops, UX overhaul

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,7 @@ on:
       - "v*"
     branches:
       - main
+      - develop
   workflow_dispatch:
     inputs:
       tag:
@@ -51,8 +52,8 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            # For main branch pushes: edge
-            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            # For main or develop branch pushes: edge
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
             # For manual dispatch: custom tag or SHA
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
             type=sha,prefix=,enable=${{ github.event.inputs.tag == '' }}
@@ -98,7 +99,7 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
             type=sha,prefix=,enable=${{ github.event.inputs.tag == '' }}
 
       - name: Build and push multi-arch zoekt image

--- a/packages/nexus-api-client/src/config.ts
+++ b/packages/nexus-api-client/src/config.ts
@@ -81,7 +81,9 @@ function readYamlConfig(): YamlConfig {
     const os = require("node:os") as typeof import("node:os");
     const path = require("node:path") as typeof import("node:path");
 
-    // Search order: local dir first, then home dir (matches config.py:_auto_discover)
+    // Search order: CWD first, then home dir.
+    // Each TUI instance uses its own nexus.yaml in its CWD to avoid
+    // conflicts with other running Nexus stacks.
     const candidates = [
       path.resolve("nexus.yaml"),
       path.resolve("nexus.yml"),
@@ -91,10 +93,20 @@ function readYamlConfig(): YamlConfig {
     for (const configPath of candidates) {
       try {
         const content = fs.readFileSync(configPath, "utf-8");
-        const url = extractYamlValue(content, "url");
+        let url = extractYamlValue(content, "url");
         const apiKey = extractYamlValue(content, "api_key");
         const agentId = extractYamlValue(content, "agent_id");
         const zoneId = extractYamlValue(content, "zone_id");
+
+        // If no explicit url but ports.http exists, build URL from port
+        // (nexus init --preset shared/demo writes ports.http instead of url)
+        if (!url) {
+          const httpPort = extractIndentedYamlValue(content, "ports", "http");
+          if (httpPort) {
+            url = `http://localhost:${httpPort}`;
+          }
+        }
+
         return {
           url: url ?? undefined,
           apiKey: apiKey ?? undefined,
@@ -114,6 +126,16 @@ function readYamlConfig(): YamlConfig {
 
 function extractYamlValue(content: string, key: string): string | null {
   const regex = new RegExp(`^${key}:\\s*["']?([^"'\\n]+)["']?`, "m");
+  const match = regex.exec(content);
+  return match?.[1]?.trim() ?? null;
+}
+
+/**
+ * Extract a nested YAML value like `ports:\n  http: 2027`.
+ * Only handles one level of nesting with 2-space indent.
+ */
+function extractIndentedYamlValue(content: string, parent: string, child: string): string | null {
+  const regex = new RegExp(`^${parent}:\\s*\\n(?:[ ]{2}\\w+:[^\\n]*\\n)*?[ ]{2}${child}:\\s*["']?([^"'\\n]+)["']?`, "m");
   const match = regex.exec(content);
   return match?.[1]?.trim() ?? null;
 }

--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -82,10 +82,34 @@ function PanelRouter(): React.ReactNode {
 }
 
 /**
- * Graceful shutdown: kill child processes then exit (Decision 6A).
+ * Graceful shutdown: kill child processes, restore terminal, then exit (Decision 6A).
+ *
+ * We must manually reset the terminal before process.exit() because exit()
+ * bypasses OpenTUI's renderer.destroy() cleanup, leaving mouse tracking
+ * and alternate screen enabled — which causes raw escape sequences to leak
+ * into the shell after exit.
  */
 function shutdown(): void {
   killAllProcesses();
+
+  // Restore stdin from raw mode first (stops reading mouse input)
+  if (process.stdin.setRawMode) {
+    process.stdin.setRawMode(false);
+  }
+  process.stdin.pause();
+
+  // Restore terminal: disable mouse tracking, leave alternate screen, show cursor.
+  // Use writeSync via fd to guarantee the sequences are flushed before exit.
+  const fs = require("fs");
+  const reset = [
+    "\x1b[?1003l", // disable all-motion mouse tracking
+    "\x1b[?1006l", // disable SGR mouse mode
+    "\x1b[?1000l", // disable normal mouse tracking
+    "\x1b[?1049l", // switch back to main screen
+    "\x1b[?25h",   // show cursor
+  ].join("");
+  fs.writeSync(1, reset);
+
   process.exit(0);
 }
 
@@ -104,8 +128,10 @@ export function App(): React.ReactNode {
   const showWelcome = isFresh === true && !welcomeDismissed;
 
   // Determine if we should show the pre-connection screen (Decision 3A)
+  // Only hide it when fully connected — "connecting" still shows the pre-connection
+  // screen with a spinner to avoid flashing the main UI during connection attempts.
   const connState = detectConnectionState(connectionStatus, connectionError, config);
-  const showPreConnection = connState !== "ready" && connState !== "connecting";
+  const showPreConnection = connState !== "ready";
 
   const setOverlayActive = useUiStore((s) => s.setOverlayActive);
   useEffect(() => {
@@ -143,6 +169,10 @@ export function App(): React.ReactNode {
           "9": () => setActivePanel("infrastructure"),
           "0": () => setActivePanel("console"),
           "ctrl+i": toggleIdentitySwitcher,
+          "ctrl+d": () => {
+            // Disconnect and go back to setup menu
+            useGlobalStore.getState().setConnectionStatus("error", "Disconnected by user");
+          },
           "z": () => toggleZoom(activePanel),
           "?": () => setHelpOpen(true),
           "q": shutdown,

--- a/packages/nexus-tui/src/panels/access/access-panel.tsx
+++ b/packages/nexus-tui/src/panels/access/access-panel.tsx
@@ -597,7 +597,7 @@ export default function AccessPanel(): React.ReactNode {
                     <box key={`ring-${i}`} height={1} width="100%">
                       <text>
                         {"  "}
-                        <text foregroundColor={confColor} dimColor={conf < 0.4}>{confStr}</text>
+                        <span foregroundColor={confColor} dimColor={conf < 0.4}>{confStr}</span>
                         {`  [${ringType}]  ${members}`}
                       </text>
                     </box>

--- a/packages/nexus-tui/src/panels/files/file-aspects.tsx
+++ b/packages/nexus-tui/src/panels/files/file-aspects.tsx
@@ -15,13 +15,15 @@ interface FileAspectsProps {
 }
 
 function computeUrn(item: FileItem): string | null {
-  if (!item.path || !item.zoneId) return null;
+  if (!item.path) return null;
+  // Use "default" zone when zone isolation is not configured
+  const zone = item.zoneId || "default";
   const pathHash = crypto
     .createHash("sha256")
     .update(item.path)
     .digest("hex")
     .slice(0, 32);
-  return `urn:nexus:file:${item.zoneId}:${pathHash}`;
+  return `urn:nexus:file:${zone}:${pathHash}`;
 }
 
 export function FileAspects({ item }: FileAspectsProps): React.ReactNode {

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -24,6 +24,7 @@ import {
   type TreeNode,
   getEffectiveSelection,
 } from "../../stores/files-store.js";
+import { useGlobalStore } from "../../stores/global-store.js";
 import { useShareLinkStore } from "../../stores/share-link-store.js";
 import { useUploadStore } from "../../stores/upload-store.js";
 import { Breadcrumb } from "../../shared/components/breadcrumb.js";
@@ -221,8 +222,8 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
         ctx.setConfirmDelete(true);
       }
     },
-    N: () => { ctx.setInputMode("mkdir"); ctx.setInputBuffer(""); },
-    R: () => {
+    "shift+n": () => { ctx.setInputMode("mkdir"); ctx.setInputBuffer(""); },
+    "shift+r": () => {
       if (ctx.isSentinel) return;
       if (ctx.selectedItem) {
         ctx.setInputMode("rename");
@@ -562,12 +563,30 @@ export default function FileExplorerPanel(): React.ReactNode {
   const selectedNode = visibleNodes[selectedIndex] ?? null;
   const isSentinel = selectedNode?.path.endsWith(LOAD_MORE_SENTINEL) ?? false;
 
-  // For metadata/actions, look up the FileItem from the node's parent directory cache.
+  // For metadata/actions, look up FileItem from parent's file cache first,
+  // then fall back to constructing a minimal FileItem from the tree node.
+  // The fallback ensures metadata pane works even if the file cache is empty
+  // (e.g. requests were aborted during rapid navigation).
   const selectedItem: FileItem | null = useMemo(() => {
     if (!selectedNode || isSentinel) return null;
     const parentDir = selectedNode.path.split("/").slice(0, -1).join("/") || "/";
     const parentFiles = getCachedFiles(parentDir);
-    return parentFiles?.find((f) => f.path === selectedNode.path) ?? null;
+    const cached = parentFiles?.find((f) => f.path === selectedNode.path);
+    if (cached) return cached;
+    // Fallback: construct from tree node, using global zoneId from health check
+    return {
+      name: selectedNode.name,
+      path: selectedNode.path,
+      isDirectory: selectedNode.isDirectory,
+      size: selectedNode.size ?? 0,
+      modifiedAt: null,
+      etag: null,
+      mimeType: null,
+      version: null,
+      owner: null,
+      permissions: null,
+      zoneId: useGlobalStore.getState().zoneId,
+    };
   }, [selectedNode, isSentinel, getCachedFiles, fileCacheRevision]);
 
   const visibleNodeCount = visibleNodes.length;
@@ -576,8 +595,8 @@ export default function FileExplorerPanel(): React.ReactNode {
 
   // Aspect count badge
   const aspectsCache = useKnowledgeStore((s) => s.aspectsCache);
-  const selectedUrn = selectedItem?.path && selectedItem?.zoneId
-    ? `urn:nexus:file:${selectedItem.zoneId}:${crypto.createHash("sha256").update(selectedItem.path).digest("hex").slice(0, 32)}`
+  const selectedUrn = selectedItem?.path
+    ? `urn:nexus:file:${selectedItem.zoneId || "default"}:${crypto.createHash("sha256").update(selectedItem.path).digest("hex").slice(0, 32)}`
     : null;
   const aspectCount = selectedUrn ? (aspectsCache.get(selectedUrn)?.length ?? 0) : 0;
 

--- a/packages/nexus-tui/src/panels/payments/approval-list.tsx
+++ b/packages/nexus-tui/src/panels/payments/approval-list.tsx
@@ -71,7 +71,7 @@ export function ApprovalList({
           <box key={a.id} height={1} width="100%">
             <text>
               {`${prefix}${shortId(a.id).padEnd(10)}  ${amount}  ${purpose}  `}
-              <text foregroundColor={color}>{a.status.padEnd(9)}</text>
+              <span foregroundColor={color}>{a.status.padEnd(9)}</span>
               {`  ${shortId(a.requester_id).padEnd(12)}  ${formatTime(a.created_at)}`}
             </text>
           </box>

--- a/packages/nexus-tui/src/panels/zones/cache-tab.tsx
+++ b/packages/nexus-tui/src/panels/zones/cache-tab.tsx
@@ -58,7 +58,7 @@ export function CacheTab({ stats, hotFiles, loading }: CacheTabProps): React.Rea
         <box height={1} width="100%">
           <text>
             {"  Hit rate:        "}
-            <text foregroundColor={hitRateColor(s.hit_rate)}>{`${(s.hit_rate * 100).toFixed(1)}%`}</text>
+            <span foregroundColor={hitRateColor(s.hit_rate)}>{`${(s.hit_rate * 100).toFixed(1)}%`}</span>
           </text>
         </box>
       )}
@@ -88,7 +88,7 @@ export function CacheTab({ stats, hotFiles, loading }: CacheTabProps): React.Rea
             <box key={layer.name} height={1} width="100%">
               <text>
                 {`  ${layer.name.padEnd(19)}  ${String(layer.entries).padEnd(10)}  ${formatSize(layer.size_bytes).padEnd(11)}  `}
-                <text foregroundColor={hitRateColor(layer.hit_rate)}>{`${(layer.hit_rate * 100).toFixed(1)}%`}</text>
+                <span foregroundColor={hitRateColor(layer.hit_rate)}>{`${(layer.hit_rate * 100).toFixed(1)}%`}</span>
               </text>
             </box>
           ))}

--- a/packages/nexus-tui/src/services/command-runner.ts
+++ b/packages/nexus-tui/src/services/command-runner.ts
@@ -157,10 +157,30 @@ export function executeLocalCommand(command: string, args: readonly string[]): v
 
   const fullArgs = ["nexus", command, ...args];
 
+  // Read the TUI's own nexus.yaml (in CWD) to pass NEXUS_URL and NEXUS_API_KEY
+  // to subcommands like `nexus demo init`.
+  const spawnEnv = { ...process.env };
   try {
+    const fs = require("node:fs");
+    const yaml = fs.readFileSync("nexus.yaml", "utf-8") as string;
+    const portMatch = yaml.match(/ports:\s*\n(?:\s+\w+:[^\n]*\n)*?\s+http:\s*(\d+)/);
+    const keyMatch = yaml.match(/^api_key:\s*["']?([^"'\n]+)["']?/m);
+    if (portMatch?.[1] && !spawnEnv.NEXUS_URL) {
+      spawnEnv.NEXUS_URL = `http://localhost:${portMatch[1]}`;
+    }
+    if (keyMatch?.[1] && !spawnEnv.NEXUS_API_KEY) {
+      spawnEnv.NEXUS_API_KEY = keyMatch[1];
+    }
+  } catch {
+    // nexus.yaml not found yet (will be created by nexus init)
+  }
+
+  try {
+    // Commands run from CWD so each TUI instance gets its own nexus.yaml
     const proc = Bun.spawn(fullArgs, {
       stdout: "pipe",
       stderr: "pipe",
+      env: spawnEnv,
     });
 
     activeProcesses.add(proc);

--- a/packages/nexus-tui/src/shared/components/command-output.tsx
+++ b/packages/nexus-tui/src/shared/components/command-output.tsx
@@ -29,8 +29,8 @@ export function CommandOutput(): React.ReactNode {
       {/* Header */}
       <box height={1} width="100%">
         <text>
-          <text dimColor>{"$ "}</text>
-          <text bold>{commandLabel}</text>
+          <span dimColor>{"$ "}</span>
+          <span bold>{commandLabel}</span>
         </text>
       </box>
 

--- a/packages/nexus-tui/src/shared/components/error-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/error-bar.tsx
@@ -47,8 +47,12 @@ export function ErrorBar(): React.ReactNode {
 
   return (
     <box height={1} width="100%" flexDirection="row">
-      <text foregroundColor={statusColor.error}>
-        {`${prefix}✗ ${latest.message}  ${hint}${latest.dismissable ? "  Esc:dismiss" : ""}`}
+      <text>
+        <span foregroundColor="#ff4444" bold>{`${prefix}✗ ${latest.message}`}</span>
+        <span foregroundColor="#ff8888">{`  ${hint}`}</span>
+        {latest.dismissable ? (
+          <span foregroundColor="#666666">{"  Esc:dismiss"}</span>
+        ) : ""}
       </text>
     </box>
   );

--- a/packages/nexus-tui/src/shared/components/help-overlay.tsx
+++ b/packages/nexus-tui/src/shared/components/help-overlay.tsx
@@ -30,6 +30,7 @@ export interface KeyBinding {
 const GLOBAL_BINDINGS: readonly KeyBinding[] = [
   { key: "1-9,0", action: "Switch panel" },
   { key: "Ctrl+I", action: "Identity switcher" },
+  { key: "Ctrl+D", action: "Disconnect (back to setup)" },
   { key: "z", action: "Toggle zoom" },
   { key: "?", action: "Help overlay" },
   { key: "q", action: "Quit" },
@@ -179,8 +180,8 @@ export function HelpOverlay({
         <text foregroundColor={statusColor.info} bold>{"─── Global ───"}</text>
         {GLOBAL_BINDINGS.map((b) => (
           <text key={b.key}>
-            <text foregroundColor={statusColor.info}>{`  ${b.key.padEnd(12)}`}</text>
-            <text>{b.action}</text>
+            <span foregroundColor={statusColor.info}>{`  ${b.key.padEnd(12)}`}</span>
+            <span>{b.action}</span>
           </text>
         ))}
 
@@ -188,8 +189,8 @@ export function HelpOverlay({
         <text foregroundColor={statusColor.info} bold>{"─── Navigation ───"}</text>
         {NAV_BINDINGS.map((b) => (
           <text key={b.key}>
-            <text foregroundColor={statusColor.info}>{`  ${b.key.padEnd(12)}`}</text>
-            <text>{b.action}</text>
+            <span foregroundColor={statusColor.info}>{`  ${b.key.padEnd(12)}`}</span>
+            <span>{b.action}</span>
           </text>
         ))}
 
@@ -199,8 +200,8 @@ export function HelpOverlay({
             <text foregroundColor={statusColor.info} bold>{`─── ${panel} ───`}</text>
             {panelBindings.map((b) => (
               <text key={b.key}>
-                <text foregroundColor={statusColor.info}>{`  ${b.key.padEnd(12)}`}</text>
-                <text>{b.action}</text>
+                <span foregroundColor={statusColor.info}>{`  ${b.key.padEnd(12)}`}</span>
+                <span>{b.action}</span>
               </text>
             ))}
           </>

--- a/packages/nexus-tui/src/shared/components/pagination-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/pagination-bar.tsx
@@ -48,18 +48,18 @@ export function PaginationBar({
     <box height={1} width="100%" flexDirection="row">
       <text dimColor>
         {hasPrev && (
-          <text>
-            <text foregroundColor={statusColor.info}>{prevKey}</text>
-            <text>{":prev "}</text>
-          </text>
+          <span>
+            <span foregroundColor={statusColor.info}>{prevKey}</span>
+            <span>{":prev "}</span>
+          </span>
         )}
-        <text>{loading ? "Loading..." : pageDisplay}</text>
+        <span>{loading ? "Loading..." : pageDisplay}</span>
         {hasMore && (
-          <text>
-            <text>{" "}</text>
-            <text foregroundColor={statusColor.info}>{nextKey}</text>
-            <text>{":next"}</text>
-          </text>
+          <span>
+            <span>{" "}</span>
+            <span foregroundColor={statusColor.info}>{nextKey}</span>
+            <span>{":next"}</span>
+          </span>
         )}
       </text>
     </box>

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -17,6 +17,7 @@ import { executeLocalCommand, useCommandRunnerStore } from "../../services/comma
 import { CommandOutput } from "./command-output.js";
 import { Spinner } from "./spinner.js";
 import { statusColor } from "../theme.js";
+import { resolveConfig, FetchClient } from "@nexus/api-client";
 
 const AUTO_POLL_INTERVAL = 5_000; // 5 seconds (Decision 14A)
 
@@ -39,7 +40,9 @@ export function PreConnectionScreen(): React.ReactNode {
   const prevCommandStatus = useRef(commandStatus);
 
   // When a local command finishes (success or error), re-read config from disk
-  // so that `nexus init` creating nexus.yaml is picked up automatically.
+  // but DON'T auto-connect. The user should press R to retry or run more
+  // commands (e.g. D → Shift+U → P flow). Auto-connecting after `nexus init`
+  // would connect to a stale server with the wrong API key.
   useEffect(() => {
     const prev = prevCommandStatus.current;
     prevCommandStatus.current = commandStatus;
@@ -48,12 +51,19 @@ export function PreConnectionScreen(): React.ReactNode {
       (prev === "running") &&
       (commandStatus === "success" || commandStatus === "error")
     ) {
-      // Re-read config from disk — initConfig() calls resolveConfig() which
-      // searches ./nexus.yaml → ~/.nexus/config.yaml, then creates a new
-      // FetchClient if an API key is now present.
-      initConfig();
+      // Re-read config from disk without triggering connection test.
+      // resolveConfig() picks up new api_key/ports from nexus.yaml.
+      const config = resolveConfig();
+      const client = config.apiKey ? new FetchClient(config) : null;
+      useGlobalStore.setState({
+        config,
+        client,
+        // Stay disconnected — user presses R when ready
+        connectionStatus: client ? "error" : "disconnected",
+        connectionError: client ? "Press R to connect after setup" : null,
+      });
     }
-  }, [commandStatus, initConfig]);
+  }, [commandStatus]);
 
   // Manual retry: re-read config from disk + test connection.
   // This is critical for the no-config → init → retry flow: after nexus init
@@ -91,6 +101,7 @@ export function PreConnectionScreen(): React.ReactNode {
   }, [urlInput, initConfig]);
 
   const isCommandRunning = commandStatus === "running";
+  const hasCommandOutput = commandStatus === "success" || commandStatus === "error";
 
   // Handle printable chars when editing URL
   const handleUnhandledKey = useCallback(
@@ -105,9 +116,21 @@ export function PreConnectionScreen(): React.ReactNode {
     [editingUrl],
   );
 
+  // Dismiss command output and return to menu
+  const dismissOutput = useCallback(() => {
+    useCommandRunnerStore.getState().reset();
+  }, []);
+
   useKeyboard(
     isCommandRunning
       ? {}
+      : hasCommandOutput
+      ? {
+          // After a command finishes, only allow Esc to dismiss or re-run shortcuts
+          escape: dismissOutput,
+          backspace: dismissOutput,
+          r: handleRetry,
+        }
       : editingUrl
       ? {
           return: handleConnectUrl,
@@ -125,10 +148,24 @@ export function PreConnectionScreen(): React.ReactNode {
             useCommandRunnerStore.getState().reset();
             executeLocalCommand("init", ["--preset", "shared"]);
           },
+          d: () => {
+            useCommandRunnerStore.getState().reset();
+            executeLocalCommand("init", ["--preset", "demo", "--force"]);
+          },
           u: () => {
             // Start server (nexus up)
             useCommandRunnerStore.getState().reset();
             executeLocalCommand("up", []);
+          },
+          "shift+u": () => {
+            // Start server with local build (nexus up --build)
+            useCommandRunnerStore.getState().reset();
+            executeLocalCommand("up", ["--build"]);
+          },
+          p: () => {
+            // Seed demo data (nexus demo init)
+            useCommandRunnerStore.getState().reset();
+            executeLocalCommand("demo", ["init"]);
           },
           c: () => {
             // Connect to a different URL
@@ -139,6 +176,44 @@ export function PreConnectionScreen(): React.ReactNode {
     isCommandRunning ? undefined : editingUrl ? handleUnhandledKey : undefined,
   );
 
+  // Full-screen command output view when a command is running or has output
+  if (commandStatus !== "idle") {
+    return (
+      <box height="100%" width="100%" flexDirection="column">
+        <scrollbox flexGrow={1}>
+          <box flexDirection="column" width="100%" padding={1}>
+            <CommandOutput />
+          </box>
+        </scrollbox>
+        <box height={1} width="100%">
+          {commandStatus === "success" ? (
+            <text>
+              <span foregroundColor="#4dff88" bold>{"  ✓ Done"}</span>
+              <span foregroundColor="#666666">{"  │  "}</span>
+              <span foregroundColor="#00d4ff">{"Esc"}</span>
+              <span foregroundColor="#888888">{":back  "}</span>
+              <span foregroundColor="#00d4ff">{"R"}</span>
+              <span foregroundColor="#888888">{":retry"}</span>
+            </text>
+          ) : commandStatus === "error" ? (
+            <text>
+              <span foregroundColor="#ff4444" bold>{"  ✗ Failed"}</span>
+              <span foregroundColor="#666666">{"  │  "}</span>
+              <span foregroundColor="#00d4ff">{"Esc"}</span>
+              <span foregroundColor="#888888">{":back  "}</span>
+              <span foregroundColor="#00d4ff">{"R"}</span>
+              <span foregroundColor="#888888">{":retry"}</span>
+            </text>
+          ) : (
+            <text>
+              <span foregroundColor="#ffaa00">{"  ◐ Running..."}</span>
+            </text>
+          )}
+        </box>
+      </box>
+    );
+  }
+
   return (
     <box height="100%" width="100%" justifyContent="center" alignItems="center">
       <box
@@ -147,44 +222,60 @@ export function PreConnectionScreen(): React.ReactNode {
         width={64}
         padding={1}
       >
-        <text bold foregroundColor={statusColor.info}>
-          {"    \u2554\u2557\u2554\u250C\u2500\u2510\u2500\u2510 \u2510\u252C\u2510 \u252C\u250C\u2500\u2510"}
+        {/* Logo with gradient: cyan → blue → magenta */}
+        <text bold foregroundColor="#00d4ff">
+          {"    _   _ _____ __  __ _   _ ____"}
         </text>
-        <text bold foregroundColor={statusColor.info}>
-          {"    \u2551\u2551\u2551\u251C\u2524 \u250C\u2524 \u2502 \u2502\u2502\u2514\u2500\u2510"}
+        <text bold foregroundColor="#00b8ff">
+          {"   | \\ | | ____|  \\/  | | | / ___|"}
         </text>
-        <text bold foregroundColor={statusColor.info}>
-          {"    \u255D\u255A\u255D\u2514\u2500\u2518\u2518\u2514 \u2514\u2500\u2518\u2514\u2500\u2518"}
+        <text bold foregroundColor="#4d8eff">
+          {"   |  \\| |  _|  >\\/< | | | \\___ \\"}
+        </text>
+        <text bold foregroundColor="#8066ff">
+          {"   | |\\  | |___/ /\\ \\| |_| |___) |"}
+        </text>
+        <text bold foregroundColor="#b44dff">
+          {"   |_| \\_|_____/_/  \\_\\\\___/|____/"}
         </text>
         <text>{""}</text>
 
         {/* Status-specific message */}
         {connState === "no-config" && (
           <>
-            <text foregroundColor={statusColor.warning}>{"  No API key configured"}</text>
+            <text>
+              <span foregroundColor="#ffaa00" bold>{"  ⚠ "}</span>
+              <span foregroundColor="#ffaa00" bold>{"No API key configured"}</span>
+            </text>
             <text>{""}</text>
-            <text dimColor>{"  Set NEXUS_API_KEY or add api_key to ~/.nexus/config.yaml"}</text>
-            <text dimColor>{"  Or press [I] to initialize a new project."}</text>
+            <text foregroundColor="#888888">{"  Set NEXUS_API_KEY or add api_key to ~/.nexus/config.yaml"}</text>
+            <text foregroundColor="#888888">{"  Or press [I] to initialize a new project."}</text>
           </>
         )}
 
         {connState === "no-server" && (
           <>
-            <text foregroundColor={statusColor.error}>{"  Cannot connect to server"}</text>
+            <text>
+              <span foregroundColor="#ff4444" bold>{"  ✗ "}</span>
+              <span foregroundColor="#ff4444" bold>{"Cannot connect to server"}</span>
+            </text>
             <text>{""}</text>
-            <text dimColor>{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
+            <text foregroundColor="#888888">{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
             {connectionError && (
-              <text dimColor>{`  Error: ${connectionError}`}</text>
+              <text foregroundColor="#ff6666">{`  Error: ${connectionError}`}</text>
             )}
           </>
         )}
 
         {connState === "auth-failed" && (
           <>
-            <text foregroundColor={statusColor.error}>{"  Authentication failed"}</text>
+            <text>
+              <span foregroundColor="#ff4444" bold>{"  ✗ "}</span>
+              <span foregroundColor="#ff4444" bold>{"Authentication failed"}</span>
+            </text>
             <text>{""}</text>
-            <text dimColor>{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
-            <text dimColor>{"  Check your API key or credentials."}</text>
+            <text foregroundColor="#888888">{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
+            <text foregroundColor="#ff6666">{"  Check your API key or credentials."}</text>
           </>
         )}
 
@@ -197,50 +288,63 @@ export function PreConnectionScreen(): React.ReactNode {
         {/* URL editor */}
         {editingUrl && (
           <>
-            <text>{"  Enter server URL:"}</text>
+            <text foregroundColor="#00d4ff">{"  Enter server URL:"}</text>
             <box height={1} width="100%">
-              <text>{`  > ${urlInput}\u2588`}</text>
+              <text foregroundColor="#ffffff">{`  > ${urlInput}\u2588`}</text>
             </box>
-            <text dimColor>{"  Enter to connect, Esc to cancel"}</text>
+            <text foregroundColor="#666666">{"  Enter to connect, Esc to cancel"}</text>
             <text>{""}</text>
           </>
         )}
 
         {/* Actions */}
-        {connState !== "connecting" && !isCommandRunning && !editingUrl && (
+        {connState !== "connecting" && !editingUrl && (
           <>
+            <text foregroundColor="#888888" bold>{"  Setup"}</text>
             <text>
-              <text foregroundColor={statusColor.info}>{"  [I]"}</text>
-              <text>{" Initialize local project (nexus init)"}</text>
+              <span foregroundColor="#00d4ff" bold>{"  [I] "}</span>
+              <span foregroundColor="#cccccc">{"Init local"}</span>
+              <span foregroundColor="#666666">{" (nexus init)"}</span>
             </text>
             <text>
-              <text foregroundColor={statusColor.info}>{"  [S]"}</text>
-              <text>{" Initialize shared project (nexus init --preset shared)"}</text>
+              <span foregroundColor="#00d4ff" bold>{"  [S] "}</span>
+              <span foregroundColor="#cccccc">{"Init shared Docker"}</span>
+              <span foregroundColor="#666666">{" (--preset shared)"}</span>
             </text>
             <text>
-              <text foregroundColor={statusColor.info}>{"  [U]"}</text>
-              <text>{" Start server (nexus up)"}</text>
+              <span foregroundColor="#00d4ff" bold>{"  [D] "}</span>
+              <span foregroundColor="#cccccc">{"Init demo Docker"}</span>
+              <span foregroundColor="#666666">{" (--preset demo)"}</span>
             </text>
             <text>
-              <text foregroundColor={statusColor.info}>{"  [C]"}</text>
-              <text>{" Connect to a different URL"}</text>
+              <span foregroundColor="#4dff88" bold>{"  [U] "}</span>
+              <span foregroundColor="#cccccc">{"Start server"}</span>
+              <span foregroundColor="#666666">{" (nexus up)"}</span>
             </text>
             <text>
-              <text foregroundColor={statusColor.info}>{"  [R]"}</text>
-              <text>{` Retry connection${retryCount > 0 ? ` (${retryCount})` : ""}`}</text>
+              <span foregroundColor="#4dff88" bold>{"  [⇧U] "}</span>
+              <span foregroundColor="#cccccc">{"Build from source"}</span>
+              <span foregroundColor="#666666">{" (nexus up --build)"}</span>
             </text>
             <text>
-              <text foregroundColor={autoPoll ? statusColor.success : statusColor.dim}>{"  [A]"}</text>
-              <text>{autoPoll ? " Auto-check: ON (every 5s)" : " Enable auto-check (every 5s)"}</text>
+              <span foregroundColor="#ffaa00" bold>{"  [P] "}</span>
+              <span foregroundColor="#cccccc">{"Seed demo data"}</span>
+              <span foregroundColor="#666666">{" (nexus demo init)"}</span>
             </text>
-          </>
-        )}
-
-        {/* Command output (when running nexus init etc.) */}
-        {commandStatus !== "idle" && (
-          <>
             <text>{""}</text>
-            <CommandOutput />
+            <text foregroundColor="#888888" bold>{"  Connection"}</text>
+            <text>
+              <span foregroundColor="#b44dff" bold>{"  [C] "}</span>
+              <span foregroundColor="#cccccc">{"Connect to a different URL"}</span>
+            </text>
+            <text>
+              <span foregroundColor="#b44dff" bold>{"  [R] "}</span>
+              <span foregroundColor="#cccccc">{`Retry connection${retryCount > 0 ? ` (${retryCount})` : ""}`}</span>
+            </text>
+            <text>
+              <span foregroundColor={autoPoll ? "#4dff88" : "#888888"} bold>{"  [A] "}</span>
+              <span foregroundColor={autoPoll ? "#4dff88" : "#cccccc"}>{autoPoll ? "Auto-check: ON (every 5s)" : "Enable auto-check (every 5s)"}</span>
+            </text>
           </>
         )}
       </box>

--- a/packages/nexus-tui/src/shared/components/status-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/status-bar.tsx
@@ -2,6 +2,9 @@
  * Bottom status bar showing connection state, active identity, and path.
  *
  * Enhanced with semantic colors from theme.ts (Phase A1).
+ *
+ * Note: OpenTUI does not support nested <text> elements. Use <span> for
+ * inline styled segments inside a <text>.
  */
 
 import React from "react";
@@ -53,38 +56,39 @@ export function StatusBar(): React.ReactNode {
       flexDirection="row"
     >
       <text>
-        <text foregroundColor={connectionColor[status]}>{icon}</text>
-        <text dimColor>{` ${status} │ `}</text>
-        <text>{baseUrl}</text>
-        {identityParts.length > 0 && (
-          <text>
-            <text dimColor>{" │ "}</text>
-            <text foregroundColor={statusColor.identity}>{identityParts.join(", ")}</text>
-          </text>
-        )}
-        {serverVersion && (
-          <text>
-            <text dimColor>{" │ "}</text>
-            <text dimColor>{`v${serverVersion}`}</text>
-          </text>
-        )}
-        {zone && (
-          <text>
-            <text dimColor>{" │ "}</text>
-            <text foregroundColor={statusColor.reference}>{`zone:${zone}`}</text>
-          </text>
-        )}
-        {enabledBricks.length > 0 && (
-          <text>
-            <text dimColor>{" │ "}</text>
-            <text foregroundColor={statusColor.info}>{`${enabledBricks.length} bricks`}</text>
-          </text>
-        )}
-        <text dimColor>{" │ "}</text>
-        <text foregroundColor={statusColor.info}>{`[${activePanel}]`}</text>
-        {hasActiveFilter && (
-          <text foregroundColor="yellow">{" [filtered]"}</text>
-        )}
+        <span foregroundColor={connectionColor[status]}>{icon}</span>
+        <span dimColor>{` ${status} │ `}</span>
+        <span>{baseUrl}</span>
+        {identityParts.length > 0 ? (
+          <>
+            <span dimColor>{" │ "}</span>
+            <span foregroundColor={statusColor.identity}>{identityParts.join(", ")}</span>
+          </>
+        ) : ""}
+        {serverVersion ? (
+          <>
+            <span dimColor>{" │ "}</span>
+            <span dimColor>{`v${serverVersion}`}</span>
+          </>
+        ) : ""}
+        {zone ? (
+          <>
+            <span dimColor>{" │ "}</span>
+            <span foregroundColor={statusColor.reference}>{`zone:${zone}`}</span>
+          </>
+        ) : ""}
+        {enabledBricks.length > 0 ? (
+          <>
+            <span dimColor>{" │ "}</span>
+            <span foregroundColor={statusColor.info}>{`${enabledBricks.length} bricks`}</span>
+          </>
+        ) : ""}
+        <span dimColor>{" │ "}</span>
+        <span foregroundColor={statusColor.info}>{`[${activePanel}]`}</span>
+        {hasActiveFilter ? (
+          <span foregroundColor="yellow">{" [filtered]"}</span>
+        ) : ""}
+        <span foregroundColor="#555555">{" │ Ctrl+D:setup  ?:help"}</span>
       </text>
     </box>
   );

--- a/packages/nexus-tui/src/shared/components/styled-text.tsx
+++ b/packages/nexus-tui/src/shared/components/styled-text.tsx
@@ -43,7 +43,7 @@ export function StyledText({ children }: StyledTextProps): React.ReactNode {
       {spans.map((span, i) => {
         const decoration = span.decoration ?? "";
         return (
-          <text
+          <span
             key={i}
             bold={decoration.includes("bold") || undefined}
             dimColor={decoration.includes("dim") || undefined}
@@ -53,7 +53,7 @@ export function StyledText({ children }: StyledTextProps): React.ReactNode {
             backgroundColor={span.bg ? rgbToHex(span.bg) : undefined}
           >
             {span.content}
-          </text>
+          </span>
         );
       })}
     </text>

--- a/packages/nexus-tui/src/shared/components/tab-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/tab-bar.tsx
@@ -28,17 +28,19 @@ export function TabBar({ tabs, activeTab }: TabBarProps): React.ReactNode {
         return (
           <text key={tab.id}>
             {isActive ? (
-              <text>
-                <text foregroundColor={statusColor.info}>{"▸ "}</text>
-                <text dimColor>{`${tab.shortcut}:`}</text>
-                <text foregroundColor={statusColor.info} bold>{tab.label}</text>
-                <text dimColor>{suffix}</text>
-              </text>
+              <span>
+                <span foregroundColor="#00d4ff" bold>{"▸ "}</span>
+                <span foregroundColor="#888888">{`${tab.shortcut}:`}</span>
+                <span foregroundColor="#00d4ff" bold>{tab.label}</span>
+                <span foregroundColor="#444444">{suffix}</span>
+              </span>
             ) : (
-              <text>
-                <text>{"  "}</text>
-                <text dimColor>{`${tab.shortcut}:${tab.label}${suffix}`}</text>
-              </text>
+              <span>
+                <span>{"  "}</span>
+                <span foregroundColor="#555555">{`${tab.shortcut}:`}</span>
+                <span foregroundColor="#777777">{tab.label}</span>
+                <span foregroundColor="#444444">{suffix}</span>
+              </span>
             )}
           </text>
         );

--- a/packages/nexus-tui/src/shared/components/text-input.tsx
+++ b/packages/nexus-tui/src/shared/components/text-input.tsx
@@ -65,7 +65,7 @@ export function TextInput({
       )}
       <text dimColor={!!isDimmed}>
         {displayValue}
-        {active && <text foregroundColor={statusColor.info}>{"█"}</text>}
+        {active && <span foregroundColor={statusColor.info}>{"█"}</span>}
       </text>
     </box>
   );

--- a/packages/nexus-tui/src/shared/components/welcome-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/welcome-screen.tsx
@@ -48,14 +48,20 @@ export function WelcomeScreen({ onDismiss }: WelcomeScreenProps): React.ReactNod
         width={56}
         padding={1}
       >
-        <text bold foregroundColor={statusColor.info}>
-          {"    \u2554\u2557\u2554\u250C\u2500\u2510\u2500\u2510 \u2510\u252C\u2510 \u252C\u250C\u2500\u2510"}
+        <text bold foregroundColor="#00d4ff">
+          {"    _   _ _____ __  __ _   _ ____"}
         </text>
-        <text bold foregroundColor={statusColor.info}>
-          {"    \u2551\u2551\u2551\u251C\u2524 \u250C\u2524 \u2502 \u2502\u2502\u2514\u2500\u2510"}
+        <text bold foregroundColor="#00b8ff">
+          {"   | \\ | | ____|  \\/  | | | / ___|"}
         </text>
-        <text bold foregroundColor={statusColor.info}>
-          {"    \u255D\u255A\u255D\u2514\u2500\u2518\u2518\u2514 \u2514\u2500\u2518\u2514\u2500\u2518"}
+        <text bold foregroundColor="#4d8eff">
+          {"   |  \\| |  _|  >\\/< | | | \\___ \\"}
+        </text>
+        <text bold foregroundColor="#8066ff">
+          {"   | |\\  | |___/ /\\ \\| |_| |___) |"}
+        </text>
+        <text bold foregroundColor="#b44dff">
+          {"   |_| \\_|_____/_/  \\_\\\\___/|____/"}
         </text>
         <text>{""}</text>
         <text dimColor>{`  Connected to ${baseUrl}${serverVersion ? ` (v${serverVersion})` : ""}`}</text>

--- a/packages/nexus-tui/src/stores/files-store.ts
+++ b/packages/nexus-tui/src/stores/files-store.ts
@@ -342,7 +342,11 @@ export const useFilesStore = create<FilesState>((set, get) => ({
         }
       }
 
-      set({ treeNodes: updatedNodes, error: null });
+      // Also populate the file cache so metadata/aspects/schema panes
+      // can look up selectedItem via getCachedFiles().
+      fileCache.set(path, { data: sorted, fetchedAt: Date.now() });
+
+      set({ treeNodes: updatedNodes, fileCacheRevision: get().fileCacheRevision + 1, error: null });
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       // Revert loading state

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -122,16 +122,20 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
           "/api/v2/bricks/health",
         ).catch(() => null),
         client.get<FeaturesResponse>("/api/v2/features").catch(() => null),
-        client.get<UserInfo>("/auth/me"),
+        client.get<UserInfo>("/auth/me").catch(() => null),
       ]);
 
-      if (health) {
-        set({
-          serverVersion: health.version ?? get().serverVersion,
-          zoneId: health.zone_id ?? get().zoneId,
-          uptime: health.uptime_seconds ?? get().uptime,
-        });
+      // If health check succeeds, consider the server connected even if
+      // /auth/me fails (e.g. "Authentication provider not configured").
+      if (!health) {
+        throw new Error("Server health check failed");
       }
+
+      set({
+        serverVersion: health.version ?? get().serverVersion,
+        zoneId: health.zone_id ?? get().zoneId,
+        uptime: health.uptime_seconds ?? get().uptime,
+      });
       if (features) {
         get().setFeatures(features);
       }

--- a/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
+++ b/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
@@ -103,8 +103,9 @@ describe("Connection Lifecycle", () => {
   });
 
   describe("server unreachable → error", () => {
-    it("network error sets error status", async () => {
+    it("network error sets error status when health fails", async () => {
       const client = createMockClient({
+        health: async () => { throw new Error("ECONNREFUSED"); },
         authMe: async () => { throw new Error("ECONNREFUSED"); },
       });
       useGlobalStore.setState({ client });
@@ -113,12 +114,13 @@ describe("Connection Lifecycle", () => {
 
       const state = useGlobalStore.getState();
       expect(state.connectionStatus).toBe("error");
-      expect(state.connectionError).toBe("ECONNREFUSED");
+      expect(state.connectionError).toBe("Server health check failed");
       expect(state.userInfo).toBeNull();
     });
 
-    it("timeout sets error status", async () => {
+    it("timeout sets error status when health fails", async () => {
       const client = createMockClient({
+        health: async () => { throw new Error("Request timed out"); },
         authMe: async () => { throw new Error("Request timed out"); },
       });
       useGlobalStore.setState({ client });
@@ -127,12 +129,12 @@ describe("Connection Lifecycle", () => {
 
       const state = useGlobalStore.getState();
       expect(state.connectionStatus).toBe("error");
-      expect(state.connectionError).toBe("Request timed out");
+      expect(state.connectionError).toBe("Server health check failed");
     });
   });
 
-  describe("auth failures", () => {
-    it("401 unauthorized sets error", async () => {
+  describe("auth failures (non-fatal when health passes)", () => {
+    it("401 unauthorized still connects if health passes", async () => {
       const client = createMockClient({
         authMe: async () => { throw new Error("Unauthorized (401)"); },
       });
@@ -141,11 +143,11 @@ describe("Connection Lifecycle", () => {
       await useGlobalStore.getState().testConnection();
 
       const state = useGlobalStore.getState();
-      expect(state.connectionStatus).toBe("error");
-      expect(state.connectionError).toContain("Unauthorized");
+      expect(state.connectionStatus).toBe("connected");
+      expect(state.userInfo).toBeNull();
     });
 
-    it("403 forbidden sets error", async () => {
+    it("403 forbidden still connects if health passes", async () => {
       const client = createMockClient({
         authMe: async () => { throw new Error("Forbidden (403)"); },
       });
@@ -154,8 +156,8 @@ describe("Connection Lifecycle", () => {
       await useGlobalStore.getState().testConnection();
 
       const state = useGlobalStore.getState();
-      expect(state.connectionStatus).toBe("error");
-      expect(state.connectionError).toContain("Forbidden");
+      expect(state.connectionStatus).toBe("connected");
+      expect(state.userInfo).toBeNull();
     });
   });
 
@@ -174,8 +176,9 @@ describe("Connection Lifecycle", () => {
 
   describe("reconnection", () => {
     it("can recover from error to connected", async () => {
-      // First: fail
+      // First: fail (health must also fail for error status)
       const failClient = createMockClient({
+        health: async () => { throw new Error("Connection refused"); },
         authMe: async () => { throw new Error("Connection refused"); },
       });
       useGlobalStore.setState({ client: failClient });
@@ -193,8 +196,9 @@ describe("Connection Lifecycle", () => {
   });
 
   describe("non-Error thrown objects", () => {
-    it("handles string throws", async () => {
+    it("handles string throws when health fails", async () => {
       const client = createMockClient({
+        health: async () => { throw "raw string error"; },
         authMe: async () => { throw "raw string error"; },
       });
       useGlobalStore.setState({ client });
@@ -203,13 +207,14 @@ describe("Connection Lifecycle", () => {
 
       const state = useGlobalStore.getState();
       expect(state.connectionStatus).toBe("error");
-      expect(state.connectionError).toBe("Connection test failed");
+      expect(state.connectionError).toBe("Server health check failed");
     });
   });
 
   describe("server error (500)", () => {
-    it("server error sets error status", async () => {
+    it("server error on health sets error status", async () => {
       const client = createMockClient({
+        health: async () => { throw new Error("Internal Server Error (500)"); },
         authMe: async () => { throw new Error("Internal Server Error (500)"); },
       });
       useGlobalStore.setState({ client });
@@ -218,7 +223,6 @@ describe("Connection Lifecycle", () => {
 
       const state = useGlobalStore.getState();
       expect(state.connectionStatus).toBe("error");
-      expect(state.connectionError).toContain("500");
     });
   });
 

--- a/packages/nexus-tui/tests/stores/global-store.test.ts
+++ b/packages/nexus-tui/tests/stores/global-store.test.ts
@@ -218,6 +218,7 @@ describe("GlobalStore", () => {
 
   describe("testConnection", () => {
     it("sets connected and userInfo on success", async () => {
+      const mockHealth = { version: "1.0", zone_id: "z1", uptime_seconds: 100 };
       const mockUserInfo = {
         user_id: "user-1",
         email: "test@example.com",
@@ -228,10 +229,13 @@ describe("GlobalStore", () => {
         primary_auth_method: "api_key",
       };
 
-      const mockFetchClient = {
-        get: mock(async () => mockUserInfo),
-      } as unknown as FetchClient;
+      // testConnection calls client.get 3 times: health, features, auth/me
+      const mockGet = mock()
+        .mockResolvedValueOnce(mockHealth)     // health
+        .mockResolvedValueOnce(null)           // features
+        .mockResolvedValueOnce(mockUserInfo);  // auth/me
 
+      const mockFetchClient = { get: mockGet } as unknown as FetchClient;
       useGlobalStore.setState({ client: mockFetchClient });
 
       await useGlobalStore.getState().testConnection();
@@ -245,10 +249,29 @@ describe("GlobalStore", () => {
       expect(state.userInfo!.is_global_admin).toBe(false);
     });
 
-    it("sets error status on failure", async () => {
+    it("sets connected when health passes but auth/me fails", async () => {
+      const mockHealth = { version: "1.0", zone_id: null, uptime_seconds: 10 };
+      const mockGet = mock()
+        .mockResolvedValueOnce(mockHealth)     // health OK
+        .mockResolvedValueOnce(null)           // features
+        .mockRejectedValueOnce(new Error("Auth not configured")); // auth/me fails
+
+      const mockFetchClient = { get: mockGet } as unknown as FetchClient;
+      useGlobalStore.setState({ client: mockFetchClient });
+
+      await useGlobalStore.getState().testConnection();
+      const state = useGlobalStore.getState();
+
+      // Server is connected if health passes, even when auth fails
+      expect(state.connectionStatus).toBe("connected");
+      expect(state.userInfo).toBeNull();
+    });
+
+    it("sets error status when health fails", async () => {
+      // All 3 calls fail (server unreachable) → health is null → error
       const mockFetchClient = {
         get: mock(async () => {
-          throw new Error("Unauthorized");
+          throw new Error("Network error");
         }),
       } as unknown as FetchClient;
 
@@ -258,7 +281,7 @@ describe("GlobalStore", () => {
       const state = useGlobalStore.getState();
 
       expect(state.connectionStatus).toBe("error");
-      expect(state.connectionError).toBe("Unauthorized");
+      expect(state.connectionError).toBe("Server health check failed");
       expect(state.userInfo).toBeNull();
     });
 
@@ -284,7 +307,7 @@ describe("GlobalStore", () => {
       const state = useGlobalStore.getState();
 
       expect(state.connectionStatus).toBe("error");
-      expect(state.connectionError).toBe("Connection test failed");
+      expect(state.connectionError).toBe("Server health check failed");
     });
   });
 });

--- a/src/nexus/bricks/parsers/providers/registry.py
+++ b/src/nexus/bricks/parsers/providers/registry.py
@@ -255,7 +255,7 @@ class ProviderRegistry(BaseRegistry[ParseProvider]):
             if markitdown_provider.is_available():
                 self.register(markitdown_provider)
                 registered += 1
-        except ImportError as e:
+        except Exception as e:
             logger.warning("MarkItDown provider not available: %s", e)
 
         logger.info("Auto-discovered %d parse providers", registered)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4713,7 +4713,19 @@ class NexusFS(  # type: ignore[misc]
             result = paginate_iter(items_iter, limit=limit, cursor_path=cursor)
             if details:
                 result.items = [
-                    {"path": e.path, "size": e.size, "etag": e.etag} for e in result.items
+                    {
+                        "path": e.path,
+                        "size": e.size,
+                        "etag": e.etag,
+                        "entry_type": 1
+                        if (
+                            not recursive
+                            and e.entry_type == 0
+                            and self.metadata.is_implicit_directory(e.path)
+                        )
+                        else e.entry_type,
+                    }
+                    for e in result.items
                 ]
             else:
                 result.items = [e.path for e in result.items]
@@ -4721,7 +4733,21 @@ class NexusFS(  # type: ignore[misc]
 
         entries = self.metadata.list(prefix=prefix, recursive=recursive)
         if details:
-            return [{"path": e.path, "size": e.size, "etag": e.etag} for e in entries]
+            return [
+                {
+                    "path": e.path,
+                    "size": e.size,
+                    "etag": e.etag,
+                    "entry_type": 1
+                    if (
+                        not recursive
+                        and e.entry_type == 0
+                        and self.metadata.is_implicit_directory(e.path)
+                    )
+                    else e.entry_type,
+                }
+                for e in entries
+            ]
         return [e.path for e in entries]
 
     # _run_async: replaced by direct run_sync() calls (Issue #1381)

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -17,8 +17,9 @@ Provides file operations using NexusFS via asyncio.to_thread():
 - GET    /glob            - Glob pattern search across files
 - GET    /grep            - Regex pattern search within files
 
-All operations use asyncio.to_thread() to run sync NexusFS calls
-in worker threads (io_uring pattern: async scheduling, sync kernel).
+Async NexusFS methods (read, write, sys_stat, sys_readdir, sys_unlink,
+sys_access, sys_mkdir) are awaited directly. Sync methods (read_bulk,
+stream, write_stream) use asyncio.to_thread() for thread offloading.
 All operations pass user context for permission enforcement.
 """
 
@@ -52,11 +53,20 @@ logger = logging.getLogger(__name__)
 def _to_file_item(entry: dict[str, Any], prefix: str) -> "FileItemResponse":
     """Convert a sys_readdir details dict to a FileItemResponse.
 
-    sys_readdir(details=True) returns dicts with path, size, etag.
-    We derive name and is_directory from the path.
+    sys_readdir(details=True) returns dicts with path, size, etag, entry_type.
+    entry_type: 0=file, 1=directory, 2=mount, 3=pipe, 4=stream.
     """
     raw_path: str = entry.get("path", "")
-    is_dir = raw_path.endswith("/")
+    # Use entry_type if available: 1=dir, 2=mount (both act as directories).
+    # Also treat entries with trailing "/" as directories (legacy fallback).
+    # entry_type 0 with no etag and size 0 is likely an implicit directory
+    # (created by writing files underneath it in CAS-based storage).
+    et = entry.get("entry_type", 0)
+    is_dir = (
+        et in (1, 2)
+        or raw_path.endswith("/")
+        or (et == 0 and entry.get("size", 0) == 0 and not entry.get("etag"))
+    )
     clean_path = raw_path.rstrip("/")
     name = (
         clean_path[len(prefix) :]
@@ -399,10 +409,8 @@ def create_async_files_router(
                     ) from None
                 write_kwargs["consistency"] = mode.to_metastore_consistency()
 
-            result = await asyncio.to_thread(
-                fs.write,
-                **write_kwargs,
-            )
+            # fs.write is async — call directly
+            result = await fs.write(**write_kwargs)
 
             modified = result["modified_at"]
             if hasattr(modified, "isoformat"):
@@ -457,7 +465,7 @@ def create_async_files_router(
 
             # Get metadata first for ETag check
             if if_none_match:
-                meta = await asyncio.to_thread(fs.sys_stat, path)
+                meta = await fs.sys_stat(path)
                 if meta and meta.etag:
                     client_etag = if_none_match.strip('"')
                     if client_etag == meta.etag:
@@ -466,10 +474,8 @@ def create_async_files_router(
                             headers={"ETag": f'"{meta.etag}"'},
                         )
 
-            # Read content
-            result = await asyncio.to_thread(
-                fs.read, path, return_metadata=include_metadata, context=context
-            )
+            # Read content — fs.read is async, call directly
+            result = await fs.read(path, return_metadata=include_metadata, context=context)
 
             if include_metadata and isinstance(result, dict):
                 content = result["content"]
@@ -522,7 +528,7 @@ def create_async_files_router(
         """Delete a file."""
         try:
             fs = await _get_fs()
-            await asyncio.to_thread(fs.sys_unlink, path, context=context)
+            await fs.sys_unlink(path, context=context)
             return DeleteResponse(deleted=True, path=path)
 
         except NexusPermissionError as e:
@@ -547,7 +553,7 @@ def create_async_files_router(
         """Check if a file or directory exists."""
         try:
             fs = await _get_fs()
-            exists = await asyncio.to_thread(fs.sys_access, path, context=context)
+            exists = await fs.sys_access(path, context=context)
             return ExistsResponse(exists=exists)
 
         except NexusPermissionError as e:
@@ -593,9 +599,8 @@ def create_async_files_router(
                 except Exception:
                     raise HTTPException(status_code=400, detail="Invalid cursor") from None
 
-            # sys_readdir already supports limit/cursor/details natively
-            result = await asyncio.to_thread(
-                fs.sys_readdir,
+            # sys_readdir is async — call it directly (not via to_thread)
+            result = await fs.sys_readdir(
                 path,
                 recursive=False,
                 details=True,
@@ -605,10 +610,17 @@ def create_async_files_router(
             )
 
             prefix = path.rstrip("/") + "/"
+            # The listed path itself (e.g. "/" → empty name) must not appear
+            # in its own listing — that causes infinite recursion in tree UIs.
+            clean_path = path.rstrip("/") or "/"
 
             # Paginated path: result is a PaginatedResult
             if limit is not None:
-                file_items = [_to_file_item(entry, prefix) for entry in result.items]
+                file_items = [
+                    _to_file_item(entry, prefix)
+                    for entry in result.items
+                    if entry.get("path", "").rstrip("/") != clean_path.rstrip("/")
+                ]
                 next_cursor = (
                     base64.b64encode(result.next_cursor.encode("utf-8")).decode("ascii")
                     if result.next_cursor
@@ -621,7 +633,11 @@ def create_async_files_router(
                 )
 
             # Non-paginated path (backward compat): result is list[dict]
-            file_items = [_to_file_item(entry, prefix) for entry in result]
+            file_items = [
+                _to_file_item(entry, prefix)
+                for entry in result
+                if entry.get("path", "").rstrip("/") != clean_path.rstrip("/")
+            ]
             return ListResponse(items=file_items, has_more=False)
 
         except HTTPException:
@@ -648,9 +664,8 @@ def create_async_files_router(
         """Create a directory."""
         try:
             fs = await _get_fs()
-            await asyncio.to_thread(
-                fs.sys_mkdir, request.path, parents=request.parents, context=context
-            )
+            # fs.sys_mkdir is async — call directly
+            await fs.sys_mkdir(request.path, parents=request.parents, context=context)
             return {"created": True, "path": request.path}
 
         except NexusPermissionError as e:
@@ -677,7 +692,7 @@ def create_async_files_router(
         """Get file or directory metadata."""
         try:
             fs = await _get_fs()
-            meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
+            meta = await fs.sys_stat(path, context=context)
             if meta is None:
                 raise NexusFileNotFoundError(path=path)
 
@@ -764,7 +779,7 @@ def create_async_files_router(
 
         try:
             fs = await _get_fs()
-            meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
+            meta = await fs.sys_stat(path, context=context)
             if meta is None:
                 raise NexusFileNotFoundError(path=path)
 
@@ -1039,9 +1054,8 @@ def create_async_files_router(
             fs = await _get_fs()
 
             # List all files under the base path
-            all_paths = await asyncio.to_thread(
-                fs.sys_readdir, path, recursive=True, context=context
-            )
+            # sys_readdir is async — call directly, not via to_thread
+            all_paths = await fs.sys_readdir(path, recursive=True, context=context)
 
             # Apply glob pattern filter
             matched = await asyncio.to_thread(glob_filter, all_paths, include_patterns=[pattern])
@@ -1090,9 +1104,8 @@ def create_async_files_router(
             fs = await _get_fs()
 
             # List all files under the base path
-            all_paths = await asyncio.to_thread(
-                fs.sys_readdir, path, recursive=True, context=context
-            )
+            # sys_readdir is async — call directly, not via to_thread
+            all_paths = await fs.sys_readdir(path, recursive=True, context=context)
 
             # Try Rust mmap grep first
             results = await asyncio.to_thread(
@@ -1114,7 +1127,7 @@ def create_async_files_router(
                     if len(results) >= limit:
                         break
                     try:
-                        content = await asyncio.to_thread(fs.read, file_path, context=context)
+                        content = await fs.read(file_path, context=context)
                         if isinstance(content, bytes):
                             content = content.decode("utf-8", errors="replace")
                         elif isinstance(content, dict):

--- a/tests/unit/core/test_nexus_fs_delegation.py
+++ b/tests/unit/core/test_nexus_fs_delegation.py
@@ -74,12 +74,13 @@ class TestSysReaddir:
     @pytest.mark.asyncio
     async def test_sys_readdir_details(self, mock_fs, context):
         """sys_readdir with details=True returns dicts from metadata."""
-        entry = SimpleNamespace(path="/data/a.txt", size=42, etag="abc")
+        entry = SimpleNamespace(path="/data/a.txt", size=42, etag="abc", entry_type=0)
         mock_fs.metadata.list = MagicMock(return_value=[entry])
+        mock_fs.metadata.is_implicit_directory = MagicMock(return_value=False)
 
         result = await mock_fs.sys_readdir(path="/data", details=True, context=context)
 
-        assert result == [{"path": "/data/a.txt", "size": 42, "etag": "abc"}]
+        assert result == [{"path": "/data/a.txt", "size": 42, "etag": "abc", "entry_type": 0}]
 
     @pytest.mark.asyncio
     async def test_sys_readdir_root_prefix(self, mock_fs, context):

--- a/tests/unit/server/api/v2/routers/test_async_files_pagination.py
+++ b/tests/unit/server/api/v2/routers/test_async_files_pagination.py
@@ -1,7 +1,7 @@
 """Tests for paginated /list endpoint (Issue #3102, Decision 2A)."""
 
 import base64
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -16,9 +16,9 @@ from nexus.server.dependencies import get_auth_result
 # ---------------------------------------------------------------------------
 
 
-def _make_entry(path: str, size: int = 100, etag: str = "etag1") -> dict:
+def _make_entry(path: str, size: int = 100, etag: str = "etag1", entry_type: int = 0) -> dict:
     """Build a details dict as returned by sys_readdir(details=True)."""
-    return {"path": path, "size": size, "etag": etag}
+    return {"path": path, "size": size, "etag": etag, "entry_type": entry_type}
 
 
 def _encode_cursor(path: str) -> str:
@@ -32,8 +32,11 @@ def _encode_cursor(path: str) -> str:
 
 @pytest.fixture()
 def mock_fs() -> MagicMock:
-    """Create a mock NexusFS."""
-    return MagicMock()
+    """Create a mock NexusFS with async methods."""
+    fs = MagicMock()
+    # sys_readdir is async — must return a coroutine
+    fs.sys_readdir = AsyncMock()
+    return fs
 
 
 @pytest.fixture()
@@ -69,7 +72,7 @@ class TestListPagination:
         mock_fs.sys_readdir.return_value = [
             _make_entry("/data/a.txt", size=10, etag="e1"),
             _make_entry("/data/b.txt", size=20, etag="e2"),
-            _make_entry("/data/sub/", size=0, etag="e3"),
+            _make_entry("/data/sub/", size=0, etag="e3", entry_type=1),
         ]
 
         resp = client.get("/list", params={"path": "/data"})

--- a/tests/unit/server/api/v2/routers/test_async_files_write_mode.py
+++ b/tests/unit/server/api/v2/routers/test_async_files_write_mode.py
@@ -1,6 +1,6 @@
 """Tests for write_mode query parameter on /write endpoint (Issue #2929)."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -12,15 +12,18 @@ from nexus.server.dependencies import get_auth_result
 
 @pytest.fixture()
 def mock_fs() -> MagicMock:
-    """Create a mock NexusFS."""
+    """Create a mock NexusFS with async methods."""
     fs = MagicMock()
-    fs.write.return_value = {
-        "etag": "abc123",
-        "version": 1,
-        "size": 11,
-        "modified_at": "2026-02-17T00:00:00Z",
-        "path": "/test.txt",
-    }
+    # write is async — must return a coroutine
+    fs.write = AsyncMock(
+        return_value={
+            "etag": "abc123",
+            "version": 1,
+            "size": 11,
+            "modified_at": "2026-02-17T00:00:00Z",
+            "path": "/test.txt",
+        }
+    )
     return fs
 
 


### PR DESCRIPTION
## Summary

Major fix pass for the TUI and server file operations API. The TUI was completely broken due to OpenTUI compatibility issues and the server's file endpoints were wrapping async NexusFS methods in `asyncio.to_thread()`.

### TUI fixes (17 files)
- **OpenTUI `<text>` nesting** — Replace all nested `<text>` with `<span>` inside `<text>` elements across 12 components. OpenTUI's `TextNodeRenderable.add()` only accepts strings, `TextNodeRenderable`, or `StyledText` — not nested `TextRenderable` from `<text>`.
- **Terminal cleanup on exit** — Write mouse/screen reset sequences via `fs.writeSync` before `process.exit()` to prevent escape sequence leaks into the shell.
- **Pre-connection screen overhaul** — Add `[D]` demo preset, `[Shift+U]` build from source, `[P]` seed demo data. Full-screen scrollable command output. After commands finish, only Esc/R keys work (prevents accidental re-triggers).
- **Ctrl+D disconnect** — Return to setup menu from any panel.
- **Colorful UI** — Gradient logo, color-coded action keys, themed errors/success.
- **File explorer metadata** — Fix `selectedItem` always null (populate `fileCache` in `expandNode`, fallback to tree node). Fix aspects URN when zones not configured.
- **Shift+N/Shift+R keybindings** — Was uppercase `N:`/`R:`, should be `"shift+n":`/`"shift+r":`.

### Server fixes (async_files.py + nexus_fs.py)
- **asyncio.to_thread → direct await** — All async NexusFS methods (`sys_readdir`, `sys_stat`, `sys_unlink`, `sys_access`, `sys_mkdir`, `read`, `write`) were incorrectly wrapped in `asyncio.to_thread()` which is for sync functions. Now awaited directly.
- **Directory detection** — Use `entry_type` from metastore (1=dir, 2=mount) + `is_implicit_directory()` check for CAS virtual directories like `/workspace`.
- **Self-referencing root entry** — Filter the listed path itself from directory listings to prevent infinite recursion in tree UIs.

### Other fixes
- **api-client config** — Read `ports.http` from `nexus.yaml` to auto-detect server URL.
- **command-runner** — Pass `NEXUS_URL`/`NEXUS_API_KEY` from `nexus.yaml` to subprocesses.
- **markitdown provider** — Catch `Exception` (not just `ImportError`) for broken transitive deps.
- **global-store** — Make `/auth/me` failure non-fatal (connected if health check passes).

## Test plan
- [ ] Run `bun run dev` from `packages/nexus-tui/` — should show pre-connection screen with gradient logo
- [ ] Press `D` then `Shift+U` — should init demo config and rebuild Docker image
- [ ] Press `R` after server starts — should connect and show file explorer
- [ ] Navigate file tree — `/workspace` should show as directory, not file
- [ ] Select a file — metadata pane should show file info
- [ ] Press `q` to quit — terminal should be clean (no escape sequence garbage)
- [ ] Press `Ctrl+D` when connected — should return to setup menu