### PR TITLE
fix: ACP CLI async bugs and enable gRPC by default

### DIFF
--- a/examples/tutorials/acp-coding-agents/README.md
+++ b/examples/tutorials/acp-coding-agents/README.md
@@ -1,0 +1,99 @@
+# ACP — Coding Agents Tutorial
+
+ACP (Agent Communication Protocol) lets you call coding agents — Claude Code,
+Codex CLI, Gemini CLI, and others — through a unified JSON-RPC interface exposed
+by nexusd.
+
+This tutorial walks through the full ACP CLI: listing agents, calling them,
+managing system prompts and skills, monitoring processes, and reviewing history.
+
+## Prerequisites
+
+- nexusd running with gRPC enabled
+- At least one agent binary on `PATH` (`claude`, `codex`, or `gemini`)
+
+```bash
+# Start nexusd (gRPC enabled on port 2028 by default)
+nexusd --port 2026
+
+# In another terminal
+export NEXUS_URL=http://localhost:2026
+```
+
+## Run the demo
+
+```bash
+./examples/tutorials/acp-coding-agents/acp_tutorial.sh
+```
+
+The script will:
+
+1. List all available ACP agents
+2. Show agent configuration (system prompt, enabled skills)
+3. Set a custom system prompt for an agent
+4. Call multiple agents in parallel with the same prompt
+5. Resume a session (multi-turn conversation)
+6. List running processes
+7. View call history
+8. Clean up
+
+## CLI reference
+
+```bash
+# List agents
+nexus acp agents
+
+# Call an agent
+nexus acp call -a claude -p "Explain this function"
+nexus acp call -a gemini -p "Fix the bug" --cwd /path/to/project --timeout 600
+
+# Resume a session (multi-turn)
+nexus acp call -a claude -p "Follow up question" -s <session_id>
+
+# System prompts
+nexus acp system-prompt get -a claude
+nexus acp system-prompt set -a claude -c "You are a concise coding assistant."
+
+# Agent config (view/update skills and system prompt)
+nexus acp config -a claude
+nexus acp config -a claude --skills /path/to/skill1.md,/path/to/skill2.md
+nexus acp config -a claude --system-prompt "Be brief."
+
+# Process management
+nexus acp ps
+nexus acp kill <pid>
+
+# History
+nexus acp history
+nexus acp history -n 10
+```
+
+## How it works
+
+When you run `nexus acp call`, the CLI sends a JSON-RPC request over gRPC to
+the `acp_rpc` service running inside nexusd. The service:
+
+1. Looks up the agent configuration (command, args, env vars)
+2. Spawns the agent binary as a subprocess with the prompt on stdin
+3. Captures stdout/stderr and parses metadata (model, tokens, cost, session ID)
+4. Returns the result to the CLI
+
+All agents use the same interface — the ACP adapter translates between the
+unified protocol and each agent's native CLI format.
+
+## Supported agents
+
+| Agent ID   | Binary     | Description      |
+|------------|------------|------------------|
+| `claude`   | `claude`   | Claude Code      |
+| `codex`    | `codex`    | Codex CLI        |
+| `gemini`   | `gemini`   | Gemini CLI       |
+| `qwen`     | `qwen`     | Qwen Code        |
+| `goose`    | `goose`    | Goose            |
+| `copilot`  | `copilot`  | GitHub Copilot   |
+| `auggie`   | `auggie`   | Augment Code     |
+| `opencode` | `opencode` | OpenCode         |
+| `droid`    | `droid`    | Factory Droid    |
+| `kimi`     | `kimi`     | Kimi CLI         |
+
+Run `nexus acp agents` to see the full list with enabled status.

--- a/examples/tutorials/acp-coding-agents/acp_tutorial.sh
+++ b/examples/tutorials/acp-coding-agents/acp_tutorial.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Nexus ACP Tutorial — Calling Coding Agents
+#
+# Prerequisites:
+#   1. nexusd running:  nexusd --port 2026  (gRPC on 2028 by default)
+#   2. Agent binaries on PATH (claude, codex, or gemini)
+#   3. export NEXUS_URL=http://localhost:2026
+#
+# Usage:
+#   ./examples/tutorials/acp-coding-agents/acp_tutorial.sh
+
+set -e
+
+NEXUS=${NEXUS_BIN:-nexus}
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+DIM='\033[2m'
+NC='\033[0m'
+
+section() {
+    echo ""
+    echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  $1${NC}"
+    echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+    echo ""
+}
+
+step() {
+    echo -e "${GREEN}▸ $1${NC}"
+}
+
+run() {
+    echo -e "${CYAN}\$ $*${NC}"
+    "$@" 2>&1 || true
+    echo ""
+}
+
+pause() {
+    echo -e "${DIM}(press Enter to continue)${NC}"
+    read -r
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+if [ -z "$NEXUS_URL" ]; then
+    echo -e "${RED}NEXUS_URL is not set.${NC}"
+    echo "  export NEXUS_URL=http://localhost:2026"
+    exit 1
+fi
+
+# Find available agents
+AGENTS=()
+for candidate in gemini codex claude; do
+    if command -v "$candidate" &>/dev/null; then
+        AGENTS+=("$candidate")
+    fi
+done
+
+if [ ${#AGENTS[@]} -eq 0 ]; then
+    echo -e "${RED}No agent binary found on PATH (tried: gemini, codex, claude).${NC}"
+    exit 1
+fi
+
+AGENT=${AGENTS[0]}
+echo -e "${GREEN}Found ${#AGENTS[@]} agent(s): ${AGENTS[*]}${NC}"
+echo -e "${GREEN}Primary agent for this tutorial: ${AGENT}${NC}"
+echo ""
+
+# ===================================================================
+section "Step 1 — List available agents"
+# ===================================================================
+step "See which agents nexusd knows about:"
+run $NEXUS acp agents
+pause
+
+# ===================================================================
+section "Step 2 — View agent configuration"
+# ===================================================================
+step "Check the current config for '${AGENT}':"
+run $NEXUS acp config -a "$AGENT"
+pause
+
+# ===================================================================
+section "Step 3 — Set a system prompt"
+# ===================================================================
+step "Give the agent a personality:"
+run $NEXUS acp system-prompt set -a "$AGENT" \
+    -c "You are a concise coding assistant. Always reply in one sentence."
+
+step "Verify it was saved:"
+run $NEXUS acp system-prompt get -a "$AGENT"
+pause
+
+# ===================================================================
+section "Step 4 — Call a single agent"
+# ===================================================================
+step "Ask a simple question:"
+run $NEXUS acp call -a "$AGENT" -p "What is 2+2?" --timeout 60
+pause
+
+# ===================================================================
+section "Step 5 — Call multiple agents in parallel"
+# ===================================================================
+if [ ${#AGENTS[@]} -ge 2 ]; then
+    step "Fan out the same prompt to ${#AGENTS[@]} agents:"
+    PIDS=()
+    TMPDIR_PARA=$(mktemp -d)
+    for ag in "${AGENTS[@]}"; do
+        $NEXUS acp call -a "$ag" -p "What is the capital of France? One word." \
+            --timeout 60 > "${TMPDIR_PARA}/${ag}.out" 2>&1 &
+        PIDS+=($!)
+    done
+    # Wait and print results
+    for i in "${!AGENTS[@]}"; do
+        wait "${PIDS[$i]}" || true
+        echo -e "${GREEN}[${AGENTS[$i]}]${NC}"
+        cat "${TMPDIR_PARA}/${AGENTS[$i]}.out"
+        echo ""
+    done
+    rm -rf "$TMPDIR_PARA"
+else
+    step "Only one agent available — skipping parallel demo."
+fi
+pause
+
+# ===================================================================
+section "Step 6 — Multi-turn session (resume)"
+# ===================================================================
+step "Start a conversation:"
+OUTPUT=$($NEXUS acp call -a "$AGENT" -p "Remember the number 42." --timeout 60 2>&1)
+echo "$OUTPUT"
+echo ""
+
+# Extract session ID from output
+SESSION_ID=$(echo "$OUTPUT" | grep -oE 'session=[0-9a-f-]+' | head -1 | cut -d= -f2)
+
+if [ -n "$SESSION_ID" ]; then
+    step "Resume the session (${SESSION_ID:0:8}…) with a follow-up:"
+    run $NEXUS acp call -a "$AGENT" -p "What number did I ask you to remember?" \
+        -s "$SESSION_ID" --timeout 60
+else
+    echo -e "${YELLOW}Could not extract session ID — skipping resume.${NC}"
+fi
+pause
+
+# ===================================================================
+section "Step 7 — Process management"
+# ===================================================================
+step "List running ACP processes (should be empty after calls finish):"
+run $NEXUS acp ps
+pause
+
+# ===================================================================
+section "Step 8 — Call history"
+# ===================================================================
+step "Review recent calls:"
+run $NEXUS acp history -n 10
+pause
+
+# ===================================================================
+section "Step 9 — Clean up"
+# ===================================================================
+step "Clear the system prompt:"
+run $NEXUS acp system-prompt set -a "$AGENT" -c ""
+
+step "Verify it was cleared:"
+run $NEXUS acp system-prompt get -a "$AGENT"
+
+echo ""
+echo -e "${GREEN}Tutorial complete! You've used every ACP CLI command.${NC}"
+echo ""
+echo -e "${DIM}Commands covered:${NC}"
+echo -e "${DIM}  nexus acp agents${NC}"
+echo -e "${DIM}  nexus acp config${NC}"
+echo -e "${DIM}  nexus acp system-prompt get/set${NC}"
+echo -e "${DIM}  nexus acp call (single, parallel, resume)${NC}"
+echo -e "${DIM}  nexus acp ps${NC}"
+echo -e "${DIM}  nexus acp history${NC}"

--- a/src/nexus/cli/commands/acp_cli.py
+++ b/src/nexus/cli/commands/acp_cli.py
@@ -298,7 +298,7 @@ async def _async_history(
             nx.close()
             return
 
-        entries = await svc.acp_history(limit=limit)
+        entries = svc.acp_history(limit=limit)
 
         if not entries:
             console.print("[yellow]No call history[/yellow]")
@@ -452,19 +452,19 @@ async def _async_config_agent(
             paths = [s.strip() for s in skills.split(",") if s.strip()]
             if paths:
                 skill_list = [_parse_skill_md(p) for p in paths]
-                await svc.acp_set_enabled_skills(agent_id=agent_id, skills=skill_list)
+                svc.acp_set_enabled_skills(agent_id=agent_id, skills=skill_list)
                 names = [sk["name"] for sk in skill_list]
                 console.print(
                     f"[green]Set enabled skills for {agent_id}:[/green] {', '.join(names)}"
                 )
             else:
-                await svc.acp_set_enabled_skills(agent_id=agent_id, skills=[])
+                svc.acp_set_enabled_skills(agent_id=agent_id, skills=[])
                 console.print(f"[green]Cleared enabled skills for {agent_id}[/green]")
             made_changes = True
 
         # Set system prompt if provided
         if system_prompt is not None:
-            await svc.acp_set_system_prompt(agent_id=agent_id, content=system_prompt)
+            svc.acp_set_system_prompt(agent_id=agent_id, content=system_prompt)
             console.print(
                 f"[green]Set system prompt for {agent_id}[/green] ({len(system_prompt)} chars)"
             )
@@ -472,8 +472,8 @@ async def _async_config_agent(
 
         # If no setters, show current config
         if not made_changes:
-            skills_result = await svc.acp_get_enabled_skills(agent_id=agent_id)
-            prompt_result = await svc.acp_get_system_prompt(agent_id=agent_id)
+            skills_result = svc.acp_get_enabled_skills(agent_id=agent_id)
+            prompt_result = svc.acp_get_system_prompt(agent_id=agent_id)
 
             console.print(f"[bold]Config for {agent_id}[/bold]\n")
 
@@ -537,7 +537,7 @@ async def _async_get_system_prompt(
             nx.close()
             return
 
-        result = await svc.acp_get_system_prompt(agent_id=agent_id)
+        result = svc.acp_get_system_prompt(agent_id=agent_id)
         content = result.get("content")
         if content:
             console.print(content)
@@ -583,7 +583,7 @@ async def _async_set_system_prompt(
             nx.close()
             return
 
-        result = await svc.acp_set_system_prompt(agent_id=agent_id, content=content)
+        result = svc.acp_set_system_prompt(agent_id=agent_id, content=content)
         console.print(
             f"[green]Set system prompt for {agent_id}[/green] ({result.get('length', 0)} chars)"
         )

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -1,8 +1,8 @@
 """gRPC server lifecycle — start/stop for the unified Nexus gRPC server (#1249).
 
 Manages a single ``grpc.aio.server()`` hosting ``NexusVFSService``.
-The server is disabled by default (port 0) and enabled by setting
-``NEXUS_GRPC_PORT`` to a non-zero port number.
+The server defaults to port 2028 and can be changed via ``NEXUS_GRPC_PORT``.
+Set ``NEXUS_GRPC_PORT=0`` to disable.
 
 All agent messaging flows through a single port via VFS.
 """
@@ -68,7 +68,7 @@ def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
 
 async def startup_grpc(app: "FastAPI", _svc: "LifespanServices") -> list[asyncio.Task]:
     """Start the gRPC server if configured."""
-    port = int(os.environ.get("NEXUS_GRPC_PORT", "0"))
+    port = int(os.environ.get("NEXUS_GRPC_PORT", "2028"))
     if not port:
         return []
 

--- a/src/nexus/system_services/acp/service.py
+++ b/src/nexus/system_services/acp/service.py
@@ -554,17 +554,7 @@ class AcpService:
         try:
             entries = await self._nexus_fs.sys_readdir(proc_dir)
             for entry in entries:
-                entry_path = getattr(entry, "path", None) or str(entry)
-                # sys_readdir may return leaf paths (e.g. .../pid/result)
-                # or directory entries (e.g. .../pid). Handle both.
-                if entry_path.endswith("/result"):
-                    result_path = entry_path
-                else:
-                    result_path = (
-                        f"{entry_path}/result"
-                        if not entry_path.endswith("/")
-                        else f"{entry_path}result"
-                    )
+                result_path = getattr(entry, "path", None) or str(entry)
                 try:
                     data: bytes = await self._nexus_fs.sys_read(result_path)
                     if data:

--- a/src/nexus/system_services/acp/service.py
+++ b/src/nexus/system_services/acp/service.py
@@ -555,11 +555,16 @@ class AcpService:
             entries = await self._nexus_fs.sys_readdir(proc_dir)
             for entry in entries:
                 entry_path = getattr(entry, "path", None) or str(entry)
-                result_path = (
-                    f"{entry_path}/result"
-                    if not entry_path.endswith("/")
-                    else f"{entry_path}result"
-                )
+                # sys_readdir may return leaf paths (e.g. .../pid/result)
+                # or directory entries (e.g. .../pid). Handle both.
+                if entry_path.endswith("/result"):
+                    result_path = entry_path
+                else:
+                    result_path = (
+                        f"{entry_path}/result"
+                        if not entry_path.endswith("/")
+                        else f"{entry_path}result"
+                    )
                 try:
                     data: bytes = await self._nexus_fs.sys_read(result_path)
                     if data:


### PR DESCRIPTION
## Summary
- Remove 8 incorrect `await` calls on sync gRPC service methods in `acp_cli.py` — `history`, `config`, and `system-prompt get/set` were all broken with `object dict can't be used in 'await' expression`
- Change default `NEXUS_GRPC_PORT` from `0` (disabled) to `2028` (enabled) so ACP CLI works out of the box without extra env vars
- Add ACP coding agents tutorial (`examples/tutorials/acp-coding-agents/`)

## Test plan
- [x] `nexus acp agents` — lists 15 agents
- [x] `nexus acp ps` — shows running processes
- [x] `nexus acp history` — was crashing, now works
- [x] `nexus acp config -a claude` — was crashing, now works
- [x] `nexus acp system-prompt get/set` — was crashing, now works
- [x] `nexus acp call -a gemini/claude/codex` — all respond correctly
- [x] `nexus acp kill <invalid>` — returns proper error
- [x] `nexusd --port 2026` starts gRPC on 2028 by default (no env var needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)