### PR TITLE
feat(nexus-fs): implement slim package extraction with full test suite

### DIFF
--- a/packages/nexus-fs/README.md
+++ b/packages/nexus-fs/README.md
@@ -1,0 +1,74 @@
+# nexus-fs
+
+Unified filesystem abstraction for cloud storage. Mount S3, GCS, Google Workspace, and local storage with two lines of Python.
+
+```python
+import nexus.fs
+
+fs = nexus.fs.mount_sync("s3://my-bucket", "local://./data")
+content = fs.read("/s3/my-bucket/README.md")
+```
+
+## Install
+
+```bash
+pip install nexus-fs            # core (local only)
+pip install nexus-fs[s3]        # + Amazon S3
+pip install nexus-fs[gcs]       # + Google Cloud Storage
+pip install nexus-fs[all]       # everything
+```
+
+## Quick Start
+
+### Async
+
+```python
+import asyncio
+import nexus.fs
+
+async def main():
+    fs = await nexus.fs.mount("s3://my-bucket", "local://./data")
+    await fs.write("/local/data/hello.txt", b"Hello!")
+    content = await fs.read("/local/data/hello.txt")
+    print(content)
+
+asyncio.run(main())
+```
+
+### Sync
+
+```python
+import nexus.fs
+
+fs = nexus.fs.mount_sync("local://./data")
+fs.write("/local/data/hello.txt", b"Hello!")
+print(fs.read("/local/data/hello.txt"))
+```
+
+### Connectors (Google Workspace, GitHub, Slack, etc.)
+
+```python
+import nexus.fs
+
+fs = nexus.fs.mount_sync("gws://sheets", "gws://docs")
+# Uses gws CLI under the hood — no server needed
+```
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `read(path)` | Read file content |
+| `write(path, content)` | Write/overwrite file |
+| `ls(path, detail, recursive)` | List directory |
+| `stat(path)` | Get file metadata |
+| `exists(path)` | Check if path exists |
+| `delete(path)` | Delete a file |
+| `rename(old, new)` | Rename/move |
+| `copy(src, dst)` | Copy a file |
+| `mkdir(path)` | Create directory |
+| `list_mounts()` | List mount points |
+
+## License
+
+Apache-2.0

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -1,0 +1,94 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nexus-fs"
+version = "0.1.0"
+description = "Unified filesystem abstraction for cloud storage — mount S3, GCS, and local storage with two lines of Python"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+authors = [
+    { name = "Nexi Lab Team" },
+]
+keywords = ["filesystem", "s3", "gcs", "cloud", "storage", "vfs", "ai", "agents"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: System :: Filesystems",
+    "Typing :: Typed",
+]
+
+# ~15 base dependencies — slim by design
+dependencies = [
+    "pydantic>=2.0",
+    "click>=8.0",
+    "rich>=13.0",
+    "orjson>=3.9",
+    "blake3>=0.4",
+    "anyio>=4.0",
+    "aiofiles>=23.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+s3 = ["boto3>=1.28"]
+gcs = ["google-cloud-storage>=2.0"]
+gdrive = [
+    "google-api-python-client>=2.0",
+    "google-auth-oauthlib>=1.0",
+]
+fsspec = ["fsspec>=2024.0"]
+tui = ["textual>=1.0"]
+langchain = ["langchain-core>=0.2"]
+all = [
+    "nexus-fs[s3,gcs,gdrive,fsspec,tui,langchain]",
+]
+dev = [
+    "nexus-fs[all]",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
+    "moto[s3]>=5.0",
+    "ruff>=0.4",
+    "mypy>=1.10",
+]
+
+[project.urls]
+Homepage = "https://github.com/nexi-lab/nexus"
+Documentation = "https://nexus-fs.dev"
+Repository = "https://github.com/nexi-lab/nexus"
+Issues = "https://github.com/nexi-lab/nexus/issues"
+
+[project.entry-points."fsspec.specs"]
+nexus = "nexus.fs._fsspec:NexusFileSystem"
+
+[project.scripts]
+nexus-fs = "nexus.fs._cli:main"
+
+[tool.hatch.build.targets.wheel]
+# Slim package owns these directories from the monorepo src/
+packages = ["../../src/nexus"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["../../tests/unit/fs"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -74,8 +74,32 @@ nexus = "nexus.fs._fsspec:NexusFileSystem"
 nexus-fs = "nexus.fs._cli:main"
 
 [tool.hatch.build.targets.wheel]
-# Slim package owns these directories from the monorepo src/
+# Slim package: only include the core/contracts/backends/lib/storage/fs layers.
+# Excludes bricks/, server/, factory/, raft/, cli/ (those live in nexus-ai-fs).
 packages = ["../../src/nexus"]
+include = [
+    "nexus/__init__.py",
+    "nexus/py.typed",
+    "nexus/fs/**",
+    "nexus/core/**",
+    "nexus/contracts/**",
+    "nexus/backends/**",
+    "nexus/lib/**",
+    "nexus/storage/**",
+    "nexus/config.py",
+]
+exclude = [
+    "nexus/bricks/**",
+    "nexus/server/**",
+    "nexus/factory/**",
+    "nexus/raft/**",
+    "nexus/cli/**",
+    "nexus/fuse/**",
+    "nexus/remote/**",
+    "nexus/system_services/**",
+    "nexus/grpc/**",
+    "nexus/security/**",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -111,6 +111,9 @@ _LAZY_IMPORTS = {
     # Core - heavy
     "NexusFilesystem": ("nexus.contracts.filesystem.filesystem_abc", "NexusFilesystemABC"),
     "NexusFS": ("nexus.core.nexus_fs", "NexusFS"),
+    # Slim package top-level API (nexus.mount / nexus.mount_sync)
+    "mount": ("nexus.fs", "mount"),
+    "mount_sync": ("nexus.fs", "mount_sync"),
 }
 
 
@@ -691,8 +694,10 @@ async def _restore_mounts(nx_fs: "NexusFS") -> None:
 __all__ = [
     # Version
     "__version__",
-    # Main entry point
+    # Main entry points
     "connect",
+    "mount",
+    "mount_sync",
     # Configuration
     "NexusConfig",
     "load_config",

--- a/src/nexus/contracts/exceptions.py
+++ b/src/nexus/contracts/exceptions.py
@@ -569,6 +569,89 @@ class CredentialError(NexusError):
         super().__init__(message)
 
 
+class NexusURIError(InvalidPathError):
+    """Invalid URI format for nexus.mount().
+
+    This is an expected error — the user provided a malformed or unsupported
+    mount URI (e.g., missing scheme, unknown scheme, empty authority).
+
+    Examples:
+        >>> raise NexusURIError("bucket-name", "Missing scheme. Did you mean 's3://bucket-name'?")
+        >>> raise NexusURIError("xyz://foo", "Unsupported scheme: xyz://")
+    """
+
+    is_expected = True
+    status_code = 400
+    error_type = "Bad Request"
+
+    def __init__(self, uri: str, message: str | None = None):
+        self.uri = uri
+        msg = message or f"Invalid URI: {uri}"
+        super().__init__(path=uri, message=msg)
+
+
+class CloudCredentialError(NexusError):
+    """Missing or invalid credentials for a cloud storage backend.
+
+    This is an expected error — the user needs to configure credentials
+    for the cloud backend (AWS, GCP, etc.).
+
+    Distinct from CredentialError which is for JWS/internal credential operations.
+
+    Examples:
+        >>> raise CloudCredentialError("s3", "AWS credentials not found. Run `aws configure` or set AWS_ACCESS_KEY_ID")
+        >>> raise CloudCredentialError("gcs", "GCP ADC not found. Run `gcloud auth application-default login`")
+    """
+
+    is_expected = True
+    status_code = 401
+    error_type = "Unauthorized"
+
+    def __init__(self, backend: str, message: str | None = None):
+        self.backend = backend
+        msg = message or f"Credentials not found for {backend}. Run `nexus doctor` for details"
+        super().__init__(msg)
+
+
+class BackendNotFoundError(BackendError):
+    """Cloud resource (bucket, container, project) not found.
+
+    This is an expected error — the user referenced a cloud resource
+    that doesn't exist or isn't accessible.
+
+    Examples:
+        >>> raise BackendNotFoundError("my-buket", "s3", "Bucket 'my-buket' not found")
+    """
+
+    is_expected = True
+    status_code = 404
+    error_type = "Not Found"
+
+    def __init__(self, resource: str, backend: str | None = None, message: str | None = None):
+        self.resource = resource
+        msg = message or f"Backend resource not found: {resource}"
+        super().__init__(msg, backend=backend)
+
+
+class BackendPermissionError(NexusPermissionError):
+    """IAM-level permission denied by cloud provider.
+
+    This is an expected error — the cloud provider's IAM rejected the
+    operation. Distinct from ReBAC permission errors (PermissionDeniedError).
+
+    Examples:
+        >>> raise BackendPermissionError("/s3/bucket/file.txt", "Access denied by AWS IAM")
+    """
+
+    is_expected = True
+    status_code = 403
+    error_type = "Forbidden"
+
+    def __init__(self, path: str, message: str | None = None):
+        msg = message or "Access denied by backend IAM"
+        super().__init__(path=path, message=msg)
+
+
 class ZoneTerminatingError(NexusError):
     """Raised when a write is attempted on a zone in Terminating phase.
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -597,40 +597,26 @@ class NexusFS(  # type: ignore[misc]
     ) -> None:
         """Remove a directory (recursive=True for rm -rf)."""
         import errno
+        import warnings
 
         path = self._validate_path(path)
 
-        # Block writes during zone deprovisioning (Issue #2061)
-
-        # P0 Fixes: Create OperationContext
-        if context is not None:
-            ctx = (
-                context
-                if isinstance(context, OperationContext)
-                else OperationContext(
-                    user_id=context.user_id,
-                    groups=context.groups,
-                    zone_id=context.zone_id or zone_id,
-                    agent_id=context.agent_id or agent_id,
-                    is_admin=context.is_admin if is_admin is None else is_admin,
-                    is_system=context.is_system,
-                    admin_capabilities=set(),
-                )
+        # Build context: prefer OperationContext, deprecate legacy kwargs
+        if context is None and subject is not None:
+            warnings.warn(
+                "sys_rmdir subject/zone_id/agent_id/is_admin kwargs are deprecated. "
+                "Pass an OperationContext instead.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-        elif subject is not None:
-            ctx = OperationContext(
+            context = OperationContext(
                 user_id=subject[1],
                 groups=[],
                 zone_id=zone_id,
                 agent_id=agent_id,
                 is_admin=is_admin or False,
-                is_system=False,
-                admin_capabilities=set(),
             )
-        else:
-            ctx = self._require_context(None)
-
-        # Check write permission on directory
+        ctx = self._require_context(context)
 
         logger.debug(
             f"rmdir: path={path}, recursive={recursive}, user={ctx.user_id}, is_admin={ctx.is_admin}"
@@ -4418,6 +4404,29 @@ class NexusFS(  # type: ignore[misc]
 
     # --- Search (sys_readdir/glob/grep) ---
 
+    def _entry_to_detail_dict(self, entry: FileMetadata, recursive: bool) -> dict[str, Any]:
+        """Convert a FileMetadata entry to a detail dict for sys_readdir.
+
+        Promotes entry_type=0 (DT_REG) to 1 (DT_DIR) for implicit directories
+        in non-recursive listings, matching ls -l semantics.
+        """
+        return {
+            "path": entry.path,
+            "size": entry.size,
+            "etag": entry.etag,
+            "entry_type": 1
+            if (
+                not recursive
+                and entry.entry_type == 0
+                and self.metadata.is_implicit_directory(entry.path)
+            )
+            else entry.entry_type,
+            "zone_id": entry.zone_id,
+            "owner_id": entry.owner_id,
+            "modified_at": entry.modified_at.isoformat() if entry.modified_at else None,
+            "version": entry.version,
+        }
+
     @rpc_expose(description="List directory entries")
     async def sys_readdir(
         self,
@@ -4439,50 +4448,14 @@ class NexusFS(  # type: ignore[misc]
             items_iter = self.metadata.list_iter(prefix=prefix, recursive=recursive)
             result = paginate_iter(items_iter, limit=limit, cursor_path=cursor)
             if details:
-                result.items = [
-                    {
-                        "path": e.path,
-                        "size": e.size,
-                        "etag": e.etag,
-                        "entry_type": 1
-                        if (
-                            not recursive
-                            and e.entry_type == 0
-                            and self.metadata.is_implicit_directory(e.path)
-                        )
-                        else e.entry_type,
-                        "zone_id": e.zone_id,
-                        "owner_id": e.owner_id,
-                        "modified_at": e.modified_at.isoformat() if e.modified_at else None,
-                        "version": e.version,
-                    }
-                    for e in result.items
-                ]
+                result.items = [self._entry_to_detail_dict(e, recursive) for e in result.items]
             else:
                 result.items = [e.path for e in result.items]
             return result
 
         entries = self.metadata.list(prefix=prefix, recursive=recursive)
         if details:
-            return [
-                {
-                    "path": e.path,
-                    "size": e.size,
-                    "etag": e.etag,
-                    "entry_type": 1
-                    if (
-                        not recursive
-                        and e.entry_type == 0
-                        and self.metadata.is_implicit_directory(e.path)
-                    )
-                    else e.entry_type,
-                    "zone_id": e.zone_id,
-                    "owner_id": e.owner_id,
-                    "modified_at": e.modified_at.isoformat() if e.modified_at else None,
-                    "version": e.version,
-                }
-                for e in entries
-            ]
+            return [self._entry_to_detail_dict(e, recursive) for e in entries]
         return [e.path for e in entries]
 
     # _run_async: replaced by direct run_sync() calls (Issue #1381)

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -220,10 +220,82 @@ def _create_backend(spec: Any) -> Any:
         return CASLocalBackend(root_path=root)
 
     else:
+        # Fall through to the connector registry for any other scheme.
+        # Connectors register themselves via @register_connector at import
+        # time. We try to discover connector modules for the requested
+        # scheme, then look up the registry.
+        return _create_connector_backend(spec)
+
+
+def _create_connector_backend(spec: Any) -> Any:
+    """Create a backend from the connector registry.
+
+    Attempts to import connector modules for the scheme and look up a
+    matching connector in the ConnectorRegistry. The lookup convention:
+    ``{scheme}_{authority}`` first, then ``{scheme}_connector`` as fallback.
+
+    This is lazy — connector modules are only imported when the scheme is
+    actually requested, so unused connectors add zero startup cost.
+    """
+    scheme = spec.scheme
+    authority = spec.authority
+
+    # Lazily import connector modules for this scheme.
+    # Convention: nexus.backends.connectors.<scheme>/
+    _discover_connector_module(scheme)
+
+    from nexus.backends.base.registry import ConnectorRegistry
+
+    # Try specific connector first: gws_sheets, gws_docs, etc.
+    connector_name = f"{scheme}_{authority}" if authority else scheme
+    # Also try gws_connector, gdrive_connector as fallback
+    fallback_name = f"{scheme}_connector"
+
+    connector_cls = None
+    for name in [connector_name, f"gws_{authority}" if scheme == "gws" else None, fallback_name]:
+        if name is None:
+            continue
+        try:
+            connector_cls = ConnectorRegistry.get(name)
+            break
+        except KeyError:
+            continue
+
+    if connector_cls is None:
         from nexus.contracts.exceptions import NexusURIError
 
+        available = ConnectorRegistry.list_available()
         raise NexusURIError(
             spec.uri,
-            f"No backend available for scheme '{spec.scheme}://'. "
-            f"Supported: s3://, gcs://, local://",
+            f"No backend or connector found for scheme '{scheme}://'. "
+            f"Built-in: s3://, gcs://, local://. "
+            f"Registered connectors: {', '.join(available) if available else 'none'}",
         )
+
+    # Instantiate the connector. CLIConnectors accept config via kwargs.
+    return connector_cls()
+
+
+def _discover_connector_module(scheme: str) -> None:
+    """Try to import the connector module for a given scheme.
+
+    Connector modules register themselves via @register_connector when
+    imported. This is a no-op if the module doesn't exist or has already
+    been imported.
+    """
+    import importlib
+
+    # Map scheme to module path. Convention:
+    #   gws    -> nexus.backends.connectors.gws.connector
+    #   gdrive -> nexus.backends.connectors.gdrive.connector
+    #   github -> nexus.backends.connectors.github.connector
+    module_paths = [
+        f"nexus.backends.connectors.{scheme}.connector",
+        f"nexus.backends.connectors.{scheme}",
+    ]
+    for mod_path in module_paths:
+        try:
+            importlib.import_module(mod_path)
+            return
+        except ImportError:
+            continue

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -1,0 +1,210 @@
+"""nexus-fs: Slim filesystem abstraction for cloud storage.
+
+Two lines to mount any combination of S3, GCS, and local storage:
+
+    import nexus.fs
+
+    fs = await nexus.fs.mount("s3://my-bucket", "local://./data")
+    readme = await fs.read("/s3/my-bucket/README.md")
+
+Sync usage:
+
+    fs = nexus.fs.mount_sync("s3://my-bucket")
+    content = fs.read("/s3/my-bucket/file.txt")
+
+All imports are lazy to keep ``import nexus.fs`` under 200ms.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+# =============================================================================
+# LAZY IMPORTS — everything is deferred for <200ms import time
+# =============================================================================
+from typing import Any
+
+_lazy_cache: dict[str, Any] = {}
+
+_LAZY_IMPORTS = {
+    "SlimNexusFS": ("nexus.fs._facade", "SlimNexusFS"),
+    "SyncNexusFS": ("nexus.fs._sync", "SyncNexusFS"),
+    "NexusFileSystem": ("nexus.fs._fsspec", "NexusFileSystem"),
+    "parse_uri": ("nexus.fs._uri", "parse_uri"),
+    "MountSpec": ("nexus.fs._uri", "MountSpec"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _lazy_cache:
+        return _lazy_cache[name]
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        mod_path, attr_name = _LAZY_IMPORTS[name]
+        mod = importlib.import_module(mod_path)
+        val = getattr(mod, attr_name)
+        _lazy_cache[name] = val
+        return val
+    raise AttributeError(f"module 'nexus.fs' has no attribute {name!r}")
+
+
+async def mount(*uris: str, at: str | None = None) -> Any:
+    """Mount one or more backends and return a SlimNexusFS facade.
+
+    Args:
+        *uris: One or more backend URIs (e.g., "s3://bucket", "local://./data").
+        at: Optional mount point override (only valid with a single URI).
+
+    Returns:
+        SlimNexusFS facade with all backends mounted.
+
+    Raises:
+        NexusURIError: If a URI is invalid.
+        CloudCredentialError: If cloud credentials are missing.
+        BackendNotFoundError: If a cloud resource doesn't exist.
+
+    Examples:
+        # Single backend
+        fs = await nexus.fs.mount("s3://my-bucket")
+
+        # Multiple backends
+        fs = await nexus.fs.mount("s3://my-bucket", "local://./data")
+
+        # Custom mount point
+        fs = await nexus.fs.mount("s3://my-bucket", at="/data")
+    """
+    from nexus.fs._uri import derive_mount_point, parse_uri, validate_mount_collision
+
+    if not uris:
+        raise ValueError("At least one URI is required")
+    if at is not None and len(uris) > 1:
+        raise ValueError("'at' override is only valid with a single URI")
+
+    # Parse all URIs first (fail fast on invalid input)
+    specs = [parse_uri(uri) for uri in uris]
+
+    # Check for collisions
+    mount_points: set[str] = set()
+    resolved_mounts = []
+    for i, spec in enumerate(specs):
+        mp = derive_mount_point(spec, at=at if i == 0 else None)
+        validate_mount_collision(mp, mount_points)
+        mount_points.add(mp)
+        resolved_mounts.append((spec, mp))
+
+    # Create the kernel infrastructure
+    import os
+
+    # SQLite metastore in a temp or user-local directory
+    import tempfile
+
+    from nexus.core.nexus_fs import NexusFS
+    from nexus.core.router import PathRouter
+    from nexus.fs._facade import SlimNexusFS
+    from nexus.fs._sqlite_meta import SQLiteMetastore
+
+    state_dir = os.environ.get("NEXUS_FS_STATE_DIR") or os.path.join(
+        tempfile.gettempdir(), "nexus-fs"
+    )
+    os.makedirs(state_dir, exist_ok=True)
+    db_path = os.path.join(state_dir, "metadata.db")
+
+    metastore = SQLiteMetastore(db_path)
+    router = PathRouter(metastore)
+
+    # Mount each backend
+    for spec, mp in resolved_mounts:
+        backend = _create_backend(spec)
+        router.add_mount(mp, backend)
+
+    # Build kernel (minimal — no factory, no bricks)
+    from nexus.core.config import BrickServices, KernelServices, PermissionConfig
+
+    kernel = NexusFS(
+        metadata_store=metastore,
+        permissions=PermissionConfig(enforce=False),
+        kernel_services=KernelServices(router=router),
+        brick_services=BrickServices(),
+    )
+
+    # Create parent directories for each mount point
+    from nexus.contracts.constants import ROOT_ZONE_ID
+    from nexus.contracts.types import OperationContext
+
+    ctx = OperationContext(user_id="local", groups=[], zone_id=ROOT_ZONE_ID, is_admin=True)
+    kernel._default_context = ctx
+
+    for _, mp in resolved_mounts:
+        await kernel.sys_mkdir(mp, parents=True, exist_ok=True, context=ctx)
+
+    return SlimNexusFS(kernel)
+
+
+def mount_sync(*uris: str, at: str | None = None) -> Any:
+    """Synchronous version of mount().
+
+    Returns a SyncNexusFS wrapper. See mount() for full documentation.
+
+    Examples:
+        fs = nexus.fs.mount_sync("s3://my-bucket")
+        content = fs.read("/s3/my-bucket/file.txt")
+    """
+    from nexus.fs._sync import SyncNexusFS, run_sync
+
+    async_fs = run_sync(mount(*uris, at=at))
+    return SyncNexusFS(async_fs)
+
+
+def _create_backend(spec: Any) -> Any:
+    """Create a storage backend from a parsed MountSpec.
+
+    Discovers credentials automatically and instantiates the
+    appropriate backend class.
+    """
+    from nexus.fs._credentials import discover_credentials
+
+    # Discover credentials (raises CloudCredentialError if missing)
+    discover_credentials(spec.scheme)
+
+    if spec.scheme == "s3":
+        try:
+            from nexus.backends.storage.path_s3 import PathS3Backend
+        except ImportError:
+            raise ImportError(
+                "boto3 is required for S3 backends. Install with: pip install nexus-fs[s3]"
+            ) from None
+        return PathS3Backend(
+            bucket_name=spec.authority,
+            prefix=spec.path.lstrip("/") if spec.path else "",
+        )
+
+    elif spec.scheme == "gcs":
+        try:
+            from nexus.backends.storage.cas_gcs import CASGCSBackend
+        except ImportError:
+            raise ImportError(
+                "google-cloud-storage is required for GCS backends. "
+                "Install with: pip install nexus-fs[gcs]"
+            ) from None
+        # GCS: gcs://project/bucket → authority=project, path=/bucket
+        bucket = spec.path.strip("/").split("/")[0] if spec.path else spec.authority
+        return CASGCSBackend(bucket_name=bucket, project_id=spec.authority)
+
+    elif spec.scheme == "local":
+        from pathlib import Path as _Path
+
+        from nexus.backends.storage.cas_local import CASLocalBackend
+
+        root = _Path(spec.authority + (spec.path or "")).expanduser().resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        return CASLocalBackend(root_path=root)
+
+    else:
+        from nexus.contracts.exceptions import NexusURIError
+
+        raise NexusURIError(
+            spec.uri,
+            f"No backend available for scheme '{spec.scheme}://'. "
+            f"Supported: s3://, gcs://, local://",
+        )

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -113,10 +113,36 @@ async def mount(*uris: str, at: str | None = None) -> Any:
     metastore = SQLiteMetastore(db_path)
     router = PathRouter(metastore)
 
-    # Mount each backend
+    # Mount each backend and create DT_MOUNT entries in the metastore
+    from datetime import UTC, datetime
+
+    from nexus.contracts.constants import ROOT_ZONE_ID
+    from nexus.contracts.metadata import FileMetadata
+    from nexus.contracts.types import OperationContext
+    from nexus.core.hash_fast import hash_content
+
+    empty_hash = hash_content(b"")
+    now = datetime.now(UTC)
+
     for spec, mp in resolved_mounts:
         backend = _create_backend(spec)
         router.add_mount(mp, backend)
+        # Create DT_MOUNT entry so stat(mount_point) works
+        metastore.put(
+            FileMetadata(
+                path=mp,
+                backend_name=backend.name,
+                physical_path=empty_hash,
+                size=0,
+                etag=empty_hash,
+                mime_type="inode/directory",
+                created_at=now,
+                modified_at=now,
+                version=1,
+                zone_id=ROOT_ZONE_ID,
+                entry_type=2,  # DT_MOUNT
+            )
+        )
 
     # Build kernel (minimal — no factory, no bricks)
     from nexus.core.config import BrickServices, KernelServices, PermissionConfig
@@ -128,15 +154,8 @@ async def mount(*uris: str, at: str | None = None) -> Any:
         brick_services=BrickServices(),
     )
 
-    # Create parent directories for each mount point
-    from nexus.contracts.constants import ROOT_ZONE_ID
-    from nexus.contracts.types import OperationContext
-
     ctx = OperationContext(user_id="local", groups=[], zone_id=ROOT_ZONE_ID, is_admin=True)
     kernel._default_context = ctx
-
-    for _, mp in resolved_mounts:
-        await kernel.sys_mkdir(mp, parents=True, exist_ok=True, context=ctx)
 
     return SlimNexusFS(kernel)
 

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -1,0 +1,37 @@
+"""CLI entry point for nexus-fs.
+
+Provides the `nexus-fs` console command with subcommands:
+- nexus-fs doctor  (Phase 2)
+- nexus-fs playground  (Phase 2)
+
+This module is referenced by pyproject.toml [project.scripts].
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.group(invoke_without_command=True)
+@click.version_option(package_name="nexus-fs")
+@click.pass_context
+def main(ctx: click.Context) -> None:
+    """nexus-fs: unified filesystem for cloud storage."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@main.command()
+def doctor() -> None:
+    """Check environment, backends, and connectivity."""
+    click.echo("nexus-fs doctor: not yet implemented (Phase 2 — Issue #3232)")
+
+
+@main.command()
+def playground() -> None:
+    """Interactive TUI file browser."""
+    click.echo("nexus-fs playground: not yet implemented (Phase 2 — Issue #3232)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nexus/fs/_credentials.py
+++ b/src/nexus/fs/_credentials.py
@@ -140,4 +140,6 @@ def discover_credentials(scheme: str) -> dict[str, str]:
         # gdrive: deferred to explicit auth step
         return {"source": "none", "scheme": scheme}
     else:
-        return {"source": "unknown", "scheme": scheme}
+        # Connector-based schemes (gws, github, slack, etc.) handle
+        # their own auth — CLI tools manage credentials externally.
+        return {"source": "connector", "scheme": scheme}

--- a/src/nexus/fs/_credentials.py
+++ b/src/nexus/fs/_credentials.py
@@ -1,0 +1,143 @@
+"""Auto-credential discovery for cloud backends.
+
+Discovers credentials from the environment following each cloud provider's
+standard chain. No credentials are stored — we just check what's available.
+
+Credential chains:
+    AWS (S3):
+        1. Environment vars: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY
+        2. Shared credentials file: ~/.aws/credentials
+        3. AWS config file: ~/.aws/config
+        4. EC2/ECS instance metadata (boto3 handles this)
+
+    GCP (GCS):
+        1. GOOGLE_APPLICATION_CREDENTIALS environment variable
+        2. gcloud application-default credentials (~/.config/gcloud/application_default_credentials.json)
+        3. Compute Engine metadata service
+
+    Local:
+        No credentials needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from nexus.contracts.exceptions import CloudCredentialError
+
+logger = logging.getLogger(__name__)
+
+
+def check_aws_credentials() -> dict[str, str]:
+    """Check for available AWS credentials.
+
+    Returns:
+        Dict with credential source info (e.g., {"source": "env", "profile": "default"}).
+
+    Raises:
+        CloudCredentialError: If no AWS credentials are found.
+    """
+    # 1. Environment variables
+    if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        return {"source": "environment", "method": "AWS_ACCESS_KEY_ID"}
+
+    # 2. Shared credentials file
+    creds_file = Path(
+        os.environ.get("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials")
+    ).expanduser()
+    if creds_file.exists():
+        profile = os.environ.get("AWS_PROFILE", "default")
+        return {"source": "credentials_file", "profile": profile, "path": str(creds_file)}
+
+    # 3. AWS config file
+    config_file = Path(os.environ.get("AWS_CONFIG_FILE", "~/.aws/config")).expanduser()
+    if config_file.exists():
+        profile = os.environ.get("AWS_PROFILE", "default")
+        return {"source": "config_file", "profile": profile, "path": str(config_file)}
+
+    # 4. Try boto3 session (catches IAM roles, SSO, etc.)
+    try:
+        import boto3
+
+        session = boto3.Session()
+        creds = session.get_credentials()
+        if creds is not None:
+            return {"source": "boto3_session", "method": type(creds).__name__}
+    except ImportError:
+        pass
+    except Exception:
+        pass
+
+    raise CloudCredentialError(
+        "s3",
+        "AWS credentials not found. Configure with:\n"
+        "  - Environment: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY\n"
+        "  - AWS CLI: aws configure\n"
+        "  - Run `nexus doctor` for detailed diagnostics",
+    )
+
+
+def check_gcs_credentials() -> dict[str, str]:
+    """Check for available GCP credentials.
+
+    Returns:
+        Dict with credential source info.
+
+    Raises:
+        CloudCredentialError: If no GCP credentials are found.
+    """
+    # 1. GOOGLE_APPLICATION_CREDENTIALS env var
+    gac = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if gac and Path(gac).exists():
+        return {"source": "service_account", "path": gac}
+
+    # 2. Application Default Credentials (ADC)
+    adc_path = Path("~/.config/gcloud/application_default_credentials.json").expanduser()
+    if adc_path.exists():
+        return {"source": "adc", "path": str(adc_path)}
+
+    # 3. Try google-auth default credentials
+    try:
+        import google.auth
+
+        credentials, project = google.auth.default()
+        if credentials is not None:
+            return {"source": "google_auth_default", "project": project or "unknown"}
+    except ImportError:
+        pass
+    except Exception:
+        pass
+
+    raise CloudCredentialError(
+        "gcs",
+        "GCP credentials not found. Configure with:\n"
+        "  - Environment: GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json\n"
+        "  - gcloud CLI: gcloud auth application-default login\n"
+        "  - Run `nexus doctor` for detailed diagnostics",
+    )
+
+
+def discover_credentials(scheme: str) -> dict[str, str]:
+    """Discover credentials for a given backend scheme.
+
+    Args:
+        scheme: URI scheme (s3, gcs, local, gdrive).
+
+    Returns:
+        Dict with credential source info.
+
+    Raises:
+        CloudCredentialError: If credentials are not found for cloud backends.
+    """
+    if scheme == "s3":
+        return check_aws_credentials()
+    elif scheme == "gcs":
+        return check_gcs_credentials()
+    elif scheme in ("local", "gdrive"):
+        # local: no credentials needed
+        # gdrive: deferred to explicit auth step
+        return {"source": "none", "scheme": scheme}
+    else:
+        return {"source": "unknown", "scheme": scheme}

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -1,0 +1,250 @@
+"""Thin NexusFS facade for the slim package.
+
+Exposes ~10 public methods from the kernel NexusFS. Internal methods
+(sandbox, workflows, bulk operations, dispatch hooks) are hidden.
+
+The facade also provides optimized implementations where the full kernel
+path is unnecessarily heavy for slim-package use (e.g., single-lookup stat).
+
+Usage:
+    from nexus.fs._facade import SlimNexusFS
+
+    facade = SlimNexusFS(kernel_fs)
+    content = await facade.read("/s3/bucket/file.txt")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.metadata import FileMetadata
+from nexus.contracts.types import OperationContext
+from nexus.core.nexus_fs import NexusFS
+
+logger = logging.getLogger(__name__)
+
+# Default context for slim-mode (single-user, no auth)
+_SLIM_CONTEXT = OperationContext(
+    user_id="local",
+    groups=[],
+    zone_id=ROOT_ZONE_ID,
+    is_admin=True,
+)
+
+
+class SlimNexusFS:
+    """Slim facade over the NexusFS kernel.
+
+    Provides a clean, minimal API surface for the standalone nexus-fs package.
+    All methods use a default local context (no auth, single-user).
+
+    Public API (~10 methods):
+        read, write, ls, stat, delete, mkdir, rmdir, rename, exists, copy
+    """
+
+    def __init__(self, kernel: NexusFS) -> None:
+        self._kernel = kernel
+        self._ctx = _SLIM_CONTEXT
+
+    @property
+    def kernel(self) -> NexusFS:
+        """Escape hatch: access the underlying kernel for advanced use."""
+        return self._kernel
+
+    # -- Read operations --
+
+    async def read(self, path: str) -> bytes:
+        """Read file content.
+
+        Args:
+            path: Virtual file path (e.g., "/s3/my-bucket/file.txt")
+
+        Returns:
+            File content as bytes.
+
+        Raises:
+            NexusFileNotFoundError: If file does not exist.
+        """
+        return await self._kernel.sys_read(path, context=self._ctx)
+
+    # -- Write operations --
+
+    async def write(self, path: str, content: bytes) -> dict[str, Any]:
+        """Write content to a file (creates or overwrites).
+
+        Args:
+            path: Virtual file path.
+            content: File content as bytes.
+
+        Returns:
+            Dict with path, size, etag, version.
+        """
+        return await self._kernel.sys_write(path, content, context=self._ctx)
+
+    # -- Directory operations --
+
+    async def ls(
+        self,
+        path: str = "/",
+        detail: bool = False,
+        recursive: bool = False,
+    ) -> list[str] | list[dict[str, Any]]:
+        """List directory contents.
+
+        Args:
+            path: Directory path to list.
+            detail: If True, return dicts with metadata. If False, return paths.
+            recursive: If True, list recursively.
+
+        Returns:
+            List of paths (detail=False) or list of metadata dicts (detail=True).
+        """
+        return await self._kernel.sys_readdir(
+            path,
+            recursive=recursive,
+            details=detail,
+            context=self._ctx,
+        )
+
+    async def mkdir(self, path: str, parents: bool = True) -> None:
+        """Create a directory.
+
+        Args:
+            path: Directory path to create.
+            parents: If True, create parent directories as needed (mkdir -p).
+        """
+        await self._kernel.sys_mkdir(
+            path,
+            parents=parents,
+            exist_ok=True,
+            context=self._ctx,
+        )
+
+    async def rmdir(self, path: str, recursive: bool = False) -> None:
+        """Remove a directory.
+
+        Args:
+            path: Directory path to remove.
+            recursive: If True, remove contents recursively (rm -rf).
+        """
+        await self._kernel.sys_rmdir(path, recursive=recursive, context=self._ctx)
+
+    # -- File operations --
+
+    async def delete(self, path: str) -> None:
+        """Delete a file.
+
+        Args:
+            path: Virtual file path to delete.
+
+        Raises:
+            NexusFileNotFoundError: If file does not exist.
+        """
+        await self._kernel.sys_unlink(path, context=self._ctx)
+
+    async def rename(self, old_path: str, new_path: str) -> None:
+        """Rename/move a file.
+
+        Args:
+            old_path: Current file path.
+            new_path: New file path.
+        """
+        await self._kernel.sys_rename(old_path, new_path, context=self._ctx)
+
+    async def exists(self, path: str) -> bool:
+        """Check if a path exists.
+
+        Args:
+            path: Virtual file path.
+
+        Returns:
+            True if the path exists (file or directory).
+        """
+        return await self._kernel.sys_access(path, context=self._ctx)
+
+    async def copy(self, src: str, dst: str) -> dict[str, Any]:
+        """Copy a file from src to dst.
+
+        Args:
+            src: Source file path.
+            dst: Destination file path.
+
+        Returns:
+            Dict with path, size, etag of the new file.
+        """
+        content = await self.read(src)
+        return await self.write(dst, content)
+
+    # -- Metadata (optimized single-lookup) --
+
+    async def stat(self, path: str) -> dict[str, Any] | None:
+        """Get file/directory metadata with a single metadata lookup.
+
+        Optimized for the slim package — avoids the kernel's double-lookup
+        pattern (sys_is_directory + metadata.get) by doing one read and
+        deriving directory status from the result.
+
+        Args:
+            path: Virtual file path.
+
+        Returns:
+            Metadata dict, or None if path does not exist.
+        """
+        from nexus.lib.path_utils import validate_path
+
+        normalized = validate_path(path, allow_root=True)
+
+        # Single metadata lookup
+        meta: FileMetadata | None = self._kernel.metadata.get(normalized)
+
+        if meta is not None:
+            is_dir = meta.is_dir or meta.is_mount or meta.mime_type == "inode/directory"
+            return {
+                "path": meta.path,
+                "size": meta.size or (4096 if is_dir else 0),
+                "etag": meta.etag,
+                "mime_type": meta.mime_type
+                or ("inode/directory" if is_dir else "application/octet-stream"),
+                "created_at": meta.created_at.isoformat() if meta.created_at else None,
+                "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
+                "is_directory": is_dir,
+                "version": meta.version,
+                "zone_id": meta.zone_id,
+                "entry_type": meta.entry_type,
+            }
+
+        # No explicit entry — check if it's an implicit directory
+        if self._kernel.metadata.is_implicit_directory(normalized):
+            return {
+                "path": normalized,
+                "size": 4096,
+                "etag": None,
+                "mime_type": "inode/directory",
+                "created_at": None,
+                "modified_at": None,
+                "is_directory": True,
+                "version": 0,
+                "zone_id": ROOT_ZONE_ID,
+                "entry_type": 1,
+            }
+
+        return None
+
+    # -- Mount management (delegated to kernel router) --
+
+    def list_mounts(self) -> list[str]:
+        """List all mount points.
+
+        Returns:
+            Sorted list of mount point paths.
+        """
+        return sorted(m.mount_point for m in self._kernel.router.list_mounts())
+
+    # -- Lifecycle --
+
+    async def close(self) -> None:
+        """Close the filesystem and release resources."""
+        if hasattr(self._kernel, "close"):
+            await self._kernel.close()

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -69,6 +69,21 @@ class SlimNexusFS:
         """
         return await self._kernel.sys_read(path, context=self._ctx)
 
+    async def read_range(self, path: str, start: int, end: int) -> bytes:
+        """Read a specific byte range from a file.
+
+        Memory-efficient — only fetches the requested range from the backend.
+
+        Args:
+            path: Virtual file path.
+            start: Start byte offset (inclusive).
+            end: End byte offset (exclusive).
+
+        Returns:
+            Bytes in the requested range.
+        """
+        return await self._kernel.read_range(path, start, end, context=self._ctx)
+
     # -- Write operations --
 
     async def write(self, path: str, content: bytes) -> dict[str, Any]:

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -230,8 +230,11 @@ class SlimNexusFS:
                 "entry_type": meta.entry_type,
             }
 
-        # No explicit entry — check if it's an implicit directory
-        if self._kernel.metadata.is_implicit_directory(normalized):
+        # No explicit entry — check if it's an implicit directory.
+        # is_implicit_directory is on concrete metastore classes, not the ABC.
+        _meta = self._kernel.metadata
+        _is_implicit = getattr(_meta, "is_implicit_directory", None)
+        if _is_implicit is not None and _is_implicit(normalized):
             return {
                 "path": normalized,
                 "size": 4096,
@@ -261,5 +264,9 @@ class SlimNexusFS:
 
     async def close(self) -> None:
         """Close the filesystem and release resources."""
-        if hasattr(self._kernel, "close"):
-            await self._kernel.close()
+        _close = getattr(self._kernel, "close", None)
+        if _close is not None:
+            result = _close()
+            # Handle both sync and async close implementations
+            if result is not None:
+                await result

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -67,7 +67,7 @@ class NexusFileSystem:
                 (NexusFileSystem, AbstractFileSystem),
                 {},
             )
-            AbstractFileSystem.__init__(self, **kwargs)
+            super().__init__(**kwargs)
         self._nexus = nexus_fs
         self._sync = _get_sync_caller()
 

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import io
 import logging
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -32,7 +33,7 @@ logger = logging.getLogger(__name__)
 MAX_CAT_FILE_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB
 
 
-def _get_fs_class():
+def _get_fs_class() -> tuple[type, type]:
     """Lazy-import fsspec base classes to avoid hard dependency."""
     try:
         from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
@@ -144,7 +145,7 @@ class NexusFileSystem:
                 f"Use open() for streaming access."
             )
 
-        content = self._sync(self._nexus.read(path))
+        content: bytes = self._sync(self._nexus.read(path))
 
         if start is not None or end is not None:
             content = content[start:end]
@@ -256,7 +257,7 @@ class NexusBufferedFile:
         end = self.size if length == -1 else min(self._pos + length, self.size)
 
         # Fetch only the requested byte range — NOT the full file
-        data = self._sync(self._nexus.read_range(self.path, self._pos, end))
+        data: bytes = self._sync(self._nexus.read_range(self.path, self._pos, end))
         self._pos = end
         return data
 
@@ -348,7 +349,10 @@ class NexusWriteFile:
         self.close()
 
 
-def _get_sync_caller():
+SyncCaller = Callable[[Coroutine[Any, Any, Any]], Any]
+
+
+def _get_sync_caller() -> SyncCaller:
     """Get a sync caller that runs async code synchronously.
 
     Uses anyio if available, falls back to asyncio.run().
@@ -358,7 +362,7 @@ def _get_sync_caller():
 
         _portal = BlockingPortalProvider()
 
-        def sync_call(coro):
+        def sync_call(coro: Coroutine[Any, Any, Any]) -> Any:
             with _portal as portal:
                 return portal.call(lambda: coro)
 
@@ -366,7 +370,7 @@ def _get_sync_caller():
     except ImportError:
         import asyncio
 
-        def sync_call(coro):
+        def sync_call(coro: Coroutine[Any, Any, Any]) -> Any:
             try:
                 asyncio.get_running_loop()
                 # If there's a running loop, we can't use asyncio.run()

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -243,7 +243,11 @@ class NexusBufferedFile:
         self._closed = False
 
     def read(self, length: int = -1) -> bytes:
-        """Read up to length bytes from current position."""
+        """Read up to length bytes from current position.
+
+        Uses read_range() for memory-efficient byte-range fetching — only
+        the requested range is transferred from the backend, not the full file.
+        """
         if self._closed:
             raise ValueError("I/O operation on closed file")
         if self._pos >= self.size:
@@ -251,9 +255,8 @@ class NexusBufferedFile:
 
         end = self.size if length == -1 else min(self._pos + length, self.size)
 
-        # Fetch the byte range from the kernel
-        content = self._sync(self._nexus.read(self.path))
-        data = content[self._pos : end]
+        # Fetch only the requested byte range — NOT the full file
+        data = self._sync(self._nexus.read_range(self.path, self._pos, end))
         self._pos = end
         return data
 

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -1,0 +1,378 @@
+"""fsspec compatibility layer for nexus-fs.
+
+Implements ``fsspec.AbstractFileSystem`` so that nexus mounts are accessible
+via standard Python data tools:
+
+    pd.read_csv("nexus:///s3/my-bucket/data.csv")
+
+Registration:
+    # Via entry point (pyproject.toml):
+    [project.entry-points."fsspec.specs"]
+    nexus = "nexus.fs._fsspec:NexusFileSystem"
+
+    # Or via code:
+    from fsspec import register_implementation
+    from nexus.fs._fsspec import NexusFileSystem
+    register_implementation("nexus", NexusFileSystem)
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.fs._facade import SlimNexusFS
+
+logger = logging.getLogger(__name__)
+
+# Maximum file size for _cat_file before refusing (1 GB).
+# Files larger than this should use _open() with streaming.
+MAX_CAT_FILE_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB
+
+
+def _get_fs_class():
+    """Lazy-import fsspec base classes to avoid hard dependency."""
+    try:
+        from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
+
+        return AbstractFileSystem, AbstractBufferedFile
+    except ImportError:
+        raise ImportError(
+            "fsspec is required for NexusFileSystem. Install with: pip install nexus-fs[fsspec]"
+        ) from None
+
+
+class NexusFileSystem:
+    """fsspec-compatible filesystem backed by nexus-fs mounts.
+
+    This class is constructed lazily — it inherits from AbstractFileSystem
+    only when fsspec is available. Use ``NexusFileSystem.create()`` or
+    import directly (which triggers the fsspec import check).
+
+    Parameters:
+        nexus_fs: A SlimNexusFS facade instance.
+    """
+
+    protocol = ("nexus",)
+
+    def __init__(self, nexus_fs: SlimNexusFS, **kwargs: Any) -> None:
+        AbstractFileSystem, _ = _get_fs_class()
+        # Mixin the base class dynamically
+        if not isinstance(self, AbstractFileSystem):
+            self.__class__ = type(
+                "NexusFileSystem",
+                (NexusFileSystem, AbstractFileSystem),
+                {},
+            )
+            AbstractFileSystem.__init__(self, **kwargs)
+        self._nexus = nexus_fs
+        self._sync = _get_sync_caller()
+
+    @classmethod
+    def _strip_protocol(cls, path: str) -> str:
+        """Remove nexus:// protocol prefix from path."""
+        if path.startswith("nexus://"):
+            path = path[len("nexus://") :]
+        if path.startswith("nexus:"):
+            path = path[len("nexus:") :]
+        # Ensure leading slash
+        if not path.startswith("/"):
+            path = "/" + path
+        return path
+
+    def ls(self, path: str, detail: bool = True, **kwargs: Any) -> list:  # noqa: ARG002
+        """List objects at path.
+
+        Args:
+            path: Directory path to list.
+            detail: If True, return list of dicts. If False, return list of paths.
+
+        Returns:
+            List of entries (dicts with name/size/type if detail=True).
+        """
+        path = self._strip_protocol(path)
+        entries = self._sync(self._nexus.ls(path, detail=True, recursive=False))
+
+        if detail:
+            return [
+                {
+                    "name": e["path"],
+                    "size": e.get("size", 0),
+                    "type": "directory" if e.get("entry_type", 0) == 1 else "file",
+                }
+                for e in entries
+            ]
+        return [e["path"] for e in entries]
+
+    def info(self, path: str, **kwargs: Any) -> dict[str, Any]:  # noqa: ARG002
+        """Return metadata for a single path."""
+        path = self._strip_protocol(path)
+        stat = self._sync(self._nexus.stat(path))
+        if stat is None:
+            raise FileNotFoundError(path)
+        return {
+            "name": stat["path"],
+            "size": stat.get("size", 0),
+            "type": "directory" if stat.get("is_directory") else "file",
+            "etag": stat.get("etag"),
+            "created": stat.get("created_at"),
+            "modified": stat.get("modified_at"),
+        }
+
+    def _cat_file(
+        self,
+        path: str,
+        start: int | None = None,
+        end: int | None = None,
+        **kwargs: Any,  # noqa: ARG002
+    ) -> bytes:
+        """Read file contents with optional byte range.
+
+        Raises ValueError if file exceeds MAX_CAT_FILE_SIZE (1 GB).
+        Use _open() for large files.
+        """
+        path = self._strip_protocol(path)
+
+        # Size guard: refuse to load files > 1 GB into memory
+        stat = self._sync(self._nexus.stat(path))
+        if stat and stat.get("size", 0) > MAX_CAT_FILE_SIZE:
+            size_gb = stat["size"] / (1024**3)
+            raise ValueError(
+                f"File too large for _cat_file ({size_gb:.1f} GB > 1 GB limit). "
+                f"Use open() for streaming access."
+            )
+
+        content = self._sync(self._nexus.read(path))
+
+        if start is not None or end is not None:
+            content = content[start:end]
+        return content
+
+    def _pipe_file(
+        self,
+        path: str,
+        value: bytes,
+        mode: str = "overwrite",  # noqa: ARG002 — fsspec API contract
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        """Write data to a file."""
+        path = self._strip_protocol(path)
+        self._sync(self._nexus.write(path, value))
+
+    def _rm(self, path: str) -> None:
+        """Delete a file."""
+        path = self._strip_protocol(path)
+        self._sync(self._nexus.delete(path))
+
+    def _cp_file(self, path1: str, path2: str, **kwargs: Any) -> None:  # noqa: ARG002
+        """Copy a single file."""
+        path1 = self._strip_protocol(path1)
+        path2 = self._strip_protocol(path2)
+        self._sync(self._nexus.copy(path1, path2))
+
+    def _mkdir(self, path: str, create_parents: bool = True, **kwargs: Any) -> None:  # noqa: ARG002
+        """Create directory."""
+        path = self._strip_protocol(path)
+        self._sync(self._nexus.mkdir(path, parents=create_parents))
+
+    def _open(
+        self,
+        path: str,
+        mode: str = "rb",
+        block_size: int | None = None,
+        **kwargs: Any,  # noqa: ARG002
+    ) -> Any:
+        """Return a file-like object for streaming access.
+
+        For read mode, returns a NexusBufferedFile that fetches byte ranges
+        on demand. For write mode, returns a BytesIO that flushes to nexus
+        on close.
+        """
+        path = self._strip_protocol(path)
+
+        if "r" in mode:
+            stat = self._sync(self._nexus.stat(path))
+            if stat is None:
+                raise FileNotFoundError(path)
+            size = stat.get("size", 0)
+            return NexusBufferedFile(
+                fs=self,
+                path=path,
+                mode=mode,
+                size=size,
+                block_size=block_size or 5 * 1024 * 1024,  # 5 MB default
+                nexus_fs=self._nexus,
+                sync_caller=self._sync,
+            )
+        else:
+            return NexusWriteFile(
+                fs=self,
+                path=path,
+                nexus_fs=self._nexus,
+                sync_caller=self._sync,
+            )
+
+
+class NexusBufferedFile:
+    """Read-only file-like object with byte-range fetching.
+
+    Implements the minimal interface needed by pandas, dask, etc.:
+    read(), seek(), tell(), close(), __enter__/__exit__.
+    """
+
+    def __init__(
+        self,
+        fs: NexusFileSystem,
+        path: str,
+        mode: str,
+        size: int,
+        block_size: int,
+        nexus_fs: SlimNexusFS,
+        sync_caller: Any,
+    ) -> None:
+        self.fs = fs
+        self.path = path
+        self.mode = mode
+        self.size = size
+        self.block_size = block_size
+        self._nexus = nexus_fs
+        self._sync = sync_caller
+        self._pos = 0
+        self._closed = False
+
+    def read(self, length: int = -1) -> bytes:
+        """Read up to length bytes from current position."""
+        if self._closed:
+            raise ValueError("I/O operation on closed file")
+        if self._pos >= self.size:
+            return b""
+
+        end = self.size if length == -1 else min(self._pos + length, self.size)
+
+        # Fetch the byte range from the kernel
+        content = self._sync(self._nexus.read(self.path))
+        data = content[self._pos : end]
+        self._pos = end
+        return data
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        """Seek to a position."""
+        if whence == 0:
+            self._pos = offset
+        elif whence == 1:
+            self._pos += offset
+        elif whence == 2:
+            self._pos = self.size + offset
+        self._pos = max(0, min(self._pos, self.size))
+        return self._pos
+
+    def tell(self) -> int:
+        return self._pos
+
+    def close(self) -> None:
+        self._closed = True
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        return True
+
+    def __enter__(self) -> NexusBufferedFile:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+class NexusWriteFile:
+    """Write-only file-like object that buffers content in memory.
+
+    Flushes to nexus on close().
+    """
+
+    def __init__(
+        self,
+        fs: NexusFileSystem,
+        path: str,
+        nexus_fs: SlimNexusFS,
+        sync_caller: Any,
+    ) -> None:
+        self.fs = fs
+        self.path = path
+        self._nexus = nexus_fs
+        self._sync = sync_caller
+        self._buffer = io.BytesIO()
+        self._closed = False
+
+    def write(self, data: bytes) -> int:
+        if self._closed:
+            raise ValueError("I/O operation on closed file")
+        return self._buffer.write(data)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._buffer.seek(0)
+            self._sync(self._nexus.write(self.path, self._buffer.read()))
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def readable(self) -> bool:
+        return False
+
+    def writable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return False
+
+    def __enter__(self) -> NexusWriteFile:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+def _get_sync_caller():
+    """Get a sync caller that runs async code synchronously.
+
+    Uses anyio if available, falls back to asyncio.run().
+    """
+    try:
+        from anyio.from_thread import BlockingPortalProvider
+
+        _portal = BlockingPortalProvider()
+
+        def sync_call(coro):
+            with _portal as portal:
+                return portal.call(lambda: coro)
+
+        return sync_call
+    except ImportError:
+        import asyncio
+
+        def sync_call(coro):
+            try:
+                asyncio.get_running_loop()
+                # If there's a running loop, we can't use asyncio.run()
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(asyncio.run, coro)
+                    return future.result()
+            except RuntimeError:
+                return asyncio.run(coro)
+
+        return sync_call

--- a/src/nexus/fs/_sqlite_meta.py
+++ b/src/nexus/fs/_sqlite_meta.py
@@ -1,0 +1,341 @@
+"""SQLite-backed MetastoreABC for the nexus-fs slim package.
+
+Lightweight, stdlib-only metastore using sqlite3. Designed for single-process
+local use where the full Raft metastore is not needed. WAL mode is enabled for
+safe concurrent reads and the busy_timeout handles brief writer contention.
+
+No connection pooling — a single serialized-mode connection is used, which is
+thread-safe via sqlite3's internal locking (check_same_thread=False).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from collections.abc import Iterator, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from nexus.contracts.metadata import FileMetadata
+from nexus.core.metastore import MetastoreABC
+
+logger = logging.getLogger(__name__)
+
+# Retry parameters for write operations hitting SQLITE_BUSY
+_MAX_RETRIES = 3
+_BASE_BACKOFF_S = 0.010  # 10ms, doubles each retry
+
+_CREATE_TABLE = """\
+CREATE TABLE IF NOT EXISTS metadata (
+    path          TEXT PRIMARY KEY,
+    backend_name  TEXT NOT NULL,
+    physical_path TEXT NOT NULL,
+    size          INTEGER NOT NULL DEFAULT 0,
+    etag          TEXT,
+    mime_type     TEXT,
+    created_at    TEXT,
+    modified_at   TEXT,
+    version       INTEGER NOT NULL DEFAULT 1,
+    created_by    TEXT,
+    zone_id       TEXT,
+    owner_id      TEXT,
+    entry_type    INTEGER NOT NULL DEFAULT 0,
+    target_zone_id TEXT
+);
+"""
+
+_UPSERT = """\
+INSERT INTO metadata (
+    path, backend_name, physical_path, size, etag, mime_type,
+    created_at, modified_at, version, created_by, zone_id,
+    owner_id, entry_type, target_zone_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(path) DO UPDATE SET
+    backend_name   = excluded.backend_name,
+    physical_path  = excluded.physical_path,
+    size           = excluded.size,
+    etag           = excluded.etag,
+    mime_type      = excluded.mime_type,
+    created_at     = excluded.created_at,
+    modified_at    = excluded.modified_at,
+    version        = excluded.version,
+    created_by     = excluded.created_by,
+    zone_id        = excluded.zone_id,
+    owner_id       = excluded.owner_id,
+    entry_type     = excluded.entry_type,
+    target_zone_id = excluded.target_zone_id;
+"""
+
+
+def _dt_to_iso(dt: datetime | None) -> str | None:
+    """Serialize datetime to ISO-8601 string for SQLite storage."""
+    return dt.isoformat() if dt else None
+
+
+def _iso_to_dt(val: str | None) -> datetime | None:
+    """Deserialize ISO-8601 string back to datetime."""
+    if val is None:
+        return None
+    return datetime.fromisoformat(val)
+
+
+def _row_to_metadata(row: sqlite3.Row) -> FileMetadata:
+    """Convert a sqlite3.Row into a FileMetadata instance."""
+    return FileMetadata(
+        path=row["path"],
+        backend_name=row["backend_name"],
+        physical_path=row["physical_path"],
+        size=row["size"],
+        etag=row["etag"],
+        mime_type=row["mime_type"],
+        created_at=_iso_to_dt(row["created_at"]),
+        modified_at=_iso_to_dt(row["modified_at"]),
+        version=row["version"],
+        created_by=row["created_by"],
+        zone_id=row["zone_id"],
+        owner_id=row["owner_id"],
+        entry_type=row["entry_type"],
+        target_zone_id=row["target_zone_id"],
+    )
+
+
+def _metadata_to_tuple(m: FileMetadata) -> tuple[Any, ...]:
+    """Convert FileMetadata to a parameter tuple matching the INSERT column order."""
+    return (
+        m.path,
+        m.backend_name,
+        m.physical_path,
+        m.size,
+        m.etag,
+        m.mime_type,
+        _dt_to_iso(m.created_at),
+        _dt_to_iso(m.modified_at),
+        m.version,
+        m.created_by,
+        m.zone_id,
+        m.owner_id,
+        m.entry_type,
+        m.target_zone_id,
+    )
+
+
+def _retry_on_busy(fn: Any) -> Any:
+    """Decorator: retry a write function up to _MAX_RETRIES on SQLITE_BUSY.
+
+    Backoff schedule: 10ms, 20ms, 40ms (exponential).
+    """
+    import functools
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        last_exc: sqlite3.OperationalError | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                return fn(*args, **kwargs)
+            except sqlite3.OperationalError as exc:
+                if "database is locked" not in str(exc):
+                    raise
+                last_exc = exc
+                if attempt < _MAX_RETRIES:
+                    backoff = _BASE_BACKOFF_S * (2**attempt)
+                    logger.warning(
+                        "SQLiteMetastore: SQLITE_BUSY on %s, retry %d/%d in %.0fms",
+                        fn.__name__,
+                        attempt + 1,
+                        _MAX_RETRIES,
+                        backoff * 1000,
+                    )
+                    time.sleep(backoff)
+        assert last_exc is not None  # guaranteed by loop logic
+        raise last_exc
+
+    return wrapper
+
+
+class SQLiteMetastore(MetastoreABC):
+    """SQLite-backed metastore for the nexus-fs slim package.
+
+    Uses a single ``metadata`` table with columns mirroring FileMetadata fields.
+    WAL journal mode is enabled for better concurrent-read performance.
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._conn = sqlite3.connect(
+            str(self._db_path),
+            check_same_thread=False,
+        )
+        self._conn.row_factory = sqlite3.Row
+
+        # Enable WAL for concurrent readers + single writer
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        # 5-second busy timeout before raising SQLITE_BUSY
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        # Create schema
+        self._conn.execute(_CREATE_TABLE)
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Abstract method implementations
+    # ------------------------------------------------------------------
+
+    def get(self, path: str) -> FileMetadata | None:
+        row = self._conn.execute("SELECT * FROM metadata WHERE path = ?", (path,)).fetchone()
+        return _row_to_metadata(row) if row else None
+
+    @_retry_on_busy
+    def put(self, metadata: FileMetadata, *, consistency: str = "sc") -> int | None:
+        del consistency
+        self._conn.execute(_UPSERT, _metadata_to_tuple(metadata))
+        self._conn.commit()
+        return None
+
+    @_retry_on_busy
+    def delete(self, path: str, *, consistency: str = "sc") -> dict[str, Any] | None:
+        del consistency
+        cur = self._conn.execute("DELETE FROM metadata WHERE path = ? RETURNING path", (path,))
+        deleted = cur.fetchone()
+        self._conn.commit()
+        return {"deleted": path} if deleted else None
+
+    def exists(self, path: str) -> bool:
+        row = self._conn.execute("SELECT 1 FROM metadata WHERE path = ?", (path,)).fetchone()
+        return row is not None
+
+    def list(self, prefix: str = "", recursive: bool = True, **_kw: Any) -> list[FileMetadata]:
+        if prefix:
+            rows = self._conn.execute(
+                "SELECT * FROM metadata WHERE path LIKE ? ESCAPE '\\'",
+                (_escape_like(prefix) + "%",),
+            ).fetchall()
+        else:
+            rows = self._conn.execute("SELECT * FROM metadata").fetchall()
+
+        results = [_row_to_metadata(r) for r in rows]
+
+        if not recursive:
+            depth = prefix.rstrip("/").count("/") + 1
+            results = [m for m in results if m.path.rstrip("/").count("/") == depth]
+
+        return results
+
+    def close(self) -> None:
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Concrete overrides for better performance
+    # ------------------------------------------------------------------
+
+    def list_iter(
+        self, prefix: str = "", recursive: bool = True, **_kw: Any
+    ) -> Iterator[FileMetadata]:
+        """Memory-efficient iteration — yields rows one at a time from the cursor."""
+        if prefix:
+            cur = self._conn.execute(
+                "SELECT * FROM metadata WHERE path LIKE ? ESCAPE '\\'",
+                (_escape_like(prefix) + "%",),
+            )
+        else:
+            cur = self._conn.execute("SELECT * FROM metadata")
+
+        depth = prefix.rstrip("/").count("/") + 1 if not recursive else -1
+        for row in cur:
+            meta = _row_to_metadata(row)
+            if not recursive and meta.path.rstrip("/").count("/") != depth:
+                continue
+            yield meta
+
+    def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
+        if not paths:
+            return {}
+        placeholders = ",".join("?" for _ in paths)
+        rows = self._conn.execute(
+            f"SELECT * FROM metadata WHERE path IN ({placeholders})",  # noqa: S608
+            tuple(paths),
+        ).fetchall()
+        found = {r["path"]: _row_to_metadata(r) for r in rows}
+        return {p: found.get(p) for p in paths}
+
+    @_retry_on_busy
+    def put_batch(self, metadata_list: Sequence[FileMetadata]) -> None:
+        if not metadata_list:
+            return
+        self._conn.executemany(_UPSERT, [_metadata_to_tuple(m) for m in metadata_list])
+        self._conn.commit()
+
+    @_retry_on_busy
+    def delete_batch(self, paths: Sequence[str]) -> None:
+        if not paths:
+            return
+        placeholders = ",".join("?" for _ in paths)
+        self._conn.execute(
+            f"DELETE FROM metadata WHERE path IN ({placeholders})",  # noqa: S608
+            tuple(paths),
+        )
+        self._conn.commit()
+
+    def batch_get_content_ids(self, paths: Sequence[str]) -> dict[str, str | None]:
+        if not paths:
+            return {}
+        placeholders = ",".join("?" for _ in paths)
+        rows = self._conn.execute(
+            f"SELECT path, etag FROM metadata WHERE path IN ({placeholders})",  # noqa: S608
+            tuple(paths),
+        ).fetchall()
+        found = {r["path"]: r["etag"] for r in rows}
+        return {p: found.get(p) for p in paths}
+
+    @_retry_on_busy
+    def rename_path(self, old_path: str, new_path: str) -> None:
+        """Rename a path (and all children if it's a directory)."""
+        from dataclasses import replace
+
+        meta = self.get(old_path)
+        if meta is not None:
+            self.delete(old_path)
+            self.put(replace(meta, path=new_path))
+
+        # Also rename children (directory rename)
+        old_prefix = old_path.rstrip("/") + "/"
+        new_prefix = new_path.rstrip("/") + "/"
+        children = self.list(old_prefix, recursive=True)
+        for child in children:
+            child_new_path = new_prefix + child.path[len(old_prefix) :]
+            self.delete(child.path)
+            self.put(replace(child, path=child_new_path))
+
+    @_retry_on_busy
+    def delete_directory_entries_recursive(self, path: str) -> None:
+        """Delete all directory index entries under a path."""
+        prefix = path.rstrip("/") + "/"
+        self._conn.execute(
+            "DELETE FROM metadata WHERE path LIKE ? ESCAPE '\\' AND entry_type = 1",
+            (_escape_like(prefix) + "%",),
+        )
+        self._conn.commit()
+
+    def is_implicit_directory(self, path: str) -> bool:
+        """A path is an implicit directory if any stored entry has it as a prefix.
+
+        Example: ``/a/b`` is an implicit directory if ``/a/b/c.txt`` exists.
+        """
+        prefix = path.rstrip("/") + "/"
+        row = self._conn.execute(
+            "SELECT 1 FROM metadata WHERE path LIKE ? ESCAPE '\\' LIMIT 1",
+            (_escape_like(prefix) + "%",),
+        ).fetchone()
+        return row is not None
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _escape_like(text: str) -> str:
+    r"""Escape LIKE-special characters (%, _, \\) so prefix matching is exact."""
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/src/nexus/fs/_sync.py
+++ b/src/nexus/fs/_sync.py
@@ -94,6 +94,10 @@ class SyncNexusFS:
         with self._portal_provider as portal:
             return portal.call(self._async.copy, src, dst)
 
+    def read_range(self, path: str, start: int, end: int) -> bytes:
+        with self._portal_provider as portal:
+            return portal.call(self._async.read_range, path, start, end)
+
     def list_mounts(self) -> list:
         """List all mount points (synchronous — no portal needed)."""
         return self._async.list_mounts()

--- a/src/nexus/fs/_sync.py
+++ b/src/nexus/fs/_sync.py
@@ -94,6 +94,10 @@ class SyncNexusFS:
         with self._portal_provider as portal:
             return portal.call(self._async.copy, src, dst)
 
+    def list_mounts(self) -> list:
+        """List all mount points (synchronous — no portal needed)."""
+        return self._async.list_mounts()
+
     def close(self) -> None:
         """Clean up resources held by the underlying async facade."""
         if hasattr(self._async, "close"):

--- a/src/nexus/fs/_sync.py
+++ b/src/nexus/fs/_sync.py
@@ -1,0 +1,101 @@
+"""Synchronous wrapper for async nexus-fs operations.
+
+Uses anyio's BlockingPortalProvider to safely bridge sync -> async,
+replacing the broken nest_asyncio approach (fails on Python 3.14+).
+
+Three supported scenarios:
+1. No event loop (normal Python script) -- creates one internally
+2. Existing event loop (Jupyter) -- uses BlockingPortal worker thread
+3. Multiple threads -- each gets its own portal, thread-safe
+
+Usage:
+    from nexus.fs._sync import SyncNexusFS
+
+    sync_fs = SyncNexusFS(async_facade)
+    content = sync_fs.read("/s3/bucket/file.txt")
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, TypeVar
+
+from anyio.from_thread import BlockingPortalProvider
+
+T = TypeVar("T")
+
+
+def run_sync(coro: Any) -> Any:
+    """Run an async coroutine synchronously.
+
+    Uses anyio's BlockingPortalProvider for safe sync→async bridging.
+    Works in all three scenarios: no event loop, existing loop (Jupyter),
+    and multi-threaded contexts.
+    """
+    _provider = BlockingPortalProvider()
+    with _provider as portal:
+        return portal.call(lambda: coro)
+
+
+class SyncNexusFS:
+    """Synchronous wrapper around the async NexusFS facade.
+
+    Delegates every call to the async facade via an anyio BlockingPortal.
+    Thread-safe -- multiple threads can use the same SyncNexusFS instance.
+
+    The BlockingPortalProvider manages a shared event loop: the first thread
+    to enter starts the loop, and the last thread to exit shuts it down.
+    ``portal.call(func, *args)`` accepts a callable (sync or async) and
+    positional arguments; if the callable returns a coroutine it is awaited
+    automatically.  For calls that require keyword arguments we use
+    ``functools.partial`` to bind them before handing the callable to the
+    portal.
+    """
+
+    def __init__(self, async_fs: Any) -> None:
+        self._async = async_fs
+        self._portal_provider = BlockingPortalProvider()
+
+    # -- Expose the public facade methods as sync versions ----------------
+
+    def read(self, path: str) -> bytes:
+        with self._portal_provider as portal:
+            return portal.call(self._async.read, path)
+
+    def write(self, path: str, content: bytes) -> dict:
+        with self._portal_provider as portal:
+            return portal.call(self._async.write, path, content)
+
+    def ls(self, path: str = "/", detail: bool = False) -> list:
+        with self._portal_provider as portal:
+            return portal.call(functools.partial(self._async.ls, path, detail=detail))
+
+    def stat(self, path: str) -> dict | None:
+        with self._portal_provider as portal:
+            return portal.call(self._async.stat, path)
+
+    def delete(self, path: str) -> None:
+        with self._portal_provider as portal:
+            return portal.call(self._async.delete, path)
+
+    def mkdir(self, path: str, parents: bool = True) -> None:
+        with self._portal_provider as portal:
+            return portal.call(functools.partial(self._async.mkdir, path, parents=parents))
+
+    def rename(self, old_path: str, new_path: str) -> None:
+        with self._portal_provider as portal:
+            return portal.call(self._async.rename, old_path, new_path)
+
+    def exists(self, path: str) -> bool:
+        with self._portal_provider as portal:
+            return portal.call(self._async.exists, path)
+
+    def copy(self, src: str, dst: str) -> dict:
+        with self._portal_provider as portal:
+            return portal.call(self._async.copy, src, dst)
+
+    def close(self) -> None:
+        """Clean up resources held by the underlying async facade."""
+        if hasattr(self._async, "close"):
+            with self._portal_provider as portal:
+                portal.call(self._async.close)

--- a/src/nexus/fs/_sync.py
+++ b/src/nexus/fs/_sync.py
@@ -18,7 +18,7 @@ Usage:
 from __future__ import annotations
 
 import functools
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from anyio.from_thread import BlockingPortalProvider
 
@@ -28,7 +28,7 @@ T = TypeVar("T")
 def run_sync(coro: Any) -> Any:
     """Run an async coroutine synchronously.
 
-    Uses anyio's BlockingPortalProvider for safe sync→async bridging.
+    Uses anyio's BlockingPortalProvider for safe sync->async bridging.
     Works in all three scenarios: no event loop, existing loop (Jupyter),
     and multi-threaded contexts.
     """
@@ -60,47 +60,50 @@ class SyncNexusFS:
 
     def read(self, path: str) -> bytes:
         with self._portal_provider as portal:
-            return portal.call(self._async.read, path)
+            return cast(bytes, portal.call(self._async.read, path))
 
-    def write(self, path: str, content: bytes) -> dict:
+    def write(self, path: str, content: bytes) -> dict[str, Any]:
         with self._portal_provider as portal:
-            return portal.call(self._async.write, path, content)
+            return cast(dict[str, Any], portal.call(self._async.write, path, content))
 
-    def ls(self, path: str = "/", detail: bool = False) -> list:
+    def ls(self, path: str = "/", detail: bool = False) -> list[Any]:
         with self._portal_provider as portal:
-            return portal.call(functools.partial(self._async.ls, path, detail=detail))
+            return cast(
+                list[Any],
+                portal.call(functools.partial(self._async.ls, path, detail=detail)),
+            )
 
-    def stat(self, path: str) -> dict | None:
+    def stat(self, path: str) -> dict[str, Any] | None:
         with self._portal_provider as portal:
-            return portal.call(self._async.stat, path)
+            return cast(dict[str, Any] | None, portal.call(self._async.stat, path))
 
     def delete(self, path: str) -> None:
         with self._portal_provider as portal:
-            return portal.call(self._async.delete, path)
+            portal.call(self._async.delete, path)
 
     def mkdir(self, path: str, parents: bool = True) -> None:
         with self._portal_provider as portal:
-            return portal.call(functools.partial(self._async.mkdir, path, parents=parents))
+            portal.call(functools.partial(self._async.mkdir, path, parents=parents))
 
     def rename(self, old_path: str, new_path: str) -> None:
         with self._portal_provider as portal:
-            return portal.call(self._async.rename, old_path, new_path)
+            portal.call(self._async.rename, old_path, new_path)
 
     def exists(self, path: str) -> bool:
         with self._portal_provider as portal:
-            return portal.call(self._async.exists, path)
+            return cast(bool, portal.call(self._async.exists, path))
 
-    def copy(self, src: str, dst: str) -> dict:
+    def copy(self, src: str, dst: str) -> dict[str, Any]:
         with self._portal_provider as portal:
-            return portal.call(self._async.copy, src, dst)
+            return cast(dict[str, Any], portal.call(self._async.copy, src, dst))
 
     def read_range(self, path: str, start: int, end: int) -> bytes:
         with self._portal_provider as portal:
-            return portal.call(self._async.read_range, path, start, end)
+            return cast(bytes, portal.call(self._async.read_range, path, start, end))
 
-    def list_mounts(self) -> list:
-        """List all mount points (synchronous — no portal needed)."""
-        return self._async.list_mounts()
+    def list_mounts(self) -> list[str]:
+        """List all mount points (synchronous -- no portal needed)."""
+        return cast(list[str], self._async.list_mounts())
 
     def close(self) -> None:
         """Clean up resources held by the underlying async facade."""

--- a/src/nexus/fs/_uri.py
+++ b/src/nexus/fs/_uri.py
@@ -31,7 +31,19 @@ from nexus.contracts.exceptions import InvalidPathError
 # Constants
 # ---------------------------------------------------------------------------
 
-SUPPORTED_SCHEMES: frozenset[str] = frozenset({"s3", "gcs", "local", "gdrive"})
+# Built-in storage schemes with dedicated backend implementations.
+BUILTIN_SCHEMES: frozenset[str] = frozenset({"s3", "gcs", "local", "gdrive"})
+
+# All recognized schemes including connector-based ones.
+# This set is extended at runtime when connectors register themselves.
+# Using a mutable set so _register_connector_scheme() can add to it.
+SUPPORTED_SCHEMES: set[str] = set(BUILTIN_SCHEMES)
+
+
+def _register_connector_scheme(scheme: str) -> None:
+    """Register an additional URI scheme (called by connector discovery)."""
+    SUPPORTED_SCHEMES.add(scheme)
+
 
 RESERVED_PATHS: frozenset[str] = frozenset({"/__sys__", "/__pipes__"})
 
@@ -88,19 +100,18 @@ def parse_uri(uri: str) -> MountSpec:
             f"Missing scheme in URI '{uri}'. "
             f"Supported schemes: {', '.join(sorted(SUPPORTED_SCHEMES))}"
         )
-    if scheme not in SUPPORTED_SCHEMES:
-        raise InvalidPathError(
-            f"Unknown scheme '{scheme}' in URI '{uri}'. "
-            f"Supported schemes: {', '.join(sorted(SUPPORTED_SCHEMES))}"
-        )
+    # Accept any scheme — built-in storage schemes have dedicated backends,
+    # other schemes are resolved via the connector registry at mount time.
+    # Only reject truly empty schemes (handled above).
 
     # --- authority -------------------------------------------------------
     authority = parsed.netloc
     if not authority:
-        # For local:// with an absolute path (e.g. local:///tmp/nexus),
-        # urlparse puts everything into path and leaves netloc empty.
-        # We treat the first path segment as the authority stand-in.
-        if scheme == "local" and parsed.path:
+        # urlparse puts everything into path when authority is empty.
+        # This happens with local:///tmp/nexus and gws://sheets (where
+        # "sheets" is treated as netloc by urlparse if the URI has //).
+        # Treat the first path segment as the authority stand-in.
+        if parsed.path:
             authority, _, remainder = parsed.path.lstrip("/").partition("/")
             if not authority:
                 raise InvalidPathError(
@@ -179,7 +190,8 @@ def derive_mount_point(spec: MountSpec, at: str | None = None) -> str:
     elif spec.scheme == "gdrive":
         mount = f"/gdrive/{spec.authority}"
     else:
-        raise InvalidPathError(f"Cannot derive mount point for scheme '{spec.scheme}'")
+        # Generic: /<scheme>/<authority> — works for any connector scheme
+        mount = f"/{spec.scheme}/{spec.authority}"
 
     # Strip trailing slash for consistent comparisons, but keep root slash.
     mount = mount.rstrip("/") or "/"

--- a/src/nexus/fs/_uri.py
+++ b/src/nexus/fs/_uri.py
@@ -1,0 +1,225 @@
+"""URI parser for cloud storage mount URIs.
+
+Parses URIs of the form ``<scheme>://<authority>/<path>`` into a
+:class:`MountSpec` dataclass and derives filesystem mount points.
+
+Supported schemes
+-----------------
+- ``s3://``     — Amazon S3
+- ``gcs://``    — Google Cloud Storage
+- ``local://``  — Local filesystem
+- ``gdrive://`` — Google Drive
+
+Examples
+--------
+>>> parse_uri("s3://my-bucket/subdir")
+MountSpec(scheme='s3', authority='my-bucket', path='subdir', mount_point='', uri='s3://my-bucket/subdir')
+
+>>> spec = parse_uri("gcs://project/bucket")
+>>> derive_mount_point(spec)
+'/gcs/bucket'
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import urllib.parse
+
+from nexus.contracts.exceptions import InvalidPathError
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SUPPORTED_SCHEMES: frozenset[str] = frozenset({"s3", "gcs", "local", "gdrive"})
+
+RESERVED_PATHS: frozenset[str] = frozenset({"/__sys__", "/__pipes__"})
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MountSpec:
+    """Parsed representation of a cloud-storage mount URI."""
+
+    scheme: str
+    authority: str
+    path: str
+    mount_point: str
+    uri: str
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_uri(uri: str) -> MountSpec:
+    """Parse a cloud-storage URI into a :class:`MountSpec`.
+
+    Parameters
+    ----------
+    uri:
+        A URI string such as ``s3://my-bucket/subdir``.
+
+    Returns
+    -------
+    MountSpec
+        Parsed components.  ``mount_point`` is left empty at this stage —
+        call :func:`derive_mount_point` to populate it.
+
+    Raises
+    ------
+    InvalidPathError
+        If the URI is malformed, uses an unsupported scheme, or has an
+        empty authority component.
+    """
+    if not uri:
+        raise InvalidPathError("URI must not be empty")
+
+    parsed = urllib.parse.urlparse(uri)
+
+    # --- scheme ----------------------------------------------------------
+    scheme = parsed.scheme.lower()
+    if not scheme:
+        raise InvalidPathError(
+            f"Missing scheme in URI '{uri}'. "
+            f"Supported schemes: {', '.join(sorted(SUPPORTED_SCHEMES))}"
+        )
+    if scheme not in SUPPORTED_SCHEMES:
+        raise InvalidPathError(
+            f"Unknown scheme '{scheme}' in URI '{uri}'. "
+            f"Supported schemes: {', '.join(sorted(SUPPORTED_SCHEMES))}"
+        )
+
+    # --- authority -------------------------------------------------------
+    authority = parsed.netloc
+    if not authority:
+        # For local:// with an absolute path (e.g. local:///tmp/nexus),
+        # urlparse puts everything into path and leaves netloc empty.
+        # We treat the first path segment as the authority stand-in.
+        if scheme == "local" and parsed.path:
+            authority, _, remainder = parsed.path.lstrip("/").partition("/")
+            if not authority:
+                raise InvalidPathError(
+                    f"Empty authority in URI '{uri}'. "
+                    "Provide a host, bucket, or path component after the scheme."
+                )
+            path = remainder.rstrip("/")
+            return MountSpec(
+                scheme=scheme,
+                authority=authority,
+                path=path,
+                mount_point="",
+                uri=uri,
+            )
+        raise InvalidPathError(
+            f"Empty authority in URI '{uri}'. "
+            "Provide a host, bucket, or path component after the scheme."
+        )
+
+    # --- path ------------------------------------------------------------
+    path = parsed.path.strip("/")
+
+    return MountSpec(
+        scheme=scheme,
+        authority=authority,
+        path=path,
+        mount_point="",
+        uri=uri,
+    )
+
+
+def derive_mount_point(spec: MountSpec, at: str | None = None) -> str:
+    """Derive the filesystem mount point for a parsed URI.
+
+    Mount-point logic per scheme:
+
+    * **s3**  — ``/s3/<authority>/``
+    * **gcs** — ``/gcs/<last-authority-or-path-segment>/``
+      (``gcs://project/bucket`` → ``/gcs/bucket``)
+    * **local** — ``/local/<sanitised-path>/``
+    * **gdrive** — ``/gdrive/<authority>/``
+
+    Parameters
+    ----------
+    spec:
+        A :class:`MountSpec` returned by :func:`parse_uri`.
+    at:
+        Optional explicit mount-point override.  When provided the
+        derivation logic is skipped entirely.
+
+    Returns
+    -------
+    str
+        Absolute mount-point path (always starts with ``/``).
+
+    Raises
+    ------
+    InvalidPathError
+        If the resulting mount point collides with a reserved path.
+    """
+    if at is not None:
+        mount = at if at.startswith("/") else f"/{at}"
+    elif spec.scheme == "s3":
+        mount = f"/s3/{spec.authority}"
+    elif spec.scheme == "gcs":
+        # gcs://project/bucket → mount at /gcs/bucket
+        # gcs://bucket          → mount at /gcs/bucket
+        last_segment = spec.path.split("/")[-1] if spec.path else spec.authority
+        mount = f"/gcs/{last_segment}"
+    elif spec.scheme == "local":
+        # Sanitise: replace slashes and dots so the mount name is a single
+        # clean segment.  e.g. /tmp/nexus → tmp-nexus, ./data → data
+        raw = spec.path if spec.path else spec.authority
+        sanitised = raw.strip(".").strip("/").replace("/", "-")
+        mount = f"/local/{sanitised}"
+    elif spec.scheme == "gdrive":
+        mount = f"/gdrive/{spec.authority}"
+    else:
+        raise InvalidPathError(f"Cannot derive mount point for scheme '{spec.scheme}'")
+
+    # Strip trailing slash for consistent comparisons, but keep root slash.
+    mount = mount.rstrip("/") or "/"
+
+    _check_reserved(mount)
+    return mount
+
+
+def validate_mount_collision(mount_point: str, existing_mounts: set[str]) -> None:
+    """Raise if *mount_point* conflicts with an existing mount.
+
+    Parameters
+    ----------
+    mount_point:
+        The candidate mount point to check.
+    existing_mounts:
+        Set of mount points that are already in use.
+
+    Raises
+    ------
+    InvalidPathError
+        If *mount_point* is already present in *existing_mounts*.
+    """
+    if mount_point in existing_mounts:
+        raise InvalidPathError(
+            f"Mount point '{mount_point}' is already mounted. "
+            "Each scheme+authority combination must be unique."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_reserved(mount_point: str) -> None:
+    """Raise if *mount_point* falls under a reserved path prefix."""
+    normalised = mount_point.rstrip("/")
+    for reserved in RESERVED_PATHS:
+        if normalised == reserved or normalised.startswith(reserved + "/"):
+            raise InvalidPathError(
+                f"Mount point '{mount_point}' conflicts with reserved path '{reserved}/'."
+            )

--- a/tests/unit/fs/test_fsspec.py
+++ b/tests/unit/fs/test_fsspec.py
@@ -36,6 +36,7 @@ def mock_nexus_fs():
     """Mock SlimNexusFS facade with async methods."""
     fs = AsyncMock()
     fs.read = AsyncMock(return_value=b"hello world")
+    fs.read_range = AsyncMock(return_value=b"hello world")
     fs.write = AsyncMock(return_value={"path": "/test.txt", "size": 11, "etag": "abc"})
     fs.ls = AsyncMock(
         return_value=[
@@ -252,6 +253,16 @@ class TestOpenRead:
         with nexus_fsspec._open("/file.txt", mode="rb") as f:
             data = f.read()
             assert data == b"hello world"
+
+    def test_open_read_uses_read_range_not_full_read(self, nexus_fsspec, mock_nexus_fs):
+        """Verify _open() uses read_range() for streaming, not read() which loads full file."""
+        mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}
+        mock_nexus_fs.read_range = AsyncMock(return_value=b"hello")
+        with nexus_fsspec._open("/file.txt", mode="rb") as f:
+            f.read(5)
+        mock_nexus_fs.read_range.assert_called_once()
+        # read() should NOT be called — only read_range()
+        mock_nexus_fs.read.assert_not_called()
 
     def test_open_read_seek_tell(self, nexus_fsspec, mock_nexus_fs):
         mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}

--- a/tests/unit/fs/test_fsspec.py
+++ b/tests/unit/fs/test_fsspec.py
@@ -1,0 +1,305 @@
+"""Tests for fsspec NexusFileSystem compatibility layer.
+
+Verifies that NexusFileSystem implements the fsspec contract:
+- ls() returns correct format (detail=True/False)
+- info() returns required keys (name, size, type)
+- _cat_file() reads content with byte ranges
+- _cat_file() enforces size guard (1 GB limit)
+- _pipe_file() writes content
+- _rm() deletes files
+- _cp_file() copies files
+- _mkdir() creates directories
+- _open() returns file-like objects (read + write modes)
+- _strip_protocol() correctly removes nexus:// prefix
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nexus.fs._fsspec import (
+    MAX_CAT_FILE_SIZE,
+    NexusBufferedFile,
+    NexusFileSystem,
+    NexusWriteFile,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_nexus_fs():
+    """Mock SlimNexusFS facade with async methods."""
+    fs = AsyncMock()
+    fs.read = AsyncMock(return_value=b"hello world")
+    fs.write = AsyncMock(return_value={"path": "/test.txt", "size": 11, "etag": "abc"})
+    fs.ls = AsyncMock(
+        return_value=[
+            {"path": "/dir/file1.txt", "size": 100, "entry_type": 0},
+            {"path": "/dir/subdir", "size": 4096, "entry_type": 1},
+        ]
+    )
+    fs.stat = AsyncMock(
+        return_value={
+            "path": "/test.txt",
+            "size": 11,
+            "etag": "abc123",
+            "is_directory": False,
+            "created_at": "2026-01-01T00:00:00",
+            "modified_at": "2026-01-01T00:00:00",
+        }
+    )
+    fs.delete = AsyncMock()
+    fs.copy = AsyncMock(return_value={"path": "/dst.txt", "size": 11})
+    fs.mkdir = AsyncMock()
+    return fs
+
+
+@pytest.fixture
+def sync_caller():
+    """Sync caller that runs coroutines immediately."""
+    import asyncio
+
+    def _call(coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    # Use a simple approach: create a new loop if needed
+    def _sync(coro):
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor(1) as pool:
+                    return pool.submit(asyncio.run, coro).result()
+            return loop.run_until_complete(coro)
+        except RuntimeError:
+            return asyncio.run(coro)
+
+    return _sync
+
+
+@pytest.fixture
+def nexus_fsspec(mock_nexus_fs, sync_caller):
+    """NexusFileSystem instance with mocked backend."""
+    fs = NexusFileSystem.__new__(NexusFileSystem)
+    fs._nexus = mock_nexus_fs
+    fs._sync = sync_caller
+    return fs
+
+
+# ---------------------------------------------------------------------------
+# _strip_protocol
+# ---------------------------------------------------------------------------
+
+
+class TestStripProtocol:
+    @pytest.mark.parametrize(
+        "input_path,expected",
+        [
+            ("nexus:///s3/bucket/file.txt", "/s3/bucket/file.txt"),
+            ("nexus://s3/bucket/file.txt", "/s3/bucket/file.txt"),
+            ("nexus:/s3/bucket/file.txt", "/s3/bucket/file.txt"),
+            ("/s3/bucket/file.txt", "/s3/bucket/file.txt"),
+            ("s3/bucket/file.txt", "/s3/bucket/file.txt"),
+            ("nexus:///", "/"),
+            ("nexus://", "/"),
+        ],
+    )
+    def test_strip_protocol(self, input_path, expected):
+        assert NexusFileSystem._strip_protocol(input_path) == expected
+
+
+# ---------------------------------------------------------------------------
+# ls()
+# ---------------------------------------------------------------------------
+
+
+class TestLs:
+    def test_ls_detail(self, nexus_fsspec, mock_nexus_fs):
+        result = nexus_fsspec.ls("/dir", detail=True)
+        assert len(result) == 2
+        assert result[0]["name"] == "/dir/file1.txt"
+        assert result[0]["type"] == "file"
+        assert result[0]["size"] == 100
+        assert result[1]["name"] == "/dir/subdir"
+        assert result[1]["type"] == "directory"
+
+    def test_ls_no_detail(self, nexus_fsspec, mock_nexus_fs):
+        result = nexus_fsspec.ls("/dir", detail=False)
+        assert result == ["/dir/file1.txt", "/dir/subdir"]
+
+
+# ---------------------------------------------------------------------------
+# info()
+# ---------------------------------------------------------------------------
+
+
+class TestInfo:
+    def test_info_file(self, nexus_fsspec):
+        result = nexus_fsspec.info("/test.txt")
+        assert result["name"] == "/test.txt"
+        assert result["size"] == 11
+        assert result["type"] == "file"
+        assert "etag" in result
+
+    def test_info_not_found(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat.return_value = None
+        with pytest.raises(FileNotFoundError):
+            nexus_fsspec.info("/nonexistent.txt")
+
+
+# ---------------------------------------------------------------------------
+# _cat_file()
+# ---------------------------------------------------------------------------
+
+
+class TestCatFile:
+    def test_cat_file_full(self, nexus_fsspec):
+        result = nexus_fsspec._cat_file("/test.txt")
+        assert result == b"hello world"
+
+    def test_cat_file_byte_range(self, nexus_fsspec):
+        result = nexus_fsspec._cat_file("/test.txt", start=0, end=5)
+        assert result == b"hello"
+
+    def test_cat_file_size_guard(self, nexus_fsspec, mock_nexus_fs):
+        """Files larger than MAX_CAT_FILE_SIZE should be refused."""
+        mock_nexus_fs.stat.return_value = {
+            "path": "/huge.bin",
+            "size": MAX_CAT_FILE_SIZE + 1,
+            "is_directory": False,
+        }
+        with pytest.raises(ValueError, match="too large"):
+            nexus_fsspec._cat_file("/huge.bin")
+
+    def test_cat_file_at_limit(self, nexus_fsspec, mock_nexus_fs):
+        """Files exactly at the limit should succeed."""
+        mock_nexus_fs.stat.return_value = {
+            "path": "/exact.bin",
+            "size": MAX_CAT_FILE_SIZE,
+            "is_directory": False,
+        }
+        result = nexus_fsspec._cat_file("/exact.bin")
+        assert result == b"hello world"
+
+
+# ---------------------------------------------------------------------------
+# _pipe_file()
+# ---------------------------------------------------------------------------
+
+
+class TestPipeFile:
+    def test_pipe_file(self, nexus_fsspec, mock_nexus_fs):
+        nexus_fsspec._pipe_file("/output.txt", b"new content")
+        mock_nexus_fs.write.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _rm()
+# ---------------------------------------------------------------------------
+
+
+class TestRm:
+    def test_rm(self, nexus_fsspec, mock_nexus_fs):
+        nexus_fsspec._rm("/file.txt")
+        mock_nexus_fs.delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _cp_file()
+# ---------------------------------------------------------------------------
+
+
+class TestCpFile:
+    def test_cp_file(self, nexus_fsspec, mock_nexus_fs):
+        nexus_fsspec._cp_file("/src.txt", "/dst.txt")
+        mock_nexus_fs.copy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _mkdir()
+# ---------------------------------------------------------------------------
+
+
+class TestMkdir:
+    def test_mkdir(self, nexus_fsspec, mock_nexus_fs):
+        nexus_fsspec._mkdir("/new/dir")
+        mock_nexus_fs.mkdir.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _open() — read mode
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRead:
+    def test_open_read_returns_file_like(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}
+        f = nexus_fsspec._open("/file.txt", mode="rb")
+        assert isinstance(f, NexusBufferedFile)
+        assert f.readable()
+        assert not f.writable()
+        assert f.seekable()
+        f.close()
+
+    def test_open_read_content(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}
+        with nexus_fsspec._open("/file.txt", mode="rb") as f:
+            data = f.read()
+            assert data == b"hello world"
+
+    def test_open_read_seek_tell(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}
+        f = nexus_fsspec._open("/file.txt", mode="rb")
+        assert f.tell() == 0
+        f.seek(5)
+        assert f.tell() == 5
+        f.close()
+
+    def test_open_read_not_found(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat.return_value = None
+        with pytest.raises(FileNotFoundError):
+            nexus_fsspec._open("/nonexistent.txt", mode="rb")
+
+
+# ---------------------------------------------------------------------------
+# _open() — write mode
+# ---------------------------------------------------------------------------
+
+
+class TestOpenWrite:
+    def test_open_write_returns_file_like(self, nexus_fsspec, mock_nexus_fs):
+        f = nexus_fsspec._open("/output.txt", mode="wb")
+        assert isinstance(f, NexusWriteFile)
+        assert f.writable()
+        assert not f.readable()
+        f.close()
+
+    def test_open_write_flushes_on_close(self, nexus_fsspec, mock_nexus_fs):
+        with nexus_fsspec._open("/output.txt", mode="wb") as f:
+            f.write(b"hello ")
+            f.write(b"world")
+        # Should have written the combined content on close
+        mock_nexus_fs.write.assert_called_once()
+        args = mock_nexus_fs.write.call_args
+        assert args[0][1] == b"hello world"
+
+    def test_open_write_context_manager(self, nexus_fsspec, mock_nexus_fs):
+        with nexus_fsspec._open("/output.txt", mode="wb") as f:
+            f.write(b"data")
+        assert f.closed
+
+
+# ---------------------------------------------------------------------------
+# Protocol attribute
+# ---------------------------------------------------------------------------
+
+
+class TestProtocol:
+    def test_protocol_tuple(self):
+        assert NexusFileSystem.protocol == ("nexus",)

--- a/tests/unit/fs/test_integration.py
+++ b/tests/unit/fs/test_integration.py
@@ -1,0 +1,332 @@
+"""Integration test: boot-to-read/write lifecycle with real storage.
+
+Uses real SQLite metadata store + real CASLocalBackend in a temp directory.
+No mocks — this verifies the full slim package actually works end-to-end.
+
+Test plan:
+1. Boot slim NexusFS with SQLite + CASLocalBackend
+2. Write a file, read it back
+3. Stat the file
+4. List directory
+5. Rename the file
+6. Delete the file
+7. Verify deleted
+8. Multi-backend: mount two local backends, write to each
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.types import OperationContext
+from nexus.core.config import BrickServices, KernelServices, PermissionConfig
+from nexus.core.nexus_fs import NexusFS
+from nexus.core.router import PathRouter
+from nexus.fs._facade import SlimNexusFS
+from nexus.fs._sqlite_meta import SQLiteMetastore
+
+
+@pytest.fixture
+def slim_fs(tmp_path: Path):
+    """Boot a full slim NexusFS with SQLite + CASLocalBackend."""
+    # SQLite metastore
+    db_path = str(tmp_path / "metadata.db")
+    metastore = SQLiteMetastore(db_path)
+
+    # CASLocalBackend
+    from nexus.backends.storage.cas_local import CASLocalBackend
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    backend = CASLocalBackend(root_path=data_dir)
+
+    # Router with mount
+    router = PathRouter(metastore)
+    router.add_mount("/local", backend)
+
+    # Create DT_MOUNT entry so stat("/local") works
+    from datetime import UTC, datetime
+
+    from nexus.contracts.metadata import FileMetadata
+    from nexus.core.hash_fast import hash_content
+
+    metastore.put(
+        FileMetadata(
+            path="/local",
+            backend_name=backend.name,
+            physical_path=hash_content(b""),
+            size=0,
+            etag=hash_content(b""),
+            mime_type="inode/directory",
+            created_at=datetime.now(UTC),
+            modified_at=datetime.now(UTC),
+            version=1,
+            zone_id=ROOT_ZONE_ID,
+            entry_type=2,  # DT_MOUNT
+        )
+    )
+
+    # Kernel
+    kernel = NexusFS(
+        metadata_store=metastore,
+        permissions=PermissionConfig(enforce=False),
+        kernel_services=KernelServices(router=router),
+        brick_services=BrickServices(),
+    )
+    kernel._default_context = OperationContext(
+        user_id="test",
+        groups=[],
+        zone_id=ROOT_ZONE_ID,
+        is_admin=True,
+    )
+
+    return SlimNexusFS(kernel)
+
+
+@pytest.fixture
+def dual_fs(tmp_path: Path):
+    """Boot slim NexusFS with two local backends."""
+    from nexus.backends.storage.cas_local import CASLocalBackend
+
+    db_path = str(tmp_path / "metadata.db")
+    metastore = SQLiteMetastore(db_path)
+
+    data_a = tmp_path / "data_a"
+    data_a.mkdir()
+    data_b = tmp_path / "data_b"
+    data_b.mkdir()
+
+    backend_a = CASLocalBackend(root_path=data_a)
+    backend_b = CASLocalBackend(root_path=data_b)
+
+    router = PathRouter(metastore)
+    router.add_mount("/a", backend_a)
+    router.add_mount("/b", backend_b)
+
+    # Create DT_MOUNT entries
+    from datetime import UTC, datetime
+
+    from nexus.contracts.metadata import FileMetadata
+    from nexus.core.hash_fast import hash_content
+
+    for mp, be in [("/a", backend_a), ("/b", backend_b)]:
+        metastore.put(
+            FileMetadata(
+                path=mp,
+                backend_name=be.name,
+                physical_path=hash_content(b""),
+                size=0,
+                etag=hash_content(b""),
+                mime_type="inode/directory",
+                created_at=datetime.now(UTC),
+                modified_at=datetime.now(UTC),
+                version=1,
+                zone_id=ROOT_ZONE_ID,
+                entry_type=2,  # DT_MOUNT
+            )
+        )
+
+    kernel = NexusFS(
+        metadata_store=metastore,
+        permissions=PermissionConfig(enforce=False),
+        kernel_services=KernelServices(router=router),
+        brick_services=BrickServices(),
+    )
+    kernel._default_context = OperationContext(
+        user_id="test",
+        groups=[],
+        zone_id=ROOT_ZONE_ID,
+        is_admin=True,
+    )
+
+    return SlimNexusFS(kernel)
+
+
+# ---------------------------------------------------------------------------
+# Single-backend lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSingleBackendLifecycle:
+    @pytest.mark.asyncio
+    async def test_write_and_read(self, slim_fs: SlimNexusFS):
+        """Write content, read it back, verify match."""
+        content = b"Hello, nexus-fs!"
+        await slim_fs.write("/local/test.txt", content)
+        result = await slim_fs.read("/local/test.txt")
+        assert result == content
+
+    @pytest.mark.asyncio
+    async def test_stat(self, slim_fs: SlimNexusFS):
+        """Write a file, stat it, verify metadata."""
+        await slim_fs.write("/local/meta.txt", b"metadata test")
+        stat = await slim_fs.stat("/local/meta.txt")
+        assert stat is not None
+        assert stat["path"] == "/local/meta.txt"
+        assert stat["size"] == 13
+        assert stat["is_directory"] is False
+
+    @pytest.mark.asyncio
+    async def test_ls(self, slim_fs: SlimNexusFS):
+        """Write files, list directory, verify they appear."""
+        await slim_fs.write("/local/a.txt", b"aaa")
+        await slim_fs.write("/local/b.txt", b"bbb")
+        entries = await slim_fs.ls("/local/", detail=False, recursive=True)
+        paths = [e for e in entries if e.endswith(".txt")]
+        assert "/local/a.txt" in paths
+        assert "/local/b.txt" in paths
+
+    @pytest.mark.asyncio
+    async def test_exists(self, slim_fs: SlimNexusFS):
+        """Check exists before and after write."""
+        assert not await slim_fs.exists("/local/nofile.txt")
+        await slim_fs.write("/local/nofile.txt", b"now I exist")
+        assert await slim_fs.exists("/local/nofile.txt")
+
+    @pytest.mark.asyncio
+    async def test_rename(self, slim_fs: SlimNexusFS):
+        """Write, rename, verify old path gone and new path exists."""
+        await slim_fs.write("/local/old.txt", b"rename me")
+        await slim_fs.rename("/local/old.txt", "/local/new.txt")
+        result = await slim_fs.read("/local/new.txt")
+        assert result == b"rename me"
+
+    @pytest.mark.asyncio
+    async def test_delete(self, slim_fs: SlimNexusFS):
+        """Write, delete, verify gone."""
+        await slim_fs.write("/local/delete-me.txt", b"bye")
+        await slim_fs.delete("/local/delete-me.txt")
+        stat = await slim_fs.stat("/local/delete-me.txt")
+        assert stat is None
+
+    @pytest.mark.asyncio
+    async def test_copy(self, slim_fs: SlimNexusFS):
+        """Write, copy, verify both exist with same content."""
+        await slim_fs.write("/local/src.txt", b"copy me")
+        await slim_fs.copy("/local/src.txt", "/local/dst.txt")
+        src = await slim_fs.read("/local/src.txt")
+        dst = await slim_fs.read("/local/dst.txt")
+        assert src == dst == b"copy me"
+
+    @pytest.mark.asyncio
+    async def test_mkdir(self, slim_fs: SlimNexusFS):
+        """Create directory, verify it's a directory."""
+        await slim_fs.mkdir("/local/subdir")
+        stat = await slim_fs.stat("/local/subdir")
+        assert stat is not None
+        assert stat["is_directory"] is True
+
+    @pytest.mark.asyncio
+    async def test_stat_directory(self, slim_fs: SlimNexusFS):
+        """Stat on the mount root should return directory."""
+        stat = await slim_fs.stat("/local")
+        assert stat is not None
+        assert stat["is_directory"] is True
+
+    @pytest.mark.asyncio
+    async def test_overwrite(self, slim_fs: SlimNexusFS):
+        """Writing to the same path should overwrite."""
+        await slim_fs.write("/local/ow.txt", b"version 1")
+        await slim_fs.write("/local/ow.txt", b"version 2")
+        result = await slim_fs.read("/local/ow.txt")
+        assert result == b"version 2"
+
+    @pytest.mark.asyncio
+    async def test_binary_content(self, slim_fs: SlimNexusFS):
+        """Write and read binary content."""
+        content = bytes(range(256))
+        await slim_fs.write("/local/binary.bin", content)
+        result = await slim_fs.read("/local/binary.bin")
+        assert result == content
+
+    @pytest.mark.asyncio
+    async def test_empty_file(self, slim_fs: SlimNexusFS):
+        """Write and read empty file."""
+        await slim_fs.write("/local/empty.txt", b"")
+        result = await slim_fs.read("/local/empty.txt")
+        assert result == b""
+
+    @pytest.mark.asyncio
+    async def test_list_mounts(self, slim_fs: SlimNexusFS):
+        """Verify mount points are listed."""
+        mounts = slim_fs.list_mounts()
+        assert "/local" in mounts
+
+
+# ---------------------------------------------------------------------------
+# Multi-backend
+# ---------------------------------------------------------------------------
+
+
+class TestMultiBackend:
+    @pytest.mark.asyncio
+    async def test_write_to_separate_backends(self, dual_fs: SlimNexusFS):
+        """Write to two different backends, verify isolation."""
+        await dual_fs.write("/a/file.txt", b"backend A")
+        await dual_fs.write("/b/file.txt", b"backend B")
+
+        assert await dual_fs.read("/a/file.txt") == b"backend A"
+        assert await dual_fs.read("/b/file.txt") == b"backend B"
+
+    @pytest.mark.asyncio
+    async def test_cross_backend_copy(self, dual_fs: SlimNexusFS):
+        """Copy from one backend to another."""
+        await dual_fs.write("/a/src.txt", b"cross-copy")
+        await dual_fs.copy("/a/src.txt", "/b/dst.txt")
+
+        assert await dual_fs.read("/b/dst.txt") == b"cross-copy"
+
+    @pytest.mark.asyncio
+    async def test_list_multiple_mounts(self, dual_fs: SlimNexusFS):
+        """Both mounts should be visible."""
+        mounts = dual_fs.list_mounts()
+        assert "/a" in mounts
+        assert "/b" in mounts
+
+
+# ---------------------------------------------------------------------------
+# SQLite metastore
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteMetastore:
+    def test_wal_mode_enabled(self, tmp_path: Path):
+        """Verify WAL mode is enabled on the SQLite database."""
+        db_path = str(tmp_path / "test.db")
+        SQLiteMetastore(db_path)  # creates DB with WAL mode
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        result = conn.execute("PRAGMA journal_mode").fetchone()
+        assert result[0] == "wal"
+        conn.close()
+
+    def test_put_and_get(self, tmp_path: Path):
+        """Basic put/get on the SQLite metastore."""
+        from datetime import UTC, datetime
+
+        from nexus.contracts.metadata import FileMetadata
+
+        db_path = str(tmp_path / "test.db")
+        meta = SQLiteMetastore(db_path)
+
+        fm = FileMetadata(
+            path="/test/file.txt",
+            backend_name="local",
+            physical_path="abc123",
+            size=42,
+            etag="abc123",
+            mime_type="text/plain",
+            created_at=datetime.now(UTC),
+            modified_at=datetime.now(UTC),
+            version=1,
+            zone_id=ROOT_ZONE_ID,
+        )
+        meta.put(fm)
+        result = meta.get("/test/file.txt")
+        assert result is not None
+        assert result.path == "/test/file.txt"
+        assert result.size == 42

--- a/tests/unit/fs/test_sync.py
+++ b/tests/unit/fs/test_sync.py
@@ -1,0 +1,238 @@
+"""Tests for SyncNexusFS -- the anyio-based sync wrapper.
+
+Covers four scenarios:
+1. No event loop   (normal Python script)
+2. Existing loop   (Jupyter-style, run sync wrapper from inside async code)
+3. Concurrent threads (10 threads calling read() in parallel)
+4. Error propagation (async exception surfaces without portal wrapping)
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import AsyncMock
+
+import anyio.to_thread
+import pytest
+
+from nexus.contracts.exceptions import NexusFileNotFoundError
+from nexus.fs._sync import SyncNexusFS
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_async_fs(**overrides: object) -> AsyncMock:
+    """Build an AsyncMock that mimics the async NexusFS facade."""
+    mock = AsyncMock()
+    for attr, value in overrides.items():
+        getattr(mock, attr).return_value = value
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# 1. No event loop -- normal script context
+# ---------------------------------------------------------------------------
+
+
+class TestNoEventLoop:
+    """Call SyncNexusFS from a plain synchronous context (no running loop)."""
+
+    def test_read_returns_bytes(self) -> None:
+        mock_fs = _make_mock_async_fs(read=b"hello world")
+        sync_fs = SyncNexusFS(mock_fs)
+
+        result = sync_fs.read("/s3/bucket/file.txt")
+
+        assert result == b"hello world"
+        mock_fs.read.assert_awaited_once_with("/s3/bucket/file.txt")
+
+    def test_write_returns_metadata(self) -> None:
+        mock_fs = _make_mock_async_fs(write={"etag": "abc123"})
+        sync_fs = SyncNexusFS(mock_fs)
+
+        result = sync_fs.write("/s3/bucket/out.bin", b"data")
+
+        assert result == {"etag": "abc123"}
+        mock_fs.write.assert_awaited_once_with("/s3/bucket/out.bin", b"data")
+
+    def test_ls_passes_detail_kwarg(self) -> None:
+        entries = [{"name": "a.txt", "size": 10}]
+        mock_fs = _make_mock_async_fs(ls=entries)
+        sync_fs = SyncNexusFS(mock_fs)
+
+        result = sync_fs.ls("/data", detail=True)
+
+        assert result == entries
+        mock_fs.ls.assert_awaited_once_with("/data", detail=True)
+
+    def test_stat_returns_dict(self) -> None:
+        info = {"size": 42, "type": "file"}
+        mock_fs = _make_mock_async_fs(stat=info)
+        sync_fs = SyncNexusFS(mock_fs)
+
+        result = sync_fs.stat("/s3/bucket/file.txt")
+
+        assert result == info
+
+    def test_delete(self) -> None:
+        mock_fs = _make_mock_async_fs(delete=None)
+        sync_fs = SyncNexusFS(mock_fs)
+
+        sync_fs.delete("/tmp/gone.txt")
+
+        mock_fs.delete.assert_awaited_once_with("/tmp/gone.txt")
+
+    def test_mkdir_passes_parents_kwarg(self) -> None:
+        mock_fs = _make_mock_async_fs(mkdir=None)
+        sync_fs = SyncNexusFS(mock_fs)
+
+        sync_fs.mkdir("/new/dir", parents=False)
+
+        mock_fs.mkdir.assert_awaited_once_with("/new/dir", parents=False)
+
+    def test_rename(self) -> None:
+        mock_fs = _make_mock_async_fs(rename=None)
+        sync_fs = SyncNexusFS(mock_fs)
+
+        sync_fs.rename("/old", "/new")
+
+        mock_fs.rename.assert_awaited_once_with("/old", "/new")
+
+    def test_exists_true(self) -> None:
+        mock_fs = _make_mock_async_fs(exists=True)
+        sync_fs = SyncNexusFS(mock_fs)
+
+        assert sync_fs.exists("/s3/bucket/file.txt") is True
+
+    def test_copy(self) -> None:
+        mock_fs = _make_mock_async_fs(copy={"etag": "new"})
+        sync_fs = SyncNexusFS(mock_fs)
+
+        result = sync_fs.copy("/src", "/dst")
+
+        assert result == {"etag": "new"}
+        mock_fs.copy.assert_awaited_once_with("/src", "/dst")
+
+    def test_close_delegates_when_method_exists(self) -> None:
+        mock_fs = _make_mock_async_fs(close=None)
+        sync_fs = SyncNexusFS(mock_fs)
+
+        sync_fs.close()
+
+        mock_fs.close.assert_awaited_once()
+
+    def test_close_skips_when_no_method(self) -> None:
+        """If the async facade has no close(), SyncNexusFS.close() is a no-op."""
+        mock_fs = AsyncMock(spec=[])  # spec=[] -> no attributes
+        sync_fs = SyncNexusFS(mock_fs)
+
+        sync_fs.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# 2. Existing event loop -- Jupyter simulation
+# ---------------------------------------------------------------------------
+
+
+class TestExistingEventLoop:
+    """Simulate Jupyter: an event loop is already running.
+
+    We launch an async context, then from inside it, run the sync wrapper
+    on a worker thread via anyio.to_thread.run_sync.  This must not deadlock.
+    """
+
+    @pytest.mark.anyio
+    async def test_read_from_worker_thread(self) -> None:
+        mock_fs = _make_mock_async_fs(read=b"jupyter data")
+        sync_fs = SyncNexusFS(mock_fs)
+
+        result = await anyio.to_thread.run_sync(sync_fs.read, "/nb/cell.txt")
+
+        assert result == b"jupyter data"
+        mock_fs.read.assert_awaited_once_with("/nb/cell.txt")
+
+    @pytest.mark.anyio
+    async def test_write_from_worker_thread(self) -> None:
+        mock_fs = _make_mock_async_fs(write={"etag": "jup"})
+        sync_fs = SyncNexusFS(mock_fs)
+
+        def _do_write() -> dict:
+            return sync_fs.write("/nb/out.bin", b"output")
+
+        result = await anyio.to_thread.run_sync(_do_write)
+
+        assert result == {"etag": "jup"}
+
+
+# ---------------------------------------------------------------------------
+# 3. Concurrent threads
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentThreads:
+    """Spawn multiple threads hitting the same SyncNexusFS instance."""
+
+    def test_ten_threads_read_no_deadlock(self) -> None:
+        mock_fs = _make_mock_async_fs(read=b"ok")
+        sync_fs = SyncNexusFS(mock_fs)
+        results: list[bytes | BaseException] = [b""] * 10
+
+        def _worker(idx: int) -> None:
+            try:
+                results[idx] = sync_fs.read(f"/file_{idx}.txt")
+            except BaseException as exc:
+                results[idx] = exc
+
+        threads = [threading.Thread(target=_worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        for i, r in enumerate(results):
+            assert r == b"ok", f"Thread {i} failed: {r!r}"
+
+        assert mock_fs.read.await_count == 10
+
+
+# ---------------------------------------------------------------------------
+# 4. Error propagation
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPropagation:
+    """Async-side exceptions must surface directly, not wrapped in a portal error."""
+
+    def test_file_not_found_propagates(self) -> None:
+        mock_fs = AsyncMock()
+        mock_fs.read.side_effect = NexusFileNotFoundError("/missing.txt")
+        sync_fs = SyncNexusFS(mock_fs)
+
+        with pytest.raises(NexusFileNotFoundError) as exc_info:
+            sync_fs.read("/missing.txt")
+
+        assert exc_info.value.path == "/missing.txt"
+        assert exc_info.value.is_expected is True
+
+    def test_generic_exception_propagates(self) -> None:
+        mock_fs = AsyncMock()
+        mock_fs.write.side_effect = RuntimeError("boom")
+        sync_fs = SyncNexusFS(mock_fs)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            sync_fs.write("/x", b"data")
+
+    @pytest.mark.anyio
+    async def test_error_propagates_through_worker_thread(self) -> None:
+        """Even when called from a worker thread, the original error type survives."""
+        mock_fs = AsyncMock()
+        mock_fs.stat.side_effect = NexusFileNotFoundError("/ghost")
+        sync_fs = SyncNexusFS(mock_fs)
+
+        def _do_stat() -> None:
+            sync_fs.stat("/ghost")
+
+        with pytest.raises(NexusFileNotFoundError):
+            await anyio.to_thread.run_sync(_do_stat)

--- a/tests/unit/fs/test_uri.py
+++ b/tests/unit/fs/test_uri.py
@@ -215,18 +215,20 @@ class TestInvalidURIs:
             parse_uri("://bucket")
 
     @pytest.mark.parametrize(
-        "uri",
+        "uri,expected_scheme",
         [
-            "ftp://host/path",
-            "hdfs://namenode/path",
-            "http://example.com",
-            "xyz://foo",
+            ("ftp://host/path", "ftp"),
+            ("hdfs://namenode/path", "hdfs"),
+            ("http://example.com", "http"),
+            ("gws://sheets", "gws"),
+            ("github://repo", "github"),
         ],
-        ids=["ftp", "hdfs", "http", "xyz"],
+        ids=["ftp", "hdfs", "http", "gws", "github"],
     )
-    def test_unknown_scheme(self, uri: str) -> None:
-        with pytest.raises(InvalidPathError, match="Unknown scheme"):
-            parse_uri(uri)
+    def test_non_builtin_schemes_accepted(self, uri: str, expected_scheme: str) -> None:
+        """Non-builtin schemes are accepted — resolved via connector registry at mount time."""
+        spec = parse_uri(uri)
+        assert spec.scheme == expected_scheme
 
     def test_empty_authority_s3(self) -> None:
         with pytest.raises(InvalidPathError, match="Empty authority"):

--- a/tests/unit/fs/test_uri.py
+++ b/tests/unit/fs/test_uri.py
@@ -1,0 +1,334 @@
+"""Comprehensive tests for nexus.fs._uri — cloud storage mount URI parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.contracts.exceptions import InvalidPathError
+from nexus.fs._uri import (
+    derive_mount_point,
+    parse_uri,
+    validate_mount_collision,
+)
+
+# =========================================================================
+# 1. Valid URI parsing — one parametrize block per scheme
+# =========================================================================
+
+
+class TestParseValidURIs:
+    """parse_uri should accept well-formed URIs for every supported scheme."""
+
+    @pytest.mark.parametrize(
+        "uri, expected_scheme, expected_authority, expected_path",
+        [
+            ("s3://my-bucket", "s3", "my-bucket", ""),
+            ("s3://my-bucket/subdir", "s3", "my-bucket", "subdir"),
+            ("s3://my-bucket/a/b/c", "s3", "my-bucket", "a/b/c"),
+            ("s3://my.dotted.bucket", "s3", "my.dotted.bucket", ""),
+            ("s3://my-bucket/trailing/", "s3", "my-bucket", "trailing"),
+            ("S3://UPPER-CASE", "s3", "UPPER-CASE", ""),
+        ],
+        ids=[
+            "s3-bucket-only",
+            "s3-with-subdir",
+            "s3-nested-path",
+            "s3-dots-in-bucket",
+            "s3-trailing-slash",
+            "s3-uppercase-scheme",
+        ],
+    )
+    def test_s3(
+        self,
+        uri: str,
+        expected_scheme: str,
+        expected_authority: str,
+        expected_path: str,
+    ) -> None:
+        spec = parse_uri(uri)
+        assert spec.scheme == expected_scheme
+        assert spec.authority == expected_authority
+        assert spec.path == expected_path
+        assert spec.uri == uri
+
+    @pytest.mark.parametrize(
+        "uri, expected_authority, expected_path",
+        [
+            ("gcs://project/bucket", "project", "bucket"),
+            ("gcs://project/bucket/subdir", "project", "bucket/subdir"),
+            ("gcs://my-project", "my-project", ""),
+        ],
+        ids=[
+            "gcs-project-bucket",
+            "gcs-nested",
+            "gcs-project-only",
+        ],
+    )
+    def test_gcs(self, uri: str, expected_authority: str, expected_path: str) -> None:
+        spec = parse_uri(uri)
+        assert spec.scheme == "gcs"
+        assert spec.authority == expected_authority
+        assert spec.path == expected_path
+
+    @pytest.mark.parametrize(
+        "uri, expected_authority, expected_path",
+        [
+            ("local://./data", ".", "data"),
+            ("local://localhost/share", "localhost", "share"),
+            ("local:///tmp/nexus", "tmp", "nexus"),
+            ("local:///a/b/c", "a", "b/c"),
+        ],
+        ids=[
+            "local-relative-dot",
+            "local-localhost",
+            "local-absolute-triple-slash",
+            "local-absolute-nested",
+        ],
+    )
+    def test_local(self, uri: str, expected_authority: str, expected_path: str) -> None:
+        spec = parse_uri(uri)
+        assert spec.scheme == "local"
+        assert spec.authority == expected_authority
+        assert spec.path == expected_path
+
+    @pytest.mark.parametrize(
+        "uri, expected_authority, expected_path",
+        [
+            ("gdrive://my-drive", "my-drive", ""),
+            ("gdrive://my-drive/folder", "my-drive", "folder"),
+            ("gdrive://my-drive/a/b", "my-drive", "a/b"),
+        ],
+        ids=[
+            "gdrive-root",
+            "gdrive-folder",
+            "gdrive-nested",
+        ],
+    )
+    def test_gdrive(self, uri: str, expected_authority: str, expected_path: str) -> None:
+        spec = parse_uri(uri)
+        assert spec.scheme == "gdrive"
+        assert spec.authority == expected_authority
+        assert spec.path == expected_path
+
+
+# =========================================================================
+# 2. Mount point derivation
+# =========================================================================
+
+
+class TestDeriveMountPoint:
+    """derive_mount_point should produce correct paths for each scheme."""
+
+    @pytest.mark.parametrize(
+        "uri, expected_mount",
+        [
+            ("s3://my-bucket", "/s3/my-bucket"),
+            ("s3://my-bucket/subdir", "/s3/my-bucket"),
+            ("s3://my.dotted.bucket/deep/path", "/s3/my.dotted.bucket"),
+        ],
+        ids=["s3-simple", "s3-subdir-ignored", "s3-dots"],
+    )
+    def test_s3_mount(self, uri: str, expected_mount: str) -> None:
+        spec = parse_uri(uri)
+        assert derive_mount_point(spec) == expected_mount
+
+    @pytest.mark.parametrize(
+        "uri, expected_mount",
+        [
+            ("gcs://project/bucket", "/gcs/bucket"),
+            ("gcs://project/bucket/subdir", "/gcs/subdir"),
+            ("gcs://my-project", "/gcs/my-project"),
+        ],
+        ids=["gcs-project-bucket", "gcs-nested-last-segment", "gcs-project-only"],
+    )
+    def test_gcs_mount(self, uri: str, expected_mount: str) -> None:
+        spec = parse_uri(uri)
+        assert derive_mount_point(spec) == expected_mount
+
+    @pytest.mark.parametrize(
+        "uri, expected_mount",
+        [
+            ("local://./data", "/local/data"),
+            ("local:///tmp/nexus", "/local/nexus"),
+            ("local://localhost/share", "/local/share"),
+        ],
+        ids=["local-dot-data", "local-tmp-nexus", "local-share"],
+    )
+    def test_local_mount(self, uri: str, expected_mount: str) -> None:
+        spec = parse_uri(uri)
+        assert derive_mount_point(spec) == expected_mount
+
+    @pytest.mark.parametrize(
+        "uri, expected_mount",
+        [
+            ("gdrive://my-drive", "/gdrive/my-drive"),
+            ("gdrive://my-drive/folder", "/gdrive/my-drive"),
+        ],
+        ids=["gdrive-root", "gdrive-folder"],
+    )
+    def test_gdrive_mount(self, uri: str, expected_mount: str) -> None:
+        spec = parse_uri(uri)
+        assert derive_mount_point(spec) == expected_mount
+
+
+# =========================================================================
+# 3. Mount point override via at=
+# =========================================================================
+
+
+class TestMountPointOverride:
+    """The at= parameter should override automatic derivation."""
+
+    def test_at_absolute(self) -> None:
+        spec = parse_uri("s3://my-bucket")
+        assert derive_mount_point(spec, at="/my-data") == "/my-data"
+
+    def test_at_relative_gets_slash_prefix(self) -> None:
+        spec = parse_uri("s3://my-bucket")
+        assert derive_mount_point(spec, at="my-data") == "/my-data"
+
+    def test_at_overrides_all_schemes(self) -> None:
+        for uri in [
+            "s3://b",
+            "gcs://p/b",
+            "local://./d",
+            "gdrive://d",
+        ]:
+            spec = parse_uri(uri)
+            assert derive_mount_point(spec, at="/custom") == "/custom"
+
+
+# =========================================================================
+# 4. Invalid URIs
+# =========================================================================
+
+
+class TestInvalidURIs:
+    """parse_uri should reject malformed inputs with InvalidPathError."""
+
+    def test_empty_string(self) -> None:
+        with pytest.raises(InvalidPathError, match="must not be empty"):
+            parse_uri("")
+
+    def test_missing_scheme(self) -> None:
+        with pytest.raises(InvalidPathError, match="Missing scheme"):
+            parse_uri("://bucket")
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "ftp://host/path",
+            "hdfs://namenode/path",
+            "http://example.com",
+            "xyz://foo",
+        ],
+        ids=["ftp", "hdfs", "http", "xyz"],
+    )
+    def test_unknown_scheme(self, uri: str) -> None:
+        with pytest.raises(InvalidPathError, match="Unknown scheme"):
+            parse_uri(uri)
+
+    def test_empty_authority_s3(self) -> None:
+        with pytest.raises(InvalidPathError, match="Empty authority"):
+            parse_uri("s3:///")
+
+    def test_empty_authority_gcs(self) -> None:
+        with pytest.raises(InvalidPathError, match="Empty authority"):
+            parse_uri("gcs:///")
+
+    def test_empty_authority_local(self) -> None:
+        with pytest.raises(InvalidPathError, match="Empty authority"):
+            parse_uri("local:///")
+
+
+# =========================================================================
+# 5. Edge cases
+# =========================================================================
+
+
+class TestEdgeCases:
+    """Tricky inputs that exercise boundary conditions."""
+
+    def test_url_encoded_chars_in_path(self) -> None:
+        spec = parse_uri("s3://bucket/my%20folder")
+        assert spec.path == "my%20folder"
+
+    def test_deeply_nested_path(self) -> None:
+        spec = parse_uri("s3://bucket/a/b/c/d/e/f")
+        assert spec.path == "a/b/c/d/e/f"
+        assert derive_mount_point(spec) == "/s3/bucket"
+
+    def test_authority_with_hyphens_and_numbers(self) -> None:
+        spec = parse_uri("s3://my-bucket-123")
+        assert spec.authority == "my-bucket-123"
+
+    def test_trailing_slash_stripped_from_path(self) -> None:
+        spec = parse_uri("s3://bucket/path/")
+        assert spec.path == "path"
+
+    def test_multiple_trailing_slashes(self) -> None:
+        spec = parse_uri("gcs://project/bucket///")
+        # urlparse collapses; path gets stripped
+        assert spec.scheme == "gcs"
+
+    def test_mount_spec_is_frozen(self) -> None:
+        import dataclasses
+
+        spec = parse_uri("s3://bucket")
+        assert dataclasses.is_dataclass(spec)
+        # Verify fields exist (frozen=True is set on the dataclass)
+        assert len(dataclasses.fields(spec)) >= 4
+
+    def test_original_uri_preserved(self) -> None:
+        uri = "S3://My-Bucket/Some/Path"
+        spec = parse_uri(uri)
+        assert spec.uri == uri
+        # scheme is lowered
+        assert spec.scheme == "s3"
+
+
+# =========================================================================
+# 6. Reserved path collision
+# =========================================================================
+
+
+class TestReservedPaths:
+    """derive_mount_point must reject reserved system paths."""
+
+    @pytest.mark.parametrize(
+        "reserved",
+        ["/__sys__", "/__pipes__"],
+        ids=["sys", "pipes"],
+    )
+    def test_at_override_hits_reserved(self, reserved: str) -> None:
+        spec = parse_uri("s3://bucket")
+        with pytest.raises(InvalidPathError, match="reserved"):
+            derive_mount_point(spec, at=reserved)
+
+    def test_at_override_nested_under_reserved(self) -> None:
+        spec = parse_uri("s3://bucket")
+        with pytest.raises(InvalidPathError, match="reserved"):
+            derive_mount_point(spec, at="/__sys__/foo")
+
+
+# =========================================================================
+# 7. Mount collision detection
+# =========================================================================
+
+
+class TestMountCollision:
+    """validate_mount_collision should detect duplicate mounts."""
+
+    def test_no_collision(self) -> None:
+        # Should not raise
+        validate_mount_collision("/s3/bucket", {"/gcs/project", "/local/data"})
+
+    def test_collision_raises(self) -> None:
+        with pytest.raises(InvalidPathError, match="already mounted"):
+            validate_mount_collision("/s3/bucket", {"/s3/bucket", "/gcs/project"})
+
+    def test_empty_existing_never_collides(self) -> None:
+        validate_mount_collision("/s3/bucket", set())
+
+    def test_different_schemes_same_name_no_collision(self) -> None:
+        validate_mount_collision("/gcs/data", {"/s3/data", "/local/data"})


### PR DESCRIPTION
## Summary

Implements the nexus-fs standalone package based on the design docs from PR #3221. This is Phase 1 of the nexus-fs open-source DX launch: core infrastructure, APIs, and test coverage for the slim filesystem abstraction.

- **16 architecture/code/test/perf decisions** reviewed interactively before implementation
- **8 new source modules** in `src/nexus/fs/` implementing the slim package core
- **118 tests** across 4 test files (URI parser, sync wrapper, fsspec, integration)
- **3 improvements** to existing kernel code (DRY fix, exception hierarchy, context unification)
- **1 package definition** (`packages/nexus-fs/pyproject.toml`)

### Architecture decisions (cross-referenced with 2025-2026 best practices)

| Decision | Choice | Why |
|----------|--------|-----|
| Sync/Async wrapper | anyio `BlockingPortalProvider` | `nest_asyncio` broken on Python 3.14+ |
| Metadata store | SQLite + WAL + retry | Zero new deps, stdlib, crash-safe |
| Package structure | pydantic-ai model (slim owns `nexus/`) | Proven pattern, clean namespace |
| Entry points | `mount()` = slim, `connect()` = full | Separate concerns, separate users |
| API surface | Thin facade (~10 methods) | Kernel internals hidden |
| fsspec | Full `_open()` + 1GB `_cat_file` guard | Eliminates both critical OOM gaps |
| Import time | All-lazy `__init__.py` | Target <200ms |
| SQLite concurrency | WAL mode + 3-retry exponential backoff | Standard best practice |

### New modules

| Module | Purpose |
|--------|---------|
| `src/nexus/fs/__init__.py` | `mount()` + `mount_sync()` entry points, lazy imports |
| `src/nexus/fs/_uri.py` | URI parser (s3/gcs/local/gdrive), mount point derivation |
| `src/nexus/fs/_sync.py` | anyio sync wrapper (Python 3.12-3.14+ safe) |
| `src/nexus/fs/_facade.py` | Slim NexusFS facade, optimized single-lookup stat |
| `src/nexus/fs/_sqlite_meta.py` | SQLite MetastoreABC with WAL + retry |
| `src/nexus/fs/_fsspec.py` | fsspec NexusFileSystem with streaming `_open()` |
| `src/nexus/fs/_credentials.py` | Auto-credential discovery (AWS chain, GCP ADC) |
| `packages/nexus-fs/pyproject.toml` | Slim package definition (~8 base deps + extras) |

### Existing code improvements

- `contracts/exceptions.py`: Add `NexusURIError`, `CloudCredentialError`, `BackendNotFoundError`, `BackendPermissionError` (subclass existing hierarchy)
- `core/nexus_fs.py`: Extract `_entry_to_detail_dict()` DRY helper, unify `sys_rmdir` context handling with deprecation warning

## Test plan

- [x] 53 URI parser tests (all schemes, edge cases, collisions, reserved paths)
- [x] 20 sync wrapper tests (no-loop, Jupyter simulation, concurrent threads, error propagation)
- [x] 27 fsspec tests (ls, info, cat, pipe, rm, cp, mkdir, open read/write, size guard)
- [x] 18 integration tests (real SQLite + CASLocalBackend, write→read→stat→ls→rename→delete, multi-backend)
- [x] Existing kernel API surface tests still pass (89 tests)
- [x] Existing mount + rename tests still pass (53 tests)
- [x] All pre-commit hooks pass (ruff, ruff-format, type-ignore check, brick imports)