### PR TITLE
chore: add CODEOWNERS for kernel-critical directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Kernel team — auto-assign kernel lead as reviewer
+/src/nexus/core/          @elfenlieds7
+/src/nexus/raft/          @elfenlieds7
+/src/nexus/contracts/     @elfenlieds7
+/src/nexus/lib/           @elfenlieds7
+/docs/architecture/       @elfenlieds7


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` to auto-assign @elfenlieds7 as reviewer for PRs touching kernel-critical paths: `core/`, `raft/`, `contracts/`, `lib/`, `docs/architecture/`
- No enforcement (no required review enabled) — just auto-assignment + notification

## Test plan
- [x] Verify CODEOWNERS syntax is valid (GitHub parses it on push)
- [x] No code changes, CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)