### PR TITLE
feat(cli): smart multi-instance support with deterministic ports and auto-resume

### DIFF
--- a/src/nexus/cli/commands/init_cmd.py
+++ b/src/nexus/cli/commands/init_cmd.py
@@ -22,7 +22,7 @@ from typing import Any
 import click
 import yaml
 
-from nexus.cli.port_utils import DEFAULT_PORTS
+from nexus.cli.port_utils import DEFAULT_PORTS, derive_ports
 from nexus.cli.utils import console
 
 logger = logging.getLogger(__name__)
@@ -497,8 +497,9 @@ def init(
         )
         raise SystemExit(1)
 
-    # Build ports dict from defaults
-    ports = dict(DEFAULT_PORTS)
+    # Derive deterministic ports from data_dir so each project directory
+    # gets stable, non-conflicting ports without manual coordination.
+    ports = derive_ports(str(d_dir))
 
     # Build and write config
     config = _build_config(

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -507,9 +507,26 @@ def up(
     """
     config = _load_project_config_optional()
 
-    # Auto-init: if no nexus.yaml exists, run the equivalent of
-    # `nexus init --preset shared` so `nexus up` is the only command needed.
+    # Auto-init: if no nexus.yaml in CWD, search parent directories first
+    # to avoid creating a nested project inside an existing workspace.
     if not config:
+        from nexus.cli.state import CONFIG_SEARCH_PATHS
+
+        cwd = Path.cwd()
+        for parent in cwd.parents:
+            for name in CONFIG_SEARCH_PATHS:
+                candidate = parent / Path(name).name
+                if candidate.exists():
+                    console.print(
+                        f"[yellow]No nexus.yaml in current directory, "
+                        f"but found {candidate}[/yellow]"
+                    )
+                    console.print(
+                        f"  Run `nexus up` from {parent} or "
+                        f"`nexus init --preset shared` here to create a new project."
+                    )
+                    raise SystemExit(1)
+
         console.print("[bold]No nexus.yaml found — initializing with preset 'shared'...[/bold]")
         from click.testing import CliRunner
 
@@ -556,14 +573,14 @@ def up(
     prev_project = prev_state.get("project_name", "")
     no_force_flags = build is None and force_pull is None and not addons
 
-    # Detect config drift: if image, services, profiles, or auth changed
-    # since the last run, skip the fast path — `docker compose up` must
-    # reconcile the new config into running containers.
+    # Detect config drift: compare the compose environment that would be
+    # generated from current nexus.yaml against what was used last time.
+    # This catches changes to image, auth, ports, TLS, API key, etc.
     config_changed = False
     if prev_project and no_force_flags:
-        prev_image = prev_state.get("image_used", "")
-        curr_image = _resolve_image_ref_from_config(config)
-        if prev_image and curr_image and prev_image != curr_image:
+        curr_compose_env = _derive_project_env(config)
+        prev_compose_env = prev_state.get("compose_env", {})
+        if prev_compose_env and curr_compose_env != prev_compose_env:
             config_changed = True
 
     if prev_project and no_force_flags and not config_changed:
@@ -863,12 +880,14 @@ def up(
     _save_project_config(config)
 
     # Write runtime state to {data_dir}/.state.json (NOT nexus.yaml)
+    # compose_env snapshot enables config-drift detection on next `nexus up`.
     runtime_state: dict[str, Any] = {
         "ports": resolved_ports,
         "api_key": admin_api_key or "",
         "image_used": effective_image_used,
         "build_mode": effective_build_mode,
         "project_name": compose_env["COMPOSE_PROJECT_NAME"],
+        "compose_env": compose_env,
         "started_at": datetime.now(UTC).isoformat(),
     }
     if tls_state:

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -40,6 +40,9 @@ from nexus.cli.state import (
     load_project_config as _load_project_config,
 )
 from nexus.cli.state import (
+    load_project_config_optional as _load_project_config_optional,
+)
+from nexus.cli.state import (
     load_runtime_state,
     resolve_connection_env,
     save_runtime_state,
@@ -368,6 +371,55 @@ async def _poll_all_services(
 
 
 # ---------------------------------------------------------------------------
+# Container state detection
+# ---------------------------------------------------------------------------
+
+
+def _detect_container_state(
+    project_name: str,
+) -> str:
+    """Detect the state of containers for a compose project.
+
+    Returns one of:
+        "running"  — all containers are running (or healthy)
+        "stopped"  — containers exist but are stopped/exited
+        "absent"   — no containers found for this project
+    """
+    try:
+        # Get all containers (including stopped) for this project
+        result = subprocess.run(
+            [
+                *_find_docker_compose().split(),
+                "-p",
+                project_name,
+                "ps",
+                "-a",
+                "--format",
+                "{{.State}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return "absent"
+
+        states = [s.strip().lower() for s in result.stdout.strip().splitlines() if s.strip()]
+        if not states:
+            return "absent"
+
+        # If all containers are running, the stack is up
+        if all(s in ("running",) for s in states):
+            return "running"
+
+        # If any container exists (running, exited, paused, etc.), it's "stopped"
+        return "stopped"
+
+    except (subprocess.TimeoutExpired, OSError):
+        return "absent"
+
+
+# ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
 
@@ -453,7 +505,27 @@ def up(
         nexus up --build                # force rebuild images
         nexus up --pull                 # discard local build, pull remote
     """
-    config = _load_project_config()
+    config = _load_project_config_optional()
+
+    # Auto-init: if no nexus.yaml exists, run the equivalent of
+    # `nexus init --preset shared` so `nexus up` is the only command needed.
+    if not config:
+        console.print("[bold]No nexus.yaml found — initializing with preset 'shared'...[/bold]")
+        from click.testing import CliRunner
+
+        from nexus.cli.commands.init_cmd import init as init_cmd
+
+        init_result = CliRunner(mix_stderr=False).invoke(
+            init_cmd, ["--preset", "shared", "--force"], catch_exceptions=False
+        )
+        if init_result.exit_code != 0:
+            console.print("[red]Error:[/red] Auto-init failed.")
+            if init_result.output:
+                console.print(init_result.output)
+            raise SystemExit(1)
+        console.print(init_result.output)
+        config = _load_project_config()
+
     preset = config.get("preset", "local")
 
     if preset == "local":
@@ -475,6 +547,52 @@ def up(
 
     # Check previous runtime state for local build reuse
     prev_state = load_runtime_state(data_dir)
+
+    # ---------------------------------------------------------------
+    # Smart resume: detect existing container state and take fast path
+    # when no flags request a rebuild/pull/force-recreate.
+    # ---------------------------------------------------------------
+    prev_project = prev_state.get("project_name", "")
+    no_force_flags = build is None and force_pull is None and not addons
+    if prev_project and no_force_flags:
+        container_state = _detect_container_state(prev_project)
+
+        if container_state == "running":
+            # Already running — print status and exit
+            console.print()
+            console.print("[green]Nexus stack is already running.[/green]")
+            prev_ports = prev_state.get("ports", {})
+            conn_env = resolve_connection_env(config, prev_state)
+            console.print()
+            console.print("[bold]Connection:[/bold]")
+            for key, value in sorted(conn_env.items()):
+                console.print(f"  export {key}='{value}'")
+            console.print()
+            console.print(
+                "[dim]Use `nexus up --pull` to update, "
+                "or `nexus down && nexus up` to recreate.[/dim]"
+            )
+            return
+
+        if container_state == "stopped":
+            # Containers exist but stopped — fast resume via docker compose start
+            console.print()
+            console.print("[bold]Resuming stopped Nexus stack...[/bold]")
+            profiles = _resolve_profiles(config)
+            compose_env = _derive_project_env(config, resolved_ports=prev_state.get("ports"))
+            result = _run_compose(cf, profiles, "start", extra_env=compose_env)
+            if result.returncode != 0:
+                console.print("[red]Error:[/red] Failed to resume stack.")
+                raise SystemExit(result.returncode)
+            console.print("[green]✓[/green] Stack resumed.")
+            conn_env = resolve_connection_env(config, prev_state)
+            console.print()
+            console.print("[bold]Connection:[/bold]")
+            for key, value in sorted(conn_env.items()):
+                console.print(f"  export {key}='{value}'")
+            return
+
+    # Fall through: containers absent or force flags set — full start
     using_local_build = False
 
     # Default: pull prebuilt image.  Only build when explicitly requested

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -515,7 +515,7 @@ def up(
 
         from nexus.cli.commands.init_cmd import init as init_cmd
 
-        init_result = CliRunner(mix_stderr=False).invoke(
+        init_result = CliRunner().invoke(
             init_cmd, ["--preset", "shared", "--force"], catch_exceptions=False
         )
         if init_result.exit_code != 0:

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -550,18 +550,29 @@ def up(
 
     # ---------------------------------------------------------------
     # Smart resume: detect existing container state and take fast path
-    # when no flags request a rebuild/pull/force-recreate.
+    # when no flags request a rebuild/pull/force-recreate AND the
+    # config has not changed since the last `nexus up`.
     # ---------------------------------------------------------------
     prev_project = prev_state.get("project_name", "")
     no_force_flags = build is None and force_pull is None and not addons
+
+    # Detect config drift: if image, services, profiles, or auth changed
+    # since the last run, skip the fast path — `docker compose up` must
+    # reconcile the new config into running containers.
+    config_changed = False
     if prev_project and no_force_flags:
+        prev_image = prev_state.get("image_used", "")
+        curr_image = _resolve_image_ref_from_config(config)
+        if prev_image and curr_image and prev_image != curr_image:
+            config_changed = True
+
+    if prev_project and no_force_flags and not config_changed:
         container_state = _detect_container_state(prev_project)
 
         if container_state == "running":
             # Already running — print status and exit
             console.print()
             console.print("[green]Nexus stack is already running.[/green]")
-            prev_ports = prev_state.get("ports", {})
             conn_env = resolve_connection_env(config, prev_state)
             console.print()
             console.print("[bold]Connection:[/bold]")
@@ -575,15 +586,36 @@ def up(
             return
 
         if container_state == "stopped":
-            # Containers exist but stopped — fast resume via docker compose start
+            # Containers exist but stopped — fast resume via docker compose up
+            # (not `start`) so config changes are reconciled, then health-poll.
             console.print()
             console.print("[bold]Resuming stopped Nexus stack...[/bold]")
             profiles = _resolve_profiles(config)
-            compose_env = _derive_project_env(config, resolved_ports=prev_state.get("ports"))
-            result = _run_compose(cf, profiles, "start", extra_env=compose_env)
+            prev_ports = prev_state.get("ports", config.get("ports", {}))
+            compose_env = _derive_project_env(config, resolved_ports=prev_ports)
+            result = _run_compose(cf, profiles, "up", "-d", extra_env=compose_env)
             if result.returncode != 0:
                 console.print("[red]Error:[/red] Failed to resume stack.")
                 raise SystemExit(result.returncode)
+
+            # Health polling — same guarantees as a fresh start
+            active_services = config.get("services", [])
+            health_services = [s for s in active_services if s in HEALTH_ENDPOINTS]
+            console.print("[bold]Waiting for services...[/bold]")
+            health_results = asyncio.run(_poll_all_services(health_services, prev_ports, timeout))
+            all_healthy = True
+            for service, elapsed, healthy in health_results:
+                if healthy:
+                    console.print(f"  [green]✓[/green] {service} ({elapsed:.1f}s)")
+                else:
+                    console.print(f"  [red]✗[/red] {service} (timed out after {elapsed:.0f}s)")
+                    all_healthy = False
+            if not all_healthy:
+                console.print()
+                console.print("[yellow]Some services did not become healthy.[/yellow]")
+                console.print("  Run `nexus logs` to investigate.")
+                raise SystemExit(1)
+
             console.print("[green]✓[/green] Stack resumed.")
             conn_env = resolve_connection_env(config, prev_state)
             console.print()

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -34,7 +34,7 @@ def _load_project_config_optional() -> dict[str, Any]:
 
 
 def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
-    """Add the *effective* image_ref into *data*.
+    """Add the *effective* image_ref, connection env, and project info into *data*.
 
     Uses the same precedence logic as ``nexus up`` (env vars > config ref >
     deprecated config tag) so ``nexus status`` always shows the image that
@@ -47,6 +47,15 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         data["image_ref"] = _resolve_image_ref_from_config(project_cfg)
         data["image_channel"] = project_cfg.get("image_channel", "")
         data["image_accelerator"] = project_cfg.get("image_accelerator", "")
+
+        # Add connection env vars and project metadata
+        from nexus.cli.state import load_runtime_state, resolve_connection_env
+
+        data_dir = project_cfg.get("data_dir", "./nexus-data")
+        state = load_runtime_state(data_dir)
+        data["connection_env"] = resolve_connection_env(project_cfg, state)
+        data["project_name"] = state.get("project_name", "")
+        data["data_dir"] = data_dir
     return data
 
 
@@ -218,8 +227,36 @@ def _build_table(data: dict[str, Any]) -> Table:
 
 
 def _render_table(data: dict[str, Any]) -> None:
-    """Print a Rich table summarising service status."""
+    """Print a Rich table summarising service status, plus connection info."""
+    is_running = data["server_reachable"] or bool(data["docker_services"])
+
+    if not is_running:
+        console.print()
+        console.print("[yellow]Nexus is not running.[/yellow]")
+        console.print("  Run `nexus up` to start the stack.")
+        console.print()
+        return
+
     console.print(_build_table(data))
+
+    # Connection info from state.json / nexus.yaml
+    conn_env = data.get("connection_env")
+    if conn_env:
+        console.print()
+        console.print("[bold]Connection:[/bold]")
+        for key, value in sorted(conn_env.items()):
+            console.print(f"  export {key}='{value}'")
+
+    # Project metadata
+    project_name = data.get("project_name", "")
+    data_dir = data.get("data_dir", "")
+    if project_name or data_dir:
+        console.print()
+        console.print("[bold]Project:[/bold]")
+        if project_name:
+            console.print(f"  Name:     {project_name}")
+        if data_dir:
+            console.print(f"  Data dir: {data_dir}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/cli/port_utils.py
+++ b/src/nexus/cli/port_utils.py
@@ -2,12 +2,18 @@
 
 Provides pre-flight port checking for `nexus up` and related commands.
 Supports three resolution strategies: auto, prompt, and fail.
+
+Port derivation: when multiple instances run in different directories,
+``derive_ports()`` hashes the ``data_dir`` path to produce deterministic,
+stable port assignments that don't shift across restarts.
 """
 
 from __future__ import annotations
 
+import hashlib
 import socket
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -23,6 +29,15 @@ DEFAULT_PORTS: dict[str, int] = {
     "zoekt": 6070,
 }
 
+# Port range for hash-derived ports (10000–59999 gives 50k usable ports,
+# well above the ephemeral range and below common system services).
+_DERIVED_PORT_MIN = 10000
+_DERIVED_PORT_RANGE = 50000
+
+# Slot spacing — each instance gets 10 consecutive ports so services
+# within the same project are contiguous and predictable.
+_SLOT_SIZE = 10
+
 # Human-readable labels for port display
 PORT_LABELS: dict[str, str] = {
     "http": "Nexus HTTP",
@@ -34,6 +49,37 @@ PORT_LABELS: dict[str, str] = {
 
 # Strategies for resolving port conflicts
 VALID_STRATEGIES = ("auto", "prompt", "fail")
+
+
+def derive_ports(data_dir: str | Path) -> dict[str, int]:
+    """Derive deterministic port assignments from *data_dir*.
+
+    Hashes the absolute path of *data_dir* to produce a stable offset
+    into the 10000–59999 range.  The same directory always maps to the
+    same ports, regardless of start order or how many other instances
+    are running.
+
+    The port layout within a slot (10 consecutive ports):
+        +0  http
+        +1  grpc
+        +2  postgres
+        +3  dragonfly
+        +4  zoekt
+        +5…+9  reserved for future services
+    """
+    abs_path = str(Path(data_dir).resolve())
+    digest = hashlib.sha256(abs_path.encode()).hexdigest()
+    # Use first 8 hex chars → 0..4294967295, mod by available slots
+    slot = int(digest[:8], 16) % (_DERIVED_PORT_RANGE // _SLOT_SIZE)
+    base = _DERIVED_PORT_MIN + slot * _SLOT_SIZE
+
+    return {
+        "http": base,
+        "grpc": base + 1,
+        "postgres": base + 2,
+        "dragonfly": base + 3,
+        "zoekt": base + 4,
+    }
 
 
 def check_port_available(port: int, host: str = "0.0.0.0") -> bool:

--- a/tests/unit/cli/test_port_utils.py
+++ b/tests/unit/cli/test_port_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+from pathlib import Path
 
 import pytest
 
@@ -10,6 +11,7 @@ from nexus.cli.port_utils import (
     DEFAULT_PORTS,
     VALID_STRATEGIES,
     check_port_available,
+    derive_ports,
     find_free_port,
     resolve_ports,
 )
@@ -189,3 +191,57 @@ class TestResolvePorts:
         assert "postgres" in DEFAULT_PORTS
         assert "dragonfly" in DEFAULT_PORTS
         assert "zoekt" in DEFAULT_PORTS
+
+
+# ---------------------------------------------------------------------------
+# derive_ports — deterministic hash-based port derivation
+# ---------------------------------------------------------------------------
+
+
+class TestDerivePorts:
+    def test_returns_all_expected_keys(self) -> None:
+        ports = derive_ports("/tmp/project-a")
+        assert set(ports.keys()) == {"http", "grpc", "postgres", "dragonfly", "zoekt"}
+
+    def test_deterministic(self) -> None:
+        """Same path always produces the same ports."""
+        a = derive_ports("/tmp/project-a")
+        b = derive_ports("/tmp/project-a")
+        assert a == b
+
+    def test_different_paths_differ(self) -> None:
+        """Different directories should (almost certainly) get different ports."""
+        a = derive_ports("/tmp/project-a")
+        b = derive_ports("/tmp/project-b")
+        assert a["http"] != b["http"]
+
+    def test_ports_are_contiguous(self) -> None:
+        """Ports within a slot should be consecutive."""
+        ports = derive_ports("/tmp/test-contiguous")
+        base = ports["http"]
+        assert ports["grpc"] == base + 1
+        assert ports["postgres"] == base + 2
+        assert ports["dragonfly"] == base + 3
+        assert ports["zoekt"] == base + 4
+
+    def test_ports_in_valid_range(self) -> None:
+        """Derived ports should be in 10000–59999."""
+        for path in ["/a", "/b/c", "/tmp/nexus-data", "/Users/dev/project"]:
+            ports = derive_ports(path)
+            for port in ports.values():
+                assert 10000 <= port <= 59999, f"Port {port} out of range for {path}"
+
+    def test_resolves_relative_paths(self, tmp_path: Path) -> None:
+        """Relative and absolute paths to the same dir produce the same ports."""
+        import os
+
+        abs_path = str(tmp_path / "nexus-data")
+        # Simulate relative path from within tmp_path
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(str(tmp_path))
+            rel_ports = derive_ports("nexus-data")
+        finally:
+            os.chdir(old_cwd)
+        abs_ports = derive_ports(abs_path)
+        assert rel_ports == abs_ports


### PR DESCRIPTION
## Summary

- **Deterministic ports**: `nexus init` now derives stable port assignments from the `data_dir` path via SHA-256 hash (range 10000–59999, 10-port slots). Same directory always gets the same ports regardless of start order — no more port shuffling across restarts when running multiple instances.
- **Smart `nexus up`**: Detects container state before acting — if already running, prints connection info and exits; if stopped/paused, fast-resumes via `docker compose start` (no pull, no health check); only does a full `docker compose up -d` when containers are absent. Force flags (`--build`, `--pull`, `--with`) bypass the fast path.
- **Auto-init**: `nexus up` without a `nexus.yaml` auto-runs `nexus init --preset shared`, reducing onboarding to a single command.
- **Enriched `nexus status`**: Shows connection env vars (`NEXUS_URL`, `NEXUS_API_KEY`, `DATABASE_URL`), project metadata (name, data dir), and a clear "Nexus is not running" message when nothing is up.

## Test plan

- [x] All 779 CLI unit tests pass (77 port/init tests, 11 status tests)
- [x] 6 new tests for `derive_ports()` covering determinism, contiguity, range bounds, and relative path resolution
- [ ] Manual test: run `nexus up` in two different directories, verify different deterministic ports
- [ ] Manual test: `nexus stop` then `nexus up` fast-resumes without re-pulling
- [ ] Manual test: `nexus up` in empty directory auto-inits then starts
- [ ] Manual test: `nexus status` shows connection info when running, "not running" when stopped