### PR TITLE
docs(#1772): SPSC/MPMC concurrency contracts for pipe primitives

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -423,8 +423,9 @@ Two-layer architecture for both: VFS metadata (inode) in MetastoreABC, data
 - **PipeManager (mkpipe)** — VFS named pipe lifecycle (created via `sys_setattr`
   upsert, read/write via `sys_read`/`sys_write`, destroyed via `sys_unlink`),
   per-pipe lock for MPMC safety. Reads are destructive (consumed on read).
-- **RingBuffer (kpipe)** — Lock-free SPSC kernel primitive (`kfifo` analogue),
-  GIL-atomic. PipeManager wraps with `asyncio.Lock` for MPMC.
+- **RingBuffer (kpipe)** — Lock-free **SPSC** kernel primitive (`kfifo` analogue),
+  no internal synchronization. PipeManager wraps with per-pipe `asyncio.Lock`
+  for **MPMC** safety. Direct RingBuffer access is kernel-internal only.
 
 **DT_STREAM (StreamManager + StreamBuffer):**
 

--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -143,6 +143,12 @@ class PipeBackend(Protocol):
     PipeManager stores ``dict[str, PipeBackend]`` — all backends share
     this interface so PipeManager is transport-agnostic.
 
+    **Concurrency contract**: All PipeBackend methods are **SPSC** (single-producer,
+    single-consumer) with no internal synchronization. The asyncio event loop provides
+    implicit serialization for coroutines, but this is a *usage property*, NOT a buffer
+    guarantee. Multi-threaded callers MUST use PipeManager.pipe_write/pipe_read (which
+    add per-pipe asyncio.Lock for MPMC safety).
+
     Implementations:
         RingBuffer              — in-process SPSC ring buffer (Rust, ~0.5μs)
         SharedRingBuffer (shm_pipe.py) — cross-process mmap'd ring buffer (~1–5μs)
@@ -174,6 +180,12 @@ class RingBuffer:
     Analogous to Linux kfifo: a kernel-internal FIFO with no filesystem
     visibility. Any kernel code or in-process service can instantiate one
     directly for fast async signaling.
+
+    **Concurrency**: All operations are **SPSC** (single-producer, single-consumer)
+    with no internal synchronization. The asyncio event loop serializes coroutine
+    execution, providing implicit MPSC safety for single-event-loop deployments.
+    This is NOT a guarantee — multi-threaded callers MUST use PipeManager.pipe_write/
+    pipe_read which add per-pipe asyncio.Lock for MPMC safety.
 
     For VFS-visible named pipes (mkfifo equivalent), use PipeManager
     from core/pipe_manager.py.


### PR DESCRIPTION
## Summary
- Document SPSC (single-producer, single-consumer) contract on PipeBackend protocol and RingBuffer
- Clarify that asyncio event loop provides implicit serialization but is NOT a guarantee for multi-threaded callers
- Update KERNEL-ARCHITECTURE.md §4.2 with corrected SPSC vs MPMC description

Docs-only change, no code behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)