### PR TITLE
fix: support NEXUS_JOIN_TOKEN env var for federation join

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -362,9 +362,8 @@ async def connect(
         peers_str = os.environ.get("NEXUS_PEERS", "")
         peers = [p.strip() for p in peers_str.split(",") if p.strip()] if peers_str else []
 
-        # Detect joiner vs first-node (#2694):
-        # A joiner was provisioned via `nexus join` or cluster_join — has all
-        # three cert files (ca.pem + node.pem + node-key.pem) but no join-token
+        # Detect joiner vs first-node (#2694, #3141):
+        # Priority: NEXUS_JOIN_TOKEN env > TLS file detection > bootstrap
         tls_dir = Path(zones_dir) / "tls"
         is_joiner = (
             (tls_dir / "ca.pem").exists()
@@ -373,8 +372,15 @@ async def connect(
             and not (tls_dir / "join-token").exists()
         )
 
-        if is_joiner:
-            # This node was provisioned via `nexus join` — join existing cluster
+        if join_token:
+            # NEXUS_JOIN_TOKEN set — join existing cluster via token
+            zone_mgr.join_zone("root", peers=peers if peers else None)
+            logger.info(
+                "Joiner node: joined root zone via NEXUS_JOIN_TOKEN (token=%s...)",
+                join_token[:20],
+            )
+        elif is_joiner:
+            # Provisioned via `nexus join` or cluster_join — has certs but no join-token
             zone_mgr.join_zone("root", peers=peers if peers else None)
             logger.info("Joiner node: joined root zone (provisioned via `nexus join`)")
         else:


### PR DESCRIPTION
## Summary
- `connect()` always called `zone_mgr.bootstrap()` even when `NEXUS_JOIN_TOKEN` was set, causing each node to independently bootstrap instead of joining an existing cluster
- Now checks `NEXUS_JOIN_TOKEN` env var first and calls `zone_mgr.join_zone()` when present
- Priority: `NEXUS_JOIN_TOKEN` env > TLS file detection (`nexus join` provisioning) > bootstrap

## Context
Discovered during cross-machine federation testing over Tailscale (Discussion #2596). Both Windows and macOS nodes independently bootstrapped despite having matching `NEXUS_PEERS` because the join token env var was never consumed.

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, brick imports)
- [ ] Manual test: set `NEXUS_JOIN_TOKEN` + `NEXUS_PEERS`, verify "Joiner node: joined root zone via NEXUS_JOIN_TOKEN" in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)