### PR TITLE
feat: change default storage backend from CAS to path_local

### DIFF
--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -131,8 +131,8 @@ class NexusConfig(BaseModel):
 
     # Backend selection
     backend: str = Field(
-        default="local",
-        description="Storage backend: 'local' for local filesystem, 'gcs' for Google Cloud Storage",
+        default="path_local",
+        description="Storage backend: 'path_local' for local filesystem, 'local' for CAS, 'gcs' for Google Cloud Storage",
     )
 
     # Local backend settings


### PR DESCRIPTION
## Summary
- Changes the default storage backend from `local` (CAS/content-addressable store) to `path_local` (plain filesystem)
- Files are stored as plain JSON at `~/.nexus/data/{zone}/{vfs-path}`, making them easy to inspect and debug
- CAS backend remains available by setting `backend: local` in config

## Test plan
- [x] Started nexusd without `NEXUS_BACKEND` env var — defaults to `path_local`
- [x] Ran `nexus acp call` — agent responded correctly
- [x] Ran `nexus acp history` — results returned correctly
- [x] Verified files on disk at `{data-dir}/root/proc/{pid}/result` as plain JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)