### PR TITLE
feat(#1801): unify boot path — mount() + make_test_nexus() via create_nexus_fs()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -855,7 +855,6 @@ ignore_imports = [
     # search -> rebac: permission enforcement + entity registry in search_service (moved from services/)
     "nexus.bricks.search.search_service -> nexus.bricks.rebac.enforcer",
     "nexus.bricks.search.search_service -> nexus.bricks.rebac.manager",
-    "nexus.bricks.search.search_service -> nexus.bricks.rebac.entity_registry",
     # search -> gateway (TYPE_CHECKING): NexusFSGateway type hint — transitive to workflows/parsers
     "nexus.bricks.search.search_service -> nexus.system_services.gateway",
     # mount -> permission_utils -> gateway: transitive chain to workflows/parsers
@@ -894,8 +893,6 @@ ignore_imports = [
     # --- tier-neutral (contracts/protocols) importing bricks ---
     # chunked_upload protocol TYPE_CHECKING import for UploadSession return type
     "nexus.contracts.protocols.chunked_upload -> nexus.bricks.upload.upload_session",
-    # process_manager protocol TYPE_CHECKING import for agent process types
-    "nexus.contracts.protocols.process_manager -> nexus.system_services.agent_runtime.types",
     # --- contracts importing lib (upward — legacy, to be fixed) ---
     "nexus.contracts.agent_utils -> nexus.storage.models",
     "nexus.contracts -> nexus.lib.validators",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -888,6 +888,8 @@ layers = [
 # Ratchet baseline — known violations. Remove entries as fixes land.
 # Run: lint-imports --contract four-tier-layers to check.
 ignore_imports = [
+    # --- core importing system_services (ServiceRegistry shutdown needs BrickLifecycleManager type) ---
+    "nexus.core.service_registry -> nexus.system_services.lifecycle.brick_lifecycle",
     # --- tier-neutral (contracts) importing core ---
     "nexus.contracts.metadata -> nexus.core._compact_generated",
     # --- tier-neutral (contracts/protocols) importing bricks ---

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -259,6 +259,7 @@ async def create_nexus_fs(
     zone_id: str | None = None,
     agent_id: str | None = None,
     workflow_engine: "WorkflowProtocol | None" = None,
+    init_cred: Any = None,
 ) -> "NexusFS":
     """Create NexusFS with default services — the recommended entry point.
 
@@ -282,6 +283,7 @@ async def create_nexus_fs(
         zone_id: Default zone ID (for WorkspaceManager, embedded mode).
         agent_id: Default agent ID (for WorkspaceManager, embedded mode).
         workflow_engine: Pre-built workflow engine override.
+        init_cred: Override kernel process identity (default: system user with is_admin flag).
 
     Returns:
         Fully configured NexusFS instance with services injected.
@@ -368,7 +370,9 @@ async def create_nexus_fs(
     from nexus.contracts.types import OperationContext as _OC
     from nexus.factory._lifecycle import _do_initialize, _do_link
 
-    _init_cred = _OC(user_id="system", groups=[], is_admin=is_admin)
+    _init_cred = (
+        init_cred if init_cred is not None else _OC(user_id="system", groups=[], is_admin=is_admin)
+    )
 
     nx = NexusFS(
         metadata_store=metadata_store,

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -93,14 +93,10 @@ async def mount(*uris: str, at: str | None = None) -> Any:
         mount_points.add(mp)
         resolved_mounts.append((spec, mp))
 
-    # Create the kernel infrastructure
+    # Create metastore + backends
     import os
-
-    # SQLite metastore in a temp or user-local directory
     import tempfile
 
-    from nexus.core.nexus_fs import NexusFS
-    from nexus.core.router import PathRouter
     from nexus.fs._facade import SlimNexusFS
     from nexus.fs._sqlite_meta import SQLiteMetastore
 
@@ -111,23 +107,59 @@ async def mount(*uris: str, at: str | None = None) -> Any:
     db_path = os.path.join(state_dir, "metadata.db")
 
     metastore = SQLiteMetastore(db_path)
-    router = PathRouter(metastore)
 
-    # Mount each backend and create DT_MOUNT entries in the metastore
+    # Create all backends
+    backends = [(mp, _create_backend(spec)) for spec, mp in resolved_mounts]
+
+    # Use first backend as root for factory boot (Issue #1801: unified boot path)
+    from nexus.contracts.constants import ROOT_ZONE_ID
+    from nexus.contracts.types import OperationContext
+    from nexus.core.config import PermissionConfig
+    from nexus.factory import create_nexus_fs
+
+    _slim_cred = OperationContext(user_id="local", groups=[], zone_id=ROOT_ZONE_ID, is_admin=True)
+    _first_mp, _first_backend = backends[0]
+
+    kernel = await create_nexus_fs(
+        backend=_first_backend,
+        metadata_store=metastore,
+        permissions=PermissionConfig(enforce=False),
+        is_admin=True,
+        enabled_bricks=frozenset(),  # SLIM profile: no bricks
+        init_cred=_slim_cred,
+    )
+
+    # Mount remaining backends (factory already mounted first at "/")
     from datetime import UTC, datetime
 
-    from nexus.contracts.constants import ROOT_ZONE_ID
     from nexus.contracts.metadata import FileMetadata
-    from nexus.contracts.types import OperationContext
     from nexus.core.hash_fast import hash_content
 
     empty_hash = hash_content(b"")
     now = datetime.now(UTC)
 
-    for spec, mp in resolved_mounts:
-        backend = _create_backend(spec)
-        router.add_mount(mp, backend)
-        # Create DT_MOUNT entry so stat(mount_point) works
+    # Create DT_MOUNT entry for first backend at its derived path
+    if _first_mp != "/":
+        kernel.router.add_mount(_first_mp, _first_backend)
+    metastore.put(
+        FileMetadata(
+            path=_first_mp,
+            backend_name=_first_backend.name,
+            physical_path=empty_hash,
+            size=0,
+            etag=empty_hash,
+            mime_type="inode/directory",
+            created_at=now,
+            modified_at=now,
+            version=1,
+            zone_id=ROOT_ZONE_ID,
+            entry_type=2,  # DT_MOUNT
+        )
+    )
+
+    # Additional mounts
+    for mp, backend in backends[1:]:
+        kernel.router.add_mount(mp, backend)
         metastore.put(
             FileMetadata(
                 path=mp,
@@ -143,18 +175,6 @@ async def mount(*uris: str, at: str | None = None) -> Any:
                 entry_type=2,  # DT_MOUNT
             )
         )
-
-    # Build kernel (minimal — no factory, no bricks)
-    from nexus.core.config import BrickServices, KernelServices, PermissionConfig
-
-    ctx = OperationContext(user_id="local", groups=[], zone_id=ROOT_ZONE_ID, is_admin=True)
-    kernel = NexusFS(
-        metadata_store=metastore,
-        permissions=PermissionConfig(enforce=False),
-        kernel_services=KernelServices(router=router),
-        brick_services=BrickServices(),
-        init_cred=ctx,
-    )
 
     return SlimNexusFS(kernel)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ if _HAS_STRUCTLOG:
         structlog.contextvars.clear_contextvars()
 
 
-def make_test_nexus(
+async def make_test_nexus(
     tmp_path,
     *,
     backend=None,
@@ -103,36 +103,31 @@ def make_test_nexus(
     cache=None,
     memory=None,
     distributed=None,
-    services=None,
     is_admin=False,
     record_store=None,
     use_raft=False,
     metadata_store=None,
     context=None,
 ):
-    """Create a NexusFS instance for testing with sensible defaults.
+    """Create a NexusFS instance for testing via factory (Issue #1801).
 
-    Defaults: permissions off, no auto-parse, no distributed features.
-    Avoids heavy I/O (event bus, lock manager, workflows) for fast tests.
-
-    A default CASLocalBackend is created and mounted at ``/`` (root) unless
-    a custom ``backend`` is provided. This mirrors ``create_nexus_fs()``
-    in the factory (``router.add_mount("/", backend)``).
+    Uses ``create_nexus_fs()`` — the same boot path as production.
+    Defaults: permissions off, no auto-parse, no distributed features,
+    no bricks (MINIMAL profile).
 
     Args:
         tmp_path: pytest tmp_path fixture for backend/metadata storage.
-        backend: Backend to mount at ``/``. Default: CASLocalBackend(tmp_path / "data").
+        backend: Backend to mount at ``/``. Default: PathLocalBackend(tmp_path / "data").
         permissions: PermissionConfig override. Default: enforce=False.
         parsing: ParseConfig override. Default: auto_parse=False.
         cache: CacheConfig override.
         memory: MemoryConfig override.
         distributed: DistributedConfig override. Default: all disabled.
-        services: KernelServices override.
-        system_services: SystemServices override.
-        is_admin: Admin flag.
+        is_admin: Admin flag for init_cred.
         record_store: Optional RecordStoreABC.
         use_raft: Use RaftMetadataStore (requires Python 3.13).
         metadata_store: Override metadata store. Default: DictMetastore or Raft.
+        context: Override init_cred identity.
 
     Returns:
         NexusFS instance ready for testing.
@@ -142,7 +137,7 @@ def make_test_nexus(
         ParseConfig,
         PermissionConfig,
     )
-    from nexus.core.nexus_fs import NexusFS
+    from nexus.factory import create_nexus_fs
 
     if permissions is None:
         permissions = PermissionConfig(enforce=False)
@@ -165,32 +160,6 @@ def make_test_nexus(
 
             metadata_store = DictMetastore()
 
-    # Issue #1801: pass init_cred at construction (immutable kernel identity)
-    from tests.helpers.test_context import TEST_ADMIN_CONTEXT, TEST_CONTEXT
-
-    if context is not None:
-        _init_cred = context
-    else:
-        _init_cred = TEST_ADMIN_CONTEXT if is_admin else TEST_CONTEXT
-
-    nx = NexusFS(
-        metadata_store=metadata_store,
-        record_store=record_store,
-        permissions=permissions,
-        parsing=parsing,
-        cache=cache,
-        memory=memory,
-        distributed=distributed,
-        kernel_services=services,
-        init_cred=_init_cred,
-    )
-    # Backward compat: some tests read nx._system_services directly.
-    # Factory sets this post-construction too (orchestrator.py line 389).
-    from nexus.core.config import SystemServices as _SystemServices
-
-    nx._system_services = _SystemServices()
-
-    # Mount backend at root (same as factory/orchestrator.py: router.add_mount("/", backend))
     if backend is None:
         from pathlib import Path
 
@@ -199,34 +168,27 @@ def make_test_nexus(
         data_dir = Path(tmp_path) / "data"
         data_dir.mkdir(exist_ok=True)
         backend = PathLocalBackend(root_path=str(data_dir))
-    nx.router.add_mount("/", backend)
 
-    # Wire PermissionCheckHook via DI (same as factory/orchestrator.py, Issue #899)
-    from nexus.bricks.rebac.checker import PermissionChecker
-    from nexus.bricks.rebac.permission_hook import PermissionCheckHook
+    # Issue #1801: unified boot path — all NexusFS goes through factory
+    from tests.helpers.test_context import TEST_ADMIN_CONTEXT, TEST_CONTEXT
 
-    _checker = PermissionChecker(
-        permission_enforcer=nx._permission_enforcer,
-        metadata_store=nx.metadata,
-        default_context=nx._init_cred,
-        enforce_permissions=nx._enforce_permissions,
+    _init_cred = (
+        context if context is not None else (TEST_ADMIN_CONTEXT if is_admin else TEST_CONTEXT)
     )
-    _perm_hook = PermissionCheckHook(
-        checker=_checker,
-        metadata_store=nx.metadata,
-        default_context=nx._init_cred,
-        enforce_permissions=nx._enforce_permissions,
-        permission_enforcer=nx._permission_enforcer,
-        descendant_checker=getattr(nx, "_descendant_checker", None),
-    )
-    nx._dispatch.register_intercept_read(_perm_hook)
-    nx._dispatch.register_intercept_write(_perm_hook)
-    nx._dispatch.register_intercept_delete(_perm_hook)
-    nx._dispatch.register_intercept_rename(_perm_hook)
-    nx._dispatch.register_intercept_mkdir(_perm_hook)
-    nx._dispatch.register_intercept_rmdir(_perm_hook)
 
-    return nx
+    return await create_nexus_fs(
+        backend=backend,
+        metadata_store=metadata_store,
+        record_store=record_store,
+        permissions=permissions,
+        parsing=parsing,
+        cache=cache,
+        memory=memory,
+        distributed=distributed,
+        is_admin=is_admin,
+        enabled_bricks=frozenset(),  # MINIMAL profile for fast tests
+        init_cred=_init_cred,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/core/test_minimal_boot_mode.py
+++ b/tests/unit/core/test_minimal_boot_mode.py
@@ -135,10 +135,10 @@ class TestMinimalFileOperations:
     """File operations work in kernel-only mode (no system services)."""
 
     @pytest.fixture()
-    def minimal_nx(self, tmp_path: "Path") -> "NexusFS":
+    async def minimal_nx(self, tmp_path: "Path") -> "NexusFS":
         from tests.conftest import make_test_nexus
 
-        return make_test_nexus(tmp_path)
+        return await make_test_nexus(tmp_path)
 
     @pytest.mark.asyncio
     async def test_write_and_read(self, minimal_nx: "NexusFS") -> None:

--- a/tests/unit/core/test_nexus_fs_provision_user.py
+++ b/tests/unit/core/test_nexus_fs_provision_user.py
@@ -65,6 +65,7 @@ async def nx_with_db(tmp_path):
             register_workspace_fn=MagicMock(),
             register_agent_fn=MagicMock(),
         ),
+        allow_overwrite=True,
     )
 
     return nx

--- a/tests/unit/core/test_nexus_fs_provision_user.py
+++ b/tests/unit/core/test_nexus_fs_provision_user.py
@@ -18,7 +18,7 @@ from tests.conftest import make_test_nexus
 
 
 @pytest.fixture()
-def nx_with_db(tmp_path):
+async def nx_with_db(tmp_path):
     """Create a NexusFS instance with a real SQLite database for provisioning tests."""
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
@@ -29,7 +29,7 @@ def nx_with_db(tmp_path):
     Base.metadata.create_all(engine)
     session_factory = sessionmaker(bind=engine)
 
-    nx = make_test_nexus(tmp_path)
+    nx = await make_test_nexus(tmp_path)
     nx.SessionLocal = session_factory
 
     # Mock entity registry
@@ -287,7 +287,7 @@ class TestProvisionUserPartialFailure:
         """Missing SessionLocal should raise TypeError (None is not callable)."""
         from nexus.system_services.lifecycle.user_provisioning import UserProvisioningService
 
-        nx = make_test_nexus(tmp_path)
+        nx = await make_test_nexus(tmp_path)
         mock_registry = MagicMock()
         mock_registry.get_entity.return_value = None
         from dataclasses import replace

--- a/tests/unit/core/test_nexus_fs_rename.py
+++ b/tests/unit/core/test_nexus_fs_rename.py
@@ -14,9 +14,9 @@ from tests.helpers.failing_backend import FailingBackend
 
 
 @pytest.fixture()
-def nx(tmp_path):
+async def nx(tmp_path):
     """Create a NexusFS instance with permissions disabled for unit tests."""
-    return make_test_nexus(tmp_path)
+    return await make_test_nexus(tmp_path)
 
 
 class TestRenameHappyPath:
@@ -126,7 +126,7 @@ class TestRenameWithFailingBackend:
             fail_on_methods=["write_content"],
             fail_on_nth=2,
         )
-        nx = make_test_nexus(tmp_path / "nx", backend=failing)
+        nx = await make_test_nexus(tmp_path / "nx", backend=failing)
         # First write succeeds
         await nx.write("/files/a.txt", b"data")
         # Second write fails due to backend

--- a/tests/unit/core/test_nexus_fs_write_batch.py
+++ b/tests/unit/core/test_nexus_fs_write_batch.py
@@ -15,9 +15,9 @@ from tests.helpers.failing_backend import FailingBackend
 
 
 @pytest.fixture()
-def nx(tmp_path):
+async def nx(tmp_path):
     """Create a NexusFS instance with permissions disabled for unit tests."""
-    return make_test_nexus(tmp_path)
+    return await make_test_nexus(tmp_path)
 
 
 class TestWriteBatchHappyPath:
@@ -119,7 +119,7 @@ class TestWriteBatchWithFailingBackend:
         real_backend = CASLocalBackend(root_path=data_dir)
         failing = FailingBackend(real_backend, fail_on_nth=2)
 
-        nx = make_test_nexus(tmp_path / "nx", backend=failing)
+        nx = await make_test_nexus(tmp_path / "nx", backend=failing)
 
         # First file write succeeds (call #1 = write_content)
         # Second file write fails (call #2 = write_content)

--- a/tests/unit/server/lifespan/test_lifespan_services.py
+++ b/tests/unit/server/lifespan/test_lifespan_services.py
@@ -38,6 +38,7 @@ def _make_nexus_fs(**attrs) -> SimpleNamespace:
         "_snapshot_service": None,
         "_namespace_manager": None,
         "config": None,
+        "service_coordinator": None,
     }
     defaults.update(attrs)
     return SimpleNamespace(**defaults)


### PR DESCRIPTION
## Summary
- Add `init_cred` param to `create_nexus_fs()` for caller-controlled identity
- Rewrite `nexus.fs.mount()` to use `create_nexus_fs()` (MINIMAL profile) instead of direct `NexusFS()` constructor
- Rewrite `make_test_nexus()` from sync → async, using `create_nexus_fs()` with `enabled_bricks=frozenset()` — tests now use the real production boot path
- Delete manual PermissionCheckHook wiring + `_system_services` hack from `make_test_nexus`
- Fix 4 test files: async fixtures + `await make_test_nexus()`

Completes PR 3 + PR 4 of the #1801 plan. After this, **all NexusFS construction goes through `create_nexus_fs()`** — no more direct `NexusFS()` constructor calls outside the kernel.

## Test plan
- [ ] CI lint + type check passes
- [ ] Unit tests pass (make_test_nexus callers work with async)
- [ ] `nexus.fs.mount()` integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)