### PR TITLE
refactor(#1798,#1800): unified agent lifecycle + Process* → Agent* rename

### DIFF
--- a/src/nexus/contracts/agent_types.py
+++ b/src/nexus/contracts/agent_types.py
@@ -1,10 +1,15 @@
-"""Agent domain types shared across tiers (Issue #2032).
+"""Agent domain types shared across tiers (Issue #2032, #1800).
 
 Pure value objects for agent identity and lifecycle. These types have zero
-runtime dependencies on kernel, services, or bricks — only stdlib imports.
+runtime dependencies on kernel, services, or bricks — only stdlib imports
+(plus ``nexus.contracts.process_types`` for the unified ``AgentState``).
 
 Originally in ``nexus.system_services.agents.agent_record``; moved here so bricks
 can import them without violating the zero-core-imports rule.
+
+Issue #1800: The old ``AgentState`` enum (UNKNOWN, CONNECTED, IDLE, SUSPENDED)
+has been deleted. The unified ``AgentState`` from ``process_types`` is the single
+source of truth (REGISTERED, WARMING_UP, READY, BUSY, SUSPENDED, TERMINATED).
 
 Issue #2169: Added AgentSpec/AgentStatus for declarative agent management
 with drift detection (Kubernetes-inspired spec/status separation).
@@ -13,9 +18,10 @@ with drift detection (Kubernetes-inspired spec/status separation).
 import types
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum, StrEnum
+from enum import StrEnum
 from typing import Any
 
+from nexus.contracts.process_types import AgentState
 from nexus.contracts.qos import AgentQoS
 
 
@@ -35,82 +41,6 @@ class EvictionReason(StrEnum):
     CHECKPOINT_TIMEOUT = "checkpoint_timeout"
 
 
-class AgentState(Enum):
-    """Agent lifecycle states (external-agent philosophy).
-
-    State machine:
-        UNKNOWN -----> CONNECTED -----> IDLE
-           ^              |               |
-           |              v               v
-           +---------- SUSPENDED <--------+
-                          |
-                          +-----> CONNECTED (reactivation)
-
-    UNKNOWN: Agent registered but never connected (initial state)
-    CONNECTED: Agent has an active session (generation incremented)
-    IDLE: Agent session ended normally, can reconnect
-    SUSPENDED: Agent temporarily disabled (admin action or policy)
-    """
-
-    UNKNOWN = "UNKNOWN"
-    CONNECTED = "CONNECTED"
-    IDLE = "IDLE"
-    SUSPENDED = "SUSPENDED"
-
-
-# Strict allowlist for valid state transitions (Decision #8A).
-# Any transition not in this table is invalid. No self-transitions allowed.
-VALID_TRANSITIONS: dict[AgentState, frozenset[AgentState]] = {
-    AgentState.UNKNOWN: frozenset({AgentState.CONNECTED}),
-    AgentState.CONNECTED: frozenset({AgentState.IDLE, AgentState.SUSPENDED}),
-    AgentState.IDLE: frozenset({AgentState.CONNECTED, AgentState.SUSPENDED}),
-    AgentState.SUSPENDED: frozenset({AgentState.CONNECTED}),
-}
-
-# States that trigger generation increment when transitioning TO CONNECTED
-_NEW_SESSION_SOURCES = frozenset({AgentState.UNKNOWN, AgentState.IDLE, AgentState.SUSPENDED})
-
-
-def validate_transition(current: AgentState, target: AgentState) -> bool:
-    """Check if a state transition is valid according to the allowlist.
-
-    Pure function with no side effects. Does not modify any state.
-
-    Args:
-        current: Current agent state.
-        target: Desired target state.
-
-    Returns:
-        True if the transition is valid, False otherwise.
-
-    Examples:
-        >>> validate_transition(AgentState.UNKNOWN, AgentState.CONNECTED)
-        True
-        >>> validate_transition(AgentState.UNKNOWN, AgentState.IDLE)
-        False
-        >>> validate_transition(AgentState.CONNECTED, AgentState.CONNECTED)
-        False
-    """
-    allowed = VALID_TRANSITIONS.get(current, frozenset())
-    return target in allowed
-
-
-def is_new_session(current: AgentState, target: AgentState) -> bool:
-    """Check if a transition represents a new session (generation should increment).
-
-    A new session occurs when transitioning TO CONNECTED from any non-CONNECTED
-    state. This is the only time the generation counter increments (Decision #2A).
-
-    Args:
-        current: Current agent state.
-        target: Desired target state.
-
-    Returns:
-        True if this transition starts a new session.
-    """
-    return target is AgentState.CONNECTED and current in _NEW_SESSION_SOURCES
-
-
 @dataclass(frozen=True)
 class AgentRecord:
     """Immutable snapshot of an agent's identity and lifecycle state.
@@ -125,7 +55,7 @@ class AgentRecord:
         owner_id: User ID who owns this agent
         zone_id: Zone/organization ID for multi-zone isolation
         name: Human-readable display name
-        state: Current lifecycle state (AgentState enum)
+        state: Current lifecycle state (AgentState from process_types)
         generation: Session generation counter (increments on new session only)
         last_heartbeat: Timestamp of last heartbeat (None if never heartbeated)
         metadata: Arbitrary agent metadata (platform, endpoint_url, etc.)
@@ -214,10 +144,12 @@ class AgentPhase(StrEnum):
 
 # Mapping from internal state to external phase (default, before condition overrides).
 AGENT_STATE_TO_PHASE: dict[AgentState, AgentPhase] = {
-    AgentState.UNKNOWN: AgentPhase.WARMING,
-    AgentState.CONNECTED: AgentPhase.ACTIVE,
-    AgentState.IDLE: AgentPhase.IDLE,
+    AgentState.REGISTERED: AgentPhase.WARMING,
+    AgentState.WARMING_UP: AgentPhase.WARMING,
+    AgentState.READY: AgentPhase.READY,
+    AgentState.BUSY: AgentPhase.ACTIVE,
     AgentState.SUSPENDED: AgentPhase.SUSPENDED,
+    AgentState.TERMINATED: AgentPhase.EVICTED,
 }
 
 
@@ -328,7 +260,7 @@ def derive_phase(
     """Map internal state + conditions to an external phase.
 
     The base mapping comes from ``AGENT_STATE_TO_PHASE``. Conditions
-    can override the phase (e.g. a "Ready" condition on a CONNECTED
+    can override the phase (e.g. a "Ready" condition on a BUSY
     agent promotes it from ACTIVE to READY).
 
     Args:

--- a/src/nexus/contracts/process_types.py
+++ b/src/nexus/contracts/process_types.py
@@ -1,18 +1,20 @@
-"""Process lifecycle types — kernel-level process management (Issue #1509).
+"""Agent lifecycle types — kernel-level agent management (Issue #1509, #1800).
 
-Pure value objects for the kernel ProcessTable. Zero runtime dependencies
+Pure value objects for the kernel AgentRegistry. Zero runtime dependencies
 on kernel/services/bricks — only stdlib + contracts.
 
     contracts/process_types.py = include/linux/sched.h (task_struct fields)
 
 Defines:
-    ProcessState     — finite state machine (CREATED → RUNNING → … → ZOMBIE)
-    ProcessSignal    — POSIX-like signals (SIGTERM, SIGSTOP, SIGCONT, SIGKILL, SIGUSR1)
-    ProcessKind      — MANAGED (nexusd-spawned) vs UNMANAGED (self-managed via gRPC)
-    ProcessDescriptor — frozen PCB (Process Control Block)
+    AgentState       — finite state machine (REGISTERED → WARMING_UP → READY ↔ BUSY → TERMINATED)
+    AgentSignal      — POSIX-like signals (SIGTERM, SIGSTOP, SIGCONT, SIGKILL, SIGUSR1)
+    AgentKind        — MANAGED (nexusd-spawned) vs UNMANAGED (self-managed via gRPC)
+    AgentDescriptor  — frozen PCB (Process Control Block)
     ExternalProcessInfo — connection metadata for external agents
 
-See: core/process_table.py for the ProcessTable implementation.
+Backward-compat aliases (ProcessState, ProcessSignal, etc.) at bottom of file.
+
+See: core/process_table.py for the AgentRegistry implementation.
 """
 
 from __future__ import annotations
@@ -28,41 +30,51 @@ from typing import Any
 # ---------------------------------------------------------------------------
 
 
-class ProcessState(StrEnum):
-    """Process lifecycle states — mirrors Linux task_struct.state."""
+class AgentState(StrEnum):
+    """Unified agent lifecycle states (Issue #1798, #1800).
 
-    CREATED = "created"
-    RUNNING = "running"
-    SLEEPING = "sleeping"
-    STOPPED = "stopped"
-    ZOMBIE = "zombie"
+    Single source of truth — replaces the dual ProcessState/AgentState
+    state machines that were out of sync.
+
+    Lifecycle::
+
+        REGISTERED → WARMING_UP → READY → BUSY → READY (loop)
+                                    ↓       ↓
+                                SUSPENDED ← ─┘
+                                    ↓
+                               TERMINATED
+    """
+
+    REGISTERED = "registered"  # Agent registered, not yet started
+    WARMING_UP = "warming_up"  # Initializing (load credentials, mount namespace)
+    READY = "ready"  # Idle, waiting for next prompt
+    BUSY = "busy"  # Actively processing a prompt / tool call
+    SUSPENDED = "suspended"  # Paused (admin / resource pressure eviction)
+    TERMINATED = "terminated"  # Finished, pending cleanup
 
 
-VALID_PROCESS_TRANSITIONS: dict[ProcessState, frozenset[ProcessState]] = {
-    ProcessState.CREATED: frozenset({ProcessState.RUNNING}),
-    ProcessState.RUNNING: frozenset(
-        {ProcessState.SLEEPING, ProcessState.STOPPED, ProcessState.ZOMBIE}
-    ),
-    ProcessState.SLEEPING: frozenset(
-        {ProcessState.RUNNING, ProcessState.STOPPED, ProcessState.ZOMBIE}
-    ),
-    ProcessState.STOPPED: frozenset({ProcessState.SLEEPING, ProcessState.ZOMBIE}),
-    ProcessState.ZOMBIE: frozenset(),  # terminal
+VALID_AGENT_TRANSITIONS: dict[AgentState, frozenset[AgentState]] = {
+    AgentState.REGISTERED: frozenset({AgentState.WARMING_UP, AgentState.TERMINATED}),
+    AgentState.WARMING_UP: frozenset({AgentState.READY, AgentState.TERMINATED}),
+    AgentState.READY: frozenset({AgentState.BUSY, AgentState.SUSPENDED, AgentState.TERMINATED}),
+    AgentState.BUSY: frozenset({AgentState.READY, AgentState.SUSPENDED, AgentState.TERMINATED}),
+    AgentState.SUSPENDED: frozenset({AgentState.READY, AgentState.TERMINATED}),
+    AgentState.TERMINATED: frozenset(),  # terminal
 }
 
 
-class ProcessSignal(StrEnum):
-    """POSIX-like process signals."""
+class AgentSignal(StrEnum):
+    """POSIX-like agent signals."""
 
-    SIGTERM = "SIGTERM"  # Graceful shutdown → ZOMBIE
-    SIGSTOP = "SIGSTOP"  # Suspend → STOPPED
-    SIGCONT = "SIGCONT"  # Resume → SLEEPING
+    SIGTERM = "SIGTERM"  # Graceful shutdown → TERMINATED
+    SIGSTOP = "SIGSTOP"  # Suspend → SUSPENDED
+    SIGCONT = "SIGCONT"  # Resume → READY
     SIGKILL = "SIGKILL"  # Immediate kill + reap
     SIGUSR1 = "SIGUSR1"  # User-defined (agent steering)
 
 
-class ProcessKind(StrEnum):
-    """Process kind — who controls the lifecycle."""
+class AgentKind(StrEnum):
+    """Agent kind — who controls the lifecycle."""
 
     MANAGED = "managed"  # nexusd spawns + owns lifecycle (spawn/kill/signal)
     UNMANAGED = "unmanaged"  # external agent connects, self-managed (register/heartbeat)
@@ -73,15 +85,15 @@ class ProcessKind(StrEnum):
 # ---------------------------------------------------------------------------
 
 
-class ProcessError(Exception):
-    """Base exception for process operations."""
+class AgentError(Exception):
+    """Base exception for agent operations."""
 
 
-class ProcessNotFoundError(ProcessError):
-    """Raised when a PID does not exist in the process table."""
+class AgentNotFoundError(AgentError):
+    """Raised when a PID does not exist in the agent registry."""
 
 
-class InvalidTransitionError(ProcessError):
+class InvalidTransitionError(AgentError):
     """Raised when a state transition is not allowed."""
 
 
@@ -102,8 +114,8 @@ class ExternalProcessInfo:
 
 
 @dataclass(frozen=True, slots=True)
-class ProcessDescriptor:
-    """Frozen PCB (Process Control Block) — kernel process descriptor.
+class AgentDescriptor:
+    """Frozen PCB (Process Control Block) — kernel agent descriptor.
 
     Immutable. Use ``dataclasses.replace()`` for state transitions.
     """
@@ -114,10 +126,10 @@ class ProcessDescriptor:
     name: str
     owner_id: str
     zone_id: str
-    kind: ProcessKind
+    kind: AgentKind
 
     # Lifecycle
-    state: ProcessState
+    state: AgentState
     exit_code: int | None = None
     generation: int = 0
 
@@ -182,7 +194,7 @@ class ProcessDescriptor:
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ProcessDescriptor:
+    def from_dict(cls, d: dict[str, Any]) -> AgentDescriptor:
         """Deserialize from dict."""
         ext_raw = d.get("external_info")
         ext_info = None
@@ -201,8 +213,8 @@ class ProcessDescriptor:
             name=d["name"],
             owner_id=d["owner_id"],
             zone_id=d["zone_id"],
-            kind=ProcessKind(d["kind"]),
-            state=ProcessState(d["state"]),
+            kind=AgentKind(d["kind"]),
+            state=AgentState(d["state"]),
             exit_code=d.get("exit_code"),
             generation=d.get("generation", 0),
             cwd=d.get("cwd", "/"),
@@ -215,6 +227,32 @@ class ProcessDescriptor:
         )
 
     @classmethod
-    def from_json(cls, s: str) -> ProcessDescriptor:
+    def from_json(cls, s: str) -> AgentDescriptor:
         """Deserialize from JSON string."""
         return cls.from_dict(json.loads(s))
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat aliases (Issue #1800)
+# ---------------------------------------------------------------------------
+
+ProcessState = AgentState
+"""Deprecated alias — use ``AgentState``."""
+
+VALID_PROCESS_TRANSITIONS = VALID_AGENT_TRANSITIONS
+"""Deprecated alias — use ``VALID_AGENT_TRANSITIONS``."""
+
+ProcessSignal = AgentSignal
+"""Deprecated alias — use ``AgentSignal``."""
+
+ProcessKind = AgentKind
+"""Deprecated alias — use ``AgentKind``."""
+
+ProcessError = AgentError
+"""Deprecated alias — use ``AgentError``."""
+
+ProcessNotFoundError = AgentNotFoundError
+"""Deprecated alias — use ``AgentNotFoundError``."""
+
+ProcessDescriptor = AgentDescriptor
+"""Deprecated alias — use ``AgentDescriptor``."""

--- a/src/nexus/contracts/protocols/acp.py
+++ b/src/nexus/contracts/protocols/acp.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from nexus.contracts.process_types import ProcessDescriptor
+    from nexus.contracts.process_types import AgentDescriptor
 
 
 @runtime_checkable
@@ -35,8 +35,8 @@ class AcpServiceProtocol(Protocol):
         *,
         zone_id: str | None = None,
         owner_id: str | None = None,
-    ) -> list[ProcessDescriptor]: ...
+    ) -> list[AgentDescriptor]: ...
 
-    def kill_agent(self, pid: str) -> ProcessDescriptor: ...
+    def kill_agent(self, pid: str) -> AgentDescriptor: ...
 
     def close_all(self) -> None: ...

--- a/src/nexus/contracts/protocols/process_table.py
+++ b/src/nexus/contracts/protocols/process_table.py
@@ -1,6 +1,6 @@
-"""ProcessTableProtocol — kernel-level process lifecycle contract (Issue #1509).
+"""AgentRegistryProtocol — kernel-level agent lifecycle contract (Issue #1509, #1800).
 
-Kernel contract for process management. No LLM, no tools, no agent logic.
+Kernel contract for agent management. No LLM, no tools, no agent logic.
 Those belong in the service-layer AgentService (Phase 4).
 
     contracts/protocols/process_table.py = kernel syscall interface
@@ -12,17 +12,17 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from nexus.contracts.process_types import (
+        AgentDescriptor,
+        AgentKind,
+        AgentSignal,
+        AgentState,
         ExternalProcessInfo,
-        ProcessDescriptor,
-        ProcessKind,
-        ProcessSignal,
-        ProcessState,
     )
 
 
 @runtime_checkable
-class ProcessTableProtocol(Protocol):
-    """Kernel process table — PID allocation, state machine, signals, wait()."""
+class AgentRegistryProtocol(Protocol):
+    """Kernel agent registry — PID allocation, state machine, signals, wait()."""
 
     def spawn(
         self,
@@ -30,47 +30,47 @@ class ProcessTableProtocol(Protocol):
         owner_id: str,
         zone_id: str,
         *,
-        kind: ProcessKind = ...,
+        kind: AgentKind = ...,
         pid: str | None = None,
         parent_pid: str | None = None,
         cwd: str = "/",
         external_info: ExternalProcessInfo | None = None,
         labels: dict[str, str] | None = None,
-    ) -> ProcessDescriptor: ...
+    ) -> AgentDescriptor: ...
 
     def kill(
         self,
         pid: str,
         *,
         exit_code: int = 0,
-    ) -> ProcessDescriptor: ...
+    ) -> AgentDescriptor: ...
 
     def signal(
         self,
         pid: str,
-        sig: ProcessSignal,
+        sig: AgentSignal,
         *,
         payload: dict[str, Any] | None = None,
-    ) -> ProcessDescriptor: ...
+    ) -> AgentDescriptor: ...
 
     async def wait(
         self,
         pid: str,
         *,
-        target_states: frozenset[ProcessState] | None = None,
+        target_states: frozenset[AgentState] | None = None,
         timeout: float | None = None,
-    ) -> ProcessDescriptor | None: ...
+    ) -> AgentDescriptor | None: ...
 
-    def get(self, pid: str) -> ProcessDescriptor | None: ...
+    def get(self, pid: str) -> AgentDescriptor | None: ...
 
     def list_processes(
         self,
         *,
         zone_id: str | None = None,
         owner_id: str | None = None,
-        kind: ProcessKind | None = None,
-        state: ProcessState | None = None,
-    ) -> list[ProcessDescriptor]: ...
+        kind: AgentKind | None = None,
+        state: AgentState | None = None,
+    ) -> list[AgentDescriptor]: ...
 
     def register_external(
         self,
@@ -84,8 +84,13 @@ class ProcessTableProtocol(Protocol):
         protocol: str = "grpc",
         parent_pid: str | None = None,
         labels: dict[str, str] | None = None,
-    ) -> ProcessDescriptor: ...
+    ) -> AgentDescriptor: ...
 
-    def heartbeat(self, pid: str) -> ProcessDescriptor: ...
+    def heartbeat(self, pid: str) -> AgentDescriptor: ...
 
     def unregister_external(self, pid: str) -> None: ...
+
+
+# Backward-compat alias (Issue #1800)
+ProcessTableProtocol = AgentRegistryProtocol
+"""Deprecated alias — use ``AgentRegistryProtocol``."""

--- a/src/nexus/core/process_table.py
+++ b/src/nexus/core/process_table.py
@@ -1,8 +1,8 @@
-"""ProcessTable — kernel process lifecycle manager (Issue #1509).
+"""AgentRegistry — kernel agent lifecycle manager (Issue #1509, #1800).
 
-Pure in-memory process table, analogous to Linux task_struct array.
-No metastore persistence — process state is ephemeral (tied to OS
-process lifespan).  On nexusd restart, all processes are gone.
+Pure in-memory agent registry, analogous to Linux task_struct array.
+No metastore persistence — agent state is ephemeral (tied to OS
+process lifespan).  On nexusd restart, all agents are gone.
 
 VFS visibility is provided by ProcResolver (procfs model): reading
 ``/{zone}/proc/{pid}/status`` generates content from memory at
@@ -15,9 +15,9 @@ Concurrency model:
   - spawn/kill/signal/get/list are synchronous (fast PID allocation
     + in-memory dict write). Safe under asyncio event loop (no await).
   - wait() is async (blocks on asyncio.Event until target state).
-  - State transitions are validated against VALID_PROCESS_TRANSITIONS.
+  - State transitions are validated against VALID_AGENT_TRANSITIONS.
 
-See: contracts/process_types.py for ProcessDescriptor, ProcessState.
+See: contracts/process_types.py for AgentDescriptor, AgentState.
 """
 
 import asyncio
@@ -29,29 +29,29 @@ from datetime import UTC, datetime
 from typing import Any
 
 from nexus.contracts.process_types import (
-    VALID_PROCESS_TRANSITIONS,
+    VALID_AGENT_TRANSITIONS,
+    AgentDescriptor,
+    AgentError,
+    AgentKind,
+    AgentNotFoundError,
+    AgentSignal,
+    AgentState,
     ExternalProcessInfo,
     InvalidTransitionError,
-    ProcessDescriptor,
-    ProcessError,
-    ProcessKind,
-    ProcessNotFoundError,
-    ProcessSignal,
-    ProcessState,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class ProcessTable:
-    """Manages process lifecycle — PID allocation, state machine, signals, wait().
+class AgentRegistry:
+    """Manages agent lifecycle — PID allocation, state machine, signals, wait().
 
     Pure in-memory — analogous to Linux's task_struct table.
     VFS visibility via ProcResolver (procfs), not metastore persistence.
     """
 
     def __init__(self) -> None:
-        self._processes: dict[str, ProcessDescriptor] = {}
+        self._processes: dict[str, AgentDescriptor] = {}
         self._wait_events: dict[str, list[asyncio.Event]] = {}
 
     # ------------------------------------------------------------------
@@ -68,12 +68,12 @@ class ProcessTable:
 
     def _transition(
         self,
-        desc: ProcessDescriptor,
-        new_state: ProcessState,
+        desc: AgentDescriptor,
+        new_state: AgentState,
         **kwargs: Any,
-    ) -> ProcessDescriptor:
+    ) -> AgentDescriptor:
         """Validate and apply state transition. Returns new descriptor."""
-        allowed = VALID_PROCESS_TRANSITIONS.get(desc.state, frozenset())
+        allowed = VALID_AGENT_TRANSITIONS.get(desc.state, frozenset())
         if new_state not in allowed:
             raise InvalidTransitionError(
                 f"cannot transition {desc.pid} from {desc.state} to {new_state}"
@@ -101,31 +101,31 @@ class ProcessTable:
         owner_id: str,
         zone_id: str,
         *,
-        kind: ProcessKind = ProcessKind.MANAGED,
+        kind: AgentKind = AgentKind.MANAGED,
         pid: str | None = None,
         parent_pid: str | None = None,
         cwd: str = "/",
         external_info: ExternalProcessInfo | None = None,
         labels: dict[str, str] | None = None,
-    ) -> ProcessDescriptor:
-        """Create a new process in RUNNING state."""
+    ) -> AgentDescriptor:
+        """Create a new process in REGISTERED state."""
         # Validate parent
         if parent_pid is not None:
             parent = self._processes.get(parent_pid)
             if parent is None:
-                raise ProcessNotFoundError(f"parent not found: {parent_pid}")
+                raise AgentNotFoundError(f"parent not found: {parent_pid}")
 
         pid = pid or self._alloc_pid()
         now = datetime.now(UTC)
 
-        desc = ProcessDescriptor(
+        desc = AgentDescriptor(
             pid=pid,
             ppid=parent_pid,
             name=name,
             owner_id=owner_id,
             zone_id=zone_id,
             kind=kind,
-            state=ProcessState.RUNNING,
+            state=AgentState.REGISTERED,
             generation=1,
             cwd=cwd,
             external_info=external_info,
@@ -149,16 +149,16 @@ class ProcessTable:
         logger.debug("process spawned: pid=%s name=%s kind=%s", pid, name, kind)
         return desc
 
-    def kill(self, pid: str, *, exit_code: int = 0) -> ProcessDescriptor:
-        """Kill a process — transition to ZOMBIE, auto-reap if orphan."""
+    def kill(self, pid: str, *, exit_code: int = 0) -> AgentDescriptor:
+        """Kill a process — transition to TERMINATED, auto-reap if orphan."""
         desc = self._processes.get(pid)
         if desc is None:
-            raise ProcessNotFoundError(f"process not found: {pid}")
+            raise AgentNotFoundError(f"process not found: {pid}")
 
-        if desc.state == ProcessState.ZOMBIE:
+        if desc.state == AgentState.TERMINATED:
             return desc  # already dead
 
-        updated = self._transition(desc, ProcessState.ZOMBIE, exit_code=exit_code)
+        updated = self._transition(desc, AgentState.TERMINATED, exit_code=exit_code)
 
         # Auto-reap if orphan (no parent to wait())
         if updated.ppid is None:
@@ -169,30 +169,30 @@ class ProcessTable:
     def signal(
         self,
         pid: str,
-        sig: ProcessSignal,
+        sig: AgentSignal,
         *,
         payload: dict[str, Any] | None = None,
-    ) -> ProcessDescriptor:
+    ) -> AgentDescriptor:
         """Send a signal to a process."""
         desc = self._processes.get(pid)
         if desc is None:
-            raise ProcessNotFoundError(f"process not found: {pid}")
+            raise AgentNotFoundError(f"process not found: {pid}")
 
         match sig:
-            case ProcessSignal.SIGSTOP:
-                return self._transition(desc, ProcessState.STOPPED)
-            case ProcessSignal.SIGCONT:
+            case AgentSignal.SIGSTOP:
+                return self._transition(desc, AgentState.SUSPENDED)
+            case AgentSignal.SIGCONT:
                 new_gen = desc.generation + 1
-                return self._transition(desc, ProcessState.SLEEPING, generation=new_gen)
-            case ProcessSignal.SIGTERM:
+                return self._transition(desc, AgentState.READY, generation=new_gen)
+            case AgentSignal.SIGTERM:
                 return self.kill(pid)
-            case ProcessSignal.SIGKILL:
+            case AgentSignal.SIGKILL:
                 # Force kill + immediate reap regardless of parent
-                if desc.state != ProcessState.ZOMBIE:
-                    desc = self._transition(desc, ProcessState.ZOMBIE, exit_code=-9)
+                if desc.state != AgentState.TERMINATED:
+                    desc = self._transition(desc, AgentState.TERMINATED, exit_code=-9)
                 self._reap(desc)
                 return desc
-            case ProcessSignal.SIGUSR1:
+            case AgentSignal.SIGUSR1:
                 # User-defined signal — merge payload into labels, notify waiters
                 if payload:
                     merged = {**desc.labels, **{k: str(v) for k, v in payload.items()}}
@@ -201,26 +201,26 @@ class ProcessTable:
                 self._notify_waiters(pid)
                 return desc
             case _:
-                raise ProcessError(f"unknown signal: {sig}")
+                raise AgentError(f"unknown signal: {sig}")
 
     async def wait(
         self,
         pid: str,
         *,
-        target_states: frozenset[ProcessState] | None = None,
+        target_states: frozenset[AgentState] | None = None,
         timeout: float | None = None,
-    ) -> ProcessDescriptor | None:
+    ) -> AgentDescriptor | None:
         """Wait for process to reach target state. Reaps ZOMBIE on return."""
         if target_states is None:
-            target_states = frozenset({ProcessState.ZOMBIE})
+            target_states = frozenset({AgentState.TERMINATED})
 
         desc = self._processes.get(pid)
         if desc is None:
-            raise ProcessNotFoundError(f"process not found: {pid}")
+            raise AgentNotFoundError(f"process not found: {pid}")
 
         # Already in target state?
         if desc.state in target_states:
-            if desc.state == ProcessState.ZOMBIE:
+            if desc.state == AgentState.TERMINATED:
                 self._reap(desc)
             return desc
 
@@ -240,7 +240,7 @@ class ProcessTable:
                     return None  # reaped by someone else
 
                 if desc.state in target_states:
-                    if desc.state == ProcessState.ZOMBIE:
+                    if desc.state == AgentState.TERMINATED:
                         self._reap(desc)
                     return desc
 
@@ -253,7 +253,7 @@ class ProcessTable:
             if not waiters:
                 self._wait_events.pop(pid, None)
 
-    def get(self, pid: str) -> ProcessDescriptor | None:
+    def get(self, pid: str) -> AgentDescriptor | None:
         """Look up process by PID."""
         return self._processes.get(pid)
 
@@ -262,9 +262,9 @@ class ProcessTable:
         *,
         zone_id: str | None = None,
         owner_id: str | None = None,
-        kind: ProcessKind | None = None,
-        state: ProcessState | None = None,
-    ) -> list[ProcessDescriptor]:
+        kind: AgentKind | None = None,
+        state: AgentState | None = None,
+    ) -> list[AgentDescriptor]:
         """List processes with optional filters."""
         result = list(self._processes.values())
         if zone_id is not None:
@@ -281,7 +281,7 @@ class ProcessTable:
     # Convenience queries (Issue #1692)
     # ------------------------------------------------------------------
 
-    def count_by_state(self, state: ProcessState, *, zone_id: str | None = None) -> int:
+    def count_by_state(self, state: AgentState, *, zone_id: str | None = None) -> int:
         """Count processes in a given state."""
         return len(self.list_processes(state=state, zone_id=zone_id))
 
@@ -290,9 +290,9 @@ class ProcessTable:
         *,
         zone_id: str | None = None,
         batch_size: int = 10,
-    ) -> list[ProcessDescriptor]:
-        """List RUNNING processes sorted by eviction priority (lowest first), then LRU."""
-        procs = self.list_processes(state=ProcessState.RUNNING, zone_id=zone_id)
+    ) -> list[AgentDescriptor]:
+        """List BUSY processes sorted by eviction priority (lowest first), then LRU."""
+        procs = self.list_processes(state=AgentState.BUSY, zone_id=zone_id)
         procs.sort(
             key=lambda p: (
                 int(p.labels.get("eviction_priority", "50")),
@@ -317,7 +317,7 @@ class ProcessTable:
         protocol: str = "grpc",
         parent_pid: str | None = None,
         labels: dict[str, str] | None = None,
-    ) -> ProcessDescriptor:
+    ) -> AgentDescriptor:
         """Register an external process (gRPC agent connects)."""
         now = datetime.now(UTC)
         ext_info = ExternalProcessInfo(
@@ -331,21 +331,21 @@ class ProcessTable:
             name,
             owner_id,
             zone_id,
-            kind=ProcessKind.UNMANAGED,
+            kind=AgentKind.UNMANAGED,
             parent_pid=parent_pid,
             external_info=ext_info,
             labels=labels,
         )
 
-    def heartbeat(self, pid: str) -> ProcessDescriptor:
+    def heartbeat(self, pid: str) -> AgentDescriptor:
         """Update heartbeat timestamp for an external process."""
         desc = self._processes.get(pid)
         if desc is None:
-            raise ProcessNotFoundError(f"process not found: {pid}")
-        if desc.kind != ProcessKind.UNMANAGED:
-            raise ProcessError(f"heartbeat only for unmanaged processes: {pid}")
+            raise AgentNotFoundError(f"process not found: {pid}")
+        if desc.kind != AgentKind.UNMANAGED:
+            raise AgentError(f"heartbeat only for unmanaged processes: {pid}")
         if desc.external_info is None:
-            raise ProcessError(f"missing external_info: {pid}")
+            raise AgentError(f"missing external_info: {pid}")
 
         now = datetime.now(UTC)
         new_ext = replace(desc.external_info, last_heartbeat=now)
@@ -354,22 +354,22 @@ class ProcessTable:
         return updated
 
     def unregister_external(self, pid: str) -> None:
-        """Unregister an external process — ZOMBIE + reap."""
+        """Unregister an external process — TERMINATED + reap."""
         desc = self._processes.get(pid)
         if desc is None:
-            raise ProcessNotFoundError(f"process not found: {pid}")
-        if desc.kind != ProcessKind.UNMANAGED:
-            raise ProcessError(f"unregister_external only for unmanaged processes: {pid}")
+            raise AgentNotFoundError(f"process not found: {pid}")
+        if desc.kind != AgentKind.UNMANAGED:
+            raise AgentError(f"unregister_external only for unmanaged processes: {pid}")
 
-        if desc.state != ProcessState.ZOMBIE:
-            desc = self._transition(desc, ProcessState.ZOMBIE)
+        if desc.state != AgentState.TERMINATED:
+            desc = self._transition(desc, AgentState.TERMINATED)
         self._reap(desc)
 
     # ------------------------------------------------------------------
     # Reap — remove process from table
     # ------------------------------------------------------------------
 
-    def _reap(self, desc: ProcessDescriptor) -> None:
+    def _reap(self, desc: AgentDescriptor) -> None:
         """Remove process from table and clean up parent.children."""
         pid = desc.pid
         self._processes.pop(pid, None)
@@ -397,9 +397,14 @@ class ProcessTable:
         """Shutdown: kill all processes, clear state."""
         for pid in list(self._processes):
             desc = self._processes.get(pid)
-            if desc is not None and desc.state != ProcessState.ZOMBIE:
-                with contextlib.suppress(ProcessError, InvalidTransitionError):
+            if desc is not None and desc.state != AgentState.TERMINATED:
+                with contextlib.suppress(AgentError, InvalidTransitionError):
                     self.kill(pid)
         self._processes.clear()
         self._wait_events.clear()
-        logger.debug("ProcessTable closed — all processes cleared")
+        logger.debug("AgentRegistry closed — all agents cleared")
+
+
+# Backward-compat alias (Issue #1800)
+ProcessTable = AgentRegistry
+"""Deprecated alias — use ``AgentRegistry``."""

--- a/src/nexus/system_services/acp/service.py
+++ b/src/nexus/system_services/acp/service.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
-from nexus.contracts.process_types import ProcessDescriptor, ProcessKind
+from nexus.contracts.process_types import AgentDescriptor, AgentKind
 from nexus.core.stdio_pipe import StdioPipe
 
 from .agents import AgentConfig
@@ -191,7 +191,7 @@ class AcpService:
             name=f"acp:{config.name}",
             owner_id=owner_id,
             zone_id=zone_id,
-            kind=ProcessKind.UNMANAGED,
+            kind=AgentKind.UNMANAGED,
             labels=merged_labels,
         )
         pid = desc.pid
@@ -350,7 +350,7 @@ class AcpService:
                 with contextlib.suppress(Exception):
                     self._pipe_manager.destroy(fd_path)
 
-    def kill_agent(self, pid: str) -> ProcessDescriptor:
+    def kill_agent(self, pid: str) -> AgentDescriptor:
         """Kill a running agent connection and mark ZOMBIE in ProcessTable."""
         active = self._connections.pop(pid, None)
         if active is not None:
@@ -361,7 +361,7 @@ class AcpService:
                 pass
             self._teardown_agent(active)
 
-        desc: ProcessDescriptor = self._process_table.kill(pid, exit_code=-9)
+        desc: AgentDescriptor = self._process_table.kill(pid, exit_code=-9)
         return desc
 
     def list_agents(
@@ -369,10 +369,10 @@ class AcpService:
         *,
         zone_id: str | None = None,
         owner_id: str | None = None,
-    ) -> list[ProcessDescriptor]:
+    ) -> list[AgentDescriptor]:
         """List ACP-managed processes from the ProcessTable."""
         procs = self._process_table.list_processes(
-            kind=ProcessKind.UNMANAGED,
+            kind=AgentKind.UNMANAGED,
             zone_id=zone_id,
             owner_id=owner_id,
         )

--- a/src/nexus/system_services/agents/agent_registration.py
+++ b/src/nexus/system_services/agents/agent_registration.py
@@ -2,7 +2,7 @@
 
 Orchestrates the multi-step registration of a top-level agent:
 1. Register in entity_registry (persistent agent identity, DB)
-2. Register in ProcessTable (runtime liveness, in-memory)
+2. Register in AgentRegistry (runtime liveness, in-memory)
 3. Create ReBAC permission tuples for grants
 4. Create permanent API key (no TTL)
 5. Provision IPC directories (inbox/outbox/processed/dead_letter)
@@ -29,7 +29,7 @@ from nexus.contracts.grant_helpers import GrantInput, grants_to_rebac_tuples
 
 if TYPE_CHECKING:
     from nexus.contracts.protocols.entity_registry import EntityRegistryProtocol
-    from nexus.core.process_table import ProcessTable
+    from nexus.core.process_table import AgentRegistry
     from nexus.storage.record_store import RecordStoreABC
 
 logger = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ class AgentRegistrationService:
     Args:
         record_store: RecordStoreABC for session creation (API key step).
         entity_registry: EntityRegistry for persistent agent identity.
-        process_table: ProcessTable for runtime agent liveness.
+        process_table: AgentRegistry for runtime agent liveness.
         rebac_manager: EnhancedReBACManager for permission tuples.
         ipc_provisioner: Optional IPC provisioner (AgentProvisioner) for IPC directories.
         key_service: Optional KeyService for Ed25519 public key storage.
@@ -77,7 +77,7 @@ class AgentRegistrationService:
         self,
         record_store: "RecordStoreABC",
         entity_registry: "EntityRegistryProtocol | None" = None,
-        process_table: "ProcessTable | None" = None,
+        process_table: "AgentRegistry | None" = None,
         rebac_manager: Any = None,
         ipc_provisioner: Any = None,
         key_service: Any = None,
@@ -105,7 +105,7 @@ class AgentRegistrationService:
         Steps (in order):
             1. Register in entity_registry (persistent identity, DB).
                409 if agent_id already exists.
-            2. Register in ProcessTable (runtime liveness, in-memory).
+            2. Register in AgentRegistry (runtime liveness, in-memory).
             3. Create ReBAC permission tuples (if grants provided).
             4. Create permanent API key (no TTL, subject_type="agent").
             5. Provision IPC directories (if ipc=True, async filesystem).
@@ -147,7 +147,7 @@ class AgentRegistrationService:
                 entity_metadata={"name": name, "zone_id": effective_zone},
             )
 
-        # ── Step 2: Runtime liveness in ProcessTable ─────────────────
+        # ── Step 2: Runtime liveness in AgentRegistry ─────────────────
         if self._process_table is not None:
             self._process_table.register_external(
                 name,

--- a/src/nexus/system_services/agents/agent_rpc_service.py
+++ b/src/nexus/system_services/agents/agent_rpc_service.py
@@ -780,9 +780,9 @@ class AgentRPCService:
 
             # Map legacy state names
             _STATE_MAP = {
-                "CONNECTED": ProcessState.RUNNING,
-                "IDLE": ProcessState.SLEEPING,
-                "SUSPENDED": ProcessState.STOPPED,
+                "CONNECTED": ProcessState.BUSY,
+                "IDLE": ProcessState.READY,
+                "SUSPENDED": ProcessState.SUSPENDED,
             }
             state_enum = _STATE_MAP.get(state.upper())
             if state_enum is None:

--- a/src/nexus/system_services/agents/agent_warmup.py
+++ b/src/nexus/system_services/agents/agent_warmup.py
@@ -33,14 +33,14 @@ from nexus.contracts.agent_warmup_types import (
     WarmupStep,
 )
 from nexus.contracts.process_types import (
+    AgentError,
+    AgentSignal,
+    AgentState,
     InvalidTransitionError,
-    ProcessError,
-    ProcessSignal,
-    ProcessState,
 )
 
 if TYPE_CHECKING:
-    from nexus.core.process_table import ProcessTable
+    from nexus.core.process_table import AgentRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ class AgentWarmupService:
 
     def __init__(
         self,
-        process_table: "ProcessTable",
+        process_table: "AgentRegistry",
         namespace_manager: Any | None = None,
         enabled_bricks: frozenset[str] | None = None,
         cache_store: Any | None = None,
@@ -137,8 +137,8 @@ class AgentWarmupService:
             )
 
         # Edge case 2: Already CONNECTED → skip (idempotent)
-        if record.state is ProcessState.RUNNING:
-            logger.info("[WARMUP] Agent %s already CONNECTED, skipping warmup", agent_id)
+        if record.state is AgentState.BUSY:
+            logger.info("[WARMUP] Agent %s already BUSY, skipping warmup", agent_id)
             return WarmupResult(
                 success=True,
                 agent_id=agent_id,
@@ -268,8 +268,8 @@ class AgentWarmupService:
                 raise InvalidTransitionError(
                     f"stale generation for {agent_id}: expected {expected_generation}, got {current.generation}"
                 )
-            self._process_table.signal(agent_id, ProcessSignal.SIGCONT)
-        except (ValueError, InvalidTransitionError, ProcessError) as exc:
+            self._process_table.signal(agent_id, AgentSignal.SIGCONT)
+        except (ValueError, InvalidTransitionError, AgentError) as exc:
             logger.warning("[WARMUP] Failed to transition agent %s to CONNECTED: %s", agent_id, exc)
             return WarmupResult(
                 success=False,

--- a/src/nexus/system_services/agents/eviction_manager.py
+++ b/src/nexus/system_services/agents/eviction_manager.py
@@ -1,6 +1,6 @@
 """Eviction manager orchestrating resource-pressure agent eviction (Issues #2170, #2171).
 
-Composes ResourceMonitor + EvictionPolicy + ProcessTable to implement the
+Composes ResourceMonitor + EvictionPolicy + AgentRegistry to implement the
 eviction pipeline: check pressure -> select candidates -> checkpoint -> evict.
 
 Follows Orleans watermark-based eviction pattern:
@@ -24,8 +24,8 @@ from nexus.contracts.agent_types import EvictionReason
 from nexus.contracts.qos import EVICTION_ORDER, EvictionContext, PressureLevel, QoSClass
 
 if TYPE_CHECKING:
-    from nexus.contracts.process_types import ProcessDescriptor
-    from nexus.core.process_table import ProcessTable
+    from nexus.contracts.process_types import AgentDescriptor
+    from nexus.core.process_table import AgentRegistry
     from nexus.lib.performance_tuning import EvictionTuning
     from nexus.system_services.agents.eviction_policy import EvictionPolicy
     from nexus.system_services.agents.resource_monitor import ResourceMonitor
@@ -54,13 +54,13 @@ class EvictionManager:
     Composes:
     - ResourceMonitor: checks memory pressure
     - EvictionPolicy: selects which agents to evict
-    - ProcessTable: manages process state transitions and signals
+    - AgentRegistry: manages process state transitions and signals
 
     Issue #2171: Adds an asyncio.Event for immediate preemption cycles
     triggered by premium agent registration when at capacity.
 
     Args:
-        process_table: ProcessTable for state transitions and signals.
+        process_table: AgentRegistry for state transitions and signals.
         monitor: ResourceMonitor for pressure detection.
         policy: EvictionPolicy for candidate selection.
         tuning: EvictionTuning with thresholds and batch sizes.
@@ -68,7 +68,7 @@ class EvictionManager:
 
     def __init__(
         self,
-        process_table: "ProcessTable",
+        process_table: "AgentRegistry",
         monitor: "ResourceMonitor",
         policy: "EvictionPolicy",
         tuning: "EvictionTuning",
@@ -155,7 +155,7 @@ class EvictionManager:
         # 1b. Check max_active_agents cap (secondary trigger, lightweight COUNT)
         over_cap = False
         if pressure is PressureLevel.NORMAL:
-            connected_count = self._process_table.count_by_state(ProcessState.RUNNING)
+            connected_count = self._process_table.count_by_state(ProcessState.BUSY)
             if connected_count > self._tuning.max_active_agents:
                 over_cap = True
                 logger.info(
@@ -208,7 +208,7 @@ class EvictionManager:
         # 5. (Checkpoint skipped — will migrate to VFS writes)
 
         # 6. Transition concurrently to SUSPENDED (semaphore-bounded, CAS-safe)
-        async def _transition_one(agent: "ProcessDescriptor") -> bool:
+        async def _transition_one(agent: "AgentDescriptor") -> bool:
             async with self._transition_semaphore:
                 try:
                     # CAS check: verify generation hasn't changed
@@ -280,8 +280,8 @@ class EvictionManager:
         record = self._process_table.get(agent_id)
         if record is None:
             raise ValueError(f"Agent '{agent_id}' not found")
-        if record.state is not ProcessState.RUNNING:
-            raise ValueError(f"Agent '{agent_id}' is {record.state}, not RUNNING")
+        if record.state is not ProcessState.BUSY:
+            raise ValueError(f"Agent '{agent_id}' is {record.state}, not BUSY")
 
         # (Checkpoint skipped — will migrate to VFS writes)
 
@@ -306,7 +306,7 @@ class EvictionManager:
         return elapsed < self._tuning.eviction_cooldown_seconds
 
     @staticmethod
-    def _build_checkpoint(agent: "ProcessDescriptor") -> dict[str, Any]:
+    def _build_checkpoint(agent: "AgentDescriptor") -> dict[str, Any]:
         """Build checkpoint data for a process before eviction.
 
         Captures the essential state needed to restore the process on

--- a/src/nexus/system_services/agents/eviction_policy.py
+++ b/src/nexus/system_services/agents/eviction_policy.py
@@ -10,7 +10,7 @@ under resource pressure. Includes:
 from datetime import datetime
 from typing import Protocol, runtime_checkable
 
-from nexus.contracts.process_types import ProcessDescriptor
+from nexus.contracts.process_types import AgentDescriptor
 from nexus.contracts.qos import EVICTION_ORDER, EvictionContext, QoSClass
 
 
@@ -25,10 +25,10 @@ class EvictionPolicy(Protocol):
 
     def select_candidates(
         self,
-        agents: list[ProcessDescriptor],
+        agents: list[AgentDescriptor],
         batch_size: int,
         context: EvictionContext | None = None,
-    ) -> list[ProcessDescriptor]:
+    ) -> list[AgentDescriptor]:
         """Select which agents to evict from the candidates list.
 
         Args:
@@ -52,10 +52,10 @@ class LRUEvictionPolicy:
 
     def select_candidates(
         self,
-        agents: list[ProcessDescriptor],
+        agents: list[AgentDescriptor],
         batch_size: int,
         context: EvictionContext | None = None,  # noqa: ARG002
-    ) -> list[ProcessDescriptor]:
+    ) -> list[AgentDescriptor]:
         """Select least-recently-used agents for eviction.
 
         Args:
@@ -82,10 +82,10 @@ class QoSEvictionPolicy:
 
     def select_candidates(
         self,
-        agents: list[ProcessDescriptor],
+        agents: list[AgentDescriptor],
         batch_size: int,
         context: EvictionContext | None = None,
-    ) -> list[ProcessDescriptor]:
+    ) -> list[AgentDescriptor]:
         """Select agents for eviction with QoS-aware ordering.
 
         Args:
@@ -99,14 +99,14 @@ class QoSEvictionPolicy:
             List of agents to evict (up to batch_size).
         """
 
-        def _eviction_class(p: ProcessDescriptor) -> QoSClass:
+        def _eviction_class(p: AgentDescriptor) -> QoSClass:
             raw = p.labels.get("eviction_class", "standard")
             try:
                 return QoSClass(raw)
             except ValueError:
                 return QoSClass.STANDARD
 
-        def _heartbeat(p: ProcessDescriptor) -> datetime | None:
+        def _heartbeat(p: AgentDescriptor) -> datetime | None:
             if p.external_info is not None:
                 return p.external_info.last_heartbeat
             return p.updated_at

--- a/src/nexus/system_services/agents/warmup_steps.py
+++ b/src/nexus/system_services/agents/warmup_steps.py
@@ -33,9 +33,9 @@ async def load_credentials(ctx: "WarmupContext") -> bool:
         logger.warning("[WARMUP:credentials] Agent %s has no owner_id", ctx.agent_id)
         return False
 
-    from nexus.contracts.agent_types import AgentState
+    from nexus.contracts.process_types import ProcessState
 
-    eligible = {AgentState.UNKNOWN, AgentState.IDLE, AgentState.SUSPENDED}
+    eligible = {ProcessState.REGISTERED, ProcessState.READY, ProcessState.SUSPENDED}
     if record.state not in eligible:
         logger.warning(
             "[WARMUP:credentials] Agent %s in non-eligible state %s",

--- a/src/nexus/system_services/proc/__init__.py
+++ b/src/nexus/system_services/proc/__init__.py
@@ -1,1 +1,1 @@
-"""Proc system service — procfs virtual filesystem for ProcessTable."""
+"""Proc system service — procfs virtual filesystem for AgentRegistry."""

--- a/src/nexus/system_services/proc/proc_resolver.py
+++ b/src/nexus/system_services/proc/proc_resolver.py
@@ -1,15 +1,15 @@
-"""ProcResolver — procfs virtual filesystem for ProcessTable.
+"""ProcResolver — procfs virtual filesystem for AgentRegistry.
 
 Implements VFSPathResolver ``try_*`` protocol (#1665) to provide
 ``/{zone}/proc/{pid}/status`` as virtual files generated from
-ProcessTable's in-memory state at read time.  Like Linux ``/proc``,
+AgentRegistry's in-memory state at read time.  Like Linux ``/proc``,
 nothing is stored on disk.
 
     system_services/proc/proc_resolver.py = fs/proc/ (procfs)
     core/process_table.py                 = kernel/fork.c (task_struct table)
 
 Registration: factory/orchestrator.py registers ProcResolver via
-coordinator.enlist() at boot, after ProcessTable creation.
+coordinator.enlist() at boot, after AgentRegistry creation.
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.contracts.protocols.service_hooks import HookSpec
 
 if TYPE_CHECKING:
-    from nexus.core.process_table import ProcessTable
+    from nexus.core.process_table import AgentRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class ProcResolver:
 
     TRIE_PATTERN = "/{}/proc/{}/status"
 
-    def __init__(self, process_table: ProcessTable) -> None:
+    def __init__(self, process_table: AgentRegistry) -> None:
         self._process_table = process_table
 
     # -- HotSwappable protocol (registered via coordinator.enlist) --

--- a/tests/e2e/server/test_agent_registration_e2e.py
+++ b/tests/e2e/server/test_agent_registration_e2e.py
@@ -1,6 +1,6 @@
 """E2E tests for POST /api/v2/agents/register (Issue #3130).
 
-Tests the full HTTP → AgentRegistrationService → EntityRegistry + ProcessTable
+Tests the full HTTP → AgentRegistrationService → EntityRegistry + AgentRegistry
 + ReBAC + IPC path using real in-memory SQLite, real IPC provisioner with
 InMemoryStorageDriver, and real service wiring. No mocks for core services.
 """
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from nexus.bricks.ipc.provisioning import AgentProvisioner
 from nexus.bricks.rebac.entity_registry import EntityRegistry
 from nexus.bricks.rebac.manager import EnhancedReBACManager
-from nexus.core.process_table import ProcessTable
+from nexus.core.process_table import AgentRegistry
 from nexus.server.api.v2.routers.agent_registration import (
     router as registration_router,
 )
@@ -48,7 +48,7 @@ def entity_registry(record_store):
 
 @pytest.fixture()
 def process_table():
-    return ProcessTable()
+    return AgentRegistry()
 
 
 @pytest.fixture()

--- a/tests/e2e/server/test_delegation_auto_warmup_e2e.py
+++ b/tests/e2e/server/test_delegation_auto_warmup_e2e.py
@@ -17,7 +17,7 @@ from nexus.bricks.delegation.models import DelegationMode
 from nexus.bricks.delegation.service import DelegationService
 from nexus.bricks.rebac.entity_registry import EntityRegistry
 from nexus.bricks.rebac.manager import EnhancedReBACManager
-from nexus.core.process_table import ProcessTable
+from nexus.core.process_table import AgentRegistry
 from nexus.server.api.v2.routers.delegation import (
     DelegateRequest,
     DelegateResponse,
@@ -44,7 +44,7 @@ def entity_registry(record_store):
 
 @pytest.fixture()
 def process_table():
-    return ProcessTable()
+    return AgentRegistry()
 
 
 @pytest.fixture()

--- a/tests/e2e/server/test_register_delegate_full_e2e.py
+++ b/tests/e2e/server/test_register_delegate_full_e2e.py
@@ -20,7 +20,7 @@ from nexus.bricks.delegation.service import DelegationService
 from nexus.bricks.ipc.provisioning import AgentProvisioner
 from nexus.bricks.rebac.entity_registry import EntityRegistry
 from nexus.bricks.rebac.manager import EnhancedReBACManager
-from nexus.core.process_table import ProcessTable
+from nexus.core.process_table import AgentRegistry
 from nexus.system_services.agents.agent_registration import AgentRegistrationService
 from tests.helpers.in_memory_record_store import InMemoryRecordStore
 from tests.unit.bricks.ipc.fakes import InMemoryStorageDriver
@@ -46,7 +46,7 @@ def entity_registry(record_store):
 
 @pytest.fixture()
 def process_table():
-    return ProcessTable()
+    return AgentRegistry()
 
 
 @pytest.fixture()

--- a/tests/unit/contracts/test_agent_phase_compat.py
+++ b/tests/unit/contracts/test_agent_phase_compat.py
@@ -1,7 +1,14 @@
-"""Phase/state compatibility matrix tests (Issue #2169).
+"""Phase/state compatibility matrix tests (Issue #2169, #1800).
 
 Ensures every AgentState maps to a valid AgentPhase and
 the mapping is stable across refactors.
+
+Updated for unified AgentState (Issue #1800):
+- REGISTERED/WARMING_UP -> WARMING
+- READY -> READY
+- BUSY -> ACTIVE
+- SUSPENDED -> SUSPENDED
+- TERMINATED -> EVICTED
 """
 
 import pytest
@@ -9,18 +16,20 @@ import pytest
 from nexus.contracts.agent_types import (
     AGENT_STATE_TO_PHASE,
     AgentPhase,
-    AgentState,
     derive_phase,
 )
+from nexus.contracts.process_types import AgentState
 
 
 @pytest.mark.parametrize(
     "state,expected_phase",
     [
-        (AgentState.UNKNOWN, AgentPhase.WARMING),
-        (AgentState.CONNECTED, AgentPhase.ACTIVE),
-        (AgentState.IDLE, AgentPhase.IDLE),
+        (AgentState.REGISTERED, AgentPhase.WARMING),
+        (AgentState.WARMING_UP, AgentPhase.WARMING),
+        (AgentState.READY, AgentPhase.READY),
+        (AgentState.BUSY, AgentPhase.ACTIVE),
         (AgentState.SUSPENDED, AgentPhase.SUSPENDED),
+        (AgentState.TERMINATED, AgentPhase.EVICTED),
     ],
 )
 def test_phase_derived_from_state(state: AgentState, expected_phase: AgentPhase) -> None:

--- a/tests/unit/contracts/test_agent_spec_types.py
+++ b/tests/unit/contracts/test_agent_spec_types.py
@@ -21,12 +21,12 @@ from nexus.contracts.agent_types import (
     AgentResources,
     AgentResourceUsage,
     AgentSpec,
-    AgentState,
     AgentStatus,
     QoSClass,
     derive_phase,
     detect_drift,
 )
+from nexus.contracts.process_types import AgentState
 
 # ---------------------------------------------------------------------------
 # QoSClass enum
@@ -262,10 +262,12 @@ class TestAgentStateToPhase:
             assert state in AGENT_STATE_TO_PHASE, f"{state} missing from mapping"
 
     def test_mapping_values(self) -> None:
-        assert AGENT_STATE_TO_PHASE[AgentState.UNKNOWN] is AgentPhase.WARMING
-        assert AGENT_STATE_TO_PHASE[AgentState.CONNECTED] is AgentPhase.ACTIVE
-        assert AGENT_STATE_TO_PHASE[AgentState.IDLE] is AgentPhase.IDLE
+        assert AGENT_STATE_TO_PHASE[AgentState.REGISTERED] is AgentPhase.WARMING
+        assert AGENT_STATE_TO_PHASE[AgentState.WARMING_UP] is AgentPhase.WARMING
+        assert AGENT_STATE_TO_PHASE[AgentState.READY] is AgentPhase.READY
+        assert AGENT_STATE_TO_PHASE[AgentState.BUSY] is AgentPhase.ACTIVE
         assert AGENT_STATE_TO_PHASE[AgentState.SUSPENDED] is AgentPhase.SUSPENDED
+        assert AGENT_STATE_TO_PHASE[AgentState.TERMINATED] is AgentPhase.EVICTED
 
 
 # ---------------------------------------------------------------------------
@@ -277,10 +279,12 @@ class TestDerivePhase:
     @pytest.mark.parametrize(
         "state,expected_phase",
         [
-            (AgentState.UNKNOWN, AgentPhase.WARMING),
-            (AgentState.CONNECTED, AgentPhase.ACTIVE),
-            (AgentState.IDLE, AgentPhase.IDLE),
+            (AgentState.REGISTERED, AgentPhase.WARMING),
+            (AgentState.WARMING_UP, AgentPhase.WARMING),
+            (AgentState.READY, AgentPhase.READY),
+            (AgentState.BUSY, AgentPhase.ACTIVE),
             (AgentState.SUSPENDED, AgentPhase.SUSPENDED),
+            (AgentState.TERMINATED, AgentPhase.EVICTED),
         ],
     )
     def test_base_mapping(self, state: AgentState, expected_phase: AgentPhase) -> None:
@@ -295,9 +299,9 @@ class TestDerivePhase:
             last_transition=datetime.now(UTC),
             observed_generation=1,
         )
-        assert derive_phase(AgentState.CONNECTED, (cond,)) == AgentPhase.READY
+        assert derive_phase(AgentState.BUSY, (cond,)) == AgentPhase.READY
 
-    def test_ready_condition_no_effect_on_idle(self) -> None:
+    def test_ready_condition_no_effect_on_ready(self) -> None:
         cond = AgentCondition(
             type="Ready",
             status="True",
@@ -306,7 +310,8 @@ class TestDerivePhase:
             last_transition=datetime.now(UTC),
             observed_generation=1,
         )
-        assert derive_phase(AgentState.IDLE, (cond,)) == AgentPhase.IDLE
+        # READY base phase is READY, not ACTIVE, so no override happens
+        assert derive_phase(AgentState.READY, (cond,)) == AgentPhase.READY
 
     def test_evicted_condition_overrides_any(self) -> None:
         cond = AgentCondition(
@@ -328,10 +333,10 @@ class TestDerivePhase:
             last_transition=datetime.now(UTC),
             observed_generation=1,
         )
-        assert derive_phase(AgentState.CONNECTED, (cond,)) == AgentPhase.THINKING
+        assert derive_phase(AgentState.BUSY, (cond,)) == AgentPhase.THINKING
 
     def test_no_conditions_returns_base(self) -> None:
-        assert derive_phase(AgentState.CONNECTED, ()) == AgentPhase.ACTIVE
+        assert derive_phase(AgentState.BUSY, ()) == AgentPhase.ACTIVE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_agent_record.py
+++ b/tests/unit/core/test_agent_record.py
@@ -1,11 +1,13 @@
-"""Unit tests for AgentRecord and AgentState state machine (Issue #1240).
+"""Unit tests for AgentRecord with unified AgentState (Issue #1240, #1800).
 
 Tests cover:
-- AgentState enum: all 4 states exist and are distinct
-- VALID_TRANSITIONS: strict allowlist covering all 16 state pairs
-- validate_transition(): parametrized 16-cell matrix (Decision #9A)
+- AgentState: unified enum from process_types (REGISTERED, WARMING_UP, READY, BUSY, SUSPENDED, TERMINATED)
 - AgentRecord: frozen dataclass immutability, defaults, field access
-- Edge cases: self-transitions, exhaustive coverage of transition table
+- AgentRecord.state uses the unified AgentState (no more old UNKNOWN/CONNECTED/IDLE)
+
+Note: The old AgentState (UNKNOWN, CONNECTED, IDLE, SUSPENDED), VALID_TRANSITIONS,
+validate_transition(), and is_new_session() have been deleted (Issue #1800).
+State machine validation is handled by the kernel AgentRegistry (VALID_AGENT_TRANSITIONS).
 """
 
 import types
@@ -14,31 +16,29 @@ from datetime import UTC, datetime
 
 import pytest
 
-from nexus.contracts.agent_types import (
-    VALID_TRANSITIONS,
-    AgentRecord,
-    AgentState,
-    validate_transition,
-)
+from nexus.contracts.agent_types import AgentRecord
+from nexus.contracts.process_types import AgentState
 
 # ---------------------------------------------------------------------------
-# AgentState enum tests
+# AgentState — unified from process_types
 # ---------------------------------------------------------------------------
 
 
 class TestAgentState:
-    """Tests for the AgentState enum."""
+    """Tests for the unified AgentState enum (from process_types)."""
 
-    def test_has_four_states(self):
-        """AgentState enum must have exactly 4 members."""
-        assert len(AgentState) == 4
+    def test_has_six_states(self):
+        """Unified AgentState enum must have exactly 6 members."""
+        assert len(AgentState) == 6
 
     def test_state_values(self):
         """Each state has the expected string value."""
-        assert AgentState.UNKNOWN.value == "UNKNOWN"
-        assert AgentState.CONNECTED.value == "CONNECTED"
-        assert AgentState.IDLE.value == "IDLE"
-        assert AgentState.SUSPENDED.value == "SUSPENDED"
+        assert AgentState.REGISTERED.value == "registered"
+        assert AgentState.WARMING_UP.value == "warming_up"
+        assert AgentState.READY.value == "ready"
+        assert AgentState.BUSY.value == "busy"
+        assert AgentState.SUSPENDED.value == "suspended"
+        assert AgentState.TERMINATED.value == "terminated"
 
     def test_states_are_distinct(self):
         """All states are distinct enum members."""
@@ -47,129 +47,15 @@ class TestAgentState:
 
     def test_from_string(self):
         """AgentState can be constructed from string value."""
-        assert AgentState("UNKNOWN") is AgentState.UNKNOWN
-        assert AgentState("CONNECTED") is AgentState.CONNECTED
-        assert AgentState("IDLE") is AgentState.IDLE
-        assert AgentState("SUSPENDED") is AgentState.SUSPENDED
+        assert AgentState("registered") is AgentState.REGISTERED
+        assert AgentState("ready") is AgentState.READY
+        assert AgentState("busy") is AgentState.BUSY
+        assert AgentState("suspended") is AgentState.SUSPENDED
 
     def test_invalid_string_raises(self):
         """Invalid string raises ValueError."""
         with pytest.raises(ValueError):
             AgentState("INVALID")
-
-
-# ---------------------------------------------------------------------------
-# VALID_TRANSITIONS allowlist tests
-# ---------------------------------------------------------------------------
-
-
-class TestValidTransitions:
-    """Tests for the VALID_TRANSITIONS strict allowlist (Decision #8A)."""
-
-    def test_covers_all_states_as_keys(self):
-        """Every AgentState must appear as a key in VALID_TRANSITIONS."""
-        for state in AgentState:
-            assert state in VALID_TRANSITIONS, f"{state} missing from VALID_TRANSITIONS"
-
-    def test_no_extra_keys(self):
-        """VALID_TRANSITIONS should not have keys that aren't AgentState members."""
-        for key in VALID_TRANSITIONS:
-            assert isinstance(key, AgentState), f"Unexpected key: {key}"
-
-    def test_values_are_frozensets_of_agent_state(self):
-        """Each value must be a frozenset of AgentState members."""
-        for state, targets in VALID_TRANSITIONS.items():
-            assert isinstance(targets, frozenset), f"{state} targets not frozenset"
-            for target in targets:
-                assert isinstance(target, AgentState), (
-                    f"{state} has non-AgentState target: {target}"
-                )
-
-    def test_no_self_transitions(self):
-        """No state should be able to transition to itself."""
-        for state, targets in VALID_TRANSITIONS.items():
-            assert state not in targets, f"{state} allows self-transition"
-
-    def test_unknown_transitions(self):
-        """UNKNOWN can only transition to CONNECTED."""
-        assert VALID_TRANSITIONS[AgentState.UNKNOWN] == frozenset({AgentState.CONNECTED})
-
-    def test_connected_transitions(self):
-        """CONNECTED can transition to IDLE or SUSPENDED."""
-        assert VALID_TRANSITIONS[AgentState.CONNECTED] == frozenset(
-            {AgentState.IDLE, AgentState.SUSPENDED}
-        )
-
-    def test_idle_transitions(self):
-        """IDLE can transition to CONNECTED or SUSPENDED."""
-        assert VALID_TRANSITIONS[AgentState.IDLE] == frozenset(
-            {AgentState.CONNECTED, AgentState.SUSPENDED}
-        )
-
-    def test_suspended_transitions(self):
-        """SUSPENDED can only transition to CONNECTED."""
-        assert VALID_TRANSITIONS[AgentState.SUSPENDED] == frozenset({AgentState.CONNECTED})
-
-
-# ---------------------------------------------------------------------------
-# validate_transition() parametrized 16-cell matrix (Decision #9A)
-# ---------------------------------------------------------------------------
-
-_U = AgentState.UNKNOWN
-_C = AgentState.CONNECTED
-_I = AgentState.IDLE
-_S = AgentState.SUSPENDED
-
-
-class TestValidateTransition:
-    """Parametrized 16-cell state transition matrix (Decision #9A)."""
-
-    @pytest.mark.parametrize(
-        "current,target,valid",
-        [
-            # From UNKNOWN
-            (_U, _U, False),
-            (_U, _C, True),
-            (_U, _I, False),
-            (_U, _S, False),
-            # From CONNECTED
-            (_C, _U, False),
-            (_C, _C, False),
-            (_C, _I, True),
-            (_C, _S, True),
-            # From IDLE
-            (_I, _U, False),
-            (_I, _C, True),
-            (_I, _I, False),
-            (_I, _S, True),
-            # From SUSPENDED
-            (_S, _U, False),
-            (_S, _C, True),
-            (_S, _I, False),
-            (_S, _S, False),
-        ],
-        ids=[
-            "UNKNOWN->UNKNOWN",
-            "UNKNOWN->CONNECTED",
-            "UNKNOWN->IDLE",
-            "UNKNOWN->SUSPENDED",
-            "CONNECTED->UNKNOWN",
-            "CONNECTED->CONNECTED",
-            "CONNECTED->IDLE",
-            "CONNECTED->SUSPENDED",
-            "IDLE->UNKNOWN",
-            "IDLE->CONNECTED",
-            "IDLE->IDLE",
-            "IDLE->SUSPENDED",
-            "SUSPENDED->UNKNOWN",
-            "SUSPENDED->CONNECTED",
-            "SUSPENDED->IDLE",
-            "SUSPENDED->SUSPENDED",
-        ],
-    )
-    def test_state_transition_matrix(self, current, target, valid):
-        """Each cell in the 4x4 transition matrix returns expected validity."""
-        assert validate_transition(current, target) == valid
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +77,7 @@ class TestAgentRecord:
             owner_id="alice",
             zone_id="root",
             name="Test Agent",
-            state=AgentState.UNKNOWN,
+            state=AgentState.REGISTERED,
             generation=0,
             last_heartbeat=None,
             metadata=types.MappingProxyType({}),
@@ -202,7 +88,7 @@ class TestAgentRecord:
     def test_is_frozen(self, record):
         """AgentRecord is immutable (frozen dataclass)."""
         with pytest.raises(FrozenInstanceError):
-            record.state = AgentState.CONNECTED  # type: ignore[misc]
+            object.__setattr__(record, "state", AgentState.READY)
 
     def test_field_access(self, record):
         """All fields are accessible."""
@@ -210,7 +96,7 @@ class TestAgentRecord:
         assert record.owner_id == "alice"
         assert record.zone_id == "root"
         assert record.name == "Test Agent"
-        assert record.state is AgentState.UNKNOWN
+        assert record.state is AgentState.REGISTERED
         assert record.generation == 0
         assert record.last_heartbeat is None
         assert record.metadata == {}
@@ -222,14 +108,14 @@ class TestAgentRecord:
             owner_id="bob",
             zone_id=None,
             name=None,
-            state=AgentState.UNKNOWN,
+            state=AgentState.REGISTERED,
             generation=0,
             last_heartbeat=None,
             metadata=types.MappingProxyType({}),
             created_at=now,
             updated_at=now,
         )
-        assert record.state is AgentState.UNKNOWN
+        assert record.state is AgentState.REGISTERED
         assert record.generation == 0
 
     def test_equality(self, now):
@@ -239,7 +125,7 @@ class TestAgentRecord:
             owner_id="u",
             zone_id=None,
             name=None,
-            state=AgentState.UNKNOWN,
+            state=AgentState.REGISTERED,
             generation=0,
             last_heartbeat=None,
             metadata=types.MappingProxyType({}),
@@ -251,7 +137,7 @@ class TestAgentRecord:
             owner_id="u",
             zone_id=None,
             name=None,
-            state=AgentState.UNKNOWN,
+            state=AgentState.REGISTERED,
             generation=0,
             last_heartbeat=None,
             metadata=types.MappingProxyType({}),
@@ -267,7 +153,7 @@ class TestAgentRecord:
             owner_id="u",
             zone_id=None,
             name=None,
-            state=AgentState.UNKNOWN,
+            state=AgentState.REGISTERED,
             generation=0,
             last_heartbeat=None,
             metadata=types.MappingProxyType({}),
@@ -279,7 +165,7 @@ class TestAgentRecord:
             owner_id="u",
             zone_id=None,
             name=None,
-            state=AgentState.CONNECTED,
+            state=AgentState.BUSY,
             generation=1,
             last_heartbeat=None,
             metadata=types.MappingProxyType({}),
@@ -295,7 +181,7 @@ class TestAgentRecord:
             owner_id="u",
             zone_id=None,
             name=None,
-            state=AgentState.UNKNOWN,
+            state=AgentState.REGISTERED,
             generation=0,
             last_heartbeat=None,
             metadata=types.MappingProxyType(
@@ -313,7 +199,7 @@ class TestAgentRecord:
             owner_id="u",
             zone_id=None,
             name=None,
-            state=AgentState.UNKNOWN,
+            state=AgentState.REGISTERED,
             generation=0,
             last_heartbeat=None,
             metadata=types.MappingProxyType({}),
@@ -329,7 +215,7 @@ class TestAgentRecord:
             owner_id="u",
             zone_id=None,
             name=None,
-            state=AgentState.UNKNOWN,
+            state=AgentState.REGISTERED,
             generation=0,
             last_heartbeat=None,
             metadata=types.MappingProxyType({}),
@@ -345,7 +231,7 @@ class TestAgentRecord:
             owner_id="u",
             zone_id=None,
             name=None,
-            state=AgentState.CONNECTED,
+            state=AgentState.BUSY,
             generation=1,
             last_heartbeat=now,
             metadata=types.MappingProxyType({}),

--- a/tests/unit/core/test_proc_resolver.py
+++ b/tests/unit/core/test_proc_resolver.py
@@ -8,7 +8,7 @@ import json
 
 import pytest
 
-from nexus.core.process_table import ProcessTable
+from nexus.core.process_table import AgentRegistry
 from nexus.system_services.proc.proc_resolver import ProcResolver
 
 ZONE = "test-zone"
@@ -20,8 +20,8 @@ OWNER = "user-1"
 # ---------------------------------------------------------------------------
 
 
-def _make_resolver() -> tuple[ProcessTable, ProcResolver]:
-    pt = ProcessTable()
+def _make_resolver() -> tuple[AgentRegistry, ProcResolver]:
+    pt = AgentRegistry()
     return pt, ProcResolver(pt)
 
 

--- a/tests/unit/core/test_process_table.py
+++ b/tests/unit/core/test_process_table.py
@@ -1,4 +1,4 @@
-"""Tests for kernel ProcessTable (Issue #1509).
+"""Tests for kernel AgentRegistry (Issue #1509).
 
 Pure in-memory — no metastore persistence.
 Covers: spawn, kill, signal, wait, external processes, close_all, serialization.
@@ -12,17 +12,17 @@ from datetime import UTC, datetime
 import pytest
 
 from nexus.contracts.process_types import (
-    VALID_PROCESS_TRANSITIONS,
+    VALID_AGENT_TRANSITIONS,
+    AgentDescriptor,
+    AgentError,
+    AgentKind,
+    AgentNotFoundError,
+    AgentSignal,
+    AgentState,
     ExternalProcessInfo,
     InvalidTransitionError,
-    ProcessDescriptor,
-    ProcessError,
-    ProcessKind,
-    ProcessNotFoundError,
-    ProcessSignal,
-    ProcessState,
 )
-from nexus.core.process_table import ProcessTable
+from nexus.core.process_table import AgentRegistry
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -32,8 +32,8 @@ ZONE = "test-zone"
 OWNER = "user-1"
 
 
-def _make_table() -> ProcessTable:
-    return ProcessTable()
+def _make_table() -> AgentRegistry:
+    return AgentRegistry()
 
 
 # ---------------------------------------------------------------------------
@@ -48,8 +48,8 @@ class TestSpawn:
         assert desc.name == "agent-1"
         assert desc.owner_id == OWNER
         assert desc.zone_id == ZONE
-        assert desc.state == ProcessState.RUNNING
-        assert desc.kind == ProcessKind.MANAGED
+        assert desc.state == AgentState.REGISTERED
+        assert desc.kind == AgentKind.MANAGED
         assert len(desc.pid) == 12
 
     def test_spawn_unique_pids(self) -> None:
@@ -69,7 +69,7 @@ class TestSpawn:
 
     def test_spawn_invalid_parent_raises(self) -> None:
         pt = _make_table()
-        with pytest.raises(ProcessNotFoundError):
+        with pytest.raises(AgentNotFoundError):
             pt.spawn("child", OWNER, ZONE, parent_pid="nonexistent")
 
     def test_spawn_with_labels(self) -> None:
@@ -111,114 +111,150 @@ class TestSpawn:
 
     def test_list_filter_kind(self) -> None:
         pt = _make_table()
-        pt.spawn("managed-agent", OWNER, ZONE, kind=ProcessKind.MANAGED)
-        pt.spawn("unmanaged-agent", OWNER, ZONE, kind=ProcessKind.UNMANAGED)
-        assert len(pt.list_processes(kind=ProcessKind.MANAGED)) == 1
+        pt.spawn("managed-agent", OWNER, ZONE, kind=AgentKind.MANAGED)
+        pt.spawn("unmanaged-agent", OWNER, ZONE, kind=AgentKind.UNMANAGED)
+        assert len(pt.list_processes(kind=AgentKind.MANAGED)) == 1
 
     def test_list_filter_state(self) -> None:
         pt = _make_table()
         pt.spawn("a1", OWNER, ZONE)
         desc = pt.spawn("a2", OWNER, ZONE)
-        # Transition a2 to SLEEPING
-        pt._transition(desc, ProcessState.SLEEPING)
-        assert len(pt.list_processes(state=ProcessState.RUNNING)) == 1
-        assert len(pt.list_processes(state=ProcessState.SLEEPING)) == 1
+        # Transition a2 to WARMING_UP (valid from REGISTERED)
+        pt._transition(desc, AgentState.WARMING_UP)
+        assert len(pt.list_processes(state=AgentState.REGISTERED)) == 1
+        assert len(pt.list_processes(state=AgentState.WARMING_UP)) == 1
 
 
 # ---------------------------------------------------------------------------
-# State Transitions (spawn creates processes in RUNNING state)
+# State Transitions (spawn creates processes in REGISTERED state)
 # ---------------------------------------------------------------------------
 
 
 class TestTransitions:
-    def test_spawn_starts_running(self) -> None:
-        """spawn() creates processes directly in RUNNING state."""
+    def test_spawn_starts_registered(self) -> None:
+        """spawn() creates processes directly in REGISTERED state."""
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        assert desc.state == ProcessState.RUNNING
+        assert desc.state == AgentState.REGISTERED
 
-    def test_running_to_sleeping(self) -> None:
+    def test_registered_to_warming_up(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        updated = pt._transition(desc, ProcessState.SLEEPING)
-        assert updated.state == ProcessState.SLEEPING
+        updated = pt._transition(desc, AgentState.WARMING_UP)
+        assert updated.state == AgentState.WARMING_UP
 
-    def test_running_to_stopped(self) -> None:
+    def test_warming_up_to_ready(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        updated = pt._transition(desc, ProcessState.STOPPED)
-        assert updated.state == ProcessState.STOPPED
+        desc = pt._transition(desc, AgentState.WARMING_UP)
+        updated = pt._transition(desc, AgentState.READY)
+        assert updated.state == AgentState.READY
 
-    def test_stopped_to_sleeping(self) -> None:
+    def test_ready_to_busy(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.STOPPED)
-        updated = pt._transition(desc, ProcessState.SLEEPING)
-        assert updated.state == ProcessState.SLEEPING
+        desc = pt._transition(desc, AgentState.WARMING_UP)
+        desc = pt._transition(desc, AgentState.READY)
+        updated = pt._transition(desc, AgentState.BUSY)
+        assert updated.state == AgentState.BUSY
+
+    def test_busy_to_ready(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, AgentState.WARMING_UP)
+        desc = pt._transition(desc, AgentState.READY)
+        desc = pt._transition(desc, AgentState.BUSY)
+        updated = pt._transition(desc, AgentState.READY)
+        assert updated.state == AgentState.READY
+
+    def test_ready_to_suspended(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, AgentState.WARMING_UP)
+        desc = pt._transition(desc, AgentState.READY)
+        updated = pt._transition(desc, AgentState.SUSPENDED)
+        assert updated.state == AgentState.SUSPENDED
+
+    def test_suspended_to_ready(self) -> None:
+        pt = _make_table()
+        desc = pt.spawn("a", OWNER, ZONE)
+        desc = pt._transition(desc, AgentState.WARMING_UP)
+        desc = pt._transition(desc, AgentState.READY)
+        desc = pt._transition(desc, AgentState.SUSPENDED)
+        updated = pt._transition(desc, AgentState.READY)
+        assert updated.state == AgentState.READY
 
     def test_invalid_transition_raises(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        # RUNNING→CREATED is invalid
+        # REGISTERED→BUSY is invalid (must go through WARMING_UP→READY first)
         with pytest.raises(InvalidTransitionError):
-            pt._transition(desc, ProcessState.CREATED)
+            pt._transition(desc, AgentState.BUSY)
 
-    def test_zombie_is_terminal(self) -> None:
+    def test_terminated_is_terminal(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt._transition(desc, ProcessState.ZOMBIE)
+        desc = pt._transition(desc, AgentState.TERMINATED)
         with pytest.raises(InvalidTransitionError):
-            pt._transition(desc, ProcessState.RUNNING)
+            pt._transition(desc, AgentState.REGISTERED)
 
     def test_all_valid_transitions(self) -> None:
-        """Verify VALID_PROCESS_TRANSITIONS is comprehensive."""
-        for state in ProcessState:
-            assert state in VALID_PROCESS_TRANSITIONS
+        """Verify VALID_AGENT_TRANSITIONS is comprehensive."""
+        for state in AgentState:
+            assert state in VALID_AGENT_TRANSITIONS
 
 
 # ---------------------------------------------------------------------------
-# Signals (spawn creates in RUNNING — no extra transition needed)
+# Signals (spawn creates in REGISTERED — transition to READY before signal tests)
 # ---------------------------------------------------------------------------
+
+
+def _spawn_ready(pt: AgentRegistry, name: str = "a") -> "AgentDescriptor":
+    """Spawn a process and advance it to READY state for signal tests."""
+    desc = pt.spawn(name, OWNER, ZONE)
+    desc = pt._transition(desc, AgentState.WARMING_UP)
+    desc = pt._transition(desc, AgentState.READY)
+    return desc
 
 
 class TestSignals:
     def test_sigstop(self) -> None:
         pt = _make_table()
-        desc = pt.spawn("a", OWNER, ZONE)
-        updated = pt.signal(desc.pid, ProcessSignal.SIGSTOP)
-        assert updated.state == ProcessState.STOPPED
+        desc = _spawn_ready(pt)
+        updated = pt.signal(desc.pid, AgentSignal.SIGSTOP)
+        assert updated.state == AgentState.SUSPENDED
 
     def test_sigcont(self) -> None:
         pt = _make_table()
-        desc = pt.spawn("a", OWNER, ZONE)
-        desc = pt.signal(desc.pid, ProcessSignal.SIGSTOP)
-        updated = pt.signal(desc.pid, ProcessSignal.SIGCONT)
-        assert updated.state == ProcessState.SLEEPING
+        desc = _spawn_ready(pt)
+        desc = pt.signal(desc.pid, AgentSignal.SIGSTOP)
+        updated = pt.signal(desc.pid, AgentSignal.SIGCONT)
+        assert updated.state == AgentState.READY
 
     def test_sigterm(self) -> None:
         pt = _make_table()
-        desc = pt.spawn("a", OWNER, ZONE)
-        updated = pt.signal(desc.pid, ProcessSignal.SIGTERM)
-        assert updated.state == ProcessState.ZOMBIE
+        desc = _spawn_ready(pt)
+        updated = pt.signal(desc.pid, AgentSignal.SIGTERM)
+        assert updated.state == AgentState.TERMINATED
 
     def test_sigkill(self) -> None:
         pt = _make_table()
-        desc = pt.spawn("a", OWNER, ZONE)
-        pt.signal(desc.pid, ProcessSignal.SIGKILL)
+        desc = _spawn_ready(pt)
+        pt.signal(desc.pid, AgentSignal.SIGKILL)
         # SIGKILL reaps immediately
         assert pt.get(desc.pid) is None
 
     def test_sigusr1_merges_payload(self) -> None:
         pt = _make_table()
         desc = pt.spawn("a", OWNER, ZONE, labels={"existing": "value"})
-        updated = pt.signal(desc.pid, ProcessSignal.SIGUSR1, payload={"steering": "pause"})
+        updated = pt.signal(desc.pid, AgentSignal.SIGUSR1, payload={"steering": "pause"})
         assert updated.labels["existing"] == "value"
         assert updated.labels["steering"] == "pause"
 
     def test_signal_unknown_pid_raises(self) -> None:
         pt = _make_table()
-        with pytest.raises(ProcessNotFoundError):
-            pt.signal("nonexistent", ProcessSignal.SIGTERM)
+        with pytest.raises(AgentNotFoundError):
+            pt.signal("nonexistent", AgentSignal.SIGTERM)
 
 
 # ---------------------------------------------------------------------------
@@ -241,11 +277,11 @@ class TestKillReap:
         # Not reaped — parent can wait()
         zombie = pt.get(child.pid)
         assert zombie is not None
-        assert zombie.state == ProcessState.ZOMBIE
+        assert zombie.state == AgentState.TERMINATED
 
     def test_kill_nonexistent_raises(self) -> None:
         pt = _make_table()
-        with pytest.raises(ProcessNotFoundError):
+        with pytest.raises(AgentNotFoundError):
             pt.kill("nonexistent")
 
     def test_kill_already_zombie(self) -> None:
@@ -255,14 +291,14 @@ class TestKillReap:
         pt.kill(child.pid)
         # Kill again — should be idempotent
         result = pt.kill(child.pid)
-        assert result.state == ProcessState.ZOMBIE
+        assert result.state == AgentState.TERMINATED
 
     def test_reap_removes_from_parent_children(self) -> None:
         pt = _make_table()
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
         # SIGKILL forces immediate reap
-        pt.signal(child.pid, ProcessSignal.SIGKILL)
+        pt.signal(child.pid, AgentSignal.SIGKILL)
         updated_parent = pt.get(parent.pid)
         assert updated_parent is not None
         assert child.pid not in updated_parent.children
@@ -275,14 +311,14 @@ class TestKillReap:
 
 class TestWait:
     @pytest.mark.asyncio
-    async def test_wait_already_zombie(self) -> None:
+    async def test_wait_already_terminated(self) -> None:
         pt = _make_table()
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
-        pt.kill(child.pid)  # ZOMBIE (not reaped — has parent)
+        pt.kill(child.pid)  # TERMINATED (not reaped — has parent)
         result = await pt.wait(child.pid)
         assert result is not None
-        assert result.state == ProcessState.ZOMBIE
+        assert result.state == AgentState.TERMINATED
 
     @pytest.mark.asyncio
     async def test_wait_blocks_until_state_change(self) -> None:
@@ -297,7 +333,7 @@ class TestWait:
         task = asyncio.create_task(_killer())
         result = await pt.wait(child.pid, timeout=2.0)
         assert result is not None
-        assert result.state == ProcessState.ZOMBIE
+        assert result.state == AgentState.TERMINATED
         await task
 
     @pytest.mark.asyncio
@@ -310,26 +346,26 @@ class TestWait:
     @pytest.mark.asyncio
     async def test_wait_nonexistent_raises(self) -> None:
         pt = _make_table()
-        with pytest.raises(ProcessNotFoundError):
+        with pytest.raises(AgentNotFoundError):
             await pt.wait("nonexistent")
 
     @pytest.mark.asyncio
     async def test_wait_custom_target_states(self) -> None:
         pt = _make_table()
-        desc = pt.spawn("a", OWNER, ZONE)
+        desc = _spawn_ready(pt)
 
         async def _stopper() -> None:
             await asyncio.sleep(0.05)
-            pt.signal(desc.pid, ProcessSignal.SIGSTOP)
+            pt.signal(desc.pid, AgentSignal.SIGSTOP)
 
         task = asyncio.create_task(_stopper())
         result = await pt.wait(
             desc.pid,
-            target_states=frozenset({ProcessState.STOPPED}),
+            target_states=frozenset({AgentState.SUSPENDED}),
             timeout=2.0,
         )
         assert result is not None
-        assert result.state == ProcessState.STOPPED
+        assert result.state == AgentState.SUSPENDED
         await task
 
     @pytest.mark.asyncio
@@ -338,7 +374,7 @@ class TestWait:
         parent = pt.spawn("parent", OWNER, ZONE)
         child = pt.spawn("child", OWNER, ZONE, parent_pid=parent.pid)
 
-        results: list[ProcessDescriptor | None] = []
+        results: list[AgentDescriptor | None] = []
 
         async def _waiter() -> None:
             r = await pt.wait(child.pid, timeout=2.0)
@@ -370,7 +406,7 @@ class TestExternalProcesses:
             host_pid=12345,
             remote_addr="127.0.0.1:50051",
         )
-        assert desc.kind == ProcessKind.UNMANAGED
+        assert desc.kind == AgentKind.UNMANAGED
         assert desc.external_info is not None
         assert desc.external_info.connection_id == "conn-1"
         assert desc.external_info.host_pid == 12345
@@ -385,7 +421,7 @@ class TestExternalProcesses:
     def test_heartbeat_on_managed_raises(self) -> None:
         pt = _make_table()
         desc = pt.spawn("managed", OWNER, ZONE)
-        with pytest.raises(ProcessError, match="heartbeat only for unmanaged"):
+        with pytest.raises(AgentError, match="heartbeat only for unmanaged"):
             pt.heartbeat(desc.pid)
 
     def test_unregister_external(self) -> None:
@@ -417,14 +453,14 @@ class TestCloseAll:
 class TestSerialization:
     def test_roundtrip(self) -> None:
         now = datetime.now(UTC)
-        desc = ProcessDescriptor(
+        desc = AgentDescriptor(
             pid="abc123",
             ppid=None,
             name="test",
             owner_id=OWNER,
             zone_id=ZONE,
-            kind=ProcessKind.MANAGED,
-            state=ProcessState.RUNNING,
+            kind=AgentKind.MANAGED,
+            state=AgentState.BUSY,
             exit_code=None,
             cwd="/workspace",
             children=("child1", "child2"),
@@ -433,7 +469,7 @@ class TestSerialization:
             labels={"key": "value"},
         )
         json_str = desc.to_json()
-        recovered = ProcessDescriptor.from_json(json_str)
+        recovered = AgentDescriptor.from_json(json_str)
         assert recovered.pid == desc.pid
         assert recovered.name == desc.name
         assert recovered.state == desc.state
@@ -442,14 +478,14 @@ class TestSerialization:
 
     def test_roundtrip_with_external_info(self) -> None:
         now = datetime.now(UTC)
-        desc = ProcessDescriptor(
+        desc = AgentDescriptor(
             pid="ext123",
             ppid=None,
             name="external",
             owner_id=OWNER,
             zone_id=ZONE,
-            kind=ProcessKind.UNMANAGED,
-            state=ProcessState.CREATED,
+            kind=AgentKind.UNMANAGED,
+            state=AgentState.REGISTERED,
             created_at=now,
             updated_at=now,
             external_info=ExternalProcessInfo(
@@ -461,7 +497,7 @@ class TestSerialization:
             ),
         )
         json_str = desc.to_json()
-        recovered = ProcessDescriptor.from_json(json_str)
+        recovered = AgentDescriptor.from_json(json_str)
         assert recovered.external_info is not None
         assert recovered.external_info.connection_id == "conn-1"
         assert recovered.external_info.host_pid == 9999

--- a/tests/unit/server/test_agent_status_endpoint.py
+++ b/tests/unit/server/test_agent_status_endpoint.py
@@ -9,7 +9,7 @@ Tests cover:
 6. Drift detection visible in status response
 
 Post-AgentRegistry deletion (PR #3109): endpoints now use ProcessTable
-directly.  Mocks target process_table.get() → ProcessDescriptor.
+directly.  Mocks target process_table.get() → AgentDescriptor.
 """
 
 import json
@@ -21,10 +21,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from nexus.contracts.process_types import (
+    AgentDescriptor,
+    AgentKind,
+    AgentState,
     ExternalProcessInfo,
-    ProcessDescriptor,
-    ProcessKind,
-    ProcessState,
 )
 from nexus.server.api.v2.routers.agent_status import router
 
@@ -70,16 +70,16 @@ def _override_auth(app: FastAPI) -> None:
 def _make_descriptor(
     pid: str = "agent-1",
     **overrides: Any,
-) -> ProcessDescriptor:
-    """Create a ProcessDescriptor with sensible defaults for testing."""
+) -> AgentDescriptor:
+    """Create a AgentDescriptor with sensible defaults for testing."""
     defaults: dict[str, Any] = {
         "pid": pid,
         "ppid": None,
         "name": "test-agent",
         "owner_id": "test-owner",
         "zone_id": "root",
-        "kind": ProcessKind.UNMANAGED,
-        "state": ProcessState.RUNNING,
+        "kind": AgentKind.UNMANAGED,
+        "state": AgentState.BUSY,
         "generation": 3,
         "created_at": datetime(2025, 6, 1, 12, 0, tzinfo=UTC),
         "updated_at": datetime(2025, 6, 1, 12, 5, tzinfo=UTC),
@@ -89,7 +89,7 @@ def _make_descriptor(
         ),
     }
     defaults.update(overrides)
-    return ProcessDescriptor(**defaults)
+    return AgentDescriptor(**defaults)
 
 
 # ---------------------------------------------------------------------------
@@ -109,7 +109,7 @@ class TestGetAgentStatus:
         resp = client.get("/api/v2/agents/agent-1/status")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["phase"] == "running"
+        assert data["phase"] == "busy"
         assert data["observed_generation"] == 3
         assert data["conditions"] == []
         assert data["inbox_depth"] == 0

--- a/tests/unit/services/test_agent_warmup.py
+++ b/tests/unit/services/test_agent_warmup.py
@@ -1,18 +1,18 @@
 """Tests for AgentWarmupService (Issue #2172).
 
 Covers:
-- Happy path: all required steps pass -> SLEEPING (connected)
+- Happy path: all required steps pass -> READY (connected)
 - Mixed required + optional steps
 - Required step failures (exception, timeout, returns False)
 - Optional step failures -> still connected
 - Edge cases: re-warmup, nonexistent agent, empty steps, concurrent, unregister-during
 - Step registry operations
 
-ProcessTable migration notes:
-  - External agents are registered via register_external() -> RUNNING (generation=1)
-  - To test warmup (which skips RUNNING), we SIGSTOP -> STOPPED first
-  - After warmup, SIGCONT transitions STOPPED -> SLEEPING, bumping generation
-  - ProcessTable.get() uses PID, not name
+AgentRegistry migration notes:
+  - External agents are registered via register_external() -> REGISTERED (generation=1)
+  - To test warmup (which skips BUSY), we advance to READY then SIGSTOP -> SUSPENDED
+  - After warmup, SIGCONT transitions SUSPENDED -> READY, bumping generation
+  - AgentRegistry.get() uses PID, not name
 """
 
 import asyncio
@@ -21,8 +21,8 @@ from datetime import timedelta
 import pytest
 
 from nexus.contracts.agent_warmup_types import WarmupContext, WarmupStep
-from nexus.contracts.process_types import ProcessSignal, ProcessState
-from nexus.core.process_table import ProcessTable
+from nexus.contracts.process_types import AgentSignal, AgentState
+from nexus.core.process_table import AgentRegistry
 from nexus.system_services.agents.agent_warmup import AgentWarmupService
 
 # ---------------------------------------------------------------------------
@@ -32,7 +32,7 @@ from nexus.system_services.agents.agent_warmup import AgentWarmupService
 
 @pytest.fixture
 def process_table():
-    return ProcessTable()
+    return AgentRegistry()
 
 
 @pytest.fixture
@@ -45,19 +45,21 @@ def warmup_service(process_table):
 
 
 def _register_agent(
-    process_table: ProcessTable, name: str = "agent-1", owner: str = "alice"
+    process_table: AgentRegistry, name: str = "agent-1", owner: str = "alice"
 ) -> str:
     """Register an external agent and STOP it so warmup can proceed.
 
-    Returns the PID.  The process starts in RUNNING (from register_external),
-    then we SIGSTOP it to STOPPED so the warmup service does not skip it
-    (warmup skips agents already in RUNNING).
+    Returns the PID.  The process starts in REGISTERED (from register_external),
+    then we advance to READY via WARMING_UP, then SIGSTOP to SUSPENDED so the
+    warmup service does not skip it (warmup skips agents already in BUSY).
     """
     desc = process_table.register_external(
         name, owner_id=owner, zone_id="test", connection_id=f"conn-{name}"
     )
-    # Move RUNNING -> STOPPED so warmup will not short-circuit
-    process_table.signal(desc.pid, ProcessSignal.SIGSTOP)
+    # Move REGISTERED -> WARMING_UP -> READY -> SUSPENDED so warmup will not short-circuit
+    desc = process_table._transition(desc, AgentState.WARMING_UP)
+    desc = process_table._transition(desc, AgentState.READY)
+    process_table.signal(desc.pid, AgentSignal.SIGSTOP)
     return desc.pid
 
 
@@ -111,7 +113,7 @@ class TestStepRegistry:
 class TestHappyPath:
     @pytest.mark.asyncio
     async def test_all_required_steps_pass(self, warmup_service, process_table):
-        """All required steps pass -> agent transitions to SLEEPING (connected)."""
+        """All required steps pass -> agent transitions to READY (connected)."""
         pid = _register_agent(process_table)
 
         warmup_service.register_step("step_a", _always_pass)
@@ -131,9 +133,9 @@ class TestHappyPath:
         assert result.error is None
         assert result.duration_ms > 0
 
-        # Verify agent transitioned (SIGCONT: STOPPED -> SLEEPING, generation bumped)
+        # Verify agent transitioned (SIGCONT: SUSPENDED -> READY, generation bumped)
         desc = process_table.get(pid)
-        assert desc.state is ProcessState.SLEEPING
+        assert desc.state is AgentState.READY
         assert desc.generation == 2  # 1 from spawn, +1 from SIGCONT
 
     @pytest.mark.asyncio
@@ -191,7 +193,7 @@ class TestHappyPath:
 class TestRequiredStepFailure:
     @pytest.mark.asyncio
     async def test_required_step_exception(self, warmup_service, process_table):
-        """Required step that raises -> warmup fails, agent stays STOPPED."""
+        """Required step that raises -> warmup fails, agent stays SUSPENDED."""
         pid = _register_agent(process_table)
 
         warmup_service.register_step("boom", _raise_error)
@@ -204,7 +206,7 @@ class TestRequiredStepFailure:
         assert result.error is not None
 
         desc = process_table.get(pid)
-        assert desc.state is ProcessState.STOPPED
+        assert desc.state is AgentState.SUSPENDED
 
     @pytest.mark.asyncio
     async def test_required_step_timeout(self, warmup_service, process_table):
@@ -220,7 +222,7 @@ class TestRequiredStepFailure:
         assert result.failed_step == "slow"
 
         desc = process_table.get(pid)
-        assert desc.state is ProcessState.STOPPED
+        assert desc.state is AgentState.SUSPENDED
 
     @pytest.mark.asyncio
     async def test_required_step_returns_false(self, warmup_service, process_table):
@@ -236,7 +238,7 @@ class TestRequiredStepFailure:
         assert result.failed_step == "nope"
 
         desc = process_table.get(pid)
-        assert desc.state is ProcessState.STOPPED
+        assert desc.state is AgentState.SUSPENDED
 
     @pytest.mark.asyncio
     async def test_unregistered_required_step(self, warmup_service, process_table):
@@ -318,12 +320,15 @@ class TestOptionalStepFailure:
 
 class TestEdgeCases:
     @pytest.mark.asyncio
-    async def test_warmup_already_running(self, warmup_service, process_table):
-        """Warmup on already-RUNNING agent -> skipped (idempotent)."""
-        # register_external creates in RUNNING; do NOT stop it
+    async def test_warmup_already_busy(self, warmup_service, process_table):
+        """Warmup on already-BUSY agent -> skipped (idempotent)."""
+        # register_external creates in REGISTERED; advance to BUSY
         desc = process_table.register_external(
             "agent-1", owner_id="alice", zone_id="test", connection_id="conn-1"
         )
+        desc = process_table._transition(desc, AgentState.WARMING_UP)
+        desc = process_table._transition(desc, AgentState.READY)
+        desc = process_table._transition(desc, AgentState.BUSY)
 
         result = await warmup_service.warmup(desc.pid, steps=[])
         assert result.success is True
@@ -338,14 +343,14 @@ class TestEdgeCases:
 
     @pytest.mark.asyncio
     async def test_empty_step_list(self, warmup_service, process_table):
-        """Empty step list -> immediate transition to SLEEPING."""
+        """Empty step list -> immediate transition to READY."""
         pid = _register_agent(process_table)
 
         result = await warmup_service.warmup(pid, steps=[])
         assert result.success is True
 
         desc = process_table.get(pid)
-        assert desc.state is ProcessState.SLEEPING
+        assert desc.state is AgentState.READY
 
     @pytest.mark.asyncio
     async def test_agent_unregistered_during_warmup(self, warmup_service, process_table):
@@ -375,13 +380,13 @@ class TestEdgeCases:
 
         steps = [WarmupStep("pass", timeout=timedelta(seconds=5))]
 
-        # First warmup succeeds: STOPPED -> SLEEPING via SIGCONT
+        # First warmup succeeds: SUSPENDED -> READY via SIGCONT
         result1 = await warmup_service.warmup(pid, steps=steps)
         assert result1.success is True
 
-        # Second warmup: agent is now SLEEPING (not RUNNING, so not skipped).
+        # Second warmup: agent is now READY (not BUSY, so not skipped).
         # Steps pass, but _transition_connected calls signal(SIGCONT) which
-        # tries SLEEPING -> SLEEPING -- an invalid transition. Warmup fails
+        # tries READY -> READY -- an invalid transition. Warmup fails
         # cleanly via InvalidTransitionError handling.
         result2 = await warmup_service.warmup(pid, steps=steps)
         assert result2.success is False

--- a/tests/unit/services/test_eviction_manager.py
+++ b/tests/unit/services/test_eviction_manager.py
@@ -18,11 +18,11 @@ import pytest
 
 from nexus.contracts.agent_types import EvictionReason
 from nexus.contracts.process_types import (
+    AgentDescriptor,
+    AgentKind,
+    AgentState,
     ExternalProcessInfo,
     InvalidTransitionError,
-    ProcessDescriptor,
-    ProcessKind,
-    ProcessState,
 )
 from nexus.contracts.qos import QoSClass
 from nexus.lib.performance_tuning import EvictionTuning
@@ -35,15 +35,15 @@ def _make_process(
     pid: str,
     generation: int = 1,
     last_heartbeat: datetime | None = None,
-) -> ProcessDescriptor:
-    """Create a minimal ProcessDescriptor for testing."""
+) -> AgentDescriptor:
+    """Create a minimal AgentDescriptor for testing."""
     now = datetime.now(UTC)
-    return ProcessDescriptor(
+    return AgentDescriptor(
         pid=pid,
         ppid=None,
         name=pid,
-        kind=ProcessKind.UNMANAGED,
-        state=ProcessState.RUNNING,
+        kind=AgentKind.UNMANAGED,
+        state=AgentState.BUSY,
         owner_id="test-owner",
         zone_id="test-zone",
         generation=generation,
@@ -308,7 +308,7 @@ class TestBuildCheckpoint:
 
         checkpoint = EvictionManager._build_checkpoint(process)
 
-        assert checkpoint["state"] == str(ProcessState.RUNNING)
+        assert checkpoint["state"] == str(AgentState.BUSY)
         assert checkpoint["generation"] == 5
         assert checkpoint["last_heartbeat"] == now.isoformat()
         assert isinstance(checkpoint["evicted_at"], float)
@@ -321,7 +321,7 @@ class TestBuildCheckpoint:
         checkpoint = EvictionManager._build_checkpoint(process)
 
         assert checkpoint["last_heartbeat"] is None
-        assert checkpoint["state"] == str(ProcessState.RUNNING)
+        assert checkpoint["state"] == str(AgentState.BUSY)
         assert checkpoint["generation"] == 1
 
 
@@ -330,7 +330,7 @@ class TestManualEviction:
 
     @pytest.mark.asyncio
     async def test_evict_connected_agent(self, manager, mock_process_table):
-        """evict_agent() sends SIGSTOP to a RUNNING process."""
+        """evict_agent() sends SIGSTOP to a BUSY process."""
         process = _make_process("agent-1")
         mock_process_table.get.return_value = process
 
@@ -352,16 +352,16 @@ class TestManualEviction:
 
     @pytest.mark.asyncio
     async def test_evict_non_running_agent_raises(self, manager, mock_process_table):
-        """evict_agent() raises ValueError for non-RUNNING process."""
+        """evict_agent() raises ValueError for non-BUSY process."""
         now = datetime.now(UTC)
-        process = ProcessDescriptor(
+        process = AgentDescriptor(
             pid="agent-1",
             ppid=None,
             name="agent-1",
             owner_id="test-owner",
             zone_id="test-zone",
-            kind=ProcessKind.UNMANAGED,
-            state=ProcessState.SLEEPING,
+            kind=AgentKind.UNMANAGED,
+            state=AgentState.READY,
             generation=1,
             created_at=now,
             updated_at=now,
@@ -369,7 +369,7 @@ class TestManualEviction:
         )
         mock_process_table.get.return_value = process
 
-        with pytest.raises(ValueError, match="not RUNNING"):
+        with pytest.raises(ValueError, match="not BUSY"):
             await manager.evict_agent("agent-1")
 
 
@@ -383,16 +383,16 @@ def _make_qos_process(
     last_heartbeat: datetime | None = None,
     generation: int = 1,
     eviction_class: QoSClass = QoSClass.STANDARD,
-) -> ProcessDescriptor:
-    """Create a ProcessDescriptor with eviction_class label for QoS testing."""
+) -> AgentDescriptor:
+    """Create a AgentDescriptor with eviction_class label for QoS testing."""
     now = datetime.now(UTC)
     hb = last_heartbeat or (now - timedelta(hours=1))
-    return ProcessDescriptor(
+    return AgentDescriptor(
         pid=pid,
         ppid=None,
         name=pid,
-        kind=ProcessKind.UNMANAGED,
-        state=ProcessState.RUNNING,
+        kind=AgentKind.UNMANAGED,
+        state=AgentState.BUSY,
         owner_id="test-owner",
         zone_id="test-zone",
         generation=generation,

--- a/tests/unit/services/test_eviction_policy.py
+++ b/tests/unit/services/test_eviction_policy.py
@@ -6,17 +6,17 @@ Tests cover:
 - QoSEvictionPolicy: spot-first ordering, preemption filtering,
   fallback to LRU within same class, mixed QoS ordering
 
-Post-AgentRegistry deletion: tests use ProcessDescriptor instead of AgentRecord.
+Post-AgentRegistry deletion: tests use AgentDescriptor instead of AgentRecord.
 """
 
 from datetime import UTC, datetime, timedelta
 
 from nexus.contracts.agent_types import EvictionReason
 from nexus.contracts.process_types import (
+    AgentDescriptor,
+    AgentKind,
+    AgentState,
     ExternalProcessInfo,
-    ProcessDescriptor,
-    ProcessKind,
-    ProcessState,
 )
 from nexus.contracts.qos import EvictionContext, QoSClass
 from nexus.system_services.agents.eviction_policy import (
@@ -31,17 +31,17 @@ def _make_agent(
     agent_id: str,
     last_heartbeat: datetime | None = None,
     eviction_class: QoSClass = QoSClass.STANDARD,
-) -> ProcessDescriptor:
-    """Create a minimal ProcessDescriptor for testing."""
+) -> AgentDescriptor:
+    """Create a minimal AgentDescriptor for testing."""
     now = datetime.now(UTC)
-    return ProcessDescriptor(
+    return AgentDescriptor(
         pid=agent_id,
         ppid=None,
         name=agent_id,
         owner_id="test-owner",
         zone_id="root",
-        kind=ProcessKind.UNMANAGED,
-        state=ProcessState.RUNNING,
+        kind=AgentKind.UNMANAGED,
+        state=AgentState.BUSY,
         generation=1,
         created_at=now,
         updated_at=now,


### PR DESCRIPTION
## Summary

Merges #1798 (state machine unification) + #1800 (rename) into one consistent PR. No naming inconsistency.

### State machine (single SSOT)
```
Old: ProcessState(CREATED/RUNNING/SLEEPING/STOPPED/ZOMBIE)
   + AgentState(UNKNOWN/CONNECTED/IDLE/SUSPENDED)  ← DELETED

New: AgentState(REGISTERED → WARMING_UP → READY ↔ BUSY → SUSPENDED → TERMINATED)
```

### Class renames
| Old | New |
|---|---|
| ProcessState | AgentState |
| ProcessSignal | AgentSignal |
| ProcessKind | AgentKind |
| ProcessDescriptor | AgentDescriptor |
| ProcessTable | AgentRegistry |
| ProcessTableProtocol | AgentRegistryProtocol |

Backward-compat aliases in definition files. Files NOT renamed.

## Test plan
- [x] ~30 files updated consistently
- [x] ruff clean, mypy clean, all pre-commit hooks pass
- [x] Backward-compat aliases for deferred imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)