### PR TITLE
refactor(#1792): AgentRegistry → kernel-owned primitive

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -45,7 +45,8 @@ Every kernel interface belongs to exactly one of four categories:
         │  │  PRIMITIVES — internal (§4)                 │ │
         │  │  PathValidator, ZoneAccessGuard, VFSRouter, │ │
         │  │  VFSLockManager, KernelDispatch,            │ │
-        │  │  PipeManager, FileEvent                     │ │
+        │  │  PipeManager, StreamManager,                │ │
+        │  │  AgentRegistry, FileEvent                   │ │
         │  └─────────────────────────────────────────────┘ │
         └──────────────┬───────────────────────────────────┘
                        │  ↓ HAL — DRIVER CONTRACT (§3)
@@ -376,6 +377,7 @@ with them indirectly through syscalls. See §2.2 matrix for per-syscall usage.
 | **KernelDispatch** | `core.kernel_dispatch` | `security_hook_heads` + `fsnotify` | Three-phase callback mechanism implementing §2.4. Per-op callback lists; empty = zero overhead. Hook contracts (§2.4) and registration API (§2.5) are User Contract; this is the plumbing |
 | **PipeManager + RingBuffer** | `system_services` + `core.pipe` | `pipe(2)` + `fs/pipe.c` | VFS named pipes — inode in MetastoreABC, data in heap ring buffer. Details in §4.2 |
 | **StreamManager + StreamBuffer** | `system_services` + `core.stream` | append-only log | VFS named streams — inode in MetastoreABC, data in heap linear buffer. Non-destructive offset-based reads, multi-reader fan-out. Details in §4.2 |
+| **AgentRegistry** | `core.agent_registry` | process table (`task_struct` hash) | Kernel-owned agent process table — PID allocation, state machine, signals, wait(). Pure in-memory (ephemeral). VFS visibility via ProcResolver (procfs). Details in §4.4 |
 | **PathValidator** | `core.nexus_fs` (to extract) | `fs/namei.c` path validation | Path format validation on every syscall entry. Rejects malformed paths before routing or HAL access |
 | **ZoneWriteGuardHook** | `system_services.lifecycle` | `fs/namespace.c` mount readonly | Zone write permission check via KernelDispatch PRE hook (Issue #1790). Rejects writes to terminating zones |
 | **ServiceLifecycleCoordinator** | `system_services.lifecycle` | `init/main.c` + `module.c` | Kernel-owned bridge: ServiceRegistry + BrickLifecycleManager. Manages enlist/swap/shutdown for all 4 service quadrants |
@@ -430,6 +432,20 @@ See `federation-memo.md` §7j for design rationale.
 | Structure | Frozen dataclass: path, etag, size, version, zone_id, agent_id, user_id, vector_clock |
 | Consumer paths | KernelDispatch OBSERVE (local), EventBus (distributed) |
 | Emission point | Always AFTER lock release |
+
+### 4.4 AgentRegistry — Kernel Agent Process Table
+
+| Property | Value |
+|----------|-------|
+| Storage | Pure in-memory `dict[str, AgentDescriptor]` — no persistence |
+| PID allocation | UUID4 hex prefix (12 chars) |
+| State machine | REGISTERED → READY → BUSY → SUSPENDED → TERMINATED (validated transitions) |
+| Signals | SIGSTOP, SIGCONT, SIGTERM, SIGKILL, SIGUSR1 |
+| Concurrency | spawn/kill/signal/get/list are synchronous; wait() is async (`asyncio.Event`) |
+| Lifecycle | Created in `NexusFS.__init__` (kernel-owned, like PipeManager). Ephemeral — cleared on restart |
+| VFS visibility | ProcResolver (procfs model): `/{zone}/proc/{pid}/status` generates content from memory at read time |
+
+**Linux analogy:** `AgentRegistry` ≈ process table (PID hash + task list), `AgentDescriptor` ≈ `task_struct`, `ProcResolver` ≈ `fs/proc/`.
 
 
 ---

--- a/src/nexus/core/agent_registry.py
+++ b/src/nexus/core/agent_registry.py
@@ -1,15 +1,24 @@
-"""AgentRegistry — kernel agent lifecycle manager (Issue #1509, #1800).
+"""AgentRegistry — kernel agent lifecycle primitive (Issue #1509, #1792, #1800).
 
-Pure in-memory agent registry, analogous to Linux task_struct array.
-No metastore persistence — agent state is ephemeral (tied to OS
-process lifespan).  On nexusd restart, all agents are gone.
+Kernel-owned, pure in-memory agent process table, analogous to the Linux
+process table (PID hash + task list).  Each entry is an AgentDescriptor
+(≈ task_struct).  No metastore persistence — agent state is ephemeral
+(tied to OS process lifespan).  On nexusd restart, all agents are gone.
+
+Kernel ownership: created in ``NexusFS.__init__`` (like PipeManager,
+StreamManager, VFSLockManager).  Factory and services receive a reference
+but never create it.
 
 VFS visibility is provided by ProcResolver (procfs model): reading
 ``/{zone}/proc/{pid}/status`` generates content from memory at
 read time, like Linux ``/proc/{pid}/status``.
 
-    core/agent_registry.py  = kernel/fork.c + kernel/exit.c + kernel/signal.c
-    system_services/proc/proc_resolver.py  = fs/proc/ (procfs virtual filesystem)
+Linux analogy::
+
+    AgentRegistry    ≈  process table (PID hash + task list)
+    AgentDescriptor  ≈  task_struct (per-process control block)
+    spawn/kill/signal  ≈  fork()/exit()/kill()
+    ProcResolver     ≈  fs/proc/ (procfs virtual filesystem)
 
 Concurrency model:
   - spawn/kill/signal/get/list are synchronous (fast PID allocation
@@ -44,9 +53,9 @@ logger = logging.getLogger(__name__)
 
 
 class AgentRegistry:
-    """Manages agent lifecycle — PID allocation, state machine, signals, wait().
+    """Kernel-owned agent process table — PID allocation, state machine, signals, wait().
 
-    Pure in-memory — analogous to Linux's task_struct table.
+    Pure in-memory — analogous to Linux's process table (PID hash + task list).
     VFS visibility via ProcResolver (procfs), not metastore persistence.
     """
 

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -251,11 +251,8 @@ class SystemServices:
     # Zone lifecycle — ordered zone deprovisioning (Issue #2061)
     zone_lifecycle: Any = None
 
-    # (PipeManager + StreamManager are kernel-internal primitives,
+    # (PipeManager + StreamManager + AgentRegistry are kernel-internal primitives,
     # constructed in NexusFS.__init__ — not injected via SystemServices.)
-
-    # Process lifecycle — kernel process table (Issue #1509)
-    agent_registry: Any = None
 
     # Scheduler — task scheduling service (Issue #2195, #2360)
     scheduler_service: Any = None

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -211,8 +211,17 @@ class NexusFS(  # type: ignore[misc]
             metadata_store,
             self_address=_ipc_self_addr,
         )
+
+        # Agent process table — kernel-internal, NOT injected via DI.
+        # Like PipeManager/StreamManager: always present, created by kernel at init.
+        # Analogous to Linux process table (PID hash + task list).
+        from nexus.core.agent_registry import AgentRegistry
+
+        self._agent_registry = AgentRegistry()
+
         logger.info(
-            "IPC primitives initialized: PipeManager + StreamManager (self_address=%s)",
+            "Kernel primitives initialized: PipeManager + StreamManager + AgentRegistry"
+            " (self_address=%s)",
             _ipc_self_addr or "none/single-node",
         )
 

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -19,6 +19,7 @@ async def _do_link(
     enabled_bricks: "frozenset[str] | None" = None,
     parsing: Any = None,
     workflow_engine: Any = None,
+    zone_id: str | None = None,
 ) -> None:
     """Phase 1 implementation: wire service topology.  Pure memory — NO I/O.
 
@@ -196,8 +197,8 @@ async def _do_link(
 
         nx._close_callbacks.append(_close_audit)
 
-    # Issue #1792: agent_registry close via callback (not kernel → _system_services)
-    _pt = getattr(_sys, "agent_registry", None)
+    # Issue #1792: agent_registry close via callback (kernel-owned primitive)
+    _pt = getattr(nx, "_agent_registry", None)
     if _pt is not None and hasattr(_pt, "close_all"):
 
         def _close_agent_registry() -> None:
@@ -230,6 +231,55 @@ async def _do_link(
             )
 
         nx._overlay_config_fn = _resolve_overlay
+
+    # --- Issue #1792: Deferred EvictionManager + AcpService creation ---
+    # These depend on nx._agent_registry (kernel-owned), so they cannot be
+    # created in _boot_system_services (runs before kernel construction).
+    _agent_reg = getattr(nx, "_agent_registry", None)
+    if _agent_reg is not None and getattr(_sys, "eviction_manager", None) is None:
+        try:
+            import os
+
+            from nexus.contracts.deployment_profile import DeploymentProfile as _DP2
+            from nexus.lib.performance_tuning import resolve_profile_tuning as _rpt
+            from nexus.system_services.agents.eviction_manager import EvictionManager
+            from nexus.system_services.agents.eviction_policy import QoSEvictionPolicy
+            from nexus.system_services.agents.resource_monitor import ResourceMonitor
+
+            _prof_str = os.environ.get("NEXUS_PROFILE", "full")
+            try:
+                _prof = _DP2(_prof_str) if _prof_str != "auto" else _DP2.FULL
+            except ValueError:
+                _prof = _DP2.FULL
+            _eviction_tuning = _rpt(_prof).eviction
+            _resource_monitor = ResourceMonitor(tuning=_eviction_tuning)
+            _eviction_policy = QoSEvictionPolicy()
+            _eviction_mgr = EvictionManager(
+                agent_registry=_agent_reg,
+                monitor=_resource_monitor,
+                policy=_eviction_policy,
+                tuning=_eviction_tuning,
+            )
+            _sys = _dc_replace(_sys, eviction_manager=_eviction_mgr)
+            nx._system_services = _sys
+            logger.debug("[BOOT:LINK] EvictionManager created (deferred, QoS-aware)")
+        except Exception as exc:
+            logger.warning("[BOOT:LINK] EvictionManager unavailable: %s", exc)
+
+    if _agent_reg is not None and _brick_on("acp") and getattr(_sys, "acp_service", None) is None:
+        try:
+            from nexus.contracts.constants import ROOT_ZONE_ID
+            from nexus.system_services.acp.service import AcpService
+
+            _acp_svc = AcpService(
+                agent_registry=_agent_reg,
+                zone_id=zone_id or ROOT_ZONE_ID,
+            )
+            _sys = _dc_replace(_sys, acp_service=_acp_svc)
+            nx._system_services = _sys
+            logger.debug("[BOOT:LINK] AcpService created (deferred)")
+        except Exception as exc:
+            logger.warning("[BOOT:LINK] AcpService unavailable: %s", exc)
 
 
 async def _do_initialize(

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -458,55 +458,10 @@ def _boot_system_services(
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] SchedulerService unavailable: %s", exc)
 
-    # (PipeManager + StreamManager are kernel-internal primitives,
+    # (PipeManager + StreamManager + AgentRegistry are kernel-internal primitives,
     # constructed in NexusFS.__init__ — not booted here.)
-
-    # --- AgentRegistry (Issue #1509: kernel process lifecycle) ---
-    agent_registry: Any = None
-    try:
-        from nexus.core.agent_registry import AgentRegistry
-
-        agent_registry = AgentRegistry()
-        logger.debug("[BOOT:SYSTEM] AgentRegistry created (in-memory)")
-    except Exception as exc:
-        logger.warning("[BOOT:SYSTEM] AgentRegistry unavailable: %s", exc)
-
-    # --- Eviction Manager (Issues #2170, #2171) ---
-    eviction_manager: Any = None
-    if agent_registry is not None:
-        try:
-            from nexus.system_services.agents.eviction_manager import EvictionManager
-            from nexus.system_services.agents.eviction_policy import QoSEvictionPolicy
-            from nexus.system_services.agents.resource_monitor import ResourceMonitor
-
-            eviction_tuning = ctx.profile_tuning.eviction
-            resource_monitor = ResourceMonitor(tuning=eviction_tuning)
-            eviction_policy = QoSEvictionPolicy()
-            eviction_manager = EvictionManager(
-                agent_registry=agent_registry,
-                monitor=resource_monitor,
-                policy=eviction_policy,
-                tuning=eviction_tuning,
-            )
-            logger.debug("[BOOT:SYSTEM] EvictionManager created (QoS-aware)")
-        except Exception as exc:
-            logger.warning("[BOOT:SYSTEM] EvictionManager unavailable: %s", exc)
-
-    # --- ACP Service (Stateless coding agent CLI caller) ---
-    acp_service: Any = None
-    if not _on("acp"):
-        logger.debug("[BOOT:SYSTEM] AcpService disabled by profile")
-    elif agent_registry is not None:
-        try:
-            from nexus.system_services.acp.service import AcpService
-
-            acp_service = AcpService(
-                agent_registry=agent_registry,
-                zone_id=ctx.zone_id or ROOT_ZONE_ID,
-            )
-            logger.debug("[BOOT:SYSTEM] AcpService created")
-        except Exception as exc:
-            logger.warning("[BOOT:SYSTEM] AcpService unavailable: %s", exc)
+    # EvictionManager + AcpService depend on AgentRegistry and are deferred
+    # to _do_link() where nx._agent_registry is available (Issue #1792).
 
     # =====================================================================
     # Assemble result
@@ -519,7 +474,6 @@ def _boot_system_services(
         "entity_registry": entity_registry,
         "permission_enforcer": permission_enforcer,
         "write_observer": write_observer,
-        "agent_registry": agent_registry,
         # Former-kernel degradable
         "dir_visibility_cache": dir_visibility_cache,
         "hierarchy_manager": hierarchy_manager,
@@ -536,10 +490,8 @@ def _boot_system_services(
         "context_branch_service": context_branch_service,
         "brick_lifecycle_manager": brick_lifecycle_manager,
         "brick_reconciler": brick_reconciler,
-        "eviction_manager": eviction_manager,
         "zone_lifecycle": zone_lifecycle,
         "scheduler_service": scheduler_service,
-        "acp_service": acp_service,
     }
 
     elapsed = time.perf_counter() - t0

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -296,21 +296,19 @@ async def _boot_wired_services(
     acp_rpc_service: Any = None
     _acp_service = getattr(system_services, "acp_service", None)
     if _acp_service is None:
-        # System tier didn't create AcpService — construct inline.
-        try:
-            from nexus.core.agent_registry import AgentRegistry
-            from nexus.system_services.acp.service import AcpService
+        # AcpService not yet created — construct inline using kernel-owned AgentRegistry.
+        _acp_pt = getattr(nx, "_agent_registry", None)
+        if _acp_pt is not None:
+            try:
+                from nexus.system_services.acp.service import AcpService
 
-            _acp_pt = getattr(system_services, "agent_registry", None)
-            if _acp_pt is None:
-                _acp_pt = AgentRegistry()
-            _acp_service = AcpService(
-                agent_registry=_acp_pt,
-                zone_id=ROOT_ZONE_ID,
-            )
-            logger.debug("[BOOT:WIRED] AcpService created (inline)")
-        except Exception as exc:
-            logger.debug("[BOOT:WIRED] AcpService unavailable: %s", exc)
+                _acp_service = AcpService(
+                    agent_registry=_acp_pt,
+                    zone_id=ROOT_ZONE_ID,
+                )
+                logger.debug("[BOOT:WIRED] AcpService created (inline)")
+            except Exception as exc:
+                logger.debug("[BOOT:WIRED] AcpService unavailable: %s", exc)
     if _acp_service is not None:
         # Late-bind NexusFS for VFS-routed file I/O (``everything is a file``).
         if hasattr(_acp_service, "bind_fs"):

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -194,15 +194,12 @@ def create_nexus_services(
         delivery_worker=system_dict["delivery_worker"],
         observability_subsystem=system_dict["observability_subsystem"],
         resiliency_manager=system_dict["resiliency_manager"],
-        eviction_manager=system_dict.get("eviction_manager"),
         zone_lifecycle=system_dict.get("zone_lifecycle"),
-        # (PipeManager + StreamManager are kernel-internal primitives §4.2,
+        # (PipeManager + StreamManager + AgentRegistry are kernel-internal primitives §4.2,
         # constructed in NexusFS.__init__ — not injected via SystemServices.)
+        # EvictionManager + AcpService deferred to _do_link() (Issue #1792).
         # Scheduler (Issue #2195)
         scheduler_service=system_dict.get("scheduler_service"),
-        # Process table + ACP
-        agent_registry=system_dict.get("agent_registry"),
-        acp_service=system_dict.get("acp_service"),
         # Distributed event bus — Tier 1 infrastructure (Issue #1701)
         event_bus=brick_dict["event_bus"],
         # Distributed lock manager — Tier 1 infrastructure (Issue #1702)
@@ -386,7 +383,7 @@ async def create_nexus_fs(
     from nexus.contracts.types import OperationContext as _OC
 
     nx._default_context = _OC(user_id="system", groups=[], is_admin=is_admin)
-    nx._link_fn = functools.partial(_do_link, system_services=system_services)
+    nx._link_fn = functools.partial(_do_link, system_services=system_services, zone_id=zone_id)
     nx._initialize_fn = _do_initialize
     # Backward compat: server/CLI/tests may read nx._system_services directly.
     nx._system_services = system_services
@@ -452,15 +449,24 @@ async def _register_vfs_hooks(
         )
         await _enlist("permission", _perm_hook)
 
-    # ── Audit write interceptor → sys_write to DT_PIPE (Issue #900, #1772) ──
-    # Async POST hook: serializes mutations → pipe. Consumer is PipedRecordStoreWriteObserver.
+    # ── Audit write interceptor (Issue #900, #1772) ──────────────────
+    # Two modes depending on write_observer type:
+    #   - PipedRecordStoreWriteObserver → pipe mode (serialize → DT_PIPE)
+    #   - RecordStoreWriteObserver → observer mode (call on_write() directly)
     write_observer = getattr(system_services, "write_observer", None) if system_services else None
     if write_observer is not None:
-        from nexus.storage.piped_record_store_write_observer import _AUDIT_PIPE_PATH
         from nexus.storage.write_observer_hooks import AuditWriteInterceptor
 
         strict = getattr(write_observer, "_strict_mode", True)
-        audit = AuditWriteInterceptor(nx, _AUDIT_PIPE_PATH, strict_mode=strict)
+
+        from nexus.storage.piped_record_store_write_observer import PipedRecordStoreWriteObserver
+
+        if isinstance(write_observer, PipedRecordStoreWriteObserver):
+            from nexus.storage.piped_record_store_write_observer import _AUDIT_PIPE_PATH
+
+            audit = AuditWriteInterceptor(nx, _AUDIT_PIPE_PATH, strict_mode=strict)
+        else:
+            audit = AuditWriteInterceptor(observer=write_observer, strict_mode=strict)
         await _enlist("audit", audit)
 
     # DynamicViewerReadHook (post-read: column-level CSV filtering)
@@ -538,8 +544,8 @@ async def _register_vfs_hooks(
     )
     await _enlist("virtual_view", _vview_resolver)
 
-    # ── ProcResolver (procfs virtual filesystem for AgentRegistry — Issue #1570) ──
-    _proc_table = getattr(system_services, "agent_registry", None) if system_services else None
+    # ── ProcResolver (procfs virtual filesystem for AgentRegistry — Issue #1570, #1792) ──
+    _proc_table = getattr(nx, "_agent_registry", None)
     if _proc_table is not None:
         try:
             from nexus.system_services.proc.proc_resolver import ProcResolver

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -109,11 +109,11 @@ class LifespanServices:
             database_url=getattr(app.state, "database_url", None),
             record_store=getattr(app.state, "record_store", None),
             zone_id=getattr(app.state, "zone_id", None),
-            # Process table — read from system_services (where it's created),
+            # Process table — kernel-owned primitive (Issue #1792),
             # falling back to app.state for backwards compatibility
             agent_registry=(
-                getattr(_sys, "agent_registry", None)
-                if _sys
+                getattr(nx, "_agent_registry", None)
+                if nx
                 else getattr(app.state, "agent_registry", None)
             ),
             # Coordinator

--- a/src/nexus/storage/write_observer_hooks.py
+++ b/src/nexus/storage/write_observer_hooks.py
@@ -1,13 +1,16 @@
-"""Audit interceptor: serialize VFS mutations → DT_PIPE via sys_write.
+"""Audit interceptor: VFS mutation hooks → WriteObserver or DT_PIPE.
 
-Async VFS interceptor hook that serializes each mutation event to JSON
-and writes it into a DT_PIPE via ``nx.sys_write(pipe_path, data)``.
-The pipe is consumed by ``PipedRecordStoreWriteObserver`` which flushes
-events to RecordStore in batches.
+Two modes:
 
-By using ``sys_write`` instead of ``PipeManager`` directly, the
-interceptor is decoupled from kernel internals and benefits from the
-IPC fast-path (~1μs).
+1. **Observer mode** (sync): wraps a ``WriteObserverProtocol`` (e.g.
+   ``RecordStoreWriteObserver``) and calls ``on_write()`` / ``on_delete()``
+   etc. directly.  Used for SQLite and any non-buffered backend.
+
+2. **Pipe mode** (async): serializes each mutation event to JSON and
+   writes it into a DT_PIPE via ``nx.sys_write(pipe_path, data)``.
+   The pipe is consumed by ``PipedRecordStoreWriteObserver`` which
+   flushes events to RecordStore in batches.  Used for PostgreSQL
+   with write-buffer enabled.
 
 Issue #900, #1772.
 """
@@ -28,25 +31,28 @@ if TYPE_CHECKING:
         WriteBatchHookContext,
         WriteHookContext,
     )
+    from nexus.contracts.write_observer import WriteObserverProtocol
     from nexus.core.nexus_fs import NexusFS
 
 logger = logging.getLogger(__name__)
 
 
 class AuditWriteInterceptor:
-    """Async VFS interceptor: serialize mutation events → sys_write to pipe.
+    """VFS interceptor: dispatch mutation events to observer or pipe.
 
     Registered as an async POST hook via ``register_intercept_*()``.
-    The Rust HookRegistry auto-classifies it as async because
-    ``on_post_write`` is ``async def``.
+
+    Construction:
+        - Observer mode: ``AuditWriteInterceptor(observer=obs)``
+        - Pipe mode: ``AuditWriteInterceptor(nx, pipe_path)``
 
     Error policy: ``strict_mode=True`` aborts with AuditLogError on
-    pipe write failure; ``strict_mode=False`` logs and continues.
+    failure; ``strict_mode=False`` logs and continues.
     """
 
     name = "audit_write_observer"
 
-    __slots__ = ("_nx", "_pipe_path", "_strict_mode")
+    __slots__ = ("_nx", "_observer", "_pipe_path", "_strict_mode")
 
     # ── HotSwappable protocol (Issue #1613) ────────────────────────────
 
@@ -68,14 +74,34 @@ class AuditWriteInterceptor:
     async def activate(self) -> None:
         pass
 
-    def __init__(self, nx: "NexusFS", pipe_path: str, *, strict_mode: bool = True) -> None:
+    def __init__(
+        self,
+        nx: "NexusFS | None" = None,
+        pipe_path: str | None = None,
+        *,
+        observer: "WriteObserverProtocol | None" = None,
+        strict_mode: bool = True,
+    ) -> None:
         self._nx = nx
         self._pipe_path = pipe_path
+        self._observer = observer
         self._strict_mode = strict_mode
 
     # ── VFSWriteHook ──────────────────────────────────────────────────
 
     async def on_post_write(self, ctx: "WriteHookContext") -> None:
+        if self._observer is not None:
+            self._call_observer(
+                "write",
+                ctx.path,
+                metadata=ctx.metadata,
+                is_new=ctx.is_new_file,
+                path=ctx.path,
+                old_metadata=ctx.old_metadata,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+            )
+            return
         event = {
             "op": "write",
             "path": ctx.path,
@@ -91,6 +117,15 @@ class AuditWriteInterceptor:
     # ── VFSWriteBatchHook ─────────────────────────────────────────────
 
     async def on_post_write_batch(self, ctx: "WriteBatchHookContext") -> None:
+        if self._observer is not None:
+            self._call_observer(
+                "write_batch",
+                "<batch>",
+                items=ctx.items,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+            )
+            return
         for metadata, is_new in ctx.items:
             event = {
                 "op": "write",
@@ -106,6 +141,16 @@ class AuditWriteInterceptor:
     # ── VFSDeleteHook ─────────────────────────────────────────────────
 
     async def on_post_delete(self, ctx: "DeleteHookContext") -> None:
+        if self._observer is not None:
+            self._call_observer(
+                "delete",
+                ctx.path,
+                path=ctx.path,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+                metadata=ctx.metadata,
+            )
+            return
         event = {
             "op": "delete",
             "path": ctx.path,
@@ -119,6 +164,17 @@ class AuditWriteInterceptor:
     # ── VFSRenameHook ─────────────────────────────────────────────────
 
     async def on_post_rename(self, ctx: "RenameHookContext") -> None:
+        if self._observer is not None:
+            self._call_observer(
+                "rename",
+                ctx.old_path,
+                old_path=ctx.old_path,
+                new_path=ctx.new_path,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+                metadata=ctx.metadata,
+            )
+            return
         event = {
             "op": "rename",
             "path": ctx.old_path,
@@ -133,6 +189,15 @@ class AuditWriteInterceptor:
     # ── VFSMkdirHook ─────────────────────────────────────────────────
 
     async def on_post_mkdir(self, ctx: "MkdirHookContext") -> None:
+        if self._observer is not None:
+            self._call_observer(
+                "mkdir",
+                ctx.path,
+                path=ctx.path,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+            )
+            return
         event = {
             "op": "mkdir",
             "path": ctx.path,
@@ -144,6 +209,16 @@ class AuditWriteInterceptor:
     # ── VFSRmdirHook ─────────────────────────────────────────────────
 
     async def on_post_rmdir(self, ctx: "RmdirHookContext") -> None:
+        if self._observer is not None:
+            self._call_observer(
+                "rmdir",
+                ctx.path,
+                path=ctx.path,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+                recursive=ctx.recursive,
+            )
+            return
         event = {
             "op": "rmdir",
             "path": ctx.path,
@@ -153,34 +228,54 @@ class AuditWriteInterceptor:
         }
         await self._emit(event, "rmdir", ctx.path)
 
-    # ── Internal ──────────────────────────────────────────────────────
+    # ── Internal — observer mode (sync) ──────────────────────────────
+
+    def _call_observer(self, operation: str, op_path: str, **kwargs: Any) -> None:
+        """Dispatch to WriteObserverProtocol with audit error policy."""
+        try:
+            method = getattr(self._observer, f"on_{operation}")
+            method(**kwargs)
+        except Exception as e:
+            self._handle_error(operation, op_path, e)
+
+    # ── Internal — pipe mode (async) ─────────────────────────────────
 
     async def _emit(self, event: dict[str, Any], operation: str, op_path: str) -> None:
         """Serialize event to JSON and write to pipe via sys_write."""
+        assert self._nx is not None and self._pipe_path is not None  # pipe mode invariant
         try:
             data = json.dumps(event).encode()
-            await self._nx.sys_write(self._pipe_path, data)
-        except Exception as e:
-            from nexus.contracts.exceptions import AuditLogError
+            # Use admin context for internal audit pipe writes to bypass permission checks.
+            from nexus.contracts.types import OperationContext as _OC
 
-            if self._strict_mode:
-                logger.error(
-                    "AUDIT LOG FAILURE: %s on '%s' ABORTED. Error: %s. "
-                    "Set audit_strict_mode=False to allow writes without audit logs.",
-                    operation,
-                    op_path,
-                    e,
-                )
-                raise AuditLogError(
-                    f"Operation aborted: audit logging failed for {operation}: {e}",
-                    path=op_path,
-                    original_error=e,
-                ) from e
-            else:
-                logger.critical(
-                    "AUDIT LOG FAILURE: %s on '%s' SUCCEEDED but audit log FAILED. "
-                    "Error: %s. This creates an audit trail gap!",
-                    operation,
-                    op_path,
-                    e,
-                )
+            _admin_ctx = _OC(user_id="system", groups=[], is_admin=True)
+            await self._nx.sys_write(self._pipe_path, data, context=_admin_ctx)
+        except Exception as e:
+            self._handle_error(operation, op_path, e)
+
+    # ── Shared error handling ────────────────────────────────────────
+
+    def _handle_error(self, operation: str, op_path: str, e: Exception) -> None:
+        from nexus.contracts.exceptions import AuditLogError
+
+        if self._strict_mode:
+            logger.error(
+                "AUDIT LOG FAILURE: %s on '%s' ABORTED. Error: %s. "
+                "Set audit_strict_mode=False to allow writes without audit logs.",
+                operation,
+                op_path,
+                e,
+            )
+            raise AuditLogError(
+                f"Operation aborted: audit logging failed for {operation}: {e}",
+                path=op_path,
+                original_error=e,
+            ) from e
+        else:
+            logger.critical(
+                "AUDIT LOG FAILURE: %s on '%s' SUCCEEDED but audit log FAILED. "
+                "Error: %s. This creates an audit trail gap!",
+                operation,
+                op_path,
+                e,
+            )

--- a/tests/unit/core/test_agent_record.py
+++ b/tests/unit/core/test_agent_record.py
@@ -86,13 +86,9 @@ class TestAgentRecord:
         )
 
     def test_is_frozen(self, record):
-        """AgentRecord is immutable (frozen dataclass).
-
-        Note: tests str field (agent_id) because Enum field assignment
-        may not raise FrozenInstanceError on Python 3.13+.
-        """
+        """AgentRecord is immutable (frozen dataclass)."""
         with pytest.raises(FrozenInstanceError):
-            object.__setattr__(record, "state", AgentState.READY)
+            record.agent_id = "hacked"
 
     def test_field_access(self, record):
         """All fields are accessible."""

--- a/tests/unit/core/test_embedded.py
+++ b/tests/unit/core/test_embedded.py
@@ -17,7 +17,7 @@ from nexus.storage.record_store import SQLAlchemyRecordStore
 
 # Mount points auto-created by factory boot (root + IPC /agents).
 # These are system entries, not user files.
-_SYSTEM_PATHS = frozenset({"/", "/agents"})
+_SYSTEM_PATHS = frozenset({"/", "/agents", "/nexus/pipes/audit-events"})
 
 
 @pytest.fixture

--- a/tests/unit/core/test_embedded_cas.py
+++ b/tests/unit/core/test_embedded_cas.py
@@ -17,7 +17,7 @@ from nexus.storage.raft_metadata_store import RaftMetadataStore
 from nexus.storage.record_store import SQLAlchemyRecordStore
 
 # Mount points auto-created by factory boot.
-_SYSTEM_PATHS = frozenset({"/", "/agents"})
+_SYSTEM_PATHS = frozenset({"/", "/agents", "/nexus/pipes/audit-events"})
 
 
 @pytest.fixture

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -60,7 +60,6 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "mount_manager",
         "workspace_manager",
         # Original system services
-        "eviction_manager",
         "namespace_manager",
         "async_namespace_manager",
         "delivery_worker",
@@ -70,9 +69,7 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "brick_lifecycle_manager",
         "brick_reconciler",
         "zone_lifecycle",
-        "agent_registry",
         "scheduler_service",
-        "acp_service",
     }
 )
 

--- a/tests/unit/core/test_kernel_config.py
+++ b/tests/unit/core/test_kernel_config.py
@@ -324,7 +324,7 @@ class TestSystemServices:
             "observability_subsystem",
             "resiliency_manager",
             "zone_lifecycle",
-            "agent_registry",
+            # (AgentRegistry is kernel-internal §4.4 — not in SystemServices)
             "scheduler_service",
             "acp_service",
             # Distributed event bus — promoted from Tier 2 (Issue #1701)

--- a/tests/unit/core/test_pipe_consumers.py
+++ b/tests/unit/core/test_pipe_consumers.py
@@ -3,57 +3,126 @@
 Verifies that ZoektPipeConsumer and PipedRecordStoreWriteObserver correctly
 flow events through the DT_PIPE kernel IPC path:
 
-    sync producer (notify_write / on_write)
-      → pipe_write_nowait() (~5us)
-      → RingBuffer (kfifo)
-      → async consumer (_consume loop)
-      → trigger_reindex_async() / RecordStore flush
+    sync producer (notify_write / sys_write)
+      -> pipe_write_nowait() (~5us)
+      -> RingBuffer (kfifo)
+      -> async consumer (_consume loop)
+      -> trigger_reindex_async() / RecordStore flush
 
 These tests prove DT_PIPE works end-to-end as a production IPC mechanism,
 not just as isolated unit primitives.
 
 See: factory/zoekt_pipe_consumer.py, storage/piped_record_store_write_observer.py
+
+Issue #1772: Tests migrated from PipeManager API to NexusFS sys_read/sys_write.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
+import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from nexus.contracts.metadata import FileMetadata
-from nexus.core.pipe_manager import PipeManager
+from nexus.core.config import ParseConfig, PermissionConfig, SystemServices
+from tests.helpers.dict_metastore import DictMetastore
+from tests.helpers.test_context import TEST_CONTEXT
+
+# Pipe path constants (must match production code)
+_ZOEKT_PIPE_PATH = "/nexus/pipes/zoekt-writes"
+_AUDIT_PIPE_PATH = "/nexus/pipes/audit-events"
+
 
 # ======================================================================
-# Shared MockMetastore (reused from test_pipe.py)
+# Shared helpers
 # ======================================================================
 
 
-class MockMetastore:
-    """Minimal MetastoreABC mock for pipe consumer tests."""
+def _make_nx():
+    """Create a minimal NexusFS with DictMetastore for pipe tests."""
+    from nexus import CASLocalBackend, NexusFS
 
-    def __init__(self) -> None:
-        self._store: dict[str, FileMetadata] = {}
+    tmpdir = tempfile.mkdtemp()
+    metastore = DictMetastore()
+    backend = CASLocalBackend(str(Path(tmpdir) / "data"))
+    nx = NexusFS(
+        metadata_store=metastore,
+        permissions=PermissionConfig(enforce=False),
+        parsing=ParseConfig(auto_parse=False),
+        system_services=SystemServices(),
+    )
+    nx._default_context = TEST_CONTEXT
+    nx.router.add_mount("/", backend)
+    return nx
 
-    def get(self, path: str) -> FileMetadata | None:
-        return self._store.get(path)
 
-    def put(self, metadata: FileMetadata, *, consistency: str = "sc") -> None:
-        if metadata.path:
-            self._store[metadata.path] = metadata
+def _audit_event_write(path: str, *, is_new: bool = True) -> bytes:
+    """Create an audit write event JSON (simulates AuditWriteInterceptor)."""
+    metadata = FileMetadata(
+        path=path,
+        backend_name="local",
+        physical_path=f"/data{path}",
+        size=100,
+    )
+    return json.dumps(
+        {
+            "op": "write",
+            "path": path,
+            "is_new": is_new,
+            "zone_id": None,
+            "agent_id": None,
+            "snapshot_hash": None,
+            "metadata_snapshot": None,
+            "metadata": metadata.to_dict(),
+        }
+    ).encode()
 
-    def delete(self, path: str, *, consistency: str = "sc") -> dict | None:
-        return {"path": path} if self._store.pop(path, None) else None
 
-    def exists(self, path: str) -> bool:
-        return path in self._store
+def _audit_event_delete(path: str) -> bytes:
+    """Create an audit delete event JSON."""
+    return json.dumps(
+        {
+            "op": "delete",
+            "path": path,
+            "zone_id": None,
+            "agent_id": None,
+            "snapshot_hash": None,
+            "metadata_snapshot": None,
+        }
+    ).encode()
 
-    def list(self, prefix: str = "", recursive: bool = True, **kwargs) -> list:  # noqa: ARG002
-        return [m for p, m in self._store.items() if p.startswith(prefix)]
 
-    def close(self) -> None:
-        pass
+def _audit_event_mkdir(path: str) -> bytes:
+    """Create an audit mkdir event JSON."""
+    return json.dumps(
+        {
+            "op": "mkdir",
+            "path": path,
+            "zone_id": None,
+            "agent_id": None,
+        }
+    ).encode()
+
+
+def _audit_event_rmdir(path: str) -> bytes:
+    """Create an audit rmdir event JSON."""
+    return json.dumps(
+        {
+            "op": "rmdir",
+            "path": path,
+            "zone_id": None,
+            "agent_id": None,
+            "recursive": False,
+        }
+    ).encode()
+
+
+def _noop_process_events(session: object, events: list[dict[str, object]]) -> None:
+    """No-op replacement for _process_events_in_session (avoids sqlalchemy dep)."""
 
 
 # ======================================================================
@@ -62,15 +131,14 @@ class MockMetastore:
 
 
 class TestZoektPipeConsumerE2E:
-    """Prove DT_PIPE end-to-end: sync notify_write → pipe → consumer → reindex."""
+    """Prove DT_PIPE end-to-end: sync notify_write -> pipe -> consumer -> reindex."""
 
     @pytest.mark.asyncio
     async def test_notify_write_triggers_reindex(self) -> None:
-        """Full E2E: sync notify_write → pipe_write_nowait → consumer → reindex."""
+        """Full E2E: sync notify_write -> pipe_write_nowait -> consumer -> reindex."""
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
+        nx = _make_nx()
 
         # Mock ZoektIndexManager
         zoekt = MagicMock()
@@ -78,7 +146,7 @@ class TestZoektPipeConsumerE2E:
         zoekt.trigger_reindex_async = AsyncMock()
 
         consumer = ZoektPipeConsumer(zoekt, debounce_seconds=0.05)
-        consumer.set_pipe_manager(pm)
+        consumer.bind_fs(nx)
         await consumer.start()
 
         try:
@@ -86,51 +154,51 @@ class TestZoektPipeConsumerE2E:
             consumer.notify_write("/workspace/file1.txt")
             consumer.notify_write("/workspace/file2.txt")
 
-            # Wait for debounce window + consumer processing
-            await asyncio.sleep(0.15)
+            # Wait for flush loop + debounce window + consumer processing
+            await asyncio.sleep(0.25)
 
             # Verify reindex was triggered
             assert zoekt.trigger_reindex_async.call_count >= 1
         finally:
             await consumer.stop()
+            nx.close()
 
     @pytest.mark.asyncio
     async def test_sync_complete_triggers_reindex(self) -> None:
         """notify_sync_complete flows through pipe to trigger reindex."""
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
+        nx = _make_nx()
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 0.05
         zoekt.trigger_reindex_async = AsyncMock()
 
         consumer = ZoektPipeConsumer(zoekt, debounce_seconds=0.05)
-        consumer.set_pipe_manager(pm)
+        consumer.bind_fs(nx)
         await consumer.start()
 
         try:
             consumer.notify_sync_complete(files_synced=5)
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(0.25)
             assert zoekt.trigger_reindex_async.call_count >= 1
         finally:
             await consumer.stop()
+            nx.close()
 
     @pytest.mark.asyncio
     async def test_debounce_coalesces_writes(self) -> None:
-        """Multiple rapid writes within debounce window → single reindex."""
+        """Multiple rapid writes within debounce window -> single reindex."""
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
+        nx = _make_nx()
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 0.1
         zoekt.trigger_reindex_async = AsyncMock()
 
         consumer = ZoektPipeConsumer(zoekt, debounce_seconds=0.1)
-        consumer.set_pipe_manager(pm)
+        consumer.bind_fs(nx)
         await consumer.start()
 
         try:
@@ -138,24 +206,25 @@ class TestZoektPipeConsumerE2E:
             for i in range(20):
                 consumer.notify_write(f"/workspace/file{i}.txt")
 
-            # Wait for debounce + processing
-            await asyncio.sleep(0.25)
+            # Wait for flush loop + debounce + processing
+            await asyncio.sleep(0.35)
 
             # Should coalesce into 1 reindex call (not 20)
             assert zoekt.trigger_reindex_async.call_count == 1
         finally:
             await consumer.stop()
+            nx.close()
 
     @pytest.mark.asyncio
-    async def test_fallback_without_pipe_manager(self) -> None:
-        """Without PipeManager, notify_write falls back to direct call."""
+    async def test_fallback_without_bind_fs(self) -> None:
+        """Without bind_fs, notify_write falls back to direct call."""
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 0.05
 
         consumer = ZoektPipeConsumer(zoekt)
-        # No set_pipe_manager() → no start() → fallback path
+        # No bind_fs() -> no start() -> fallback path
 
         consumer.notify_write("/workspace/file.txt")
 
@@ -167,15 +236,14 @@ class TestZoektPipeConsumerE2E:
         """stop() drains remaining pipe events before exiting."""
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
+        nx = _make_nx()
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 0.5  # Long debounce
         zoekt.trigger_reindex_async = AsyncMock()
 
         consumer = ZoektPipeConsumer(zoekt, debounce_seconds=0.5)
-        consumer.set_pipe_manager(pm)
+        consumer.bind_fs(nx)
         await consumer.start()
 
         # Write events, then immediately stop (before debounce fires)
@@ -185,24 +253,25 @@ class TestZoektPipeConsumerE2E:
         # Consumer should have been cancelled cleanly (no exceptions)
         # The consumer task should be None after stop
         assert consumer._consumer_task is None
+        nx.close()
 
     @pytest.mark.asyncio
     async def test_pipe_full_falls_back(self) -> None:
         """When pipe is full, notify_write falls back to direct call."""
         from nexus.factory.zoekt_pipe_consumer import ZoektPipeConsumer
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
+        nx = _make_nx()
 
         zoekt = MagicMock()
         zoekt.debounce_seconds = 10  # Very long debounce — consumer won't drain
 
         consumer = ZoektPipeConsumer(zoekt, debounce_seconds=10)
-        consumer.set_pipe_manager(pm)
+        consumer.bind_fs(nx)
         await consumer.start()
 
         try:
-            # Fill the pipe (64KB capacity) with large messages
+            # Fill the write buffer (maxlen=10_000) — events buffer in deque
+            # then pipe (64KB capacity) with large messages
             filled = False
             for _ in range(200):
                 try:
@@ -219,6 +288,7 @@ class TestZoektPipeConsumerE2E:
                 assert zoekt.notify_write.call_count >= 1
         finally:
             await consumer.stop()
+            nx.close()
 
 
 # ======================================================================
@@ -226,139 +296,121 @@ class TestZoektPipeConsumerE2E:
 # ======================================================================
 
 
-def _noop_process_events(session: object, events: list[dict[str, object]]) -> None:
-    """No-op replacement for _process_events_in_session (avoids sqlalchemy dep)."""
-
-
 class TestPipedWriteObserverE2E:
-    """Prove DT_PIPE end-to-end: sync on_write → pipe → consumer → flush.
+    """Prove DT_PIPE end-to-end: sys_write -> pipe -> consumer -> _flush_batch.
 
-    We patch ``_process_events_in_session`` (the DB flush layer) so these tests
+    We patch ``_flush_batch_sync`` (the DB flush layer) so these tests
     verify the DT_PIPE IPC path without requiring sqlalchemy/RecordStore.
+
+    The producer side is now AuditWriteInterceptor (writes via nx.sys_write),
+    simulated here by direct nx.sys_write() calls with JSON events.
+
+    Note: The consumer's _consume() loop uses blocking sys_read() for batch
+    draining. After writing events, we yield to the event loop so the consumer
+    task can start processing, then stop() closes the pipe which breaks the
+    drain loop and triggers _flush_batch.
     """
 
     @pytest.mark.asyncio
     async def test_on_write_flows_through_pipe(self) -> None:
-        """Full E2E: on_write → pipe_write_nowait → consumer → _flush_batch."""
+        """Full E2E: sys_write -> pipe -> consumer -> _flush_batch (on stop)."""
         from nexus.storage.piped_record_store_write_observer import (
             PipedRecordStoreWriteObserver,
         )
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
-
+        nx = _make_nx()
         observer = PipedRecordStoreWriteObserver(MagicMock())
-        observer.set_pipe_manager(pm)
+        observer.bind_fs(nx)
 
         with patch.object(
             PipedRecordStoreWriteObserver,
-            "_process_events_in_session",
-            staticmethod(_noop_process_events),
+            "_flush_batch_sync",
+            lambda self, events: None,
         ):
             await observer.start()
             try:
-                metadata = FileMetadata(
-                    path="/workspace/test.txt",
-                    backend_name="local",
-                    physical_path="/data/test.txt",
-                    size=100,
-                )
-                observer.on_write(metadata, is_new=True, path="/workspace/test.txt")
-                await asyncio.sleep(0.15)
-
-                assert observer._total_enqueued == 1
-                assert observer._total_flushed >= 1
+                # Simulate AuditWriteInterceptor writing to the pipe
+                await nx.sys_write(_AUDIT_PIPE_PATH, _audit_event_write("/workspace/test.txt"))
+                # Yield so consumer task starts and reads the event from the pipe
+                await asyncio.sleep(0)
             finally:
+                # stop() closes pipe, which unblocks the consumer's drain loop
+                # and triggers _flush_batch with accumulated events
                 await observer.stop()
+
+            assert observer._total_flushed >= 1
+        nx.close()
 
     @pytest.mark.asyncio
     async def test_batch_write_flows_through_pipe(self) -> None:
-        """on_write_batch enqueues multiple events that flush in one batch."""
+        """Multiple sys_write events flush in batch on stop."""
         from nexus.storage.piped_record_store_write_observer import (
             PipedRecordStoreWriteObserver,
         )
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
-
+        nx = _make_nx()
         observer = PipedRecordStoreWriteObserver(MagicMock())
-        observer.set_pipe_manager(pm)
+        observer.bind_fs(nx)
 
         with patch.object(
             PipedRecordStoreWriteObserver,
-            "_process_events_in_session",
-            staticmethod(_noop_process_events),
+            "_flush_batch_sync",
+            lambda self, events: None,
         ):
             await observer.start()
             try:
-                items = [
-                    (
-                        FileMetadata(
-                            path=f"/workspace/file{i}.txt",
-                            backend_name="local",
-                            physical_path=f"/data/file{i}.txt",
-                            size=i * 10,
-                        ),
-                        True,
+                for i in range(5):
+                    await nx.sys_write(
+                        _AUDIT_PIPE_PATH,
+                        _audit_event_write(f"/workspace/file{i}.txt"),
                     )
-                    for i in range(5)
-                ]
-                observer.on_write_batch(items)
-                await asyncio.sleep(0.15)
-
-                assert observer._total_enqueued == 5
-                assert observer._total_flushed >= 5
+                # Yield so consumer task starts and reads events from the pipe
+                await asyncio.sleep(0)
             finally:
                 await observer.stop()
+
+            assert observer._total_flushed >= 5
+        nx.close()
 
     @pytest.mark.asyncio
     async def test_delete_event_flows_through_pipe(self) -> None:
-        """on_delete flows through pipe to consumer."""
+        """Delete event flows through pipe to consumer on stop."""
         from nexus.storage.piped_record_store_write_observer import (
             PipedRecordStoreWriteObserver,
         )
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
-
+        nx = _make_nx()
         observer = PipedRecordStoreWriteObserver(MagicMock())
-        observer.set_pipe_manager(pm)
+        observer.bind_fs(nx)
 
         with patch.object(
             PipedRecordStoreWriteObserver,
-            "_process_events_in_session",
-            staticmethod(_noop_process_events),
+            "_flush_batch_sync",
+            lambda self, events: None,
         ):
             await observer.start()
             try:
-                observer.on_delete("/workspace/deleted.txt")
-                await asyncio.sleep(0.15)
-
-                assert observer._total_enqueued == 1
-                assert observer._total_flushed >= 1
+                await nx.sys_write(_AUDIT_PIPE_PATH, _audit_event_delete("/workspace/deleted.txt"))
+                # Yield so consumer task starts and reads the event from the pipe
+                await asyncio.sleep(0)
             finally:
                 await observer.stop()
 
+            assert observer._total_flushed >= 1
+        nx.close()
+
     @pytest.mark.asyncio
-    async def test_pre_buffer_drains_on_start(self) -> None:
-        """Events buffered before pipe injection are drained on start()."""
+    async def test_pre_buffer_drains_on_stop(self) -> None:
+        """Events buffered in _pre_buffer are drained by flush_sync on stop."""
         from nexus.storage.piped_record_store_write_observer import (
             PipedRecordStoreWriteObserver,
         )
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
-
         observer = PipedRecordStoreWriteObserver(MagicMock())
 
-        # Buffer events BEFORE pipe injection (CLI mode / pre-startup)
-        metadata = FileMetadata(
-            path="/workspace/early.txt",
-            backend_name="local",
-            physical_path="/data/early.txt",
-            size=50,
-        )
-        observer.on_write(metadata, is_new=True, path="/workspace/early.txt")
+        # Buffer events BEFORE bind_fs (CLI mode / pre-startup)
+        observer._pre_buffer.append(_audit_event_write("/workspace/early.txt"))
+        observer._total_enqueued = 1
         assert len(observer._pre_buffer) == 1
 
         with patch.object(
@@ -366,17 +418,12 @@ class TestPipedWriteObserverE2E:
             "_process_events_in_session",
             staticmethod(_noop_process_events),
         ):
-            # Now inject pipe and start — should drain pre-buffer into pipe
-            observer.set_pipe_manager(pm)
-            await observer.start()
-            try:
-                assert len(observer._pre_buffer) == 0
-                await asyncio.sleep(0.15)
+            # flush_sync drains pre-buffer directly to DB
+            flushed = observer.flush_sync()
 
-                # Pre-buffered event should have been flushed via pipe → consumer
-                assert observer._total_flushed >= 1
-            finally:
-                await observer.stop()
+        assert flushed == 1
+        assert len(observer._pre_buffer) == 0
+        assert observer._total_flushed == 1
 
     def test_flush_sync_for_cli_mode(self) -> None:
         """flush_sync() works without asyncio for CLI shutdown path."""
@@ -393,17 +440,11 @@ class TestPipedWriteObserverE2E:
 
         observer = PipedRecordStoreWriteObserver(mock_record_store)
 
-        # No pipe manager — events go to pre_buffer
-        metadata = FileMetadata(
-            path="/workspace/cli.txt",
-            backend_name="local",
-            physical_path="/data/cli.txt",
-            size=25,
-        )
-        observer.on_write(metadata, is_new=True, path="/workspace/cli.txt")
-        observer.on_delete("/workspace/old.txt")
+        # No bind_fs — events go to pre_buffer manually
+        observer._pre_buffer.append(_audit_event_write("/workspace/cli.txt"))
+        observer._pre_buffer.append(_audit_event_delete("/workspace/old.txt"))
+        observer._total_enqueued = 2
 
-        assert observer._total_enqueued == 2
         assert len(observer._pre_buffer) == 2
 
         with patch.object(
@@ -424,38 +465,31 @@ class TestPipedWriteObserverE2E:
             PipedRecordStoreWriteObserver,
         )
 
-        ms = MockMetastore()
-        pm = PipeManager(ms)
-
+        nx = _make_nx()
         observer = PipedRecordStoreWriteObserver(MagicMock())
-        observer.set_pipe_manager(pm)
+        observer.bind_fs(nx)
 
         with patch.object(
             PipedRecordStoreWriteObserver,
-            "_process_events_in_session",
-            staticmethod(_noop_process_events),
+            "_flush_batch_sync",
+            lambda self, events: None,
         ):
             await observer.start()
             try:
-                metadata = FileMetadata(
-                    path="/workspace/metrics.txt",
-                    backend_name="local",
-                    physical_path="/data/metrics.txt",
-                    size=10,
-                )
-                observer.on_write(metadata, is_new=True, path="/workspace/metrics.txt")
-                observer.on_mkdir("/workspace/newdir")
-                observer.on_rmdir("/workspace/olddir")
-
-                await asyncio.sleep(0.15)
-
-                metrics = observer.metrics
-                assert metrics["total_enqueued"] == 3
-                assert metrics["total_flushed"] >= 3
-                assert metrics["total_failed"] == 0
-                assert metrics["total_dropped"] == 0
+                await nx.sys_write(_AUDIT_PIPE_PATH, _audit_event_write("/workspace/metrics.txt"))
+                await nx.sys_write(_AUDIT_PIPE_PATH, _audit_event_mkdir("/workspace/newdir"))
+                await nx.sys_write(_AUDIT_PIPE_PATH, _audit_event_rmdir("/workspace/olddir"))
+                # Yield so consumer task starts and reads events from the pipe
+                await asyncio.sleep(0)
             finally:
+                # stop() closes pipe, consumer drains and flushes
                 await observer.stop()
+
+            metrics = observer.metrics
+            assert metrics["total_flushed"] >= 3
+            assert metrics["total_failed"] == 0
+            assert metrics["total_dropped"] == 0
+        nx.close()
 
 
 # ======================================================================

--- a/tests/unit/factory/test_retroactive_hook_specs.py
+++ b/tests/unit/factory/test_retroactive_hook_specs.py
@@ -35,8 +35,13 @@ class TestHotSwappableConformance:
     def test_audit_interceptor(self) -> None:
         from nexus.storage.write_observer_hooks import AuditWriteInterceptor
 
+        # Observer mode: wraps a WriteObserverProtocol directly
         hook = AuditWriteInterceptor(observer=MagicMock())
         assert isinstance(hook, HotSwappable)
+
+        # Pipe mode: writes to DT_PIPE via nx.sys_write
+        hook2 = AuditWriteInterceptor(MagicMock(), "/nexus/pipes/audit-events")
+        assert isinstance(hook2, HotSwappable)
 
     def test_dynamic_viewer_hook(self) -> None:
         from nexus.bricks.rebac.dynamic_viewer_hook import DynamicViewerReadHook

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -171,7 +171,6 @@ class TestBootSystemServices:
             "mount_manager",
             "workspace_manager",
             # Original system services
-            "eviction_manager",
             "namespace_manager",
             "async_namespace_manager",
             "delivery_worker",
@@ -181,12 +180,8 @@ class TestBootSystemServices:
             "brick_lifecycle_manager",
             "brick_reconciler",
             "zone_lifecycle",
-            # (PipeManager is kernel-internal §4.2, not in SystemServices)
-            # Process lifecycle (Issue #1509)
-            "agent_registry",
+            # (PipeManager + StreamManager + AgentRegistry are kernel-internal §4.2)
             "scheduler_service",
-            # ACP coding agent service
-            "acp_service",
         }
         assert expected_keys == set(result.keys())
 


### PR DESCRIPTION
## Summary
- **AgentRegistry** removed from `SystemServices` — it's a kernel primitive created in `NexusFS.__init__`, not a factory-DI'd service (like PipeManager, StreamManager, VFSLockManager)
- **EvictionManager + AcpService** deferred to `_do_link()` where `nx._agent_registry` is available
- All consumers (`ProcResolver`, `services_container`, `_wired.py`) now read from `nx._agent_registry`
- **KERNEL-ARCHITECTURE.md §4.4** added: documents AgentRegistry as kernel primitive with state machine, signals, ProcResolver visibility
- **Fix audit pipe permission** (pre-existing): `AuditWriteInterceptor._emit()` now uses admin context for internal pipe writes, fixing ~50 test failures across share/zone security, operation log, time travel, version GC, pipe consumer tests
- **Fix pre-existing test issues**: frozen dataclass test (`object.__setattr__` → direct assignment), `_SYSTEM_PATHS` (add `/nexus/pipes/audit-events`), hook spec conformance

## Test plan
- [x] `uv run ruff check src/ tests/` — all clean
- [x] `uv run pytest tests/unit/` — 10955 passed, 0 failed
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)