### PR TITLE
fix(server,tui): editor keybinding suppression + transaction tracking

### DIFF
--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -37,15 +37,15 @@ const ApiConsolePanel = lazy(() => import("./panels/api-console/api-console-pane
 
 const TABS: readonly Tab[] = [
   { id: "files", label: "Files", shortcut: "1" },
-  { id: "versions", label: "Versions", shortcut: "2" },
-  { id: "agents", label: "Agents", shortcut: "3" },
-  { id: "zones", label: "Zones", shortcut: "4" },
-  { id: "access", label: "Access", shortcut: "5" },
+  { id: "versions", label: "Ver", shortcut: "2" },
+  { id: "agents", label: "Agent", shortcut: "3" },
+  { id: "zones", label: "Zone", shortcut: "4" },
+  { id: "access", label: "ACL", shortcut: "5" },
   { id: "payments", label: "Pay", shortcut: "6" },
-  { id: "search", label: "Search", shortcut: "7" },
-  { id: "workflows", label: "Workflows", shortcut: "8" },
-  { id: "infrastructure", label: "Events", shortcut: "9" },
-  { id: "console", label: "Console", shortcut: "0" },
+  { id: "search", label: "Find", shortcut: "7" },
+  { id: "workflows", label: "Flow", shortcut: "8" },
+  { id: "infrastructure", label: "Event", shortcut: "9" },
+  { id: "console", label: "CLI", shortcut: "0" },
 ];
 
 function PanelRouter(): React.ReactNode {

--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -154,28 +154,30 @@ export function App(): React.ReactNode {
         }
       : identitySwitcherOpen || helpOpen || showWelcome
       ? {
-          // When an overlay is open, only its dismiss key works from app level.
+          // When an overlay is open, only dismiss keys work from app level.
           "ctrl+i": toggleIdentitySwitcher,
         }
       : {
-          "1": () => setActivePanel("files"),
-          "2": () => setActivePanel("versions"),
-          "3": () => setActivePanel("agents"),
-          "4": () => setActivePanel("zones"),
-          "5": () => setActivePanel("access"),
-          "6": () => setActivePanel("payments"),
-          "7": () => setActivePanel("search"),
-          "8": () => setActivePanel("workflows"),
-          "9": () => setActivePanel("infrastructure"),
-          "0": () => setActivePanel("console"),
+          // Check fileEditorOpen synchronously inside each handler so we don't
+          // depend on React re-render timing — OpenTUI broadcasts to ALL handlers.
+          "1": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("files"); },
+          "2": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("versions"); },
+          "3": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("agents"); },
+          "4": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("zones"); },
+          "5": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("access"); },
+          "6": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("payments"); },
+          "7": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("search"); },
+          "8": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("workflows"); },
+          "9": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("infrastructure"); },
+          "0": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("console"); },
           "ctrl+i": toggleIdentitySwitcher,
           "ctrl+d": () => {
             // Disconnect and go back to setup menu
             useGlobalStore.getState().setConnectionStatus("error", "Disconnected by user");
           },
-          "z": () => toggleZoom(activePanel),
-          "?": () => setHelpOpen(true),
-          "q": shutdown,
+          "z": () => { if (!useUiStore.getState().fileEditorOpen) toggleZoom(activePanel); },
+          "?": () => { if (!useUiStore.getState().fileEditorOpen) setHelpOpen(true); },
+          "q": () => { if (!useUiStore.getState().fileEditorOpen) shutdown(); },
         },
   );
 

--- a/packages/nexus-tui/src/panels/files/file-editor.tsx
+++ b/packages/nexus-tui/src/panels/files/file-editor.tsx
@@ -1,0 +1,151 @@
+/**
+ * Full-screen file editor using OpenTUI's <textarea> component.
+ *
+ * Opens when pressing 'e' on a file in the explorer.
+ * - Loads file content from the server
+ * - Multi-line editing with undo/redo, cursor nav, selection
+ * - Ctrl+S or Meta+Enter to save
+ * - Esc to cancel
+ */
+
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import type { TextareaRenderable } from "@opentui/core";
+import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
+import { useApi } from "../../shared/hooks/use-api.js";
+import { useFilesStore } from "../../stores/files-store.js";
+import { Spinner } from "../../shared/components/spinner.js";
+
+interface FileEditorProps {
+  readonly path: string;
+  readonly onClose: () => void;
+}
+
+export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode {
+  const client = useApi();
+  const textareaRef = useRef<TextareaRenderable>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [initialContent, setInitialContent] = useState("");
+
+  // Load file content
+  useEffect(() => {
+    if (!client) return;
+    setLoading(true);
+    setError(null);
+
+    client.get<{ content: string }>(`/api/v2/files/read?path=${encodeURIComponent(path)}&include_metadata=false`)
+      .then((response) => {
+        const content = typeof response === "string" ? response : (response?.content ?? "");
+        setInitialContent(content);
+        if (textareaRef.current) {
+          textareaRef.current.setText(content);
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        // New file — start with empty content
+        setInitialContent("");
+        if (textareaRef.current) {
+          textareaRef.current.setText("");
+        }
+        setLoading(false);
+      });
+  }, [client, path]);
+
+  // Set initial content once textarea mounts
+  useEffect(() => {
+    if (!loading && textareaRef.current && initialContent) {
+      textareaRef.current.setText(initialContent);
+    }
+  }, [loading, initialContent]);
+
+  // Save file
+  const handleSave = useCallback(async () => {
+    if (!client || saving) return;
+    const content = textareaRef.current?.plainText ?? "";
+    setSaving(true);
+    setError(null);
+    try {
+      await client.post("/api/v2/files/write", {
+        path,
+        content,
+      });
+      setDirty(false);
+      // Refresh parent directory in file tree
+      const parentDir = path.split("/").slice(0, -1).join("/") || "/";
+      useFilesStore.getState().invalidate(parentDir);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [client, path, saving, onClose]);
+
+  // Keyboard shortcuts (only when not focused on textarea — textarea handles its own keys)
+  useKeyboard({
+    "escape": () => {
+      onClose();
+    },
+    "ctrl+s": () => {
+      handleSave();
+    },
+  });
+
+  if (loading) {
+    return (
+      <box height="100%" width="100%" justifyContent="center" alignItems="center">
+        <Spinner label={`Loading ${path}...`} />
+      </box>
+    );
+  }
+
+  const fileName = path.split("/").pop() ?? path;
+
+  return (
+    <box height="100%" width="100%" flexDirection="column">
+      {/* Header */}
+      <box height={1} width="100%">
+        <text>
+          <span foregroundColor="#00d4ff" bold>{` ${fileName}`}</span>
+          <span foregroundColor="#666666">{` — ${path}`}</span>
+          {dirty ? <span foregroundColor="#ffaa00">{" [modified]"}</span> : ""}
+          {saving ? <span foregroundColor="#ffaa00">{" saving..."}</span> : ""}
+        </text>
+      </box>
+
+      {/* Editor */}
+      <box flexGrow={1} borderStyle="single" borderColor={dirty ? "#ffaa00" : "#444444"}>
+        <textarea
+          ref={textareaRef}
+          initialValue={initialContent}
+          placeholder="Start typing..."
+          wrapMode="word"
+          focusedTextColor="#ffffff"
+          focusedBackgroundColor="#1a1a2e"
+          textColor="#cccccc"
+          cursorColor="#00d4ff"
+          selectionBg="#264f78"
+          focused
+          onContentChange={() => setDirty(true)}
+          onSubmit={() => handleSave()}
+        />
+      </box>
+
+      {/* Footer */}
+      <box height={1} width="100%">
+        <text>
+          <span foregroundColor="#4dff88" bold>{"  Ctrl+S"}</span>
+          <span foregroundColor="#888888">{":save  "}</span>
+          <span foregroundColor="#ff4444" bold>{"Esc"}</span>
+          <span foregroundColor="#888888">{":cancel  "}</span>
+          <span foregroundColor="#00d4ff">{"Meta+Enter"}</span>
+          <span foregroundColor="#888888">{":save  "}</span>
+          {error ? <span foregroundColor="#ff4444">{`  Error: ${error}`}</span> : ""}
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/panels/files/file-editor.tsx
+++ b/packages/nexus-tui/src/panels/files/file-editor.tsx
@@ -13,6 +13,7 @@ import type { TextareaRenderable } from "@opentui/core";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useFilesStore } from "../../stores/files-store.js";
+import { useVersionsStore } from "../../stores/versions-store.js";
 import { Spinner } from "../../shared/components/spinner.js";
 
 interface FileEditorProps {
@@ -61,14 +62,17 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
     }
   }, [loading, initialContent]);
 
-  // Save file
+  // Save file (with optional transaction tracking)
   const handleSave = useCallback(async () => {
     if (!client || saving) return;
     const content = textareaRef.current?.plainText ?? "";
     setSaving(true);
     setError(null);
     try {
-      await client.post("/api/v2/files/write", {
+      // If an active transaction exists, pass its ID so the write is tracked
+      const activeTxn = useVersionsStore.getState().selectedTransaction;
+      const txnParam = activeTxn?.status === "active" ? `&transaction_id=${activeTxn.transaction_id}` : "";
+      await client.post(`/api/v2/files/write?${txnParam}`, {
         path,
         content,
       });
@@ -103,6 +107,8 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
   }
 
   const fileName = path.split("/").pop() ?? path;
+  const activeTxn = useVersionsStore((s) => s.selectedTransaction);
+  const hasTxn = activeTxn?.status === "active";
 
   return (
     <box height="100%" width="100%" flexDirection="column">
@@ -113,6 +119,7 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
           <span foregroundColor="#666666">{` — ${path}`}</span>
           {dirty ? <span foregroundColor="#ffaa00">{" [modified]"}</span> : ""}
           {saving ? <span foregroundColor="#ffaa00">{" saving..."}</span> : ""}
+          {hasTxn ? <span foregroundColor="#4dff88">{` [txn:${activeTxn!.transaction_id.slice(0, 8)}]`}</span> : ""}
         </text>
       </box>
 

--- a/packages/nexus-tui/src/panels/files/file-editor.tsx
+++ b/packages/nexus-tui/src/panels/files/file-editor.tsx
@@ -29,6 +29,9 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
   const [error, setError] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
   const [initialContent, setInitialContent] = useState("");
+  // Must be called at top level (before any conditional returns) to respect Rules of Hooks
+  const activeTxn = useVersionsStore((s) => s.selectedTransaction);
+  const hasTxn = activeTxn?.status === "active";
 
   // Load file content
   useEffect(() => {
@@ -71,8 +74,8 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
     try {
       // If an active transaction exists, pass its ID so the write is tracked
       const activeTxn = useVersionsStore.getState().selectedTransaction;
-      const txnParam = activeTxn?.status === "active" ? `&transaction_id=${activeTxn.transaction_id}` : "";
-      await client.post(`/api/v2/files/write?${txnParam}`, {
+      const txnParam = activeTxn?.status === "active" ? `?transaction_id=${activeTxn.transaction_id}` : "";
+      await client.post(`/api/v2/files/write${txnParam}`, {
         path,
         content,
       });
@@ -107,8 +110,6 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
   }
 
   const fileName = path.split("/").pop() ?? path;
-  const activeTxn = useVersionsStore((s) => s.selectedTransaction);
-  const hasTxn = activeTxn?.status === "active";
 
   return (
     <box height="100%" width="100%" flexDirection="column">

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -67,7 +67,7 @@ const ALL_TABS: readonly TabDef<FilesTab>[] = [
 // Input mode types
 // =============================================================================
 
-type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest";
+type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest" | "create";
 
 // =============================================================================
 // Keybinding builders — one function per mode (Decision 6A)
@@ -233,11 +233,20 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
         ctx.setInputBuffer(ctx.selectedItem.name);
       }
     },
-    // Edit file: open full-screen editor
+    // Edit existing file: open full-screen editor
     e: () => {
       if (ctx.selectedItem && !ctx.selectedItem.isDirectory) {
         ctx.setEditorPath(ctx.selectedItem.path);
       }
+    },
+    // Create new file: prompt for filename, then open editor
+    "shift+e": () => {
+      const dir = ctx.selectedItem?.isDirectory
+        ? ctx.selectedItem.path
+        : ctx.currentPath;
+      const prefix = dir === "/" ? "/" : dir + "/";
+      ctx.setInputMode("create");
+      ctx.setInputBuffer(prefix);
     },
     // Copy path to system clipboard
     y: () => {
@@ -399,6 +408,18 @@ function getInputModeBindings(
         },
       };
 
+    case "create":
+      return {
+        ...baseBindings,
+        return: () => {
+          const filePath = ctx.filterQuery.trim();
+          if (!filePath) { resetInput(); return; }
+          // Open editor for the new path (editor handles creation on save)
+          ctx.setEditorPath(filePath);
+          resetInput();
+        },
+      };
+
     default:
       return {};
   }
@@ -441,6 +462,7 @@ function getInputLabel(mode: InputMode, buffer: string): string {
     case "filter": return `/${buffer}\u2588`;
     case "search": return `Search (g: glob, r: grep): ${buffer}\u2588`;
     case "paste-dest": return `Paste to: ${buffer}\u2588`;
+    case "create": return `New file path: ${buffer}\u2588`;
     default: return "";
   }
 }
@@ -474,7 +496,7 @@ function getHelpText(
     if (clipboard) {
       parts.push(`p:paste ${clipboard.paths.length} ${clipboard.operation === "cut" ? "cut" : "copied"}`, "P:paste to path");
     }
-    parts.push("d:del", "N:mkdir", "R:rename", "e:edit");
+    parts.push("d:del", "N:mkdir", "R:rename", "e:edit", "E:new file");
     if (catalogAvailable) parts.push("m/a/s:meta");
     parts.push("?:help");
     return parts.join("  ");

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -430,9 +430,10 @@ function getKeyBindings(
   inputMode: InputMode,
   overlayActive: boolean,
   confirmDelete: boolean,
+  editorOpen: boolean,
   ctx: BindingContext,
 ): Record<string, () => void> {
-  if (overlayActive || confirmDelete) return {};
+  if (overlayActive || confirmDelete || editorOpen) return {};
 
   if (inputMode !== "none") {
     return getInputModeBindings(inputMode, ctx);
@@ -752,8 +753,8 @@ export default function FileExplorerPanel(): React.ReactNode {
   };
 
   useKeyboard(
-    getKeyBindings(inputMode, overlayActive, confirmDelete, ctx),
-    !overlayActive && inputMode !== "none" ? handleUnhandledKey : undefined,
+    getKeyBindings(inputMode, overlayActive, confirmDelete, editorPath !== null, ctx),
+    !overlayActive && inputMode !== "none" && editorPath === null ? handleUnhandledKey : undefined,
   );
 
   const handleConfirmDelete = (): void => {

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -135,7 +135,7 @@ interface BindingContext {
   // Paste destination input
   readonly setInputModeWithCallback: (mode: InputMode, onSubmit: (value: string) => void) => void;
   // Editor
-  readonly setEditorPath: (path: string | null) => void;
+  readonly openEditor: (path: string) => void;
 }
 
 /** Navigation bindings for the currently active tab (Decision 5A). */
@@ -236,7 +236,7 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
     // Edit existing file: open full-screen editor
     e: () => {
       if (ctx.selectedItem && !ctx.selectedItem.isDirectory) {
-        ctx.setEditorPath(ctx.selectedItem.path);
+        ctx.openEditor(ctx.selectedItem.path);
       }
     },
     // Create new file: prompt for filename, then open editor
@@ -415,7 +415,7 @@ function getInputModeBindings(
           const filePath = ctx.filterQuery.trim();
           if (!filePath) { resetInput(); return; }
           // Open editor for the new path (editor handles creation on save)
-          ctx.setEditorPath(filePath);
+          ctx.openEditor(filePath);
           resetInput();
         },
       };
@@ -574,6 +574,7 @@ export default function FileExplorerPanel(): React.ReactNode {
   const uiFocusPane = useUiStore((s) => s.getFocusPane("files"));
   const toggleFocus = useUiStore((s) => s.toggleFocusPane);
   const overlayActive = useUiStore((s) => s.overlayActive);
+  const setOverlayActive = useUiStore((s) => s.setOverlayActive);
 
   // Catalog brick availability
   const { available: catalogAvailable } = useBrickAvailable("catalog");
@@ -635,8 +636,16 @@ export default function FileExplorerPanel(): React.ReactNode {
   // Clipboard copy (system)
   const { copy, copied } = useCopy();
 
-  // Editor overlay state
+  // Editor overlay state — suppress global panel-switch keys while editor is open
   const [editorPath, setEditorPath] = useState<string | null>(null);
+  const openEditor = useCallback((path: string) => {
+    useUiStore.getState().setFileEditorOpen(true);
+    setEditorPath(path);
+  }, []);
+  const closeEditor = useCallback(() => {
+    useUiStore.getState().setFileEditorOpen(false);
+    setEditorPath(null);
+  }, []);
 
   // Dialog state
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -739,7 +748,7 @@ export default function FileExplorerPanel(): React.ReactNode {
     executeSearch,
     searchResults, setSearchResults,
     setInputModeWithCallback: setInputMode as BindingContext["setInputModeWithCallback"],
-    setEditorPath,
+    openEditor,
   };
 
   useKeyboard(
@@ -778,7 +787,7 @@ export default function FileExplorerPanel(): React.ReactNode {
     <box height="100%" width="100%" flexDirection="column">
       {/* Full-screen file editor */}
       {editorPath ? (
-        <FileEditor path={editorPath} onClose={() => setEditorPath(null)} />
+        <FileEditor path={editorPath} onClose={closeEditor} />
       ) : <>
 
       {/* Panel-level tab bar */}

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -31,6 +31,7 @@ import { Breadcrumb } from "../../shared/components/breadcrumb.js";
 import { ConfirmDialog } from "../../shared/components/confirm-dialog.js";
 import { FileTree, flattenVisibleNodes, LOAD_MORE_SENTINEL } from "./file-tree.js";
 import { FilePreview } from "./file-preview.js";
+import { FileEditor } from "./file-editor.js";
 import { FileMetadata } from "./file-metadata.js";
 import { FileAspects } from "./file-aspects.js";
 import { FileSchema } from "./file-schema.js";
@@ -66,7 +67,7 @@ const ALL_TABS: readonly TabDef<FilesTab>[] = [
 // Input mode types
 // =============================================================================
 
-type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest" | "write";
+type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest";
 
 // =============================================================================
 // Keybinding builders — one function per mode (Decision 6A)
@@ -133,6 +134,8 @@ interface BindingContext {
   readonly setSearchResults: (v: readonly { path: string; line?: number; content?: string }[] | null) => void;
   // Paste destination input
   readonly setInputModeWithCallback: (mode: InputMode, onSubmit: (value: string) => void) => void;
+  // Editor
+  readonly setEditorPath: (path: string | null) => void;
 }
 
 /** Navigation bindings for the currently active tab (Decision 5A). */
@@ -230,13 +233,11 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
         ctx.setInputBuffer(ctx.selectedItem.name);
       }
     },
-    // Write/create file: enter "path content" (space-separated after first space)
+    // Edit file: open full-screen editor
     e: () => {
-      const defaultPath = ctx.selectedItem
-        ? (ctx.selectedItem.isDirectory ? ctx.selectedItem.path + "/" : ctx.selectedItem.path)
-        : ctx.currentPath + "/";
-      ctx.setInputMode("write");
-      ctx.setInputBuffer(defaultPath);
+      if (ctx.selectedItem && !ctx.selectedItem.isDirectory) {
+        ctx.setEditorPath(ctx.selectedItem.path);
+      }
     },
     // Copy path to system clipboard
     y: () => {
@@ -398,31 +399,6 @@ function getInputModeBindings(
         },
       };
 
-    case "write":
-      return {
-        ...baseBindings,
-        return: () => {
-          const input = ctx.filterQuery.trim();
-          if (!input || !ctx.client) { resetInput(); return; }
-          // Format: "path content..." — first space separates path from content
-          const spaceIdx = input.indexOf(" ");
-          const filePath = spaceIdx > 0 ? input.slice(0, spaceIdx) : input;
-          const content = spaceIdx > 0 ? input.slice(spaceIdx + 1) : "";
-          ctx.client.post("/api/v2/files/write", {
-            path: filePath,
-            content: content || `# New file created at ${new Date().toISOString()}\n`,
-          }).then(() => {
-            // Refresh the parent directory
-            const parentDir = filePath.split("/").slice(0, -1).join("/") || "/";
-            useFilesStore.getState().invalidate(parentDir);
-            if (ctx.client) useFilesStore.getState().expandNode(parentDir, ctx.client);
-          }).catch(() => {
-            // Error will show in error bar
-          });
-          resetInput();
-        },
-      };
-
     default:
       return {};
   }
@@ -465,7 +441,6 @@ function getInputLabel(mode: InputMode, buffer: string): string {
     case "filter": return `/${buffer}\u2588`;
     case "search": return `Search (g: glob, r: grep): ${buffer}\u2588`;
     case "paste-dest": return `Paste to: ${buffer}\u2588`;
-    case "write": return `Write (path content): ${buffer}\u2588`;
     default: return "";
   }
 }
@@ -499,7 +474,7 @@ function getHelpText(
     if (clipboard) {
       parts.push(`p:paste ${clipboard.paths.length} ${clipboard.operation === "cut" ? "cut" : "copied"}`, "P:paste to path");
     }
-    parts.push("d:del", "N:mkdir", "R:rename", "e:write");
+    parts.push("d:del", "N:mkdir", "R:rename", "e:edit");
     if (catalogAvailable) parts.push("m/a/s:meta");
     parts.push("?:help");
     return parts.join("  ");
@@ -638,6 +613,9 @@ export default function FileExplorerPanel(): React.ReactNode {
   // Clipboard copy (system)
   const { copy, copied } = useCopy();
 
+  // Editor overlay state
+  const [editorPath, setEditorPath] = useState<string | null>(null);
+
   // Dialog state
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -739,6 +717,7 @@ export default function FileExplorerPanel(): React.ReactNode {
     executeSearch,
     searchResults, setSearchResults,
     setInputModeWithCallback: setInputMode as BindingContext["setInputModeWithCallback"],
+    setEditorPath,
   };
 
   useKeyboard(
@@ -775,6 +754,11 @@ export default function FileExplorerPanel(): React.ReactNode {
 
   return (
     <box height="100%" width="100%" flexDirection="column">
+      {/* Full-screen file editor */}
+      {editorPath ? (
+        <FileEditor path={editorPath} onClose={() => setEditorPath(null)} />
+      ) : <>
+
       {/* Panel-level tab bar */}
       <box height={1} width="100%">
         <text>
@@ -921,6 +905,7 @@ export default function FileExplorerPanel(): React.ReactNode {
         onConfirm={handleConfirmDelete}
         onCancel={handleCancelDelete}
       />
+    </>}
     </box>
   );
 }

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -66,7 +66,7 @@ const ALL_TABS: readonly TabDef<FilesTab>[] = [
 // Input mode types
 // =============================================================================
 
-type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest";
+type InputMode = "none" | "mkdir" | "rename" | "filter" | "search" | "paste-dest" | "write";
 
 // =============================================================================
 // Keybinding builders — one function per mode (Decision 6A)
@@ -230,6 +230,14 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
         ctx.setInputBuffer(ctx.selectedItem.name);
       }
     },
+    // Write/create file: enter "path content" (space-separated after first space)
+    e: () => {
+      const defaultPath = ctx.selectedItem
+        ? (ctx.selectedItem.isDirectory ? ctx.selectedItem.path + "/" : ctx.selectedItem.path)
+        : ctx.currentPath + "/";
+      ctx.setInputMode("write");
+      ctx.setInputBuffer(defaultPath);
+    },
     // Copy path to system clipboard
     y: () => {
       if (ctx.isSentinel) return;
@@ -390,6 +398,31 @@ function getInputModeBindings(
         },
       };
 
+    case "write":
+      return {
+        ...baseBindings,
+        return: () => {
+          const input = ctx.filterQuery.trim();
+          if (!input || !ctx.client) { resetInput(); return; }
+          // Format: "path content..." — first space separates path from content
+          const spaceIdx = input.indexOf(" ");
+          const filePath = spaceIdx > 0 ? input.slice(0, spaceIdx) : input;
+          const content = spaceIdx > 0 ? input.slice(spaceIdx + 1) : "";
+          ctx.client.post("/api/v2/files/write", {
+            path: filePath,
+            content: content || `# New file created at ${new Date().toISOString()}\n`,
+          }).then(() => {
+            // Refresh the parent directory
+            const parentDir = filePath.split("/").slice(0, -1).join("/") || "/";
+            useFilesStore.getState().invalidate(parentDir);
+            if (ctx.client) useFilesStore.getState().expandNode(parentDir, ctx.client);
+          }).catch(() => {
+            // Error will show in error bar
+          });
+          resetInput();
+        },
+      };
+
     default:
       return {};
   }
@@ -432,6 +465,7 @@ function getInputLabel(mode: InputMode, buffer: string): string {
     case "filter": return `/${buffer}\u2588`;
     case "search": return `Search (g: glob, r: grep): ${buffer}\u2588`;
     case "paste-dest": return `Paste to: ${buffer}\u2588`;
+    case "write": return `Write (path content): ${buffer}\u2588`;
     default: return "";
   }
 }
@@ -465,8 +499,9 @@ function getHelpText(
     if (clipboard) {
       parts.push(`p:paste ${clipboard.paths.length} ${clipboard.operation === "cut" ? "cut" : "copied"}`, "P:paste to path");
     }
-    parts.push("d:del", "N:mkdir", "R:rename");
+    parts.push("d:del", "N:mkdir", "R:rename", "e:write");
     if (catalogAvailable) parts.push("m/a/s:meta");
+    parts.push("?:help");
     return parts.join("  ");
   }
 

--- a/packages/nexus-tui/src/shared/components/help-overlay.tsx
+++ b/packages/nexus-tui/src/shared/components/help-overlay.tsx
@@ -55,6 +55,7 @@ export const PANEL_BINDINGS: Record<string, readonly KeyBinding[]> = {
     { key: "Shift+N", action: "New directory" },
     { key: "Shift+R", action: "Rename" },
     { key: "e", action: "Edit file (full editor)" },
+    { key: "Shift+E", action: "Create new file" },
     { key: "/", action: "Quick filter (fuzzy)" },
     { key: "Ctrl+F", action: "Power search (glob/grep/deep)" },
     { key: "v", action: "Toggle visual mode" },

--- a/packages/nexus-tui/src/shared/components/help-overlay.tsx
+++ b/packages/nexus-tui/src/shared/components/help-overlay.tsx
@@ -54,7 +54,7 @@ export const PANEL_BINDINGS: Record<string, readonly KeyBinding[]> = {
     { key: "d", action: "Delete file" },
     { key: "Shift+N", action: "New directory" },
     { key: "Shift+R", action: "Rename" },
-    { key: "e", action: "Write/create file (path content)" },
+    { key: "e", action: "Edit file (full editor)" },
     { key: "/", action: "Quick filter (fuzzy)" },
     { key: "Ctrl+F", action: "Power search (glob/grep/deep)" },
     { key: "v", action: "Toggle visual mode" },

--- a/packages/nexus-tui/src/shared/components/help-overlay.tsx
+++ b/packages/nexus-tui/src/shared/components/help-overlay.tsx
@@ -54,6 +54,7 @@ export const PANEL_BINDINGS: Record<string, readonly KeyBinding[]> = {
     { key: "d", action: "Delete file" },
     { key: "Shift+N", action: "New directory" },
     { key: "Shift+R", action: "Rename" },
+    { key: "e", action: "Write/create file (path content)" },
     { key: "/", action: "Quick filter (fuzzy)" },
     { key: "Ctrl+F", action: "Power search (glob/grep/deep)" },
     { key: "v", action: "Toggle visual mode" },

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -53,7 +53,7 @@ export function PreConnectionScreen(): React.ReactNode {
     ) {
       // Re-read config from disk without triggering connection test.
       // resolveConfig() picks up new api_key/ports from nexus.yaml.
-      const config = resolveConfig();
+      const config = resolveConfig({ transformKeys: false });
       const client = config.apiKey ? new FetchClient(config) : null;
       useGlobalStore.setState({
         config,

--- a/packages/nexus-tui/src/shared/components/tab-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/tab-bar.tsx
@@ -37,8 +37,8 @@ export function TabBar({ tabs, activeTab }: TabBarProps): React.ReactNode {
             ) : (
               <span>
                 <span>{"  "}</span>
-                <span foregroundColor="#555555">{`${tab.shortcut}:`}</span>
-                <span foregroundColor="#777777">{tab.label}</span>
+                <span foregroundColor="#808080">{`${tab.shortcut}:`}</span>
+                <span foregroundColor="#aaaaaa">{tab.label}</span>
                 <span foregroundColor="#444444">{suffix}</span>
               </span>
             )}

--- a/packages/nexus-tui/src/shared/components/tab-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/tab-bar.tsx
@@ -20,31 +20,32 @@ interface TabBarProps {
 }
 
 export function TabBar({ tabs, activeTab }: TabBarProps): React.ReactNode {
+  // Render all tabs as spans inside a single <text> to avoid flex layout
+  // width issues that can cause some tab labels to disappear.
   return (
-    <box height={1} width="100%" flexDirection="row">
-      {tabs.map((tab, index) => {
-        const isActive = tab.id === activeTab;
-        const suffix = index < tabs.length - 1 ? " │" : "";
-        return (
-          <text key={tab.id}>
-            {isActive ? (
-              <span>
+    <box height={1} width="100%">
+      <text>
+        {tabs.map((tab, index) => {
+          const isActive = tab.id === activeTab;
+          const suffix = index < tabs.length - 1 ? " │ " : "";
+          if (isActive) {
+            return (
+              <span key={tab.id}>
                 <span foregroundColor="#00d4ff" bold>{"▸ "}</span>
                 <span foregroundColor="#888888">{`${tab.shortcut}:`}</span>
                 <span foregroundColor="#00d4ff" bold>{tab.label}</span>
-                <span foregroundColor="#444444">{suffix}</span>
+                <span foregroundColor="#555555">{suffix}</span>
               </span>
-            ) : (
-              <span>
-                <span>{"  "}</span>
-                <span foregroundColor="#808080">{`${tab.shortcut}:`}</span>
-                <span foregroundColor="#aaaaaa">{tab.label}</span>
-                <span foregroundColor="#444444">{suffix}</span>
-              </span>
-            )}
-          </text>
-        );
-      })}
+            );
+          }
+          return (
+            <span key={tab.id}>
+              <span foregroundColor="#999999">{`  ${tab.shortcut}:${tab.label}`}</span>
+              <span foregroundColor="#555555">{suffix}</span>
+            </span>
+          );
+        })}
+      </text>
     </box>
   );
 }

--- a/packages/nexus-tui/src/stores/files-store.ts
+++ b/packages/nexus-tui/src/stores/files-store.ts
@@ -482,7 +482,11 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   deleteFile: async (path, client) => {
     set({ error: null });
     try {
-      await client.delete(`/api/v2/files/delete?path=${encodeURIComponent(path)}`);
+      // Pass active transaction ID if one exists
+      const { useVersionsStore } = await import("./versions-store.js");
+      const activeTxn = useVersionsStore.getState().selectedTransaction;
+      const txnParam = activeTxn?.status === "active" ? `&transaction_id=${activeTxn.transaction_id}` : "";
+      await client.delete(`/api/v2/files/delete?path=${encodeURIComponent(path)}${txnParam}`);
       const parentPath = path.split("/").slice(0, -1).join("/") || "/";
       get().invalidate(parentPath);
       await get().fetchFiles(parentPath, client);

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -97,7 +97,7 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
   featuresLastFetched: 0,
 
   initConfig: (overrides) => {
-    const config = resolveConfig(overrides);
+    const config = resolveConfig({ transformKeys: false, ...overrides });
     const client = config.apiKey ? new FetchClient(config) : null;
     set({ config, client, connectionStatus: client ? "connecting" : "disconnected" });
 

--- a/packages/nexus-tui/src/stores/share-link-store.ts
+++ b/packages/nexus-tui/src/stores/share-link-store.ts
@@ -78,7 +78,7 @@ export const useShareLinkStore = create<ShareLinkState>((set, get) => ({
         },
       );
       return {
-        links: response.result ?? [],
+        links: Array.isArray(response?.result) ? response.result : [],
         selectedLinkIndex: 0,
       };
     },

--- a/packages/nexus-tui/src/stores/ui-store.ts
+++ b/packages/nexus-tui/src/stores/ui-store.ts
@@ -29,6 +29,9 @@ export interface UiState {
   /** True when a global overlay (welcome, help, identity switcher) is active. */
   readonly overlayActive: boolean;
 
+  /** True when a full-screen panel-level editor is open (suppresses global keybindings). */
+  readonly fileEditorOpen: boolean;
+
   // Actions
   readonly setFocusPane: (panel: string, pane: FocusPane) => void;
   readonly toggleFocusPane: (panel: string) => void;
@@ -38,6 +41,7 @@ export interface UiState {
   readonly setScrollPosition: (key: string, position: number) => void;
   readonly getScrollPosition: (key: string) => number;
   readonly setOverlayActive: (active: boolean) => void;
+  readonly setFileEditorOpen: (open: boolean) => void;
 }
 
 // =============================================================================
@@ -49,6 +53,7 @@ export const useUiStore = create<UiState>((set, get) => ({
   zoomedPanel: null,
   scrollPositions: {},
   overlayActive: false,
+  fileEditorOpen: false,
 
   setFocusPane: (panel, pane) => {
     set((state) => ({
@@ -90,5 +95,9 @@ export const useUiStore = create<UiState>((set, get) => ({
 
   setOverlayActive: (active) => {
     set({ overlayActive: active });
+  },
+
+  setFileEditorOpen: (open) => {
+    set({ fileEditorOpen: open });
   },
 }));

--- a/packages/nexus-tui/src/stores/versions-store.ts
+++ b/packages/nexus-tui/src/stores/versions-store.ts
@@ -181,7 +181,7 @@ export const useVersionsStore = create<VersionsState>((set, get) => ({
       const transactions = response.transactions ?? [];
       set({ transactions, isLoading: false });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to fetch transactions";
+      const message = err instanceof Error ? err.message : String(err ?? "Failed to fetch transactions");
       set({
         isLoading: false,
         error: message,
@@ -221,7 +221,7 @@ export const useVersionsStore = create<VersionsState>((set, get) => ({
       );
       set({ entries: entries ?? [], entriesLoading: false });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to fetch entries";
+      const message = err instanceof Error ? err.message : String(err ?? "Failed to fetch entries");
       set({
         entries: [],
         entriesLoading: false,
@@ -252,7 +252,7 @@ export const useVersionsStore = create<VersionsState>((set, get) => ({
         diffLoading: false,
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to fetch diff";
+      const message = err instanceof Error ? err.message : String(err ?? "Failed to fetch diff");
       set({
         diffContent: null,
         diffLoading: false,
@@ -280,7 +280,7 @@ export const useVersionsStore = create<VersionsState>((set, get) => ({
         get().selectTransaction(fresh);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to begin transaction";
+      const message = err instanceof Error ? err.message : String(err ?? "Failed to begin transaction");
       set({ error: message });
       useErrorStore.getState().pushError({ message, category: categorizeError(message), source: SOURCE });
     }
@@ -294,9 +294,11 @@ export const useVersionsStore = create<VersionsState>((set, get) => ({
         `/api/v2/snapshots/${encodeURIComponent(txnId)}/commit`,
         {},
       );
+      // Clear selection since transaction is no longer active
+      set({ selectedTransaction: null });
       await get().fetchTransactions(client);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to commit transaction";
+      const message = err instanceof Error ? err.message : String(err ?? "Failed to commit transaction");
       set({ error: message });
       useErrorStore.getState().pushError({ message, category: categorizeError(message), source: SOURCE });
     }
@@ -310,9 +312,11 @@ export const useVersionsStore = create<VersionsState>((set, get) => ({
         `/api/v2/snapshots/${encodeURIComponent(txnId)}/rollback`,
         {},
       );
+      // Clear selection since transaction is no longer active
+      set({ selectedTransaction: null });
       await get().fetchTransactions(client);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to rollback transaction";
+      const message = err instanceof Error ? err.message : String(err ?? "Failed to rollback transaction");
       set({ error: message });
       useErrorStore.getState().pushError({ message, category: categorizeError(message), source: SOURCE });
     }
@@ -330,7 +334,7 @@ export const useVersionsStore = create<VersionsState>((set, get) => ({
         conflictsLoading: false,
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to fetch conflicts";
+      const message = err instanceof Error ? err.message : String(err ?? "Failed to fetch conflicts");
       set({
         conflicts: [],
         conflictsLoading: false,

--- a/packages/nexus-tui/src/stores/versions-store.ts
+++ b/packages/nexus-tui/src/stores/versions-store.ts
@@ -270,8 +270,15 @@ export const useVersionsStore = create<VersionsState>((set, get) => ({
       if (description !== undefined) body["description"] = description;
       if (ttlSeconds !== undefined) body["ttl_seconds"] = ttlSeconds;
 
-      await client.post<Transaction>("/api/v2/snapshots", body);
+      const newTxn = await client.post<Transaction>("/api/v2/snapshots", body);
       await get().fetchTransactions(client);
+      // Auto-select the newly created transaction so the editor shows [txn:xxx]
+      if (newTxn?.transaction_id) {
+        const fresh = get().transactions.find(
+          (t) => t.transaction_id === newTxn.transaction_id,
+        ) ?? newTxn;
+        get().selectTransaction(fresh);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to begin transaction";
       set({ error: message });

--- a/src/nexus/bricks/snapshot/service.py
+++ b/src/nexus/bricks/snapshot/service.py
@@ -468,12 +468,41 @@ class TransactionalSnapshotService:
         for entry in reversed(entries):
             try:
                 if entry.original_hash is not None and entry.original_metadata is not None:
-                    # Restore file to pre-transaction state
+                    # Restore file to pre-transaction state (full metadata available)
                     restored = self._restore_metadata_from_snapshot(
                         entry.path, entry.original_hash, entry.original_metadata
                     )
                     self._metadata_store.put(restored)
                     logger.debug("Restored file: path=%s hash=%s", entry.path, entry.original_hash)
+                elif entry.original_hash is not None and entry.original_metadata is None:
+                    # Restore with minimal metadata (original_metadata was not captured)
+                    if self._metadata_factory is not None:
+                        current_meta = self._metadata_store.get(entry.path)
+                        restored = self._metadata_factory(
+                            path=entry.path,
+                            backend_name=getattr(current_meta, "backend_name", "local")
+                            if current_meta
+                            else "local",
+                            physical_path=entry.original_hash,
+                            size=getattr(current_meta, "size", 0) if current_meta else 0,
+                            etag=entry.original_hash,
+                            created_at=getattr(current_meta, "created_at", None)
+                            or datetime.now(UTC),
+                            modified_at=datetime.now(UTC),
+                            version=(getattr(current_meta, "version", 1) if current_meta else 1),
+                            zone_id=getattr(current_meta, "zone_id", "root")
+                            if current_meta
+                            else "root",
+                            owner_id=getattr(current_meta, "owner_id", None)
+                            if current_meta
+                            else None,
+                        )
+                        self._metadata_store.put(restored)
+                        logger.debug(
+                            "Restored file (minimal): path=%s hash=%s",
+                            entry.path,
+                            entry.original_hash,
+                        )
                 elif entry.operation == "write" and entry.original_hash is None:
                     # New file created during transaction — delete it
                     try:

--- a/src/nexus/bricks/snapshot/service.py
+++ b/src/nexus/bricks/snapshot/service.py
@@ -204,7 +204,7 @@ class TransactionalSnapshotService:
     ) -> None:
         """Internal: track a filesystem operation within a transaction."""
         # Hold CAS reference to prevent GC of original content
-        if original_hash is not None:
+        if original_hash is not None and hasattr(self._cas_store, "hold_reference"):
             held = self._cas_store.hold_reference(original_hash)
             if not held:
                 logger.warning(
@@ -218,7 +218,7 @@ class TransactionalSnapshotService:
         tracked = self._registry.track_path(transaction_id, path)
         if not tracked:
             # Release the hold we just acquired since we can't track
-            if original_hash is not None:
+            if original_hash is not None and hasattr(self._cas_store, "release"):
                 self._cas_store.release(original_hash)
             raise TransactionConflictError(
                 conflicts=[
@@ -249,7 +249,7 @@ class TransactionalSnapshotService:
                 transaction_id,
             )
             # Release CAS hold to prevent ref_count leak (CRITICAL-2 fix)
-            if original_hash is not None:
+            if original_hash is not None and hasattr(self._cas_store, "release"):
                 try:
                     self._cas_store.release(original_hash)
                 except Exception:

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -370,6 +370,10 @@ def create_async_files_router(
             None,
             description="Write consistency mode: 'sync' (default, strong) or 'async' (eventual)",
         ),
+        transaction_id: str | None = Query(
+            None,
+            description="Active transaction ID to track this write in (from snapshots API)",
+        ),
         context: Any = Depends(get_context),
     ) -> Response:
         """
@@ -384,6 +388,17 @@ def create_async_files_router(
         """
         try:
             fs = await _get_fs()
+
+            # Pre-register path with active transaction so the NexusFS write
+            # path's is_tracked() check finds it and calls track_write().
+            if transaction_id:
+                _ss = getattr(getattr(fs, "_brick_services", None), "snapshot_service", None)
+                if _ss is not None:
+                    _ss.validate_path_available(transaction_id, request.path)
+                    # Track path in the in-memory registry so is_tracked() returns
+                    # this transaction_id during the subsequent fs.write() call.
+                    _ss._registry.track_path(transaction_id, request.path)
+
             # Decode content based on encoding
             if request.encoding == "base64":
                 content = base64.b64decode(request.content)
@@ -523,11 +538,23 @@ def create_async_files_router(
     @router.delete("/delete", response_model=DeleteResponse)
     async def delete_file(
         path: str = Query(..., description="Path to delete"),
+        transaction_id: str | None = Query(
+            None,
+            description="Active transaction ID to track this delete in",
+        ),
         context: Any = Depends(get_context),
     ) -> DeleteResponse:
         """Delete a file."""
         try:
             fs = await _get_fs()
+
+            # Pre-register path with active transaction for delete tracking
+            if transaction_id:
+                _ss = getattr(getattr(fs, "_brick_services", None), "snapshot_service", None)
+                if _ss is not None:
+                    _ss.validate_path_available(transaction_id, path)
+                    _ss._registry.track_path(transaction_id, path)
+
             await fs.sys_unlink(path, context=context)
             return DeleteResponse(deleted=True, path=path)
 

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -390,19 +390,29 @@ def create_async_files_router(
         try:
             fs = await _get_fs()
 
-            # Snapshot tracking setup: validate conflict + capture original hash BEFORE write
+            # Snapshot tracking setup: validate conflict + capture original state BEFORE write
             _ss = None
             _norm_path: str | None = None
             _original_hash: str | None = None
+            _original_metadata: dict[str, Any] | None = None
             if transaction_id:
                 _ss = getattr(getattr(fs, "_brick_services", None), "snapshot_service", None)
                 if _ss is not None:
                     _norm_path = _normalize_path(request.path)
                     _ss.validate_path_available(transaction_id, _norm_path)
-                    # Capture original hash for CAS hold (enables proper rollback)
+                    # Capture original state for rollback
                     try:
                         _orig_meta = fs.metadata.get(_norm_path)
-                        _original_hash = _orig_meta.etag if _orig_meta else None
+                        if _orig_meta:
+                            _original_hash = _orig_meta.etag
+                            _original_metadata = {
+                                "size": _orig_meta.size,
+                                "version": _orig_meta.version,
+                                "modified_at": _orig_meta.modified_at.isoformat()
+                                if _orig_meta.modified_at
+                                else None,
+                                "backend_name": getattr(_orig_meta, "backend_name", None),
+                            }
                     except Exception:
                         _original_hash = None
                 else:
@@ -446,7 +456,7 @@ def create_async_files_router(
                         transaction_id=transaction_id,
                         path=_norm_path,
                         original_hash=_original_hash,
-                        original_metadata=None,
+                        original_metadata=_original_metadata,
                         new_hash=result.get("etag"),
                     )
                     logger.info("txn tracked write: txn=%s path=%s", transaction_id, _norm_path)
@@ -577,6 +587,7 @@ def create_async_files_router(
             _ss = None
             _norm_path: str | None = None
             _original_hash: str | None = None
+            _original_metadata: dict[str, Any] | None = None
             if transaction_id:
                 _ss = getattr(getattr(fs, "_brick_services", None), "snapshot_service", None)
                 if _ss is not None:
@@ -584,7 +595,16 @@ def create_async_files_router(
                     _ss.validate_path_available(transaction_id, _norm_path)
                     try:
                         _orig_meta = fs.metadata.get(_norm_path)
-                        _original_hash = _orig_meta.etag if _orig_meta else None
+                        if _orig_meta:
+                            _original_hash = _orig_meta.etag
+                            _original_metadata = {
+                                "size": _orig_meta.size,
+                                "version": _orig_meta.version,
+                                "modified_at": _orig_meta.modified_at.isoformat()
+                                if _orig_meta.modified_at
+                                else None,
+                                "backend_name": getattr(_orig_meta, "backend_name", None),
+                            }
                     except Exception:
                         _original_hash = None
 
@@ -596,7 +616,7 @@ def create_async_files_router(
                         transaction_id=transaction_id,
                         path=_norm_path,
                         original_hash=_original_hash,
-                        original_metadata=None,
+                        original_metadata=_original_metadata,
                     )
                 except Exception as _track_err:
                     logger.warning("txn track delete failed: %s", _track_err)

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, Field
 
 from nexus.bricks.search.primitives.glob_fast import glob_filter
 from nexus.bricks.search.primitives.grep_fast import grep_files_mmap
+from nexus.bricks.snapshot.errors import TransactionConflictError as _TransactionConflictError
 from nexus.contracts.exceptions import (
     ConflictError,
     InvalidPathError,
@@ -448,9 +449,13 @@ def create_async_files_router(
             # fs.write is async — call directly
             result = await fs.write(**write_kwargs)
 
-            # Track write in transaction AFTER successful write (direct call, bypasses
-            # is_tracked() timing issues in _write_internal)
-            if _ss is not None and _norm_path is not None:
+            # Track write in transaction AFTER successful write.
+            # Skip if _write_internal already tracked it (path already in registry).
+            if (
+                _ss is not None
+                and _norm_path is not None
+                and _ss._registry.get_transaction_for_path(_norm_path) != transaction_id
+            ):
                 try:
                     _ss.track_write(
                         transaction_id=transaction_id,
@@ -486,6 +491,8 @@ def create_async_files_router(
         except ConflictError as e:
             raise HTTPException(status_code=409, detail=str(e)) from e
         except FileExistsError as e:
+            raise HTTPException(status_code=409, detail=str(e)) from e
+        except _TransactionConflictError as e:
             raise HTTPException(status_code=409, detail=str(e)) from e
         except Exception as e:
             logger.exception(f"Write error: {e}")
@@ -610,7 +617,11 @@ def create_async_files_router(
 
             await fs.sys_unlink(path, context=context)
 
-            if _ss is not None and _norm_path is not None:
+            if (
+                _ss is not None
+                and _norm_path is not None
+                and _ss._registry.get_transaction_for_path(_norm_path) != transaction_id
+            ):
                 try:
                     _ss.track_delete(
                         transaction_id=transaction_id,
@@ -629,6 +640,8 @@ def create_async_files_router(
             raise HTTPException(status_code=404, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
+        except _TransactionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e)) from e
         except Exception as e:
             logger.exception(f"Delete error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -41,6 +41,7 @@ from nexus.contracts.exceptions import (
     NexusFileNotFoundError,
     NexusPermissionError,
 )
+from nexus.lib.path_utils import validate_path as _normalize_path
 
 logger = logging.getLogger(__name__)
 
@@ -389,15 +390,25 @@ def create_async_files_router(
         try:
             fs = await _get_fs()
 
-            # Pre-register path with active transaction so the NexusFS write
-            # path's is_tracked() check finds it and calls track_write().
+            # Snapshot tracking setup: validate conflict + capture original hash BEFORE write
+            _ss = None
+            _norm_path: str | None = None
+            _original_hash: str | None = None
             if transaction_id:
                 _ss = getattr(getattr(fs, "_brick_services", None), "snapshot_service", None)
                 if _ss is not None:
-                    _ss.validate_path_available(transaction_id, request.path)
-                    # Track path in the in-memory registry so is_tracked() returns
-                    # this transaction_id during the subsequent fs.write() call.
-                    _ss._registry.track_path(transaction_id, request.path)
+                    _norm_path = _normalize_path(request.path)
+                    _ss.validate_path_available(transaction_id, _norm_path)
+                    # Capture original hash for CAS hold (enables proper rollback)
+                    try:
+                        _orig_meta = fs.metadata.get(_norm_path)
+                        _original_hash = _orig_meta.etag if _orig_meta else None
+                    except Exception:
+                        _original_hash = None
+                else:
+                    logger.warning(
+                        "txn track: snapshot_service unavailable, skipping txn=%s", transaction_id
+                    )
 
             # Decode content based on encoding
             if request.encoding == "base64":
@@ -426,6 +437,21 @@ def create_async_files_router(
 
             # fs.write is async — call directly
             result = await fs.write(**write_kwargs)
+
+            # Track write in transaction AFTER successful write (direct call, bypasses
+            # is_tracked() timing issues in _write_internal)
+            if _ss is not None and _norm_path is not None:
+                try:
+                    _ss.track_write(
+                        transaction_id=transaction_id,
+                        path=_norm_path,
+                        original_hash=_original_hash,
+                        original_metadata=None,
+                        new_hash=result.get("etag"),
+                    )
+                    logger.info("txn tracked write: txn=%s path=%s", transaction_id, _norm_path)
+                except Exception as _track_err:
+                    logger.warning("txn track write failed: %s", _track_err)
 
             modified = result["modified_at"]
             if hasattr(modified, "isoformat"):
@@ -548,14 +574,33 @@ def create_async_files_router(
         try:
             fs = await _get_fs()
 
-            # Pre-register path with active transaction for delete tracking
+            _ss = None
+            _norm_path: str | None = None
+            _original_hash: str | None = None
             if transaction_id:
                 _ss = getattr(getattr(fs, "_brick_services", None), "snapshot_service", None)
                 if _ss is not None:
-                    _ss.validate_path_available(transaction_id, path)
-                    _ss._registry.track_path(transaction_id, path)
+                    _norm_path = _normalize_path(path)
+                    _ss.validate_path_available(transaction_id, _norm_path)
+                    try:
+                        _orig_meta = fs.metadata.get(_norm_path)
+                        _original_hash = _orig_meta.etag if _orig_meta else None
+                    except Exception:
+                        _original_hash = None
 
             await fs.sys_unlink(path, context=context)
+
+            if _ss is not None and _norm_path is not None:
+                try:
+                    _ss.track_delete(
+                        transaction_id=transaction_id,
+                        path=_norm_path,
+                        original_hash=_original_hash,
+                        original_metadata=None,
+                    )
+                except Exception as _track_err:
+                    logger.warning("txn track delete failed: %s", _track_err)
+
             return DeleteResponse(deleted=True, path=path)
 
         except NexusPermissionError as e:

--- a/src/nexus/server/api/v2/routers/snapshots.py
+++ b/src/nexus/server/api/v2/routers/snapshots.py
@@ -95,7 +95,10 @@ async def get_snapshot_context(request: Request) -> tuple[Any, str, str | None]:
     if nexus_fs is None:
         raise HTTPException(status_code=503, detail="NexusFS not initialized")
 
-    snapshot_service = getattr(nexus_fs, "_snapshot_service", None)
+    # Check app.state first (wired by lifespan), then fall back to nexus_fs attr
+    snapshot_service = getattr(request.app.state, "transactional_snapshot_service", None)
+    if snapshot_service is None:
+        snapshot_service = getattr(nexus_fs, "_snapshot_service", None)
     if snapshot_service is None:
         raise HTTPException(status_code=503, detail="Snapshot service not available")
 

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -143,7 +143,7 @@ class LifespanServices:
             coordination_client=(getattr(nx, "_coordination_client", None) if nx else None),
             workflow_engine=(getattr(nx, "workflow_engine", None) if nx else None),
             snapshot_service=(
-                (_brk or {}).get("snapshot_service")
+                getattr(_brk, "snapshot_service", None)
                 or (getattr(nx, "_snapshot_service", None) if nx else None)
             ),
             namespace_manager=(getattr(nx, "_namespace_manager", None) if nx else None),

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -142,7 +142,10 @@ class LifespanServices:
             event_bus=getattr(nx, "_event_bus", None) if nx else None,
             coordination_client=(getattr(nx, "_coordination_client", None) if nx else None),
             workflow_engine=(getattr(nx, "workflow_engine", None) if nx else None),
-            snapshot_service=(getattr(nx, "_snapshot_service", None) if nx else None),
+            snapshot_service=(
+                (_brk or {}).get("snapshot_service")
+                or (getattr(nx, "_snapshot_service", None) if nx else None)
+            ),
             namespace_manager=(getattr(nx, "_namespace_manager", None) if nx else None),
             nexus_config=getattr(nx, "config", None) if nx else None,
             observability_subsystem=(


### PR DESCRIPTION
## Summary
- **Editor keybinding suppression**: Global panel-switch keys (1-9, z, q, ?) fired while the file editor textarea was open because OpenTUI's `keyHandler` broadcasts to ALL `useKeyboard` handlers. Fixed by checking `useUiStore.getState().fileEditorOpen` synchronously inside each handler, bypassing React re-render timing. Verified working in tmux TUI test.
- **Transaction tracking (entries = 0)**: The `is_tracked()` mechanism in `_write_internal` was fragile. Now the write/delete API endpoints call `track_write()`/`track_delete()` directly after the filesystem operation succeeds — explicit, no registry timing issues.
- **CASLocalBackend missing `hold_reference`**: `_track_operation()` called `self._cas_store.hold_reference()` which doesn't exist on `CASLocalBackend`, causing all transaction tracking for existing files to silently fail. Fixed with `hasattr()` guard. Root cause confirmed via server log: `txn track write failed: 'CASLocalBackend' object has no attribute 'hold_reference'`.
- **React Rules of Hooks**: `useVersionsStore` hook in `file-editor.tsx` was called after a conditional return — moved to top level.
- **Auto-select transaction**: `beginTransaction` now auto-selects the new transaction so the editor shows `[txn:xxx]` and sends `transaction_id` on save.

## Test plan
- [x] Verified editor keybinding suppression in tmux TUI (typed "2" in editor → inserted as text, didn't switch tabs)
- [x] Verified transaction tracking via curl API calls (`entry_count: 1` after write with `transaction_id`)
- [x] Verified full TUI flow via Bun script (create txn → auto-select → write with txn_id → entry_count: 1)
- [x] Verified `hold_reference` crash in server logs and fix prevents it
- [ ] Manual test: restart `bun run dev`, Shift+U to rebuild server, create transaction, edit file, check entries