### PR TITLE
feat(#1320): add old_etag to FileEvent for write-overwrite detection

### DIFF
--- a/src/nexus/core/file_events.py
+++ b/src/nexus/core/file_events.py
@@ -61,6 +61,7 @@ class FileEvent:
     version: int | None = None  # write-specific: file version counter
     is_new: bool = False  # write-specific: True if file was created (not overwritten)
     new_path: str | None = None  # rename-specific: destination path
+    old_etag: str | None = None  # write-specific: previous content hash (for overwrite detection)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
@@ -93,6 +94,8 @@ class FileEvent:
             result["is_new"] = self.is_new
         if self.new_path is not None:
             result["new_path"] = self.new_path
+        if self.old_etag is not None:
+            result["old_etag"] = self.old_etag
         return result
 
     def to_json(self) -> str:
@@ -118,6 +121,7 @@ class FileEvent:
             version=data.get("version"),
             is_new=data.get("is_new", False),
             new_path=data.get("new_path"),
+            old_etag=data.get("old_etag"),
         )
 
     @classmethod

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -2460,6 +2460,7 @@ class NexusFS(  # type: ignore[misc]
                 size=metadata.size,
                 version=new_version,
                 is_new=(meta is None),
+                old_etag=meta.etag if meta else None,
             )
         )
 
@@ -3041,7 +3042,8 @@ class NexusFS(  # type: ignore[misc]
 
         # Issue #900: Unified two-phase dispatch — OBSERVE (fire-and-forget)
         for metadata in metadata_list:
-            is_new = existing_metadata.get(metadata.path) is None
+            old_meta = existing_metadata.get(metadata.path)
+            is_new = old_meta is None
             self._dispatch.notify(
                 FileEvent(
                     type=FileEventType.FILE_WRITE,
@@ -3052,6 +3054,7 @@ class NexusFS(  # type: ignore[misc]
                     size=metadata.size,
                     version=metadata.version,
                     is_new=is_new,
+                    old_etag=old_meta.etag if old_meta else None,
                 )
             )
 


### PR DESCRIPTION
## Summary
- Add `old_etag: str | None = None` field to `FileEvent` dataclass — carries previous content hash on write-overwrite
- Populate `old_etag` in `sys_write` and `write_batch` OBSERVE notify calls from pre-fetched metadata
- Same kernel-level pattern as `old_path` for renames — generic, not CAS-specific

## Context
Part of CAS async GC chain (#1320). OBSERVE observers need old_etag to know which content to release when a file is overwritten.

## Test plan
- [x] Existing observer tests pass (old_etag defaults to None, backward compatible)
- [x] ruff + mypy clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)