### PR TITLE
fix: remove NEXUS_TLS_CERT/KEY/CA env vars — TLS auto-detected from disk

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -215,22 +215,13 @@ async def connect(
         # Single shared RPCTransport (gRPC channel) for all remote proxies.
         from nexus.remote.rpc_transport import RPCTransport
 
-        # TLS: honour NEXUS_TLS_CERT / KEY / CA env vars (same convention
-        # as the gRPC server) so that `nexus connect` works against a
-        # server started with --tls.
+        # TLS: auto-detect from NEXUS_DATA_DIR/tls/ (provisioned by 2-phase bootstrap)
         _tls_config = None
-        _tls_cert = os.getenv("NEXUS_TLS_CERT")
-        _tls_key = os.getenv("NEXUS_TLS_KEY")
-        _tls_ca = os.getenv("NEXUS_TLS_CA")
-        if _tls_cert and _tls_key and _tls_ca:
+        _data_dir = os.getenv("NEXUS_DATA_DIR")
+        if _data_dir:
             from nexus.security.tls.config import ZoneTlsConfig
 
-            _tls_config = ZoneTlsConfig(
-                ca_cert_path=Path(_tls_ca),
-                node_cert_path=Path(_tls_cert),
-                node_key_path=Path(_tls_key),
-                known_zones_path=Path(_tls_ca).parent / "known_zones",
-            )
+            _tls_config = ZoneTlsConfig.from_data_dir(_data_dir)
 
         transport = RPCTransport(
             server_address=grpc_address,

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -117,15 +117,7 @@ async def _get_nexus_client(config: dict[str, Any]) -> Any:
 
         # When TLS is enabled, set env vars so nexus.connect() builds
         # an RPCTransport with mTLS credentials (dev certs double as
-        # both server and client certs).
-        if config.get("tls"):
-            tls_cert = config.get("tls_cert", "")
-            tls_key = config.get("tls_key", "")
-            tls_ca = config.get("tls_ca", "")
-            if tls_cert and tls_key and tls_ca:
-                os.environ["NEXUS_TLS_CERT"] = tls_cert
-                os.environ["NEXUS_TLS_KEY"] = tls_key
-                os.environ["NEXUS_TLS_CA"] = tls_ca
+        # TLS is auto-detected from NEXUS_DATA_DIR/tls/ (provisioned by 2-phase bootstrap)
 
         try:
             nx = await nexus.connect(
@@ -871,14 +863,7 @@ def _revoke_identities(config: dict[str, Any], manifest: dict[str, Any]) -> int:
         return 0
 
     # Set TLS env vars so admin RPC uses mTLS when TLS is enabled
-    if config.get("tls"):
-        tls_cert = config.get("tls_cert", "")
-        tls_key = config.get("tls_key", "")
-        tls_ca = config.get("tls_ca", "")
-        if tls_cert and tls_key and tls_ca:
-            os.environ["NEXUS_TLS_CERT"] = tls_cert
-            os.environ["NEXUS_TLS_KEY"] = tls_key
-            os.environ["NEXUS_TLS_CA"] = tls_ca
+    # TLS is auto-detected from NEXUS_DATA_DIR/tls/
 
     try:
         from nexus.cli.commands.admin import get_admin_rpc

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -139,12 +139,8 @@ def _derive_project_env(
     if image_ref:
         env["NEXUS_IMAGE_REF"] = image_ref
 
-    if config.get("tls"):
-        env["NEXUS_TLS_ENABLED"] = "true"
-        env["NEXUS_TLS_CERT"] = "/app/data/tls/server.crt"
-        env["NEXUS_TLS_KEY"] = "/app/data/tls/server.key"
-        env["NEXUS_TLS_CA"] = "/app/data/tls/ca.crt"
-    # No TLS → gRPC server auto-detects: no certs found → insecure loopback
+    # TLS is provisioned automatically by 2-phase TLS bootstrap.
+    # No env vars needed — certs are auto-detected from disk.
 
     return env
 

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -22,31 +22,16 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
-    """Resolve TLS config from env vars, ZoneManager, or auto-detection.
+    """Resolve TLS config from ZoneManager or auto-detection.
 
     Priority:
-    1. Explicit env vars: NEXUS_TLS_CERT / NEXUS_TLS_KEY / NEXUS_TLS_CA
-    2. ZoneManager.tls_config (auto-generated or passed via --tls-* flags)
-    3. Auto-detect from {NEXUS_DATA_DIR}/tls/
-    4. None → insecure (no certs available)
+    1. ZoneManager.tls_config (provisioned by 2-phase TLS bootstrap)
+    2. Auto-detect from {NEXUS_DATA_DIR}/tls/
+    3. None → insecure (no certs available)
     """
     from nexus.security.tls.config import ZoneTlsConfig
 
-    # 1. Explicit env vars
-    cert = os.environ.get("NEXUS_TLS_CERT")
-    key = os.environ.get("NEXUS_TLS_KEY")
-    ca = os.environ.get("NEXUS_TLS_CA")
-    if cert and key and ca:
-        from pathlib import Path
-
-        return ZoneTlsConfig(
-            ca_cert_path=Path(ca),
-            node_cert_path=Path(cert),
-            node_key_path=Path(key),
-            known_zones_path=Path(ca).parent / "known_zones",
-        )
-
-    # 2. ZoneManager (if running federation / Raft)
+    # 1. ZoneManager (if running federation / Raft)
     zone_mgr = getattr(app.state, "zone_manager", None)
     if zone_mgr is not None:
         tls_cfg: ZoneTlsConfig | None = getattr(zone_mgr, "tls_config", None)

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -279,7 +279,8 @@ class TestDeriveProjectEnv:
         assert env["POSTGRES_PORT"] == "5432"
         assert env["NEXUS_HOST_DATA_DIR"] == str(tmp_path / "data")
         assert env["NEXUS_AUTH_TYPE"] == "database"
-        assert "NEXUS_TLS_ENABLED" not in env
+        # TLS is auto-detected from disk, no env vars
+        assert "NEXUS_TLS_CERT" not in env
 
     def test_image_ref_in_env(self, tmp_path: Path) -> None:
         """image_ref from config is passed as NEXUS_IMAGE_REF."""
@@ -318,14 +319,12 @@ class TestDeriveProjectEnv:
         assert env["NEXUS_PORT"] == "3026"
         assert env["NEXUS_GRPC_PORT"] == "3028"
 
-    def test_tls_env(self, tmp_path: Path) -> None:
-        """When tls is enabled, TLS env vars are set."""
+    def test_tls_config_ignored(self, tmp_path: Path) -> None:
+        """TLS config key no longer produces env vars (auto-detected from disk)."""
         config = {"data_dir": str(tmp_path / "data"), "tls": True, "ports": {}}
         env = _derive_project_env(config)
-        assert env["NEXUS_TLS_ENABLED"] == "true"
-        assert env["NEXUS_TLS_CERT"] == "/app/data/tls/server.crt"
-        assert env["NEXUS_TLS_KEY"] == "/app/data/tls/server.key"
-        assert env["NEXUS_TLS_CA"] == "/app/data/tls/ca.crt"
+        assert "NEXUS_TLS_ENABLED" not in env
+        assert "NEXUS_TLS_CERT" not in env
 
     def test_deterministic_project_name(self, tmp_path: Path) -> None:
         """Same data_dir always produces same project name."""


### PR DESCRIPTION
## Summary
Remove `NEXUS_TLS_CERT`, `NEXUS_TLS_KEY`, `NEXUS_TLS_CA` env vars. TLS is now provisioned automatically by 2-phase TLS bootstrap and auto-detected from `{NEXUS_DATA_DIR}/tls/`.

- `grpc/server.py`: remove env var priority
- `__init__.py`: remote profile auto-detects from disk
- `stack.py`, `demo.py`: remove env var injection
- `test_stack.py`: verify env vars absent

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)