### PR TITLE
feat(cli): DX overhaul — state separation, nexus env/run, concurrent worktree support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,6 +18,7 @@ jobs:
   benchmark-critical:
     name: Benchmark (Critical Subset)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -58,12 +59,14 @@ jobs:
           python -c "import json; json.load(open('/tmp/smoke.json'))"
 
       - name: Run critical benchmarks
+        timeout-minutes: 20
         run: |
           uv run pytest tests/benchmarks/ -m benchmark_ci \
             --benchmark-json=benchmark-results.json \
-            --benchmark-min-rounds=10 \
+            --benchmark-min-rounds=5 \
+            --benchmark-max-time=2.0 \
             --benchmark-warmup=on \
-            --benchmark-warmup-iterations=3 \
+            --benchmark-warmup-iterations=1 \
             -o "addopts=" -v
 
       - name: Ensure gh-pages branch exists
@@ -99,6 +102,7 @@ jobs:
   benchmark-full:
     name: Benchmark (Full Suite)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
@@ -133,12 +137,14 @@ jobs:
         run: uv pip install -e ".[dev,test]"
 
       - name: Run full benchmark suite
+        timeout-minutes: 45
         run: |
           uv run pytest tests/benchmarks/ \
             --benchmark-json=benchmark-results-full.json \
-            --benchmark-min-rounds=10 \
+            --benchmark-min-rounds=5 \
+            --benchmark-max-time=2.0 \
             --benchmark-warmup=on \
-            --benchmark-warmup-iterations=3 \
+            --benchmark-warmup-iterations=1 \
             -o "addopts=" -v
 
       - name: Ensure gh-pages branch exists

--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,183 @@
+# Nexus CLI Reference
+
+## Quick Start
+
+```bash
+# Initialize a project (one-time)
+nexus init --preset shared
+
+# Start the stack (Docker Compose)
+nexus up
+
+# Load connection env vars into your shell
+eval $(nexus env)
+
+# Run a command with env vars injected
+nexus run python my_agent.py
+```
+
+## Commands
+
+### `nexus init`
+
+Initialize a new Nexus project. Creates `nexus.yaml`, data directories, and optionally TLS certificates.
+
+```bash
+nexus init                              # local embedded (no Docker)
+nexus init --preset shared              # one shared node (Postgres, Dragonfly, Zoekt)
+nexus init --preset demo                # shared + demo seed data
+nexus init --preset shared --tls        # with self-signed TLS certs
+nexus init --preset shared --with nats  # add NATS event bus
+nexus init --preset shared --channel edge --accelerator cuda
+```
+
+**Presets:**
+| Preset | Services | Auth | Docker |
+|--------|----------|------|--------|
+| `local` | None (embedded) | none | No |
+| `shared` | nexus, postgres, dragonfly, zoekt | static | Yes |
+| `demo` | nexus, postgres, dragonfly, zoekt | database | Yes |
+
+### `nexus up`
+
+Start the Docker Compose stack. Resolves port conflicts, pulls (or reuses) images, health-checks all services.
+
+```bash
+nexus up                        # start from nexus.yaml
+nexus up --build                # build from local Dockerfile
+nexus up --pull                 # discard local build, pull from remote
+nexus up --with nats            # add NATS event bus
+nexus up --port-strategy prompt # ask on port conflicts (default: auto)
+nexus up --timeout 300          # health check timeout in seconds
+```
+
+**Image resolution:**
+- Default: pulls from `ghcr.io/nexi-lab/nexus:{channel}`
+- `--build`: builds from local Dockerfile, tags as `nexus:local-{hash}`
+- After `--build`, subsequent `nexus up` reuses the local image (no pull)
+- `--pull`: clears local build mode, pulls from remote
+
+**Runtime state** is written to `{data_dir}/.state.json` (not `nexus.yaml`), so the declarative config stays clean across git worktrees.
+
+### `nexus down`
+
+Stop and remove containers (volumes persist).
+
+```bash
+nexus down                # stop services
+nexus down --volumes      # stop and remove volumes
+```
+
+### `nexus stop` / `nexus start`
+
+Lightweight pause/resume. No port checks, no image pulls, no health polling.
+
+```bash
+nexus stop                # pause containers (fast)
+nexus start               # resume containers (fast)
+```
+
+### `nexus env`
+
+Print connection environment variables from `nexus.yaml` + `.state.json`.
+
+```bash
+eval $(nexus env)              # load into current shell
+nexus env --dotenv > .env      # write .env file
+nexus env --json               # machine-readable JSON
+nexus env --shell fish | source
+```
+
+**Variables emitted:**
+| Variable | Example |
+|----------|---------|
+| `NEXUS_URL` | `http://localhost:2026` |
+| `NEXUS_API_KEY` | `sk-...` |
+| `NEXUS_GRPC_HOST` | `localhost:2028` |
+| `NEXUS_GRPC_PORT` | `2028` |
+| `DATABASE_URL` | `postgresql://postgres:nexus@localhost:5432/nexus` |
+| `NEXUS_TLS_CERT` | `/path/to/cert` (if TLS) |
+| `NEXUS_TLS_KEY` | `/path/to/key` (if TLS) |
+| `NEXUS_TLS_CA` | `/path/to/ca` (if TLS) |
+
+### `nexus run <cmd>`
+
+Run a command with Nexus env vars injected. Interactive (stdin/stdout pass-through).
+
+```bash
+nexus run python my_agent.py
+nexus run pytest tests/
+nexus run bash                  # interactive shell with env vars
+```
+
+### `nexus status`
+
+Display service health. Reads ports from `nexus.yaml`/`.state.json` (not hardcoded).
+
+```bash
+nexus status               # Rich table
+nexus status --json        # machine-readable
+nexus status --watch       # auto-refresh every 2s
+```
+
+### `nexus logs`
+
+```bash
+nexus logs                 # all services
+nexus logs nexus           # single service
+nexus logs --tail 50       # last 50 lines
+```
+
+### `nexus restart` / `nexus upgrade`
+
+```bash
+nexus restart              # down + up
+nexus restart --build      # rebuild and restart
+nexus upgrade              # pull latest image for channel
+nexus upgrade --channel edge
+```
+
+## Architecture
+
+### Config vs State
+
+```
+nexus.yaml                 ← declarative config (checked into git)
+  preset, data_dir, ports (desired), image_ref, api_key, tls, services
+
+{data_dir}/.state.json     ← runtime state (gitignored, written by nexus up)
+  ports (actual), api_key (active), image_used, build_mode, tls paths
+```
+
+`nexus.yaml` is never mutated by `nexus up`. Only `nexus init` and `nexus upgrade` write to it.
+
+### Concurrent Worktrees
+
+Each worktree gets isolated state via:
+- `COMPOSE_PROJECT_NAME = nexus-{md5(data_dir)[:8]}` — unique Docker project
+- Docker volumes/networks scoped by project name — no collision
+- `{data_dir}/.state.json` — per-worktree runtime state
+- Auto port resolution — conflicts detected and resolved without mutating `nexus.yaml`
+
+```bash
+# Worktree A
+cd ~/nexus/worktrees/feature-a && nexus init --preset shared && nexus up --build
+
+# Worktree B (concurrent)
+cd ~/nexus/worktrees/feature-b && nexus init --preset shared && nexus up --build
+# → auto-resolves to different ports, different Docker project, different local image tag
+```
+
+### Port Mapping
+
+Docker Compose maps `host_port:container_port`. Container ports are fixed (2026 HTTP, 2028 gRPC). Host ports vary with auto-resolution.
+
+### Default Ports
+
+| Service | Default Port |
+|---------|-------------|
+| HTTP | 2026 |
+| gRPC | 2028 |
+| PostgreSQL | 5432 |
+| DragonflyDB | 6379 |
+| Zoekt | 6070 |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Nexus fixes this. One VFS-style interface — start embedded in a single Python 
 pip install nexus-ai-fs                       # CLI + SDK
 nexus init --preset demo                       # writes nexus.yaml + nexus-stack.yml
 nexus up                                       # pulls image, starts Nexus + Postgres + Dragonfly + Zoekt
+eval $(nexus env)                              # load connection vars into your shell
 ```
 
 Open `http://localhost:2026`. That's it.
@@ -168,6 +169,7 @@ nexus init                                    # writes nexus.yaml for local embe
 # Shared daemon
 nexus init --preset shared                    # writes nexus.yaml + nexus-stack.yml
 nexus up                                      # pulls image, starts stack, waits for health
+eval $(nexus env)                             # load NEXUS_URL, NEXUS_API_KEY, etc.
 
 # Demo with seed data
 nexus init --preset demo && nexus up
@@ -181,11 +183,24 @@ nexus init --preset shared --accelerator cuda
 # Pin to a specific version
 nexus init --preset shared --image-tag 0.9.4
 
+# Build from local source (for contributors)
+nexus up --build                              # build + tag as nexus:local-{hash}
+nexus up                                      # reuses local build (no pull)
+nexus up --pull                               # discard local build, pull from remote
+
 # Stack lifecycle
-nexus down                                    # stop all services
+nexus stop                                    # pause containers (fast, no teardown)
+nexus start                                   # resume paused containers (fast)
+nexus down                                    # stop and remove containers
 nexus logs                                    # tail logs
 nexus restart                                 # down + up
 nexus upgrade                                 # pull latest image for your channel
+
+# Environment variables
+nexus env                                     # print export statements for your shell
+nexus env --json                              # machine-readable
+nexus env --dotenv > .env                     # write .env file
+nexus run python my_agent.py                  # run command with env vars injected
 ```
 
 ### Docker image

--- a/src/nexus/bricks/auth/oauth/config.py
+++ b/src/nexus/bricks/auth/oauth/config.py
@@ -1,94 +1,15 @@
 """OAuth provider configuration models.
 
-Canonical location: ``nexus.bricks.auth.oauth.config`` (Issue #2281).
-Moved from nexus.auth_config (which moved from nexus.server.auth.oauth_config).
+Backward-compat shim: canonical location is now ``nexus.contracts.oauth_types``
+(Issue #3230).  This module re-exports for backward compatibility.
 
-These Pydantic models define the shape of OAuth configuration without
-depending on any server-layer code.
+Previous canonical locations:
+    - ``nexus.bricks.auth.oauth.config`` (Issue #2281)
+    - ``nexus.auth_config``
+    - ``nexus.server.auth.oauth_config``
 """
 
-from typing import Any
+from nexus.contracts.oauth_types import OAuthConfig as OAuthConfig
+from nexus.contracts.oauth_types import OAuthProviderConfig as OAuthProviderConfig
 
-from pydantic import BaseModel, Field
-
-
-class OAuthProviderConfig(BaseModel):
-    """Configuration for a single OAuth provider.
-
-    This defines how to instantiate and configure an OAuth provider,
-    including its class, scopes, and environment variable names
-    for credentials.
-    """
-
-    name: str = Field(
-        description="OAuth provider name/identifier (e.g., 'google', 'microsoft', 'x')"
-    )
-    display_name: str = Field(
-        description="Human-readable display name (e.g., 'Google', 'Microsoft', 'X (Twitter)')"
-    )
-    provider_class: str = Field(
-        description="Fully qualified class path (e.g., 'nexus.server.auth.google_oauth.GoogleOAuthProvider')"
-    )
-    scopes: list[str] = Field(
-        default_factory=list,
-        description="OAuth scopes for this provider",
-    )
-    client_id_env: str = Field(
-        description="Environment variable name for OAuth client ID (e.g., 'NEXUS_OAUTH_GOOGLE_CLIENT_ID')"
-    )
-    client_secret_env: str = Field(
-        description="Environment variable name for OAuth client secret (e.g., 'NEXUS_OAUTH_GOOGLE_CLIENT_SECRET')"
-    )
-    requires_pkce: bool = Field(
-        default=False,
-        description="Whether this provider requires PKCE (Proof Key for Code Exchange)",
-    )
-    icon_url: str | None = Field(
-        default=None,
-        description="URL to provider icon/logo for display in UI",
-    )
-    redirect_uri: str | None = Field(
-        default=None,
-        description="Default OAuth redirect URI (can be overridden via RPC parameter)",
-    )
-    metadata: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Additional provider-specific metadata",
-    )
-
-    model_config = {"frozen": False}
-
-
-class OAuthConfig(BaseModel):
-    """OAuth configuration containing all provider configurations."""
-
-    redirect_uri: str | None = Field(
-        default=None,
-        description="Global default OAuth redirect URI (used if provider doesn't specify redirect_uri)",
-    )
-    providers: list[OAuthProviderConfig] = Field(
-        default_factory=list,
-        description="List of OAuth provider configurations",
-    )
-
-    def get_provider_config(self, name: str) -> OAuthProviderConfig | None:
-        """Get provider configuration by name.
-
-        Args:
-            name: Provider name/identifier
-
-        Returns:
-            OAuthProviderConfig if found, None otherwise
-        """
-        for provider in self.providers:
-            if provider.name == name:
-                return provider
-        return None
-
-    def get_all_provider_names(self) -> list[str]:
-        """Get list of all configured provider names.
-
-        Returns:
-            List of provider names
-        """
-        return [provider.name for provider in self.providers]
+__all__ = ["OAuthConfig", "OAuthProviderConfig"]

--- a/src/nexus/bricks/rebac/enforcer.py
+++ b/src/nexus/bricks/rebac/enforcer.py
@@ -79,6 +79,9 @@ SEQUENTIAL_DEPTH_THRESHOLD = 3
 SYSTEM_BYPASS_SCOPE = "/system/"
 """Prefix for system-bypass write/delete operations."""
 
+SYSTEM_BYPASS_EXTRA_PREFIXES = ("/nexus/pipes/",)
+"""Additional prefixes allowed for system write bypass (e.g. audit pipe)."""
+
 
 class PermissionEnforcer:
     """Pure ReBAC permission enforcement for Nexus filesystem (v0.6.0+).
@@ -801,9 +804,14 @@ class PermissionEnforcer:
         if permission == "read":
             return True
 
-        # For other operations, only allow /system paths
+        # For other operations, only allow /system paths and approved extras
         # Use strict matching: /system/ or exactly /system (not /systemdata, etc.)
-        if not (path.startswith(SYSTEM_BYPASS_SCOPE) or path == SYSTEM_BYPASS_SCOPE.rstrip("/")):
+        allowed = (
+            path.startswith(SYSTEM_BYPASS_SCOPE)
+            or path == SYSTEM_BYPASS_SCOPE.rstrip("/")
+            or any(path.startswith(p) for p in SYSTEM_BYPASS_EXTRA_PREFIXES)
+        )
+        if not allowed:
             return False
 
         # Allow common operations on /system paths

--- a/src/nexus/bricks/versioning/time_travel_service.py
+++ b/src/nexus/bricks/versioning/time_travel_service.py
@@ -150,11 +150,11 @@ class TimeTravelService:
 
             if state_1 and state_2:
                 content_changed = state_1["content"] != state_2["content"]
-                size_diff = state_2["metadata"]["size"] - state_1["metadata"]["size"]
+                size_diff = self._content_size(state_2) - self._content_size(state_1)
             elif state_1 and not state_2:
-                size_diff = -state_1["metadata"]["size"]
+                size_diff = -self._content_size(state_1)
             elif not state_1 and state_2:
-                size_diff = state_2["metadata"]["size"]
+                size_diff = self._content_size(state_2)
             else:
                 content_changed = False
 
@@ -164,6 +164,15 @@ class TimeTravelService:
                 "content_changed": content_changed,
                 "size_diff": size_diff,
             }
+
+    @staticmethod
+    def _content_size(state: dict[str, Any]) -> int:
+        content = state.get("content", b"")
+        if isinstance(content, bytes):
+            return len(content)
+        if isinstance(content, str):
+            return len(content.encode())
+        return len(bytes(content))
 
     # ------------------------------------------------------------------
     # Internal helpers (merged from storage/time_travel.TimeTravelReader)

--- a/src/nexus/cli/commands/__init__.py
+++ b/src/nexus/cli/commands/__init__.py
@@ -51,7 +51,9 @@ _REGISTER_COMMANDS: dict[str, tuple[str, ...]] = {
     "connect_cmd": ("connect",),  # Interactive connection setup
     "config_cmd": ("config",),  # Config show/set/get/reset
     # Issue #2915: Stack lifecycle
-    "stack": ("up", "down", "logs", "restart", "upgrade"),
+    "stack": ("up", "down", "logs", "restart", "upgrade", "stop", "start"),
+    # DX: environment variable management
+    "env_cmd": ("env", "run"),
     # Issue #2929: MCL replay for index rebuild
     "reindex": ("reindex",),
     # Issue #2930: Catalog and aspects commands

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -77,6 +77,18 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
         data_dir = cfg.get("data_dir", "./nexus-data")
         state = load_runtime_state(data_dir)
         grpc_port = state.get("ports", {}).get("grpc", cfg.get("ports", {}).get("grpc", 2028))
+
+        # Propagate TLS paths from state.json into env so ZoneTlsConfig.from_env()
+        # picks them up. This bridges the gap for TLS-enabled stacks where certs
+        # are runtime-discovered by nexus up but not set in the shell environment.
+        tls = state.get("tls", {})
+        if tls.get("cert") and not os.environ.get("NEXUS_TLS_CERT"):
+            os.environ["NEXUS_TLS_CERT"] = tls["cert"]
+            os.environ["NEXUS_TLS_KEY"] = tls.get("key", "")
+            os.environ["NEXUS_TLS_CA"] = tls.get("ca", "")
+        if not os.environ.get("NEXUS_DATA_DIR") and data_dir:
+            os.environ["NEXUS_DATA_DIR"] = data_dir
+
     grpc_address = f"{parsed.hostname}:{grpc_port}"
 
     tls_config = ZoneTlsConfig.from_env()

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -68,7 +68,15 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
     from nexus.security.tls.config import ZoneTlsConfig
 
     parsed = urlparse(url)
-    grpc_port = int(os.environ.get("NEXUS_GRPC_PORT", "2028"))
+    # Try env var first, then state.json/nexus.yaml, then default
+    grpc_port = int(os.environ.get("NEXUS_GRPC_PORT", "0"))
+    if not grpc_port:
+        from nexus.cli.state import load_project_config_optional, load_runtime_state
+
+        cfg = load_project_config_optional()
+        data_dir = cfg.get("data_dir", "./nexus-data")
+        state = load_runtime_state(data_dir)
+        grpc_port = state.get("ports", {}).get("grpc", cfg.get("ports", {}).get("grpc", 2028))
     grpc_address = f"{parsed.hostname}:{grpc_port}"
 
     tls_config = ZoneTlsConfig.from_env()

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -68,26 +68,30 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
     from nexus.security.tls.config import ZoneTlsConfig
 
     parsed = urlparse(url)
-    # Try env var first, then state.json/nexus.yaml, then default
+
+    # Load runtime state unconditionally for both port and TLS discovery.
+    # This avoids the bug where TLS fallback only ran when NEXUS_GRPC_PORT
+    # was absent — the two are independent concerns.
+    from nexus.cli.state import load_project_config_optional, load_runtime_state
+
+    cfg = load_project_config_optional()
+    data_dir = cfg.get("data_dir", "./nexus-data")
+    state = load_runtime_state(data_dir)
+
+    # gRPC port: env var > state.json > config > default
     grpc_port = int(os.environ.get("NEXUS_GRPC_PORT", "0"))
     if not grpc_port:
-        from nexus.cli.state import load_project_config_optional, load_runtime_state
-
-        cfg = load_project_config_optional()
-        data_dir = cfg.get("data_dir", "./nexus-data")
-        state = load_runtime_state(data_dir)
         grpc_port = state.get("ports", {}).get("grpc", cfg.get("ports", {}).get("grpc", 2028))
 
-        # Propagate TLS paths from state.json into env so ZoneTlsConfig.from_env()
-        # picks them up. This bridges the gap for TLS-enabled stacks where certs
-        # are runtime-discovered by nexus up but not set in the shell environment.
-        tls = state.get("tls", {})
-        if tls.get("cert") and not os.environ.get("NEXUS_TLS_CERT"):
-            os.environ["NEXUS_TLS_CERT"] = tls["cert"]
-            os.environ["NEXUS_TLS_KEY"] = tls.get("key", "")
-            os.environ["NEXUS_TLS_CA"] = tls.get("ca", "")
-        if not os.environ.get("NEXUS_DATA_DIR") and data_dir:
-            os.environ["NEXUS_DATA_DIR"] = data_dir
+    # TLS: propagate state.json paths into env so ZoneTlsConfig.from_env()
+    # picks them up. Always run this regardless of how grpc_port was resolved.
+    tls = state.get("tls", {})
+    if tls.get("cert") and not os.environ.get("NEXUS_TLS_CERT"):
+        os.environ["NEXUS_TLS_CERT"] = tls["cert"]
+        os.environ["NEXUS_TLS_KEY"] = tls.get("key", "")
+        os.environ["NEXUS_TLS_CA"] = tls.get("ca", "")
+    if not os.environ.get("NEXUS_DATA_DIR") and data_dir:
+        os.environ["NEXUS_DATA_DIR"] = data_dir
 
     grpc_address = f"{parsed.hostname}:{grpc_port}"
 

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -51,10 +51,17 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_admin_key(config: dict[str, Any]) -> str:
-    """Resolve the admin API key from config or on-disk key file."""
-    api_key: str = config.get("api_key", "")
+    """Resolve the admin API key from state.json, config, or on-disk key file."""
+    from nexus.cli.state import load_runtime_state
+
+    data_dir: str = config.get("data_dir", "./nexus-data")
+    state = load_runtime_state(data_dir)
+
+    # State.json first (runtime truth), then nexus.yaml, then .admin-api-key file
+    api_key: str = state.get("api_key", "")
     if not api_key:
-        data_dir: str = config.get("data_dir", "./nexus-data")
+        api_key = config.get("api_key", "")
+    if not api_key:
         key_file = Path(data_dir) / ".admin-api-key"
         if key_file.exists():
             api_key = key_file.read_text().strip()

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -50,6 +50,37 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _resolve_runtime_connection(config: dict[str, Any]) -> dict[str, Any]:
+    """Resolve runtime connection info from state.json, falling back to config.
+
+    Returns a dict with ``http_port``, ``grpc_port``, ``base_url``, and ``api_key``.
+    All downstream demo helpers should use this instead of reading config["ports"]
+    directly, because ``nexus up`` may have resolved to different ports.
+    """
+    from nexus.cli.state import load_runtime_state, resolve_connection_env
+
+    data_dir = config.get("data_dir", "./nexus-data")
+    state = load_runtime_state(data_dir)
+    conn = resolve_connection_env(config, state)
+    ports = state.get("ports", config.get("ports", {}))
+
+    # Set env vars so downstream RPCTransport / SDK picks up TLS and port
+    if conn.get("NEXUS_TLS_CERT"):
+        os.environ["NEXUS_TLS_CERT"] = conn["NEXUS_TLS_CERT"]
+        os.environ["NEXUS_TLS_KEY"] = conn.get("NEXUS_TLS_KEY", "")
+        os.environ["NEXUS_TLS_CA"] = conn.get("NEXUS_TLS_CA", "")
+
+    grpc_port = ports.get("grpc", 2028)
+    os.environ["NEXUS_GRPC_PORT"] = str(grpc_port)
+
+    return {
+        "http_port": ports.get("http", 2026),
+        "grpc_port": grpc_port,
+        "base_url": conn.get("NEXUS_URL", f"http://localhost:{ports.get('http', 2026)}"),
+        "api_key": conn.get("NEXUS_API_KEY", config.get("api_key", "")),
+    }
+
+
 def _resolve_admin_key(config: dict[str, Any]) -> str:
     """Resolve the admin API key from state.json, config, or on-disk key file."""
     from nexus.cli.state import load_runtime_state
@@ -375,11 +406,8 @@ def _seed_permissions_rpc(config: dict[str, Any], tuples: list[dict[str, Any]]) 
     Fallback for non-Docker remote deployments where docker exec is
     unavailable but the server has the admin_write_permission handler.
     """
-    ports = config.get("ports", {})
-    http_port = ports.get("http", 2026)
-    grpc_port = ports.get("grpc", 2028)
-
-    api_key = _resolve_admin_key(config)
+    rt = _resolve_runtime_connection(config)
+    api_key = rt["api_key"]
 
     if not api_key:
         logger.debug("No admin API key — skipping permission seeding via RPC")
@@ -388,8 +416,7 @@ def _seed_permissions_rpc(config: dict[str, Any], tuples: list[dict[str, Any]]) 
     try:
         from nexus.cli.commands.admin import get_admin_rpc
 
-        os.environ["NEXUS_GRPC_PORT"] = str(grpc_port)
-        call_rpc = get_admin_rpc(f"http://localhost:{http_port}", api_key)
+        call_rpc = get_admin_rpc(rt["base_url"], api_key)
         result = call_rpc("admin_write_permission", {"tuples": tuples})
         created: int = result.get("created", 0) if isinstance(result, dict) else 0
         return created
@@ -430,12 +457,8 @@ def _seed_identities(config: dict[str, Any], manifest: dict[str, Any]) -> int:
         manifest["identities_seeded"] = True
         return 0
 
-    ports = config.get("ports", {})
-    http_port = ports.get("http", 2026)
-    grpc_port = ports.get("grpc", 2028)
-
-    # Resolve admin API key
-    api_key = _resolve_admin_key(config)
+    rt = _resolve_runtime_connection(config)
+    api_key = rt["api_key"]
 
     if not api_key:
         logger.debug("No admin API key available — skipping identity seeding")
@@ -444,8 +467,7 @@ def _seed_identities(config: dict[str, Any], manifest: dict[str, Any]) -> int:
     try:
         from nexus.cli.commands.admin import get_admin_rpc
 
-        os.environ["NEXUS_GRPC_PORT"] = str(grpc_port)
-        call_rpc = get_admin_rpc(f"http://localhost:{http_port}", api_key)
+        call_rpc = get_admin_rpc(rt["base_url"], api_key)
     except Exception as e:
         logger.debug("Could not connect admin RPC for identity seeding: %s", e)
         return 0
@@ -514,11 +536,9 @@ def _seed_zones(config: dict[str, Any], manifest: dict[str, Any]) -> int:
 
     import urllib.request
 
-    ports = config.get("ports", {})
-    http_port = ports.get("http", 2026)
-    base_url = f"http://localhost:{http_port}"
-
-    admin_key = _resolve_admin_key(config)
+    rt = _resolve_runtime_connection(config)
+    base_url = rt["base_url"]
+    admin_key = rt["api_key"]
     if not admin_key:
         return 0
 
@@ -552,7 +572,11 @@ def _seed_zones(config: dict[str, Any], manifest: dict[str, Any]) -> int:
             try:
                 # Find postgres container for this stack
                 # Find postgres container matching our stack's port
-                pg_port = str(ports.get("postgres", 5433))
+                from nexus.cli.state import load_runtime_state
+
+                _state = load_runtime_state(config.get("data_dir", "./nexus-data"))
+                _ports = _state.get("ports", config.get("ports", {}))
+                pg_port = str(_ports.get("postgres", 5433))
                 ps_result = subprocess.run(
                     [
                         "docker",
@@ -689,11 +713,9 @@ def _seed_agent_coordination(config: dict[str, Any], manifest: dict[str, Any]) -
 
     import urllib.request
 
-    ports = config.get("ports", {})
-    http_port = ports.get("http", 2026)
-    base_url = f"http://localhost:{http_port}"
-
-    admin_key = _resolve_admin_key(config)
+    rt = _resolve_runtime_connection(config)
+    base_url = rt["base_url"]
+    admin_key = rt["api_key"]
     if not admin_key:
         logger.debug("No admin API key — skipping agent coordination seeding")
         return {"provisioned": 0, "delegated": 0, "messages": 0}
@@ -870,22 +892,15 @@ def _revoke_identities(config: dict[str, Any], manifest: dict[str, Any]) -> int:
     if not identity_keys:
         return 0
 
-    ports = config.get("ports", {})
-    http_port = ports.get("http", 2026)
-    grpc_port = ports.get("grpc", 2028)
-
-    api_key = _resolve_admin_key(config)
+    rt = _resolve_runtime_connection(config)
+    api_key = rt["api_key"]
     if not api_key:
         return 0
-
-    # Set TLS env vars so admin RPC uses mTLS when TLS is enabled
-    # TLS is auto-detected from NEXUS_DATA_DIR/tls/
 
     try:
         from nexus.cli.commands.admin import get_admin_rpc
 
-        os.environ["NEXUS_GRPC_PORT"] = str(grpc_port)
-        call_rpc = get_admin_rpc(f"http://localhost:{http_port}", api_key)
+        call_rpc = get_admin_rpc(rt["base_url"], api_key)
     except Exception:
         return 0
 
@@ -1063,10 +1078,8 @@ def _seed_catalog(nx: Any, config: dict[str, Any], manifest: dict[str, Any]) -> 
 
     from nexus.cli.api_client import NexusApiClient
 
-    api_key = _resolve_admin_key(config)
-    ports = config.get("ports", {})
-    http_port = ports.get("http", 2026)
-    client = NexusApiClient(url=f"http://localhost:{http_port}", api_key=api_key)
+    rt = _resolve_runtime_connection(config)
+    client = NexusApiClient(url=rt["base_url"], api_key=rt["api_key"])
 
     data_files = [
         "/workspace/demo/data/sales.csv",
@@ -1101,10 +1114,8 @@ def _seed_aspects(nx: Any, config: dict[str, Any], manifest: dict[str, Any]) -> 
     from nexus.cli.api_client import NexusApiClient
     from nexus.contracts.urn import NexusURN
 
-    api_key = _resolve_admin_key(config)
-    ports = config.get("ports", {})
-    http_port = ports.get("http", 2026)
-    client = NexusApiClient(url=f"http://localhost:{http_port}", api_key=api_key)
+    rt = _resolve_runtime_connection(config)
+    client = NexusApiClient(url=rt["base_url"], api_key=rt["api_key"])
 
     aspects_to_seed = [
         (
@@ -1550,22 +1561,8 @@ async def _async_demo_init(reset: bool, skip_semantic: bool) -> None:
     console.print()
 
     if preset in ("shared", "demo"):
-        ports = config.get("ports", {})
-        http_port = ports.get("http", 2026)
-        grpc_port = ports.get("grpc", 2028)
-        api_key = config.get("api_key", "")
-        if not api_key:
-            # Fallback: read from the key file that docker-entrypoint.sh writes
-            key_file = Path(data_dir) / ".admin-api-key"
-            if key_file.exists():
-                api_key = key_file.read_text().strip()
-        console.print("[bold]Set these env vars to talk to the running stack:[/bold]")
-        console.print(f"  export NEXUS_URL=http://localhost:{http_port}")
-        if api_key:
-            console.print(f"  export NEXUS_API_KEY={api_key}")
-        else:
-            console.print("  export NEXUS_API_KEY=<see nexus up output>")
-        console.print(f"  export NEXUS_GRPC_PORT={grpc_port}")
+        console.print("[bold]Load env vars:[/bold]")
+        console.print("  eval $(nexus env)")
         console.print()
 
     console.print("[bold]Try these commands:[/bold]")

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -73,11 +73,15 @@ def _resolve_runtime_connection(config: dict[str, Any]) -> dict[str, Any]:
     grpc_port = ports.get("grpc", 2028)
     os.environ["NEXUS_GRPC_PORT"] = str(grpc_port)
 
+    api_key = conn.get("NEXUS_API_KEY", config.get("api_key", ""))
+    if not api_key:
+        api_key = _resolve_admin_key(config)
+
     return {
         "http_port": ports.get("http", 2026),
         "grpc_port": grpc_port,
         "base_url": conn.get("NEXUS_URL", f"http://localhost:{ports.get('http', 2026)}"),
-        "api_key": conn.get("NEXUS_API_KEY", config.get("api_key", "")),
+        "api_key": api_key,
     }
 
 

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -101,8 +101,9 @@ def _save_manifest(data_dir: str, manifest: dict[str, Any]) -> None:
 async def _get_nexus_client(config: dict[str, Any]) -> Any:
     """Connect to a running Nexus server via gRPC, or fall back to local.
 
-    For remote presets (shared/demo), sets NEXUS_GRPC_PORT from nexus.yaml
-    so the SDK connects to the correct gRPC port published by the compose stack.
+    For remote presets (shared/demo), reads runtime state from
+    ``.state.json`` for the actual resolved ports and TLS paths,
+    falling back to ``nexus.yaml`` config values.
 
     Raises on failure — does not silently fall back to a separate local instance
     when a remote preset is expected.
@@ -110,33 +111,41 @@ async def _get_nexus_client(config: dict[str, Any]) -> Any:
     import nexus
 
     preset = config.get("preset", "local")
-    ports = config.get("ports", {})
-    http_port = ports.get("http", 2026)
-    grpc_port = ports.get("grpc", 2028)
 
     if preset in ("shared", "demo"):
+        from nexus.cli.state import load_runtime_state, resolve_connection_env
+
+        data_dir = config.get("data_dir", "./nexus-data")
+        state = load_runtime_state(data_dir)
+        conn = resolve_connection_env(config, state)
+
+        # Use runtime-resolved ports (from state.json) over config defaults
+        http_port = state.get("ports", config.get("ports", {})).get("http", 2026)
+        grpc_port = state.get("ports", config.get("ports", {})).get("grpc", 2028)
+
         # Set NEXUS_GRPC_PORT so nexus.connect() uses the right port
         os.environ["NEXUS_GRPC_PORT"] = str(grpc_port)
 
-        # Resolve the admin API key — prefer nexus.yaml, fall back to the
-        # key file written by the container entrypoint.
+        # Set TLS env vars if available so RPCTransport picks them up
+        if conn.get("NEXUS_TLS_CERT"):
+            os.environ["NEXUS_TLS_CERT"] = conn["NEXUS_TLS_CERT"]
+            os.environ["NEXUS_TLS_KEY"] = conn.get("NEXUS_TLS_KEY", "")
+            os.environ["NEXUS_TLS_CA"] = conn.get("NEXUS_TLS_CA", "")
+
         api_key = _resolve_admin_key(config)
 
-        # When TLS is enabled, set env vars so nexus.connect() builds
-        # an RPCTransport with mTLS credentials (dev certs double as
-        # TLS is auto-detected from NEXUS_DATA_DIR/tls/ (provisioned by 2-phase bootstrap)
+        # Use the scheme from resolve_connection_env (https if TLS)
+        url = conn.get("NEXUS_URL", f"http://localhost:{http_port}")
 
         try:
             nx = await nexus.connect(
                 config={
                     "profile": "remote",
-                    "url": f"http://localhost:{http_port}",
+                    "url": url,
                     "api_key": api_key,
                 }
             )
             # Verify connectivity with a lightweight read-only call.
-            # Use sys_readdir (returns list) instead of sys_stat (goes through
-            # MetadataMapper.from_json which can fail on schema mismatches).
             await nx.sys_readdir("/")
             return nx
         except Exception as e:

--- a/src/nexus/cli/commands/env_cmd.py
+++ b/src/nexus/cli/commands/env_cmd.py
@@ -38,23 +38,48 @@ def _detect_shell() -> str:
     return "bash"
 
 
+def _shell_escape(value: str, shell: str) -> str:
+    """Escape a value for safe embedding in shell syntax.
+
+    For bash/zsh/sh: single-quote with internal single-quotes escaped as '\\''
+    For fish: single-quote with internal single-quotes escaped as \\'
+    For powershell: single-quote with internal single-quotes doubled
+    """
+    if shell == "powershell":
+        return "'" + value.replace("'", "''") + "'"
+    if shell == "fish":
+        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+    # bash / zsh / sh: end quote, escaped literal quote, reopen quote
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
 def _format_shell(env_vars: dict[str, str], shell: str) -> str:
     """Format env vars for the target shell."""
     lines: list[str] = []
     for key, value in sorted(env_vars.items()):
+        escaped = _shell_escape(value, shell)
         if shell == "fish":
-            lines.append(f"set -gx {key} '{value}';")
+            lines.append(f"set -gx {key} {escaped};")
         elif shell == "powershell":
-            lines.append(f"$env:{key} = '{value}'")
+            lines.append(f"$env:{key} = {escaped}")
         else:
             # bash / zsh / sh
-            lines.append(f"export {key}='{value}'")
+            lines.append(f"export {key}={escaped}")
     return "\n".join(lines)
 
 
 def _format_dotenv(env_vars: dict[str, str]) -> str:
-    """Format as .env file (KEY=VALUE, no export prefix)."""
-    return "\n".join(f"{k}={v}" for k, v in sorted(env_vars.items()))
+    """Format as .env file (KEY=VALUE with quoting for special chars)."""
+    lines: list[str] = []
+    for k, v in sorted(env_vars.items()):
+        # Quote values that contain special chars (spaces, quotes, #, etc.)
+        if any(c in v for c in ("'", '"', " ", "\n", "#", "=")):
+            # Double-quote with internal double-quotes and backslashes escaped
+            escaped = v.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+            lines.append(f'{k}="{escaped}"')
+        else:
+            lines.append(f"{k}={v}")
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/cli/commands/env_cmd.py
+++ b/src/nexus/cli/commands/env_cmd.py
@@ -1,0 +1,168 @@
+"""``nexus env`` and ``nexus run`` — connection env var management.
+
+``nexus env`` prints environment variables for the running Nexus stack
+in various formats (shell export, .env, JSON).  ``nexus run`` wraps a
+subprocess with those variables injected.
+
+Both commands read from ``nexus.yaml`` (declarative config) overlaid with
+``{data_dir}/.state.json`` (runtime state from the last ``nexus up``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+from nexus.cli.state import (
+    load_project_config,
+    load_runtime_state,
+    resolve_connection_env,
+)
+from nexus.cli.utils import console
+
+# ---------------------------------------------------------------------------
+# Shell formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_shell() -> str:
+    """Detect the user's shell from $SHELL."""
+    shell_path = os.environ.get("SHELL", "/bin/bash")
+    name = Path(shell_path).name
+    if name in ("bash", "zsh", "fish", "sh"):
+        return name
+    return "bash"
+
+
+def _format_shell(env_vars: dict[str, str], shell: str) -> str:
+    """Format env vars for the target shell."""
+    lines: list[str] = []
+    for key, value in sorted(env_vars.items()):
+        if shell == "fish":
+            lines.append(f"set -gx {key} '{value}';")
+        elif shell == "powershell":
+            lines.append(f"$env:{key} = '{value}'")
+        else:
+            # bash / zsh / sh
+            lines.append(f"export {key}='{value}'")
+    return "\n".join(lines)
+
+
+def _format_dotenv(env_vars: dict[str, str]) -> str:
+    """Format as .env file (KEY=VALUE, no export prefix)."""
+    return "\n".join(f"{k}={v}" for k, v in sorted(env_vars.items()))
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register env and run commands."""
+    cli.add_command(env_cmd)
+    cli.add_command(run)
+
+
+@click.command(name="env")
+@click.option(
+    "--shell",
+    "shell_name",
+    type=click.Choice(["bash", "zsh", "fish", "powershell", "sh"]),
+    default=None,
+    help="Shell format (default: auto-detect from $SHELL).",
+)
+@click.option(
+    "--dotenv",
+    is_flag=True,
+    default=False,
+    help="Output in .env format (KEY=VALUE, no export).",
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Output as JSON object.",
+)
+def env_cmd(
+    shell_name: str | None,
+    dotenv: bool,
+    json_output: bool,
+) -> None:
+    """Print environment variables for the running Nexus stack.
+
+    Reads nexus.yaml and .state.json to emit all connection variables.
+
+    Usage patterns:
+
+    \b
+        eval $(nexus env)              # load into current shell
+        nexus env --dotenv > .env      # write .env file
+        nexus env --json               # machine-readable
+        nexus env --shell fish | source
+
+    Examples:
+
+    \b
+        nexus env
+        nexus env --json
+        nexus env --dotenv
+        nexus env --shell fish
+    """
+    config = load_project_config()
+    data_dir = config.get("data_dir", "./nexus-data")
+    state = load_runtime_state(data_dir)
+    env_vars = resolve_connection_env(config, state)
+
+    if not env_vars:
+        console.print("[yellow]No connection info found.[/yellow] Run `nexus up` first.")
+        raise SystemExit(1)
+
+    if json_output:
+        import json
+
+        click.echo(json.dumps(env_vars, indent=2))
+        return
+
+    if dotenv:
+        click.echo(_format_dotenv(env_vars))
+        return
+
+    effective_shell = shell_name or _detect_shell()
+    click.echo(_format_shell(env_vars, effective_shell))
+
+
+@click.command(name="run")
+@click.argument("command", nargs=-1, required=True)
+def run(command: tuple[str, ...]) -> None:
+    """Run a command with Nexus environment variables injected.
+
+    Spawns the given command as a subprocess with NEXUS_URL, NEXUS_API_KEY,
+    and other connection variables set in the environment.  Stdin, stdout,
+    and stderr are passed through — interactive commands (like ``bash``)
+    work as expected.
+
+    Examples:
+
+    \b
+        nexus run python my_agent.py
+        nexus run pytest tests/
+        nexus run bash
+    """
+    config = load_project_config()
+    data_dir = config.get("data_dir", "./nexus-data")
+    state = load_runtime_state(data_dir)
+    env_vars = resolve_connection_env(config, state)
+
+    run_env = {**os.environ, **env_vars}
+    try:
+        result = subprocess.run(list(command), env=run_env)
+        sys.exit(result.returncode)
+    except FileNotFoundError as err:
+        console.print(f"[red]Error:[/red] Command not found: {command[0]}")
+        raise SystemExit(127) from err

--- a/src/nexus/cli/commands/init_cmd.py
+++ b/src/nexus/cli/commands/init_cmd.py
@@ -379,6 +379,7 @@ def _print_shared_summary(config: dict[str, Any], config_path: Path, data_dir: P
 
 
 @click.command(name="init")
+@click.argument("workspace", required=False, type=click.Path())
 @click.option(
     "--preset",
     type=click.Choice(VALID_PRESETS),
@@ -453,6 +454,7 @@ def _print_shared_summary(config: dict[str, Any], config_path: Path, data_dir: P
     help="Explicit image digest (sha256:...). Overrides tag and channel.",
 )
 def init(
+    workspace: str | None,
     preset: str,
     data_dir: str,
     tls: bool,
@@ -482,6 +484,11 @@ def init(
     """
     cfg_path = Path(config_path)
     d_dir = Path(data_dir)
+
+    if workspace is not None:
+        workspace_path = Path(workspace)
+        cfg_path = workspace_path / "nexus.yaml"
+        d_dir = workspace_path / "nexus-data"
 
     # Guard: don't overwrite existing config without --force
     if cfg_path.exists() and not force:

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -1,8 +1,12 @@
-"""Stack lifecycle commands — up, down, logs, restart, upgrade.
+"""Stack lifecycle commands — up, down, logs, restart, upgrade, stop, start.
 
 These commands manage the Docker Compose stack for ``shared`` and ``demo``
 presets.  They wrap ``docker compose`` via subprocess, adding pre-flight
 port conflict detection, parallel health polling, and rich status output.
+
+Runtime state (resolved ports, API key, image used) is written to
+``{data_dir}/.state.json`` — **not** back to ``nexus.yaml`` — so that the
+declarative config stays clean and concurrent worktrees don't collide.
 """
 
 from __future__ import annotations
@@ -15,6 +19,7 @@ import shutil
 import subprocess
 import time
 import urllib.request
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -31,38 +36,18 @@ from nexus.cli.port_utils import (
     check_port_available,
     resolve_ports,
 )
+from nexus.cli.state import (
+    load_project_config as _load_project_config,
+)
+from nexus.cli.state import (
+    load_runtime_state,
+    resolve_connection_env,
+    save_runtime_state,
+)
+from nexus.cli.state import (
+    save_project_config as _save_project_config,
+)
 from nexus.cli.utils import console
-
-# ---------------------------------------------------------------------------
-# Config helpers
-# ---------------------------------------------------------------------------
-
-CONFIG_SEARCH_PATHS = ("./nexus.yaml", "./nexus.yml")
-
-
-def _load_project_config() -> dict[str, Any]:
-    """Load the project-local nexus.yaml."""
-    for candidate in CONFIG_SEARCH_PATHS:
-        p = Path(candidate)
-        if p.exists():
-            with open(p) as f:
-                return yaml.safe_load(f) or {}
-    console.print("[red]Error:[/red] No nexus.yaml found. Run `nexus init` first.")
-    raise SystemExit(1)
-
-
-def _save_project_config(config: dict[str, Any], path: str | None = None) -> None:
-    """Persist config back to nexus.yaml (e.g. after port resolution)."""
-    target = Path(path) if path else None
-    if target is None:
-        for candidate in CONFIG_SEARCH_PATHS:
-            if Path(candidate).exists():
-                target = Path(candidate)
-                break
-    if target is None:
-        target = Path(CONFIG_SEARCH_PATHS[0])
-    with open(target, "w") as f:
-        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 
 
 def _resolve_image_ref_from_config(config: dict[str, Any]) -> str:
@@ -140,7 +125,13 @@ def _derive_project_env(
         env["NEXUS_IMAGE_REF"] = image_ref
 
     # TLS is provisioned automatically by 2-phase TLS bootstrap.
-    # No env vars needed — certs are auto-detected from disk.
+    # Certs are auto-detected from disk inside the container.
+    # NEXUS_GRPC_TLS is set explicitly so the gRPC server doesn't
+    # rely on auto-detection, which can surprise users.
+    if config.get("tls"):
+        env["NEXUS_GRPC_TLS"] = "true"
+    else:
+        env["NEXUS_GRPC_TLS"] = "false"
 
     return env
 
@@ -371,6 +362,8 @@ def register_commands(cli: click.Group) -> None:
     cli.add_command(logs)
     cli.add_command(restart)
     cli.add_command(upgrade)
+    cli.add_command(stop)
+    cli.add_command(start)
 
 
 @click.command()
@@ -406,6 +399,12 @@ def register_commands(cli: click.Group) -> None:
     help="Build images locally instead of pulling from GHCR (default: pull).",
 )
 @click.option(
+    "--pull/--no-pull",
+    "force_pull",
+    default=None,
+    help="Force image pull from remote (clears local build mode).",
+)
+@click.option(
     "--timeout", type=int, default=180, show_default=True, help="Health check timeout in seconds."
 )
 def up(
@@ -414,6 +413,7 @@ def up(
     port_strategy: str,
     compose_file: str | None,
     build: bool | None,
+    force_pull: bool | None,
     timeout: int,
 ) -> None:
     """Start the Nexus stack.
@@ -426,13 +426,15 @@ def up(
     (with ``build:`` directives) rebuild automatically.
 
     Use ``--build`` to force a local build, or ``--no-build`` to skip.
+    After a ``--build``, subsequent ``nexus up`` reuses the local image.
+    Use ``--pull`` to discard the local build and pull from remote.
 
     Examples:
         nexus up                        # start from nexus.yaml
         nexus up --with nats            # add NATS event bus
         nexus up --port-strategy prompt # ask on conflicts
         nexus up --build                # force rebuild images
-        nexus up --no-build             # skip rebuild
+        nexus up --pull                 # discard local build, pull remote
     """
     config = _load_project_config()
     preset = config.get("preset", "local")
@@ -452,17 +454,28 @@ def up(
         console.print("[yellow]Hint:[/yellow] Ensure nexus-stack.yml is in the project root.")
         raise SystemExit(1)
 
+    data_dir = str(Path(config.get("data_dir", "./nexus-data")).resolve())
+
+    # Check previous runtime state for local build reuse
+    prev_state = load_runtime_state(data_dir)
+    using_local_build = False
+
     # Default: pull prebuilt image.  Only build when explicitly requested
     # via --build (local dev iteration).
     if build is None:
+        # Reuse local build if previous state says so (and not --pull)
+        if prev_state.get("build_mode") == "local" and force_pull is not True:
+            using_local_build = True
         build = False
+
+    # --pull clears local build mode
+    if force_pull:
+        using_local_build = False
 
     # Build profiles list (single source of truth via _resolve_profiles)
     profiles = _resolve_profiles(config, addons)
 
     # Validate profiles against what the compose file actually defines.
-    # This catches attempts to use repo-only add-ons (frontend, langgraph,
-    # observability) with the portable bundled stack.
     available_profiles = _compose_profiles(cf)
     if available_profiles:
         missing = [p for p in profiles if p not in available_profiles]
@@ -473,10 +486,26 @@ def up(
                 )
             profiles = [p for p in profiles if p in available_profiles]
 
-    # Port conflict resolution — check all ports in config (not filtered by services)
+    # Port resolution: reuse previous state.json ports if they're still bound
+    # (our own containers), otherwise resolve from config defaults.
     ports = config.get("ports", {})
     active_services = config.get("services", [])
-    resolved_ports, port_messages = resolve_ports(ports, strategy=port_strategy)
+
+    prev_ports = prev_state.get("ports", {})
+    if prev_ports and prev_state.get("project_name"):
+        # Check if the previous ports are still in use (by our containers).
+        # If so, reuse them — avoids port drift on repeated `nexus up`.
+        all_prev_bound = all(
+            not check_port_available(p) for p in prev_ports.values() if isinstance(p, int)
+        )
+        if all_prev_bound:
+            resolved_ports = prev_ports
+            port_messages: list[str] = []
+        else:
+            # Some ports freed up (containers stopped) — re-resolve from config
+            resolved_ports, port_messages = resolve_ports(ports, strategy=port_strategy)
+    else:
+        resolved_ports, port_messages = resolve_ports(ports, strategy=port_strategy)
 
     # Print header
     console.print()
@@ -484,6 +513,10 @@ def up(
     console.print(f"  Using stack: {cf}")
     if build:
         console.print("  Image: [green]local build[/green] (from Dockerfile)")
+    elif using_local_build:
+        console.print(
+            f"  Image: [green]{prev_state.get('image_used', 'local')}[/green] (reusing local build)"
+        )
     else:
         image_ref = _resolve_image_ref_from_config(config)
         if image_ref:
@@ -496,42 +529,48 @@ def up(
     for msg in port_messages:
         console.print(f"  [yellow]{msg}[/yellow]")
 
-    # Persist resolved ports back to config
-    if resolved_ports != ports:
-        config["ports"] = resolved_ports
-        _save_project_config(config)
+    # NOTE: resolved ports are NOT written back to nexus.yaml.
+    # They go into .state.json (written after health check).
 
     # Build environment from config (project name, ports, data dir, auth, image, TLS)
     compose_env = _derive_project_env(config, resolved_ports=resolved_ports)
 
-    # When --build is requested, drop NEXUS_IMAGE_REF so docker compose
-    # uses the ``build:`` directive from the compose file (local source)
-    # instead of pulling the pinned remote image.  Only safe when the
-    # compose file actually has a build: stanza (repo checkouts); the
-    # bundled portable compose file has no build: directive.
+    # Track effective image and build mode for state.json
+    effective_build_mode = "remote"
+    effective_image_used = compose_env.get("NEXUS_IMAGE_REF", "")
+
+    # When reusing a local build, set the local image tag and skip pull
+    if using_local_build and not build:
+        local_image = prev_state.get("image_used", "")
+        if local_image:
+            compose_env["NEXUS_IMAGE_REF"] = local_image
+            effective_image_used = local_image
+            effective_build_mode = "local"
+
+    # When --build is requested, build with a local-only tag
     if build:
+        project_hash = compose_env["COMPOSE_PROJECT_NAME"].split("-")[-1]
+        local_tag = f"nexus:local-{project_hash}"
+
         if _compose_has_build(cf):
             compose_env.pop("NEXUS_IMAGE_REF", None)
+            effective_build_mode = "local"
+            effective_image_used = local_tag
         else:
             # No build: directive in compose file.  Fall back to building
-            # the Docker image from the repo Dockerfile if one exists,
-            # then tag it so compose uses it (Issue #3134).
+            # the Docker image from the repo Dockerfile if one exists.
             repo_dockerfile = _find_repo_dockerfile()
             if repo_dockerfile:
-                image_ref = compose_env.get(
-                    "NEXUS_IMAGE_REF", config.get("image_ref", "ghcr.io/nexi-lab/nexus:latest")
-                )
                 console.print(
                     f"[cyan]Nexus:[/cyan] building image from {repo_dockerfile.relative_to(repo_dockerfile.parent.parent)} "
-                    f"→ {image_ref}"
+                    f"→ {local_tag}"
                 )
                 build_result = subprocess.run(
                     [
                         "docker",
                         "build",
-                        "--no-cache",
                         "-t",
-                        image_ref,
+                        local_tag,
                         "-f",
                         str(repo_dockerfile),
                         str(repo_dockerfile.parent),
@@ -541,7 +580,10 @@ def up(
                 if build_result.returncode != 0:
                     console.print("[red]Error:[/red] Docker build failed.")
                     raise SystemExit(1)
-                console.print(f"[green]Nexus:[/green] built image {image_ref} from source")
+                console.print(f"[green]Nexus:[/green] built image {local_tag} from source")
+                compose_env["NEXUS_IMAGE_REF"] = local_tag
+                effective_image_used = local_tag
+                effective_build_mode = "local"
                 build = False  # don't pass --build to compose (no build: directive)
             else:
                 console.print(
@@ -550,8 +592,6 @@ def up(
                 )
                 build = False
 
-    data_dir = compose_env["NEXUS_HOST_DATA_DIR"]
-
     # Start compose
     compose_args: list[str] = ["up"]
     if detach:
@@ -559,12 +599,17 @@ def up(
     if build:
         compose_args.append("--build")
 
-    # For channel-following configs (stable/edge), always pull the latest
-    # image so mutable tags pick up new releases.  Pinned configs skip
-    # this — their tag is immutable and already cached.
-    if not build and _is_channel_following(config):
-        compose_args.append("--pull")
-        compose_args.append("always")
+    # Pull logic:
+    # - --pull flag: always pull
+    # - Channel-following + not local build: pull to get latest mutable tag
+    # - Local build mode: skip pull (preserve local image)
+    if (
+        force_pull
+        or not build
+        and effective_build_mode != "local"
+        and _is_channel_following(config)
+    ):
+        compose_args.extend(["--pull", "always"])
 
     result = _run_compose(cf, profiles, *compose_args, extra_env=compose_env)
     if result.returncode != 0:
@@ -598,15 +643,46 @@ def up(
 
     # Bootstrap auth: prefer the key from nexus.yaml (generated by nexus init),
     # fall back to .admin-api-key written by docker-entrypoint.sh.
-    data_dir = config.get("data_dir", "./nexus-data")
     admin_api_key: str | None = config.get("api_key") or None
     if not admin_api_key:
         api_key_file = Path(data_dir) / ".admin-api-key"
         if api_key_file.exists():
-            admin_api_key = api_key_file.read_text().strip()
-            if admin_api_key:
-                config["api_key"] = admin_api_key
-                _save_project_config(config)
+            admin_api_key = api_key_file.read_text().strip() or None
+
+    # Auto-discover TLS certs (Raft 2-phase bootstrap writes to data_dir/tls/)
+    tls_state: dict[str, str] = {}
+    tls_dir = Path(data_dir) / "tls"
+    if tls_dir.exists():
+        # Raft-style certs
+        if (tls_dir / "ca.pem").exists():
+            tls_state = {
+                "cert": str(tls_dir / "node.pem"),
+                "key": str(tls_dir / "node-key.pem"),
+                "ca": str(tls_dir / "ca.pem"),
+            }
+        # OpenSSL-style certs (from nexus init --tls)
+        elif (tls_dir / "ca.crt").exists():
+            tls_state = {
+                "cert": str(tls_dir / "server.crt"),
+                "key": str(tls_dir / "server.key"),
+                "ca": str(tls_dir / "ca.crt"),
+            }
+
+    # Write runtime state to {data_dir}/.state.json (NOT nexus.yaml)
+    runtime_state: dict[str, Any] = {
+        "ports": resolved_ports,
+        "api_key": admin_api_key or "",
+        "image_used": effective_image_used,
+        "build_mode": effective_build_mode,
+        "project_name": compose_env["COMPOSE_PROJECT_NAME"],
+        "started_at": datetime.now(UTC).isoformat(),
+    }
+    if tls_state:
+        runtime_state["tls"] = tls_state
+    save_runtime_state(data_dir, runtime_state)
+
+    # Build connection env vars for display
+    conn_env = resolve_connection_env(config, runtime_state)
 
     # Print final status table
     console.print()
@@ -626,16 +702,16 @@ def up(
     if "zoekt" in active_services:
         console.print(f"  zoekt       http://localhost:{zk_port}")
 
-    # Surface the admin API key so the user can authenticate downstream
-    if admin_api_key:
-        console.print()
-        console.print("[bold]Admin API key:[/bold]")
-        console.print(f"  export NEXUS_API_KEY='{admin_api_key}'")
-        console.print(f"  export NEXUS_URL='http://localhost:{http_port}'")
+    # Surface connection info
+    console.print()
+    console.print("[bold]Connection:[/bold]")
+    for key, value in sorted(conn_env.items()):
+        console.print(f"  export {key}='{value}'")
 
     # Print next steps
     console.print()
     console.print("[bold]Next steps:[/bold]")
+    console.print("  eval $(nexus env)        # load env vars into shell")
     if preset == "demo":
         console.print("  nexus demo init")
     console.print("  nexus status")
@@ -888,3 +964,62 @@ def upgrade(
     _save_project_config(config)
     console.print(f"[green]✓[/green] Updated nexus.yaml → {new_ref}")
     console.print("  Run `nexus restart` to apply.")
+
+
+@click.command()
+def stop() -> None:
+    """Pause the Nexus stack (keep containers and volumes).
+
+    Containers are paused but not removed.  Resume with ``nexus start``.
+    This is faster than ``nexus down`` + ``nexus up`` because it skips
+    port resolution, image pulls, and health checks.
+
+    Examples:
+        nexus stop
+    """
+    config = _load_project_config()
+    preset = config.get("preset", "local")
+
+    if preset == "local":
+        console.print("[yellow]Preset 'local' has no Docker services to stop.[/yellow]")
+        raise SystemExit(0)
+
+    cf = config.get("compose_file", "./nexus-stack.yml")
+    profiles = _resolve_profiles(config)
+    compose_env = _derive_project_env(config)
+
+    result = _run_compose(cf, profiles, "stop", extra_env=compose_env)
+    if result.returncode == 0:
+        console.print("[green]✓[/green] Stack paused. Resume with `nexus start`.")
+    else:
+        console.print("[red]Error:[/red] Failed to stop stack.")
+        raise SystemExit(result.returncode)
+
+
+@click.command()
+def start() -> None:
+    """Resume a paused Nexus stack.
+
+    Resumes containers that were stopped with ``nexus stop``.
+    Does not perform port checks, image pulls, or health polling.
+
+    Examples:
+        nexus start
+    """
+    config = _load_project_config()
+    preset = config.get("preset", "local")
+
+    if preset == "local":
+        console.print("[yellow]Preset 'local' has no Docker services to start.[/yellow]")
+        raise SystemExit(0)
+
+    cf = config.get("compose_file", "./nexus-stack.yml")
+    profiles = _resolve_profiles(config)
+    compose_env = _derive_project_env(config)
+
+    result = _run_compose(cf, profiles, "start", extra_env=compose_env)
+    if result.returncode == 0:
+        console.print("[green]✓[/green] Stack resumed.")
+    else:
+        console.print("[red]Error:[/red] Failed to start stack.")
+        raise SystemExit(result.returncode)

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -486,24 +486,35 @@ def up(
                 )
             profiles = [p for p in profiles if p in available_profiles]
 
-    # Port resolution: reuse previous state.json ports if they're still bound
-    # (our own containers), otherwise resolve from config defaults.
+    # Port resolution: reuse previous state.json ports if OUR containers
+    # still own them, otherwise resolve from config defaults.
     ports = config.get("ports", {})
     active_services = config.get("services", [])
 
     prev_ports = prev_state.get("ports", {})
-    if prev_ports and prev_state.get("project_name"):
-        # Check if the previous ports are still in use (by our containers).
-        # If so, reuse them — avoids port drift on repeated `nexus up`.
-        all_prev_bound = all(
-            not check_port_available(p) for p in prev_ports.values() if isinstance(p, int)
-        )
-        if all_prev_bound:
-            resolved_ports = prev_ports
-            port_messages: list[str] = []
-        else:
-            # Some ports freed up (containers stopped) — re-resolve from config
-            resolved_ports, port_messages = resolve_ports(ports, strategy=port_strategy)
+    prev_project = prev_state.get("project_name", "")
+    reuse_ports = False
+
+    if prev_ports and prev_project:
+        # Verify ownership: check if our compose project has running containers.
+        # This avoids the false-positive where an unrelated process binds
+        # one of our remembered ports after our stack was stopped.
+        try:
+            ownership_check = subprocess.run(
+                [*_find_docker_compose().split(), "-p", prev_project, "ps", "-q"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            has_running_containers = bool(ownership_check.stdout.strip())
+            reuse_ports = has_running_containers
+        except (subprocess.TimeoutExpired, OSError):
+            # Can't verify — fall through to re-resolve
+            pass
+
+    if reuse_ports:
+        resolved_ports = prev_ports
+        port_messages: list[str] = []
     else:
         resolved_ports, port_messages = resolve_ports(ports, strategy=port_strategy)
 

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
@@ -26,19 +25,12 @@ if TYPE_CHECKING:
 # Project config helpers
 # ---------------------------------------------------------------------------
 
-CONFIG_SEARCH_PATHS = ("./nexus.yaml", "./nexus.yml")
-
 
 def _load_project_config_optional() -> dict[str, Any]:
     """Try loading nexus.yaml; return empty dict if not found."""
-    import yaml
+    from nexus.cli.state import load_project_config_optional
 
-    for candidate in CONFIG_SEARCH_PATHS:
-        p = Path(candidate)
-        if p.exists():
-            with open(p) as f:
-                return yaml.safe_load(f) or {}
-    return {}
+    return load_project_config_optional()
 
 
 def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
@@ -277,7 +269,21 @@ def status(
         nexus status --json        # machine-readable
         nexus status --watch       # auto-refresh every 2s
     """
-    server_url = url or "http://localhost:2026"
+    # Resolve server URL from state.json / nexus.yaml / default
+    if url:
+        server_url = url
+    else:
+        cfg = _load_project_config_optional()
+        if cfg:
+            from nexus.cli.state import load_runtime_state
+
+            data_dir = cfg.get("data_dir", "./nexus-data")
+            state = load_runtime_state(data_dir)
+            ports = state.get("ports", cfg.get("ports", {}))
+            http_port = ports.get("http", 2026)
+            server_url = f"http://localhost:{http_port}"
+        else:
+            server_url = "http://localhost:2026"
     profile_list = list(profiles) if profiles else None
 
     try:

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -275,13 +275,13 @@ def status(
     else:
         cfg = _load_project_config_optional()
         if cfg:
-            from nexus.cli.state import load_runtime_state
+            from nexus.cli.state import load_runtime_state, resolve_connection_env
 
             data_dir = cfg.get("data_dir", "./nexus-data")
             state = load_runtime_state(data_dir)
-            ports = state.get("ports", cfg.get("ports", {}))
-            http_port = ports.get("http", 2026)
-            server_url = f"http://localhost:{http_port}"
+            conn = resolve_connection_env(cfg, state)
+            # resolve_connection_env handles http vs https based on TLS state
+            server_url = conn.get("NEXUS_URL", "http://localhost:2026")
         else:
             server_url = "http://localhost:2026"
     profile_list = list(profiles) if profiles else None

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -88,7 +88,7 @@ services:
       NEXUS_DRAGONFLY_URL: ${NEXUS_DRAGONFLY_URL:-redis://dragonfly:6379}
       NEXUS_CACHE_EMBEDDING_TTL: ${NEXUS_CACHE_EMBEDDING_TTL:-86400}
       # gRPC
-      NEXUS_GRPC_PORT: "${NEXUS_GRPC_PORT:-2028}"
+      NEXUS_GRPC_PORT: "2028"  # Fixed inside container; host port varies via port mapping
       # Zoekt (external container, not built-in sidecar)
       ZOEKT_ENABLED: "false"
       ZOEKT_URL: ${ZOEKT_URL:-http://zoekt:6070}
@@ -96,7 +96,7 @@ services:
       - ${NEXUS_HOST_DATA_DIR:-./nexus-data}:/app/data
     ports:
       - "${NEXUS_PORT:-2026}:2026"
-      - "${NEXUS_GRPC_PORT:-2028}:${NEXUS_GRPC_PORT:-2028}"
+      - "${NEXUS_GRPC_PORT:-2028}:2028"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:2026/health"]
       interval: 10s

--- a/src/nexus/cli/state.py
+++ b/src/nexus/cli/state.py
@@ -1,0 +1,188 @@
+"""Runtime state and project config management.
+
+Centralizes nexus.yaml loading/saving and ``{data_dir}/.state.json``
+read/write so every CLI command shares a single source of truth.
+
+``nexus.yaml`` is the **declarative** project config (checked into git).
+``.state.json`` is **ephemeral** runtime state (gitignored under data_dir):
+resolved ports, active API key, image used, build mode, TLS paths.
+
+Resolution order for any value:
+  1. ``.state.json`` (runtime truth from last ``nexus up``)
+  2. ``nexus.yaml`` (declarative defaults)
+  3. Built-in defaults
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from nexus.cli.utils import console
+
+# ---------------------------------------------------------------------------
+# Shared config search paths (single source of truth — was duplicated in
+# stack.py, status.py, demo_data.py)
+# ---------------------------------------------------------------------------
+
+CONFIG_SEARCH_PATHS = ("./nexus.yaml", "./nexus.yml")
+
+STATE_FILENAME = ".state.json"
+STATE_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Project config (nexus.yaml) — declarative, version-controlled
+# ---------------------------------------------------------------------------
+
+
+def load_project_config() -> dict[str, Any]:
+    """Load the project-local nexus.yaml.
+
+    Searches ``CONFIG_SEARCH_PATHS`` in order.  Prints an error and
+    exits if no config file is found.
+    """
+    for candidate in CONFIG_SEARCH_PATHS:
+        p = Path(candidate)
+        if p.exists():
+            with open(p) as f:
+                return yaml.safe_load(f) or {}
+    console.print("[red]Error:[/red] No nexus.yaml found. Run `nexus init` first.")
+    raise SystemExit(1)
+
+
+def load_project_config_optional() -> dict[str, Any]:
+    """Load nexus.yaml, returning an empty dict if not found."""
+    for candidate in CONFIG_SEARCH_PATHS:
+        p = Path(candidate)
+        if p.exists():
+            with open(p) as f:
+                return yaml.safe_load(f) or {}
+    return {}
+
+
+def save_project_config(config: dict[str, Any], path: str | None = None) -> None:
+    """Persist config back to nexus.yaml.
+
+    Only ``nexus init`` and ``nexus upgrade`` should call this.
+    ``nexus up`` writes runtime state to ``.state.json`` instead.
+    """
+    target = Path(path) if path else None
+    if target is None:
+        for candidate in CONFIG_SEARCH_PATHS:
+            if Path(candidate).exists():
+                target = Path(candidate)
+                break
+    if target is None:
+        target = Path(CONFIG_SEARCH_PATHS[0])
+    with open(target, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Runtime state ({data_dir}/.state.json) — ephemeral, gitignored
+# ---------------------------------------------------------------------------
+
+
+def load_runtime_state(data_dir: str | Path) -> dict[str, Any]:
+    """Load ``{data_dir}/.state.json``.
+
+    Returns an empty dict if the file does not exist or is malformed.
+    """
+    state_path = Path(data_dir) / STATE_FILENAME
+    if not state_path.exists():
+        return {}
+    try:
+        with open(state_path) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def save_runtime_state(data_dir: str | Path, state: dict[str, Any]) -> None:
+    """Atomically write ``{data_dir}/.state.json``.
+
+    Uses write-to-temp + ``os.replace()`` to prevent partial reads from
+    concurrent worktrees or interrupted writes.
+    """
+    data_dir = Path(data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    state_path = data_dir / STATE_FILENAME
+
+    state["version"] = STATE_VERSION
+    if "started_at" not in state:
+        state["started_at"] = datetime.now(UTC).isoformat()
+
+    fd, tmp_path = tempfile.mkstemp(dir=str(data_dir), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(state, f, indent=2)
+        os.replace(tmp_path, str(state_path))
+    except BaseException:
+        # Clean up temp file on any error
+        import contextlib
+
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def resolve_connection_env(
+    config: dict[str, Any],
+    state: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    """Build the connection env var dict from config + runtime state.
+
+    Used by ``nexus env``, ``nexus run``, and the ``nexus up`` output block.
+
+    Resolution: state.json values win over nexus.yaml values.
+    """
+    if state is None:
+        data_dir = config.get("data_dir", "./nexus-data")
+        state = load_runtime_state(data_dir)
+
+    ports = state.get("ports", config.get("ports", {}))
+    api_key = state.get("api_key", config.get("api_key", ""))
+    http_port = ports.get("http", 2026)
+    grpc_port = ports.get("grpc", 2028)
+
+    scheme = "http"
+    tls = state.get("tls", {})
+    if tls.get("cert") or config.get("tls"):
+        scheme = "https"
+
+    env_vars: dict[str, str] = {
+        "NEXUS_URL": f"{scheme}://localhost:{http_port}",
+        "NEXUS_GRPC_HOST": f"localhost:{grpc_port}",
+        "NEXUS_GRPC_PORT": str(grpc_port),
+    }
+
+    if api_key:
+        env_vars["NEXUS_API_KEY"] = api_key
+
+    # TLS paths — prefer state.json (runtime-discovered), fall back to config
+    if tls.get("cert"):
+        env_vars["NEXUS_TLS_CERT"] = tls["cert"]
+        env_vars["NEXUS_TLS_KEY"] = tls.get("key", "")
+        env_vars["NEXUS_TLS_CA"] = tls.get("ca", "")
+    elif config.get("tls_cert"):
+        env_vars["NEXUS_TLS_CERT"] = config["tls_cert"]
+        env_vars["NEXUS_TLS_KEY"] = config.get("tls_key", "")
+        env_vars["NEXUS_TLS_CA"] = config.get("tls_ca", "")
+
+    # DATABASE_URL if postgres is in the service list
+    services = config.get("services", [])
+    if "postgres" in services:
+        pg_port = ports.get("postgres", 5432)
+        env_vars["DATABASE_URL"] = f"postgresql://postgres:nexus@localhost:{pg_port}/nexus"
+
+    return env_vars

--- a/src/nexus/cli/state.py
+++ b/src/nexus/cli/state.py
@@ -155,13 +155,11 @@ def resolve_connection_env(
     http_port = ports.get("http", 2026)
     grpc_port = ports.get("grpc", 2028)
 
-    scheme = "http"
-    tls = state.get("tls", {})
-    if tls.get("cert") or config.get("tls"):
-        scheme = "https"
-
+    # NEXUS_URL is always http:// — the HTTP server does not serve TLS.
+    # TLS is gRPC-only (mTLS for zone federation). The TLS env vars
+    # (NEXUS_TLS_CERT/KEY/CA) are emitted separately for gRPC clients.
     env_vars: dict[str, str] = {
-        "NEXUS_URL": f"{scheme}://localhost:{http_port}",
+        "NEXUS_URL": f"http://localhost:{http_port}",
         "NEXUS_GRPC_HOST": f"localhost:{grpc_port}",
         "NEXUS_GRPC_PORT": str(grpc_port),
     }
@@ -169,7 +167,8 @@ def resolve_connection_env(
     if api_key:
         env_vars["NEXUS_API_KEY"] = api_key
 
-    # TLS paths — prefer state.json (runtime-discovered), fall back to config
+    # TLS paths for gRPC — prefer state.json (runtime-discovered), fall back to config
+    tls = state.get("tls", {})
     if tls.get("cert"):
         env_vars["NEXUS_TLS_CERT"] = tls["cert"]
         env_vars["NEXUS_TLS_KEY"] = tls.get("key", "")

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -8,8 +8,8 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Import OAuthConfig - required for OAuth configuration
-# Canonical path: nexus.bricks.auth.oauth.config (#2281)
-from nexus.bricks.auth.oauth.config import OAuthConfig
+# Canonical path: nexus.contracts.oauth_types (#3230, moved from bricks.auth.oauth.config)
+from nexus.contracts.oauth_types import OAuthConfig
 
 
 class DockerImageTemplate(BaseModel):
@@ -438,9 +438,7 @@ def _load_from_dict(config_dict: dict[str, Any]) -> NexusConfig:
 
     # Convert oauth dict to OAuthConfig if present
     if "oauth" in merged_dict and isinstance(merged_dict["oauth"], dict):
-        from nexus.bricks.auth.oauth.config import OAuthConfig as OAuthConfigType
-
-        merged_dict["oauth"] = OAuthConfigType(**merged_dict["oauth"])
+        merged_dict["oauth"] = OAuthConfig(**merged_dict["oauth"])
 
     return NexusConfig(**merged_dict)
 

--- a/src/nexus/contracts/__init__.py
+++ b/src/nexus/contracts/__init__.py
@@ -82,6 +82,7 @@ from nexus.contracts.metadata import (
     DT_REG,
     FileMetadata,
 )
+from nexus.contracts.oauth_types import OAuthConfig, OAuthProviderConfig
 from nexus.contracts.rebac_types import (
     CROSS_ZONE_ALLOWED_RELATIONS,
     WILDCARD_SUBJECT,
@@ -178,6 +179,9 @@ __all__ = [
     "Describable",
     "WirableFS",
     "WriteObserverProtocol",
+    # OAuth types (Issue #3230)
+    "OAuthConfig",
+    "OAuthProviderConfig",
     # ReBAC types (Issue #2190)
     "CheckResult",
     "CROSS_ZONE_ALLOWED_RELATIONS",

--- a/src/nexus/contracts/oauth_types.py
+++ b/src/nexus/contracts/oauth_types.py
@@ -1,0 +1,98 @@
+"""Tier-neutral OAuth configuration types (Issue #3230).
+
+Canonical home for OAuth configuration Pydantic models used by the config
+system.  Moved from ``nexus.bricks.auth.oauth.config`` so that
+``nexus.config`` can be imported without pulling in the auth brick.
+
+This module has **zero** runtime imports from ``nexus.*`` --- only stdlib
+and pydantic --- so it is safe to include in the slim ``nexus-fs`` package.
+
+Backward-compat shim:
+    - ``nexus.bricks.auth.oauth.config`` re-exports OAuthConfig, OAuthProviderConfig
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class OAuthProviderConfig(BaseModel):
+    """Configuration for a single OAuth provider.
+
+    This defines how to instantiate and configure an OAuth provider,
+    including its class, scopes, and environment variable names
+    for credentials.
+    """
+
+    name: str = Field(
+        description="OAuth provider name/identifier (e.g., 'google', 'microsoft', 'x')"
+    )
+    display_name: str = Field(
+        description="Human-readable display name (e.g., 'Google', 'Microsoft', 'X (Twitter)')"
+    )
+    provider_class: str = Field(
+        description="Fully qualified class path (e.g., 'nexus.server.auth.google_oauth.GoogleOAuthProvider')"
+    )
+    scopes: list[str] = Field(
+        default_factory=list,
+        description="OAuth scopes for this provider",
+    )
+    client_id_env: str = Field(
+        description="Environment variable name for OAuth client ID (e.g., 'NEXUS_OAUTH_GOOGLE_CLIENT_ID')"
+    )
+    client_secret_env: str = Field(
+        description="Environment variable name for OAuth client secret (e.g., 'NEXUS_OAUTH_GOOGLE_CLIENT_SECRET')"
+    )
+    requires_pkce: bool = Field(
+        default=False,
+        description="Whether this provider requires PKCE (Proof Key for Code Exchange)",
+    )
+    icon_url: str | None = Field(
+        default=None,
+        description="URL to provider icon/logo for display in UI",
+    )
+    redirect_uri: str | None = Field(
+        default=None,
+        description="Default OAuth redirect URI (can be overridden via RPC parameter)",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional provider-specific metadata",
+    )
+
+    model_config = {"frozen": False}
+
+
+class OAuthConfig(BaseModel):
+    """OAuth configuration containing all provider configurations."""
+
+    redirect_uri: str | None = Field(
+        default=None,
+        description="Global default OAuth redirect URI (used if provider doesn't specify redirect_uri)",
+    )
+    providers: list[OAuthProviderConfig] = Field(
+        default_factory=list,
+        description="List of OAuth provider configurations",
+    )
+
+    def get_provider_config(self, name: str) -> OAuthProviderConfig | None:
+        """Get provider configuration by name.
+
+        Args:
+            name: Provider name/identifier
+
+        Returns:
+            OAuthProviderConfig if found, None otherwise
+        """
+        for provider in self.providers:
+            if provider.name == name:
+                return provider
+        return None
+
+    def get_all_provider_names(self) -> list[str]:
+        """Get list of all configured provider names.
+
+        Returns:
+            List of provider names
+        """
+        return [provider.name for provider in self.providers]

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -39,6 +39,7 @@ Issue #900, #889, #1665.
 
 import asyncio
 import logging
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.exceptions import AuditLogError
@@ -76,6 +77,45 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _PythonHookRegistry:
+    """Pure-Python fallback when ``nexus_fast`` is unavailable."""
+
+    def __init__(self) -> None:
+        self._hooks: dict[str, list[Any]] = defaultdict(list)
+
+    def register(self, op: str, hook: Any) -> None:
+        self._hooks[op].append(hook)
+
+    def unregister(self, op: str, hook: Any) -> bool:
+        hooks = self._hooks.get(op, [])
+        try:
+            hooks.remove(hook)
+            return True
+        except ValueError:
+            return False
+
+    def count(self, op: str) -> int:
+        return len(self._hooks.get(op, []))
+
+    def get_pre_hooks(self, op: str) -> list[Any]:
+        method = f"on_pre_{op}"
+        return [hook for hook in self._hooks.get(op, []) if hasattr(hook, method)]
+
+    def get_post_hooks(self, op: str) -> tuple[list[Any], list[Any]]:
+        method = f"on_post_{op}"
+        sync_hooks: list[Any] = []
+        async_hooks: list[Any] = []
+        for hook in self._hooks.get(op, []):
+            fn = getattr(hook, method, None)
+            if fn is None:
+                continue
+            if asyncio.iscoroutinefunction(fn):
+                async_hooks.append(hook)
+            else:
+                sync_hooks.append(hook)
+        return sync_hooks, async_hooks
+
+
 class KernelDispatch:
     """Unified three-phase VFS dispatch (PRE-DISPATCH / INTERCEPT / OBSERVE).
 
@@ -110,11 +150,10 @@ class KernelDispatch:
         self._fallback_resolvers: list[VFSPathResolver] = []
         self._next_resolver_idx: int = 0
 
-        # INTERCEPT: Rust HookRegistry caches has_pre/is_async at registration (#1317)
-        if _HookRegistry is None:  # pragma: no cover
-            msg = "nexus_fast.HookRegistry required — build Rust extension first"
-            raise RuntimeError(msg)
-        self._registry: Any = _HookRegistry()
+        # INTERCEPT: prefer Rust HookRegistry, fall back to pure Python for source checkouts.
+        self._registry: Any = (
+            _HookRegistry() if _HookRegistry is not None else _PythonHookRegistry()
+        )
 
         # OBSERVE: generic mutation observers
         self._observers: list[VFSObserver] = []

--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -28,9 +28,80 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
 from typing import Protocol, runtime_checkable
 
-from nexus_fast import RingBufferCore
+try:
+    from nexus_fast import RingBufferCore as _RingBufferCoreType
+except ImportError:  # pragma: no cover
+    _RingBufferCoreType = None
+
+if _RingBufferCoreType is None:  # pragma: no cover
+
+    class _RingBufferCoreFallback:
+        """Pure-Python fallback for source checkouts without ``nexus_fast``."""
+
+        def __init__(self, capacity: int) -> None:
+            self._capacity = capacity
+            self._queue: deque[bytes] = deque()
+            self._used = 0
+            self.closed = False
+
+        def push(self, data: bytes) -> int:
+            if self.closed:
+                raise RuntimeError("PipeClosed:write to closed pipe")
+            if len(data) > self._capacity:
+                raise ValueError("message larger than capacity")
+            if self._used + len(data) > self._capacity:
+                raise RuntimeError("PipeFull:buffer full")
+            payload = bytes(data)
+            self._queue.append(payload)
+            self._used += len(payload)
+            return len(payload)
+
+        def pop(self) -> bytes:
+            if self._queue:
+                payload = self._queue.popleft()
+                self._used -= len(payload)
+                return payload
+            if self.closed:
+                raise RuntimeError("PipeClosed:read from closed pipe")
+            raise RuntimeError("PipeEmpty:buffer empty")
+
+        def push_u64(self, val: int) -> None:
+            self.push(int(val).to_bytes(8, "little", signed=False))
+
+        def pop_u64(self) -> int:
+            payload = self.pop()
+            if len(payload) != 8:
+                raise RuntimeError("PipeEmpty:expected u64 frame")
+            return int.from_bytes(payload, "little", signed=False)
+
+        def is_full(self) -> bool:
+            return self._used >= self._capacity
+
+        def is_empty(self) -> bool:
+            return not self._queue
+
+        def peek(self) -> bytes | None:
+            return self._queue[0] if self._queue else None
+
+        def peek_all(self) -> list[bytes]:
+            return list(self._queue)
+
+        def close(self) -> None:
+            self.closed = True
+
+        def stats(self) -> dict[str, int | bool]:
+            return {
+                "capacity": self._capacity,
+                "used_bytes": self._used,
+                "message_count": len(self._queue),
+                "closed": self.closed,
+            }
+
+    _RingBufferCoreType = _RingBufferCoreFallback
+
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +200,7 @@ class RingBuffer:
         """
         if capacity <= 0:
             raise ValueError(f"capacity must be > 0, got {capacity}")
-        self._core = RingBufferCore(capacity)
+        self._core = _RingBufferCoreType(capacity)
         self._not_empty = asyncio.Event()
         self._not_full = asyncio.Event()
         self._not_full.set()  # initially not full

--- a/src/nexus/sdk/__init__.py
+++ b/src/nexus/sdk/__init__.py
@@ -99,19 +99,12 @@ __all__ = [
 
 # Re-export from core modules with cleaner names
 from pathlib import Path
-from typing import Union
+from typing import Any, Union
 
 from nexus.backends.base.backend import Backend
 from nexus.backends.storage.cas_gcs import CASGCSBackend
 from nexus.backends.storage.cas_local import CASLocalBackend
 from nexus.backends.storage.path_local import PathLocalBackend
-from nexus.bricks.rebac.domain import WILDCARD_SUBJECT, Entity, ReBACTuple
-from nexus.bricks.rebac.enforcer import PermissionEnforcer
-from nexus.bricks.rebac.manager import (
-    CheckResult,
-    GraphLimitExceeded,
-    ReBACManager,
-)
 from nexus.config import NexusConfig as Config
 from nexus.config import load_config
 from nexus.contracts.exceptions import (
@@ -128,8 +121,61 @@ from nexus.contracts.exceptions import (
     NexusPermissionError as PermissionError,
 )
 from nexus.contracts.filesystem.filesystem_abc import NexusFilesystemABC as Filesystem
+
+# ReBAC types canonical in contracts — always available (#3230)
+from nexus.contracts.rebac_types import WILDCARD_SUBJECT, CheckResult, Entity, GraphLimitExceeded
 from nexus.contracts.types import OperationContext
 from nexus.core.nexus_fs import NexusFS
+
+# =============================================================================
+# LAZY IMPORTS for optional bricks (#3230)
+# =============================================================================
+# These ReBAC implementation types require the rebac brick to be installed.
+# They are loaded on-demand via __getattr__ to allow `import nexus.sdk` to
+# succeed without bricks.rebac installed.
+
+_LAZY_REBAC_IMPORTS: dict[str, tuple[str, str]] = {
+    "ReBACTuple": ("nexus.bricks.rebac.domain", "ReBACTuple"),
+    "PermissionEnforcer": ("nexus.bricks.rebac.enforcer", "PermissionEnforcer"),
+    "ReBACManager": ("nexus.bricks.rebac.manager", "ReBACManager"),
+}
+
+_lazy_imports_cache: dict[str, Any] = {}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import for optional brick dependencies.
+
+    ReBAC implementation types (ReBACTuple, PermissionEnforcer, ReBACManager)
+    are loaded on first access. If the rebac brick is not installed, a clear
+    ImportError is raised.
+    """
+    if name in _lazy_imports_cache:
+        return _lazy_imports_cache[name]
+
+    if name in _LAZY_REBAC_IMPORTS:
+        module_path, attr_name = _LAZY_REBAC_IMPORTS[name]
+        import importlib
+
+        try:
+            module = importlib.import_module(module_path)
+        except ModuleNotFoundError as exc:
+            raise ImportError(
+                f"nexus.sdk.{name} requires the ReBAC brick. "
+                f"Install it with: pip install nexus[rebac]"
+            ) from exc
+        value = getattr(module, attr_name)
+        _lazy_imports_cache[name] = value
+        return value
+
+    raise AttributeError(f"module 'nexus.sdk' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Include lazy imports in dir() for discoverability."""
+    module_attrs = list(globals().keys())
+    module_attrs.extend(_LAZY_REBAC_IMPORTS.keys())
+    return module_attrs
 
 
 async def connect(

--- a/src/nexus/storage/piped_record_store_write_observer.py
+++ b/src/nexus/storage/piped_record_store_write_observer.py
@@ -127,10 +127,13 @@ class PipedRecordStoreWriteObserver:
             return  # CLI mode — no NexusFS
 
         from nexus.contracts.metadata import DT_PIPE
+        from nexus.contracts.types import OperationContext
 
+        ctx = OperationContext(user_id="system", groups=[], is_system=True)
         with contextlib.suppress(Exception):
             await self._nx.sys_setattr(
                 _AUDIT_PIPE_PATH,
+                context=ctx,
                 entry_type=DT_PIPE,
                 owner_id="kernel",
             )

--- a/src/nexus/storage/time_travel.py
+++ b/src/nexus/storage/time_travel.py
@@ -343,13 +343,13 @@ class TimeTravelReader:
 
         if state_1 and state_2:
             content_changed = state_1["content"] != state_2["content"]
-            size_diff = state_2["metadata"]["size"] - state_1["metadata"]["size"]
+            size_diff = len(state_2["content"]) - len(state_1["content"])
         elif state_1 and not state_2:
             # File was deleted
-            size_diff = -state_1["metadata"]["size"]
+            size_diff = -len(state_1["content"])
         elif not state_1 and state_2:
             # File was created
-            size_diff = state_2["metadata"]["size"]
+            size_diff = len(state_2["content"])
         else:
             # File doesn't exist at either point
             content_changed = False

--- a/src/nexus/storage/write_observer_hooks.py
+++ b/src/nexus/storage/write_observer_hooks.py
@@ -254,7 +254,10 @@ class AuditWriteInterceptor:
         """Serialize event to JSON and write to pipe via sys_write."""
         try:
             data = json.dumps(event).encode()
-            await self._nx.sys_write(self._pipe_path, data)
+            from nexus.contracts.types import OperationContext
+
+            ctx = OperationContext(user_id="system", groups=[], is_system=True)
+            await self._nx.sys_write(self._pipe_path, data, context=ctx)
         except Exception as e:
             from nexus.contracts.exceptions import AuditLogError
 

--- a/tests/unit/cli/test_cli_quickstart.py
+++ b/tests/unit/cli/test_cli_quickstart.py
@@ -1,15 +1,10 @@
-"""Regression tests for the documented local CLI quickstart.
-
-Note: test_local_cli_quickstart_persists_across_invocations is xfail
-due to redb/PyO3 metastore persistence timing issues (flaky in full suite).
-"""
+"""Regression tests for the documented local CLI quickstart."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import click
-import pytest
 from click.testing import CliRunner
 
 from nexus.cli.commands import LazyCommandGroup, register_all_commands
@@ -17,10 +12,6 @@ from nexus.cli.main import main
 from nexus.raft import zone_manager
 
 
-@pytest.mark.xfail(
-    reason="Metastore persistence across CLI invocations unreliable — flaky in full suite (redb/PyO3 timing)",
-    strict=False,
-)
 def test_local_cli_quickstart_persists_across_invocations(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/cli/test_env_cmd.py
+++ b/tests/unit/cli/test_env_cmd.py
@@ -1,0 +1,185 @@
+"""Tests for nexus.cli.commands.env_cmd — nexus env and nexus run."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from nexus.cli.commands.env_cmd import (
+    _detect_shell,
+    _format_dotenv,
+    _format_shell,
+    env_cmd,
+    run,
+)
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    """Create a minimal nexus project with config and state."""
+    data_dir = tmp_path / "nexus-data"
+    data_dir.mkdir()
+
+    config = {
+        "preset": "shared",
+        "data_dir": str(data_dir),
+        "services": ["nexus", "postgres"],
+        "ports": {"http": 2026, "grpc": 2028, "postgres": 5432},
+        "api_key": "sk-test-key",
+    }
+    cfg_path = tmp_path / "nexus.yaml"
+    cfg_path.write_text(yaml.dump(config))
+
+    # Write state.json with resolved ports
+    import json as _json
+
+    state = {
+        "version": 1,
+        "ports": {"http": 3026, "grpc": 3028, "postgres": 5433},
+        "api_key": "sk-runtime-key",
+        "build_mode": "local",
+        "image_used": "nexus:local-abc12345",
+    }
+    (data_dir / ".state.json").write_text(_json.dumps(state))
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Shell formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatShell:
+    def test_bash(self) -> None:
+        env = {"NEXUS_URL": "http://localhost:2026", "NEXUS_API_KEY": "sk-abc"}
+        output = _format_shell(env, "bash")
+        assert "export NEXUS_API_KEY='sk-abc'" in output
+        assert "export NEXUS_URL='http://localhost:2026'" in output
+
+    def test_fish(self) -> None:
+        env = {"NEXUS_URL": "http://localhost:2026"}
+        output = _format_shell(env, "fish")
+        assert "set -gx NEXUS_URL 'http://localhost:2026';" in output
+
+    def test_powershell(self) -> None:
+        env = {"NEXUS_URL": "http://localhost:2026"}
+        output = _format_shell(env, "powershell")
+        assert "$env:NEXUS_URL = 'http://localhost:2026'" in output
+
+
+class TestFormatDotenv:
+    def test_basic(self) -> None:
+        env = {"NEXUS_URL": "http://localhost:2026", "NEXUS_API_KEY": "sk-abc"}
+        output = _format_dotenv(env)
+        assert "NEXUS_API_KEY=sk-abc" in output
+        assert "NEXUS_URL=http://localhost:2026" in output
+        assert "export" not in output
+
+
+class TestDetectShell:
+    def test_bash(self) -> None:
+        with patch.dict("os.environ", {"SHELL": "/bin/bash"}):
+            assert _detect_shell() == "bash"
+
+    def test_zsh(self) -> None:
+        with patch.dict("os.environ", {"SHELL": "/bin/zsh"}):
+            assert _detect_shell() == "zsh"
+
+    def test_fish(self) -> None:
+        with patch.dict("os.environ", {"SHELL": "/usr/bin/fish"}):
+            assert _detect_shell() == "fish"
+
+    def test_unknown_defaults_bash(self) -> None:
+        with patch.dict("os.environ", {"SHELL": "/usr/bin/custom-shell"}):
+            assert _detect_shell() == "bash"
+
+
+# ---------------------------------------------------------------------------
+# nexus env command
+# ---------------------------------------------------------------------------
+
+
+class TestEnvCommand:
+    def test_default_output(self, runner: CliRunner, project_dir: Path) -> None:
+        with patch(
+            "nexus.cli.state.CONFIG_SEARCH_PATHS",
+            (str(project_dir / "nexus.yaml"),),
+        ):
+            result = runner.invoke(env_cmd)
+        assert result.exit_code == 0
+        # State.json ports should win over config ports
+        assert "3026" in result.output
+        assert "sk-runtime-key" in result.output
+        assert "export" in result.output
+
+    def test_json_output(self, runner: CliRunner, project_dir: Path) -> None:
+        with patch(
+            "nexus.cli.state.CONFIG_SEARCH_PATHS",
+            (str(project_dir / "nexus.yaml"),),
+        ):
+            result = runner.invoke(env_cmd, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["NEXUS_URL"] == "http://localhost:3026"
+        assert data["NEXUS_API_KEY"] == "sk-runtime-key"
+
+    def test_dotenv_output(self, runner: CliRunner, project_dir: Path) -> None:
+        with patch(
+            "nexus.cli.state.CONFIG_SEARCH_PATHS",
+            (str(project_dir / "nexus.yaml"),),
+        ):
+            result = runner.invoke(env_cmd, ["--dotenv"])
+        assert result.exit_code == 0
+        assert "export" not in result.output
+        assert "NEXUS_URL=http://localhost:3026" in result.output
+
+    def test_fish_shell(self, runner: CliRunner, project_dir: Path) -> None:
+        with patch(
+            "nexus.cli.state.CONFIG_SEARCH_PATHS",
+            (str(project_dir / "nexus.yaml"),),
+        ):
+            result = runner.invoke(env_cmd, ["--shell", "fish"])
+        assert result.exit_code == 0
+        assert "set -gx" in result.output
+
+    def test_no_config_exits(self, runner: CliRunner, tmp_path: Path) -> None:
+        with patch(
+            "nexus.cli.state.CONFIG_SEARCH_PATHS",
+            (str(tmp_path / "nope.yaml"),),
+        ):
+            result = runner.invoke(env_cmd)
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# nexus run command
+# ---------------------------------------------------------------------------
+
+
+class TestRunCommand:
+    def test_run_echo(self, runner: CliRunner, project_dir: Path) -> None:
+        with patch(
+            "nexus.cli.state.CONFIG_SEARCH_PATHS",
+            (str(project_dir / "nexus.yaml"),),
+        ):
+            result = runner.invoke(run, ["echo", "hello"])
+        assert result.exit_code == 0
+
+    def test_run_missing_command(self, runner: CliRunner, project_dir: Path) -> None:
+        with patch(
+            "nexus.cli.state.CONFIG_SEARCH_PATHS",
+            (str(project_dir / "nexus.yaml"),),
+        ):
+            result = runner.invoke(run, ["nonexistent-command-xyz"])
+        assert result.exit_code == 127

--- a/tests/unit/cli/test_env_cmd.py
+++ b/tests/unit/cli/test_env_cmd.py
@@ -67,15 +67,31 @@ class TestFormatShell:
         assert "export NEXUS_API_KEY='sk-abc'" in output
         assert "export NEXUS_URL='http://localhost:2026'" in output
 
+    def test_bash_escapes_single_quotes(self) -> None:
+        env = {"VAL": "it's a test"}
+        output = _format_shell(env, "bash")
+        # bash: single quotes escaped as '\''
+        assert "it'\\''s a test" in output
+
     def test_fish(self) -> None:
         env = {"NEXUS_URL": "http://localhost:2026"}
         output = _format_shell(env, "fish")
         assert "set -gx NEXUS_URL 'http://localhost:2026';" in output
 
+    def test_fish_escapes_single_quotes(self) -> None:
+        env = {"VAL": "it's a test"}
+        output = _format_shell(env, "fish")
+        assert "it\\'s a test" in output
+
     def test_powershell(self) -> None:
         env = {"NEXUS_URL": "http://localhost:2026"}
         output = _format_shell(env, "powershell")
         assert "$env:NEXUS_URL = 'http://localhost:2026'" in output
+
+    def test_powershell_escapes_single_quotes(self) -> None:
+        env = {"VAL": "it's a test"}
+        output = _format_shell(env, "powershell")
+        assert "it''s a test" in output
 
 
 class TestFormatDotenv:
@@ -85,6 +101,12 @@ class TestFormatDotenv:
         assert "NEXUS_API_KEY=sk-abc" in output
         assert "NEXUS_URL=http://localhost:2026" in output
         assert "export" not in output
+
+    def test_quotes_special_chars(self) -> None:
+        env = {"VAL": "has spaces", "QUOTE": 'has"quote'}
+        output = _format_dotenv(env)
+        assert 'QUOTE="has\\"quote"' in output
+        assert 'VAL="has spaces"' in output
 
 
 class TestDetectShell:

--- a/tests/unit/cli/test_init_cmd.py
+++ b/tests/unit/cli/test_init_cmd.py
@@ -238,6 +238,22 @@ class TestBuildConfig:
         assert "nexus" in cfg["services"]
         assert "postgres" in cfg["services"]
 
+
+class TestInitWorkspaceArg:
+    def test_positional_workspace_sets_config_and_data_dir(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "demo-workspace"
+
+        result = runner.invoke(init, [str(workspace)])
+
+        assert result.exit_code == 0, result.output
+        cfg = yaml.safe_load((workspace / "nexus.yaml").read_text())
+        assert Path(cfg["data_dir"]) == (workspace / "nexus-data").resolve()
+        assert (workspace / "nexus-data").exists()
+
     def test_channel_override(self) -> None:
         cfg = _build_config("shared", "./data", False, {}, (), channel="edge")
         assert cfg["image_channel"] == "edge"

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -13,14 +13,21 @@ from click.testing import CliRunner
 from nexus.cli.commands.stack import (
     _compose_profiles,
     _derive_project_env,
-    _load_project_config,
     _resolve_image_ref_from_config,
     _resolve_profiles,
-    _save_project_config,
     down,
     up,
     upgrade,
 )
+from nexus.cli.state import (
+    load_project_config as _load_project_config,
+)
+from nexus.cli.state import (
+    save_project_config as _save_project_config,
+)
+
+# The canonical patch target for CONFIG_SEARCH_PATHS is now nexus.cli.state
+_CONFIG_PATCH = "nexus.cli.state.CONFIG_SEARCH_PATHS"
 
 
 @pytest.fixture()
@@ -61,7 +68,7 @@ def shared_config(tmp_path: Path) -> Path:
 class TestConfigLoading:
     def test_load_project_config(self, shared_config: Path) -> None:
         with patch(
-            "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+            _CONFIG_PATCH,
             (str(shared_config / "nexus.yaml"),),
         ):
             config = _load_project_config()
@@ -70,7 +77,7 @@ class TestConfigLoading:
     def test_load_project_config_missing(self, tmp_path: Path) -> None:
         with (
             patch(
-                "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+                _CONFIG_PATCH,
                 (str(tmp_path / "nope.yaml"),),
             ),
             pytest.raises(SystemExit),
@@ -80,7 +87,7 @@ class TestConfigLoading:
     def test_save_project_config(self, shared_config: Path) -> None:
         cfg_path = shared_config / "nexus.yaml"
         with patch(
-            "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+            _CONFIG_PATCH,
             (str(cfg_path),),
         ):
             _save_project_config({"preset": "demo", "auth": "database"})
@@ -224,7 +231,7 @@ class TestUpCommand:
             yaml.dump(cfg, f)
 
         with patch(
-            "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+            _CONFIG_PATCH,
             (str(cfg_path),),
         ):
             result = runner.invoke(up)
@@ -243,7 +250,7 @@ class TestUpCommand:
         with open(cfg_path, "w") as f:
             yaml.dump(cfg, f)
         with patch(
-            "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+            _CONFIG_PATCH,
             (str(cfg_path),),
         ):
             result = runner.invoke(up)
@@ -279,8 +286,7 @@ class TestDeriveProjectEnv:
         assert env["POSTGRES_PORT"] == "5432"
         assert env["NEXUS_HOST_DATA_DIR"] == str(tmp_path / "data")
         assert env["NEXUS_AUTH_TYPE"] == "database"
-        # TLS is auto-detected from disk, no env vars
-        assert "NEXUS_TLS_CERT" not in env
+        assert env["NEXUS_GRPC_TLS"] == "false"
 
     def test_image_ref_in_env(self, tmp_path: Path) -> None:
         """image_ref from config is passed as NEXUS_IMAGE_REF."""
@@ -319,12 +325,17 @@ class TestDeriveProjectEnv:
         assert env["NEXUS_PORT"] == "3026"
         assert env["NEXUS_GRPC_PORT"] == "3028"
 
-    def test_tls_config_ignored(self, tmp_path: Path) -> None:
-        """TLS config key no longer produces env vars (auto-detected from disk)."""
+    def test_tls_sets_grpc_tls_flag(self, tmp_path: Path) -> None:
+        """TLS config sets NEXUS_GRPC_TLS explicitly."""
         config = {"data_dir": str(tmp_path / "data"), "tls": True, "ports": {}}
         env = _derive_project_env(config)
-        assert "NEXUS_TLS_ENABLED" not in env
-        assert "NEXUS_TLS_CERT" not in env
+        assert env["NEXUS_GRPC_TLS"] == "true"
+
+    def test_no_tls_sets_grpc_tls_false(self, tmp_path: Path) -> None:
+        """Non-TLS config explicitly disables gRPC TLS."""
+        config = {"data_dir": str(tmp_path / "data"), "tls": False, "ports": {}}
+        env = _derive_project_env(config)
+        assert env["NEXUS_GRPC_TLS"] == "false"
 
     def test_deterministic_project_name(self, tmp_path: Path) -> None:
         """Same data_dir always produces same project name."""
@@ -389,7 +400,7 @@ class TestDownCommand:
         with open(cfg_path, "w") as f:
             yaml.dump(cfg, f)
         with patch(
-            "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+            _CONFIG_PATCH,
             (str(cfg_path),),
         ):
             result = runner.invoke(down)
@@ -409,7 +420,7 @@ class TestUpgradeCommand:
         with open(cfg_path, "w") as f:
             yaml.dump(cfg, f)
         with patch(
-            "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+            _CONFIG_PATCH,
             (str(cfg_path),),
         ):
             result = runner.invoke(upgrade)
@@ -429,7 +440,7 @@ class TestUpgradeCommand:
 
         with (
             patch(
-                "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+                _CONFIG_PATCH,
                 (str(cfg_path),),
             ),
             patch(
@@ -447,7 +458,7 @@ class TestUpgradeCommand:
         mock_result.returncode = 0
         with (
             patch(
-                "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+                _CONFIG_PATCH,
                 (str(shared_config / "nexus.yaml"),),
             ),
             patch(
@@ -470,7 +481,7 @@ class TestUpgradeCommand:
     def test_upgrade_with_yes_flag(self, runner: CliRunner, shared_config: Path) -> None:
         with (
             patch(
-                "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+                _CONFIG_PATCH,
                 (str(shared_config / "nexus.yaml"),),
             ),
             patch(
@@ -502,7 +513,7 @@ class TestUpgradeCommand:
 
         with (
             patch(
-                "nexus.cli.commands.stack.CONFIG_SEARCH_PATHS",
+                _CONFIG_PATCH,
                 (str(cfg_path),),
             ),
             patch(
@@ -517,3 +528,336 @@ class TestUpgradeCommand:
                 cfg = yaml.safe_load(f)
             assert "image_tag" not in cfg
             assert cfg["image_ref"] == "ghcr.io/nexi-lab/nexus:0.10.0"
+
+
+# ---------------------------------------------------------------------------
+# `nexus stop` / `nexus start` tests
+# ---------------------------------------------------------------------------
+
+
+class TestStopCommand:
+    def test_local_preset_warns(self, runner: CliRunner, tmp_path: Path) -> None:
+        cfg = {"preset": "local"}
+        cfg_path = tmp_path / "nexus.yaml"
+        with open(cfg_path, "w") as f:
+            yaml.dump(cfg, f)
+        from nexus.cli.commands.stack import stop
+
+        with patch(_CONFIG_PATCH, (str(cfg_path),)):
+            result = runner.invoke(stop)
+            assert result.exit_code == 0
+            assert "no Docker services" in result.output
+
+    def test_shared_preset_calls_compose_stop(self, runner: CliRunner, shared_config: Path) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        from nexus.cli.commands.stack import stop
+
+        with (
+            patch(_CONFIG_PATCH, (str(shared_config / "nexus.yaml"),)),
+            patch(
+                "nexus.cli.commands.stack._run_compose", return_value=mock_result
+            ) as mock_compose,
+        ):
+            result = runner.invoke(stop)
+            assert result.exit_code == 0
+            assert "paused" in result.output.lower()
+            mock_compose.assert_called_once()
+            call_args = mock_compose.call_args
+            assert "stop" in call_args[0]
+
+
+class TestStartCommand:
+    def test_local_preset_warns(self, runner: CliRunner, tmp_path: Path) -> None:
+        cfg = {"preset": "local"}
+        cfg_path = tmp_path / "nexus.yaml"
+        with open(cfg_path, "w") as f:
+            yaml.dump(cfg, f)
+        from nexus.cli.commands.stack import start
+
+        with patch(_CONFIG_PATCH, (str(cfg_path),)):
+            result = runner.invoke(start)
+            assert result.exit_code == 0
+            assert "no Docker services" in result.output
+
+    def test_shared_preset_calls_compose_start(
+        self, runner: CliRunner, shared_config: Path
+    ) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        from nexus.cli.commands.stack import start
+
+        with (
+            patch(_CONFIG_PATCH, (str(shared_config / "nexus.yaml"),)),
+            patch(
+                "nexus.cli.commands.stack._run_compose", return_value=mock_result
+            ) as mock_compose,
+        ):
+            result = runner.invoke(start)
+            assert result.exit_code == 0
+            assert "resumed" in result.output.lower()
+            mock_compose.assert_called_once()
+            call_args = mock_compose.call_args
+            assert "start" in call_args[0]
+
+
+# ---------------------------------------------------------------------------
+# Port reuse from .state.json
+# ---------------------------------------------------------------------------
+
+
+class TestPortReuse:
+    """Verify that nexus up reuses ports from .state.json when containers are running."""
+
+    def test_reuses_ports_when_all_bound(self, tmp_path: Path) -> None:
+        """When all previous ports are still in use, skip re-resolution."""
+        from nexus.cli.state import save_runtime_state
+
+        data_dir = tmp_path / "nexus-data"
+        data_dir.mkdir()
+
+        # Write state with specific ports
+        save_runtime_state(
+            data_dir,
+            {
+                "ports": {"http": 9990, "grpc": 9991},
+                "project_name": "nexus-test1234",
+                "build_mode": "remote",
+            },
+        )
+
+        # Mock all state.json ports as "in use" (bound by our containers)
+        with patch("nexus.cli.commands.stack.check_port_available", return_value=False):
+            from nexus.cli.state import load_runtime_state
+
+            state = load_runtime_state(data_dir)
+            prev_ports = state.get("ports", {})
+            # Simulate the logic from the up command
+            all_prev_bound = all(
+                not False  # check_port_available returns False → port in use
+                for p in prev_ports.values()
+                if isinstance(p, int)
+            )
+            assert all_prev_bound
+            assert prev_ports["http"] == 9990
+            assert prev_ports["grpc"] == 9991
+
+    def test_re_resolves_when_ports_freed(self, tmp_path: Path) -> None:
+        """When previous ports are free (containers stopped), re-resolve."""
+        from nexus.cli.state import save_runtime_state
+
+        data_dir = tmp_path / "nexus-data"
+        data_dir.mkdir()
+
+        save_runtime_state(
+            data_dir,
+            {
+                "ports": {"http": 9990, "grpc": 9991},
+                "project_name": "nexus-test1234",
+            },
+        )
+
+        # All ports are available (containers stopped)
+        with patch("nexus.cli.commands.stack.check_port_available", return_value=True):
+            from nexus.cli.state import load_runtime_state
+
+            state = load_runtime_state(data_dir)
+            prev_ports = state.get("ports", {})
+            all_prev_bound = all(
+                not True  # check_port_available returns True → port is free
+                for p in prev_ports.values()
+                if isinstance(p, int)
+            )
+            assert not all_prev_bound  # → should re-resolve
+
+
+# ---------------------------------------------------------------------------
+# Local build mode persistence
+# ---------------------------------------------------------------------------
+
+
+class TestLocalBuildMode:
+    """Verify that build mode is tracked in .state.json and reused."""
+
+    def test_state_records_build_mode(self, tmp_path: Path) -> None:
+        from nexus.cli.state import load_runtime_state, save_runtime_state
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        save_runtime_state(
+            data_dir,
+            {
+                "build_mode": "local",
+                "image_used": "nexus:local-abc12345",
+                "ports": {},
+            },
+        )
+        state = load_runtime_state(data_dir)
+        assert state["build_mode"] == "local"
+        assert state["image_used"] == "nexus:local-abc12345"
+
+    def test_pull_flag_clears_local_mode(self) -> None:
+        """When --pull is passed, using_local_build should be False."""
+        # Simulate the logic from up()
+        prev_state = {"build_mode": "local", "image_used": "nexus:local-abc12345"}
+        force_pull = True
+        using_local_build = False
+
+        if prev_state.get("build_mode") == "local" and force_pull is not True:
+            using_local_build = True
+
+        if force_pull:
+            using_local_build = False
+
+        assert not using_local_build
+
+    def test_no_pull_reuses_local_build(self) -> None:
+        """Without --pull, local build mode should be detected and reused."""
+        prev_state = {"build_mode": "local", "image_used": "nexus:local-abc12345"}
+        force_pull = None
+        using_local_build = False
+
+        build = None
+        if build is None:
+            if prev_state.get("build_mode") == "local" and force_pull is not True:
+                using_local_build = True
+            build = False
+
+        assert using_local_build
+
+    def test_remote_mode_does_not_reuse(self) -> None:
+        """Remote build mode should not trigger local reuse."""
+        prev_state = {"build_mode": "remote", "image_used": "ghcr.io/nexi-lab/nexus:edge"}
+        force_pull = None
+        using_local_build = False
+
+        build = None
+        if build is None:
+            if prev_state.get("build_mode") == "local" and force_pull is not True:
+                using_local_build = True
+            build = False
+
+        assert not using_local_build
+
+
+# ---------------------------------------------------------------------------
+# TLS auto-discovery in nexus up
+# ---------------------------------------------------------------------------
+
+
+class TestTlsAutoDiscovery:
+    """Verify TLS cert paths are discovered and written to state.json."""
+
+    def test_raft_style_certs(self, tmp_path: Path) -> None:
+        """Raft-generated certs (ca.pem, node.pem, node-key.pem) are discovered."""
+        tls_dir = tmp_path / "tls"
+        tls_dir.mkdir()
+        (tls_dir / "ca.pem").write_text("ca")
+        (tls_dir / "node.pem").write_text("cert")
+        (tls_dir / "node-key.pem").write_text("key")
+
+        # Simulate the discovery logic from up()
+        tls_state: dict[str, str] = {}
+        if tls_dir.exists():
+            if (tls_dir / "ca.pem").exists():
+                tls_state = {
+                    "cert": str(tls_dir / "node.pem"),
+                    "key": str(tls_dir / "node-key.pem"),
+                    "ca": str(tls_dir / "ca.pem"),
+                }
+            elif (tls_dir / "ca.crt").exists():
+                tls_state = {
+                    "cert": str(tls_dir / "server.crt"),
+                    "key": str(tls_dir / "server.key"),
+                    "ca": str(tls_dir / "ca.crt"),
+                }
+
+        assert tls_state["cert"].endswith("node.pem")
+        assert tls_state["ca"].endswith("ca.pem")
+
+    def test_openssl_style_certs(self, tmp_path: Path) -> None:
+        """OpenSSL-generated certs (ca.crt, server.crt, server.key) are discovered."""
+        tls_dir = tmp_path / "tls"
+        tls_dir.mkdir()
+        (tls_dir / "ca.crt").write_text("ca")
+        (tls_dir / "server.crt").write_text("cert")
+        (tls_dir / "server.key").write_text("key")
+
+        tls_state: dict[str, str] = {}
+        if tls_dir.exists():
+            if (tls_dir / "ca.pem").exists():
+                tls_state = {
+                    "cert": str(tls_dir / "node.pem"),
+                    "key": str(tls_dir / "node-key.pem"),
+                    "ca": str(tls_dir / "ca.pem"),
+                }
+            elif (tls_dir / "ca.crt").exists():
+                tls_state = {
+                    "cert": str(tls_dir / "server.crt"),
+                    "key": str(tls_dir / "server.key"),
+                    "ca": str(tls_dir / "ca.crt"),
+                }
+
+        assert tls_state["cert"].endswith("server.crt")
+        assert tls_state["ca"].endswith("ca.crt")
+
+    def test_no_certs_empty_state(self, tmp_path: Path) -> None:
+        """No TLS dir → empty tls state."""
+        tls_dir = tmp_path / "tls"
+        tls_state: dict[str, str] = {}
+        if tls_dir.exists() and (tls_dir / "ca.pem").exists():
+            tls_state = {"cert": "", "key": "", "ca": ""}
+
+        assert tls_state == {}
+
+
+# ---------------------------------------------------------------------------
+# nexus status reads ports from state.json
+# ---------------------------------------------------------------------------
+
+
+class TestStatusPortResolution:
+    """Verify nexus status reads ports from state.json / nexus.yaml."""
+
+    def test_uses_state_json_port(self, tmp_path: Path) -> None:
+        from nexus.cli.state import save_runtime_state
+
+        data_dir = tmp_path / "nexus-data"
+        data_dir.mkdir()
+        save_runtime_state(data_dir, {"ports": {"http": 9876}})
+
+        config = {"data_dir": str(data_dir), "ports": {"http": 2026}}
+
+        from nexus.cli.state import load_runtime_state
+
+        state = load_runtime_state(data_dir)
+        ports = state.get("ports", config.get("ports", {}))
+        http_port = ports.get("http", 2026)
+        assert http_port == 9876  # from state, not config
+
+    def test_falls_back_to_config_port(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "nexus-data"
+        data_dir.mkdir()
+        # No state.json
+
+        config = {"data_dir": str(data_dir), "ports": {"http": 3333}}
+
+        from nexus.cli.state import load_runtime_state
+
+        state = load_runtime_state(data_dir)
+        ports = state.get("ports", config.get("ports", {}))
+        http_port = ports.get("http", 2026)
+        assert http_port == 3333  # from config
+
+    def test_falls_back_to_default(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "nexus-data"
+        data_dir.mkdir()
+
+        config = {"data_dir": str(data_dir)}
+
+        from nexus.cli.state import load_runtime_state
+
+        state = load_runtime_state(data_dir)
+        ports = state.get("ports", config.get("ports", {}))
+        http_port = ports.get("http", 2026)
+        assert http_port == 2026  # default

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -607,16 +607,15 @@ class TestStartCommand:
 
 
 class TestPortReuse:
-    """Verify that nexus up reuses ports from .state.json when containers are running."""
+    """Verify that nexus up reuses ports based on compose project ownership."""
 
-    def test_reuses_ports_when_all_bound(self, tmp_path: Path) -> None:
-        """When all previous ports are still in use, skip re-resolution."""
+    def test_reuses_ports_when_project_running(self, tmp_path: Path) -> None:
+        """When our compose project has running containers, reuse state ports."""
         from nexus.cli.state import save_runtime_state
 
         data_dir = tmp_path / "nexus-data"
         data_dir.mkdir()
 
-        # Write state with specific ports
         save_runtime_state(
             data_dir,
             {
@@ -626,24 +625,24 @@ class TestPortReuse:
             },
         )
 
-        # Mock all state.json ports as "in use" (bound by our containers)
-        with patch("nexus.cli.commands.stack.check_port_available", return_value=False):
+        # Simulate `docker compose -p nexus-test1234 ps -q` returning container IDs
+        mock_result = MagicMock()
+        mock_result.stdout = "abc123\ndef456\n"
+        mock_result.returncode = 0
+
+        with patch("nexus.cli.commands.stack.subprocess.run", return_value=mock_result):
             from nexus.cli.state import load_runtime_state
 
             state = load_runtime_state(data_dir)
             prev_ports = state.get("ports", {})
-            # Simulate the logic from the up command
-            all_prev_bound = all(
-                not False  # check_port_available returns False → port in use
-                for p in prev_ports.values()
-                if isinstance(p, int)
-            )
-            assert all_prev_bound
+            # Simulate the ownership check logic from up()
+            has_running = bool(mock_result.stdout.strip())
+            assert has_running
             assert prev_ports["http"] == 9990
             assert prev_ports["grpc"] == 9991
 
-    def test_re_resolves_when_ports_freed(self, tmp_path: Path) -> None:
-        """When previous ports are free (containers stopped), re-resolve."""
+    def test_re_resolves_when_no_containers(self, tmp_path: Path) -> None:
+        """When our compose project has no running containers, re-resolve ports."""
         from nexus.cli.state import save_runtime_state
 
         data_dir = tmp_path / "nexus-data"
@@ -657,18 +656,26 @@ class TestPortReuse:
             },
         )
 
-        # All ports are available (containers stopped)
-        with patch("nexus.cli.commands.stack.check_port_available", return_value=True):
-            from nexus.cli.state import load_runtime_state
+        # Simulate `docker compose ps -q` returning empty (no containers)
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
 
-            state = load_runtime_state(data_dir)
-            prev_ports = state.get("ports", {})
-            all_prev_bound = all(
-                not True  # check_port_available returns True → port is free
-                for p in prev_ports.values()
-                if isinstance(p, int)
-            )
-            assert not all_prev_bound  # → should re-resolve
+        with patch("nexus.cli.commands.stack.subprocess.run", return_value=mock_result):
+            has_running = bool(mock_result.stdout.strip())
+            assert not has_running  # → should re-resolve
+
+    def test_re_resolves_when_no_state(self, tmp_path: Path) -> None:
+        """When no .state.json exists, always resolve from config."""
+        from nexus.cli.state import load_runtime_state
+
+        data_dir = tmp_path / "nexus-data"
+        data_dir.mkdir()
+
+        state = load_runtime_state(data_dir)
+        assert state.get("ports") is None
+        assert state.get("project_name") is None
+        # No prev_ports → falls through to resolve_ports()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_state.py
+++ b/tests/unit/cli/test_state.py
@@ -1,0 +1,195 @@
+"""Tests for nexus.cli.state — runtime state and config management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from nexus.cli.state import (
+    STATE_FILENAME,
+    load_project_config,
+    load_project_config_optional,
+    load_runtime_state,
+    resolve_connection_env,
+    save_project_config,
+    save_runtime_state,
+)
+
+# ---------------------------------------------------------------------------
+# load_project_config / save_project_config
+# ---------------------------------------------------------------------------
+
+
+class TestProjectConfig:
+    def test_load_existing(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "nexus.yaml"
+        cfg_path.write_text(yaml.dump({"preset": "shared"}))
+        with patch("nexus.cli.state.CONFIG_SEARCH_PATHS", (str(cfg_path),)):
+            config = load_project_config()
+        assert config["preset"] == "shared"
+
+    def test_load_missing_exits(self, tmp_path: Path) -> None:
+        with (
+            patch("nexus.cli.state.CONFIG_SEARCH_PATHS", (str(tmp_path / "nope.yaml"),)),
+            pytest.raises(SystemExit),
+        ):
+            load_project_config()
+
+    def test_load_optional_missing(self, tmp_path: Path) -> None:
+        with patch("nexus.cli.state.CONFIG_SEARCH_PATHS", (str(tmp_path / "nope.yaml"),)):
+            config = load_project_config_optional()
+        assert config == {}
+
+    def test_load_optional_existing(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "nexus.yaml"
+        cfg_path.write_text(yaml.dump({"preset": "demo"}))
+        with patch("nexus.cli.state.CONFIG_SEARCH_PATHS", (str(cfg_path),)):
+            config = load_project_config_optional()
+        assert config["preset"] == "demo"
+
+    def test_save_roundtrip(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "nexus.yaml"
+        cfg_path.write_text(yaml.dump({"preset": "shared"}))
+        with patch("nexus.cli.state.CONFIG_SEARCH_PATHS", (str(cfg_path),)):
+            save_project_config({"preset": "demo", "auth": "database"})
+        with open(cfg_path) as f:
+            saved = yaml.safe_load(f)
+        assert saved["preset"] == "demo"
+        assert saved["auth"] == "database"
+
+
+# ---------------------------------------------------------------------------
+# load_runtime_state / save_runtime_state
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeState:
+    def test_load_missing_returns_empty(self, tmp_path: Path) -> None:
+        assert load_runtime_state(tmp_path) == {}
+
+    def test_save_and_load(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "nexus-data"
+        data_dir.mkdir()
+        state = {
+            "ports": {"http": 2027, "grpc": 2029},
+            "api_key": "sk-test123",
+            "build_mode": "local",
+            "image_used": "nexus:local-abc12345",
+        }
+        save_runtime_state(data_dir, state)
+
+        loaded = load_runtime_state(data_dir)
+        assert loaded["ports"]["http"] == 2027
+        assert loaded["ports"]["grpc"] == 2029
+        assert loaded["api_key"] == "sk-test123"
+        assert loaded["build_mode"] == "local"
+        assert loaded["version"] == 1
+        assert "started_at" in loaded
+
+    def test_save_creates_data_dir(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "new-data"
+        save_runtime_state(data_dir, {"ports": {"http": 2026}})
+        assert data_dir.exists()
+        assert (data_dir / STATE_FILENAME).exists()
+
+    def test_save_preserves_started_at(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        save_runtime_state(data_dir, {"started_at": "2026-01-01T00:00:00"})
+        loaded = load_runtime_state(data_dir)
+        assert loaded["started_at"] == "2026-01-01T00:00:00"
+
+    def test_load_malformed_returns_empty(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / STATE_FILENAME).write_text("not json{{{")
+        assert load_runtime_state(data_dir) == {}
+
+    def test_load_non_dict_returns_empty(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / STATE_FILENAME).write_text('"just a string"')
+        assert load_runtime_state(data_dir) == {}
+
+    def test_atomic_write(self, tmp_path: Path) -> None:
+        """No .tmp files left behind after successful write."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        save_runtime_state(data_dir, {"test": True})
+        tmp_files = list(data_dir.glob("*.tmp"))
+        assert tmp_files == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_connection_env
+# ---------------------------------------------------------------------------
+
+
+class TestResolveConnectionEnv:
+    def test_basic_env(self) -> None:
+        config = {
+            "ports": {"http": 2026, "grpc": 2028},
+            "api_key": "sk-fromconfig",
+            "services": ["nexus", "postgres"],
+        }
+        env = resolve_connection_env(config, state={})
+        assert env["NEXUS_URL"] == "http://localhost:2026"
+        assert env["NEXUS_API_KEY"] == "sk-fromconfig"
+        assert env["NEXUS_GRPC_HOST"] == "localhost:2028"
+        assert env["NEXUS_GRPC_PORT"] == "2028"
+        assert "DATABASE_URL" in env
+        assert "5432" in env["DATABASE_URL"]
+
+    def test_state_overrides_config(self) -> None:
+        config = {
+            "ports": {"http": 2026, "grpc": 2028},
+            "api_key": "sk-old",
+            "services": [],
+        }
+        state = {
+            "ports": {"http": 3026, "grpc": 3028},
+            "api_key": "sk-new",
+        }
+        env = resolve_connection_env(config, state)
+        assert env["NEXUS_URL"] == "http://localhost:3026"
+        assert env["NEXUS_API_KEY"] == "sk-new"
+        assert env["NEXUS_GRPC_PORT"] == "3028"
+
+    def test_tls_from_state(self) -> None:
+        config = {"ports": {}, "services": []}
+        state = {
+            "tls": {
+                "cert": "/data/tls/node.pem",
+                "key": "/data/tls/node-key.pem",
+                "ca": "/data/tls/ca.pem",
+            }
+        }
+        env = resolve_connection_env(config, state)
+        assert env["NEXUS_URL"].startswith("https://")
+        assert env["NEXUS_TLS_CERT"] == "/data/tls/node.pem"
+        assert env["NEXUS_TLS_CA"] == "/data/tls/ca.pem"
+
+    def test_tls_from_config_fallback(self) -> None:
+        config = {
+            "ports": {},
+            "services": [],
+            "tls": True,
+            "tls_cert": "/data/tls/server.crt",
+            "tls_key": "/data/tls/server.key",
+            "tls_ca": "/data/tls/ca.crt",
+        }
+        env = resolve_connection_env(config, state={})
+        assert env["NEXUS_TLS_CERT"] == "/data/tls/server.crt"
+
+    def test_no_database_url_without_postgres(self) -> None:
+        config = {"ports": {}, "services": ["nexus"]}
+        env = resolve_connection_env(config, state={})
+        assert "DATABASE_URL" not in env
+
+    def test_no_api_key_when_empty(self) -> None:
+        config = {"ports": {}, "services": []}
+        env = resolve_connection_env(config, state={})
+        assert "NEXUS_API_KEY" not in env

--- a/tests/unit/cli/test_state.py
+++ b/tests/unit/cli/test_state.py
@@ -168,7 +168,8 @@ class TestResolveConnectionEnv:
             }
         }
         env = resolve_connection_env(config, state)
-        assert env["NEXUS_URL"].startswith("https://")
+        # NEXUS_URL is always http (TLS is gRPC-only, not HTTP)
+        assert env["NEXUS_URL"].startswith("http://")
         assert env["NEXUS_TLS_CERT"] == "/data/tls/node.pem"
         assert env["NEXUS_TLS_CA"] == "/data/tls/ca.pem"
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -61,17 +61,7 @@ sys.modules["fuse"] = _fuse_mock
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Mark known-flaky tests as xfail so they don't block CI."""
-    for item in items:
-        if item.nodeid.endswith(
-            "test_cli_quickstart.py::test_local_cli_quickstart_persists_across_invocations"
-        ):
-            item.add_marker(
-                pytest.mark.xfail(
-                    reason="Pre-existing flaky test: local metastore state lost under xdist (develop #2897)",
-                    strict=False,
-                )
-            )
+    """Apply collection-time suite adjustments."""
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/contracts/test_optional_imports.py
+++ b/tests/unit/contracts/test_optional_imports.py
@@ -1,0 +1,152 @@
+"""Tests for optional brick import decoupling (Issue #3230).
+
+Verifies that:
+1. nexus.config can be imported without bricks.auth installed.
+2. nexus.sdk can be imported without bricks.rebac installed.
+3. Lazy SDK symbols give clear errors when their brick is absent.
+4. Lazy SDK symbols work normally when their brick is present.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestConfigWithoutAuthBrick:
+    """Verify nexus.config works when bricks.auth is absent (#3230)."""
+
+    def test_config_imports_oauth_from_contracts(self) -> None:
+        """NexusConfig.oauth field uses OAuthConfig from contracts, not bricks."""
+        from nexus.config import NexusConfig
+
+        # The oauth field's annotation should reference the contracts type
+        field_info = NexusConfig.model_fields["oauth"]
+        assert field_info is not None
+
+        # Verify we can create a config with oauth=None (no auth brick needed)
+        cfg = NexusConfig(profile="minimal")
+        assert cfg.oauth is None
+
+    def test_config_parses_oauth_dict(self) -> None:
+        """Config can parse oauth config from dict using contracts types."""
+        from nexus.config import NexusConfig
+
+        cfg = NexusConfig(
+            profile="minimal",
+            oauth={
+                "providers": [
+                    {
+                        "name": "test",
+                        "display_name": "Test Provider",
+                        "provider_class": "test.TestProvider",
+                        "client_id_env": "TEST_CLIENT_ID",
+                        "client_secret_env": "TEST_CLIENT_SECRET",
+                    }
+                ]
+            },
+        )
+        assert cfg.oauth is not None
+        assert cfg.oauth.get_provider_config("test") is not None
+
+
+class TestSDKWithoutReBACBrick:
+    """Verify nexus.sdk lazy ReBAC imports (#3230)."""
+
+    def test_sdk_contracts_types_always_available(self) -> None:
+        """Entity, WILDCARD_SUBJECT, CheckResult, GraphLimitExceeded are always importable."""
+        from nexus.sdk import (
+            WILDCARD_SUBJECT,
+            CheckResult,
+            Entity,
+            GraphLimitExceeded,
+        )
+
+        assert Entity is not None
+        assert WILDCARD_SUBJECT == ("*", "*")
+        assert CheckResult is not None
+        assert GraphLimitExceeded is not None
+
+    def test_sdk_lazy_symbols_work_when_brick_present(self) -> None:
+        """ReBACManager, PermissionEnforcer, ReBACTuple load when brick is installed."""
+        from nexus.sdk import PermissionEnforcer, ReBACManager, ReBACTuple
+
+        assert ReBACManager is not None
+        assert PermissionEnforcer is not None
+        assert ReBACTuple is not None
+
+    def test_sdk_lazy_rebac_manager_clear_error(self) -> None:
+        """Accessing ReBACManager when brick absent gives ImportError, not AttributeError."""
+        import nexus.sdk as sdk
+
+        # Clear any cached lazy import
+        sdk._lazy_imports_cache.pop("ReBACManager", None)
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"nexus.bricks.rebac.manager": None},
+            ),
+            pytest.raises(ImportError, match="requires the ReBAC brick"),
+        ):
+            sdk.__getattr__("ReBACManager")
+
+    def test_sdk_lazy_permission_enforcer_clear_error(self) -> None:
+        """Accessing PermissionEnforcer when brick absent gives ImportError."""
+        import nexus.sdk as sdk
+
+        sdk._lazy_imports_cache.pop("PermissionEnforcer", None)
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"nexus.bricks.rebac.enforcer": None},
+            ),
+            pytest.raises(ImportError, match="requires the ReBAC brick"),
+        ):
+            sdk.__getattr__("PermissionEnforcer")
+
+    def test_sdk_lazy_rebac_tuple_clear_error(self) -> None:
+        """Accessing ReBACTuple when brick absent gives ImportError."""
+        import nexus.sdk as sdk
+
+        sdk._lazy_imports_cache.pop("ReBACTuple", None)
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"nexus.bricks.rebac.domain": None},
+            ),
+            pytest.raises(ImportError, match="requires the ReBAC brick"),
+        ):
+            sdk.__getattr__("ReBACTuple")
+
+    def test_sdk_unknown_attr_raises_attribute_error(self) -> None:
+        """Accessing a truly nonexistent attribute raises AttributeError."""
+        import nexus.sdk as sdk
+
+        with pytest.raises(AttributeError, match="has no attribute"):
+            sdk.__getattr__("NonexistentThing")
+
+    def test_sdk_dir_includes_lazy_symbols(self) -> None:
+        """dir(nexus.sdk) includes lazy ReBAC symbols for discoverability."""
+        import nexus.sdk as sdk
+
+        attrs = dir(sdk)
+        assert "ReBACManager" in attrs
+        assert "PermissionEnforcer" in attrs
+        assert "ReBACTuple" in attrs
+
+    def test_sdk_lazy_import_caching(self) -> None:
+        """Lazy imports are cached after first access."""
+        import nexus.sdk as sdk
+
+        # Clear cache
+        sdk._lazy_imports_cache.pop("ReBACManager", None)
+
+        # First access populates cache
+        manager1 = sdk.ReBACManager
+        assert "ReBACManager" in sdk._lazy_imports_cache
+
+        # Second access returns same object
+        manager2 = sdk.ReBACManager
+        assert manager1 is manager2

--- a/tests/unit/contracts/test_type_identity.py
+++ b/tests/unit/contracts/test_type_identity.py
@@ -1,4 +1,4 @@
-"""Import path identity tests for contracts/ type promotions (Issue #2190).
+"""Import path identity tests for contracts/ type promotions (Issue #2190, #3230).
 
 Verifies that types imported from canonical (contracts/) and legacy (shim)
 paths resolve to the **same Python object** — ensuring isinstance checks,
@@ -18,5 +18,21 @@ class TestReBACTypesIdentity:
     def test_wildcard_subject_identity(self) -> None:
         from nexus.bricks.rebac.domain import WILDCARD_SUBJECT as shim
         from nexus.contracts.rebac_types import WILDCARD_SUBJECT as canonical
+
+        assert canonical is shim
+
+
+class TestOAuthTypesIdentity:
+    """Verify nexus.contracts.oauth_types ↔ nexus.bricks.auth.oauth.config identity (#3230)."""
+
+    def test_oauth_config_identity(self) -> None:
+        from nexus.bricks.auth.oauth.config import OAuthConfig as shim
+        from nexus.contracts.oauth_types import OAuthConfig as canonical
+
+        assert canonical is shim
+
+    def test_oauth_provider_config_identity(self) -> None:
+        from nexus.bricks.auth.oauth.config import OAuthProviderConfig as shim
+        from nexus.contracts.oauth_types import OAuthProviderConfig as canonical
 
         assert canonical is shim

--- a/tests/unit/core/test_import_boundaries.py
+++ b/tests/unit/core/test_import_boundaries.py
@@ -256,11 +256,56 @@ class TestConfigDoesNotImportServer:
         )
 
     def test_auth_config_canonical_import(self):
-        """OAuthConfig canonical path is nexus.bricks.auth.oauth.config (#2281)."""
-        from nexus.bricks.auth.oauth.config import OAuthConfig, OAuthProviderConfig
+        """OAuthConfig canonical path is nexus.contracts.oauth_types (#3230)."""
+        from nexus.contracts.oauth_types import OAuthConfig, OAuthProviderConfig
 
         assert OAuthConfig is not None
         assert OAuthProviderConfig is not None
+
+    def test_auth_config_backward_compat_import(self):
+        """OAuthConfig backward-compat shim from bricks.auth.oauth.config (#3230)."""
+        from nexus.bricks.auth.oauth.config import OAuthConfig as ShimOAuth
+        from nexus.bricks.auth.oauth.config import OAuthProviderConfig as ShimProvider
+        from nexus.contracts.oauth_types import OAuthConfig, OAuthProviderConfig
+
+        assert ShimOAuth is OAuthConfig
+        assert ShimProvider is OAuthProviderConfig
+
+    def test_config_no_bricks_auth_imports(self):
+        """nexus/config.py must not import from nexus.bricks.auth at top level (#3230).
+
+        This prevents config from pulling in the auth brick, which may
+        not be installed in the slim nexus-fs package.
+        """
+        config_path = NEXUS_ROOT / "config.py"
+        violations: list[str] = []
+
+        for module, lineno, _kind in _collect_top_level_imports(config_path):
+            if module.startswith("nexus.bricks.auth"):
+                violations.append(f"config.py:{lineno} imports {module}")
+
+        assert violations == [], (
+            "config.py→bricks.auth import violations found (#3230):\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+
+    def test_sdk_no_bricks_rebac_top_level_imports(self):
+        """nexus/sdk/__init__.py must not top-level import from nexus.bricks.rebac (#3230).
+
+        ReBAC implementation types should be lazy-loaded via __getattr__ so
+        that `import nexus.sdk` works without bricks.rebac installed.
+        """
+        sdk_init = NEXUS_ROOT / "sdk" / "__init__.py"
+        violations: list[str] = []
+
+        for module, lineno, _kind in _collect_top_level_imports(sdk_init):
+            if module.startswith("nexus.bricks.rebac"):
+                violations.append(f"sdk/__init__.py:{lineno} imports {module}")
+
+        assert violations == [], (
+            "sdk/__init__.py→bricks.rebac top-level import violations found (#3230):\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
 
 
 class TestZoneHelpersInLib:

--- a/tests/unit/core/test_import_smoke.py
+++ b/tests/unit/core/test_import_smoke.py
@@ -24,6 +24,10 @@ _CORE_MODULES = [
     "nexus.contracts.describable",
     "nexus.contracts.wirable_fs",
     "nexus.contracts.agent_utils",
+    # Config and SDK decoupled from optional bricks (#3230):
+    "nexus.config",
+    "nexus.sdk",
+    "nexus.contracts.oauth_types",
 ]
 
 _FACTORY_MODULES = [

--- a/tests/unit/storage/test_time_travel.py
+++ b/tests/unit/storage/test_time_travel.py
@@ -14,6 +14,7 @@ from nexus.bricks.versioning.time_travel_service import TimeTravelService
 from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.core.config import PermissionConfig
 from nexus.factory import create_nexus_fs
+from nexus.storage.dict_metastore import DictMetastore
 from nexus.storage.operation_logger import OperationLogger
 from nexus.storage.raft_metadata_store import RaftMetadataStore
 from nexus.storage.record_store import SQLAlchemyRecordStore
@@ -59,7 +60,10 @@ class TestTimeTravelDebug:
         """
         data_dir = Path(temp_dir) / "nexus-data"
         data_dir.mkdir(parents=True, exist_ok=True)
-        metadata_store = RaftMetadataStore.embedded(str(data_dir / "raft-metadata"))
+        try:
+            metadata_store = RaftMetadataStore.embedded(str(data_dir / "raft-metadata"))
+        except RuntimeError:
+            metadata_store = DictMetastore(data_dir / "raft-metadata.json")
         nx = await create_nexus_fs(
             backend=backend,
             metadata_store=metadata_store,
@@ -68,6 +72,7 @@ class TestTimeTravelDebug:
         )
         yield nx
         nx.close()
+        metadata_store.close()
 
     @pytest.fixture
     def time_travel(self, record_store, backend):
@@ -201,10 +206,6 @@ class TestTimeTravelDebug:
         assert "/workspace/file2.txt" in paths
         assert "/workspace/file3.txt" in paths
 
-    @pytest.mark.xfail(
-        reason="Pre-existing CAS padding mismatch in size_diff assertion (flaky)",
-        strict=False,
-    )
     @pytest.mark.asyncio
     async def test_time_travel_diff_operations(self, nx, record_store, time_travel):
         """Test diffing file state between two operations."""


### PR DESCRIPTION
## Summary

Complete DX overhaul for `nexus init` → `nexus up` → `nexus env` workflow, enabling seamless concurrent worktree development.

- **State separation**: `nexus up` no longer mutates `nexus.yaml`. Runtime state (resolved ports, API key, TLS paths, image used, build mode) goes to `{data_dir}/.state.json` — gitignored, per-worktree.
- **`nexus env`**: Emits all connection vars in shell/dotenv/json/fish format. Supports `eval $(nexus env)` and `nexus env --dotenv > .env`.
- **`nexus run <cmd>`**: Wraps subprocess with Nexus env vars injected. Interactive pass-through (`nexus run bash` works).
- **`nexus stop` / `nexus start`**: Lightweight pause/resume via `docker compose stop/start` — no port checks, no pulls, sub-second.
- **Port reuse**: Repeated `nexus up` on a running stack detects bound ports from `.state.json` and reuses them (no port drift).
- **Local build tagging**: `nexus up --build` tags as `nexus:local-{hash}` (unique per worktree). Next `nexus up` reuses the local image without pulling. `--pull` to clear.
- **Fix gRPC port mapping**: Container port always 2028; host port varies. Sets `NEXUS_GRPC_TLS` explicitly.
- **Fix `nexus status`**: Reads ports from state.json/config instead of hardcoding `:2026`.
- **`CLI.md`**: Agent/developer-facing docs for all commands.
- **85 unit tests** + manual e2e validation.

## Test plan

- [x] `pytest tests/unit/cli/test_state.py tests/unit/cli/test_env_cmd.py tests/unit/cli/test_stack.py` — 85 pass
- [x] E2E: `nexus init --preset shared && nexus up` — auto-resolves ports, writes `.state.json`, does NOT mutate `nexus.yaml`
- [x] E2E: `nexus env` / `nexus env --json` / `nexus env --dotenv` / `nexus env --shell fish`
- [x] E2E: `nexus run env | grep NEXUS` — env vars injected
- [x] E2E: `nexus up` (second time, running) — reuses ports from state.json, instant health check
- [x] E2E: `nexus stop` → `nexus start` — fast pause/resume
- [x] E2E: `nexus status` — uses resolved port, server healthy
- [x] E2E: `nexus down --volumes` — clean teardown