### PR TITLE
fix: use hostname from NEXUS_PEERS for cert SAN

### DIFF
--- a/rust/nexus_raft/src/bin/witness.rs
+++ b/rust/nexus_raft/src/bin/witness.rs
@@ -151,9 +151,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if needs_bootstrap && !peers.is_empty() {
             let tls_dir_bg = tls_dir.clone();
             let peers_bg = peers.clone();
-            let bind_addr_str = format!("http://{}", bind_addr);
+            // Use own address from peers (e.g. "http://witness:2126") so cert SAN
+            // includes the actual hostname, not "0.0.0.0".
+            let my_addr = peers
+                .iter()
+                .find(|p| p.id == node_id)
+                .map(|p| p.endpoint.clone())
+                .unwrap_or_else(|| format!("http://{}", bind_addr));
             tokio::spawn(async move {
-                tls_bootstrap_loop(node_id, &bind_addr_str, &peers_bg, &tls_dir_bg).await;
+                tls_bootstrap_loop(node_id, &my_addr, &peers_bg, &tls_dir_bg).await;
             });
         }
 

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -833,8 +833,11 @@ class ZoneManager:
         save_pem(tls_dir / "ca.pem", ca_cert)
         save_pem(tls_dir / "ca-key.pem", ca_key, is_private=True)
 
-        # Include this node's advertise hostname in cert SAN (CockroachDB pattern)
-        leader_hostnames = self._extract_hostnames(self._advertise_addr)
+        # Include this node's hostname in cert SAN (CockroachDB pattern).
+        # Use NEXUS_PEERS to get the actual hostname (e.g. nexus-1) instead of bind addr (0.0.0.0).
+        peers_str = os.environ.get("NEXUS_PEERS", "")
+        my_peer_addr = self._find_peer_address(peers_str, self._node_id) or self._advertise_addr
+        leader_hostnames = self._extract_hostnames(my_peer_addr)
         node_cert, node_key = generate_node_cert(
             self._node_id, zone_id, ca_cert, ca_key, hostnames=leader_hostnames
         )
@@ -872,11 +875,14 @@ class ZoneManager:
         if leader_addr is None:
             return
 
+        # Use this node's address from NEXUS_PEERS (contains the actual hostname
+        # like nexus-2:2126) so the cert SAN includes the correct hostname.
+        my_addr = self._find_peer_address(peers_str, self._node_id) or self._advertise_addr
         try:
             resp_ca, resp_cert, resp_key = self._py_mgr.call_join_cluster(
                 leader_addr=leader_addr,
                 node_id=self._node_id,
-                node_address=self._advertise_addr,
+                node_address=my_addr,
                 zone_id=ROOT_ZONE_ID,
             )
         except Exception as e:


### PR DESCRIPTION
node_address was 0.0.0.0 (bind addr), so cert SANs didn't include the Docker hostname. Now all nodes look up their own entry in NEXUS_PEERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)