### PR TITLE
fix(#1812): make OBSERVE notify() sync — fire-and-forget contract fix

### DIFF
--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -429,8 +429,17 @@ class KernelDispatch:
 
     # ── OBSERVE dispatch ───────────────────────────────────────────────
 
-    async def notify(self, event: FileEvent) -> None:
-        """OBSERVE phase — fire-and-forget to all registered observers."""
+    def notify(self, event: FileEvent) -> None:
+        """OBSERVE phase — fire-and-forget to all registered observers.
+
+        Synchronous: all VFSObserver.on_mutation() implementations are sync
+        by protocol contract.  Observers that need async dispatch (e.g.
+        EventBusObserver) use internal fire_and_forget().
+
+        Issue #1812: was ``async def`` but never awaited anything internally —
+        the ``async`` keyword forced callers to ``await`` a no-op coroutine,
+        violating the fire-and-forget contract.
+        """
         for obs in self._observers:
             try:
                 obs.on_mutation(event)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -574,7 +574,7 @@ class NexusFS(  # type: ignore[misc]
                 agent_id=ctx.agent_id,
             )
         )
-        await self._dispatch.notify(
+        self._dispatch.notify(
             FileEvent(
                 type=FileEventType.DIR_CREATE,
                 path=path,
@@ -692,7 +692,7 @@ class NexusFS(  # type: ignore[misc]
                 recursive=recursive,
             )
         )
-        await self._dispatch.notify(
+        self._dispatch.notify(
             FileEvent(
                 type=FileEventType.DIR_DELETE,
                 path=path,
@@ -2472,7 +2472,7 @@ class NexusFS(  # type: ignore[misc]
         # --- Lock released — event dispatch + side effects (like Linux inotify after i_rwsem) ---
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
-        await self._dispatch.notify(
+        self._dispatch.notify(
             FileEvent(
                 type=FileEventType.FILE_WRITE,
                 path=path,
@@ -3064,7 +3064,7 @@ class NexusFS(  # type: ignore[misc]
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         for metadata in metadata_list:
             is_new = existing_metadata.get(metadata.path) is None
-            await self._dispatch.notify(
+            self._dispatch.notify(
                 FileEvent(
                     type=FileEventType.FILE_WRITE,
                     path=metadata.path,
@@ -3196,7 +3196,7 @@ class NexusFS(  # type: ignore[misc]
         # --- Lock released — event dispatch (like Linux inotify after i_rwsem) ---
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
-        await self._dispatch.notify(
+        self._dispatch.notify(
             FileEvent(
                 type=FileEventType.FILE_DELETE,
                 path=path,
@@ -3348,7 +3348,7 @@ class NexusFS(  # type: ignore[misc]
         # --- Lock released — event dispatch + side effects (like Linux inotify after i_rwsem) ---
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
-        await self._dispatch.notify(
+        self._dispatch.notify(
             FileEvent(
                 type=FileEventType.FILE_RENAME,
                 path=old_path,

--- a/tests/unit/core/test_kernel_dispatch_parallel.py
+++ b/tests/unit/core/test_kernel_dispatch_parallel.py
@@ -167,7 +167,7 @@ class TestAsyncNotify:
         obs = MagicMock()
         dispatch.register_observe(obs)
         event = FileEvent(type=FileEventType.FILE_WRITE, path="/test")
-        await dispatch.notify(event)
+        dispatch.notify(event)
         obs.on_mutation.assert_called_once_with(event)
 
     async def test_notify_fault_isolation(self, dispatch: KernelDispatch) -> None:
@@ -180,6 +180,6 @@ class TestAsyncNotify:
         dispatch.register_observe(good)
 
         event = FileEvent(type=FileEventType.FILE_WRITE, path="/test")
-        await dispatch.notify(event)
+        dispatch.notify(event)
 
         good.on_mutation.assert_called_once_with(event)

--- a/tests/unit/core/test_kernel_dispatch_unregister.py
+++ b/tests/unit/core/test_kernel_dispatch_unregister.py
@@ -100,7 +100,7 @@ class TestUnregisterObserve:
         from nexus.core.file_events import FileEvent, FileEventType
 
         event = FileEvent(type=FileEventType.FILE_WRITE, path="/test")
-        await dispatch.notify(event)
+        dispatch.notify(event)
         obs1.on_mutation.assert_called_once_with(event)
         obs3.on_mutation.assert_called_once_with(event)
         obs2.on_mutation.assert_not_called()

--- a/tests/unit/core/test_write_observer_calls.py
+++ b/tests/unit/core/test_write_observer_calls.py
@@ -61,7 +61,7 @@ def mock_notify(nx: NexusFS) -> AsyncMock:
     mock_dispatch.resolve_write.return_value = (False, None)
     mock_dispatch.resolve_delete.return_value = (False, None)
     # All post-dispatch and notify methods are now async
-    mock_dispatch.notify = AsyncMock()
+    mock_dispatch.notify = MagicMock()  # sync after #1812
     mock_dispatch.intercept_post_write = AsyncMock()
     mock_dispatch.intercept_post_delete = AsyncMock()
     mock_dispatch.intercept_post_rename = AsyncMock()
@@ -203,7 +203,7 @@ class TestWriteStreamCallsDispatch:
         mock_dispatch.resolve_delete.return_value = (False, None)
         # All post-dispatch methods are now async
         mock_dispatch.intercept_post_write = AsyncMock()
-        mock_dispatch.notify = AsyncMock()
+        mock_dispatch.notify = MagicMock()  # sync after #1812
         nx._dispatch = mock_dispatch
 
         await nx.write_stream("/streamed.txt", iter([b"chunk1", b"chunk2"]))


### PR DESCRIPTION
## Summary
- `KernelDispatch.notify()` was `async def` but never awaited anything internally — all `VFSObserver.on_mutation()` are sync by protocol contract
- This forced all 6 NexusFS call sites to `await` a no-op coroutine, violating fire-and-forget semantics and adding overhead on the critical path
- Changed to `def notify()` (sync) and removed `await` from all call sites + tests

## Test plan
- [x] All 49 existing KernelDispatch + observer tests pass
- [x] ruff + mypy clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)