### PR TITLE
feat(#3059): task_manager kernel compliance — AcpService worker + proper wiring

### DIFF
--- a/src/nexus/bricks/task_manager/__init__.py
+++ b/src/nexus/bricks/task_manager/__init__.py
@@ -1,9 +1,9 @@
 """Task Manager brick — NexusFS-backed task and mission management."""
 
-from nexus.bricks.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
 from nexus.bricks.task_manager.events import TaskSignalHandler
 from nexus.bricks.task_manager.service import TaskManagerService
 from nexus.bricks.task_manager.write_hook import TaskWriteHook
+from nexus.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
 
 __all__ = [
     "TaskDispatchPipeConsumer",

--- a/src/nexus/bricks/task_manager/service.py
+++ b/src/nexus/bricks/task_manager/service.py
@@ -217,13 +217,15 @@ class TaskManagerService:
             "created_at": now,
             "started_at": None,
             "completed_at": None,
+            "worker_pid": None,  # set when AcpService spawns the worker agent
+            "agent_name": None,  # set from AcpResult.agent_id after spawn
         }
         self._write_json(self._task_path(task_id), doc)
         return doc
 
     def update_task(self, task_id: str, **fields: Any) -> dict[str, Any]:
         """Update task fields — enforces state machine for status changes."""
-        allowed = {"status", "output_refs"}
+        allowed = {"status", "output_refs", "worker_pid", "agent_name"}
         for key in fields:
             if key not in allowed:
                 raise ValidationError(f"Cannot update field '{key}' on task")
@@ -253,6 +255,10 @@ class TaskManagerService:
         if "output_refs" in fields:
             doc["output_refs"] = fields["output_refs"]
 
+        for field in ("worker_pid", "agent_name"):
+            if field in fields:
+                doc[field] = fields[field]
+
         self._write_json(path, doc)
 
         # Auto-complete mission when all its tasks are terminal
@@ -276,8 +282,8 @@ class TaskManagerService:
         artifact_refs: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create a comment on a task."""
-        if author not in ("copilot", "worker"):
-            raise ValidationError(f"Invalid author '{author}'. Must be 'copilot' or 'worker'.")
+        if not author or not isinstance(author, str):
+            raise ValidationError("author must be a non-empty string")
 
         # Verify task exists
         self.get_task(task_id)

--- a/src/nexus/bricks/task_manager/task_agent_resolver.py
+++ b/src/nexus/bricks/task_manager/task_agent_resolver.py
@@ -1,0 +1,101 @@
+"""VFS read resolver: /.tasks/tasks/{task_id}/agent/status → live ProcessDescriptor.
+
+Intercepts reads to the virtual path and returns the ProcessDescriptor
+for the task's worker agent, assembled live from ProcessTable.
+No data is stored on disk — like Linux /proc, it is generated on demand.
+
+Virtual path: /.tasks/tasks/{task_id}/agent/status
+Source of truth: worker_pid field in task JSON (set by TaskDispatchPipeConsumer)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.bricks.task_manager.service import TaskManagerService
+    from nexus.contracts.protocols.service_hooks import HookSpec
+
+_AGENT_STATUS_RE = re.compile(r"^/\.tasks/tasks/([^/]+)/agent/status$")
+
+
+class TaskAgentResolver:
+    """VFSPathResolver for /.tasks/tasks/{task_id}/agent/status.
+
+    Follows the ``try_*`` protocol (#1665): each method returns ``None``
+    when the path is not claimed, or the result/raises when it is.
+    Write and delete raise PermissionError (read-only virtual path).
+    """
+
+    def __init__(self, task_svc: "TaskManagerService", process_table: Any) -> None:
+        self._task_svc = task_svc
+        self._process_table = process_table
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(resolvers=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    def _match_task_id(self, path: str) -> str | None:
+        m = _AGENT_STATUS_RE.match(path)
+        return m.group(1) if m is not None else None
+
+    def try_read(
+        self,
+        path: str,
+        *,
+        return_metadata: bool = False,
+        context: Any = None,
+    ) -> bytes | dict | None:
+        """Return agent status JSON for the task's worker, or None."""
+        _ = context
+        task_id = self._match_task_id(path)
+        if task_id is None:
+            return None  # not our path — pass through
+
+        try:
+            task = self._task_svc.get_task(task_id)
+        except Exception:
+            return None  # task not found — let VFS 404 handle it
+
+        worker_pid = task.get("worker_pid")
+        if not worker_pid:
+            payload: dict[str, Any] = {"status": "no_worker", "task_id": task_id}
+        else:
+            proc = self._process_table.get(worker_pid) if self._process_table else None
+            if proc is None:
+                payload = {"status": "exited", "task_id": task_id, "worker_pid": worker_pid}
+            else:
+                payload = proc.to_dict()
+                payload["task_id"] = task_id
+
+        body = json.dumps(payload, ensure_ascii=False).encode()
+
+        if return_metadata:
+            return {
+                "content": body,
+                "size": len(body),
+                "entry_type": 0,  # DT_REG
+            }
+        return body
+
+    def try_write(self, path: str, _content: bytes) -> dict[str, Any] | None:
+        """Reject writes on agent status paths (read-only virtual path)."""
+        if self._match_task_id(path) is not None:
+            raise PermissionError(f"{path}: task agent status is read-only")
+        return None
+
+    def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None:
+        """Reject deletes on agent status paths (read-only virtual path)."""
+        _ = context
+        if self._match_task_id(path) is not None:
+            raise PermissionError(f"{path}: task agent status is read-only")
+        return None

--- a/src/nexus/bricks/task_manager/write_hook.py
+++ b/src/nexus/bricks/task_manager/write_hook.py
@@ -32,7 +32,7 @@ class TaskWriteHook:
     cache — all state comes from the written content and ``ctx.is_new_file``.
     """
 
-    # ── HotSwappable protocol (Issue #1616) ────────────────────────────
+    # ── HotSwappable protocol ──────────────────────────────────────────
 
     def hook_spec(self) -> "HookSpec":
         from nexus.contracts.protocols.service_hooks import HookSpec
@@ -58,7 +58,7 @@ class TaskWriteHook:
 
     # ── VFSWriteHook protocol ──────────────────────────────────────────
 
-    def on_post_write(self, ctx: WriteHookContext) -> None:
+    def on_post_write(self, ctx: "WriteHookContext") -> None:
         if not fnmatch(ctx.path, _TASK_PATTERN):
             return
 

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -71,6 +71,7 @@ BRICK_WORKSPACE = "workspace"
 BRICK_PORTABILITY = "portability"
 BRICK_PARSERS = "parsers"
 BRICK_SNAPSHOT = "snapshot"
+BRICK_TASK_MANAGER = "task_manager"
 
 # Cloud-only
 BRICK_FEDERATION = "federation"
@@ -107,6 +108,7 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_PORTABILITY,
         BRICK_PARSERS,
         BRICK_SNAPSHOT,
+        BRICK_TASK_MANAGER,
         BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
         BRICK_ACP,
@@ -195,6 +197,7 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
         BRICK_DISCOVERY,
         BRICK_MCP,
         BRICK_MEMORY,
+        BRICK_TASK_MANAGER,
         BRICK_OBSERVABILITY,
         BRICK_UPLOADS,
         BRICK_RESILIENCY,

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -313,6 +313,9 @@ class BrickServices:
     # --- Search Brick (Issue #810) ---
     zoekt_pipe_consumer: Any = None  # DT_PIPE consumer for Zoekt index notifications
 
+    # --- Task Manager Brick ---
+    task_dispatch_consumer: Any = None  # TaskDispatchPipeConsumer (DT_PIPE lifecycle signals)
+
     # --- Factory-created bricks (Issue #2134: moved from NexusFS flat params) ---
     parse_fn: Any = None  # Callable for parsing files (ParsersBrick)
     content_cache: Any = None  # ContentCache instance

--- a/src/nexus/factory/_bricks.py
+++ b/src/nexus/factory/_bricks.py
@@ -150,6 +150,7 @@ def _boot_independent_bricks(
     # === Manually-wired bricks (complex conditional logic) ===
 
     zoekt_pipe_consumer: Any = None  # Issue #810: DT_PIPE Zoekt consumer
+    task_dispatch_consumer: Any = None  # Task Manager: DT_PIPE lifecycle consumer
 
     # --- Search Brick Import Validation (Issue #1520) ---
     if _on("search"):
@@ -196,6 +197,23 @@ def _boot_independent_bricks(
             logger.debug("[BOOT:BRICK] Zoekt not available, skipping callback wiring")
     else:
         logger.debug("[BOOT:BRICK] Search brick disabled by profile")
+
+    # --- Task Manager Brick ---
+    if _on("task_manager"):
+        try:
+            from nexus.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
+
+            task_dispatch_consumer = TaskDispatchPipeConsumer(
+                acp_service=system.get("acp_service"),
+                process_table=system.get("process_table"),
+            )
+            # TaskManagerService and TaskWriteHook are registered in _register_vfs_hooks
+            # (needs NexusFS reference); consumer stored here for lifespan startup.
+            logger.debug("[BOOT:BRICK] TaskDispatchPipeConsumer created")
+        except Exception as exc:
+            logger.warning("[BOOT:BRICK] task_manager unavailable: %s", exc)
+    else:
+        logger.debug("[BOOT:BRICK] task_manager brick disabled by profile")
 
     # --- Wallet Provisioner (Issue #1210) ---
     wallet_provisioner: Any = None
@@ -533,6 +551,8 @@ def _boot_independent_bricks(
         "governance_response_service": governance_response_service,
         # DT_PIPE consumers (Issue #810)
         "zoekt_pipe_consumer": zoekt_pipe_consumer,
+        # Task Manager Brick
+        "task_dispatch_consumer": task_dispatch_consumer,
     }
 
     elapsed = time.perf_counter() - t0

--- a/src/nexus/factory/_helpers.py
+++ b/src/nexus/factory/_helpers.py
@@ -57,6 +57,7 @@ _FACTORY_SKIP: frozenset[str] = frozenset(
         "wallet_provisioner",  # nexus/factory/wallet
         "version_service",  # nexus/services/versioning/
         "zoekt_pipe_consumer",  # nexus/factory/zoekt_pipe_consumer
+        "task_dispatch_consumer",  # nexus/task_manager/dispatch_consumer
         # --- Stateless bricks (no start/stop — unmount is cosmetic) ---
         "manifest_resolver",  # nexus/bricks/context_manifest/
         "manifest_metrics",  # nexus/bricks/context_manifest/

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -531,15 +531,29 @@ async def _register_vfs_hooks(
         except Exception as exc:
             logger.debug("[BOOT:HOOKS] ProcResolver unavailable: %s", exc)
 
-    # ── TaskWriteHook (post-write: emit task lifecycle events) ─────────
+    # ── TaskWriteHook + TaskDispatchPipeConsumer + TaskAgentResolver ───────────
     if _on("task_manager"):
-        from nexus.bricks.task_manager.write_hook import TaskWriteHook
+        try:
+            from nexus.bricks.task_manager.service import TaskManagerService
+            from nexus.bricks.task_manager.task_agent_resolver import TaskAgentResolver
+            from nexus.bricks.task_manager.write_hook import TaskWriteHook
 
-        _task_write_hook = TaskWriteHook()
-        await _enlist("task_write", _task_write_hook)
-        nx._task_write_hook = _task_write_hook
+            _task_svc = TaskManagerService(nexus_fs=nx)
+            _task_write_hook = TaskWriteHook()
+
+            # Wire consumer from brick_services (created in _bricks.py)
+            _task_consumer = getattr(nx._brick_services, "task_dispatch_consumer", None)
+            if _task_consumer is not None:
+                _task_write_hook.register_handler(_task_consumer)
+                _task_consumer.set_task_service(_task_svc)
+
+            await _enlist("task_write", _task_write_hook)
+            await _enlist("task_agent_resolver", TaskAgentResolver(_task_svc, _proc_table))
+            nx._task_write_hook = _task_write_hook
+        except Exception as exc:
+            logger.warning("[BOOT:BRICK] task_manager wiring failed: %s", exc)
     else:
-        logger.debug("[BOOT:BRICK] TaskWriteHook disabled by profile")
+        logger.debug("[BOOT:BRICK] task_manager disabled by profile")
 
     # ── OBSERVE observers (Issue #900, #922) ──────────────────────────
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).

--- a/src/nexus/lib/device_capabilities.py
+++ b/src/nexus/lib/device_capabilities.py
@@ -96,6 +96,7 @@ BRICK_REQUIREMENTS: dict[str, BrickRequirement] = {
     "parsers": BrickRequirement(min_memory_mb=128),
     "snapshot": BrickRequirement(min_memory_mb=64),
     "acp": BrickRequirement(min_memory_mb=64),
+    "task_manager": BrickRequirement(min_memory_mb=32),
     # Kernel (always on, listed for completeness)
     "storage": BrickRequirement(min_memory_mb=0),
 }

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -620,6 +620,17 @@ async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> No
         except Exception as e:
             logger.warning("[PIPE] ZoektPipeConsumer start failed: %s", e, exc_info=True)
 
+    # TaskDispatchPipeConsumer (task lifecycle signals)
+    tdc = svc.task_dispatch_consumer
+    if tdc is not None and hasattr(tdc, "set_pipe_manager"):
+        try:
+            tdc.set_pipe_manager(pipe_manager)
+            await tdc.start()
+            app.state.task_dispatch_consumer = tdc
+            logger.info("[PIPE] TaskDispatchPipeConsumer started")
+        except Exception as e:
+            logger.warning("[PIPE] TaskDispatchPipeConsumer start failed: %s", e, exc_info=True)
+
 
 async def _shutdown_pipe_consumers(app: "FastAPI") -> None:
     """Stop DT_PIPE consumers (Issue #809, #810)."""
@@ -642,3 +653,12 @@ async def _shutdown_pipe_consumers(app: "FastAPI") -> None:
             logger.info("[PIPE] ZoektPipeConsumer stopped")
         except Exception as e:
             logger.warning("[PIPE] Error stopping ZoektPipeConsumer: %s", e, exc_info=True)
+
+    # TaskDispatchPipeConsumer
+    tdc = getattr(app.state, "task_dispatch_consumer", None)
+    if tdc is not None and hasattr(tdc, "stop"):
+        try:
+            await tdc.stop()
+            logger.info("[PIPE] TaskDispatchPipeConsumer stopped")
+        except Exception as e:
+            logger.warning("[PIPE] Error stopping TaskDispatchPipeConsumer: %s", e, exc_info=True)

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -67,6 +67,7 @@ class LifespanServices:
 
     # --- DT_PIPE consumers (Issue #810) -----------------------------------
     zoekt_pipe_consumer: Any = None
+    task_dispatch_consumer: Any = None  # Task Manager DT_PIPE consumer
 
     # --- Brick services container ----------------------------------------
     brick_services: Any = None  # The whole BrickServices dataclass
@@ -129,6 +130,10 @@ class LifespanServices:
             pipe_manager=(getattr(nx, "_pipe_manager", None) if nx else None),
             # Issue #810: DT_PIPE Zoekt consumer
             zoekt_pipe_consumer=(getattr(_brk, "zoekt_pipe_consumer", None) if _brk else None),
+            # Task Manager DT_PIPE consumer
+            task_dispatch_consumer=(
+                getattr(_brk, "task_dispatch_consumer", None) if _brk else None
+            ),
             # Issue #2195: Scheduler
             scheduler_service=(getattr(_sys, "scheduler_service", None) if _sys else None),
             # Brick services

--- a/src/nexus/task_manager/dispatch_consumer.py
+++ b/src/nexus/task_manager/dispatch_consumer.py
@@ -1,0 +1,352 @@
+"""DT_PIPE-backed dispatch consumer for task lifecycle signals.
+
+Produces task signals into a kernel ring buffer pipe and consumes them
+in a background asyncio task, following the same pattern as
+``WorkflowDispatchService`` and ``ZoektPipeConsumer``.
+
+Flow::
+
+    TaskWriteHook.on_post_write() [sync, kernel dispatch]
+      → TaskDispatchPipeConsumer.on_task_signal(signal_type, payload)
+        → JSON → pipe_write_nowait("/nexus/pipes/task-dispatch")
+
+    Background _consume() [asyncio.Task]
+      → pipe_read() → JSON → _dispatch()
+        → "task_created" → spawn worker via AcpService
+        → "task_updated" + status="in_review" → copilot review via VFS
+
+All state mutations use TaskManagerService (VFS-backed) directly —
+no HTTP loopback, no subprocess calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.bricks.task_manager.service import TaskManagerService
+    from nexus.system_services.pipe_manager import PipeManager
+
+logger = logging.getLogger(__name__)
+
+_TASK_DISPATCH_PIPE_PATH = "/nexus/pipes/task-dispatch"
+_TASK_DISPATCH_PIPE_CAPACITY = 65_536  # 64KB
+
+# Type alias for injectable LLM provider (used by copilot review path)
+LLMCallable = Callable[[str], Awaitable[str]]
+
+
+async def _no_llm(_prompt: str) -> str:
+    """Placeholder LLM provider — returns a stub until VFS-routed LLM is wired."""
+    return "(LLM provider not configured — VFS-routed LLM pending)"
+
+
+class TaskDispatchPipeConsumer:
+    """Produces and consumes task dispatch signals via DT_PIPE.
+
+    Implements ``TaskSignalHandler`` so it can be registered with
+    :class:`TaskWriteHook`.  The producer side serialises signals to JSON
+    and writes them into the kernel pipe.  The consumer side runs a
+    background ``asyncio.Task`` that reads from the pipe and routes
+    signals via ``_dispatch()``.
+
+    All state mutations go through ``TaskManagerService`` which uses
+    NexusFS ``sys_read``/``sys_write`` — getting file events, permissions,
+    and audit trail for free.
+
+    Worker completion is environment-driven: ``AcpService.call_agent()``
+    awaits the subprocess to exit (ZOMBIE → reap), so no polling is needed.
+
+    Lifecycle (deferred injection)::
+
+        consumer = TaskDispatchPipeConsumer()
+        task_write_hook.register_handler(consumer)
+        consumer.set_pipe_manager(pipe_manager)
+        consumer.set_task_service(task_manager_service)
+        await consumer.start()
+        ...
+        await consumer.stop()
+    """
+
+    def __init__(
+        self,
+        *,
+        acp_service: Any | None = None,
+        process_table: Any | None = None,
+        llm_fn: LLMCallable | None = None,
+    ) -> None:
+        self._pipe_manager: PipeManager | None = None
+        self._task_svc: TaskManagerService | None = None
+        self._acp_service = acp_service
+        self._process_table = process_table
+        self._llm_fn: LLMCallable = llm_fn or _no_llm  # used by copilot review
+        self._pipe_ready = False
+        self._consumer_task: asyncio.Task[None] | None = None
+
+    # ------------------------------------------------------------------
+    # Deferred injection
+    # ------------------------------------------------------------------
+
+    def set_pipe_manager(self, pipe_manager: PipeManager) -> None:
+        """Inject PipeManager after server lifespan initialization."""
+        self._pipe_manager = pipe_manager
+
+    def set_task_service(self, task_svc: TaskManagerService) -> None:
+        """Inject TaskManagerService for direct VFS-backed operations."""
+        self._task_svc = task_svc
+
+    def set_acp_service(self, acp_service: Any) -> None:
+        self._acp_service = acp_service
+
+    def set_process_table(self, process_table: Any) -> None:
+        self._process_table = process_table
+
+    # ------------------------------------------------------------------
+    # TaskSignalHandler (producer side)
+    # ------------------------------------------------------------------
+
+    def on_task_signal(self, signal_type: str, payload: dict[str, Any]) -> None:
+        """Serialize signal and write to pipe (non-blocking)."""
+        if self._pipe_manager is None or not self._pipe_ready:
+            return
+
+        from nexus.core.pipe import PipeClosedError, PipeFullError
+
+        try:
+            data = json.dumps({"type": signal_type, "payload": payload}).encode()
+            self._pipe_manager.pipe_write_nowait(_TASK_DISPATCH_PIPE_PATH, data)
+        except (PipeClosedError, PipeFullError):
+            logger.warning("[TASK-DISPATCH] pipe full/closed, dropping signal: %s", signal_type)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Create the dispatch pipe and start the background consumer."""
+        if self._pipe_ready:
+            return
+
+        if self._pipe_manager is None:
+            return
+
+        from nexus.core.pipe import PipeError
+
+        try:
+            self._pipe_manager.create(
+                _TASK_DISPATCH_PIPE_PATH,
+                capacity=_TASK_DISPATCH_PIPE_CAPACITY,
+                owner_id="kernel",
+            )
+        except PipeError:
+            self._pipe_manager.open(_TASK_DISPATCH_PIPE_PATH, capacity=_TASK_DISPATCH_PIPE_CAPACITY)
+
+        self._pipe_ready = True
+        self._consumer_task = asyncio.create_task(self._consume())
+        logger.info("[TASK-DISPATCH] pipe consumer started")
+
+    async def stop(self) -> None:
+        """Graceful shutdown: close pipe, cancel consumer task."""
+        if self._consumer_task is not None and not self._consumer_task.done():
+            if self._pipe_manager is not None and self._pipe_ready:
+                with contextlib.suppress(Exception):
+                    self._pipe_manager.close(_TASK_DISPATCH_PIPE_PATH)
+
+            self._consumer_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._consumer_task
+
+            self._consumer_task = None
+
+        self._pipe_ready = False
+        logger.info("[TASK-DISPATCH] pipe consumer stopped")
+
+    # ------------------------------------------------------------------
+    # Consumer loop
+    # ------------------------------------------------------------------
+
+    async def _consume(self) -> None:
+        """Background loop: read from pipe, deserialize, dispatch."""
+        from nexus.core.pipe import PipeClosedError, PipeNotFoundError
+
+        assert self._pipe_manager is not None
+        pipe_mgr = self._pipe_manager
+
+        while True:
+            try:
+                data = await pipe_mgr.pipe_read(_TASK_DISPATCH_PIPE_PATH)
+            except (PipeClosedError, PipeNotFoundError):
+                logger.debug("[TASK-DISPATCH] pipe closed, consumer exiting")
+                break
+
+            try:
+                msg = json.loads(data)
+                await self._dispatch(msg)
+            except Exception as e:
+                logger.error("[TASK-DISPATCH] event processing failed: %s", e)
+
+    # ------------------------------------------------------------------
+    # Dispatch routing — all ops via VFS-backed TaskManagerService
+    # ------------------------------------------------------------------
+
+    async def _dispatch(self, msg: dict[str, Any]) -> None:
+        """Route a deserialized pipe message by signal type."""
+        if self._task_svc is None:
+            logger.warning("[TASK-DISPATCH] no TaskManagerService — dropping signal")
+            return
+
+        signal_type = msg.get("type")
+        payload = msg.get("payload", {})
+
+        if signal_type == "task_created":
+            task_id = payload.get("task_id", "?")
+            mission_id = payload.get("mission_id", "?")
+
+            # Record audit via VFS
+            self._task_svc.create_audit_entry(task_id, "task_created", detail="task created")
+
+            # Check if task is blocked
+            blocked_by = payload.get("blocked_by") or []
+            if blocked_by:
+                logger.info(
+                    "[TASK-DISPATCH] task_created task_id=%s mission_id=%s blocked_by=%s",
+                    task_id,
+                    mission_id,
+                    blocked_by,
+                )
+                return
+
+            logger.info(
+                "[TASK-DISPATCH] task_created task_id=%s mission_id=%s → starting worker",
+                task_id,
+                mission_id,
+            )
+            await self._start_worker(task_id)
+
+        elif signal_type == "task_updated":
+            task_id = payload.get("task_id", "?")
+            status = payload.get("status", "?")
+
+            if status == "in_review":
+                logger.info("[TASK-DISPATCH] task_id=%s in_review → copilot review", task_id)
+                await self._copilot_review(task_id)
+            elif status in ("completed", "failed", "cancelled"):
+                logger.info(
+                    "[TASK-DISPATCH] task_id=%s %s → checking unblocked tasks",
+                    task_id,
+                    status,
+                )
+                self._dispatch_unblocked_tasks()
+            else:
+                logger.debug("[TASK-DISPATCH] task_id=%s status=%s (no action)", task_id, status)
+        else:
+            logger.warning("[TASK-DISPATCH] unknown signal type: %s", signal_type)
+
+    async def _start_worker(self, task_id: str) -> None:
+        """Spawn worker agent via AcpService — environment-driven completion."""
+        assert self._task_svc is not None
+        svc = self._task_svc
+
+        try:
+            task = svc.get_task(task_id)
+            instruction = task.get("instruction", "do the task")
+            agent_id = task.get("worker_type") or "claude-code"
+
+            svc.update_task(task_id, status="running")
+            svc.create_audit_entry(task_id, "status_changed", actor="system", detail="task started")
+
+            if self._acp_service is None:
+                logger.error("[TASK-DISPATCH] AcpService not wired for task %s", task_id)
+                svc.update_task(task_id, status="failed")
+                svc.create_audit_entry(
+                    task_id, "status_changed", actor="system", detail="AcpService unavailable"
+                )
+                return
+
+            from nexus.contracts.constants import ROOT_ZONE_ID
+
+            result = await self._acp_service.call_agent(
+                agent_id=agent_id,
+                prompt=instruction,
+                owner_id="task_manager",
+                zone_id=ROOT_ZONE_ID,
+                labels={"task_id": task_id},
+            )
+
+            agent_label = f"{result.agent_id}:{result.pid}"
+            svc.update_task(task_id, worker_pid=result.pid, agent_name=result.agent_id)
+            svc.create_comment(task_id, agent_label, result.response)
+            svc.create_audit_entry(
+                task_id,
+                "status_changed",
+                actor=agent_label,
+                detail="worker completed, pending review",
+            )
+            svc.update_task(task_id, status="in_review")
+
+        except Exception as e:
+            logger.error("[TASK-DISPATCH] worker failed for task %s: %s", task_id, e)
+            try:
+                svc.create_comment(task_id, "system", f"Worker failed: {e}")
+                svc.update_task(task_id, status="failed")
+                svc.create_audit_entry(
+                    task_id, "status_changed", actor="system", detail=f"task failed: {e}"
+                )
+            except Exception:
+                logger.error("[TASK-DISPATCH] cleanup after failure also failed", exc_info=True)
+
+    async def _copilot_review(self, task_id: str) -> None:
+        """Copilot reviews the worker output and completes or fails the task.
+
+        TODO: migrate to AcpService.call_agent() — spawn copilot agent subprocess
+        instead of calling LLM directly.
+        """
+        assert self._task_svc is not None
+        svc = self._task_svc
+
+        try:
+            comments = svc.get_comments(task_id)
+            last_content = comments[-1].get("content", "") if comments else "(no worker comment)"
+
+            review = await self._llm_fn(
+                f"Review this worker output and give brief feedback:\n\n{last_content}"
+            )
+
+            svc.create_comment(task_id, "copilot", review)
+            svc.update_task(task_id, status="completed")
+            svc.create_audit_entry(
+                task_id, "status_changed", actor="copilot", detail="task completed by copilot"
+            )
+        except Exception as e:
+            logger.error("[TASK-DISPATCH] copilot review failed for task %s: %s", task_id, e)
+            try:
+                svc.create_comment(task_id, "copilot", f"Review failed: {e}")
+                svc.update_task(task_id, status="failed")
+                svc.create_audit_entry(
+                    task_id, "status_changed", actor="copilot", detail=f"review failed: {e}"
+                )
+            except Exception:
+                logger.error(
+                    "[TASK-DISPATCH] cleanup after copilot failure also failed", exc_info=True
+                )
+
+    def _dispatch_unblocked_tasks(self) -> None:
+        """Check for dispatchable tasks (created + unblocked) and start them."""
+        assert self._task_svc is not None
+
+        try:
+            dispatchable = self._task_svc.list_dispatchable_tasks()
+        except Exception:
+            logger.warning("[TASK-DISPATCH] failed to list dispatchable tasks", exc_info=True)
+            return
+
+        for task in dispatchable:
+            tid = task.get("id", "?")
+            logger.info("[TASK-DISPATCH] unblocked: dispatching task %s", tid)
+            # Schedule worker start as a separate task to avoid blocking the consumer
+            asyncio.create_task(self._start_worker(tid))

--- a/tests/unit/core/test_kernel_config.py
+++ b/tests/unit/core/test_kernel_config.py
@@ -421,6 +421,8 @@ class TestBrickServices:
             "governance_response_service",
             # DT_PIPE consumer (Issue #810)
             "zoekt_pipe_consumer",
+            # Task Manager DT_PIPE consumer
+            "task_dispatch_consumer",
         }
         assert field_names == expected_fields, (
             f"Extra: {field_names - expected_fields}, Missing: {expected_fields - field_names}"

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -279,6 +279,8 @@ class TestBootBrickServices:
             "governance_response_service",
             # DT_PIPE Zoekt consumer (Issue #810)
             "zoekt_pipe_consumer",
+            # Task Manager DT_PIPE consumer
+            "task_dispatch_consumer",
         }
         assert expected_keys == set(result.keys())
 


### PR DESCRIPTION
## Summary

Fixes two kernel architecture violations in the `task_manager` brick (merged to `develop` via #3059 without proper review):

- **Prompt-driven completion** (`_llm_fn` callback in worker): replaced with `AcpService.call_agent()` — worker is now a subprocess that runs to completion, with `worker_pid`/`agent_name` tracked in the task JSON
- **Dead wiring**: `TaskDispatchPipeConsumer` was never instantiated or started; now properly wired through `_bricks.py` → `BrickServices` → `LifespanServices` → `_startup_pipe_consumers` (matches `ZoektPipeConsumer` pattern)

Additional fixes:
- `service.py`: add `worker_pid`/`agent_name` fields; relax `create_comment` author check to allow any non-empty string (ACP agents use `"agent_name:pid"` format)
- `task_agent_resolver.py`: new VFSPathResolver for `/.tasks/tasks/{id}/agent/status` → live ProcessTable lookup via `try_read` protocol (matches `ProcResolver`); enlisted via coordinator
- `nexus.task_manager.dispatch_consumer` (outside bricks): moved out of `nexus.bricks.*` to satisfy brick import boundary (no `nexus.core` imports allowed in `nexus.bricks.*`)
- `deployment_profile.py`: `BRICK_TASK_MANAGER` added to FULL/CLOUD/INNOVATION profiles
- `_copilot_review()` preserved with original LLM-based logic + TODO note for future ACP migration

## Test plan

- [ ] All pre-commit hooks pass (ruff, mypy, brick-import check) ✅
- [ ] CI green on this PR
- [ ] `TaskDispatchPipeConsumer.start()` called at server startup via `_startup_pipe_consumers`
- [ ] `TaskDispatchPipeConsumer.stop()` called at shutdown
- [ ] `/.tasks/tasks/{id}/agent/status` returns live process data after worker spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)