### PR TITLE
feat(#1320): CASRefCountObserver + release_content + hook_spec

### DIFF
--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -71,6 +71,7 @@ def _validate_hash(content_hash: str) -> None:
 
 if TYPE_CHECKING:
     from nexus.backends.engines.cdc import ChunkingStrategy
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
@@ -440,6 +441,32 @@ class CASAddressingEngine(Backend):
                 path=content_hash,
             ) from e
 
+    def release_content(self, content_id: str) -> None:
+        """Decrement ref_count without physical delete (GC does that later).
+
+        Used by OBSERVE-phase observers to release content references
+        on write-overwrite or file delete.  Physical cleanup of blobs
+        with ref_count=0 is handled by CASGarbageCollector (PR #1320).
+
+        Safe to call with a nonexistent content_id (no-op).
+        """
+        content_hash = content_id
+
+        # Feature DI: CDC chunked content
+        if self._cdc is not None and self._cdc.is_chunked(content_hash):
+            self._cdc.release_chunked(content_hash)
+            return
+
+        key = self._blob_key(content_hash)
+        if not self._transport.blob_exists(key):
+            return  # Already gone — idempotent
+
+        def _dec_ref(meta: dict[str, Any]) -> dict[str, Any]:
+            meta["ref_count"] = max(meta.get("ref_count", 1) - 1, 0)
+            return meta
+
+        self._meta_update_locked(content_hash, _dec_ref)
+
     def content_exists(self, content_id: str, context: "OperationContext | None" = None) -> bool:
         content_hash = content_id  # CAS: content_id is a SHA-256 hash
         try:
@@ -507,6 +534,17 @@ class CASAddressingEngine(Backend):
 
         meta = self._read_meta(content_id)
         return int(meta.get("ref_count", 0))
+
+    def hook_spec(self) -> "HookSpec":
+        """Declare OBSERVE observer for CAS ref_count management.
+
+        Called by the factory/orchestrator at mount time to register
+        CASRefCountObserver with KernelDispatch.
+        """
+        from nexus.backends.observers.cas_ref_count_observer import CASRefCountObserver
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(observers=(CASRefCountObserver(self),))
 
     def stream_content(
         self,

--- a/src/nexus/backends/engines/cdc.py
+++ b/src/nexus/backends/engines/cdc.py
@@ -98,6 +98,10 @@ class ChunkingStrategy(Protocol):
         """Delete chunked content, handling chunk reference counts."""
         ...
 
+    def release_chunked(self, content_hash: str) -> None:
+        """Decrement ref_count for manifest + cascade to chunks (no physical delete)."""
+        ...
+
     def write_chunked_partial(
         self,
         old_manifest_hash: str,
@@ -564,6 +568,42 @@ class CDCEngine:
     def get_size(self, content_hash: str) -> int:
         """Get original file size from manifest metadata."""
         return int(self._backend._read_meta(content_hash).get("size", 0))
+
+    # === Release (ref_count-- only, no physical delete) ===
+
+    def release_chunked(self, content_hash: str) -> None:
+        """Decrement ref_count for manifest; cascade to chunks if manifest reaches 0.
+
+        Unlike ``delete_chunked``, this never physically removes blobs.
+        Physical cleanup is deferred to CASGarbageCollector (PR #1320).
+        """
+        b = self._backend
+
+        def _dec_ref(meta: dict[str, Any]) -> dict[str, Any]:
+            meta["ref_count"] = max(meta.get("ref_count", 1) - 1, 0)
+            return meta
+
+        updated = b._meta_update_locked(content_hash, _dec_ref)
+
+        if updated.get("ref_count", 0) > 0:
+            return
+
+        # Manifest reached 0 — cascade ref_count-- to all chunks
+        key = b._blob_key(content_hash)
+        try:
+            manifest_data, _ = b._transport.get_blob(key)
+        except Exception:
+            logger.warning("release_chunked: manifest blob missing for %s", content_hash[:16])
+            return
+        manifest = ChunkedReference.from_json(manifest_data)
+
+        with ThreadPoolExecutor(max_workers=self.workers) as executor:
+            futures = [
+                executor.submit(b._meta_update_locked, ci.chunk_hash, _dec_ref)
+                for ci in manifest.chunks
+            ]
+            for future in as_completed(futures):
+                future.result()  # propagate exceptions
 
     # === Delete ===
 

--- a/src/nexus/backends/observers/cas_ref_count_observer.py
+++ b/src/nexus/backends/observers/cas_ref_count_observer.py
@@ -1,0 +1,60 @@
+"""CAS ref_count observer — decrements ref_count on write-overwrite and delete.
+
+Registered in KernelDispatch OBSERVE phase via CASAddressingEngine.hook_spec().
+Calls engine.release_content() which only decrements ref_count — physical
+cleanup is deferred to CASGarbageCollector.
+
+Issue #1320: CAS async GC.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
+    from nexus.core.file_events import FileEvent
+
+logger = logging.getLogger(__name__)
+
+
+class CASRefCountObserver:
+    """OBSERVE-phase observer that decrements CAS ref_count on mutations.
+
+    - FILE_WRITE with old_etag != new etag: release old content
+    - FILE_DELETE with etag: release deleted content
+
+    Must not raise — KernelDispatch catches and logs observer exceptions.
+    """
+
+    def __init__(self, engine: CASAddressingEngine) -> None:
+        self._engine = engine
+
+    def on_mutation(self, event: FileEvent) -> None:
+        from nexus.core.file_events import FileEventType
+
+        if event.type == FileEventType.FILE_WRITE:
+            old_etag = getattr(event, "old_etag", None)
+            if old_etag and old_etag != event.etag:
+                try:
+                    self._engine.release_content(old_etag)
+                except Exception:
+                    logger.warning(
+                        "CASRefCountObserver: failed to release old_etag %s for %s",
+                        old_etag[:16],
+                        event.path,
+                        exc_info=True,
+                    )
+
+        elif event.type == FileEventType.FILE_DELETE:
+            if event.etag:
+                try:
+                    self._engine.release_content(event.etag)
+                except Exception:
+                    logger.warning(
+                        "CASRefCountObserver: failed to release etag %s for %s",
+                        event.etag[:16],
+                        event.path,
+                        exc_info=True,
+                    )


### PR DESCRIPTION
## Summary
- New `CASRefCountObserver` (VFSObserver) — decrements CAS ref_count on FILE_WRITE overwrite and FILE_DELETE
- `CASAddressingEngine.release_content()` — ref_count-- without physical delete (GC does that)
- `CDCEngine.release_chunked()` — manifest ref_count-- with chunk cascade
- `CASAddressingEngine.hook_spec()` — declares observer for mount-time registration

## Context
Part of CAS async GC chain (#1320). This PR subsumes PR 3 content (release_content/release_chunked) since both need to land together for mypy to pass.

## Test plan
- [x] All 1077 backend tests pass
- [x] ruff + mypy clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)