### PR TITLE
fix(security): server-side cert signing + join flow refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +518,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +554,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1147,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1302,7 @@ dependencies = [
  "protobuf",
  "pyo3",
  "raft",
+ "rcgen",
  "redb",
  "serde",
  "serde_json",
@@ -1257,6 +1334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,10 +1353,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1278,6 +1384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1313,6 +1428,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1769,6 +1894,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redb"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1983,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -2146,6 +2294,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -2882,10 +3042,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "zerocopy"

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -377,25 +377,10 @@ load_saved_mounts_if_needed() {
     fi
 }
 
-join_cluster_if_needed() {
-    # If NEXUS_JOIN_TOKEN and NEXUS_PEER are set, provision TLS certs before serving
-    if [ -n "${NEXUS_JOIN_TOKEN:-}" ] && [ -n "${NEXUS_PEER:-}" ]; then
-        echo ""
-        echo "🔗 Joining cluster via ${NEXUS_PEER}..."
-
-        local join_cmd="nexus join --token ${NEXUS_JOIN_TOKEN}"
-        [ -n "${NEXUS_NODE_ID:-}" ] && join_cmd="${join_cmd} --node-id ${NEXUS_NODE_ID}"
-        [ -n "${NEXUS_DATA_DIR:-}" ] && join_cmd="${join_cmd} --data-dir ${NEXUS_DATA_DIR}"
-        join_cmd="${join_cmd} ${NEXUS_PEER}"
-
-        if eval "$join_cmd"; then
-            echo -e "${GREEN}✓ Cluster join complete — TLS certificates provisioned${NC}"
-        else
-            echo -e "${RED}✗ Cluster join failed${NC}"
-            exit 1
-        fi
-    fi
-}
+# join_cluster_if_needed() — REMOVED.
+# Cluster join is now integrated into nexusd startup via NEXUS_JOIN_TOKEN +
+# NEXUS_PEER env vars (see nexus.security.tls.cluster_join). The legacy
+# `nexus join` CLI command is deprecated.
 
 cleanup_stale_pid_files() {
     # After an abnormal exit (e.g. SIGSEGV from a native extension), nexusd
@@ -463,7 +448,8 @@ main() {
     setup_admin_api_key
     init_semantic_search_if_enabled
     start_zoekt_if_enabled
-    join_cluster_if_needed
+    # Note: cluster join is now handled by nexusd itself when
+    # NEXUS_JOIN_TOKEN + NEXUS_PEER env vars are set.
     start_nexus_server
 }
 

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -121,7 +121,6 @@ services:
       NEXUS_OAUTH_GOOGLE_CLIENT_SECRET: ${NEXUS_OAUTH_GOOGLE_CLIENT_SECRET:-}
       # gRPC
       NEXUS_GRPC_PORT: "${NEXUS_GRPC_PORT:-2028}"
-      NEXUS_GRPC_INSECURE: "${NEXUS_GRPC_INSECURE:-false}"
       NEXUS_GRPC_BIND_ALL: "true"  # Required: Docker port-forwarding needs 0.0.0.0
       # Runtime
       NEXUS_USE_UVLOOP: ${NEXUS_USE_UVLOOP:-true}

--- a/proto/nexus/raft/transport.proto
+++ b/proto/nexus/raft/transport.proto
@@ -61,8 +61,8 @@ service ZoneApiService {
 
   // JoinCluster provisions a new node with cluster TLS certificates.
   // Called by `nexus join` before `nexus serve`. The caller authenticates
-  // with the join token password; the server returns the cluster CA + key
-  // so the joiner can generate its own node cert locally.
+  // with the join token password; the server signs a node cert and returns
+  // it along with the CA cert. CA key never leaves node-1 (security fix).
   // K3s-style bootstrap: token = shared secret, TLS encrypts the channel.
   rpc JoinCluster(JoinClusterRequest) returns (JoinClusterResponse);
 }
@@ -140,9 +140,9 @@ message JoinZoneResponse {
 }
 
 // JoinClusterRequest is sent by `nexus join` to provision TLS certificates.
-// The caller authenticates with the join token password. The server verifies
-// the password and returns the cluster CA certificate + private key so the
-// joiner can generate its own node cert locally (K3s-style bootstrap).
+// The caller authenticates with the join token password. The server signs a
+// node certificate and returns it along with the CA cert. The CA private key
+// never leaves the initial node (security fix: server-side cert signing).
 message JoinClusterRequest {
   // Join token password (64-char hex string).
   string password = 1;
@@ -150,18 +150,24 @@ message JoinClusterRequest {
   uint64 node_id = 2;
   // The joining node's advertise address (e.g., "http://10.0.0.3:2126").
   string node_address = 3;
+  // Zone ID for the node certificate CN (e.g., "root").
+  string zone_id = 4;
 }
 
 // JoinClusterResponse returns cluster TLS material on success.
+// The server signs the node cert — CA key never leaves node-1.
 message JoinClusterResponse {
   bool success = 1;
   optional string error = 2;
   // Cluster CA certificate (PEM-encoded). Used to verify peer certs.
   bytes ca_pem = 3;
-  // Cluster CA private key (PEM-encoded). Safe — channel is TLS-encrypted,
-  // and the join token authenticates the caller. The joiner needs the CA key
-  // to: (1) generate its own node cert, (2) accept future joiners itself.
-  bytes ca_key_pem = 4;
+  // Reserved: was ca_key_pem — removed for security (CA key stays on node-1).
+  reserved 4;
+  reserved "ca_key_pem";
+  // Server-signed node certificate (PEM-encoded).
+  bytes node_cert_pem = 5;
+  // Node private key (PEM-encoded). Generated server-side for the joiner.
+  bytes node_key_pem = 6;
 }
 
 // === Cluster Configuration ===

--- a/rust/nexus_raft/Cargo.toml
+++ b/rust/nexus_raft/Cargo.toml
@@ -55,6 +55,7 @@ bytes = { version = "1", optional = true }
 dashmap = { version = "6", optional = true }
 time = { version = "0.3", features = ["parsing"], optional = true }
 sha2 = { version = "0.10", optional = true }  # SHA-256 for JoinCluster token verification
+rcgen = { version = "0.13", features = ["pem", "x509-parser"], optional = true }  # Server-side node cert generation for JoinCluster
 
 # Python bindings (PyO3 FFI)
 pyo3 = { version = "0.27.2", features = ["extension-module"], optional = true }
@@ -86,7 +87,7 @@ consensus = ["raft", "protobuf", "slog", "async"]
 # Enable gRPC transport (tonic + protobuf) — EXPERIMENTAL, default OFF.
 # Requires `consensus` feature. Not used in production.
 # See: docs/rfcs/adr-raft-sled-strategy.md (Decision 4)
-grpc = ["tonic", "prost", "bytes", "tonic-build", "async", "tracing-subscriber", "consensus", "dashmap", "time", "sha2"]
+grpc = ["tonic", "prost", "bytes", "tonic-build", "async", "tracing-subscriber", "consensus", "dashmap", "time", "sha2", "rcgen"]
 
 # Enable everything (including experimental features)
 full = ["grpc", "consensus", "python"]

--- a/rust/nexus_raft/src/pyo3_bindings.rs
+++ b/rust/nexus_raft/src/pyo3_bindings.rs
@@ -671,7 +671,7 @@ impl PyZoneManager {
     ///     tls_cert_path: Path to PEM certificate file (mTLS). All three TLS paths must be set, or none.
     ///     tls_key_path: Path to PEM private key file (mTLS).
     ///     tls_ca_path: Path to PEM CA certificate file (mTLS).
-    ///     ca_key_path: Path to CA private key file (for JoinCluster RPC to send to joiners).
+    ///     ca_key_path: Path to CA private key file (read once at startup for server-side cert signing).
     ///     join_token_hash: SHA-256 hash of join token password (for JoinCluster verification).
     #[new]
     #[pyo3(signature = (node_id, base_path, bind_addr="0.0.0.0:2126", tls_cert_path=None, tls_key_path=None, tls_ca_path=None, ca_key_path=None, join_token_hash=None))]
@@ -742,10 +742,14 @@ impl PyZoneManager {
         };
         let use_tls = tls_config.is_some();
         let mut server = RaftGrpcServer::new(registry.clone(), config);
-        // Configure JoinCluster RPC support if join token is available
-        if let (Some(ca_key), Some(token_hash)) = (ca_key_path, join_token_hash) {
+        // Configure JoinCluster RPC support if join token is available.
+        // Read CA key from disk once — held in memory for server-side cert signing.
+        if let (Some(ca_key_path), Some(token_hash)) = (ca_key_path, join_token_hash) {
+            let ca_key_pem = std::fs::read(ca_key_path).map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to read CA key for JoinCluster: {}", e))
+            })?;
             server = server.with_join_config(
-                std::path::PathBuf::from(ca_key),
+                ca_key_pem,
                 token_hash.to_string(),
                 std::path::PathBuf::from(base_path),
             );

--- a/rust/nexus_raft/src/transport/certgen.rs
+++ b/rust/nexus_raft/src/transport/certgen.rs
@@ -1,0 +1,143 @@
+//! Server-side node certificate generation for JoinCluster RPC.
+//!
+//! Generates X.509 node certificates signed by the cluster CA, matching
+//! the output of Python `certgen.py`: EC P-256, SHA-256, mTLS-ready SANs.
+//!
+//! The CA private key never leaves node-1 — this module is called server-side
+//! during JoinCluster to sign certs for joining nodes.
+
+use rcgen::{
+    CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+    KeyUsagePurpose, SanType, PKCS_ECDSA_P256_SHA256,
+};
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Generate a node certificate signed by the cluster CA.
+///
+/// Returns `(node_cert_pem, node_key_pem)` as PEM-encoded bytes.
+///
+/// The certificate matches Python `certgen.py` output:
+/// - Algorithm: EC P-256 (ECDSA with SHA-256)
+/// - CN: `nexus-zone-{zone_id}-node-{node_id}`
+/// - SANs: localhost, 127.0.0.1, ::1
+/// - Extended Key Usage: serverAuth + clientAuth (mTLS)
+/// - Validity: 365 days
+pub fn generate_node_cert(
+    node_id: u64,
+    zone_id: &str,
+    ca_cert_pem: &[u8],
+    ca_key_pem: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), String> {
+    // Parse CA key pair
+    let ca_key_str =
+        std::str::from_utf8(ca_key_pem).map_err(|e| format!("CA key is not valid UTF-8: {e}"))?;
+    let ca_key_pair =
+        KeyPair::from_pem(ca_key_str).map_err(|e| format!("Failed to parse CA key: {e}"))?;
+
+    // Parse CA certificate
+    let ca_cert_str =
+        std::str::from_utf8(ca_cert_pem).map_err(|e| format!("CA cert is not valid UTF-8: {e}"))?;
+    let ca_cert_params = CertificateParams::from_ca_cert_pem(ca_cert_str)
+        .map_err(|e| format!("Failed to parse CA cert: {e}"))?;
+    let ca_cert = ca_cert_params
+        .self_signed(&ca_key_pair)
+        .map_err(|e| format!("Failed to reconstruct CA cert: {e}"))?;
+
+    // Generate node key pair (EC P-256)
+    let node_key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+        .map_err(|e| format!("Failed to generate node key: {e}"))?;
+
+    // Build node certificate parameters
+    let mut params = CertificateParams::default();
+
+    // Distinguished name: CN=nexus-zone-{zone_id}-node-{node_id}, O=Nexus
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::OrganizationName, "Nexus");
+    dn.push(
+        DnType::CommonName,
+        format!("nexus-zone-{zone_id}-node-{node_id}"),
+    );
+    params.distinguished_name = dn;
+
+    // SANs: localhost, 127.0.0.1, ::1 (matches Python certgen.py)
+    params.subject_alt_names = vec![
+        SanType::DnsName(
+            "localhost"
+                .try_into()
+                .map_err(|e| format!("SAN error: {e}"))?,
+        ),
+        SanType::IpAddress(Ipv4Addr::LOCALHOST.into()),
+        SanType::IpAddress(Ipv6Addr::LOCALHOST.into()),
+    ];
+
+    // Extended key usage: serverAuth + clientAuth (mTLS)
+    params.extended_key_usages = vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ];
+
+    // Key usage
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+
+    // Not a CA
+    params.is_ca = IsCa::NoCa;
+
+    // Validity: 365 days (matches Python default)
+    let now = time::OffsetDateTime::now_utc();
+    params.not_before = now;
+    params.not_after = now + time::Duration::days(365);
+
+    // Sign with CA
+    let node_cert = params
+        .signed_by(&node_key_pair, &ca_cert, &ca_key_pair)
+        .map_err(|e| format!("Failed to sign node cert: {e}"))?;
+
+    let cert_pem = node_cert.pem().into_bytes();
+    let key_pem = node_key_pair.serialize_pem().into_bytes();
+
+    Ok((cert_pem, key_pem))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn generate_test_ca() -> (String, String) {
+        let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut params = CertificateParams::default();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::OrganizationName, "Nexus");
+        dn.push(DnType::CommonName, "nexus-zone-root-ca");
+        params.distinguished_name = dn;
+        params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Constrained(0));
+        params.key_usages = vec![
+            KeyUsagePurpose::DigitalSignature,
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+        ];
+        let ca_cert = params.self_signed(&ca_key).unwrap();
+        (ca_cert.pem(), ca_key.serialize_pem())
+    }
+
+    #[test]
+    fn test_generate_node_cert() {
+        let (ca_cert_pem, ca_key_pem) = generate_test_ca();
+        let (cert_pem, key_pem) =
+            generate_node_cert(2, "root", ca_cert_pem.as_bytes(), ca_key_pem.as_bytes()).unwrap();
+
+        assert!(!cert_pem.is_empty());
+        assert!(!key_pem.is_empty());
+        assert!(String::from_utf8_lossy(&cert_pem).contains("BEGIN CERTIFICATE"));
+        assert!(String::from_utf8_lossy(&key_pem).contains("BEGIN PRIVATE KEY"));
+    }
+
+    #[test]
+    fn test_invalid_ca_key() {
+        let (ca_cert_pem, _) = generate_test_ca();
+        let result = generate_node_cert(1, "root", ca_cert_pem.as_bytes(), b"not-a-key");
+        assert!(result.is_err());
+    }
+}

--- a/rust/nexus_raft/src/transport/mod.rs
+++ b/rust/nexus_raft/src/transport/mod.rs
@@ -40,6 +40,8 @@
 //! ```
 
 #[cfg(all(feature = "grpc", has_protos))]
+pub(crate) mod certgen;
+#[cfg(all(feature = "grpc", has_protos))]
 mod client;
 #[cfg(all(feature = "grpc", has_protos))]
 mod server;

--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -69,8 +69,9 @@ impl Default for ServerConfig {
 pub struct RaftGrpcServer {
     config: ServerConfig,
     registry: Arc<ZoneRaftRegistry>,
-    /// Path to CA private key — read by JoinCluster handler to send to joiners.
-    ca_key_path: Option<PathBuf>,
+    /// CA private key bytes — read once at startup, held in memory for JoinCluster cert signing.
+    /// The CA key never leaves this process (security: server-side cert signing).
+    ca_key_pem: Option<Vec<u8>>,
     /// SHA-256 hash of the join token password — for JoinCluster verification.
     join_token_hash: Option<String>,
     /// Base path for data directory — used for peers_joined marker file.
@@ -87,20 +88,23 @@ impl RaftGrpcServer {
         Self {
             config,
             registry,
-            ca_key_path: None,
+            ca_key_pem: None,
             join_token_hash: None,
             base_path: None,
         }
     }
 
     /// Set cluster join parameters for JoinCluster RPC support.
+    ///
+    /// Reads the CA private key from disk once and holds it in memory.
+    /// The CA key never leaves this process — server signs certs for joiners.
     pub fn with_join_config(
         mut self,
-        ca_key_path: PathBuf,
+        ca_key_pem: Vec<u8>,
         join_token_hash: String,
         base_path: PathBuf,
     ) -> Self {
-        self.ca_key_path = Some(ca_key_path);
+        self.ca_key_pem = Some(ca_key_pem);
         self.join_token_hash = Some(join_token_hash);
         self.base_path = Some(base_path);
         self
@@ -128,7 +132,7 @@ impl RaftGrpcServer {
         let client_service = ZoneApiServiceImpl {
             registry: self.registry.clone(),
             tls: self.config.tls.clone(),
-            ca_key_path: self.ca_key_path.clone(),
+            ca_key_pem: self.ca_key_pem.clone(),
             join_token_hash: self.join_token_hash.clone(),
             base_path: self.base_path.clone(),
         };
@@ -186,7 +190,7 @@ impl RaftGrpcServer {
         let client_service = ZoneApiServiceImpl {
             registry: self.registry.clone(),
             tls: self.config.tls.clone(),
-            ca_key_path: self.ca_key_path.clone(),
+            ca_key_pem: self.ca_key_pem.clone(),
             join_token_hash: self.join_token_hash.clone(),
             base_path: self.base_path.clone(),
         };
@@ -483,8 +487,8 @@ struct ZoneApiServiceImpl {
     registry: Arc<ZoneRaftRegistry>,
     /// TLS config for outbound connections.
     tls: Option<super::TlsConfig>,
-    /// Path to CA private key file — read by JoinCluster handler to send to joiners.
-    ca_key_path: Option<PathBuf>,
+    /// CA private key bytes — held in memory for server-side cert signing.
+    ca_key_pem: Option<Vec<u8>>,
     /// SHA-256 hash of the join token password — for JoinCluster verification.
     join_token_hash: Option<String>,
     /// Base path for data directory — used to write peers_joined marker.
@@ -871,8 +875,9 @@ impl ZoneApiService for ZoneApiServiceImpl {
 
     /// Handle a JoinCluster request — K3s-style TLS certificate provisioning.
     ///
-    /// Verifies the join token password, then returns the cluster CA cert + key
-    /// so the joiner can generate its own node cert locally.
+    /// Verifies the join token password, signs a node certificate server-side,
+    /// and returns the CA cert + signed node cert + node key.
+    /// The CA private key never leaves this process (security fix).
     /// After success, writes a `peers_joined` marker to signal mTLS upgrade.
     async fn join_cluster(
         &self,
@@ -883,6 +888,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
         tracing::info!(
             node_id = req.node_id,
             node_address = req.node_address,
+            zone_id = req.zone_id,
             "JoinCluster request received",
         );
 
@@ -897,7 +903,8 @@ impl ZoneApiService for ZoneApiServiceImpl {
                             .to_string(),
                     ),
                     ca_pem: Vec::new(),
-                    ca_key_pem: Vec::new(),
+                    node_cert_pem: Vec::new(),
+                    node_key_pem: Vec::new(),
                 }));
             }
         };
@@ -919,19 +926,21 @@ impl ZoneApiService for ZoneApiServiceImpl {
                 success: false,
                 error: Some("Invalid join token password".to_string()),
                 ca_pem: Vec::new(),
-                ca_key_pem: Vec::new(),
+                node_cert_pem: Vec::new(),
+                node_key_pem: Vec::new(),
             }));
         }
 
-        // Read CA cert and key from disk
-        let ca_key_path = match &self.ca_key_path {
-            Some(p) => p,
+        // Get CA cert and key (both in memory — no disk reads)
+        let ca_key_pem = match &self.ca_key_pem {
+            Some(k) => k,
             None => {
                 return Ok(Response::new(JoinClusterResponse {
                     success: false,
-                    error: Some("CA key path not configured".to_string()),
+                    error: Some("CA key not configured".to_string()),
                     ca_pem: Vec::new(),
-                    ca_key_pem: Vec::new(),
+                    node_cert_pem: Vec::new(),
+                    node_key_pem: Vec::new(),
                 }));
             }
         };
@@ -943,23 +952,32 @@ impl ZoneApiService for ZoneApiServiceImpl {
                     success: false,
                     error: Some("TLS not configured on this node".to_string()),
                     ca_pem: Vec::new(),
-                    ca_key_pem: Vec::new(),
+                    node_cert_pem: Vec::new(),
+                    node_key_pem: Vec::new(),
                 }));
             }
         };
 
-        let ca_key_pem = match std::fs::read(ca_key_path) {
-            Ok(data) => data,
-            Err(e) => {
-                tracing::error!("Failed to read CA key: {}", e);
-                return Ok(Response::new(JoinClusterResponse {
-                    success: false,
-                    error: Some(format!("Failed to read CA key: {}", e)),
-                    ca_pem: Vec::new(),
-                    ca_key_pem: Vec::new(),
-                }));
-            }
+        // Server-side cert signing — CA key never leaves this process
+        let zone_id = if req.zone_id.is_empty() {
+            "root"
+        } else {
+            &req.zone_id
         };
+        let (node_cert_pem, node_key_pem) =
+            match super::certgen::generate_node_cert(req.node_id, zone_id, &ca_pem, ca_key_pem) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    tracing::error!("Failed to generate node cert: {}", e);
+                    return Ok(Response::new(JoinClusterResponse {
+                        success: false,
+                        error: Some(format!("Failed to generate node cert: {}", e)),
+                        ca_pem: Vec::new(),
+                        node_cert_pem: Vec::new(),
+                        node_key_pem: Vec::new(),
+                    }));
+                }
+            };
 
         // Write peers_joined marker to signal mTLS upgrade on next restart
         if let Some(ref base) = self.base_path {
@@ -973,14 +991,15 @@ impl ZoneApiService for ZoneApiServiceImpl {
         tracing::info!(
             node_id = req.node_id,
             node_address = req.node_address,
-            "JoinCluster: certificates provisioned successfully",
+            "JoinCluster: node certificate signed and provisioned successfully",
         );
 
         Ok(Response::new(JoinClusterResponse {
             success: true,
             error: None,
             ca_pem,
-            ca_key_pem,
+            node_cert_pem,
+            node_key_pem,
         }))
     }
 }

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -334,6 +334,23 @@ async def connect(
         bind_addr = os.environ.get("NEXUS_BIND_ADDR", DEFAULT_GRPC_BIND_ADDR)
         advertise_addr = os.environ.get("NEXUS_ADVERTISE_ADDR")
         zones_dir = os.environ.get("NEXUS_DATA_DIR", str(Path(metadata_path).parent / "zones"))
+
+        # Auto-join cluster if NEXUS_JOIN_TOKEN + NEXUS_PEER are set and certs don't exist yet
+        join_token = os.environ.get("NEXUS_JOIN_TOKEN")
+        join_peer = os.environ.get("NEXUS_PEER")
+        tls_dir_check = Path(zones_dir) / "tls"
+        if join_token and join_peer and not (tls_dir_check / "node.pem").exists():
+            from nexus.security.tls.cluster_join import join_cluster_sync
+
+            logger.info("NEXUS_JOIN_TOKEN + NEXUS_PEER set — joining cluster before startup")
+            join_cluster_sync(
+                peer_address=join_peer,
+                token=join_token,
+                node_id=node_id,
+                tls_dir=tls_dir_check,
+            )
+            logger.info("Cluster join complete — continuing with ZoneManager init")
+
         zone_mgr = ZoneManager(
             node_id=node_id,
             base_path=zones_dir,
@@ -346,9 +363,15 @@ async def connect(
         peers = [p.strip() for p in peers_str.split(",") if p.strip()] if peers_str else []
 
         # Detect joiner vs first-node (#2694):
-        # A joiner was provisioned via `nexus join` — has ca.pem but no join-token
+        # A joiner was provisioned via `nexus join` or cluster_join — has all
+        # three cert files (ca.pem + node.pem + node-key.pem) but no join-token
         tls_dir = Path(zones_dir) / "tls"
-        is_joiner = (tls_dir / "ca.pem").exists() and not (tls_dir / "join-token").exists()
+        is_joiner = (
+            (tls_dir / "ca.pem").exists()
+            and (tls_dir / "node.pem").exists()
+            and (tls_dir / "node-key.pem").exists()
+            and not (tls_dir / "join-token").exists()
+        )
 
         if is_joiner:
             # This node was provisioned via `nexus join` — join existing cluster

--- a/src/nexus/cli/commands/cluster.py
+++ b/src/nexus/cli/commands/cluster.py
@@ -1,12 +1,15 @@
 """Cluster join command — K3s-style TLS certificate provisioning (#2694).
 
-Usage::
+DEPRECATED: Use NEXUS_JOIN_TOKEN + NEXUS_PEER env vars with nexusd instead.
+The join flow is now integrated into nexusd startup (see nexus.security.tls.cluster_join).
 
-    # Join an existing cluster (provisions TLS certs from leader)
+Usage (legacy CLI — deprecated)::
+
     nexus join --token K10abc...::server:SHA256:xyz... --node-id 2 nodeA:2126
 
-    # Using env vars (Docker-friendly)
-    NEXUS_JOIN_TOKEN=K10abc... NEXUS_NODE_ID=2 nexus join nodeA:2126
+Usage (preferred — env vars)::
+
+    NEXUS_JOIN_TOKEN=K10abc... NEXUS_PEER=nodeA:2126 NEXUS_NODE_ID=2 nexusd
 """
 
 from __future__ import annotations
@@ -45,14 +48,23 @@ logger = logging.getLogger(__name__)
 def join(peer_address: str, token: str, node_id: int, data_dir: str | None) -> None:
     """Join an existing Nexus cluster by provisioning TLS certificates.
 
-    Connects to the leader, authenticates with the join token, receives
-    the cluster CA, and generates a node certificate locally.
+    DEPRECATED: Use NEXUS_JOIN_TOKEN + NEXUS_PEER env vars with nexusd instead.
+
+    Connects to the leader, authenticates with the join token, and receives
+    a server-signed node certificate. The CA key never leaves the leader.
     After this, start the node with `nexusd`.
     """
+    click.echo(
+        "WARNING: `nexus join` is deprecated. Use env vars with nexusd instead:\n"
+        "  NEXUS_JOIN_TOKEN=<token> NEXUS_PEER=<addr> NEXUS_NODE_ID=<id> nexusd\n"
+        "Continuing with legacy join flow...\n",
+        err=True,
+    )
+
     try:
-        from nexus.security.tls.join_token import parse_join_token
+        from nexus.security.tls.cluster_join import join_cluster_sync
     except ImportError:
-        click.echo("Error: 'cryptography' package is required for TLS operations.", err=True)
+        click.echo("Error: required packages not available for TLS operations.", err=True)
         sys.exit(1)
 
     # Resolve data directory
@@ -61,121 +73,28 @@ def join(peer_address: str, token: str, node_id: int, data_dir: str | None) -> N
     tls_dir = Path(data_dir) / "tls"
 
     # Check if certs already exist
-    if (tls_dir / "ca.pem").exists() and (tls_dir / "node.pem").exists():
+    if (
+        (tls_dir / "ca.pem").exists()
+        and (tls_dir / "node.pem").exists()
+        and (tls_dir / "node-key.pem").exists()
+    ):
         click.echo(f"TLS certificates already exist in {tls_dir}/")
         click.echo("This node has already been provisioned. Start with: nexusd")
         sys.exit(1)
 
-    # Parse token
     try:
-        password, expected_fingerprint = parse_join_token(token)
-    except ValueError as e:
-        click.echo(f"Invalid join token: {e}", err=True)
-        sys.exit(1)
-
-    # Normalize peer address
-    if not peer_address.startswith("http"):
-        peer_address = f"https://{peer_address}"
-
-    click.echo(f"Joining cluster via {peer_address} (node_id={node_id})...")
-
-    # Connect via gRPC (server-TLS only — no client cert)
-    try:
-        import grpc
-    except ImportError:
-        click.echo("Error: 'grpcio' package is required.", err=True)
-        sys.exit(1)
-
-    # For server-TLS without client auth, use ssl_channel_credentials
-    # without private_key/certificate_chain
-    channel_creds = grpc.ssl_channel_credentials()
-    # Strip scheme for gRPC channel target
-    target = peer_address.replace("https://", "").replace("http://", "")
-
-    try:
-        channel = grpc.secure_channel(target, channel_creds)
-
-        # Import generated stubs
-        from nexus.raft._proto.nexus.raft import transport_pb2, transport_pb2_grpc
-
-        stub = transport_pb2_grpc.ZoneApiServiceStub(channel)
-        request = transport_pb2.JoinClusterRequest(
-            password=password,
+        join_cluster_sync(
+            peer_address=peer_address,
+            token=token,
             node_id=node_id,
-            node_address=peer_address,
+            tls_dir=tls_dir,
         )
-        response = stub.JoinCluster(request, timeout=30.0)
-    except grpc.RpcError as e:
-        click.echo(f"gRPC error connecting to {peer_address}: {e}", err=True)
-        sys.exit(1)
-    except ImportError:
-        click.echo(
-            "Error: gRPC stubs not available. "
-            "Build with: maturin develop -m rust/nexus_raft/Cargo.toml --features full",
-            err=True,
-        )
+    except Exception as e:
+        click.echo(f"Join failed: {e}", err=True)
         sys.exit(1)
 
-    if not response.success:
-        click.echo(f"Join rejected: {response.error}", err=True)
-        sys.exit(1)
-
-    # Verify CA fingerprint matches token
-    from cryptography import x509
-
-    from nexus.security.tls.certgen import (
-        cert_fingerprint,
-        generate_node_cert,
-        save_pem,
-    )
-
-    ca_cert = x509.load_pem_x509_certificate(response.ca_pem)
-    actual_fingerprint = cert_fingerprint(ca_cert)
-
-    if actual_fingerprint != expected_fingerprint:
-        click.echo(
-            f"CA fingerprint mismatch!\n"
-            f"  Expected: {expected_fingerprint}\n"
-            f"  Got:      {actual_fingerprint}\n"
-            f"This may indicate a man-in-the-middle attack. Aborting.",
-            err=True,
-        )
-        sys.exit(1)
-
-    # Save CA cert and key
-    from cryptography.hazmat.primitives import serialization
-
-    ca_key = serialization.load_pem_private_key(response.ca_key_pem, password=None)
-
-    tls_dir.mkdir(parents=True, exist_ok=True)
-    save_pem(tls_dir / "ca.pem", ca_cert)
-
-    # Save CA key manually (save_pem only handles EC keys)
-    (tls_dir / "ca-key.pem").write_bytes(response.ca_key_pem)
-    import os
-
-    os.chmod(tls_dir / "ca-key.pem", 0o600)
-
-    # Generate node cert locally using the cluster CA
-    from cryptography.hazmat.primitives.asymmetric import ec
-
-    if not isinstance(ca_key, ec.EllipticCurvePrivateKey):
-        click.echo("Error: CA key is not an EC key", err=True)
-        sys.exit(1)
-
-    node_cert, node_key = generate_node_cert(
-        node_id=node_id,
-        zone_id="cluster",
-        ca_cert=ca_cert,
-        ca_key=ca_key,
-    )
-    save_pem(tls_dir / "node.pem", node_cert)
-    save_pem(tls_dir / "node-key.pem", node_key, is_private=True)
-
-    click.echo(f"Certificates provisioned in {tls_dir}/")
-    click.echo(f"  CA fingerprint: {actual_fingerprint}")
-    click.echo(f"  Node CN: nexus-zone-cluster-node-{node_id}")
-    click.echo("\nStart this node with: nexusd")
+    click.echo(f"\nCertificates provisioned in {tls_dir}/")
+    click.echo("Start this node with: nexusd")
 
 
 def register_commands(cli: click.Group) -> None:

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -144,11 +144,7 @@ def _derive_project_env(
         env["NEXUS_TLS_CERT"] = "/app/data/tls/server.crt"
         env["NEXUS_TLS_KEY"] = "/app/data/tls/server.key"
         env["NEXUS_TLS_CA"] = "/app/data/tls/ca.crt"
-        # TLS enabled — let the server use mTLS for gRPC
-        env["NEXUS_GRPC_INSECURE"] = "false"
-    else:
-        # No TLS — skip TOFU mTLS so CLI can connect without certs
-        env["NEXUS_GRPC_INSECURE"] = "true"
+    # No TLS → gRPC server auto-detects: no certs found → insecure loopback
 
     return env
 

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -89,7 +89,6 @@ services:
       NEXUS_CACHE_EMBEDDING_TTL: ${NEXUS_CACHE_EMBEDDING_TTL:-86400}
       # gRPC
       NEXUS_GRPC_PORT: "${NEXUS_GRPC_PORT:-2028}"
-      NEXUS_GRPC_INSECURE: "${NEXUS_GRPC_INSECURE:-false}"
       # Zoekt (external container, not built-in sidecar)
       ZOEKT_ENABLED: "false"
       ZOEKT_URL: ${ZOEKT_URL:-http://zoekt:6070}

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -25,16 +25,11 @@ def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
     """Resolve TLS config from env vars, ZoneManager, or auto-detection.
 
     Priority:
-    0. NEXUS_GRPC_INSECURE=true → skip all TLS (for demo/local dev)
     1. Explicit env vars: NEXUS_TLS_CERT / NEXUS_TLS_KEY / NEXUS_TLS_CA
     2. ZoneManager.tls_config (auto-generated or passed via --tls-* flags)
     3. Auto-detect from {NEXUS_DATA_DIR}/tls/
+    4. None → insecure (no certs available)
     """
-    # 0. Allow explicit insecure mode for demo/dev (Issue #2961)
-    if os.environ.get("NEXUS_GRPC_INSECURE", "").lower() in ("true", "1", "yes"):
-        logger.debug("NEXUS_GRPC_INSECURE set — skipping TLS for gRPC")
-        return None
-
     from nexus.security.tls.config import ZoneTlsConfig
 
     # 1. Explicit env vars

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -158,11 +158,12 @@ class ZoneManager:
             from nexus.security.tls.join_token import generate_join_token
 
             tls_dir = Path(base_path) / "tls"
-            ca_cert, ca_key = generate_zone_ca("cluster")
+            zone_id = ROOT_ZONE_ID
+            ca_cert, ca_key = generate_zone_ca(zone_id)
             save_pem(tls_dir / "ca.pem", ca_cert)
             save_pem(tls_dir / "ca-key.pem", ca_key, is_private=True)
 
-            node_cert, node_key = generate_node_cert(node_id, "cluster", ca_cert, ca_key)
+            node_cert, node_key = generate_node_cert(node_id, zone_id, ca_cert, ca_key)
             save_pem(tls_dir / "node.pem", node_cert)
             save_pem(tls_dir / "node-key.pem", node_key, is_private=True)
 

--- a/src/nexus/security/tls/cluster_join.py
+++ b/src/nexus/security/tls/cluster_join.py
@@ -1,0 +1,106 @@
+"""Synchronous cluster join — provisions TLS certs from the leader.
+
+Extracted from the legacy ``nexus join`` CLI command so it can be called
+during ``nexusd`` startup when ``NEXUS_JOIN_TOKEN`` + ``NEXUS_PEER`` are set.
+
+The leader signs the node certificate server-side — the CA key never
+leaves node-1 (security fix).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def join_cluster_sync(
+    peer_address: str,
+    token: str,
+    node_id: int,
+    tls_dir: Path,
+) -> None:
+    """Provision TLS certificates from the cluster leader.
+
+    Parses the join token, connects via gRPC, verifies the CA fingerprint,
+    and saves the server-signed certs to *tls_dir*.
+
+    Args:
+        peer_address: Leader gRPC address (e.g., "nodeA:2126").
+        token: Join token (K10<password>::server:<fingerprint>).
+        node_id: This node's Raft ID.
+        tls_dir: Directory to save certs (ca.pem, node.pem, node-key.pem).
+
+    Raises:
+        ValueError: Invalid token format or CA fingerprint mismatch.
+        RuntimeError: gRPC connection or cert provisioning failed.
+    """
+    from nexus.security.tls.join_token import parse_join_token
+
+    # Parse token
+    password, expected_fingerprint = parse_join_token(token)
+
+    # Normalize peer address
+    if not peer_address.startswith("http"):
+        peer_address = f"https://{peer_address}"
+
+    logger.info("Joining cluster via %s (node_id=%d)...", peer_address, node_id)
+
+    # Connect via gRPC (server-TLS only — no client cert)
+    import grpc
+
+    channel_creds = grpc.ssl_channel_credentials()
+    target = peer_address.replace("https://", "").replace("http://", "")
+
+    try:
+        channel = grpc.secure_channel(target, channel_creds)
+
+        from nexus.contracts.constants import ROOT_ZONE_ID
+        from nexus.raft._proto.nexus.raft import transport_pb2, transport_pb2_grpc
+
+        stub = transport_pb2_grpc.ZoneApiServiceStub(channel)
+        request = transport_pb2.JoinClusterRequest(
+            password=password,
+            node_id=node_id,
+            node_address=peer_address,
+            zone_id=ROOT_ZONE_ID,
+        )
+        response = stub.JoinCluster(request, timeout=30.0)
+    except grpc.RpcError as e:
+        raise RuntimeError(f"gRPC error connecting to {peer_address}: {e}") from e
+
+    if not response.success:
+        raise RuntimeError(f"Join rejected by leader: {response.error}")
+
+    # Verify CA fingerprint matches token
+    from cryptography import x509
+
+    from nexus.security.tls.certgen import cert_fingerprint
+
+    ca_cert = x509.load_pem_x509_certificate(response.ca_pem)
+    actual_fingerprint = cert_fingerprint(ca_cert)
+
+    if actual_fingerprint != expected_fingerprint:
+        raise ValueError(
+            f"CA fingerprint mismatch!\n"
+            f"  Expected: {expected_fingerprint}\n"
+            f"  Got:      {actual_fingerprint}\n"
+            f"This may indicate a man-in-the-middle attack."
+        )
+
+    # Save certs — CA cert, server-signed node cert, node key (no CA key!)
+    tls_dir.mkdir(parents=True, exist_ok=True)
+
+    (tls_dir / "ca.pem").write_bytes(response.ca_pem)
+    logger.info("Saved CA cert to %s/ca.pem", tls_dir)
+
+    (tls_dir / "node.pem").write_bytes(response.node_cert_pem)
+    logger.info("Saved node cert to %s/node.pem", tls_dir)
+
+    from nexus.security.secret_file import write_secret_file
+
+    write_secret_file(tls_dir / "node-key.pem", response.node_key_pem)
+    logger.info("Saved node key to %s/node-key.pem", tls_dir)
+
+    logger.info("Cluster join complete — CA fingerprint: %s", actual_fingerprint)


### PR DESCRIPTION
## Summary
- **Security fix**: JoinCluster RPC no longer returns CA private key. Server signs node certs server-side using new Rust `certgen.rs` module (rcgen, EC P-256). CA key read once at startup, held in memory.
- **Join flow refactor**: Extracted `cluster_join.py` reusable module. `nexusd` auto-joins on startup when `NEXUS_JOIN_TOKEN` + `NEXUS_PEER` env vars set. Deprecated `nexus join` CLI. Removed shell shim from docker-entrypoint.
- **Proto**: Reserved field 4 (`ca_key_pem`), added `node_cert_pem` (5), `node_key_pem` (6), `zone_id` on request
- **is_joiner detection**: Strengthened to require all three cert files (ca.pem + node.pem + node-key.pem)

## Test plan
- [ ] `cargo build --features grpc -p nexus_raft` — verify rcgen compiles
- [ ] `cargo test --features grpc -p nexus_raft` — certgen unit tests pass
- [ ] Docker 3-node cluster: node-2 joins via `NEXUS_JOIN_TOKEN` + `NEXUS_PEER`, verify no `ca-key.pem` on node-2
- [ ] Verify CA fingerprint check still works (mismatch → reject)
- [ ] Verify `nexus join` CLI shows deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)