### PR TITLE
feat(#1801): SLIM profile rename + migrate remaining test NexusFS() to factory

### DIFF
--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -88,7 +88,7 @@ USER nexus
 # ---------- Environment variables ----------
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    NEXUS_PROFILE=minimal \
+    NEXUS_PROFILE=slim \
     NEXUS_HOST=0.0.0.0 \
     NEXUS_PORT=2026 \
     NEXUS_DATA_DIR=/app/data

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -613,14 +613,14 @@ which bricks to enable and which drivers to inject.
 
 | Profile | Target | Bricks | Metastore | Linux Analogue |
 |---------|--------|--------|-----------|----------------|
-| **minimal** | Bare minimum runnable | 1 (storage only) | redb (embedded) | initramfs |
+| **slim** | Bare minimum runnable | 1 (storage only) | redb (embedded) | initramfs |
 | **embedded** | MCU, WASM (<1 MB) | 2 (storage + eventlog) | redb (embedded) | BusyBox |
 | **lite** | Pi, Jetson, mobile | 8 (+namespace, agent, permissions, ...) | redb (embedded) | Alpine |
 | **full** | Desktop, laptop | 21 (all except federation) | redb (embedded) | Ubuntu Desktop |
 | **cloud** | k8s, serverless | 22 (all, incl. federation) | redb (Raft) | Ubuntu Server |
 | **remote** | Client-side proxy | 0 (zero local bricks) | RemoteMetastore | NFS client |
 
-Profile hierarchy: `minimal ⊂ embedded ⊂ lite ⊂ full ⊆ cloud`.
+Profile hierarchy: `slim ⊂ embedded ⊂ lite ⊂ full ⊆ cloud`.
 REMOTE is orthogonal — stateless proxy, all operations via gRPC to server.
 
 Same kernel binary, different driver injection. See §1 `connect()`.

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,4 +1,4 @@
-# Minimal dependencies for the verified local quickstart and NEXUS_PROFILE=minimal.
+# Minimal dependencies for the verified local quickstart and NEXUS_PROFILE=slim.
 # Subset of pyproject.toml for a lightweight Nexus server with storage only.
 # No cloud connectors, no LLM/ML packages, no Zoekt, no sandbox providers.
 

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -5,7 +5,7 @@ Nexus combines a VFS-style filesystem interface with deployment-aware context,
 storage, and service composition for agent systems.
 
 Deployment profiles control which bricks are enabled:
-- minimal: Bare VFS, storage only
+- slim: Bare VFS, storage only
 - embedded: Storage + eventlog
 - lite: Core services
 - full: All bricks (default)
@@ -19,7 +19,7 @@ For programmatic access (building tools, libraries, integrations), use the SDK:
 
     from nexus.sdk import connect
 
-    nx = connect(config={"profile": "minimal", "data_dir": "./nexus-data"})
+    nx = connect(config={"profile": "slim", "data_dir": "./nexus-data"})
     await nx.sys_write("/workspace/data.txt", b"Hello World")
     content = await nx.sys_read("/workspace/data.txt")
 

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -205,7 +205,7 @@ async def connect_local_workspace(data_dir: str) -> NexusFilesystem:
     with _isolated_local_workspace_env(data_dir):
         filesystem = await nexus.connect(
             config={
-                "profile": "minimal",
+                "profile": "slim",
                 "backend": "local",
                 "data_dir": data_dir,
                 "db_path": None,
@@ -285,7 +285,7 @@ async def get_filesystem(
                     "NEXUS_DATA_DIR",
                     str(Path(nexus.NEXUS_STATE_DIR) / "data"),
                 )
-                return await nexus.connect(config={"profile": "minimal", "data_dir": data_dir})
+                return await nexus.connect(config={"profile": "slim", "data_dir": data_dir})
 
             console.print("[red]Error:[/red] NEXUS_URL or --remote-url is required")
             console.print(

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -348,9 +348,9 @@ class NexusConfig(BaseModel):
     def validate_profile(cls, v: str) -> str:
         """Validate deployment profile.
 
-        Valid profiles: minimal, embedded, lite, full, cloud, innovation, remote, auto
+        Valid profiles: slim, embedded, lite, full, cloud, innovation, remote, auto
         """
-        allowed = ["minimal", "embedded", "lite", "full", "cloud", "innovation", "remote", "auto"]
+        allowed = ["slim", "embedded", "lite", "full", "cloud", "innovation", "remote", "auto"]
         if v not in allowed:
             raise ValueError(f"profile must be one of {allowed}, got '{v}'")
         return v

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -11,7 +11,7 @@ The profile sets the *defaults*; explicit overrides always win.
 Lego Architecture reference: Part 10 — Edge Deployment.
 
 Profile hierarchy (superset relationship):
-    minimal ⊂ embedded ⊂ lite ⊂ full ⊆ cloud ⊆ innovation
+    slim ⊂ embedded ⊂ lite ⊂ full ⊆ cloud ⊆ innovation
 
 INNOVATION extends CLOUD with all bricks enabled + experimental validation.
 Requires explicit opt-in (``nexusd --innovation`` or ``--profile innovation``).
@@ -124,7 +124,7 @@ class DeploymentProfile(StrEnum):
     """Deployment profile controlling which bricks are enabled by default.
 
     Profiles define capability tiers for different deployment targets:
-    - minimal: Bare minimum runnable — storage only, no system services (Issue #2194)
+    - slim: Bare minimum runnable — storage only, no system services (Issue #1801)
     - embedded: MCU / WASM (<1 MB) — storage + eventlog only
     - lite: Pi, Jetson, mobile (512 MB–4 GB) — core services, no LLM/Pay
     - full: Desktop, laptop (4–32 GB) — all bricks, local inference
@@ -133,7 +133,7 @@ class DeploymentProfile(StrEnum):
     - remote: Client-side proxy — zero local bricks, NFS-client model (Issue #844)
     """
 
-    MINIMAL = "minimal"
+    SLIM = "slim"
     EMBEDDED = "embedded"
     LITE = "lite"
     FULL = "full"
@@ -163,13 +163,13 @@ class DeploymentProfile(StrEnum):
 # Profile-to-brick mappings (frozen — immutable at runtime)
 # ---------------------------------------------------------------------------
 
-_MINIMAL_BRICKS: frozenset[str] = frozenset(
+_SLIM_BRICKS: frozenset[str] = frozenset(
     {
         BRICK_STORAGE,
     }
 )
 
-_EMBEDDED_BRICKS: frozenset[str] = _MINIMAL_BRICKS | frozenset(
+_EMBEDDED_BRICKS: frozenset[str] = _SLIM_BRICKS | frozenset(
     {
         BRICK_EVENTLOG,
     }
@@ -228,7 +228,7 @@ _INNOVATION_BRICKS: frozenset[str] = (
 _REMOTE_BRICKS: frozenset[str] = frozenset()  # no local bricks — NFS-client model
 
 _PROFILE_BRICKS: dict[DeploymentProfile, frozenset[str]] = {
-    DeploymentProfile.MINIMAL: _MINIMAL_BRICKS,
+    DeploymentProfile.SLIM: _SLIM_BRICKS,
     DeploymentProfile.EMBEDDED: _EMBEDDED_BRICKS,
     DeploymentProfile.LITE: _LITE_BRICKS,
     DeploymentProfile.FULL: _FULL_BRICKS,

--- a/src/nexus/lib/device_capabilities.py
+++ b/src/nexus/lib/device_capabilities.py
@@ -254,11 +254,11 @@ def detect_capabilities() -> DeviceCapabilities:
 # ---------------------------------------------------------------------------
 
 # Profile tier indices for comparison
-# minimal=-1: never auto-detected, always explicit user choice (Issue #2194)
+# slim=-1: never auto-detected, always explicit user choice (Issue #2194)
 # remote=-2: never auto-detected, always explicit (Issue #844)
 _PROFILE_INDEX: dict[str, int] = {
     "remote": -2,
-    "minimal": -1,
+    "slim": -1,
     "embedded": 0,
     "lite": 1,
     "full": 2,

--- a/src/nexus/lib/performance_tuning.py
+++ b/src/nexus/lib/performance_tuning.py
@@ -290,7 +290,7 @@ class ProfileTuning:
 # Profile-to-tuning mappings (frozen — immutable at runtime)
 # ---------------------------------------------------------------------------
 
-_MINIMAL_TUNING = ProfileTuning(
+_SLIM_TUNING = ProfileTuning(
     concurrency=ConcurrencyTuning(
         default_workers=1,
         thread_pool_size=4,
@@ -691,13 +691,13 @@ def _get_profile_tuning_map() -> dict[str, ProfileTuning]:
     from nexus.contracts.deployment_profile import DeploymentProfile
 
     return {
-        DeploymentProfile.MINIMAL: _MINIMAL_TUNING,
+        DeploymentProfile.SLIM: _SLIM_TUNING,
         DeploymentProfile.EMBEDDED: _EMBEDDED_TUNING,
         DeploymentProfile.LITE: _LITE_TUNING,
         DeploymentProfile.FULL: _FULL_TUNING,
         DeploymentProfile.CLOUD: _CLOUD_TUNING,
         DeploymentProfile.INNOVATION: _CLOUD_TUNING,  # INNOVATION reuses CLOUD tuning
-        DeploymentProfile.REMOTE: _MINIMAL_TUNING,  # REMOTE reuses MINIMAL tuning
+        DeploymentProfile.REMOTE: _SLIM_TUNING,  # REMOTE reuses SLIM tuning
     }
 
 

--- a/src/nexus/sdk/__init__.py
+++ b/src/nexus/sdk/__init__.py
@@ -16,7 +16,7 @@ The SDK interface is stable and semantic-versioned separately from CLI changes.
 Quick Start (Local - Verified):
     >>> from nexus.sdk import connect
     >>>
-    >>> nx = connect(config={"profile": "minimal", "data_dir": "./nexus-data"})
+    >>> nx = connect(config={"profile": "slim", "data_dir": "./nexus-data"})
     >>> await nx.sys_write("/workspace/file.txt", b"Hello World")
     >>> content = await nx.sys_read("/workspace/file.txt")
 
@@ -55,7 +55,7 @@ Configuration:
     >>>
     >>> # Local mode
     >>> nx = connect(config={
-    ...     "profile": "minimal",
+    ...     "profile": "slim",
     ...     "data_dir": "./nexus-data"
     ... })
     >>>

--- a/tests/benchmarks/bench_pipe_syscall_overhead.py
+++ b/tests/benchmarks/bench_pipe_syscall_overhead.py
@@ -70,24 +70,28 @@ def _print_stats(label: str, idx: int, st: dict) -> None:
 # ── Setup ──────────────────────────────────────────────────────────────
 
 
-def _setup(tmp_dir: Path):
+async def _setup(tmp_dir: Path):
     """Create NexusFS + PipeManager with a single pipe for benchmarking."""
+    from nexus.backends.storage.path_local import PathLocalBackend
     from nexus.core.config import ParseConfig
-    from nexus.core.nexus_fs import NexusFS
     from nexus.core.pipe_manager import PipeManager
+    from nexus.factory import create_nexus_fs
     from nexus.storage.raft_metadata_store import RaftMetadataStore
     from tests.helpers.test_context import TEST_ADMIN_CONTEXT
 
     raft_path = tmp_dir / "raft"
+    data_dir = tmp_dir / "data"
+    data_dir.mkdir(exist_ok=True)
 
     metastore = RaftMetadataStore.embedded(str(raft_path))
     pipe_manager = PipeManager(metastore)
 
-    nx = NexusFS(
+    nx = await create_nexus_fs(
+        backend=PathLocalBackend(root_path=str(data_dir)),
         metadata_store=metastore,
         parsing=ParseConfig(auto_parse=False),
+        init_cred=TEST_ADMIN_CONTEXT,
     )
-    nx._init_cred = TEST_ADMIN_CONTEXT
 
     # Create the benchmark pipe
     pipe_manager.create(_BENCH_PIPE_PATH, capacity=_BENCH_PIPE_CAPACITY, owner_id="bench")
@@ -258,7 +262,7 @@ def _bench_ideal_fast_path(pm, path: str, data: bytes) -> list[float]:
 async def _run() -> dict:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
-        nx, pm, metastore = _setup(tmp_dir)
+        nx, pm, metastore = await _setup(tmp_dir)
 
         payload = json.dumps(
             {

--- a/tests/benchmarks/benchmark_write_performance.py
+++ b/tests/benchmarks/benchmark_write_performance.py
@@ -85,7 +85,8 @@ async def run_benchmark(enable_deferred: bool = False):
     """
     from nexus.backends.storage.cas_local import CASLocalBackend
     from nexus.contracts.types import OperationContext
-    from nexus.core.nexus_fs import NexusFS
+    from nexus.core.config import ParseConfig, PermissionConfig
+    from nexus.factory import create_nexus_fs
 
     mode = "DEFERRED" if enable_deferred else "SYNC"
     print("=" * 70)
@@ -99,18 +100,15 @@ async def run_benchmark(enable_deferred: bool = False):
 
         backend = CASLocalBackend(str(storage_path))
 
-        # Create NexusFS with permissions ENABLED
-        nx = NexusFS(
+        # Create NexusFS with permissions ENABLED via factory
+        nx = await create_nexus_fs(
             backend=backend,
             metadata_store=RaftMetadataStore.embedded(str(db_path).replace(".db", "-raft")),
             record_store=SQLAlchemyRecordStore(db_path=str(db_path)),
-            zone_id="benchmark_zone",
-            enforce_permissions=True,
-            auto_parse=False,
-            enable_tiger_cache=False,  # SQLite doesn't support Tiger Cache
-            enable_deferred_permissions=enable_deferred,  # Issue #1071
+            permissions=PermissionConfig(enforce=True),
+            parsing=ParseConfig(auto_parse=False),
+            init_cred=TEST_CONTEXT,
         )
-        nx._init_cred = TEST_CONTEXT
 
         # Create user context
         ctx = OperationContext(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ async def make_test_nexus(
 
     Uses ``create_nexus_fs()`` — the same boot path as production.
     Defaults: permissions off, no auto-parse, no distributed features,
-    no bricks (MINIMAL profile).
+    no bricks (SLIM profile).
 
     Args:
         tmp_path: pytest tmp_path fixture for backend/metadata storage.
@@ -186,7 +186,7 @@ async def make_test_nexus(
         memory=memory,
         distributed=distributed,
         is_admin=is_admin,
-        enabled_bricks=frozenset(),  # MINIMAL profile for fast tests
+        enabled_bricks=frozenset(),  # SLIM profile for fast tests
         init_cred=_init_cred,
     )
 

--- a/tests/e2e/self_contained/test_dual_write_consistency.py
+++ b/tests/e2e/self_contained/test_dual_write_consistency.py
@@ -11,16 +11,20 @@ from __future__ import annotations
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
-from nexus import CASLocalBackend, NexusFS
+from nexus import CASLocalBackend
 from nexus.core.config import ParseConfig, PermissionConfig
 from nexus.factory import create_nexus_fs
 from nexus.storage.models import FilePathModel, VersionHistoryModel
 from nexus.storage.operation_logger import OperationLogger
 from nexus.storage.record_store import SQLAlchemyRecordStore
 from tests.helpers.test_context import TEST_CONTEXT
+
+if TYPE_CHECKING:
+    from nexus.core.nexus_fs import NexusFS
 
 # Try to import RaftMetadataStore — skip if native module unavailable
 try:
@@ -55,31 +59,23 @@ def record_store(temp_dir: Path) -> Generator[SQLAlchemyRecordStore, None, None]
 
 
 @pytest.fixture
-async def nx(temp_dir: Path, record_store: SQLAlchemyRecordStore) -> Generator[NexusFS, None, None]:
+async def nx(temp_dir: Path, record_store: SQLAlchemyRecordStore):
     raft_store = _try_create_raft_store(str(temp_dir / "raft-metadata"))
     if raft_store is None:
-        # Fallback to DictMetastore with factory-style wiring
         from tests.helpers.dict_metastore import DictMetastore
 
         metadata_store = DictMetastore()
-
-        _backend = CASLocalBackend(str(temp_dir / "data"))
-        nx = NexusFS(
-            metadata_store=metadata_store,
-            record_store=record_store,
-            permissions=PermissionConfig(enforce=False),
-            parsing=ParseConfig(auto_parse=False),
-            init_cred=TEST_CONTEXT,
-        )
-        nx.router.add_mount("/", _backend)
     else:
-        nx = await create_nexus_fs(
-            backend=CASLocalBackend(str(temp_dir / "data")),
-            metadata_store=raft_store,
-            record_store=record_store,
-            parsing=ParseConfig(auto_parse=False),
-            permissions=PermissionConfig(enforce=False),
-        )
+        metadata_store = raft_store
+
+    nx = await create_nexus_fs(
+        backend=CASLocalBackend(str(temp_dir / "data")),
+        metadata_store=metadata_store,
+        record_store=record_store,
+        parsing=ParseConfig(auto_parse=False),
+        permissions=PermissionConfig(enforce=False),
+        init_cred=TEST_CONTEXT,
+    )
     yield nx
     nx.close()
 

--- a/tests/e2e/server/test_credentials_e2e.py
+++ b/tests/e2e/server/test_credentials_e2e.py
@@ -87,14 +87,14 @@ def api_keys(session_factory: Any) -> dict[str, Any]:
 
 
 @pytest.fixture
-def app(tmp_path: Any, db_path: Any, session_factory: Any, api_keys: Any) -> Any:
+async def app(tmp_path: Any, db_path: Any, session_factory: Any, api_keys: Any) -> Any:
     """FastAPI app with permissions enabled, database auth, identity + credentials."""
     from types import SimpleNamespace
 
     from nexus.backends.storage.cas_local import CASLocalBackend
     from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
     from nexus.bricks.auth.providers.discriminator import DiscriminatingAuthProvider
-    from nexus.core.nexus_fs import NexusFS
+    from nexus.factory import create_nexus_fs
     from nexus.server.fastapi_server import create_app
     from nexus.storage.record_store import SQLAlchemyRecordStore
 
@@ -103,14 +103,14 @@ def app(tmp_path: Any, db_path: Any, session_factory: Any, api_keys: Any) -> Any
     metadata_store = DictMetastore()
     record_store = SQLAlchemyRecordStore(db_url=f"sqlite:///{db_path}")
 
-    nx = NexusFS(
+    nx = await create_nexus_fs(
         backend=backend,
         metadata_store=metadata_store,
         record_store=record_store,
         permissions=PermissionConfig(enforce=True),
         parsing=ParseConfig(auto_parse=False),
+        init_cred=TEST_CONTEXT,
     )
-    nx._init_cred = TEST_CONTEXT
 
     db_key_auth = DatabaseAPIKeyAuth(record_store=SimpleNamespace(session_factory=session_factory))
     auth_provider = DiscriminatingAuthProvider(

--- a/tests/e2e/server/test_identity_e2e.py
+++ b/tests/e2e/server/test_identity_e2e.py
@@ -88,16 +88,18 @@ def api_keys(session_factory: Any) -> dict[str, Any]:
 
 
 @pytest.fixture
-def app(tmp_path: Any, db_path: Any, session_factory: Any, api_keys: Any) -> Any:
+async def app(tmp_path: Any, db_path: Any, session_factory: Any, api_keys: Any) -> Any:
     """FastAPI app with permissions enabled, database auth, identity layer.
 
-    Uses RaftMetadataStore.embedded() for realistic filesystem operations
+    Uses factory boot path for realistic filesystem operations
     (mkdir, write) that the identity layer needs for DID document writing.
     """
+    from types import SimpleNamespace
+
     from nexus.backends.storage.cas_local import CASLocalBackend
     from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
     from nexus.bricks.auth.providers.discriminator import DiscriminatingAuthProvider
-    from nexus.core.nexus_fs import NexusFS
+    from nexus.factory import create_nexus_fs
     from nexus.server.fastapi_server import create_app
     from nexus.storage.record_store import SQLAlchemyRecordStore
 
@@ -106,18 +108,16 @@ def app(tmp_path: Any, db_path: Any, session_factory: Any, api_keys: Any) -> Any
     metadata_store = DictMetastore()
     record_store = SQLAlchemyRecordStore(db_url=f"sqlite:///{db_path}")
 
-    nx = NexusFS(
+    nx = await create_nexus_fs(
         backend=backend,
         metadata_store=metadata_store,
         record_store=record_store,
         permissions=PermissionConfig(enforce=True),
         parsing=ParseConfig(auto_parse=False),
+        init_cred=TEST_CONTEXT,
     )
-    nx._init_cred = TEST_CONTEXT
 
     # Wire database auth
-    from types import SimpleNamespace
-
     db_key_auth = DatabaseAPIKeyAuth(record_store=SimpleNamespace(session_factory=session_factory))
     auth_provider = DiscriminatingAuthProvider(
         api_key_provider=db_key_auth,

--- a/tests/e2e/server/test_path_unscoping_e2e.py
+++ b/tests/e2e/server/test_path_unscoping_e2e.py
@@ -22,27 +22,28 @@ from starlette.testclient import TestClient
 from nexus.backends.storage.cas_local import CASLocalBackend
 from nexus.core.config import PermissionConfig
 from nexus.core.nexus_fs import NexusFS
+from nexus.factory import create_nexus_fs
 from nexus.storage.raft_metadata_store import RaftMetadataStore
 from nexus.storage.record_store import SQLAlchemyRecordStore
 from tests.helpers.test_context import TEST_CONTEXT
 
 
 @pytest.fixture
-def nexus_fs_local(tmp_path: Path):
-    """Create a real NexusFS with RaftMetadataStore."""
+async def nexus_fs_local(tmp_path: Path):
+    """Create a real NexusFS with RaftMetadataStore via factory."""
     storage_path = tmp_path / "storage"
     storage_path.mkdir()
     backend = CASLocalBackend(root_path=storage_path)
     raft_dir = str(tmp_path / "raft-metadata")
     metadata_store = RaftMetadataStore.embedded(raft_dir)
     record_store = SQLAlchemyRecordStore(db_url=f"sqlite:///{tmp_path / 'records.db'}")
-    nx = NexusFS(
+    nx = await create_nexus_fs(
         backend=backend,
         metadata_store=metadata_store,
         record_store=record_store,
         permissions=PermissionConfig(enforce=False),
+        init_cred=TEST_CONTEXT,
     )
-    nx._init_cred = TEST_CONTEXT
     yield nx
     nx.close()
 

--- a/tests/integration/core/test_cold_start.py
+++ b/tests/integration/core/test_cold_start.py
@@ -6,7 +6,7 @@ circular import errors or missing dependencies. Does NOT require a database.
 
 import importlib
 
-from tests.helpers.test_context import TEST_CONTEXT
+import pytest
 
 
 class TestColdStartImports:
@@ -61,48 +61,31 @@ class TestColdStartImports:
 
 
 class TestColdStartNexusFSConstruction:
-    """Verify NexusFS can be constructed without factory (test mode)."""
+    """Verify NexusFS can be constructed via factory (test mode)."""
 
-    def test_nexus_fs_minimal_construction(self) -> None:
-        """NexusFS should construct with just metadata_store."""
-        from unittest.mock import MagicMock
+    @pytest.mark.asyncio
+    async def test_nexus_fs_minimal_construction(self, tmp_path) -> None:
+        """NexusFS should construct via make_test_nexus with defaults."""
+        from tests.conftest import make_test_nexus
 
-        from nexus.core.config import ParseConfig
-        from nexus.core.nexus_fs import NexusFS
+        nx = await make_test_nexus(tmp_path)
 
-        mock_metadata = MagicMock()
-        mock_metadata.list = MagicMock(return_value=[])
-
-        nx = NexusFS(
-            metadata_store=mock_metadata,
-            parsing=ParseConfig(auto_parse=False),
-        )
-        nx._init_cred = TEST_CONTEXT
-
-        # ServiceRegistry should be empty (no factory wiring)
+        # ServiceRegistry should be empty (SLIM profile — no bricks)
         assert nx.service("rebac") is None
         assert nx.service("mount") is None
         assert nx.service("mcp") is None
 
-    def test_enlist_wired_services(self) -> None:
+    @pytest.mark.asyncio
+    async def test_enlist_wired_services(self, tmp_path) -> None:
         """enlist_wired_services should register services via registry (#1708)."""
-        import asyncio
         from unittest.mock import MagicMock
 
-        from nexus.core.config import ParseConfig
-        from nexus.core.nexus_fs import NexusFS
         from nexus.factory.service_routing import enlist_wired_services
+        from tests.conftest import make_test_nexus
 
-        mock_metadata = MagicMock()
-        mock_metadata.list = MagicMock(return_value=[])
-
-        nx = NexusFS(
-            metadata_store=mock_metadata,
-            parsing=ParseConfig(auto_parse=False),
-        )
-        nx._init_cred = TEST_CONTEXT
+        nx = await make_test_nexus(tmp_path)
 
         reg = nx._service_registry  # ServiceRegistry now has lifecycle methods
         mock_svc = MagicMock()
-        asyncio.run(enlist_wired_services(reg, {"rebac_service": mock_svc}))
+        await enlist_wired_services(reg, {"rebac_service": mock_svc})
         assert nx.service("rebac")._service_instance is mock_svc

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -127,10 +127,8 @@ def isolated_db(tmp_path, monkeypatch):
     The database is automatically cleaned up after the test completes.
 
     Usage:
-        def test_something(isolated_db):
-            metadata_store = RaftMetadataStore.embedded(str(isolated_db).replace(".db", ""))
-            nx = NexusFS(metadata_store=metadata_store)
-            nx._init_cred = TEST_CONTEXT
+        async def test_something(isolated_db, tmp_path):
+            nx = await make_test_nexus(tmp_path, use_raft=True)
             # Test code here
             nx.close()
 

--- a/tests/unit/contracts/test_optional_imports.py
+++ b/tests/unit/contracts/test_optional_imports.py
@@ -24,7 +24,7 @@ class TestConfigWithoutAuthBrick:
         assert field_info is not None
 
         # Verify we can create a config with oauth=None (no auth brick needed)
-        cfg = NexusConfig(profile="minimal")
+        cfg = NexusConfig(profile="slim")
         assert cfg.oauth is None
 
     def test_config_parses_oauth_dict(self) -> None:
@@ -32,7 +32,7 @@ class TestConfigWithoutAuthBrick:
         from nexus.config import NexusConfig
 
         cfg = NexusConfig(
-            profile="minimal",
+            profile="slim",
             oauth={
                 "providers": [
                     {

--- a/tests/unit/contracts/test_protocol_conformance.py
+++ b/tests/unit/contracts/test_protocol_conformance.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 import pytest
 
-from tests.helpers.test_context import TEST_CONTEXT
-
 
 class TestDescribableConformance:
     """Verify concrete types implement the Describable protocol."""
@@ -33,12 +31,11 @@ class TestDescribableConformance:
 class TestWirableFSConformance:
     """Verify NexusFS implements the WirableFS protocol."""
 
-    def test_nexus_fs_is_wirable(self) -> None:
-        from unittest.mock import MagicMock
-
+    @pytest.mark.asyncio
+    async def test_nexus_fs_is_wirable(self, tmp_path) -> None:
         from nexus.contracts.wirable_fs import WirableFS
-        from nexus.core.config import ParseConfig
         from nexus.core.nexus_fs import NexusFS
+        from tests.conftest import make_test_nexus
 
         # NexusFS.sys_read exists at class level (method)
         assert callable(getattr(NexusFS, "sys_read", None))
@@ -47,13 +44,7 @@ class TestWirableFSConformance:
         assert hasattr(WirableFS, "__protocol_attrs__") or True
 
         # Verify an instance satisfies the protocol structurally
-        mock_metadata = MagicMock()
-        mock_metadata.list = MagicMock(return_value=[])
-        nx = NexusFS(
-            metadata_store=mock_metadata,
-            parsing=ParseConfig(auto_parse=False),
-        )
-        nx._init_cred = TEST_CONTEXT
+        nx = await make_test_nexus(tmp_path)
         assert isinstance(nx, WirableFS)
 
 

--- a/tests/unit/core/test_deployment_profile.py
+++ b/tests/unit/core/test_deployment_profile.py
@@ -36,7 +36,7 @@ class TestDeploymentProfileEnum:
     """Tests for DeploymentProfile enum values."""
 
     def test_enum_values(self) -> None:
-        assert DeploymentProfile.MINIMAL == "minimal"
+        assert DeploymentProfile.SLIM == "slim"
         assert DeploymentProfile.EMBEDDED == "embedded"
         assert DeploymentProfile.LITE == "lite"
         assert DeploymentProfile.FULL == "full"
@@ -248,7 +248,7 @@ class TestNexusConfigProfile:
     def test_valid_profiles(self) -> None:
         from nexus.config import NexusConfig
 
-        for p in ["minimal", "embedded", "lite", "full", "cloud", "innovation"]:
+        for p in ["slim", "embedded", "lite", "full", "cloud", "innovation"]:
             cfg = NexusConfig(profile=p)
             assert cfg.profile == p
         # "remote" requires url

--- a/tests/unit/core/test_minimal_boot_mode.py
+++ b/tests/unit/core/test_minimal_boot_mode.py
@@ -1,9 +1,9 @@
-"""Tests for minimal boot mode (Issue #2194).
+"""Tests for slim boot mode (Issue #2194).
 
-Verifies that DeploymentProfile.MINIMAL provides the smallest runnable
+Verifies that DeploymentProfile.SLIM provides the smallest runnable
 deployment with only the storage brick, no system services, and working file ops.
 
-Profile hierarchy: minimal < embedded < lite < full <= cloud
+Profile hierarchy: slim < embedded < lite < full <= cloud
 """
 
 from typing import TYPE_CHECKING
@@ -16,38 +16,38 @@ if TYPE_CHECKING:
     from nexus.core.nexus_fs import NexusFS
 
 # ---------------------------------------------------------------------------
-# TestMinimalProfileBricks — enum + brick set
+# TestSlimProfileBricks — enum + brick set
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalProfileBricks:
-    """MINIMAL profile returns only {storage} as default bricks."""
+class TestSlimProfileBricks:
+    """SLIM profile returns only {storage} as default bricks."""
 
-    def test_minimal_enum_value(self) -> None:
+    def test_slim_enum_value(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        assert DeploymentProfile.MINIMAL.value == "minimal"
+        assert DeploymentProfile.SLIM.value == "slim"
 
-    def test_minimal_default_bricks_only_storage(self) -> None:
+    def test_slim_default_bricks_only_storage(self) -> None:
         from nexus.contracts.deployment_profile import BRICK_STORAGE, DeploymentProfile
 
-        bricks = DeploymentProfile.MINIMAL.default_bricks()
+        bricks = DeploymentProfile.SLIM.default_bricks()
         assert bricks == frozenset({BRICK_STORAGE})
 
-    def test_minimal_storage_is_enabled(self) -> None:
+    def test_slim_storage_is_enabled(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        assert DeploymentProfile.MINIMAL.is_brick_enabled("storage") is True
+        assert DeploymentProfile.SLIM.is_brick_enabled("storage") is True
 
-    def test_minimal_eventlog_is_disabled(self) -> None:
+    def test_slim_eventlog_is_disabled(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        assert DeploymentProfile.MINIMAL.is_brick_enabled("eventlog") is False
+        assert DeploymentProfile.SLIM.is_brick_enabled("eventlog") is False
 
-    def test_minimal_search_is_disabled(self) -> None:
+    def test_slim_search_is_disabled(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        assert DeploymentProfile.MINIMAL.is_brick_enabled("search") is False
+        assert DeploymentProfile.SLIM.is_brick_enabled("search") is False
 
     def test_resolve_with_no_overrides(self) -> None:
         from nexus.contracts.deployment_profile import (
@@ -56,7 +56,7 @@ class TestMinimalProfileBricks:
             resolve_enabled_bricks,
         )
 
-        result = resolve_enabled_bricks(DeploymentProfile.MINIMAL)
+        result = resolve_enabled_bricks(DeploymentProfile.SLIM)
         assert result == frozenset({BRICK_STORAGE})
 
     def test_resolve_with_override_enables_extra_brick(self) -> None:
@@ -67,7 +67,7 @@ class TestMinimalProfileBricks:
             resolve_enabled_bricks,
         )
 
-        result = resolve_enabled_bricks(DeploymentProfile.MINIMAL, overrides={"eventlog": True})
+        result = resolve_enabled_bricks(DeploymentProfile.SLIM, overrides={"eventlog": True})
         assert result == frozenset({BRICK_STORAGE, BRICK_EVENTLOG})
 
     def test_resolve_with_override_disables_storage(self) -> None:
@@ -76,17 +76,17 @@ class TestMinimalProfileBricks:
             resolve_enabled_bricks,
         )
 
-        result = resolve_enabled_bricks(DeploymentProfile.MINIMAL, overrides={"storage": False})
+        result = resolve_enabled_bricks(DeploymentProfile.SLIM, overrides={"storage": False})
         assert result == frozenset()
 
 
 # ---------------------------------------------------------------------------
-# TestMinimalBootViaFactory — create_nexus_fs with record_store=None
+# TestSlimBootViaFactory — create_nexus_fs with record_store=None
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalBootViaFactory:
-    """Factory creates bare kernel when record_store is None (MINIMAL path)."""
+class TestSlimBootViaFactory:
+    """Factory creates bare kernel when record_store is None (SLIM path)."""
 
     @pytest.mark.asyncio
     async def test_create_nexus_fs_no_record_store(self, tmp_path: "Path") -> None:
@@ -127,11 +127,11 @@ class TestMinimalBootViaFactory:
 
 
 # ---------------------------------------------------------------------------
-# TestMinimalFileOperations — write/read/exists/delete/list in minimal mode
+# TestSlimFileOperations — write/read/exists/delete/list in slim mode
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalFileOperations:
+class TestSlimFileOperations:
     """File operations work in kernel-only mode (no system services)."""
 
     @pytest.fixture()
@@ -172,18 +172,18 @@ class TestMinimalFileOperations:
 
 
 # ---------------------------------------------------------------------------
-# TestMinimalConfigValidation — NexusConfig accepts "minimal"
+# TestSlimConfigValidation — NexusConfig accepts "slim"
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalConfigValidation:
-    """NexusConfig validates 'kernel' as a valid profile value."""
+class TestSlimConfigValidation:
+    """NexusConfig validates 'slim' as a valid profile value."""
 
-    def test_minimal_profile_accepted(self) -> None:
+    def test_slim_profile_accepted(self) -> None:
         from nexus.config import NexusConfig
 
-        cfg = NexusConfig(profile="minimal")
-        assert cfg.profile == "minimal"
+        cfg = NexusConfig(profile="slim")
+        assert cfg.profile == "slim"
 
     def test_invalid_profile_rejected(self) -> None:
         from nexus.config import NexusConfig
@@ -193,77 +193,75 @@ class TestMinimalConfigValidation:
 
 
 # ---------------------------------------------------------------------------
-# TestMinimalTuning — performance tuning exists and values <= EMBEDDED
+# TestSlimTuning — performance tuning exists and values <= EMBEDDED
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalTuning:
-    """MINIMAL profile has tuning values that are <= EMBEDDED for resources."""
+class TestSlimTuning:
+    """SLIM profile has tuning values that are <= EMBEDDED for resources."""
 
-    def test_minimal_tuning_exists(self) -> None:
+    def test_slim_tuning_exists(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        tuning = DeploymentProfile.MINIMAL.tuning()
+        tuning = DeploymentProfile.SLIM.tuning()
         assert tuning is not None
 
     def test_thread_pool_lte_embedded(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal = DeploymentProfile.MINIMAL.tuning()
+        slim = DeploymentProfile.SLIM.tuning()
         embedded = DeploymentProfile.EMBEDDED.tuning()
-        assert minimal.concurrency.thread_pool_size <= embedded.concurrency.thread_pool_size
+        assert slim.concurrency.thread_pool_size <= embedded.concurrency.thread_pool_size
 
     def test_db_pool_lte_embedded(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal = DeploymentProfile.MINIMAL.tuning()
+        slim = DeploymentProfile.SLIM.tuning()
         embedded = DeploymentProfile.EMBEDDED.tuning()
-        assert minimal.storage.db_pool_size <= embedded.storage.db_pool_size
+        assert slim.storage.db_pool_size <= embedded.storage.db_pool_size
 
     def test_asyncpg_max_lte_embedded(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal = DeploymentProfile.MINIMAL.tuning()
+        slim = DeploymentProfile.SLIM.tuning()
         embedded = DeploymentProfile.EMBEDDED.tuning()
-        assert minimal.pool.asyncpg_max_size <= embedded.pool.asyncpg_max_size
+        assert slim.pool.asyncpg_max_size <= embedded.pool.asyncpg_max_size
 
     def test_default_workers_lte_embedded(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal = DeploymentProfile.MINIMAL.tuning()
+        slim = DeploymentProfile.SLIM.tuning()
         embedded = DeploymentProfile.EMBEDDED.tuning()
-        assert minimal.concurrency.default_workers <= embedded.concurrency.default_workers
+        assert slim.concurrency.default_workers <= embedded.concurrency.default_workers
 
     def test_intervals_gte_embedded(self) -> None:
         """Intervals (cleanup, heartbeat) should be >= EMBEDDED (less frequent)."""
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal = DeploymentProfile.MINIMAL.tuning()
+        slim = DeploymentProfile.SLIM.tuning()
         embedded = DeploymentProfile.EMBEDDED.tuning()
         assert (
-            minimal.background_task.heartbeat_flush_interval
+            slim.background_task.heartbeat_flush_interval
             >= embedded.background_task.heartbeat_flush_interval
         )
         assert (
-            minimal.background_task.sandbox_cleanup_interval
+            slim.background_task.sandbox_cleanup_interval
             >= embedded.background_task.sandbox_cleanup_interval
         )
 
 
 # ---------------------------------------------------------------------------
-# TestMinimalHierarchy — kernel < embedded < lite < full <= cloud
+# TestSlimHierarchy — slim < embedded < lite < full <= cloud
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalHierarchy:
+class TestSlimHierarchy:
     """Profile hierarchy: each tier's bricks are a superset of the previous."""
 
-    def test_minimal_subset_of_embedded(self) -> None:
+    def test_slim_subset_of_embedded(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        assert (
-            DeploymentProfile.MINIMAL.default_bricks() < DeploymentProfile.EMBEDDED.default_bricks()
-        )
+        assert DeploymentProfile.SLIM.default_bricks() < DeploymentProfile.EMBEDDED.default_bricks()
 
     def test_embedded_subset_of_lite(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
@@ -280,54 +278,54 @@ class TestMinimalHierarchy:
 
         assert DeploymentProfile.FULL.default_bricks() <= DeploymentProfile.CLOUD.default_bricks()
 
-    def test_minimal_is_strict_minimum(self) -> None:
-        """MINIMAL has exactly 1 brick (storage)."""
+    def test_slim_is_strict_minimum(self) -> None:
+        """SLIM has exactly 1 brick (storage)."""
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        assert len(DeploymentProfile.MINIMAL.default_bricks()) == 1
+        assert len(DeploymentProfile.SLIM.default_bricks()) == 1
 
 
 # ---------------------------------------------------------------------------
-# TestMinimalDeviceCapabilities — profile index
+# TestSlimDeviceCapabilities — profile index
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalDeviceCapabilities:
-    """Kernel appears in device capability profile index."""
+class TestSlimDeviceCapabilities:
+    """Slim appears in device capability profile index."""
 
-    def test_minimal_in_profile_index(self) -> None:
+    def test_slim_in_profile_index(self) -> None:
         from nexus.lib.device_capabilities import _PROFILE_INDEX
 
-        assert "minimal" in _PROFILE_INDEX
+        assert "slim" in _PROFILE_INDEX
 
-    def test_minimal_index_below_embedded(self) -> None:
+    def test_slim_index_below_embedded(self) -> None:
         from nexus.lib.device_capabilities import _PROFILE_INDEX
 
-        assert _PROFILE_INDEX["minimal"] < _PROFILE_INDEX["embedded"]
+        assert _PROFILE_INDEX["slim"] < _PROFILE_INDEX["embedded"]
 
-    def test_minimal_never_auto_suggested(self) -> None:
-        """suggest_profile() never returns MINIMAL — it must be explicit."""
+    def test_slim_never_auto_suggested(self) -> None:
+        """suggest_profile() never returns SLIM — it must be explicit."""
         from nexus.lib.device_capabilities import DeviceCapabilities, suggest_profile
 
-        # Even with very low memory, suggest_profile returns EMBEDDED, not MINIMAL
+        # Even with very low memory, suggest_profile returns EMBEDDED, not SLIM
         tiny = DeviceCapabilities(memory_mb=16, cpu_cores=1)
         suggested = suggest_profile(tiny)
-        assert suggested.value != "minimal"
+        assert suggested.value != "slim"
 
 
 # ---------------------------------------------------------------------------
-# TestMinimalIntegrationViaConnect — full connect() path with profile=kernel
+# TestSlimIntegrationViaConnect — full connect() path with profile=slim
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalIntegrationViaConnect:
-    """Integration: nexus.connect() with profile=kernel boots bare kernel."""
+class TestSlimIntegrationViaConnect:
+    """Integration: nexus.connect() with profile=slim boots bare kernel."""
 
     @pytest.mark.asyncio
-    async def test_connect_kernel_profile_creates_nexusfs(
+    async def test_connect_slim_profile_creates_nexusfs(
         self, tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """connect() with profile=kernel gives a functional NexusFS."""
+        """connect() with profile=slim gives a functional NexusFS."""
         from nexus.backends.storage.path_local import PathLocalBackend
         from nexus.contracts.deployment_profile import DeploymentProfile, resolve_enabled_bricks
         from nexus.core.config import PermissionConfig
@@ -337,9 +335,9 @@ class TestMinimalIntegrationViaConnect:
         data_dir = tmp_path / "data"
         data_dir.mkdir(exist_ok=True)
 
-        monkeypatch.setenv("NEXUS_PROFILE", "minimal")
+        monkeypatch.setenv("NEXUS_PROFILE", "slim")
 
-        profile = DeploymentProfile.MINIMAL
+        profile = DeploymentProfile.SLIM
         enabled_bricks = resolve_enabled_bricks(profile)
         assert enabled_bricks == frozenset({"storage"})
 
@@ -358,30 +356,30 @@ class TestMinimalIntegrationViaConnect:
         assert getattr(nx._system_services, "audit_store", None) is None
 
         # File operations should work
-        await nx.write("/hello.txt", b"minimal mode")
-        assert await nx.sys_read("/hello.txt") == b"minimal mode"
+        await nx.write("/hello.txt", b"slim mode")
+        assert await nx.sys_read("/hello.txt") == b"slim mode"
         assert await nx.sys_access("/hello.txt") is True
         await nx.sys_unlink("/hello.txt")
         assert await nx.sys_access("/hello.txt") is False
 
     @pytest.mark.asyncio
-    async def test_minimal_factory_enabled_bricks_logged(
+    async def test_slim_factory_enabled_bricks_logged(
         self, tmp_path: "Path", monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Factory logs exactly 1 enabled brick for MINIMAL profile."""
+        """Factory logs exactly 1 enabled brick for SLIM profile."""
         import logging
 
         data_dir = tmp_path / "data"
         data_dir.mkdir(exist_ok=True)
 
-        monkeypatch.setenv("NEXUS_PROFILE", "minimal")
+        monkeypatch.setenv("NEXUS_PROFILE", "slim")
 
         from nexus.backends.storage.path_local import PathLocalBackend
         from nexus.contracts.deployment_profile import DeploymentProfile, resolve_enabled_bricks
         from nexus.factory.orchestrator import create_nexus_fs
         from tests.helpers.dict_metastore import DictMetastore
 
-        enabled_bricks = resolve_enabled_bricks(DeploymentProfile.MINIMAL)
+        enabled_bricks = resolve_enabled_bricks(DeploymentProfile.SLIM)
 
         with caplog.at_level(logging.INFO, logger="nexus.factory.orchestrator"):
             # Using record_store triggers create_nexus_services which logs bricks
@@ -396,8 +394,8 @@ class TestMinimalIntegrationViaConnect:
         assert nx is not None
 
     @pytest.mark.asyncio
-    async def test_minimal_profile_dispatch_has_no_observers(self, tmp_path: "Path") -> None:
-        """MINIMAL mode has only the late-binding EventBusObserver (no record store to sync)."""
+    async def test_slim_profile_dispatch_has_no_observers(self, tmp_path: "Path") -> None:
+        """SLIM mode has only the late-binding EventBusObserver (no record store to sync)."""
         from nexus.backends.storage.path_local import PathLocalBackend
         from nexus.contracts.deployment_profile import DeploymentProfile, resolve_enabled_bricks
         from nexus.factory.orchestrator import create_nexus_fs
@@ -410,7 +408,7 @@ class TestMinimalIntegrationViaConnect:
             backend=PathLocalBackend(root_path=data_dir),
             metadata_store=DictMetastore(),
             record_store=None,
-            enabled_bricks=resolve_enabled_bricks(DeploymentProfile.MINIMAL),
+            enabled_bricks=resolve_enabled_bricks(DeploymentProfile.SLIM),
         )
 
         # EventBusObserver + RevisionTrackingObserver are unconditionally
@@ -419,8 +417,8 @@ class TestMinimalIntegrationViaConnect:
         assert nx._dispatch.observer_count == 2
 
     @pytest.mark.asyncio
-    async def test_minimal_profile_no_workflow_engine(self, tmp_path: "Path") -> None:
-        """MINIMAL mode has no workflow engine."""
+    async def test_slim_profile_no_workflow_engine(self, tmp_path: "Path") -> None:
+        """SLIM mode has no workflow engine."""
         from nexus.backends.storage.path_local import PathLocalBackend
         from nexus.contracts.deployment_profile import DeploymentProfile, resolve_enabled_bricks
         from nexus.factory.orchestrator import create_nexus_fs
@@ -433,7 +431,7 @@ class TestMinimalIntegrationViaConnect:
             backend=PathLocalBackend(root_path=data_dir),
             metadata_store=DictMetastore(),
             record_store=None,
-            enabled_bricks=resolve_enabled_bricks(DeploymentProfile.MINIMAL),
+            enabled_bricks=resolve_enabled_bricks(DeploymentProfile.SLIM),
         )
 
         # workflow_engine is no longer a NexusFS attribute; it lives in
@@ -442,46 +440,44 @@ class TestMinimalIntegrationViaConnect:
 
 
 # ---------------------------------------------------------------------------
-# TestMinimalPerformanceCharacteristics — no perf regressions
+# TestSlimPerformanceCharacteristics — no perf regressions
 # ---------------------------------------------------------------------------
 
 
-class TestMinimalPerformanceCharacteristics:
-    """Verify minimal tuning values are the most conservative across all profiles."""
+class TestSlimPerformanceCharacteristics:
+    """Verify slim tuning values are the most conservative across all profiles."""
 
-    def test_minimal_has_smallest_thread_pool(self) -> None:
+    def test_slim_has_smallest_thread_pool(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal_tp = DeploymentProfile.MINIMAL.tuning().concurrency.thread_pool_size
+        slim_tp = DeploymentProfile.SLIM.tuning().concurrency.thread_pool_size
         for profile in DeploymentProfile:
             other_tp = profile.tuning().concurrency.thread_pool_size
-            assert minimal_tp <= other_tp, (
-                f"MINIMALthread_pool ({minimal_tp}) > {profile} ({other_tp})"
-            )
+            assert slim_tp <= other_tp, f"SLIM thread_pool ({slim_tp}) > {profile} ({other_tp})"
 
-    def test_minimal_has_smallest_db_pool(self) -> None:
+    def test_slim_has_smallest_db_pool(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal_dp = DeploymentProfile.MINIMAL.tuning().storage.db_pool_size
+        slim_dp = DeploymentProfile.SLIM.tuning().storage.db_pool_size
         for profile in DeploymentProfile:
             other_dp = profile.tuning().storage.db_pool_size
-            assert minimal_dp <= other_dp, f"MINIMALdb_pool ({minimal_dp}) > {profile} ({other_dp})"
+            assert slim_dp <= other_dp, f"SLIM db_pool ({slim_dp}) > {profile} ({other_dp})"
 
-    def test_minimal_has_fewest_workers(self) -> None:
+    def test_slim_has_fewest_workers(self) -> None:
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal_w = DeploymentProfile.MINIMAL.tuning().concurrency.default_workers
+        slim_w = DeploymentProfile.SLIM.tuning().concurrency.default_workers
         for profile in DeploymentProfile:
             other_w = profile.tuning().concurrency.default_workers
-            assert minimal_w <= other_w, f"MINIMALworkers ({minimal_w}) > {profile} ({other_w})"
+            assert slim_w <= other_w, f"SLIM workers ({slim_w}) > {profile} ({other_w})"
 
-    def test_minimal_has_longest_cleanup_intervals(self) -> None:
-        """MINIMAL should have the longest (least frequent) cleanup intervals."""
+    def test_slim_has_longest_cleanup_intervals(self) -> None:
+        """SLIM should have the longest (least frequent) cleanup intervals."""
         from nexus.contracts.deployment_profile import DeploymentProfile
 
-        minimal_hb = DeploymentProfile.MINIMAL.tuning().background_task.heartbeat_flush_interval
+        slim_hb = DeploymentProfile.SLIM.tuning().background_task.heartbeat_flush_interval
         for profile in DeploymentProfile:
             other_hb = profile.tuning().background_task.heartbeat_flush_interval
-            assert minimal_hb >= other_hb, (
-                f"MINIMALheartbeat interval ({minimal_hb}) < {profile} ({other_hb})"
+            assert slim_hb >= other_hb, (
+                f"SLIM heartbeat interval ({slim_hb}) < {profile} ({other_hb})"
             )

--- a/tests/unit/core/test_write_observer_calls.py
+++ b/tests/unit/core/test_write_observer_calls.py
@@ -15,39 +15,22 @@ Issue #900: Migrated from _write_observer to KernelDispatch.
 
 from __future__ import annotations
 
-import tempfile
-from collections.abc import Generator
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from nexus import CASLocalBackend, NexusFS
-from nexus.core.config import ParseConfig, PermissionConfig
 from nexus.core.file_events import FileEventType
-from tests.helpers.dict_metastore import DictMetastore
-from tests.helpers.test_context import TEST_CONTEXT
+from tests.conftest import make_test_nexus
+
+if TYPE_CHECKING:
+    from nexus.core.nexus_fs import NexusFS
 
 
 @pytest.fixture
-def temp_dir() -> Generator[Path, None, None]:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield Path(tmpdir)
-
-
-@pytest.fixture
-def nx(temp_dir: Path) -> Generator[NexusFS, None, None]:
-    metastore = DictMetastore()
-    backend = CASLocalBackend(str(temp_dir / "data"))
-    nx = NexusFS(
-        metadata_store=metastore,
-        permissions=PermissionConfig(enforce=False),
-        parsing=ParseConfig(auto_parse=False),
-        init_cred=TEST_CONTEXT,
-    )
-    nx.router.add_mount("/", backend)
-    yield nx
-    nx.close()
+async def nx(tmp_path: Path) -> NexusFS:
+    return await make_test_nexus(tmp_path)
 
 
 @pytest.fixture
@@ -286,19 +269,10 @@ class TestVFSObserverCoverage:
         return mock
 
     @pytest.fixture
-    def nx_with_hook(self, temp_dir: Path, hook: AsyncMock) -> Generator[NexusFS, None, None]:
-        metastore = DictMetastore()
-        backend = CASLocalBackend(str(temp_dir / "data"))
-        nx = NexusFS(
-            metadata_store=metastore,
-            permissions=PermissionConfig(enforce=False),
-            parsing=ParseConfig(auto_parse=False),
-            init_cred=TEST_CONTEXT,
-        )
-        nx.router.add_mount("/", backend)
+    async def nx_with_hook(self, tmp_path: Path, hook: AsyncMock) -> NexusFS:
+        nx = await make_test_nexus(tmp_path)
         nx.register_observe(hook)
-        yield nx
-        nx.close()
+        return nx
 
     @pytest.mark.asyncio
     async def test_write_fires_hook(self, nx_with_hook: NexusFS, hook: AsyncMock) -> None:

--- a/tests/unit/factory/test_wired_services.py
+++ b/tests/unit/factory/test_wired_services.py
@@ -9,7 +9,6 @@ import pytest
 
 from nexus.core.config import WiredServices
 from nexus.factory.service_routing import enlist_wired_services
-from tests.helpers.test_context import TEST_CONTEXT
 
 
 class TestWiredServicesDataclass:
@@ -47,21 +46,11 @@ class TestEnlistWiredServices:
     """Test enlist_wired_services accepts both WiredServices and dict (#1708)."""
 
     @pytest.fixture()
-    def nx(self) -> Any:
-        """Minimal NexusFS with mocked pillars."""
-        from nexus.core.config import KernelServices, ParseConfig
-        from nexus.core.nexus_fs import NexusFS
+    async def nx(self, tmp_path: Any) -> Any:
+        """Minimal NexusFS via factory boot path."""
+        from tests.conftest import make_test_nexus
 
-        mock_metadata = MagicMock()
-        mock_metadata.list = MagicMock(return_value=[])
-
-        nx = NexusFS(
-            metadata_store=mock_metadata,
-            kernel_services=KernelServices(),
-            parsing=ParseConfig(auto_parse=False),
-        )
-        nx._init_cred = TEST_CONTEXT
-        return nx
+        return await make_test_nexus(tmp_path)
 
     @pytest.fixture()
     def registry(self, nx: Any) -> Any:

--- a/tests/unit/test_connect_quickstart.py
+++ b/tests/unit/test_connect_quickstart.py
@@ -28,7 +28,7 @@ async def test_local_connect_falls_back_when_full_federation_build_is_unavailabl
 
     nx = await nexus.connect(
         config={
-            "profile": "minimal",
+            "profile": "slim",
             "data_dir": str(tmp_path / "nexus-data"),
         }
     )


### PR DESCRIPTION
## Summary
- Rename `DeploymentProfile.MINIMAL` → `SLIM` (no backward compat) — 15 files
- Migrate 11 test files from direct `NexusFS()` constructor to `make_test_nexus()` / `create_nexus_fs()` — tests now use the same boot path as production
- Delete manual wiring from tests: `_init_cred` setattr, `router.add_mount()`, `_system_services`, `PermissionCheckHook`

Completes the #1801 plan — unified boot path, no more bypass.

## Test plan
- [ ] CI lint + type check
- [ ] Unit tests pass (all migrated fixtures work async)
- [ ] Profile rename: `"slim"` recognized everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)