### PR TITLE
fix(ci): use valid GitHub runner labels for conda-pack

### DIFF
--- a/.github/workflows/conda-pack.yml
+++ b/.github/workflows/conda-pack.yml
@@ -86,12 +86,12 @@ jobs:
           - os: windows-latest
             artifact_name: nexus-windows-x86_64
 
-          # Intel Mac (x86_64) — matches the runner used in release.yml
-          - os: macos-15-intel
+          # Intel Mac (x86_64) — macos-13 is the last Intel runner
+          - os: macos-13
             artifact_name: nexus-macos-x86_64
 
           # Apple Silicon (arm64)
-          - os: macos-14
+          - os: macos-15
             artifact_name: nexus-macos-arm64
 
     steps:


### PR DESCRIPTION
## Summary
- `macos-15-intel` → `macos-13` (last Intel runner provided by GitHub)
- `macos-14` → `macos-15` (match version with Intel runner)

GitHub does not provide `macos-15-intel` runner, causing the matrix to skip Windows and Intel Mac jobs.

## Test plan
- [ ] Verify CI runs on all three platforms after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)