### PR TITLE
fix: include node hostname in cert SAN (CockroachDB pattern)

### DIFF
--- a/rust/nexus_raft/src/transport/certgen.rs
+++ b/rust/nexus_raft/src/transport/certgen.rs
@@ -27,6 +27,7 @@ pub fn generate_node_cert(
     zone_id: &str,
     ca_cert_pem: &[u8],
     ca_key_pem: &[u8],
+    extra_hostnames: &[String],
 ) -> Result<(Vec<u8>, Vec<u8>), String> {
     // Parse CA key pair
     let ca_key_str =
@@ -59,8 +60,9 @@ pub fn generate_node_cert(
     );
     params.distinguished_name = dn;
 
-    // SANs: localhost, 127.0.0.1, ::1 (matches Python certgen.py)
-    params.subject_alt_names = vec![
+    // SANs: localhost, 127.0.0.1, ::1, plus any extra hostnames from node_address
+    // (CockroachDB pattern: cert SANs include all hostnames the node is reachable at)
+    let mut sans = vec![
         SanType::DnsName(
             "localhost"
                 .try_into()
@@ -69,6 +71,20 @@ pub fn generate_node_cert(
         SanType::IpAddress(Ipv4Addr::LOCALHOST.into()),
         SanType::IpAddress(Ipv6Addr::LOCALHOST.into()),
     ];
+    for hostname in extra_hostnames {
+        // Try parsing as IP first, fall back to DNS name
+        if let Ok(ip) = hostname.parse::<std::net::IpAddr>() {
+            sans.push(SanType::IpAddress(ip));
+        } else {
+            sans.push(SanType::DnsName(
+                hostname
+                    .as_str()
+                    .try_into()
+                    .map_err(|e| format!("SAN error for '{hostname}': {e}"))?,
+            ));
+        }
+    }
+    params.subject_alt_names = sans;
 
     // Extended key usage: serverAuth + clientAuth (mTLS)
     params.extended_key_usages = vec![
@@ -125,8 +141,14 @@ mod tests {
     #[test]
     fn test_generate_node_cert() {
         let (ca_cert_pem, ca_key_pem) = generate_test_ca();
-        let (cert_pem, key_pem) =
-            generate_node_cert(2, "root", ca_cert_pem.as_bytes(), ca_key_pem.as_bytes()).unwrap();
+        let (cert_pem, key_pem) = generate_node_cert(
+            2,
+            "root",
+            ca_cert_pem.as_bytes(),
+            ca_key_pem.as_bytes(),
+            &[],
+        )
+        .unwrap();
 
         assert!(!cert_pem.is_empty());
         assert!(!key_pem.is_empty());
@@ -137,7 +159,7 @@ mod tests {
     #[test]
     fn test_invalid_ca_key() {
         let (ca_cert_pem, _) = generate_test_ca();
-        let result = generate_node_cert(1, "root", ca_cert_pem.as_bytes(), b"not-a-key");
+        let result = generate_node_cert(1, "root", ca_cert_pem.as_bytes(), b"not-a-key", &[]);
         assert!(result.is_err());
     }
 }

--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -398,6 +398,29 @@ fn command_result_to_proto(result: &CommandResult) -> RaftResponse {
 
 /// Check that a sender node is a known member of a zone.
 ///
+/// Extract hostnames from a node_address for cert SAN inclusion.
+///
+/// Parses addresses like "http://nexus-1:2126" or "0.0.0.0:2126" and returns
+/// the hostname/IP portion. Multiple formats are handled gracefully.
+fn extract_hostnames(node_address: &str) -> Vec<String> {
+    let addr = node_address
+        .trim_start_matches("http://")
+        .trim_start_matches("https://");
+
+    // Split off port
+    let host = if let Some((h, _)) = addr.rsplit_once(':') {
+        h
+    } else {
+        addr
+    };
+
+    if host.is_empty() || host == "0.0.0.0" || host == "localhost" || host == "127.0.0.1" {
+        return vec![];
+    }
+
+    vec![host.to_string()]
+}
+
 /// Soft check: if the peer list is unavailable (e.g. during bootstrap), the
 /// request is allowed.  This prevents rogue nodes from injecting Raft messages
 /// for zones they don't belong to (CockroachDB/etcd pattern: zone auth at app
@@ -1032,14 +1055,21 @@ impl ZoneApiService for ZoneApiServiceImpl {
         } else {
             &req.zone_id
         };
-        let (node_cert_pem, node_key_pem) =
-            match super::certgen::generate_node_cert(req.node_id, zone_id, &ca_pem, &ca_key_pem) {
-                Ok(pair) => pair,
-                Err(e) => {
-                    tracing::error!("Failed to generate node cert: {}", e);
-                    return Ok(err_resp(&format!("Failed to generate node cert: {}", e)));
-                }
-            };
+        // Extract hostname from node_address for cert SAN (CockroachDB pattern)
+        let extra_hostnames = extract_hostnames(&req.node_address);
+        let (node_cert_pem, node_key_pem) = match super::certgen::generate_node_cert(
+            req.node_id,
+            zone_id,
+            &ca_pem,
+            &ca_key_pem,
+            &extra_hostnames,
+        ) {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::error!("Failed to generate node cert: {}", e);
+                return Ok(err_resp(&format!("Failed to generate node cert: {}", e)));
+            }
+        };
 
         // Write peers_joined marker to signal mTLS upgrade on next restart
         if let Some(ref base) = self.base_path {

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -833,7 +833,11 @@ class ZoneManager:
         save_pem(tls_dir / "ca.pem", ca_cert)
         save_pem(tls_dir / "ca-key.pem", ca_key, is_private=True)
 
-        node_cert, node_key = generate_node_cert(self._node_id, zone_id, ca_cert, ca_key)
+        # Include this node's advertise hostname in cert SAN (CockroachDB pattern)
+        leader_hostnames = self._extract_hostnames(self._advertise_addr)
+        node_cert, node_key = generate_node_cert(
+            self._node_id, zone_id, ca_cert, ca_key, hostnames=leader_hostnames
+        )
         save_pem(tls_dir / "node.pem", node_cert)
         save_pem(tls_dir / "node-key.pem", node_key, is_private=True)
 
@@ -938,6 +942,15 @@ class ZoneManager:
                 except ValueError:
                     continue
         return None
+
+    @staticmethod
+    def _extract_hostnames(address: str) -> list[str]:
+        """Extract hostname from an address for cert SAN inclusion."""
+        addr = address.removeprefix("http://").removeprefix("https://")
+        host = addr.rsplit(":", 1)[0] if ":" in addr else addr
+        if not host or host in ("0.0.0.0", "localhost", "127.0.0.1"):
+            return []
+        return [host]
 
     def _restart_with_tls(self, tls_config: "ZoneTlsConfig") -> None:
         """Restart the gRPC server with mTLS. Existing Raft zones are preserved."""


### PR DESCRIPTION
## Summary
Cert SANs now include the node's actual hostname (e.g. nexus-1, nexus-2) extracted from `node_address`. This follows the CockroachDB/etcd pattern where cert SANs match all reachable hostnames.

- `certgen.rs`: accept `extra_hostnames` parameter, add to SAN list
- `server.rs`: extract hostname from JoinCluster request's `node_address`
- `zone_manager.py`: leader adds its own advertise_addr hostname

## Test plan
- [ ] CI green
- [ ] Docker cluster: TLS connections succeed between nodes with different hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)