### PR TITLE
fix(#1740,#1741): remove _brick_on and _dir_visibility_cache from kernel

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4381,9 +4381,6 @@ class NexusFS(  # type: ignore[misc]
         "list_mounts": ("mount_service", "list_mounts_sync"),
         "get_mount": ("mount_service", "get_mount_sync"),
         "has_mount": ("mount_service", "has_mount_sync"),
-        # Dir visibility cache: NexusFS method names → cache method names
-        "get_dir_visibility_cache_metrics": ("_dir_visibility_cache", "get_metrics"),
-        "clear_dir_visibility_cache": ("_dir_visibility_cache", "clear"),
         # SearchService async methods: a-prefix removed when calling service
         "asemantic_search": ("search_service", "semantic_search"),
         "asemantic_search_index": ("search_service", "semantic_search_index"),

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -88,8 +88,10 @@ async def _do_link(
     def _brick_on(name: str) -> bool:
         return name in _resolved_bricks
 
-    # Stash on kernel so _do_initialize() can pass it to _register_vfs_hooks()
-    nx._brick_on = _brick_on
+    # Issue #1740: capture _brick_on via partial so it never touches nx.__dict__.
+    import functools
+
+    nx._initialize_fn = functools.partial(_do_initialize, brick_on=_brick_on)
 
     # --- Boot wired services → register into ServiceRegistry ---
     _wired = await _boot_wired_services(
@@ -138,7 +140,7 @@ async def _do_link(
     )
 
 
-async def _do_initialize(nx: Any) -> None:
+async def _do_initialize(nx: Any, *, brick_on: "Any" = None) -> None:
     """Phase 2 implementation: one-time side effects.  NO background threads.
 
     Prepares resources but remains static — no active threads or async loops.
@@ -163,7 +165,7 @@ async def _do_initialize(nx: Any) -> None:
         nx,
         permission_checker=nx._permission_checker,
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
-        brick_on=getattr(nx, "_brick_on", None),
+        brick_on=brick_on,
     )
 
     # --- BLM registration for late bricks (Issue #1704, #2991) ---

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -126,9 +126,6 @@ def test_all_public_methods_are_exposed_or_excluded():
         "grant_traverse_on_implicit_dirs",  # Internal - grants TRAVERSE on implicit dirs during init
         "process_tiger_cache_queue",  # Internal - background worker processes cache updates
         "warm_tiger_cache",  # Internal - pre-computes permissions for cache warming
-        # Directory Visibility Cache internal methods - server-side optimization only
-        "clear_dir_visibility_cache",  # Internal - clears the directory visibility cache
-        "get_dir_visibility_cache_metrics",  # Internal - returns cache metrics for monitoring
         # Phase 2 Service Composition - Async delegation methods (Issue #988)
         # These are internal async methods that delegate to services. The original
         # sync mixin methods (without "a" prefix) already have @rpc_expose decorators.


### PR DESCRIPTION
## Summary

Two small factory cleanups:

**#1740 — `_brick_on`**: Factory-phase predicate that never belonged on `nx`. Previously stashed as `nx._brick_on = _brick_on` so `_do_initialize()` could read it. Now uses `functools.partial(_do_initialize, brick_on=_brick_on)` — `_brick_on` lives entirely in factory code, kernel has zero contact.

**#1741 — `_dir_visibility_cache` proxy removed from kernel**: Deletes `get_dir_visibility_cache_metrics` and `clear_dir_visibility_cache` from `_SERVICE_ALIASES`. Kernel no longer proxies ReBAC-internal cache ops. Access via `nx._system_services.dir_visibility_cache` directly. Updates `test_rpc_parity.py` accordingly.

## Changes
- `_lifecycle.py`: replace `nx._brick_on = _brick_on` with `nx._initialize_fn = functools.partial(_do_initialize, brick_on=_brick_on)`; `_do_initialize` takes `*, brick_on=None` param
- `nexus_fs.py`: delete 2 entries from `_SERVICE_ALIASES`
- `test_rpc_parity.py`: remove the 2 deleted methods from the allowlist

## Test plan
- [x] `uv run pytest tests/unit/` — 10867 passed
- [x] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)