### PR TITLE
fix: Rust extensions build on Windows + default to full features

### DIFF
--- a/rust/nexus_pyo3/src/lib.rs
+++ b/rust/nexus_pyo3/src/lib.rs
@@ -17,7 +17,9 @@ mod prefix;
 mod rebac;
 mod search;
 mod semaphore;
+#[cfg(unix)]
 mod shm_pipe;
+#[cfg(unix)]
 mod shm_stream;
 mod simd;
 mod stream;
@@ -90,7 +92,9 @@ fn nexus_fast(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<lock::VFSLockManager>()?;
     m.add_class::<pipe::RingBufferCore>()?;
     m.add_class::<stream::StreamBufferCore>()?;
+    #[cfg(unix)]
     m.add_class::<shm_pipe::SharedRingBufferCore>()?;
+    #[cfg(unix)]
     m.add_class::<shm_stream::SharedStreamBufferCore>()?;
     m.add_class::<semaphore::VFSSemaphore>()?;
     // Dispatch (Issue #1317)

--- a/rust/nexus_raft/Cargo.toml
+++ b/rust/nexus_raft/Cargo.toml
@@ -67,7 +67,7 @@ tonic-build = { version = "0.12", optional = true }
 tokio-test = "0.4"
 
 [features]
-default = []
+default = ["full"]
 mimalloc = ["dep:mimalloc"]
 
 # Enable async support (Tokio runtime)


### PR DESCRIPTION
## Summary
- **nexus_pyo3**: gate `shm_pipe`/`shm_stream` with `#[cfg(unix)]` — these use `fcntl`/`pipe` (Unix-only), causing 21 compile errors on Windows
- **nexus_raft**: change default features from `[]` to `["full"]` so bare `maturin develop` gives a complete `_nexus_raft` with `ZoneManager` + `ZoneHandle` — previously required undiscoverable `--features full`

## Test plan
- [x] `maturin develop -m rust/nexus_pyo3/Cargo.toml` succeeds on Windows
- [x] `maturin develop -m rust/nexus_raft/Cargo.toml` (no extra flags) produces working ZoneManager
- [x] `nexusd --profile full` starts with federation enabled
- [x] Rust format + clippy pass in pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)