### PR TITLE
refactor(#1780): rename CASBackend/PathBackend → CASAddressingEngine/PathAddressingEngine

### DIFF
--- a/src/nexus/backends/__init__.py
+++ b/src/nexus/backends/__init__.py
@@ -5,9 +5,9 @@ import logging
 import threading
 
 from nexus.backends.base.backend import Backend, HandlerStatusResponse
-from nexus.backends.base.cas_backend import CASBackend
+from nexus.backends.base.cas_backend import CASAddressingEngine, CASBackend
 from nexus.backends.base.factory import BackendFactory
-from nexus.backends.base.path_backend import PathBackend
+from nexus.backends.base.path_backend import PathAddressingEngine, PathBackend
 from nexus.backends.base.registry import (
     ArgType,
     ConnectionArg,
@@ -99,7 +99,9 @@ __all__ = [
     "HandlerStatusResponse",
     "ObjectStoreABC",
     "WriteResult",
+    "CASAddressingEngine",
     "CASBackend",
+    "PathAddressingEngine",
     "PathBackend",
     "CacheConnectorMixin",
     "CacheEntry",

--- a/src/nexus/backends/base/blob_transport.py
+++ b/src/nexus/backends/base/blob_transport.py
@@ -1,7 +1,7 @@
 """BlobTransport Protocol — raw key→blob I/O abstraction.
 
 BlobTransport captures the *transport* dimension (WHERE data lives) while
-CASBackend / PathBackend capture the *addressing* dimension (HOW data is
+CASAddressingEngine / PathAddressingEngine capture the *addressing* dimension (HOW data is
 addressed).  These two dimensions are orthogonal:
 
               Transport (WHERE)
@@ -22,7 +22,7 @@ Design decisions:
       any class with matching methods is a valid transport.
     - 9 methods matching the original BaseBlobStorageConnector abstract methods,
       but renamed to transport-neutral terminology (put/get vs upload/download).
-    - CASBackend uses a subset (6 methods). PathBackend uses all 9.
+    - CASAddressingEngine uses a subset (6 methods). PathAddressingEngine uses all 9.
 """
 
 from __future__ import annotations

--- a/src/nexus/backends/base/cas_backend.py
+++ b/src/nexus/backends/base/cas_backend.py
@@ -1,10 +1,10 @@
 """CAS addressing engine over any BlobTransport.
 
-CASBackend implements ObjectStoreABC (via Backend) using content-addressable
+CASAddressingEngine implements ObjectStoreABC (via Backend) using content-addressable
 storage semantics: content is stored by hash, automatically deduplicated,
 and reference-counted.
 
-    CASBackend(transport: BlobTransport)
+    CASAddressingEngine(transport: BlobTransport)
         ├── CASGCSBackend   — thin: creates GCSBlobTransport, registered as "cas_gcs"
         ├── CASLocalBackend  — thin: creates LocalBlobTransport + features
         └── (future S3CAS)  — thin: creates S3BlobTransport
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CAS_BACKEND_CAPABILITIES: frozenset[ConnectorCapability] = frozenset(
+CAS_ADDRESSING_CAPABILITIES: frozenset[ConnectorCapability] = frozenset(
     {
         ConnectorCapability.CAS,
         ConnectorCapability.STREAMING,
@@ -62,7 +62,7 @@ CAS_BACKEND_CAPABILITIES: frozenset[ConnectorCapability] = frozenset(
 """Common capabilities for CAS-based backends."""
 
 
-class CASBackend(Backend):
+class CASAddressingEngine(Backend):
     """CAS addressing over any BlobTransport.  Full ObjectStoreABC implementation.
 
     Content is stored at ``cas/<h[:2]>/<h[2:4]>/<h>`` with a JSON metadata
@@ -75,7 +75,7 @@ class CASBackend(Backend):
         _backend_name: Human-readable backend identifier.
     """
 
-    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = CAS_BACKEND_CAPABILITIES
+    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = CAS_ADDRESSING_CAPABILITIES
 
     def __init__(
         self,
@@ -688,3 +688,8 @@ class CASBackend(Backend):
                 backend=self.name,
                 path=path,
             ) from e
+
+
+# Backward-compat alias (will be removed in a future cleanup)
+CASBackend = CASAddressingEngine
+CAS_BACKEND_CAPABILITIES = CAS_ADDRESSING_CAPABILITIES

--- a/src/nexus/backends/base/path_backend.py
+++ b/src/nexus/backends/base/path_backend.py
@@ -1,16 +1,16 @@
 """Path-based addressing engine over any BlobTransport.
 
-PathBackend implements ObjectStoreABC (via Backend) using direct path mapping:
+PathAddressingEngine implements ObjectStoreABC (via Backend) using direct path mapping:
 files are stored at their actual paths, with no CAS transformation or
 deduplication.
 
-    PathBackend(transport: BlobTransport)
+    PathAddressingEngine(transport: BlobTransport)
         ├── PathGCSBackend       — thin: creates GCSBlobTransport + cache
         ├── PathS3Backend        — thin: creates S3BlobTransport + cache + multipart
         └── (future Azure)       — thin: creates AzureBlobTransport
 
 This replaces ``BaseBlobStorageConnector`` which used abstract methods (inheritance)
-for cloud-specific I/O.  PathBackend uses composition (BlobTransport protocol).
+for cloud-specific I/O.  PathAddressingEngine uses composition (BlobTransport protocol).
 
 References:
     - Issue #1323: CAS x Backend orthogonal composition
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class PathBackend(Backend):
+class PathAddressingEngine(Backend):
     """Path-based addressing over any BlobTransport.
 
     Files are stored at their actual paths (with optional prefix).
@@ -524,3 +524,7 @@ class PathBackend(Backend):
                 backend=self.name,
                 path=old_path,
             ) from e
+
+
+# Backward-compat alias (will be removed in a future cleanup)
+PathBackend = PathAddressingEngine

--- a/src/nexus/backends/base/registry.py
+++ b/src/nexus/backends/base/registry.py
@@ -310,7 +310,7 @@ class ConnectorRegistry:
 
     Example:
         >>> @register_connector("azure_blob", description="Azure Blob Storage")
-        ... class AzureBlobConnector(PathBackend):
+        ... class AzureBlobConnector(PathAddressingEngine):
         ...     pass
         ...
         >>> ConnectorRegistry.get("azure_blob")
@@ -566,7 +566,7 @@ def register_connector(
         ...     description="Azure Blob Storage connector",
         ...     requires=["azure-storage-blob"]
         ... )
-        ... class AzureBlobConnector(PathBackend):
+        ... class AzureBlobConnector(PathAddressingEngine):
         ...     pass
     """
 

--- a/src/nexus/backends/base/stripe_lock.py
+++ b/src/nexus/backends/base/stripe_lock.py
@@ -4,7 +4,7 @@ A fixed-size array of threading.Lock objects indexed by content hash.
 Provides per-hash coordination for metadata read-modify-write cycles
 without any disk I/O. Much cheaper than FileLock (~us vs ~ms).
 
-Used by CASBackend and CASLocalBackend for ref_count updates.
+Used by CASAddressingEngine and CASLocalBackend for ref_count updates.
 """
 
 from __future__ import annotations

--- a/src/nexus/backends/compute/llm_blob_transport.py
+++ b/src/nexus/backends/compute/llm_blob_transport.py
@@ -4,7 +4,7 @@ Stores CAS blobs in process memory. LLM conversations are ephemeral
 during a session — persistence is handled by CAS flush to durable
 backends (local/GCS/S3) in Step 2 (DT_STREAM + CAS flush).
 
-Satisfies the 6-method CASBackend subset of BlobTransport:
+Satisfies the 6-method CASAddressingEngine subset of BlobTransport:
     put_blob, get_blob, delete_blob, blob_exists, get_blob_size, stream_blob.
 """
 

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -1,6 +1,6 @@
 """OpenAI-compatible LLM backend — CAS addressing over any OpenAI API.
 
-Composes CASBackend (addressing) + LLMBlobTransport (in-memory I/O)
+Composes CASAddressingEngine (addressing) + LLMBlobTransport (in-memory I/O)
 to expose LLM inference as a VFS-mountable backend.
 
     nexus mount /zone/llm/openai --backend=openai_compatible \
@@ -30,7 +30,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from nexus.backends.base.cas_backend import CASBackend
+from nexus.backends.base.cas_backend import CASAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.compute.llm_blob_transport import LLMBlobTransport
 from nexus.contracts.capabilities import ConnectorCapability
@@ -66,8 +66,8 @@ def _build_openai_client(base_url: str, api_key: str, timeout: float) -> Any:
     category="compute",
     requires=["openai"],
 )
-class OpenAICompatibleBackend(CASBackend):
-    """CAS addressing + OpenAI-compatible LLM transport.
+class OpenAICompatibleBackend(CASAddressingEngine):
+    """CAS addressing engine + OpenAI-compatible LLM transport.
 
     Sync MVP: write_content stores request + calls LLM + stores response.
     All data lives in CAS (in-memory transport, flushed to durable store later).

--- a/src/nexus/backends/engines/cdc.py
+++ b/src/nexus/backends/engines/cdc.py
@@ -1,12 +1,12 @@
 """Content-Defined Chunking (CDC) for large files (Issue #1074).
 
-CDCEngine provides chunking for any CASBackend subclass via Feature DI:
+CDCEngine provides chunking for any CASAddressingEngine subclass via Feature DI:
 
-    class CASBackend(Backend):
+    class CASAddressingEngine(Backend):
         def __init__(self, transport, ..., cdc_engine=None):
             self._cdc = cdc_engine  # Optional, None-safe
 
-CDC routing is handled by CASBackend base class — subclasses do NOT
+CDC routing is handled by CASAddressingEngine base class — subclasses do NOT
 need to override write_content/read_content for CDC.
 
 ChunkingStrategy protocol allows pluggable chunking algorithms:
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 from nexus.core.hash_fast import hash_content
 
 if TYPE_CHECKING:
-    from nexus.backends.base.cas_backend import CASBackend
+    from nexus.backends.base.cas_backend import CASAddressingEngine
     from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class ChunkingStrategy(Protocol):
     - Default: ``CDCEngine`` (Rabin fingerprint, 16MB threshold)
     - Custom: message-boundary chunking for LLM conversations, etc.
 
-    All methods receive the parent ``CASBackend`` instance for transport access.
+    All methods receive the parent ``CASAddressingEngine`` instance for transport access.
     """
 
     def should_chunk(self, content: bytes) -> bool:
@@ -177,9 +177,9 @@ class ChunkedReference:
 
 
 class CDCEngine:
-    """CDC chunking engine — composed into CASBackend subclasses.
+    """CDC chunking engine — composed into CASAddressingEngine subclasses.
 
-    Uses CASBackend's internal methods directly:
+    Uses CASAddressingEngine's internal methods directly:
     ``_transport``, ``_blob_key()``, ``_read_meta()``, ``_write_meta()``,
     ``_meta_update_locked()``, ``_stripe_lock``, ``_bloom``.
     """
@@ -188,7 +188,7 @@ class CDCEngine:
 
     def __init__(
         self,
-        backend: CASBackend,
+        backend: CASAddressingEngine,
         *,
         threshold: int = CDC_THRESHOLD_BYTES,
         min_chunk: int = CDC_MIN_CHUNK_SIZE,

--- a/src/nexus/backends/misc/backend_io.py
+++ b/src/nexus/backends/misc/backend_io.py
@@ -98,7 +98,7 @@ class BackendIOService:
         """Batch read content directly from backend (bypassing cache).
 
         Leverages _bulk_download_blobs() for efficient parallel downloads when
-        available (PathBackend subclasses). Falls back to sequential
+        available (PathAddressingEngine subclasses). Falls back to sequential
         reads for other connector types.
 
         Args:

--- a/src/nexus/backends/storage/cas_gcs.py
+++ b/src/nexus/backends/storage/cas_gcs.py
@@ -1,6 +1,6 @@
 """Google Cloud Storage backend with CAS deduplication.
 
-Thin subclass of CASBackend that:
+Thin subclass of CASAddressingEngine that:
 - Creates a GCSBlobTransport for raw GCS I/O
 - Registers as "cas_gcs" connector via @register_connector
 - Declares CONNECTION_ARGS for factory instantiation
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from nexus.backends.base.cas_backend import CASBackend
+from nexus.backends.base.cas_backend import CASAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.contracts.exceptions import BackendError
 
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
     category="storage",
     requires=["google-cloud-storage"],
 )
-class CASGCSBackend(CASBackend):
+class CASGCSBackend(CASAddressingEngine):
     """Google Cloud Storage backend with CAS deduplication.
 
     Storage layout:

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -1,14 +1,14 @@
 """CAS + Local transport backend — full-featured local storage.
 
-Composes CASBackend (addressing) + LocalBlobTransport (I/O) +
+Composes CASAddressingEngine (addressing) + LocalBlobTransport (I/O) +
 MultipartUpload (resumable uploads) using Feature DI for Bloom filter,
 content cache, stripe lock, and CDCEngine (chunking).
 
-    CASLocalBackend = CASBackend(LocalBlobTransport)
+    CASLocalBackend = CASAddressingEngine(LocalBlobTransport)
                     + MultipartUpload     (resumable uploads, ABC)
                     + Feature DI          (Bloom, cache, stripe lock, CDC)
 
-CDC routing is handled by CASBackend base class via Feature DI —
+CDC routing is handled by CASAddressingEngine base class via Feature DI —
 CASLocalBackend only instantiates and passes CDCEngine.
 
 Naming convention: {addressing}_{transport} per Section 5.2 of
@@ -26,7 +26,7 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from nexus.backends.base.cas_backend import CASBackend
+from nexus.backends.base.cas_backend import CASAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.base.stripe_lock import _StripeLock
 from nexus.backends.engines.cdc import CDCEngine
@@ -76,11 +76,11 @@ def _init_bloom(cas_root: Path, capacity: int, fp_rate: float) -> Any:
     description="Local filesystem with CAS deduplication (new architecture)",
     category="storage",
 )
-class CASLocalBackend(CASBackend, MultipartUpload):
+class CASLocalBackend(CASAddressingEngine, MultipartUpload):
     """CAS addressing + local filesystem transport.
 
-    CDCEngine is injected via CASBackend Feature DI (``self._cdc``).
-    CDC routing (write/read/delete) is handled by CASBackend base class.
+    CDCEngine is injected via CASAddressingEngine Feature DI (``self._cdc``).
+    CDC routing (write/read/delete) is handled by CASAddressingEngine base class.
     """
 
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
@@ -133,7 +133,7 @@ class CASLocalBackend(CASBackend, MultipartUpload):
 
         meta_cache: Any = cachetools.LRUCache(maxsize=10_000)
 
-        # Initialize CASBackend with Feature DI (including CDC)
+        # Initialize CASAddressingEngine with Feature DI (including CDC)
         # CDCEngine requires a reference to the backend, so we create a
         # temporary instance and wire it after super().__init__().
         super().__init__(
@@ -146,7 +146,7 @@ class CASLocalBackend(CASBackend, MultipartUpload):
             on_write_callback=on_write_callback,
         )
 
-        # CDCEngine needs self (CASBackend internals) — wire after init
+        # CDCEngine needs self (CASAddressingEngine internals) — wire after init
         self._cdc = CDCEngine(self)
 
     @property
@@ -172,7 +172,7 @@ class CASLocalBackend(CASBackend, MultipartUpload):
         return bool(self._cdc.is_chunked(content_hash))
 
     # Content operations (write_content, read_content, delete_content,
-    # get_content_size, read_content_range) — all inherited from CASBackend
+    # get_content_size, read_content_range) — all inherited from CASAddressingEngine
     # which handles CDC routing via Feature DI (self._cdc).
 
     # === Directory Operations (local FS native, not blob markers) ===

--- a/src/nexus/backends/storage/path_gcs.py
+++ b/src/nexus/backends/storage/path_gcs.py
@@ -1,6 +1,6 @@
 """Google Cloud Storage connector backend with direct path mapping.
 
-Thin subclass of PathBackend that:
+Thin subclass of PathAddressingEngine that:
 - Creates a GCSBlobTransport for raw GCS I/O (shared with GCSBackend CAS)
 - Mixes in CacheConnectorMixin for L1+L2 caching
 - Registers as "path_gcs" via @register_connector
@@ -24,7 +24,7 @@ import time
 from typing import TYPE_CHECKING
 
 from nexus.backends.base.backend import FileInfo, HandlerStatusResponse
-from nexus.backends.base.path_backend import PathBackend
+from nexus.backends.base.path_backend import PathAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
 from nexus.contracts.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorCapability
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
     requires=["google-cloud-storage"],
     service_name="gcs",
 )
-class PathGCSBackend(PathBackend, CacheConnectorMixin):
+class PathGCSBackend(PathAddressingEngine, CacheConnectorMixin):
     """Google Cloud Storage connector with direct path mapping and caching.
 
     Features:

--- a/src/nexus/backends/storage/path_local.py
+++ b/src/nexus/backends/storage/path_local.py
@@ -1,6 +1,6 @@
 """Path-based local filesystem backend (no CAS overhead).
 
-Thin subclass of PathBackend that:
+Thin subclass of PathAddressingEngine that:
 - Creates a LocalBlobTransport for raw local I/O
 - Registers as "path_local" via @register_connector
 - Exposes root_path / has_root_path for orchestrator
@@ -22,7 +22,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import ClassVar
 
-from nexus.backends.base.path_backend import PathBackend
+from nexus.backends.base.path_backend import PathAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.transports.local_transport import LocalBlobTransport
 from nexus.contracts.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorCapability
@@ -33,7 +33,7 @@ from nexus.contracts.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorC
     description="Local filesystem with direct path mapping (no CAS)",
     category="storage",
 )
-class PathLocalBackend(PathBackend):
+class PathLocalBackend(PathAddressingEngine):
     """Local filesystem backend with direct path mapping.
 
     Unlike ``CASLocalBackend`` (CAS addressing + local transport), this uses

--- a/src/nexus/backends/storage/path_s3.py
+++ b/src/nexus/backends/storage/path_s3.py
@@ -1,6 +1,6 @@
 """AWS S3 connector backend with direct path mapping.
 
-Thin subclass of PathBackend that:
+Thin subclass of PathAddressingEngine that:
 - Creates an S3BlobTransport for raw S3 I/O
 - Mixes in CacheConnectorMixin for L1+L2 caching
 - Mixes in MultipartUpload for chunked uploads
@@ -18,7 +18,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from nexus.backends.base.backend import FileInfo, HandlerStatusResponse
-from nexus.backends.base.path_backend import PathBackend
+from nexus.backends.base.path_backend import PathAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.engines.multipart import MultipartUpload
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
     requires=["boto3"],
     service_name="s3",
 )
-class PathS3Backend(PathBackend, CacheConnectorMixin, MultipartUpload):
+class PathS3Backend(PathAddressingEngine, CacheConnectorMixin, MultipartUpload):
     """AWS S3 connector with direct path mapping, caching, and multipart upload."""
 
     _CAPABILITIES = BLOB_CONNECTOR_CAPABILITIES | frozenset(

--- a/src/nexus/backends/transports/local_transport.py
+++ b/src/nexus/backends/transports/local_transport.py
@@ -12,7 +12,7 @@ keys to filesystem paths under root_path.
 
 References:
     - Issue #1323: CAS x Backend orthogonal composition
-    - CASBackend — atomic write patterns
+    - CASAddressingEngine — atomic write patterns
     - transports/gcs_transport.py — reference transport implementation
 """
 
@@ -283,7 +283,7 @@ class LocalBlobTransport:
     def put_blob_from_path(self, key: str, src_path: str | Path) -> str | None:
         """Atomic move: src_path → final blob path (no memory copy).
 
-        Used by CASBackend.write_stream to avoid loading streamed content
+        Used by CASAddressingEngine.write_stream to avoid loading streamed content
         back into memory after hashing to a temp file.
         """
         path = self._resolve(key)

--- a/src/nexus/backends/transports/s3_transport.py
+++ b/src/nexus/backends/transports/s3_transport.py
@@ -1,7 +1,7 @@
 """S3 BlobTransport — raw key→blob I/O over AWS S3.
 
 Shared between PathS3Backend (path addressing) and potential future
-S3CASBackend (CAS addressing).
+S3CASAddressingEngine (CAS addressing).
 
 Authentication priority:
     1. Explicit credentials (access_key_id + secret_access_key)

--- a/src/nexus/backends/wrappers/cache_mixin.py
+++ b/src/nexus/backends/wrappers/cache_mixin.py
@@ -53,7 +53,7 @@ class CacheConnectorMixin:
     - L2: Disk-based content + metadata sidecar (FileContentCache)
 
     Usage:
-        class PathGCSBackend(PathBackend, CacheConnectorMixin):
+        class PathGCSBackend(PathAddressingEngine, CacheConnectorMixin):
             pass
     """
 

--- a/src/nexus/bricks/snapshot/service.py
+++ b/src/nexus/bricks/snapshot/service.py
@@ -6,7 +6,7 @@ an in-memory registry for fast-path O(1) lookups.
 
 Architecture:
     - TransactionRegistry: in-memory fast-path (zero cost when no txns active)
-    - CASBackend.hold_reference(): prevents GC of pre-modification content
+    - CASAddressingEngine.hold_reference(): prevents GC of pre-modification content
     - DB: TransactionSnapshotModel + SnapshotEntryModel for durability
     - Conflict detection: MVCC at commit time via hash comparison
 
@@ -96,7 +96,7 @@ class TransactionalSnapshotService:
 
         Args:
             record_store: RecordStoreABC for DB persistence.
-            cas_store: CASBackend for hold_reference/release.
+            cas_store: CASAddressingEngine for hold_reference/release.
             metadata_store: MetastoreABC for reading current file state.
             metadata_factory: Callable to construct FileMetadata-like objects
                 (injected by factory.py to avoid importing nexus.contracts.metadata).

--- a/tests/unit/backends/test_batch_operations.py
+++ b/tests/unit/backends/test_batch_operations.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from nexus.backends.base.backend import Backend
-from nexus.backends.base.path_backend import PathBackend
+from nexus.backends.base.path_backend import PathAddressingEngine
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.contracts.types import OperationContext
@@ -67,7 +67,7 @@ class InMemoryBlobTransport:
             yield data[i : i + chunk_size]
 
 
-class MockBlobConnector(PathBackend, CacheConnectorMixin):
+class MockBlobConnector(PathAddressingEngine, CacheConnectorMixin):
     """Mock blob connector for testing batch operations."""
 
     def __init__(self, session_factory):
@@ -577,7 +577,7 @@ class TestGCSBatchReadContent:
 # === S3 batch_read_content tests (#1626) ===
 
 
-class MockS3ConnectorForBatch(PathBackend, CacheConnectorMixin):
+class MockS3ConnectorForBatch(PathAddressingEngine, CacheConnectorMixin):
     """Mock S3-like connector for testing batch_read_content with per-file contexts.
 
     Simulates path-based access where each file needs its own OperationContext.

--- a/tests/unit/backends/test_cas_backend.py
+++ b/tests/unit/backends/test_cas_backend.py
@@ -1,4 +1,4 @@
-"""Unit tests for CASBackend — CAS addressing over InMemoryBlobTransport.
+"""Unit tests for CASAddressingEngine — CAS addressing over InMemoryBlobTransport.
 
 Tests cover:
 - Content-addressable write/read/delete with hash-based paths
@@ -17,7 +17,7 @@ from collections.abc import Iterator
 
 import pytest
 
-from nexus.backends.base.cas_backend import CASBackend
+from nexus.backends.base.cas_backend import CASAddressingEngine
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
@@ -97,17 +97,19 @@ def transport() -> InMemoryBlobTransport:
 
 
 @pytest.fixture
-def backend(transport: InMemoryBlobTransport) -> CASBackend:
-    return CASBackend(transport, backend_name="test-cas")
+def backend(transport: InMemoryBlobTransport) -> CASAddressingEngine:
+    return CASAddressingEngine(transport, backend_name="test-cas")
 
 
 # === Test Classes ===
 
 
-class TestCASBackendWriteContent:
+class TestCASAddressingEngineWriteContent:
     """Test write_content() — CAS dedup and ref counting."""
 
-    def test_write_stores_at_cas_path(self, backend: CASBackend, transport: InMemoryBlobTransport):
+    def test_write_stores_at_cas_path(
+        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
+    ):
         content = b"hello world"
         h = hash_content(content)
         result = backend.write_content(content)
@@ -121,7 +123,7 @@ class TestCASBackendWriteContent:
         assert transport.files[cas_key] == content
 
     def test_write_creates_metadata_sidecar(
-        self, backend: CASBackend, transport: InMemoryBlobTransport
+        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
     ):
         content = b"test metadata"
         h = hash_content(content)
@@ -136,7 +138,7 @@ class TestCASBackendWriteContent:
         assert meta["ref_count"] == 1
         assert meta["size"] == len(content)
 
-    def test_write_dedup_increments_ref_count(self, backend: CASBackend):
+    def test_write_dedup_increments_ref_count(self, backend: CASAddressingEngine):
         content = b"duplicate content"
 
         r1 = backend.write_content(content)
@@ -145,32 +147,32 @@ class TestCASBackendWriteContent:
         assert r1.content_hash == r2.content_hash
         assert backend.get_ref_count(r1.content_hash) == 2
 
-    def test_write_different_content_different_hashes(self, backend: CASBackend):
+    def test_write_different_content_different_hashes(self, backend: CASAddressingEngine):
         r1 = backend.write_content(b"content A")
         r2 = backend.write_content(b"content B")
 
         assert r1.content_hash != r2.content_hash
 
-    def test_write_returns_write_result(self, backend: CASBackend):
+    def test_write_returns_write_result(self, backend: CASAddressingEngine):
         result = backend.write_content(b"test")
         assert isinstance(result, WriteResult)
 
 
-class TestCASBackendReadContent:
+class TestCASAddressingEngineReadContent:
     """Test read_content() — hash-based retrieval and integrity verification."""
 
-    def test_read_returns_content(self, backend: CASBackend):
+    def test_read_returns_content(self, backend: CASAddressingEngine):
         content = b"read me"
         result = backend.write_content(content)
         data = backend.read_content(result.content_hash)
         assert data == content
 
-    def test_read_missing_raises(self, backend: CASBackend):
+    def test_read_missing_raises(self, backend: CASAddressingEngine):
         with pytest.raises(NexusFileNotFoundError):
             backend.read_content("a" * 64)
 
     def test_read_verifies_hash_integrity(
-        self, backend: CASBackend, transport: InMemoryBlobTransport
+        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
     ):
         content = b"original"
         result = backend.write_content(content)
@@ -183,11 +185,11 @@ class TestCASBackendReadContent:
             backend.read_content(result.content_hash)
 
 
-class TestCASBackendDeleteContent:
+class TestCASAddressingEngineDeleteContent:
     """Test delete_content() — ref counting and cleanup."""
 
     def test_delete_removes_blob_on_last_ref(
-        self, backend: CASBackend, transport: InMemoryBlobTransport
+        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
     ):
         content = b"delete me"
         result = backend.write_content(content)
@@ -198,7 +200,7 @@ class TestCASBackendDeleteContent:
         cas_key = f"cas/{h[:2]}/{h[2:4]}/{h}"
         assert cas_key not in transport.files
 
-    def test_delete_decrements_ref_count(self, backend: CASBackend):
+    def test_delete_decrements_ref_count(self, backend: CASAddressingEngine):
         content = b"ref counted"
         result = backend.write_content(content)
         backend.write_content(content)  # ref_count = 2
@@ -206,12 +208,12 @@ class TestCASBackendDeleteContent:
         backend.delete_content(result.content_hash)
         assert backend.get_ref_count(result.content_hash) == 1
 
-    def test_delete_missing_raises(self, backend: CASBackend):
+    def test_delete_missing_raises(self, backend: CASAddressingEngine):
         with pytest.raises(NexusFileNotFoundError):
             backend.delete_content("b" * 64)
 
     def test_delete_cleans_up_meta_sidecar(
-        self, backend: CASBackend, transport: InMemoryBlobTransport
+        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
     ):
         content = b"cleanup"
         result = backend.write_content(content)
@@ -223,45 +225,45 @@ class TestCASBackendDeleteContent:
         assert meta_key not in transport.files
 
 
-class TestCASBackendContentOperations:
+class TestCASAddressingEngineContentOperations:
     """Test content_exists, get_content_size, get_ref_count."""
 
-    def test_content_exists_true(self, backend: CASBackend):
+    def test_content_exists_true(self, backend: CASAddressingEngine):
         result = backend.write_content(b"exists")
         assert backend.content_exists(result.content_hash) is True
 
-    def test_content_exists_false(self, backend: CASBackend):
+    def test_content_exists_false(self, backend: CASAddressingEngine):
         assert backend.content_exists("c" * 64) is False
 
-    def test_get_content_size(self, backend: CASBackend):
+    def test_get_content_size(self, backend: CASAddressingEngine):
         content = b"size check"
         result = backend.write_content(content)
         assert backend.get_content_size(result.content_hash) == len(content)
 
-    def test_get_content_size_missing_raises(self, backend: CASBackend):
+    def test_get_content_size_missing_raises(self, backend: CASAddressingEngine):
         with pytest.raises(NexusFileNotFoundError):
             backend.get_content_size("d" * 64)
 
-    def test_get_ref_count_missing_raises(self, backend: CASBackend):
+    def test_get_ref_count_missing_raises(self, backend: CASAddressingEngine):
         with pytest.raises(NexusFileNotFoundError):
             backend.get_ref_count("e" * 64)
 
 
-class TestCASBackendStreaming:
+class TestCASAddressingEngineStreaming:
     """Test stream_content and write_stream."""
 
-    def test_stream_content_yields_chunks(self, backend: CASBackend):
+    def test_stream_content_yields_chunks(self, backend: CASAddressingEngine):
         content = b"A" * 100
         result = backend.write_content(content)
 
         chunks = list(backend.stream_content(result.content_hash, chunk_size=30))
         assert b"".join(chunks) == content
 
-    def test_stream_missing_raises(self, backend: CASBackend):
+    def test_stream_missing_raises(self, backend: CASAddressingEngine):
         with pytest.raises(NexusFileNotFoundError):
             list(backend.stream_content("f" * 64))
 
-    def test_write_stream(self, backend: CASBackend):
+    def test_write_stream(self, backend: CASAddressingEngine):
         chunks = [b"chunk1", b"chunk2", b"chunk3"]
         result = backend.write_stream(iter(chunks))
 
@@ -269,10 +271,10 @@ class TestCASBackendStreaming:
         assert data == b"chunk1chunk2chunk3"
 
 
-class TestCASBackendBatchRead:
+class TestCASAddressingEngineBatchRead:
     """Test batch_read_content."""
 
-    def test_batch_read_multiple(self, backend: CASBackend):
+    def test_batch_read_multiple(self, backend: CASAddressingEngine):
         h1 = backend.write_content(b"file1").content_hash
         h2 = backend.write_content(b"file2").content_hash
         h3 = backend.write_content(b"file3").content_hash
@@ -283,15 +285,15 @@ class TestCASBackendBatchRead:
         assert result[h2] == b"file2"
         assert result[h3] == b"file3"
 
-    def test_batch_read_empty(self, backend: CASBackend):
+    def test_batch_read_empty(self, backend: CASAddressingEngine):
         assert backend.batch_read_content([]) == {}
 
-    def test_batch_read_single_optimization(self, backend: CASBackend):
+    def test_batch_read_single_optimization(self, backend: CASAddressingEngine):
         h = backend.write_content(b"single").content_hash
         result = backend.batch_read_content([h])
         assert result[h] == b"single"
 
-    def test_batch_read_partial_failures(self, backend: CASBackend):
+    def test_batch_read_partial_failures(self, backend: CASAddressingEngine):
         h = backend.write_content(b"exists").content_hash
         fake = "a" * 64
 
@@ -301,54 +303,56 @@ class TestCASBackendBatchRead:
         assert result[fake] is None
 
 
-class TestCASBackendDirectories:
+class TestCASAddressingEngineDirectories:
     """Test directory operations (CAS uses dirs/ prefix)."""
 
-    def test_mkdir_creates_marker(self, backend: CASBackend, transport: InMemoryBlobTransport):
+    def test_mkdir_creates_marker(
+        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
+    ):
         backend.mkdir("data")
         assert "dirs/data/" in transport.files
 
-    def test_mkdir_root_noop(self, backend: CASBackend, transport: InMemoryBlobTransport):
+    def test_mkdir_root_noop(self, backend: CASAddressingEngine, transport: InMemoryBlobTransport):
         backend.mkdir("")
         # Root always exists, no marker created
         assert not any(k.startswith("dirs/") for k in transport.files)
 
-    def test_mkdir_exist_ok(self, backend: CASBackend):
+    def test_mkdir_exist_ok(self, backend: CASAddressingEngine):
         backend.mkdir("data")
         backend.mkdir("data", exist_ok=True)  # No error
 
-    def test_mkdir_duplicate_raises(self, backend: CASBackend):
+    def test_mkdir_duplicate_raises(self, backend: CASAddressingEngine):
         backend.mkdir("data")
         with pytest.raises(FileExistsError):
             backend.mkdir("data")
 
-    def test_is_directory(self, backend: CASBackend):
+    def test_is_directory(self, backend: CASAddressingEngine):
         assert backend.is_directory("") is True  # Root
         assert backend.is_directory("nonexistent") is False
         backend.mkdir("data")
         assert backend.is_directory("data") is True
 
-    def test_rmdir(self, backend: CASBackend, transport: InMemoryBlobTransport):
+    def test_rmdir(self, backend: CASAddressingEngine, transport: InMemoryBlobTransport):
         backend.mkdir("data")
         backend.rmdir("data")
         assert "dirs/data/" not in transport.files
 
-    def test_rmdir_missing_raises(self, backend: CASBackend):
+    def test_rmdir_missing_raises(self, backend: CASAddressingEngine):
         with pytest.raises(NexusFileNotFoundError):
             backend.rmdir("nonexistent")
 
-    def test_rmdir_root_raises(self, backend: CASBackend):
+    def test_rmdir_root_raises(self, backend: CASAddressingEngine):
         with pytest.raises(BackendError, match="root"):
             backend.rmdir("")
 
 
-class TestCASBackendName:
+class TestCASAddressingEngineName:
     """Test name property and default name generation."""
 
     def test_custom_name(self, transport: InMemoryBlobTransport):
-        backend = CASBackend(transport, backend_name="my-cas")
+        backend = CASAddressingEngine(transport, backend_name="my-cas")
         assert backend.name == "my-cas"
 
     def test_default_name(self, transport: InMemoryBlobTransport):
-        backend = CASBackend(transport)
+        backend = CASAddressingEngine(transport)
         assert backend.name == "cas-memory"

--- a/tests/unit/backends/test_cas_local_crud.py
+++ b/tests/unit/backends/test_cas_local_crud.py
@@ -1,4 +1,4 @@
-"""CRUD verification: CASBackend(LocalBlobTransport) end-to-end.
+"""CRUD verification: CASAddressingEngine(LocalBlobTransport) end-to-end.
 
 This is the **first time** production CRUD has been verified on the new
 CAS x BlobTransport composition with a real filesystem. Previous tests
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nexus.backends.base.cas_backend import CASBackend
+from nexus.backends.base.cas_backend import CASAddressingEngine
 from nexus.backends.base.stripe_lock import _StripeLock
 from nexus.backends.transports.local_transport import LocalBlobTransport
 from nexus.contracts.exceptions import NexusFileNotFoundError
@@ -38,17 +38,17 @@ def transport(tmp_path):
 
 @pytest.fixture
 def backend(transport):
-    return CASBackend(transport, backend_name="test-local")
+    return CASAddressingEngine(transport, backend_name="test-local")
 
 
 @pytest.fixture
 def backend_with_features(transport):
-    """CASBackend with all Feature DI enabled."""
+    """CASAddressingEngine with all Feature DI enabled."""
     cache = SimpleCache()
     bloom = SimpleBloom()
     stripe = _StripeLock(num_stripes=16)
     callback = MagicMock()
-    return CASBackend(
+    return CASAddressingEngine(
         transport,
         backend_name="test-local-features",
         bloom_filter=bloom,
@@ -308,7 +308,7 @@ class TestStripeLock:
         """50 threads writing same content should produce ref_count=50."""
         transport = LocalBlobTransport(root_path=tmp_path, fsync=False)
         stripe = _StripeLock(num_stripes=16)
-        backend = CASBackend(transport, backend_name="concurrent", stripe_lock=stripe)
+        backend = CASAddressingEngine(transport, backend_name="concurrent", stripe_lock=stripe)
 
         content = b"concurrent-content"
         results = []
@@ -343,7 +343,7 @@ class TestStripeLock:
         """50 threads writing different content should all succeed."""
         transport = LocalBlobTransport(root_path=tmp_path, fsync=False)
         stripe = _StripeLock(num_stripes=16)
-        backend = CASBackend(transport, backend_name="concurrent", stripe_lock=stripe)
+        backend = CASAddressingEngine(transport, backend_name="concurrent", stripe_lock=stripe)
 
         results = []
         errors = []
@@ -388,7 +388,7 @@ class TestOnWriteCallback:
 
 
 class TestNoFeatures:
-    """Verify CASBackend works correctly with no features injected (cloud mode)."""
+    """Verify CASAddressingEngine works correctly with no features injected (cloud mode)."""
 
     def test_crud_without_features(self, backend):
         r = backend.write_content(b"cloud-style")

--- a/tests/unit/backends/test_cas_metadata_cache.py
+++ b/tests/unit/backends/test_cas_metadata_cache.py
@@ -1,4 +1,4 @@
-"""Unit tests for CASBackend metadata LRU cache (Issue #2940).
+"""Unit tests for CASAddressingEngine metadata LRU cache (Issue #2940).
 
 Tests cover:
 - Meta cache hit/miss counters
@@ -12,7 +12,7 @@ Tests cover:
 import cachetools
 import pytest
 
-from nexus.backends.base.cas_backend import CASBackend
+from nexus.backends.base.cas_backend import CASAddressingEngine
 from tests.unit.backends.test_cas_backend import InMemoryBlobTransport
 
 
@@ -27,27 +27,29 @@ def meta_cache() -> cachetools.LRUCache:
 
 
 @pytest.fixture
-def backend(transport: InMemoryBlobTransport, meta_cache: cachetools.LRUCache) -> CASBackend:
-    return CASBackend(transport, backend_name="test-cas", meta_cache=meta_cache)
+def backend(
+    transport: InMemoryBlobTransport, meta_cache: cachetools.LRUCache
+) -> CASAddressingEngine:
+    return CASAddressingEngine(transport, backend_name="test-cas", meta_cache=meta_cache)
 
 
 @pytest.fixture
-def backend_no_cache(transport: InMemoryBlobTransport) -> CASBackend:
+def backend_no_cache(transport: InMemoryBlobTransport) -> CASAddressingEngine:
     """Backend without meta_cache (simulates cloud backends)."""
-    return CASBackend(transport, backend_name="test-cas-no-cache")
+    return CASAddressingEngine(transport, backend_name="test-cas-no-cache")
 
 
 class TestCacheStats:
     """Test cache_stats property."""
 
-    def test_initial_stats_empty(self, backend: CASBackend):
+    def test_initial_stats_empty(self, backend: CASAddressingEngine):
         stats = backend.cache_stats
         assert stats["hits"] == 0
         assert stats["misses"] == 0
         assert stats["size"] == 0
         assert stats["maxsize"] == 100
 
-    def test_stats_without_cache(self, backend_no_cache: CASBackend):
+    def test_stats_without_cache(self, backend_no_cache: CASAddressingEngine):
         stats = backend_no_cache.cache_stats
         assert stats["hits"] == 0
         assert stats["misses"] == 0
@@ -58,7 +60,7 @@ class TestCacheStats:
 class TestMetaCacheReadThrough:
     """Test _read_meta with cache read-through."""
 
-    def test_first_read_is_miss(self, backend: CASBackend):
+    def test_first_read_is_miss(self, backend: CASAddressingEngine):
         content = b"test content"
         backend.write_content(content)
 
@@ -66,7 +68,7 @@ class TestMetaCacheReadThrough:
         # The initial _read_meta in _meta_update_locked is a miss
         assert backend.cache_stats["misses"] >= 1
 
-    def test_second_read_is_hit(self, backend: CASBackend):
+    def test_second_read_is_hit(self, backend: CASAddressingEngine):
         content = b"test content"
         result = backend.write_content(content)
 
@@ -80,7 +82,9 @@ class TestMetaCacheReadThrough:
         assert backend.cache_stats["hits"] == 1
         assert backend.cache_stats["misses"] == 0
 
-    def test_cache_populated_after_miss(self, backend: CASBackend, meta_cache: cachetools.LRUCache):
+    def test_cache_populated_after_miss(
+        self, backend: CASAddressingEngine, meta_cache: cachetools.LRUCache
+    ):
         content = b"populate cache"
         result = backend.write_content(content)
 
@@ -88,7 +92,7 @@ class TestMetaCacheReadThrough:
         assert result.content_hash in meta_cache
         assert meta_cache[result.content_hash]["ref_count"] == 1
 
-    def test_no_cache_no_error(self, backend_no_cache: CASBackend):
+    def test_no_cache_no_error(self, backend_no_cache: CASAddressingEngine):
         """Backend without cache should work normally."""
         content = b"no cache content"
         result = backend_no_cache.write_content(content)
@@ -99,7 +103,9 @@ class TestMetaCacheReadThrough:
 class TestMetaCacheWriteThrough:
     """Test that _write_meta updates the cache."""
 
-    def test_write_meta_updates_cache(self, backend: CASBackend, meta_cache: cachetools.LRUCache):
+    def test_write_meta_updates_cache(
+        self, backend: CASAddressingEngine, meta_cache: cachetools.LRUCache
+    ):
         content = b"write-through test"
         result = backend.write_content(content)
 
@@ -118,7 +124,7 @@ class TestMetaCacheEviction:
     """Test cache eviction on delete_content."""
 
     def test_delete_last_ref_evicts_cache(
-        self, backend: CASBackend, meta_cache: cachetools.LRUCache
+        self, backend: CASAddressingEngine, meta_cache: cachetools.LRUCache
     ):
         content = b"delete me"
         result = backend.write_content(content)
@@ -132,7 +138,7 @@ class TestMetaCacheEviction:
         assert h not in meta_cache
 
     def test_delete_decrement_keeps_cache(
-        self, backend: CASBackend, meta_cache: cachetools.LRUCache
+        self, backend: CASAddressingEngine, meta_cache: cachetools.LRUCache
     ):
         content = b"keep in cache"
         result = backend.write_content(content)
@@ -151,7 +157,7 @@ class TestMetaCacheLRUBehavior:
 
     def test_cache_maxsize_respected(self, transport: InMemoryBlobTransport):
         small_cache = cachetools.LRUCache(maxsize=3)
-        backend = CASBackend(transport, backend_name="test", meta_cache=small_cache)
+        backend = CASAddressingEngine(transport, backend_name="test", meta_cache=small_cache)
 
         hashes = []
         for i in range(5):

--- a/tests/unit/backends/test_local_cas_backend.py
+++ b/tests/unit/backends/test_local_cas_backend.py
@@ -1,7 +1,7 @@
 """Unit tests for CASLocalBackend — full-featured local CAS backend.
 
 Tests cover:
-- Basic CRUD (inherited from CASBackend)
+- Basic CRUD (inherited from CASAddressingEngine)
 - CDC: write large file → chunked, read back → reassembled
 - Multipart: init/upload_parts/complete/abort
 - Concurrent writes with stripe lock (50 threads)

--- a/tests/unit/backends/test_local_transport.py
+++ b/tests/unit/backends/test_local_transport.py
@@ -261,7 +261,7 @@ class TestFsyncOption:
 
 
 class TestCASKeyPattern:
-    """Verify transport works with CAS-style keys (what CASBackend sends)."""
+    """Verify transport works with CAS-style keys (what CASAddressingEngine sends)."""
 
     def test_cas_key_roundtrip(self, transport):
         key = "cas/ab/cd/abcdef1234567890"

--- a/tests/unit/backends/test_openai_compat.py
+++ b/tests/unit/backends/test_openai_compat.py
@@ -290,7 +290,7 @@ class TestOpenAICompatibleBackend:
             backend.read_content(result.content_hash)
 
     def test_content_exists(self) -> None:
-        """Verify content_exists works via CASBackend."""
+        """Verify content_exists works via CASAddressingEngine."""
         client = MagicMock()
         client.chat.completions.create.return_value = _mock_completion()
         backend, _ = self._make_backend(client)

--- a/tests/unit/backends/test_path_backend.py
+++ b/tests/unit/backends/test_path_backend.py
@@ -1,4 +1,4 @@
-"""Unit tests for PathBackend — path addressing over InMemoryBlobTransport.
+"""Unit tests for PathAddressingEngine — path addressing over InMemoryBlobTransport.
 
 Tests cover:
 - Path-based write/read/delete (requires OperationContext with backend_path)
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nexus.backends.base.path_backend import PathBackend
+from nexus.backends.base.path_backend import PathAddressingEngine
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.contracts.types import OperationContext
 from nexus.core.hash_fast import hash_content
@@ -110,13 +110,13 @@ def transport() -> InMemoryBlobTransport:
 
 
 @pytest.fixture
-def backend(transport: InMemoryBlobTransport) -> PathBackend:
-    return PathBackend(transport, backend_name="test-path", bucket_name="test-bucket")
+def backend(transport: InMemoryBlobTransport) -> PathAddressingEngine:
+    return PathAddressingEngine(transport, backend_name="test-path", bucket_name="test-bucket")
 
 
 @pytest.fixture
-def prefixed_backend(transport: InMemoryBlobTransport) -> PathBackend:
-    return PathBackend(
+def prefixed_backend(transport: InMemoryBlobTransport) -> PathAddressingEngine:
+    return PathAddressingEngine(
         transport, backend_name="test-prefixed", bucket_name="test-bucket", prefix="data"
     )
 
@@ -124,11 +124,11 @@ def prefixed_backend(transport: InMemoryBlobTransport) -> PathBackend:
 # === Test Classes ===
 
 
-class TestPathBackendWriteContent:
+class TestPathAddressingEngineWriteContent:
     """Test write_content() — path-based storage."""
 
     def test_write_stores_at_backend_path(
-        self, backend: PathBackend, transport: InMemoryBlobTransport
+        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
     ):
         ctx = _make_context("docs/file.txt")
         result = backend.write_content(b"hello world", context=ctx)
@@ -138,23 +138,23 @@ class TestPathBackendWriteContent:
         assert "docs/file.txt" in transport.files
         assert transport.files["docs/file.txt"] == b"hello world"
 
-    def test_write_requires_backend_path(self, backend: PathBackend):
+    def test_write_requires_backend_path(self, backend: PathAddressingEngine):
         with pytest.raises(BackendError, match="requires backend_path"):
             backend.write_content(b"no context")
 
-    def test_write_requires_context(self, backend: PathBackend):
+    def test_write_requires_context(self, backend: PathAddressingEngine):
         with pytest.raises(BackendError, match="requires backend_path"):
             backend.write_content(b"no path", context=_make_context(""))
 
     def test_write_with_prefix(
-        self, prefixed_backend: PathBackend, transport: InMemoryBlobTransport
+        self, prefixed_backend: PathAddressingEngine, transport: InMemoryBlobTransport
     ):
         ctx = _make_context("file.txt")
         prefixed_backend.write_content(b"prefixed", context=ctx)
 
         assert "data/file.txt" in transport.files
 
-    def test_write_computes_hash(self, backend: PathBackend):
+    def test_write_computes_hash(self, backend: PathAddressingEngine):
         content = b"hash me"
         ctx = _make_context("file.txt")
         result = backend.write_content(content, context=ctx)
@@ -163,30 +163,32 @@ class TestPathBackendWriteContent:
         assert result.content_hash == expected
 
 
-class TestPathBackendReadContent:
+class TestPathAddressingEngineReadContent:
     """Test read_content() — path-based retrieval."""
 
-    def test_read_returns_content(self, backend: PathBackend):
+    def test_read_returns_content(self, backend: PathAddressingEngine):
         ctx = _make_context("file.txt")
         backend.write_content(b"read me", context=ctx)
 
         data = backend.read_content("any-hash", context=ctx)
         assert data == b"read me"
 
-    def test_read_requires_backend_path(self, backend: PathBackend):
+    def test_read_requires_backend_path(self, backend: PathAddressingEngine):
         with pytest.raises(BackendError, match="requires backend_path"):
             backend.read_content("hash")
 
-    def test_read_missing_raises(self, backend: PathBackend):
+    def test_read_missing_raises(self, backend: PathAddressingEngine):
         ctx = _make_context("nonexistent.txt")
         with pytest.raises(NexusFileNotFoundError):
             backend.read_content("hash", context=ctx)
 
 
-class TestPathBackendDeleteContent:
+class TestPathAddressingEngineDeleteContent:
     """Test delete_content()."""
 
-    def test_delete_removes_blob(self, backend: PathBackend, transport: InMemoryBlobTransport):
+    def test_delete_removes_blob(
+        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
+    ):
         ctx = _make_context("file.txt")
         backend.write_content(b"delete me", context=ctx)
         assert "file.txt" in transport.files
@@ -194,57 +196,57 @@ class TestPathBackendDeleteContent:
         backend.delete_content("hash", context=ctx)
         assert "file.txt" not in transport.files
 
-    def test_delete_requires_backend_path(self, backend: PathBackend):
+    def test_delete_requires_backend_path(self, backend: PathAddressingEngine):
         with pytest.raises(BackendError, match="requires backend_path"):
             backend.delete_content("hash")
 
-    def test_delete_missing_raises(self, backend: PathBackend):
+    def test_delete_missing_raises(self, backend: PathAddressingEngine):
         ctx = _make_context("missing.txt")
         with pytest.raises(NexusFileNotFoundError):
             backend.delete_content("hash", context=ctx)
 
 
-class TestPathBackendContentOps:
+class TestPathAddressingEngineContentOps:
     """Test content_exists, get_content_size, get_ref_count."""
 
-    def test_content_exists(self, backend: PathBackend):
+    def test_content_exists(self, backend: PathAddressingEngine):
         ctx = _make_context("file.txt")
         backend.write_content(b"exists", context=ctx)
 
         assert backend.content_exists("hash", context=ctx) is True
         assert backend.content_exists("hash", context=_make_context("nope.txt")) is False
 
-    def test_content_exists_no_context(self, backend: PathBackend):
+    def test_content_exists_no_context(self, backend: PathAddressingEngine):
         assert backend.content_exists("hash") is False
 
-    def test_get_content_size(self, backend: PathBackend):
+    def test_get_content_size(self, backend: PathAddressingEngine):
         ctx = _make_context("file.txt")
         backend.write_content(b"size test", context=ctx)
         assert backend.get_content_size("hash", context=ctx) == 9
 
-    def test_get_ref_count_always_one(self, backend: PathBackend):
+    def test_get_ref_count_always_one(self, backend: PathAddressingEngine):
         assert backend.get_ref_count("hash") == 1
 
 
-class TestPathBackendStreaming:
+class TestPathAddressingEngineStreaming:
     """Test stream_content."""
 
-    def test_stream_yields_chunks(self, backend: PathBackend):
+    def test_stream_yields_chunks(self, backend: PathAddressingEngine):
         ctx = _make_context("file.txt")
         backend.write_content(b"A" * 100, context=ctx)
 
         chunks = list(backend.stream_content("hash", chunk_size=30, context=ctx))
         assert b"".join(chunks) == b"A" * 100
 
-    def test_stream_requires_backend_path(self, backend: PathBackend):
+    def test_stream_requires_backend_path(self, backend: PathAddressingEngine):
         with pytest.raises(ValueError, match="requires backend_path"):
             list(backend.stream_content("hash"))
 
 
-class TestPathBackendBatchRead:
+class TestPathAddressingEngineBatchRead:
     """Test batch_read_content."""
 
-    def test_batch_read_multiple(self, backend: PathBackend):
+    def test_batch_read_multiple(self, backend: PathAddressingEngine):
         ctx1 = _make_context("file1.txt")
         ctx2 = _make_context("file2.txt")
         ctx3 = _make_context("file3.txt")
@@ -261,17 +263,17 @@ class TestPathBackendBatchRead:
         assert result["h2"] == b"content2"
         assert result["h3"] == b"content3"
 
-    def test_batch_read_empty(self, backend: PathBackend):
+    def test_batch_read_empty(self, backend: PathAddressingEngine):
         assert backend.batch_read_content([]) == {}
 
-    def test_batch_read_single(self, backend: PathBackend):
+    def test_batch_read_single(self, backend: PathAddressingEngine):
         ctx = _make_context("file.txt")
         backend.write_content(b"single", context=ctx)
 
         result = backend.batch_read_content(["h"], context=ctx)
         assert result["h"] == b"single"
 
-    def test_batch_read_partial_failures(self, backend: PathBackend):
+    def test_batch_read_partial_failures(self, backend: PathAddressingEngine):
         ctx1 = _make_context("file1.txt")
         ctx2 = _make_context("missing.txt")
         backend.write_content(b"exists", context=ctx1)
@@ -282,56 +284,56 @@ class TestPathBackendBatchRead:
         assert result["h2"] is None
 
 
-class TestPathBackendDirectories:
+class TestPathAddressingEngineDirectories:
     """Test directory operations."""
 
-    def test_mkdir(self, backend: PathBackend, transport: InMemoryBlobTransport):
+    def test_mkdir(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
         backend.mkdir("data")
         assert "data/" in transport.files
 
     def test_mkdir_with_prefix(
-        self, prefixed_backend: PathBackend, transport: InMemoryBlobTransport
+        self, prefixed_backend: PathAddressingEngine, transport: InMemoryBlobTransport
     ):
         prefixed_backend.mkdir("subdir")
         assert "data/subdir/" in transport.files
 
-    def test_mkdir_root_noop(self, backend: PathBackend, transport: InMemoryBlobTransport):
+    def test_mkdir_root_noop(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
         backend.mkdir("")
         assert not any(k.endswith("/") for k in transport.files)
 
-    def test_mkdir_exist_ok(self, backend: PathBackend):
+    def test_mkdir_exist_ok(self, backend: PathAddressingEngine):
         backend.mkdir("data")
         backend.mkdir("data", exist_ok=True)
 
-    def test_mkdir_duplicate_raises(self, backend: PathBackend):
+    def test_mkdir_duplicate_raises(self, backend: PathAddressingEngine):
         backend.mkdir("data")
         with pytest.raises(BackendError, match="already exists"):
             backend.mkdir("data")
 
-    def test_is_directory(self, backend: PathBackend):
+    def test_is_directory(self, backend: PathAddressingEngine):
         assert backend.is_directory("") is True
         assert backend.is_directory("nonexistent") is False
         backend.mkdir("data")
         assert backend.is_directory("data") is True
 
-    def test_rmdir(self, backend: PathBackend, transport: InMemoryBlobTransport):
+    def test_rmdir(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
         backend.mkdir("data")
         backend.rmdir("data")
         assert "data/" not in transport.files
 
-    def test_rmdir_missing_raises(self, backend: PathBackend):
+    def test_rmdir_missing_raises(self, backend: PathAddressingEngine):
         with pytest.raises(NexusFileNotFoundError):
             backend.rmdir("nonexistent")
 
-    def test_rmdir_root_raises(self, backend: PathBackend):
+    def test_rmdir_root_raises(self, backend: PathAddressingEngine):
         with pytest.raises(BackendError, match="root"):
             backend.rmdir("")
 
 
-class TestPathBackendRename:
+class TestPathAddressingEngineRename:
     """Test rename_file (copy + delete)."""
 
-    def test_rename(self, backend: PathBackend, transport: InMemoryBlobTransport):
+    def test_rename(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
         transport.files["old.txt"] = b"content"
 
         backend.rename_file("old.txt", "new.txt")
@@ -339,12 +341,12 @@ class TestPathBackendRename:
         assert "old.txt" not in transport.files
         assert transport.files["new.txt"] == b"content"
 
-    def test_rename_source_missing_raises(self, backend: PathBackend):
+    def test_rename_source_missing_raises(self, backend: PathAddressingEngine):
         with pytest.raises(FileNotFoundError):
             backend.rename_file("missing.txt", "new.txt")
 
     def test_rename_dest_exists_raises(
-        self, backend: PathBackend, transport: InMemoryBlobTransport
+        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
     ):
         transport.files["old.txt"] = b"old"
         transport.files["new.txt"] = b"new"
@@ -353,10 +355,10 @@ class TestPathBackendRename:
             backend.rename_file("old.txt", "new.txt")
 
 
-class TestPathBackendBulkDownload:
+class TestPathAddressingEngineBulkDownload:
     """Test _bulk_download_blobs (BackendIOService compat)."""
 
-    def test_bulk_download(self, backend: PathBackend, transport: InMemoryBlobTransport):
+    def test_bulk_download(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
         transport.files["a.txt"] = b"content_a"
         transport.files["b.txt"] = b"content_b"
 
@@ -365,11 +367,11 @@ class TestPathBackendBulkDownload:
         assert result["a.txt"] == b"content_a"
         assert result["b.txt"] == b"content_b"
 
-    def test_bulk_download_empty(self, backend: PathBackend):
+    def test_bulk_download_empty(self, backend: PathAddressingEngine):
         assert backend._bulk_download_blobs([]) == {}
 
     def test_bulk_download_handles_failures(
-        self, backend: PathBackend, transport: InMemoryBlobTransport
+        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
     ):
         transport.files["exists.txt"] = b"data"
 
@@ -379,31 +381,31 @@ class TestPathBackendBulkDownload:
         assert "missing.txt" not in result
 
 
-class TestPathBackendPrefix:
+class TestPathAddressingEnginePrefix:
     """Test prefix handling in _get_blob_path."""
 
-    def test_no_prefix(self, backend: PathBackend):
+    def test_no_prefix(self, backend: PathAddressingEngine):
         assert backend._get_blob_path("file.txt") == "file.txt"
         assert backend._get_blob_path("dir/file.txt") == "dir/file.txt"
 
-    def test_with_prefix(self, prefixed_backend: PathBackend):
+    def test_with_prefix(self, prefixed_backend: PathAddressingEngine):
         assert prefixed_backend._get_blob_path("file.txt") == "data/file.txt"
         assert prefixed_backend._get_blob_path("dir/file.txt") == "data/dir/file.txt"
 
-    def test_strips_leading_slash(self, backend: PathBackend):
+    def test_strips_leading_slash(self, backend: PathAddressingEngine):
         assert backend._get_blob_path("/file.txt") == "file.txt"
 
 
-class TestPathBackendName:
+class TestPathAddressingEngineName:
     """Test name property and default name generation."""
 
     def test_custom_name(self, transport: InMemoryBlobTransport):
-        backend = PathBackend(transport, backend_name="my-path")
+        backend = PathAddressingEngine(transport, backend_name="my-path")
         assert backend.name == "my-path"
 
     def test_default_name(self, transport: InMemoryBlobTransport):
-        backend = PathBackend(transport)
+        backend = PathAddressingEngine(transport)
         assert backend.name == "path-memory"
 
-    def test_supports_rename(self, backend: PathBackend):
+    def test_supports_rename(self, backend: PathAddressingEngine):
         assert backend.supports_rename is True

--- a/tests/unit/backends/test_streaming.py
+++ b/tests/unit/backends/test_streaming.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.backends.base.backend import Backend
-from nexus.backends.base.path_backend import PathBackend
+from nexus.backends.base.path_backend import PathAddressingEngine
 from nexus.backends.storage.cas_local import CASLocalBackend
 from nexus.core.config import ParseConfig, PermissionConfig
 from nexus.core.hash_fast import create_hasher, hash_content
@@ -312,8 +312,8 @@ class TestStreamingMemoryEfficiency:
         assert result.size == total_bytes
 
 
-class TestPathBackendStreamContent:
-    """Test stream_content in PathBackend (Issue #480)."""
+class TestPathAddressingEngineStreamContent:
+    """Test stream_content in PathAddressingEngine (Issue #480)."""
 
     def test_stream_content_default_yields_chunks(self) -> None:
         """Test default stream_content yields chunks from transport.stream_blob."""
@@ -362,7 +362,9 @@ class TestPathBackendStreamContent:
 
         transport = TestTransport()
         transport.files["test/file.txt"] = b"Hello World!"
-        connector = PathBackend(transport, backend_name="test_connector", bucket_name="test-bucket")
+        connector = PathAddressingEngine(
+            transport, backend_name="test_connector", bucket_name="test-bucket"
+        )
 
         # Create mock context with backend_path
         context = MagicMock()
@@ -412,7 +414,7 @@ class TestPathBackendStreamContent:
                 return iter([])
 
         transport = TestTransport()
-        connector = PathBackend(transport, backend_name="test", bucket_name="test")
+        connector = PathAddressingEngine(transport, backend_name="test", bucket_name="test")
 
         with pytest.raises(ValueError, match="requires backend_path"):
             list(connector.stream_content("hash", context=None))
@@ -462,7 +464,9 @@ class TestPathBackendStreamContent:
                 yield b"chunk3"
 
         transport = StreamingTransport()
-        connector = PathBackend(transport, backend_name="streaming_test", bucket_name="test")
+        connector = PathAddressingEngine(
+            transport, backend_name="streaming_test", bucket_name="test"
+        )
         context = MagicMock()
         context.backend_path = "test/file.txt"
 


### PR DESCRIPTION
## Summary
- **Rename addressing ABCs** to disambiguate from concrete backends:
  - `CASBackend` → `CASAddressingEngine`
  - `PathBackend` → `PathAddressingEngine`
  - `CAS_BACKEND_CAPABILITIES` → `CAS_ADDRESSING_CAPABILITIES`
- **Backward-compat aliases** in definition files (`CASBackend = CASAddressingEngine`) so any missed references don't break
- **Files NOT renamed** — only class names changed, minimizing merge conflicts
- 28 files updated (13 src + 9 tests + 6 docstring-only)

## Why
Addressing ABCs (`CASBackend`, `PathBackend`) and concrete backends (`CASLocalBackend`, `PathGCSBackend`) both used "Backend" in their names. This caused confusion about whether `CASBackend` is an ABC or a concrete implementation. The new names make the layering explicit: `CASAddressingEngine` is the addressing layer, subclasses are concrete compositions (addressing × transport).

## Test plan
- [x] 143 backend tests pass
- [x] ruff + mypy clean
- [x] All pre-commit hooks pass
- [x] Backward-compat aliases ensure no breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)