### PR TITLE
feat(#1320): metadata-only unlink/rmdir + CAS GC background task

### DIFF
--- a/src/nexus/backends/engines/cas_gc.py
+++ b/src/nexus/backends/engines/cas_gc.py
@@ -1,0 +1,148 @@
+"""CAS Garbage Collector — background task for physical content cleanup.
+
+Periodically scans CAS .meta sidecars for ref_count=0 entries past a grace
+period, then deletes the corresponding blob + meta files.
+
+Each CASAddressingEngine instance owns its own GC — no shared state, no
+federation concerns (each node GCs its own local transport).
+
+Design:
+    - Grace period: uses ``released_at`` timestamp in meta sidecar
+    - Scan interval is configurable (default 60s)
+    - GC runs as an asyncio.Task, started/stopped by the engine owner
+    - Thread-safe: blob deletion is idempotent (already-deleted = no-op)
+
+Issue #1320: CAS async GC.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
+
+logger = logging.getLogger(__name__)
+
+# Defaults
+DEFAULT_GRACE_PERIOD_S = 300.0  # 5 minutes
+DEFAULT_SCAN_INTERVAL_S = 60.0  # 1 minute
+
+
+class CASGarbageCollector:
+    """Background GC for CAS blobs with ref_count=0.
+
+    Usage::
+
+        gc = CASGarbageCollector(engine)
+        gc.start()   # spawns asyncio.Task
+        ...
+        await gc.stop()  # cancels task, waits for clean exit
+    """
+
+    def __init__(
+        self,
+        engine: CASAddressingEngine,
+        *,
+        grace_period: float = DEFAULT_GRACE_PERIOD_S,
+        scan_interval: float = DEFAULT_SCAN_INTERVAL_S,
+    ) -> None:
+        self._engine = engine
+        self._grace_period = grace_period
+        self._scan_interval = scan_interval
+        self._task: asyncio.Task[None] | None = None
+        self._stopped = False
+
+    def start(self) -> None:
+        """Start GC background task in the current event loop."""
+        if self._task is not None:
+            return
+        self._stopped = False
+        self._task = asyncio.ensure_future(self._run())
+        logger.info(
+            "CAS GC started for %s (grace=%ds, interval=%ds)",
+            self._engine.name,
+            self._grace_period,
+            self._scan_interval,
+        )
+
+    async def stop(self) -> None:
+        """Stop GC background task."""
+        self._stopped = True
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+            logger.info("CAS GC stopped for %s", self._engine.name)
+
+    async def _run(self) -> None:
+        """Main GC loop — scan + collect on interval."""
+        while not self._stopped:
+            try:
+                await asyncio.sleep(self._scan_interval)
+                if self._stopped:
+                    break
+                self._collect()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.warning("CAS GC scan error for %s", self._engine.name, exc_info=True)
+
+    def _collect(self) -> None:
+        """Single GC pass — find and delete ref_count=0 blobs past grace period.
+
+        Grace period is checked via ``released_at`` timestamp in the meta
+        sidecar. If ``released_at`` is missing (legacy), the blob is treated
+        as immediately eligible.
+        """
+        engine = self._engine
+        transport = engine._transport
+        now = time.time()
+        collected = 0
+
+        # list_blobs returns (blob_keys, common_prefixes)
+        try:
+            blob_keys, _ = transport.list_blobs(prefix="cas/")
+        except Exception:
+            logger.debug("CAS GC: list_blobs failed for %s", engine.name, exc_info=True)
+            return
+
+        meta_keys = [k for k in blob_keys if k.endswith(".meta")]
+
+        for meta_key in meta_keys:
+            try:
+                meta_data, _ = transport.get_blob(meta_key)
+                meta = json.loads(meta_data)
+
+                if meta.get("ref_count", 1) > 0:
+                    continue
+
+                # Check grace period via released_at timestamp in meta
+                released_at = meta.get("released_at", 0.0)
+                if released_at > 0 and (now - released_at) < self._grace_period:
+                    continue
+
+                # ref_count=0 and past grace period — delete blob + meta
+                blob_key = meta_key[: -len(".meta")]
+                with contextlib.suppress(Exception):
+                    transport.delete_blob(blob_key)
+                with contextlib.suppress(Exception):
+                    transport.delete_blob(meta_key)
+
+                # Evict from meta cache
+                content_hash = blob_key.split("/")[-1]
+                if engine._meta_cache is not None:
+                    engine._meta_cache.pop(content_hash, None)
+
+                collected += 1
+            except Exception:
+                continue  # Skip broken entries, continue scanning
+
+        if collected > 0:
+            logger.info("CAS GC: collected %d blobs for %s", collected, engine.name)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -633,30 +633,8 @@ class NexusFS(  # type: ignore[misc]
             # Use batch delete for better performance (single transaction instead of N queries)
             file_paths = [file_meta.path for file_meta in files_in_dir]
 
-            # Delete content from backend for each file
-            _errors: list[str] = []
-            for file_meta in files_in_dir:
-                if file_meta.etag:
-                    try:
-                        _file_route = self.router.route(file_meta.path)
-                        if ctx:
-                            _del_ctx = _dc_replace(ctx, backend_path=_file_route.backend_path)
-                        else:
-                            _del_ctx = OperationContext(
-                                user_id="anonymous",
-                                groups=[],
-                                backend_path=_file_route.backend_path,
-                            )
-                        _file_route.backend.delete_content(file_meta.etag, context=_del_ctx)
-                    except Exception as e:
-                        if len(_errors) < 100:
-                            _errors.append(f"{file_meta.path}: {e}")
-            if _errors:
-                logger.debug(
-                    "Bulk content delete: %d error(s) (showing up to 100): %s",
-                    len(_errors),
-                    "; ".join(_errors),
-                )
+            # Issue #1320: Content cleanup deferred to CAS GC via OBSERVE
+            # observer (CASRefCountObserver). Kernel only deletes metadata.
 
             # Batch delete from metadata store
             self.metadata.delete_batch(file_paths)
@@ -3177,18 +3155,8 @@ class NexusFS(  # type: ignore[misc]
         # VFS I/O Lock: exclusive write lock around CAS delete + metadata delete.
         # Like Linux i_rwsem: held for I/O duration only, released before observers.
         with self._vfs_locked(path, "write"):
-            if meta.etag and meta.mime_type != "inode/directory":
-                # CAS file: delete from routed backend (decrements ref count)
-                # Content is only physically deleted when ref_count reaches 0
-                # Skip content deletion for directories (no CAS entry)
-                # Add backend_path to context for path-based backends
-                if context:
-                    _del_ctx = _dc_replace(context, backend_path=route.backend_path)
-                else:
-                    _del_ctx = OperationContext(
-                        user_id="anonymous", groups=[], backend_path=route.backend_path
-                    )
-                route.backend.delete_content(meta.etag, context=_del_ctx)
+            # Issue #1320: Content cleanup deferred to CAS GC via OBSERVE
+            # observer (CASRefCountObserver). Kernel only deletes metadata.
 
             # Remove from metadata
             self.metadata.delete(path)
@@ -3904,30 +3872,8 @@ class NexusFS(  # type: ignore[misc]
             raise OSError(errno.ENOTEMPTY, "Directory not empty", path)
 
         if recursive and files_in_dir:
-            # Delete content from backend for each file
-            _errors: list[str] = []
-            for file_meta in files_in_dir:
-                if file_meta.etag and file_meta.mime_type != "inode/directory":
-                    try:
-                        _file_route = self.router.route(file_meta.path)
-                        if context:
-                            _del_ctx = _dc_replace(context, backend_path=_file_route.backend_path)
-                        else:
-                            _del_ctx = OperationContext(
-                                user_id="anonymous",
-                                groups=[],
-                                backend_path=_file_route.backend_path,
-                            )
-                        _file_route.backend.delete_content(file_meta.etag, context=_del_ctx)
-                    except Exception as e:
-                        if len(_errors) < 100:
-                            _errors.append(f"{file_meta.path}: {e}")
-            if _errors:
-                logger.debug(
-                    "Bulk content delete: %d error(s) (showing up to 100): %s",
-                    len(_errors),
-                    "; ".join(_errors),
-                )
+            # Issue #1320: Content cleanup deferred to CAS GC via OBSERVE
+            # observer (CASRefCountObserver). Kernel only deletes metadata.
 
             # Batch delete from metadata store
             file_paths = [file_meta.path for file_meta in files_in_dir]


### PR DESCRIPTION
## Summary
- **sys_unlink**: remove synchronous `delete_content()` call — metadata-only delete, content cleanup via OBSERVE + GC
- **sys_rmdir** (2 sites): remove synchronous `delete_content()` loops — same pattern
- **New `CASGarbageCollector`**: background asyncio.Task that periodically scans .meta sidecars for ref_count=0 blobs past grace period and physically deletes them

## Context
Final PR in CAS async GC chain (#1320). Depends on PRs 1-4 for the full pipeline:
1. PR #3283: OBSERVE is truly non-blocking
2. PR #3284: old_etag in FileEvent
3. PR #3285: release_content() (superseded by #3286)
4. PR #3286: CASRefCountObserver + release_content + hook_spec

## GC Design
- `grace_period=300s`: prevents premature delete during concurrent reads
- `scan_interval=60s`: periodic scan of CAS .meta sidecars
- Each engine instance owns its own GC (federation-safe via BackendAddress.origins)
- Uses `released_at` timestamp in meta sidecar for grace period tracking

## Test plan
- [x] All existing tests pass (backend + kernel dispatch)
- [x] ruff + mypy clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)