### PR TITLE
feat(#1310): clean up local replica blob on federation delete

### DIFF
--- a/src/nexus/raft/federation_content_resolver.py
+++ b/src/nexus/raft/federation_content_resolver.py
@@ -281,6 +281,8 @@ class FederationContentResolver:
             )
             try:
                 self._delete_on_peer(origin, path)
+                # Clean up local replica blob if we have a local ObjectStore (#1310)
+                self._cleanup_local_replica(meta.etag)
                 return {}
             except Exception:
                 logger.warning("Federation delete to %s failed, trying next origin", origin)
@@ -288,6 +290,31 @@ class FederationContentResolver:
 
         logger.warning("Federation delete: all origins unreachable for %s", path)
         return {}
+
+    # === Local replica cleanup (#1310) ===
+
+    def _cleanup_local_replica(self, content_hash: str | None) -> None:
+        """Best-effort cleanup of local replica blob after remote delete.
+
+        If local_object_store is injected and has the content, delete it.
+        Failure is logged but never propagates — the remote delete already
+        succeeded, and orphan blobs are harmless (just waste disk).
+        """
+        if not content_hash or self._local_object_store is None:
+            return
+        store = self._local_object_store
+        try:
+            if hasattr(store, "content_exists") and store.content_exists(content_hash):
+                store.delete_content(content_hash)
+                logger.debug(
+                    "Cleaned up local replica blob %s",
+                    content_hash[:16],
+                )
+        except Exception:
+            logger.debug(
+                "Failed to clean up local replica %s (harmless)",
+                content_hash[:16],
+            )
 
     # === gRPC Remote Operations ===
 

--- a/tests/unit/raft/test_federation_content_resolver.py
+++ b/tests/unit/raft/test_federation_content_resolver.py
@@ -300,6 +300,79 @@ class TestTryDeleteRemoteContent:
         assert mock_delete.call_count == 2
 
 
+class TestDeleteLocalReplicaCleanup:
+    """Tests for local replica blob cleanup on delete (#1310)."""
+
+    @patch.object(FederationContentResolver, "_delete_on_peer")
+    def test_local_replica_cleaned_up_after_remote_delete(self, mock_delete):
+        """After successful remote delete, local replica blob is cleaned up."""
+        meta = _make_meta(f"local@{REMOTE_ADDR}", etag="blob_hash")
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+
+        mock_store = MagicMock()
+        mock_store.content_exists.return_value = True
+
+        resolver = _make_resolver(
+            metastore=metastore,
+            local_object_store=mock_store,
+        )
+        result = resolver.try_delete("/test/file.txt")
+
+        assert result == {}
+        mock_store.delete_content.assert_called_once_with("blob_hash")
+
+    @patch.object(FederationContentResolver, "_delete_on_peer")
+    def test_no_local_replica_no_cleanup(self, mock_delete):
+        """If local CAS doesn't have the blob, skip cleanup."""
+        meta = _make_meta(f"local@{REMOTE_ADDR}", etag="blob_hash")
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+
+        mock_store = MagicMock()
+        mock_store.content_exists.return_value = False
+
+        resolver = _make_resolver(
+            metastore=metastore,
+            local_object_store=mock_store,
+        )
+        result = resolver.try_delete("/test/file.txt")
+
+        assert result == {}
+        mock_store.delete_content.assert_not_called()
+
+    @patch.object(FederationContentResolver, "_delete_on_peer")
+    def test_cleanup_failure_does_not_break_delete(self, mock_delete):
+        """Local cleanup failure is swallowed — remote delete already succeeded."""
+        meta = _make_meta(f"local@{REMOTE_ADDR}", etag="blob_hash")
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+
+        mock_store = MagicMock()
+        mock_store.content_exists.return_value = True
+        mock_store.delete_content.side_effect = Exception("disk error")
+
+        resolver = _make_resolver(
+            metastore=metastore,
+            local_object_store=mock_store,
+        )
+        result = resolver.try_delete("/test/file.txt")
+
+        assert result == {}  # Still succeeds
+
+    @patch.object(FederationContentResolver, "_delete_on_peer")
+    def test_no_object_store_skips_cleanup(self, mock_delete):
+        """Without local_object_store injected, cleanup is skipped."""
+        meta = _make_meta(f"local@{REMOTE_ADDR}", etag="blob_hash")
+        metastore = MagicMock()
+        metastore.get.return_value = meta
+
+        resolver = _make_resolver(metastore=metastore)  # No local_object_store
+        result = resolver.try_delete("/test/file.txt")
+
+        assert result == {}
+
+
 class TestKernelDispatchIntegration:
     """Verify FederationContentResolver works with KernelDispatch."""
 


### PR DESCRIPTION
## Summary
- After successful remote delete via Delete RPC, best-effort cleanup of the local CAS replica blob
- Prevents orphan blob accumulation on replica nodes (from ContentReplicationService or CDC-aware reads)
- Failure is swallowed — remote delete already succeeded, orphan blobs are harmless (just waste disk)
- Only activates when `local_object_store` is injected (Feature DI)

## Test plan
- [x] `test_local_replica_cleaned_up_after_remote_delete` — blob deleted locally
- [x] `test_no_local_replica_no_cleanup` — skip if not in local CAS
- [x] `test_cleanup_failure_does_not_break_delete` — swallowed errors
- [x] `test_no_object_store_skips_cleanup` — backward compat without DI
- [x] All 37 resolver tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)