### PR TITLE
fix(docker): upgrade Go 1.24 → 1.25 for zoekt compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG USE_CHINA_MIRROR=false
 ARG TORCH_VARIANT=cpu
 
 # ---------- Stage 1: Build Zoekt binaries (independent, cached separately) ----------
-FROM golang:1.24 AS zoekt-builder
+FROM golang:1.25 AS zoekt-builder
 ARG USE_CHINA_MIRROR
 RUN if [ "$USE_CHINA_MIRROR" = "true" ]; then \
         go env -w GOPROXY=https://goproxy.cn,direct GOSUMDB=off; \

--- a/dockerfiles/Dockerfile.zoekt
+++ b/dockerfiles/Dockerfile.zoekt
@@ -1,7 +1,7 @@
 # Zoekt search server + indexer — multi-arch (amd64 + arm64)
 # Replaces sourcegraph/zoekt-webserver which is amd64-only.
 # Builds native Go binaries for the target platform.
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest && \


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.24 to 1.25 in `Dockerfile` and `dockerfiles/Dockerfile.zoekt`
- zoekt `v0.0.0-20260318140357` now requires `go >= 1.25.0`, breaking Docker builds with `go 1.24.13`

## Test plan
- [x] Docker Build Smoke Test should pass with `golang:1.25`

🤖 Generated with [Claude Code](https://claude.com/claude-code)