### PR TITLE
feat(#3128): scoped API key creation with per-path grants

### DIFF
--- a/alembic/versions/add_grant_tuple_ids_to_api_keys.py
+++ b/alembic/versions/add_grant_tuple_ids_to_api_keys.py
@@ -1,0 +1,40 @@
+"""Add grant_tuple_ids column to api_keys
+
+Revision ID: add_grant_tuple_ids
+Revises: update_file_namespace_shared
+Create Date: 2026-03-17
+
+Stores JSON array of ReBAC tuple IDs created as grants for this key,
+enabling targeted cleanup on key revocation (Issue #3128).
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_grant_tuple_ids"
+down_revision: Union[str, Sequence[str], None] = "a3062sec01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add grant_tuple_ids column to api_keys table."""
+    op.add_column(
+        "api_keys",
+        sa.Column(
+            "grant_tuple_ids",
+            sa.Text,
+            nullable=True,
+            comment="JSON array of ReBAC tuple IDs created as grants for this key",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove grant_tuple_ids column."""
+    op.drop_column("api_keys", "grant_tuple_ids")

--- a/examples/cli/permissions_demo_enhanced.sh
+++ b/examples/cli/permissions_demo_enhanced.sh
@@ -70,7 +70,11 @@ export DEMO_BASE="/workspace/rebac-comprehensive-demo"  # BUGFIX: Export for Pyt
 # scoping — meaning files created by root-zone admin live at /workspace/... while
 # non-admin users see /zone/default/workspace/... (zone-scoped). Using a
 # default-zone admin key ensures consistent path scoping across all operations.
-ADMIN_KEY=$(python3 scripts/create-api-key.py admin "Demo Admin (default zone)" --days 1 --zone-id default --admin 2>/dev/null | grep "API Key:" | awk '{print $3}')
+ADMIN_KEY=$(curl -s -X POST "$NEXUS_URL/api/v2/auth/keys" \
+    -H "Authorization: Bearer $NEXUS_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"user_id":"admin","name":"Demo Admin (default zone)","zone_id":"default","is_admin":true,"expires_days":1}' \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('key',''))" 2>/dev/null)
 if [ -z "$ADMIN_KEY" ]; then
     echo "WARNING: Failed to create default-zone admin key, falling back to root admin"
     ADMIN_KEY="$ROOT_ADMIN_KEY"
@@ -138,7 +142,7 @@ print(f"  Deleted {len(demo_tuples)} tuples related to demo paths")
 
 # 2. Delete all tuples for test users to ensure clean state
 print("  Deleting test user tuples...")
-for user in ['alice', 'bob', 'charlie', 'acme_user']:
+for user in ['alice', 'bob', 'charlie', 'acme_user', 'scoped-dave', 'multi-eve']:
     tuples = nx.rebac_list_tuples(subject=("user", user))
     for t in tuples:
         try:
@@ -226,18 +230,66 @@ echo ""
 echo "  This is the actual behavior - owners need editor/viewer role for read!"
 echo ""
 
-# Create test users
-ALICE_KEY=$(python3 scripts/create-api-key.py alice "Alice Owner" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
-BOB_KEY=$(python3 scripts/create-api-key.py bob "Bob Editor" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
-CHARLIE_KEY=$(python3 scripts/create-api-key.py charlie "Charlie Viewer" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
+# Helper: create a scoped API key via the REST API (Issue #3128)
+# Usage: create_scoped_key <user_id> <name> [--grant path:role ...] [--expires-days N]
+# Returns: raw API key on stdout
+create_scoped_key() {
+    local user_id="$1"; shift
+    local key_name="$1"; shift
+    local grants_json=""
+    local expires_days=""
 
-# BUGFIX: Ensure test resources exist before assigning permissions
+    # Parse remaining args
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --grant)
+                local path="${2%%:*}"
+                local role="${2##*:}"
+                if [ -z "$grants_json" ]; then
+                    grants_json="[{\"path\":\"$path\",\"role\":\"$role\"}"
+                else
+                    grants_json="$grants_json,{\"path\":\"$path\",\"role\":\"$role\"}"
+                fi
+                shift 2 ;;
+            --expires-days)
+                expires_days="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    [ -n "$grants_json" ] && grants_json="$grants_json]"
+
+    local body="{\"user_id\":\"$user_id\",\"name\":\"$key_name\",\"subject_type\":\"user\""
+    [ -n "$expires_days" ] && body="$body,\"expires_days\":$expires_days"
+    [ -n "$grants_json" ] && body="$body,\"grants\":$grants_json"
+    body="$body}"
+
+    curl -s -X POST "$NEXUS_URL/api/v2/auth/keys" \
+        -H "Authorization: Bearer $NEXUS_API_KEY" \
+        -H "Content-Type: application/json" \
+        -d "$body"
+}
+
+# Create test users with scoped grants via REST API (Issue #3128)
 echo "test content" | nexus write $DEMO_BASE/test-file.txt - 2>/dev/null
 print_success "Created test-file.txt"
 
-nexus rebac create user alice direct_owner file $DEMO_BASE/test-file.txt
-nexus rebac create user bob direct_editor file $DEMO_BASE/test-file.txt
-nexus rebac create user charlie direct_viewer file $DEMO_BASE/test-file.txt
+ALICE_RESP=$(create_scoped_key alice "Alice Owner" \
+    --grant "$DEMO_BASE/test-file.txt:owner" --expires-days 1)
+ALICE_KEY=$(echo "$ALICE_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])")
+ALICE_KEY_ID=$(echo "$ALICE_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key_id'])")
+print_success "Created alice with owner grant on test-file.txt (via REST API)"
+
+BOB_RESP=$(create_scoped_key bob "Bob Editor" \
+    --grant "$DEMO_BASE/test-file.txt:editor" --expires-days 1)
+BOB_KEY=$(echo "$BOB_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])")
+BOB_KEY_ID=$(echo "$BOB_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key_id'])")
+print_success "Created bob with editor grant on test-file.txt (via REST API)"
+
+CHARLIE_RESP=$(create_scoped_key charlie "Charlie Viewer" \
+    --grant "$DEMO_BASE/test-file.txt:viewer" --expires-days 1)
+CHARLIE_KEY=$(echo "$CHARLIE_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])")
+CHARLIE_KEY_ID=$(echo "$CHARLIE_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key_id'])")
+print_success "Created charlie with viewer grant on test-file.txt (via REST API)"
 
 print_test "Verify alice (owner) has write+execute (but NOT read in this model)"
 if nexus rebac check user alice write file $DEMO_BASE/test-file.txt 2>&1 | grep -q "GRANTED" && \
@@ -684,7 +736,11 @@ fi
 print_section "9. Multi-Tenant Isolation"
 
 print_subsection "9.1 Create user in different tenant"
-TENANT_ACME_KEY=$(python3 scripts/create-api-key.py acme_user "ACME Corp User" --days 1 --zone-id acme 2>/dev/null | grep "API Key:" | awk '{print $3}')
+TENANT_ACME_KEY=$(curl -s -X POST "$NEXUS_URL/api/v2/auth/keys" \
+    -H "Authorization: Bearer $NEXUS_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"user_id":"acme_user","name":"ACME Corp User","zone_id":"acme","expires_days":1}' \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('key',''))" 2>/dev/null)
 print_success "Created acme_user (tenant: acme)"
 print_info "Alice, Bob, Charlie are in tenant: default"
 
@@ -699,6 +755,128 @@ else
 fi
 
 export NEXUS_API_KEY="$ADMIN_KEY"
+
+# ════════════════════════════════════════════════════════════
+# Section 10: Scoped API Key Grants (Issue #3128)
+# ════════════════════════════════════════════════════════════
+
+print_section "10. Scoped API Key Grants (Issue #3128)"
+
+print_subsection "10.1 Create scoped key with multiple grants"
+
+# Create two files for scoping
+echo "allowed content" | nexus write $DEMO_BASE/scoped-allowed.txt -
+echo "forbidden content" | nexus write $DEMO_BASE/scoped-forbidden.txt -
+print_success "Created scoped-allowed.txt and scoped-forbidden.txt"
+
+SCOPED_RESP=$(create_scoped_key scoped-dave "Dave Scoped" \
+    --grant "$DEMO_BASE/scoped-allowed.txt:editor" \
+    --expires-days 1)
+SCOPED_KEY=$(echo "$SCOPED_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key'])")
+SCOPED_KEY_ID=$(echo "$SCOPED_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key_id'])")
+SCOPED_GRANTS=$(echo "$SCOPED_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('grants',[])))")
+print_success "Created scoped key for scoped-dave (grants in response: $SCOPED_GRANTS)"
+
+print_test "Scoped user should have editor access to allowed file"
+if nexus rebac check user scoped-dave write file $DEMO_BASE/scoped-allowed.txt 2>&1 | grep -q "GRANTED"; then
+    print_success "✅ Scoped editor grant works"
+else
+    print_error "❌ Scoped editor grant NOT working"
+fi
+
+print_test "Scoped user should NOT have access to forbidden file"
+if nexus rebac check user scoped-dave read file $DEMO_BASE/scoped-forbidden.txt 2>&1 | grep -q "DENIED"; then
+    print_success "✅ Scoped user denied on ungranteded path"
+else
+    print_error "❌ Scoped user has access to ungranted path"
+fi
+
+print_subsection "10.2 Real I/O with scoped key"
+export NEXUS_API_KEY="$SCOPED_KEY"
+
+print_test "Scoped user writes to allowed file (real I/O)"
+echo "Written by scoped-dave" > /tmp/demo-scoped-write.txt
+if cat /tmp/demo-scoped-write.txt | nexus write $DEMO_BASE/scoped-allowed.txt - 2>/dev/null; then
+    print_success "✅ Scoped write to allowed path succeeded"
+else
+    print_error "❌ Scoped write to allowed path failed"
+fi
+
+print_test "Scoped user denied write to forbidden file (real I/O)"
+if echo "nope" | nexus write $DEMO_BASE/scoped-forbidden.txt - 2>/dev/null; then
+    print_error "❌ Scoped user wrote to forbidden path"
+else
+    print_success "✅ Scoped user correctly denied write to forbidden path"
+fi
+
+export NEXUS_API_KEY="$ADMIN_KEY"
+
+print_subsection "10.3 Revoke scoped key — verify grants cleaned up"
+
+# Create a pre-existing grant for scoped-dave on another file (should survive revocation)
+nexus rebac create user scoped-dave direct_viewer file $DEMO_BASE/scoped-forbidden.txt
+print_info "Created pre-existing grant on scoped-forbidden.txt (NOT from the key)"
+
+print_test "Pre-existing grant exists before revocation"
+if nexus rebac check user scoped-dave read file $DEMO_BASE/scoped-forbidden.txt 2>&1 | grep -q "GRANTED"; then
+    print_success "✅ Pre-existing grant confirmed"
+else
+    print_error "Pre-existing grant missing"
+fi
+
+# Revoke the scoped key via REST API
+REVOKE_RESP=$(curl -s -X DELETE "$NEXUS_URL/api/v2/auth/keys/$SCOPED_KEY_ID" \
+    -H "Authorization: Bearer $NEXUS_API_KEY")
+print_success "Revoked scoped key: $SCOPED_KEY_ID"
+
+print_test "Key's grants should be cleaned up after revocation"
+if nexus rebac check user scoped-dave write file $DEMO_BASE/scoped-allowed.txt 2>&1 | grep -q "DENIED"; then
+    print_success "✅ Key's editor grant on scoped-allowed.txt removed"
+else
+    print_error "❌ Key's grant NOT cleaned up after revocation"
+fi
+
+print_test "Pre-existing grant should SURVIVE key revocation"
+if nexus rebac check user scoped-dave read file $DEMO_BASE/scoped-forbidden.txt 2>&1 | grep -q "GRANTED"; then
+    print_success "✅ Pre-existing grant survived (targeted cleanup works!)"
+else
+    print_error "❌ Pre-existing grant was deleted (blanket cleanup bug!)"
+fi
+
+print_subsection "10.4 Multiple keys for same user — independent grant lifecycles"
+
+# Create two keys for the same user with different grants
+KEY_X_RESP=$(create_scoped_key multi-eve "Eve Key X" \
+    --grant "$DEMO_BASE/scoped-allowed.txt:editor" --expires-days 1)
+KEY_X_ID=$(echo "$KEY_X_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key_id'])")
+
+KEY_Y_RESP=$(create_scoped_key multi-eve "Eve Key Y" \
+    --grant "$DEMO_BASE/scoped-forbidden.txt:viewer" --expires-days 1)
+KEY_Y_ID=$(echo "$KEY_Y_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['key_id'])")
+print_success "Created two keys for multi-eve with different grants"
+
+print_test "multi-eve has access to both paths"
+if nexus rebac check user multi-eve write file $DEMO_BASE/scoped-allowed.txt 2>&1 | grep -q "GRANTED" && \
+   nexus rebac check user multi-eve read file $DEMO_BASE/scoped-forbidden.txt 2>&1 | grep -q "GRANTED"; then
+    print_success "✅ Both grants active"
+else
+    print_error "❌ Not all grants active"
+fi
+
+# Revoke key X only
+curl -s -X DELETE "$NEXUS_URL/api/v2/auth/keys/$KEY_X_ID" \
+    -H "Authorization: Bearer $NEXUS_API_KEY" > /dev/null
+print_info "Revoked key X (editor on scoped-allowed.txt)"
+
+print_test "Key X's grant should be gone, key Y's grant should remain"
+if nexus rebac check user multi-eve write file $DEMO_BASE/scoped-allowed.txt 2>&1 | grep -q "DENIED" && \
+   nexus rebac check user multi-eve read file $DEMO_BASE/scoped-forbidden.txt 2>&1 | grep -q "GRANTED"; then
+    print_success "✅ Independent grant lifecycles verified!"
+else
+    KEY_X_CHECK=$(nexus rebac check user multi-eve write file $DEMO_BASE/scoped-allowed.txt 2>&1)
+    KEY_Y_CHECK=$(nexus rebac check user multi-eve read file $DEMO_BASE/scoped-forbidden.txt 2>&1)
+    print_error "❌ Grant lifecycle broken (X: $KEY_X_CHECK, Y: $KEY_Y_CHECK)"
+fi
 
 # ════════════════════════════════════════════════════════════
 # Summary
@@ -719,6 +897,8 @@ echo "║  ✅ Auditability (Concrete Assertions)                            ║
 echo "║  ✅ Negative Test Cases & Edge Cases                              ║"
 echo "║  ✅ Shared Resources (Universal Write Denial)                     ║"
 echo "║  ✅ Multi-Tenant Isolation                                        ║"
+echo "║  ✅ Scoped API Key Grants (Issue #3128)                           ║"
+echo "║  ✅ Targeted Grant Cleanup on Revocation                          ║"
 echo "╚═══════════════════════════════════════════════════════════════════╝"
 echo ""
 print_info "All tests passed! ReBAC system is production-ready."

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -100,6 +100,37 @@ def admin() -> None:
     pass
 
 
+def _parse_grants(grant_strings: tuple[str, ...]) -> list[dict[str, str]] | None:
+    """Parse --grant PATH:ROLE options into a list of grant dicts.
+
+    Returns None if no grants provided, or a list of {"path": ..., "role": ...}.
+    """
+    if not grant_strings:
+        return None
+    grants: list[dict[str, str]] = []
+    for g in grant_strings:
+        if ":" not in g:
+            raise click.BadParameter(
+                f"Invalid grant format: {g!r}. Expected PATH:ROLE (e.g. /workspace/*:editor)",
+                param_hint="--grant",
+            )
+        path, role = g.rsplit(":", 1)
+        if role not in ("viewer", "editor", "owner"):
+            raise click.BadParameter(
+                f"Invalid role: {role!r}. Must be viewer, editor, or owner",
+                param_hint="--grant",
+            )
+        grants.append({"path": path, "role": role})
+    return grants
+
+
+def _print_grants(grants: list[dict[str, str]]) -> None:
+    """Print created grants to console."""
+    console.print(f"\nGrants ({len(grants)}):")
+    for g in grants:
+        console.print(f"  {g['role']:8s} {g['path']}")
+
+
 @admin.command("create-user")
 @click.argument("user_id")
 @click.option("--name", required=True, help="Human-readable name for the API key")
@@ -108,6 +139,7 @@ def admin() -> None:
 @click.option("--expires-days", type=int, help="API key expiry in days")
 @click.option("--zone-id", default=ROOT_ZONE_ID, help="Zone ID (default: root)")
 @click.option("--subject-type", default="user", help="Subject type: user or agent")
+@click.option("--grant", "grants", multiple=True, help="Path grant as PATH:ROLE (repeatable)")
 @add_output_options
 @REMOTE_API_KEY_OPTION
 @REMOTE_URL_OPTION
@@ -119,6 +151,7 @@ def create_user(
     expires_days: int | None,
     zone_id: str,
     subject_type: str,
+    grants: tuple[str, ...],
     output_opts: OutputOptions,
     remote_url: str | None,
     remote_api_key: str | None,
@@ -135,8 +168,10 @@ def create_user(
         # Create admin user
         nexus admin create-user admin --name "Admin Key" --is-admin
 
-        # Create agent key
-        nexus admin create-user bot1 --name "Bot Agent" --subject-type agent
+        # Create scoped user with per-path grants
+        nexus admin create-user alice --name "Alice" \\
+            --grant "/workspace/project-a/*:editor" \\
+            --grant "/workspace/shared/*:viewer"
     """
     timing = CommandTiming()
     try:
@@ -157,6 +192,10 @@ def create_user(
         if expires_days is not None:
             params["expires_days"] = expires_days
 
+        parsed_grants = _parse_grants(grants)
+        if parsed_grants:
+            params["grants"] = parsed_grants
+
         # Call admin API
         with timing.phase("server"):
             result = call_rpc("admin_create_key", params)
@@ -173,6 +212,8 @@ def create_user(
             console.print(f"Admin:       {data['is_admin']}")
             if data.get("expires_at"):
                 console.print(f"Expires:     {data['expires_at']}")
+            if data.get("grants"):
+                _print_grants(data["grants"])
 
             if email:
                 console.print(f"\n[dim]Email: {email}[/dim]")
@@ -350,6 +391,7 @@ def revoke_key(
 @click.argument("user_id")
 @click.option("--name", required=True, help="Human-readable name for the new key")
 @click.option("--expires-days", type=int, help="API key expiry in days")
+@click.option("--grant", "grants", multiple=True, help="Path grant as PATH:ROLE (repeatable)")
 @add_output_options
 @REMOTE_API_KEY_OPTION
 @REMOTE_URL_OPTION
@@ -357,6 +399,7 @@ def create_key(
     user_id: str,
     name: str,
     expires_days: int | None,
+    grants: tuple[str, ...],
     output_opts: OutputOptions,
     remote_url: str | None,
     remote_api_key: str | None,
@@ -366,6 +409,10 @@ def create_key(
     \b
     Examples:
         nexus admin create-key alice --name "Alice's new laptop" --expires-days 90
+
+        # Create scoped key with grants
+        nexus admin create-key alice --name "Project key" \\
+            --grant "/workspace/project-a/*:editor"
     """
     timing = CommandTiming()
     try:
@@ -379,6 +426,10 @@ def create_key(
 
         if expires_days is not None:
             params["expires_days"] = expires_days
+
+        parsed_grants = _parse_grants(grants)
+        if parsed_grants:
+            params["grants"] = parsed_grants
 
         # Call admin API
         with timing.phase("server"):
@@ -394,6 +445,8 @@ def create_key(
             console.print(f"[bold]API Key:[/bold]     {data['api_key']}")
             if data.get("expires_at"):
                 console.print(f"Expires:     {data['expires_at']}")
+            if data.get("grants"):
+                _print_grants(data["grants"])
 
         render_output(
             data=result,
@@ -493,6 +546,7 @@ def get_user(
 @click.argument("agent_id")
 @click.option("--name", help="Human-readable name for the API key (default: 'Agent: <agent_id>')")
 @click.option("--expires-days", type=int, help="API key expiry in days")
+@click.option("--grant", "grants", multiple=True, help="Path grant as PATH:ROLE (repeatable)")
 @add_output_options
 @REMOTE_API_KEY_OPTION
 @REMOTE_URL_OPTION
@@ -501,6 +555,7 @@ def create_agent_key(
     agent_id: str,
     name: str | None,
     expires_days: int | None,
+    grants: tuple[str, ...],
     output_opts: OutputOptions,
     remote_url: str | None,
     remote_api_key: str | None,
@@ -516,8 +571,9 @@ def create_agent_key(
         # Create API key for alice's agent (1 day expiry)
         nexus admin create-agent-key alice alice_agent --expires-days 1
 
-        # Create API key with custom name
-        nexus admin create-agent-key alice alice_agent --name "Production Agent" --expires-days 90
+        # Create scoped agent key with grants
+        nexus admin create-agent-key alice alice_agent \\
+            --grant "/workspace/tools/*:editor" --expires-days 1
     """
     timing = CommandTiming()
     try:
@@ -538,6 +594,10 @@ def create_agent_key(
         if expires_days is not None:
             params["expires_days"] = expires_days
 
+        parsed_grants = _parse_grants(grants)
+        if parsed_grants:
+            params["grants"] = parsed_grants
+
         # Call admin API
         with timing.phase("server"):
             result = call_rpc("admin_create_key", params)
@@ -553,6 +613,8 @@ def create_agent_key(
             console.print(f"[bold]API Key:[/bold]     {data['api_key']}")
             if data.get("expires_at"):
                 console.print(f"Expires:     {data['expires_at']}")
+            if data.get("grants"):
+                _print_grants(data["grants"])
 
             console.print(
                 "\n[cyan]\u2139 Info:[/cyan] This agent can now authenticate independently."

--- a/src/nexus/remote/domain/admin.py
+++ b/src/nexus/remote/domain/admin.py
@@ -24,6 +24,7 @@ class AsyncAdminClient:
         expires_days: int | None = None,
         subject_type: str | None = None,
         subject_id: str | None = None,
+        grants: builtins.list[dict[str, str]] | None = None,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
             "user_id": user_id,
@@ -37,6 +38,8 @@ class AsyncAdminClient:
             params["subject_type"] = subject_type
         if subject_id is not None:
             params["subject_id"] = subject_id
+        if grants is not None:
+            params["grants"] = grants
         return await self._call_rpc("admin_create_key", params)  # type: ignore[no-any-return]
 
     async def list_keys(

--- a/src/nexus/server/api/v2/routers/auth_keys.py
+++ b/src/nexus/server/api/v2/routers/auth_keys.py
@@ -10,11 +10,13 @@ Wraps the existing RPC admin handlers with proper REST semantics.
 Admin auth required for all operations.
 """
 
+import json
 import logging
-from typing import Any
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_admin
@@ -33,6 +35,34 @@ router = APIRouter(
 # ---------------------------------------------------------------------------
 
 
+class GrantRequest(BaseModel):
+    """A single per-path permission grant."""
+
+    path: str = Field(..., description="File or directory path (use /* suffix for directory)")
+    role: Literal["viewer", "editor", "owner"] = Field(
+        ..., description="Role: 'viewer', 'editor', or 'owner'"
+    )
+
+    @field_validator("path")
+    @classmethod
+    def _validate_path(cls, v: str) -> str:
+        if not v or not v.startswith("/"):
+            raise ValueError("path must be absolute (start with '/')")
+        if ".." in v.split("/"):
+            raise ValueError("path must not contain '..' segments")
+        return v
+
+
+# Maps human-readable role names to ReBAC relation names.
+ROLE_TO_RELATION: dict[str, str] = {
+    "viewer": "direct_viewer",
+    "editor": "direct_editor",
+    "owner": "direct_owner",
+}
+
+MAX_GRANTS_PER_REQUEST = 100
+
+
 class CreateKeyRequest(BaseModel):
     """Request body for creating an API key."""
 
@@ -44,6 +74,17 @@ class CreateKeyRequest(BaseModel):
     subject_id: str | None = Field(default=None, description="Subject ID (defaults to user_id)")
     is_admin: bool = Field(default=False, description="Whether the key has admin privileges")
     expires_days: int | None = Field(default=None, description="Expiration in days from now")
+    grants: list[GrantRequest] | None = Field(
+        default=None,
+        description="Optional per-path permission grants to create as ReBAC tuples",
+    )
+
+    @field_validator("grants")
+    @classmethod
+    def _validate_grants_limit(cls, v: list[GrantRequest] | None) -> list[GrantRequest] | None:
+        if v is not None and len(v) > MAX_GRANTS_PER_REQUEST:
+            raise ValueError(f"Too many grants: max {MAX_GRANTS_PER_REQUEST}")
+        return v
 
 
 class ListKeysParams(BaseModel):
@@ -61,6 +102,92 @@ class ListKeysParams(BaseModel):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _resolve_rebac_manager(request: Request) -> Any:
+    """Resolve the ReBACManager from app.state.
+
+    Raises:
+        HTTPException: 503 if rebac_manager is not available.
+    """
+    rebac_manager = getattr(request.app.state, "rebac_manager", None)
+    if rebac_manager is None:
+        raise HTTPException(
+            status_code=503,
+            detail="ReBAC manager not available; cannot create grants",
+        )
+    return rebac_manager
+
+
+def _create_key_grants(
+    rebac_manager: Any,
+    subject_type: str,
+    subject_id: str,
+    grants: list[GrantRequest],
+    zone_id: str,
+    expires_at: datetime | None,
+) -> tuple[list[dict[str, str]], list[str]]:
+    """Create ReBAC permission tuples for API key grants.
+
+    Returns (created_grants for response, list of tuple_ids for storage).
+    """
+    tuples: list[dict[str, Any]] = []
+    created_grants: list[dict[str, str]] = []
+
+    for grant in grants:
+        relation = ROLE_TO_RELATION[grant.role]
+        tuples.append(
+            {
+                "subject": (subject_type, subject_id),
+                "relation": relation,
+                "object": ("file", grant.path),
+                "zone_id": zone_id,
+                "expires_at": expires_at,
+            }
+        )
+        created_grants.append({"path": grant.path, "role": grant.role})
+
+    tuple_ids: list[str] = []
+    if tuples:
+        # Snapshot pre-existing tuple_ids so we only track genuinely new ones
+        pre_existing: set[str] = set()
+        for t in tuples:
+            for f in rebac_manager.rebac_list_tuples(
+                subject=(t["subject"][0], t["subject"][1]),
+                relation=t["relation"],
+                object=(t["object"][0], t["object"][1]),
+            ):
+                tid = f.get("tuple_id", "")
+                if tid:
+                    pre_existing.add(tid)
+
+        rebac_manager.rebac_write_batch(tuples)
+
+        # Collect only newly created tuple_ids
+        for t in tuples:
+            for f in rebac_manager.rebac_list_tuples(
+                subject=(t["subject"][0], t["subject"][1]),
+                relation=t["relation"],
+                object=(t["object"][0], t["object"][1]),
+            ):
+                tid = f.get("tuple_id", "")
+                if tid and tid not in pre_existing and tid not in tuple_ids:
+                    tuple_ids.append(tid)
+
+    return created_grants, tuple_ids
+
+
+def _store_grant_tuple_ids(db_provider: Any, key_id: str, tuple_ids: list[str]) -> None:
+    """Persist grant tuple_ids on the API key record for targeted revocation cleanup."""
+    from sqlalchemy import select
+
+    from nexus.storage.models import APIKeyModel
+
+    with db_provider.session_factory() as session:
+        api_key = session.scalar(select(APIKeyModel).where(APIKeyModel.key_id == key_id))
+        if api_key is not None:
+            api_key.grant_tuple_ids = json.dumps(tuple_ids)
+            session.commit()
 
 
 def _resolve_db_auth(request: Request) -> Any:
@@ -106,6 +233,11 @@ async def create_key(
     from nexus.server.rpc.handlers.admin import handle_admin_create_key
 
     db_provider = _resolve_db_auth(request)
+
+    # Fail-fast: verify rebac_manager is available before creating the key
+    if body.grants:
+        _resolve_rebac_manager(request)
+
     key_name = body.label or body.name or "unnamed"
 
     params = SimpleNamespace(
@@ -123,7 +255,7 @@ async def create_key(
     result = handle_admin_create_key(db_provider, params, context)
 
     # Normalize response keys for test fixture compatibility
-    return {
+    response: dict[str, Any] = {
         "key_id": result["key_id"],
         "id": result["key_id"],
         "key": result["api_key"],
@@ -134,6 +266,46 @@ async def create_key(
         "is_admin": result.get("is_admin", body.is_admin),
         "expires_at": result.get("expires_at"),
     }
+
+    # Create ReBAC grants if requested — rollback key on failure
+    if body.grants:
+        rebac_manager = _resolve_rebac_manager(request)
+        subject_id = result.get("subject_id") or result["user_id"]
+        subject_type = body.subject_type or "user"
+
+        expires_at = None
+        if body.expires_days:
+            expires_at = datetime.now(UTC) + timedelta(days=body.expires_days)
+
+        try:
+            created_grants, tuple_ids = _create_key_grants(
+                rebac_manager=rebac_manager,
+                subject_type=subject_type,
+                subject_id=subject_id,
+                grants=body.grants,
+                zone_id=body.zone_id,
+                expires_at=expires_at,
+            )
+        except Exception:
+            # Grant creation failed — revoke the key so it doesn't exist without grants
+            logger.exception("Grant creation failed; rolling back API key %s", result["key_id"])
+            from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
+
+            with db_provider.session_factory() as session:
+                DatabaseAPIKeyAuth.revoke_key(session, result["key_id"])
+                session.commit()
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to create grants; API key has been rolled back",
+            ) from None
+
+        # Persist tuple_ids on the key for targeted cleanup on revocation
+        if tuple_ids:
+            _store_grant_tuple_ids(db_provider, result["key_id"], tuple_ids)
+
+        response["grants"] = created_grants
+
+    return response
 
 
 @router.get("")
@@ -189,16 +361,49 @@ async def revoke_key(
     key_id: str,
     zone_id: str | None = None,
 ) -> dict[str, Any]:
-    """Revoke an API key."""
+    """Revoke an API key and clean up only the ReBAC grants created for it."""
     from types import SimpleNamespace
+
+    from sqlalchemy import select
 
     from nexus.server.dependencies import _reset_auth_cache
     from nexus.server.rpc.handlers.admin import handle_admin_revoke_key
+    from nexus.storage.models import APIKeyModel
 
     db_provider = _resolve_db_auth(request)
+
+    # Read grant_tuple_ids before revocation so we can do targeted cleanup
+    grant_tuple_ids: list[str] = []
+    with db_provider.session_factory() as session:
+        stmt = select(APIKeyModel).where(APIKeyModel.key_id == key_id)
+        if zone_id:
+            stmt = stmt.where(APIKeyModel.zone_id == zone_id)
+        api_key = session.scalar(stmt)
+        if api_key is not None and api_key.grant_tuple_ids:
+            try:
+                grant_tuple_ids = json.loads(api_key.grant_tuple_ids)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Invalid grant_tuple_ids JSON on key %s", key_id)
+
     params = SimpleNamespace(key_id=key_id, zone_id=zone_id)
     context = SimpleNamespace(is_admin=True)
     result = handle_admin_revoke_key(db_provider, params, context)
+
+    # Delete only the ReBAC tuples that were created for this specific key
+    if grant_tuple_ids:
+        rebac_manager = getattr(request.app.state, "rebac_manager", None)
+        if rebac_manager is not None:
+            deleted = 0
+            for tid in grant_tuple_ids:
+                if rebac_manager.rebac_delete(tid):
+                    deleted += 1
+            if deleted:
+                logger.info(
+                    "Cleaned up %d/%d ReBAC grant tuple(s) for key %s",
+                    deleted,
+                    len(grant_tuple_ids),
+                    key_id,
+                )
 
     # Flush auth cache so revoked key is immediately rejected (Issue #2195)
     auth_cache = getattr(request.app.state, "auth_cache_store", None)

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -4,11 +4,130 @@ Extracted from fastapi_server.py (#1602). Admin handlers accept both
 ``nexus_fs`` and ``auth_provider`` as explicit parameters.
 """
 
+import json
 import logging
 from datetime import UTC, datetime
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+ROLE_TO_RELATION: dict[str, str] = {
+    "viewer": "direct_viewer",
+    "editor": "direct_editor",
+    "owner": "direct_owner",
+}
+
+
+def _resolve_record_store(auth_provider: Any) -> Any | None:
+    """Resolve _record_store from auth_provider, unwrapping if needed."""
+    store = getattr(auth_provider, "_record_store", None)
+    if store is None and hasattr(auth_provider, "api_key_provider"):
+        store = getattr(auth_provider.api_key_provider, "_record_store", None)
+    return store
+
+
+def _create_grants_for_key(
+    auth_provider: Any,
+    subject_type: str,
+    subject_id: str,
+    grants: list[dict[str, str]],
+    zone_id: str,
+    expires_at: "datetime | None",
+    key_id: str,
+) -> list[dict[str, str]]:
+    """Create ReBAC permission tuples for API key grants (Issue #3128).
+
+    Creates tuples and stores their IDs on the API key record for
+    targeted cleanup on revocation.
+
+    Args:
+        auth_provider: Auth provider (to resolve record_store/engine).
+        subject_type: e.g. "user" or "agent".
+        subject_id: Subject identifier.
+        grants: List of {"path": ..., "role": ...} dicts.
+        zone_id: Zone to scope tuples to.
+        expires_at: Optional expiry for the tuples.
+        key_id: API key ID to store tuple_ids on.
+
+    Returns:
+        List of created grant dicts for the response.
+    """
+    from sqlalchemy import select
+
+    from nexus.bricks.rebac.manager import ReBACManager
+    from nexus.contracts.constants import ROOT_ZONE_ID
+    from nexus.storage.models import APIKeyModel
+
+    record_store = _resolve_record_store(auth_provider)
+    if record_store is None:
+        raise RuntimeError("Cannot create grants: record_store not available")
+
+    manager = ReBACManager(engine=record_store.engine, cache_ttl_seconds=0, max_depth=5)
+    try:
+        tuples: list[dict[str, Any]] = []
+        created: list[dict[str, str]] = []
+        for grant in grants:
+            path = grant.get("path", "")
+            role = grant.get("role", "")
+            relation = ROLE_TO_RELATION.get(role)
+            if not relation:
+                raise ValueError(
+                    f"Invalid role: {role!r}. Must be one of: {list(ROLE_TO_RELATION)}"
+                )
+            if not path or not path.startswith("/"):
+                raise ValueError(f"Invalid path: {path!r}. Must be absolute.")
+            tuples.append(
+                {
+                    "subject": (subject_type, subject_id),
+                    "relation": relation,
+                    "object": ("file", path),
+                    "zone_id": zone_id or ROOT_ZONE_ID,
+                    "expires_at": expires_at,
+                }
+            )
+            created.append({"path": path, "role": role})
+
+        if tuples:
+            # Snapshot pre-existing tuple_ids so we only track genuinely new ones
+            pre_existing: set[str] = set()
+            for t in tuples:
+                for f in manager.rebac_list_tuples(
+                    subject=(t["subject"][0], t["subject"][1]),
+                    relation=t["relation"],
+                    object=(t["object"][0], t["object"][1]),
+                ):
+                    tid = f.get("tuple_id", "")
+                    if tid:
+                        pre_existing.add(tid)
+
+            manager.rebac_write_batch(tuples)
+
+            # Collect only newly created tuple_ids
+            tuple_ids: list[str] = []
+            for t in tuples:
+                for f in manager.rebac_list_tuples(
+                    subject=(t["subject"][0], t["subject"][1]),
+                    relation=t["relation"],
+                    object=(t["object"][0], t["object"][1]),
+                ):
+                    tid = f.get("tuple_id", "")
+                    if tid and tid not in pre_existing and tid not in tuple_ids:
+                        tuple_ids.append(tid)
+
+            # Store tuple_ids on the key for targeted revocation cleanup
+            if tuple_ids:
+                with auth_provider.session_factory() as session:
+                    api_key = session.scalar(
+                        select(APIKeyModel).where(APIKeyModel.key_id == key_id)
+                    )
+                    if api_key is not None:
+                        api_key.grant_tuple_ids = json.dumps(tuple_ids)
+                        session.commit()
+
+        return created
+    finally:
+        manager.close()
 
 
 def require_admin(context: Any) -> None:
@@ -109,10 +228,7 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
         user_id = f"user_{uuid.uuid4().hex[:12]}"
 
     if params.subject_type == "user" or not params.subject_type:
-        # Resolve _record_store: DiscriminatingAuthProvider delegates to api_key_provider
-        _record_store = getattr(auth_provider, "_record_store", None)
-        if _record_store is None and hasattr(auth_provider, "api_key_provider"):
-            _record_store = getattr(auth_provider.api_key_provider, "_record_store", None)
+        _record_store = _resolve_record_store(auth_provider)
         if _record_store is not None:
             entity_registry = EntityRegistry(_record_store)
             entity_registry.register_entity(
@@ -139,7 +255,7 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
         )
         session.commit()
 
-        return {
+        result: dict[str, Any] = {
             "key_id": key_id,
             "api_key": raw_key,
             "user_id": user_id,
@@ -150,6 +266,22 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
             "is_admin": params.is_admin,
             "expires_at": expires_at.isoformat() if expires_at else None,
         }
+
+        # Create ReBAC grants if requested (Issue #3128)
+        grants = getattr(params, "grants", None)
+        if grants:
+            created = _create_grants_for_key(
+                auth_provider=auth_provider,
+                subject_type=params.subject_type or "user",
+                subject_id=params.subject_id or user_id,
+                grants=grants,
+                zone_id=params.zone_id,
+                expires_at=expires_at,
+                key_id=key_id,
+            )
+            result["grants"] = created
+
+        return result
 
 
 def handle_admin_list_keys(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:

--- a/src/nexus/storage/models/auth.py
+++ b/src/nexus/storage/models/auth.py
@@ -163,6 +163,8 @@ class APIKeyModel(Base):
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
     expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    grant_tuple_ids: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     revoked: Mapped[int] = mapped_column(Integer, default=0, index=True)
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/tests/unit/server/api/v2/routers/test_auth_keys_grants.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_grants.py
@@ -1,0 +1,587 @@
+"""Tests for scoped API key creation with per-path grants (Issue #3128).
+
+Tests the grants extension to POST /api/v2/auth/keys using a real
+EnhancedReBACManager backed by in-memory SQLite.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.bricks.rebac.manager import EnhancedReBACManager
+from nexus.server.api.v2.routers.auth_keys import (
+    ROLE_TO_RELATION,
+    GrantRequest,
+    router,
+)
+from tests.helpers.in_memory_record_store import InMemoryRecordStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def record_store():
+    store = InMemoryRecordStore()
+    yield store
+    store.close()
+
+
+@pytest.fixture()
+def rebac_manager(record_store):
+    manager = EnhancedReBACManager(
+        engine=record_store.engine,
+        cache_ttl_seconds=0,
+        max_depth=10,
+    )
+    yield manager
+    manager.close()
+
+
+@pytest.fixture()
+def mock_db_provider(record_store):
+    """A mock auth provider with a real session_factory for key creation."""
+    provider = MagicMock(spec=["session_factory", "_record_store"])
+    provider.session_factory = record_store.session_factory
+    provider._record_store = record_store
+    return provider
+
+
+@pytest.fixture()
+def client(mock_db_provider, rebac_manager):
+    """TestClient with admin dependency overridden and real rebac_manager."""
+    from nexus.server.dependencies import require_admin
+
+    app = FastAPI()
+    app.include_router(router)
+
+    # Override admin dependency to always pass
+    app.dependency_overrides[require_admin] = lambda: None
+
+    # Wire up app.state
+    app.state.auth_provider = mock_db_provider
+    app.state.rebac_manager = rebac_manager
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests — backward compatibility (no grants)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateKeyWithoutGrants:
+    """Existing behavior must be unchanged when grants is omitted."""
+
+    def test_create_key_no_grants(self, client):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={"name": "basic-key", "is_admin": False},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "key_id" in data
+        assert "key" in data
+        assert "grants" not in data
+
+    def test_create_key_grants_null(self, client):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={"name": "null-grants", "grants": None},
+        )
+        assert resp.status_code == 201
+        assert "grants" not in resp.json()
+
+    def test_create_key_grants_empty_list(self, client):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={"name": "empty-grants", "grants": []},
+        )
+        assert resp.status_code == 201
+        # Empty list is falsy, so no grants in response
+        assert "grants" not in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests — grants creation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateKeyWithGrants:
+    """Key creation with per-path ReBAC grants."""
+
+    def test_single_grant(self, client, rebac_manager):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "alice",
+                "subject_type": "user",
+                "grants": [{"path": "/workspace/project-a/*", "role": "editor"}],
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "grants" in data
+        assert len(data["grants"]) == 1
+        assert data["grants"][0] == {"path": "/workspace/project-a/*", "role": "editor"}
+
+    def test_multiple_grants(self, client, rebac_manager):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "bob",
+                "subject_type": "user",
+                "grants": [
+                    {"path": "/workspace/project-a/*", "role": "editor"},
+                    {"path": "/workspace/shared/*", "role": "viewer"},
+                    {"path": "/workspace/admin/*", "role": "owner"},
+                ],
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert len(data["grants"]) == 3
+        roles = {g["role"] for g in data["grants"]}
+        assert roles == {"editor", "viewer", "owner"}
+
+    def test_grants_create_rebac_tuples(self, client, rebac_manager):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "carol",
+                "user_id": "carol-123",
+                "subject_type": "user",
+                "grants": [{"path": "/docs/readme.md", "role": "viewer"}],
+            },
+        )
+        assert resp.status_code == 201
+
+        # Verify the ReBAC tuple was actually created
+        has_perm = rebac_manager.rebac_check(
+            subject=("user", "carol-123"),
+            permission="read",
+            object=("file", "/docs/readme.md"),
+        )
+        assert has_perm is True
+
+        # Viewer should NOT have write permission
+        has_write = rebac_manager.rebac_check(
+            subject=("user", "carol-123"),
+            permission="write",
+            object=("file", "/docs/readme.md"),
+        )
+        assert has_write is False
+
+    def test_editor_grant_gives_read_and_write(self, client, rebac_manager):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "dave",
+                "user_id": "dave-456",
+                "subject_type": "user",
+                "grants": [{"path": "/src/main.py", "role": "editor"}],
+            },
+        )
+        assert resp.status_code == 201
+
+        assert rebac_manager.rebac_check(
+            subject=("user", "dave-456"),
+            permission="read",
+            object=("file", "/src/main.py"),
+        )
+        assert rebac_manager.rebac_check(
+            subject=("user", "dave-456"),
+            permission="write",
+            object=("file", "/src/main.py"),
+        )
+
+    def test_grants_with_agent_subject_type(self, client, rebac_manager):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "agent-key",
+                "user_id": "agent-007",
+                "subject_type": "agent",
+                "grants": [{"path": "/workspace/tools/*", "role": "editor"}],
+            },
+        )
+        assert resp.status_code == 201
+
+        has_perm = rebac_manager.rebac_check(
+            subject=("agent", "agent-007"),
+            permission="write",
+            object=("file", "/workspace/tools/*"),
+        )
+        assert has_perm is True
+
+    def test_grants_with_expiry(self, client):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "temp-key",
+                "expires_days": 30,
+                "grants": [{"path": "/tmp/*", "role": "viewer"}],
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["expires_at"] is not None
+        assert len(data["grants"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — validation
+# ---------------------------------------------------------------------------
+
+
+class TestGrantValidation:
+    """Input validation for grant fields."""
+
+    def test_invalid_role(self, client):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "bad-role",
+                "grants": [{"path": "/foo", "role": "superadmin"}],
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_relative_path(self, client):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "rel-path",
+                "grants": [{"path": "relative/path", "role": "viewer"}],
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_path_traversal(self, client):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "traversal",
+                "grants": [{"path": "/workspace/../secrets/key", "role": "viewer"}],
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_empty_path(self, client):
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "empty",
+                "grants": [{"path": "", "role": "viewer"}],
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_too_many_grants(self, client):
+        grants = [{"path": f"/path/{i}", "role": "viewer"} for i in range(101)]
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={"name": "too-many", "grants": grants},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Tests — error handling
+# ---------------------------------------------------------------------------
+
+
+class TestGrantErrorHandling:
+    """Error cases for grant creation."""
+
+    def test_rebac_manager_unavailable_no_key_created(self, mock_db_provider, record_store):
+        """503 when rebac_manager is missing — key must NOT be created."""
+        from sqlalchemy import func, select
+
+        from nexus.server.dependencies import require_admin
+        from nexus.storage.models import APIKeyModel
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: None
+        app.state.auth_provider = mock_db_provider
+        # Deliberately do NOT set app.state.rebac_manager
+
+        # Count keys before
+        with record_store.session_factory() as session:
+            before = session.scalar(select(func.count()).select_from(APIKeyModel))
+
+        no_rebac_client = TestClient(app)
+        resp = no_rebac_client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "no-rebac",
+                "grants": [{"path": "/foo", "role": "viewer"}],
+            },
+        )
+        assert resp.status_code == 503
+        assert "ReBAC manager not available" in resp.json()["detail"]
+
+        # No key should have been created
+        with record_store.session_factory() as session:
+            after = session.scalar(select(func.count()).select_from(APIKeyModel))
+        assert after == before
+
+    def test_grant_failure_rolls_back_key(self, mock_db_provider, record_store):
+        """If grant creation fails, the API key should be revoked."""
+        from nexus.server.dependencies import require_admin
+        from nexus.storage.models import APIKeyModel
+
+        # Use a rebac_manager that raises on write
+        broken_rebac = MagicMock()
+        broken_rebac.rebac_write_batch.side_effect = RuntimeError("db exploded")
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: None
+        app.state.auth_provider = mock_db_provider
+        app.state.rebac_manager = broken_rebac
+
+        err_client = TestClient(app)
+        resp = err_client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "doomed-key",
+                "user_id": "doomed-user",
+                "grants": [{"path": "/foo", "role": "viewer"}],
+            },
+        )
+        assert resp.status_code == 500
+        assert "rolled back" in resp.json()["detail"]
+
+        # Verify the key was revoked
+        with record_store.session_factory() as session:
+            from sqlalchemy import select
+
+            key = session.scalar(select(APIKeyModel).where(APIKeyModel.user_id == "doomed-user"))
+            assert key is not None
+            assert key.revoked == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — revocation grant cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestRevokeKeyGrantCleanup:
+    """Revoking a key should delete its associated ReBAC grants."""
+
+    def test_revoke_deletes_grants(self, client, rebac_manager):
+        # Create a key with grants
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "eve",
+                "user_id": "eve-789",
+                "subject_type": "user",
+                "grants": [
+                    {"path": "/workspace/a", "role": "editor"},
+                    {"path": "/workspace/b", "role": "viewer"},
+                ],
+            },
+        )
+        assert resp.status_code == 201
+        key_id = resp.json()["key_id"]
+
+        # Confirm grants exist
+        assert rebac_manager.rebac_check(
+            subject=("user", "eve-789"),
+            permission="write",
+            object=("file", "/workspace/a"),
+        )
+
+        # Revoke the key
+        resp = client.delete(f"/api/v2/auth/keys/{key_id}")
+        assert resp.status_code == 200
+
+        # Grants should be gone
+        assert not rebac_manager.rebac_check(
+            subject=("user", "eve-789"),
+            permission="write",
+            object=("file", "/workspace/a"),
+        )
+        assert not rebac_manager.rebac_check(
+            subject=("user", "eve-789"),
+            permission="read",
+            object=("file", "/workspace/b"),
+        )
+
+    def test_revoke_does_not_delete_identical_preexisting_grant(self, client, rebac_manager):
+        """Exact codex repro: pre-existing grant with same (subject, relation, object)
+        must survive key revocation when the key requested the same grant."""
+        # Create a pre-existing direct_viewer on /same
+        rebac_manager.rebac_write_batch(
+            [
+                {
+                    "subject": ("user", "overlap-user"),
+                    "relation": "direct_viewer",
+                    "object": ("file", "/same"),
+                    "zone_id": "root",
+                }
+            ]
+        )
+        assert rebac_manager.rebac_check(
+            subject=("user", "overlap-user"),
+            permission="read",
+            object=("file", "/same"),
+        )
+
+        # Create a key requesting the SAME viewer grant
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "overlap-key",
+                "user_id": "overlap-user",
+                "subject_type": "user",
+                "grants": [{"path": "/same", "role": "viewer"}],
+            },
+        )
+        assert resp.status_code == 201
+        key_id = resp.json()["key_id"]
+
+        # Revoke the key
+        resp = client.delete(f"/api/v2/auth/keys/{key_id}")
+        assert resp.status_code == 200
+
+        # The original pre-existing grant must still be alive
+        assert rebac_manager.rebac_check(
+            subject=("user", "overlap-user"),
+            permission="read",
+            object=("file", "/same"),
+        )
+
+    def test_revoke_only_deletes_own_grants(self, client, rebac_manager):
+        """Revoking key A must not delete grants from key B for the same user."""
+        # Create key A with grants
+        resp_a = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "key-a",
+                "user_id": "shared-user",
+                "subject_type": "user",
+                "grants": [{"path": "/project-a/*", "role": "editor"}],
+            },
+        )
+        assert resp_a.status_code == 201
+        key_a_id = resp_a.json()["key_id"]
+
+        # Create key B with different grants for the SAME user
+        resp_b = client.post(
+            "/api/v2/auth/keys",
+            json={
+                "name": "key-b",
+                "user_id": "shared-user",
+                "subject_type": "user",
+                "grants": [{"path": "/project-b/*", "role": "viewer"}],
+            },
+        )
+        assert resp_b.status_code == 201
+
+        # Also create a pre-existing grant NOT from any key
+        rebac_manager.rebac_write_batch(
+            [
+                {
+                    "subject": ("user", "shared-user"),
+                    "relation": "direct_viewer",
+                    "object": ("file", "/preexisting"),
+                    "zone_id": "root",
+                }
+            ]
+        )
+
+        # Confirm all three grants exist
+        assert rebac_manager.rebac_check(
+            subject=("user", "shared-user"),
+            permission="write",
+            object=("file", "/project-a/*"),
+        )
+        assert rebac_manager.rebac_check(
+            subject=("user", "shared-user"),
+            permission="read",
+            object=("file", "/project-b/*"),
+        )
+        assert rebac_manager.rebac_check(
+            subject=("user", "shared-user"),
+            permission="read",
+            object=("file", "/preexisting"),
+        )
+
+        # Revoke key A only
+        resp = client.delete(f"/api/v2/auth/keys/{key_a_id}")
+        assert resp.status_code == 200
+
+        # Key A's grants should be gone
+        assert not rebac_manager.rebac_check(
+            subject=("user", "shared-user"),
+            permission="write",
+            object=("file", "/project-a/*"),
+        )
+
+        # Key B's grants must still exist
+        assert rebac_manager.rebac_check(
+            subject=("user", "shared-user"),
+            permission="read",
+            object=("file", "/project-b/*"),
+        )
+
+        # Pre-existing grant must still exist
+        assert rebac_manager.rebac_check(
+            subject=("user", "shared-user"),
+            permission="read",
+            object=("file", "/preexisting"),
+        )
+
+    def test_revoke_without_grants_still_works(self, client):
+        # Create a key without grants
+        resp = client.post(
+            "/api/v2/auth/keys",
+            json={"name": "frank", "user_id": "frank-000"},
+        )
+        assert resp.status_code == 201
+        key_id = resp.json()["key_id"]
+
+        # Revoke should succeed normally
+        resp = client.delete(f"/api/v2/auth/keys/{key_id}")
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests — model unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestGrantRequestModel:
+    """Unit tests for GrantRequest Pydantic model."""
+
+    def test_valid_grant(self):
+        g = GrantRequest(path="/workspace/a", role="editor")
+        assert g.path == "/workspace/a"
+        assert g.role == "editor"
+
+    def test_role_literal_constraint(self):
+        with pytest.raises(ValueError):
+            GrantRequest(path="/foo", role="invalid")
+
+    def test_path_must_be_absolute(self):
+        with pytest.raises(ValueError):
+            GrantRequest(path="relative", role="viewer")
+
+    def test_path_no_traversal(self):
+        with pytest.raises(ValueError):
+            GrantRequest(path="/a/../b", role="viewer")
+
+    def test_role_to_relation_mapping(self):
+        assert ROLE_TO_RELATION == {
+            "viewer": "direct_viewer",
+            "editor": "direct_editor",
+            "owner": "direct_owner",
+        }


### PR DESCRIPTION
## Summary

- Extends `POST /api/v2/auth/keys` with an optional `grants` field for fine-grained per-path permissions via ReBAC tuples
- Adds `--grant PATH:ROLE` CLI option to `create-user`, `create-key`, and `create-agent-key` commands
- Rolls back (revokes) the API key if grant creation fails
- Cleans up associated ReBAC tuples when a key is revoked

## Changes

**REST API** (`src/nexus/server/api/v2/routers/auth_keys.py`)
- `GrantRequest` model with validated `path` and `role` (`viewer`/`editor`/`owner`)
- Optional `grants` field on `CreateKeyRequest` (max 100 per request)
- `create_key()` creates ReBAC tuples, rolls back key on failure
- `revoke_key()` calls `rebac_delete_by_subject()` to clean up grants

**RPC handler** (`src/nexus/server/rpc/handlers/admin.py`)
- `handle_admin_create_key()` now handles `grants` in params
- Creates ReBAC tuples via a lightweight `ReBACManager` from the existing record_store
- Shared `_resolve_record_store()` helper (refactored from inline code)

**CLI** (`src/nexus/cli/commands/admin.py`)
- `--grant PATH:ROLE` repeatable option on `create-user`, `create-key`, `create-agent-key`
- `_parse_grants()` validates format and role, `_print_grants()` renders output

**Async client** (`src/nexus/remote/domain/admin.py`)
- `grants` parameter on `AsyncAdminClient.create_key()`

**Tests** (`tests/unit/server/api/v2/routers/test_auth_keys_grants.py`)
- 23 tests: backward compat, grant creation, ReBAC verification, validation, rollback on failure, revocation cleanup

## Test plan

- [x] 23 new tests pass
- [x] 1056 total server unit tests pass (zero regressions)
- [ ] Verify in staging with real ReBAC backend
- [ ] Test CLI `--grant` against running server

Closes #3128