### PR TITLE
feat: 2-phase TLS bootstrap — Raft-coordinated plaintext→mTLS upgrade

### DIFF
--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -39,7 +39,7 @@ RUN for d in nexus_core nexus_pyo3 nexus_tasks; do \
 
 # Build the witness binary
 WORKDIR /build/rust/nexus_raft
-RUN cargo build --release --features grpc --bin nexus-witness
+RUN cargo build --release --no-default-features --features grpc --bin nexus-witness
 
 # ---------- Production image ----------
 FROM debian:bookworm-slim

--- a/dockerfiles/docker-compose.dynamic-federation-test.yml
+++ b/dockerfiles/docker-compose.dynamic-federation-test.yml
@@ -61,7 +61,7 @@ services:
     command: >
       dragonfly
       --maxmemory=256mb
-      --proactor_threads=2
+      --proactor_threads=1
       --logtostderr
       --cache_mode=true
     ports:

--- a/dockerfiles/docker-compose.dynamic-federation-test.yml
+++ b/dockerfiles/docker-compose.dynamic-federation-test.yml
@@ -135,11 +135,11 @@ services:
     networks:
       - dyn-nexus-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2026/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:2026/healthz/live"]
       interval: 10s
       timeout: 5s
-      retries: 20
-      start_period: 60s
+      retries: 12
+      start_period: 30s
 
   # ==========================================================================
   # NexusFS Node 2 — Full node (follower)
@@ -191,11 +191,11 @@ services:
     networks:
       - dyn-nexus-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2026/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:2026/healthz/live"]
       interval: 10s
       timeout: 5s
-      retries: 20
-      start_period: 60s
+      retries: 12
+      start_period: 30s
 
   # ==========================================================================
   # Raft Witness — vote-only node (no static zones)

--- a/proto/nexus/raft/transport.proto
+++ b/proto/nexus/raft/transport.proto
@@ -139,12 +139,15 @@ message JoinZoneResponse {
   optional ClusterConfig config = 4;
 }
 
-// JoinClusterRequest is sent by `nexus join` to provision TLS certificates.
-// The caller authenticates with the join token password. The server signs a
-// node certificate and returns it along with the CA cert. The CA private key
-// never leaves the initial node (security fix: server-side cert signing).
+// JoinClusterRequest is sent during TLS bootstrap to provision certificates.
+//
+// Two auth modes:
+//   1. Token-based: password field contains join token password (legacy/external join)
+//   2. Peers-based: peers_bootstrap=true, server verifies node_id is in NEXUS_PEERS
+//
+// The server signs a node certificate — CA key never leaves the leader.
 message JoinClusterRequest {
-  // Join token password (64-char hex string).
+  // Join token password (64-char hex string). Empty for peers_bootstrap mode.
   string password = 1;
   // The joining node's Raft ID.
   uint64 node_id = 2;
@@ -152,6 +155,9 @@ message JoinClusterRequest {
   string node_address = 3;
   // Zone ID for the node certificate CN (e.g., "root").
   string zone_id = 4;
+  // When true, authenticate by verifying node_id is in the static peers list
+  // instead of requiring a join token password. Used during 2-phase TLS bootstrap.
+  bool peers_bootstrap = 5;
 }
 
 // JoinClusterResponse returns cluster TLS material on success.

--- a/rust/nexus_raft/src/pyo3_bindings.rs
+++ b/rust/nexus_raft/src/pyo3_bindings.rs
@@ -654,6 +654,12 @@ pub struct PyZoneManager {
     runtime: tokio::runtime::Runtime,
     shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
     node_id: u64,
+    /// Handle for injecting CA material into the running server (2-phase bootstrap).
+    tls_bootstrap_handle: Option<crate::transport::TlsBootstrapHandle>,
+    /// Bind address (stored for server restart).
+    bind_addr: std::net::SocketAddr,
+    /// Base path (stored for server restart).
+    base_path_str: String,
 }
 
 #[cfg(all(feature = "grpc", has_protos))]
@@ -673,8 +679,9 @@ impl PyZoneManager {
     ///     tls_ca_path: Path to PEM CA certificate file (mTLS).
     ///     ca_key_path: Path to CA private key file (read once at startup for server-side cert signing).
     ///     join_token_hash: SHA-256 hash of join token password (for JoinCluster verification).
+    ///     authorized_peer_ids: Node IDs authorized for peers_bootstrap JoinCluster (from NEXUS_PEERS).
     #[new]
-    #[pyo3(signature = (node_id, base_path, bind_addr="0.0.0.0:2126", tls_cert_path=None, tls_key_path=None, tls_ca_path=None, ca_key_path=None, join_token_hash=None))]
+    #[pyo3(signature = (node_id, base_path, bind_addr="0.0.0.0:2126", tls_cert_path=None, tls_key_path=None, tls_ca_path=None, ca_key_path=None, join_token_hash=None, authorized_peer_ids=None))]
     #[allow(clippy::too_many_arguments)] // PyO3 constructor — Python API needs flat keyword args
     pub fn new(
         node_id: u64,
@@ -685,6 +692,7 @@ impl PyZoneManager {
         tls_ca_path: Option<&str>,
         ca_key_path: Option<&str>,
         join_token_hash: Option<&str>,
+        authorized_peer_ids: Option<Vec<u64>>,
     ) -> PyResult<Self> {
         use crate::raft::ZoneRaftRegistry;
         use crate::transport::{RaftGrpcServer, ServerConfig, TlsConfig};
@@ -754,6 +762,10 @@ impl PyZoneManager {
                 std::path::PathBuf::from(base_path),
             );
         }
+        if let Some(peer_ids) = authorized_peer_ids {
+            server = server.with_authorized_peers(peer_ids);
+        }
+        let tls_bootstrap_handle = server.tls_bootstrap_handle();
         let shutdown_rx_server = shutdown_rx.clone();
         runtime.spawn(async move {
             let shutdown = async move {
@@ -777,6 +789,9 @@ impl PyZoneManager {
             runtime,
             shutdown_tx: Some(shutdown_tx),
             node_id,
+            tls_bootstrap_handle: Some(tls_bootstrap_handle),
+            bind_addr: bind_socket,
+            base_path_str: base_path.to_string(),
         })
     }
 
@@ -884,6 +899,120 @@ impl PyZoneManager {
             let _ = tx.send(true);
         }
         tracing::info!("ZoneManager node {} shut down", self.node_id);
+        Ok(())
+    }
+
+    /// Set CA material on the running server for JoinCluster (2-phase bootstrap).
+    /// Called by the leader after generating the CA, before followers request certs.
+    pub fn set_ca_material(&self, ca_pem: Vec<u8>, ca_key_pem: Vec<u8>) -> PyResult<()> {
+        match &self.tls_bootstrap_handle {
+            Some(handle) => {
+                handle.set_ca_material(ca_pem, ca_key_pem);
+                tracing::info!("CA material set on running server for JoinCluster");
+                Ok(())
+            }
+            None => Err(PyRuntimeError::new_err(
+                "TLS bootstrap handle not available",
+            )),
+        }
+    }
+
+    /// Set authorized peer IDs for peers_bootstrap mode.
+    /// Must be called before followers attempt JoinCluster with peers_bootstrap=true.
+    pub fn set_authorized_peers(&self, peer_ids: Vec<u64>) -> PyResult<()> {
+        // The authorized peers are stored on the server via the bootstrap handle.
+        // For now we update the registry-level peer list. The server reads authorized_peer_ids
+        // from its construction — we need a different approach for runtime updates.
+        // TODO: This is a workaround. The proper fix is to make authorized_peer_ids
+        // shared via Arc<RwLock<>> like dynamic_ca.
+        tracing::info!("Authorized peers set: {:?}", peer_ids);
+        Ok(())
+    }
+
+    /// Restart the gRPC server with TLS. Existing zones are preserved.
+    /// Called after all nodes have received their certs (plaintext→mTLS upgrade).
+    #[pyo3(signature = (tls_cert_path, tls_key_path, tls_ca_path, ca_key_path=None, join_token_hash=None, authorized_peer_ids=None))]
+    pub fn restart_with_tls(
+        &mut self,
+        tls_cert_path: &str,
+        tls_key_path: &str,
+        tls_ca_path: &str,
+        ca_key_path: Option<&str>,
+        join_token_hash: Option<&str>,
+        authorized_peer_ids: Option<Vec<u64>>,
+    ) -> PyResult<()> {
+        use crate::transport::{RaftGrpcServer, ServerConfig, TlsConfig};
+
+        // Read TLS material from files
+        let cert_pem = std::fs::read(tls_cert_path)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to read TLS cert: {}", e)))?;
+        let key_pem = std::fs::read(tls_key_path)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to read TLS key: {}", e)))?;
+        let ca_pem = std::fs::read(tls_ca_path)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to read TLS CA: {}", e)))?;
+        let tls_config = TlsConfig {
+            cert_pem,
+            key_pem,
+            ca_pem,
+        };
+
+        // 1. Shutdown existing gRPC server
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(true);
+        }
+        // Brief pause for server to shut down
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        // 2. Update registry TLS config + upgrade peer schemes
+        self.registry.set_tls(Some(tls_config.clone()));
+        self.registry.upgrade_peer_schemes();
+
+        // 3. Start new server with TLS
+        let config = ServerConfig {
+            bind_address: self.bind_addr,
+            tls: Some(tls_config),
+            ..Default::default()
+        };
+        let mut server = RaftGrpcServer::new(self.registry.clone(), config);
+
+        // Configure JoinCluster support
+        if let Some(ca_key_path) = ca_key_path {
+            if let Some(token_hash) = join_token_hash {
+                let ca_key_pem = std::fs::read(ca_key_path).map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to read CA key: {}", e))
+                })?;
+                server = server.with_join_config(
+                    ca_key_pem,
+                    token_hash.to_string(),
+                    std::path::PathBuf::from(&self.base_path_str),
+                );
+            }
+        }
+        if let Some(peer_ids) = authorized_peer_ids {
+            server = server.with_authorized_peers(peer_ids);
+        }
+
+        let new_handle = server.tls_bootstrap_handle();
+        let (new_shutdown_tx, new_shutdown_rx) = tokio::sync::watch::channel(false);
+
+        self.runtime.spawn(async move {
+            let shutdown = async move {
+                let mut rx = new_shutdown_rx;
+                let _ = rx.changed().await;
+            };
+            if let Err(e) = server.serve_with_shutdown(shutdown).await {
+                tracing::error!("ZoneManager gRPC server error after TLS restart: {}", e);
+            }
+        });
+
+        self.shutdown_tx = Some(new_shutdown_tx);
+        self.tls_bootstrap_handle = Some(new_handle);
+
+        tracing::info!(
+            "ZoneManager node {} restarted with mTLS (bind={})",
+            self.node_id,
+            self.bind_addr,
+        );
         Ok(())
     }
 }

--- a/rust/nexus_raft/src/pyo3_bindings.rs
+++ b/rust/nexus_raft/src/pyo3_bindings.rs
@@ -917,16 +917,13 @@ impl PyZoneManager {
         }
     }
 
-    /// Set authorized peer IDs for peers_bootstrap mode.
-    /// Must be called before followers attempt JoinCluster with peers_bootstrap=true.
-    pub fn set_authorized_peers(&self, peer_ids: Vec<u64>) -> PyResult<()> {
-        // The authorized peers are stored on the server via the bootstrap handle.
-        // For now we update the registry-level peer list. The server reads authorized_peer_ids
-        // from its construction — we need a different approach for runtime updates.
-        // TODO: This is a workaround. The proper fix is to make authorized_peer_ids
-        // shared via Arc<RwLock<>> like dynamic_ca.
-        tracing::info!("Authorized peers set: {:?}", peer_ids);
-        Ok(())
+    /// Get the set of node IDs that have successfully called JoinCluster.
+    /// Used by the leader to check if all peers have their certs before proposing TLS upgrade.
+    pub fn joined_peer_ids(&self) -> PyResult<Vec<u64>> {
+        match &self.tls_bootstrap_handle {
+            Some(handle) => Ok(handle.joined_peer_ids()),
+            None => Ok(vec![]),
+        }
     }
 
     /// Restart the gRPC server with TLS. Existing zones are preserved.

--- a/rust/nexus_raft/src/pyo3_bindings.rs
+++ b/rust/nexus_raft/src/pyo3_bindings.rs
@@ -698,6 +698,18 @@ impl PyZoneManager {
         use crate::transport::{RaftGrpcServer, ServerConfig, TlsConfig};
         use std::sync::Arc;
 
+        // Initialize Rust tracing (once) so gRPC server logs are visible.
+        // Uses RUST_LOG env var (e.g., "info,nexus_raft=debug").
+        static TRACING_INIT: std::sync::Once = std::sync::Once::new();
+        TRACING_INIT.call_once(|| {
+            let _ = tracing_subscriber::fmt()
+                .with_env_filter(
+                    tracing_subscriber::EnvFilter::from_default_env()
+                        .add_directive("info".parse().unwrap()),
+                )
+                .try_init();
+        });
+
         // Parse TLS config from file paths (all-or-nothing)
         let tls_config = match (tls_cert_path, tls_key_path, tls_ca_path) {
             (Some(cert), Some(key), Some(ca)) => {

--- a/rust/nexus_raft/src/raft/zone_registry.rs
+++ b/rust/nexus_raft/src/raft/zone_registry.rs
@@ -57,8 +57,9 @@ pub struct ZoneRaftRegistry {
     base_path: PathBuf,
     /// This node's global ID (same across all zones on this node).
     node_id: u64,
-    /// Optional TLS config for outbound client connections (shared across all zones).
-    tls: Option<TlsConfig>,
+    /// Shared TLS config — can be updated at runtime for plaintext→mTLS upgrade.
+    /// All zones' client pools read from this on new connections.
+    tls: Arc<RwLock<Option<TlsConfig>>>,
 }
 
 impl ZoneRaftRegistry {
@@ -72,7 +73,7 @@ impl ZoneRaftRegistry {
             zones: DashMap::new(),
             base_path,
             node_id,
-            tls: None,
+            tls: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -82,8 +83,32 @@ impl ZoneRaftRegistry {
             zones: DashMap::new(),
             base_path,
             node_id,
-            tls,
+            tls: Arc::new(RwLock::new(tls)),
         }
+    }
+
+    /// Get a snapshot of the current TLS config.
+    pub fn tls_config(&self) -> Option<TlsConfig> {
+        self.tls.read().unwrap().clone()
+    }
+
+    /// Update TLS config at runtime (for plaintext→mTLS upgrade).
+    pub fn set_tls(&self, tls: Option<TlsConfig>) {
+        *self.tls.write().unwrap() = tls;
+    }
+
+    /// Upgrade all peer endpoints from http:// to https:// scheme.
+    /// Called after TLS upgrade so outbound connections use TLS.
+    pub fn upgrade_peer_schemes(&self) {
+        for entry in self.zones.iter() {
+            let mut peers = entry.peers.write().unwrap();
+            for addr in peers.values_mut() {
+                if addr.endpoint.starts_with("http://") {
+                    addr.endpoint = addr.endpoint.replacen("http://", "https://", 1);
+                }
+            }
+        }
+        tracing::info!("Upgraded all peer endpoints to https://");
     }
 
     /// Create a new zone with its own Raft group.
@@ -187,7 +212,7 @@ impl ZoneRaftRegistry {
         driver.set_peer_map(shared_peers.clone());
 
         let client_config = ClientConfig {
-            tls: self.tls.clone(),
+            tls: self.tls.read().unwrap().clone(),
             ..Default::default()
         };
         let transport_loop = TransportLoop::new(

--- a/rust/nexus_raft/src/transport/mod.rs
+++ b/rust/nexus_raft/src/transport/mod.rs
@@ -54,7 +54,9 @@ pub use client::{
     RaftClientPool,
 };
 #[cfg(all(feature = "grpc", has_protos))]
-pub use server::{RaftGrpcServer, RaftWitnessServer, ServerConfig, WitnessZoneRegistry};
+pub use server::{
+    RaftGrpcServer, RaftWitnessServer, ServerConfig, TlsBootstrapHandle, WitnessZoneRegistry,
+};
 #[cfg(all(feature = "grpc", has_protos))]
 pub use transport_loop::TransportLoop;
 

--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -81,6 +81,8 @@ pub struct RaftGrpcServer {
     /// Dynamic CA material — set by leader after CA generation (2-phase bootstrap).
     /// Shared with the running service impl via Arc<RwLock<>>.
     dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
+    /// Tracks which peers have successfully called JoinCluster (peers_bootstrap mode).
+    joined_peers: Arc<RwLock<std::collections::HashSet<u64>>>,
 }
 
 /// CA material injected at runtime for 2-phase TLS bootstrap.
@@ -93,12 +95,19 @@ struct DynamicCaMaterial {
 /// Handle for injecting CA material into a running server (2-phase bootstrap).
 pub struct TlsBootstrapHandle {
     dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
+    /// Set of node IDs that have successfully called JoinCluster (peers_bootstrap mode).
+    joined_peers: Arc<RwLock<std::collections::HashSet<u64>>>,
 }
 
 impl TlsBootstrapHandle {
     /// Set CA material so the running server can handle JoinCluster requests.
     pub fn set_ca_material(&self, ca_pem: Vec<u8>, ca_key_pem: Vec<u8>) {
         *self.dynamic_ca.write().unwrap() = Some(DynamicCaMaterial { ca_pem, ca_key_pem });
+    }
+
+    /// Get the set of node IDs that have called JoinCluster successfully.
+    pub fn joined_peer_ids(&self) -> Vec<u64> {
+        self.joined_peers.read().unwrap().iter().copied().collect()
     }
 }
 
@@ -117,6 +126,7 @@ impl RaftGrpcServer {
             base_path: None,
             authorized_peer_ids: None,
             dynamic_ca: Arc::new(RwLock::new(None)),
+            joined_peers: Arc::new(RwLock::new(std::collections::HashSet::new())),
         }
     }
 
@@ -146,6 +156,7 @@ impl RaftGrpcServer {
     pub fn tls_bootstrap_handle(&self) -> TlsBootstrapHandle {
         TlsBootstrapHandle {
             dynamic_ca: self.dynamic_ca.clone(),
+            joined_peers: self.joined_peers.clone(),
         }
     }
 
@@ -176,6 +187,7 @@ impl RaftGrpcServer {
             base_path: self.base_path.clone(),
             authorized_peer_ids: self.authorized_peer_ids.clone(),
             dynamic_ca: self.dynamic_ca.clone(),
+            joined_peers: self.joined_peers.clone(),
         };
 
         let mut builder = tonic::transport::Server::builder();
@@ -236,6 +248,7 @@ impl RaftGrpcServer {
             base_path: self.base_path.clone(),
             authorized_peer_ids: self.authorized_peer_ids.clone(),
             dynamic_ca: self.dynamic_ca.clone(),
+            joined_peers: self.joined_peers.clone(),
         };
 
         let mut builder = tonic::transport::Server::builder();
@@ -540,6 +553,8 @@ struct ZoneApiServiceImpl {
     authorized_peer_ids: Option<Vec<u64>>,
     /// Dynamic CA material — set at runtime by leader (2-phase bootstrap).
     dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
+    /// Tracks which peers have successfully called JoinCluster.
+    joined_peers: Arc<RwLock<std::collections::HashSet<u64>>>,
 }
 
 #[tonic::async_trait]
@@ -1034,9 +1049,13 @@ impl ZoneApiService for ZoneApiServiceImpl {
             }
         }
 
+        // Track this peer as joined (for leader's all-ready check)
+        self.joined_peers.write().unwrap().insert(req.node_id);
+
         tracing::info!(
             node_id = req.node_id,
             node_address = req.node_address,
+            joined_count = self.joined_peers.read().unwrap().len(),
             "JoinCluster: node certificate signed and provisioned successfully",
         );
 

--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -76,6 +76,30 @@ pub struct RaftGrpcServer {
     join_token_hash: Option<String>,
     /// Base path for data directory — used for peers_joined marker file.
     base_path: Option<PathBuf>,
+    /// Node IDs authorized for peers_bootstrap mode (from NEXUS_PEERS).
+    authorized_peer_ids: Option<Vec<u64>>,
+    /// Dynamic CA material — set by leader after CA generation (2-phase bootstrap).
+    /// Shared with the running service impl via Arc<RwLock<>>.
+    dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
+}
+
+/// CA material injected at runtime for 2-phase TLS bootstrap.
+#[derive(Clone)]
+struct DynamicCaMaterial {
+    ca_pem: Vec<u8>,
+    ca_key_pem: Vec<u8>,
+}
+
+/// Handle for injecting CA material into a running server (2-phase bootstrap).
+pub struct TlsBootstrapHandle {
+    dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
+}
+
+impl TlsBootstrapHandle {
+    /// Set CA material so the running server can handle JoinCluster requests.
+    pub fn set_ca_material(&self, ca_pem: Vec<u8>, ca_key_pem: Vec<u8>) {
+        *self.dynamic_ca.write().unwrap() = Some(DynamicCaMaterial { ca_pem, ca_key_pem });
+    }
 }
 
 impl RaftGrpcServer {
@@ -91,6 +115,8 @@ impl RaftGrpcServer {
             ca_key_pem: None,
             join_token_hash: None,
             base_path: None,
+            authorized_peer_ids: None,
+            dynamic_ca: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -108,6 +134,19 @@ impl RaftGrpcServer {
         self.join_token_hash = Some(join_token_hash);
         self.base_path = Some(base_path);
         self
+    }
+
+    /// Set authorized peer IDs for peers_bootstrap mode (from NEXUS_PEERS).
+    pub fn with_authorized_peers(mut self, peer_ids: Vec<u64>) -> Self {
+        self.authorized_peer_ids = Some(peer_ids);
+        self
+    }
+
+    /// Get a handle for injecting CA material into the running server (2-phase bootstrap).
+    pub fn tls_bootstrap_handle(&self) -> TlsBootstrapHandle {
+        TlsBootstrapHandle {
+            dynamic_ca: self.dynamic_ca.clone(),
+        }
     }
 
     /// Get the bind address.
@@ -135,6 +174,8 @@ impl RaftGrpcServer {
             ca_key_pem: self.ca_key_pem.clone(),
             join_token_hash: self.join_token_hash.clone(),
             base_path: self.base_path.clone(),
+            authorized_peer_ids: self.authorized_peer_ids.clone(),
+            dynamic_ca: self.dynamic_ca.clone(),
         };
 
         let mut builder = tonic::transport::Server::builder();
@@ -193,6 +234,8 @@ impl RaftGrpcServer {
             ca_key_pem: self.ca_key_pem.clone(),
             join_token_hash: self.join_token_hash.clone(),
             base_path: self.base_path.clone(),
+            authorized_peer_ids: self.authorized_peer_ids.clone(),
+            dynamic_ca: self.dynamic_ca.clone(),
         };
 
         let mut builder = tonic::transport::Server::builder();
@@ -493,6 +536,10 @@ struct ZoneApiServiceImpl {
     join_token_hash: Option<String>,
     /// Base path for data directory — used to write peers_joined marker.
     base_path: Option<PathBuf>,
+    /// Node IDs authorized for peers_bootstrap mode (from NEXUS_PEERS).
+    authorized_peer_ids: Option<Vec<u64>>,
+    /// Dynamic CA material — set at runtime by leader (2-phase bootstrap).
+    dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
 }
 
 #[tonic::async_trait]
@@ -873,109 +920,109 @@ impl ZoneApiService for ZoneApiServiceImpl {
         }
     }
 
-    /// Handle a JoinCluster request — K3s-style TLS certificate provisioning.
+    /// Handle a JoinCluster request — TLS certificate provisioning.
     ///
-    /// Verifies the join token password, signs a node certificate server-side,
-    /// and returns the CA cert + signed node cert + node key.
-    /// The CA private key never leaves this process (security fix).
-    /// After success, writes a `peers_joined` marker to signal mTLS upgrade.
+    /// Two auth modes:
+    /// 1. Token-based (peers_bootstrap=false): verify password against join_token_hash
+    /// 2. Peers-based (peers_bootstrap=true): verify node_id is in authorized_peer_ids
+    ///
+    /// In both modes, the server signs a node certificate and returns CA + cert + key.
+    /// The CA private key never leaves this process.
     async fn join_cluster(
         &self,
         request: Request<JoinClusterRequest>,
     ) -> std::result::Result<Response<JoinClusterResponse>, Status> {
         let req = request.into_inner();
+        let err_resp = |msg: &str| {
+            Response::new(JoinClusterResponse {
+                success: false,
+                error: Some(msg.to_string()),
+                ca_pem: Vec::new(),
+                node_cert_pem: Vec::new(),
+                node_key_pem: Vec::new(),
+            })
+        };
 
         tracing::info!(
             node_id = req.node_id,
             node_address = req.node_address,
             zone_id = req.zone_id,
+            peers_bootstrap = req.peers_bootstrap,
             "JoinCluster request received",
         );
 
-        // Verify join token password
-        let stored_hash = match &self.join_token_hash {
-            Some(h) => h,
-            None => {
-                return Ok(Response::new(JoinClusterResponse {
-                    success: false,
-                    error: Some(
-                        "This node does not accept join requests (no join token configured)"
-                            .to_string(),
-                    ),
-                    ca_pem: Vec::new(),
-                    node_cert_pem: Vec::new(),
-                    node_key_pem: Vec::new(),
-                }));
+        // --- Authentication ---
+        if req.peers_bootstrap {
+            // Peers-based auth: verify node_id is in the static NEXUS_PEERS list
+            match &self.authorized_peer_ids {
+                Some(peers) if peers.contains(&req.node_id) => {
+                    tracing::info!(
+                        node_id = req.node_id,
+                        "JoinCluster: peers_bootstrap auth OK"
+                    );
+                }
+                Some(_) => {
+                    tracing::warn!(
+                        node_id = req.node_id,
+                        "JoinCluster: node_id not in authorized peers"
+                    );
+                    return Ok(err_resp("Node ID not in authorized peers list"));
+                }
+                None => {
+                    return Ok(err_resp("Peers bootstrap not configured on this node"));
+                }
             }
-        };
-
-        // Constant-time password verification
-        let candidate_hash = {
-            use sha2::{Digest, Sha256};
-            use std::fmt::Write;
-            let digest = Sha256::digest(req.password.as_bytes());
-            let mut hex = String::with_capacity(64);
-            for byte in &digest[..] {
-                let _ = write!(hex, "{:02x}", byte);
+        } else {
+            // Token-based auth: verify password hash
+            let stored_hash = match &self.join_token_hash {
+                Some(h) => h,
+                None => {
+                    return Ok(err_resp(
+                        "This node does not accept join requests (no join token configured)",
+                    ));
+                }
+            };
+            let candidate_hash = {
+                use sha2::{Digest, Sha256};
+                use std::fmt::Write;
+                let digest = Sha256::digest(req.password.as_bytes());
+                let mut hex = String::with_capacity(64);
+                for byte in &digest[..] {
+                    let _ = write!(hex, "{:02x}", byte);
+                }
+                hex
+            };
+            if candidate_hash != *stored_hash {
+                tracing::warn!(node_id = req.node_id, "JoinCluster: invalid password");
+                return Ok(err_resp("Invalid join token password"));
             }
-            hex
-        };
-        if candidate_hash != *stored_hash {
-            tracing::warn!(node_id = req.node_id, "JoinCluster: invalid password",);
-            return Ok(Response::new(JoinClusterResponse {
-                success: false,
-                error: Some("Invalid join token password".to_string()),
-                ca_pem: Vec::new(),
-                node_cert_pem: Vec::new(),
-                node_key_pem: Vec::new(),
-            }));
         }
 
-        // Get CA cert and key (both in memory — no disk reads)
-        let ca_key_pem = match &self.ca_key_pem {
-            Some(k) => k,
-            None => {
-                return Ok(Response::new(JoinClusterResponse {
-                    success: false,
-                    error: Some("CA key not configured".to_string()),
-                    ca_pem: Vec::new(),
-                    node_cert_pem: Vec::new(),
-                    node_key_pem: Vec::new(),
-                }));
-            }
+        // --- Get CA material ---
+        // Try static config first (set at startup), then dynamic (set by leader at runtime)
+        let (ca_pem, ca_key_pem) = if let (Some(ca_key), Some(tls)) = (&self.ca_key_pem, &self.tls)
+        {
+            (tls.ca_pem.clone(), ca_key.clone())
+        } else if let Some(dynamic) = self.dynamic_ca.read().unwrap().as_ref() {
+            (dynamic.ca_pem.clone(), dynamic.ca_key_pem.clone())
+        } else {
+            return Ok(err_resp(
+                "CA material not available (leader may not have generated CA yet)",
+            ));
         };
 
-        let ca_pem = match &self.tls {
-            Some(tls) => tls.ca_pem.clone(),
-            None => {
-                return Ok(Response::new(JoinClusterResponse {
-                    success: false,
-                    error: Some("TLS not configured on this node".to_string()),
-                    ca_pem: Vec::new(),
-                    node_cert_pem: Vec::new(),
-                    node_key_pem: Vec::new(),
-                }));
-            }
-        };
-
-        // Server-side cert signing — CA key never leaves this process
+        // --- Sign node certificate ---
         let zone_id = if req.zone_id.is_empty() {
             "root"
         } else {
             &req.zone_id
         };
         let (node_cert_pem, node_key_pem) =
-            match super::certgen::generate_node_cert(req.node_id, zone_id, &ca_pem, ca_key_pem) {
+            match super::certgen::generate_node_cert(req.node_id, zone_id, &ca_pem, &ca_key_pem) {
                 Ok(pair) => pair,
                 Err(e) => {
                     tracing::error!("Failed to generate node cert: {}", e);
-                    return Ok(Response::new(JoinClusterResponse {
-                        success: false,
-                        error: Some(format!("Failed to generate node cert: {}", e)),
-                        ca_pem: Vec::new(),
-                        node_cert_pem: Vec::new(),
-                        node_key_pem: Vec::new(),
-                    }));
+                    return Ok(err_resp(&format!("Failed to generate node cert: {}", e)));
                 }
             };
 
@@ -984,7 +1031,6 @@ impl ZoneApiService for ZoneApiServiceImpl {
             let marker = base.join("tls/peers_joined");
             if let Err(e) = std::fs::write(&marker, b"1") {
                 tracing::warn!("Failed to write peers_joined marker: {}", e);
-                // Non-fatal — continue anyway
             }
         }
 

--- a/scripts/generate_raft_proto.py
+++ b/scripts/generate_raft_proto.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Generate Python proto stubs for nexus.raft.
+
+Runs grpc_tools.protoc to generate *_pb2.py and *_pb2_grpc.py from
+the Raft proto files, then moves the output from the nested package
+directory to the flat src/nexus/raft/ layout.
+
+Usage:
+    python scripts/generate_raft_proto.py
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PROTO_DIR = ROOT / "proto"
+OUT_DIR = ROOT / "src" / "nexus" / "raft"
+TMP_DIR = OUT_DIR / "_proto_gen_tmp"
+
+PROTO_FILES = [
+    "nexus/raft/commands.proto",
+    "nexus/raft/transport.proto",
+]
+
+
+def main() -> None:
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "grpc_tools.protoc",
+        f"-I{PROTO_DIR}",
+        f"--python_out={TMP_DIR}",
+        f"--grpc_python_out={TMP_DIR}",
+        *PROTO_FILES,
+    ]
+    print(f"Running: {' '.join(cmd)}")
+    subprocess.check_call(cmd)
+
+    # protoc outputs to {TMP_DIR}/nexus/raft/ — move to flat layout
+    nested = TMP_DIR / "nexus" / "raft"
+    for pb_file in nested.glob("*.py"):
+        dest = OUT_DIR / pb_file.name
+        shutil.move(str(pb_file), str(dest))
+        print(f"  {pb_file.name} → {dest}")
+
+    shutil.rmtree(TMP_DIR, ignore_errors=True)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -335,53 +335,6 @@ async def connect(
         advertise_addr = os.environ.get("NEXUS_ADVERTISE_ADDR")
         zones_dir = os.environ.get("NEXUS_DATA_DIR", str(Path(metadata_path).parent / "zones"))
 
-        # Auto-join cluster if NEXUS_JOIN_TOKEN is set and certs don't exist yet.
-        # NEXUS_PEER (singular) specifies the leader address for TLS provisioning.
-        # If not set, infer it from NEXUS_PEERS by picking the first peer that
-        # isn't this node — avoids a confusing NEXUS_PEER vs NEXUS_PEERS distinction.
-        join_token = os.environ.get("NEXUS_JOIN_TOKEN")
-        join_peer = os.environ.get("NEXUS_PEER")
-        if join_token and not join_peer:
-            # Infer leader from NEXUS_PEERS (exclude self)
-            peers_env = os.environ.get("NEXUS_PEERS", "")
-            for entry in peers_env.split(","):
-                entry = entry.strip()
-                if not entry:
-                    continue
-                # Format: "id@host:port" — skip our own node_id
-                if "@" in entry:
-                    peer_id_str, peer_addr = entry.split("@", 1)
-                    if peer_id_str.strip() != str(node_id):
-                        join_peer = peer_addr
-                        break
-                else:
-                    join_peer = entry
-                    break
-            if join_peer:
-                logger.info(
-                    "NEXUS_PEER not set; inferred leader address %s from NEXUS_PEERS",
-                    join_peer,
-                )
-        tls_dir_check = Path(zones_dir) / "tls"
-        if join_token and join_peer and not (tls_dir_check / "node.pem").exists():
-            from nexus.security.tls.cluster_join import join_cluster_sync
-
-            logger.info(
-                "NEXUS_JOIN_TOKEN set — joining cluster via %s before startup",
-                join_peer,
-            )
-            try:
-                join_cluster_sync(
-                    peer_address=join_peer,
-                    token=join_token,
-                    node_id=node_id,
-                    tls_dir=tls_dir_check,
-                )
-                logger.info("Cluster join complete — continuing with ZoneManager init")
-            except Exception:
-                logger.exception("TLS provisioning failed via %s — cannot join cluster", join_peer)
-                raise
-
         zone_mgr = ZoneManager(
             node_id=node_id,
             base_path=zones_dir,
@@ -393,8 +346,9 @@ async def connect(
         peers_str = os.environ.get("NEXUS_PEERS", "")
         peers = [p.strip() for p in peers_str.split(",") if p.strip()] if peers_str else []
 
-        # Detect joiner vs first-node (#2694, #3141):
-        # Priority: NEXUS_JOIN_TOKEN env > TLS file detection > bootstrap
+        # Detect joiner vs first-node:
+        # Joiner = has all cert files (provisioned by 2-phase bootstrap or join flow)
+        # but no join-token (not the CA holder / first node)
         tls_dir = Path(zones_dir) / "tls"
         is_joiner = (
             (tls_dir / "ca.pem").exists()
@@ -403,19 +357,12 @@ async def connect(
             and not (tls_dir / "join-token").exists()
         )
 
-        if join_token:
-            # NEXUS_JOIN_TOKEN set — join existing cluster via token
+        if is_joiner:
             zone_mgr.join_zone("root", peers=peers if peers else None)
-            logger.info(
-                "Joiner node: joined root zone via NEXUS_JOIN_TOKEN (token=%s...)",
-                join_token[:20],
-            )
-        elif is_joiner:
-            # Provisioned via `nexus join` or cluster_join — has certs but no join-token
-            zone_mgr.join_zone("root", peers=peers if peers else None)
-            logger.info("Joiner node: joined root zone (provisioned via `nexus join`)")
+            logger.info("Joiner node: joined root zone (certs provisioned)")
         else:
-            # First node — bootstrap
+            # First node or 2-phase mode (no certs yet — bootstrap creates Raft group,
+            # TLS is handled by zone_manager.bootstrap_tls() during ensure_topology)
             zone_mgr.bootstrap(peers=peers if peers else None)
 
         # Static Day-1 topology from env vars (idempotent)

--- a/src/nexus/raft/transport_pb2.py
+++ b/src/nexus/raft/transport_pb2.py
@@ -19,7 +19,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1anexus/raft/transport.proto\x12\nnexus.raft\x1a\x19nexus/raft/commands.proto"_\n\x0eProposeRequest\x12(\n\x07\x63ommand\x18\x01 \x01(\x0b\x32\x17.nexus.raft.RaftCommand\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x0f\n\x07zone_id\x18\x03 \x01(\t"\xc1\x01\n\x0fProposeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12-\n\x06result\x18\x04 \x01(\x0b\x32\x18.nexus.raft.RaftResponseH\x02\x88\x01\x01\x12\x15\n\rapplied_index\x18\x05 \x01(\x04\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_result"_\n\x0cQueryRequest\x12$\n\x05query\x18\x01 \x01(\x0b\x32\x15.nexus.raft.RaftQuery\x12\x18\n\x10read_from_leader\x18\x02 \x01(\x08\x12\x0f\n\x07zone_id\x18\x03 \x01(\t"\xad\x01\n\rQueryResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12\x32\n\x06result\x18\x04 \x01(\x0b\x32\x1d.nexus.raft.RaftQueryResponseH\x02\x88\x01\x01\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_result"(\n\x15GetClusterInfoRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t"\xb8\x01\n\x16GetClusterInfoResponse\x12\x0f\n\x07node_id\x18\x01 \x01(\x04\x12\x11\n\tleader_id\x18\x02 \x01(\x04\x12\x0c\n\x04term\x18\x03 \x01(\x04\x12)\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x19.nexus.raft.ClusterConfig\x12\x11\n\tis_leader\x18\x05 \x01(\x08\x12\x1b\n\x0eleader_address\x18\x06 \x01(\tH\x00\x88\x01\x01\x42\x11\n\x0f_leader_address"I\n\x0fJoinZoneRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t\x12\x0f\n\x07node_id\x18\x02 \x01(\x04\x12\x14\n\x0cnode_address\x18\x03 \x01(\t"\xac\x01\n\x10JoinZoneResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12.\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x19.nexus.raft.ClusterConfigH\x02\x88\x01\x01\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_config"M\n\x12JoinClusterRequest\x12\x10\n\x08password\x18\x01 \x01(\t\x12\x0f\n\x07node_id\x18\x02 \x01(\x04\x12\x14\n\x0cnode_address\x18\x03 \x01(\t"h\n\x13JoinClusterResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0e\n\x06\x63\x61_pem\x18\x03 \x01(\x0c\x12\x12\n\nca_key_pem\x18\x04 \x01(\x0c\x42\x08\n\x06_error"\x86\x01\n\rClusterConfig\x12$\n\x06voters\x18\x01 \x03(\x0b\x32\x14.nexus.raft.NodeInfo\x12&\n\x08learners\x18\x02 \x03(\x0b\x32\x14.nexus.raft.NodeInfo\x12\'\n\twitnesses\x18\x03 \x03(\x0b\x32\x14.nexus.raft.NodeInfo"K\n\x08NodeInfo\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x0f\n\x07\x61\x64\x64ress\x18\x02 \x01(\t\x12"\n\x04role\x18\x03 \x01(\x0e\x32\x14.nexus.raft.NodeRole"6\n\x12StepMessageRequest\x12\x0f\n\x07message\x18\x01 \x01(\x0c\x12\x0f\n\x07zone_id\x18\x02 \x01(\t"D\n\x13StepMessageResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\x08\n\x06_error"V\n\x12\x45\x43ReplicationEntry\x12\x0b\n\x03seq\x18\x01 \x01(\x04\x12\x0f\n\x07\x63ommand\x18\x02 \x01(\x0c\x12\x11\n\ttimestamp\x18\x03 \x01(\x04\x12\x0f\n\x07node_id\x18\x04 \x01(\x04"s\n\x17ReplicateEntriesRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t\x12/\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x1e.nexus.raft.ECReplicationEntry\x12\x16\n\x0esender_node_id\x18\x03 \x01(\x04"`\n\x18ReplicateEntriesResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x15\n\rapplied_up_to\x18\x03 \x01(\x04\x42\x08\n\x06_error*>\n\x08NodeRole\x12\x0e\n\nROLE_VOTER\x10\x00\x12\x10\n\x0cROLE_LEARNER\x10\x01\x12\x10\n\x0cROLE_WITNESS\x10\x02\x32\xc5\x01\n\x14ZoneTransportService\x12N\n\x0bStepMessage\x12\x1e.nexus.raft.StepMessageRequest\x1a\x1f.nexus.raft.StepMessageResponse\x12]\n\x10ReplicateEntries\x12#.nexus.raft.ReplicateEntriesRequest\x1a$.nexus.raft.ReplicateEntriesResponse2\x82\x03\n\x0eZoneApiService\x12\x42\n\x07Propose\x12\x1a.nexus.raft.ProposeRequest\x1a\x1b.nexus.raft.ProposeResponse\x12<\n\x05Query\x12\x18.nexus.raft.QueryRequest\x1a\x19.nexus.raft.QueryResponse\x12W\n\x0eGetClusterInfo\x12!.nexus.raft.GetClusterInfoRequest\x1a".nexus.raft.GetClusterInfoResponse\x12\x45\n\x08JoinZone\x12\x1b.nexus.raft.JoinZoneRequest\x1a\x1c.nexus.raft.JoinZoneResponse\x12N\n\x0bJoinCluster\x12\x1e.nexus.raft.JoinClusterRequest\x1a\x1f.nexus.raft.JoinClusterResponseb\x06proto3'
+    b'\n\x1anexus/raft/transport.proto\x12\nnexus.raft\x1a\x19nexus/raft/commands.proto"_\n\x0eProposeRequest\x12(\n\x07\x63ommand\x18\x01 \x01(\x0b\x32\x17.nexus.raft.RaftCommand\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x0f\n\x07zone_id\x18\x03 \x01(\t"\xc1\x01\n\x0fProposeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12-\n\x06result\x18\x04 \x01(\x0b\x32\x18.nexus.raft.RaftResponseH\x02\x88\x01\x01\x12\x15\n\rapplied_index\x18\x05 \x01(\x04\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_result"_\n\x0cQueryRequest\x12$\n\x05query\x18\x01 \x01(\x0b\x32\x15.nexus.raft.RaftQuery\x12\x18\n\x10read_from_leader\x18\x02 \x01(\x08\x12\x0f\n\x07zone_id\x18\x03 \x01(\t"\xad\x01\n\rQueryResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12\x32\n\x06result\x18\x04 \x01(\x0b\x32\x1d.nexus.raft.RaftQueryResponseH\x02\x88\x01\x01\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_result"(\n\x15GetClusterInfoRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t"\xb8\x01\n\x16GetClusterInfoResponse\x12\x0f\n\x07node_id\x18\x01 \x01(\x04\x12\x11\n\tleader_id\x18\x02 \x01(\x04\x12\x0c\n\x04term\x18\x03 \x01(\x04\x12)\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x19.nexus.raft.ClusterConfig\x12\x11\n\tis_leader\x18\x05 \x01(\x08\x12\x1b\n\x0eleader_address\x18\x06 \x01(\tH\x00\x88\x01\x01\x42\x11\n\x0f_leader_address"I\n\x0fJoinZoneRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t\x12\x0f\n\x07node_id\x18\x02 \x01(\x04\x12\x14\n\x0cnode_address\x18\x03 \x01(\t"\xac\x01\n\x10JoinZoneResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12.\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x19.nexus.raft.ClusterConfigH\x02\x88\x01\x01\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_config"w\n\x12JoinClusterRequest\x12\x10\n\x08password\x18\x01 \x01(\t\x12\x0f\n\x07node_id\x18\x02 \x01(\x04\x12\x14\n\x0cnode_address\x18\x03 \x01(\t\x12\x0f\n\x07zone_id\x18\x04 \x01(\t\x12\x17\n\x0fpeers_bootstrap\x18\x05 \x01(\x08"\x93\x01\n\x13JoinClusterResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0e\n\x06\x63\x61_pem\x18\x03 \x01(\x0c\x12\x15\n\rnode_cert_pem\x18\x05 \x01(\x0c\x12\x14\n\x0cnode_key_pem\x18\x06 \x01(\x0c\x42\x08\n\x06_errorJ\x04\x08\x04\x10\x05R\nca_key_pem"\x86\x01\n\rClusterConfig\x12$\n\x06voters\x18\x01 \x03(\x0b\x32\x14.nexus.raft.NodeInfo\x12&\n\x08learners\x18\x02 \x03(\x0b\x32\x14.nexus.raft.NodeInfo\x12\'\n\twitnesses\x18\x03 \x03(\x0b\x32\x14.nexus.raft.NodeInfo"K\n\x08NodeInfo\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x0f\n\x07\x61\x64\x64ress\x18\x02 \x01(\t\x12"\n\x04role\x18\x03 \x01(\x0e\x32\x14.nexus.raft.NodeRole"6\n\x12StepMessageRequest\x12\x0f\n\x07message\x18\x01 \x01(\x0c\x12\x0f\n\x07zone_id\x18\x02 \x01(\t"D\n\x13StepMessageResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\x08\n\x06_error"V\n\x12\x45\x43ReplicationEntry\x12\x0b\n\x03seq\x18\x01 \x01(\x04\x12\x0f\n\x07\x63ommand\x18\x02 \x01(\x0c\x12\x11\n\ttimestamp\x18\x03 \x01(\x04\x12\x0f\n\x07node_id\x18\x04 \x01(\x04"s\n\x17ReplicateEntriesRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t\x12/\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x1e.nexus.raft.ECReplicationEntry\x12\x16\n\x0esender_node_id\x18\x03 \x01(\x04"`\n\x18ReplicateEntriesResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x15\n\rapplied_up_to\x18\x03 \x01(\x04\x42\x08\n\x06_error*>\n\x08NodeRole\x12\x0e\n\nROLE_VOTER\x10\x00\x12\x10\n\x0cROLE_LEARNER\x10\x01\x12\x10\n\x0cROLE_WITNESS\x10\x02\x32\xc5\x01\n\x14ZoneTransportService\x12N\n\x0bStepMessage\x12\x1e.nexus.raft.StepMessageRequest\x1a\x1f.nexus.raft.StepMessageResponse\x12]\n\x10ReplicateEntries\x12#.nexus.raft.ReplicateEntriesRequest\x1a$.nexus.raft.ReplicateEntriesResponse2\x82\x03\n\x0eZoneApiService\x12\x42\n\x07Propose\x12\x1a.nexus.raft.ProposeRequest\x1a\x1b.nexus.raft.ProposeResponse\x12<\n\x05Query\x12\x18.nexus.raft.QueryRequest\x1a\x19.nexus.raft.QueryResponse\x12W\n\x0eGetClusterInfo\x12!.nexus.raft.GetClusterInfoRequest\x1a".nexus.raft.GetClusterInfoResponse\x12\x45\n\x08JoinZone\x12\x1b.nexus.raft.JoinZoneRequest\x1a\x1c.nexus.raft.JoinZoneResponse\x12N\n\x0bJoinCluster\x12\x1e.nexus.raft.JoinClusterRequest\x1a\x1f.nexus.raft.JoinClusterResponseb\x06proto3'
 )
 
 _globals = globals()
@@ -27,8 +27,8 @@ _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "nexus.raft.transport_pb2", _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
     DESCRIPTOR._loaded_options = None
-    _globals["_NODEROLE"]._serialized_start = 1942
-    _globals["_NODEROLE"]._serialized_end = 2004
+    _globals["_NODEROLE"]._serialized_start = 2028
+    _globals["_NODEROLE"]._serialized_end = 2090
     _globals["_PROPOSEREQUEST"]._serialized_start = 69
     _globals["_PROPOSEREQUEST"]._serialized_end = 164
     _globals["_PROPOSERESPONSE"]._serialized_start = 167
@@ -46,25 +46,25 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_JOINZONERESPONSE"]._serialized_start = 940
     _globals["_JOINZONERESPONSE"]._serialized_end = 1112
     _globals["_JOINCLUSTERREQUEST"]._serialized_start = 1114
-    _globals["_JOINCLUSTERREQUEST"]._serialized_end = 1191
-    _globals["_JOINCLUSTERRESPONSE"]._serialized_start = 1193
-    _globals["_JOINCLUSTERRESPONSE"]._serialized_end = 1297
-    _globals["_CLUSTERCONFIG"]._serialized_start = 1300
-    _globals["_CLUSTERCONFIG"]._serialized_end = 1434
-    _globals["_NODEINFO"]._serialized_start = 1436
-    _globals["_NODEINFO"]._serialized_end = 1511
-    _globals["_STEPMESSAGEREQUEST"]._serialized_start = 1513
-    _globals["_STEPMESSAGEREQUEST"]._serialized_end = 1567
-    _globals["_STEPMESSAGERESPONSE"]._serialized_start = 1569
-    _globals["_STEPMESSAGERESPONSE"]._serialized_end = 1637
-    _globals["_ECREPLICATIONENTRY"]._serialized_start = 1639
-    _globals["_ECREPLICATIONENTRY"]._serialized_end = 1725
-    _globals["_REPLICATEENTRIESREQUEST"]._serialized_start = 1727
-    _globals["_REPLICATEENTRIESREQUEST"]._serialized_end = 1842
-    _globals["_REPLICATEENTRIESRESPONSE"]._serialized_start = 1844
-    _globals["_REPLICATEENTRIESRESPONSE"]._serialized_end = 1940
-    _globals["_ZONETRANSPORTSERVICE"]._serialized_start = 2007
-    _globals["_ZONETRANSPORTSERVICE"]._serialized_end = 2204
-    _globals["_ZONEAPISERVICE"]._serialized_start = 2207
-    _globals["_ZONEAPISERVICE"]._serialized_end = 2593
+    _globals["_JOINCLUSTERREQUEST"]._serialized_end = 1233
+    _globals["_JOINCLUSTERRESPONSE"]._serialized_start = 1236
+    _globals["_JOINCLUSTERRESPONSE"]._serialized_end = 1383
+    _globals["_CLUSTERCONFIG"]._serialized_start = 1386
+    _globals["_CLUSTERCONFIG"]._serialized_end = 1520
+    _globals["_NODEINFO"]._serialized_start = 1522
+    _globals["_NODEINFO"]._serialized_end = 1597
+    _globals["_STEPMESSAGEREQUEST"]._serialized_start = 1599
+    _globals["_STEPMESSAGEREQUEST"]._serialized_end = 1653
+    _globals["_STEPMESSAGERESPONSE"]._serialized_start = 1655
+    _globals["_STEPMESSAGERESPONSE"]._serialized_end = 1723
+    _globals["_ECREPLICATIONENTRY"]._serialized_start = 1725
+    _globals["_ECREPLICATIONENTRY"]._serialized_end = 1811
+    _globals["_REPLICATEENTRIESREQUEST"]._serialized_start = 1813
+    _globals["_REPLICATEENTRIESREQUEST"]._serialized_end = 1928
+    _globals["_REPLICATEENTRIESRESPONSE"]._serialized_start = 1930
+    _globals["_REPLICATEENTRIESRESPONSE"]._serialized_end = 2026
+    _globals["_ZONETRANSPORTSERVICE"]._serialized_start = 2093
+    _globals["_ZONETRANSPORTSERVICE"]._serialized_end = 2290
+    _globals["_ZONEAPISERVICE"]._serialized_start = 2293
+    _globals["_ZONEAPISERVICE"]._serialized_end = 2679
 # @@protoc_insertion_point(module_scope)

--- a/src/nexus/raft/transport_pb2_grpc.py
+++ b/src/nexus/raft/transport_pb2_grpc.py
@@ -276,8 +276,8 @@ class ZoneApiServiceServicer:
     def JoinCluster(self, request, context):
         """JoinCluster provisions a new node with cluster TLS certificates.
         Called by `nexus join` before `nexus serve`. The caller authenticates
-        with the join token password; the server returns the cluster CA + key
-        so the joiner can generate its own node cert locally.
+        with the join token password; the server signs a node cert and returns
+        it along with the CA cert. CA key never leaves node-1 (security fix).
         K3s-style bootstrap: token = shared secret, TLS encrypts the channel.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -17,7 +17,7 @@ All zones share one gRPC port (zone_id routing in transport layer).
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.metadata import DT_DIR, DT_MOUNT, FileMetadata
@@ -738,32 +738,25 @@ class ZoneManager:
     # 2-phase TLS bootstrap
     # -------------------------------------------------------------------------
 
+    # System keys in the Raft metastore for TLS coordination.
+    # All nodes see these via Raft consensus (deterministic, ordered).
+    _TLS_CA_KEY = "__system__/tls/ca_pem"
+    _TLS_UPGRADE_KEY = "__system__/tls/upgrade"
+
     def bootstrap_tls(self) -> bool:
-        """Phase 2 of 2-phase TLS bootstrap: leader generates CA, followers get certs.
+        """2-phase TLS bootstrap coordinated via Raft consensus.
 
         Called by ensure_topology() before topology work. Returns True when
-        TLS is ready (or not needed).
+        TLS is ready (or not needed). Each call advances the state machine:
+
+        1. Leader generates CA → proposes ca_pem to Raft metastore
+        2. All nodes see CA via Raft → followers call JoinCluster for certs
+        3. Leader tracks JoinCluster calls → when all peers served, proposes upgrade
+        4. All nodes see upgrade → restart transport with mTLS
+
+        Only the leader writes to Raft. Followers only read + call JoinCluster RPC.
         """
-        import time
-
         if not self._two_phase_tls:
-            return True
-
-        # Check if certs appeared on disk (from a previous call or restart)
-        from nexus.security.tls.config import ZoneTlsConfig
-
-        existing = ZoneTlsConfig.from_data_dir(self._base_path)
-        if existing is not None:
-            # Grace period: leader waits before upgrading to mTLS so followers
-            # can call JoinCluster over plaintext first.
-            ca_pem_path = Path(self._base_path) / "tls" / "ca.pem"
-            if ca_pem_path.exists():
-                age = time.time() - ca_pem_path.stat().st_mtime
-                if age < 15:
-                    logger.debug("TLS certs ready but waiting for grace period (%.1fs/15s)", age)
-                    return False
-            self._restart_with_tls(existing)
-            self._two_phase_tls = False
             return True
 
         if not self._root_zone_id:
@@ -773,22 +766,61 @@ class ZoneManager:
         if root_store is None:
             return False
 
-        leader_id = root_store._engine.leader_id()
+        raft_engine = root_store._engine
+        leader_id = raft_engine.leader_id()
         if not leader_id:
             return False  # No leader yet
 
-        if leader_id == self._node_id:
-            return self._leader_tls_bootstrap()
-        else:
-            return self._follower_tls_bootstrap(leader_id)
+        # --- Check if upgrade signal is in Raft → restart transport ---
+        upgrade = raft_engine.get_metadata(self._TLS_UPGRADE_KEY)
+        if upgrade is not None:
+            from nexus.security.tls.config import ZoneTlsConfig
 
-    def _leader_tls_bootstrap(self) -> bool:
-        """Leader: generate CA + own cert, set CA material on running server."""
-        from nexus.security.tls.certgen import generate_node_cert, generate_zone_ca, save_pem
+            existing = ZoneTlsConfig.from_data_dir(self._base_path)
+            if existing is not None:
+                self._restart_with_tls(existing)
+                self._two_phase_tls = False
+                logger.info("TLS bootstrap complete — transport upgraded to mTLS")
+                return True
+            logger.warning("TLS upgrade signal seen but no certs on disk")
+            return False
+
+        # --- Leader: generate CA and propose to Raft ---
+        ca_pem_in_raft = raft_engine.get_metadata(self._TLS_CA_KEY)
+        if ca_pem_in_raft is None:
+            if leader_id == self._node_id:
+                self._leader_generate_ca(raft_engine)
+            return False
+
+        # --- Followers: get cert from leader via JoinCluster ---
+        tls_dir = Path(self._base_path) / "tls"
+        if not (tls_dir / "node.pem").exists():
+            if leader_id != self._node_id:
+                self._follower_get_cert(leader_id, ca_pem_in_raft)
+            return False
+
+        # --- Leader: check if all peers have certs (tracked via JoinCluster RPCs) ---
+        # The leader proposes upgrade once all expected peers called JoinCluster.
+        # Followers just wait for the upgrade signal.
+        if leader_id == self._node_id:
+            self._leader_check_all_ready(raft_engine)
+
+        return False  # Wait for upgrade signal
+
+    def _leader_generate_ca(self, raft_engine: Any) -> None:
+        """Leader: generate CA + own cert, propose CA to Raft, set on server."""
+        from nexus.security.tls.certgen import (
+            cert_fingerprint,
+            generate_node_cert,
+            generate_zone_ca,
+            save_pem,
+        )
+        from nexus.security.tls.join_token import generate_join_token
 
         tls_dir = Path(self._base_path) / "tls"
         zone_id = ROOT_ZONE_ID
 
+        # Generate CA + own node cert
         ca_cert, ca_key = generate_zone_ca(zone_id)
         save_pem(tls_dir / "ca.pem", ca_cert)
         save_pem(tls_dir / "ca-key.pem", ca_key, is_private=True)
@@ -797,48 +829,34 @@ class ZoneManager:
         save_pem(tls_dir / "node.pem", node_cert)
         save_pem(tls_dir / "node-key.pem", node_key, is_private=True)
 
-        # Generate join token for future joiners
-        from nexus.security.tls.certgen import cert_fingerprint
-        from nexus.security.tls.join_token import generate_join_token
-
+        # Generate join token for future external joiners
         token, pw_hash = generate_join_token(ca_cert)
         (tls_dir / "join-token").write_text(token)
         (tls_dir / "join-token-hash").write_text(pw_hash)
-        fp = cert_fingerprint(ca_cert)
-        logger.info("Leader: CA generated (fingerprint: %s), join token: %s", fp, token)
 
-        # Set CA material on the running plaintext server so followers can call JoinCluster
+        fp = cert_fingerprint(ca_cert)
+        logger.info("Leader: CA generated (fingerprint: %s)", fp)
+
+        # Propose CA cert to Raft — all nodes will see it after commit
         ca_pem = (tls_dir / "ca.pem").read_bytes()
+        try:
+            raft_engine.set_metadata(self._TLS_CA_KEY, ca_pem)
+            logger.info("Leader: CA cert proposed to Raft metastore")
+        except RuntimeError as e:
+            logger.warning("Failed to propose CA to Raft: %s", e)
+            return
+
+        # Set CA material on running server so JoinCluster RPCs work
         ca_key_pem = (tls_dir / "ca-key.pem").read_bytes()
         self._py_mgr.set_ca_material(ca_pem, ca_key_pem)
 
-        # Don't restart with mTLS yet — followers need to call JoinCluster first (over plaintext).
-        # On the NEXT health check call, certs will exist on disk → restart_with_tls().
-        return False
-
-    def _follower_tls_bootstrap(self, leader_id: int) -> bool:
-        """Follower: call JoinCluster on leader to get signed certs."""
+    def _follower_get_cert(self, leader_id: int, ca_pem: bytes) -> None:
+        """Follower: call JoinCluster on leader over plaintext to get signed cert."""
         peers_str = os.environ.get("NEXUS_PEERS", "")
-        leader_addr = None
-        for p in peers_str.split(","):
-            p = p.strip()
-            if "@" in p:
-                parts = p.split("@", 1)
-                try:
-                    if int(parts[0]) == leader_id:
-                        addr = parts[1]
-                        if not addr.startswith("http"):
-                            addr = f"http://{addr}"
-                        leader_addr = addr
-                        break
-                except ValueError:
-                    continue
-
+        leader_addr = self._find_peer_address(peers_str, leader_id)
         if leader_addr is None:
-            logger.warning("Cannot find leader %d address in NEXUS_PEERS", leader_id)
-            return False
+            return
 
-        # Call JoinCluster via gRPC (plaintext — no certs yet)
         try:
             import grpc
 
@@ -857,13 +875,18 @@ class ZoneManager:
             response = stub.JoinCluster(request, timeout=10.0)
         except Exception as e:
             logger.debug("JoinCluster to leader %d failed (will retry): %s", leader_id, e)
-            return False
+            return
 
         if not response.success:
             logger.debug("JoinCluster rejected (will retry): %s", response.error)
-            return False
+            return
 
-        # Save certs
+        # Verify CA matches what's in Raft
+        if response.ca_pem != ca_pem:
+            logger.error("CA mismatch: JoinCluster response CA differs from Raft CA")
+            return
+
+        # Save certs to disk
         tls_dir = Path(self._base_path) / "tls"
         tls_dir.mkdir(parents=True, exist_ok=True)
         (tls_dir / "ca.pem").write_bytes(response.ca_pem)
@@ -873,8 +896,50 @@ class ZoneManager:
         write_secret_file(tls_dir / "node-key.pem", response.node_key_pem)
         logger.info("Follower: received signed cert from leader %d", leader_id)
 
-        # On next call, certs exist on disk → restart_with_tls()
-        return False
+    def _leader_check_all_ready(self, raft_engine: Any) -> None:
+        """Leader: check if all peers have called JoinCluster, then propose upgrade.
+
+        The server tracks JoinCluster calls via joined_peers HashSet in Rust.
+        The leader also counts itself (it has certs from _leader_generate_ca).
+        """
+        if not self._authorized_peer_ids:
+            return
+
+        joined = set(self._py_mgr.joined_peer_ids())
+        # Leader counts itself (it generated its own cert, didn't call JoinCluster)
+        joined.add(self._node_id)
+
+        expected = set(self._authorized_peer_ids)
+        missing = expected - joined
+        if missing:
+            logger.debug(
+                "TLS upgrade: waiting for peers %s (joined: %s)", sorted(missing), sorted(joined)
+            )
+            return
+
+        # All peers ready — propose upgrade via Raft consensus
+        try:
+            raft_engine.set_metadata(self._TLS_UPGRADE_KEY, b"1")
+            logger.info("Leader: all peers ready — TLS upgrade proposed to Raft")
+        except RuntimeError as e:
+            logger.warning("Failed to propose TLS upgrade: %s", e)
+
+    @staticmethod
+    def _find_peer_address(peers_str: str, node_id: int) -> str | None:
+        """Find a peer's address from NEXUS_PEERS string."""
+        for p in peers_str.split(","):
+            p = p.strip()
+            if "@" in p:
+                parts = p.split("@", 1)
+                try:
+                    if int(parts[0]) == node_id:
+                        addr = parts[1]
+                        if not addr.startswith("http"):
+                            addr = f"http://{addr}"
+                        return addr
+                except ValueError:
+                    continue
+        return None
 
     def _restart_with_tls(self, tls_config: "ZoneTlsConfig") -> None:
         """Restart the gRPC server with mTLS. Existing Raft zones are preserved."""

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -78,6 +78,8 @@ class ZoneManager:
                 "Build with: maturin develop -m rust/nexus_raft/Cargo.toml --features full"
             )
 
+        from nexus.security.tls.config import ZoneTlsConfig
+
         # TLS bootstrap logic:
         # 1. Existing certs on disk → use them (normal restart)
         # 2. NEXUS_PEERS set + no certs → 2-phase mode (start plaintext, bootstrap TLS after leader election)

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -868,7 +868,6 @@ class ZoneManager:
         try:
             import grpc
 
-            from nexus.raft import commands_pb2 as _  # noqa: F811,F401 — must load before transport
             from nexus.raft import transport_pb2, transport_pb2_grpc
 
             target = leader_addr.replace("http://", "").replace("https://", "")

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -769,6 +769,7 @@ class ZoneManager:
         raft_engine = root_store._engine
         leader_id = raft_engine.leader_id()
         if not leader_id:
+            logger.info("bootstrap_tls: no leader yet (node=%d)", self._node_id)
             return False  # No leader yet
 
         # --- Check if upgrade signal is in Raft → restart transport ---
@@ -787,6 +788,13 @@ class ZoneManager:
 
         # --- Leader: generate CA and propose to Raft ---
         ca_pem_in_raft = raft_engine.get_metadata(self._TLS_CA_KEY)
+        logger.info(
+            "bootstrap_tls: node=%d leader=%d ca_in_raft=%s has_cert=%s",
+            self._node_id,
+            leader_id,
+            ca_pem_in_raft is not None,
+            (Path(self._base_path) / "tls" / "node.pem").exists(),
+        )
         if ca_pem_in_raft is None:
             if leader_id == self._node_id:
                 self._leader_generate_ca(raft_engine)
@@ -860,7 +868,7 @@ class ZoneManager:
         try:
             import grpc
 
-            from nexus.raft._proto.nexus.raft import transport_pb2, transport_pb2_grpc
+            from nexus.raft import transport_pb2, transport_pb2_grpc
 
             target = leader_addr.replace("http://", "").replace("https://", "")
             channel = grpc.insecure_channel(target)
@@ -874,11 +882,11 @@ class ZoneManager:
             )
             response = stub.JoinCluster(request, timeout=10.0)
         except Exception as e:
-            logger.debug("JoinCluster to leader %d failed (will retry): %s", leader_id, e)
+            logger.info("JoinCluster to leader %d failed (will retry): %s", leader_id, e)
             return
 
         if not response.success:
-            logger.debug("JoinCluster rejected (will retry): %s", response.error)
+            logger.info("JoinCluster rejected by leader (will retry): %s", response.error)
             return
 
         # Verify CA matches what's in Raft

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -868,6 +868,7 @@ class ZoneManager:
         try:
             import grpc
 
+            from nexus.raft import commands_pb2 as _  # noqa: F811,F401 — must load before transport
             from nexus.raft import transport_pb2, transport_pb2_grpc
 
             target = leader_addr.replace("http://", "").replace("https://", "")

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -15,6 +15,7 @@ All zones share one gRPC port (zone_id routing in transport layer).
 """
 
 import logging
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -77,22 +78,59 @@ class ZoneManager:
                 "Build with: maturin develop -m rust/nexus_raft/Cargo.toml --features full"
             )
 
-        # Auto-generate TLS certs if none provided and none on disk (#1250)
+        # TLS bootstrap logic:
+        # 1. Existing certs on disk → use them (normal restart)
+        # 2. NEXUS_PEERS set + no certs → 2-phase mode (start plaintext, bootstrap TLS after leader election)
+        # 3. Single-node (no peers) → auto-generate (existing behavior)
         self._tls_config: ZoneTlsConfig | None = None
+        self._two_phase_tls = False
         ca_key_path: str | None = None
         join_token_hash: str | None = None
+        authorized_peer_ids: list[int] | None = None
+        peers_str = os.environ.get("NEXUS_PEERS", "")
+        has_peers = bool(peers_str.strip())
+
         if tls_cert_path is None and tls_key_path is None and tls_ca_path is None:
-            auto = self._auto_generate_tls(base_path, node_id)
-            if auto is not None:
-                tls_cert_path = str(auto.node_cert_path)
-                tls_key_path = str(auto.node_key_path)
-                tls_ca_path = str(auto.ca_cert_path)
-                self._tls_config = auto
-                # Read join token hash if this is the first node (has join-token-hash file)
+            existing = ZoneTlsConfig.from_data_dir(base_path)
+            if existing is not None:
+                # Certs exist from a previous run → use them
+                tls_cert_path = str(existing.node_cert_path)
+                tls_key_path = str(existing.node_key_path)
+                tls_ca_path = str(existing.ca_cert_path)
+                self._tls_config = existing
                 hash_path = Path(base_path) / "tls" / "join-token-hash"
                 if hash_path.exists():
                     join_token_hash = hash_path.read_text().strip()
                     ca_key_path = str(Path(base_path) / "tls" / "ca-key.pem")
+                logger.debug("Auto-detected existing TLS certs in %s/tls/", base_path)
+            elif has_peers:
+                # No certs + NEXUS_PEERS → 2-phase bootstrap (start plaintext)
+                self._two_phase_tls = True
+                # Parse peer IDs for authorized peers_bootstrap
+                authorized_peer_ids = []
+                for p in peers_str.split(","):
+                    p = p.strip()
+                    if "@" in p:
+                        import contextlib
+
+                        with contextlib.suppress(ValueError):
+                            authorized_peer_ids.append(int(p.split("@")[0]))
+                logger.info(
+                    "2-phase TLS bootstrap: starting in plaintext mode (peers=%s)",
+                    authorized_peer_ids,
+                )
+            else:
+                # Single-node, no peers → auto-generate
+                auto = self._auto_generate_tls(base_path, node_id)
+                if auto is not None:
+                    tls_cert_path = str(auto.node_cert_path)
+                    tls_key_path = str(auto.node_key_path)
+                    tls_ca_path = str(auto.ca_cert_path)
+                    self._tls_config = auto
+                    hash_path = Path(base_path) / "tls" / "join-token-hash"
+                    if hash_path.exists():
+                        join_token_hash = hash_path.read_text().strip()
+                        ca_key_path = str(Path(base_path) / "tls" / "ca-key.pem")
 
         self._py_mgr = PyZoneManager(
             node_id,
@@ -103,17 +141,20 @@ class ZoneManager:
             tls_ca_path=tls_ca_path,
             ca_key_path=ca_key_path,
             join_token_hash=join_token_hash,
+            authorized_peer_ids=authorized_peer_ids,
         )
         self._stores: dict[str, RaftMetadataStore] = {}
         self._node_id = node_id
         self._base_path = base_path
         self._advertise_addr = advertise_addr or bind_addr
+        self._bind_addr = bind_addr
         self._root_zone_id: str | None = None
         self._tls_cert_path = tls_cert_path
         self._tls_key_path = tls_key_path
         self._tls_ca_path = tls_ca_path
         self._pending_mounts: dict[str, str] | None = None
         self._topology_initialized = False
+        self._authorized_peer_ids = authorized_peer_ids
 
     @property
     def tls_config(self) -> "ZoneTlsConfig | None":
@@ -691,6 +732,162 @@ class ZoneManager:
         if mounts:
             self._pending_mounts = mounts
 
+    # -------------------------------------------------------------------------
+    # 2-phase TLS bootstrap
+    # -------------------------------------------------------------------------
+
+    def bootstrap_tls(self) -> bool:
+        """Phase 2 of 2-phase TLS bootstrap: leader generates CA, followers get certs.
+
+        Called by ensure_topology() before topology work. Returns True when
+        TLS is ready (or not needed).
+        """
+        if not self._two_phase_tls:
+            return True
+
+        # Check if certs appeared on disk (from a previous call or restart)
+        from nexus.security.tls.config import ZoneTlsConfig
+
+        existing = ZoneTlsConfig.from_data_dir(self._base_path)
+        if existing is not None:
+            self._restart_with_tls(existing)
+            self._two_phase_tls = False
+            return True
+
+        if not self._root_zone_id:
+            return False
+
+        root_store = self.get_store(self._root_zone_id)
+        if root_store is None:
+            return False
+
+        leader_id = root_store._engine.leader_id()
+        if not leader_id:
+            return False  # No leader yet
+
+        if leader_id == self._node_id:
+            return self._leader_tls_bootstrap()
+        else:
+            return self._follower_tls_bootstrap(leader_id)
+
+    def _leader_tls_bootstrap(self) -> bool:
+        """Leader: generate CA + own cert, set CA material on running server."""
+        from nexus.security.tls.certgen import generate_node_cert, generate_zone_ca, save_pem
+
+        tls_dir = Path(self._base_path) / "tls"
+        zone_id = ROOT_ZONE_ID
+
+        ca_cert, ca_key = generate_zone_ca(zone_id)
+        save_pem(tls_dir / "ca.pem", ca_cert)
+        save_pem(tls_dir / "ca-key.pem", ca_key, is_private=True)
+
+        node_cert, node_key = generate_node_cert(self._node_id, zone_id, ca_cert, ca_key)
+        save_pem(tls_dir / "node.pem", node_cert)
+        save_pem(tls_dir / "node-key.pem", node_key, is_private=True)
+
+        # Generate join token for future joiners
+        from nexus.security.tls.certgen import cert_fingerprint
+        from nexus.security.tls.join_token import generate_join_token
+
+        token, pw_hash = generate_join_token(ca_cert)
+        (tls_dir / "join-token").write_text(token)
+        (tls_dir / "join-token-hash").write_text(pw_hash)
+        fp = cert_fingerprint(ca_cert)
+        logger.info("Leader: CA generated (fingerprint: %s), join token: %s", fp, token)
+
+        # Set CA material on the running plaintext server so followers can call JoinCluster
+        ca_pem = (tls_dir / "ca.pem").read_bytes()
+        ca_key_pem = (tls_dir / "ca-key.pem").read_bytes()
+        self._py_mgr.set_ca_material(ca_pem, ca_key_pem)
+
+        # Don't restart with mTLS yet — followers need to call JoinCluster first (over plaintext).
+        # On the NEXT health check call, certs will exist on disk → restart_with_tls().
+        return False
+
+    def _follower_tls_bootstrap(self, leader_id: int) -> bool:
+        """Follower: call JoinCluster on leader to get signed certs."""
+        peers_str = os.environ.get("NEXUS_PEERS", "")
+        leader_addr = None
+        for p in peers_str.split(","):
+            p = p.strip()
+            if "@" in p:
+                parts = p.split("@", 1)
+                try:
+                    if int(parts[0]) == leader_id:
+                        addr = parts[1]
+                        if not addr.startswith("http"):
+                            addr = f"http://{addr}"
+                        leader_addr = addr
+                        break
+                except ValueError:
+                    continue
+
+        if leader_addr is None:
+            logger.warning("Cannot find leader %d address in NEXUS_PEERS", leader_id)
+            return False
+
+        # Call JoinCluster via gRPC (plaintext — no certs yet)
+        try:
+            import grpc
+
+            from nexus.raft._proto.nexus.raft import transport_pb2, transport_pb2_grpc
+
+            target = leader_addr.replace("http://", "").replace("https://", "")
+            channel = grpc.insecure_channel(target)
+            stub = transport_pb2_grpc.ZoneApiServiceStub(channel)
+            request = transport_pb2.JoinClusterRequest(
+                password="",
+                node_id=self._node_id,
+                node_address=self._advertise_addr,
+                zone_id=ROOT_ZONE_ID,
+                peers_bootstrap=True,
+            )
+            response = stub.JoinCluster(request, timeout=10.0)
+        except Exception as e:
+            logger.debug("JoinCluster to leader %d failed (will retry): %s", leader_id, e)
+            return False
+
+        if not response.success:
+            logger.debug("JoinCluster rejected (will retry): %s", response.error)
+            return False
+
+        # Save certs
+        tls_dir = Path(self._base_path) / "tls"
+        tls_dir.mkdir(parents=True, exist_ok=True)
+        (tls_dir / "ca.pem").write_bytes(response.ca_pem)
+        (tls_dir / "node.pem").write_bytes(response.node_cert_pem)
+        from nexus.security.secret_file import write_secret_file
+
+        write_secret_file(tls_dir / "node-key.pem", response.node_key_pem)
+        logger.info("Follower: received signed cert from leader %d", leader_id)
+
+        # On next call, certs exist on disk → restart_with_tls()
+        return False
+
+    def _restart_with_tls(self, tls_config: "ZoneTlsConfig") -> None:
+        """Restart the gRPC server with mTLS. Existing Raft zones are preserved."""
+        ca_key_path = None
+        join_token_hash = None
+        hash_path = Path(self._base_path) / "tls" / "join-token-hash"
+        if hash_path.exists():
+            join_token_hash = hash_path.read_text().strip()
+            ca_key_path = str(Path(self._base_path) / "tls" / "ca-key.pem")
+
+        self._py_mgr.restart_with_tls(
+            tls_cert_path=str(tls_config.node_cert_path),
+            tls_key_path=str(tls_config.node_key_path),
+            tls_ca_path=str(tls_config.ca_cert_path),
+            ca_key_path=ca_key_path,
+            join_token_hash=join_token_hash,
+            authorized_peer_ids=self._authorized_peer_ids,
+        )
+        self._tls_config = tls_config
+        logger.info("Transport upgraded to mTLS")
+
+    # -------------------------------------------------------------------------
+    # Topology management
+    # -------------------------------------------------------------------------
+
     def ensure_topology(self) -> bool:
         """Ensure root "/" and mount topology exist via standard Raft proposals.
 
@@ -714,6 +911,10 @@ class ZoneManager:
             True if topology is fully ready on this node, False if still
             waiting for leader writes or Raft replication.
         """
+        # Phase 0: TLS bootstrap (if in 2-phase mode)
+        if not self.bootstrap_tls():
+            return False
+
         if self._topology_initialized:
             return True
 

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -744,6 +744,8 @@ class ZoneManager:
         Called by ensure_topology() before topology work. Returns True when
         TLS is ready (or not needed).
         """
+        import time
+
         if not self._two_phase_tls:
             return True
 
@@ -752,6 +754,14 @@ class ZoneManager:
 
         existing = ZoneTlsConfig.from_data_dir(self._base_path)
         if existing is not None:
+            # Grace period: leader waits before upgrading to mTLS so followers
+            # can call JoinCluster over plaintext first.
+            ca_pem_path = Path(self._base_path) / "tls" / "ca.pem"
+            if ca_pem_path.exists():
+                age = time.time() - ca_pem_path.stat().st_mtime
+                if age < 15:
+                    logger.debug("TLS certs ready but waiting for grace period (%.1fs/15s)", age)
+                    return False
             self._restart_with_tls(existing)
             self._two_phase_tls = False
             return True


### PR DESCRIPTION
## Summary
- **2-phase TLS bootstrap**: All nodes start plaintext with NEXUS_PEERS → leader election → leader generates CA → proposes to Raft → followers call JoinCluster → leader tracks all joined → proposes upgrade → all nodes restart with mTLS
- **Raft-coordinated upgrade**: No time-based grace periods. Leader tracks JoinCluster calls via `HashSet<u64>`, proposes `__system__/tls/upgrade` when all peers ready. All nodes see committed entry → restart transport.
- **Remove NEXUS_JOIN_TOKEN + NEXUS_PEER**: Replaced by automatic 2-phase flow via NEXUS_PEERS
- **Witness Dockerfile**: `--no-default-features` to avoid PyO3 dependency
- **Dragonfly**: Fix `proactor_threads=1` (256MB limit)

## Status: WIP
- [x] Rust: proto, server dual-auth, dynamic CA, joined_peers tracking, PyO3 bindings
- [x] Python: zone_manager 5-step bootstrap_tls flow, ensure_topology integration
- [ ] Debug: witness h2 protocol error connecting to node-1 (Rust tracing not visible in Docker)
- [ ] Verify full 5-step flow end-to-end in Docker cluster
- [ ] Witness binary: needs its own 2-phase TLS bootstrap loop

## Test plan
- [ ] Docker 3-node cluster: all nodes start plaintext → leader generates CA → followers get certs → all upgrade to mTLS
- [ ] Dynamic federation E2E tests pass after mTLS upgrade
- [ ] Single-node (no NEXUS_PEERS) still auto-generates certs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)