### PR TITLE
fix: TLS provisioning TOFU for self-signed CA + explicit error logging

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -366,14 +366,21 @@ async def connect(
         if join_token and join_peer and not (tls_dir_check / "node.pem").exists():
             from nexus.security.tls.cluster_join import join_cluster_sync
 
-            logger.info("NEXUS_JOIN_TOKEN + NEXUS_PEER set — joining cluster before startup")
-            join_cluster_sync(
-                peer_address=join_peer,
-                token=join_token,
-                node_id=node_id,
-                tls_dir=tls_dir_check,
+            logger.info(
+                "NEXUS_JOIN_TOKEN set — joining cluster via %s before startup",
+                join_peer,
             )
-            logger.info("Cluster join complete — continuing with ZoneManager init")
+            try:
+                join_cluster_sync(
+                    peer_address=join_peer,
+                    token=join_token,
+                    node_id=node_id,
+                    tls_dir=tls_dir_check,
+                )
+                logger.info("Cluster join complete — continuing with ZoneManager init")
+            except Exception:
+                logger.exception("TLS provisioning failed via %s — cannot join cluster", join_peer)
+                raise
 
         zone_mgr = ZoneManager(
             node_id=node_id,

--- a/src/nexus/security/tls/cluster_join.py
+++ b/src/nexus/security/tls/cluster_join.py
@@ -47,13 +47,22 @@ def join_cluster_sync(
 
     logger.info("Joining cluster via %s (node_id=%d)...", peer_address, node_id)
 
-    # Connect via gRPC (server-TLS only — no client cert)
+    # Connect via gRPC — the leader uses a self-signed CA that we don't
+    # have yet (we're trying to obtain it).  Fetch the server's TLS cert
+    # first, then use it as root_certificates for the gRPC channel.
+    # Security comes from the join token: after receiving the CA cert
+    # we verify its SHA256 fingerprint matches the token.
+    import ssl
+
     import grpc
 
-    channel_creds = grpc.ssl_channel_credentials()
     target = peer_address.replace("https://", "").replace("http://", "")
 
     try:
+        # Fetch server's TLS certificate (TOFU — trust on first use)
+        host, port_str = target.rsplit(":", 1)
+        server_cert_pem = ssl.get_server_certificate((host, int(port_str))).encode()
+        channel_creds = grpc.ssl_channel_credentials(root_certificates=server_cert_pem)
         channel = grpc.secure_channel(target, channel_creds)
 
         from nexus.contracts.constants import ROOT_ZONE_ID


### PR DESCRIPTION
## Summary
- **cluster_join.py**: `ssl_channel_credentials()` rejects self-signed certs from the leader. Fix: fetch server's TLS cert via `ssl.get_server_certificate()` (TOFU), use it as `root_certificates`. CA fingerprint verified against join token after receipt.
- **__init__.py**: `join_cluster_sync` exceptions were silently caught by outer `RuntimeError` handler. Add explicit `try/except` with `logger.exception` so failures are visible.

## Context
When macOS tries to join Windows cluster, `join_cluster_sync` connects via `grpc.ssl_channel_credentials()` which uses system CA store — rejects the leader's self-signed cert. The gRPC error was caught as `RuntimeError` by the federation fallback handler, silently dropping to single-node mode with no error log.

## Test plan
- [ ] macOS joiner can connect to Windows leader's self-signed gRPC TLS
- [x] Pre-commit: ruff, mypy, brick-imports pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)