### PR TITLE
refactor: K3s-style TLS bootstrap — delete 2-phase in-place upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,10 +1294,12 @@ dependencies = [
 name = "nexus_raft"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "bincode",
  "bytes",
  "dashmap",
  "mimalloc",
+ "pem",
  "prost",
  "protobuf",
  "pyo3",

--- a/rust/nexus_raft/Cargo.toml
+++ b/rust/nexus_raft/Cargo.toml
@@ -56,6 +56,8 @@ dashmap = { version = "6", optional = true }
 time = { version = "0.3", features = ["parsing"], optional = true }
 sha2 = { version = "0.10", optional = true }  # SHA-256 for JoinCluster token verification
 rcgen = { version = "0.13", features = ["pem", "x509-parser"], optional = true }  # Server-side node cert generation for JoinCluster
+pem = { version = "3", optional = true }  # PEM parsing for CA fingerprint verification
+base64 = { version = "0.22", optional = true }  # Base64 encoding for CA fingerprint
 
 # Python bindings (PyO3 FFI)
 pyo3 = { version = "0.27.2", features = ["extension-module"], optional = true }
@@ -87,7 +89,7 @@ consensus = ["raft", "protobuf", "slog", "async"]
 # Enable gRPC transport (tonic + protobuf) — EXPERIMENTAL, default OFF.
 # Requires `consensus` feature. Not used in production.
 # See: docs/rfcs/adr-raft-sled-strategy.md (Decision 4)
-grpc = ["tonic", "prost", "bytes", "tonic-build", "async", "tracing-subscriber", "consensus", "dashmap", "time", "sha2", "rcgen"]
+grpc = ["tonic", "prost", "bytes", "tonic-build", "async", "tracing-subscriber", "consensus", "dashmap", "time", "sha2", "rcgen", "pem", "base64"]
 
 # Enable everything (including experimental features)
 full = ["grpc", "consensus", "python"]

--- a/rust/nexus_raft/src/pyo3_bindings.rs
+++ b/rust/nexus_raft/src/pyo3_bindings.rs
@@ -654,12 +654,6 @@ pub struct PyZoneManager {
     runtime: tokio::runtime::Runtime,
     shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
     node_id: u64,
-    /// Handle for injecting CA material into the running server (2-phase bootstrap).
-    tls_bootstrap_handle: Option<crate::transport::TlsBootstrapHandle>,
-    /// Bind address (stored for server restart).
-    bind_addr: std::net::SocketAddr,
-    /// Base path (stored for server restart).
-    base_path_str: String,
 }
 
 #[cfg(all(feature = "grpc", has_protos))]
@@ -679,9 +673,8 @@ impl PyZoneManager {
     ///     tls_ca_path: Path to PEM CA certificate file (mTLS).
     ///     ca_key_path: Path to CA private key file (read once at startup for server-side cert signing).
     ///     join_token_hash: SHA-256 hash of join token password (for JoinCluster verification).
-    ///     authorized_peer_ids: Node IDs authorized for peers_bootstrap JoinCluster (from NEXUS_PEERS).
     #[new]
-    #[pyo3(signature = (node_id, base_path, bind_addr="0.0.0.0:2126", tls_cert_path=None, tls_key_path=None, tls_ca_path=None, ca_key_path=None, join_token_hash=None, authorized_peer_ids=None))]
+    #[pyo3(signature = (node_id, base_path, bind_addr="0.0.0.0:2126", tls_cert_path=None, tls_key_path=None, tls_ca_path=None, ca_key_path=None, join_token_hash=None))]
     #[allow(clippy::too_many_arguments)] // PyO3 constructor — Python API needs flat keyword args
     pub fn new(
         node_id: u64,
@@ -692,7 +685,6 @@ impl PyZoneManager {
         tls_ca_path: Option<&str>,
         ca_key_path: Option<&str>,
         join_token_hash: Option<&str>,
-        authorized_peer_ids: Option<Vec<u64>>,
     ) -> PyResult<Self> {
         use crate::raft::ZoneRaftRegistry;
         use crate::transport::{RaftGrpcServer, ServerConfig, TlsConfig};
@@ -774,10 +766,6 @@ impl PyZoneManager {
                 std::path::PathBuf::from(base_path),
             );
         }
-        if let Some(peer_ids) = authorized_peer_ids {
-            server = server.with_authorized_peers(peer_ids);
-        }
-        let tls_bootstrap_handle = server.tls_bootstrap_handle();
         let shutdown_rx_server = shutdown_rx.clone();
         runtime.spawn(async move {
             let shutdown = async move {
@@ -801,9 +789,6 @@ impl PyZoneManager {
             runtime,
             shutdown_tx: Some(shutdown_tx),
             node_id,
-            tls_bootstrap_handle: Some(tls_bootstrap_handle),
-            bind_addr: bind_socket,
-            base_path_str: base_path.to_string(),
         })
     }
 
@@ -911,148 +896,6 @@ impl PyZoneManager {
             let _ = tx.send(true);
         }
         tracing::info!("ZoneManager node {} shut down", self.node_id);
-        Ok(())
-    }
-
-    /// Set CA material on the running server for JoinCluster (2-phase bootstrap).
-    /// Called by the leader after generating the CA, before followers request certs.
-    pub fn set_ca_material(&self, ca_pem: Vec<u8>, ca_key_pem: Vec<u8>) -> PyResult<()> {
-        match &self.tls_bootstrap_handle {
-            Some(handle) => {
-                handle.set_ca_material(ca_pem, ca_key_pem);
-                tracing::info!("CA material set on running server for JoinCluster");
-                Ok(())
-            }
-            None => Err(PyRuntimeError::new_err(
-                "TLS bootstrap handle not available",
-            )),
-        }
-    }
-
-    /// Get the set of node IDs that have successfully called JoinCluster.
-    /// Used by the leader to check if all peers have their certs before proposing TLS upgrade.
-    pub fn joined_peer_ids(&self) -> PyResult<Vec<u64>> {
-        match &self.tls_bootstrap_handle {
-            Some(handle) => Ok(handle.joined_peer_ids()),
-            None => Ok(vec![]),
-        }
-    }
-
-    /// Call JoinCluster RPC on the leader to get a signed node certificate.
-    /// Used by followers during 2-phase TLS bootstrap.
-    ///
-    /// Returns: (ca_pem, node_cert_pem, node_key_pem) as bytes.
-    #[pyo3(signature = (leader_addr, node_id, node_address, zone_id, peers_bootstrap=true, password="", timeout_secs=10))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn call_join_cluster(
-        &self,
-        leader_addr: &str,
-        node_id: u64,
-        node_address: &str,
-        zone_id: &str,
-        peers_bootstrap: bool,
-        password: &str,
-        timeout_secs: u64,
-    ) -> PyResult<(Vec<u8>, Vec<u8>, Vec<u8>)> {
-        let result = self
-            .runtime
-            .block_on(crate::transport::call_join_cluster(
-                leader_addr,
-                node_id,
-                node_address,
-                zone_id,
-                peers_bootstrap,
-                password,
-                timeout_secs,
-            ))
-            .map_err(|e| PyRuntimeError::new_err(format!("JoinCluster failed: {}", e)))?;
-        Ok((result.ca_pem, result.node_cert_pem, result.node_key_pem))
-    }
-
-    /// Restart the gRPC server with TLS. Existing zones are preserved.
-    /// Called after all nodes have received their certs (plaintext→mTLS upgrade).
-    #[pyo3(signature = (tls_cert_path, tls_key_path, tls_ca_path, ca_key_path=None, join_token_hash=None, authorized_peer_ids=None))]
-    pub fn restart_with_tls(
-        &mut self,
-        tls_cert_path: &str,
-        tls_key_path: &str,
-        tls_ca_path: &str,
-        ca_key_path: Option<&str>,
-        join_token_hash: Option<&str>,
-        authorized_peer_ids: Option<Vec<u64>>,
-    ) -> PyResult<()> {
-        use crate::transport::{RaftGrpcServer, ServerConfig, TlsConfig};
-
-        // Read TLS material from files
-        let cert_pem = std::fs::read(tls_cert_path)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to read TLS cert: {}", e)))?;
-        let key_pem = std::fs::read(tls_key_path)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to read TLS key: {}", e)))?;
-        let ca_pem = std::fs::read(tls_ca_path)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to read TLS CA: {}", e)))?;
-        let tls_config = TlsConfig {
-            cert_pem,
-            key_pem,
-            ca_pem,
-        };
-
-        // 1. Shutdown existing gRPC server
-        if let Some(tx) = self.shutdown_tx.take() {
-            let _ = tx.send(true);
-        }
-        // Brief pause for server to shut down
-        std::thread::sleep(std::time::Duration::from_millis(200));
-
-        // 2. Update registry TLS config + upgrade peer schemes
-        self.registry.set_tls(Some(tls_config.clone()));
-        self.registry.upgrade_peer_schemes();
-
-        // 3. Start new server with TLS
-        let config = ServerConfig {
-            bind_address: self.bind_addr,
-            tls: Some(tls_config),
-            ..Default::default()
-        };
-        let mut server = RaftGrpcServer::new(self.registry.clone(), config);
-
-        // Configure JoinCluster support
-        if let Some(ca_key_path) = ca_key_path {
-            if let Some(token_hash) = join_token_hash {
-                let ca_key_pem = std::fs::read(ca_key_path).map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to read CA key: {}", e))
-                })?;
-                server = server.with_join_config(
-                    ca_key_pem,
-                    token_hash.to_string(),
-                    std::path::PathBuf::from(&self.base_path_str),
-                );
-            }
-        }
-        if let Some(peer_ids) = authorized_peer_ids {
-            server = server.with_authorized_peers(peer_ids);
-        }
-
-        let new_handle = server.tls_bootstrap_handle();
-        let (new_shutdown_tx, new_shutdown_rx) = tokio::sync::watch::channel(false);
-
-        self.runtime.spawn(async move {
-            let shutdown = async move {
-                let mut rx = new_shutdown_rx;
-                let _ = rx.changed().await;
-            };
-            if let Err(e) = server.serve_with_shutdown(shutdown).await {
-                tracing::error!("ZoneManager gRPC server error after TLS restart: {}", e);
-            }
-        });
-
-        self.shutdown_tx = Some(new_shutdown_tx);
-        self.tls_bootstrap_handle = Some(new_handle);
-
-        tracing::info!(
-            "ZoneManager node {} restarted with mTLS (bind={})",
-            self.node_id,
-            self.bind_addr,
-        );
         Ok(())
     }
 }
@@ -1398,6 +1241,115 @@ impl PyZoneHandle {
     }
 }
 
+// =============================================================================
+// Standalone join_cluster function (K3s-style pre-provision)
+// =============================================================================
+
+/// Join an existing cluster by provisioning TLS certificates from the leader.
+///
+/// Called BEFORE ZoneManager is created. Connects to the leader using TLS
+/// without certificate verification (TOFU), then verifies the CA fingerprint
+/// from the join token after receipt.
+///
+/// Args:
+///     peer_address: Leader's gRPC address (e.g., "10.0.0.1:2126").
+///     join_token: K3s-style join token ("K10<password>::server:<ca_fingerprint>").
+///     node_id: This node's ID.
+///     tls_dir: Directory to write ca.pem, node.pem, node-key.pem.
+#[cfg(all(feature = "grpc", has_protos))]
+#[pyfunction]
+fn join_cluster(peer_address: &str, join_token: &str, node_id: u64, tls_dir: &str) -> PyResult<()> {
+    use crate::transport::call_join_cluster;
+
+    // Parse join token: K10<password>::server:<ca_fingerprint>
+    let token_prefix = "K10";
+    let separator = "::server:";
+    if !join_token.starts_with(token_prefix) {
+        return Err(PyRuntimeError::new_err(
+            "Invalid join token: must start with 'K10'",
+        ));
+    }
+    let body = &join_token[token_prefix.len()..];
+    let sep_pos = body.find(separator).ok_or_else(|| {
+        PyRuntimeError::new_err("Invalid join token: missing '::server:' separator")
+    })?;
+    let password = &body[..sep_pos];
+    let expected_fingerprint = &body[sep_pos + separator.len()..];
+
+    if password.is_empty() {
+        return Err(PyRuntimeError::new_err(
+            "Invalid join token: empty password",
+        ));
+    }
+    if !expected_fingerprint.starts_with("SHA256:") {
+        return Err(PyRuntimeError::new_err(
+            "Invalid join token: fingerprint must start with 'SHA256:'",
+        ));
+    }
+
+    // Build endpoint URL
+    let endpoint = if peer_address.starts_with("http") {
+        peer_address.to_string()
+    } else {
+        format!("http://{}", peer_address)
+    };
+
+    // Create a temporary Tokio runtime for the blocking call
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to create runtime: {}", e)))?;
+
+    let result = runtime
+        .block_on(call_join_cluster(
+            &endpoint, node_id, "", // node_address — not needed for pre-provision
+            "root", false, // peers_bootstrap = false (using password auth)
+            password, 30, // timeout_secs
+        ))
+        .map_err(|e| PyRuntimeError::new_err(format!("JoinCluster RPC failed: {}", e)))?;
+
+    // Verify CA fingerprint matches the join token
+    let ca_fingerprint = crate::transport::certgen::ca_fingerprint_from_pem(&result.ca_pem)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to compute CA fingerprint: {}", e)))?;
+    if ca_fingerprint != expected_fingerprint {
+        return Err(PyRuntimeError::new_err(format!(
+            "CA fingerprint mismatch: expected '{}', got '{}'",
+            expected_fingerprint, ca_fingerprint
+        )));
+    }
+
+    // Write certs to disk
+    let dir = std::path::Path::new(tls_dir);
+    std::fs::create_dir_all(dir)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to create TLS dir: {}", e)))?;
+
+    std::fs::write(dir.join("ca.pem"), &result.ca_pem)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to write ca.pem: {}", e)))?;
+    std::fs::write(dir.join("node.pem"), &result.node_cert_pem)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to write node.pem: {}", e)))?;
+
+    // Write private key with restricted permissions
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+        use std::io::Write;
+        let mut f = opts
+            .open(dir.join("node-key.pem"))
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to write node-key.pem: {}", e)))?;
+        f.write_all(&result.node_key_pem)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to write node-key.pem: {}", e)))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(dir.join("node-key.pem"), &result.node_key_pem)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to write node-key.pem: {}", e)))?;
+    }
+
+    Ok(())
+}
+
 /// Python module initialization.
 /// Module name: _nexus_raft (consistent with _nexus_fast)
 /// Import as: from _nexus_raft import Metastore, ZoneManager, ZoneHandle
@@ -1411,5 +1363,7 @@ fn _nexus_raft(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyZoneManager>()?;
     #[cfg(all(feature = "grpc", has_protos))]
     m.add_class::<PyZoneHandle>()?;
+    #[cfg(all(feature = "grpc", has_protos))]
+    m.add_function(wrap_pyfunction!(join_cluster, m)?)?;
     Ok(())
 }

--- a/rust/nexus_raft/src/raft/zone_registry.rs
+++ b/rust/nexus_raft/src/raft/zone_registry.rs
@@ -97,20 +97,6 @@ impl ZoneRaftRegistry {
         *self.tls.write().unwrap() = tls;
     }
 
-    /// Upgrade all peer endpoints from http:// to https:// scheme.
-    /// Called after TLS upgrade so outbound connections use TLS.
-    pub fn upgrade_peer_schemes(&self) {
-        for entry in self.zones.iter() {
-            let mut peers = entry.peers.write().unwrap();
-            for addr in peers.values_mut() {
-                if addr.endpoint.starts_with("http://") {
-                    addr.endpoint = addr.endpoint.replacen("http://", "https://", 1);
-                }
-            }
-        }
-        tracing::info!("Upgraded all peer endpoints to https://");
-    }
-
     /// Create a new zone with its own Raft group.
     ///
     /// # Arguments

--- a/rust/nexus_raft/src/transport/certgen.rs
+++ b/rust/nexus_raft/src/transport/certgen.rs
@@ -117,6 +117,30 @@ pub fn generate_node_cert(
     Ok((cert_pem, key_pem))
 }
 
+/// Compute a SHA-256 fingerprint of a PEM-encoded CA certificate.
+///
+/// Returns the fingerprint in `SHA256:<base64-no-padding>` format,
+/// matching the Python `cert_fingerprint()` output used in join tokens.
+pub fn ca_fingerprint_from_pem(ca_pem: &[u8]) -> Result<String, String> {
+    use sha2::{Digest, Sha256};
+
+    // Extract DER bytes from PEM
+    let pem_str =
+        std::str::from_utf8(ca_pem).map_err(|e| format!("CA PEM is not valid UTF-8: {e}"))?;
+    let pem = pem::parse(pem_str).map_err(|e| format!("Failed to parse PEM: {e}"))?;
+    let der = pem.contents();
+
+    // SHA-256 hash of DER-encoded certificate
+    let hash = Sha256::digest(der);
+
+    // Base64-encode without padding (matching Python's rstrip("="))
+    use base64::engine::general_purpose::STANDARD_NO_PAD;
+    use base64::Engine;
+    let b64 = STANDARD_NO_PAD.encode(hash);
+
+    Ok(format!("SHA256:{}", b64))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -326,6 +326,36 @@ async def connect(
         advertise_addr = os.environ.get("NEXUS_ADVERTISE_ADDR")
         zones_dir = os.environ.get("NEXUS_DATA_DIR", str(Path(metadata_path).parent / "zones"))
 
+        # K3s-style pre-provision: if NEXUS_JOIN_TOKEN is set and certs
+        # don't exist yet, provision TLS from the leader BEFORE creating
+        # ZoneManager (so Raft transport starts with mTLS from the start).
+        join_token = os.environ.get("NEXUS_JOIN_TOKEN")
+        if join_token:
+            tls_dir_pre = Path(zones_dir) / "tls"
+            if not (tls_dir_pre / "node.pem").exists():
+                # Find a peer address to join from NEXUS_PEERS
+                join_peer = None
+                for entry in (os.environ.get("NEXUS_PEERS", "")).split(","):
+                    entry = entry.strip()
+                    if "@" in entry:
+                        peer_id_str, peer_addr = entry.split("@", 1)
+                        if peer_id_str.strip() != str(node_id):
+                            join_peer = peer_addr.strip()
+                            break
+                if join_peer:
+                    from _nexus_raft import join_cluster as _join_cluster
+
+                    logger.info(
+                        "NEXUS_JOIN_TOKEN set -- provisioning TLS from %s",
+                        join_peer,
+                    )
+                    _join_cluster(join_peer, join_token, node_id, str(tls_dir_pre))
+                    logger.info("TLS provisioning complete")
+                else:
+                    raise RuntimeError(
+                        "NEXUS_JOIN_TOKEN set but no peer found in NEXUS_PEERS to join"
+                    )
+
         zone_mgr = ZoneManager(
             node_id=node_id,
             base_path=zones_dir,
@@ -338,7 +368,7 @@ async def connect(
         peers = [p.strip() for p in peers_str.split(",") if p.strip()] if peers_str else []
 
         # Detect joiner vs first-node:
-        # Joiner = has all cert files (provisioned by 2-phase bootstrap or join flow)
+        # Joiner = has all cert files (pre-provisioned by join_cluster above)
         # but no join-token (not the CA holder / first node)
         tls_dir = Path(zones_dir) / "tls"
         is_joiner = (
@@ -352,8 +382,8 @@ async def connect(
             zone_mgr.join_zone("root", peers=peers if peers else None)
             logger.info("Joiner node: joined root zone (certs provisioned)")
         else:
-            # First node or 2-phase mode (no certs yet — bootstrap creates Raft group,
-            # TLS is handled by zone_manager.bootstrap_tls() during ensure_topology)
+            # First node — auto_generate_tls creates CA + certs,
+            # ZoneManager starts with mTLS from the beginning.
             zone_mgr.bootstrap(peers=peers if peers else None)
 
         # Static Day-1 topology from env vars (idempotent)

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -15,9 +15,8 @@ All zones share one gRPC port (zone_id routing in transport layer).
 """
 
 import logging
-import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.metadata import DT_DIR, DT_MOUNT, FileMetadata
@@ -80,22 +79,18 @@ class ZoneManager:
 
         from nexus.security.tls.config import ZoneTlsConfig
 
-        # TLS bootstrap logic:
-        # 1. Existing certs on disk → use them (normal restart)
-        # 2. NEXUS_PEERS set + no certs → 2-phase mode (start plaintext, bootstrap TLS after leader election)
-        # 3. Single-node (no peers) → auto-generate (existing behavior)
+        # TLS bootstrap logic (K3s-style pre-provision):
+        # 1. Existing certs on disk → use them (normal restart or pre-provisioned by join_cluster)
+        # 2. Single-node (no peers) or first node → auto-generate
+        # Note: joiners must call _nexus_raft.join_cluster() BEFORE creating ZoneManager.
         self._tls_config: ZoneTlsConfig | None = None
-        self._two_phase_tls = False
         ca_key_path: str | None = None
         join_token_hash: str | None = None
-        authorized_peer_ids: list[int] | None = None
-        peers_str = os.environ.get("NEXUS_PEERS", "")
-        has_peers = bool(peers_str.strip())
 
         if tls_cert_path is None and tls_key_path is None and tls_ca_path is None:
             existing = ZoneTlsConfig.from_data_dir(base_path)
             if existing is not None:
-                # Certs exist from a previous run → use them
+                # Certs exist (from auto-generate, previous run, or pre-provisioned join)
                 tls_cert_path = str(existing.node_cert_path)
                 tls_key_path = str(existing.node_key_path)
                 tls_ca_path = str(existing.ca_cert_path)
@@ -105,24 +100,8 @@ class ZoneManager:
                     join_token_hash = hash_path.read_text().strip()
                     ca_key_path = str(Path(base_path) / "tls" / "ca-key.pem")
                 logger.debug("Auto-detected existing TLS certs in %s/tls/", base_path)
-            elif has_peers:
-                # No certs + NEXUS_PEERS → 2-phase bootstrap (start plaintext)
-                self._two_phase_tls = True
-                # Parse peer IDs for authorized peers_bootstrap
-                authorized_peer_ids = []
-                for p in peers_str.split(","):
-                    p = p.strip()
-                    if "@" in p:
-                        import contextlib
-
-                        with contextlib.suppress(ValueError):
-                            authorized_peer_ids.append(int(p.split("@")[0]))
-                logger.info(
-                    "2-phase TLS bootstrap: starting in plaintext mode (peers=%s)",
-                    authorized_peer_ids,
-                )
             else:
-                # Single-node, no peers → auto-generate
+                # No certs → auto-generate (first node bootstrap)
                 auto = self._auto_generate_tls(base_path, node_id)
                 if auto is not None:
                     tls_cert_path = str(auto.node_cert_path)
@@ -143,7 +122,6 @@ class ZoneManager:
             tls_ca_path=tls_ca_path,
             ca_key_path=ca_key_path,
             join_token_hash=join_token_hash,
-            authorized_peer_ids=authorized_peer_ids,
         )
         self._stores: dict[str, RaftMetadataStore] = {}
         self._node_id = node_id
@@ -156,7 +134,6 @@ class ZoneManager:
         self._tls_ca_path = tls_ca_path
         self._pending_mounts: dict[str, str] | None = None
         self._topology_initialized = False
-        self._authorized_peer_ids = authorized_peer_ids
 
     @property
     def tls_config(self) -> "ZoneTlsConfig | None":
@@ -735,250 +712,6 @@ class ZoneManager:
             self._pending_mounts = mounts
 
     # -------------------------------------------------------------------------
-    # 2-phase TLS bootstrap
-    # -------------------------------------------------------------------------
-
-    # System keys in the Raft metastore for TLS coordination.
-    # All nodes see these via Raft consensus (deterministic, ordered).
-    _TLS_CA_KEY = "__system__/tls/ca_pem"
-    _TLS_UPGRADE_KEY = "__system__/tls/upgrade"
-
-    def bootstrap_tls(self) -> bool:
-        """2-phase TLS bootstrap coordinated via Raft consensus.
-
-        Called by ensure_topology() before topology work. Returns True when
-        TLS is ready (or not needed). Each call advances the state machine:
-
-        1. Leader generates CA → proposes ca_pem to Raft metastore
-        2. All nodes see CA via Raft → followers call JoinCluster for certs
-        3. Leader tracks JoinCluster calls → when all peers served, proposes upgrade
-        4. All nodes see upgrade → restart transport with mTLS
-
-        Only the leader writes to Raft. Followers only read + call JoinCluster RPC.
-        """
-        if not self._two_phase_tls:
-            return True
-
-        if not self._root_zone_id:
-            return False
-
-        root_store = self.get_store(self._root_zone_id)
-        if root_store is None:
-            return False
-
-        raft_engine = root_store._engine
-        leader_id = raft_engine.leader_id()
-        if not leader_id:
-            logger.info("bootstrap_tls: no leader yet (node=%d)", self._node_id)
-            return False  # No leader yet
-
-        # --- Check if upgrade signal is in Raft → restart transport ---
-        upgrade = raft_engine.get_metadata(self._TLS_UPGRADE_KEY)
-        if upgrade is not None:
-            from nexus.security.tls.config import ZoneTlsConfig
-
-            existing = ZoneTlsConfig.from_data_dir(self._base_path)
-            if existing is not None:
-                self._restart_with_tls(existing)
-                self._two_phase_tls = False
-                logger.info("TLS bootstrap complete — transport upgraded to mTLS")
-                return True
-            logger.warning("TLS upgrade signal seen but no certs on disk")
-            return False
-
-        # --- Leader: generate CA and propose to Raft ---
-        ca_pem_in_raft = raft_engine.get_metadata(self._TLS_CA_KEY)
-        logger.info(
-            "bootstrap_tls: node=%d leader=%d ca_in_raft=%s has_cert=%s",
-            self._node_id,
-            leader_id,
-            ca_pem_in_raft is not None,
-            (Path(self._base_path) / "tls" / "node.pem").exists(),
-        )
-        if ca_pem_in_raft is None:
-            if leader_id == self._node_id:
-                self._leader_generate_ca(raft_engine)
-            return False
-
-        # --- Followers: get cert from leader via JoinCluster ---
-        tls_dir = Path(self._base_path) / "tls"
-        if not (tls_dir / "node.pem").exists():
-            if leader_id != self._node_id:
-                self._follower_get_cert(leader_id, ca_pem_in_raft)
-            return False
-
-        # --- Leader: check if all peers have certs (tracked via JoinCluster RPCs) ---
-        # The leader proposes upgrade once all expected peers called JoinCluster.
-        # Followers just wait for the upgrade signal.
-        if leader_id == self._node_id:
-            self._leader_check_all_ready(raft_engine)
-
-        return False  # Wait for upgrade signal
-
-    def _leader_generate_ca(self, raft_engine: Any) -> None:
-        """Leader: generate CA + own cert, propose CA to Raft, set on server."""
-        from nexus.security.tls.certgen import (
-            cert_fingerprint,
-            generate_node_cert,
-            generate_zone_ca,
-            save_pem,
-        )
-        from nexus.security.tls.join_token import generate_join_token
-
-        tls_dir = Path(self._base_path) / "tls"
-        zone_id = ROOT_ZONE_ID
-
-        # Generate CA + own node cert
-        ca_cert, ca_key = generate_zone_ca(zone_id)
-        save_pem(tls_dir / "ca.pem", ca_cert)
-        save_pem(tls_dir / "ca-key.pem", ca_key, is_private=True)
-
-        # Include this node's hostname in cert SAN (CockroachDB pattern).
-        # Use NEXUS_PEERS to get the actual hostname (e.g. nexus-1) instead of bind addr (0.0.0.0).
-        peers_str = os.environ.get("NEXUS_PEERS", "")
-        my_peer_addr = self._find_peer_address(peers_str, self._node_id) or self._advertise_addr
-        leader_hostnames = self._extract_hostnames(my_peer_addr)
-        node_cert, node_key = generate_node_cert(
-            self._node_id, zone_id, ca_cert, ca_key, hostnames=leader_hostnames
-        )
-        save_pem(tls_dir / "node.pem", node_cert)
-        save_pem(tls_dir / "node-key.pem", node_key, is_private=True)
-
-        # Generate join token for future external joiners
-        token, pw_hash = generate_join_token(ca_cert)
-        (tls_dir / "join-token").write_text(token)
-        (tls_dir / "join-token-hash").write_text(pw_hash)
-
-        fp = cert_fingerprint(ca_cert)
-        logger.info("Leader: CA generated (fingerprint: %s)", fp)
-
-        # Propose CA cert to Raft — all nodes will see it after commit
-        ca_pem = (tls_dir / "ca.pem").read_bytes()
-        try:
-            raft_engine.set_metadata(self._TLS_CA_KEY, ca_pem)
-            logger.info("Leader: CA cert proposed to Raft metastore")
-        except RuntimeError as e:
-            logger.warning("Failed to propose CA to Raft: %s", e)
-            return
-
-        # Set CA material on running server so JoinCluster RPCs work
-        ca_key_pem = (tls_dir / "ca-key.pem").read_bytes()
-        self._py_mgr.set_ca_material(ca_pem, ca_key_pem)
-
-    def _follower_get_cert(self, leader_id: int, ca_pem: bytes) -> None:
-        """Follower: call JoinCluster on leader over plaintext to get signed cert.
-
-        Uses the shared Rust implementation (transport::call_join_cluster) via PyO3.
-        """
-        peers_str = os.environ.get("NEXUS_PEERS", "")
-        leader_addr = self._find_peer_address(peers_str, leader_id)
-        if leader_addr is None:
-            return
-
-        # Use this node's address from NEXUS_PEERS (contains the actual hostname
-        # like nexus-2:2126) so the cert SAN includes the correct hostname.
-        my_addr = self._find_peer_address(peers_str, self._node_id) or self._advertise_addr
-        try:
-            resp_ca, resp_cert, resp_key = self._py_mgr.call_join_cluster(
-                leader_addr=leader_addr,
-                node_id=self._node_id,
-                node_address=my_addr,
-                zone_id=ROOT_ZONE_ID,
-            )
-        except Exception as e:
-            logger.info("JoinCluster to leader %d failed (will retry): %s", leader_id, e)
-            return
-
-        # Verify CA matches what's in Raft
-        if resp_ca != ca_pem:
-            logger.error("CA mismatch: JoinCluster response CA differs from Raft CA")
-            return
-
-        # Save certs to disk
-        tls_dir = Path(self._base_path) / "tls"
-        tls_dir.mkdir(parents=True, exist_ok=True)
-        (tls_dir / "ca.pem").write_bytes(resp_ca)
-        (tls_dir / "node.pem").write_bytes(resp_cert)
-        from nexus.security.secret_file import write_secret_file
-
-        write_secret_file(tls_dir / "node-key.pem", resp_key)
-        logger.info("Follower: received signed cert from leader %d", leader_id)
-
-    def _leader_check_all_ready(self, raft_engine: Any) -> None:
-        """Leader: check if all peers have called JoinCluster, then propose upgrade.
-
-        The server tracks JoinCluster calls via joined_peers HashSet in Rust.
-        The leader also counts itself (it has certs from _leader_generate_ca).
-        """
-        if not self._authorized_peer_ids:
-            return
-
-        joined = set(self._py_mgr.joined_peer_ids())
-        # Leader counts itself (it generated its own cert, didn't call JoinCluster)
-        joined.add(self._node_id)
-
-        expected = set(self._authorized_peer_ids)
-        missing = expected - joined
-        if missing:
-            logger.debug(
-                "TLS upgrade: waiting for peers %s (joined: %s)", sorted(missing), sorted(joined)
-            )
-            return
-
-        # All peers ready — propose upgrade via Raft consensus
-        try:
-            raft_engine.set_metadata(self._TLS_UPGRADE_KEY, b"1")
-            logger.info("Leader: all peers ready — TLS upgrade proposed to Raft")
-        except RuntimeError as e:
-            logger.warning("Failed to propose TLS upgrade: %s", e)
-
-    @staticmethod
-    def _find_peer_address(peers_str: str, node_id: int) -> str | None:
-        """Find a peer's address from NEXUS_PEERS string."""
-        for p in peers_str.split(","):
-            p = p.strip()
-            if "@" in p:
-                parts = p.split("@", 1)
-                try:
-                    if int(parts[0]) == node_id:
-                        addr = parts[1]
-                        if not addr.startswith("http"):
-                            addr = f"http://{addr}"
-                        return addr
-                except ValueError:
-                    continue
-        return None
-
-    @staticmethod
-    def _extract_hostnames(address: str) -> list[str]:
-        """Extract hostname from an address for cert SAN inclusion."""
-        addr = address.removeprefix("http://").removeprefix("https://")
-        host = addr.rsplit(":", 1)[0] if ":" in addr else addr
-        if not host or host in ("0.0.0.0", "localhost", "127.0.0.1"):
-            return []
-        return [host]
-
-    def _restart_with_tls(self, tls_config: "ZoneTlsConfig") -> None:
-        """Restart the gRPC server with mTLS. Existing Raft zones are preserved."""
-        ca_key_path = None
-        join_token_hash = None
-        hash_path = Path(self._base_path) / "tls" / "join-token-hash"
-        if hash_path.exists():
-            join_token_hash = hash_path.read_text().strip()
-            ca_key_path = str(Path(self._base_path) / "tls" / "ca-key.pem")
-
-        self._py_mgr.restart_with_tls(
-            tls_cert_path=str(tls_config.node_cert_path),
-            tls_key_path=str(tls_config.node_key_path),
-            tls_ca_path=str(tls_config.ca_cert_path),
-            ca_key_path=ca_key_path,
-            join_token_hash=join_token_hash,
-            authorized_peer_ids=self._authorized_peer_ids,
-        )
-        self._tls_config = tls_config
-        logger.info("Transport upgraded to mTLS")
-
-    # -------------------------------------------------------------------------
     # Topology management
     # -------------------------------------------------------------------------
 
@@ -1005,10 +738,6 @@ class ZoneManager:
             True if topology is fully ready on this node, False if still
             waiting for leader writes or Raft replication.
         """
-        # Phase 0: TLS bootstrap (if in 2-phase mode)
-        if not self.bootstrap_tls():
-            return False
-
         if self._topology_initialized:
             return True
 


### PR DESCRIPTION
## Summary
Replace the 2-phase "start plaintext → upgrade to mTLS" pattern with the industry-standard K3s-style "pre-provision certs → start with TLS" pattern.

**Motivation:** The 2-phase approach (plaintext → leader election → CA distribution via Raft → in-place transport upgrade) is architecturally unique — no production Raft system (etcd, CockroachDB, TiKV, Consul) does this. It introduced bugs where `restart_with_tls` didn't update client pool TLS config, breaking Raft communication after the upgrade.

**New flow:**
```
Node 1: nexusd → auto_generate_tls() → TLS from start
Node 2: NEXUS_JOIN_TOKEN=... nexusd → Rust join_cluster() → certs on disk → TLS from start
```

**Deleted (-435 lines):**
- `_two_phase_tls`, `_authorized_peer_ids`, `bootstrap_tls()`, `_restart_with_tls()`, `_leader_generate_ca()`, `_follower_get_cert()`, `_leader_check_all_ready()`, `upgrade_peer_schemes()`

**Added (+181 lines):**
- Rust `join_cluster()` PyO3 function: parses K10 token, calls JoinCluster RPC, verifies CA fingerprint, writes certs
- `connect()` calls `join_cluster()` BEFORE `ZoneManager` construction
- `ca_fingerprint_from_pem()` in `transport/certgen.rs`

## Test plan
- [x] Rust compiles cleanly (`maturin develop`)
- [x] `from _nexus_raft import join_cluster` works
- [x] Pre-commit: ruff, mypy, rust-fmt, rust-clippy all pass
- [ ] E2E: Node 1 auto-generates TLS, Node 2 joins with token

🤖 Generated with [Claude Code](https://claude.com/claude-code)