### PR TITLE
fix(#1788): inject distributed lock_manager directly — kernel knows pattern

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -162,6 +162,9 @@ class NexusFS(  # type: ignore[misc]
         self._overlay_resolver = None
         # Issue #1791: factory-injected overlay config resolver (captures workspace_registry)
         self._overlay_config_fn: Callable[..., Any] | None = None
+        # Issue #1788: distributed lock manager — kernel knows (like _permission_enforcer).
+        # In-process locks use _vfs_lock_manager (kernel owns); distributed locks use this.
+        self._distributed_lock_manager: Any = None
         # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)
 
         # Lazy-init sentinels
@@ -1167,10 +1170,7 @@ class NexusFS(  # type: ignore[misc]
         """
         import asyncio
 
-        # Issue #1570: lock_manager accessed from container, not flat attr.
-        _lm = (
-            getattr(self._system_services, "lock_manager", None) if self._system_services else None
-        )
+        _lm = self._distributed_lock_manager
         if _lm is None:
             raise RuntimeError(
                 "write(lock=True) called but distributed lock manager not configured. "
@@ -1221,10 +1221,7 @@ class NexusFS(  # type: ignore[misc]
         if not lock_id:
             return
 
-        # Issue #1570: lock_manager accessed from container, not flat attr.
-        _lm = (
-            getattr(self._system_services, "lock_manager", None) if self._system_services else None
-        )
+        _lm = self._distributed_lock_manager
         if _lm is None:
             return
 
@@ -2587,10 +2584,7 @@ class NexusFS(  # type: ignore[misc]
             ...     lambda c: json.dumps({**json.loads(c), "version": 2}).encode()
             ... )
         """
-        # Issue #1570: lock_manager accessed from container, not flat attr.
-        _lm = (
-            getattr(self._system_services, "lock_manager", None) if self._system_services else None
-        )
+        _lm = self._distributed_lock_manager
         if _lm is None:
             raise RuntimeError(
                 "atomic_update() requires distributed lock manager. "

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -144,6 +144,9 @@ async def _do_link(
     if _dc is not None:
         nx._descendant_checker = _dc
 
+    # Issue #1788: inject distributed lock_manager directly (kernel knows pattern)
+    nx._distributed_lock_manager = getattr(_sys, "lock_manager", None)
+
     # --- Register close callbacks (Issue #1793, #1789) ---
     # Services that need cleanup at close() register callbacks here instead of
     # kernel reading _system_services directly.  Callbacks run BEFORE pillar


### PR DESCRIPTION
## Summary

Kernel no longer reads `lock_manager` from `_system_services` container. Instead, factory injects it as `self._distributed_lock_manager` (sentinel in `__init__`, real value set by `_do_link()`). Same pattern as `_permission_enforcer` and `_descendant_checker`.

3 reads migrated: `_acquire_lock_sync()`, `_release_lock_sync()`, `atomic_update()`

## Remaining `_system_services` reads in kernel
Only `rebac_manager` (3 hot-path) + `hierarchy_manager` (3) + `write_observer` (1 RPC flush) — all tracked by #1682.

## Test plan
- [x] `uv run pytest tests/unit/` — 10944 passed
- [x] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)