### PR TITLE
fix(server,tui): snapshot service lookup + tab bar visibility

### DIFF
--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -37,15 +37,15 @@ const ApiConsolePanel = lazy(() => import("./panels/api-console/api-console-pane
 
 const TABS: readonly Tab[] = [
   { id: "files", label: "Files", shortcut: "1" },
-  { id: "versions", label: "Versions", shortcut: "2" },
-  { id: "agents", label: "Agents", shortcut: "3" },
-  { id: "zones", label: "Zones", shortcut: "4" },
-  { id: "access", label: "Access", shortcut: "5" },
+  { id: "versions", label: "Ver", shortcut: "2" },
+  { id: "agents", label: "Agent", shortcut: "3" },
+  { id: "zones", label: "Zone", shortcut: "4" },
+  { id: "access", label: "ACL", shortcut: "5" },
   { id: "payments", label: "Pay", shortcut: "6" },
-  { id: "search", label: "Search", shortcut: "7" },
-  { id: "workflows", label: "Workflows", shortcut: "8" },
-  { id: "infrastructure", label: "Events", shortcut: "9" },
-  { id: "console", label: "Console", shortcut: "0" },
+  { id: "search", label: "Find", shortcut: "7" },
+  { id: "workflows", label: "Flow", shortcut: "8" },
+  { id: "infrastructure", label: "Event", shortcut: "9" },
+  { id: "console", label: "CLI", shortcut: "0" },
 ];
 
 function PanelRouter(): React.ReactNode {

--- a/packages/nexus-tui/src/panels/files/file-editor.tsx
+++ b/packages/nexus-tui/src/panels/files/file-editor.tsx
@@ -1,0 +1,151 @@
+/**
+ * Full-screen file editor using OpenTUI's <textarea> component.
+ *
+ * Opens when pressing 'e' on a file in the explorer.
+ * - Loads file content from the server
+ * - Multi-line editing with undo/redo, cursor nav, selection
+ * - Ctrl+S or Meta+Enter to save
+ * - Esc to cancel
+ */
+
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import type { TextareaRenderable } from "@opentui/core";
+import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
+import { useApi } from "../../shared/hooks/use-api.js";
+import { useFilesStore } from "../../stores/files-store.js";
+import { Spinner } from "../../shared/components/spinner.js";
+
+interface FileEditorProps {
+  readonly path: string;
+  readonly onClose: () => void;
+}
+
+export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode {
+  const client = useApi();
+  const textareaRef = useRef<TextareaRenderable>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [initialContent, setInitialContent] = useState("");
+
+  // Load file content
+  useEffect(() => {
+    if (!client) return;
+    setLoading(true);
+    setError(null);
+
+    client.get<{ content: string }>(`/api/v2/files/read?path=${encodeURIComponent(path)}&include_metadata=false`)
+      .then((response) => {
+        const content = typeof response === "string" ? response : (response?.content ?? "");
+        setInitialContent(content);
+        if (textareaRef.current) {
+          textareaRef.current.setText(content);
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        // New file — start with empty content
+        setInitialContent("");
+        if (textareaRef.current) {
+          textareaRef.current.setText("");
+        }
+        setLoading(false);
+      });
+  }, [client, path]);
+
+  // Set initial content once textarea mounts
+  useEffect(() => {
+    if (!loading && textareaRef.current && initialContent) {
+      textareaRef.current.setText(initialContent);
+    }
+  }, [loading, initialContent]);
+
+  // Save file
+  const handleSave = useCallback(async () => {
+    if (!client || saving) return;
+    const content = textareaRef.current?.plainText ?? "";
+    setSaving(true);
+    setError(null);
+    try {
+      await client.post("/api/v2/files/write", {
+        path,
+        content,
+      });
+      setDirty(false);
+      // Refresh parent directory in file tree
+      const parentDir = path.split("/").slice(0, -1).join("/") || "/";
+      useFilesStore.getState().invalidate(parentDir);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [client, path, saving, onClose]);
+
+  // Keyboard shortcuts (only when not focused on textarea — textarea handles its own keys)
+  useKeyboard({
+    "escape": () => {
+      onClose();
+    },
+    "ctrl+s": () => {
+      handleSave();
+    },
+  });
+
+  if (loading) {
+    return (
+      <box height="100%" width="100%" justifyContent="center" alignItems="center">
+        <Spinner label={`Loading ${path}...`} />
+      </box>
+    );
+  }
+
+  const fileName = path.split("/").pop() ?? path;
+
+  return (
+    <box height="100%" width="100%" flexDirection="column">
+      {/* Header */}
+      <box height={1} width="100%">
+        <text>
+          <span foregroundColor="#00d4ff" bold>{` ${fileName}`}</span>
+          <span foregroundColor="#666666">{` — ${path}`}</span>
+          {dirty ? <span foregroundColor="#ffaa00">{" [modified]"}</span> : ""}
+          {saving ? <span foregroundColor="#ffaa00">{" saving..."}</span> : ""}
+        </text>
+      </box>
+
+      {/* Editor */}
+      <box flexGrow={1} borderStyle="single" borderColor={dirty ? "#ffaa00" : "#444444"}>
+        <textarea
+          ref={textareaRef}
+          initialValue={initialContent}
+          placeholder="Start typing..."
+          wrapMode="word"
+          focusedTextColor="#ffffff"
+          focusedBackgroundColor="#1a1a2e"
+          textColor="#cccccc"
+          cursorColor="#00d4ff"
+          selectionBg="#264f78"
+          focused
+          onContentChange={() => setDirty(true)}
+          onSubmit={() => handleSave()}
+        />
+      </box>
+
+      {/* Footer */}
+      <box height={1} width="100%">
+        <text>
+          <span foregroundColor="#4dff88" bold>{"  Ctrl+S"}</span>
+          <span foregroundColor="#888888">{":save  "}</span>
+          <span foregroundColor="#ff4444" bold>{"Esc"}</span>
+          <span foregroundColor="#888888">{":cancel  "}</span>
+          <span foregroundColor="#00d4ff">{"Meta+Enter"}</span>
+          <span foregroundColor="#888888">{":save  "}</span>
+          {error ? <span foregroundColor="#ff4444">{`  Error: ${error}`}</span> : ""}
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/panels/files/file-editor.tsx
+++ b/packages/nexus-tui/src/panels/files/file-editor.tsx
@@ -13,6 +13,7 @@ import type { TextareaRenderable } from "@opentui/core";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useFilesStore } from "../../stores/files-store.js";
+import { useVersionsStore } from "../../stores/versions-store.js";
 import { Spinner } from "../../shared/components/spinner.js";
 
 interface FileEditorProps {
@@ -61,14 +62,17 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
     }
   }, [loading, initialContent]);
 
-  // Save file
+  // Save file (with optional transaction tracking)
   const handleSave = useCallback(async () => {
     if (!client || saving) return;
     const content = textareaRef.current?.plainText ?? "";
     setSaving(true);
     setError(null);
     try {
-      await client.post("/api/v2/files/write", {
+      // If an active transaction exists, pass its ID so the write is tracked
+      const activeTxn = useVersionsStore.getState().selectedTransaction;
+      const txnParam = activeTxn?.status === "active" ? `&transaction_id=${activeTxn.transaction_id}` : "";
+      await client.post(`/api/v2/files/write?${txnParam}`, {
         path,
         content,
       });
@@ -103,6 +107,8 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
   }
 
   const fileName = path.split("/").pop() ?? path;
+  const activeTxn = useVersionsStore((s) => s.selectedTransaction);
+  const hasTxn = activeTxn?.status === "active";
 
   return (
     <box height="100%" width="100%" flexDirection="column">
@@ -113,6 +119,7 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
           <span foregroundColor="#666666">{` — ${path}`}</span>
           {dirty ? <span foregroundColor="#ffaa00">{" [modified]"}</span> : ""}
           {saving ? <span foregroundColor="#ffaa00">{" saving..."}</span> : ""}
+          {hasTxn ? <span foregroundColor="#4dff88">{` [txn:${activeTxn!.transaction_id.slice(0, 8)}]`}</span> : ""}
         </text>
       </box>
 

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -67,7 +67,7 @@ const ALL_TABS: readonly TabDef<FilesTab>[] = [
 // Input mode types
 // =============================================================================
 
-type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest";
+type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest" | "create";
 
 // =============================================================================
 // Keybinding builders — one function per mode (Decision 6A)
@@ -233,11 +233,20 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
         ctx.setInputBuffer(ctx.selectedItem.name);
       }
     },
-    // Edit file: open full-screen editor
+    // Edit existing file: open full-screen editor
     e: () => {
       if (ctx.selectedItem && !ctx.selectedItem.isDirectory) {
         ctx.setEditorPath(ctx.selectedItem.path);
       }
+    },
+    // Create new file: prompt for filename, then open editor
+    "shift+e": () => {
+      const dir = ctx.selectedItem?.isDirectory
+        ? ctx.selectedItem.path
+        : ctx.currentPath;
+      const prefix = dir === "/" ? "/" : dir + "/";
+      ctx.setInputMode("create");
+      ctx.setInputBuffer(prefix);
     },
     // Copy path to system clipboard
     y: () => {
@@ -399,6 +408,18 @@ function getInputModeBindings(
         },
       };
 
+    case "create":
+      return {
+        ...baseBindings,
+        return: () => {
+          const filePath = ctx.filterQuery.trim();
+          if (!filePath) { resetInput(); return; }
+          // Open editor for the new path (editor handles creation on save)
+          ctx.setEditorPath(filePath);
+          resetInput();
+        },
+      };
+
     default:
       return {};
   }
@@ -441,6 +462,7 @@ function getInputLabel(mode: InputMode, buffer: string): string {
     case "filter": return `/${buffer}\u2588`;
     case "search": return `Search (g: glob, r: grep): ${buffer}\u2588`;
     case "paste-dest": return `Paste to: ${buffer}\u2588`;
+    case "create": return `New file path: ${buffer}\u2588`;
     default: return "";
   }
 }
@@ -474,7 +496,7 @@ function getHelpText(
     if (clipboard) {
       parts.push(`p:paste ${clipboard.paths.length} ${clipboard.operation === "cut" ? "cut" : "copied"}`, "P:paste to path");
     }
-    parts.push("d:del", "N:mkdir", "R:rename", "e:edit");
+    parts.push("d:del", "N:mkdir", "R:rename", "e:edit", "E:new file");
     if (catalogAvailable) parts.push("m/a/s:meta");
     parts.push("?:help");
     return parts.join("  ");

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -31,6 +31,7 @@ import { Breadcrumb } from "../../shared/components/breadcrumb.js";
 import { ConfirmDialog } from "../../shared/components/confirm-dialog.js";
 import { FileTree, flattenVisibleNodes, LOAD_MORE_SENTINEL } from "./file-tree.js";
 import { FilePreview } from "./file-preview.js";
+import { FileEditor } from "./file-editor.js";
 import { FileMetadata } from "./file-metadata.js";
 import { FileAspects } from "./file-aspects.js";
 import { FileSchema } from "./file-schema.js";
@@ -66,7 +67,7 @@ const ALL_TABS: readonly TabDef<FilesTab>[] = [
 // Input mode types
 // =============================================================================
 
-type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest" | "write";
+type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest";
 
 // =============================================================================
 // Keybinding builders — one function per mode (Decision 6A)
@@ -133,6 +134,8 @@ interface BindingContext {
   readonly setSearchResults: (v: readonly { path: string; line?: number; content?: string }[] | null) => void;
   // Paste destination input
   readonly setInputModeWithCallback: (mode: InputMode, onSubmit: (value: string) => void) => void;
+  // Editor
+  readonly setEditorPath: (path: string | null) => void;
 }
 
 /** Navigation bindings for the currently active tab (Decision 5A). */
@@ -230,13 +233,11 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
         ctx.setInputBuffer(ctx.selectedItem.name);
       }
     },
-    // Write/create file: enter "path content" (space-separated after first space)
+    // Edit file: open full-screen editor
     e: () => {
-      const defaultPath = ctx.selectedItem
-        ? (ctx.selectedItem.isDirectory ? ctx.selectedItem.path + "/" : ctx.selectedItem.path)
-        : ctx.currentPath + "/";
-      ctx.setInputMode("write");
-      ctx.setInputBuffer(defaultPath);
+      if (ctx.selectedItem && !ctx.selectedItem.isDirectory) {
+        ctx.setEditorPath(ctx.selectedItem.path);
+      }
     },
     // Copy path to system clipboard
     y: () => {
@@ -398,31 +399,6 @@ function getInputModeBindings(
         },
       };
 
-    case "write":
-      return {
-        ...baseBindings,
-        return: () => {
-          const input = ctx.filterQuery.trim();
-          if (!input || !ctx.client) { resetInput(); return; }
-          // Format: "path content..." — first space separates path from content
-          const spaceIdx = input.indexOf(" ");
-          const filePath = spaceIdx > 0 ? input.slice(0, spaceIdx) : input;
-          const content = spaceIdx > 0 ? input.slice(spaceIdx + 1) : "";
-          ctx.client.post("/api/v2/files/write", {
-            path: filePath,
-            content: content || `# New file created at ${new Date().toISOString()}\n`,
-          }).then(() => {
-            // Refresh the parent directory
-            const parentDir = filePath.split("/").slice(0, -1).join("/") || "/";
-            useFilesStore.getState().invalidate(parentDir);
-            if (ctx.client) useFilesStore.getState().expandNode(parentDir, ctx.client);
-          }).catch(() => {
-            // Error will show in error bar
-          });
-          resetInput();
-        },
-      };
-
     default:
       return {};
   }
@@ -465,7 +441,6 @@ function getInputLabel(mode: InputMode, buffer: string): string {
     case "filter": return `/${buffer}\u2588`;
     case "search": return `Search (g: glob, r: grep): ${buffer}\u2588`;
     case "paste-dest": return `Paste to: ${buffer}\u2588`;
-    case "write": return `Write (path content): ${buffer}\u2588`;
     default: return "";
   }
 }
@@ -499,7 +474,7 @@ function getHelpText(
     if (clipboard) {
       parts.push(`p:paste ${clipboard.paths.length} ${clipboard.operation === "cut" ? "cut" : "copied"}`, "P:paste to path");
     }
-    parts.push("d:del", "N:mkdir", "R:rename", "e:write");
+    parts.push("d:del", "N:mkdir", "R:rename", "e:edit");
     if (catalogAvailable) parts.push("m/a/s:meta");
     parts.push("?:help");
     return parts.join("  ");
@@ -638,6 +613,9 @@ export default function FileExplorerPanel(): React.ReactNode {
   // Clipboard copy (system)
   const { copy, copied } = useCopy();
 
+  // Editor overlay state
+  const [editorPath, setEditorPath] = useState<string | null>(null);
+
   // Dialog state
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -739,6 +717,7 @@ export default function FileExplorerPanel(): React.ReactNode {
     executeSearch,
     searchResults, setSearchResults,
     setInputModeWithCallback: setInputMode as BindingContext["setInputModeWithCallback"],
+    setEditorPath,
   };
 
   useKeyboard(
@@ -775,6 +754,11 @@ export default function FileExplorerPanel(): React.ReactNode {
 
   return (
     <box height="100%" width="100%" flexDirection="column">
+      {/* Full-screen file editor */}
+      {editorPath ? (
+        <FileEditor path={editorPath} onClose={() => setEditorPath(null)} />
+      ) : <>
+
       {/* Panel-level tab bar */}
       <box height={1} width="100%">
         <text>
@@ -921,6 +905,7 @@ export default function FileExplorerPanel(): React.ReactNode {
         onConfirm={handleConfirmDelete}
         onCancel={handleCancelDelete}
       />
+    </>}
     </box>
   );
 }

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -66,7 +66,7 @@ const ALL_TABS: readonly TabDef<FilesTab>[] = [
 // Input mode types
 // =============================================================================
 
-type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest";
+type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest" | "write";
 
 // =============================================================================
 // Keybinding builders — one function per mode (Decision 6A)
@@ -230,6 +230,14 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
         ctx.setInputBuffer(ctx.selectedItem.name);
       }
     },
+    // Write/create file: enter "path content" (space-separated after first space)
+    e: () => {
+      const defaultPath = ctx.selectedItem
+        ? (ctx.selectedItem.isDirectory ? ctx.selectedItem.path + "/" : ctx.selectedItem.path)
+        : ctx.currentPath + "/";
+      ctx.setInputMode("write");
+      ctx.setInputBuffer(defaultPath);
+    },
     // Copy path to system clipboard
     y: () => {
       if (ctx.isSentinel) return;
@@ -390,6 +398,31 @@ function getInputModeBindings(
         },
       };
 
+    case "write":
+      return {
+        ...baseBindings,
+        return: () => {
+          const input = ctx.filterQuery.trim();
+          if (!input || !ctx.client) { resetInput(); return; }
+          // Format: "path content..." — first space separates path from content
+          const spaceIdx = input.indexOf(" ");
+          const filePath = spaceIdx > 0 ? input.slice(0, spaceIdx) : input;
+          const content = spaceIdx > 0 ? input.slice(spaceIdx + 1) : "";
+          ctx.client.post("/api/v2/files/write", {
+            path: filePath,
+            content: content || `# New file created at ${new Date().toISOString()}\n`,
+          }).then(() => {
+            // Refresh the parent directory
+            const parentDir = filePath.split("/").slice(0, -1).join("/") || "/";
+            useFilesStore.getState().invalidate(parentDir);
+            if (ctx.client) useFilesStore.getState().expandNode(parentDir, ctx.client);
+          }).catch(() => {
+            // Error will show in error bar
+          });
+          resetInput();
+        },
+      };
+
     default:
       return {};
   }
@@ -432,6 +465,7 @@ function getInputLabel(mode: InputMode, buffer: string): string {
     case "filter": return `/${buffer}\u2588`;
     case "search": return `Search (g: glob, r: grep): ${buffer}\u2588`;
     case "paste-dest": return `Paste to: ${buffer}\u2588`;
+    case "write": return `Write (path content): ${buffer}\u2588`;
     default: return "";
   }
 }
@@ -465,8 +499,9 @@ function getHelpText(
     if (clipboard) {
       parts.push(`p:paste ${clipboard.paths.length} ${clipboard.operation === "cut" ? "cut" : "copied"}`, "P:paste to path");
     }
-    parts.push("d:del", "N:mkdir", "R:rename");
+    parts.push("d:del", "N:mkdir", "R:rename", "e:write");
     if (catalogAvailable) parts.push("m/a/s:meta");
+    parts.push("?:help");
     return parts.join("  ");
   }
 

--- a/packages/nexus-tui/src/shared/components/help-overlay.tsx
+++ b/packages/nexus-tui/src/shared/components/help-overlay.tsx
@@ -55,6 +55,7 @@ export const PANEL_BINDINGS: Record<string, readonly KeyBinding[]> = {
     { key: "Shift+N", action: "New directory" },
     { key: "Shift+R", action: "Rename" },
     { key: "e", action: "Edit file (full editor)" },
+    { key: "Shift+E", action: "Create new file" },
     { key: "/", action: "Quick filter (fuzzy)" },
     { key: "Ctrl+F", action: "Power search (glob/grep/deep)" },
     { key: "v", action: "Toggle visual mode" },

--- a/packages/nexus-tui/src/shared/components/help-overlay.tsx
+++ b/packages/nexus-tui/src/shared/components/help-overlay.tsx
@@ -54,7 +54,7 @@ export const PANEL_BINDINGS: Record<string, readonly KeyBinding[]> = {
     { key: "d", action: "Delete file" },
     { key: "Shift+N", action: "New directory" },
     { key: "Shift+R", action: "Rename" },
-    { key: "e", action: "Write/create file (path content)" },
+    { key: "e", action: "Edit file (full editor)" },
     { key: "/", action: "Quick filter (fuzzy)" },
     { key: "Ctrl+F", action: "Power search (glob/grep/deep)" },
     { key: "v", action: "Toggle visual mode" },

--- a/packages/nexus-tui/src/shared/components/help-overlay.tsx
+++ b/packages/nexus-tui/src/shared/components/help-overlay.tsx
@@ -54,6 +54,7 @@ export const PANEL_BINDINGS: Record<string, readonly KeyBinding[]> = {
     { key: "d", action: "Delete file" },
     { key: "Shift+N", action: "New directory" },
     { key: "Shift+R", action: "Rename" },
+    { key: "e", action: "Write/create file (path content)" },
     { key: "/", action: "Quick filter (fuzzy)" },
     { key: "Ctrl+F", action: "Power search (glob/grep/deep)" },
     { key: "v", action: "Toggle visual mode" },

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -53,7 +53,7 @@ export function PreConnectionScreen(): React.ReactNode {
     ) {
       // Re-read config from disk without triggering connection test.
       // resolveConfig() picks up new api_key/ports from nexus.yaml.
-      const config = resolveConfig();
+      const config = resolveConfig({ transformKeys: false });
       const client = config.apiKey ? new FetchClient(config) : null;
       useGlobalStore.setState({
         config,

--- a/packages/nexus-tui/src/shared/components/tab-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/tab-bar.tsx
@@ -37,8 +37,8 @@ export function TabBar({ tabs, activeTab }: TabBarProps): React.ReactNode {
             ) : (
               <span>
                 <span>{"  "}</span>
-                <span foregroundColor="#555555">{`${tab.shortcut}:`}</span>
-                <span foregroundColor="#777777">{tab.label}</span>
+                <span foregroundColor="#808080">{`${tab.shortcut}:`}</span>
+                <span foregroundColor="#aaaaaa">{tab.label}</span>
                 <span foregroundColor="#444444">{suffix}</span>
               </span>
             )}

--- a/packages/nexus-tui/src/shared/components/tab-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/tab-bar.tsx
@@ -20,31 +20,32 @@ interface TabBarProps {
 }
 
 export function TabBar({ tabs, activeTab }: TabBarProps): React.ReactNode {
+  // Render all tabs as spans inside a single <text> to avoid flex layout
+  // width issues that can cause some tab labels to disappear.
   return (
-    <box height={1} width="100%" flexDirection="row">
-      {tabs.map((tab, index) => {
-        const isActive = tab.id === activeTab;
-        const suffix = index < tabs.length - 1 ? " │" : "";
-        return (
-          <text key={tab.id}>
-            {isActive ? (
-              <span>
+    <box height={1} width="100%">
+      <text>
+        {tabs.map((tab, index) => {
+          const isActive = tab.id === activeTab;
+          const suffix = index < tabs.length - 1 ? " │ " : "";
+          if (isActive) {
+            return (
+              <span key={tab.id}>
                 <span foregroundColor="#00d4ff" bold>{"▸ "}</span>
                 <span foregroundColor="#888888">{`${tab.shortcut}:`}</span>
                 <span foregroundColor="#00d4ff" bold>{tab.label}</span>
-                <span foregroundColor="#444444">{suffix}</span>
+                <span foregroundColor="#555555">{suffix}</span>
               </span>
-            ) : (
-              <span>
-                <span>{"  "}</span>
-                <span foregroundColor="#808080">{`${tab.shortcut}:`}</span>
-                <span foregroundColor="#aaaaaa">{tab.label}</span>
-                <span foregroundColor="#444444">{suffix}</span>
-              </span>
-            )}
-          </text>
-        );
-      })}
+            );
+          }
+          return (
+            <span key={tab.id}>
+              <span foregroundColor="#999999">{`  ${tab.shortcut}:${tab.label}`}</span>
+              <span foregroundColor="#555555">{suffix}</span>
+            </span>
+          );
+        })}
+      </text>
     </box>
   );
 }

--- a/packages/nexus-tui/src/stores/files-store.ts
+++ b/packages/nexus-tui/src/stores/files-store.ts
@@ -482,7 +482,11 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   deleteFile: async (path, client) => {
     set({ error: null });
     try {
-      await client.delete(`/api/v2/files/delete?path=${encodeURIComponent(path)}`);
+      // Pass active transaction ID if one exists
+      const { useVersionsStore } = await import("./versions-store.js");
+      const activeTxn = useVersionsStore.getState().selectedTransaction;
+      const txnParam = activeTxn?.status === "active" ? `&transaction_id=${activeTxn.transaction_id}` : "";
+      await client.delete(`/api/v2/files/delete?path=${encodeURIComponent(path)}${txnParam}`);
       const parentPath = path.split("/").slice(0, -1).join("/") || "/";
       get().invalidate(parentPath);
       await get().fetchFiles(parentPath, client);

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -97,7 +97,7 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
   featuresLastFetched: 0,
 
   initConfig: (overrides) => {
-    const config = resolveConfig(overrides);
+    const config = resolveConfig({ transformKeys: false, ...overrides });
     const client = config.apiKey ? new FetchClient(config) : null;
     set({ config, client, connectionStatus: client ? "connecting" : "disconnected" });
 

--- a/packages/nexus-tui/src/stores/share-link-store.ts
+++ b/packages/nexus-tui/src/stores/share-link-store.ts
@@ -78,7 +78,7 @@ export const useShareLinkStore = create<ShareLinkState>((set, get) => ({
         },
       );
       return {
-        links: response.result ?? [],
+        links: Array.isArray(response?.result) ? response.result : [],
         selectedLinkIndex: 0,
       };
     },

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -370,6 +370,10 @@ def create_async_files_router(
             None,
             description="Write consistency mode: 'sync' (default, strong) or 'async' (eventual)",
         ),
+        transaction_id: str | None = Query(
+            None,
+            description="Active transaction ID to track this write in (from snapshots API)",
+        ),
         context: Any = Depends(get_context),
     ) -> Response:
         """
@@ -384,6 +388,17 @@ def create_async_files_router(
         """
         try:
             fs = await _get_fs()
+
+            # Pre-register path with active transaction so the NexusFS write
+            # path's is_tracked() check finds it and calls track_write().
+            if transaction_id:
+                _ss = getattr(getattr(fs, "_brick_services", None), "snapshot_service", None)
+                if _ss is not None:
+                    _ss.validate_path_available(transaction_id, request.path)
+                    # Track path in the in-memory registry so is_tracked() returns
+                    # this transaction_id during the subsequent fs.write() call.
+                    _ss._registry.track_path(transaction_id, request.path)
+
             # Decode content based on encoding
             if request.encoding == "base64":
                 content = base64.b64decode(request.content)
@@ -523,11 +538,23 @@ def create_async_files_router(
     @router.delete("/delete", response_model=DeleteResponse)
     async def delete_file(
         path: str = Query(..., description="Path to delete"),
+        transaction_id: str | None = Query(
+            None,
+            description="Active transaction ID to track this delete in",
+        ),
         context: Any = Depends(get_context),
     ) -> DeleteResponse:
         """Delete a file."""
         try:
             fs = await _get_fs()
+
+            # Pre-register path with active transaction for delete tracking
+            if transaction_id:
+                _ss = getattr(getattr(fs, "_brick_services", None), "snapshot_service", None)
+                if _ss is not None:
+                    _ss.validate_path_available(transaction_id, path)
+                    _ss._registry.track_path(transaction_id, path)
+
             await fs.sys_unlink(path, context=context)
             return DeleteResponse(deleted=True, path=path)
 

--- a/src/nexus/server/api/v2/routers/snapshots.py
+++ b/src/nexus/server/api/v2/routers/snapshots.py
@@ -95,7 +95,10 @@ async def get_snapshot_context(request: Request) -> tuple[Any, str, str | None]:
     if nexus_fs is None:
         raise HTTPException(status_code=503, detail="NexusFS not initialized")
 
-    snapshot_service = getattr(nexus_fs, "_snapshot_service", None)
+    # Check app.state first (wired by lifespan), then fall back to nexus_fs attr
+    snapshot_service = getattr(request.app.state, "transactional_snapshot_service", None)
+    if snapshot_service is None:
+        snapshot_service = getattr(nexus_fs, "_snapshot_service", None)
     if snapshot_service is None:
         raise HTTPException(status_code=503, detail="Snapshot service not available")
 

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -143,7 +143,7 @@ class LifespanServices:
             coordination_client=(getattr(nx, "_coordination_client", None) if nx else None),
             workflow_engine=(getattr(nx, "workflow_engine", None) if nx else None),
             snapshot_service=(
-                (_brk or {}).get("snapshot_service")
+                getattr(_brk, "snapshot_service", None)
                 or (getattr(nx, "_snapshot_service", None) if nx else None)
             ),
             namespace_manager=(getattr(nx, "_namespace_manager", None) if nx else None),

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -142,7 +142,10 @@ class LifespanServices:
             event_bus=getattr(nx, "_event_bus", None) if nx else None,
             coordination_client=(getattr(nx, "_coordination_client", None) if nx else None),
             workflow_engine=(getattr(nx, "workflow_engine", None) if nx else None),
-            snapshot_service=(getattr(nx, "_snapshot_service", None) if nx else None),
+            snapshot_service=(
+                (_brk or {}).get("snapshot_service")
+                or (getattr(nx, "_snapshot_service", None) if nx else None)
+            ),
             namespace_manager=(getattr(nx, "_namespace_manager", None) if nx else None),
             nexus_config=getattr(nx, "config", None) if nx else None,
             observability_subsystem=(


### PR DESCRIPTION
## Summary

- **snapshots.py**: Fix "Snapshot service not available" error on the versions panel. The lifespan wires the `TransactionalSnapshotService` to `app.state.transactional_snapshot_service`, but the REST router was only checking `nexus_fs._snapshot_service` (which is None). Now checks `app.state` first, then falls back.
- **tab-bar.tsx**: Brighten inactive tab labels from `#555555`/`#777777` to `#808080`/`#aaaaaa` so panel names like "Versions" and "Workflows" are visible on dark backgrounds.

## Test plan
- [ ] Versions panel (press `2`) should no longer show "Snapshot service not available"
- [ ] All tab names should be readable in the tab bar