### PR TITLE
fix(#1771): eliminate _system_services from kernel — factory-internal only

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -29,7 +29,6 @@ from nexus.core.config import (
     MemoryConfig,
     ParseConfig,
     PermissionConfig,
-    SystemServices,
 )
 from nexus.core.file_events import FileEvent, FileEventType
 from nexus.core.hash_fast import hash_content
@@ -72,7 +71,7 @@ class NexusFS(  # type: ignore[misc]
         memory: MemoryConfig | None = None,
         parsing: ParseConfig | None = None,
         kernel_services: KernelServices | None = None,
-        system_services: SystemServices | None = None,
+        system_services: Any = None,
         brick_services: BrickServices | None = None,
     ):
         """Initialize NexusFS kernel.
@@ -80,6 +79,11 @@ class NexusFS(  # type: ignore[misc]
         Kernel boots with MetastoreABC (inode layer) and an optional router
         (via KernelServices). Backends are mounted externally via
         ``router.add_mount()`` — like Linux VFS, no global backend.
+
+        .. deprecated:: Issue #1771
+            ``system_services`` is accepted for backward compatibility but the
+            kernel no longer reads it.  The factory layer sets
+            ``nx._system_services`` post-construction instead.
         """
         # Config defaults
         cache = cache or CacheConfig()
@@ -88,7 +92,6 @@ class NexusFS(  # type: ignore[misc]
         memory = memory or MemoryConfig()
         parsing = parsing or ParseConfig()
         ksvc = kernel_services or KernelServices()
-        sys_svc = system_services or SystemServices()
         brk_svc = brick_services or BrickServices()
 
         # Per-instance VFS revision counter (H21: must not be class-level)
@@ -104,7 +107,16 @@ class NexusFS(  # type: ignore[misc]
         self._parse_config = parsing
         # Issue #1767: _kernel_services wrapper removed — only field was router,
         # which is already stored as self.router (set a few lines below).
-        self._system_services = sys_svc
+        # Issue #1771: _system_services removed from kernel logic — accepted
+        # only for backward compat (tests/server/CLI may still pass it).
+        # The factory layer re-sets this post-construction via setattr.
+        # Default to SystemServices() for backward compat with tests that
+        # call dataclasses.replace(nx._system_services, ...).
+        if system_services is None:
+            from nexus.core.config import SystemServices as _SystemServices
+
+            system_services = _SystemServices()
+        self._system_services = system_services
         self._brick_services = brk_svc
         self._config: Any | None = None
 
@@ -164,6 +176,9 @@ class NexusFS(  # type: ignore[misc]
         # Issue #1788: distributed lock manager — kernel knows (like _permission_enforcer).
         # In-process locks use _vfs_lock_manager (kernel owns); distributed locks use this.
         self._distributed_lock_manager: Any = None
+        # Issue #1771: factory-injected async flush fn — replaces _system_services read
+        # in flush_write_observer(). Captures write_observer via closure.
+        self._flush_write_observer_fn: Any = None
         # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)
 
         # Lazy-init sentinels
@@ -4128,14 +4143,12 @@ class NexusFS(  # type: ignore[misc]
         if alias is not None:
             svc_attr, svc_method = alias
             svc = self.__dict__.get(svc_attr)
-            # Fallback: check containers for attrs removed from instance dict (Issue #1570)
+            # Fallback: check _brick_services container for attrs removed from
+            # instance dict (Issue #1570).  _system_services removed (Issue #1771).
             if svc is None:
-                _sys = object.__getattribute__(self, "_system_services")
                 _brk = object.__getattribute__(self, "_brick_services")
                 _bare = svc_attr.lstrip("_")
-                if _sys is not None:
-                    svc = getattr(_sys, _bare, None)
-                if svc is None and _brk is not None:
+                if _brk is not None:
                     svc = getattr(_brk, _bare, None)
             if svc is not None:
                 return getattr(svc, svc_method)
@@ -4144,14 +4157,12 @@ class NexusFS(  # type: ignore[misc]
         svc_attr_std = NexusFS._SERVICE_METHODS.get(name)
         if svc_attr_std is not None:
             svc = self.__dict__.get(svc_attr_std)
-            # Fallback: check containers for attrs removed from instance dict (Issue #1570)
+            # Fallback: check _brick_services container for attrs removed from
+            # instance dict (Issue #1570).  _system_services removed (Issue #1771).
             if svc is None:
-                _sys = object.__getattribute__(self, "_system_services")
                 _brk = object.__getattribute__(self, "_brick_services")
                 _bare = svc_attr_std.lstrip("_")
-                if _sys is not None:
-                    svc = getattr(_sys, _bare, None)
-                if svc is None and _brk is not None:
+                if _brk is not None:
                     svc = getattr(_brk, _bare, None)
             if svc is not None:
                 return getattr(svc, name)
@@ -4524,15 +4535,12 @@ class NexusFS(  # type: ignore[misc]
         Returns:
             Dict with ``flushed`` count.
         """
-        # Issue #1789: delegate to write_observer via service registry or
-        # _system_services as last resort.  _close_callbacks handles close().
-        wo = None
-        _sys = self._system_services
-        if _sys is not None:
-            wo = getattr(_sys, "write_observer", None)
-        if wo is None or not hasattr(wo, "flush"):
+        # Issue #1771: use factory-injected _flush_write_observer_fn instead of
+        # reading _system_services directly.  Captures write_observer via closure.
+        _flush_fn = self._flush_write_observer_fn
+        if _flush_fn is None:
             return {"flushed": 0}
-        flushed: int = NexusFS._run_async(wo.flush())
+        flushed: int = NexusFS._run_async(_flush_fn())
         return {"flushed": flushed}
 
     # ------------------------------------------------------------------

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 async def _do_link(
     nx: Any,
     *,
+    system_services: Any = None,
     enabled_bricks: "frozenset[str] | None" = None,
     parsing: Any = None,
     workflow_engine: Any = None,
@@ -31,7 +32,7 @@ async def _do_link(
     from nexus.factory._wired import _boot_wired_services
     from nexus.factory.service_routing import enlist_wired_services
 
-    _sys = nx._system_services
+    _sys = system_services
     _brk = nx._brick_services
     nx._permission_enforcer = _sys.permission_enforcer  # Issue #1706: override sentinel
 
@@ -103,6 +104,7 @@ async def _do_link(
 
     nx._initialize_fn = functools.partial(
         _do_initialize,
+        system_services=system_services,
         brick_on=_brick_on,
         parse_fn=_parse_fn,
         permission_checker=_permission_checker,
@@ -112,7 +114,7 @@ async def _do_link(
     _wired = await _boot_wired_services(
         nx,
         nx.router,  # Issue #1767: KernelServices wrapper removed
-        nx._system_services,
+        system_services,
         nx._brick_services,
         _brick_on,
     )
@@ -123,7 +125,7 @@ async def _do_link(
         ServiceLifecycleCoordinator,
     )
 
-    _blm = getattr(nx._system_services, "brick_lifecycle_manager", None)
+    _blm = getattr(system_services, "brick_lifecycle_manager", None)
     coordinator = ServiceLifecycleCoordinator(nx._service_registry, _blm, nx._dispatch)
     nx._service_coordinator = coordinator
     await enlist_wired_services(coordinator, _wired)
@@ -131,10 +133,10 @@ async def _do_link(
     # Issue #1666: Register system-tier PersistentService instances.
     # These are Q3 (PersistentService) — enlist() defers start() because
     # coordinator is not yet bootstrapped (mark_bootstrapped at bootstrap).
-    _dpb = getattr(nx._system_services, "deferred_permission_buffer", None)
+    _dpb = getattr(system_services, "deferred_permission_buffer", None)
     if _dpb is not None:
         await coordinator.enlist("deferred_permission_buffer", _dpb)
-    _dw = getattr(nx._system_services, "delivery_worker", None)
+    _dw = getattr(system_services, "delivery_worker", None)
     if _dw is not None:
         await coordinator.enlist("delivery_worker", _dw)
 
@@ -161,6 +163,16 @@ async def _do_link(
                 logger.debug("close: write_observer flush_sync failed (best-effort): %s", exc)
 
         nx._close_callbacks.append(_close_write_observer)
+
+    # Issue #1771: inject _flush_write_observer_fn so kernel flush_write_observer()
+    # no longer reads _system_services.
+    if _wo is not None and hasattr(_wo, "flush"):
+
+        async def _flush_wo() -> int:
+            result: int = await _wo.flush()
+            return result
+
+        nx._flush_write_observer_fn = _flush_wo
 
     _rebac = getattr(_sys, "rebac_manager", None)
     if _rebac is not None and hasattr(_rebac, "close"):
@@ -221,7 +233,12 @@ async def _do_link(
 
 
 async def _do_initialize(
-    nx: Any, *, brick_on: "Any" = None, parse_fn: "Any" = None, permission_checker: "Any" = None
+    nx: Any,
+    *,
+    system_services: Any = None,
+    brick_on: "Any" = None,
+    parse_fn: "Any" = None,
+    permission_checker: "Any" = None,
 ) -> None:
     """Phase 2 implementation: one-time side effects.  NO background threads.
 
@@ -245,6 +262,7 @@ async def _do_initialize(
 
     await _register_vfs_hooks(
         nx,
+        system_services=system_services,
         permission_checker=permission_checker,
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
         brick_on=brick_on,
@@ -252,7 +270,7 @@ async def _do_initialize(
     )
 
     # --- BLM registration for late bricks (Issue #1704, #2991) ---
-    _blm = getattr(nx._system_services, "brick_lifecycle_manager", None)
+    _blm = getattr(system_services, "brick_lifecycle_manager", None)
     if _blm is not None:
         from nexus.factory._helpers import _register_late_bricks
 
@@ -267,7 +285,7 @@ async def _do_initialize(
     # implement PersistentService and are auto-started by the coordinator's
     # start_persistent_services() at bootstrap.  Manual callbacks deleted.
 
-    _zl = getattr(nx._system_services, "zone_lifecycle", None) if nx._system_services else None
+    _zl = getattr(system_services, "zone_lifecycle", None) if system_services else None
     if _zl is not None and hasattr(_zl, "load_terminating_zones"):
 
         async def _load_zones() -> None:

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -366,6 +366,8 @@ async def create_nexus_fs(
     if brick_services is None:
         brick_services = _BrickServices()
 
+    import functools
+
     from nexus.factory._lifecycle import _do_initialize, _do_link
 
     nx = NexusFS(
@@ -379,11 +381,12 @@ async def create_nexus_fs(
         memory=memory,
         parsing=parsing,
         kernel_services=kernel_services,
-        system_services=system_services,
         brick_services=brick_services,
     )
-    nx._link_fn = _do_link
+    nx._link_fn = functools.partial(_do_link, system_services=system_services)
     nx._initialize_fn = _do_initialize
+    # Backward compat: server/CLI/tests may read nx._system_services directly.
+    nx._system_services = system_services
     await nx.link(
         enabled_bricks=enabled_bricks,
         parsing=parsing,
@@ -396,6 +399,7 @@ async def create_nexus_fs(
 async def _register_vfs_hooks(
     nx: "NexusFS",
     *,
+    system_services: Any = None,
     permission_checker: Any = None,
     auto_parse: bool = True,
     brick_on: "Callable[[str], bool] | None" = None,
@@ -425,7 +429,7 @@ async def _register_vfs_hooks(
     # Rejects writes to zones being deprovisioned (Issue #2061).
     # Replaces _check_zone_writable() in nexus_fs — kernel no longer
     # reads zone_lifecycle from _system_services.
-    _zl = getattr(nx._system_services, "zone_lifecycle", None) if nx._system_services else None
+    _zl = getattr(system_services, "zone_lifecycle", None) if system_services else None
     if _zl is not None:
         from nexus.system_services.lifecycle.zone_write_guard_hook import ZoneWriteGuardHook
 
@@ -440,18 +444,14 @@ async def _register_vfs_hooks(
             metadata_store=nx.metadata,
             default_context=nx._default_context,
             enforce_permissions=nx._enforce_permissions,
-            permission_enforcer=nx._system_services.permission_enforcer
-            if nx._system_services
-            else None,
+            permission_enforcer=system_services.permission_enforcer if system_services else None,
             descendant_checker=getattr(nx, "_descendant_checker", None),
         )
         await _enlist("permission", _perm_hook)
 
     # ── Audit write observer as interceptor (Issue #900) ──────────
     # Registered FIRST so it runs before other hooks (audit before side effects).
-    write_observer = (
-        getattr(nx._system_services, "write_observer", None) if nx._system_services else None
-    )
+    write_observer = getattr(system_services, "write_observer", None) if system_services else None
     if write_observer is not None:
         from nexus.storage.write_observer_hooks import AuditWriteInterceptor
 
@@ -461,8 +461,7 @@ async def _register_vfs_hooks(
 
     # DynamicViewerReadHook (post-read: column-level CSV filtering)
     has_viewer = (
-        (getattr(nx._system_services, "rebac_manager", None) if nx._system_services else None)
-        is not None
+        (getattr(system_services, "rebac_manager", None) if system_services else None) is not None
         and hasattr(nx, "get_dynamic_viewer_config")
         and hasattr(nx, "apply_dynamic_viewer_filter")
     )
@@ -498,9 +497,7 @@ async def _register_vfs_hooks(
         await _enlist("auto_parse", _auto_parse_hook)
 
     # TigerCacheRenameHook (post-rename: bitmap updates)
-    _rebac_mgr = (
-        getattr(nx._system_services, "rebac_manager", None) if nx._system_services else None
-    )
+    _rebac_mgr = getattr(system_services, "rebac_manager", None) if system_services else None
     tiger_cache = getattr(_rebac_mgr, "_tiger_cache", None) if _rebac_mgr else None
     if tiger_cache is not None:
         from nexus.bricks.rebac.cache.tiger.rename_hook import TigerCacheRenameHook
@@ -538,9 +535,7 @@ async def _register_vfs_hooks(
     await _enlist("virtual_view", _vview_resolver)
 
     # ── ProcResolver (procfs virtual filesystem for ProcessTable — Issue #1570) ──
-    _proc_table = (
-        getattr(nx._system_services, "process_table", None) if nx._system_services else None
-    )
+    _proc_table = getattr(system_services, "process_table", None) if system_services else None
     if _proc_table is not None:
         try:
             from nexus.system_services.proc.proc_resolver import ProcResolver
@@ -582,14 +577,8 @@ async def _register_vfs_hooks(
         await _enlist("snapshot_write", SnapshotWriteHook(_snapshot_svc))
 
     # ── Deferred permission buffer (Issue #1773, #1682) ────────────────
-    _dpb = (
-        getattr(nx._system_services, "deferred_permission_buffer", None)
-        if nx._system_services
-        else None
-    )
-    _rebac_for_perm = (
-        getattr(nx._system_services, "rebac_manager", None) if nx._system_services else None
-    )
+    _dpb = getattr(system_services, "deferred_permission_buffer", None) if system_services else None
+    _rebac_for_perm = getattr(system_services, "rebac_manager", None) if system_services else None
     if _dpb is not None:
         from nexus.bricks.rebac.deferred_permission_hook import DeferredPermissionHook
 
@@ -599,9 +588,7 @@ async def _register_vfs_hooks(
         )
     else:
         # Sync fallback — same logic, runs as post-write hook instead of inline kernel code
-        _hier = (
-            getattr(nx._system_services, "hierarchy_manager", None) if nx._system_services else None
-        )
+        _hier = getattr(system_services, "hierarchy_manager", None) if system_services else None
         if _hier is not None or _rebac_for_perm is not None:
             from nexus.bricks.rebac.sync_permission_hook import SyncPermissionWriteHook
 
@@ -614,7 +601,7 @@ async def _register_vfs_hooks(
     # Replaces NexusFS._check_zone_writable() — kernel should not know
     # about zone lifecycle.  PRE hooks on all mutating ops block writes
     # to zones being deprovisioned.
-    _zl = getattr(nx._system_services, "zone_lifecycle", None) if nx._system_services else None
+    _zl = getattr(system_services, "zone_lifecycle", None) if system_services else None
     if _zl is not None:
         from nexus.system_services.lifecycle.zone_writability_hook import ZoneWritabilityHook
 
@@ -628,7 +615,7 @@ async def _register_vfs_hooks(
     from nexus.system_services.event_bus.observer import EventBusObserver
 
     _bus_observer = EventBusObserver(
-        event_bus=nx._system_services.event_bus if nx._system_services else None
+        event_bus=system_services.event_bus if system_services else None
     )
     await _enlist("event_bus_observer", _bus_observer)
 


### PR DESCRIPTION
## Summary
- Kernel `nexus_fs.py` no longer reads `_system_services` attributes for any logic (zero `self._system_services.` hits)
- `flush_write_observer` now uses factory-injected `_flush_write_observer_fn` closure
- `__getattr__` SERVICE_METHODS fallback: removed `_system_services` container lookup
- Factory `_do_link`/`_do_initialize`/`_register_vfs_hooks` receive `system_services` as closure parameter via `functools.partial`
- `create_nexus_fs` still sets `nx._system_services` post-construction for backward compat (server, CLI, ~50 tests)

## Test plan
- [x] 10970 unit tests pass (0 failures)
- [x] ruff lint + format clean, mypy passes
- [x] All pre-commit hooks pass
- [x] `grep -n "self._system_services\." src/nexus/core/nexus_fs.py` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)