### PR TITLE
fix: CI failures from #3281 — keyword-only context + async write_skill_docs

### DIFF
--- a/src/nexus/backends/connectors/base.py
+++ b/src/nexus/backends/connectors/base.py
@@ -284,10 +284,10 @@ class SkillDocMixin:
         """Get the full path to the .skill directory."""
         return self._get_doc_generator().get_skill_path(mount_path)
 
-    def write_skill_docs(self, mount_path: str, filesystem: Any = None) -> dict[str, str]:
+    async def write_skill_docs(self, mount_path: str, filesystem: Any = None) -> dict[str, str]:
         """Generate and write .skill/ directory to the filesystem."""
         self._mount_path = mount_path
-        return self._get_doc_generator().write_skill_docs(mount_path, filesystem)
+        return await self._get_doc_generator().write_skill_docs(mount_path, filesystem)
 
     def format_error_with_skill_ref(
         self,

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -330,7 +330,7 @@ class GmailConnectorBackend(
             logger.warning(f"Failed to load static SKILL.md: {e}, using auto-generated")
             return super().generate_skill_doc(mount_path)
 
-    def write_skill_docs(self, mount_path: str, filesystem: Any = None) -> dict[str, Any]:
+    async def write_skill_docs(self, mount_path: str, filesystem: Any = None) -> dict[str, Any]:
         """Write SKILL.md to filesystem using static template.
 
         Overrides SkillDocMixin.write_skill_docs to use the static SKILL.md
@@ -353,11 +353,11 @@ class GmailConnectorBackend(
         skill_dir = posixpath.join(mount_path.rstrip("/"), self.SKILL_DIR)
 
         try:
-            filesystem.mkdir(skill_dir, parents=True, exist_ok=True)
+            await filesystem.mkdir(skill_dir, parents=True, exist_ok=True)
 
             skill_md_path = posixpath.join(skill_dir, "SKILL.md")
             content = self.generate_skill_doc(mount_path)
-            filesystem.write(skill_md_path, content.encode("utf-8"))
+            await filesystem.write(skill_md_path, content.encode("utf-8"))
             result["skill_md"] = skill_md_path
 
             return result

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -103,7 +103,7 @@ class SkillDocGenerator:
         """Get the full path to the .skill directory."""
         return posixpath.join(mount_path.rstrip("/"), self._skill_dir)
 
-    def write_skill_docs(self, mount_path: str, filesystem: Any = None) -> dict[str, Any]:
+    async def write_skill_docs(self, mount_path: str, filesystem: Any = None) -> dict[str, Any]:
         """Generate and write .skill/ directory to the filesystem.
 
         Creates:
@@ -134,35 +134,35 @@ class SkillDocGenerator:
             return result
 
         try:
-            filesystem.mkdir(skill_dir, parents=True, exist_ok=True)
+            await filesystem.mkdir(skill_dir, parents=True, exist_ok=True)
 
             # Write SKILL.md
             skill_md_path = posixpath.join(skill_dir, "SKILL.md")
             content = self.generate_skill_doc(mount_path)
-            filesystem.write(skill_md_path, content.encode("utf-8"))
+            await filesystem.write(skill_md_path, content.encode("utf-8"))
             result["skill_md"] = skill_md_path
             logger.info("Generated SKILL.md at %s", skill_md_path)
 
             # Write example files
             if self._examples:
                 examples_dir = posixpath.join(skill_dir, "examples")
-                filesystem.mkdir(examples_dir, parents=True, exist_ok=True)
+                await filesystem.mkdir(examples_dir, parents=True, exist_ok=True)
 
                 for filename, file_content in self._examples.items():
                     example_path = posixpath.join(examples_dir, filename)
-                    filesystem.write(example_path, file_content.encode("utf-8"))
+                    await filesystem.write(example_path, file_content.encode("utf-8"))
                     result["examples"].append(example_path)
                     logger.debug("Generated example at %s", example_path)
 
             # Write individual schema files (Issue #3148, Decision #7B)
             if self._schemas:
                 schemas_dir = posixpath.join(skill_dir, "schemas")
-                filesystem.mkdir(schemas_dir, parents=True, exist_ok=True)
+                await filesystem.mkdir(schemas_dir, parents=True, exist_ok=True)
 
                 for op_name, schema in self._schemas.items():
                     schema_content = self._generate_annotated_schema(op_name, schema)
                     schema_path = posixpath.join(schemas_dir, f"{op_name}.yaml")
-                    filesystem.write(schema_path, schema_content.encode("utf-8"))
+                    await filesystem.write(schema_path, schema_content.encode("utf-8"))
                     result["schemas"].append(schema_path)
                     logger.debug("Generated schema at %s", schema_path)
 

--- a/src/nexus/bricks/mount/mount_service.py
+++ b/src/nexus/bricks/mount/mount_service.py
@@ -143,7 +143,7 @@ class MountService:
             if hasattr(backend, "has_capability") and backend.has_capability(
                 ConnectorCapability.SKILL_DOC
             ):
-                await asyncio.to_thread(self._generate_skill_docs, mount_point, backend)
+                await self._generate_skill_docs(mount_point, backend)
 
             # Search indexing — index the mount point so content is discoverable.
             # Uses search_service DI (Issue #3148 Phase 1).
@@ -171,8 +171,8 @@ class MountService:
                 "Post-mount hooks failed for %s (mount still active)", mount_point, exc_info=True
             )
 
-    def _generate_skill_docs(self, mount_point: str, backend: Any) -> None:
-        """Generate .skill/ directory for a connector backend (sync).
+    async def _generate_skill_docs(self, mount_point: str, backend: Any) -> None:
+        """Generate .skill/ directory for a connector backend (async).
 
         Called from post-mount hooks and sync completion.
         """
@@ -194,7 +194,7 @@ class MountService:
 
         if fs is not None:
             try:
-                result = backend.write_skill_docs(mount_point, fs)
+                result = await backend.write_skill_docs(mount_point, fs)
                 if result.get("skill_md"):
                     logger.info(
                         "Generated skill docs for %s at %s", mount_point, result["skill_md"]
@@ -1558,7 +1558,7 @@ class MountService:
             try:
                 route = self.router.route(mount_point)
                 if route:
-                    await asyncio.to_thread(self._generate_skill_docs, mount_point, route.backend)
+                    await self._generate_skill_docs(mount_point, route.backend)
             except Exception:
                 logger.warning(
                     "Post-sync skill doc regeneration failed for %s",

--- a/tests/e2e/self_contained/test_gcalendar_connector.py
+++ b/tests/e2e/self_contained/test_gcalendar_connector.py
@@ -306,7 +306,7 @@ class TestSkillDocGeneration:
 
         try:
             # Write SKILL.md
-            result = calendar_backend.write_skill_docs("/mnt/calendar/", filesystem=nx)
+            result = await calendar_backend.write_skill_docs("/mnt/calendar/", filesystem=nx)
             assert isinstance(result, dict)
             skill_path = result.get("skill_md")
 

--- a/tests/e2e/self_contained/test_gmail_connector.py
+++ b/tests/e2e/self_contained/test_gmail_connector.py
@@ -334,7 +334,7 @@ class TestSkillDocGeneration:
 
         try:
             # Write SKILL.md
-            result = gmail_backend.write_skill_docs("/mnt/gmail/", filesystem=nx)
+            result = await gmail_backend.write_skill_docs("/mnt/gmail/", filesystem=nx)
             assert isinstance(result, dict)
             skill_path = result.get("skill_md")
 

--- a/tests/unit/backends/connectors/cli/test_lifecycle_e2e.py
+++ b/tests/unit/backends/connectors/cli/test_lifecycle_e2e.py
@@ -9,7 +9,7 @@ This uses the FakeConnectorSyncProvider and mock filesystem to test
 the orchestration without requiring real CLI tools or OAuth tokens.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import BaseModel, Field
@@ -142,12 +142,15 @@ class TestConnectorLifecycleE2E:
         assert "# Github Connector" in skill_doc or "# GitHub Connector" in skill_doc.title()
         assert "create_issue" in skill_doc.lower() or "Create Issue" in skill_doc
 
-    def test_step2_skill_doc_writes_to_filesystem(self) -> None:
+    @pytest.mark.asyncio
+    async def test_step2_skill_doc_writes_to_filesystem(self) -> None:
         """Step 2: Skill docs written to .skill/ directory with schema files."""
         connector = FakeGHConnector()
         fs = MagicMock()
+        fs.mkdir = AsyncMock()
+        fs.write = AsyncMock()
 
-        result = connector.write_skill_docs("/mnt/github", fs)
+        result = await connector.write_skill_docs("/mnt/github", fs)
 
         # SKILL.md should be written
         assert result["skill_md"] == "/mnt/github/.skill/SKILL.md"

--- a/tests/unit/connectors/test_schema_generator.py
+++ b/tests/unit/connectors/test_schema_generator.py
@@ -1,6 +1,6 @@
 """Tests for SkillDocGenerator — schema-to-doc generation extracted from SkillDocMixin."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import BaseModel
@@ -112,8 +112,8 @@ def empty_generator() -> SkillDocGenerator:
 @pytest.fixture()
 def mock_filesystem() -> MagicMock:
     fs = MagicMock()
-    fs.mkdir = MagicMock()
-    fs.write = MagicMock()
+    fs.mkdir = AsyncMock()
+    fs.write = AsyncMock()
     return fs
 
 
@@ -176,10 +176,11 @@ class TestGenerateSkillDoc:
 
 
 class TestWriteSkillDocs:
-    def test_writes_skill_md(
+    @pytest.mark.asyncio
+    async def test_writes_skill_md(
         self, generator: SkillDocGenerator, mock_filesystem: MagicMock
     ) -> None:
-        result = generator.write_skill_docs("/mnt/calendar", filesystem=mock_filesystem)
+        result = await generator.write_skill_docs("/mnt/calendar", filesystem=mock_filesystem)
 
         assert result["skill_md"] == "/mnt/calendar/.skill/SKILL.md"
         mock_filesystem.mkdir.assert_any_call("/mnt/calendar/.skill", parents=True, exist_ok=True)
@@ -189,10 +190,11 @@ class TestWriteSkillDocs:
         assert skill_md_call[0][0] == "/mnt/calendar/.skill/SKILL.md"
         assert isinstance(skill_md_call[0][1], bytes)
 
-    def test_writes_examples(
+    @pytest.mark.asyncio
+    async def test_writes_examples(
         self, generator: SkillDocGenerator, mock_filesystem: MagicMock
     ) -> None:
-        result = generator.write_skill_docs("/mnt/calendar", filesystem=mock_filesystem)
+        result = await generator.write_skill_docs("/mnt/calendar", filesystem=mock_filesystem)
 
         assert "/mnt/calendar/.skill/examples/create_meeting.yaml" in result["examples"]
         mock_filesystem.mkdir.assert_any_call(
@@ -203,12 +205,14 @@ class TestWriteSkillDocs:
         assert example_call[0][0] == "/mnt/calendar/.skill/examples/create_meeting.yaml"
         assert example_call[0][1] == b"summary: Team Standup\n"
 
-    def test_no_filesystem_returns_empty_result(self, generator: SkillDocGenerator) -> None:
-        result = generator.write_skill_docs("/mnt/calendar", filesystem=None)
+    @pytest.mark.asyncio
+    async def test_no_filesystem_returns_empty_result(self, generator: SkillDocGenerator) -> None:
+        result = await generator.write_skill_docs("/mnt/calendar", filesystem=None)
         assert result["skill_md"] is None
         assert result["examples"] == []
 
-    def test_empty_skill_name_returns_empty_result(self, mock_filesystem: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_empty_skill_name_returns_empty_result(self, mock_filesystem: MagicMock) -> None:
         gen = SkillDocGenerator(
             skill_name="",
             schemas={},
@@ -216,12 +220,13 @@ class TestWriteSkillDocs:
             error_registry={},
             examples={},
         )
-        result = gen.write_skill_docs("/mnt/x", filesystem=mock_filesystem)
+        result = await gen.write_skill_docs("/mnt/x", filesystem=mock_filesystem)
         assert result["skill_md"] is None
         assert result["examples"] == []
         mock_filesystem.write.assert_not_called()
 
-    def test_no_examples_skips_examples_dir(self, mock_filesystem: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_no_examples_skips_examples_dir(self, mock_filesystem: MagicMock) -> None:
         gen = SkillDocGenerator(
             skill_name="test",
             schemas=_DEFAULT_SCHEMAS,
@@ -229,14 +234,17 @@ class TestWriteSkillDocs:
             error_registry=_DEFAULT_ERRORS,
             examples={},
         )
-        result = gen.write_skill_docs("/mnt/x", filesystem=mock_filesystem)
+        result = await gen.write_skill_docs("/mnt/x", filesystem=mock_filesystem)
         assert result["skill_md"] is not None
         assert result["examples"] == []
         # Only the .skill dir mkdir, not examples/
         mkdir_paths = [c[0][0] for c in mock_filesystem.mkdir.call_args_list]
         assert "/mnt/x/.skill/examples" not in mkdir_paths
 
-    def test_filesystem_error_returns_partial_result(self, mock_filesystem: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_filesystem_error_returns_partial_result(
+        self, mock_filesystem: MagicMock
+    ) -> None:
         mock_filesystem.mkdir.side_effect = OSError("permission denied")
         gen = SkillDocGenerator(
             skill_name="test",
@@ -245,11 +253,12 @@ class TestWriteSkillDocs:
             error_registry={},
             examples={},
         )
-        result = gen.write_skill_docs("/mnt/x", filesystem=mock_filesystem)
+        result = await gen.write_skill_docs("/mnt/x", filesystem=mock_filesystem)
         assert result["skill_md"] is None
         assert result["examples"] == []
 
-    def test_custom_skill_dir(self, mock_filesystem: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_custom_skill_dir(self, mock_filesystem: MagicMock) -> None:
         gen = SkillDocGenerator(
             skill_name="test",
             schemas={},
@@ -258,7 +267,7 @@ class TestWriteSkillDocs:
             examples={},
             skill_dir=".docs",
         )
-        gen.write_skill_docs("/mnt/x", filesystem=mock_filesystem)
+        await gen.write_skill_docs("/mnt/x", filesystem=mock_filesystem)
         mock_filesystem.mkdir.assert_any_call("/mnt/x/.docs", parents=True, exist_ok=True)
 
 

--- a/tests/unit/core/test_scoped_filesystem.py
+++ b/tests/unit/core/test_scoped_filesystem.py
@@ -220,7 +220,7 @@ class TestCoreFileOperations:
         """Test delete with path scoping."""
         await scoped_fs.sys_unlink("/workspace/file.txt")
         mock_fs.sys_unlink.assert_called_once_with(
-            "/zones/team_12/users/user_1/workspace/file.txt", None
+            "/zones/team_12/users/user_1/workspace/file.txt", context=None
         )
 
     @pytest.mark.asyncio
@@ -230,7 +230,7 @@ class TestCoreFileOperations:
         mock_fs.sys_rename.assert_called_once_with(
             "/zones/team_12/users/user_1/workspace/old.txt",
             "/zones/team_12/users/user_1/workspace/new.txt",
-            None,
+            context=None,
         )
 
     @pytest.mark.asyncio
@@ -239,7 +239,7 @@ class TestCoreFileOperations:
         mock_fs.sys_access.return_value = True
         result = await scoped_fs.sys_access("/workspace/file.txt")
         mock_fs.sys_access.assert_called_once_with(
-            "/zones/team_12/users/user_1/workspace/file.txt", None
+            "/zones/team_12/users/user_1/workspace/file.txt", context=None
         )
         assert result is True
 
@@ -302,7 +302,7 @@ class TestDirectoryOperations:
         """Test mkdir with path scoping."""
         await scoped_fs.sys_mkdir("/workspace/new_dir", parents=True, exist_ok=True)
         mock_fs.sys_mkdir.assert_called_once_with(
-            "/zones/team_12/users/user_1/workspace/new_dir", True, True, None
+            "/zones/team_12/users/user_1/workspace/new_dir", True, True, context=None
         )
 
     @pytest.mark.asyncio
@@ -310,7 +310,7 @@ class TestDirectoryOperations:
         """Test rmdir with path scoping."""
         await scoped_fs.sys_rmdir("/workspace/old_dir", recursive=True)
         mock_fs.sys_rmdir.assert_called_once_with(
-            "/zones/team_12/users/user_1/workspace/old_dir", True, None
+            "/zones/team_12/users/user_1/workspace/old_dir", True, context=None
         )
 
     @pytest.mark.asyncio
@@ -319,7 +319,7 @@ class TestDirectoryOperations:
         mock_fs.sys_is_directory.return_value = True
         result = await scoped_fs.sys_is_directory("/workspace/dir")
         mock_fs.sys_is_directory.assert_called_once_with(
-            "/zones/team_12/users/user_1/workspace/dir", None
+            "/zones/team_12/users/user_1/workspace/dir", context=None
         )
         assert result is True
 


### PR DESCRIPTION
## Summary
Fixes CI failures introduced by PR #3281 (syscall contract audit):

1. **test_scoped_filesystem.py**: mock assertions updated for keyword-only context (`None` → `context=None`)
2. **write_skill_docs async**: re-apply async fix lost during merge queue squash of PR #3274

## Test plan
- [x] Pre-commit hooks pass
- [ ] **CI must be green before merge** (will NOT auto-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)