### PR TITLE
feat(#1770,#1773): migrate snapshot + deferred_permission to KernelDispatch hooks

### DIFF
--- a/src/nexus/bricks/rebac/deferred_permission_hook.py
+++ b/src/nexus/bricks/rebac/deferred_permission_hook.py
@@ -1,0 +1,68 @@
+"""VFS write hook for deferred permission buffer (Issue #1773).
+
+Wraps ``DeferredPermissionBuffer.queue_hierarchy()`` /
+``queue_owner_grant()`` as a proper KernelDispatch hook, eliminating
+the kernel's getattr() calls to
+``_system_services.deferred_permission_buffer``.
+
+Data mapping:
+    ctx.path          → path
+    ctx.zone_id       → zone_id (default "root")
+    ctx.context       → OperationContext (user_id, is_system)
+    ctx.is_new_file   → only queue_owner_grant for new files
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.operation_result import OperationWarning
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
+    from nexus.contracts.vfs_hooks import WriteHookContext
+
+logger = logging.getLogger(__name__)
+
+
+class DeferredPermissionHook:
+    """Post-write hook that queues hierarchy + owner grants in background."""
+
+    name = "deferred_permission"
+    __slots__ = ("_buf",)
+
+    # ── HotSwappable protocol (Issue #1773) ────────────────────────────
+
+    def hook_spec(self) -> HookSpec:
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(write_hooks=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    def __init__(self, deferred_buffer: Any) -> None:
+        self._buf = deferred_buffer
+
+    # ── Hook callback ──────────────────────────────────────────────────
+
+    def on_post_write(self, ctx: WriteHookContext) -> None:
+        zone = ctx.zone_id or "root"
+        try:
+            self._buf.queue_hierarchy(ctx.path, zone)
+            if ctx.is_new_file and ctx.context:
+                user = ctx.context.user_id
+                if user and not ctx.context.is_system:
+                    self._buf.queue_owner_grant(user, ctx.path, zone)
+        except Exception as e:
+            ctx.warnings.append(
+                OperationWarning(
+                    severity="degraded",
+                    component="deferred_permission",
+                    message=f"queue failed: {e}",
+                )
+            )

--- a/src/nexus/bricks/rebac/sync_permission_hook.py
+++ b/src/nexus/bricks/rebac/sync_permission_hook.py
@@ -1,0 +1,90 @@
+"""VFS write hook for synchronous permission hierarchy + owner grant (Issue #1773).
+
+This is the sync fallback for when ``DeferredPermissionBuffer`` is not
+available (``enable_deferred=False``).  Wraps the same
+``hierarchy_manager.ensure_parent_tuples()`` and
+``rebac_manager.rebac_write()`` calls that previously lived inline in
+``NexusFS._write_internal()``.
+
+Exactly one of ``DeferredPermissionHook`` or ``SyncPermissionWriteHook``
+is enlisted at boot — never both.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.operation_result import OperationWarning
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
+    from nexus.contracts.vfs_hooks import WriteHookContext
+
+logger = logging.getLogger(__name__)
+
+
+class SyncPermissionWriteHook:
+    """Post-write hook: sync hierarchy tuples + owner grant."""
+
+    name = "sync_permission"
+    __slots__ = ("_hierarchy", "_rebac")
+
+    # ── HotSwappable protocol (Issue #1773) ────────────────────────────
+
+    def hook_spec(self) -> HookSpec:
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(write_hooks=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    def __init__(
+        self,
+        hierarchy_manager: Any | None = None,
+        rebac_manager: Any | None = None,
+    ) -> None:
+        self._hierarchy = hierarchy_manager
+        self._rebac = rebac_manager
+
+    # ── Hook callback ──────────────────────────────────────────────────
+
+    def on_post_write(self, ctx: WriteHookContext) -> None:
+        zone = ctx.zone_id or "root"
+
+        # Hierarchy tuples — enables permission inheritance from parents
+        if self._hierarchy is not None:
+            try:
+                self._hierarchy.ensure_parent_tuples(ctx.path, zone_id=zone)
+            except Exception as e:
+                ctx.warnings.append(
+                    OperationWarning(
+                        severity="degraded",
+                        component="sync_permission",
+                        message=f"ensure_parent_tuples failed: {e}",
+                    )
+                )
+
+        # Owner grant — only for new files by non-system users
+        if ctx.is_new_file and self._rebac is not None and ctx.context:
+            user = ctx.context.user_id
+            if user and not ctx.context.is_system:
+                try:
+                    self._rebac.rebac_write(
+                        subject=("user", user),
+                        relation="direct_owner",
+                        object=("file", ctx.path),
+                        zone_id=zone,
+                    )
+                except Exception as e:
+                    ctx.warnings.append(
+                        OperationWarning(
+                            severity="degraded",
+                            component="sync_permission",
+                            message=f"owner grant failed: {e}",
+                        )
+                    )

--- a/src/nexus/bricks/snapshot/snapshot_hook.py
+++ b/src/nexus/bricks/snapshot/snapshot_hook.py
@@ -1,0 +1,85 @@
+"""VFS write/delete hook for transactional snapshot tracking (Issue #1770).
+
+Wraps ``TransactionalSnapshotService.track_write()`` / ``track_delete()``
+as a proper KernelDispatch hook, eliminating the kernel's getattr() calls
+to ``_brick_services.snapshot_service``.
+
+Data mapping:
+    WriteHookContext.old_metadata  → snapshot_hash (etag), metadata_snapshot
+    WriteHookContext.content_hash  → new content hash
+    DeleteHookContext.metadata     → pre-delete snapshot_hash, metadata_snapshot
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
+    from nexus.contracts.vfs_hooks import DeleteHookContext, WriteHookContext
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotWriteHook:
+    """Post-write/delete hook that auto-tracks mutations in active transactions."""
+
+    name = "snapshot_write_tracker"
+    __slots__ = ("_svc",)
+
+    # ── HotSwappable protocol (Issue #1770) ────────────────────────────
+
+    def hook_spec(self) -> HookSpec:
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(write_hooks=(self,), delete_hooks=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    def __init__(self, snapshot_service: Any) -> None:
+        self._svc = snapshot_service
+
+    # ── Hook callbacks ─────────────────────────────────────────────────
+
+    def on_post_write(self, ctx: WriteHookContext) -> None:
+        txn_id = self._svc.is_tracked(ctx.path)
+        if txn_id is None:
+            return
+        old = ctx.old_metadata
+        snapshot_hash = old.etag if old else None
+        metadata_snapshot: dict[str, Any] | None = None
+        if old:
+            metadata_snapshot = {
+                "size": old.size,
+                "version": old.version,
+                "modified_at": old.modified_at.isoformat() if old.modified_at else None,
+            }
+        self._svc.track_write(
+            txn_id,
+            ctx.path,
+            snapshot_hash,
+            metadata_snapshot,
+            ctx.content_hash,
+        )
+
+    def on_post_delete(self, ctx: DeleteHookContext) -> None:
+        txn_id = self._svc.is_tracked(ctx.path)
+        if txn_id is None:
+            return
+        meta = ctx.metadata  # pre-delete state
+        if meta is None:
+            return
+        snapshot_hash = meta.etag
+        metadata_snapshot: dict[str, Any] = {
+            "size": meta.size,
+            "version": meta.version,
+            "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
+            "backend_name": meta.backend_name,
+            "physical_path": meta.physical_path,
+        }
+        self._svc.track_delete(txn_id, ctx.path, snapshot_hash, metadata_snapshot)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -2426,16 +2426,6 @@ class NexusFS(  # type: ignore[misc]
         now = datetime.now(UTC)
         meta = self.metadata.get(path)
 
-        # Capture snapshot before operation for undo capability
-        snapshot_hash = meta.etag if meta else None
-        metadata_snapshot = None
-        if meta:
-            metadata_snapshot = {
-                "size": meta.size,
-                "version": meta.version,
-                "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
-            }
-
         # PRE-INTERCEPT: pre-write hooks (Issue #899)
         # Hook handles existing-file (owner fast-path) vs new-file (parent check)
         from nexus.contracts.vfs_hooks import WriteHookContext as _WHC
@@ -2536,88 +2526,6 @@ class NexusFS(  # type: ignore[misc]
                 is_new=(meta is None),
             )
         )
-
-        # P0-3: Create parent relationship tuples for file inheritance
-        # This enables permission inheritance from parent directories
-        # Issue #1071: Use deferred buffer for async permission operations if available
-        # This reduces single-file write latency from ~36ms to ~10ms by batching
-        # permission operations in the background. Owner access is guaranteed by
-        # owner_id in metadata (fast-path check).
-        ctx = context if context is not None else self._default_context
-        # Issue #1570: deferred_permission_buffer accessed from container, not flat attr.
-        deferred_buffer = (
-            getattr(self._system_services, "deferred_permission_buffer", None)
-            if self._system_services
-            else None
-        )
-
-        if deferred_buffer is not None:
-            # DEFERRED PATH: Queue permission operations for background batch processing
-            # Owner can still access file immediately via owner_id fast-path
-            try:
-                deferred_buffer.queue_hierarchy(path, ctx.zone_id or "root")
-                if meta is None and ctx.user_id and not ctx.is_system:
-                    deferred_buffer.queue_owner_grant(ctx.user_id, path, ctx.zone_id or "root")
-            except Exception as e:
-                logger.warning("write: Failed to queue deferred permissions for %s: %s", path, e)
-        else:
-            # SYNC PATH: Execute permission operations immediately (original behavior)
-            _hier = (
-                getattr(self._system_services, "hierarchy_manager", None)
-                if self._system_services
-                else None
-            )
-            if _hier is not None:
-                try:
-                    logger.info(
-                        "write: Calling ensure_parent_tuples for %s, zone_id=%s",
-                        path,
-                        ctx.zone_id or ROOT_ZONE_ID,
-                    )
-                    created_count = _hier.ensure_parent_tuples(path, zone_id=ctx.zone_id or "root")
-                    logger.info("write: Created %d parent tuples for %s", created_count, path)
-                except Exception as e:
-                    logger.warning(
-                        f"write: Failed to create parent tuples for {path}: {type(e).__name__}: {e}"
-                    )
-
-            # Issue #548: Grant direct_owner permission to the user who created the file
-            _rebac = (
-                getattr(self._system_services, "rebac_manager", None)
-                if self._system_services
-                else None
-            )
-            if meta is None and _rebac:
-                try:
-                    if ctx.user_id and not ctx.is_system:
-                        logger.debug(
-                            f"write: Granting direct_owner permission to {ctx.user_id} for {path}"
-                        )
-                        _rebac.rebac_write(
-                            subject=("user", ctx.user_id),
-                            relation="direct_owner",
-                            object=("file", path),
-                            zone_id=ctx.zone_id or "root",
-                        )
-                        logger.debug(
-                            f"write: Granted direct_owner permission to {ctx.user_id} for {path}"
-                        )
-                except Exception as e:
-                    logger.warning(
-                        f"write: Failed to grant direct_owner permission for {path}: {e}"
-                    )
-
-        # Issue #1752: Auto-track write in active transaction (snapshot for rollback)
-        # Issue #1570: snapshot_service accessed from container, not flat attr.
-        _ss = (
-            getattr(self._brick_services, "snapshot_service", None)
-            if self._brick_services
-            else None
-        )
-        if _ss is not None:
-            _txn_id = _ss.is_tracked(path)
-            if _txn_id is not None:
-                _ss.track_write(_txn_id, path, snapshot_hash, metadata_snapshot, content_hash)
 
         # Issue #900: Unified two-phase dispatch — INTERCEPT (observer + hooks)
         from nexus.contracts.vfs_hooks import WriteHookContext
@@ -3390,32 +3298,10 @@ class NexusFS(  # type: ignore[misc]
         if meta is None:
             raise NexusFileNotFoundError(path)
 
-        # Capture snapshot before operation for undo capability
-        snapshot_hash = meta.etag
-        metadata_snapshot = {
-            "size": meta.size,
-            "version": meta.version,
-            "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
-            "backend_name": meta.backend_name,
-            "physical_path": meta.physical_path,
-        }
-
         # PRE-INTERCEPT: pre-delete hooks (Issue #899)
         from nexus.contracts.vfs_hooks import DeleteHookContext as _DHC
 
         self._dispatch.intercept_pre_delete(_DHC(path=path, context=context))
-
-        # Issue #1752: Auto-track delete in active transaction (snapshot for rollback)
-        # Issue #1570: snapshot_service accessed from container, not flat attr.
-        _ss = (
-            getattr(self._brick_services, "snapshot_service", None)
-            if self._brick_services
-            else None
-        )
-        if _ss is not None:
-            _txn_id = _ss.is_tracked(path)
-            if _txn_id is not None:
-                _ss.track_delete(_txn_id, path, snapshot_hash, metadata_snapshot)
 
         # Issue #900: Unified two-phase dispatch — INTERCEPT (observer + hooks)
         # Placed BEFORE physical content delete to preserve audit integrity.
@@ -4984,18 +4870,6 @@ class NexusFS(  # type: ignore[misc]
         )
         if _pt is not None:
             _pt.close_all()
-
-        # Stop DeferredPermissionBuffer first to flush pending permissions.
-        # Uses _stop_sync() because close() is sync; async stop() is handled
-        # by coordinator.stop_persistent_services() in aclose().
-        # Issue #1570: accessed from container, not flat attr.
-        _dpb = (
-            getattr(self._system_services, "deferred_permission_buffer", None)
-            if self._system_services
-            else None
-        )
-        if _dpb:
-            _dpb._stop_sync()
 
         # Flush write observer pre-buffer (CLI mode: events buffered in memory
         # because PipeManager was never injected). Must happen before

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -563,6 +563,37 @@ async def _register_vfs_hooks(
     else:
         logger.debug("[BOOT:BRICK] task_manager disabled by profile")
 
+    # ── Snapshot write tracker (Issue #1770) ─────────────────────────
+    _snapshot_svc = getattr(nx._brick_services, "snapshot_service", None)
+    if _snapshot_svc is not None:
+        from nexus.bricks.snapshot.snapshot_hook import SnapshotWriteHook
+
+        await _enlist("snapshot_write", SnapshotWriteHook(_snapshot_svc))
+
+    # ── Deferred permission buffer (Issue #1773) ──────────────────────
+    _dpb = (
+        getattr(nx._system_services, "deferred_permission_buffer", None)
+        if nx._system_services
+        else None
+    )
+    if _dpb is not None:
+        from nexus.bricks.rebac.deferred_permission_hook import DeferredPermissionHook
+
+        await _enlist("deferred_permission", DeferredPermissionHook(_dpb))
+    else:
+        # Sync fallback — same logic, runs as post-write hook instead of inline kernel code
+        _hier = (
+            getattr(nx._system_services, "hierarchy_manager", None) if nx._system_services else None
+        )
+        _rebac = getattr(nx, "_rebac_manager", None)
+        if _hier is not None or _rebac is not None:
+            from nexus.bricks.rebac.sync_permission_hook import SyncPermissionWriteHook
+
+            await _enlist(
+                "sync_permission",
+                SyncPermissionWriteHook(hierarchy_manager=_hier, rebac_manager=_rebac),
+            )
+
     # ── OBSERVE observers (Issue #900, #922) ──────────────────────────
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).
     # Replaces _publish_file_event() direct calls — single dispatch exit point.

--- a/tests/unit/bricks/snapshot/test_snapshot_hook.py
+++ b/tests/unit/bricks/snapshot/test_snapshot_hook.py
@@ -1,0 +1,156 @@
+"""Unit tests for SnapshotWriteHook (Issue #1770)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.snapshot.snapshot_hook import SnapshotWriteHook
+from nexus.contracts.vfs_hooks import DeleteHookContext, WriteHookContext
+
+
+@pytest.fixture()
+def mock_svc() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def hook(mock_svc: MagicMock) -> SnapshotWriteHook:
+    return SnapshotWriteHook(mock_svc)
+
+
+def _make_meta(**overrides: object) -> MagicMock:
+    meta = MagicMock()
+    meta.etag = overrides.get("etag", "old-etag")
+    meta.size = overrides.get("size", 1024)
+    meta.version = overrides.get("version", 3)
+    meta.modified_at = overrides.get("modified_at", datetime(2026, 1, 1, tzinfo=UTC))
+    meta.backend_name = overrides.get("backend_name", "default")
+    meta.physical_path = overrides.get("physical_path", "/data/abc")
+    return meta
+
+
+# ── HotSwappable protocol ────────────────────────────────────────────
+
+
+class TestHotSwappable:
+    def test_hook_spec_declares_write_and_delete(self, hook: SnapshotWriteHook) -> None:
+        spec = hook.hook_spec()
+        assert hook in spec.write_hooks
+        assert hook in spec.delete_hooks
+
+    def test_name(self, hook: SnapshotWriteHook) -> None:
+        assert hook.name == "snapshot_write_tracker"
+
+    @pytest.mark.asyncio()
+    async def test_drain_is_noop(self, hook: SnapshotWriteHook) -> None:
+        await hook.drain()
+
+    @pytest.mark.asyncio()
+    async def test_activate_is_noop(self, hook: SnapshotWriteHook) -> None:
+        await hook.activate()
+
+
+# ── on_post_write ─────────────────────────────────────────────────────
+
+
+class TestOnPostWrite:
+    def test_tracks_write_when_transaction_active(
+        self, hook: SnapshotWriteHook, mock_svc: MagicMock
+    ) -> None:
+        mock_svc.is_tracked.return_value = "txn-1"
+        old = _make_meta()
+        ctx = WriteHookContext(
+            path="/file.txt",
+            content=b"data",
+            context=None,
+            old_metadata=old,
+            content_hash="new-hash",
+        )
+        hook.on_post_write(ctx)
+
+        mock_svc.track_write.assert_called_once_with(
+            "txn-1",
+            "/file.txt",
+            "old-etag",
+            {
+                "size": 1024,
+                "version": 3,
+                "modified_at": "2026-01-01T00:00:00+00:00",
+            },
+            "new-hash",
+        )
+
+    def test_skips_when_no_transaction(self, hook: SnapshotWriteHook, mock_svc: MagicMock) -> None:
+        mock_svc.is_tracked.return_value = None
+        ctx = WriteHookContext(
+            path="/file.txt",
+            content=b"data",
+            context=None,
+            old_metadata=_make_meta(),
+            content_hash="new-hash",
+        )
+        hook.on_post_write(ctx)
+        mock_svc.track_write.assert_not_called()
+
+    def test_handles_new_file_no_old_metadata(
+        self, hook: SnapshotWriteHook, mock_svc: MagicMock
+    ) -> None:
+        mock_svc.is_tracked.return_value = "txn-2"
+        ctx = WriteHookContext(
+            path="/new.txt",
+            content=b"data",
+            context=None,
+            old_metadata=None,
+            content_hash="hash-1",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+
+        mock_svc.track_write.assert_called_once_with(
+            "txn-2",
+            "/new.txt",
+            None,
+            None,
+            "hash-1",
+        )
+
+
+# ── on_post_delete ────────────────────────────────────────────────────
+
+
+class TestOnPostDelete:
+    def test_tracks_delete_when_transaction_active(
+        self, hook: SnapshotWriteHook, mock_svc: MagicMock
+    ) -> None:
+        mock_svc.is_tracked.return_value = "txn-1"
+        meta = _make_meta(backend_name="s3", physical_path="/bucket/key")
+        ctx = DeleteHookContext(path="/file.txt", context=None, metadata=meta)
+        hook.on_post_delete(ctx)
+
+        mock_svc.track_delete.assert_called_once_with(
+            "txn-1",
+            "/file.txt",
+            "old-etag",
+            {
+                "size": 1024,
+                "version": 3,
+                "modified_at": "2026-01-01T00:00:00+00:00",
+                "backend_name": "s3",
+                "physical_path": "/bucket/key",
+            },
+        )
+
+    def test_skips_when_no_transaction(self, hook: SnapshotWriteHook, mock_svc: MagicMock) -> None:
+        mock_svc.is_tracked.return_value = None
+        ctx = DeleteHookContext(path="/file.txt", context=None, metadata=_make_meta())
+        hook.on_post_delete(ctx)
+        mock_svc.track_delete.assert_not_called()
+
+    def test_skips_when_no_metadata(self, hook: SnapshotWriteHook, mock_svc: MagicMock) -> None:
+        mock_svc.is_tracked.return_value = "txn-3"
+        ctx = DeleteHookContext(path="/file.txt", context=None, metadata=None)
+        hook.on_post_delete(ctx)
+        mock_svc.track_delete.assert_not_called()

--- a/tests/unit/rebac/test_deferred_permission_hook.py
+++ b/tests/unit/rebac/test_deferred_permission_hook.py
@@ -1,0 +1,158 @@
+"""Unit tests for DeferredPermissionHook (Issue #1773)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.rebac.deferred_permission_hook import DeferredPermissionHook
+from nexus.contracts.vfs_hooks import WriteHookContext
+
+
+@pytest.fixture()
+def mock_buf() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def hook(mock_buf: MagicMock) -> DeferredPermissionHook:
+    return DeferredPermissionHook(mock_buf)
+
+
+def _make_context(**overrides: object) -> MagicMock:
+    ctx = MagicMock()
+    ctx.user_id = overrides.get("user_id", "user-1")
+    ctx.is_system = overrides.get("is_system", False)
+    ctx.zone_id = overrides.get("zone_id", "zone-a")
+    return ctx
+
+
+# ── HotSwappable protocol ────────────────────────────────────────────
+
+
+class TestHotSwappable:
+    def test_hook_spec_declares_write(self, hook: DeferredPermissionHook) -> None:
+        spec = hook.hook_spec()
+        assert hook in spec.write_hooks
+        assert spec.delete_hooks == ()
+
+    def test_name(self, hook: DeferredPermissionHook) -> None:
+        assert hook.name == "deferred_permission"
+
+    @pytest.mark.asyncio()
+    async def test_drain_is_noop(self, hook: DeferredPermissionHook) -> None:
+        await hook.drain()
+
+    @pytest.mark.asyncio()
+    async def test_activate_is_noop(self, hook: DeferredPermissionHook) -> None:
+        await hook.activate()
+
+
+# ── on_post_write ─────────────────────────────────────────────────────
+
+
+class TestOnPostWrite:
+    def test_queues_hierarchy_always(
+        self, hook: DeferredPermissionHook, mock_buf: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/dir/file.txt",
+            content=b"data",
+            context=_make_context(),
+            zone_id="zone-a",
+            is_new_file=False,
+        )
+        hook.on_post_write(ctx)
+
+        mock_buf.queue_hierarchy.assert_called_once_with("/dir/file.txt", "zone-a")
+        mock_buf.queue_owner_grant.assert_not_called()
+
+    def test_queues_owner_grant_for_new_file(
+        self, hook: DeferredPermissionHook, mock_buf: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/new.txt",
+            content=b"data",
+            context=_make_context(user_id="alice"),
+            zone_id="zone-b",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+
+        mock_buf.queue_hierarchy.assert_called_once_with("/new.txt", "zone-b")
+        mock_buf.queue_owner_grant.assert_called_once_with("alice", "/new.txt", "zone-b")
+
+    def test_skips_owner_grant_for_system_user(
+        self, hook: DeferredPermissionHook, mock_buf: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/new.txt",
+            content=b"data",
+            context=_make_context(is_system=True),
+            zone_id="zone-a",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+
+        mock_buf.queue_hierarchy.assert_called_once()
+        mock_buf.queue_owner_grant.assert_not_called()
+
+    def test_skips_owner_grant_when_no_user_id(
+        self, hook: DeferredPermissionHook, mock_buf: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/new.txt",
+            content=b"data",
+            context=_make_context(user_id=None),
+            zone_id="zone-a",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+
+        mock_buf.queue_hierarchy.assert_called_once()
+        mock_buf.queue_owner_grant.assert_not_called()
+
+    def test_defaults_zone_to_root(self, hook: DeferredPermissionHook, mock_buf: MagicMock) -> None:
+        ctx = WriteHookContext(
+            path="/file.txt",
+            content=b"data",
+            context=None,
+            zone_id=None,
+            is_new_file=False,
+        )
+        hook.on_post_write(ctx)
+        mock_buf.queue_hierarchy.assert_called_once_with("/file.txt", "root")
+
+    def test_exception_becomes_warning(
+        self, hook: DeferredPermissionHook, mock_buf: MagicMock
+    ) -> None:
+        mock_buf.queue_hierarchy.side_effect = RuntimeError("buffer full")
+        ctx = WriteHookContext(
+            path="/file.txt",
+            content=b"data",
+            context=None,
+            zone_id="z",
+            is_new_file=False,
+        )
+        hook.on_post_write(ctx)
+
+        assert len(ctx.warnings) == 1
+        assert ctx.warnings[0].severity == "degraded"
+        assert ctx.warnings[0].component == "deferred_permission"
+        assert "buffer full" in ctx.warnings[0].message
+
+    def test_skips_owner_grant_when_no_context(
+        self, hook: DeferredPermissionHook, mock_buf: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/new.txt",
+            content=b"data",
+            context=None,
+            zone_id="zone-a",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+
+        mock_buf.queue_hierarchy.assert_called_once()
+        mock_buf.queue_owner_grant.assert_not_called()

--- a/tests/unit/rebac/test_sync_permission_hook.py
+++ b/tests/unit/rebac/test_sync_permission_hook.py
@@ -1,0 +1,163 @@
+"""Unit tests for SyncPermissionWriteHook (Issue #1773)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.rebac.sync_permission_hook import SyncPermissionWriteHook
+from nexus.contracts.vfs_hooks import WriteHookContext
+
+
+@pytest.fixture()
+def mock_hier() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def mock_rebac() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def hook(mock_hier: MagicMock, mock_rebac: MagicMock) -> SyncPermissionWriteHook:
+    return SyncPermissionWriteHook(hierarchy_manager=mock_hier, rebac_manager=mock_rebac)
+
+
+def _make_context(**overrides: object) -> MagicMock:
+    ctx = MagicMock()
+    ctx.user_id = overrides.get("user_id", "user-1")
+    ctx.is_system = overrides.get("is_system", False)
+    return ctx
+
+
+# ── HotSwappable ──────────────────────────────────────────────────────
+
+
+class TestHotSwappable:
+    def test_hook_spec_declares_write(self, hook: SyncPermissionWriteHook) -> None:
+        spec = hook.hook_spec()
+        assert hook in spec.write_hooks
+
+    def test_name(self, hook: SyncPermissionWriteHook) -> None:
+        assert hook.name == "sync_permission"
+
+    @pytest.mark.asyncio()
+    async def test_drain_is_noop(self, hook: SyncPermissionWriteHook) -> None:
+        await hook.drain()
+
+    @pytest.mark.asyncio()
+    async def test_activate_is_noop(self, hook: SyncPermissionWriteHook) -> None:
+        await hook.activate()
+
+
+# ── on_post_write ─────────────────────────────────────────────────────
+
+
+class TestOnPostWrite:
+    def test_calls_ensure_parent_tuples(
+        self, hook: SyncPermissionWriteHook, mock_hier: MagicMock, mock_rebac: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/dir/file.txt",
+            content=b"data",
+            context=_make_context(),
+            zone_id="zone-a",
+            is_new_file=False,
+        )
+        hook.on_post_write(ctx)
+
+        mock_hier.ensure_parent_tuples.assert_called_once_with("/dir/file.txt", zone_id="zone-a")
+        mock_rebac.rebac_write.assert_not_called()
+
+    def test_grants_owner_for_new_file(
+        self, hook: SyncPermissionWriteHook, mock_hier: MagicMock, mock_rebac: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/new.txt",
+            content=b"data",
+            context=_make_context(user_id="alice"),
+            zone_id="zone-b",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+
+        mock_hier.ensure_parent_tuples.assert_called_once()
+        mock_rebac.rebac_write.assert_called_once_with(
+            subject=("user", "alice"),
+            relation="direct_owner",
+            object=("file", "/new.txt"),
+            zone_id="zone-b",
+        )
+
+    def test_skips_owner_grant_for_system(
+        self, hook: SyncPermissionWriteHook, mock_rebac: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/new.txt",
+            content=b"data",
+            context=_make_context(is_system=True),
+            zone_id="z",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+        mock_rebac.rebac_write.assert_not_called()
+
+    def test_defaults_zone_to_root(
+        self, hook: SyncPermissionWriteHook, mock_hier: MagicMock
+    ) -> None:
+        ctx = WriteHookContext(
+            path="/file.txt",
+            content=b"x",
+            context=None,
+            zone_id=None,
+            is_new_file=False,
+        )
+        hook.on_post_write(ctx)
+        mock_hier.ensure_parent_tuples.assert_called_once_with("/file.txt", zone_id="root")
+
+    def test_hierarchy_error_becomes_warning(
+        self, hook: SyncPermissionWriteHook, mock_hier: MagicMock
+    ) -> None:
+        mock_hier.ensure_parent_tuples.side_effect = RuntimeError("db down")
+        ctx = WriteHookContext(
+            path="/f.txt",
+            content=b"x",
+            context=None,
+            zone_id="z",
+            is_new_file=False,
+        )
+        hook.on_post_write(ctx)
+
+        assert len(ctx.warnings) == 1
+        assert ctx.warnings[0].component == "sync_permission"
+        assert "ensure_parent_tuples" in ctx.warnings[0].message
+
+    def test_owner_grant_error_becomes_warning(
+        self, hook: SyncPermissionWriteHook, mock_rebac: MagicMock
+    ) -> None:
+        mock_rebac.rebac_write.side_effect = RuntimeError("fail")
+        ctx = WriteHookContext(
+            path="/new.txt",
+            content=b"x",
+            context=_make_context(user_id="bob"),
+            zone_id="z",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+
+        assert len(ctx.warnings) == 1
+        assert "owner grant" in ctx.warnings[0].message
+
+    def test_works_with_none_managers(self) -> None:
+        hook = SyncPermissionWriteHook(hierarchy_manager=None, rebac_manager=None)
+        ctx = WriteHookContext(
+            path="/f.txt",
+            content=b"x",
+            context=_make_context(),
+            zone_id="z",
+            is_new_file=True,
+        )
+        hook.on_post_write(ctx)
+        assert len(ctx.warnings) == 0


### PR DESCRIPTION
## Summary
- Migrate `snapshot_service` and `deferred_permission_buffer` from kernel `getattr()` to proper KernelDispatch hooks
- Create `SnapshotWriteHook` (post-write/delete), `DeferredPermissionHook` (post-write), `SyncPermissionWriteHook` (sync fallback)
- Remove all 4 `getattr` blocks from `nexus_fs.py` (`_write_internal`, `sys_unlink`, `close()`)
- Enlist hooks in orchestrator via `coordinator.enlist()`

## Test plan
- [x] 32 new unit tests (snapshot_hook, deferred_permission_hook, sync_permission_hook)
- [x] `ruff check` + `mypy` clean
- [x] No `getattr(self._brick_services, "snapshot_service"` in nexus_fs.py
- [x] No `getattr(self._system_services, "deferred_permission_buffer"` in nexus_fs.py
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)