### PR TITLE
feat(tui): UX polish — auto-reconnect, error hints, preview errors, status bar

### DIFF
--- a/packages/nexus-tui/src/panels/files/file-preview.tsx
+++ b/packages/nexus-tui/src/panels/files/file-preview.tsx
@@ -13,6 +13,7 @@ export function FilePreview(): React.ReactNode {
   const previewPath = useFilesStore((s) => s.previewPath);
   const previewContent = useFilesStore((s) => s.previewContent);
   const previewLoading = useFilesStore((s) => s.previewLoading);
+  const previewError = useFilesStore((s) => s.error);
   const fetchPreview = useFilesStore((s) => s.fetchPreview);
 
   useEffect(() => {
@@ -39,8 +40,11 @@ export function FilePreview(): React.ReactNode {
 
   if (previewContent === null) {
     return (
-      <box height="100%" width="100%">
+      <box height="100%" width="100%" flexDirection="column">
         <text>Unable to load preview</text>
+        {previewError && (
+          <text dimColor>{previewError}</text>
+        )}
       </box>
     );
   }

--- a/packages/nexus-tui/src/shared/components/command-output.tsx
+++ b/packages/nexus-tui/src/shared/components/command-output.tsx
@@ -11,6 +11,26 @@ import { StyledText } from "./styled-text.js";
 import { Spinner } from "./spinner.js";
 import { statusColor } from "../theme.js";
 
+const ERROR_HINTS: ReadonlyArray<{ pattern: RegExp; hint: string }> = [
+  { pattern: /authentication required|unauthorized|401/i, hint: "Check your API key (NEXUS_API_KEY or nexus.yaml api_key)" },
+  { pattern: /connection refused/i, hint: "Is the server running? Try Shift+U to start it" },
+  { pattern: /grpc.*unavailable|failed to connect/i, hint: "gRPC endpoint unreachable — check server logs" },
+  { pattern: /timed? ?out|deadline exceeded/i, hint: "Request timed out — the server may be overloaded" },
+  { pattern: /address already in use|EADDRINUSE/i, hint: "Port is already in use — stop the existing process or change ports" },
+  { pattern: /permission denied|EACCES/i, hint: "Permission denied — check file/directory permissions" },
+  { pattern: /no such file|ENOENT|not found/i, hint: "File or command not found — check paths and installation" },
+];
+
+function findErrorHint(lines: readonly string[]): string | null {
+  const tail = lines.slice(-20);
+  for (const line of tail) {
+    for (const { pattern, hint } of ERROR_HINTS) {
+      if (pattern.test(line)) return hint;
+    }
+  }
+  return null;
+}
+
 export function CommandOutput(): React.ReactNode {
   const status = useCommandRunnerStore((s) => s.status);
   const outputLines = useCommandRunnerStore((s) => s.outputLines);
@@ -61,6 +81,14 @@ export function CommandOutput(): React.ReactNode {
           <text foregroundColor={statusColor.error}>{`Command failed with exit code ${exitCode}`}</text>
         </box>
       )}
+      {status === "error" && (() => {
+        const hint = findErrorHint(outputLines);
+        return hint ? (
+          <box height={1} width="100%">
+            <text foregroundColor={statusColor.warning}>{`  Hint: ${hint}`}</text>
+          </box>
+        ) : null;
+      })()}
     </box>
   );
 }

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -18,6 +18,7 @@ import { CommandOutput } from "./command-output.js";
 import { Spinner } from "./spinner.js";
 import { statusColor } from "../theme.js";
 import { resolveConfig, FetchClient } from "@nexus/api-client";
+import { useFilesStore } from "../../stores/files-store.js";
 
 const AUTO_POLL_INTERVAL = 5_000; // 5 seconds (Decision 14A)
 
@@ -35,14 +36,19 @@ export function PreConnectionScreen(): React.ReactNode {
   const [retryCount, setRetryCount] = useState(0);
   const [urlInput, setUrlInput] = useState("");
   const [editingUrl, setEditingUrl] = useState(false);
+  const [apiKeyWarning, setApiKeyWarning] = useState<string | null>(null);
 
   // Track previous commandStatus to detect completion
   const prevCommandStatus = useRef(commandStatus);
+  // Track API key before init commands to detect changes
+  const prevApiKey = useRef<string | undefined>(undefined);
 
-  // When a local command finishes (success or error), re-read config from disk
-  // but DON'T auto-connect. The user should press R to retry or run more
-  // commands (e.g. D → Shift+U → P flow). Auto-connecting after `nexus init`
-  // would connect to a stale server with the wrong API key.
+  // When a local command finishes (success or error), re-read config from disk.
+  // Behavior depends on command type:
+  //   - "nexus up" success → auto-reconnect (server just started)
+  //   - "nexus init" success + API key changed → warn user to restart server
+  //   - "nexus demo" / "nexus up" success → clear file cache (data may have changed)
+  //   - All others → stay disconnected, user presses R when ready
   useEffect(() => {
     const prev = prevCommandStatus.current;
     prevCommandStatus.current = commandStatus;
@@ -51,19 +57,44 @@ export function PreConnectionScreen(): React.ReactNode {
       (prev === "running") &&
       (commandStatus === "success" || commandStatus === "error")
     ) {
+      const label = useCommandRunnerStore.getState().commandLabel;
+      const isUpCommand = label.startsWith("nexus up");
+      const isDataCommand = label.startsWith("nexus demo") || isUpCommand;
+      const isInitCommand = label.startsWith("nexus init");
+
       // Re-read config from disk without triggering connection test.
       // resolveConfig() picks up new api_key/ports from nexus.yaml.
-      const config = resolveConfig({ transformKeys: false });
-      const client = config.apiKey ? new FetchClient(config) : null;
-      useGlobalStore.setState({
-        config,
-        client,
-        // Stay disconnected — user presses R when ready
-        connectionStatus: client ? "error" : "disconnected",
-        connectionError: client ? "Press R to connect after setup" : null,
-      });
+      const newConfig = resolveConfig({ transformKeys: false });
+      const client = newConfig.apiKey ? new FetchClient(newConfig) : null;
+
+      // #3: Detect API key change after init commands
+      if (commandStatus === "success" && isInitCommand && prevApiKey.current !== undefined) {
+        if (newConfig.apiKey && newConfig.apiKey !== prevApiKey.current) {
+          setApiKeyWarning("API key changed. Restart server (Shift+U) to apply.");
+        }
+      }
+      prevApiKey.current = undefined;
+
+      // #6: Clear file cache after data-mutating commands
+      if (commandStatus === "success" && isDataCommand) {
+        useFilesStore.getState().clearCache();
+      }
+
+      // #1: Auto-reconnect after "nexus up" succeeds
+      if (commandStatus === "success" && isUpCommand && client) {
+        useGlobalStore.setState({ config: newConfig, client });
+        initConfig();
+      } else {
+        useGlobalStore.setState({
+          config: newConfig,
+          client,
+          // Stay disconnected — user presses R when ready
+          connectionStatus: client ? "error" : "disconnected",
+          connectionError: client ? "Press R to connect after setup" : null,
+        });
+      }
     }
-  }, [commandStatus]);
+  }, [commandStatus, initConfig]);
 
   // Manual retry: re-read config from disk + test connection.
   // This is critical for the no-config → init → retry flow: after nexus init
@@ -141,14 +172,20 @@ export function PreConnectionScreen(): React.ReactNode {
           r: handleRetry,
           a: () => setAutoPoll((prev) => !prev),
           i: () => {
+            prevApiKey.current = config.apiKey;
+            setApiKeyWarning(null);
             useCommandRunnerStore.getState().reset();
             executeLocalCommand("init", []);
           },
           s: () => {
+            prevApiKey.current = config.apiKey;
+            setApiKeyWarning(null);
             useCommandRunnerStore.getState().reset();
             executeLocalCommand("init", ["--preset", "shared"]);
           },
           d: () => {
+            prevApiKey.current = config.apiKey;
+            setApiKeyWarning(null);
             useCommandRunnerStore.getState().reset();
             executeLocalCommand("init", ["--preset", "demo", "--force"]);
           },
@@ -281,6 +318,13 @@ export function PreConnectionScreen(): React.ReactNode {
 
         {connState === "connecting" && (
           <Spinner label="  Connecting..." />
+        )}
+
+        {apiKeyWarning && (
+          <>
+            <text>{""}</text>
+            <text foregroundColor="#ffaa00">{`  ⚠ ${apiKeyWarning}`}</text>
+          </>
         )}
 
         <text>{""}</text>

--- a/packages/nexus-tui/src/shared/components/status-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/status-bar.tsx
@@ -27,6 +27,8 @@ export function StatusBar(): React.ReactNode {
   const activePanel = useGlobalStore((s) => s.activePanel);
   const userInfo = useGlobalStore((s) => s.userInfo);
   const enabledBricks = useGlobalStore((s) => s.enabledBricks);
+  const profile = useGlobalStore((s) => s.profile);
+  const mode = useGlobalStore((s) => s.mode);
 
   // Check if events panel has active filters
   const eventFilters = useEventsStore((s) => s.filters);
@@ -68,7 +70,7 @@ export function StatusBar(): React.ReactNode {
         {serverVersion ? (
           <>
             <span dimColor>{" │ "}</span>
-            <span dimColor>{`v${serverVersion}`}</span>
+            <span dimColor>{`v${serverVersion}${profile ? `/${profile}` : ""}${mode ? `/${mode}` : ""}`}</span>
           </>
         ) : ""}
         {zone ? (

--- a/packages/nexus-tui/src/stores/files-store.ts
+++ b/packages/nexus-tui/src/stores/files-store.ts
@@ -149,6 +149,7 @@ export interface FilesState {
   readonly renameFile: (oldPath: string, newPath: string, client: FetchClient) => Promise<void>;
   readonly getCachedFiles: (path: string) => readonly FileItem[] | undefined;
   readonly abortAllInFlight: () => void;
+  readonly clearCache: () => void;
 
   // Selection actions
   readonly toggleSelect: (path: string) => void;
@@ -226,6 +227,11 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   },
 
   abortAllInFlight,
+
+  clearCache: () => {
+    fileCache.clear();
+    set({ fileCacheRevision: get().fileCacheRevision + 1, treeNodes: new Map() });
+  },
 
   fetchFiles: async (path, client) => {
     // Check SWR cache


### PR DESCRIPTION
## Summary

Six targeted UX improvements discovered during real-world TUI testing (~5–20 lines each):

- **Auto-reconnect after Shift+U**: When `nexus up` succeeds, automatically calls `initConfig()` to connect — no manual R needed
- **Error hints for failed commands**: Scans last 20 output lines for common patterns (auth, connection refused, timeout, EADDRINUSE, etc.) and shows an actionable yellow hint
- **API key change warning**: Saves API key before init commands, compares after completion, shows "API key changed. Restart server (Shift+U) to apply." warning
- **Preview pane shows actual error**: Subscribes to `useFilesStore.error` and displays the real error message in dim text below "Unable to load preview"
- **Profile/mode in status bar**: Shows `v0.9.6/full/standalone` instead of just `v0.9.6` — uses existing `profile` and `mode` from global store
- **Auto-refresh file tree after seed/up**: Adds `clearCache()` action to files-store (clears LRU cache + resets tree nodes), called after `nexus demo` or `nexus up` succeeds

## Files changed (5)

| File | Change |
|------|--------|
| `stores/files-store.ts` | Add `clearCache()` action |
| `shared/components/pre-connection-screen.tsx` | Combined useEffect for #1, #3, #6 |
| `shared/components/command-output.tsx` | `findErrorHint()` + hint display |
| `panels/files/file-preview.tsx` | Show actual error from store |
| `shared/components/status-bar.tsx` | Subscribe to profile/mode |

## Test plan

- [x] `bun test` — 862 pass, 0 fail across 48 files
- [ ] Press Shift+U → verify auto-reconnect after server starts
- [ ] Press D → verify "API key changed" warning appears
- [ ] Press P → verify file tree refreshes with demo data
- [ ] Navigate to a file → verify preview loads (or shows actual error)
- [ ] Check status bar shows version/profile/mode
- [ ] Kill server → select a file → verify error detail in preview pane