### PR TITLE
feat(#1589): LLM streaming via DT_STREAM + CAS flush

### DIFF
--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -1,26 +1,26 @@
-"""OpenAI-compatible LLM backend — CAS addressing over any OpenAI API.
+"""OpenAI-compatible LLM backend — CAS addressing + LLM transport.
 
-Composes CASAddressingEngine (addressing) + LLMBlobTransport (in-memory I/O)
-to expose LLM inference as a VFS-mountable backend.
+Thin CASBackend subclass: registration + CONNECTION_ARGS + OpenAI client.
+Follows the same composition pattern as CASLocalBackend (CAS + LocalBlobTransport)
+and CASGCSBackend (CAS + GCSBlobTransport).
 
     nexus mount /zone/llm/openai --backend=openai_compatible \
         --config='{"base_url":"https://api.sudorouter.ai","api_key":"sk-..."}'
     nexus mount /zone/llm/local  --backend=openai_compatible \
         --config='{"base_url":"http://localhost:11434/v1"}'
 
-Write path (sync MVP):
-    1. Agent writes request JSON via sys_write
-    2. Backend calls OpenAI chat.completions.create (sync)
-    3. Response stored in CAS
-    4. Returns WriteResult(hash(request+response), size)
+write_content() is inherited from CASBackend — pure CAS storage,
+no LLM logic. LLM call orchestration lives in the service layer
+(LLMStreamingService), not in the storage driver.
 
-Read path: Standard CAS — read_content(hash) returns stored data.
-
-Streaming (Step 2, DT_STREAM) will add async token-by-token delivery.
+LLM-specific methods (additions, not overrides):
+    generate_streaming(request) → Iterator[(token, metadata)]
+        Pure compute — yields tokens from OpenAI streaming API.
+    persist_session(request, response, ...) → WriteResult
+        CAS persist: request + response + session envelope.
 
 References:
     - Task #1589: LLM backend driver design
-    - Plan: curious-gliding-orbit.md
 """
 
 from __future__ import annotations
@@ -28,9 +28,10 @@ from __future__ import annotations
 import json
 import logging
 import time
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from nexus.backends.base.cas_backend import CASAddressingEngine
+from nexus.backends.base.cas_backend import CASBackend
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.compute.llm_blob_transport import LLMBlobTransport
 from nexus.contracts.capabilities import ConnectorCapability
@@ -66,25 +67,30 @@ def _build_openai_client(base_url: str, api_key: str, timeout: float) -> Any:
     category="compute",
     requires=["openai"],
 )
-class OpenAICompatibleBackend(CASAddressingEngine):
-    """CAS addressing engine + OpenAI-compatible LLM transport.
+class OpenAICompatibleBackend(CASBackend):
+    """CAS addressing + OpenAI-compatible LLM transport.
 
-    Sync MVP: write_content stores request + calls LLM + stores response.
-    All data lives in CAS (in-memory transport, flushed to durable store later).
+    Thin subclass for connector registration and OpenAI client holder.
+    ``write_content()`` is inherited from CASBackend — pure CAS, no override.
+    LLM orchestration lives in ``LLMStreamingService``.
+
+    LLM-specific methods (additions, not overrides):
+
+    - ``generate_streaming()`` — pure compute, yields tokens
+    - ``persist_session()`` — CAS persist request + response + envelope
 
     Usage::
 
         backend = OpenAICompatibleBackend(
-            base_url="https://api.sudorouter.ai",
-            api_key="sk-...",
-            default_model="gpt-4o",
+            base_url="https://api.sudorouter.ai", api_key="sk-...",
         )
-        # Write request → triggers LLM call
-        result = backend.write_content(json.dumps({
-            "messages": [{"role": "user", "content": "Hello"}]
-        }).encode())
-        # Read response
-        data = backend.read_content(result.content_hash)
+        # Standard CAS write (inherited, no LLM call):
+        backend.write_content(b"raw data")
+
+        # LLM streaming (service orchestrates):
+        for token, meta in backend.generate_streaming(request_dict):
+            stream.push(token)
+        backend.persist_session(req_bytes, full_resp, **meta)
     """
 
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
@@ -139,54 +145,50 @@ class OpenAICompatibleBackend(CASAddressingEngine):
     def name(self) -> str:
         return "openai_compatible"
 
-    # === LLM-specific write ===
+    # ------------------------------------------------------------------
+    # Streaming — pure compute, no kernel IPC
+    # ------------------------------------------------------------------
 
-    def write_content(
-        self, content: bytes, context: "OperationContext | None" = None
-    ) -> WriteResult:
-        """Write request JSON, call LLM, store both request and response in CAS.
+    def generate_streaming(
+        self, request: dict[str, Any]
+    ) -> Iterator[tuple[str, dict[str, Any] | None]]:
+        """Yield ``(token, None)`` per chunk, ``("", metadata)`` at end.
 
-        The request is parsed as JSON with at minimum a ``messages`` field.
-        The LLM response is stored as a separate CAS entry. A "session"
-        envelope containing both request hash and response hash is the
-        returned WriteResult.
+        Pure LLM compute — no kernel IPC, no StreamManager dependency.
+        The service layer (LLMStreamingService) bridges these tokens
+        to DT_STREAM for real-time fan-out.
 
         Args:
-            content: JSON-encoded request (``{"messages": [...], "model": "...", ...}``)
-            context: Operation context (optional)
+            request: Parsed request dict with ``messages`` and optional
+                ``model``, ``temperature``, etc.
 
-        Returns:
-            WriteResult with content_hash of the session envelope.
+        Yields:
+            ``(token_str, None)`` for each content token.
+            ``("", metadata_dict)`` as the final item with model/usage/latency.
+
+        Raises:
+            BackendError: On API failure or missing ``messages``.
         """
-        # Store the raw request in CAS first
-        request_result = super().write_content(content, context=context)
-
-        # Parse request
-        try:
-            request = json.loads(content)
-        except (json.JSONDecodeError, UnicodeDecodeError) as e:
-            raise BackendError(
-                f"Invalid request JSON: {e}",
-                backend="openai_compatible",
-            ) from e
-
         if "messages" not in request:
             raise BackendError(
                 "Request must contain 'messages' field",
                 backend="openai_compatible",
             )
 
-        # Call LLM
-        model = request.pop("model", self._default_model)
-        messages = request.pop("messages")
-        extra_params = request  # remaining keys passed through
+        model = request.get("model", self._default_model)
+        messages = request["messages"]
+        extra_params = {k: v for k, v in request.items() if k not in ("model", "messages")}
 
         start_time = time.perf_counter()
+        collected_model = model
+        usage: dict[str, int] = {}
+
         try:
-            completion = self._client.chat.completions.create(
+            stream = self._client.chat.completions.create(
                 model=model,
                 messages=messages,
-                stream=False,
+                stream=True,
+                stream_options={"include_usage": True},
                 **extra_params,
             )
         except Exception as e:
@@ -195,48 +197,106 @@ class OpenAICompatibleBackend(CASAddressingEngine):
                 backend="openai_compatible",
             ) from e
 
+        try:
+            for chunk in stream:
+                # Capture model from response
+                if chunk.model:
+                    collected_model = chunk.model
+
+                # Yield content tokens
+                if chunk.choices:
+                    delta = chunk.choices[0].delta
+                    token = (delta.content or "") if delta else ""
+                    if token:
+                        yield (token, None)
+
+                # Capture usage from final chunk (stream_options.include_usage)
+                if chunk.usage:
+                    usage = {
+                        "prompt_tokens": chunk.usage.prompt_tokens or 0,
+                        "completion_tokens": chunk.usage.completion_tokens or 0,
+                        "total_tokens": chunk.usage.total_tokens or 0,
+                    }
+        except Exception as e:
+            raise BackendError(
+                f"LLM streaming failed: {e}",
+                backend="openai_compatible",
+            ) from e
+
         elapsed_ms = (time.perf_counter() - start_time) * 1000
 
-        # Extract response
-        choice = completion.choices[0] if completion.choices else None
-        response_content = choice.message.content if choice and choice.message else ""
-        finish_reason = choice.finish_reason if choice else "unknown"
+        # Final metadata message
+        yield (
+            "",
+            {
+                "model": collected_model,
+                "usage": usage,
+                "latency_ms": round(elapsed_ms, 1),
+            },
+        )
 
-        # Build response payload
+    # ------------------------------------------------------------------
+    # CAS persistence — session envelope storage
+    # ------------------------------------------------------------------
+
+    def persist_session(
+        self,
+        request_bytes: bytes,
+        response_content: str,
+        model: str,
+        finish_reason: str,
+        usage: dict[str, int],
+        latency_ms: float,
+        context: "OperationContext | None" = None,
+    ) -> WriteResult:
+        """Persist request + response + session envelope in CAS.
+
+        Called by LLMStreamingService after DT_STREAM flush, or
+        directly by callers for sync (non-streaming) LLM calls.
+        Uses inherited ``write_content()`` (pure CAS) internally.
+
+        Args:
+            request_bytes: Raw request JSON bytes.
+            response_content: Full LLM response text.
+            model: Model name from the API response.
+            finish_reason: Finish reason (e.g. "stop", "length").
+            usage: Token usage dict (prompt_tokens, completion_tokens, total_tokens).
+            latency_ms: End-to-end latency in milliseconds.
+            context: Operation context (optional).
+
+        Returns:
+            WriteResult with content_hash of the session envelope.
+        """
+        # Store raw request in CAS
+        request_result = self.write_content(request_bytes, context=context)
+
+        # Build and store response payload
         response_payload = {
-            "model": completion.model,
+            "model": model,
             "content": response_content,
             "finish_reason": finish_reason,
-            "usage": {
-                "prompt_tokens": completion.usage.prompt_tokens if completion.usage else 0,
-                "completion_tokens": completion.usage.completion_tokens if completion.usage else 0,
-                "total_tokens": completion.usage.total_tokens if completion.usage else 0,
-            },
-            "latency_ms": round(elapsed_ms, 1),
+            "usage": usage,
+            "latency_ms": round(latency_ms, 1),
         }
-        response_bytes = json.dumps(response_payload, separators=(",", ":")).encode("utf-8")
+        response_json = json.dumps(response_payload, separators=(",", ":")).encode("utf-8")
+        response_result = self.write_content(response_json, context=context)
 
-        # Store response in CAS
-        response_result = super().write_content(response_bytes, context=context)
-
-        # Build session envelope (links request + response)
+        # Build and store session envelope
         session = {
             "type": "llm_session_v1",
             "request_hash": request_result.content_hash,
             "response_hash": response_result.content_hash,
-            "model": completion.model,
-            "latency_ms": round(elapsed_ms, 1),
+            "model": model,
+            "latency_ms": round(latency_ms, 1),
         }
         session_bytes = json.dumps(session, separators=(",", ":")).encode("utf-8")
-
-        # Store session envelope in CAS
-        session_result = super().write_content(session_bytes, context=context)
+        session_result = self.write_content(session_bytes, context=context)
 
         logger.info(
-            "LLM call completed: model=%s tokens=%d latency=%.1fms session=%s",
-            completion.model,
-            completion.usage.total_tokens if completion.usage else 0,
-            elapsed_ms,
+            "LLM session persisted: model=%s tokens=%d latency=%.1fms session=%s",
+            model,
+            usage.get("total_tokens", 0),
+            latency_ms,
             session_result.content_hash[:16],
         )
 

--- a/src/nexus/core/stream_manager.py
+++ b/src/nexus/core/stream_manager.py
@@ -338,6 +338,42 @@ class StreamManager:
         )
 
     # ------------------------------------------------------------------
+    # Data extraction (for CAS flush by storage layer)
+    # ------------------------------------------------------------------
+
+    def collect_all(self, path: str) -> bytes:
+        """Collect all messages from a stream into a single bytes object.
+
+        Non-destructive bulk read from offset 0 to tail. Fan-out contract
+        is preserved — other readers at their own offsets are unaffected.
+
+        This is a kernel-level read primitive. CAS persistence is the
+        responsibility of the storage layer (e.g. OpenAICompatibleBackend
+        calls ``collect_all()`` then ``backend.write_content()``).
+
+        Args:
+            path: VFS path of the stream.
+
+        Returns:
+            Concatenated bytes of all messages in the stream.
+            Empty bytes if the stream has no data.
+
+        Raises:
+            StreamNotFoundError: No buffer at this path.
+        """
+        buf = self._get_buffer(path)
+        chunks: list[bytes] = []
+        offset = 0
+        while True:
+            try:
+                data, next_offset = buf.read_at(offset)
+                chunks.append(data)
+                offset = next_offset
+            except (StreamEmptyError, StreamClosedError):
+                break
+        return b"".join(chunks)
+
+    # ------------------------------------------------------------------
     # Observability
     # ------------------------------------------------------------------
 

--- a/src/nexus/system_services/llm_streaming_service.py
+++ b/src/nexus/system_services/llm_streaming_service.py
@@ -1,0 +1,249 @@
+"""LLM streaming service — DT_STREAM orchestration for LLM token delivery.
+
+Bridges kernel IPC (StreamManager / DT_STREAM) and backend compute
+(OpenAICompatibleBackend), following the DT_PIPE consumer pattern
+established by WorkflowDispatchService and TaskDispatchPipeConsumer.
+
+Architecture boundaries:
+    - Backend never imports/touches StreamManager (pure compute + CAS)
+    - Kernel never parses LLM request JSON or knows about streaming
+    - Service orchestrates both, bridging tokens from backend → DT_STREAM
+
+Streaming flow:
+    1. start_stream(request_bytes, stream_path)
+       → creates DT_STREAM, spawns background task, returns immediately
+    2. _run_stream() background task:
+       → runs backend.generate_streaming() in thread (sync OpenAI SDK)
+       → each token pushed to DT_STREAM via queue bridge (μs, heap)
+       → after streaming: collect_all() → persist_session() (CAS)
+       → signal_close() → readers notified
+
+DI dependencies (no god-object access):
+    - stream_manager: StreamManager for kernel DT_STREAM lifecycle
+    - backend: OpenAICompatibleBackend for LLM compute + CAS persist
+
+References:
+    - Task #1589: LLM backend driver design
+    - WorkflowDispatchService: DT_PIPE consumer pattern precedent
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import queue
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from nexus.backends.compute.openai_compatible import OpenAICompatibleBackend
+    from nexus.core.stream_manager import StreamManager
+
+logger = logging.getLogger(__name__)
+
+# Default stream capacity: 8MB for LLM responses
+_DEFAULT_STREAM_CAPACITY = 8 * 1024 * 1024
+
+
+class LLMStreamingService:
+    """Orchestrates LLM streaming via DT_STREAM + CAS persistence.
+
+    Service-layer bridge between kernel IPC (StreamManager) and
+    backend compute (OpenAICompatibleBackend). Backend produces tokens
+    via a sync generator; this service pushes them to DT_STREAM for
+    real-time fan-out, then flushes to CAS after streaming completes.
+
+    DI pattern follows WorkflowDispatchService: constructor injection
+    for stream_manager + backend, late injection not needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        stream_manager: "StreamManager",
+        backend: "OpenAICompatibleBackend",
+    ) -> None:
+        self._stream_manager = stream_manager
+        self._backend = backend
+        self._active_tasks: dict[str, asyncio.Task[None]] = {}
+
+    async def start_stream(
+        self,
+        request_bytes: bytes,
+        stream_path: str,
+        *,
+        capacity: int = _DEFAULT_STREAM_CAPACITY,
+        owner_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Start a streaming LLM call, delivering tokens via DT_STREAM.
+
+        Creates a DT_STREAM at ``stream_path``, spawns a background task
+        that iterates the backend's sync generator and pushes tokens to
+        the stream. Returns immediately — callers read tokens via
+        ``sys_read(stream_path, offset=N)``.
+
+        Args:
+            request_bytes: JSON-encoded request with ``messages`` field.
+            stream_path: VFS path for the DT_STREAM (e.g.
+                ``/zone/llm/.streams/sid-123``).
+            capacity: Stream buffer byte capacity (default 8MB).
+            owner_id: Owner for ReBAC permission checks.
+
+        Returns:
+            ``{"stream_path": ..., "status": "streaming"}``
+
+        Raises:
+            BackendError: If StreamManager is not available.
+        """
+        self._stream_manager.create(stream_path, capacity=capacity, owner_id=owner_id)
+
+        task = asyncio.create_task(
+            self._run_stream(request_bytes, stream_path),
+            name=f"llm-stream:{stream_path}",
+        )
+        self._active_tasks[stream_path] = task
+
+        return {"stream_path": stream_path, "status": "streaming"}
+
+    async def cancel_stream(self, stream_path: str) -> bool:
+        """Cancel an active streaming LLM call.
+
+        Cancels the background task and destroys the DT_STREAM.
+
+        Returns:
+            True if the stream was active and cancelled, False otherwise.
+        """
+        task = self._active_tasks.pop(stream_path, None)
+        if task is None:
+            return False
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        with contextlib.suppress(Exception):
+            self._stream_manager.destroy(stream_path)
+
+        logger.info("LLM stream cancelled: %s", stream_path)
+        return True
+
+    # ------------------------------------------------------------------
+    # Background streaming task
+    # ------------------------------------------------------------------
+
+    async def _run_stream(self, request_bytes: bytes, stream_path: str) -> None:
+        """Background task: pump tokens from LLM to DT_STREAM, then CAS persist.
+
+        Uses a ``queue.Queue`` to bridge the sync generator (running in
+        a thread) to the async event loop. The consumer reads from the
+        queue and pushes tokens to DT_STREAM via ``stream_write_nowait()``.
+        """
+        sm = self._stream_manager
+
+        # Thread-safe queue bridging sync generator → async consumer
+        _SENTINEL: object = object()
+        token_q: queue.Queue[tuple[str, dict[str, Any] | None] | object | Exception] = queue.Queue(
+            maxsize=4096
+        )
+
+        def _producer() -> None:
+            """Thread: iterate sync generator, push to queue."""
+            try:
+                request = json.loads(request_bytes)
+                for item in self._backend.generate_streaming(request):
+                    token_q.put(item)
+                token_q.put(_SENTINEL)
+            except Exception as exc:
+                token_q.put(exc)
+
+        loop = asyncio.get_running_loop()
+        producer_fut = loop.run_in_executor(None, _producer)
+
+        meta: dict[str, Any] = {}
+        try:
+            # Consume tokens from queue, push to DT_STREAM
+            while True:
+                item = await loop.run_in_executor(None, token_q.get)
+                if item is _SENTINEL:
+                    break
+                if isinstance(item, Exception):
+                    raise item
+
+                token_item = cast(tuple[str, dict[str, Any] | None], item)
+                token: str = token_item[0]
+                token_meta: dict[str, Any] | None = token_item[1]
+                if token:
+                    sm.stream_write_nowait(stream_path, token.encode("utf-8"))
+                if token_meta is not None:
+                    meta = token_meta
+
+            # CAS persist: collect all tokens → build session envelope
+            full_response = sm.collect_all(stream_path)
+            result = self._backend.persist_session(
+                request_bytes=request_bytes,
+                response_content=full_response.decode("utf-8"),
+                model=meta.get("model", ""),
+                finish_reason="stop",
+                usage=meta.get("usage", {}),
+                latency_ms=meta.get("latency_ms", 0),
+            )
+
+            # Notify readers: streaming done + session hash for CAS replay
+            done_msg = json.dumps(
+                {
+                    "type": "done",
+                    "session_hash": result.content_hash,
+                    "model": meta.get("model", ""),
+                    "latency_ms": meta.get("latency_ms", 0),
+                },
+                separators=(",", ":"),
+            )
+            sm.stream_write_nowait(stream_path, done_msg.encode("utf-8"))
+            sm.signal_close(stream_path)
+
+            logger.info(
+                "LLM stream completed: %s model=%s session=%s",
+                stream_path,
+                meta.get("model", ""),
+                result.content_hash[:16],
+            )
+
+        except asyncio.CancelledError:
+            logger.info("LLM stream cancelled: %s", stream_path)
+            with contextlib.suppress(Exception):
+                sm.signal_close(stream_path)
+            raise
+
+        except Exception as exc:
+            logger.error("LLM stream failed: %s error=%s", stream_path, exc)
+            # Write error to stream so readers know what happened
+            error_msg = json.dumps(
+                {"type": "error", "message": str(exc)},
+                separators=(",", ":"),
+            )
+            with contextlib.suppress(Exception):
+                sm.stream_write_nowait(stream_path, error_msg.encode("utf-8"))
+                sm.signal_close(stream_path)
+
+        finally:
+            # Ensure producer thread completes
+            with contextlib.suppress(Exception):
+                await producer_fut
+            self._active_tasks.pop(stream_path, None)
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    @property
+    def active_streams(self) -> list[str]:
+        """Return VFS paths of currently active streaming LLM calls."""
+        return list(self._active_tasks.keys())
+
+    async def shutdown(self) -> None:
+        """Cancel all active streams. Called on kernel shutdown."""
+        paths = list(self._active_tasks.keys())
+        for path in paths:
+            await self.cancel_stream(path)
+        logger.info("LLM streaming service shut down (%d streams cancelled)", len(paths))

--- a/tests/helpers/in_memory_record_store.py
+++ b/tests/helpers/in_memory_record_store.py
@@ -26,6 +26,25 @@ class InMemoryRecordStore(RecordStoreABC):
             poolclass=StaticPool,
         )
         Base.metadata.create_all(self._engine)
+
+        # rebac_namespaces removed from ORM models (#183) but still accessed
+        # via raw SQL in EnhancedReBACManager. Create it explicitly.
+        from sqlalchemy import text
+
+        with self._engine.connect() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE IF NOT EXISTS rebac_namespaces ("
+                    "  namespace_id TEXT PRIMARY KEY,"
+                    "  object_type TEXT UNIQUE NOT NULL,"
+                    "  config TEXT NOT NULL,"
+                    "  created_at TEXT NOT NULL,"
+                    "  updated_at TEXT NOT NULL"
+                    ")"
+                )
+            )
+            conn.commit()
+
         self._session_factory = sessionmaker(bind=self._engine, expire_on_commit=False)
 
     @property

--- a/tests/unit/backends/test_openai_compat.py
+++ b/tests/unit/backends/test_openai_compat.py
@@ -1,13 +1,17 @@
-"""Tests for OpenAI-compatible LLM backend (sync MVP).
+"""Tests for OpenAI-compatible LLM backend.
 
 Tests cover:
 - LLMBlobTransport: in-memory blob operations
-- OpenAICompatibleBackend: CAS write → LLM call → session envelope
-- Error handling: invalid JSON, missing messages, API failure
+- OpenAICompatibleBackend: thin CASBackend subclass (no write_content override)
+  - write_content(): inherited from CASBackend (pure CAS, no LLM call)
+  - generate_streaming(): pure LLM compute, yields tokens
+  - persist_session(): CAS persist request + response + session envelope
+- LLMStreamingService: DT_STREAM orchestration + CAS flush
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -115,177 +119,210 @@ class TestLLMBlobTransport:
 # =============================================================================
 
 
-def _mock_completion(
-    content: str = "Hello! I'm an AI assistant.",
+def _make_backend(mock_client: MagicMock | None = None) -> tuple[Any, MagicMock]:
+    """Create backend with mocked OpenAI client."""
+    from nexus.backends.compute.openai_compatible import OpenAICompatibleBackend
+
+    with patch("nexus.backends.compute.openai_compatible._build_openai_client") as mock_build:
+        client = mock_client or MagicMock()
+        mock_build.return_value = client
+        backend = OpenAICompatibleBackend(
+            base_url="https://api.test.com/v1",
+            api_key="sk-test",
+            default_model="gpt-4o",
+        )
+    return backend, client
+
+
+def _mock_streaming_chunks(
+    tokens: list[str],
     model: str = "gpt-4o",
     prompt_tokens: int = 10,
     completion_tokens: int = 20,
-    finish_reason: str = "stop",
-) -> MagicMock:
-    """Build a mock OpenAI ChatCompletion response."""
+) -> list[MagicMock]:
+    """Build mock OpenAI streaming chunks."""
+    chunks = []
+    for token in tokens:
+        chunk = MagicMock()
+        chunk.model = model
+        chunk.usage = None
+        delta = MagicMock()
+        delta.content = token
+        choice = MagicMock()
+        choice.delta = delta
+        chunk.choices = [choice]
+        chunks.append(chunk)
+
+    # Final chunk with usage (stream_options.include_usage)
+    final = MagicMock()
+    final.model = model
+    final.choices = []
     usage = MagicMock()
     usage.prompt_tokens = prompt_tokens
     usage.completion_tokens = completion_tokens
     usage.total_tokens = prompt_tokens + completion_tokens
+    final.usage = usage
+    chunks.append(final)
 
-    message = MagicMock()
-    message.content = content
-
-    choice = MagicMock()
-    choice.message = message
-    choice.finish_reason = finish_reason
-
-    completion = MagicMock()
-    completion.choices = [choice]
-    completion.model = model
-    completion.usage = usage
-    return completion
+    return chunks
 
 
 class TestOpenAICompatibleBackend:
     """Test OpenAI-compatible backend with mocked API."""
 
-    def _make_backend(self, mock_client: MagicMock | None = None) -> Any:
-        """Create backend with mocked OpenAI client."""
-        from nexus.backends.compute.openai_compatible import OpenAICompatibleBackend
-
-        with patch("nexus.backends.compute.openai_compatible._build_openai_client") as mock_build:
-            client = mock_client or MagicMock()
-            mock_build.return_value = client
-            backend = OpenAICompatibleBackend(
-                base_url="https://api.test.com/v1",
-                api_key="sk-test",
-                default_model="gpt-4o",
-            )
-        return backend, client
-
     def test_name(self) -> None:
-        backend, _ = self._make_backend()
+        backend, _ = _make_backend()
         assert backend.name == "openai_compatible"
 
-    def test_write_and_read_session(self) -> None:
-        """Write request → LLM call → read session envelope."""
-        client = MagicMock()
-        client.chat.completions.create.return_value = _mock_completion()
-        backend, _ = self._make_backend(client)
+    def test_write_content_is_pure_cas(self) -> None:
+        """write_content() is inherited from CASBackend — no LLM call."""
+        backend, client = _make_backend()
 
-        request = {"messages": [{"role": "user", "content": "Hello"}]}
-        request_bytes = json.dumps(request).encode()
-
-        result = backend.write_content(request_bytes)
+        data = b"hello world"
+        result = backend.write_content(data)
         assert result.content_hash
-        assert result.size > 0
+        assert result.size == len(data)
 
-        # Read session envelope
-        session_bytes = backend.read_content(result.content_hash)
-        session = json.loads(session_bytes)
-        assert session["type"] == "llm_session_v1"
-        assert "request_hash" in session
-        assert "response_hash" in session
-        assert session["model"] == "gpt-4o"
+        # No LLM API call was made
+        client.chat.completions.create.assert_not_called()
 
-    def test_read_request_and_response(self) -> None:
-        """Verify request and response are readable from CAS."""
+        # Can read back the data
+        stored = backend.read_content(result.content_hash)
+        assert stored == data
+
+    def test_generate_streaming_yields_tokens(self) -> None:
+        """generate_streaming yields (token, None) then ("", metadata)."""
         client = MagicMock()
-        client.chat.completions.create.return_value = _mock_completion(content="The answer is 42.")
-        backend, _ = self._make_backend(client)
+        mock_chunks = _mock_streaming_chunks(["Hello", " world", "!"])
+        client.chat.completions.create.return_value = iter(mock_chunks)
+        backend, _ = _make_backend(client)
 
-        request = {"messages": [{"role": "user", "content": "What is the answer?"}]}
-        result = backend.write_content(json.dumps(request).encode())
+        request = {"messages": [{"role": "user", "content": "Hi"}]}
+        results = list(backend.generate_streaming(request))
 
-        session = json.loads(backend.read_content(result.content_hash))
+        # Tokens
+        tokens = [(t, m) for t, m in results if t]
+        assert len(tokens) == 3
+        assert tokens[0] == ("Hello", None)
+        assert tokens[1] == (" world", None)
+        assert tokens[2] == ("!", None)
 
-        # Read request
-        req_data = json.loads(backend.read_content(session["request_hash"]))
-        assert req_data["messages"][0]["content"] == "What is the answer?"
+        # Final metadata
+        final = results[-1]
+        assert final[0] == ""
+        assert final[1] is not None
+        meta = final[1]
+        assert meta["model"] == "gpt-4o"
+        assert meta["usage"]["total_tokens"] == 30
+        assert "latency_ms" in meta
 
-        # Read response
-        resp_data = json.loads(backend.read_content(session["response_hash"]))
-        assert resp_data["content"] == "The answer is 42."
-        assert resp_data["usage"]["total_tokens"] == 30
-
-    def test_custom_model(self) -> None:
-        """Model from request overrides default."""
+    def test_generate_streaming_custom_model(self) -> None:
+        """Model from request is used."""
         client = MagicMock()
-        client.chat.completions.create.return_value = _mock_completion(model="claude-3-opus")
-        backend, _ = self._make_backend(client)
+        mock_chunks = _mock_streaming_chunks(["OK"], model="claude-3-opus")
+        client.chat.completions.create.return_value = iter(mock_chunks)
+        backend, _ = _make_backend(client)
 
         request = {
             "messages": [{"role": "user", "content": "Hi"}],
             "model": "claude-3-opus",
         }
-        result = backend.write_content(json.dumps(request).encode())
+        results = list(backend.generate_streaming(request))
 
-        # Verify the API was called with the custom model
-        call_kwargs = client.chat.completions.create.call_args
-        assert call_kwargs.kwargs["model"] == "claude-3-opus"
+        call_kwargs = client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "claude-3-opus"
+        assert call_kwargs["stream"] is True
 
-        session = json.loads(backend.read_content(result.content_hash))
-        assert session["model"] == "claude-3-opus"
+        meta = results[-1][1]
+        assert meta["model"] == "claude-3-opus"
 
-    def test_extra_params_passed_through(self) -> None:
-        """Extra parameters (temperature, etc.) are passed to the API."""
+    def test_generate_streaming_extra_params(self) -> None:
+        """Extra params (temperature, etc.) are passed through."""
         client = MagicMock()
-        client.chat.completions.create.return_value = _mock_completion()
-        backend, _ = self._make_backend(client)
+        mock_chunks = _mock_streaming_chunks(["OK"])
+        client.chat.completions.create.return_value = iter(mock_chunks)
+        backend, _ = _make_backend(client)
 
         request = {
             "messages": [{"role": "user", "content": "Hi"}],
             "temperature": 0.7,
             "max_tokens": 100,
         }
-        backend.write_content(json.dumps(request).encode())
+        list(backend.generate_streaming(request))
 
         call_kwargs = client.chat.completions.create.call_args.kwargs
         assert call_kwargs["temperature"] == 0.7
         assert call_kwargs["max_tokens"] == 100
 
-    def test_invalid_json_raises(self) -> None:
-        backend, _ = self._make_backend()
-        with pytest.raises(BackendError, match="Invalid request JSON"):
-            backend.write_content(b"not json {{{")
-
-    def test_missing_messages_raises(self) -> None:
-        backend, _ = self._make_backend()
+    def test_generate_streaming_missing_messages_raises(self) -> None:
+        backend, _ = _make_backend()
         with pytest.raises(BackendError, match="must contain 'messages'"):
-            backend.write_content(json.dumps({"model": "gpt-4o"}).encode())
+            list(backend.generate_streaming({"model": "gpt-4o"}))
 
-    def test_api_failure_raises(self) -> None:
+    def test_generate_streaming_api_failure_raises(self) -> None:
         client = MagicMock()
         client.chat.completions.create.side_effect = Exception("Connection timeout")
-        backend, _ = self._make_backend(client)
+        backend, _ = _make_backend(client)
 
         request = {"messages": [{"role": "user", "content": "Hi"}]}
         with pytest.raises(BackendError, match="LLM API call failed"):
-            backend.write_content(json.dumps(request).encode())
+            list(backend.generate_streaming(request))
+
+    def test_persist_session(self) -> None:
+        """persist_session stores request + response + envelope in CAS."""
+        backend, _ = _make_backend()
+
+        request_bytes = json.dumps({"messages": [{"role": "user", "content": "Hello"}]}).encode()
+
+        result = backend.persist_session(
+            request_bytes=request_bytes,
+            response_content="Hi there!",
+            model="gpt-4o",
+            finish_reason="stop",
+            usage={"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+            latency_ms=42.5,
+        )
+
+        # Read session envelope
+        session = json.loads(backend.read_content(result.content_hash))
+        assert session["type"] == "llm_session_v1"
+        assert session["model"] == "gpt-4o"
+        assert "request_hash" in session
+        assert "response_hash" in session
+
+        # Read request
+        req_data = json.loads(backend.read_content(session["request_hash"]))
+        assert req_data["messages"][0]["content"] == "Hello"
+
+        # Read response
+        resp_data = json.loads(backend.read_content(session["response_hash"]))
+        assert resp_data["content"] == "Hi there!"
+        assert resp_data["usage"]["total_tokens"] == 8
+        assert resp_data["finish_reason"] == "stop"
 
     def test_capabilities(self) -> None:
         from nexus.contracts.capabilities import ConnectorCapability
 
-        backend, _ = self._make_backend()
+        backend, _ = _make_backend()
         assert backend.has_capability(ConnectorCapability.CAS)
         assert backend.has_capability(ConnectorCapability.STREAMING)
         assert not backend.has_capability(ConnectorCapability.ROOT_PATH)
 
     def test_mkdir_rmdir_noop(self) -> None:
         """Directory ops are no-ops for compute backends."""
-        backend, _ = self._make_backend()
+        backend, _ = _make_backend()
         backend.mkdir("/some/path")  # Should not raise
         backend.rmdir("/some/path")  # Should not raise
 
+    def test_content_exists(self) -> None:
+        backend, _ = _make_backend()
+        result = backend.write_content(b"test data")
+        assert backend.content_exists(result.content_hash)
+
     def test_delete_content(self) -> None:
-        """Verify content can be deleted."""
-        client = MagicMock()
-        client.chat.completions.create.return_value = _mock_completion()
-        backend, _ = self._make_backend(client)
-
-        request = {"messages": [{"role": "user", "content": "Hi"}]}
-        result = backend.write_content(json.dumps(request).encode())
-
-        # Should not raise
+        backend, _ = _make_backend()
+        result = backend.write_content(b"test data")
         backend.delete_content(result.content_hash)
-
-        # Now reading should fail
         with pytest.raises(NexusFileNotFoundError):
             backend.read_content(result.content_hash)
 
@@ -299,15 +336,206 @@ class TestOpenAICompatibleBackend:
         result = backend.write_content(json.dumps(request).encode())
         assert backend.content_exists(result.content_hash)
 
-    def test_get_content_size(self) -> None:
-        """Verify get_content_size returns correct size."""
-        client = MagicMock()
-        client.chat.completions.create.return_value = _mock_completion()
-        backend, _ = self._make_backend(client)
 
-        request = {"messages": [{"role": "user", "content": "Hi"}]}
-        result = backend.write_content(json.dumps(request).encode())
+# =============================================================================
+# LLMStreamingService tests
+# =============================================================================
 
-        size = backend.get_content_size(result.content_hash)
-        # Session envelope is a small JSON
-        assert size > 0
+
+class TestLLMStreamingService:
+    """Test DT_STREAM orchestration with mock backend + stream manager."""
+
+    @pytest.fixture()
+    def mock_stream_manager(self) -> MagicMock:
+        """Create a mock StreamManager that stores writes in a list."""
+        sm = MagicMock()
+        # Track writes for verification
+        sm._written: list[bytes] = []
+        sm._closed = False
+
+        def _write_nowait(path: str, data: bytes) -> int:
+            sm._written.append(data)
+            return len(data)
+
+        def _collect_all(path: str) -> bytes:
+            return b"".join(sm._written)
+
+        def _signal_close(path: str) -> None:
+            sm._closed = True
+
+        sm.stream_write_nowait.side_effect = _write_nowait
+        sm.collect_all.side_effect = _collect_all
+        sm.signal_close.side_effect = _signal_close
+        return sm
+
+    @pytest.fixture()
+    def mock_backend(self) -> MagicMock:
+        """Create a mock OpenAICompatibleBackend."""
+        backend = MagicMock()
+
+        def _generate_streaming(request: dict) -> list[tuple[str, dict | None]]:
+            return [
+                ("Hello", None),
+                (" world", None),
+                ("!", None),
+                (
+                    "",
+                    {
+                        "model": "gpt-4o",
+                        "usage": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": 3,
+                            "total_tokens": 13,
+                        },
+                        "latency_ms": 50.0,
+                    },
+                ),
+            ]
+
+        backend.generate_streaming.side_effect = _generate_streaming
+
+        persist_result = MagicMock()
+        persist_result.content_hash = "abc123deadbeef"
+        backend.persist_session.return_value = persist_result
+
+        return backend
+
+    @pytest.mark.asyncio()
+    async def test_start_stream(
+        self, mock_stream_manager: MagicMock, mock_backend: MagicMock
+    ) -> None:
+        """start_stream creates DT_STREAM and returns immediately."""
+        from nexus.system_services.llm_streaming_service import (
+            LLMStreamingService,
+        )
+
+        service = LLMStreamingService(stream_manager=mock_stream_manager, backend=mock_backend)
+
+        request = json.dumps({"messages": [{"role": "user", "content": "Hi"}]}).encode()
+        result = await service.start_stream(request, "/zone/llm/.streams/s1")
+
+        assert result["status"] == "streaming"
+        assert result["stream_path"] == "/zone/llm/.streams/s1"
+        mock_stream_manager.create.assert_called_once()
+
+        # Wait for background task to complete
+        await asyncio.sleep(0.1)
+
+    @pytest.mark.asyncio()
+    async def test_stream_delivers_tokens(
+        self, mock_stream_manager: MagicMock, mock_backend: MagicMock
+    ) -> None:
+        """Tokens are pushed to DT_STREAM, then CAS persist + signal_close."""
+        from nexus.system_services.llm_streaming_service import (
+            LLMStreamingService,
+        )
+
+        service = LLMStreamingService(stream_manager=mock_stream_manager, backend=mock_backend)
+
+        request = json.dumps({"messages": [{"role": "user", "content": "Hi"}]}).encode()
+        await service.start_stream(request, "/zone/llm/.streams/s2")
+
+        # Wait for background task
+        await asyncio.sleep(0.5)
+
+        # Verify tokens were written to stream
+        written = mock_stream_manager._written
+        # Tokens: "Hello", " world", "!" + done message
+        assert len(written) >= 3
+        assert written[0] == b"Hello"
+        assert written[1] == b" world"
+        assert written[2] == b"!"
+
+        # Verify done message
+        done_msg = json.loads(written[-1])
+        assert done_msg["type"] == "done"
+        assert done_msg["session_hash"] == "abc123deadbeef"
+
+        # Verify CAS persist was called
+        mock_backend.persist_session.assert_called_once()
+        call_kwargs = mock_backend.persist_session.call_args
+        assert call_kwargs.kwargs["response_content"] == "Hello world!"
+        assert call_kwargs.kwargs["model"] == "gpt-4o"
+
+        # Verify stream was closed
+        assert mock_stream_manager._closed
+
+    @pytest.mark.asyncio()
+    async def test_stream_error_handling(self, mock_stream_manager: MagicMock) -> None:
+        """On LLM failure, error is written to stream and stream is closed."""
+        from nexus.system_services.llm_streaming_service import (
+            LLMStreamingService,
+        )
+
+        backend = MagicMock()
+        backend.generate_streaming.side_effect = BackendError(
+            "API down", backend="openai_compatible"
+        )
+
+        service = LLMStreamingService(stream_manager=mock_stream_manager, backend=backend)
+
+        request = json.dumps({"messages": [{"role": "user", "content": "Hi"}]}).encode()
+        await service.start_stream(request, "/zone/llm/.streams/err")
+
+        # Wait for background task
+        await asyncio.sleep(0.5)
+
+        # Verify error message was written
+        written = mock_stream_manager._written
+        assert len(written) >= 1
+        error_msg = json.loads(written[-1])
+        assert error_msg["type"] == "error"
+
+        # Stream was closed
+        assert mock_stream_manager._closed
+
+    @pytest.mark.asyncio()
+    async def test_cancel_stream(self, mock_stream_manager: MagicMock) -> None:
+        """cancel_stream cancels the background task and destroys the stream."""
+        from nexus.system_services.llm_streaming_service import (
+            LLMStreamingService,
+        )
+
+        # Slow backend that blocks
+        backend = MagicMock()
+
+        def _slow_generate(request: dict) -> list[tuple[str, dict | None]]:
+            import time
+
+            time.sleep(10)
+            return [("x", None), ("", {"model": "m", "usage": {}, "latency_ms": 0})]
+
+        backend.generate_streaming.side_effect = _slow_generate
+
+        service = LLMStreamingService(stream_manager=mock_stream_manager, backend=backend)
+
+        request = json.dumps({"messages": [{"role": "user", "content": "Hi"}]}).encode()
+        await service.start_stream(request, "/zone/llm/.streams/cancel")
+
+        assert "/zone/llm/.streams/cancel" in service.active_streams
+        cancelled = await service.cancel_stream("/zone/llm/.streams/cancel")
+        assert cancelled
+        assert "/zone/llm/.streams/cancel" not in service.active_streams
+
+    @pytest.mark.asyncio()
+    async def test_active_streams(
+        self, mock_stream_manager: MagicMock, mock_backend: MagicMock
+    ) -> None:
+        """active_streams tracks running streams."""
+        from nexus.system_services.llm_streaming_service import (
+            LLMStreamingService,
+        )
+
+        service = LLMStreamingService(stream_manager=mock_stream_manager, backend=mock_backend)
+
+        assert service.active_streams == []
+
+        request = json.dumps({"messages": [{"role": "user", "content": "Hi"}]}).encode()
+        await service.start_stream(request, "/zone/llm/.streams/track")
+
+        # Task is active briefly
+        assert "/zone/llm/.streams/track" in service.active_streams
+
+        # Wait for completion
+        await asyncio.sleep(0.5)
+        assert "/zone/llm/.streams/track" not in service.active_streams


### PR DESCRIPTION
## Summary
- **Remove `write_content()` override** from `OpenAICompatibleBackend` — now a thin CASBackend subclass (registration + CONNECTION_ARGS + OpenAI client holder), consistent with CASLocalBackend/CASGCSBackend composition pattern. `write_content()` inherited from CASBackend = pure CAS, no LLM logic in storage driver.
- **Add `generate_streaming()`** — pure LLM compute, yields `(token, metadata)` from OpenAI streaming API. No kernel IPC dependency. Service layer bridges tokens to DT_STREAM.
- **Add `persist_session()`** — CAS persist request + response + session envelope. Called by service layer after DT_STREAM flush.
- **Add `StreamManager.collect_all()`** — kernel read primitive for non-destructive bulk read from stream offset 0 to tail (for CAS flush).
- **Add `LLMStreamingService`** — service-layer orchestration bridging kernel IPC (StreamManager/DT_STREAM) and backend compute, following WorkflowDispatchService DI pattern. Queue-based bridge from sync OpenAI generator to async event loop.

## Architecture
```
Backend (storage driver):  CASBackend + LLMBlobTransport
  - write_content() → inherited pure CAS (hash + store)
  - generate_streaming() → pure OpenAI compute (yield tokens)
  - persist_session() → CAS persist (request + response + envelope)

Service (orchestration):   LLMStreamingService
  - start_stream() → create DT_STREAM + spawn background task
  - _run_stream() → pump tokens to stream → CAS flush on done

Kernel (IPC):              StreamManager + DT_STREAM
  - collect_all() → bulk read for CAS flush
  - signal_close() → notify readers
```

## Test plan
- [x] 31 unit tests pass (LLMBlobTransport, OpenAICompatibleBackend, LLMStreamingService)
- [x] `generate_streaming()` with mocked OpenAI streaming chunks
- [x] `persist_session()` creates correct CAS session envelope
- [x] `LLMStreamingService` delivers tokens to mock stream + CAS persist
- [x] Error handling: error written to stream on LLM failure
- [x] Cancel stream: background task cancelled, stream destroyed
- [x] ruff + mypy clean, all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)