### PR TITLE
feat(#1320): add release_content() to CAS engine for deferred GC

### DIFF
--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -440,6 +440,32 @@ class CASAddressingEngine(Backend):
                 path=content_hash,
             ) from e
 
+    def release_content(self, content_id: str) -> None:
+        """Decrement ref_count without physical delete (GC does that later).
+
+        Used by OBSERVE-phase observers to release content references
+        on write-overwrite or file delete.  Physical cleanup of blobs
+        with ref_count=0 is handled by CASGarbageCollector (PR #1320).
+
+        Safe to call with a nonexistent content_id (no-op).
+        """
+        content_hash = content_id
+
+        # Feature DI: CDC chunked content
+        if self._cdc is not None and self._cdc.is_chunked(content_hash):
+            self._cdc.release_chunked(content_hash)
+            return
+
+        key = self._blob_key(content_hash)
+        if not self._transport.blob_exists(key):
+            return  # Already gone — idempotent
+
+        def _dec_ref(meta: dict[str, Any]) -> dict[str, Any]:
+            meta["ref_count"] = max(meta.get("ref_count", 1) - 1, 0)
+            return meta
+
+        self._meta_update_locked(content_hash, _dec_ref)
+
     def content_exists(self, content_id: str, context: "OperationContext | None" = None) -> bool:
         content_hash = content_id  # CAS: content_id is a SHA-256 hash
         try:

--- a/src/nexus/backends/engines/cdc.py
+++ b/src/nexus/backends/engines/cdc.py
@@ -98,6 +98,10 @@ class ChunkingStrategy(Protocol):
         """Delete chunked content, handling chunk reference counts."""
         ...
 
+    def release_chunked(self, content_hash: str) -> None:
+        """Decrement ref_count for manifest + cascade to chunks (no physical delete)."""
+        ...
+
     def write_chunked_partial(
         self,
         old_manifest_hash: str,
@@ -564,6 +568,42 @@ class CDCEngine:
     def get_size(self, content_hash: str) -> int:
         """Get original file size from manifest metadata."""
         return int(self._backend._read_meta(content_hash).get("size", 0))
+
+    # === Release (ref_count-- only, no physical delete) ===
+
+    def release_chunked(self, content_hash: str) -> None:
+        """Decrement ref_count for manifest; cascade to chunks if manifest reaches 0.
+
+        Unlike ``delete_chunked``, this never physically removes blobs.
+        Physical cleanup is deferred to CASGarbageCollector (PR #1320).
+        """
+        b = self._backend
+
+        def _dec_ref(meta: dict[str, Any]) -> dict[str, Any]:
+            meta["ref_count"] = max(meta.get("ref_count", 1) - 1, 0)
+            return meta
+
+        updated = b._meta_update_locked(content_hash, _dec_ref)
+
+        if updated.get("ref_count", 0) > 0:
+            return
+
+        # Manifest reached 0 — cascade ref_count-- to all chunks
+        key = b._blob_key(content_hash)
+        try:
+            manifest_data, _ = b._transport.get_blob(key)
+        except Exception:
+            logger.warning("release_chunked: manifest blob missing for %s", content_hash[:16])
+            return
+        manifest = ChunkedReference.from_json(manifest_data)
+
+        with ThreadPoolExecutor(max_workers=self.workers) as executor:
+            futures = [
+                executor.submit(b._meta_update_locked, ci.chunk_hash, _dec_ref)
+                for ci in manifest.chunks
+            ]
+            for future in as_completed(futures):
+                future.result()  # propagate exceptions
 
     # === Delete ===
 


### PR DESCRIPTION
## Summary
- Add `CASAddressingEngine.release_content(content_id)`: ref_count-- via `_meta_update_locked`, no physical delete
- Add `CDCEngine.release_chunked(content_hash)`: manifest ref_count--, cascade to chunks if manifest reaches 0
- Add `release_chunked()` to `ChunkingStrategy` protocol
- Idempotent: no-op if content doesn't exist

## Context
Part of CAS async GC chain (#1320). Unlike `delete_content()` which immediately deletes at ref_count=0, `release_content()` only decrements — physical delete is deferred to CASGarbageCollector (PR 5).

## Test plan
- [x] All 1077 backend tests pass
- [x] ruff + mypy clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)