### PR TITLE
fix(#1790): migrate zone_lifecycle out of kernel via ZoneWriteGuardHook

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -371,6 +371,10 @@ class NexusFS(  # type: ignore[misc]
             )
         return context.zone_id, context.agent_id, getattr(context, "is_admin", self.is_admin)
 
+    # Issue #1790: _check_zone_writable() deleted — now handled by
+    # ZoneWriteGuardHook (pre-intercept on all write-like operations).
+    # Kernel no longer reads zone_lifecycle from _system_services.
+
     @property
     def zone_id(self) -> str | None:
         """Default zone_id from the instance context."""
@@ -4000,7 +4004,6 @@ class NexusFS(  # type: ignore[misc]
             ...     else:
             ...         print(f"Failed {path}: {result['error']}")
         """
-
         results = {}
         for path in paths:
             try:

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -421,6 +421,16 @@ async def _register_vfs_hooks(
         """Enlist hook via coordinator — the single entry point."""
         await _coordinator.enlist(name, hook)
 
+    # ── Zone write guard hook (Issue #1790) ────────────────────────
+    # Rejects writes to zones being deprovisioned (Issue #2061).
+    # Replaces _check_zone_writable() in nexus_fs — kernel no longer
+    # reads zone_lifecycle from _system_services.
+    _zl = getattr(nx._system_services, "zone_lifecycle", None) if nx._system_services else None
+    if _zl is not None:
+        from nexus.system_services.lifecycle.zone_write_guard_hook import ZoneWriteGuardHook
+
+        await _enlist("zone_write_guard", ZoneWriteGuardHook(zone_lifecycle=_zl))
+
     # ── Permission pre-intercept hook (Issue #899) ────────────────
     if permission_checker is not None:
         from nexus.bricks.rebac.permission_hook import PermissionCheckHook

--- a/src/nexus/system_services/lifecycle/zone_write_guard_hook.py
+++ b/src/nexus/system_services/lifecycle/zone_write_guard_hook.py
@@ -1,0 +1,115 @@
+"""ZoneWriteGuardHook — rejects writes to zones being deprovisioned.
+
+Issue #1790: Replaces _check_zone_writable() in nexus_fs.py.
+Kernel no longer reads zone_lifecycle from _system_services.
+
+Fires on ALL write-like pre-intercept phases (write, delete, rename,
+mkdir, rmdir) and raises ZoneTerminatingError if the target zone
+is being deprovisioned (Issue #2061, Decision #4A).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
+    from nexus.contracts.vfs_hooks import (
+        DeleteHookContext,
+        MkdirHookContext,
+        RenameHookContext,
+        RmdirHookContext,
+        WriteBatchHookContext,
+        WriteHookContext,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class ZoneWriteGuardHook:
+    """Pre-intercept hook that rejects writes to terminating zones.
+
+    Implements HotSwappable so it can be enlisted via coordinator.
+    Registered for all write-like operations.
+    """
+
+    # ── HotSwappable protocol ───────────────────────────────────────────
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(
+            write_hooks=(self,),
+            write_batch_hooks=(self,),
+            delete_hooks=(self,),
+            rename_hooks=(self,),
+            mkdir_hooks=(self,),
+            rmdir_hooks=(self,),
+        )
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    # ── Constructor ─────────────────────────────────────────────────────
+
+    def __init__(self, zone_lifecycle: Any) -> None:
+        self._zone_lifecycle = zone_lifecycle
+
+    # ── Zone check (shared logic) ───────────────────────────────────────
+
+    def _check(self, context: Any) -> None:
+        """Raise ZoneTerminatingError if context's zone is being deprovisioned."""
+        if context is None:
+            return
+        zone_id = getattr(context, "zone_id", None)
+        if zone_id and self._zone_lifecycle.is_zone_terminating(zone_id):
+            from nexus.contracts.exceptions import ZoneTerminatingError
+
+            raise ZoneTerminatingError(zone_id)
+
+    # ── Pre-intercept hooks (all write-like ops) ────────────────────────
+
+    def on_pre_write(self, ctx: "WriteHookContext") -> None:
+        self._check(ctx.context)
+
+    def on_post_write(self, ctx: "WriteHookContext") -> None:
+        pass
+
+    def on_pre_write_batch(self, ctx: "WriteBatchHookContext") -> None:
+        # WriteBatchHookContext has zone_id directly, not a context object
+        zone_id = ctx.zone_id
+        if zone_id and self._zone_lifecycle.is_zone_terminating(zone_id):
+            from nexus.contracts.exceptions import ZoneTerminatingError
+
+            raise ZoneTerminatingError(zone_id)
+
+    def on_post_write_batch(self, ctx: "WriteBatchHookContext") -> None:
+        pass
+
+    def on_pre_delete(self, ctx: "DeleteHookContext") -> None:
+        self._check(ctx.context)
+
+    def on_post_delete(self, ctx: "DeleteHookContext") -> None:
+        pass
+
+    def on_pre_rename(self, ctx: "RenameHookContext") -> None:
+        self._check(ctx.context)
+
+    def on_post_rename(self, ctx: "RenameHookContext") -> None:
+        pass
+
+    def on_pre_mkdir(self, ctx: "MkdirHookContext") -> None:
+        self._check(ctx.context)
+
+    def on_post_mkdir(self, ctx: "MkdirHookContext") -> None:
+        pass
+
+    def on_pre_rmdir(self, ctx: "RmdirHookContext") -> None:
+        self._check(ctx.context)
+
+    def on_post_rmdir(self, ctx: "RmdirHookContext") -> None:
+        pass


### PR DESCRIPTION
## Summary

Kernel no longer accesses `zone_lifecycle` from `_system_services`. A new `ZoneWriteGuardHook` (HotSwappable Q2) replaces `_check_zone_writable()`.

**What**: Zone write-gating during zone deprovision (Issue #2061 Decision #4A). If a zone is being terminated, all write operations are rejected with `ZoneTerminatingError`.

**How**:
- New `system_services/lifecycle/zone_write_guard_hook.py` — pre-intercept on write/delete/rename/mkdir/rmdir
- `nexus_fs.py`: delete `_check_zone_writable()` method + all 9 call sites + remove dead `ctx` variable
- `orchestrator.py`: enlist `ZoneWriteGuardHook` when `zone_lifecycle` is available
- Factory `_lifecycle.py` bootstrap callback stays (it's factory code, reads from factory-local `_sys`)

**Net**: one fewer `_system_services` read in kernel, moving toward #1771 vision.

## Test plan
- [x] `uv run pytest tests/unit/` — 10935 passed
- [x] All hooks pass (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)