### PR TITLE
fix(#1770): migrate snapshot_service out of kernel via SnapshotWriteInterceptor

### DIFF
--- a/src/nexus/bricks/snapshot/write_hook.py
+++ b/src/nexus/bricks/snapshot/write_hook.py
@@ -1,0 +1,98 @@
+"""SnapshotWriteInterceptor — records write/delete ops into active snapshot transactions.
+
+Issue #1770: Replaces direct snapshot_service calls in nexus_fs.sys_write and
+sys_unlink. Kernel no longer needs to know about snapshot_service.
+
+VFSWriteHook on_post_write → captures pre-write state (old_metadata) and
+post-write hash (content_hash) from WriteHookContext.
+
+VFSDeleteHook on_pre_delete → captures pre-delete metadata from
+DeleteHookContext (enriched by sys_unlink with metadata=meta).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
+    from nexus.contracts.vfs_hooks import DeleteHookContext, WriteHookContext
+
+
+class SnapshotWriteInterceptor:
+    """Record write/delete operations into active snapshot transactions.
+
+    Implements HotSwappable so it can be enlisted via coordinator and
+    registered into KernelDispatch hook chains.
+    """
+
+    # ── HotSwappable protocol ───────────────────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(write_hooks=(self,), delete_hooks=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    # ── Constructor ─────────────────────────────────────────────────────
+
+    def __init__(self, snapshot_service: Any) -> None:
+        self._snapshot_service = snapshot_service
+
+    # ── VFSWriteHook ────────────────────────────────────────────────────
+
+    def on_post_write(self, ctx: "WriteHookContext") -> None:
+        """Record write into active snapshot transaction.
+
+        Fires after the physical write completes so ctx.content_hash
+        (the new CAS hash) is available alongside ctx.old_metadata
+        (the pre-write state needed for rollback).
+        """
+        txn_id = self._snapshot_service.is_tracked(ctx.path)
+        if txn_id is None:
+            return
+        old_meta = ctx.old_metadata
+        snapshot_hash = old_meta.etag if old_meta is not None else None
+        metadata_snapshot = None
+        if old_meta is not None:
+            metadata_snapshot = {
+                "size": old_meta.size,
+                "version": old_meta.version,
+                "modified_at": old_meta.modified_at.isoformat() if old_meta.modified_at else None,
+            }
+        self._snapshot_service.track_write(
+            txn_id, ctx.path, snapshot_hash, metadata_snapshot, ctx.content_hash
+        )
+
+    # ── VFSDeleteHook ───────────────────────────────────────────────────
+
+    def on_post_delete(self, ctx: "DeleteHookContext") -> None:
+        """No-op: snapshot tracking is done in on_pre_delete (before actual deletion)."""
+
+    def on_pre_delete(self, ctx: "DeleteHookContext") -> None:
+        """Record delete into active snapshot transaction.
+
+        Must fire BEFORE the physical delete so the file's metadata is
+        still accessible. Requires sys_unlink to pass metadata=meta
+        when constructing DeleteHookContext (Issue #1770).
+        """
+        txn_id = self._snapshot_service.is_tracked(ctx.path)
+        if txn_id is None:
+            return
+        meta = ctx.metadata
+        if meta is None:
+            return
+        snapshot_hash = meta.etag
+        metadata_snapshot = {
+            "size": meta.size,
+            "version": meta.version,
+            "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
+            "backend_name": meta.backend_name,
+            "physical_path": meta.physical_path,
+        }
+        self._snapshot_service.track_delete(txn_id, ctx.path, snapshot_hash, metadata_snapshot)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -2430,16 +2430,6 @@ class NexusFS(  # type: ignore[misc]
         now = datetime.now(UTC)
         meta = self.metadata.get(path)
 
-        # Capture snapshot before operation for undo capability
-        snapshot_hash = meta.etag if meta else None
-        metadata_snapshot = None
-        if meta:
-            metadata_snapshot = {
-                "size": meta.size,
-                "version": meta.version,
-                "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
-            }
-
         # PRE-INTERCEPT: pre-write hooks (Issue #899)
         # Hook handles existing-file (owner fast-path) vs new-file (parent check)
         from nexus.contracts.vfs_hooks import WriteHookContext as _WHC
@@ -2611,19 +2601,10 @@ class NexusFS(  # type: ignore[misc]
                         f"write: Failed to grant direct_owner permission for {path}: {e}"
                     )
 
-        # Issue #1752: Auto-track write in active transaction (snapshot for rollback)
-        # Issue #1570: snapshot_service accessed from container, not flat attr.
-        _ss = (
-            getattr(self._brick_services, "snapshot_service", None)
-            if self._brick_services
-            else None
-        )
-        if _ss is not None:
-            _txn_id = _ss.is_tracked(path)
-            if _txn_id is not None:
-                _ss.track_write(_txn_id, path, snapshot_hash, metadata_snapshot, content_hash)
-
         # Issue #900: Unified two-phase dispatch — INTERCEPT (observer + hooks)
+        # Issue #1770: snapshot tracking moved to SnapshotWriteInterceptor.on_post_write()
+        # which fires during intercept_post_write below (hook receives old_metadata +
+        # content_hash from context).
         from nexus.contracts.vfs_hooks import WriteHookContext
 
         _write_ctx = WriteHookContext(
@@ -3396,32 +3377,13 @@ class NexusFS(  # type: ignore[misc]
         if meta is None:
             raise NexusFileNotFoundError(path)
 
-        # Capture snapshot before operation for undo capability
-        snapshot_hash = meta.etag
-        metadata_snapshot = {
-            "size": meta.size,
-            "version": meta.version,
-            "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
-            "backend_name": meta.backend_name,
-            "physical_path": meta.physical_path,
-        }
-
         # PRE-INTERCEPT: pre-delete hooks (Issue #899)
+        # Issue #1770: pass metadata so SnapshotWriteInterceptor.on_pre_delete()
+        # can capture the pre-deletion state for snapshot/rollback (no direct
+        # snapshot_service access in kernel).
         from nexus.contracts.vfs_hooks import DeleteHookContext as _DHC
 
-        self._dispatch.intercept_pre_delete(_DHC(path=path, context=context))
-
-        # Issue #1752: Auto-track delete in active transaction (snapshot for rollback)
-        # Issue #1570: snapshot_service accessed from container, not flat attr.
-        _ss = (
-            getattr(self._brick_services, "snapshot_service", None)
-            if self._brick_services
-            else None
-        )
-        if _ss is not None:
-            _txn_id = _ss.is_tracked(path)
-            if _txn_id is not None:
-                _ss.track_delete(_txn_id, path, snapshot_hash, metadata_snapshot)
+        self._dispatch.intercept_pre_delete(_DHC(path=path, context=context, metadata=meta))
 
         # Issue #900: Unified two-phase dispatch — INTERCEPT (observer + hooks)
         # Placed BEFORE physical content delete to preserve audit integrity.

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -564,6 +564,22 @@ async def _register_vfs_hooks(
     else:
         logger.debug("[BOOT:BRICK] task_manager disabled by profile")
 
+    # ── SnapshotWriteInterceptor (Issue #1770) ─────────────────────────
+    # Records write/delete ops into active snapshot transactions.
+    # Replaces direct snapshot_service calls in nexus_fs — kernel no longer
+    # knows about snapshot_service.
+    _snap_svc = (
+        getattr(nx._brick_services, "snapshot_service", None) if nx._brick_services else None
+    )
+    if _snap_svc is not None:
+        try:
+            from nexus.bricks.snapshot.write_hook import SnapshotWriteInterceptor
+
+            _snap_hook = SnapshotWriteInterceptor(snapshot_service=_snap_svc)
+            await _enlist("snapshot", _snap_hook)
+        except Exception as exc:
+            logger.debug("[BOOT:HOOKS] SnapshotWriteInterceptor unavailable: %s", exc)
+
     # ── OBSERVE observers (Issue #900, #922) ──────────────────────────
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).
     # Replaces _publish_file_event() direct calls — single dispatch exit point.


### PR DESCRIPTION
## Summary

Kernel no longer accesses `snapshot_service` directly. Replaced with a new `SnapshotWriteInterceptor` (HotSwappable Q2) enlisted via coordinator.

**Why**: snapshot_service called from kernel `sys_write`/`sys_unlink` is service code bleeding into kernel — violates the architecture layering.

**How**:
- New `src/nexus/bricks/snapshot/write_hook.py` — `SnapshotWriteInterceptor` implements `VFSWriteHook` + `VFSDeleteHook` + HotSwappable
  - `on_post_write`: uses `ctx.old_metadata` (pre-write state) + `ctx.content_hash` (post-write hash) from `WriteHookContext`
  - `on_pre_delete`: uses `ctx.metadata` (pre-deletion state) from enriched `DeleteHookContext`
- `nexus_fs.py sys_write`: remove direct `snapshot_service` getattr block + remove now-dead `snapshot_hash`/`metadata_snapshot` capture
- `nexus_fs.py sys_unlink`: pass `metadata=meta` to `DeleteHookContext` so hook has file state before deletion; remove direct block
- `orchestrator.py _register_vfs_hooks()`: enlist `SnapshotWriteInterceptor` when `snapshot_service` is available

## Test plan
- [x] `uv run pytest tests/unit/` — 10899 passed
- [x] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)