### PR TITLE
revert(ci): remove profile-based conda-pack builds for v0.9.11 release

### DIFF
--- a/.github/workflows/conda-pack.yml
+++ b/.github/workflows/conda-pack.yml
@@ -12,90 +12,37 @@ name: Conda Pack
 #   3. Compile nexus_raft  (rust/nexus_raft --features full) via maturin
 #   4. pip install both .whl files into the nexus env
 #   5. conda-pack the nexus env → <artifact_name>-<version>.tar.gz
-#
-# Profiles:
-#   - full:    Complete dependencies + Rust extensions (default)
-#   - minimal: Storage-only dependencies + Rust extensions (for embedded metastore)
-#   - remote:  SDK/CLI client only, no Rust extensions (pure gRPC client)
 
 on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
-    inputs:
-      profile:
-        description: 'Build profile (all/remote/minimal/full)'
-        required: false
-        default: 'all'
-        type: choice
-        options:
-          - all
-          - remote
-          - minimal
-          - full
 
 permissions:
   contents: write
 
 jobs:
-  # Generate full matrix: all platforms × all profiles
-  generate-matrix:
-    name: Generate build matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Set matrix
-        id: set-matrix
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PROFILE="${{ github.event.inputs.profile }}"
-            case "$PROFILE" in
-              remote)
-                PROFILES='[{"name":"-remote","requirements":"requirements-remote.txt"}]'
-                ;;
-              minimal)
-                PROFILES='[{"name":"-minimal","requirements":"requirements-minimal.txt"}]'
-                ;;
-              full)
-                PROFILES='[{"name":"","requirements":""}]'
-                ;;
-              *)  # all
-                PROFILES='[{"name":"","requirements":""},{"name":"-remote","requirements":"requirements-remote.txt"},{"name":"-minimal","requirements":"requirements-minimal.txt"}]'
-                ;;
-            esac
-          else
-            # Tag trigger: build all profiles
-            PROFILES='[{"name":"","requirements":""},{"name":"-remote","requirements":"requirements-remote.txt"},{"name":"-minimal","requirements":"requirements-minimal.txt"}]'
-          fi
-
-          # Platforms (Windows, Intel Mac, ARM Mac)
-          PLATFORMS='[{"os":"windows-latest","artifact_name":"nexus-windows-x86_64"},{"os":"macos-13","artifact_name":"nexus-macos-x86_64"},{"os":"macos-15","artifact_name":"nexus-macos-arm64"}]'
-
-          # Build cartesian product using Python
-          MATRIX=$(python3 -c "
-          import json
-          profiles = json.loads('''$PROFILES''')
-          platforms = json.loads('''$PLATFORMS''')
-          matrix = []
-          for p in profiles:
-            for plat in platforms:
-              entry = dict(plat)
-              entry['profile'] = p
-              matrix.append(entry)
-          print(json.dumps({'include': matrix}))
-          ")
-          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
-
   conda-pack:
-    needs: generate-matrix
-    name: conda-pack / ${{ matrix.artifact_name }}${{ matrix.profile.name }}
+    name: conda-pack / ${{ matrix.artifact_name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 90        # Rust compilation can be slow on macOS/Windows runners
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+      matrix:
+        include:
+          # nexus_pyo3 (shm_pipe/shm_stream) uses POSIX-only APIs (fcntl, pipe,
+          # O_NONBLOCK) that do not exist on Windows. That wheel is skipped on
+          # Windows via `if: matrix.os != 'windows-latest'` below.
+          - os: windows-latest
+            artifact_name: nexus-windows-x86_64
+
+          # Intel Mac (x86_64) — macos-13 is the last Intel runner
+          - os: macos-13
+            artifact_name: nexus-macos-x86_64
+
+          # Apple Silicon (arm64)
+          - os: macos-15
+            artifact_name: nexus-macos-arm64
 
     steps:
       - name: Checkout code
@@ -122,41 +69,26 @@ jobs:
       - name: Install project into nexus environment
         shell: bash -el {0}
         run: |
-          if [ -n "${{ matrix.profile.requirements }}" ]; then
-            echo "Installing dependencies from ${{ matrix.profile.requirements }} (lightweight profile)"
-            conda run -n nexus pip install -r ${{ matrix.profile.requirements }}
-            # Install project itself (without deps, already installed above) to get CLI entrypoints (nexus, nexusd)
-            echo "Installing project package for CLI entrypoints"
-            conda run -n nexus pip install --no-deps .
-          else
-            echo "Installing full dependencies from pyproject.toml"
-            conda run -n nexus pip install .
-          fi
+          conda run -n nexus pip install .
 
       # ── Rust toolchain ────────────────────────────────────────────────────
       # Reads the required toolchain version from rust-toolchain.toml
       # automatically. No need to specify the version explicitly.
-      # Only remote profile skips Rust (pure gRPC client).
-      # Both full and minimal profiles need nexus_raft for embedded metastore.
       - name: Setup Rust toolchain
-        if: matrix.profile.name != '-remote'
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Add rustfmt and clippy components
-        if: matrix.profile.name != '-remote'
         shell: bash -el {0}
         run: rustup component add rustfmt clippy
 
       # raft-proto build.rs requires protoc >= 3.1.0 for codegen
       - name: Install protoc
-        if: matrix.profile.name != '-remote'
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Cache compiled Rust artifacts across runs to speed up re-builds.
       - name: Rust build cache
-        if: matrix.profile.name != '-remote'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: conda-pack-rust-${{ matrix.os }}
@@ -168,15 +100,13 @@ jobs:
       # Install maturin inside the nexus env so it automatically uses the
       # correct Python interpreter when building the extension modules.
       - name: Install maturin into nexus environment
-        if: matrix.profile.name != '-remote'
         shell: bash -el {0}
         run: |
           conda run -n nexus pip install maturin
 
       # Skipped on Windows: shm_pipe.rs / shm_stream.rs use POSIX-only APIs.
-      # Skipped on remote: pure gRPC client, no local Rust extensions needed.
       - name: Build nexus_fast wheel  (rust/nexus_pyo3)
-        if: matrix.profile.name != '-remote' && matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-latest'
         shell: bash -el {0}
         run: |
           mkdir -p build/dist
@@ -187,9 +117,7 @@ jobs:
       # Use --features python only: consensus + grpc are EXPERIMENTAL and
       # "not used in production" (see Cargo.toml). --no-default-features is
       # required because default = ["full"] pulls in grpc which needs protoc.
-      # Both full and minimal profiles need nexus_raft for embedded metastore.
       - name: Build nexus_raft wheel  (rust/nexus_raft --features python)
-        if: matrix.profile.name != '-remote'
         shell: bash -el {0}
         run: |
           mkdir -p build/dist
@@ -200,7 +128,6 @@ jobs:
 
       # ── Install wheels into the nexus env ────────────────────────────────
       - name: Install Rust wheels into nexus environment
-        if: matrix.profile.name != '-remote'
         shell: bash -el {0}
         run: |
           echo "=== Built wheels ==="
@@ -216,14 +143,8 @@ jobs:
       - name: Pack nexus environment
         shell: bash -el {0}
         run: |
-          # Get version from tag or pyproject.toml
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-            VERSION="${VERSION}-dev"  # Mark as dev build for non-tag builds
-          fi
-          OUTPUT="${{ matrix.artifact_name }}${{ matrix.profile.name }}.tar.gz"
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          OUTPUT="${{ matrix.artifact_name }}.tar.gz"
 
           # Write a VERSION file into the conda env so users know what
           # version they downloaded after extraction.
@@ -237,19 +158,17 @@ jobs:
       - name: Upload packed artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact_name }}${{ matrix.profile.name }}
-          path: ${{ matrix.artifact_name }}${{ matrix.profile.name }}.tar.gz
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}.tar.gz
           if-no-files-found: error
 
   # ── Attach to GitHub Release ──────────────────────────────────────────────
-  # Runs after all conda-pack jobs succeed. The release itself is
-  # created by release.yml — this job simply appends the tarballs.
-  # Only runs on tag pushes (not manual triggers).
+  # Runs after all three conda-pack jobs succeed. The release itself is
+  # created by release.yml — this job simply appends the three tarballs.
   attach-to-release:
     name: Attach conda packs to GitHub Release
     needs: conda-pack
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all conda-pack artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Revert profile-based conda-pack builds (remote/minimal) to release v0.9.11 with full builds only
- Keep the fixed runner labels (macos-13 for Intel, macos-15 for ARM)
- The remote/minimal profiles will be re-introduced in a future release

## Context
Temporarily rolling back the profile feature to ship v0.9.11 with stable full builds.

## Test plan
- [ ] Tag v0.9.11 triggers conda-pack workflow
- [ ] Full builds complete for all 3 platforms (Windows, Intel Mac, ARM Mac)
- [ ] Artifacts attach to GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)