### PR TITLE
feat(#1811): DriverLifecycleCoordinator + mount/unmount KernelDispatch hooks + fix CAS wiring

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -394,6 +394,7 @@ with them indirectly through syscalls. See §2.2 matrix for per-syscall usage.
 | **PathValidator** | `core.nexus_fs` (to extract) | `fs/namei.c` path validation | Path format validation on every syscall entry. Rejects malformed paths before routing or HAL access |
 | **DistributedLockManager** | `core.nexus_fs` (sentinel) | `fs/locks.c` | Factory-injected sentinel (`_distributed_lock_manager`). Advisory locks via `AdvisoryLockManager` (`SemaphoreAdvisoryLockManager` standalone, `RaftLockManager` federation). Always available after factory boot |
 | **ServiceLifecycleCoordinator** | `system_services.lifecycle` | `init/main.c` + `module.c` | Kernel-owned bridge: ServiceRegistry + BrickLifecycleManager. Manages enlist/swap/shutdown for all 4 service quadrants |
+| **DriverLifecycleCoordinator** | `core.driver_lifecycle_coordinator` | `register_filesystem` + `kern_mount` | Manages driver mount lifecycle: routing table + VFS hook registration + mount/unmount KernelDispatch notification. Orthogonal to ServiceLifecycleCoordinator (drivers vs services) |
 | **AgentRegistry** | `core.agent_registry` | `task_struct` list | In-memory agent process table. Kernel-owned, created at `__init__`. Details in §4.5 |
 | **FileEvent** | `core.file_events` | `fsnotify_event` | Immutable mutation records. Details in §4.3 |
 

--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -545,15 +545,25 @@ class CASAddressingEngine(Backend):
         return int(meta.get("ref_count", 0))
 
     def hook_spec(self) -> "HookSpec":
-        """Declare OBSERVE observer for CAS ref_count management.
+        """Declare VFS hooks for CAS lifecycle.
 
-        Called by the factory/orchestrator at mount time to register
-        CASRefCountObserver with KernelDispatch.
+        - OBSERVE: CASRefCountObserver — decrements ref_count on overwrite/delete
+        - MOUNT: on_mount — mount-time logging
+
+        Called by DriverLifecycleCoordinator at mount time to register
+        hooks with KernelDispatch (Issue #1811, #1320).
         """
         from nexus.backends.observers.cas_ref_count_observer import CASRefCountObserver
         from nexus.contracts.protocols.service_hooks import HookSpec
 
-        return HookSpec(observers=(CASRefCountObserver(self),))
+        return HookSpec(
+            observers=(CASRefCountObserver(self),),
+            mount_hooks=(self,),
+        )
+
+    def on_mount(self, ctx: Any) -> None:
+        """VFSMountHook: receive mount notification from KernelDispatch."""
+        logger.info("CAS engine mounted at %s (backend=%s)", ctx.mount_point, self._backend_name)
 
     def stream_content(
         self,

--- a/src/nexus/contracts/protocols/service_hooks.py
+++ b/src/nexus/contracts/protocols/service_hooks.py
@@ -37,6 +37,8 @@ class HookSpec:
     rmdir_hooks: tuple[Any, ...] = ()
     observers: tuple[Any, ...] = ()
     resolvers: tuple[Any, ...] = ()
+    mount_hooks: tuple[Any, ...] = ()
+    unmount_hooks: tuple[Any, ...] = ()
 
     @property
     def is_empty(self) -> bool:
@@ -52,6 +54,8 @@ class HookSpec:
                 self.rmdir_hooks,
                 self.observers,
                 self.resolvers,
+                self.mount_hooks,
+                self.unmount_hooks,
             )
         )
 
@@ -68,4 +72,6 @@ class HookSpec:
             + len(self.rmdir_hooks)
             + len(self.observers)
             + len(self.resolvers)
+            + len(self.mount_hooks)
+            + len(self.unmount_hooks)
         )

--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -265,3 +265,47 @@ class VFSPathResolver(Protocol):
     def try_read(self, path: str, *, context: Any = None) -> bytes | None: ...
     def try_write(self, path: str, content: bytes) -> dict[str, Any] | None: ...
     def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None: ...
+
+
+# ---------------------------------------------------------------------------
+# MOUNT/UNMOUNT hooks — driver lifecycle notifications (Issue #1811)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MountHookContext:
+    """Context passed to mount hooks when a backend is mounted."""
+
+    mount_point: str
+    backend: Any  # ObjectStoreABC
+
+
+@dataclass
+class UnmountHookContext:
+    """Context passed to unmount hooks when a backend is unmounted."""
+
+    mount_point: str
+    backend: Any  # ObjectStoreABC
+
+
+@runtime_checkable
+class VFSMountHook(Protocol):
+    """Hook that runs when a backend is mounted (Issue #1811).
+
+    Linux analogue: ``file_system_type.mount()``.
+    Fire-and-forget — failures are caught and logged by KernelDispatch.
+    Dispatched by DriverLifecycleCoordinator via KernelDispatch.
+    """
+
+    def on_mount(self, ctx: MountHookContext) -> None: ...
+
+
+@runtime_checkable
+class VFSUnmountHook(Protocol):
+    """Hook that runs when a backend is unmounted (Issue #1811).
+
+    Linux analogue: ``kill_sb()``.
+    Fire-and-forget — failures are caught and logged by KernelDispatch.
+    """
+
+    def on_unmount(self, ctx: UnmountHookContext) -> None: ...

--- a/src/nexus/core/driver_lifecycle_coordinator.py
+++ b/src/nexus/core/driver_lifecycle_coordinator.py
@@ -1,0 +1,206 @@
+"""DriverLifecycleCoordinator — kernel primitive for driver mount lifecycle.
+
+Linux analogue: ``register_filesystem()`` + ``kern_mount()`` + ``kill_sb()``.
+Orthogonal to ``ServiceLifecycleCoordinator`` (services vs drivers).
+
+Services have singleton cardinality and are boot-triggered.
+Drivers have N-per-type cardinality and are mount-triggered.
+
+Responsibilities:
+    1. Add/remove backend in PathRouter (routing table)
+    2. Register/unregister backend's hook_spec with KernelDispatch
+    3. Broadcast mount/unmount events via KernelDispatch hooks
+
+Boot timing:
+    create_nexus_fs()  → router.add_mount("/", backend)   # before KernelDispatch
+    NexusFS.__init__() → creates _dispatch
+    _do_link()         → creates DriverLifecycleCoordinator
+                       → adopt_existing_mount("/")          # retroactive hook_spec
+
+Issue #1811, #1320.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.protocols.service_hooks import HookSpec
+
+if TYPE_CHECKING:
+    from nexus.core.kernel_dispatch import KernelDispatch
+    from nexus.core.router import PathRouter
+
+logger = logging.getLogger(__name__)
+
+
+class DriverLifecycleCoordinator:
+    """Kernel primitive: driver mount lifecycle.
+
+    Manages driver mount lifecycle: routing table + VFS hook registration
+    + mount/unmount notification via KernelDispatch.
+
+    Parallel to ServiceLifecycleCoordinator (services vs drivers).
+    """
+
+    __slots__ = ("_router", "_dispatch", "_mount_specs")
+
+    def __init__(self, router: "PathRouter", dispatch: "KernelDispatch") -> None:
+        self._router = router
+        self._dispatch = dispatch
+        self._mount_specs: dict[str, HookSpec] = {}
+
+    def mount(
+        self,
+        mount_point: str,
+        backend: Any,
+        *,
+        readonly: bool = False,
+        admin_only: bool = False,
+        io_profile: str = "balanced",
+    ) -> None:
+        """Mount a backend with full lifecycle: routing + hooks + notification.
+
+        1. Add to routing table (PathRouter)
+        2. Register VFS hooks from hook_spec (fixes CAS wiring bug #1320)
+        3. Broadcast mount event via KernelDispatch
+        """
+        # 1. Add to routing table
+        self._router.add_mount(
+            mount_point,
+            backend,
+            readonly=readonly,
+            admin_only=admin_only,
+            io_profile=io_profile,
+        )
+
+        # 2. Register hook_spec
+        self._register_backend_hooks(mount_point, backend)
+
+        # 3. Broadcast mount event
+        self._dispatch.notify_mount(mount_point, backend)
+
+    def adopt_existing_mount(self, mount_point: str) -> None:
+        """Adopt a backend already in the routing table.
+
+        For mounts that predate coordinator creation (root mount in
+        create_nexus_fs).  Registers hook_spec VFS hooks and broadcasts
+        mount notification.
+        """
+        info = self._router.get_mount(mount_point)
+        if info is None:
+            logger.debug("[DRIVER] adopt_existing_mount(%s): not found", mount_point)
+            return
+
+        backend = info.backend
+
+        # Register hook_spec
+        self._register_backend_hooks(mount_point, backend)
+
+        # Broadcast mount event
+        self._dispatch.notify_mount(mount_point, backend)
+
+        logger.debug(
+            "[DRIVER] adopted existing mount %s (backend=%s)",
+            mount_point,
+            getattr(backend, "name", "?"),
+        )
+
+    def unmount(self, mount_point: str) -> bool:
+        """Unmount with full lifecycle: unhook + notify + remove.
+
+        Returns True if mount was removed, False if not found.
+        """
+        info = self._router.get_mount(mount_point)
+        if info is None:
+            return False
+
+        backend = info.backend
+
+        # 1. Unregister VFS hooks
+        spec = self._mount_specs.pop(mount_point, None)
+        if spec is not None:
+            self._unregister_hooks_for_spec(spec)
+
+        # 2. Broadcast unmount event (best-effort)
+        try:
+            self._dispatch.notify_unmount(mount_point, backend)
+        except Exception as exc:
+            logger.warning("[DRIVER] on_unmount notification failed for %s: %s", mount_point, exc)
+
+        # 3. Remove from routing table
+        self._router.remove_mount(mount_point)
+        return True
+
+    # ------------------------------------------------------------------
+    # Internal hook registration (mirrors ServiceLifecycleCoordinator)
+    # ------------------------------------------------------------------
+
+    def _register_backend_hooks(self, mount_point: str, backend: Any) -> None:
+        """Extract and register hook_spec from backend."""
+        if not hasattr(backend, "hook_spec"):
+            return
+
+        spec: HookSpec = backend.hook_spec()
+        if spec is None or spec.is_empty:
+            return
+
+        self._mount_specs[mount_point] = spec
+        self._register_hooks_for_spec(spec)
+        logger.debug(
+            "[DRIVER] registered %d hooks for mount %s",
+            spec.total_hooks,
+            mount_point,
+        )
+
+    def _register_hooks_for_spec(self, spec: HookSpec) -> None:
+        """Register all hooks from a HookSpec into KernelDispatch."""
+        d = self._dispatch
+        for h in spec.resolvers:
+            d.register_resolver(h)
+        for h in spec.read_hooks:
+            d.register_intercept_read(h)
+        for h in spec.write_hooks:
+            d.register_intercept_write(h)
+        for h in spec.write_batch_hooks:
+            d.register_intercept_write_batch(h)
+        for h in spec.delete_hooks:
+            d.register_intercept_delete(h)
+        for h in spec.rename_hooks:
+            d.register_intercept_rename(h)
+        for h in spec.mkdir_hooks:
+            d.register_intercept_mkdir(h)
+        for h in spec.rmdir_hooks:
+            d.register_intercept_rmdir(h)
+        for h in spec.observers:
+            d.register_observe(h)
+        for h in spec.mount_hooks:
+            d.register_mount_hook(h)
+        for h in spec.unmount_hooks:
+            d.register_unmount_hook(h)
+
+    def _unregister_hooks_for_spec(self, spec: HookSpec) -> None:
+        """Unregister all hooks from a HookSpec from KernelDispatch."""
+        d = self._dispatch
+        for h in spec.resolvers:
+            d.unregister_resolver(h)
+        for h in spec.read_hooks:
+            d.unregister_intercept_read(h)
+        for h in spec.write_hooks:
+            d.unregister_intercept_write(h)
+        for h in spec.write_batch_hooks:
+            d.unregister_intercept_write_batch(h)
+        for h in spec.delete_hooks:
+            d.unregister_intercept_delete(h)
+        for h in spec.rename_hooks:
+            d.unregister_intercept_rename(h)
+        for h in spec.mkdir_hooks:
+            d.unregister_intercept_mkdir(h)
+        for h in spec.rmdir_hooks:
+            d.unregister_intercept_rmdir(h)
+        for h in spec.observers:
+            d.unregister_observe(h)
+        for h in spec.mount_hooks:
+            d.unregister_mount_hook(h)
+        for h in spec.unmount_hooks:
+            d.unregister_unmount_hook(h)

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -55,15 +55,19 @@ except ImportError:  # pragma: no cover — Rust extension not built
 from nexus.contracts.vfs_hooks import (
     DeleteHookContext,
     MkdirHookContext,
+    MountHookContext,
     ReadHookContext,
     RenameHookContext,
     RmdirHookContext,
+    UnmountHookContext,
     VFSDeleteHook,
     VFSMkdirHook,
+    VFSMountHook,
     VFSObserver,
     VFSReadHook,
     VFSRenameHook,
     VFSRmdirHook,
+    VFSUnmountHook,
     VFSWriteBatchHook,
     VFSWriteHook,
     WriteBatchHookContext,
@@ -141,6 +145,8 @@ class KernelDispatch:
         "_next_resolver_idx",
         "_registry",
         "_observers",
+        "_mount_hooks",
+        "_unmount_hooks",
     )
 
     def __init__(self) -> None:
@@ -157,6 +163,10 @@ class KernelDispatch:
 
         # OBSERVE: generic mutation observers
         self._observers: list[VFSObserver] = []
+
+        # MOUNT/UNMOUNT: driver lifecycle hooks (Issue #1811)
+        self._mount_hooks: list[VFSMountHook] = []
+        self._unmount_hooks: list[VFSUnmountHook] = []
 
     # ── PRE-DISPATCH: virtual path resolvers (Issue #889, #1317) ──────
 
@@ -446,6 +456,50 @@ class KernelDispatch:
             except Exception as exc:
                 logger.warning("Observer %s failed: %s", type(obs).__name__, exc)
 
+    # ── MOUNT/UNMOUNT hooks (Issue #1811) ──────────────────────────────
+
+    def register_mount_hook(self, hook: VFSMountHook) -> None:
+        self._mount_hooks.append(hook)
+
+    def register_unmount_hook(self, hook: VFSUnmountHook) -> None:
+        self._unmount_hooks.append(hook)
+
+    def unregister_mount_hook(self, hook: VFSMountHook) -> bool:
+        try:
+            self._mount_hooks.remove(hook)
+            return True
+        except ValueError:
+            return False
+
+    def unregister_unmount_hook(self, hook: VFSUnmountHook) -> bool:
+        try:
+            self._unmount_hooks.remove(hook)
+            return True
+        except ValueError:
+            return False
+
+    def notify_mount(self, mount_point: str, backend: Any) -> None:
+        """Fire-and-forget mount notification to all registered hooks."""
+        if not self._mount_hooks:
+            return
+        ctx = MountHookContext(mount_point=mount_point, backend=backend)
+        for hook in self._mount_hooks:
+            try:
+                hook.on_mount(ctx)
+            except Exception as exc:
+                logger.warning("Mount hook %s failed: %s", type(hook).__name__, exc)
+
+    def notify_unmount(self, mount_point: str, backend: Any) -> None:
+        """Fire-and-forget unmount notification to all registered hooks."""
+        if not self._unmount_hooks:
+            return
+        ctx = UnmountHookContext(mount_point=mount_point, backend=backend)
+        for hook in self._unmount_hooks:
+            try:
+                hook.on_unmount(ctx)
+            except Exception as exc:
+                logger.warning("Unmount hook %s failed: %s", type(hook).__name__, exc)
+
     # ── Hook counts ────────────────────────────────────────────────────
 
     @property
@@ -479,3 +533,11 @@ class KernelDispatch:
     @property
     def observer_count(self) -> int:
         return len(self._observers)
+
+    @property
+    def mount_hook_count(self) -> int:
+        return len(self._mount_hooks)
+
+    @property
+    def unmount_hook_count(self) -> int:
+        return len(self._unmount_hooks)

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -131,6 +131,16 @@ async def _do_link(
     nx._service_coordinator = coordinator
     await enlist_wired_services(coordinator, _wired)
 
+    # Issue #1811: Create DriverLifecycleCoordinator and adopt root mount.
+    # Root mount ("/") was added to PathRouter in create_nexus_fs() before
+    # KernelDispatch existed.  adopt_existing_mount() retroactively registers
+    # the backend's hook_spec (fixes CAS ref_count wiring bug #1320).
+    from nexus.core.driver_lifecycle_coordinator import DriverLifecycleCoordinator
+
+    driver_coordinator = DriverLifecycleCoordinator(nx.router, nx._dispatch)
+    nx._driver_coordinator = driver_coordinator
+    driver_coordinator.adopt_existing_mount("/")
+
     # Issue #1666: Register system-tier PersistentService instances.
     # These are Q3 (PersistentService) — enlist() defers start() because
     # coordinator is not yet bootstrapped (mark_bootstrapped at bootstrap).
@@ -330,14 +340,9 @@ async def _do_initialize(
     # _build_retroactive_hook_specs() has been deleted — hooks self-describe.
     from nexus.factory.orchestrator import _register_vfs_hooks
 
-    # Get root backend for hook_spec registration (Issue #1320: CAS ref_count observer)
-    _root_backend = None
-    try:
-        _root_route = nx.router.route("/")
-        _root_backend = _root_route.backend
-    except Exception:
-        pass
-
+    # Issue #1811: CAS ref_count observer is now registered via
+    # DriverLifecycleCoordinator.adopt_existing_mount() in _do_link().
+    # The `backend` parameter has been removed from _register_vfs_hooks().
     await _register_vfs_hooks(
         nx,
         system_services=system_services,
@@ -345,7 +350,6 @@ async def _do_initialize(
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
         brick_on=brick_on,
         parse_fn=parse_fn,
-        backend=_root_backend,
     )
 
     # --- BLM registration for late bricks (Issue #1704, #2991) ---

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -404,7 +404,6 @@ async def _register_vfs_hooks(
     auto_parse: bool = True,
     brick_on: "Callable[[str], bool] | None" = None,
     parse_fn: Any = None,
-    backend: Any = None,
 ) -> None:
     """Register hooks + observers via coordinator.enlist() (Issue #900, #1709).
 
@@ -643,12 +642,10 @@ async def _register_vfs_hooks(
     _rev_observer = RevisionTrackingObserver(revision_notifier=_rev_notifier)
     await _enlist("revision_tracking", _rev_observer)
 
-    # ── CAS ref_count observer (Issue #1320) ────────────────────────
-    # Backend declares its own OBSERVE observer via hook_spec().
-    # CASAddressingEngine.hook_spec() returns CASRefCountObserver which
-    # decrements ref_count on write-overwrite and delete events.
-    if backend is not None and hasattr(backend, "hook_spec"):
-        await _enlist("cas_ref_count_observer", backend)
+    # ── CAS ref_count observer (Issue #1320, #1811) ────────────────────
+    # Moved to DriverLifecycleCoordinator.adopt_existing_mount() in _do_link().
+    # The coordinator registers CASRefCountObserver via hook_spec() at mount
+    # time, fixing the silent failure where enlist() classified backends as Q1.
 
     # ── Test hooks (Issue #2) ────────────────────────────────────────
     # Only registered when NEXUS_TEST_HOOKS=true for E2E hook testing.

--- a/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
+++ b/src/nexus/system_services/lifecycle/service_lifecycle_coordinator.py
@@ -636,6 +636,10 @@ class ServiceLifecycleCoordinator:
             d.register_intercept_rmdir(h)
         for h in spec.observers:
             d.register_observe(h)
+        for h in spec.mount_hooks:
+            d.register_mount_hook(h)
+        for h in spec.unmount_hooks:
+            d.register_unmount_hook(h)
 
     def _unregister_hooks(self, name: str) -> None:
         spec = self._hook_specs.get(name)
@@ -663,3 +667,7 @@ class ServiceLifecycleCoordinator:
             d.unregister_intercept_rmdir(h)
         for h in spec.observers:
             d.unregister_observe(h)
+        for h in spec.mount_hooks:
+            d.unregister_mount_hook(h)
+        for h in spec.unmount_hooks:
+            d.unregister_unmount_hook(h)

--- a/tests/unit/core/test_driver_lifecycle_coordinator.py
+++ b/tests/unit/core/test_driver_lifecycle_coordinator.py
@@ -1,0 +1,275 @@
+"""Unit tests for DriverLifecycleCoordinator.
+
+Tests mount/unmount lifecycle: routing table + VFS hook registration
++ mount/unmount KernelDispatch notification.
+
+Issue #1811, #1320.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from nexus.contracts.protocols.service_hooks import HookSpec
+from nexus.contracts.vfs_hooks import MountHookContext, UnmountHookContext
+from nexus.core.driver_lifecycle_coordinator import DriverLifecycleCoordinator
+from nexus.core.kernel_dispatch import KernelDispatch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackend:
+    """Minimal backend with name, no hook_spec."""
+
+    def __init__(self, name: str = "fake") -> None:
+        self.name = name
+
+
+class _FakeObserver:
+    """Minimal VFSObserver."""
+
+    def on_mutation(self, event: object) -> None:
+        pass
+
+
+class _FakeMountHook:
+    """VFSMountHook that records calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[MountHookContext] = []
+
+    def on_mount(self, ctx: MountHookContext) -> None:
+        self.calls.append(ctx)
+
+
+class _FakeUnmountHook:
+    """VFSUnmountHook that records calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[UnmountHookContext] = []
+
+    def on_unmount(self, ctx: UnmountHookContext) -> None:
+        self.calls.append(ctx)
+
+
+class _BackendWithHookSpec:
+    """Backend that declares hook_spec with an observer and mount hook."""
+
+    def __init__(self, name: str = "cas-test") -> None:
+        self.name = name
+        self._observer = _FakeObserver()
+        self._mount_hook = _FakeMountHook()
+
+    def hook_spec(self) -> HookSpec:
+        return HookSpec(
+            observers=(self._observer,),
+            mount_hooks=(self._mount_hook,),
+        )
+
+
+def _make_coordinator() -> tuple[MagicMock, KernelDispatch, DriverLifecycleCoordinator]:
+    """Create a coordinator with a mock router and real KernelDispatch."""
+    router = MagicMock()
+    dispatch = KernelDispatch()
+    coord = DriverLifecycleCoordinator(router, dispatch)
+    return router, dispatch, coord
+
+
+# ---------------------------------------------------------------------------
+# mount()
+# ---------------------------------------------------------------------------
+
+
+class TestMount:
+    def test_mount_calls_router_add_mount(self) -> None:
+        router, _, coord = _make_coordinator()
+        backend = _FakeBackend()
+
+        coord.mount("/data", backend, readonly=True, io_profile="throughput")
+
+        router.add_mount.assert_called_once_with(
+            "/data", backend, readonly=True, admin_only=False, io_profile="throughput"
+        )
+
+    def test_mount_registers_hook_spec_observers(self) -> None:
+        _, dispatch, coord = _make_coordinator()
+        backend = _BackendWithHookSpec()
+
+        coord.mount("/data", backend)
+
+        assert dispatch.observer_count == 1
+
+    def test_mount_registers_hook_spec_mount_hooks(self) -> None:
+        _, dispatch, coord = _make_coordinator()
+        backend = _BackendWithHookSpec()
+
+        coord.mount("/data", backend)
+
+        assert dispatch.mount_hook_count == 1
+
+    def test_mount_calls_on_mount(self) -> None:
+        """Mount hooks receive notification via KernelDispatch."""
+        _, dispatch, coord = _make_coordinator()
+        backend = _BackendWithHookSpec()
+
+        coord.mount("/data", backend)
+
+        hook = backend._mount_hook
+        assert len(hook.calls) == 1
+        assert hook.calls[0].mount_point == "/data"
+        assert hook.calls[0].backend is backend
+
+    def test_mount_no_hook_spec_still_routes(self) -> None:
+        router, dispatch, coord = _make_coordinator()
+        backend = _FakeBackend()
+
+        coord.mount("/plain", backend)
+
+        router.add_mount.assert_called_once()
+        assert dispatch.observer_count == 0
+
+
+# ---------------------------------------------------------------------------
+# unmount()
+# ---------------------------------------------------------------------------
+
+
+class TestUnmount:
+    def test_unmount_unregisters_hooks(self) -> None:
+        router, dispatch, coord = _make_coordinator()
+        backend = _BackendWithHookSpec()
+
+        coord.mount("/data", backend)
+        assert dispatch.observer_count == 1
+
+        # Setup router.get_mount to return the backend
+        mount_info = MagicMock()
+        mount_info.backend = backend
+        router.get_mount.return_value = mount_info
+
+        result = coord.unmount("/data")
+        assert result is True
+        assert dispatch.observer_count == 0
+        assert dispatch.mount_hook_count == 0
+
+    def test_unmount_calls_on_unmount(self) -> None:
+        router, dispatch, coord = _make_coordinator()
+        backend = _FakeBackend()
+
+        # Register an unmount hook directly
+        unmount_hook = _FakeUnmountHook()
+        dispatch.register_unmount_hook(unmount_hook)
+
+        mount_info = MagicMock()
+        mount_info.backend = backend
+        router.get_mount.return_value = mount_info
+
+        coord.unmount("/data")
+
+        assert len(unmount_hook.calls) == 1
+        assert unmount_hook.calls[0].mount_point == "/data"
+        assert unmount_hook.calls[0].backend is backend
+
+    def test_unmount_not_found_returns_false(self) -> None:
+        router, _, coord = _make_coordinator()
+        router.get_mount.return_value = None
+
+        assert coord.unmount("/nonexistent") is False
+
+    def test_unmount_catches_notification_exception(self) -> None:
+        """on_unmount errors don't propagate (best-effort)."""
+        router, dispatch, coord = _make_coordinator()
+        backend = _FakeBackend()
+
+        class _FailingUnmountHook:
+            def on_unmount(self, ctx: UnmountHookContext) -> None:
+                raise RuntimeError("boom")
+
+        dispatch.register_unmount_hook(_FailingUnmountHook())
+
+        mount_info = MagicMock()
+        mount_info.backend = backend
+        router.get_mount.return_value = mount_info
+
+        # Should not raise
+        coord.unmount("/data")
+
+
+# ---------------------------------------------------------------------------
+# adopt_existing_mount()
+# ---------------------------------------------------------------------------
+
+
+class TestAdoptExistingMount:
+    def test_adopt_registers_hooks(self) -> None:
+        router, dispatch, coord = _make_coordinator()
+        backend = _BackendWithHookSpec()
+
+        mount_info = MagicMock()
+        mount_info.backend = backend
+        router.get_mount.return_value = mount_info
+
+        coord.adopt_existing_mount("/")
+
+        assert dispatch.observer_count == 1
+        assert dispatch.mount_hook_count == 1
+
+    def test_adopt_broadcasts_mount(self) -> None:
+        router, dispatch, coord = _make_coordinator()
+        backend = _BackendWithHookSpec()
+
+        mount_info = MagicMock()
+        mount_info.backend = backend
+        router.get_mount.return_value = mount_info
+
+        coord.adopt_existing_mount("/")
+
+        hook = backend._mount_hook
+        assert len(hook.calls) == 1
+        assert hook.calls[0].mount_point == "/"
+
+    def test_adopt_not_found_does_nothing(self) -> None:
+        router, dispatch, coord = _make_coordinator()
+        router.get_mount.return_value = None
+
+        coord.adopt_existing_mount("/missing")  # No exception
+
+    def test_adopt_plain_backend_no_hooks(self) -> None:
+        router, dispatch, coord = _make_coordinator()
+        backend = _FakeBackend()
+
+        mount_info = MagicMock()
+        mount_info.backend = backend
+        router.get_mount.return_value = mount_info
+
+        coord.adopt_existing_mount("/plain")
+        assert dispatch.observer_count == 0
+
+
+# ---------------------------------------------------------------------------
+# CAS wiring fix (#1320)
+# ---------------------------------------------------------------------------
+
+
+class TestCASWiringFix:
+    def test_cas_hook_spec_observer_registered_via_adopt(self) -> None:
+        """CASRefCountObserver is registered via adopt, not coordinator.enlist()."""
+        from nexus.backends.observers.cas_ref_count_observer import CASRefCountObserver
+
+        router, dispatch, coord = _make_coordinator()
+
+        # Create a minimal CAS-like backend with hook_spec
+        observer = CASRefCountObserver(MagicMock())
+        backend = MagicMock()
+        backend.name = "cas-local"
+        backend.hook_spec.return_value = HookSpec(observers=(observer,))
+
+        mount_info = MagicMock()
+        mount_info.backend = backend
+        router.get_mount.return_value = mount_info
+
+        coord.adopt_existing_mount("/")
+
+        assert dispatch.observer_count == 1


### PR DESCRIPTION
## Summary
- **New kernel primitive: `DriverLifecycleCoordinator`** — manages driver mount lifecycle (routing table + VFS hook registration + mount/unmount KernelDispatch notification). Orthogonal to `ServiceLifecycleCoordinator` (drivers vs services).
- **New KernelDispatch hook types: `VFSMountHook` / `VFSUnmountHook`** — fire-and-forget mount/unmount notifications, parallel to existing OBSERVE phase. Context dataclasses: `MountHookContext`, `UnmountHookContext`.
- **`HookSpec` gains `mount_hooks` / `unmount_hooks` fields** — both coordinators (Service + Driver) register/unregister them.
- **Fix CAS wiring bug (#1320):** `_enlist("cas_ref_count_observer", backend)` silently failed because `CASAddressingEngine` isn't `HotSwappable`, so `coordinator.enlist()` classified it as Q1 (register only, no hooks). Now `DriverLifecycleCoordinator.adopt_existing_mount("/")` directly registers `CASRefCountObserver` via `hook_spec()` at link time.
- **CASAddressingEngine** now implements `VFSMountHook.on_mount()` for mount-time logging, declared via `hook_spec(mount_hooks=(self,))`.

## Test plan
- [x] 14 new tests for `DriverLifecycleCoordinator` (mount, unmount, adopt, CAS wiring fix)
- [x] Existing CAS tests pass (`test_embedded_cas.py`)
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [x] KERNEL-ARCHITECTURE.md updated (§4 primitives table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)