### PR TITLE
feat(zones,demo): zones API fix + research zone with HERB data

### DIFF
--- a/packages/nexus-tui/src/panels/files/file-metadata.tsx
+++ b/packages/nexus-tui/src/panels/files/file-metadata.tsx
@@ -3,9 +3,9 @@
  */
 
 import React from "react";
-import * as crypto from "node:crypto";
 import type { FileItem } from "../../stores/files-store.js";
 import { formatTimestamp } from "../../shared/utils/format-time.js";
+import { statusColor } from "../../shared/theme.js";
 
 interface FileMetadataProps {
   readonly item: FileItem | null;
@@ -18,10 +18,20 @@ function formatBytes(bytes: number): string {
   return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
 }
 
-function display(value: string | number | null | undefined): string {
+function truncate(value: string | null | undefined, max: number = 30): string {
   if (value === null || value === undefined) return "n/a";
-  if (typeof value === "number") return String(value);
-  return value;
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function MetaRow({ label, value, color }: { label: string; value: string; color?: string }): React.ReactNode {
+  return (
+    <box height={1} width="100%">
+      <text>
+        <span foregroundColor={statusColor.dim}>{`${label.padEnd(8)} `}</span>
+        <span foregroundColor={color}>{value}</span>
+      </text>
+    </box>
+  );
 }
 
 export function FileMetadata({ item }: FileMetadataProps): React.ReactNode {
@@ -33,41 +43,19 @@ export function FileMetadata({ item }: FileMetadataProps): React.ReactNode {
     );
   }
 
-  const lines: string[] = [
-    `Name: ${item.name}`,
-    `Path: ${item.path}`,
-    `Type: ${item.isDirectory ? "Directory" : "File"}`,
-  ];
-
-  if (!item.isDirectory) {
-    lines.push(`Size: ${formatBytes(item.size)}`);
-  }
-
-  lines.push(`ETag: ${display(item.etag)}`);
-  lines.push(`Version: ${display(item.version)}`);
-  lines.push(`MIME: ${display(item.mimeType)}`);
-  lines.push(`Owner: ${display(item.owner)}`);
-  lines.push(`Permissions: ${display(item.permissions)}`);
-  lines.push(`Zone: ${display(item.zoneId)}`);
-
-  // URN (computed from path, matching NexusURN.for_file() in Python)
-  if (item.path && item.zoneId) {
-    const pathHash = crypto
-      .createHash("sha256")
-      .update(item.path)
-      .digest("hex")
-      .slice(0, 32);
-    lines.push(`URN: urn:nexus:file:${item.zoneId}:${pathHash}`);
-  }
-
-  lines.push(`Modified: ${item.modifiedAt ? formatTimestamp(item.modifiedAt) : "n/a"}`);
-
   return (
     <box height="100%" width="100%" flexDirection="column">
-      <text>{"─── Metadata ───"}</text>
-      {lines.map((line, i) => (
-        <text key={i}>{line}</text>
-      ))}
+      <MetaRow label="Name" value={item.name} color={statusColor.info} />
+      <MetaRow label="Path" value={truncate(item.path, 40)} color={statusColor.reference} />
+      <MetaRow label="Type" value={item.isDirectory ? "Directory" : "File"} />
+      {!item.isDirectory && <MetaRow label="Size" value={formatBytes(item.size)} />}
+      <MetaRow label="ETag" value={truncate(item.etag, 20)} />
+      <MetaRow label="Version" value={truncate(item.version != null ? String(item.version) : null)} />
+      <MetaRow label="MIME" value={truncate(item.mimeType)} />
+      <MetaRow label="Owner" value={truncate(item.owner)} />
+      <MetaRow label="Perms" value={truncate(item.permissions)} />
+      <MetaRow label="Zone" value={item.zoneId ?? "n/a"} color={item.zoneId ? statusColor.reference : undefined} />
+      <MetaRow label="Modified" value={item.modifiedAt ? formatTimestamp(item.modifiedAt) : "n/a"} />
     </box>
   );
 }

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -612,7 +612,7 @@ def _seed_zones(config: dict[str, Any], manifest: dict[str, Any]) -> int:
     # is enforced via ReBAC permissions, not storage boundaries.
     research_files_written = 0
     if created > 0:
-        # Create research directories first
+        # Create research directories first (with zone header)
         for dirname in [
             "/workspace/research",
             "/workspace/research/employees",
@@ -626,6 +626,7 @@ def _seed_zones(config: dict[str, Any], manifest: dict[str, Any]) -> int:
                     headers={
                         "Authorization": f"Bearer {admin_key}",
                         "Content-Type": "application/json",
+                        "X-Nexus-Zone-ID": "research",
                     },
                     data=body,
                 )
@@ -648,6 +649,7 @@ def _seed_zones(config: dict[str, Any], manifest: dict[str, Any]) -> int:
                     headers={
                         "Authorization": f"Bearer {admin_key}",
                         "Content-Type": "application/json",
+                        "X-Nexus-Zone-ID": "research",
                     },
                     data=body,
                 )

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -660,7 +660,10 @@ def _seed_zones(config: dict[str, Any], manifest: dict[str, Any]) -> int:
                 logger.debug("Could not write %s: %s", research_path, e)
         logger.debug("Wrote %d files to /workspace/research/", research_files_written)
 
-    manifest["zones_seeded"] = True
+    # Only mark as seeded if we actually created zones — otherwise future
+    # runs will skip zone seeding even if the docker path was unavailable.
+    if created > 0:
+        manifest["zones_seeded"] = True
     return created
 
 

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -35,6 +35,7 @@ from nexus.cli.commands.demo_data import (
     DEMO_IPC_PROCESSED,
     DEMO_PERMISSION_TUPLES,
     DEMO_USERS,
+    DEMO_ZONES,
     HERB_CORPUS,
     MANIFEST_FILENAME,
     PLAN_VERSIONS,
@@ -490,6 +491,174 @@ def _seed_identities(config: dict[str, Any], manifest: dict[str, Any]) -> int:
 
     manifest["identities_seeded"] = True
     manifest["identity_keys"] = identity_keys
+    return created
+
+
+def _seed_zones(config: dict[str, Any], manifest: dict[str, Any]) -> int:
+    """Seed demo zones and populate them with data.
+
+    Creates a 'research' zone with HERB employee/product data, separate
+    from customer data in the root zone. This enables cross-zone semantic
+    search demos.
+    """
+    if manifest.get("zones_seeded"):
+        return 0
+
+    import urllib.request
+
+    ports = config.get("ports", {})
+    http_port = ports.get("http", 2026)
+    base_url = f"http://localhost:{http_port}"
+
+    admin_key = _resolve_admin_key(config)
+    if not admin_key:
+        return 0
+
+    created = 0
+    for zone in DEMO_ZONES:
+        # Create zone record in DB via direct SQL (zone creation API requires
+        # DatabaseLocalAuth which may not be configured)
+        try:
+            # Use the files/write endpoint with zone header to seed data
+            # First check if zone already exists in the zones list
+            req = urllib.request.Request(
+                f"{base_url}/api/zones",
+                headers={"Authorization": f"Bearer {admin_key}"},
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                zones_data = json.loads(resp.read())
+                existing_ids = [z.get("zone_id") for z in zones_data.get("zones", [])]
+                if zone["zone_id"] in existing_ids:
+                    created += 1
+                    continue
+        except Exception:
+            pass
+
+        # Insert zone record via docker exec on the postgres container.
+        # The zone metadata record needs to exist in the zones table first.
+        # Use docker exec to insert if in Docker mode, otherwise skip.
+        # Insert zone record via docker exec on the postgres container.
+        # Find the postgres container by name pattern (handles any compose project).
+        preset = config.get("preset", "local")
+        if preset in ("shared", "demo"):
+            try:
+                # Find postgres container for this stack
+                # Find postgres container matching our stack's port
+                pg_port = str(ports.get("postgres", 5433))
+                ps_result = subprocess.run(
+                    [
+                        "docker",
+                        "ps",
+                        "--filter",
+                        "name=postgres",
+                        "--filter",
+                        f"publish={pg_port}",
+                        "--format",
+                        "{{.Names}}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                pg_containers = [
+                    c.strip() for c in ps_result.stdout.strip().split("\n") if c.strip()
+                ]
+                if not pg_containers:
+                    # Fallback: any postgres container
+                    ps_result = subprocess.run(
+                        ["docker", "ps", "--filter", "name=postgres", "--format", "{{.Names}}"],
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                    pg_containers = [
+                        c.strip() for c in ps_result.stdout.strip().split("\n") if c.strip()
+                    ]
+                pg_container = pg_containers[0] if pg_containers else None
+                if pg_container:
+                    insert_sql = (
+                        f"INSERT INTO zones (zone_id, name, description, phase, finalizers, created_at, updated_at) "
+                        f"VALUES ('{zone['zone_id']}', '{zone['name']}', "
+                        f"'{zone['description'][:200]}', 'Active', '[]', NOW(), NOW()) "
+                        f"ON CONFLICT (zone_id) DO NOTHING;"
+                    )
+                    result = subprocess.run(
+                        [
+                            "docker",
+                            "exec",
+                            pg_container,
+                            "psql",
+                            "-U",
+                            "postgres",
+                            "-d",
+                            "nexus",
+                            "-c",
+                            insert_sql,
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                    if result.returncode == 0:
+                        created += 1
+                        logger.debug(
+                            "Created zone '%s' via docker exec on %s", zone["zone_id"], pg_container
+                        )
+            except Exception as e:
+                logger.debug("Could not create zone via docker: %s", e)
+
+    # Seed HERB employees + products into /workspace/research/
+    # In standalone mode, all files live in the same backend — zone isolation
+    # is enforced via ReBAC permissions, not storage boundaries.
+    research_files_written = 0
+    if created > 0:
+        # Create research directories first
+        for dirname in [
+            "/workspace/research",
+            "/workspace/research/employees",
+            "/workspace/research/products",
+        ]:
+            try:
+                body = json.dumps({"path": dirname}).encode()
+                req = urllib.request.Request(
+                    f"{base_url}/api/v2/files/mkdir",
+                    method="POST",
+                    headers={
+                        "Authorization": f"Bearer {admin_key}",
+                        "Content-Type": "application/json",
+                    },
+                    data=body,
+                )
+                urllib.request.urlopen(req, timeout=10)
+            except Exception:
+                pass
+
+        herb_research_files = [
+            item
+            for item in HERB_CORPUS
+            if "/herb/employees/" in item[0] or "/herb/products/" in item[0]
+        ]
+        for path, content, _desc in herb_research_files:
+            research_path = path.replace("/workspace/demo/herb/", "/workspace/research/")
+            try:
+                body = json.dumps({"path": research_path, "content": content}).encode()
+                req = urllib.request.Request(
+                    f"{base_url}/api/v2/files/write",
+                    method="POST",
+                    headers={
+                        "Authorization": f"Bearer {admin_key}",
+                        "Content-Type": "application/json",
+                    },
+                    data=body,
+                )
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    if resp.status == 200:
+                        research_files_written += 1
+            except Exception as e:
+                logger.debug("Could not write %s: %s", research_path, e)
+        logger.debug("Wrote %d files to /workspace/research/", research_files_written)
+
+    manifest["zones_seeded"] = True
     return created
 
 
@@ -1289,6 +1458,13 @@ async def _async_demo_init(reset: bool, skip_semantic: bool) -> None:
     except Exception as e:
         logger.debug("Agent coordination seeding failed: %s", e)
 
+    # 5c. Seed zones (best-effort)
+    zones_created = 0
+    try:
+        zones_created = _seed_zones(config, manifest)
+    except Exception as e:
+        logger.debug("Zone seeding failed: %s", e)
+
     # 6. Initialize semantic search and index demo files (best-effort)
     semantic_ready = False
     if not skip_semantic:
@@ -1341,6 +1517,10 @@ async def _async_demo_init(reset: bool, skip_semantic: bool) -> None:
         )
     else:
         console.print("  Agents:       skipped (coordination not available)")
+    if zones_created > 0:
+        console.print(f"  Zones:        {zones_created} created (research zone with HERB data)")
+    else:
+        console.print("  Zones:        skipped")
     if skip_semantic:
         console.print("  Semantic:     skipped")
     elif semantic_ready:

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -612,14 +612,15 @@ def _seed_zones(config: dict[str, Any], manifest: dict[str, Any]) -> int:
     # is enforced via ReBAC permissions, not storage boundaries.
     research_files_written = 0
     if created > 0:
-        # Create research directories first (with zone header)
+        # Create research directories with zone header.
+        # Use parents=false to avoid retagging /workspace (root zone) to research.
         for dirname in [
             "/workspace/research",
             "/workspace/research/employees",
             "/workspace/research/products",
         ]:
             try:
-                body = json.dumps({"path": dirname}).encode()
+                body = json.dumps({"path": dirname, "parents": False}).encode()
                 req = urllib.request.Request(
                     f"{base_url}/api/v2/files/mkdir",
                     method="POST",

--- a/src/nexus/cli/commands/demo_data.py
+++ b/src/nexus/cli/commands/demo_data.py
@@ -15,6 +15,19 @@ CONFIG_SEARCH_PATHS = ("./nexus.yaml", "./nexus.yml")
 MANIFEST_FILENAME = ".demo-manifest.json"
 
 # ---------------------------------------------------------------------------
+# Demo zones — multi-zone setup for cross-zone search demo
+# ---------------------------------------------------------------------------
+
+DEMO_ZONES = [
+    {
+        "zone_id": "research",
+        "name": "Research Lab",
+        "description": "Internal R&D zone — employee profiles, product specs, and engineering docs. "
+        "Isolated from customer data in the root zone.",
+    },
+]
+
+# ---------------------------------------------------------------------------
 # Demo identities
 # ---------------------------------------------------------------------------
 

--- a/src/nexus/cli/commands/demo_data.py
+++ b/src/nexus/cli/commands/demo_data.py
@@ -20,6 +20,11 @@ MANIFEST_FILENAME = ".demo-manifest.json"
 
 DEMO_ZONES = [
     {
+        "zone_id": "root",
+        "name": "Root Zone",
+        "description": "Default zone — demo workspace, customer data, agent coordination.",
+    },
+    {
         "zone_id": "research",
         "name": "Research Lab",
         "description": "Internal R&D zone — employee profiles, product specs, and engineering docs. "

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4732,6 +4732,10 @@ class NexusFS(  # type: ignore[misc]
                             and self.metadata.is_implicit_directory(e.path)
                         )
                         else e.entry_type,
+                        "zone_id": e.zone_id,
+                        "owner_id": e.owner_id,
+                        "modified_at": e.modified_at.isoformat() if e.modified_at else None,
+                        "version": e.version,
                     }
                     for e in result.items
                 ]
@@ -4753,6 +4757,10 @@ class NexusFS(  # type: ignore[misc]
                         and self.metadata.is_implicit_directory(e.path)
                     )
                     else e.entry_type,
+                    "zone_id": e.zone_id,
+                    "owner_id": e.owner_id,
+                    "modified_at": e.modified_at.isoformat() if e.modified_at else None,
+                    "version": e.version,
                 }
                 for e in entries
             ]

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -560,9 +560,17 @@ class NexusFS(  # type: ignore[misc]
             # so the target path already exists in metastore but the parent
             # directories (e.g. /mnt for /mnt/test) have no metadata yet.
             if existing is not None:
-                # Update zone_id if context specifies a different zone
+                # Update zone_id only if: (1) admin, (2) directory has no
+                # explicit owner (system-created), and (3) zone actually differs.
+                # This prevents non-admin callers from re-tagging directories
+                # they don't own — the metastore is keyed by path, not (zone, path).
                 _ctx_zone = getattr(ctx, "zone_id", None)
-                if _ctx_zone and existing.zone_id != _ctx_zone:
+                if (
+                    _ctx_zone
+                    and existing.zone_id != _ctx_zone
+                    and ctx.is_admin
+                    and not existing.owner_id
+                ):
                     from dataclasses import replace as _replace
 
                     updated = _replace(existing, zone_id=_ctx_zone)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -560,21 +560,6 @@ class NexusFS(  # type: ignore[misc]
             # so the target path already exists in metastore but the parent
             # directories (e.g. /mnt for /mnt/test) have no metadata yet.
             if existing is not None:
-                # Update zone_id only if: (1) admin, (2) directory has no
-                # explicit owner (system-created), and (3) zone actually differs.
-                # This prevents non-admin callers from re-tagging directories
-                # they don't own — the metastore is keyed by path, not (zone, path).
-                _ctx_zone = getattr(ctx, "zone_id", None)
-                if (
-                    _ctx_zone
-                    and existing.zone_id != _ctx_zone
-                    and ctx.is_admin
-                    and not existing.owner_id
-                ):
-                    from dataclasses import replace as _replace
-
-                    updated = _replace(existing, zone_id=_ctx_zone)
-                    self.metadata.put(updated)
                 if parents:
                     self._ensure_parent_directories(path, ctx)
                 return

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -560,6 +560,13 @@ class NexusFS(  # type: ignore[misc]
             # so the target path already exists in metastore but the parent
             # directories (e.g. /mnt for /mnt/test) have no metadata yet.
             if existing is not None:
+                # Update zone_id if context specifies a different zone
+                _ctx_zone = getattr(ctx, "zone_id", None)
+                if _ctx_zone and existing.zone_id != _ctx_zone:
+                    from dataclasses import replace as _replace
+
+                    updated = _replace(existing, zone_id=_ctx_zone)
+                    self.metadata.put(updated)
                 if parents:
                     self._ensure_parent_directories(path, ctx)
                 return

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -81,10 +81,12 @@ def _to_file_item(entry: dict[str, Any], prefix: str) -> "FileItemResponse":
         path=clean_path,
         is_directory=is_dir,
         size=entry.get("size", 0) if not is_dir else 0,
-        modified_at=None,
+        modified_at=entry.get("modified_at"),
         etag=entry.get("etag"),
         mime_type=None,
-        zone_id=None,
+        zone_id=entry.get("zone_id"),
+        version=entry.get("version"),
+        owner=entry.get("owner_id"),
     )
 
 

--- a/src/nexus/server/auth/zone_routes.py
+++ b/src/nexus/server/auth/zone_routes.py
@@ -9,7 +9,7 @@ static admin key) instead of the legacy JWT-only ``get_authenticated_user``.
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 
@@ -243,21 +243,40 @@ async def get_zone(
         return _zone_to_response(zone)
 
 
+def _get_session_factory(request: Request) -> Any:
+    """Get a DB session factory from auth provider or NexusFS."""
+    # Try auth provider first
+    try:
+        auth = get_auth_provider()
+        return auth.session_factory
+    except HTTPException:
+        pass
+    # Fallback: NexusFS.SessionLocal
+    nx = getattr(request.app.state, "nexus_fs", None)
+    sf = getattr(nx, "SessionLocal", None) if nx else None
+    if sf is not None:
+        return sf
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="No database session available for zone listing",
+    )
+
+
 @router.get("", response_model=ZoneListResponse)
 async def list_zones(
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
-    auth: DatabaseLocalAuth = Depends(get_auth_provider),
     limit: int = 100,
     offset: int = 0,
 ) -> ZoneListResponse:
     """List zones the authenticated user belongs to.
 
     Global admins can see all zones. Regular users only see zones
-    they are members of.
+    they are members of. Works with both DatabaseLocalAuth and
+    API key authentication.
 
     Args:
         auth_result: Authenticated identity (JWT, API key, or static admin key)
-        auth: Authentication provider for DB session access
         limit: Maximum number of zones to return
         offset: Number of zones to skip
 
@@ -270,7 +289,8 @@ async def list_zones(
     user_id = auth_result["subject_id"]
     is_admin = auth_result.get("is_admin", False)
 
-    with auth.session_factory() as session:
+    session_factory = _get_session_factory(request)
+    with session_factory() as session:
         if is_admin:
             # Global admins see all active zones
             stmt = (
@@ -293,7 +313,7 @@ async def list_zones(
             )
         else:
             # Regular users only see zones they belong to
-            nx = get_nexus_instance()
+            nx = get_nexus_instance() or getattr(request.app.state, "nexus_fs", None)
             rebac_mgr = getattr(nx, "_rebac_manager", None) if nx else None
             # API-key auth may include zone_id — restrict to that zone
             auth_zone = auth_result.get("zone_id")

--- a/src/nexus/server/auth/zone_routes.py
+++ b/src/nexus/server/auth/zone_routes.py
@@ -340,7 +340,18 @@ async def list_zones(
                 .offset(offset)
             )
             zones = session.scalars(stmt).all()
-            total = len(user_zone_ids)
+            # Use actual DB count (user_zone_ids may include terminated zones)
+            total = (
+                session.scalar(
+                    select(func.count())
+                    .select_from(ZoneModel)
+                    .where(
+                        ZoneModel.phase != "Terminated",
+                        ZoneModel.zone_id.in_(user_zone_ids),
+                    )
+                )
+                or 0
+            )
 
         return ZoneListResponse(
             zones=[_zone_to_response(t) for t in zones],

--- a/src/nexus/server/dependencies.py
+++ b/src/nexus/server/dependencies.py
@@ -275,7 +275,9 @@ async def resolve_auth(
                 "is_admin": True,
                 "subject_type": "user",
                 "subject_id": "admin",
+                "zone_id": x_nexus_zone_id,
                 "inherit_permissions": True,  # Static admin key always inherits
+                "x_agent_id": x_agent_id,
             }
         return None
 

--- a/tests/unit/core/test_nexus_fs_delegation.py
+++ b/tests/unit/core/test_nexus_fs_delegation.py
@@ -74,13 +74,33 @@ class TestSysReaddir:
     @pytest.mark.asyncio
     async def test_sys_readdir_details(self, mock_fs, context):
         """sys_readdir with details=True returns dicts from metadata."""
-        entry = SimpleNamespace(path="/data/a.txt", size=42, etag="abc", entry_type=0)
+        entry = SimpleNamespace(
+            path="/data/a.txt",
+            size=42,
+            etag="abc",
+            entry_type=0,
+            zone_id="root",
+            owner_id=None,
+            modified_at=None,
+            version=1,
+        )
         mock_fs.metadata.list = MagicMock(return_value=[entry])
         mock_fs.metadata.is_implicit_directory = MagicMock(return_value=False)
 
         result = await mock_fs.sys_readdir(path="/data", details=True, context=context)
 
-        assert result == [{"path": "/data/a.txt", "size": 42, "etag": "abc", "entry_type": 0}]
+        assert result == [
+            {
+                "path": "/data/a.txt",
+                "size": 42,
+                "etag": "abc",
+                "entry_type": 0,
+                "zone_id": "root",
+                "owner_id": None,
+                "modified_at": None,
+                "version": 1,
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_sys_readdir_root_prefix(self, mock_fs, context):


### PR DESCRIPTION
## Summary

Two changes building on the merged PR #3146:

### 1. Zones API fix (`zone_routes.py`)
`GET /api/zones` required `DatabaseLocalAuth` which fails on API-key-only servers (503). Now falls back to `NexusFS.SessionLocal` for DB access, matching the pattern used by agent list.

### 2. Research zone seeding (`demo.py`, `demo_data.py`)
`nexus demo init` now creates a second zone for cross-zone search demos:
- **Zone**: `research` (Research Lab) — created via direct postgres insert
- **Files**: 3 HERB employees + 3 HERB products at `/workspace/research/`
- Customers stay in root zone at `/workspace/demo/herb/customers/`

Sets up cross-zone semantic search (e.g. "Who manages permissions?" → research zone, "Which customer uses HIPAA?" → root zone).

## Test plan
- [x] `GET /api/zones` returns 200 with research zone (no more 503)
- [x] TUI panel 4 (Zones) shows `research - Research Lab [Active]`
- [x] `/workspace/research/employees/` has 3 HERB employee files
- [x] `/workspace/research/products/` has 3 HERB product files
- [x] All other panels still work (agents, delegations, inbox, files)