### PR TITLE
fix(#1371,#1790): migrate _check_zone_writable to KernelDispatch PRE hooks

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -371,25 +371,6 @@ class NexusFS(  # type: ignore[misc]
             )
         return context.zone_id, context.agent_id, getattr(context, "is_admin", self.is_admin)
 
-    def _check_zone_writable(self, context: OperationContext | dict | None = None) -> None:
-        """Raise ZoneTerminatingError if the zone is being deprovisioned.
-
-        Issue #2061: Write-gating during zone finalization (Decision #4A).
-        Issue #1570: zone_lifecycle accessed from container, not flat attr.
-        """
-        _zl = (
-            getattr(self._system_services, "zone_lifecycle", None)
-            if self._system_services
-            else None
-        )
-        if _zl is None:
-            return
-        zone_id, _, _ = self._get_routing_params(context)
-        if zone_id and _zl.is_zone_terminating(zone_id):
-            from nexus.contracts.exceptions import ZoneTerminatingError
-
-            raise ZoneTerminatingError(zone_id)
-
     @property
     def zone_id(self) -> str | None:
         """Default zone_id from the instance context."""
@@ -533,7 +514,6 @@ class NexusFS(  # type: ignore[misc]
         ctx = context if context is not None else self._default_context
 
         # Block writes during zone deprovisioning (Issue #2061)
-        self._check_zone_writable(ctx)
 
         # PRE-INTERCEPT: pre-mkdir hooks (Issue #899)
         from nexus.contracts.vfs_hooks import MkdirHookContext
@@ -676,7 +656,6 @@ class NexusFS(  # type: ignore[misc]
         path = self._validate_path(path)
 
         # Block writes during zone deprovisioning (Issue #2061)
-        self._check_zone_writable(context)
 
         # P0 Fixes: Create OperationContext
         if context is not None:
@@ -978,8 +957,6 @@ class NexusFS(  # type: ignore[misc]
             Dict with path, created flag, and type-specific fields.
         """
         path = self._validate_path(path)
-        ctx = context or self._default_context
-        self._check_zone_writable(ctx)
 
         meta = self.metadata.get(path)
 
@@ -2156,7 +2133,6 @@ class NexusFS(  # type: ignore[misc]
             >>> result = nx.write_stream("/workspace/large.bin", file_chunks("/tmp/large.bin"))
         """
         path = self._validate_path(path)
-        self._check_zone_writable(context)  # Issue #2061: write-gating
 
         # Route to backend with write access check
         zone_id, agent_id, is_admin = self._get_routing_params(context)
@@ -2282,7 +2258,6 @@ class NexusFS(  # type: ignore[misc]
             return {"path": path, "bytes_written": n, "created": False}
 
         path = self._validate_path(path)
-        self._check_zone_writable(context)  # Issue #2061: write-gating
 
         # PRE-DISPATCH: virtual path resolvers (Issue #889)
         _handled, _result = self._dispatch.resolve_write(path, buf)
@@ -2388,7 +2363,6 @@ class NexusFS(  # type: ignore[misc]
             buf = buf[:count]
 
         path = self._validate_path(path)
-        self._check_zone_writable(context)
 
         # PRE-DISPATCH: virtual path resolvers
         _handled, _result = self._dispatch.resolve_write(path, buf)
@@ -3014,8 +2988,6 @@ class NexusFS(  # type: ignore[misc]
         if not files:
             return []
 
-        self._check_zone_writable(context)  # Issue #2061: write-gating
-
         # Validate all paths first
         validated_files: list[tuple[str, bytes]] = []
         for path, content in files:
@@ -3272,7 +3244,6 @@ class NexusFS(  # type: ignore[misc]
             PermissionError: If path is read-only or user doesn't have write permission
         """
         path = self._validate_path(path)
-        self._check_zone_writable(context)  # Issue #2061: write-gating
 
         # PRE-DISPATCH: virtual path resolvers (Issue #889)
         _handled, _result = self._dispatch.resolve_delete(path, context=context)
@@ -3404,7 +3375,6 @@ class NexusFS(  # type: ignore[misc]
         new_path = self._validate_path(new_path)
         # Normalize context dict to OperationContext dataclass (CLI passes dicts)
         context = self._parse_context(context)
-        self._check_zone_writable(context)  # Issue #2061: write-gating
 
         # Route both paths
         zone_id, agent_id, is_admin = self._get_routing_params(context)
@@ -4030,7 +4000,7 @@ class NexusFS(  # type: ignore[misc]
             ...     else:
             ...         print(f"Failed {path}: {result['error']}")
         """
-        self._check_zone_writable(context)  # Issue #2061: write-gating
+
         results = {}
         for path in paths:
             try:

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -595,6 +595,16 @@ async def _register_vfs_hooks(
                 SyncPermissionWriteHook(hierarchy_manager=_hier, rebac_manager=_rebac),
             )
 
+    # ── Zone writability gate (Issue #1371, #2061) ─────────────────────
+    # Replaces NexusFS._check_zone_writable() — kernel should not know
+    # about zone lifecycle.  PRE hooks on all mutating ops block writes
+    # to zones being deprovisioned.
+    _zl = getattr(nx._system_services, "zone_lifecycle", None) if nx._system_services else None
+    if _zl is not None:
+        from nexus.system_services.lifecycle.zone_writability_hook import ZoneWritabilityHook
+
+        await _enlist("zone_writability", ZoneWritabilityHook(_zl))
+
     # ── OBSERVE observers (Issue #900, #922) ──────────────────────────
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).
     # Replaces _publish_file_event() direct calls — single dispatch exit point.

--- a/src/nexus/system_services/lifecycle/zone_writability_hook.py
+++ b/src/nexus/system_services/lifecycle/zone_writability_hook.py
@@ -1,0 +1,87 @@
+"""Zone writability hook — gate all writes during zone deprovision (Issue #2061).
+
+Migrated from NexusFS._check_zone_writable() (Issue #1371):
+kernel should not know about zone lifecycle — this is a federation concern
+injected via KernelDispatch PRE hooks.
+
+When a zone is terminating (being deprovisioned), all write operations
+to that zone are blocked with ZoneTerminatingError. This prevents data
+corruption during the multi-step zone finalization process.
+
+Same pattern as PermissionEnforcerHook (#1706) and SnapshotWriteHook (#1774).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.protocols.service_hooks import HookSpec
+from nexus.contracts.protocols.service_lifecycle import HotSwappable
+
+if TYPE_CHECKING:
+    from nexus.contracts.vfs_hooks import (
+        DeleteHookContext,
+        MkdirHookContext,
+        RenameHookContext,
+        RmdirHookContext,
+        WriteHookContext,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class ZoneWritabilityHook(HotSwappable):
+    """PRE hook: block writes to zones being deprovisioned.
+
+    Registered on write, delete, rename, mkdir, rmdir — all mutating ops.
+    Raises ZoneTerminatingError if the zone is in finalization state.
+
+    No-op when zone_lifecycle service is not available (single-node deploy).
+    """
+
+    name = "zone_writability"
+    __slots__ = ("_zone_lifecycle",)
+
+    def __init__(self, zone_lifecycle: Any) -> None:
+        self._zone_lifecycle = zone_lifecycle
+
+    # --- HotSwappable protocol ---
+
+    def hook_spec(self) -> HookSpec:
+        return HookSpec(
+            write_hooks=(self,),
+            delete_hooks=(self,),
+            rename_hooks=(self,),
+            mkdir_hooks=(self,),
+            rmdir_hooks=(self,),
+        )
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    # --- PRE hooks (raise to abort) ---
+
+    def _check(self, zone_id: str | None) -> None:
+        if zone_id and self._zone_lifecycle.is_zone_terminating(zone_id):
+            from nexus.contracts.exceptions import ZoneTerminatingError
+
+            raise ZoneTerminatingError(zone_id)
+
+    def on_pre_write(self, ctx: WriteHookContext) -> None:
+        self._check(ctx.zone_id)
+
+    def on_pre_delete(self, ctx: DeleteHookContext) -> None:
+        self._check(ctx.zone_id)
+
+    def on_pre_rename(self, ctx: RenameHookContext) -> None:
+        self._check(ctx.zone_id)
+
+    def on_pre_mkdir(self, ctx: MkdirHookContext) -> None:
+        self._check(ctx.zone_id)
+
+    def on_pre_rmdir(self, ctx: RmdirHookContext) -> None:
+        self._check(ctx.zone_id)

--- a/tests/unit/services/test_zone_writability_hook.py
+++ b/tests/unit/services/test_zone_writability_hook.py
@@ -1,0 +1,74 @@
+"""Tests for ZoneWritabilityHook — PRE hook gating writes during zone deprovision."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.system_services.lifecycle.zone_writability_hook import ZoneWritabilityHook
+
+
+@pytest.fixture
+def zone_lifecycle():
+    zl = MagicMock()
+    zl.is_zone_terminating.return_value = False
+    return zl
+
+
+@pytest.fixture
+def hook(zone_lifecycle):
+    return ZoneWritabilityHook(zone_lifecycle)
+
+
+class TestZoneWritabilityHook:
+    def test_hook_spec_declares_all_mutating_ops(self, hook):
+        spec = hook.hook_spec()
+        assert len(spec.write_hooks) == 1
+        assert len(spec.delete_hooks) == 1
+        assert len(spec.rename_hooks) == 1
+        assert len(spec.mkdir_hooks) == 1
+        assert len(spec.rmdir_hooks) == 1
+        assert spec.read_hooks == ()
+
+    def test_pre_write_allows_normal_zone(self, hook):
+        ctx = MagicMock(zone_id="root")
+        hook.on_pre_write(ctx)  # should not raise
+
+    def test_pre_write_blocks_terminating_zone(self, hook, zone_lifecycle):
+        zone_lifecycle.is_zone_terminating.return_value = True
+        ctx = MagicMock(zone_id="doomed-zone")
+        with pytest.raises(Exception, match="doomed-zone"):
+            hook.on_pre_write(ctx)
+
+    def test_pre_delete_blocks_terminating_zone(self, hook, zone_lifecycle):
+        zone_lifecycle.is_zone_terminating.return_value = True
+        ctx = MagicMock(zone_id="doomed-zone")
+        with pytest.raises(Exception, match="doomed-zone"):
+            hook.on_pre_delete(ctx)
+
+    def test_pre_mkdir_blocks_terminating_zone(self, hook, zone_lifecycle):
+        zone_lifecycle.is_zone_terminating.return_value = True
+        ctx = MagicMock(zone_id="doomed-zone")
+        with pytest.raises(Exception, match="doomed-zone"):
+            hook.on_pre_mkdir(ctx)
+
+    def test_pre_rename_blocks_terminating_zone(self, hook, zone_lifecycle):
+        zone_lifecycle.is_zone_terminating.return_value = True
+        ctx = MagicMock(zone_id="doomed-zone")
+        with pytest.raises(Exception, match="doomed-zone"):
+            hook.on_pre_rename(ctx)
+
+    def test_pre_rmdir_blocks_terminating_zone(self, hook, zone_lifecycle):
+        zone_lifecycle.is_zone_terminating.return_value = True
+        ctx = MagicMock(zone_id="doomed-zone")
+        with pytest.raises(Exception, match="doomed-zone"):
+            hook.on_pre_rmdir(ctx)
+
+    def test_none_zone_id_is_noop(self, hook, zone_lifecycle):
+        zone_lifecycle.is_zone_terminating.return_value = True
+        ctx = MagicMock(zone_id=None)
+        hook.on_pre_write(ctx)  # should not raise — None zone_id is no-op
+
+    def test_empty_zone_id_is_noop(self, hook, zone_lifecycle):
+        zone_lifecycle.is_zone_terminating.return_value = True
+        ctx = MagicMock(zone_id="")
+        hook.on_pre_write(ctx)  # should not raise — empty zone_id is no-op


### PR DESCRIPTION
## Summary
- Migrate `_check_zone_writable()` from NexusFS kernel to `ZoneWritabilityHook` (KernelDispatch PRE hooks)
- Delete method + all 11 call sites from `nexus_fs.py`
- Register hook via orchestrator when `zone_lifecycle` service is available
- Without federation, no hook = no zone check = zero cost

## Design
Zone write-gating during deprovision (#2061) is a **federation concern** — kernel should not call zone_lifecycle directly. The hook implements `HotSwappable` and registers PRE hooks on all mutating ops (write, delete, rename, mkdir, rmdir).

Same pattern as PermissionEnforcerHook (#1706), SnapshotWriteHook (#1774), DeferredPermissionHook (#1775).

## Test plan
- [x] 9 unit tests for ZoneWritabilityHook (all ops + edge cases)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)