### PR TITLE
feat(#1320): wire CASRefCountObserver at boot + released_at + unit tests

### DIFF
--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -461,8 +461,12 @@ class CASAddressingEngine(Backend):
         if not self._transport.blob_exists(key):
             return  # Already gone — idempotent
 
+        import time as _time
+
         def _dec_ref(meta: dict[str, Any]) -> dict[str, Any]:
             meta["ref_count"] = max(meta.get("ref_count", 1) - 1, 0)
+            if meta["ref_count"] == 0:
+                meta["released_at"] = _time.time()
             return meta
 
         self._meta_update_locked(content_hash, _dec_ref)

--- a/src/nexus/backends/engines/cas_gc.py
+++ b/src/nexus/backends/engines/cas_gc.py
@@ -108,7 +108,7 @@ class CASGarbageCollector:
 
         # list_blobs returns (blob_keys, common_prefixes)
         try:
-            blob_keys, _ = transport.list_blobs(prefix="cas/")
+            blob_keys, _ = transport.list_blobs(prefix="cas/", delimiter="")
         except Exception:
             logger.debug("CAS GC: list_blobs failed for %s", engine.name, exc_info=True)
             return

--- a/src/nexus/backends/engines/cdc.py
+++ b/src/nexus/backends/engines/cdc.py
@@ -581,6 +581,8 @@ class CDCEngine:
 
         def _dec_ref(meta: dict[str, Any]) -> dict[str, Any]:
             meta["ref_count"] = max(meta.get("ref_count", 1) - 1, 0)
+            if meta["ref_count"] == 0:
+                meta["released_at"] = time.time()
             return meta
 
         updated = b._meta_update_locked(content_hash, _dec_ref)

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -330,6 +330,14 @@ async def _do_initialize(
     # _build_retroactive_hook_specs() has been deleted — hooks self-describe.
     from nexus.factory.orchestrator import _register_vfs_hooks
 
+    # Get root backend for hook_spec registration (Issue #1320: CAS ref_count observer)
+    _root_backend = None
+    try:
+        _root_route = nx.router.route("/")
+        _root_backend = _root_route.backend
+    except Exception:
+        pass
+
     await _register_vfs_hooks(
         nx,
         system_services=system_services,
@@ -337,6 +345,7 @@ async def _do_initialize(
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
         brick_on=brick_on,
         parse_fn=parse_fn,
+        backend=_root_backend,
     )
 
     # --- BLM registration for late bricks (Issue #1704, #2991) ---

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -404,6 +404,7 @@ async def _register_vfs_hooks(
     auto_parse: bool = True,
     brick_on: "Callable[[str], bool] | None" = None,
     parse_fn: Any = None,
+    backend: Any = None,
 ) -> None:
     """Register hooks + observers via coordinator.enlist() (Issue #900, #1709).
 
@@ -641,6 +642,13 @@ async def _register_vfs_hooks(
     _rev_notifier = RevisionNotifier()
     _rev_observer = RevisionTrackingObserver(revision_notifier=_rev_notifier)
     await _enlist("revision_tracking", _rev_observer)
+
+    # ── CAS ref_count observer (Issue #1320) ────────────────────────
+    # Backend declares its own OBSERVE observer via hook_spec().
+    # CASAddressingEngine.hook_spec() returns CASRefCountObserver which
+    # decrements ref_count on write-overwrite and delete events.
+    if backend is not None and hasattr(backend, "hook_spec"):
+        await _enlist("cas_ref_count_observer", backend)
 
     # ── Test hooks (Issue #2) ────────────────────────────────────────
     # Only registered when NEXUS_TEST_HOOKS=true for E2E hook testing.

--- a/tests/unit/backends/test_cas_gc.py
+++ b/tests/unit/backends/test_cas_gc.py
@@ -1,0 +1,85 @@
+"""Unit tests for CASGarbageCollector (Issue #1320).
+
+Verifies that GC correctly:
+- Deletes ref_count=0 blobs past grace period
+- Skips ref_count>0 blobs
+- Skips ref_count=0 blobs within grace period
+"""
+
+from __future__ import annotations
+
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus import CASLocalBackend
+from nexus.backends.engines.cas_gc import CASGarbageCollector
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def engine(temp_dir: Path) -> CASLocalBackend:
+    return CASLocalBackend(str(temp_dir / "data"))
+
+
+class TestGCCollect:
+    def test_gc_deletes_zero_ref_past_grace(self, engine: CASLocalBackend) -> None:
+        """ref_count=0 + released_at past grace → blob deleted."""
+        result = engine.write_content(b"garbage")
+        content_id = result.content_id
+        assert engine.content_exists(content_id)
+
+        # Simulate release + expired grace period
+        engine.release_content(content_id)
+        meta = engine._read_meta(content_id)
+        meta["released_at"] = time.time() - 600  # 10 min ago
+        engine._write_meta(content_id, meta)
+
+        gc = CASGarbageCollector(engine, grace_period=300, scan_interval=1)
+        gc._collect()
+
+        assert not engine.content_exists(content_id)
+
+    def test_gc_skips_nonzero_ref(self, engine: CASLocalBackend) -> None:
+        """ref_count>0 → blob NOT deleted."""
+        result = engine.write_content(b"still in use")
+        content_id = result.content_id
+
+        gc = CASGarbageCollector(engine, grace_period=0, scan_interval=1)
+        gc._collect()
+
+        assert engine.content_exists(content_id)
+        assert engine.get_ref_count(content_id) == 1
+
+    def test_gc_skips_within_grace_period(self, engine: CASLocalBackend) -> None:
+        """ref_count=0 but released_at within grace → blob NOT deleted yet."""
+        result = engine.write_content(b"recently released")
+        content_id = result.content_id
+
+        engine.release_content(content_id)
+        # released_at is fresh (just set by release_content)
+
+        gc = CASGarbageCollector(engine, grace_period=300, scan_interval=1)
+        gc._collect()
+
+        # Should still exist — within grace period
+        assert engine.content_exists(content_id)
+
+    def test_gc_zero_grace_deletes_immediately(self, engine: CASLocalBackend) -> None:
+        """grace_period=0 → delete immediately after release."""
+        result = engine.write_content(b"ephemeral")
+        content_id = result.content_id
+
+        engine.release_content(content_id)
+
+        gc = CASGarbageCollector(engine, grace_period=0, scan_interval=1)
+        gc._collect()
+
+        assert not engine.content_exists(content_id)

--- a/tests/unit/backends/test_cas_ref_count_observer.py
+++ b/tests/unit/backends/test_cas_ref_count_observer.py
@@ -1,0 +1,111 @@
+"""Unit tests for CASRefCountObserver (Issue #1320).
+
+Verifies that the observer correctly calls release_content() on:
+- FILE_WRITE with old_etag != new etag (overwrite)
+- FILE_DELETE with etag (deletion)
+- Skips when old_etag == new etag (same content rewrite)
+- Skips when old_etag is None (new file creation)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.backends.observers.cas_ref_count_observer import CASRefCountObserver
+from nexus.core.file_events import FileEvent, FileEventType
+
+
+@pytest.fixture
+def engine() -> MagicMock:
+    mock = MagicMock()
+    mock.release_content = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def observer(engine: MagicMock) -> CASRefCountObserver:
+    return CASRefCountObserver(engine)
+
+
+class TestWriteOverwrite:
+    def test_overwrite_releases_old_etag(
+        self, observer: CASRefCountObserver, engine: MagicMock
+    ) -> None:
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/file.txt",
+            etag="new_hash",
+            old_etag="old_hash",
+        )
+        observer.on_mutation(event)
+        engine.release_content.assert_called_once_with("old_hash")
+
+    def test_same_etag_no_release(self, observer: CASRefCountObserver, engine: MagicMock) -> None:
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/file.txt",
+            etag="same_hash",
+            old_etag="same_hash",
+        )
+        observer.on_mutation(event)
+        engine.release_content.assert_not_called()
+
+    def test_new_file_no_release(self, observer: CASRefCountObserver, engine: MagicMock) -> None:
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/file.txt",
+            etag="new_hash",
+            old_etag=None,
+            is_new=True,
+        )
+        observer.on_mutation(event)
+        engine.release_content.assert_not_called()
+
+
+class TestDelete:
+    def test_delete_releases_etag(self, observer: CASRefCountObserver, engine: MagicMock) -> None:
+        event = FileEvent(
+            type=FileEventType.FILE_DELETE,
+            path="/file.txt",
+            etag="deleted_hash",
+        )
+        observer.on_mutation(event)
+        engine.release_content.assert_called_once_with("deleted_hash")
+
+    def test_delete_no_etag_no_release(
+        self, observer: CASRefCountObserver, engine: MagicMock
+    ) -> None:
+        event = FileEvent(
+            type=FileEventType.FILE_DELETE,
+            path="/dir",
+            etag=None,
+        )
+        observer.on_mutation(event)
+        engine.release_content.assert_not_called()
+
+
+class TestFaultIsolation:
+    def test_release_exception_does_not_propagate(
+        self, observer: CASRefCountObserver, engine: MagicMock
+    ) -> None:
+        engine.release_content.side_effect = RuntimeError("backend down")
+        event = FileEvent(
+            type=FileEventType.FILE_DELETE,
+            path="/file.txt",
+            etag="hash123",
+        )
+        # Should not raise — observer catches and logs
+        observer.on_mutation(event)
+
+    def test_unrelated_event_ignored(
+        self, observer: CASRefCountObserver, engine: MagicMock
+    ) -> None:
+        event = FileEvent(
+            type=FileEventType.FILE_RENAME,
+            path="/old.txt",
+            new_path="/new.txt",
+        )
+        observer.on_mutation(event)
+        engine.release_content.assert_not_called()

--- a/tests/unit/backends/test_cas_release_content.py
+++ b/tests/unit/backends/test_cas_release_content.py
@@ -1,0 +1,72 @@
+"""Unit tests for CASAddressingEngine.release_content() (Issue #1320).
+
+Verifies ref_count decrement without physical delete, and released_at timestamp.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from nexus import CASLocalBackend
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def engine(temp_dir: Path) -> CASLocalBackend:
+    return CASLocalBackend(str(temp_dir / "data"))
+
+
+class TestReleaseContent:
+    def test_release_decrements_ref_count(self, engine: CASLocalBackend) -> None:
+        result = engine.write_content(b"hello world")
+        content_id = result.content_id
+        assert engine.get_ref_count(content_id) == 1
+
+        engine.release_content(content_id)
+        # ref_count should be 0 but blob still exists (GC hasn't run)
+        meta = engine._read_meta(content_id)
+        assert meta["ref_count"] == 0
+        assert engine.content_exists(content_id)
+
+    def test_release_sets_released_at(self, engine: CASLocalBackend) -> None:
+        result = engine.write_content(b"timestamp test")
+        content_id = result.content_id
+
+        engine.release_content(content_id)
+        meta = engine._read_meta(content_id)
+        assert "released_at" in meta
+        assert meta["released_at"] > 0
+
+    def test_release_idempotent_on_missing(self, engine: CASLocalBackend) -> None:
+        # Should not raise on nonexistent content
+        engine.release_content("0000000000000000000000000000000000000000000000000000000000000000")
+
+    def test_release_does_not_go_negative(self, engine: CASLocalBackend) -> None:
+        result = engine.write_content(b"once")
+        content_id = result.content_id
+
+        engine.release_content(content_id)
+        engine.release_content(content_id)  # second release
+        meta = engine._read_meta(content_id)
+        assert meta["ref_count"] == 0  # not -1
+
+    def test_dedup_release_keeps_other_refs(self, engine: CASLocalBackend) -> None:
+        """Two writes of same content → ref_count=2. Release once → ref_count=1."""
+        r1 = engine.write_content(b"shared content")
+        r2 = engine.write_content(b"shared content")
+        assert r1.content_id == r2.content_id
+        assert engine.get_ref_count(r1.content_id) == 2
+
+        engine.release_content(r1.content_id)
+        assert engine.get_ref_count(r1.content_id) == 1
+        # Content still readable
+        data = engine.read_content(r1.content_id)
+        assert data == b"shared content"


### PR DESCRIPTION
## Summary
Closes the 3 remaining gaps from the CAS async GC plan (#1320):

1. **Factory wiring** — `CASRefCountObserver` is now registered with KernelDispatch at boot via `_register_vfs_hooks(backend=...)`. Without this, the observer existed but was never active.

2. **`released_at` timestamp** — `release_content()` and `release_chunked()` now set `meta["released_at"]` when ref_count reaches 0, enabling GC grace period checks.

3. **16 unit tests**:
   - `test_cas_ref_count_observer.py` — overwrite releases old_etag, delete releases etag, same-etag skip, new-file skip, fault isolation, unrelated event skip
   - `test_cas_release_content.py` — ref_count decrement, released_at set, idempotent on missing, no negative, dedup keeps other refs
   - `test_cas_gc.py` — delete past grace, skip nonzero, skip within grace, zero-grace immediate delete

Also fixes `cas_gc.py` `list_blobs` to use `delimiter=""` for recursive scan.

## Test plan
- [x] All 16 new tests pass
- [x] All existing backend tests pass
- [x] ruff + mypy + ruff-format clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)