### PR TITLE
fix(#1791,#1792,#1793,#1789): eliminate 5 _system_services reads from kernel + doc update

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -125,10 +125,10 @@ required (structural typing).
 | `HotSwappable` | `hook_spec()`, `drain()`, `activate()` | Hook registration into KernelDispatch + activate on bootstrap; drain + unregister on shutdown |
 | `PersistentService` | `start()`, `stop()` | `start()` on bootstrap (dependency order); `stop()` on shutdown (reverse order) |
 
-One-click contract: implement protocol → `coordinator.register_service()` →
-kernel handles the rest. `ServiceLifecycleCoordinator` (optional, injected by
-factory) scans the registry and auto-calls the appropriate methods during
-`NexusFS.bootstrap()` / `NexusFS.aclose()`.
+One-click contract: implement protocol → `coordinator.enlist()` →
+kernel handles the rest. `ServiceLifecycleCoordinator` (kernel-owned, created by
+factory at link time) scans the registry and auto-calls the appropriate methods during
+`NexusFS.bootstrap()` / `NexusFS.close()`.
 
 **Source of truth:** `contracts/protocols/service_lifecycle.py`
 
@@ -377,7 +377,8 @@ with them indirectly through syscalls. See §2.2 matrix for per-syscall usage.
 | **PipeManager + RingBuffer** | `system_services` + `core.pipe` | `pipe(2)` + `fs/pipe.c` | VFS named pipes — inode in MetastoreABC, data in heap ring buffer. Details in §4.2 |
 | **StreamManager + StreamBuffer** | `system_services` + `core.stream` | append-only log | VFS named streams — inode in MetastoreABC, data in heap linear buffer. Non-destructive offset-based reads, multi-reader fan-out. Details in §4.2 |
 | **PathValidator** | `core.nexus_fs` (to extract) | `fs/namei.c` path validation | Path format validation on every syscall entry. Rejects malformed paths before routing or HAL access |
-| **ZoneAccessGuard** | `core.nexus_fs` (to extract) | `fs/namespace.c` mount readonly | Zone write permission check on every mutating syscall. Rejects writes to read-only zones before routing |
+| **ZoneWriteGuardHook** | `system_services.lifecycle` | `fs/namespace.c` mount readonly | Zone write permission check via KernelDispatch PRE hook (Issue #1790). Rejects writes to terminating zones |
+| **ServiceLifecycleCoordinator** | `system_services.lifecycle` | `init/main.c` + `module.c` | Kernel-owned bridge: ServiceRegistry + BrickLifecycleManager. Manages enlist/swap/shutdown for all 4 service quadrants |
 | **FileEvent** | `core.file_events` | `fsnotify_event` | Immutable mutation records. Details in §4.3 |
 
 ### 4.1 VFSLockManager — Per-Path RW Lock

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -160,6 +160,8 @@ class NexusFS(  # type: ignore[misc]
         self._descendant_checker: Any = None
         # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
         self._overlay_resolver = None
+        # Issue #1791: factory-injected overlay config resolver (captures workspace_registry)
+        self._overlay_config_fn: Callable[..., Any] | None = None
         # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)
 
         # Lazy-init sentinels
@@ -1093,40 +1095,15 @@ class NexusFS(  # type: ignore[misc]
     def _get_overlay_config(self, path: str) -> Any:
         """Get overlay config for a path, if overlay is active.
 
-        Issue #1264: Looks up the workspace containing this path and returns
-        its OverlayConfig if overlay is enabled.
-
-        Args:
-            path: File path to check
+        Issue #1791: Delegates to factory-injected callable. Kernel does NOT
+        read workspace_registry from _system_services — the factory captures
+        the registry reference in a closure at link() time.
 
         Returns:
             OverlayConfig if overlay active for this path, None otherwise
         """
-        registry = (
-            getattr(self._system_services, "workspace_registry", None)
-            if self._system_services
-            else None
-        )
-        if registry is None:
-            return None
-
-        ws_config = registry.find_workspace_for_path(path)
-        if ws_config is None:
-            return None
-
-        # Check if workspace has overlay metadata
-        overlay_data = ws_config.metadata.get("overlay_config")
-        if overlay_data is None:
-            return None
-
-        from nexus.contracts.overlay_config import OverlayConfig
-
-        return OverlayConfig(
-            enabled=overlay_data.get("enabled", False),
-            base_manifest_hash=overlay_data.get("base_manifest_hash"),
-            workspace_path=ws_config.path,
-            agent_id=overlay_data.get("agent_id"),
-        )
+        fn = self._overlay_config_fn
+        return fn(path) if fn is not None else None
 
     # =========================================================================
     # VFS I/O Lock — kernel-internal path-level read/write protection
@@ -4865,15 +4842,7 @@ class NexusFS(  # type: ignore[misc]
         if hasattr(self, "_stream_manager"):
             self._stream_manager.close_all()
 
-        # Close ProcessTable — kill all processes, clear state
-        # Issue #1570: accessed from container, not flat attr.
-        _pt = (
-            getattr(self._system_services, "process_table", None) if self._system_services else None
-        )
-        if _pt is not None:
-            _pt.close_all()
-
-        # Issue #1793/#1789: Service close via factory-registered callbacks.
+        # Issue #1793/#1789/#1792: Service close via factory-registered callbacks.
         # Replaces direct _system_services reads for write_observer, rebac_manager,
         # audit_store. Runs BEFORE pillar close so DB connections are still open.
         for _close_cb in self._close_callbacks:

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -181,6 +181,41 @@ async def _do_link(
 
         nx._close_callbacks.append(_close_audit)
 
+    # Issue #1792: process_table close via callback (not kernel → _system_services)
+    _pt = getattr(_sys, "process_table", None)
+    if _pt is not None and hasattr(_pt, "close_all"):
+
+        def _close_process_table() -> None:
+            try:
+                _pt.close_all()
+            except Exception as exc:
+                logger.debug("close: process_table.close_all() failed: %s", exc)
+
+        nx._close_callbacks.append(_close_process_table)
+
+    # Issue #1791: overlay config resolver — kernel calls self._overlay_config_fn(path)
+    # instead of reading workspace_registry from _system_services.
+    _ws_reg = getattr(_sys, "workspace_registry", None)
+    if _ws_reg is not None:
+
+        def _resolve_overlay(path: str) -> "Any":
+            ws_config = _ws_reg.find_workspace_for_path(path)
+            if ws_config is None:
+                return None
+            overlay_data = ws_config.metadata.get("overlay_config")
+            if overlay_data is None:
+                return None
+            from nexus.contracts.overlay_config import OverlayConfig
+
+            return OverlayConfig(
+                enabled=overlay_data.get("enabled", False),
+                base_manifest_hash=overlay_data.get("base_manifest_hash"),
+                workspace_path=ws_config.path,
+                agent_id=overlay_data.get("agent_id"),
+            )
+
+        nx._overlay_config_fn = _resolve_overlay
+
 
 async def _do_initialize(
     nx: Any, *, brick_on: "Any" = None, parse_fn: "Any" = None, permission_checker: "Any" = None


### PR DESCRIPTION
## Summary

Eliminates 5 more `_system_services` reads from kernel, continuing #1771 direction.

**#1793 + #1789 — close() service cleanup via factory callbacks**
Kernel `close()` no longer reads `_system_services` for `write_observer`, `rebac_manager`, `audit_store`. Factory registers `_close_callbacks` (like `_bootstrap_callbacks`).

**#1792 — process_table close**
`process_table.close_all()` moved to `_close_callbacks` too.

**#1791 — workspace_registry → factory-injected callable**
`_get_overlay_config()` now delegates to `self._overlay_config_fn` (factory captures `workspace_registry` in closure). Kernel doesn't read `_system_services.workspace_registry`.

**KERNEL-ARCHITECTURE.md**
- `register_service()` → `enlist()`
- `ZoneAccessGuard` → `ZoneWriteGuardHook` (now a hook, not kernel primitive)
- Added `ServiceLifecycleCoordinator` to primitives table

## Remaining `_system_services` reads in kernel
`rebac_manager` (3), `hierarchy_manager` (3), `lock_manager` (3), `write_observer` (1 RPC flush) — tracked by #1682, #1788

## Test plan
- [x] `uv run pytest tests/unit/` — 10944 passed
- [x] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)