### PR TITLE
feat(#1570): coordinator cleanup — enlist() as single entry point

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -288,6 +288,7 @@ class NexusFS(  # type: ignore[misc]
         if coord is not None:
             await coord.activate_hot_swappable_services()
             await coord.start_persistent_services()
+            coord.mark_bootstrapped()  # future enlist() calls auto-start Q3
         self._bootstrapped = True
 
     def _register_runtime_closeable(self, resource: Any) -> None:

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -270,27 +270,6 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         """Return the full ``ServiceInfo`` envelope, or ``None``."""
         return self.get(name)
 
-    # -- bulk registration -------------------------------------------------
-
-    def register_many(
-        self,
-        services: dict[str, Any],
-        *,
-        is_remote: bool = False,
-    ) -> int:
-        """Register multiple services at once (skips ``None`` values).
-
-        Used by factory ``enlist_wired_services()`` for batch wiring.
-        Returns the number of services actually registered.
-        """
-        count = 0
-        for name, instance in services.items():
-            if instance is None:
-                continue
-            self.register_service(name, instance, is_remote=is_remote)
-            count += 1
-        return count
-
     # -- diagnostics -------------------------------------------------------
 
     def snapshot(self) -> list[dict[str, Any]]:

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -132,14 +132,14 @@ async def _do_link(
     await enlist_wired_services(coordinator, _wired)
 
     # Issue #1666: Register system-tier PersistentService instances.
-    # These are Q3 (PersistentService) — registered via register_service()
-    # (NOT enlist) so start() is deferred to bootstrap, not link().
+    # These are Q3 (PersistentService) — enlist() defers start() because
+    # coordinator is not yet bootstrapped (mark_bootstrapped at bootstrap).
     _dpb = getattr(nx._system_services, "deferred_permission_buffer", None)
     if _dpb is not None:
-        coordinator.register_service("deferred_permission_buffer", _dpb, exports=())
+        await coordinator.enlist("deferred_permission_buffer", _dpb)
     _dw = getattr(nx._system_services, "delivery_worker", None)
     if _dw is not None:
-        coordinator.register_service("delivery_worker", _dw, exports=())
+        await coordinator.enlist("delivery_worker", _dw)
 
     # Kernel DI: _descendant_checker is a kernel component (like Linux LSM hook),
     # not an external service — inject directly onto the kernel instance.

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -292,17 +292,7 @@ async def _boot_wired_services(
     except Exception as exc:
         logger.warning("[BOOT:WIRED] AgentRPCService unavailable: %s", exc)
 
-    # --- ProcResolver (procfs virtual filesystem for ProcessTable) ---
-    _proc_table = getattr(system_services, "process_table", None)
-    if _proc_table is not None:
-        try:
-            from nexus.system_services.proc.proc_resolver import ProcResolver
-
-            _proc_resolver = ProcResolver(_proc_table)
-            nx._dispatch.register_resolver(_proc_resolver)
-            logger.debug("[BOOT:WIRED] ProcResolver registered")
-        except Exception as exc:
-            logger.debug("[BOOT:WIRED] ProcResolver unavailable: %s", exc)
+    # ProcResolver moved to orchestrator._register_vfs_hooks() (Issue #1570)
 
     acp_rpc_service: Any = None
     _acp_service = getattr(system_services, "acp_service", None)
@@ -312,7 +302,7 @@ async def _boot_wired_services(
             from nexus.core.process_table import ProcessTable
             from nexus.system_services.acp.service import AcpService
 
-            _acp_pt = _proc_table
+            _acp_pt = getattr(system_services, "process_table", None)
             if _acp_pt is None:
                 _acp_pt = ProcessTable(zone_id=ROOT_ZONE_ID)
             _acp_service = AcpService(

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -518,6 +518,19 @@ async def _register_vfs_hooks(
     )
     await _enlist("virtual_view", _vview_resolver)
 
+    # ── ProcResolver (procfs virtual filesystem for ProcessTable — Issue #1570) ──
+    _proc_table = (
+        getattr(nx._system_services, "process_table", None) if nx._system_services else None
+    )
+    if _proc_table is not None:
+        try:
+            from nexus.system_services.proc.proc_resolver import ProcResolver
+
+            _proc_resolver = ProcResolver(_proc_table)
+            await _enlist("proc", _proc_resolver)
+        except Exception as exc:
+            logger.debug("[BOOT:HOOKS] ProcResolver unavailable: %s", exc)
+
     # ── TaskWriteHook (post-write: emit task lifecycle events) ─────────
     if _on("task_manager"):
         from nexus.bricks.task_manager.write_hook import TaskWriteHook

--- a/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
+++ b/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
@@ -1,32 +1,35 @@
 """ServiceLifecycleCoordinator — bridge between ServiceRegistry and BrickLifecycleManager.
 
-Provides five Linux-inspired verbs for service lifecycle management:
+``enlist()`` is the **single public entry point** for all service registration.
+It auto-detects the service quadrant and applies appropriate lifecycle:
 
-    insmod  → register_service()   — register instance in both Registry and BLM
-    mount   → mount_service()      — BLM mount + register VFS hooks
-    umount  → unmount_service()    — unregister VFS hooks + BLM unmount
-    rmmod   → unregister_service() — remove from both Registry and BLM
-    swap    → swap_service()       — atomic replace + drain + hook swap
+    Q1 (static)         — register only
+    Q2 (HotSwappable)   — register + capture hook_spec + activate
+    Q3 (Persistent)     — register + start (deferred pre-bootstrap)
+    Q4 (both)           — register + start + hooks + activate
+
+Bootstrap-aware: Q3 ``start()`` is deferred during link phase and batch-started
+at ``start_persistent_services()``.  After ``mark_bootstrapped()``, late-enlisted
+Q3 services are auto-started immediately.
+
+Public API surface (9 methods):
+    enlist()                           — single registration entry point
+    unregister_service()               — rmmod — remove service
+    swap_service()                     — atomic hot-swap (Q2/Q4 only)
+    start_persistent_services()        — bootstrap batch start Q3
+    stop_persistent_services()         — shutdown batch stop Q3
+    activate_hot_swappable_services()  — bootstrap batch activate Q2
+    deactivate_hot_swappable_services()— shutdown batch deactivate Q2
+    mark_bootstrapped()                — phase transition signal
+    classify_all()                     — observability / diagnostics
 
 The coordinator lives at the System Services tier (not kernel) — it composes
 kernel-owned ServiceRegistry with optional BrickLifecycleManager.  Always
 created for all deployment profiles (Issue #1708).
 
-Hot-swap flow (HotSwappable services only):
-    1. Validate old service implements HotSwappable (TypeError if not)
-    2. Call old_service.drain() — stop accepting new work
-    3. Drain ServiceRef refcount → 0 (wait for in-flight calls)
-    4. Unregister old VFS hooks (from old_service.hook_spec())
-    5. Atomic replace in ServiceRegistry
-    6. BLM state transitions for old (unmount+unregister) and new (register+mount)
-    7. Register new VFS hooks (from new_service.hook_spec() if HotSwappable)
-    8. Call new_service.activate() if HotSwappable
-
-Static (non-HotSwappable) services cannot be hot-swapped — they raise TypeError.
-Use full restart instead.
-
 Issue #1452 Phase 3.
 Issue #1577: HotSwappable + PersistentService protocol integration.
+Issue #1570: enlist() as THE single entry point, API surface cleanup.
 """
 
 from __future__ import annotations
@@ -59,7 +62,14 @@ class ServiceLifecycleCoordinator:
     Always instantiated for all profiles (Issue #1708); BLM is optional.
     """
 
-    __slots__ = ("_registry", "_blm", "_dispatch", "_hook_specs", "_hooks_on_dispatch")
+    __slots__ = (
+        "_registry",
+        "_blm",
+        "_dispatch",
+        "_hook_specs",
+        "_hooks_on_dispatch",
+        "_bootstrapped",
+    )
 
     def __init__(
         self,
@@ -75,12 +85,25 @@ class ServiceLifecycleCoordinator:
         # initialize() time by _enlist_hook().  activate_hot_swappable_services()
         # skips _register_hooks() for these to avoid double registration.
         self._hooks_on_dispatch: set[str] = set()
+        self._bootstrapped: bool = False
 
     # ------------------------------------------------------------------
-    # insmod — register service in both Registry and BLM
+    # mark_bootstrapped — phase transition signal
     # ------------------------------------------------------------------
 
-    def register_service(
+    def mark_bootstrapped(self) -> None:
+        """Mark that bootstrap() has completed.
+
+        After this, enlist() auto-starts Q3 PersistentService instances
+        immediately instead of deferring to start_persistent_services().
+        """
+        self._bootstrapped = True
+
+    # ------------------------------------------------------------------
+    # insmod — register service in both Registry and BLM (internal)
+    # ------------------------------------------------------------------
+
+    def _register_service(
         self,
         name: str,
         instance: Any,
@@ -139,23 +162,20 @@ class ServiceLifecycleCoordinator:
         - **Q3** (PersistentService): register + ``start()``.
         - **Q4** (both): register + ``start()`` + capture hooks + activate.
 
-        Used by lifespan startup functions for services created *after*
-        ``NexusFS.bootstrap()`` has already been called.  For pre-bootstrap
-        factory services, ``register_service()`` + auto-lifecycle at bootstrap
-        is the equivalent path.
+        Post-bootstrap, Q3 services are auto-started immediately.
+        Pre-bootstrap, Q3 start() is deferred to start_persistent_services().
         """
-        self.register_service(name, instance, exports=exports, depends_on=depends_on)
+        self._register_service(name, instance, exports=exports, depends_on=depends_on)
 
-        # Q3 / Q4: auto-start persistent background work
-        if isinstance(instance, PersistentService):
+        # Q3 / Q4: auto-start persistent background work (only post-bootstrap)
+        if isinstance(instance, PersistentService) and self._bootstrapped:
             await instance.start()
             logger.info("[COORDINATOR] enlist %r — started (PersistentService)", name)
 
         # Q2 / Q4: auto-capture hooks and activate
         if isinstance(instance, HotSwappable):
-            spec = instance.hook_spec()
-            self._hook_specs[name] = spec
-            if not spec.is_empty:
+            spec = self._ensure_hook_spec(name, instance)
+            if spec is not None and not spec.is_empty:
                 self._register_hooks(name)
                 self._hooks_on_dispatch.add(name)
             await instance.activate()
@@ -168,7 +188,7 @@ class ServiceLifecycleCoordinator:
     # mount — BLM mount + register VFS hooks
     # ------------------------------------------------------------------
 
-    async def mount_service(self, name: str, *, timeout: float = 5.0) -> None:
+    async def _mount_service(self, name: str, *, timeout: float = 5.0) -> None:
         """Mount a service: BLM state → ACTIVE, then register VFS hooks."""
         if self._blm is not None:
             await self._blm.mount(name, timeout=timeout)
@@ -189,7 +209,7 @@ class ServiceLifecycleCoordinator:
     # umount — unregister VFS hooks + BLM unmount
     # ------------------------------------------------------------------
 
-    async def unmount_service(self, name: str) -> None:
+    async def _unmount_service(self, name: str) -> None:
         """Unmount: unregister VFS hooks, then BLM unmount."""
         self._unregister_hooks(name)
         if self._blm is not None:
@@ -207,7 +227,7 @@ class ServiceLifecycleCoordinator:
 
             status = self._blm.get_status(name)
             if status is not None and status.state == BrickState.ACTIVE:
-                await self.unmount_service(name)
+                await self._unmount_service(name)
 
             # BLM: UNMOUNTED → UNREGISTERED
             status = self._blm.get_status(name)
@@ -347,29 +367,18 @@ class ServiceLifecycleCoordinator:
         logger.info("[COORDINATOR] swap %r — complete", name)
 
     # ------------------------------------------------------------------
-    # Distro classification — persistent vs invocation-compatible
+    # Diagnostics — quadrant classification
     # ------------------------------------------------------------------
-
-    def classify_service(self, name: str) -> ServiceQuadrant:
-        """Return the quadrant classification for a registered service.
-
-        Raises:
-            KeyError: If service is not registered.
-        """
-        info = self._registry.service_info(name)
-        if info is None:
-            raise KeyError(f"classify_service: {name!r} not registered")
-        return ServiceQuadrant.of(info.instance)
 
     def classify_all(self) -> dict[str, ServiceQuadrant]:
         """Return quadrant classification for all registered services."""
         return {info.name: ServiceQuadrant.of(info.instance) for info in self._registry.list_all()}
 
     # ------------------------------------------------------------------
-    # Single-service activate / deactivate (with quadrant guard)
+    # Single-service activate / deactivate (internal, with quadrant guard)
     # ------------------------------------------------------------------
 
-    async def activate_service(self, name: str) -> None:
+    async def _activate_service(self, name: str) -> None:
         """Activate a single HotSwappable service: register hooks + activate().
 
         Raises:
@@ -385,16 +394,12 @@ class ServiceLifecycleCoordinator:
                 f"activate_service: {name!r} is {quadrant.label} — cannot activate. "
                 f"Only Q2/Q4 services (HotSwappable) support activate/drain."
             )
-        spec = self._hook_specs.get(name)
-        if spec is None:
-            spec = info.instance.hook_spec()
-            if spec is not None and not spec.is_empty:
-                self._hook_specs[name] = spec
+        self._ensure_hook_spec(name, info.instance)
         self._register_hooks(name)
         await info.instance.activate()
-        logger.info("[COORDINATOR] activate_service %r — done (%s)", name, quadrant.label)
+        logger.info("[COORDINATOR] _activate_service %r — done (%s)", name, quadrant.label)
 
-    async def deactivate_service(self, name: str) -> None:
+    async def _deactivate_service(self, name: str) -> None:
         """Deactivate a single HotSwappable service: drain + unregister hooks.
 
         Raises:
@@ -412,36 +417,7 @@ class ServiceLifecycleCoordinator:
             )
         await info.instance.drain()
         self._unregister_hooks(name)
-        logger.info("[COORDINATOR] deactivate_service %r — done (%s)", name, quadrant.label)
-
-    def classify_distro(self) -> tuple[bool, list[str]]:
-        """Determine whether this distro requires a persistent process.
-
-        Scans all registered services for ``PersistentService`` protocol.
-        Returns ``(is_persistent, service_names)`` where ``is_persistent``
-        is True if any service requires background workers.
-
-        Used by nexusd startup and CLI ``nexus info`` to report distro type.
-        """
-        persistent_names: list[str] = []
-        for info in self._registry.list_all():
-            if isinstance(info.instance, PersistentService):
-                persistent_names.append(info.name)
-        return bool(persistent_names), persistent_names
-
-    def classify_hot_swappable(self) -> tuple[list[str], list[str]]:
-        """Classify services into hot-swappable vs static.
-
-        Returns ``(hot_swappable_names, static_names)``.
-        """
-        hot: list[str] = []
-        static: list[str] = []
-        for info in self._registry.list_all():
-            if ServiceQuadrant.of(info.instance).is_hot_swappable:
-                hot.append(info.name)
-            else:
-                static.append(info.name)
-        return hot, static
+        logger.info("[COORDINATOR] _deactivate_service %r — done (%s)", name, quadrant.label)
 
     # ------------------------------------------------------------------
     # Auto-lifecycle — four-quadrant "one-click" management (Issue #1580)
@@ -521,11 +497,7 @@ class ServiceLifecycleCoordinator:
                 continue
             try:
                 # Auto-capture hook_spec from protocol if not already set
-                spec = self._hook_specs.get(name)
-                if spec is None:
-                    spec = info.instance.hook_spec()
-                    if spec is not None and not spec.is_empty:
-                        self._hook_specs[name] = spec
+                self._ensure_hook_spec(name, info.instance)
                 # Register hooks into dispatch (skip if pre-registered by _enlist_hook)
                 if name not in self._hooks_on_dispatch:
                     self._register_hooks(name)
@@ -588,11 +560,20 @@ class ServiceLifecycleCoordinator:
     # Hook spec management (retroactive spec capture for existing services)
     # ------------------------------------------------------------------
 
-    def set_hook_spec(self, name: str, spec: HookSpec) -> None:
+    def _ensure_hook_spec(self, name: str, instance: Any) -> HookSpec | None:
+        """Capture HookSpec from protocol if not already stored."""
+        spec = self._hook_specs.get(name)
+        if spec is None and isinstance(instance, HotSwappable):
+            spec = instance.hook_spec()
+            if spec is not None:
+                self._hook_specs[name] = spec
+        return spec
+
+    def _set_hook_spec(self, name: str, spec: HookSpec) -> None:
         """Set/replace the HookSpec for a service (retroactive capture)."""
         self._hook_specs[name] = spec
 
-    def get_hook_spec(self, name: str) -> HookSpec | None:
+    def _get_hook_spec(self, name: str) -> HookSpec | None:
         """Return the HookSpec for a service, or None."""
         return self._hook_specs.get(name)
 

--- a/src/nexus/system_services/proc/proc_resolver.py
+++ b/src/nexus/system_services/proc/proc_resolver.py
@@ -8,8 +8,8 @@ nothing is stored on disk.
     system_services/proc/proc_resolver.py = fs/proc/ (procfs)
     core/process_table.py                 = kernel/fork.c (task_struct table)
 
-Registration: factory/_wired.py registers ProcResolver on KernelDispatch
-at boot, after ProcessTable creation.
+Registration: factory/orchestrator.py registers ProcResolver via
+coordinator.enlist() at boot, after ProcessTable creation.
 """
 
 from __future__ import annotations
@@ -18,6 +18,8 @@ import json
 import logging
 import re
 from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.protocols.service_hooks import HookSpec
 
 if TYPE_CHECKING:
     from nexus.core.process_table import ProcessTable
@@ -38,6 +40,17 @@ class ProcResolver:
 
     def __init__(self, process_table: ProcessTable) -> None:
         self._process_table = process_table
+
+    # -- HotSwappable protocol (registered via coordinator.enlist) --
+
+    def hook_spec(self) -> HookSpec:
+        return HookSpec(resolvers=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
 
     def _match_pid(self, path: str) -> str | None:
         """Extract PID from path if it matches and process exists."""

--- a/tests/unit/core/test_service_registry.py
+++ b/tests/unit/core/test_service_registry.py
@@ -131,32 +131,6 @@ class TestDependencyValidation:
 
 
 # ---------------------------------------------------------------------------
-# register_many
-# ---------------------------------------------------------------------------
-
-
-class TestRegisterMany:
-    def test_skips_none(self, registry: ServiceRegistry) -> None:
-        svc = MagicMock()
-        count = registry.register_many({"search": svc, "mcp": None, "llm": None})
-        assert count == 1
-        ref = registry.service("search")
-        assert ref is not None
-        assert ref._service_instance is svc
-        assert registry.service("mcp") is None
-
-    def test_is_remote_flag(self, registry: ServiceRegistry) -> None:
-        svc = MagicMock()
-        registry.register_many({"search": svc}, is_remote=True)
-        info = registry.service_info("search")
-        assert info is not None
-        assert info.is_remote is True
-
-    def test_empty_dict(self, registry: ServiceRegistry) -> None:
-        assert registry.register_many({}) == 0
-
-
-# ---------------------------------------------------------------------------
 # snapshot
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/test_service_lifecycle_coordinator.py
+++ b/tests/unit/services/test_service_lifecycle_coordinator.py
@@ -154,7 +154,7 @@ class TestRegisterService:
         blm: BrickLifecycleManager,
     ) -> None:
         svc = _FakeService()
-        coordinator.register_service(
+        coordinator._register_service(
             "search", svc, exports=("glob", "grep"), protocol_name="SearchProtocol"
         )
         # ServiceRegistry
@@ -172,8 +172,8 @@ class TestRegisterService:
         svc = _FakeService()
         hook = MagicMock()
         spec = HookSpec(read_hooks=(hook,))
-        coordinator.register_service("search", svc, hook_spec=spec)
-        assert coordinator.get_hook_spec("search") is spec
+        coordinator._register_service("search", svc, hook_spec=spec)
+        assert coordinator._get_hook_spec("search") is spec
 
 
 # ---------------------------------------------------------------------------
@@ -190,8 +190,8 @@ class TestMountService:
         read_hook = MagicMock()
         observer = MagicMock()
         spec = HookSpec(read_hooks=(read_hook,), observers=(observer,))
-        coordinator.register_service("search", svc, hook_spec=spec)
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc, hook_spec=spec)
+        await coordinator._mount_service("search")
 
         assert dispatch.read_hook_count == 1
         assert dispatch.observer_count == 1
@@ -201,8 +201,8 @@ class TestMountService:
         self, coordinator: ServiceLifecycleCoordinator, dispatch: KernelDispatch
     ) -> None:
         svc = _FakeService()
-        coordinator.register_service("search", svc)
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc)
+        await coordinator._mount_service("search")
         assert dispatch.read_hook_count == 0
         assert dispatch.observer_count == 0
 
@@ -220,11 +220,11 @@ class TestUnmountService:
         svc = _FakeService()
         read_hook = MagicMock()
         spec = HookSpec(read_hooks=(read_hook,))
-        coordinator.register_service("search", svc, hook_spec=spec)
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc, hook_spec=spec)
+        await coordinator._mount_service("search")
         assert dispatch.read_hook_count == 1
 
-        await coordinator.unmount_service("search")
+        await coordinator._unmount_service("search")
         assert dispatch.read_hook_count == 0
 
 
@@ -242,8 +242,8 @@ class TestUnregisterService:
         blm: BrickLifecycleManager,
     ) -> None:
         svc = _FakeService()
-        coordinator.register_service("search", svc)
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc)
+        await coordinator._mount_service("search")
         await coordinator.unregister_service("search")
 
         # Gone from registry
@@ -268,8 +268,8 @@ class TestSwapService:
         hook1 = MagicMock()
         spec1 = HookSpec(read_hooks=(hook1,))
         svc1 = _HotSwappableService(hook_spec_value=spec1)
-        coordinator.register_service("search", svc1, exports=("glob",), hook_spec=spec1)
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc1, exports=("glob",), hook_spec=spec1)
+        await coordinator._mount_service("search")
         assert dispatch.read_hook_count == 1
 
         hook2 = MagicMock()
@@ -299,8 +299,8 @@ class TestSwapService:
     ) -> None:
         """Verify that service(name) NEVER returns None during swap."""
         svc1 = _HotSwappableService()
-        coordinator.register_service("search", svc1, exports=("glob",))
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc1, exports=("glob",))
+        await coordinator._mount_service("search")
 
         assert registry.service("search") is not None
 
@@ -318,8 +318,8 @@ class TestSwapService:
     ) -> None:
         """Static (non-HotSwappable) services cannot be hot-swapped."""
         svc1 = _FakeService()  # NOT HotSwappable
-        coordinator.register_service("search", svc1, exports=("glob",))
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc1, exports=("glob",))
+        await coordinator._mount_service("search")
 
         svc2 = _FakeServiceV2()
         with pytest.raises(TypeError, match="cannot hot-swap"):
@@ -337,8 +337,8 @@ class TestSwapService:
         spec1 = HookSpec(read_hooks=(hook1,))
         svc1 = _HotSwappableService(hook_spec_value=spec1)
         # Register WITH explicit hook_spec (retroactive capture)
-        coordinator.register_service("search", svc1, hook_spec=spec1)
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc1, hook_spec=spec1)
+        await coordinator._mount_service("search")
         assert dispatch.read_hook_count == 1
 
         hook2 = MagicMock()
@@ -367,8 +367,8 @@ class TestSwapService:
                 return [pattern]
 
         svc1 = _SlowHotSwappable()
-        coordinator.register_service("search", svc1, exports=("glob",))
-        await coordinator.mount_service("search")
+        coordinator._register_service("search", svc1, exports=("glob",))
+        await coordinator._mount_service("search")
 
         # Start an in-flight call via ServiceRef
         ref = registry.service("search")
@@ -399,11 +399,11 @@ class TestSwapService:
 class TestHookSpecManagement:
     def test_set_and_get_hook_spec(self, coordinator: ServiceLifecycleCoordinator) -> None:
         spec = HookSpec(observers=(MagicMock(),))
-        coordinator.set_hook_spec("events", spec)
-        assert coordinator.get_hook_spec("events") is spec
+        coordinator._set_hook_spec("events", spec)
+        assert coordinator._get_hook_spec("events") is spec
 
     def test_get_missing_returns_none(self, coordinator: ServiceLifecycleCoordinator) -> None:
-        assert coordinator.get_hook_spec("nonexistent") is None
+        assert coordinator._get_hook_spec("nonexistent") is None
 
 
 # ---------------------------------------------------------------------------
@@ -480,8 +480,8 @@ class TestSwapWithFullHookSpec:
             observers=(old_observer,),
         )
         svc1 = _HotSwappableService(hook_spec_value=spec1)
-        coordinator.register_service("rebac", svc1, hook_spec=spec1)
-        await coordinator.mount_service("rebac")
+        coordinator._register_service("rebac", svc1, hook_spec=spec1)
+        await coordinator._mount_service("rebac")
 
         assert dispatch.read_hook_count == 1
         assert dispatch.write_hook_count == 1
@@ -519,8 +519,8 @@ class TestSwapWithFullHookSpec:
         old_hook = MagicMock()
         spec1 = HookSpec(read_hooks=(old_hook,))
         svc1 = _HotSwappableService(hook_spec_value=spec1)
-        coordinator.register_service("parser", svc1, hook_spec=spec1)
-        await coordinator.mount_service("parser")
+        coordinator._register_service("parser", svc1, hook_spec=spec1)
+        await coordinator._mount_service("parser")
         assert dispatch.read_hook_count == 1
 
         svc2 = _HotSwappableServiceV2()  # empty hook_spec
@@ -568,51 +568,6 @@ class TestProtocolConformance:
 
 
 # ---------------------------------------------------------------------------
-# Distro classification (Issue #1577)
-# ---------------------------------------------------------------------------
-
-
-class TestDistroClassification:
-    def test_no_persistent_services(self, coordinator: ServiceLifecycleCoordinator) -> None:
-        """All static services → invocation-compatible distro."""
-        svc = _FakeService()
-        coordinator.register_service("search", svc)
-
-        is_persistent, names = coordinator.classify_distro()
-        assert is_persistent is False
-        assert names == []
-
-    def test_persistent_service_detected(self, coordinator: ServiceLifecycleCoordinator) -> None:
-        """PersistentService present → persistent distro."""
-        svc = _PersistentFakeService()
-        coordinator.register_service("delivery_worker", svc)
-
-        is_persistent, names = coordinator.classify_distro()
-        assert is_persistent is True
-        assert names == ["delivery_worker"]
-
-    def test_mixed_services(self, coordinator: ServiceLifecycleCoordinator) -> None:
-        """Mix of static and persistent → persistent distro."""
-        coordinator.register_service("search", _FakeService())
-        coordinator.register_service("worker", _PersistentFakeService())
-
-        is_persistent, names = coordinator.classify_distro()
-        assert is_persistent is True
-        assert names == ["worker"]
-
-    def test_classify_hot_swappable(self, coordinator: ServiceLifecycleCoordinator) -> None:
-        """Classify services into hot-swappable vs static."""
-        coordinator.register_service("search", _FakeService())
-        coordinator.register_service("rebac", _HotSwappableService())
-        coordinator.register_service("worker", _PersistentFakeService())
-
-        hot, static = coordinator.classify_hot_swappable()
-        assert "rebac" in hot
-        assert "search" in static
-        assert "worker" in static  # persistent but not hot-swappable
-
-
-# ---------------------------------------------------------------------------
 # Auto-lifecycle — four-quadrant "one-click" management (Issue #1580)
 # ---------------------------------------------------------------------------
 
@@ -625,7 +580,7 @@ class TestAutoLifecyclePersistentService:
         self, coordinator: ServiceLifecycleCoordinator
     ) -> None:
         svc = _PersistentFakeService()
-        coordinator.register_service("worker", svc)
+        coordinator._register_service("worker", svc)
         started = await coordinator.start_persistent_services()
         assert started == ["worker"]
         assert svc.started is True
@@ -634,7 +589,7 @@ class TestAutoLifecyclePersistentService:
     async def test_start_skips_non_persistent(
         self, coordinator: ServiceLifecycleCoordinator
     ) -> None:
-        coordinator.register_service("search", _FakeService())
+        coordinator._register_service("search", _FakeService())
         started = await coordinator.start_persistent_services()
         assert started == []
 
@@ -643,7 +598,7 @@ class TestAutoLifecyclePersistentService:
         self, coordinator: ServiceLifecycleCoordinator
     ) -> None:
         svc = _PersistentFakeService()
-        coordinator.register_service("worker", svc)
+        coordinator._register_service("worker", svc)
         stopped = await coordinator.stop_persistent_services()
         assert stopped == ["worker"]
         assert svc.stopped is True
@@ -660,8 +615,8 @@ class TestAutoLifecyclePersistentService:
                 pass
 
         ok_svc = _PersistentFakeService()
-        coordinator.register_service("fail", _FailStart())
-        coordinator.register_service("ok", ok_svc)
+        coordinator._register_service("fail", _FailStart())
+        coordinator._register_service("ok", ok_svc)
         started = await coordinator.start_persistent_services()
         assert "ok" in started
         assert "fail" not in started
@@ -679,8 +634,8 @@ class TestAutoLifecyclePersistentService:
                 raise RuntimeError("boom")
 
         ok_svc = _PersistentFakeService()
-        coordinator.register_service("fail", _FailStop())
-        coordinator.register_service("ok", ok_svc)
+        coordinator._register_service("fail", _FailStop())
+        coordinator._register_service("ok", ok_svc)
         stopped = await coordinator.stop_persistent_services()
         assert "ok" in stopped
         assert "fail" not in stopped
@@ -698,8 +653,8 @@ class TestAutoLifecyclePersistentService:
                 pass
 
         ok_svc = _PersistentFakeService()
-        coordinator.register_service("slow", _SlowStart())
-        coordinator.register_service("ok", ok_svc)
+        coordinator._register_service("slow", _SlowStart())
+        coordinator._register_service("ok", ok_svc)
         started = await coordinator.start_persistent_services(timeout=0.01)
         assert "ok" in started
         assert "slow" not in started
@@ -707,7 +662,7 @@ class TestAutoLifecyclePersistentService:
     @pytest.mark.asyncio()
     async def test_start_stop_idempotent(self, coordinator: ServiceLifecycleCoordinator) -> None:
         svc = _PersistentFakeService()
-        coordinator.register_service("worker", svc)
+        coordinator._register_service("worker", svc)
         await coordinator.start_persistent_services()
         await coordinator.start_persistent_services()
         assert svc.started is True
@@ -728,7 +683,7 @@ class TestAutoLifecycleHotSwappable:
         hook = MagicMock()
         spec = HookSpec(read_hooks=(hook,))
         svc = _HotSwappableService(hook_spec_value=spec)
-        coordinator.register_service("rebac", svc)
+        coordinator._register_service("rebac", svc)
         activated = await coordinator.activate_hot_swappable_services()
         assert activated == ["rebac"]
         assert svc.activated is True
@@ -745,17 +700,17 @@ class TestAutoLifecycleHotSwappable:
         spec = HookSpec(read_hooks=(hook,))
         svc = _HotSwappableService(hook_spec_value=spec)
         # Register WITHOUT explicit hook_spec — should auto-capture
-        coordinator.register_service("rebac", svc)
-        assert coordinator.get_hook_spec("rebac") is None
+        coordinator._register_service("rebac", svc)
+        assert coordinator._get_hook_spec("rebac") is None
         await coordinator.activate_hot_swappable_services()
-        assert coordinator.get_hook_spec("rebac") is spec
+        assert coordinator._get_hook_spec("rebac") is spec
         assert dispatch.read_hook_count == 1
 
     @pytest.mark.asyncio()
     async def test_activate_skips_non_hot_swappable(
         self, coordinator: ServiceLifecycleCoordinator
     ) -> None:
-        coordinator.register_service("search", _FakeService())
+        coordinator._register_service("search", _FakeService())
         activated = await coordinator.activate_hot_swappable_services()
         assert activated == []
 
@@ -768,7 +723,7 @@ class TestAutoLifecycleHotSwappable:
         hook = MagicMock()
         spec = HookSpec(read_hooks=(hook,))
         svc = _HotSwappableService(hook_spec_value=spec)
-        coordinator.register_service("rebac", svc, hook_spec=spec)
+        coordinator._register_service("rebac", svc, hook_spec=spec)
         await coordinator.activate_hot_swappable_services()
         assert dispatch.read_hook_count == 1
 
@@ -792,8 +747,8 @@ class TestAutoLifecycleHotSwappable:
                 raise RuntimeError("boom")
 
         ok_svc = _HotSwappableService()
-        coordinator.register_service("fail", _FailActivate())
-        coordinator.register_service("ok", ok_svc)
+        coordinator._register_service("fail", _FailActivate())
+        coordinator._register_service("ok", ok_svc)
         activated = await coordinator.activate_hot_swappable_services()
         assert "ok" in activated
         assert "fail" not in activated
@@ -811,7 +766,7 @@ class TestAutoLifecycleQ4BothProtocols:
         hook = MagicMock()
         spec = HookSpec(read_hooks=(hook,))
         svc = _BothProtocolsService(hook_spec_value=spec)
-        coordinator.register_service("q4svc", svc)
+        coordinator._register_service("q4svc", svc)
 
         activated = await coordinator.activate_hot_swappable_services()
         started = await coordinator.start_persistent_services()
@@ -831,7 +786,7 @@ class TestAutoLifecycleQ4BothProtocols:
         hook = MagicMock()
         spec = HookSpec(read_hooks=(hook,))
         svc = _BothProtocolsService(hook_spec_value=spec)
-        coordinator.register_service("q4svc", svc)
+        coordinator._register_service("q4svc", svc)
         await coordinator.activate_hot_swappable_services()
         await coordinator.start_persistent_services()
 
@@ -853,21 +808,21 @@ class TestAutoLifecycleQ4BothProtocols:
         """All four quadrants coexist — each gets its appropriate lifecycle."""
         # Q1: static + invocation
         q1 = _FakeService()
-        coordinator.register_service("q1_search", q1)
+        coordinator._register_service("q1_search", q1)
 
         # Q2: hot-swappable + invocation
         q2_hook = MagicMock()
         q2 = _HotSwappableService(hook_spec_value=HookSpec(read_hooks=(q2_hook,)))
-        coordinator.register_service("q2_rebac", q2)
+        coordinator._register_service("q2_rebac", q2)
 
         # Q3: static + persistent
         q3 = _PersistentFakeService()
-        coordinator.register_service("q3_worker", q3)
+        coordinator._register_service("q3_worker", q3)
 
         # Q4: both
         q4_hook = MagicMock()
         q4 = _BothProtocolsService(hook_spec_value=HookSpec(observers=(q4_hook,)))
-        coordinator.register_service("q4_full", q4)
+        coordinator._register_service("q4_full", q4)
 
         # --- Bootstrap ---
         activated = await coordinator.activate_hot_swappable_services()
@@ -918,12 +873,29 @@ class TestEnlist:
         assert info.instance is svc
 
     @pytest.mark.asyncio
-    async def test_enlist_q3_persistent(
+    async def test_enlist_q3_persistent_pre_bootstrap(
         self,
         coordinator: ServiceLifecycleCoordinator,
         registry: ServiceRegistry,
     ) -> None:
-        """Q3 service: enlist registers + calls start()."""
+        """Q3 service pre-bootstrap: enlist registers but defers start()."""
+        svc = _PersistentFakeService()
+        assert svc.started is False
+
+        await coordinator.enlist("q3_svc", svc)
+
+        assert svc.started is False  # deferred — not yet bootstrapped
+        info = registry.service_info("q3_svc")
+        assert info is not None
+
+    @pytest.mark.asyncio
+    async def test_enlist_q3_persistent_post_bootstrap(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        registry: ServiceRegistry,
+    ) -> None:
+        """Q3 service post-bootstrap: enlist registers + calls start() immediately."""
+        coordinator.mark_bootstrapped()
         svc = _PersistentFakeService()
         assert svc.started is False
 
@@ -948,18 +920,35 @@ class TestEnlist:
         assert svc.activated is True
         info = registry.service_info("q2_svc")
         assert info is not None
-        assert coordinator.get_hook_spec("q2_svc") is not None
+        assert coordinator._get_hook_spec("q2_svc") is not None
 
     @pytest.mark.asyncio
-    async def test_enlist_q4_both(
+    async def test_enlist_q4_both_pre_bootstrap(
         self,
         coordinator: ServiceLifecycleCoordinator,
         registry: ServiceRegistry,
     ) -> None:
-        """Q4 service: enlist registers + start + hooks + activate."""
+        """Q4 pre-bootstrap: enlist registers + activate but defers start."""
         svc = _BothProtocolsService()
         assert svc.started is False
         assert svc.activated is False
+
+        await coordinator.enlist("q4_svc", svc)
+
+        assert svc.started is False  # deferred — not yet bootstrapped
+        assert svc.activated is True  # HotSwappable activate is always immediate
+        info = registry.service_info("q4_svc")
+        assert info is not None
+
+    @pytest.mark.asyncio
+    async def test_enlist_q4_both_post_bootstrap(
+        self,
+        coordinator: ServiceLifecycleCoordinator,
+        registry: ServiceRegistry,
+    ) -> None:
+        """Q4 post-bootstrap: enlist registers + start + activate."""
+        coordinator.mark_bootstrapped()
+        svc = _BothProtocolsService()
 
         await coordinator.enlist("q4_svc", svc)
 
@@ -1028,38 +1017,15 @@ class TestServiceQuadrant:
         assert q.is_hot_swappable
         assert q.is_persistent
 
-    def test_coordinator_classify_service(
-        self,
-        coordinator: ServiceLifecycleCoordinator,
-    ) -> None:
-        from nexus.contracts.protocols.service_lifecycle import ServiceQuadrant
-
-        coordinator.register_service("q1", _FakeService())
-        coordinator.register_service("q2", _HotSwappableService())
-        coordinator.register_service("q3", _PersistentFakeService())
-        coordinator.register_service("q4", _BothProtocolsService())
-
-        assert coordinator.classify_service("q1") == ServiceQuadrant.Q1_STATIC
-        assert coordinator.classify_service("q2") == ServiceQuadrant.Q2_HOT_SWAPPABLE
-        assert coordinator.classify_service("q3") == ServiceQuadrant.Q3_PERSISTENT
-        assert coordinator.classify_service("q4") == ServiceQuadrant.Q4_BOTH
-
-    def test_coordinator_classify_service_not_found(
-        self,
-        coordinator: ServiceLifecycleCoordinator,
-    ) -> None:
-        with pytest.raises(KeyError, match="not registered"):
-            coordinator.classify_service("nonexistent")
-
     def test_coordinator_classify_all(
         self,
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         from nexus.contracts.protocols.service_lifecycle import ServiceQuadrant
 
-        coordinator.register_service("q1", _FakeService())
-        coordinator.register_service("q2", _HotSwappableService())
-        coordinator.register_service("q3", _PersistentFakeService())
+        coordinator._register_service("q1", _FakeService())
+        coordinator._register_service("q2", _HotSwappableService())
+        coordinator._register_service("q3", _PersistentFakeService())
 
         result = coordinator.classify_all()
         assert result == {
@@ -1078,8 +1044,8 @@ class TestQuadrantGuards:
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         """Swapping Q1 service includes quadrant label in error."""
-        coordinator.register_service("svc", _FakeService())
-        await coordinator.mount_service("svc")
+        coordinator._register_service("svc", _FakeService())
+        await coordinator._mount_service("svc")
 
         with pytest.raises(TypeError, match="Q1.*static.*cannot hot-swap"):
             await coordinator.swap_service("svc", _FakeServiceV2())
@@ -1090,8 +1056,8 @@ class TestQuadrantGuards:
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         """Swapping Q3 (PersistentService) includes quadrant label in error."""
-        coordinator.register_service("svc", _PersistentFakeService())
-        await coordinator.mount_service("svc")
+        coordinator._register_service("svc", _PersistentFakeService())
+        await coordinator._mount_service("svc")
 
         with pytest.raises(TypeError, match="Q3.*PersistentService.*cannot hot-swap"):
             await coordinator.swap_service("svc", _PersistentFakeService())
@@ -1104,8 +1070,8 @@ class TestQuadrantGuards:
     ) -> None:
         """Q2 service can be swapped."""
         svc1 = _HotSwappableService()
-        coordinator.register_service("svc", svc1)
-        await coordinator.mount_service("svc")
+        coordinator._register_service("svc", svc1)
+        await coordinator._mount_service("svc")
 
         svc2 = _HotSwappableServiceV2()
         await coordinator.swap_service("svc", svc2)
@@ -1122,8 +1088,8 @@ class TestQuadrantGuards:
     ) -> None:
         """Q4 service can be swapped."""
         svc1 = _BothProtocolsService()
-        coordinator.register_service("svc", svc1)
-        await coordinator.mount_service("svc")
+        coordinator._register_service("svc", svc1)
+        await coordinator._mount_service("svc")
 
         svc2 = _BothProtocolsService()
         await coordinator.swap_service("svc", svc2)
@@ -1138,9 +1104,9 @@ class TestQuadrantGuards:
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         """activate_service on Q1 raises TypeError with quadrant info."""
-        coordinator.register_service("svc", _FakeService())
+        coordinator._register_service("svc", _FakeService())
         with pytest.raises(TypeError, match="Q1.*static.*cannot activate"):
-            await coordinator.activate_service("svc")
+            await coordinator._activate_service("svc")
 
     @pytest.mark.asyncio
     async def test_activate_rejects_q3(
@@ -1148,9 +1114,9 @@ class TestQuadrantGuards:
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         """activate_service on Q3 raises TypeError with quadrant info."""
-        coordinator.register_service("svc", _PersistentFakeService())
+        coordinator._register_service("svc", _PersistentFakeService())
         with pytest.raises(TypeError, match="Q3.*PersistentService.*cannot activate"):
-            await coordinator.activate_service("svc")
+            await coordinator._activate_service("svc")
 
     @pytest.mark.asyncio
     async def test_activate_allows_q2(
@@ -1159,8 +1125,8 @@ class TestQuadrantGuards:
     ) -> None:
         """activate_service on Q2 succeeds."""
         svc = _HotSwappableService()
-        coordinator.register_service("svc", svc)
-        await coordinator.activate_service("svc")
+        coordinator._register_service("svc", svc)
+        await coordinator._activate_service("svc")
         assert svc.activated is True
 
     @pytest.mark.asyncio
@@ -1170,8 +1136,8 @@ class TestQuadrantGuards:
     ) -> None:
         """activate_service on Q4 succeeds."""
         svc = _BothProtocolsService()
-        coordinator.register_service("svc", svc)
-        await coordinator.activate_service("svc")
+        coordinator._register_service("svc", svc)
+        await coordinator._activate_service("svc")
         assert svc.activated is True
 
     @pytest.mark.asyncio
@@ -1180,9 +1146,9 @@ class TestQuadrantGuards:
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         """deactivate_service on Q1 raises TypeError."""
-        coordinator.register_service("svc", _FakeService())
+        coordinator._register_service("svc", _FakeService())
         with pytest.raises(TypeError, match="Q1.*static.*cannot deactivate"):
-            await coordinator.deactivate_service("svc")
+            await coordinator._deactivate_service("svc")
 
     @pytest.mark.asyncio
     async def test_deactivate_rejects_q3(
@@ -1190,9 +1156,9 @@ class TestQuadrantGuards:
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         """deactivate_service on Q3 raises TypeError."""
-        coordinator.register_service("svc", _PersistentFakeService())
+        coordinator._register_service("svc", _PersistentFakeService())
         with pytest.raises(TypeError, match="Q3.*PersistentService.*cannot deactivate"):
-            await coordinator.deactivate_service("svc")
+            await coordinator._deactivate_service("svc")
 
     @pytest.mark.asyncio
     async def test_deactivate_allows_q2(
@@ -1201,9 +1167,9 @@ class TestQuadrantGuards:
     ) -> None:
         """deactivate_service on Q2 succeeds — calls drain + unregister hooks."""
         svc = _HotSwappableService()
-        coordinator.register_service("svc", svc)
-        await coordinator.activate_service("svc")
-        await coordinator.deactivate_service("svc")
+        coordinator._register_service("svc", svc)
+        await coordinator._activate_service("svc")
+        await coordinator._deactivate_service("svc")
         assert svc.drained is True
 
     @pytest.mark.asyncio
@@ -1212,7 +1178,7 @@ class TestQuadrantGuards:
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         with pytest.raises(KeyError, match="not registered"):
-            await coordinator.activate_service("ghost")
+            await coordinator._activate_service("ghost")
 
     @pytest.mark.asyncio
     async def test_deactivate_not_found(
@@ -1220,4 +1186,4 @@ class TestQuadrantGuards:
         coordinator: ServiceLifecycleCoordinator,
     ) -> None:
         with pytest.raises(KeyError, match="not registered"):
-            await coordinator.deactivate_service("ghost")
+            await coordinator._deactivate_service("ghost")


### PR DESCRIPTION
## Summary
- **Bootstrap-aware `enlist()`**: Q3 `start()` deferred pre-bootstrap, auto-started post-bootstrap via `mark_bootstrapped()`
- **Shrink coordinator public API 13→9 methods**: delete 3 classify variants, privatize 7 internal methods (`register_service`, `mount_service`, `unmount_service`, `activate_service`, `deactivate_service`, `set_hook_spec`, `get_hook_spec`)
- **Migrate all registration to `enlist()`**: DPB + EDW from `register_service()`, ProcResolver from direct dispatch
- **Delete dead code**: `register_many()` from ServiceRegistry, extract `_ensure_hook_spec()` dedup

## Test plan
- [x] All 115 target tests pass (coordinator + registry + wired + cold_start)
- [x] Full unit suite: 10,769 passed, 31 skipped, 2 xfailed
- [x] Ruff check + ruff format clean
- [x] mypy clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)