### PR TITLE
refactor: remove all 2-phase TLS bootstrap residue

### DIFF
--- a/proto/nexus/raft/transport.proto
+++ b/proto/nexus/raft/transport.proto
@@ -140,14 +140,10 @@ message JoinZoneResponse {
 }
 
 // JoinClusterRequest is sent during TLS bootstrap to provision certificates.
-//
-// Two auth modes:
-//   1. Token-based: password field contains join token password (legacy/external join)
-//   2. Peers-based: peers_bootstrap=true, server verifies node_id is in NEXUS_PEERS
-//
+// The caller authenticates with a join token password (K3s-style).
 // The server signs a node certificate — CA key never leaves the leader.
 message JoinClusterRequest {
-  // Join token password (64-char hex string). Empty for peers_bootstrap mode.
+  // Join token password (64-char hex string).
   string password = 1;
   // The joining node's Raft ID.
   uint64 node_id = 2;
@@ -155,9 +151,9 @@ message JoinClusterRequest {
   string node_address = 3;
   // Zone ID for the node certificate CN (e.g., "root").
   string zone_id = 4;
-  // When true, authenticate by verifying node_id is in the static peers list
-  // instead of requiring a join token password. Used during 2-phase TLS bootstrap.
-  bool peers_bootstrap = 5;
+  // Reserved: was peers_bootstrap (removed — only token-based auth supported).
+  reserved 5;
+  reserved "peers_bootstrap";
 }
 
 // JoinClusterResponse returns cluster TLS material on success.

--- a/rust/nexus_raft/src/bin/witness.rs
+++ b/rust/nexus_raft/src/bin/witness.rs
@@ -147,20 +147,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
         let server = RaftWitnessServer::new(registry.clone(), server_config);
 
-        // If no certs, spawn a background task to call JoinCluster when leader is available
+        // If no certs, spawn a background task to call JoinCluster with token
         if needs_bootstrap && !peers.is_empty() {
-            let tls_dir_bg = tls_dir.clone();
-            let peers_bg = peers.clone();
-            // Use own address from peers (e.g. "http://witness:2126") so cert SAN
-            // includes the actual hostname, not "0.0.0.0".
-            let my_addr = peers
-                .iter()
-                .find(|p| p.id == node_id)
-                .map(|p| p.endpoint.clone())
-                .unwrap_or_else(|| format!("http://{}", bind_addr));
-            tokio::spawn(async move {
-                tls_bootstrap_loop(node_id, &my_addr, &peers_bg, &tls_dir_bg).await;
-            });
+            // Parse join token from NEXUS_JOIN_TOKEN (K3s-style: K10<password>::server:<fingerprint>)
+            let join_token = env::var("NEXUS_JOIN_TOKEN").unwrap_or_default();
+            let password = if let Some(body) = join_token.strip_prefix("K10") {
+                body.split("::server:").next().unwrap_or("").to_string()
+            } else {
+                if !join_token.is_empty() {
+                    tracing::warn!("NEXUS_JOIN_TOKEN has invalid format (expected K10...)");
+                } else {
+                    tracing::warn!("NEXUS_JOIN_TOKEN not set — cannot join cluster for TLS certs");
+                }
+                String::new()
+            };
+
+            if !password.is_empty() {
+                let tls_dir_bg = tls_dir.clone();
+                let peers_bg = peers.clone();
+                let my_addr = peers
+                    .iter()
+                    .find(|p| p.id == node_id)
+                    .map(|p| p.endpoint.clone())
+                    .unwrap_or_else(|| format!("http://{}", bind_addr));
+                tokio::spawn(async move {
+                    tls_bootstrap_loop(node_id, &my_addr, &peers_bg, &tls_dir_bg, &password).await;
+                });
+            }
         }
 
         tracing::info!("Witness server starting on {}", bind_addr);
@@ -222,6 +235,7 @@ async fn tls_bootstrap_loop(
     node_address: &str,
     peers: &[_nexus_raft::transport::NodeAddress],
     tls_dir: &std::path::Path,
+    password: &str,
 ) {
     use _nexus_raft::transport::call_join_cluster;
 
@@ -248,9 +262,8 @@ async fn tls_bootstrap_loop(
                 node_id,
                 node_address,
                 "root",
-                true, // peers_bootstrap
-                "",   // no password
-                10,   // timeout
+                password,
+                10, // timeout
             )
             .await
             {

--- a/rust/nexus_raft/src/pyo3_bindings.rs
+++ b/rust/nexus_raft/src/pyo3_bindings.rs
@@ -760,11 +760,7 @@ impl PyZoneManager {
             let ca_key_pem = std::fs::read(ca_key_path).map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to read CA key for JoinCluster: {}", e))
             })?;
-            server = server.with_join_config(
-                ca_key_pem,
-                token_hash.to_string(),
-                std::path::PathBuf::from(base_path),
-            );
+            server = server.with_join_config(ca_key_pem, token_hash.to_string());
         }
         let shutdown_rx_server = shutdown_rx.clone();
         runtime.spawn(async move {
@@ -1303,8 +1299,7 @@ fn join_cluster(peer_address: &str, join_token: &str, node_id: u64, tls_dir: &st
     let result = runtime
         .block_on(call_join_cluster(
             &endpoint, node_id, "", // node_address — not needed for pre-provision
-            "root", false, // peers_bootstrap = false (using password auth)
-            password, 30, // timeout_secs
+            "root", password, 30, // timeout_secs
         ))
         .map_err(|e| PyRuntimeError::new_err(format!("JoinCluster RPC failed: {}", e)))?;
 

--- a/rust/nexus_raft/src/raft/zone_registry.rs
+++ b/rust/nexus_raft/src/raft/zone_registry.rs
@@ -92,11 +92,6 @@ impl ZoneRaftRegistry {
         self.tls.read().unwrap().clone()
     }
 
-    /// Update TLS config at runtime (for plaintext→mTLS upgrade).
-    pub fn set_tls(&self, tls: Option<TlsConfig>) {
-        *self.tls.write().unwrap() = tls;
-    }
-
     /// Create a new zone with its own Raft group.
     ///
     /// # Arguments

--- a/rust/nexus_raft/src/transport/client.rs
+++ b/rust/nexus_raft/src/transport/client.rs
@@ -707,14 +707,15 @@ pub struct JoinClusterResult {
 
 /// Call JoinCluster on a leader to get a signed node certificate.
 ///
-/// Used during 2-phase TLS bootstrap by both fullnodes (via PyO3) and
-/// the witness binary. Connects over plaintext (no TLS — certs don't exist yet).
+/// Call JoinCluster on a leader to get a signed node certificate.
+///
+/// K3s-style: authenticates with join token password. The leader signs
+/// the cert server-side — CA key never leaves node-1.
 pub async fn call_join_cluster(
     leader_addr: &str,
     node_id: u64,
     node_address: &str,
     zone_id: &str,
-    peers_bootstrap: bool,
     password: &str,
     timeout_secs: u64,
 ) -> Result<JoinClusterResult> {
@@ -734,7 +735,6 @@ pub async fn call_join_cluster(
         node_id,
         node_address: node_address.to_string(),
         zone_id: zone_id.to_string(),
-        peers_bootstrap,
     };
 
     let response = client

--- a/rust/nexus_raft/src/transport/mod.rs
+++ b/rust/nexus_raft/src/transport/mod.rs
@@ -54,9 +54,7 @@ pub use client::{
     QueryResult, RaftApiClient, RaftClient, RaftClientPool,
 };
 #[cfg(all(feature = "grpc", has_protos))]
-pub use server::{
-    RaftGrpcServer, RaftWitnessServer, ServerConfig, TlsBootstrapHandle, WitnessZoneRegistry,
-};
+pub use server::{RaftGrpcServer, RaftWitnessServer, ServerConfig, WitnessZoneRegistry};
 #[cfg(all(feature = "grpc", has_protos))]
 pub use transport_loop::TransportLoop;
 

--- a/rust/nexus_raft/src/transport/server.rs
+++ b/rust/nexus_raft/src/transport/server.rs
@@ -70,94 +70,26 @@ pub struct RaftGrpcServer {
     config: ServerConfig,
     registry: Arc<ZoneRaftRegistry>,
     /// CA private key bytes — read once at startup, held in memory for JoinCluster cert signing.
-    /// The CA key never leaves this process (security: server-side cert signing).
     ca_key_pem: Option<Vec<u8>>,
     /// SHA-256 hash of the join token password — for JoinCluster verification.
     join_token_hash: Option<String>,
-    /// Base path for data directory — used for peers_joined marker file.
-    base_path: Option<PathBuf>,
-    /// Node IDs authorized for peers_bootstrap mode (from NEXUS_PEERS).
-    authorized_peer_ids: Option<Vec<u64>>,
-    /// Dynamic CA material — set by leader after CA generation (2-phase bootstrap).
-    /// Shared with the running service impl via Arc<RwLock<>>.
-    dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
-    /// Tracks which peers have successfully called JoinCluster (peers_bootstrap mode).
-    joined_peers: Arc<RwLock<std::collections::HashSet<u64>>>,
-}
-
-/// CA material injected at runtime for 2-phase TLS bootstrap.
-#[derive(Clone)]
-struct DynamicCaMaterial {
-    ca_pem: Vec<u8>,
-    ca_key_pem: Vec<u8>,
-}
-
-/// Handle for injecting CA material into a running server (2-phase bootstrap).
-pub struct TlsBootstrapHandle {
-    dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
-    /// Set of node IDs that have successfully called JoinCluster (peers_bootstrap mode).
-    joined_peers: Arc<RwLock<std::collections::HashSet<u64>>>,
-}
-
-impl TlsBootstrapHandle {
-    /// Set CA material so the running server can handle JoinCluster requests.
-    pub fn set_ca_material(&self, ca_pem: Vec<u8>, ca_key_pem: Vec<u8>) {
-        *self.dynamic_ca.write().unwrap() = Some(DynamicCaMaterial { ca_pem, ca_key_pem });
-    }
-
-    /// Get the set of node IDs that have called JoinCluster successfully.
-    pub fn joined_peer_ids(&self) -> Vec<u64> {
-        self.joined_peers.read().unwrap().iter().copied().collect()
-    }
 }
 
 impl RaftGrpcServer {
-    /// Create a new server backed by the given zone registry.
-    ///
-    /// # Arguments
-    /// * `registry` — Zone registry for routing requests.
-    /// * `config` — Server configuration.
     pub fn new(registry: Arc<ZoneRaftRegistry>, config: ServerConfig) -> Self {
         Self {
             config,
             registry,
             ca_key_pem: None,
             join_token_hash: None,
-            base_path: None,
-            authorized_peer_ids: None,
-            dynamic_ca: Arc::new(RwLock::new(None)),
-            joined_peers: Arc::new(RwLock::new(std::collections::HashSet::new())),
         }
     }
 
     /// Set cluster join parameters for JoinCluster RPC support.
-    ///
-    /// Reads the CA private key from disk once and holds it in memory.
-    /// The CA key never leaves this process — server signs certs for joiners.
-    pub fn with_join_config(
-        mut self,
-        ca_key_pem: Vec<u8>,
-        join_token_hash: String,
-        base_path: PathBuf,
-    ) -> Self {
+    pub fn with_join_config(mut self, ca_key_pem: Vec<u8>, join_token_hash: String) -> Self {
         self.ca_key_pem = Some(ca_key_pem);
         self.join_token_hash = Some(join_token_hash);
-        self.base_path = Some(base_path);
         self
-    }
-
-    /// Set authorized peer IDs for peers_bootstrap mode (from NEXUS_PEERS).
-    pub fn with_authorized_peers(mut self, peer_ids: Vec<u64>) -> Self {
-        self.authorized_peer_ids = Some(peer_ids);
-        self
-    }
-
-    /// Get a handle for injecting CA material into the running server (2-phase bootstrap).
-    pub fn tls_bootstrap_handle(&self) -> TlsBootstrapHandle {
-        TlsBootstrapHandle {
-            dynamic_ca: self.dynamic_ca.clone(),
-            joined_peers: self.joined_peers.clone(),
-        }
     }
 
     /// Get the bind address.
@@ -184,33 +116,19 @@ impl RaftGrpcServer {
             tls: self.config.tls.clone(),
             ca_key_pem: self.ca_key_pem.clone(),
             join_token_hash: self.join_token_hash.clone(),
-            base_path: self.base_path.clone(),
-            authorized_peer_ids: self.authorized_peer_ids.clone(),
-            dynamic_ca: self.dynamic_ca.clone(),
-            joined_peers: self.joined_peers.clone(),
         };
 
         let mut builder = tonic::transport::Server::builder();
         if let Some(ref tls) = self.config.tls {
             let identity = tonic::transport::Identity::from_pem(&tls.cert_pem, &tls.key_pem);
-            let use_mtls = self
-                .base_path
-                .as_ref()
-                .map(|p| p.join("tls/peers_joined").exists())
-                .unwrap_or(true); // default to mTLS if no base_path
-            let mut tls_config = tonic::transport::ServerTlsConfig::new().identity(identity);
-            if use_mtls {
-                let client_ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);
-                tls_config = tls_config.client_ca_root(client_ca);
-                tracing::info!("TLS mode: full mTLS (client auth required)");
-            } else {
-                tracing::info!(
-                    "TLS mode: server-TLS only (no client auth — awaiting first joiner)"
-                );
-            }
+            let client_ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);
+            let tls_config = tonic::transport::ServerTlsConfig::new()
+                .identity(identity)
+                .client_ca_root(client_ca);
             builder = builder
                 .tls_config(tls_config)
                 .map_err(|e| TransportError::Connection(format!("TLS config error: {}", e)))?;
+            tracing::info!("TLS mode: mTLS (client auth required)");
         }
 
         builder
@@ -245,33 +163,19 @@ impl RaftGrpcServer {
             tls: self.config.tls.clone(),
             ca_key_pem: self.ca_key_pem.clone(),
             join_token_hash: self.join_token_hash.clone(),
-            base_path: self.base_path.clone(),
-            authorized_peer_ids: self.authorized_peer_ids.clone(),
-            dynamic_ca: self.dynamic_ca.clone(),
-            joined_peers: self.joined_peers.clone(),
         };
 
         let mut builder = tonic::transport::Server::builder();
         if let Some(ref tls) = self.config.tls {
             let identity = tonic::transport::Identity::from_pem(&tls.cert_pem, &tls.key_pem);
-            let use_mtls = self
-                .base_path
-                .as_ref()
-                .map(|p| p.join("tls/peers_joined").exists())
-                .unwrap_or(true);
-            let mut tls_config = tonic::transport::ServerTlsConfig::new().identity(identity);
-            if use_mtls {
-                let client_ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);
-                tls_config = tls_config.client_ca_root(client_ca);
-                tracing::info!("TLS mode: full mTLS (client auth required)");
-            } else {
-                tracing::info!(
-                    "TLS mode: server-TLS only (no client auth — awaiting first joiner)"
-                );
-            }
+            let client_ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);
+            let tls_config = tonic::transport::ServerTlsConfig::new()
+                .identity(identity)
+                .client_ca_root(client_ca);
             builder = builder
                 .tls_config(tls_config)
                 .map_err(|e| TransportError::Connection(format!("TLS config error: {}", e)))?;
+            tracing::info!("TLS mode: mTLS (client auth required)");
         }
 
         builder
@@ -564,20 +468,12 @@ impl ZoneTransportService for ZoneTransportServiceImpl {
 /// Zone-routed implementation of the ZoneApiService gRPC trait.
 struct ZoneApiServiceImpl {
     registry: Arc<ZoneRaftRegistry>,
-    /// TLS config for outbound connections.
+    /// TLS config (for CA cert access in JoinCluster handler).
     tls: Option<super::TlsConfig>,
     /// CA private key bytes — held in memory for server-side cert signing.
     ca_key_pem: Option<Vec<u8>>,
     /// SHA-256 hash of the join token password — for JoinCluster verification.
     join_token_hash: Option<String>,
-    /// Base path for data directory — used to write peers_joined marker.
-    base_path: Option<PathBuf>,
-    /// Node IDs authorized for peers_bootstrap mode (from NEXUS_PEERS).
-    authorized_peer_ids: Option<Vec<u64>>,
-    /// Dynamic CA material — set at runtime by leader (2-phase bootstrap).
-    dynamic_ca: Arc<RwLock<Option<DynamicCaMaterial>>>,
-    /// Tracks which peers have successfully called JoinCluster.
-    joined_peers: Arc<RwLock<std::collections::HashSet<u64>>>,
 }
 
 #[tonic::async_trait]
@@ -961,8 +857,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
     /// Handle a JoinCluster request — TLS certificate provisioning.
     ///
     /// Two auth modes:
-    /// 1. Token-based (peers_bootstrap=false): verify password against join_token_hash
-    /// 2. Peers-based (peers_bootstrap=true): verify node_id is in authorized_peer_ids
+    /// Authenticates with join token password (K3s-style).
     ///
     /// In both modes, the server signs a node certificate and returns CA + cert + key.
     /// The CA private key never leaves this process.
@@ -985,68 +880,39 @@ impl ZoneApiService for ZoneApiServiceImpl {
             node_id = req.node_id,
             node_address = req.node_address,
             zone_id = req.zone_id,
-            peers_bootstrap = req.peers_bootstrap,
             "JoinCluster request received",
         );
 
-        // --- Authentication ---
-        if req.peers_bootstrap {
-            // Peers-based auth: verify node_id is in the static NEXUS_PEERS list
-            match &self.authorized_peer_ids {
-                Some(peers) if peers.contains(&req.node_id) => {
-                    tracing::info!(
-                        node_id = req.node_id,
-                        "JoinCluster: peers_bootstrap auth OK"
-                    );
-                }
-                Some(_) => {
-                    tracing::warn!(
-                        node_id = req.node_id,
-                        "JoinCluster: node_id not in authorized peers"
-                    );
-                    return Ok(err_resp("Node ID not in authorized peers list"));
-                }
-                None => {
-                    return Ok(err_resp("Peers bootstrap not configured on this node"));
-                }
+        // --- Token-based authentication (K3s-style) ---
+        let stored_hash = match &self.join_token_hash {
+            Some(h) => h,
+            None => {
+                return Ok(err_resp(
+                    "This node does not accept join requests (no join token configured)",
+                ));
             }
-        } else {
-            // Token-based auth: verify password hash
-            let stored_hash = match &self.join_token_hash {
-                Some(h) => h,
-                None => {
-                    return Ok(err_resp(
-                        "This node does not accept join requests (no join token configured)",
-                    ));
-                }
-            };
-            let candidate_hash = {
-                use sha2::{Digest, Sha256};
-                use std::fmt::Write;
-                let digest = Sha256::digest(req.password.as_bytes());
-                let mut hex = String::with_capacity(64);
-                for byte in &digest[..] {
-                    let _ = write!(hex, "{:02x}", byte);
-                }
-                hex
-            };
-            if candidate_hash != *stored_hash {
-                tracing::warn!(node_id = req.node_id, "JoinCluster: invalid password");
-                return Ok(err_resp("Invalid join token password"));
+        };
+        let candidate_hash = {
+            use sha2::{Digest, Sha256};
+            use std::fmt::Write;
+            let digest = Sha256::digest(req.password.as_bytes());
+            let mut hex = String::with_capacity(64);
+            for byte in &digest[..] {
+                let _ = write!(hex, "{:02x}", byte);
             }
+            hex
+        };
+        if candidate_hash != *stored_hash {
+            tracing::warn!(node_id = req.node_id, "JoinCluster: invalid password");
+            return Ok(err_resp("Invalid join token password"));
         }
 
-        // --- Get CA material ---
-        // Try static config first (set at startup), then dynamic (set by leader at runtime)
-        let (ca_pem, ca_key_pem) = if let (Some(ca_key), Some(tls)) = (&self.ca_key_pem, &self.tls)
-        {
-            (tls.ca_pem.clone(), ca_key.clone())
-        } else if let Some(dynamic) = self.dynamic_ca.read().unwrap().as_ref() {
-            (dynamic.ca_pem.clone(), dynamic.ca_key_pem.clone())
-        } else {
-            return Ok(err_resp(
-                "CA material not available (leader may not have generated CA yet)",
-            ));
+        // --- Get CA material (static — set at startup) ---
+        let (ca_pem, ca_key_pem) = match (&self.ca_key_pem, &self.tls) {
+            (Some(ca_key), Some(tls)) => (tls.ca_pem.clone(), ca_key.clone()),
+            _ => {
+                return Ok(err_resp("CA material not configured on this node"));
+            }
         };
 
         // --- Sign node certificate ---
@@ -1055,7 +921,6 @@ impl ZoneApiService for ZoneApiServiceImpl {
         } else {
             &req.zone_id
         };
-        // Extract hostname from node_address for cert SAN (CockroachDB pattern)
         let extra_hostnames = extract_hostnames(&req.node_address);
         let (node_cert_pem, node_key_pem) = match super::certgen::generate_node_cert(
             req.node_id,
@@ -1071,21 +936,9 @@ impl ZoneApiService for ZoneApiServiceImpl {
             }
         };
 
-        // Write peers_joined marker to signal mTLS upgrade on next restart
-        if let Some(ref base) = self.base_path {
-            let marker = base.join("tls/peers_joined");
-            if let Err(e) = std::fs::write(&marker, b"1") {
-                tracing::warn!("Failed to write peers_joined marker: {}", e);
-            }
-        }
-
-        // Track this peer as joined (for leader's all-ready check)
-        self.joined_peers.write().unwrap().insert(req.node_id);
-
         tracing::info!(
             node_id = req.node_id,
             node_address = req.node_address,
-            joined_count = self.joined_peers.read().unwrap().len(),
             "JoinCluster: node certificate signed and provisioned successfully",
         );
 

--- a/src/nexus/raft/transport_pb2.py
+++ b/src/nexus/raft/transport_pb2.py
@@ -21,7 +21,7 @@ _sym_db = _symbol_database.Default()
 from nexus.raft import commands_pb2 as nexus_dot_raft_dot_commands__pb2  # noqa: F401, E402
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1anexus/raft/transport.proto\x12\nnexus.raft\x1a\x19nexus/raft/commands.proto"_\n\x0eProposeRequest\x12(\n\x07\x63ommand\x18\x01 \x01(\x0b\x32\x17.nexus.raft.RaftCommand\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x0f\n\x07zone_id\x18\x03 \x01(\t"\xc1\x01\n\x0fProposeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12-\n\x06result\x18\x04 \x01(\x0b\x32\x18.nexus.raft.RaftResponseH\x02\x88\x01\x01\x12\x15\n\rapplied_index\x18\x05 \x01(\x04\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_result"_\n\x0cQueryRequest\x12$\n\x05query\x18\x01 \x01(\x0b\x32\x15.nexus.raft.RaftQuery\x12\x18\n\x10read_from_leader\x18\x02 \x01(\x08\x12\x0f\n\x07zone_id\x18\x03 \x01(\t"\xad\x01\n\rQueryResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12\x32\n\x06result\x18\x04 \x01(\x0b\x32\x1d.nexus.raft.RaftQueryResponseH\x02\x88\x01\x01\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_result"(\n\x15GetClusterInfoRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t"\xb8\x01\n\x16GetClusterInfoResponse\x12\x0f\n\x07node_id\x18\x01 \x01(\x04\x12\x11\n\tleader_id\x18\x02 \x01(\x04\x12\x0c\n\x04term\x18\x03 \x01(\x04\x12)\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x19.nexus.raft.ClusterConfig\x12\x11\n\tis_leader\x18\x05 \x01(\x08\x12\x1b\n\x0eleader_address\x18\x06 \x01(\tH\x00\x88\x01\x01\x42\x11\n\x0f_leader_address"I\n\x0fJoinZoneRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t\x12\x0f\n\x07node_id\x18\x02 \x01(\x04\x12\x14\n\x0cnode_address\x18\x03 \x01(\t"\xac\x01\n\x10JoinZoneResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12.\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x19.nexus.raft.ClusterConfigH\x02\x88\x01\x01\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_config"w\n\x12JoinClusterRequest\x12\x10\n\x08password\x18\x01 \x01(\t\x12\x0f\n\x07node_id\x18\x02 \x01(\x04\x12\x14\n\x0cnode_address\x18\x03 \x01(\t\x12\x0f\n\x07zone_id\x18\x04 \x01(\t\x12\x17\n\x0fpeers_bootstrap\x18\x05 \x01(\x08"\x93\x01\n\x13JoinClusterResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0e\n\x06\x63\x61_pem\x18\x03 \x01(\x0c\x12\x15\n\rnode_cert_pem\x18\x05 \x01(\x0c\x12\x14\n\x0cnode_key_pem\x18\x06 \x01(\x0c\x42\x08\n\x06_errorJ\x04\x08\x04\x10\x05R\nca_key_pem"\x86\x01\n\rClusterConfig\x12$\n\x06voters\x18\x01 \x03(\x0b\x32\x14.nexus.raft.NodeInfo\x12&\n\x08learners\x18\x02 \x03(\x0b\x32\x14.nexus.raft.NodeInfo\x12\'\n\twitnesses\x18\x03 \x03(\x0b\x32\x14.nexus.raft.NodeInfo"K\n\x08NodeInfo\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x0f\n\x07\x61\x64\x64ress\x18\x02 \x01(\t\x12"\n\x04role\x18\x03 \x01(\x0e\x32\x14.nexus.raft.NodeRole"6\n\x12StepMessageRequest\x12\x0f\n\x07message\x18\x01 \x01(\x0c\x12\x0f\n\x07zone_id\x18\x02 \x01(\t"D\n\x13StepMessageResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\x08\n\x06_error"V\n\x12\x45\x43ReplicationEntry\x12\x0b\n\x03seq\x18\x01 \x01(\x04\x12\x0f\n\x07\x63ommand\x18\x02 \x01(\x0c\x12\x11\n\ttimestamp\x18\x03 \x01(\x04\x12\x0f\n\x07node_id\x18\x04 \x01(\x04"s\n\x17ReplicateEntriesRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t\x12/\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x1e.nexus.raft.ECReplicationEntry\x12\x16\n\x0esender_node_id\x18\x03 \x01(\x04"`\n\x18ReplicateEntriesResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x15\n\rapplied_up_to\x18\x03 \x01(\x04\x42\x08\n\x06_error*>\n\x08NodeRole\x12\x0e\n\nROLE_VOTER\x10\x00\x12\x10\n\x0cROLE_LEARNER\x10\x01\x12\x10\n\x0cROLE_WITNESS\x10\x02\x32\xc5\x01\n\x14ZoneTransportService\x12N\n\x0bStepMessage\x12\x1e.nexus.raft.StepMessageRequest\x1a\x1f.nexus.raft.StepMessageResponse\x12]\n\x10ReplicateEntries\x12#.nexus.raft.ReplicateEntriesRequest\x1a$.nexus.raft.ReplicateEntriesResponse2\x82\x03\n\x0eZoneApiService\x12\x42\n\x07Propose\x12\x1a.nexus.raft.ProposeRequest\x1a\x1b.nexus.raft.ProposeResponse\x12<\n\x05Query\x12\x18.nexus.raft.QueryRequest\x1a\x19.nexus.raft.QueryResponse\x12W\n\x0eGetClusterInfo\x12!.nexus.raft.GetClusterInfoRequest\x1a".nexus.raft.GetClusterInfoResponse\x12\x45\n\x08JoinZone\x12\x1b.nexus.raft.JoinZoneRequest\x1a\x1c.nexus.raft.JoinZoneResponse\x12N\n\x0bJoinCluster\x12\x1e.nexus.raft.JoinClusterRequest\x1a\x1f.nexus.raft.JoinClusterResponseb\x06proto3'
+    b'\n\x1anexus/raft/transport.proto\x12\nnexus.raft\x1a\x19nexus/raft/commands.proto"_\n\x0eProposeRequest\x12(\n\x07\x63ommand\x18\x01 \x01(\x0b\x32\x17.nexus.raft.RaftCommand\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x0f\n\x07zone_id\x18\x03 \x01(\t"\xc1\x01\n\x0fProposeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12-\n\x06result\x18\x04 \x01(\x0b\x32\x18.nexus.raft.RaftResponseH\x02\x88\x01\x01\x12\x15\n\rapplied_index\x18\x05 \x01(\x04\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_result"_\n\x0cQueryRequest\x12$\n\x05query\x18\x01 \x01(\x0b\x32\x15.nexus.raft.RaftQuery\x12\x18\n\x10read_from_leader\x18\x02 \x01(\x08\x12\x0f\n\x07zone_id\x18\x03 \x01(\t"\xad\x01\n\rQueryResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12\x32\n\x06result\x18\x04 \x01(\x0b\x32\x1d.nexus.raft.RaftQueryResponseH\x02\x88\x01\x01\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_result"(\n\x15GetClusterInfoRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t"\xb8\x01\n\x16GetClusterInfoResponse\x12\x0f\n\x07node_id\x18\x01 \x01(\x04\x12\x11\n\tleader_id\x18\x02 \x01(\x04\x12\x0c\n\x04term\x18\x03 \x01(\x04\x12)\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x19.nexus.raft.ClusterConfig\x12\x11\n\tis_leader\x18\x05 \x01(\x08\x12\x1b\n\x0eleader_address\x18\x06 \x01(\tH\x00\x88\x01\x01\x42\x11\n\x0f_leader_address"I\n\x0fJoinZoneRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t\x12\x0f\n\x07node_id\x18\x02 \x01(\x04\x12\x14\n\x0cnode_address\x18\x03 \x01(\t"\xac\x01\n\x10JoinZoneResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0eleader_address\x18\x03 \x01(\tH\x01\x88\x01\x01\x12.\n\x06\x63onfig\x18\x04 \x01(\x0b\x32\x19.nexus.raft.ClusterConfigH\x02\x88\x01\x01\x42\x08\n\x06_errorB\x11\n\x0f_leader_addressB\t\n\x07_config"u\n\x12JoinClusterRequest\x12\x10\n\x08password\x18\x01 \x01(\t\x12\x0f\n\x07node_id\x18\x02 \x01(\x04\x12\x14\n\x0cnode_address\x18\x03 \x01(\t\x12\x0f\n\x07zone_id\x18\x04 \x01(\tJ\x04\x08\x05\x10\x06R\x0fpeers_bootstrap"\x93\x01\n\x13JoinClusterResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0e\n\x06\x63\x61_pem\x18\x03 \x01(\x0c\x12\x15\n\rnode_cert_pem\x18\x05 \x01(\x0c\x12\x14\n\x0cnode_key_pem\x18\x06 \x01(\x0c\x42\x08\n\x06_errorJ\x04\x08\x04\x10\x05R\nca_key_pem"\x86\x01\n\rClusterConfig\x12$\n\x06voters\x18\x01 \x03(\x0b\x32\x14.nexus.raft.NodeInfo\x12&\n\x08learners\x18\x02 \x03(\x0b\x32\x14.nexus.raft.NodeInfo\x12\'\n\twitnesses\x18\x03 \x03(\x0b\x32\x14.nexus.raft.NodeInfo"K\n\x08NodeInfo\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x0f\n\x07\x61\x64\x64ress\x18\x02 \x01(\t\x12"\n\x04role\x18\x03 \x01(\x0e\x32\x14.nexus.raft.NodeRole"6\n\x12StepMessageRequest\x12\x0f\n\x07message\x18\x01 \x01(\x0c\x12\x0f\n\x07zone_id\x18\x02 \x01(\t"D\n\x13StepMessageResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\x08\n\x06_error"V\n\x12\x45\x43ReplicationEntry\x12\x0b\n\x03seq\x18\x01 \x01(\x04\x12\x0f\n\x07\x63ommand\x18\x02 \x01(\x0c\x12\x11\n\ttimestamp\x18\x03 \x01(\x04\x12\x0f\n\x07node_id\x18\x04 \x01(\x04"s\n\x17ReplicateEntriesRequest\x12\x0f\n\x07zone_id\x18\x01 \x01(\t\x12/\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x1e.nexus.raft.ECReplicationEntry\x12\x16\n\x0esender_node_id\x18\x03 \x01(\x04"`\n\x18ReplicateEntriesResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x15\n\rapplied_up_to\x18\x03 \x01(\x04\x42\x08\n\x06_error*>\n\x08NodeRole\x12\x0e\n\nROLE_VOTER\x10\x00\x12\x10\n\x0cROLE_LEARNER\x10\x01\x12\x10\n\x0cROLE_WITNESS\x10\x02\x32\xc5\x01\n\x14ZoneTransportService\x12N\n\x0bStepMessage\x12\x1e.nexus.raft.StepMessageRequest\x1a\x1f.nexus.raft.StepMessageResponse\x12]\n\x10ReplicateEntries\x12#.nexus.raft.ReplicateEntriesRequest\x1a$.nexus.raft.ReplicateEntriesResponse2\x82\x03\n\x0eZoneApiService\x12\x42\n\x07Propose\x12\x1a.nexus.raft.ProposeRequest\x1a\x1b.nexus.raft.ProposeResponse\x12<\n\x05Query\x12\x18.nexus.raft.QueryRequest\x1a\x19.nexus.raft.QueryResponse\x12W\n\x0eGetClusterInfo\x12!.nexus.raft.GetClusterInfoRequest\x1a".nexus.raft.GetClusterInfoResponse\x12\x45\n\x08JoinZone\x12\x1b.nexus.raft.JoinZoneRequest\x1a\x1c.nexus.raft.JoinZoneResponse\x12N\n\x0bJoinCluster\x12\x1e.nexus.raft.JoinClusterRequest\x1a\x1f.nexus.raft.JoinClusterResponseb\x06proto3'
 )
 
 _globals = globals()
@@ -29,8 +29,8 @@ _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "nexus.raft.transport_pb2", _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
     DESCRIPTOR._loaded_options = None
-    _globals["_NODEROLE"]._serialized_start = 2028
-    _globals["_NODEROLE"]._serialized_end = 2090
+    _globals["_NODEROLE"]._serialized_start = 2026
+    _globals["_NODEROLE"]._serialized_end = 2088
     _globals["_PROPOSEREQUEST"]._serialized_start = 69
     _globals["_PROPOSEREQUEST"]._serialized_end = 164
     _globals["_PROPOSERESPONSE"]._serialized_start = 167
@@ -48,25 +48,25 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_JOINZONERESPONSE"]._serialized_start = 940
     _globals["_JOINZONERESPONSE"]._serialized_end = 1112
     _globals["_JOINCLUSTERREQUEST"]._serialized_start = 1114
-    _globals["_JOINCLUSTERREQUEST"]._serialized_end = 1233
-    _globals["_JOINCLUSTERRESPONSE"]._serialized_start = 1236
-    _globals["_JOINCLUSTERRESPONSE"]._serialized_end = 1383
-    _globals["_CLUSTERCONFIG"]._serialized_start = 1386
-    _globals["_CLUSTERCONFIG"]._serialized_end = 1520
-    _globals["_NODEINFO"]._serialized_start = 1522
-    _globals["_NODEINFO"]._serialized_end = 1597
-    _globals["_STEPMESSAGEREQUEST"]._serialized_start = 1599
-    _globals["_STEPMESSAGEREQUEST"]._serialized_end = 1653
-    _globals["_STEPMESSAGERESPONSE"]._serialized_start = 1655
-    _globals["_STEPMESSAGERESPONSE"]._serialized_end = 1723
-    _globals["_ECREPLICATIONENTRY"]._serialized_start = 1725
-    _globals["_ECREPLICATIONENTRY"]._serialized_end = 1811
-    _globals["_REPLICATEENTRIESREQUEST"]._serialized_start = 1813
-    _globals["_REPLICATEENTRIESREQUEST"]._serialized_end = 1928
-    _globals["_REPLICATEENTRIESRESPONSE"]._serialized_start = 1930
-    _globals["_REPLICATEENTRIESRESPONSE"]._serialized_end = 2026
-    _globals["_ZONETRANSPORTSERVICE"]._serialized_start = 2093
-    _globals["_ZONETRANSPORTSERVICE"]._serialized_end = 2290
-    _globals["_ZONEAPISERVICE"]._serialized_start = 2293
-    _globals["_ZONEAPISERVICE"]._serialized_end = 2679
+    _globals["_JOINCLUSTERREQUEST"]._serialized_end = 1231
+    _globals["_JOINCLUSTERRESPONSE"]._serialized_start = 1234
+    _globals["_JOINCLUSTERRESPONSE"]._serialized_end = 1381
+    _globals["_CLUSTERCONFIG"]._serialized_start = 1384
+    _globals["_CLUSTERCONFIG"]._serialized_end = 1518
+    _globals["_NODEINFO"]._serialized_start = 1520
+    _globals["_NODEINFO"]._serialized_end = 1595
+    _globals["_STEPMESSAGEREQUEST"]._serialized_start = 1597
+    _globals["_STEPMESSAGEREQUEST"]._serialized_end = 1651
+    _globals["_STEPMESSAGERESPONSE"]._serialized_start = 1653
+    _globals["_STEPMESSAGERESPONSE"]._serialized_end = 1721
+    _globals["_ECREPLICATIONENTRY"]._serialized_start = 1723
+    _globals["_ECREPLICATIONENTRY"]._serialized_end = 1809
+    _globals["_REPLICATEENTRIESREQUEST"]._serialized_start = 1811
+    _globals["_REPLICATEENTRIESREQUEST"]._serialized_end = 1926
+    _globals["_REPLICATEENTRIESRESPONSE"]._serialized_start = 1928
+    _globals["_REPLICATEENTRIESRESPONSE"]._serialized_end = 2024
+    _globals["_ZONETRANSPORTSERVICE"]._serialized_start = 2091
+    _globals["_ZONETRANSPORTSERVICE"]._serialized_end = 2288
+    _globals["_ZONEAPISERVICE"]._serialized_start = 2291
+    _globals["_ZONEAPISERVICE"]._serialized_end = 2677
 # @@protoc_insertion_point(module_scope)

--- a/tests/unit/core/test_agent_record.py
+++ b/tests/unit/core/test_agent_record.py
@@ -88,7 +88,7 @@ class TestAgentRecord:
     def test_is_frozen(self, record):
         """AgentRecord is immutable (frozen dataclass)."""
         with pytest.raises(FrozenInstanceError):
-            object.__setattr__(record, "state", AgentState.READY)
+            record.state = AgentState.READY
 
     def test_field_access(self, record):
         """All fields are accessible."""


### PR DESCRIPTION
Delete all 2-phase plaintext→mTLS code (-262 lines). Only K3s-style token-based join remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)