### PR TITLE
feat(#1763): CAS+CDC incremental chunk write — skip existing chunks

### DIFF
--- a/src/nexus/backends/engines/cdc.py
+++ b/src/nexus/backends/engines/cdc.py
@@ -230,9 +230,12 @@ class CDCEngine:
                 futures[future] = (offset, length)
 
             results: dict[int, ChunkInfo] = {}
+            dedup_count = 0
             for future in as_completed(futures):
                 offset, length = futures[future]
-                chunk_hash = future.result()
+                chunk_hash, was_deduped = future.result()
+                if was_deduped:
+                    dedup_count += 1
                 results[offset] = ChunkInfo(chunk_hash=chunk_hash, offset=offset, length=length)
 
         for offset in sorted(results.keys()):
@@ -264,19 +267,33 @@ class CDCEngine:
         if updated.get("ref_count", 0) == 1 and b._bloom is not None:
             b._bloom.add(manifest_hash)
 
+        written = len(chunk_infos) - dedup_count
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         logger.info(
-            f"Wrote chunked content: {len(content)} bytes -> {len(chunk_infos)} chunks "
-            f"in {elapsed_ms:.1f}ms (manifest={manifest_hash[:16]}...)"
+            "Wrote chunked: %d bytes -> %d chunks (%d written, %d deduped) in %.1fms",
+            len(content),
+            len(chunk_infos),
+            written,
+            dedup_count,
+            elapsed_ms,
         )
         return manifest_hash
 
-    def _write_single_chunk(self, chunk_bytes: bytes) -> str:
+    def _write_single_chunk(self, chunk_bytes: bytes) -> tuple[str, bool]:
+        """Write a single chunk to CAS. Returns (chunk_hash, was_deduped)."""
         b = self._backend
         chunk_hash = hash_content(chunk_bytes)
         key = b._blob_key(chunk_hash)
-        b._transport.put_blob(key, chunk_bytes)
 
+        # Skip put_blob if chunk already exists in local CAS
+        deduped = False
+        if b._bloom is not None and b._bloom.might_exist(chunk_hash):
+            deduped = b._transport.blob_exists(key)
+
+        if not deduped:
+            b._transport.put_blob(key, chunk_bytes)
+
+        # ref_count MUST always increment (new manifest references this chunk)
         def _update(meta: dict[str, Any]) -> dict[str, Any]:
             meta["ref_count"] = meta.get("ref_count", 0) + 1
             meta["size"] = len(chunk_bytes)
@@ -287,7 +304,7 @@ class CDCEngine:
         is_new = updated.get("ref_count", 0) == 1
         if is_new and b._bloom is not None:
             b._bloom.add(chunk_hash)
-        return chunk_hash
+        return chunk_hash, deduped
 
     # === Read ===
 

--- a/tests/unit/backends/test_local_cas_backend.py
+++ b/tests/unit/backends/test_local_cas_backend.py
@@ -242,6 +242,162 @@ class TestBloomFilter:
         assert not backend.content_exists("deadbeef" * 8)
 
 
+# === Incremental Chunk Write (Dedup) ===
+
+
+class TestIncrementalChunkWrite:
+    """Tests for CAS+CDC incremental write optimization (#1763).
+
+    Uses low threshold + small fixed chunks for fast testing.
+    """
+
+    @pytest.fixture
+    def cdc_backend(self, tmp_path):
+        b = CASLocalBackend(root_path=tmp_path)
+        b._cdc.threshold = 1024  # 1KB threshold
+        b._cdc.min_chunk = 256
+        b._cdc.avg_chunk = 512
+        b._cdc.max_chunk = 1024
+        return b
+
+    def test_incremental_write_skips_existing_chunks(self, cdc_backend):
+        """Second write of identical content should skip put_blob for all chunks."""
+        content = b"A" * 2048  # Above threshold, will be chunked
+
+        cdc_backend.write_content(content)
+
+        # Patch put_blob to count non-meta blob writes on second write
+        original_put_blob = cdc_backend._transport.put_blob
+        blob_writes = []
+
+        def counting_put_blob(key, data, *args, **kwargs):
+            if not key.endswith(".meta"):
+                blob_writes.append(key)
+            return original_put_blob(key, data, *args, **kwargs)
+
+        cdc_backend._transport.put_blob = counting_put_blob
+
+        # Second write — chunks already exist, should be deduped
+        cdc_backend.write_content(content)
+
+        # Only manifest blob should be written (chunk blobs skipped via dedup)
+        assert len(blob_writes) == 1, (
+            f"Expected 1 blob write (manifest only), got {len(blob_writes)}: {blob_writes}"
+        )
+
+    def test_incremental_write_ref_count_correct(self, cdc_backend):
+        """Writing same content twice → chunk ref_counts should double."""
+        # Use varied content so each chunk has a unique hash
+        content = bytes(range(256)) * 8  # 2048 bytes, varied
+
+        r1 = cdc_backend.write_content(content)
+
+        # Record ref_counts after first write
+        from nexus.backends.engines.cdc import ChunkedReference
+
+        manifest_data = cdc_backend._transport.get_blob(cdc_backend._blob_key(r1.content_hash))[0]
+        manifest = ChunkedReference.from_json(manifest_data)
+
+        first_counts = {}
+        for ci in manifest.chunks:
+            first_counts[ci.chunk_hash] = cdc_backend._read_meta(ci.chunk_hash)["ref_count"]
+
+        # Second write
+        r2 = cdc_backend.write_content(content)
+        assert r1.content_hash == r2.content_hash
+
+        for ci in manifest.chunks:
+            meta = cdc_backend._read_meta(ci.chunk_hash)
+            expected = first_counts[ci.chunk_hash] * 2
+            assert meta["ref_count"] == expected, (
+                f"Chunk {ci.chunk_hash[:16]} ref_count={meta['ref_count']}, expected {expected}"
+            )
+
+    def test_incremental_write_partial_overlap(self, cdc_backend):
+        """Two files sharing some chunks → shared ref_count=2, unique ref_count=1."""
+        # Use fixed chunking (avg_chunk=512) so we get predictable boundaries
+        # File A: [AAAA][BBBB][CCCC][DDDD] (4 chunks of 512)
+        chunk_a = b"A" * 512
+        chunk_b = b"B" * 512
+        chunk_c = b"C" * 512
+        chunk_d = b"D" * 512
+        chunk_e = b"E" * 512
+
+        content_a = chunk_a + chunk_b + chunk_c + chunk_d  # 2048 bytes
+        content_b = chunk_a + chunk_b + chunk_e + chunk_d  # shares chunks a, b, d
+
+        cdc_backend.write_content(content_a)
+        r_b = cdc_backend.write_content(content_b)
+
+        from nexus.backends.engines.cdc import ChunkedReference
+
+        manifest_b_data = cdc_backend._transport.get_blob(cdc_backend._blob_key(r_b.content_hash))[
+            0
+        ]
+        manifest_b = ChunkedReference.from_json(manifest_b_data)
+
+        from nexus.core.hash_fast import hash_content
+
+        shared_hashes = {hash_content(chunk_a), hash_content(chunk_b), hash_content(chunk_d)}
+        unique_hashes = {hash_content(chunk_e)}
+
+        for ci in manifest_b.chunks:
+            meta = cdc_backend._read_meta(ci.chunk_hash)
+            if ci.chunk_hash in shared_hashes:
+                assert meta["ref_count"] == 2, "Shared chunk ref_count should be 2"
+            elif ci.chunk_hash in unique_hashes:
+                assert meta["ref_count"] == 1, "Unique chunk ref_count should be 1"
+
+    def test_delete_after_incremental_write(self, cdc_backend):
+        """Write twice (ref=2), delete once (ref=1, readable), delete again (gone)."""
+        content = bytes(range(256)) * 8  # 2048 bytes, varied
+
+        r = cdc_backend.write_content(content)
+        cdc_backend.write_content(content)  # ref_count = 2
+
+        # Delete once — ref_count drops to 1, still readable
+        cdc_backend.delete_content(r.content_hash)
+        assert cdc_backend.content_exists(r.content_hash)
+        assert cdc_backend.read_content(r.content_hash) == content
+
+        # Delete again — ref_count = 0, gone
+        cdc_backend.delete_content(r.content_hash)
+        assert not cdc_backend.content_exists(r.content_hash)
+
+    def test_no_bloom_skips_optimization(self, tmp_path):
+        """Backend without bloom filter should always write (backward compat)."""
+        b = CASLocalBackend(root_path=tmp_path)
+        b._cdc.threshold = 1024
+        b._cdc.min_chunk = 256
+        b._cdc.avg_chunk = 512
+        b._cdc.max_chunk = 1024
+        b._bloom = None  # Disable bloom
+
+        content = b"N" * 2048
+        b.write_content(content)
+
+        # Patch put_blob to count non-meta blob writes on second write
+        original_put_blob = b._transport.put_blob
+        blob_writes = []
+
+        def counting_put_blob(key, data, *args, **kwargs):
+            if not key.endswith(".meta"):
+                blob_writes.append(key)
+            return original_put_blob(key, data, *args, **kwargs)
+
+        b._transport.put_blob = counting_put_blob
+
+        r2 = b.write_content(content)
+
+        # Without bloom, all chunk blobs + manifest should be written
+        meta = b._read_meta(r2.content_hash)
+        chunk_count = meta.get("chunk_count", 0)
+        assert len(blob_writes) == chunk_count + 1, (
+            f"Without bloom, expected {chunk_count + 1} blob writes "
+            f"(all chunks + manifest), got {len(blob_writes)}"
+        )
+
+
 # === On-Write Callback ===
 
 


### PR DESCRIPTION
## Summary
- In `_write_single_chunk()`, check bloom filter + `blob_exists()` before `put_blob()` — skip the expensive disk write for chunks that already exist in local CAS
- ref_count always increments regardless (new manifest references this chunk)
- Backward compatible: no bloom filter → always writes (cloud backends)
- Log message now shows `(N written, M deduped)` stats

## Performance
100MB file, 100 chunks, 95 unchanged:
| | Current | Optimized |
|---|---|---|
| put_blob() calls | 100 | 5 |
| bloom checks | 0 | 100 (~0 cost) |
| blob_exists() | 0 | 95 (stat syscall, ~10μs each) |
| Disk write I/O | ~100MB | ~5MB |

## Test plan
- [x] `test_incremental_write_skips_existing_chunks` — second write skips chunk blob writes
- [x] `test_incremental_write_ref_count_correct` — ref_counts double on second write
- [x] `test_incremental_write_partial_overlap` — shared chunks ref_count=2, unique=1
- [x] `test_delete_after_incremental_write` — ref_count decrement + final cleanup
- [x] `test_no_bloom_skips_optimization` — no bloom = always writes (backward compat)
- [x] All 915 backend tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)