### PR TITLE
fix(#1767): remove _kernel_services wrapper from NexusFS

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -102,7 +102,8 @@ class NexusFS(  # type: ignore[misc]
         self._distributed_config = distributed
         self._memory_config_obj = memory
         self._parse_config = parsing
-        self._kernel_services = ksvc
+        # Issue #1767: _kernel_services wrapper removed — only field was router,
+        # which is already stored as self.router (set a few lines below).
         self._system_services = sys_svc
         self._brick_services = brk_svc
         self._config: Any | None = None

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -96,7 +96,7 @@ async def _do_link(
     # --- Boot wired services → register into ServiceRegistry ---
     _wired = await _boot_wired_services(
         nx,
-        nx._kernel_services,
+        nx.router,  # Issue #1767: KernelServices wrapper removed
         nx._system_services,
         nx._brick_services,
         _brick_on,

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -8,14 +8,15 @@ from typing import TYPE_CHECKING, Any
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
-    from nexus.core.config import BrickServices, KernelServices, WiredServices
+    from nexus.core.config import BrickServices, WiredServices
+    from nexus.core.router import PathRouter
 
 logger = logging.getLogger(__name__)
 
 
 async def _boot_wired_services(
     nx: Any,
-    kernel_services: "KernelServices",
+    router: "PathRouter",
     system_services: Any,
     brick_services: "BrickServices",
     brick_on: Callable[[str], bool] | None = None,
@@ -31,12 +32,12 @@ async def _boot_wired_services(
     Issue #643: Migrated from ``NexusFS._wire_services()`` to factory.py
     so the kernel never imports or creates services.
 
-    Issue #2133: Typed with KernelServices + BrickServices
-    and returns WiredServices instead of dict[str, Any].
+    Issue #1767: Takes ``router`` directly instead of KernelServices wrapper
+    (KernelServices only wrapped the router, which is already on nx.router).
 
     Args:
         nx: The NexusFS instance (already constructed).
-        kernel_services: KernelServices container (Tier 0 — router only).
+        router: PathRouter (Tier 0 — router only).
         system_services: SystemServices container (Tier 1 — rebac, permissions, etc.).
         brick_services: BrickServices container (Tier 2).
         brick_on: Callable ``(name: str) -> bool`` for profile-based gating.
@@ -117,9 +118,7 @@ async def _boot_wired_services(
             mcp_service = MCPService(
                 filesystem=nx,
                 credential_service=oauth_service,
-                mount_lister=lambda: [
-                    (m.mount_point, "mounted") for m in kernel_services.router.list_mounts()
-                ],
+                mount_lister=lambda: [(m.mount_point, "mounted") for m in router.list_mounts()],
             )
             logger.debug("[BOOT:WIRED] MCPService created")
         except Exception as exc:
@@ -172,7 +171,7 @@ async def _boot_wired_services(
         from nexus.bricks.mount.mount_service import MountService
 
         mount_service = MountService(
-            router=kernel_services.router,
+            router=router,
             mount_manager=system_services.mount_manager,
             nexus_fs=nx,
             gateway=gateway,
@@ -201,7 +200,7 @@ async def _boot_wired_services(
         search_service = SearchService(
             metadata_store=nx.metadata,
             permission_enforcer=system_services.permission_enforcer,
-            router=kernel_services.router,
+            router=router,
             rebac_manager=system_services.rebac_manager,
             enforce_permissions=getattr(nx, "_enforce_permissions", True),
             default_context=getattr(nx, "_default_context", None),
@@ -415,7 +414,7 @@ async def _boot_wired_services(
             from nexus.bricks.versioning.operations_service import OperationsService
 
             _undo_service = OperationUndoService(
-                router=kernel_services.router,
+                router=router,
                 write_fn=nx.sys_write,
                 delete_fn=nx.sys_unlink,
                 rename_fn=nx.sys_rename,


### PR DESCRIPTION
## Summary

`KernelServices` was a single-field dataclass (`router` only). The router is already stored directly as `self.router` in `NexusFS.__init__` — no reason to also store the wrapper.

**Changes:**
- `nexus_fs.py`: remove `self._kernel_services = ksvc`
- `_wired.py`: `_boot_wired_services()` takes `router: PathRouter` directly instead of `kernel_services: KernelServices`
- `_lifecycle.py`: pass `nx.router` instead of `nx._kernel_services`

`KernelServices` dataclass is kept as factory public API (returned from `create_nexus_services()`, accepted by `create_nexus_fs()`).

## Test plan
- [x] `uv run pytest tests/unit/` — 10899 passed
- [x] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)