### PR TITLE
fix(test): stabilize flaky bulk_check snapshot test

### DIFF
--- a/tests/unit/services/permissions/test_rebac_manager_snapshot.py
+++ b/tests/unit/services/permissions/test_rebac_manager_snapshot.py
@@ -42,6 +42,11 @@ def engine():
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
+        # AUTOCOMMIT avoids stale-transaction issues that arise when the
+        # writer commits via raw DBAPI while SQLAlchemy manages the shared
+        # StaticPool connection.  Production uses PostgreSQL where proper
+        # connection pooling prevents this class of bug.
+        isolation_level="AUTOCOMMIT",
     )
     Base.metadata.create_all(engine)
     # Also create rebac_group_closure table for Leopard


### PR DESCRIPTION
## Summary
- Fix ~10% flaky failure in `test_bulk_check_returns_dict_of_results` caused by SQLite+StaticPool transaction management conflict
- The ReBAC writer's raw DBAPI `conn.commit()` and SQLAlchemy's transaction tracking get out of sync on the shared StaticPool connection; cache-invalidation eager-recompute failures then trigger `sa_conn.rollback()` that undoes committed tuple INSERTs
- Set `isolation_level="AUTOCOMMIT"` on the test engine so every DML auto-commits immediately — SQLite+StaticPool-specific, does not affect production (PostgreSQL)

## Test plan
- [x] 200 consecutive runs of `test_bulk_check_returns_dict_of_results` with 0 assertion failures (was ~10% failure rate)
- [x] Full `test_rebac_manager_snapshot.py` suite passes
- [x] Full `tests/unit/services/permissions/` suite passes