### PR TITLE
fix(#1797,#1624): remove zone_id from NexusFS _default_context

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -140,11 +140,10 @@ class NexusFS(  # type: ignore[misc]
         else:
             self.router = PathRouter(metadata_store)
 
-        # Default context for embedded mode
+        # Default context for embedded mode (no zone_id — federation injects it)
         self._default_context = OperationContext(
             user_id="anonymous",
             groups=[],
-            zone_id=ROOT_ZONE_ID,
             agent_id=None,
             is_admin=is_admin,
             is_system=False,
@@ -365,13 +364,13 @@ class NexusFS(  # type: ignore[misc]
         """Extract (zone_id, agent_id, is_admin) from context."""
         if context is None:
             return (
-                self._default_context.zone_id,
+                self._default_context.zone_id,  # None unless federation sets it
                 self._default_context.agent_id,
                 self._default_context.is_admin,
             )
         if isinstance(context, dict):
             return (
-                context.get("zone_id", self._default_context.zone_id),
+                context.get("zone_id"),
                 context.get("agent_id", self._default_context.agent_id),
                 context.get("is_admin", self.is_admin),
             )
@@ -383,7 +382,7 @@ class NexusFS(  # type: ignore[misc]
 
     @property
     def zone_id(self) -> str | None:
-        """Default zone_id from the instance context."""
+        """Zone ID from context. None in embedded mode (no federation)."""
         return self._default_context.zone_id
 
     @property


### PR DESCRIPTION
## Summary
Remove `zone_id=ROOT_ZONE_ID` from NexusFS `_default_context`. In embedded mode (no federation), zone_id is now `None`. Federation injects zone_id via explicit `OperationContext` on each syscall.

## This completes #1371 zone_id kernel leak cleanup
1. `_check_zone_writable` → KernelDispatch PRE hooks (#3175) ✅
2. `_get_routing_params` → `_get_context_identity` (#3178) ✅
3. PipeManager/StreamManager `self._zone_id` removed (#3183) ✅
4. ProcessTable `self._zone_id` removed (#3188) ✅
5. **NexusFS `_default_context.zone_id` removed (this PR)** ✅

## Test plan
- [x] Lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)