### PR TITLE
fix(ci): install project package for CLI entrypoints in lightweight p…

### DIFF
--- a/.github/workflows/conda-pack.yml
+++ b/.github/workflows/conda-pack.yml
@@ -120,8 +120,11 @@ jobs:
         shell: bash -el {0}
         run: |
           if [ -n "${{ matrix.profile.requirements }}" ]; then
-            echo "Installing from ${{ matrix.profile.requirements }} (lightweight profile)"
+            echo "Installing dependencies from ${{ matrix.profile.requirements }} (lightweight profile)"
             conda run -n nexus pip install -r ${{ matrix.profile.requirements }}
+            # Install project itself (without deps, already installed above) to get CLI entrypoints (nexus, nexusd)
+            echo "Installing project package for CLI entrypoints"
+            conda run -n nexus pip install --no-deps .
           else
             echo "Installing full dependencies from pyproject.toml"
             conda run -n nexus pip install .


### PR DESCRIPTION
…rofiles

When using requirements-remote.txt or requirements-minimal.txt, only dependencies were installed but not the project itself. This meant the CLI entrypoints (nexus, nexusd) were missing from the packed environment.

Now we install the project package with --no-deps after installing the requirements file to get the entrypoints without re-installing dependencies.