### PR TITLE
fix(docker,cli): hnswlib SIGILL fix + edge default + build-from-source fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,16 +78,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         "txtai[ann]>=9.0" \
         "sentence-transformers>=5.3"
 
-# On arm64, uninstall hnswlib after txtai[ann] pulls it in.
-# hnswlib 0.8.0's C extension executes SVE2 instructions that SIGILL on
-# Apple Silicon Docker (M-chips do not implement SVE). Confirmed via:
-#   python3 -c "from hnswlib import Index"  →  exit 132 (SIGILL)
-#   python3 -c "import txtai.ann.dense.hnsw" →  SIGILL (last import before crash)
-# txtai falls back gracefully to faiss or pgvector ANN without hnswlib.
-# torch, sentence-transformers, faiss, and all other imports are unaffected.
-RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-        pip uninstall -y hnswlib || true; \
-    fi
+# NOTE: hnswlib removal moved to after the final pip install (line ~121)
+# to ensure it's not re-introduced by any subsequent install step.
 
 # ---------- Build Rust extensions (Issue #3125) ----------
 # On arm64, disable SimSIMD SVE backends at compile time. Apple Silicon does
@@ -118,6 +110,17 @@ COPY alembic/ ./alembic/
 COPY alembic/alembic.ini ./alembic.ini
 RUN rm -rf src/*.egg-info build/ && \
     pip install --no-cache-dir --no-deps --force-reinstall .
+
+# On arm64, remove hnswlib LAST — after all pip installs are done.
+# hnswlib 0.8.0's C extension executes SVE2 instructions that SIGILL on
+# Apple Silicon Docker (M-chips do not implement SVE). txtai falls back
+# gracefully to faiss/pgvector ANN without hnswlib.
+ARG TARGETARCH
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+        pip uninstall -y hnswlib && \
+        rm -f /usr/local/lib/python3.13/site-packages/hnswlib*.so && \
+        echo "✓ hnswlib removed (ARM64 SIGILL fix)"; \
+    fi
 
 # ---------- Production image ----------
 FROM python:3.13-slim

--- a/src/nexus/cli/commands/init_cmd.py
+++ b/src/nexus/cli/commands/init_cmd.py
@@ -50,7 +50,7 @@ class PresetConfig:
     auth: str
     compose_profiles: tuple[str, ...]
     port_keys: tuple[str, ...]
-    image_channel: str = "stable"
+    image_channel: str = "edge"
     image_accelerator: str = "cpu"
 
 
@@ -146,7 +146,7 @@ def _build_config(
     addons: tuple[str, ...],
     compose_file_override: str | None = None,
     *,
-    channel: str = "stable",
+    channel: str = "edge",
     accelerator: str = "cpu",
     image_tag: str | None = None,
     image_digest: str | None = None,
@@ -431,7 +431,7 @@ def _print_shared_summary(config: dict[str, Any], config_path: Path, data_dir: P
 @click.option(
     "--channel",
     type=click.Choice(VALID_CHANNELS),
-    default="stable",
+    default="edge",
     show_default=True,
     help="Release channel for the prebuilt image.",
 )

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -204,6 +204,24 @@ def _compose_profiles(compose_file: str) -> set[str]:
     return profiles
 
 
+def _find_repo_dockerfile() -> Path | None:
+    """Walk up from CWD to find a Dockerfile in a nexus repo checkout."""
+    cwd = Path.cwd()
+    for parent in (cwd, *cwd.parents):
+        candidate = parent / "Dockerfile"
+        if candidate.exists() and (parent / "pyproject.toml").exists():
+            # Verify it's actually a nexus repo (not some random Dockerfile)
+            try:
+                text = (parent / "pyproject.toml").read_text(errors="ignore")
+                if "nexus" in text.lower():
+                    return candidate
+            except OSError:
+                pass
+        if parent == parent.parent:
+            break
+    return None
+
+
 def _compose_has_build(compose_file: str) -> bool:
     """Return True if the nexus service in the compose file has a ``build:`` directive."""
     try:
@@ -503,11 +521,41 @@ def up(
         if _compose_has_build(cf):
             compose_env.pop("NEXUS_IMAGE_REF", None)
         else:
-            console.print(
-                "[yellow]Warning:[/yellow] --build ignored — compose file "
-                f"({Path(cf).name}) has no build: directive."
-            )
-            build = False
+            # No build: directive in compose file.  Fall back to building
+            # the Docker image from the repo Dockerfile if one exists,
+            # then tag it so compose uses it (Issue #3134).
+            repo_dockerfile = _find_repo_dockerfile()
+            if repo_dockerfile:
+                image_ref = compose_env.get(
+                    "NEXUS_IMAGE_REF", config.get("image_ref", "ghcr.io/nexi-lab/nexus:latest")
+                )
+                console.print(
+                    f"[cyan]Nexus:[/cyan] building image from {repo_dockerfile.relative_to(repo_dockerfile.parent.parent)} "
+                    f"→ {image_ref}"
+                )
+                build_result = subprocess.run(
+                    [
+                        "docker",
+                        "build",
+                        "-t",
+                        image_ref,
+                        "-f",
+                        str(repo_dockerfile),
+                        str(repo_dockerfile.parent),
+                    ],
+                    env={**os.environ, **compose_env},
+                )
+                if build_result.returncode != 0:
+                    console.print("[red]Error:[/red] Docker build failed.")
+                    raise SystemExit(1)
+                console.print(f"[green]Nexus:[/green] built image {image_ref} from source")
+                build = False  # don't pass --build to compose (no build: directive)
+            else:
+                console.print(
+                    "[yellow]Warning:[/yellow] --build ignored — compose file "
+                    f"({Path(cf).name}) has no build: directive and no Dockerfile found."
+                )
+                build = False
 
     data_dir = compose_env["NEXUS_HOST_DATA_DIR"]
 

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -537,6 +537,7 @@ def up(
                     [
                         "docker",
                         "build",
+                        "--no-cache",
                         "-t",
                         image_ref,
                         "-f",

--- a/tests/unit/cli/test_init_cmd.py
+++ b/tests/unit/cli/test_init_cmd.py
@@ -77,7 +77,7 @@ class TestPresetConfig:
 
     def test_default_channel_and_accelerator(self) -> None:
         for preset in VALID_PRESETS:
-            assert PRESETS[preset].image_channel == "stable"
+            assert PRESETS[preset].image_channel == "edge"
             assert PRESETS[preset].image_accelerator == "cpu"
 
 
@@ -226,7 +226,7 @@ class TestBuildConfig:
         cfg = _build_config("shared", "./data", False, {}, ())
         assert "image_ref" in cfg
         assert cfg["image_ref"].startswith("ghcr.io/nexi-lab/nexus:")
-        assert cfg["image_channel"] == "stable"
+        assert cfg["image_channel"] == "edge"
         assert cfg["image_accelerator"] == "cpu"
 
     def test_demo_preset(self) -> None:
@@ -338,7 +338,7 @@ class TestInitCliCommand:
         assert cfg["auth"] == "static"
         assert "postgres" in cfg["services"]
         assert "image_ref" in cfg
-        assert cfg["image_channel"] == "stable"
+        assert cfg["image_channel"] == "edge"
 
     def test_shared_preset_with_channel(
         self, runner: CliRunner, tmp_project: Path, _compose_file: Path


### PR DESCRIPTION
## Summary

- **Dockerfile**: Move `pip uninstall hnswlib` to the LAST builder step — after all pip installs complete. The previous position (before `COPY src/` and `pip install .`) allowed Docker layer cache to serve stale results where hnswlib was still present. Also `rm -f` the `.so` explicitly.
- **`nexus init`**: Default `--channel` from `stable` to `edge`. Edge images are built from develop on every push; stable lags behind releases.
- **`nexus up --build`**: When the compose file has no `build:` directive (portable stacks), fall back to `docker build` from the repo Dockerfile. Previously `--build` was silently ignored for portable stacks, making TUI Shift+U a no-op.

## Root cause

`hnswlib 0.8.0`'s C extension (`.so`) executes SVE2 instructions that SIGILL on Apple Silicon Docker (M-chips lack SVE). Confirmed via `python3 -v` import trace:

```
import 'txtai.ann.dense.hnsw'  # ← last import before SIGILL
```

Direct test: `python3 -c "from hnswlib import Index"` → exit code 132 (SIGILL).

faiss, torch, sentence-transformers, nexus_fast SIMD — all unaffected. Only hnswlib crashes. txtai falls back gracefully when hnswlib is absent (`try/except ImportError`).

## Test plan

- [ ] `docker build` on Apple Silicon → image builds, no SIGILL
- [ ] `docker run --entrypoint python3 <image> -c "from txtai import Embeddings"` → passes
- [ ] `nexus init --preset demo` generates `image_channel: edge`
- [ ] `nexus up --build` from portable stack runs `docker build` from repo Dockerfile