### PR TITLE
fix(#183): add namespace_store to remaining test fixtures

### DIFF
--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -77,11 +77,11 @@ def _boot_system_services(
             _is_pg = not ctx.db_url.startswith("sqlite")
 
             # --- ReBAC Manager ---
-            from nexus.bricks.rebac.consistency.metastore_version_store import (
-                MetastoreVersionStore,
-            )
             from nexus.bricks.rebac.consistency.metastore_namespace_store import (
                 MetastoreNamespaceStore,
+            )
+            from nexus.bricks.rebac.consistency.metastore_version_store import (
+                MetastoreVersionStore,
             )
             from nexus.bricks.rebac.manager import ReBACManager
 

--- a/tests/e2e/self_contained/mcp/test_tool_namespace_integration.py
+++ b/tests/e2e/self_contained/mcp/test_tool_namespace_integration.py
@@ -26,8 +26,8 @@ from nexus.bricks.mcp.profiles import (
     revoke_tools_by_tuple_ids,
 )
 from nexus.bricks.mcp.server import create_mcp_server
-from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
+from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.manager import EnhancedReBACManager
 from nexus.storage.models import Base
 from tests.helpers.dict_metastore import DictMetastore

--- a/tests/e2e/self_contained/test_persistent_view_store.py
+++ b/tests/e2e/self_contained/test_persistent_view_store.py
@@ -273,7 +273,6 @@ class TestAgentReconnection:
         from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
         from nexus.bricks.rebac.manager import EnhancedReBACManager
         from nexus.bricks.rebac.namespace_manager import MountEntry, NamespaceManager
-        from tests.helpers.dict_metastore import DictMetastore
 
         rebac = EnhancedReBACManager(
             engine=engine,

--- a/tests/e2e/server/test_wildcard_public_access_e2e.py
+++ b/tests/e2e/server/test_wildcard_public_access_e2e.py
@@ -10,7 +10,6 @@ Usage:
     uv run pytest tests/e2e/test_wildcard_public_access_e2e.py -v --override-ini="addopts="
 """
 
-import json
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -162,46 +161,51 @@ class TestWildcardDirectDB:
     """Direct database tests for wildcard - doesn't require full server."""
 
     @pytest.fixture
-    def db_engine(self, isolated_db):
+    def namespace_store(self):
+        """Create a MetastoreNamespaceStore backed by in-memory DictMetastore."""
+        from nexus.bricks.rebac.consistency.metastore_namespace_store import (
+            MetastoreNamespaceStore,
+        )
+        from tests.helpers.dict_metastore import DictMetastore
+
+        return MetastoreNamespaceStore(DictMetastore())
+
+    @pytest.fixture
+    def db_engine(self, isolated_db, namespace_store):
         """Create database with ReBAC tables using ORM models."""
+        from nexus.bricks.rebac.domain import NamespaceConfig
         from nexus.storage.models import Base
 
         engine = create_engine(f"sqlite:///{isolated_db}")
         Base.metadata.create_all(engine)
 
-        # Insert file namespace with reader -> read permission
-        config = json.dumps(
-            {
-                "relations": {"reader": {}, "writer": {}, "owner": {}},
-                "permissions": {
-                    "read": {"union": ["reader", "writer", "owner"]},
-                    "write": {"union": ["writer", "owner"]},
+        # Insert file namespace with reader -> read permission via MetastoreNamespaceStore
+        namespace_store.create_or_update(
+            NamespaceConfig(
+                namespace_id="file_ns",
+                object_type="file",
+                config={
+                    "relations": {"reader": {}, "writer": {}, "owner": {}},
+                    "permissions": {
+                        "read": {"union": ["reader", "writer", "owner"]},
+                        "write": {"union": ["writer", "owner"]},
+                    },
                 },
-            }
-        )
-        now = datetime.now(UTC).isoformat()
-        with engine.connect() as conn:
-            conn.execute(
-                text(
-                    "INSERT OR IGNORE INTO rebac_namespaces (namespace_id, object_type, config, created_at, updated_at) "
-                    "VALUES (:id, :type, :config, :now, :now)"
-                ),
-                {"id": "file_ns", "type": "file", "config": config, "now": now},
+                created_at=datetime.now(UTC),
             )
-            conn.commit()
+        )
 
         yield engine
         engine.dispose()
 
     @pytest.fixture
-    def async_manager(self, db_engine, isolated_db):
+    def async_manager(self, db_engine, namespace_store):
         """Create AsyncReBACManager for testing."""
         from nexus.bricks.rebac.manager import AsyncReBACManager, ReBACManager
 
-        # Use the existing sync db_engine directly — avoids MissingGreenlet
-        # errors that arise from using async_engine.sync_engine with
-        # asyncio.to_thread() in AsyncReBACManager.
-        sync_manager = ReBACManager(db_engine, enable_tiger_cache=False)
+        sync_manager = ReBACManager(
+            db_engine, enable_tiger_cache=False, namespace_store=namespace_store
+        )
         manager = AsyncReBACManager(sync_manager)
         yield manager
 
@@ -309,42 +313,51 @@ class TestWildcardPerformance:
     """Performance tests to verify wildcard check doesn't impact performance."""
 
     @pytest.fixture
-    def db_engine(self, isolated_db):
+    def namespace_store(self):
+        """Create a MetastoreNamespaceStore backed by in-memory DictMetastore."""
+        from nexus.bricks.rebac.consistency.metastore_namespace_store import (
+            MetastoreNamespaceStore,
+        )
+        from tests.helpers.dict_metastore import DictMetastore
+
+        return MetastoreNamespaceStore(DictMetastore())
+
+    @pytest.fixture
+    def db_engine(self, isolated_db, namespace_store):
         """Create database with ReBAC tables using ORM models."""
+        from nexus.bricks.rebac.domain import NamespaceConfig
         from nexus.storage.models import Base
 
         engine = create_engine(f"sqlite:///{isolated_db}")
         Base.metadata.create_all(engine)
 
-        config = json.dumps(
-            {
-                "relations": {"reader": {}, "writer": {}},
-                "permissions": {"read": ["reader", "writer"], "write": ["writer"]},
-            }
-        )
-        now = datetime.now(UTC).isoformat()
-        with engine.connect() as conn:
-            conn.execute(
-                text(
-                    "INSERT OR IGNORE INTO rebac_namespaces (namespace_id, object_type, config, created_at, updated_at) "
-                    "VALUES (:id, :type, :config, :now, :now)"
-                ),
-                {"id": "file_ns", "type": "file", "config": config, "now": now},
+        # Insert file namespace via MetastoreNamespaceStore
+        namespace_store.create_or_update(
+            NamespaceConfig(
+                namespace_id="file_ns",
+                object_type="file",
+                config={
+                    "relations": {"reader": {}, "writer": {}},
+                    "permissions": {"read": ["reader", "writer"], "write": ["writer"]},
+                },
+                created_at=datetime.now(UTC),
             )
-            conn.commit()
+        )
 
         yield engine
         engine.dispose()
 
     @pytest.mark.asyncio
-    async def test_wildcard_check_performance(self, db_engine, isolated_db):
+    async def test_wildcard_check_performance(self, db_engine, namespace_store, isolated_db):
         """Benchmark wildcard check to ensure no performance regression."""
         import time
 
         from nexus.bricks.rebac.manager import AsyncReBACManager, ReBACManager
 
         # Use the existing sync db_engine directly — avoids MissingGreenlet.
-        sync_manager = ReBACManager(db_engine, enable_tiger_cache=False)
+        sync_manager = ReBACManager(
+            db_engine, enable_tiger_cache=False, namespace_store=namespace_store
+        )
         manager = AsyncReBACManager(sync_manager)
 
         # Insert many tuples to simulate real workload

--- a/tests/unit/core/test_rebac_revision_cache.py
+++ b/tests/unit/core/test_rebac_revision_cache.py
@@ -19,8 +19,12 @@ import uuid
 import pytest
 from sqlalchemy import create_engine, text
 
+from nexus.bricks.rebac.consistency.metastore_namespace_store import (
+    MetastoreNamespaceStore,
+)
 from nexus.bricks.rebac.manager import ReBACManager
 from nexus.storage.models import Base
+from tests.helpers.dict_metastore import DictMetastore
 
 
 def _check_postgres_available():
@@ -82,6 +86,7 @@ def manager(engine, test_zone):
     manager = ReBACManager(
         engine=engine,
         is_postgresql=True,
+        namespace_store=MetastoreNamespaceStore(DictMetastore()),
     )
     yield manager
 

--- a/tests/unit/server/api/v2/routers/test_auth_keys_grants.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_grants.py
@@ -10,12 +10,16 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from nexus.bricks.rebac.consistency.metastore_namespace_store import (
+    MetastoreNamespaceStore,
+)
 from nexus.bricks.rebac.manager import EnhancedReBACManager
 from nexus.server.api.v2.routers.auth_keys import (
     ROLE_TO_RELATION,
     GrantRequest,
     router,
 )
+from tests.helpers.dict_metastore import DictMetastore
 from tests.helpers.in_memory_record_store import InMemoryRecordStore
 
 # ---------------------------------------------------------------------------
@@ -36,6 +40,7 @@ def rebac_manager(record_store):
         engine=record_store.engine,
         cache_ttl_seconds=0,
         max_depth=10,
+        namespace_store=MetastoreNamespaceStore(DictMetastore()),
     )
     yield manager
     manager.close()

--- a/tests/unit/services/permissions/graph/test_traversal_edge_cases.py
+++ b/tests/unit/services/permissions/graph/test_traversal_edge_cases.py
@@ -26,8 +26,8 @@ import pytest
 from freezegun import freeze_time
 from sqlalchemy import create_engine
 
-from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
+from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.domain import NamespaceConfig
 from nexus.bricks.rebac.manager import ReBACManager
 from nexus.storage.models import Base

--- a/tests/unit/services/permissions/test_rebac_manager_snapshot.py
+++ b/tests/unit/services/permissions/test_rebac_manager_snapshot.py
@@ -23,8 +23,8 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.pool import StaticPool
 
-from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
+from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.manager import (
     EnhancedReBACManager,
 )


### PR DESCRIPTION
## Summary
- Fix 6 broken tests in `test_auth_keys_grants.py` (`no such table: rebac_namespaces`) caused by PR #3057 merging without test fixture updates
- Add `namespace_store=MetastoreNamespaceStore(DictMetastore())` to `test_auth_keys_grants.py`, `test_rebac_revision_cache.py`, and `test_wildcard_public_access_e2e.py`
- Fix ruff import sorting errors in `_system.py` and 4 test files introduced by the #3057 merge

## Test plan
- [x] `test_auth_keys_grants.py` — 25/25 pass locally
- [x] `ruff check .` — all checks passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)