### PR TITLE
Fix durable search indexing and demo stack validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -238,7 +238,7 @@ ENV PYTHONUNBUFFERED=1 \
     ZOEKT_INDEX_DIR=/app/data/.zoekt-index \
     ZOEKT_DATA_DIR=/app/data \
     NEXUS_TXTAI_RERANKER=cross-encoder/ms-marco-MiniLM-L-2-v2 \
-    NEXUS_TXTAI_SPARSE=true
+    NEXUS_TXTAI_SPARSE=false
 
 EXPOSE 2026 2126 6070
 

--- a/src/nexus/bricks/search/chunk_store.py
+++ b/src/nexus/bricks/search/chunk_store.py
@@ -1,0 +1,110 @@
+"""Shared document chunk persistence for search indexing."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import text
+
+
+@dataclass(frozen=True)
+class ChunkRecord:
+    """Normalized document chunk row payload."""
+
+    chunk_text: str
+    chunk_tokens: int
+    start_offset: int | None = None
+    end_offset: int | None = None
+    line_start: int | None = None
+    line_end: int | None = None
+    embedding: list[float] | None = None
+    embedding_model: str | None = None
+    chunk_context: str | None = None
+    chunk_position: int | None = None
+    source_document_id: str | None = None
+
+
+class ChunkStore:
+    """Canonical writer for document_chunks replacement semantics."""
+
+    def __init__(self, *, async_session_factory: Any, db_type: str = "sqlite") -> None:
+        self._async_session_factory = async_session_factory
+        self._db_type = db_type
+
+    async def delete_document_chunks(self, path_id: str) -> None:
+        async with self._async_session_factory() as session:
+            await session.execute(
+                text("DELETE FROM document_chunks WHERE path_id = :path_id"),
+                {"path_id": path_id},
+            )
+            await session.commit()
+
+    async def replace_document_chunks(self, path_id: str, chunks: list[ChunkRecord]) -> None:
+        now = datetime.now(UTC).replace(tzinfo=None)
+        async with self._async_session_factory() as session:
+            await session.execute(
+                text("DELETE FROM document_chunks WHERE path_id = :path_id"),
+                {"path_id": path_id},
+            )
+
+            for index, chunk in enumerate(chunks):
+                params: dict[str, Any] = {
+                    "chunk_id": str(uuid.uuid4()),
+                    "path_id": path_id,
+                    "chunk_index": index,
+                    "chunk_text": chunk.chunk_text,
+                    "chunk_tokens": chunk.chunk_tokens,
+                    "start_offset": chunk.start_offset,
+                    "end_offset": chunk.end_offset,
+                    "line_start": chunk.line_start,
+                    "line_end": chunk.line_end,
+                    "embedding_model": chunk.embedding_model,
+                    "chunk_context": chunk.chunk_context,
+                    "chunk_position": chunk.chunk_position,
+                    "source_document_id": chunk.source_document_id,
+                    "created_at": now,
+                }
+                insert_sql = self._insert_sql(include_embedding=chunk.embedding is not None)
+                if chunk.embedding is not None and self._db_type == "postgresql":
+                    params["embedding"] = "[" + ",".join(str(v) for v in chunk.embedding) + "]"
+                await session.execute(insert_sql, params)
+
+            await session.commit()
+
+    def _insert_sql(self, *, include_embedding: bool) -> Any:
+        if include_embedding and self._db_type == "postgresql":
+            return text(
+                """
+                INSERT INTO document_chunks
+                (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens,
+                 start_offset, end_offset, line_start, line_end,
+                 embedding_model, embedding,
+                 chunk_context, chunk_position, source_document_id,
+                 created_at)
+                VALUES
+                (:chunk_id, :path_id, :chunk_index, :chunk_text, :chunk_tokens,
+                 :start_offset, :end_offset, :line_start, :line_end,
+                 :embedding_model, CAST(:embedding AS halfvec),
+                 :chunk_context, :chunk_position, :source_document_id,
+                 :created_at)
+                """
+            )
+        return text(
+            """
+            INSERT INTO document_chunks
+            (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens,
+             start_offset, end_offset, line_start, line_end,
+             embedding_model,
+             chunk_context, chunk_position, source_document_id,
+             created_at)
+            VALUES
+            (:chunk_id, :path_id, :chunk_index, :chunk_text, :chunk_tokens,
+             :start_offset, :end_offset, :line_start, :line_end,
+             :embedding_model,
+             :chunk_context, :chunk_position, :source_document_id,
+             :created_at)
+            """
+        )

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -621,7 +621,9 @@ class SearchDaemon:
                     return zoekt_results
 
             # Delegate to txtai backend for all search types (Issue #2663)
-            if self._backend is not None and self._txtai_bootstrapped:
+            if self._backend is not None and (
+                self._txtai_bootstrapped or self._txtai_bootstrap_task is None
+            ):
                 backend_start = time.perf_counter()
                 backend_results = await self._backend.search(
                     query,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -36,13 +36,19 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from sqlalchemy import text as sa_text
 
 from nexus.bricks.search.chunk_store import ChunkRecord, ChunkStore
-from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_events import (
+    SearchMutationEvent,
+    SearchMutationOp,
+    extract_zone_id,
+    strip_zone_prefix,
+)
 from nexus.bricks.search.mutation_resolver import MutationResolver, ResolvedMutation
 from nexus.bricks.search.results import BaseSearchResult
 from nexus.lib.env import get_database_url
@@ -721,12 +727,12 @@ class SearchDaemon:
                         SELECT
                             fp.zone_id,
                             fp.virtual_path,
-                            string_agg(c.chunk_text, E'\n' ORDER BY c.chunk_index) AS content
+                            c.chunk_index,
+                            c.chunk_text
                         FROM document_chunks c
                         JOIN file_paths fp ON c.path_id = fp.path_id
                         WHERE fp.deleted_at IS NULL
-                        GROUP BY fp.zone_id, fp.virtual_path
-                        ORDER BY fp.zone_id, fp.virtual_path
+                        ORDER BY fp.zone_id, fp.virtual_path, c.chunk_index
                         """
                     )
                 )
@@ -737,10 +743,14 @@ class SearchDaemon:
                 return
 
             docs_by_zone: dict[str, list[dict[str, Any]]] = {}
+            grouped_content: dict[tuple[str, str], list[str]] = {}
             for row in rows:
                 zone = row.zone_id or "root"
                 path = row.virtual_path
-                content = row.content or ""
+                grouped_content.setdefault((zone, path), []).append(row.chunk_text or "")
+
+            for (zone, path), parts in grouped_content.items():
+                content = "\n".join(part for part in parts if part)
                 if not path or not content.strip():
                     continue
                 doc_id = f"{zone}:{path}" if zone != "root" else path
@@ -1204,7 +1214,7 @@ class SearchDaemon:
                     self._pending_delete_paths.clear()
 
                 if delete_paths:
-                    await self._refresh_indexes(delete_paths)
+                    await self._delete_indexes_for_paths(delete_paths)
                 if refresh_paths:
                     await self._refresh_indexes(refresh_paths)
             except asyncio.CancelledError:
@@ -1213,16 +1223,43 @@ class SearchDaemon:
                 logger.warning("Legacy search refresh loop failed: %s", exc)
                 await asyncio.sleep(1)
 
-    @staticmethod
-    def _strip_zone_prefix(path: str) -> str:
-        """Strip /zone/{zone_id} prefix from a path for DB virtual_path lookup.
+    async def _delete_indexes_for_paths(self, paths: list[str]) -> None:
+        """Best-effort delete propagation for fallback stacks without op-log delivery."""
+        if not paths:
+            return
 
-        DB stores virtual_path as '/test-search/...' not '/zone/root/test-search/...'.
-        """
-        import re
+        events = [
+            SearchMutationEvent(
+                event_id=f"legacy-delete:{path}",
+                operation_id=f"legacy-delete:{path}",
+                op=SearchMutationOp.DELETE,
+                path=path,
+                zone_id=extract_zone_id(path),
+                timestamp=datetime.now(UTC).replace(tzinfo=None),
+                sequence_number=0,
+            )
+            for path in paths
+        ]
+        resolved = await self._resolve_mutations(events)
+        if not resolved:
+            return
 
-        m = re.match(r"^/zone/[^/]+(/.*)", path)
-        return m.group(1) if m else path
+        if self._chunk_store is not None:
+            for mutation in resolved:
+                if mutation.path_id != mutation.virtual_path:
+                    await self._chunk_store.delete_document_chunks(mutation.path_id)
+
+        if self._backend is not None:
+            deletes_by_zone: dict[str, list[str]] = {}
+            for mutation in resolved:
+                deletes_by_zone.setdefault(mutation.zone_id, []).append(mutation.doc_id)
+            for zone_id, ids in deletes_by_zone.items():
+                await self._backend.delete(ids, zone_id=zone_id)
+
+        if self._bm25s_index is not None and hasattr(self._bm25s_index, "delete_document"):
+            for mutation in resolved:
+                with contextlib.suppress(Exception):
+                    await self._bm25s_index.delete_document(mutation.path_id)
 
     @staticmethod
     def _coalesce_subtrees(
@@ -1569,7 +1606,7 @@ class SearchDaemon:
         for path in paths:
             try:
                 # Strip /zone/{zone_id} prefix for DB virtual_path lookup
-                virtual_path = self._strip_zone_prefix(path)
+                virtual_path = strip_zone_prefix(path)
 
                 # Read file content via file reader or database
                 content: str | None = None
@@ -1771,12 +1808,17 @@ class SearchDaemon:
         async with self._async_session() as session:
             for batch_start in range(0, len(unique_vpaths), 100):
                 batch_vpaths = unique_vpaths[batch_start : batch_start + 100]
+                where_clauses = []
+                params: dict[str, str] = {}
+                for idx, vpath in enumerate(batch_vpaths):
+                    where_clauses.append(f"virtual_path = :vpath_{idx}")
+                    params[f"vpath_{idx}"] = vpath
                 result = await session.execute(
                     text(
                         "SELECT path_id, virtual_path FROM file_paths "
-                        "WHERE virtual_path = ANY(:vpaths) AND deleted_at IS NULL"
+                        "WHERE deleted_at IS NULL AND (" + " OR ".join(where_clauses) + ")"
                     ),
-                    {"vpaths": batch_vpaths},
+                    params,
                 )
                 for row in result.fetchall():
                     existing_pids[row[1]] = row[0]

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -32,11 +32,18 @@ Issue: #951
 
 import asyncio
 import contextlib
+import json
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+from sqlalchemy import text as sa_text
+
+from nexus.bricks.search.chunk_store import ChunkRecord, ChunkStore
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_resolver import MutationResolver, ResolvedMutation
 from nexus.bricks.search.results import BaseSearchResult
 from nexus.lib.env import get_database_url
 
@@ -66,6 +73,7 @@ class DaemonStats:
     last_index_refresh: float | None = None
     zoekt_available: bool = False
     embedding_cache_connected: bool = False
+    mutation_consumers: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 @dataclass
@@ -99,6 +107,8 @@ class DaemonConfig:
     # Index refresh settings
     refresh_debounce_seconds: float = 5.0
     refresh_enabled: bool = True
+    mutation_poll_seconds: float = 2.0
+    mutation_batch_size: int = 100
 
     # Performance settings
     query_timeout_seconds: float = 10.0
@@ -140,6 +150,7 @@ class SearchDaemon:
         async_session_factory: Any | None = None,
         zoekt_client: Any | None = None,
         cache_brick: Any | None = None,
+        settings_store: Any | None = None,
     ):
         """Initialize the search daemon.
 
@@ -149,11 +160,14 @@ class SearchDaemon:
                 When provided, skips creating a private engine (Issue #1597).
             zoekt_client: Injected ZoektClient instance (Issue #2188).
             cache_brick: Injected CacheBrick for embedding cache health checks.
+            settings_store: Optional SystemSettingsStoreProtocol for durable
+                consumer checkpoints.
         """
         self.config = config or DaemonConfig()
         self.stats = DaemonStats()
         self._zoekt_client = zoekt_client
         self._cache_brick = cache_brick
+        self._settings_store = settings_store
 
         # Search components (initialized on startup)
         self._bm25s_index: BM25SIndex | None = None
@@ -180,9 +194,21 @@ class SearchDaemon:
 
         # Index refresh task
         self._refresh_task: asyncio.Task | None = None
+        self._legacy_refresh_task: asyncio.Task | None = None
+        self._mutation_wakeup = asyncio.Event()
         self._pending_refresh_paths: set[str] = set()
         self._pending_delete_paths: set[str] = set()
         self._refresh_lock = asyncio.Lock()
+        self._mutation_resolver: MutationResolver | None = None
+        self._chunk_store: ChunkStore | None = None
+        self._consumer_tasks: dict[str, asyncio.Task[None]] = {}
+        self._consumer_failures: dict[str, int] = {}
+        self._consumer_last_error: dict[str, str | None] = {}
+        self._consumer_last_sequence: dict[str, int] = {}
+        self._checkpoint_file = (
+            Path(self.config.bm25s_index_dir).parent / "mutation-checkpoints.json"
+        )
+        self._checkpoint_lock = asyncio.Lock()
 
         # FileReaderProtocol reference for reading file content (set by FastAPI server)
         # Issue #1520: Replaces direct NexusFS dependency
@@ -193,6 +219,8 @@ class SearchDaemon:
 
         # txtai backend (Issue #2663) — used for semantic/hybrid search + graph
         self._backend: Any = None
+        self._txtai_bootstrap_task: asyncio.Task[None] | None = None
+        self._txtai_bootstrapped = False
         self.last_search_timing: dict[str, float] = {}
 
         # Latency tracking (circular buffer)
@@ -248,13 +276,15 @@ class SearchDaemon:
                 reranker_model=self.config.txtai_reranker,
                 sparse=self.config.txtai_sparse,
             )
-            await self._backend.startup()
-            logger.info("txtai backend initialized successfully")
+            self._backend.kickoff_startup()
+            self._txtai_bootstrap_task = asyncio.create_task(self._bootstrap_txtai_backend())
+            logger.info("txtai backend startup kicked off in background")
         except Exception:
             logger.warning(
                 "txtai backend init failed, falling back to legacy search", exc_info=True
             )
             self._backend = None
+            self._txtai_bootstrapped = False
 
         # Initialize entropy-aware chunker if enabled (Issue #1024)
         if self.config.entropy_filtering:
@@ -288,10 +318,20 @@ class SearchDaemon:
             max_concurrency=self.config.max_indexing_concurrency,
             cross_doc_batching=True,
         )
+        if self._async_session is not None:
+            self._chunk_store = ChunkStore(
+                async_session_factory=self._async_session,
+                db_type=_db_type,
+            )
+        self._mutation_resolver = MutationResolver(
+            file_reader=self._file_reader,
+            async_session_factory=self._async_session,
+        )
 
-        # Start index refresh background task
+        # Start durable mutation consumers
         if self.config.refresh_enabled:
             self._refresh_task = asyncio.create_task(self._index_refresh_loop())
+            self._legacy_refresh_task = asyncio.create_task(self._legacy_refresh_loop())
 
         # If BM25S not loaded, count existing DB documents for stats
         if not self._bm25s_index and self._async_session:
@@ -331,10 +371,22 @@ class SearchDaemon:
         logger.info("Shutting down SearchDaemon...")
 
         # Cancel refresh task
+        for task in self._consumer_tasks.values():
+            task.cancel()
+        if self._txtai_bootstrap_task and not self._txtai_bootstrap_task.done():
+            self._txtai_bootstrap_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._txtai_bootstrap_task
+        self._txtai_bootstrap_task = None
+        if self._legacy_refresh_task:
+            self._legacy_refresh_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._legacy_refresh_task
         if self._refresh_task:
             self._refresh_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._refresh_task
+        self._consumer_tasks.clear()
 
         # Shutdown txtai backend (Issue #2663)
         if self._backend is not None:
@@ -343,6 +395,7 @@ class SearchDaemon:
             except Exception as e:
                 logger.debug("txtai backend shutdown error: %s", e)
             self._backend = None
+        self._txtai_bootstrapped = False
 
         # Close database connections (only if we created them)
         if self._owns_engine:
@@ -562,7 +615,7 @@ class SearchDaemon:
                     return zoekt_results
 
             # Delegate to txtai backend for all search types (Issue #2663)
-            if self._backend is not None:
+            if self._backend is not None and self._txtai_bootstrapped:
                 backend_start = time.perf_counter()
                 backend_results = await self._backend.search(
                     query,
@@ -651,6 +704,68 @@ class SearchDaemon:
         if count:
             self.stats.last_index_refresh = time.time()
         return count
+
+    async def _bootstrap_txtai_backend(self) -> None:
+        """Populate txtai from canonical SQL chunks so restarts keep semantic search."""
+        if self._backend is None or self._async_session is None:
+            self._txtai_bootstrapped = self._backend is None
+            return
+
+        from sqlalchemy import text as sa_text
+
+        try:
+            async with self._async_session() as session:
+                result = await session.execute(
+                    sa_text(
+                        """
+                        SELECT
+                            fp.zone_id,
+                            fp.virtual_path,
+                            string_agg(c.chunk_text, E'\n' ORDER BY c.chunk_index) AS content
+                        FROM document_chunks c
+                        JOIN file_paths fp ON c.path_id = fp.path_id
+                        WHERE fp.deleted_at IS NULL
+                        GROUP BY fp.zone_id, fp.virtual_path
+                        ORDER BY fp.zone_id, fp.virtual_path
+                        """
+                    )
+                )
+                rows = result.fetchall()
+
+            if not rows:
+                self._txtai_bootstrapped = True
+                return
+
+            docs_by_zone: dict[str, list[dict[str, Any]]] = {}
+            for row in rows:
+                zone = row.zone_id or "root"
+                path = row.virtual_path
+                content = row.content or ""
+                if not path or not content.strip():
+                    continue
+                doc_id = f"{zone}:{path}" if zone != "root" else path
+                docs_by_zone.setdefault(zone, []).append(
+                    {
+                        "id": doc_id,
+                        "text": content,
+                        "path": path,
+                        "zone_id": zone,
+                    }
+                )
+
+            total = 0
+            for zone_id, docs in docs_by_zone.items():
+                total += int(await self._backend.upsert(docs, zone_id=zone_id))
+
+            self._txtai_bootstrapped = True
+            if total:
+                self.stats.last_index_refresh = time.time()
+            logger.info("txtai bootstrap indexed %d existing documents", total)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._txtai_bootstrapped = False
+            logger.warning("txtai bootstrap failed, continuing with legacy search: %s", exc)
 
     async def delete_documents(
         self,
@@ -1033,65 +1148,70 @@ class SearchDaemon:
     # =========================================================================
 
     async def notify_file_change(self, path: str, change_type: str = "update") -> None:
-        """Notify the daemon of a file change for index refresh.
+        """Wake durable mutation consumers after a filesystem change.
 
-        Changes are debounced and batched for efficiency.
-
-        Args:
-            path: File path that changed
-            change_type: Type of change ("create", "update", "delete")
+        The durable source of truth is the operation log. Hooks only wake the
+        consumer loop so successful writes are reflected quickly. A legacy
+        in-process fallback queue is kept for stacks where the operation log
+        is absent or not populated for local file mutations.
         """
         if not self.config.refresh_enabled:
             return
 
-        async with self._refresh_lock:
-            if change_type == "delete":
-                self._pending_delete_paths.add(path)
-                self._pending_refresh_paths.discard(path)
-            else:
-                self._pending_refresh_paths.add(path)
-                self._pending_delete_paths.discard(path)
+        if self._mutation_resolver is not None:
+            self._mutation_resolver.invalidate_path(path)
+        if change_type == "delete":
+            self._pending_delete_paths.add(path)
+            self._pending_refresh_paths.discard(path)
+        else:
+            self._pending_refresh_paths.add(path)
+            self._pending_delete_paths.discard(path)
+        self._mutation_wakeup.set()
 
     async def _index_refresh_loop(self) -> None:
-        """Background task to refresh indexes for changed files."""
+        """Background task to drive durable per-indexer mutation consumers."""
+        consumer_specs = {
+            "bm25": self._consume_bm25_mutations,
+            "fts": self._consume_fts_mutations,
+            "embedding": self._consume_embedding_mutations,
+            "txtai": self._consume_txtai_mutations,
+        }
+        self._consumer_tasks = {
+            name: asyncio.create_task(
+                self._run_mutation_consumer(name, handler), name=f"search-{name}"
+            )
+            for name, handler in consumer_specs.items()
+        }
+        try:
+            await asyncio.gather(*self._consumer_tasks.values())
+        finally:
+            self._consumer_tasks.clear()
+
+    async def _legacy_refresh_loop(self) -> None:
+        """Fallback hook-driven refresh path for stacks without usable op-log events."""
         while not self._shutting_down:
             try:
+                await self._mutation_wakeup.wait()
                 await asyncio.sleep(self.config.refresh_debounce_seconds)
+                self._mutation_wakeup.clear()
 
                 async with self._refresh_lock:
-                    if not self._pending_refresh_paths and not self._pending_delete_paths:
+                    refresh_paths = sorted(self._pending_refresh_paths)
+                    delete_paths = sorted(self._pending_delete_paths)
+                    if not refresh_paths and not delete_paths:
                         continue
-
-                    paths = self._coalesce_subtrees(self._pending_refresh_paths)
                     self._pending_refresh_paths.clear()
-                    delete_paths = list(self._pending_delete_paths)
                     self._pending_delete_paths.clear()
 
-                # Delete removed files from the index
-                # Doc IDs are "zone:path" for non-root, plain path for root
-                if delete_paths and self._backend is not None:
-                    from nexus.contracts.constants import ROOT_ZONE_ID
-
-                    delete_ids = []
-                    for dp in delete_paths:
-                        vp = self._strip_zone_prefix(dp)
-                        # Infer zone from the scoped path prefix
-                        import re as _re_del
-
-                        zm = _re_del.match(r"^/zone/([^/]+)/", dp)
-                        zone = zm.group(1) if zm else ROOT_ZONE_ID
-                        delete_ids.append(f"{zone}:{vp}" if zone != ROOT_ZONE_ID else vp)
-                    await self.delete_documents(delete_ids, zone_id=ROOT_ZONE_ID)
-
-                # Refresh indexes for changed paths
-                if paths:
-                    await self._refresh_indexes(paths)
-                self.stats.last_index_refresh = time.time()
-
+                if delete_paths:
+                    await self._refresh_indexes(delete_paths)
+                if refresh_paths:
+                    await self._refresh_indexes(refresh_paths)
             except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.error(f"Index refresh error: {e}")
+                raise
+            except Exception as exc:
+                logger.warning("Legacy search refresh loop failed: %s", exc)
+                await asyncio.sleep(1)
 
     @staticmethod
     def _strip_zone_prefix(path: str) -> str:
@@ -1155,61 +1275,279 @@ class SearchDaemon:
 
     async def _index_to_document_chunks(self, path_id: str, path: str, content: str) -> None:
         """Insert content as document_chunks for FTS search."""
-        if not self._async_session:
+        if self._chunk_store is None:
             return
 
         try:
-            import uuid
-            from datetime import UTC, datetime
-
-            from sqlalchemy import text as sa_text
-
             # Split into chunks (~1000 chars each for search granularity)
             chunk_size = 1000
             chunks = [content[i : i + chunk_size] for i in range(0, len(content), chunk_size)]
-            now = datetime.now(UTC).replace(tzinfo=None)
-
-            async with self._async_session() as sess:
-                # Delete existing chunks for this path
-                await sess.execute(
-                    sa_text("DELETE FROM document_chunks WHERE path_id = :pid"),
-                    {"pid": path_id},
-                )
-
-                for idx, chunk_text in enumerate(chunks):
-                    if not chunk_text.strip():
-                        continue
-                    # Compute approximate line numbers
-                    preceding = content[: idx * chunk_size]
-                    line_start = preceding.count("\n") + 1
-                    line_end = line_start + chunk_text.count("\n")
-                    # Approximate token count (~4 chars per token)
-                    chunk_tokens = max(1, len(chunk_text) // 4)
-
-                    await sess.execute(
-                        sa_text(
-                            "INSERT INTO document_chunks "
-                            "(chunk_id, path_id, chunk_index, chunk_text, chunk_tokens, "
-                            "start_offset, end_offset, line_start, line_end, created_at) "
-                            "VALUES (:cid, :pid, :idx, :txt, :tokens, "
-                            ":s_off, :e_off, :ls, :le, :created)"
-                        ),
-                        {
-                            "cid": str(uuid.uuid4()),
-                            "pid": path_id,
-                            "idx": idx,
-                            "txt": chunk_text,
-                            "tokens": chunk_tokens,
-                            "s_off": idx * chunk_size,
-                            "e_off": idx * chunk_size + len(chunk_text),
-                            "ls": line_start,
-                            "le": line_end,
-                            "created": now,
-                        },
+            records: list[ChunkRecord] = []
+            for idx, chunk_text in enumerate(chunks):
+                if not chunk_text.strip():
+                    continue
+                preceding = content[: idx * chunk_size]
+                line_start = preceding.count("\n") + 1
+                line_end = line_start + chunk_text.count("\n")
+                records.append(
+                    ChunkRecord(
+                        chunk_text=chunk_text,
+                        chunk_tokens=max(1, len(chunk_text) // 4),
+                        start_offset=idx * chunk_size,
+                        end_offset=idx * chunk_size + len(chunk_text),
+                        line_start=line_start,
+                        line_end=line_end,
                     )
-                await sess.commit()
+                )
+            await self._chunk_store.replace_document_chunks(path_id, records)
         except Exception as e:
             logger.debug("Failed to index %s to document_chunks: %s", path, e)
+
+    def _checkpoint_key(self, consumer_name: str) -> str:
+        return f"search_mutation_checkpoint:{consumer_name}"
+
+    async def _load_checkpoint_file(self) -> dict[str, int]:
+        def _read() -> dict[str, int]:
+            if not self._checkpoint_file.exists():
+                return {}
+            try:
+                payload = json.loads(self._checkpoint_file.read_text())
+            except (OSError, json.JSONDecodeError):
+                return {}
+            if not isinstance(payload, dict):
+                return {}
+            checkpoints: dict[str, int] = {}
+            for key, value in payload.items():
+                with contextlib.suppress(TypeError, ValueError):
+                    checkpoints[str(key)] = int(value)
+            return checkpoints
+
+        return await asyncio.to_thread(_read)
+
+    async def _write_checkpoint_file(self, checkpoints: dict[str, int]) -> None:
+        def _write() -> None:
+            self._checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
+            self._checkpoint_file.write_text(json.dumps(checkpoints, sort_keys=True))
+
+        await asyncio.to_thread(_write)
+
+    async def _read_persisted_checkpoint(self, consumer_name: str) -> int | None:
+        if self._settings_store is not None:
+            try:
+                setting = self._settings_store.get_setting(self._checkpoint_key(consumer_name))
+                if setting is not None:
+                    with contextlib.suppress(ValueError):
+                        return int(setting.value)
+            except Exception as exc:
+                logger.warning(
+                    "Search mutation checkpoints falling back to file storage: %s",
+                    exc,
+                )
+                self._settings_store = None
+
+        async with self._checkpoint_lock:
+            checkpoints = await self._load_checkpoint_file()
+        return checkpoints.get(consumer_name)
+
+    async def _persist_checkpoint(self, consumer_name: str, sequence_number: int) -> None:
+        if self._settings_store is not None:
+            try:
+                self._settings_store.set_setting(
+                    self._checkpoint_key(consumer_name),
+                    str(sequence_number),
+                    description=f"Search mutation checkpoint for {consumer_name}",
+                )
+                return
+            except Exception as exc:
+                logger.warning(
+                    "Search mutation checkpoints falling back to file storage: %s",
+                    exc,
+                )
+                self._settings_store = None
+
+        async with self._checkpoint_lock:
+            checkpoints = await self._load_checkpoint_file()
+            checkpoints[consumer_name] = sequence_number
+            await self._write_checkpoint_file(checkpoints)
+
+    async def _initialize_consumer_checkpoint(self, consumer_name: str) -> int:
+        persisted = await self._read_persisted_checkpoint(consumer_name)
+        if persisted is not None:
+            return persisted
+
+        max_sequence = 0
+        if self._async_session is not None:
+            async with self._async_session() as session:
+                row = (
+                    await session.execute(
+                        sa_text("SELECT COALESCE(MAX(sequence_number), 0) FROM operation_log")
+                    )
+                ).first()
+                max_sequence = int(row[0]) if row and row[0] is not None else 0
+        await self._save_consumer_checkpoint(consumer_name, max_sequence)
+        return max_sequence
+
+    async def _save_consumer_checkpoint(self, consumer_name: str, sequence_number: int) -> None:
+        self._consumer_last_sequence[consumer_name] = sequence_number
+        await self._persist_checkpoint(consumer_name, sequence_number)
+
+    async def _fetch_mutation_events(
+        self,
+        consumer_name: str,
+    ) -> list[SearchMutationEvent]:
+        if self._async_session is None:
+            return []
+
+        last_sequence = self._consumer_last_sequence.get(consumer_name)
+        if last_sequence is None:
+            last_sequence = await self._initialize_consumer_checkpoint(consumer_name)
+
+        async with self._async_session() as session:
+            result = await session.execute(
+                sa_text(
+                    "SELECT operation_id, operation_type, zone_id, path, new_path, "
+                    "created_at, sequence_number, change_type "
+                    "FROM operation_log "
+                    "WHERE status = 'success' "
+                    "AND sequence_number > :last_sequence "
+                    "AND operation_type IN ('write', 'delete', 'rename') "
+                    "ORDER BY sequence_number "
+                    "LIMIT :limit"
+                ),
+                {
+                    "last_sequence": last_sequence,
+                    "limit": self.config.mutation_batch_size,
+                },
+            )
+            rows = result.fetchall()
+
+        events: list[SearchMutationEvent] = []
+        for row in rows:
+            event = SearchMutationEvent.from_operation_log_row(row)
+            if event is not None:
+                events.append(event)
+        return events
+
+    async def _run_mutation_consumer(
+        self,
+        consumer_name: str,
+        handler: Any,
+    ) -> None:
+        while not self._shutting_down:
+            try:
+                events = await self._fetch_mutation_events(consumer_name)
+                if events:
+                    await handler(events)
+                    await self._save_consumer_checkpoint(consumer_name, events[-1].sequence_number)
+                    self._consumer_failures[consumer_name] = 0
+                    self._consumer_last_error[consumer_name] = None
+                    self.stats.mutation_consumers[consumer_name] = {
+                        "last_sequence": events[-1].sequence_number,
+                        "last_success_at": time.time(),
+                        "failures": 0,
+                    }
+                    self.stats.last_index_refresh = time.time()
+                    continue
+
+                self._mutation_wakeup.clear()
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(
+                        self._mutation_wakeup.wait(),
+                        timeout=self.config.mutation_poll_seconds,
+                    )
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self._consumer_failures[consumer_name] = (
+                    self._consumer_failures.get(consumer_name, 0) + 1
+                )
+                self._consumer_last_error[consumer_name] = str(exc)
+                self.stats.mutation_consumers[consumer_name] = {
+                    "last_sequence": self._consumer_last_sequence.get(consumer_name, 0),
+                    "last_success_at": self.stats.mutation_consumers.get(consumer_name, {}).get(
+                        "last_success_at"
+                    ),
+                    "failures": self._consumer_failures[consumer_name],
+                    "last_error": str(exc),
+                }
+                logger.warning("Search mutation consumer %s failed: %s", consumer_name, exc)
+                await asyncio.sleep(self.config.mutation_poll_seconds)
+
+    async def _resolve_mutations(
+        self,
+        events: list[SearchMutationEvent],
+    ) -> list[ResolvedMutation]:
+        if self._mutation_resolver is None:
+            return []
+        return await self._mutation_resolver.resolve_batch(events)
+
+    async def _consume_bm25_mutations(self, events: list[SearchMutationEvent]) -> None:
+        if self._bm25s_index is None:
+            return
+        resolved = await self._resolve_mutations(events)
+        for mutation in resolved:
+            if mutation.event.op != SearchMutationOp.UPSERT or not mutation.content:
+                continue
+            await self._bm25s_index.index_document(
+                mutation.path_id,
+                mutation.event.path,
+                mutation.content,
+            )
+
+    async def _consume_fts_mutations(self, events: list[SearchMutationEvent]) -> None:
+        if self._chunk_store is None:
+            return
+        resolved = await self._resolve_mutations(events)
+        for mutation in resolved:
+            if mutation.event.op == SearchMutationOp.DELETE:
+                await self._chunk_store.delete_document_chunks(mutation.path_id)
+                continue
+            if mutation.content:
+                await self._index_to_document_chunks(
+                    mutation.path_id,
+                    mutation.event.path,
+                    mutation.content,
+                )
+
+    async def _consume_embedding_mutations(self, events: list[SearchMutationEvent]) -> None:
+        if self._indexing_pipeline is None or self._embedding_provider is None:
+            return
+        resolved = await self._resolve_mutations(events)
+        for mutation in resolved:
+            if mutation.event.op != SearchMutationOp.UPSERT or not mutation.content:
+                continue
+            await self._indexing_pipeline.index_document(
+                mutation.event.path,
+                mutation.content,
+                mutation.path_id,
+            )
+
+    async def _consume_txtai_mutations(self, events: list[SearchMutationEvent]) -> None:
+        if self._backend is None:
+            return
+
+        resolved = await self._resolve_mutations(events)
+        deletes_by_zone: dict[str, list[str]] = {}
+        upserts_by_zone: dict[str, list[dict[str, Any]]] = {}
+
+        for mutation in resolved:
+            if mutation.event.op == SearchMutationOp.DELETE:
+                deletes_by_zone.setdefault(mutation.zone_id, []).append(mutation.doc_id)
+                continue
+            if mutation.content:
+                upserts_by_zone.setdefault(mutation.zone_id, []).append(
+                    {
+                        "id": mutation.doc_id,
+                        "text": mutation.content,
+                        "path": mutation.virtual_path,
+                        "zone_id": mutation.zone_id,
+                    }
+                )
+
+        for zone_id, ids in deletes_by_zone.items():
+            await self._backend.delete(ids, zone_id=zone_id)
+        for zone_id, docs in upserts_by_zone.items():
+            await self._backend.upsert(docs, zone_id=zone_id)
 
     async def _refresh_indexes(self, paths: list[str]) -> None:
         """Refresh indexes for a batch of changed files.
@@ -1541,6 +1879,7 @@ class SearchDaemon:
             "txtai_model": self.config.txtai_model,
             "txtai_reranker": self.config.txtai_reranker,
             "txtai_graph": self.config.txtai_graph,
+            "mutation_consumers": self.stats.mutation_consumers,
         }
 
     def get_health(self) -> dict[str, Any]:

--- a/src/nexus/bricks/search/indexing.py
+++ b/src/nexus/bricks/search/indexing.py
@@ -13,14 +13,11 @@ Features:
 
 import asyncio
 import logging
-import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import text
-
+from nexus.bricks.search.chunk_store import ChunkRecord, ChunkStore
 from nexus.bricks.search.chunking import DocumentChunker, EntropyAwareChunker
 from nexus.bricks.search.contextual_chunking import (
     ContextualChunker,
@@ -324,150 +321,27 @@ class IndexingPipeline:
             raise RuntimeError("async_session_factory required for bulk insert")
 
         embeddings: list[list[float]] | None = getattr(doc, "_embeddings", None)
-
-        if self._db_type == "postgresql":
-            await self._pg_bulk_insert(doc, embeddings)
-        else:
-            await self._sqlite_bulk_insert(doc, embeddings)
-
-    async def _pg_bulk_insert(
-        self,
-        doc: _ChunkedDoc,
-        embeddings: list[list[float]] | None,
-    ) -> None:
-        """PostgreSQL bulk insert using batched INSERT with unnest."""
-        assert self._async_session_factory is not None  # guarded by _bulk_insert
-        now = datetime.now(UTC).replace(tzinfo=None)
         embedding_model = (
             self._embedding_provider.__class__.__name__ if self._embedding_provider else None
         )
-
-        async with self._async_session_factory() as session:
-            # Delete existing chunks
-            await session.execute(
-                text("DELETE FROM document_chunks WHERE path_id = :path_id"),
-                {"path_id": doc.path_id},
-            )
-
-            if embeddings:
-                insert_sql = text("""
-                    INSERT INTO document_chunks
-                    (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens,
-                     start_offset, end_offset, line_start, line_end,
-                     embedding_model, embedding,
-                     chunk_context, chunk_position, source_document_id,
-                     created_at)
-                    VALUES
-                    (:chunk_id, :path_id, :chunk_index, :chunk_text, :chunk_tokens,
-                     :start_offset, :end_offset, :line_start, :line_end,
-                     :embedding_model, CAST(:embedding AS halfvec),
-                     :chunk_context, :chunk_position, :source_document_id,
-                     :created_at)
-                """)
-            else:
-                insert_sql = text("""
-                    INSERT INTO document_chunks
-                    (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens,
-                     start_offset, end_offset, line_start, line_end,
-                     embedding_model,
-                     chunk_context, chunk_position, source_document_id,
-                     created_at)
-                    VALUES
-                    (:chunk_id, :path_id, :chunk_index, :chunk_text, :chunk_tokens,
-                     :start_offset, :end_offset, :line_start, :line_end,
-                     :embedding_model,
-                     :chunk_context, :chunk_position, :source_document_id,
-                     :created_at)
-                """)
-
-            params_list = []
-            for i, chunk in enumerate(doc.chunks):
-                params: dict[str, Any] = {
-                    "chunk_id": str(uuid.uuid4()),
-                    "path_id": doc.path_id,
-                    "chunk_index": i,
-                    "chunk_text": chunk.text,
-                    "chunk_tokens": chunk.tokens,
-                    "start_offset": chunk.start_offset,
-                    "end_offset": chunk.end_offset,
-                    "line_start": chunk.line_start,
-                    "line_end": chunk.line_end,
-                    "embedding_model": embedding_model,
-                    "chunk_context": doc.context_jsons[i] if doc.context_jsons else None,
-                    "chunk_position": doc.context_positions[i] if doc.context_positions else None,
-                    "source_document_id": doc.source_document_id,
-                    "created_at": now,
-                }
-                if embeddings:
-                    # Convert to pgvector string format for asyncpg compatibility
-                    emb = embeddings[i]
-                    params["embedding"] = "[" + ",".join(str(v) for v in emb) + "]"
-                params_list.append(params)
-
-            # executemany-style: execute each row (SA text doesn't support executemany directly)
-            for params in params_list:
-                await session.execute(insert_sql, params)
-
-            await session.commit()
-
-    async def _sqlite_bulk_insert(
-        self,
-        doc: _ChunkedDoc,
-        _embeddings: list[list[float]] | None,
-    ) -> None:
-        """SQLite bulk insert using executemany."""
-        assert self._async_session_factory is not None  # guarded by _bulk_insert
-        now = datetime.now(UTC).replace(tzinfo=None)
-        embedding_model = (
-            self._embedding_provider.__class__.__name__ if self._embedding_provider else None
+        chunk_store = ChunkStore(
+            async_session_factory=self._async_session_factory,
+            db_type=self._db_type,
         )
-
-        async with self._async_session_factory() as session:
-            # Delete existing chunks
-            await session.execute(
-                text("DELETE FROM document_chunks WHERE path_id = :path_id"),
-                {"path_id": doc.path_id},
+        records = [
+            ChunkRecord(
+                chunk_text=chunk.text,
+                chunk_tokens=chunk.tokens,
+                start_offset=chunk.start_offset,
+                end_offset=chunk.end_offset,
+                line_start=chunk.line_start,
+                line_end=chunk.line_end,
+                embedding=embeddings[i] if embeddings else None,
+                embedding_model=embedding_model,
+                chunk_context=doc.context_jsons[i] if doc.context_jsons else None,
+                chunk_position=doc.context_positions[i] if doc.context_positions else None,
+                source_document_id=doc.source_document_id,
             )
-
-            insert_sql = text("""
-                INSERT INTO document_chunks
-                (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens,
-                 start_offset, end_offset, line_start, line_end,
-                 embedding_model,
-                 chunk_context, chunk_position, source_document_id,
-                 created_at)
-                VALUES
-                (:chunk_id, :path_id, :chunk_index, :chunk_text, :chunk_tokens,
-                 :start_offset, :end_offset, :line_start, :line_end,
-                 :embedding_model,
-                 :chunk_context, :chunk_position, :source_document_id,
-                 :created_at)
-            """)
-
-            params_list = []
-            for i, chunk in enumerate(doc.chunks):
-                params_list.append(
-                    {
-                        "chunk_id": str(uuid.uuid4()),
-                        "path_id": doc.path_id,
-                        "chunk_index": i,
-                        "chunk_text": chunk.text,
-                        "chunk_tokens": chunk.tokens,
-                        "start_offset": chunk.start_offset,
-                        "end_offset": chunk.end_offset,
-                        "line_start": chunk.line_start,
-                        "line_end": chunk.line_end,
-                        "embedding_model": embedding_model,
-                        "chunk_context": doc.context_jsons[i] if doc.context_jsons else None,
-                        "chunk_position": doc.context_positions[i]
-                        if doc.context_positions
-                        else None,
-                        "source_document_id": doc.source_document_id,
-                        "created_at": now,
-                    }
-                )
-
-            for params in params_list:
-                await session.execute(insert_sql, params)
-
-            await session.commit()
+            for i, chunk in enumerate(doc.chunks)
+        ]
+        await chunk_store.replace_document_chunks(doc.path_id, records)

--- a/src/nexus/bricks/search/mutation_events.py
+++ b/src/nexus/bricks/search/mutation_events.py
@@ -1,0 +1,116 @@
+"""Search mutation event contract and normalization helpers.
+
+The search indexing pipeline consumes filesystem mutations from the durable
+operation log. This module converts those records into a small, explicit
+event shape so each consumer sees the same semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+
+class SearchMutationOp(StrEnum):
+    """Normalized operation type for search index maintenance."""
+
+    UPSERT = "upsert"
+    DELETE = "delete"
+
+
+@dataclass(frozen=True)
+class SearchMutationEvent:
+    """Normalized filesystem mutation for search consumers."""
+
+    event_id: str
+    operation_id: str
+    op: SearchMutationOp
+    path: str
+    zone_id: str
+    timestamp: datetime
+    sequence_number: int
+    new_path: str | None = None
+
+    @property
+    def virtual_path(self) -> str:
+        """Return the unscoped DB virtual_path for this event."""
+        return strip_zone_prefix(self.path)
+
+    @classmethod
+    def from_operation_log_row(cls, row: Any) -> "SearchMutationEvent | None":
+        """Build a normalized event from an OperationLogModel-like row.
+
+        Returns None for operation types that do not affect search indexing.
+        """
+        op = infer_mutation_op(
+            operation_type=getattr(row, "operation_type", None),
+            change_type=getattr(row, "change_type", None),
+        )
+        if op is None:
+            return None
+
+        created_at = getattr(row, "created_at", None)
+        if created_at is None:
+            created_at = datetime.now(UTC).replace(tzinfo=None)
+        elif getattr(created_at, "tzinfo", None) is not None:
+            created_at = created_at.astimezone(UTC).replace(tzinfo=None)
+
+        sequence_number = getattr(row, "sequence_number", None)
+        if sequence_number is None:
+            raise ValueError("operation log row missing sequence_number")
+
+        operation_id = getattr(row, "operation_id", None)
+        if operation_id is None:
+            raise ValueError("operation log row missing operation_id")
+
+        path = getattr(row, "path", None)
+        if not path:
+            raise ValueError("operation log row missing path")
+
+        zone_id = getattr(row, "zone_id", None) or "root"
+
+        return cls(
+            event_id=f"search:{operation_id}",
+            operation_id=operation_id,
+            op=op,
+            path=path,
+            zone_id=zone_id,
+            timestamp=created_at,
+            sequence_number=int(sequence_number),
+            new_path=getattr(row, "new_path", None),
+        )
+
+
+def infer_mutation_op(
+    *,
+    operation_type: str | None,
+    change_type: str | None,
+) -> SearchMutationOp | None:
+    """Map operation log fields to a normalized search mutation op."""
+    if operation_type == "write":
+        return SearchMutationOp.UPSERT
+    if operation_type == "delete":
+        return SearchMutationOp.DELETE
+    if operation_type == "rename":
+        if change_type == "delete":
+            return SearchMutationOp.DELETE
+        return SearchMutationOp.UPSERT
+    return None
+
+
+def strip_zone_prefix(path: str) -> str:
+    """Strip /zone/{zone_id} prefix from a scoped VFS path."""
+    import re
+
+    match = re.match(r"^/zone/[^/]+(/.*)", path)
+    return match.group(1) if match else path
+
+
+def extract_zone_id(path: str, default: str = "root") -> str:
+    """Extract zone ID from a scoped path when present."""
+    import re
+
+    match = re.match(r"^/zone/([^/]+)/", path)
+    return match.group(1) if match else default

--- a/src/nexus/bricks/search/mutation_resolver.py
+++ b/src/nexus/bricks/search/mutation_resolver.py
@@ -44,6 +44,10 @@ class MutationResolver:
         self._cache_ttl_seconds = cache_ttl_seconds
         self._cache: dict[str, tuple[float, ResolvedMutation]] = {}
 
+    @staticmethod
+    def _path_key(zone_id: str, virtual_path: str) -> tuple[str, str]:
+        return (zone_id, virtual_path)
+
     def set_file_reader(self, file_reader: Any | None) -> None:
         self._file_reader = file_reader
 
@@ -64,7 +68,7 @@ class MutationResolver:
         now = time.monotonic()
         resolved: list[ResolvedMutation | None] = [None] * len(events)
         unresolved_indices: list[int] = []
-        unresolved_vpaths: list[str] = []
+        unresolved_keys: list[tuple[str, str]] = []
 
         for idx, event in enumerate(events):
             cached = self._cache.get(event.event_id)
@@ -72,15 +76,15 @@ class MutationResolver:
                 resolved[idx] = cached[1]
                 continue
             unresolved_indices.append(idx)
-            unresolved_vpaths.append(event.virtual_path)
+            unresolved_keys.append(self._path_key(event.zone_id, event.virtual_path))
 
-        path_id_map = await self._lookup_path_ids(unresolved_vpaths)
+        path_id_map = await self._lookup_path_ids(unresolved_keys)
         content_map = await self._lookup_content(events, unresolved_indices)
 
         for idx in unresolved_indices:
             event = events[idx]
             virtual_path = event.virtual_path
-            path_id = path_id_map.get(virtual_path, virtual_path)
+            path_id = path_id_map.get(self._path_key(event.zone_id, virtual_path), virtual_path)
             zone_id = event.zone_id
             doc_id = f"{zone_id}:{virtual_path}" if zone_id != "root" else virtual_path
             mutation = ResolvedMutation(
@@ -96,21 +100,34 @@ class MutationResolver:
 
         return [item for item in resolved if item is not None]
 
-    async def _lookup_path_ids(self, virtual_paths: list[str]) -> dict[str, str]:
-        if not virtual_paths or self._async_session_factory is None:
+    async def _lookup_path_ids(
+        self,
+        path_keys: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], str]:
+        if not path_keys or self._async_session_factory is None:
             return {}
 
-        path_id_map: dict[str, str] = {}
-        unique_paths = list(dict.fromkeys(virtual_paths))
+        path_id_map: dict[tuple[str, str], str] = {}
+        unique_keys = list(dict.fromkeys(path_keys))
+        where_clauses = []
+        params: dict[str, str] = {}
+        for idx, (zone_id, virtual_path) in enumerate(unique_keys):
+            where_clauses.append(
+                f"(zone_id = :zone_id_{idx} AND virtual_path = :virtual_path_{idx})"
+            )
+            params[f"zone_id_{idx}"] = zone_id
+            params[f"virtual_path_{idx}"] = virtual_path
         async with self._async_session_factory() as session:
             result = await session.execute(
                 sa_text(
-                    "SELECT virtual_path, path_id FROM file_paths WHERE virtual_path = ANY(:vpaths)"
+                    "SELECT zone_id, virtual_path, path_id "
+                    "FROM file_paths "
+                    "WHERE deleted_at IS NULL AND (" + " OR ".join(where_clauses) + ")"
                 ),
-                {"vpaths": unique_paths},
+                params,
             )
             for row in result.fetchall():
-                path_id_map[str(row[0])] = str(row[1])
+                path_id_map[self._path_key(str(row[0]), str(row[1]))] = str(row[2])
         return path_id_map
 
     async def _lookup_content(
@@ -135,10 +152,10 @@ class MutationResolver:
 
         if missing_events and self._async_session_factory is not None:
             db_content = await self._lookup_content_cache(
-                [event.virtual_path for event in missing_events]
+                [self._path_key(event.zone_id, event.virtual_path) for event in missing_events]
             )
             for event in missing_events:
-                content = db_content.get(event.virtual_path)
+                content = db_content.get(self._path_key(event.zone_id, event.virtual_path))
                 if content:
                     content_map[event.event_id] = content
 
@@ -157,24 +174,35 @@ class MutationResolver:
                 return virtual_content if isinstance(virtual_content, str) else None
         return None
 
-    async def _lookup_content_cache(self, virtual_paths: list[str]) -> dict[str, str]:
-        if not virtual_paths or self._async_session_factory is None:
+    async def _lookup_content_cache(
+        self,
+        path_keys: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], str]:
+        if not path_keys or self._async_session_factory is None:
             return {}
 
-        content_map: dict[str, str] = {}
-        unique_paths = list(dict.fromkeys(virtual_paths))
+        content_map: dict[tuple[str, str], str] = {}
+        unique_keys = list(dict.fromkeys(path_keys))
+        where_clauses = []
+        params: dict[str, str] = {}
+        for idx, (zone_id, virtual_path) in enumerate(unique_keys):
+            where_clauses.append(
+                f"(fp.zone_id = :zone_id_{idx} AND fp.virtual_path = :virtual_path_{idx})"
+            )
+            params[f"zone_id_{idx}"] = zone_id
+            params[f"virtual_path_{idx}"] = virtual_path
         async with self._async_session_factory() as session:
             result = await session.execute(
                 sa_text(
-                    "SELECT fp.virtual_path, cc.content_text "
+                    "SELECT fp.zone_id, fp.virtual_path, cc.content_text "
                     "FROM content_cache cc "
                     "JOIN file_paths fp ON cc.path_id = fp.path_id "
-                    "WHERE fp.virtual_path = ANY(:vpaths) "
+                    "WHERE fp.deleted_at IS NULL AND (" + " OR ".join(where_clauses) + ") "
                     "AND cc.content_text IS NOT NULL"
                 ),
-                {"vpaths": unique_paths},
+                params,
             )
             for row in result.fetchall():
-                if row[1]:
-                    content_map[str(row[0])] = str(row[1])
+                if row[2]:
+                    content_map[self._path_key(str(row[0]), str(row[1]))] = str(row[2])
         return content_map

--- a/src/nexus/bricks/search/mutation_resolver.py
+++ b/src/nexus/bricks/search/mutation_resolver.py
@@ -1,0 +1,180 @@
+"""Shared mutation resolution for search consumers.
+
+Normalizes search mutation events into resolved document payloads and provides
+small in-process caching so multiple consumers can reuse the same file read
+and path lookup within a worker cycle.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text as sa_text
+
+from nexus.bricks.search.mutation_events import SearchMutationEvent
+
+
+@dataclass(frozen=True)
+class ResolvedMutation:
+    """Resolved mutation payload shared across search consumers."""
+
+    event: SearchMutationEvent
+    zone_id: str
+    virtual_path: str
+    path_id: str
+    doc_id: str
+    content: str | None = None
+
+
+class MutationResolver:
+    """Resolve search mutation events into indexable payloads."""
+
+    def __init__(
+        self,
+        *,
+        file_reader: Any | None,
+        async_session_factory: Any | None,
+        cache_ttl_seconds: float = 30.0,
+    ) -> None:
+        self._file_reader = file_reader
+        self._async_session_factory = async_session_factory
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._cache: dict[str, tuple[float, ResolvedMutation]] = {}
+
+    def set_file_reader(self, file_reader: Any | None) -> None:
+        self._file_reader = file_reader
+
+    def invalidate_path(self, path: str) -> None:
+        keys_to_delete = [
+            key
+            for key, (_, resolved) in self._cache.items()
+            if resolved.event.path == path or resolved.virtual_path == path
+        ]
+        for key in keys_to_delete:
+            self._cache.pop(key, None)
+
+    async def resolve_batch(self, events: list[SearchMutationEvent]) -> list[ResolvedMutation]:
+        """Resolve a batch of events with shared DB lookups and cache reuse."""
+        if not events:
+            return []
+
+        now = time.monotonic()
+        resolved: list[ResolvedMutation | None] = [None] * len(events)
+        unresolved_indices: list[int] = []
+        unresolved_vpaths: list[str] = []
+
+        for idx, event in enumerate(events):
+            cached = self._cache.get(event.event_id)
+            if cached is not None and (now - cached[0]) < self._cache_ttl_seconds:
+                resolved[idx] = cached[1]
+                continue
+            unresolved_indices.append(idx)
+            unresolved_vpaths.append(event.virtual_path)
+
+        path_id_map = await self._lookup_path_ids(unresolved_vpaths)
+        content_map = await self._lookup_content(events, unresolved_indices)
+
+        for idx in unresolved_indices:
+            event = events[idx]
+            virtual_path = event.virtual_path
+            path_id = path_id_map.get(virtual_path, virtual_path)
+            zone_id = event.zone_id
+            doc_id = f"{zone_id}:{virtual_path}" if zone_id != "root" else virtual_path
+            mutation = ResolvedMutation(
+                event=event,
+                zone_id=zone_id,
+                virtual_path=virtual_path,
+                path_id=path_id,
+                doc_id=doc_id,
+                content=content_map.get(event.event_id),
+            )
+            self._cache[event.event_id] = (now, mutation)
+            resolved[idx] = mutation
+
+        return [item for item in resolved if item is not None]
+
+    async def _lookup_path_ids(self, virtual_paths: list[str]) -> dict[str, str]:
+        if not virtual_paths or self._async_session_factory is None:
+            return {}
+
+        path_id_map: dict[str, str] = {}
+        unique_paths = list(dict.fromkeys(virtual_paths))
+        async with self._async_session_factory() as session:
+            result = await session.execute(
+                sa_text(
+                    "SELECT virtual_path, path_id FROM file_paths WHERE virtual_path = ANY(:vpaths)"
+                ),
+                {"vpaths": unique_paths},
+            )
+            for row in result.fetchall():
+                path_id_map[str(row[0])] = str(row[1])
+        return path_id_map
+
+    async def _lookup_content(
+        self,
+        events: list[SearchMutationEvent],
+        unresolved_indices: list[int],
+    ) -> dict[str, str]:
+        content_map: dict[str, str] = {}
+        update_events = [
+            events[idx] for idx in unresolved_indices if events[idx].op.value == "upsert"
+        ]
+        if not update_events:
+            return content_map
+
+        missing_events: list[SearchMutationEvent] = []
+        for event in update_events:
+            content = await self._read_content(event.path, event.virtual_path)
+            if content:
+                content_map[event.event_id] = content
+            else:
+                missing_events.append(event)
+
+        if missing_events and self._async_session_factory is not None:
+            db_content = await self._lookup_content_cache(
+                [event.virtual_path for event in missing_events]
+            )
+            for event in missing_events:
+                content = db_content.get(event.virtual_path)
+                if content:
+                    content_map[event.event_id] = content
+
+        return content_map
+
+    async def _read_content(self, scoped_path: str, virtual_path: str) -> str | None:
+        if self._file_reader is None:
+            return None
+
+        try:
+            scoped_content = await self._file_reader.read_text(scoped_path)
+            return scoped_content if isinstance(scoped_content, str) else None
+        except Exception:
+            with contextlib.suppress(OSError, ValueError, Exception):
+                virtual_content = await self._file_reader.read_text(virtual_path)
+                return virtual_content if isinstance(virtual_content, str) else None
+        return None
+
+    async def _lookup_content_cache(self, virtual_paths: list[str]) -> dict[str, str]:
+        if not virtual_paths or self._async_session_factory is None:
+            return {}
+
+        content_map: dict[str, str] = {}
+        unique_paths = list(dict.fromkeys(virtual_paths))
+        async with self._async_session_factory() as session:
+            result = await session.execute(
+                sa_text(
+                    "SELECT fp.virtual_path, cc.content_text "
+                    "FROM content_cache cc "
+                    "JOIN file_paths fp ON cc.path_id = fp.path_id "
+                    "WHERE fp.virtual_path = ANY(:vpaths) "
+                    "AND cc.content_text IS NOT NULL"
+                ),
+                {"vpaths": unique_paths},
+            )
+            for row in result.fetchall():
+                if row[1]:
+                    content_map[str(row[0])] = str(row[1])
+        return content_map

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -2481,7 +2481,7 @@ class SearchService:
             db_path = _unscope(path) if path != "/" else None
             daemon_results = await daemon.search(
                 query=query,
-                search_type=search_mode if search_mode != "semantic" else "hybrid",
+                search_type=search_mode,
                 limit=fetch_limit,
                 path_filter=db_path,
                 zone_id=zone_id,

--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -14,6 +14,7 @@ Graph methods provide semantic graph search using txtai's built-in graph module.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from typing import Any, Protocol, cast, runtime_checkable
@@ -21,6 +22,9 @@ from typing import Any, Protocol, cast, runtime_checkable
 from nexus.bricks.search.results import BaseSearchResult
 
 logger = logging.getLogger(__name__)
+
+_RERANK_MAX_CHARS = 800
+_RERANK_MAX_WORDS = 128
 
 
 # =============================================================================
@@ -122,6 +126,10 @@ class TxtaiBackend:
         self._embeddings: Any = None
         self._reranker: Any = None
         self.last_rerank_ms: float = 0.0
+        self._started = False
+        self._startup_lock = asyncio.Lock()
+        self._startup_task: asyncio.Task[None] | None = None
+        self._reranker_task: asyncio.Task[None] | None = None
         # Serialise all access to _embeddings / _reranker across coroutines.
         # faiss (used by txtai) is NOT thread-safe for concurrent search+write
         # operations. Since asyncio.to_thread() dispatches to a thread pool,
@@ -129,6 +137,31 @@ class TxtaiBackend:
         self._lock = asyncio.Lock()
 
     async def startup(self) -> None:
+        """Initialize txtai resources once."""
+        if self._started or self._embeddings is not None:
+            if self._embeddings is not None:
+                self._started = True
+            return
+
+        async with self._startup_lock:
+            if self._started:
+                return
+            if self._startup_task is None or self._startup_task.done():
+                self._startup_task = asyncio.create_task(self._startup_impl())
+            task = self._startup_task
+
+        await task
+
+    def kickoff_startup(self) -> None:
+        """Begin backend startup in the background without blocking app readiness."""
+        if self._started or self._embeddings is not None:
+            if self._embeddings is not None:
+                self._started = True
+            return
+        if self._startup_task is None or self._startup_task.done():
+            self._startup_task = asyncio.create_task(self._startup_impl())
+
+    async def _startup_impl(self) -> None:
         """Initialize txtai Embeddings with pgvector backend (with fallback).
 
         Fallback chain:
@@ -137,7 +170,13 @@ class TxtaiBackend:
         3. Keyword-only BM25 (embedding model fails to load)
         4. Degraded mode — _embeddings stays None, all searches return []
         """
-        from txtai import Embeddings
+        try:
+            from txtai import Embeddings
+        except ModuleNotFoundError:
+            logger.warning("txtai package not installed; starting in degraded search mode")
+            self._embeddings = None
+            self._started = True
+            return
 
         # Auto-detect GPU: MPS (Apple Silicon) > CUDA > CPU
         gpu_device: str | bool = False
@@ -223,21 +262,13 @@ class TxtaiBackend:
                 )
                 self._embeddings = None
 
-        # Initialize cross-encoder reranker if configured
-        if self._reranker_model and self._embeddings is not None:
-            try:
-                from txtai.pipeline import Similarity
+        # Mark backend usable as soon as embeddings are ready. Reranker startup
+        # can continue in the background without blocking indexing/search.
+        self._started = True
 
-                self._reranker = await asyncio.to_thread(
-                    lambda: Similarity(path=self._reranker_model, crossencode=True)
-                )
-                logger.info("Reranker initialized: %s", self._reranker_model)
-            except Exception:
-                logger.warning(
-                    "Reranker init failed (model=%s). Continuing without reranking.",
-                    self._reranker_model,
-                    exc_info=True,
-                )
+        # Initialize cross-encoder reranker in the background if configured.
+        if self._reranker_model and self._embeddings is not None:
+            self._reranker_task = asyncio.create_task(self._init_reranker())
 
         logger.info(
             "txtai backend started: model=%s, hybrid=%s, graph=%s, pgvector=%s, "
@@ -246,18 +277,44 @@ class TxtaiBackend:
             self._hybrid,
             self._graph,
             use_pgvector,
-            self._reranker_model if self._reranker else None,
+            self._reranker_model,
             bool(self._sparse),
             self._embeddings is None,
         )
 
+    async def _init_reranker(self) -> None:
+        """Load the optional cross-encoder reranker without blocking backend readiness."""
+        try:
+            from txtai.pipeline import Similarity
+
+            reranker = await asyncio.to_thread(
+                lambda: Similarity(path=self._reranker_model, crossencode=True)
+            )
+            async with self._lock:
+                self._reranker = reranker
+            logger.info("Reranker initialized: %s", self._reranker_model)
+        except Exception:
+            logger.warning(
+                "Reranker init failed (model=%s). Continuing without reranking.",
+                self._reranker_model,
+                exc_info=True,
+            )
+            async with self._lock:
+                self._reranker = None
+
     async def shutdown(self) -> None:
         """Release txtai resources."""
+        if self._reranker_task is not None and not self._reranker_task.done():
+            self._reranker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._reranker_task
+        self._reranker_task = None
         async with self._lock:
             self._reranker = None
             if self._embeddings is not None:
                 await asyncio.to_thread(self._embeddings.close)
                 self._embeddings = None
+            self._started = False
         logger.info("txtai backend shut down")
 
     # ----- Index operations ---------------------------------------------------
@@ -266,6 +323,7 @@ class TxtaiBackend:
         """Index documents (full rebuild for zone_id)."""
         if not documents:
             return 0
+        await self.startup()
 
         stamped = _stamp_zone_id(documents, zone_id)
         rows = [(doc["id"], doc, None) for doc in stamped]
@@ -283,6 +341,7 @@ class TxtaiBackend:
         """
         if not documents:
             return 0
+        await self.startup()
 
         stamped = _stamp_zone_id(documents, zone_id)
         rows = [(doc["id"], doc, None) for doc in stamped]
@@ -302,6 +361,7 @@ class TxtaiBackend:
         """Delete documents by id."""
         if not ids:
             return 0
+        await self.startup()
 
         async with self._lock:
             if not self._embeddings:
@@ -322,6 +382,7 @@ class TxtaiBackend:
     ) -> list[BaseSearchResult]:
         """Search with mandatory zone_id isolation via txtai SQL WHERE clause."""
         self.last_rerank_ms = 0.0
+        await self.startup()
 
         # Over-fetch when reranker is available so it has enough candidates.
         # 2x balances rerank quality vs CPU latency (~10ms per candidate).
@@ -367,7 +428,7 @@ class TxtaiBackend:
         """Rerank results using cross-encoder model."""
         start = time.perf_counter()
 
-        texts = [r.chunk_text for r in results if r.chunk_text]
+        texts = [_truncate_reranker_text(r.chunk_text) for r in results if r.chunk_text]
         if not texts:
             return results[:limit]
 
@@ -375,7 +436,15 @@ class TxtaiBackend:
         async with self._lock:
             if not self._reranker:
                 return results[:limit]
-            scored: list[tuple[int, float]] = await asyncio.to_thread(self._reranker, query, texts)
+            try:
+                scored: list[tuple[int, float]] = await asyncio.to_thread(
+                    self._reranker,
+                    query,
+                    texts,
+                )
+            except Exception as exc:
+                logger.warning("Reranker failed, falling back to backend ranking: %s", exc)
+                return results[:limit]
 
         reranked: list[BaseSearchResult] = []
         for idx, score in scored:
@@ -399,6 +468,7 @@ class TxtaiBackend:
         limit: int = 10,
     ) -> list[BaseSearchResult]:
         """Graph-augmented search using txtai's semantic graph."""
+        await self.startup()
         async with self._lock:
             if not self._embeddings or not getattr(self._embeddings, "graph", None):
                 return []
@@ -429,6 +499,7 @@ class TxtaiBackend:
 
         Returns list of neighbor dicts with ``id``, ``text``, ``score`` keys.
         """
+        await self.startup()
         if not self._embeddings or not getattr(self._embeddings, "graph", None):
             return []
 
@@ -505,6 +576,19 @@ def _build_search_sql(
 def _stamp_zone_id(documents: list[dict[str, Any]], zone_id: str) -> list[dict[str, Any]]:
     """Return new document list with zone_id stamped on each (immutable)."""
     return [{**doc, "zone_id": zone_id} for doc in documents]
+
+
+def _truncate_reranker_text(text: str) -> str:
+    """Trim reranker candidates to avoid cross-encoder sequence overflows."""
+    trimmed = text.strip()
+    if len(trimmed) > _RERANK_MAX_CHARS:
+        trimmed = trimmed[:_RERANK_MAX_CHARS]
+
+    words = trimmed.split()
+    if len(words) > _RERANK_MAX_WORDS:
+        trimmed = " ".join(words[:_RERANK_MAX_WORDS])
+
+    return trimmed
 
 
 # =============================================================================

--- a/src/nexus/bricks/task_manager/dispatch_consumer.py
+++ b/src/nexus/bricks/task_manager/dispatch_consumer.py
@@ -116,14 +116,15 @@ class TaskDispatchPipeConsumer:
         if self._nx is None:
             return
 
-        from nexus.contracts.metadata import DT_PIPE
+        pipe_manager = getattr(self._nx, "_pipe_manager", None)
+        if pipe_manager is None:
+            raise RuntimeError("PipeManager not available for task dispatch startup")
 
-        with contextlib.suppress(Exception):
-            await self._nx.sys_setattr(
-                _TASK_DISPATCH_PIPE_PATH,
-                entry_type=DT_PIPE,
-                owner_id="kernel",
-            )
+        pipe_manager.ensure(
+            _TASK_DISPATCH_PIPE_PATH,
+            capacity=_TASK_DISPATCH_PIPE_CAPACITY,
+            owner_id="kernel",
+        )
 
         self._pipe_ready = True
         self._consumer_task = asyncio.create_task(self._consume())

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -83,19 +83,20 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
     if not grpc_port:
         grpc_port = state.get("ports", {}).get("grpc", cfg.get("ports", {}).get("grpc", 2028))
 
-    # TLS: propagate state.json paths into env so ZoneTlsConfig.from_env()
-    # picks them up. Always run this regardless of how grpc_port was resolved.
+    # TLS: trust explicit runtime state / env, not blind auto-detection from
+    # NEXUS_DATA_DIR. Standalone demo/shared stacks may still have a tls/
+    # directory for internal services while exposing insecure host gRPC.
     tls = state.get("tls", {})
     if tls.get("cert") and not os.environ.get("NEXUS_TLS_CERT"):
         os.environ["NEXUS_TLS_CERT"] = tls["cert"]
         os.environ["NEXUS_TLS_KEY"] = tls.get("key", "")
         os.environ["NEXUS_TLS_CA"] = tls.get("ca", "")
-    if not os.environ.get("NEXUS_DATA_DIR") and data_dir:
-        os.environ["NEXUS_DATA_DIR"] = data_dir
 
     grpc_address = f"{parsed.hostname}:{grpc_port}"
 
-    tls_config = ZoneTlsConfig.from_env()
+    tls_config = None
+    if tls.get("cert") or os.environ.get("NEXUS_TLS_CERT"):
+        tls_config = ZoneTlsConfig.from_env()
     transport = RPCTransport(server_address=grpc_address, auth_token=api_key, tls_config=tls_config)
     return transport.call_rpc
 

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -130,8 +130,12 @@ def _derive_project_env(
     # rely on auto-detection, which can surprise users.
     if config.get("tls"):
         env["NEXUS_GRPC_TLS"] = "true"
+        env.pop("NEXUS_GRPC_BIND_ALL", None)
     else:
         env["NEXUS_GRPC_TLS"] = "false"
+        # Standalone demo/shared stacks expose gRPC through a published Docker
+        # port, so the server must not stay bound to container loopback.
+        env["NEXUS_GRPC_BIND_ALL"] = "true"
 
     return env
 
@@ -214,6 +218,19 @@ def _compose_has_build(compose_file: str) -> bool:
         return False
     nexus_svc = (stack.get("services") or {}).get("nexus")
     return isinstance(nexus_svc, dict) and "build" in nexus_svc
+
+
+def _resolve_pgvector_init_sql(compose_file: str) -> str | None:
+    """Resolve an absolute pgvector init SQL path for portable compose stacks."""
+    sibling = Path(compose_file).with_name("001-enable-pgvector.sql")
+    if sibling.exists():
+        return str(sibling.resolve())
+
+    bundled = Path(__file__).resolve().parent.parent / "data" / "001-enable-pgvector.sql"
+    if bundled.exists():
+        return str(bundled.resolve())
+
+    return None
 
 
 def _is_channel_following(config: dict[str, Any]) -> bool:
@@ -545,6 +562,9 @@ def up(
 
     # Build environment from config (project name, ports, data dir, auth, image, TLS)
     compose_env = _derive_project_env(config, resolved_ports=resolved_ports)
+    pgvector_init_sql = _resolve_pgvector_init_sql(cf)
+    if pgvector_init_sql:
+        compose_env["NEXUS_PGVECTOR_INIT_SQL"] = pgvector_init_sql
 
     # Track effective image and build mode for state.json
     effective_build_mode = "remote"
@@ -662,11 +682,12 @@ def up(
             if admin_api_key:
                 config["api_key"] = admin_api_key
 
-    # Auto-discover TLS certs (Raft 2-phase bootstrap writes to data_dir/tls/)
-    # and persist them so downstream commands auto-discover mTLS credentials.
+    # Auto-discover TLS certs only for TLS-enabled stacks. Demo/shared stacks
+    # can create a tls/ directory for internal services without exposing
+    # gRPC TLS on the host port, and advertising those files to the host CLI
+    # causes clients to attempt TLS against a plain-text port.
     tls_state: dict[str, str] = {}
     tls_dir = Path(data_dir) / "tls"
-    # Only persist TLS config when the server is configured to use mTLS.
     if config.get("tls") and tls_dir.exists():
         # Raft-style certs
         if (tls_dir / "ca.pem").exists():

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -89,6 +89,8 @@ services:
       NEXUS_CACHE_EMBEDDING_TTL: ${NEXUS_CACHE_EMBEDDING_TTL:-86400}
       # gRPC
       NEXUS_GRPC_PORT: "2028"  # Fixed inside container; host port varies via port mapping
+      NEXUS_GRPC_TLS: ${NEXUS_GRPC_TLS:-false}
+      NEXUS_GRPC_BIND_ALL: ${NEXUS_GRPC_BIND_ALL:-true}
       # Zoekt (external container, not built-in sidecar)
       ZOEKT_ENABLED: "false"
       ZOEKT_URL: ${ZOEKT_URL:-http://zoekt:6070}

--- a/src/nexus/core/pipe_manager.py
+++ b/src/nexus/core/pipe_manager.py
@@ -135,6 +135,36 @@ class PipeManager:
         logger.debug("pipe created: %s (capacity=%d)", path, capacity)
         return buf
 
+    def ensure(
+        self,
+        path: str,
+        *,
+        capacity: int = 65_536,
+        owner_id: str | None = None,
+        zone_id: str = ROOT_ZONE_ID,
+    ) -> PipeBackend:
+        """Ensure a named pipe has both an inode and a live in-memory buffer.
+
+        This is the idempotent startup path for long-lived DT_PIPE services.
+        It handles three cases:
+
+        1. pipe already open in-memory -> return existing buffer
+        2. no inode yet -> create inode + buffer
+        3. inode persisted but buffer lost after restart -> reopen buffer
+        """
+        if path in self._buffers and not self._buffers[path].closed:
+            return self._buffers[path]
+
+        try:
+            return self.create(
+                path,
+                capacity=capacity,
+                owner_id=owner_id,
+                zone_id=zone_id,
+            )
+        except PipeError:
+            return self.open(path, capacity=capacity)
+
     def open(self, path: str, *, capacity: int = 65_536) -> PipeBackend:
         """Open an existing pipe, or recover its buffer after restart.
 

--- a/src/nexus/factory/zoekt_pipe_consumer.py
+++ b/src/nexus/factory/zoekt_pipe_consumer.py
@@ -116,13 +116,15 @@ class ZoektPipeConsumer:
             return  # CLI mode
 
         pipe_manager = getattr(self._nx, "_pipe_manager", None)
-        if pipe_manager is None:
-            raise RuntimeError("PipeManager not available for Zoekt pipe startup")
-
-        pipe_manager.ensure(
-            _ZOEKT_PIPE_PATH,
-            owner_id="kernel",
-        )
+        if pipe_manager is not None:
+            pipe_manager.ensure(
+                _ZOEKT_PIPE_PATH,
+                owner_id="kernel",
+            )
+        else:
+            # Test/degraded path: fall back to direct syscall-based pipe creation
+            # when NexusFS exposes DT_PIPE syscalls but no PipeManager object.
+            await self._nx.sys_setattr(_ZOEKT_PIPE_PATH)
 
         self._pipe_ready = True
         self._consumer_task = asyncio.create_task(self._consume())

--- a/src/nexus/factory/zoekt_pipe_consumer.py
+++ b/src/nexus/factory/zoekt_pipe_consumer.py
@@ -115,14 +115,14 @@ class ZoektPipeConsumer:
         if self._nx is None:
             return  # CLI mode
 
-        from nexus.contracts.metadata import DT_PIPE
+        pipe_manager = getattr(self._nx, "_pipe_manager", None)
+        if pipe_manager is None:
+            raise RuntimeError("PipeManager not available for Zoekt pipe startup")
 
-        with contextlib.suppress(Exception):
-            await self._nx.sys_setattr(
-                _ZOEKT_PIPE_PATH,
-                entry_type=DT_PIPE,
-                owner_id="kernel",
-            )
+        pipe_manager.ensure(
+            _ZOEKT_PIPE_PATH,
+            owner_id="kernel",
+        )
 
         self._pipe_ready = True
         self._consumer_task = asyncio.create_task(self._consume())

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -407,7 +407,8 @@ def create_app(
             # Issue #914: Inject getter into delivery worker (fixes services→server import)
             from nexus.server.subscriptions import get_subscription_manager
 
-            _dw = nexus_fs.exposed_services().get("delivery_worker")
+            _sys = getattr(nexus_fs, "_system_services", None)
+            _dw = getattr(_sys, "delivery_worker", None)
             if _dw is not None:
                 _dw._subscription_manager_getter = get_subscription_manager
             logger.info("Subscription manager initialized and injected into NexusFS")

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -91,14 +91,32 @@ async def _startup_cache_brick(app: "FastAPI", svc: "LifespanServices") -> None:
             brk = svc.brick_services
             cache_brick = getattr(brk, "cache_brick", None) if brk else None
 
-        if cache_brick is None:
+        from nexus.cache.settings import CacheSettings
+
+        cache_settings = CacheSettings.from_env()
+        needs_env_cache_brick = cache_brick is None
+        if cache_brick is not None and not cache_brick.has_cache_store:
+            needs_env_cache_brick = cache_settings.should_use_dragonfly()
+
+        if needs_env_cache_brick:
             # Fallback: create CacheBrick from env settings (standalone mode)
             from nexus.cache.brick import CacheBrick
-            from nexus.cache.settings import CacheSettings
+            from nexus.cache.dragonfly import DragonflyCacheStore, DragonflyClient
 
-            cache_settings = CacheSettings.from_env()
             record_store = svc.record_store
             cache_store = getattr(svc.nexus_fs, "_cache_store", None)
+            if cache_settings.should_use_dragonfly() and cache_settings.dragonfly_url:
+                client = DragonflyClient(
+                    url=cache_settings.dragonfly_url,
+                    pool_size=cache_settings.dragonfly_pool_size,
+                    timeout=cache_settings.dragonfly_timeout,
+                    connect_timeout=cache_settings.dragonfly_connect_timeout,
+                    pool_timeout=cache_settings.dragonfly_pool_timeout,
+                    socket_keepalive=cache_settings.dragonfly_keepalive,
+                    retry_on_timeout=cache_settings.dragonfly_retry_on_timeout,
+                )
+                await client.connect()
+                cache_store = DragonflyCacheStore(client)
             cache_brick = CacheBrick(
                 cache_store=cache_store,
                 settings=cache_settings,

--- a/src/nexus/server/lifespan/realtime.py
+++ b/src/nexus/server/lifespan/realtime.py
@@ -246,16 +246,15 @@ def _startup_exporter_registry(app: "FastAPI", _svc: "LifespanServices") -> None
     """Initialize ExporterRegistry and configured exporters (Issue #1138)."""
     app.state.exporter_registry = None
 
-    try:
-        from nexus.system_services.event_subsystem.log.exporter_registry import ExporterRegistry
-        from nexus.system_services.event_subsystem.log.exporters.config import EventStreamConfig
-        from nexus.system_services.event_subsystem.log.exporters.factory import create_exporter
+    enabled = os.getenv("NEXUS_EVENT_STREAM_ENABLED", "").lower() in ("true", "1", "yes")
+    if not enabled:
+        logger.debug("Event stream export disabled (NEXUS_EVENT_STREAM_ENABLED not set)")
+        return
 
-        # Read config from env vars
-        enabled = os.getenv("NEXUS_EVENT_STREAM_ENABLED", "").lower() in ("true", "1", "yes")
-        if not enabled:
-            logger.debug("Event stream export disabled (NEXUS_EVENT_STREAM_ENABLED not set)")
-            return
+    try:
+        from nexus.system_services.event_log.exporter_registry import ExporterRegistry
+        from nexus.system_services.event_log.exporters.config import EventStreamConfig
+        from nexus.system_services.event_log.exporters.factory import create_exporter
 
         exporter_type = os.getenv("NEXUS_EVENT_STREAM_EXPORTER", "kafka")
         config = EventStreamConfig(enabled=True, exporter=exporter_type)

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -56,6 +56,11 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         if _record_store is not None:
             with contextlib.suppress(AttributeError):
                 _async_sf = _record_store.async_session_factory
+        _settings_store = None
+        with contextlib.suppress(ImportError, AttributeError):
+            from nexus.storage.auth_stores.metastore_settings_store import MetastoreSettingsStore
+
+            _settings_store = MetastoreSettingsStore(svc.nexus_fs.metadata)
 
         # Issue #2188: Create ZoektClient + embedding provider via DI
         _zoekt_client = None
@@ -80,6 +85,7 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             async_session_factory=_async_sf,
             zoekt_client=_zoekt_client,
             cache_brick=_cache_brick,
+            settings_store=_settings_store,
         )
 
         # Embeddings are now handled by txtai backend (Issue #2663).
@@ -97,6 +103,10 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             from nexus.factory import _NexusFSFileReader
 
             app.state.search_daemon._file_reader = _NexusFSFileReader(svc.nexus_fs)
+            if getattr(app.state.search_daemon, "_mutation_resolver", None) is not None:
+                app.state.search_daemon._mutation_resolver.set_file_reader(  # noqa: SLF001
+                    app.state.search_daemon._file_reader
+                )
 
         # Wire SearchDaemon into SearchService so semantic_search queries
         # use the txtai backend instead of falling back to SQL ILIKE.

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -599,19 +599,26 @@ async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> No
     1. PipedRecordStoreWriteObserver — async RecordStore sync via kernel IPC
     2. ZoektPipeConsumer — async Zoekt index notifications via kernel IPC
 
-    Both follow the deferred-injection pattern: created in factory without
-    PipeManager, then PipeManager is injected here and start() spawns the
-    background consumer task.
+    Consumers support two deferred-injection styles:
+    1. Legacy DT_PIPE consumers expect ``set_pipe_manager(pipe_manager)``
+    2. Current syscall-backed consumers expect ``bind_fs(nexus_fs)``
+
+    Lifespan startup handles both so write-observer/search indexing does
+    not silently stop when the implementation migrates away from PipeManager.
     """
     pipe_manager = svc.pipe_manager
-    if pipe_manager is None:
-        return
+    nx = svc.nexus_fs
 
     # Issue #809: PipedRecordStoreWriteObserver
     wo = svc.write_observer
-    if wo is not None and hasattr(wo, "set_pipe_manager"):
+    if wo is not None:
         try:
-            wo.set_pipe_manager(pipe_manager)
+            if hasattr(wo, "bind_fs") and nx is not None:
+                wo.bind_fs(nx)
+            elif hasattr(wo, "set_pipe_manager") and pipe_manager is not None:
+                wo.set_pipe_manager(pipe_manager)
+            else:
+                raise RuntimeError("write observer missing startup binding hook")
             await wo.start()
             app.state.write_observer = wo
             logger.info("[PIPE] PipedRecordStoreWriteObserver started")
@@ -630,9 +637,14 @@ async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> No
 
     # Issue #810: ZoektPipeConsumer
     zpc = svc.zoekt_pipe_consumer
-    if zpc is not None and hasattr(zpc, "set_pipe_manager"):
+    if zpc is not None:
         try:
-            zpc.set_pipe_manager(pipe_manager)
+            if hasattr(zpc, "bind_fs") and nx is not None:
+                zpc.bind_fs(nx)
+            elif hasattr(zpc, "set_pipe_manager") and pipe_manager is not None:
+                zpc.set_pipe_manager(pipe_manager)
+            else:
+                raise RuntimeError("zoekt consumer missing startup binding hook")
             await zpc.start()
             app.state.zoekt_pipe_consumer = zpc
             logger.info("[PIPE] ZoektPipeConsumer started")
@@ -642,34 +654,32 @@ async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> No
     # TaskDispatchPipeConsumer (task lifecycle signals)
     tdc = svc.task_dispatch_consumer
     # Fallback: create consumer if not provided by factory (e.g. no record_store)
-    if tdc is None:
-        nx = svc.nexus_fs
-        if nx is not None:
-            try:
-                from nexus.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
+    if tdc is None and nx is not None:
+        try:
+            from nexus.task_manager.dispatch_consumer import TaskDispatchPipeConsumer
 
-                _task_svc = getattr(nx, "_task_manager_service", None)
-                # AcpService lives on AcpRPCService (created in _boot_wired_services)
-                _acp_svc = None
-                _acp_rpc_ref = nx.service("acp_rpc") if hasattr(nx, "service") else None
-                if _acp_rpc_ref is not None:
-                    _acp_rpc_obj = getattr(_acp_rpc_ref, "_service", _acp_rpc_ref)
-                    _acp_svc = getattr(_acp_rpc_obj, "_acp", None)
-                _proc_tbl = app.state.agent_registry
-                if _task_svc is not None:
-                    tdc = TaskDispatchPipeConsumer(
-                        acp_service=_acp_svc,
-                        agent_registry=_proc_tbl,
-                    )
-                    tdc.set_task_service(_task_svc)
-                    # Wire into existing TaskWriteHook
-                    _twh = getattr(nx, "_task_write_hook", None)
-                    if _twh is not None:
-                        _twh.register_handler(tdc)
-                    logger.info("[PIPE] TaskDispatchPipeConsumer created (lifespan fallback)")
-            except Exception as e:
-                logger.warning("[PIPE] TaskDispatchPipeConsumer fallback failed: %s", e)
-    if tdc is not None and hasattr(tdc, "set_pipe_manager"):
+            _task_svc = getattr(nx, "_task_manager_service", None)
+            # AcpService lives on AcpRPCService (created in _boot_wired_services)
+            _acp_svc = None
+            _acp_rpc_ref = nx.service("acp_rpc") if hasattr(nx, "service") else None
+            if _acp_rpc_ref is not None:
+                _acp_rpc_obj = getattr(_acp_rpc_ref, "_service", _acp_rpc_ref)
+                _acp_svc = getattr(_acp_rpc_obj, "_acp", None)
+            _proc_tbl = app.state.agent_registry
+            if _task_svc is not None:
+                tdc = TaskDispatchPipeConsumer(
+                    acp_service=_acp_svc,
+                    agent_registry=_proc_tbl,
+                )
+                tdc.set_task_service(_task_svc)
+                # Wire into existing TaskWriteHook
+                _twh = getattr(nx, "_task_write_hook", None)
+                if _twh is not None:
+                    _twh.register_handler(tdc)
+                logger.info("[PIPE] TaskDispatchPipeConsumer created (lifespan fallback)")
+        except Exception as e:
+            logger.warning("[PIPE] TaskDispatchPipeConsumer fallback failed: %s", e)
+    if tdc is not None and hasattr(tdc, "set_pipe_manager") and pipe_manager is not None:
         try:
             tdc.set_pipe_manager(pipe_manager)
             # Inject server base URL so enriched worker prompts can reference the API

--- a/src/nexus/storage/piped_record_store_write_observer.py
+++ b/src/nexus/storage/piped_record_store_write_observer.py
@@ -127,14 +127,16 @@ class PipedRecordStoreWriteObserver:
             return  # CLI mode — no NexusFS
 
         pipe_manager = getattr(self._nx, "_pipe_manager", None)
-        if pipe_manager is None:
-            raise RuntimeError("PipeManager not available for audit observer startup")
-
-        pipe_manager.ensure(
-            _AUDIT_PIPE_PATH,
-            capacity=_AUDIT_PIPE_CAPACITY,
-            owner_id="kernel",
-        )
+        if pipe_manager is not None:
+            pipe_manager.ensure(
+                _AUDIT_PIPE_PATH,
+                capacity=_AUDIT_PIPE_CAPACITY,
+                owner_id="kernel",
+            )
+        else:
+            # Test/degraded path: fall back to direct syscall-based pipe creation
+            # when NexusFS exposes DT_PIPE syscalls but no PipeManager object.
+            await self._nx.sys_setattr(_AUDIT_PIPE_PATH)
 
         self._pipe_ready = True
         self._consumer_task = asyncio.create_task(self._consume())

--- a/src/nexus/storage/piped_record_store_write_observer.py
+++ b/src/nexus/storage/piped_record_store_write_observer.py
@@ -126,17 +126,15 @@ class PipedRecordStoreWriteObserver:
         if self._nx is None:
             return  # CLI mode — no NexusFS
 
-        from nexus.contracts.metadata import DT_PIPE
-        from nexus.contracts.types import OperationContext
+        pipe_manager = getattr(self._nx, "_pipe_manager", None)
+        if pipe_manager is None:
+            raise RuntimeError("PipeManager not available for audit observer startup")
 
-        ctx = OperationContext(user_id="system", groups=[], is_system=True)
-        with contextlib.suppress(Exception):
-            await self._nx.sys_setattr(
-                _AUDIT_PIPE_PATH,
-                context=ctx,
-                entry_type=DT_PIPE,
-                owner_id="kernel",
-            )
+        pipe_manager.ensure(
+            _AUDIT_PIPE_PATH,
+            capacity=_AUDIT_PIPE_CAPACITY,
+            owner_id="kernel",
+        )
 
         self._pipe_ready = True
         self._consumer_task = asyncio.create_task(self._consume())

--- a/src/nexus/storage/write_observer_hooks.py
+++ b/src/nexus/storage/write_observer_hooks.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_INTERNAL_PIPE_PREFIX = "/nexus/pipes/"
+
 
 class SyncAuditWriteInterceptor:
     """Sync VFS interceptor: call RecordStoreWriteObserver methods directly.
@@ -79,6 +81,8 @@ class SyncAuditWriteInterceptor:
     # ── Sync POST hooks (called by KernelDispatch serial path) ─────────
 
     def on_post_write(self, ctx: "WriteHookContext") -> None:
+        if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
+            return
         self._observer.on_write(
             ctx.metadata,
             is_new=ctx.is_new_file,
@@ -89,13 +93,22 @@ class SyncAuditWriteInterceptor:
         )
 
     def on_post_write_batch(self, ctx: "WriteBatchHookContext") -> None:
+        filtered_items = [
+            (metadata, is_new)
+            for metadata, is_new in ctx.items
+            if not metadata.path.startswith(_INTERNAL_PIPE_PREFIX)
+        ]
+        if not filtered_items:
+            return
         self._observer.on_write_batch(
-            ctx.items,
+            filtered_items,
             zone_id=ctx.zone_id,
             agent_id=ctx.agent_id,
         )
 
     def on_post_delete(self, ctx: "DeleteHookContext") -> None:
+        if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
+            return
         self._observer.on_delete(
             path=ctx.path,
             metadata=ctx.metadata,
@@ -104,6 +117,10 @@ class SyncAuditWriteInterceptor:
         )
 
     def on_post_rename(self, ctx: "RenameHookContext") -> None:
+        if ctx.old_path.startswith(_INTERNAL_PIPE_PREFIX) or ctx.new_path.startswith(
+            _INTERNAL_PIPE_PREFIX
+        ):
+            return
         self._observer.on_rename(
             old_path=ctx.old_path,
             new_path=ctx.new_path,
@@ -113,6 +130,8 @@ class SyncAuditWriteInterceptor:
         )
 
     def on_post_mkdir(self, ctx: "MkdirHookContext") -> None:
+        if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
+            return
         self._observer.on_mkdir(
             path=ctx.path,
             zone_id=ctx.zone_id,
@@ -120,6 +139,8 @@ class SyncAuditWriteInterceptor:
         )
 
     def on_post_rmdir(self, ctx: "RmdirHookContext") -> None:
+        if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
+            return
         self._observer.on_rmdir(
             path=ctx.path,
             zone_id=ctx.zone_id,
@@ -171,6 +192,8 @@ class AuditWriteInterceptor:
     # ── VFSWriteHook ──────────────────────────────────────────────────
 
     async def on_post_write(self, ctx: "WriteHookContext") -> None:
+        if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
+            return
         event = {
             "op": "write",
             "path": ctx.path,
@@ -187,6 +210,8 @@ class AuditWriteInterceptor:
 
     async def on_post_write_batch(self, ctx: "WriteBatchHookContext") -> None:
         for metadata, is_new in ctx.items:
+            if metadata.path.startswith(_INTERNAL_PIPE_PREFIX):
+                continue
             event = {
                 "op": "write",
                 "path": metadata.path,
@@ -201,6 +226,8 @@ class AuditWriteInterceptor:
     # ── VFSDeleteHook ─────────────────────────────────────────────────
 
     async def on_post_delete(self, ctx: "DeleteHookContext") -> None:
+        if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
+            return
         event = {
             "op": "delete",
             "path": ctx.path,
@@ -214,6 +241,10 @@ class AuditWriteInterceptor:
     # ── VFSRenameHook ─────────────────────────────────────────────────
 
     async def on_post_rename(self, ctx: "RenameHookContext") -> None:
+        if ctx.old_path.startswith(_INTERNAL_PIPE_PREFIX) or ctx.new_path.startswith(
+            _INTERNAL_PIPE_PREFIX
+        ):
+            return
         event = {
             "op": "rename",
             "path": ctx.old_path,
@@ -228,6 +259,8 @@ class AuditWriteInterceptor:
     # ── VFSMkdirHook ─────────────────────────────────────────────────
 
     async def on_post_mkdir(self, ctx: "MkdirHookContext") -> None:
+        if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
+            return
         event = {
             "op": "mkdir",
             "path": ctx.path,
@@ -239,6 +272,8 @@ class AuditWriteInterceptor:
     # ── VFSRmdirHook ─────────────────────────────────────────────────
 
     async def on_post_rmdir(self, ctx: "RmdirHookContext") -> None:
+        if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
+            return
         event = {
             "op": "rmdir",
             "path": ctx.path,

--- a/tests/unit/bricks/search/test_chunk_store.py
+++ b/tests/unit/bricks/search/test_chunk_store.py
@@ -1,0 +1,38 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.bricks.search.chunk_store import ChunkRecord, ChunkStore
+
+
+@pytest.mark.asyncio
+async def test_chunk_store_replaces_document_chunks() -> None:
+    session = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = session
+    ctx.__aexit__.return_value = False
+    session_factory = MagicMock(return_value=ctx)
+
+    store = ChunkStore(async_session_factory=session_factory, db_type="sqlite")
+    await store.replace_document_chunks(
+        "pid-1",
+        [ChunkRecord(chunk_text="hello", chunk_tokens=1, line_start=1, line_end=1)],
+    )
+
+    assert session.execute.await_count == 2
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_chunk_store_deletes_document_chunks() -> None:
+    session = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = session
+    ctx.__aexit__.return_value = False
+    session_factory = MagicMock(return_value=ctx)
+
+    store = ChunkStore(async_session_factory=session_factory, db_type="sqlite")
+    await store.delete_document_chunks("pid-2")
+
+    session.execute.assert_awaited_once()
+    session.commit.assert_awaited_once()

--- a/tests/unit/bricks/search/test_mutation_events.py
+++ b/tests/unit/bricks/search/test_mutation_events.py
@@ -1,0 +1,54 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from nexus.bricks.search.mutation_events import (
+    SearchMutationEvent,
+    SearchMutationOp,
+    extract_zone_id,
+    strip_zone_prefix,
+)
+
+
+def test_strip_zone_prefix() -> None:
+    assert strip_zone_prefix("/zone/root/docs/readme.md") == "/docs/readme.md"
+    assert strip_zone_prefix("/docs/readme.md") == "/docs/readme.md"
+
+
+def test_extract_zone_id() -> None:
+    assert extract_zone_id("/zone/corp/docs/readme.md") == "corp"
+    assert extract_zone_id("/docs/readme.md") == "root"
+
+
+def test_from_operation_log_row_normalizes_rename_rows() -> None:
+    created_at = datetime.now(UTC).replace(tzinfo=None)
+    delete_row = SimpleNamespace(
+        operation_id="op-1",
+        operation_type="rename",
+        zone_id="corp",
+        path="/zone/corp/docs/old.md",
+        new_path="/zone/corp/docs/new.md",
+        created_at=created_at,
+        sequence_number=10,
+        change_type="delete",
+    )
+    upsert_row = SimpleNamespace(
+        operation_id="op-2",
+        operation_type="rename",
+        zone_id="corp",
+        path="/zone/corp/docs/new.md",
+        new_path=None,
+        created_at=created_at,
+        sequence_number=11,
+        change_type="upsert",
+    )
+
+    delete_event = SearchMutationEvent.from_operation_log_row(delete_row)
+    upsert_event = SearchMutationEvent.from_operation_log_row(upsert_row)
+
+    assert delete_event is not None
+    assert delete_event.op == SearchMutationOp.DELETE
+    assert delete_event.virtual_path == "/docs/old.md"
+
+    assert upsert_event is not None
+    assert upsert_event.op == SearchMutationOp.UPSERT
+    assert upsert_event.virtual_path == "/docs/new.md"

--- a/tests/unit/bricks/search/test_mutation_resolver.py
+++ b/tests/unit/bricks/search/test_mutation_resolver.py
@@ -17,7 +17,7 @@ class _Result:
 
 class _SessionCtx:
     def __init__(self, rows):
-        self._rows = list(rows)
+        self._rows = rows
 
     async def __aenter__(self):
         return self
@@ -35,7 +35,7 @@ async def test_resolver_batches_path_lookup_and_reuses_cache() -> None:
     file_reader.read_text.side_effect = ["alpha", "beta"]
     session_factory = lambda: _SessionCtx(  # noqa: E731
         [
-            [("/docs/a.txt", "pid-a"), ("/docs/b.txt", "pid-b")],
+            [("root", "/docs/a.txt", "pid-a"), ("root", "/docs/b.txt", "pid-b")],
         ]
     )
 
@@ -71,3 +71,48 @@ async def test_resolver_batches_path_lookup_and_reuses_cache() -> None:
     resolved_again = await resolver.resolve_batch(events)
     assert [item.path_id for item in resolved_again] == ["pid-a", "pid-b"]
     assert file_reader.read_text.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_resolver_keeps_zone_isolation_for_duplicate_virtual_paths() -> None:
+    file_reader = AsyncMock()
+    file_reader.read_text.side_effect = [OSError("missing"), OSError("missing")]
+    rows = [
+        [("root", "/docs/readme.md", "pid-root"), ("other", "/docs/readme.md", "pid-other")],
+        [
+            ("root", "/docs/readme.md", "root content"),
+            ("other", "/docs/readme.md", "other content"),
+        ],
+    ]
+    session_factory = lambda: _SessionCtx(rows)  # noqa: E731
+
+    resolver = MutationResolver(
+        file_reader=file_reader,
+        async_session_factory=session_factory,
+    )
+    events = [
+        SearchMutationEvent(
+            event_id="evt-root",
+            operation_id="op-root",
+            op=SearchMutationOp.UPSERT,
+            path="/zone/root/docs/readme.md",
+            zone_id="root",
+            timestamp=SimpleNamespace(tzinfo=None),
+            sequence_number=1,
+        ),
+        SearchMutationEvent(
+            event_id="evt-other",
+            operation_id="op-other",
+            op=SearchMutationOp.UPSERT,
+            path="/zone/other/docs/readme.md",
+            zone_id="other",
+            timestamp=SimpleNamespace(tzinfo=None),
+            sequence_number=2,
+        ),
+    ]
+
+    resolved = await resolver.resolve_batch(events)
+    assert [(item.zone_id, item.path_id, item.content) for item in resolved] == [
+        ("root", "pid-root", "root content"),
+        ("other", "pid-other", "other content"),
+    ]

--- a/tests/unit/bricks/search/test_mutation_resolver.py
+++ b/tests/unit/bricks/search/test_mutation_resolver.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_resolver import MutationResolver
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _SessionCtx:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, _stmt, _params):
+        return _Result(self._rows.pop(0))
+
+
+@pytest.mark.asyncio
+async def test_resolver_batches_path_lookup_and_reuses_cache() -> None:
+    file_reader = AsyncMock()
+    file_reader.read_text.side_effect = ["alpha", "beta"]
+    session_factory = lambda: _SessionCtx(  # noqa: E731
+        [
+            [("/docs/a.txt", "pid-a"), ("/docs/b.txt", "pid-b")],
+        ]
+    )
+
+    resolver = MutationResolver(
+        file_reader=file_reader,
+        async_session_factory=session_factory,
+    )
+    events = [
+        SearchMutationEvent(
+            event_id="evt-1",
+            operation_id="op-1",
+            op=SearchMutationOp.UPSERT,
+            path="/zone/root/docs/a.txt",
+            zone_id="root",
+            timestamp=SimpleNamespace(tzinfo=None),
+            sequence_number=1,
+        ),
+        SearchMutationEvent(
+            event_id="evt-2",
+            operation_id="op-2",
+            op=SearchMutationOp.UPSERT,
+            path="/zone/root/docs/b.txt",
+            zone_id="root",
+            timestamp=SimpleNamespace(tzinfo=None),
+            sequence_number=2,
+        ),
+    ]
+
+    resolved = await resolver.resolve_batch(events)
+    assert [item.path_id for item in resolved] == ["pid-a", "pid-b"]
+    assert file_reader.read_text.await_count == 2
+
+    resolved_again = await resolver.resolve_batch(events)
+    assert [item.path_id for item in resolved_again] == ["pid-a", "pid-b"]
+    assert file_reader.read_text.await_count == 2

--- a/tests/unit/bricks/search/test_search_mutation_flow.py
+++ b/tests/unit/bricks/search/test_search_mutation_flow.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -44,3 +45,92 @@ async def test_consumer_checkpoint_advances_only_after_success() -> None:
 
     assert settings_store.get_setting("search_mutation_checkpoint:txtai").value == "7"
     handler.assert_awaited_once_with([event])
+
+
+@pytest.mark.asyncio
+async def test_legacy_delete_paths_call_delete_backends() -> None:
+    daemon = SearchDaemon()
+    daemon._chunk_store = AsyncMock()
+    daemon._backend = AsyncMock()
+    daemon._resolve_mutations = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                zone_id="root",
+                doc_id="/docs/readme.md",
+                path_id="pid-1",
+                virtual_path="/docs/readme.md",
+            )
+        ]
+    )
+
+    await daemon._delete_indexes_for_paths(["/zone/root/docs/readme.md"])
+
+    daemon._chunk_store.delete_document_chunks.assert_awaited_once_with("pid-1")
+    daemon._backend.delete.assert_awaited_once_with(["/docs/readme.md"], zone_id="root")
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _SessionCtx:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, _stmt, _params=None):
+        return _RowsResult(self._rows)
+
+
+@pytest.mark.asyncio
+async def test_txtai_bootstrap_groups_chunks_without_postgres_aggregates() -> None:
+    daemon = SearchDaemon()
+    daemon._backend = AsyncMock()
+    daemon._async_session = lambda: _SessionCtx(  # noqa: E731
+        [
+            SimpleNamespace(
+                zone_id="root", virtual_path="/docs/a.md", chunk_index=0, chunk_text="A1"
+            ),
+            SimpleNamespace(
+                zone_id="root", virtual_path="/docs/a.md", chunk_index=1, chunk_text="A2"
+            ),
+            SimpleNamespace(
+                zone_id="other", virtual_path="/docs/b.md", chunk_index=0, chunk_text="B1"
+            ),
+        ]
+    )
+
+    await daemon._bootstrap_txtai_backend()
+
+    assert daemon._txtai_bootstrapped is True
+    daemon._backend.upsert.assert_any_await(
+        [
+            {
+                "id": "/docs/a.md",
+                "text": "A1\nA2",
+                "path": "/docs/a.md",
+                "zone_id": "root",
+            }
+        ],
+        zone_id="root",
+    )
+    daemon._backend.upsert.assert_any_await(
+        [
+            {
+                "id": "other:/docs/b.md",
+                "text": "B1",
+                "path": "/docs/b.md",
+                "zone_id": "other",
+            }
+        ],
+        zone_id="other",
+    )

--- a/tests/unit/bricks/search/test_search_mutation_flow.py
+++ b/tests/unit/bricks/search/test_search_mutation_flow.py
@@ -1,0 +1,46 @@
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nexus.bricks.search.daemon import SearchDaemon
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+
+
+class _SettingsStore:
+    def __init__(self) -> None:
+        self._values: dict[str, str] = {}
+
+    def get_setting(self, key: str):
+        value = self._values.get(key)
+        if value is None:
+            return None
+        return type("Setting", (), {"value": value})()
+
+    def set_setting(self, key: str, value: str, *, description: str | None = None) -> None:
+        self._values[key] = value
+
+
+@pytest.mark.asyncio
+async def test_consumer_checkpoint_advances_only_after_success() -> None:
+    settings_store = _SettingsStore()
+    daemon = SearchDaemon(settings_store=settings_store)
+    daemon._shutting_down = False
+
+    event = SearchMutationEvent(
+        event_id="evt-1",
+        operation_id="op-1",
+        op=SearchMutationOp.UPSERT,
+        path="/zone/root/docs/readme.md",
+        zone_id="root",
+        timestamp=datetime.now(UTC).replace(tzinfo=None),
+        sequence_number=7,
+    )
+    daemon._fetch_mutation_events = AsyncMock(side_effect=[[event], asyncio.CancelledError()])
+    handler = AsyncMock()
+
+    await daemon._run_mutation_consumer("txtai", handler)
+
+    assert settings_store.get_setting("search_mutation_checkpoint:txtai").value == "7"
+    handler.assert_awaited_once_with([event])

--- a/uv.lock
+++ b/uv.lock
@@ -668,6 +668,84 @@ wheels = [
 ]
 
 [[package]]
+name = "cachebox"
+version = "5.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/04/0a0e6517ce0b4805dbd4a2a07ab679fb862938f841ea365403c7e51298dc/cachebox-5.2.2.tar.gz", hash = "sha256:a140ea693faf2c9aa9fccdf80bed9912f8f3eba6dfb74f921a34877fcb93a902", size = 61716 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/ea/f7c214049f87ca43f9022ba64d90063b64af3ece2f80df95880700544249/cachebox-5.2.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8f52a2d7902ca65a5c2c824a038a09c924a4322d2792d87178d5c49aec857598", size = 372901 },
+    { url = "https://files.pythonhosted.org/packages/97/3e/77505237cc325a1ab6a058be8b4444716e48e0a89ac57eab4f521ef80f04/cachebox-5.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e419dc10599f65e9f6115319fd66517e639e6bd6bf40cdfd0190ac3360663ed", size = 353395 },
+    { url = "https://files.pythonhosted.org/packages/0c/b2/99792ee9bdf2a3eeb85d30e7257a1b69a0f852b2b437979b70d582f31c92/cachebox-5.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:803be9146e51d904dbbd8ca104fe366754c77d7f0bb60012d332c194fad7173e", size = 392588 },
+    { url = "https://files.pythonhosted.org/packages/41/e8/9d61183e9286bbe8bfa7a9b40432384bda7e3696f74e1d658cfba111c33a/cachebox-5.2.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:33157e5c132f3919495071c506f574d66d96f8a21456f998f60be10c2f92e25f", size = 346963 },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c5aff2efa8b5df445f79b8589e22221de5a5fce1c5e7f475346f3c27e271/cachebox-5.2.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05ea02d6745223c33b04f48d801aec449118f085f77f615b8f0a7fb00c121c2d", size = 374259 },
+    { url = "https://files.pythonhosted.org/packages/a7/03/2727f6b383d0838704460cbcf964bec69311acbbe8f6b90344872b61474b/cachebox-5.2.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ecacc803639c4bc38ccde3983b1b021ca11eb472271b45187e310c7e363b482f", size = 400941 },
+    { url = "https://files.pythonhosted.org/packages/bf/ca/37a9cc44981d0e810af69562f432eee2ac2bdcb4a33d9a2484cb755ce0a7/cachebox-5.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ad685fb02bd63aa09d031af8507cee3bb308d6c7486c7fa8b4e28b310be6555", size = 411260 },
+    { url = "https://files.pythonhosted.org/packages/f7/67/ec6e4a32caf1aef79aa976edc5104c354411e33aa8699e53bb40f7c6a607/cachebox-5.2.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7a95936bedace3878a200700c00d5a7c0f0afdbc85d1ecc7d1fb47da6d7617bc", size = 433700 },
+    { url = "https://files.pythonhosted.org/packages/e8/ad/96c259366eed4108cc72bde38f5cff24fcc85b6dca2eb1f2d294918237ff/cachebox-5.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:715eb907d8d595bc83a62250b84aa21e8794a9644b92c9eb254a7a50a56e3d5e", size = 569585 },
+    { url = "https://files.pythonhosted.org/packages/61/90/98c1cf839e3ab3ed97f83da87b2041eaa8b912068c0bd000306687b7d26b/cachebox-5.2.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:17b54f13b55e72e67aa531e0c805b2cc9a42ac746937c2df22bcdef21d0704b6", size = 657216 },
+    { url = "https://files.pythonhosted.org/packages/df/29/c31c6b9e76068b3aede93a5270bcb6e285a62dbd9a8ce1f6fe8f36761d97/cachebox-5.2.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d2870529575fdf0989ad081cd585e01b2e9e30177a14696fdb6f32a7edfeae07", size = 650096 },
+    { url = "https://files.pythonhosted.org/packages/d7/da/f1e48ebfd1ebe336d3ab7a50f4b4f18e2854311d4cdd2c8c5da1ce13f866/cachebox-5.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:678f7963400981cd62973b3f8d7231b77eaae88ebee11e06d02659f565d46bc4", size = 625769 },
+    { url = "https://files.pythonhosted.org/packages/22/d8/05b50b50dcb7bd1cea1561f0a2a3c74cacebf129e366e268e3dfa8b12c71/cachebox-5.2.2-cp312-cp312-win32.whl", hash = "sha256:809cc6459e947951a074e4af32ad60bc6beb615e2d4a7fd76f43c157343a3be4", size = 287661 },
+    { url = "https://files.pythonhosted.org/packages/07/34/5ed62f3c328f4f5c6320944b23481e4650e81cc56ec7b48f3fa347b918be/cachebox-5.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:9029c9ec274c594215931171ead7ecfbc61771a2db6ec5cce02b51e4fb182792", size = 301548 },
+    { url = "https://files.pythonhosted.org/packages/15/1b/1c4a713f2f58b8d35f933f8b4959633f90338d7283f8065d1d25074c4182/cachebox-5.2.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:935384e42a44567c33802d020c410578ee57592092123d0a68c0f5f139c4c158", size = 372549 },
+    { url = "https://files.pythonhosted.org/packages/9e/a7/858163cfe980dd573d4615bfc970286232123830f12744da03686d6229fc/cachebox-5.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1be730d2a45215e740bfb1917bb0e08240f77a6f1d824f40142395782a08b0fe", size = 353094 },
+    { url = "https://files.pythonhosted.org/packages/e2/8f/86663e705127b502465e8541be1d5230b12ea38076f0c208ede79b62f599/cachebox-5.2.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d425b08cdd64d9dbbf8de55c36db89850d99bd2f919278d119d4b88d3909493", size = 392199 },
+    { url = "https://files.pythonhosted.org/packages/46/8e/bf99e4ec106e23c0b5f4dfeee19110d4009049fb76a7135d3ee3dc5dc218/cachebox-5.2.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aef8a9eff15352ebc4a56896fe39521109217f6b030806aaac6879e31d0b9bd6", size = 346355 },
+    { url = "https://files.pythonhosted.org/packages/0c/2e/f74abfda57690cf73afe8e4473d5355badf6d7d7adb9335a9556ddf49f61/cachebox-5.2.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b64feb73fed71f11ee74b645d3a91bd18fceef137805c9490d29499bc651807", size = 373892 },
+    { url = "https://files.pythonhosted.org/packages/c1/01/5a9481b0b46e54b2132200b60571868ca23b4faae8c5b19ba3813bf33e5f/cachebox-5.2.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86e202ed168bf6ba23bf5139df07c44d3f5c68bc08d9de4d15be25def79b336a", size = 400660 },
+    { url = "https://files.pythonhosted.org/packages/03/d0/b5064b399f9c2be13f99962475b103c31bdca49c349d355f47b282979fc1/cachebox-5.2.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b273e02fc44770443ad1f4d29b3d07b1e2f275498b09fb9d874b55a99eb91d16", size = 410973 },
+    { url = "https://files.pythonhosted.org/packages/47/34/f973fe4d2e0327842fe4cc3c9be4b0d9c3d140cee6c1dc727b987f6d5eff/cachebox-5.2.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a00dd65a1db60058ef484e8f8519486396bfbdedc2edf43c60111ee941c08bcf", size = 433364 },
+    { url = "https://files.pythonhosted.org/packages/01/d4/95683aed50ba6ca8e1488cd4dd355416520a40b661a33f27f508705725b7/cachebox-5.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0d2bd466f4e55626e075bdb9322bf5b7afd3d31fcc963fe0a5cb6e1ffb5d9609", size = 569258 },
+    { url = "https://files.pythonhosted.org/packages/7a/6f/4de6f0d6a32daa6f89286abcbf24a7b68921eb7f2e460062b5c6fee984ec/cachebox-5.2.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:c69c21e4d7bf9433df63b6c06aa80a3a6423139202e2ac0fb5f82a5a3989455a", size = 656762 },
+    { url = "https://files.pythonhosted.org/packages/22/cc/132bc26a403bb12d0a37e88efdfd915e008af91b419680588e190cded72b/cachebox-5.2.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e3d90a427aad7592b067c1ab482ac557235b6140c6005e0f6e734ebd69edd7db", size = 649578 },
+    { url = "https://files.pythonhosted.org/packages/6d/35/7f64dc14b4f234c7ee4cf8bcdb20f38793a9d1c90ea4d747163479ebc1c2/cachebox-5.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6fa7a3ea5e51b4fc027155911c0586939133d92ce03ca2b496188ab4cfde0971", size = 625482 },
+    { url = "https://files.pythonhosted.org/packages/5b/85/4ab5fdb591cda9113506c6994384068428a0fca8e6dc570b64095c4f2333/cachebox-5.2.2-cp313-cp313-win32.whl", hash = "sha256:ad77a61e0f88bb1fa4625b9ff82f47314c3e729a7357e7d0748fc7232709339e", size = 287216 },
+    { url = "https://files.pythonhosted.org/packages/54/aa/44cfa1d0fe8ad47a392e54756f5950bc524af95258bea660558145eaaa7c/cachebox-5.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2c08080058b5a4680946201e454bd42bb0581b883b459d2f2b002735c5e33922", size = 301289 },
+    { url = "https://files.pythonhosted.org/packages/70/29/ad1a0d9027d41780a875fa1728d7c317d021a2bf6074e52c1969a4925fee/cachebox-5.2.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:d17f37752081050886463540509b0a3ec4e48be3b2fe5a827ceccbbf7a1aea76", size = 364904 },
+    { url = "https://files.pythonhosted.org/packages/c2/54/aacd8a79aec38baf6918f1df8c49ea0133f758ca12907dfabe2046f44c28/cachebox-5.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d9ad8a3fdc8e86bbe66d586015defc0ef6b9c38d65c2b8cf8f37e28782e86b80", size = 347169 },
+    { url = "https://files.pythonhosted.org/packages/ee/a2/a7d72ca01475c16f6a9a2b2d76e62810aae102bd023256e58ceefa44dd8a/cachebox-5.2.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39db2251161a680d67b343ae0319116541976e85089dba29ba60c6048c8406b8", size = 387246 },
+    { url = "https://files.pythonhosted.org/packages/c9/07/e1759bcc3409de59925766df4eb29f7a3606e71efc361365749cf0b6dbf2/cachebox-5.2.2-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:effc0ae9042d499e18d6e4916e57993bb321ac8a82910aed2f31479c176aceaa", size = 342484 },
+    { url = "https://files.pythonhosted.org/packages/f3/c7/b07155f7fca73ac0c1cb1f76bdb7607d254c3b7d78c0cec99ab0e39148d3/cachebox-5.2.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7a7ab37439e898714f6dab93b687f65055d28b2b8f94e980f640192ee0b1fae5", size = 369582 },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/f6cbec89e838022177c6f256b88e54106679e0aa63965bea85f0a0e56681/cachebox-5.2.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:daae7ca234c6ee5130c0c0a5145742a07293945ea22b6bd15310dbb3fff81783", size = 390489 },
+    { url = "https://files.pythonhosted.org/packages/a5/98/878ba4d0712bd3cfa01539f3d3483cb1b92cb949ee74b085abd507569d36/cachebox-5.2.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a175803f9bc97944a98f19648f91f101164b0c1a3f57024cd42bf5b0a95c8ec9", size = 404476 },
+    { url = "https://files.pythonhosted.org/packages/e6/85/ca7f3e790940eba5ebfb3fe44bac8a60deec76058c7571689348f2efee69/cachebox-5.2.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6489194eeae7c83ce3db725932af2c01bf65dfc3a3f52ba591133207cc11974e", size = 424332 },
+    { url = "https://files.pythonhosted.org/packages/9e/53/38a29db17c585d6c2849fd2675ac73489955b40e2659414fae302f826000/cachebox-5.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:405345c4fc1b97e154f321ee079dde1d5d88af60133c96ba620c685a45f52726", size = 563574 },
+    { url = "https://files.pythonhosted.org/packages/8b/a1/76f2b8bab61a1e02bce796bfbccb171145312241492c5217fe1e29905b25/cachebox-5.2.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:901e38c58cbcd5f045fa4f871ad0cc1541753234b54ad522f49e2a2f70e226cb", size = 652771 },
+    { url = "https://files.pythonhosted.org/packages/03/cd/ccf6872583d0aa7204ffaebc6fed434f793163b38d7fe43c151d6385458e/cachebox-5.2.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d1f2dc6cd54515f53a424632ab3277a641f7d7ffdd27a4f000383ef4bb3a148", size = 641666 },
+    { url = "https://files.pythonhosted.org/packages/12/66/3eab9a0ab1c6609ba3b273eb93cdb76b19ab8a45ebd6ccce77940e0d43a9/cachebox-5.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e12bfdd6aacdcf11c18483c953c63935bbef19940e03253547a25d66488a842", size = 618400 },
+    { url = "https://files.pythonhosted.org/packages/06/29/60f26762022a538a1479fef21a61df916610e01714df555c64a12dbd0228/cachebox-5.2.2-cp313-cp313t-win32.whl", hash = "sha256:7f841477b4e091aaf1f621eb54dc80b1e2e413ae9c6f2758db1b59d986eb6fa7", size = 287056 },
+    { url = "https://files.pythonhosted.org/packages/8e/7f/abb3a56fa37a8f93c243201aa44e39d7cf1811accc7df4cd560f93fc86ba/cachebox-5.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:66f287dac540212e71e4d6d47dd3a5f0a922e1ab1989923c8c667984a2a30042", size = 292511 },
+    { url = "https://files.pythonhosted.org/packages/ea/a1/cdb7da3228323be9078ef58ac324d0d79a07ad9ce7f8446707689cd79214/cachebox-5.2.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:2038809aa51466c7ebd6005a2bcb569e0f01cc7323316c0a25611b5fca37dcfb", size = 374472 },
+    { url = "https://files.pythonhosted.org/packages/b2/68/803c012ca8247fce1741cfdc762dbaed631355c406ee485c196f08c63f25/cachebox-5.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:693160cf7e23da376e44fc8265f97288bfff591ec30ce9b4f4d9a7000ebf459e", size = 355901 },
+    { url = "https://files.pythonhosted.org/packages/0e/d3/b19fdd7b8f5d83aa803b220d28b8ddcb04b36bed01f086543035d7884a13/cachebox-5.2.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ad7b9f11d3651ae0c33c94cd0536e634ed248d0845dcebfb4615300dff7ec62", size = 394881 },
+    { url = "https://files.pythonhosted.org/packages/ae/0e/4a44ce22efda72f8a731a8c864d6191cdd3b054c1860db3155a0f572a8c6/cachebox-5.2.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bc5bf83fb1f2e4e52e0bcf7196c0b95259ff09d5682608124e8290d1d816027c", size = 347690 },
+    { url = "https://files.pythonhosted.org/packages/c1/11/e075c6e2e7f3a62168b915a46148c465e936c3b39de6d9c11e0fec41b242/cachebox-5.2.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc9136e3469defe44e9ad481d863978097eee213f696b802b11ea80a6825b88", size = 375523 },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/8b1b63ba9071cb3759c2ac2ebe65391775f9de507579a3946676e8dd7d70/cachebox-5.2.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d7cc7b1e8d63e3537f4633961086c8819a1a9717781337dedc4adebf2fe9c78f", size = 402132 },
+    { url = "https://files.pythonhosted.org/packages/98/11/83dfa59b01510898a3c716bc57b333360ddfccdc15a35c6894aecb71b5cc/cachebox-5.2.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d9eefaba6c7103e2e9b78d55a4d1a5563a9b89aa7235bbf41505318deceb917", size = 408848 },
+    { url = "https://files.pythonhosted.org/packages/9e/8e/ccff3957d3b098dbdf9008298877894fb852f7559a57b59b5482eb700b5c/cachebox-5.2.2-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d7e830619abb4fdbec61612c5f720eede1273fbdb4bcbe94febc94e322629cc2", size = 429641 },
+    { url = "https://files.pythonhosted.org/packages/14/3d/2738fede983b45b30ce15bf97a9feb11ece6e991fc09407f16dca5e37acc/cachebox-5.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c471ed3bb3244499ffac81ebc8739f3d9c00e08cf837ae3d1673ec0deff47bf1", size = 572004 },
+    { url = "https://files.pythonhosted.org/packages/8d/7b/521087b31d890fd4bbcc6c08335e5e7f079769fdadd5d8ddab47f9452d4e/cachebox-5.2.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ecf4a20bae389f306cb8729b95a38606bb21ad1fb4a35608c4f4d73f9baa56a2", size = 657913 },
+    { url = "https://files.pythonhosted.org/packages/52/f5/0f8d4fc2b68229f6d7aed08a665a62eb1f34d265896c307376fb6b3d7fa6/cachebox-5.2.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:653567610a757add69e15e1dc6dddfe6c3cc26d93d8607406626e4bb184257ca", size = 645597 },
+    { url = "https://files.pythonhosted.org/packages/51/42/a2f9991b78a8cbb5659b3f54ee1ba3a731ea7ba03fdeb128b073fb9e79bf/cachebox-5.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8f471ce3ebfb3cd40338113591c4f88bf1ae5b30f97ce9c92daeb66f9f44438", size = 623119 },
+    { url = "https://files.pythonhosted.org/packages/35/57/d4964aa418deffdf03859fc89e06ba2a6705514c4f04429dc15f48cd28db/cachebox-5.2.2-cp314-cp314-win32.whl", hash = "sha256:f94923bfe3f1ee9451c5981fa3a170d12d446fdc82860d5ef8ee32ea89ee2c0b", size = 283210 },
+    { url = "https://files.pythonhosted.org/packages/80/e5/26d664d73c80f45848de795dbe91790ae9575813bbc3cde5ef9c381ca73f/cachebox-5.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:350c61329ae9452b6472b3eecfa7e20361781f3639a5f9ff5db2694d2547c1a9", size = 300108 },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/a2d350f584071088cf0b5f2dfb536057dc2d4734dcbb0eb7b43454c9f03e/cachebox-5.2.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:2f0f4c87d74ad65d452ff988689052f7d958e73d12a3e67aa9d36bb2f2467013", size = 368689 },
+    { url = "https://files.pythonhosted.org/packages/90/10/495ff7b53298661ac74518778e013ec2979ad141051598d5d7b2934c28b0/cachebox-5.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:68f0e34f2cf8f40cd9f863e9e930f8eeed78ed9b61ad84438dd88b6b1b6c321f", size = 349816 },
+    { url = "https://files.pythonhosted.org/packages/b0/33/eea89f3fa588d367c00be3cecf002f3e5f01ad1b2dabfb3a9181c9da08bc/cachebox-5.2.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f1f11ebb33728a33cae112c809e5d7537fe71868350b4a2bb3489c8b15d5569", size = 388469 },
+    { url = "https://files.pythonhosted.org/packages/95/0d/6ce50c3345718cb7b06646607202a4bfdf8d08e893f84a24752c60915379/cachebox-5.2.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:157d19007843d2e4c5237d303a24da9cb35d07744e51e85a2e12fab60adb6771", size = 342692 },
+    { url = "https://files.pythonhosted.org/packages/ce/19/8f03d3bff454a0495a41fdaaa44504fb4b8373f08c74dca510e0474a80cd/cachebox-5.2.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc84c1709332060568dd584345258bc7460c28459e41cd512328a11e77fa0b74", size = 370368 },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/6ee165e6b9c1dfbcd0d3b672d9ffa3655b056b82b9dd3d31eb12e996bdf4/cachebox-5.2.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fee532924171b9f836b00127afda1414a6d753bdc7e160c63aba03bce7bc54af", size = 390389 },
+    { url = "https://files.pythonhosted.org/packages/11/65/895d021091755b51b699b9ad179f01b13612a75edc4194eaa58621a69a9d/cachebox-5.2.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb32fcc0bf78c676d3377de55824057ec1068ec454745a445db6865ee1b86360", size = 401905 },
+    { url = "https://files.pythonhosted.org/packages/d8/63/2313b378547529f03ede0c315790ef94858f29ac2fca4e697cc82ec96b3a/cachebox-5.2.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:93baf8621f39353e67927d4b94ef55a36fbf8393fe7c0feb3456062dae8ad36e", size = 421812 },
+    { url = "https://files.pythonhosted.org/packages/61/8e/55e26bf0e6f1b1645979d3fe8a3bd316212747e23bc251a6710269e60a31/cachebox-5.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3ff3a7e49829ae0d92167844d77bf19cb01f19e467e1d14d5af6bd765d96bddf", size = 565762 },
+    { url = "https://files.pythonhosted.org/packages/17/3f/06929d96df2e2388919de1047a491f5867e523e8ad18a82efe0322ba421e/cachebox-5.2.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:9d9f2d0dc4ffc2998e6b7affa2f8318f2083cbd09a0686a5f9cc55815900d876", size = 653209 },
+    { url = "https://files.pythonhosted.org/packages/8c/9c/52ada501753f70a786409af32ec2263a4e0251d6269e8ed2f1abc075c48d/cachebox-5.2.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e9479bf0583ec9e2ca1fdf9a5c748f1ce03ebaf8ecb4194b4758140b53e6fe44", size = 639922 },
+    { url = "https://files.pythonhosted.org/packages/26/8f/eb040df9ca28ab415b3d22c2356bd21169ad7bbff4dff2cbdaceac978829/cachebox-5.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0192492bc1a96cde1fec2adb10d7c48c3cc76e31d731305940d646dc8ed947ae", size = 615745 },
+    { url = "https://files.pythonhosted.org/packages/02/1a/ec14fe807a910c85b8ad310787933d59d68708bbe83992ed0bfb576ee7af/cachebox-5.2.2-cp314-cp314t-win32.whl", hash = "sha256:46d8973d1dd52f72f2aea414f5673af7bd6ae7738b9c76685904d1819d07f3d5", size = 287039 },
+    { url = "https://files.pythonhosted.org/packages/d7/4b/95b114f063d0ba7b5ed64646f957ce245077707331d801c1db971b83dec0/cachebox-5.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:e1fbc20c9ef09a6895f6f0894e1c272586ff3483176b2ba26118fd2c30e003a1", size = 289195 },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1328,6 +1406,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/9c/11969bd3e3bc4aa3a711f83dd3720239d3565a934929c74fc32f6c9f3638/fastapi-0.124.0.tar.gz", hash = "sha256:260cd178ad75e6d259991f2fd9b0fee924b224850079df576a3ba604ce58f4e6", size = 357623 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/29/9e1e82e16e9a1763d3b55bfbe9b2fa39d7175a1fd97685c482fa402e111d/fastapi-0.124.0-py3-none-any.whl", hash = "sha256:91596bdc6dde303c318f06e8d2bc75eafb341fc793a0c9c92c0bc1db1ac52480", size = 112505 },
+]
+
+[[package]]
+name = "fastbloom-rs"
+version = "0.5.10"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/a1/02f68de112876e230fa359bdc7f5c4d00457730f07df6937cb28038fc790/fastbloom_rs-0.5.10-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:723b7e96df0af56c9e0c57a3de8402db520d6379fac8588c2c31b0426e579791", size = 261296 },
+    { url = "https://files.pythonhosted.org/packages/37/d6/adf8328ad7618217b45200987f5d09ec2c703848f5174673a4000afcb81a/fastbloom_rs-0.5.10-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:a9026c4e1cf496f0c23bbfb782881b8a7afde2c81d7159ecc39fc4c5017223c9", size = 251517 },
+    { url = "https://files.pythonhosted.org/packages/ff/af/aac0dd1f503dbdc8f9b9801b4b1aede04b31282b6351aa46029d52e639bd/fastbloom_rs-0.5.10-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7568bc4c2be81f908a20ae467dfb47456535bf90036c93bb87a7a89949f6b4cf", size = 269421 },
+    { url = "https://files.pythonhosted.org/packages/de/b7/dcd455ab8c1678f83415bdd8dbd9b62cca681390468075b78a480211ddbf/fastbloom_rs-0.5.10-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fe695abd15e772f6323602fd2c1b52ddcb13e3f56d2ec766085149adcdd030d2", size = 283405 },
+    { url = "https://files.pythonhosted.org/packages/b2/0b/eec1e563f14e379bec48719c2cb70a4849a2bdf04c39be0fb09d29f57066/fastbloom_rs-0.5.10-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8656de9a5589b9e3700eb576deaa2d4e6190386debf2dc79c598749bbc72c119", size = 418552 },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/dc24bb80680278458a227e70eff75ed2c0faec9a84c8bbbbb46fda1cd42a/fastbloom_rs-0.5.10-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3737d3bfe98f2eb6009292a09f7329fa2f360f196d3e4bdafd595b97b9834610", size = 408093 },
+    { url = "https://files.pythonhosted.org/packages/e0/98/1224a402f89cb89cd6a0918e55d68d5c1aff8f75e93d64d00990f600d2c6/fastbloom_rs-0.5.10-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:1cd58d7eac2dceec8055583e719ceac6edceae80c3abcb53110391b76e4cff47", size = 282107 },
+    { url = "https://files.pythonhosted.org/packages/c8/92/c949d09b1988321a40b915a8ef7cdd0b5dfba4d1510471239fccae8ecfbd/fastbloom_rs-0.5.10-cp37-abi3-win_amd64.whl", hash = "sha256:dc18c0ed6bd800dbd54617b51acbc977869975d5f87577cedec5fb6b653f24d6", size = 189908 },
 ]
 
 [[package]]
@@ -3260,11 +3353,13 @@ dependencies = [
     { name = "bm25s" },
     { name = "boto3" },
     { name = "bsdiff4" },
+    { name = "cachebox" },
     { name = "cachetools" },
     { name = "click" },
     { name = "cryptography" },
     { name = "dotenv" },
     { name = "fastapi" },
+    { name = "fastbloom-rs" },
     { name = "fastcdc" },
     { name = "fastmcp" },
     { name = "frozenlist" },
@@ -3452,6 +3547,7 @@ requires-dist = [
     { name = "bm25s", specifier = ">=0.2.0" },
     { name = "boto3", specifier = ">=1.42.4" },
     { name = "bsdiff4", specifier = ">=1.2.0" },
+    { name = "cachebox", specifier = ">=4.0.0" },
     { name = "cachetools", specifier = ">=6.2.2" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "cloud-sql-python-connector", extras = ["asyncpg"], marker = "extra == 'cloud-sql'", specifier = ">=1.14.0" },
@@ -3463,6 +3559,7 @@ requires-dist = [
     { name = "faiss-cpu", marker = "(platform_machine == 'aarch64' and extra == 'all') or (platform_machine == 'arm64' and extra == 'all') or (platform_machine == 'x86_64' and extra == 'all')", specifier = ">=1.11.0" },
     { name = "faiss-cpu", marker = "(platform_machine == 'aarch64' and extra == 'semantic-search') or (platform_machine == 'arm64' and extra == 'semantic-search') or (platform_machine == 'x86_64' and extra == 'semantic-search')", specifier = ">=1.11.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
+    { name = "fastbloom-rs", specifier = ">=0.5.0" },
     { name = "fastcdc", specifier = ">=1.5.0" },
     { name = "fastembed", marker = "extra == 'performance'", specifier = ">=0.4.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- replace sequential search refresh handling with durable mutation-driven indexing helpers and a canonical chunk store
- fix startup/runtime wiring for pipe-backed observers and consumers so operation-log driven indexing works after fresh startup and restart
- stabilize demo-stack search behavior across txtai bootstrap, non-TLS gRPC wiring, permission-filtered search, and fresh-stack validation coverage

## Root cause fixes
- recover DT_PIPE buffers when inodes already exist via PipeManager.ensure() and use it from the audit, task dispatch, and zoekt consumers
- start the service-side pipe consumers during lifespan boot so writes actually reach operation_log
- bootstrap txtai from canonical SQL-backed chunks so semantic search works on existing demo/HERB data after startup, not only after new edits
- clean up startup wiring drift in realtime exporter registration and subscription-manager worker lookup

## Validation
- targeted unit suite for txtai backend, mutation flow, chunk store, resolver, app state, lifespan services, and piped write observer: 86 passed
- fresh demo stack: scripts/test_build_perf_e2e.py -> 25 passed, 0 failed

## Follow-up
- performance/scalability follow-up tracked in #3293

Closes #3195
