### PR TITLE
fix(#1795): remove self._zone_id from PipeManager/StreamManager constructors

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -194,12 +194,10 @@ class NexusFS(  # type: ignore[misc]
         _ipc_self_addr = _os_ipc.environ.get("NEXUS_ADVERTISE_ADDR")
         self._pipe_manager = PipeManager(
             metadata_store,
-            zone_id=ROOT_ZONE_ID,
             self_address=_ipc_self_addr,
         )
         self._stream_manager = StreamManager(
             metadata_store,
-            zone_id=ROOT_ZONE_ID,
             self_address=_ipc_self_addr,
         )
         logger.info(

--- a/src/nexus/core/pipe_manager.py
+++ b/src/nexus/core/pipe_manager.py
@@ -68,11 +68,9 @@ class PipeManager:
     def __init__(
         self,
         metastore: "MetastoreABC",
-        zone_id: str = ROOT_ZONE_ID,
         self_address: str | None = None,
     ) -> None:
         self._metastore = metastore
-        self._zone_id = zone_id
         self._self_address = self_address
         self._buffers: dict[str, PipeBackend] = {}
         self._locks: dict[str, asyncio.Lock] = {}
@@ -88,6 +86,7 @@ class PipeManager:
         *,
         capacity: int = 65_536,
         owner_id: str | None = None,
+        zone_id: str = ROOT_ZONE_ID,
     ) -> RingBuffer:
         """Create a new named pipe at the given VFS path.
 
@@ -124,7 +123,7 @@ class PipeManager:
             physical_path="mem://",
             size=capacity,
             entry_type=DT_PIPE,
-            zone_id=self._zone_id,
+            zone_id=zone_id,
             owner_id=owner_id,
         )
         self._metastore.put(metadata)
@@ -177,6 +176,7 @@ class PipeManager:
         backend: PipeBackend,
         *,
         owner_id: str | None = None,
+        zone_id: str = ROOT_ZONE_ID,
     ) -> PipeBackend:
         """Create a named pipe backed by an external PipeBackend.
 
@@ -214,7 +214,7 @@ class PipeManager:
             physical_path="mem://",
             size=0,
             entry_type=DT_PIPE,
-            zone_id=self._zone_id,
+            zone_id=zone_id,
             owner_id=owner_id,
         )
         self._metastore.put(metadata)

--- a/src/nexus/core/stream_manager.py
+++ b/src/nexus/core/stream_manager.py
@@ -61,11 +61,9 @@ class StreamManager:
     def __init__(
         self,
         metastore: "MetastoreABC",
-        zone_id: str = ROOT_ZONE_ID,
         self_address: str | None = None,
     ) -> None:
         self._metastore = metastore
-        self._zone_id = zone_id
         self._self_address = self_address
         self._buffers: dict[str, StreamBackend] = {}
         self._locks: dict[str, asyncio.Lock] = {}
@@ -81,6 +79,7 @@ class StreamManager:
         *,
         capacity: int = 65_536,
         owner_id: str | None = None,
+        zone_id: str = ROOT_ZONE_ID,
     ) -> StreamBuffer:
         """Create a new named stream at the given VFS path.
 
@@ -117,7 +116,7 @@ class StreamManager:
             physical_path="mem://",
             size=capacity,
             entry_type=DT_STREAM,
-            zone_id=self._zone_id,
+            zone_id=zone_id,
             owner_id=owner_id,
         )
         self._metastore.put(metadata)
@@ -170,6 +169,7 @@ class StreamManager:
         backend: StreamBackend,
         *,
         owner_id: str | None = None,
+        zone_id: str = ROOT_ZONE_ID,
     ) -> StreamBackend:
         """Create a named stream backed by an external StreamBackend.
 
@@ -207,7 +207,7 @@ class StreamManager:
             physical_path="mem://",
             size=0,
             entry_type=DT_STREAM,
-            zone_id=self._zone_id,
+            zone_id=zone_id,
             owner_id=owner_id,
         )
         self._metastore.put(metadata)

--- a/tests/unit/core/test_pipe.py
+++ b/tests/unit/core/test_pipe.py
@@ -305,11 +305,13 @@ class MockMetastore:
 class TestPipeManager:
     def _make_manager(self) -> tuple[PipeManager, MockMetastore]:
         ms = MockMetastore()
-        return PipeManager(ms, zone_id="test-zone"), ms
+        return PipeManager(ms), ms
 
     def test_create_pipe(self) -> None:
         mgr, ms = self._make_manager()
-        buf = mgr.create("/nexus/pipes/test", capacity=4096, owner_id="agent-1")
+        buf = mgr.create(
+            "/nexus/pipes/test", capacity=4096, owner_id="agent-1", zone_id="test-zone"
+        )
 
         assert isinstance(buf, RingBuffer)
         assert buf.stats["capacity"] == 4096
@@ -679,7 +681,7 @@ class TestRingBufferU64:
 class TestPipeManagerMPMC:
     def _make_manager(self) -> tuple[PipeManager, MockMetastore]:
         ms = MockMetastore()
-        return PipeManager(ms, zone_id="test-zone"), ms
+        return PipeManager(ms), ms
 
     @pytest.mark.asyncio
     async def test_concurrent_writers(self) -> None:
@@ -827,7 +829,7 @@ class TestSysSetAttrUpsert:
 
     def _make_manager(self) -> tuple[PipeManager, MockMetastore]:
         ms = MockMetastore()
-        return PipeManager(ms, zone_id="test-zone"), ms
+        return PipeManager(ms), ms
 
     def test_setattr_create_pipe(self) -> None:
         """sys_setattr with entry_type=DT_PIPE creates a pipe (replaces sys_mkpipe)."""

--- a/tests/unit/core/test_pipe_consumers.py
+++ b/tests/unit/core/test_pipe_consumers.py
@@ -70,7 +70,7 @@ class TestZoektPipeConsumerE2E:
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         # Mock ZoektIndexManager
         zoekt = MagicMock()
@@ -100,7 +100,7 @@ class TestZoektPipeConsumerE2E:
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 0.05
@@ -123,7 +123,7 @@ class TestZoektPipeConsumerE2E:
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 0.1
@@ -168,7 +168,7 @@ class TestZoektPipeConsumerE2E:
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 0.5  # Long debounce
@@ -192,7 +192,7 @@ class TestZoektPipeConsumerE2E:
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 10  # Very long debounce — consumer won't drain
@@ -245,7 +245,7 @@ class TestPipedWriteObserverE2E:
         )
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         observer = PipedRecordStoreWriteObserver(MagicMock())
         observer.set_pipe_manager(pm)
@@ -279,7 +279,7 @@ class TestPipedWriteObserverE2E:
         )
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         observer = PipedRecordStoreWriteObserver(MagicMock())
         observer.set_pipe_manager(pm)
@@ -319,7 +319,7 @@ class TestPipedWriteObserverE2E:
         )
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         observer = PipedRecordStoreWriteObserver(MagicMock())
         observer.set_pipe_manager(pm)
@@ -347,7 +347,7 @@ class TestPipedWriteObserverE2E:
         )
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         observer = PipedRecordStoreWriteObserver(MagicMock())
 
@@ -425,7 +425,7 @@ class TestPipedWriteObserverE2E:
         )
 
         ms = MockMetastore()
-        pm = PipeManager(ms, zone_id="test-zone")
+        pm = PipeManager(ms)
 
         observer = PipedRecordStoreWriteObserver(MagicMock())
         observer.set_pipe_manager(pm)

--- a/tests/unit/core/test_pipe_dispatch.py
+++ b/tests/unit/core/test_pipe_dispatch.py
@@ -56,7 +56,7 @@ class TestPathRouterPipeRoute:
     def test_pipe_path_returns_pipe_route_result(self) -> None:
         ms = MockMetastore()
         router = PathRouter(ms)
-        mgr = PipeManager(ms, zone_id="test-zone")
+        mgr = PipeManager(ms)
         mgr.create("/pipes/inbox", capacity=1024)
 
         result = router.route("/pipes/inbox")
@@ -91,7 +91,7 @@ class TestPathRouterPipeRoute:
         """DT_PIPE only matches at exact target path, not parent paths."""
         ms = MockMetastore()
         router = PathRouter(ms)
-        mgr = PipeManager(ms, zone_id="test-zone")
+        mgr = PipeManager(ms)
         mgr.create("/pipes/inbox", capacity=1024)
 
         # /pipes/inbox is a pipe
@@ -113,7 +113,7 @@ class TestPathRouterPipeRoute:
 class TestPipeReadWrite:
     def test_pipe_write_then_read(self) -> None:
         ms = MockMetastore()
-        mgr = PipeManager(ms, zone_id="test-zone")
+        mgr = PipeManager(ms)
         buf = mgr.create("/pipes/roundtrip", capacity=1024)
 
         mgr.pipe_write_nowait("/pipes/roundtrip", b"hello")
@@ -122,7 +122,7 @@ class TestPipeReadWrite:
 
     def test_pipe_write_full_raises(self) -> None:
         ms = MockMetastore()
-        mgr = PipeManager(ms, zone_id="test-zone")
+        mgr = PipeManager(ms)
         mgr.create("/pipes/tiny", capacity=10)
         mgr.pipe_write_nowait("/pipes/tiny", b"x" * 10)
 
@@ -131,7 +131,7 @@ class TestPipeReadWrite:
 
     def test_pipe_destroy(self) -> None:
         ms = MockMetastore()
-        mgr = PipeManager(ms, zone_id="test-zone")
+        mgr = PipeManager(ms)
         buf = mgr.create("/pipes/delme", capacity=1024)
 
         mgr.destroy("/pipes/delme")

--- a/tests/unit/core/test_stream.py
+++ b/tests/unit/core/test_stream.py
@@ -250,7 +250,7 @@ class TestStreamManager:
 
         from nexus.core.stream_manager import StreamManager
 
-        return StreamManager(mock, zone_id="root", self_address=None)
+        return StreamManager(mock, self_address=None)
 
     def test_create_and_read(self, manager):
         buf = manager.create("/streams/test", capacity=1024)
@@ -474,7 +474,7 @@ class TestStreamManagerBlockingRead:
 
         from nexus.core.stream_manager import StreamManager
 
-        return StreamManager(mock, zone_id="root")
+        return StreamManager(mock)
 
     async def test_stream_read_blocking(self, manager):
         """stream_read() blocks until data arrives."""

--- a/tests/unit/services/test_workflow_dispatch.py
+++ b/tests/unit/services/test_workflow_dispatch.py
@@ -51,7 +51,7 @@ class MockMetastore:
 def _make_service(
     *, enable_workflows: bool = True, pipe_manager: PipeManager | None = None
 ) -> tuple[WorkflowDispatchService, PipeManager | None]:
-    pm = pipe_manager or PipeManager(MockMetastore(), zone_id="test")
+    pm = pipe_manager or PipeManager(MockMetastore())
     engine = AsyncMock()
     svc = WorkflowDispatchService(
         pipe_manager=pm,


### PR DESCRIPTION
## Summary
- Remove `zone_id` from PipeManager and StreamManager constructors
- Add `zone_id` parameter to `create()` and `create_from_backend()` methods (defaults to ROOT_ZONE_ID)
- Remove `zone_id=ROOT_ZONE_ID` from NexusFS constructor calls
- Update 7 test files to match new API

## Design rationale
zone_id is a federation concept — kernel IPC primitives should not bind to a zone at construction time. Callers pass zone_id when creating individual pipes/streams, just as they pass owner_id.

Part of #1371 zone_id kernel leak cleanup.

## Test plan
- [x] 104 pipe/stream tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)