### PR TITLE
fix(#1764,#1765,#1766,#1768): kernel attr cleanup — sentinel, factory-internal, enlist

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -139,8 +139,6 @@ class NexusFS(  # type: ignore[misc]
         else:
             self.router = PathRouter(metadata_store)
 
-        self._virtual_view_parse_fn = brk_svc.parse_fn
-
         # Default context for embedded mode
         self._default_context = OperationContext(
             user_id="anonymous",
@@ -155,6 +153,10 @@ class NexusFS(  # type: ignore[misc]
         # Issue #1706: sentinel — real value wired by factory._do_link().
         # Kept as sentinel (not deleted) because 8 kernel methods access without hasattr guard.
         self._permission_enforcer: Any = None
+        # Issue #1764: sentinel for kernel LSM-style hook (like _permission_enforcer).
+        # Real value injected by factory._do_link() via _wired.descendant_checker.
+        # Consider rename → _descendant_access_checker for clarity.
+        self._descendant_checker: Any = None
         # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
         self._overlay_resolver = None
         # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)
@@ -216,7 +218,6 @@ class NexusFS(  # type: ignore[misc]
         self._bootstrapped: bool = False
         self._bootstrap_callbacks: list[Callable[[], Any]] = []
         self._runtime_closeables: list[Any] = []
-        self._permission_checker: Any = None  # set by link()
         # Factory-injected lifecycle implementations.
         # Keeps nexus.core free of nexus.factory / nexus.bricks imports.
         self._link_fn: Callable[..., Any] | None = None

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -77,9 +77,6 @@ async def _do_link(
         _brick_updates["workflow_engine"] = workflow_engine
     nx._brick_services = _dc_replace(nx._brick_services, **_brick_updates)
 
-    # Update kernel-side references set by __init__ from original BrickServices
-    nx._virtual_view_parse_fn = _parse_fn
-
     # --- Resolve enabled_bricks for profile gating ---
     _resolved_bricks = enabled_bricks
     if _resolved_bricks is None:
@@ -88,10 +85,28 @@ async def _do_link(
     def _brick_on(name: str) -> bool:
         return name in _resolved_bricks
 
-    # Issue #1740: capture _brick_on via partial so it never touches nx.__dict__.
+    # --- PermissionChecker (services layer — Issue #899, #1766) ---
+    # Factory-local: _permission_checker is only needed by _register_vfs_hooks()
+    # at initialize() time. Captured via partial — never stored on nx.
+    from nexus.bricks.rebac.checker import PermissionChecker as _PC
+
+    _permission_checker = _PC(
+        permission_enforcer=_sys.permission_enforcer,
+        metadata_store=nx.metadata,
+        default_context=nx._default_context,
+        enforce_permissions=nx._enforce_permissions,
+    )
+
+    # Issue #1740/#1765/#1766: capture factory-phase locals via partial so they
+    # never touch nx.__dict__. _do_initialize receives them as keyword args.
     import functools
 
-    nx._initialize_fn = functools.partial(_do_initialize, brick_on=_brick_on)
+    nx._initialize_fn = functools.partial(
+        _do_initialize,
+        brick_on=_brick_on,
+        parse_fn=_parse_fn,
+        permission_checker=_permission_checker,
+    )
 
     # --- Boot wired services → register into ServiceRegistry ---
     _wired = await _boot_wired_services(
@@ -129,18 +144,10 @@ async def _do_link(
     if _dc is not None:
         nx._descendant_checker = _dc
 
-    # --- PermissionChecker (services layer — Issue #899) ---
-    from nexus.bricks.rebac.checker import PermissionChecker as _PC
 
-    nx._permission_checker = _PC(
-        permission_enforcer=_sys.permission_enforcer,
-        metadata_store=nx.metadata,
-        default_context=nx._default_context,
-        enforce_permissions=nx._enforce_permissions,
-    )
-
-
-async def _do_initialize(nx: Any, *, brick_on: "Any" = None) -> None:
+async def _do_initialize(
+    nx: Any, *, brick_on: "Any" = None, parse_fn: "Any" = None, permission_checker: "Any" = None
+) -> None:
     """Phase 2 implementation: one-time side effects.  NO background threads.
 
     Prepares resources but remains static — no active threads or async loops.
@@ -163,9 +170,10 @@ async def _do_initialize(nx: Any, *, brick_on: "Any" = None) -> None:
 
     await _register_vfs_hooks(
         nx,
-        permission_checker=nx._permission_checker,
+        permission_checker=permission_checker,
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
         brick_on=brick_on,
+        parse_fn=parse_fn,
     )
 
     # --- BLM registration for late bricks (Issue #1704, #2991) ---

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -398,6 +398,7 @@ async def _register_vfs_hooks(
     permission_checker: Any = None,
     auto_parse: bool = True,
     brick_on: "Callable[[str], bool] | None" = None,
+    parse_fn: Any = None,
 ) -> None:
     """Register hooks + observers via coordinator.enlist() (Issue #900, #1709).
 
@@ -475,7 +476,6 @@ async def _register_vfs_hooks(
 
     # AutoParseWriteHook (post-write: background parsing + cache invalidation)
     parser_reg = nx._brick_services.parser_registry
-    parse_fn = getattr(nx, "_virtual_view_parse_fn", None)
     if auto_parse and parser_reg is not None and parse_fn is not None:
         from nexus.bricks.parsers.auto_parse_hook import AutoParseWriteHook
 
@@ -521,7 +521,7 @@ async def _register_vfs_hooks(
         metadata=nx.metadata,
         path_router=nx.router,
         permission_checker=permission_checker,
-        parse_fn=getattr(nx, "_virtual_view_parse_fn", None),
+        parse_fn=parse_fn,
         read_tracker_fn=None,
     )
     await _enlist("virtual_view", _vview_resolver)
@@ -557,7 +557,7 @@ async def _register_vfs_hooks(
 
             await _enlist("task_write", _task_write_hook)
             await _enlist("task_agent_resolver", TaskAgentResolver(_proc_table))
-            nx._task_manager_service = _task_svc
+            await _enlist("task_manager", _task_svc)  # Issue #1768: Q1 service via coordinator
         except Exception as exc:
             logger.warning("[BOOT:BRICK] task_manager wiring failed: %s", exc)
     else:

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -405,7 +405,7 @@ def _startup_task_manager(app: "FastAPI", svc: "LifespanServices") -> None:
     """Wire TaskManagerService from factory to app.state (PR #3124)."""
     if svc.nexus_fs is None:
         return
-    task_svc = getattr(svc.nexus_fs, "_task_manager_service", None)
+    task_svc = svc.nexus_fs.service("task_manager")  # Issue #1768: via coordinator
     app.state.task_manager_service = task_svc
     if task_svc is not None:
         logger.info("[TASK-MGR] TaskManagerService wired to app.state")


### PR DESCRIPTION
## Summary

**#1764 — `_descendant_checker` sentinel (BUG FIX)**
Kernel calls `self._descendant_checker.has_access()` in 5 places but `__init__` had no sentinel → `AttributeError` if `link()` not called first. Fixed by adding `self._descendant_checker: Any = None` alongside `_permission_enforcer`.

**#1765 — `_virtual_view_parse_fn` → factory-internal**
Never read by kernel — only set in `_do_link()` and read in `_register_vfs_hooks()`. Same pattern as `_brick_on` (#1740): captured via `functools.partial` into `_initialize_fn`, passed as `parse_fn` param. Removed from `NexusFS.__init__`.

**#1766 — `_permission_checker` → factory-local**
Never read by kernel — only passed to `_register_vfs_hooks()`. Constructed in `_do_link()`, captured via partial, received as `permission_checker` param. Removed sentinel from `__init__`.

**#1768 — `_task_manager_service` → `enlist("task_manager", ...)`**
Was `nx._task_manager_service = _task_svc` (bypassing coordinator). Now Q1 service via `coordinator.enlist()`. Server reads via `nx.service("task_manager")`.

## Test plan
- [x] `uv run pytest tests/unit/` — 10899 passed, 0 failed
- [x] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)