### PR TITLE
refactor(#1801): internalize rebac sub-components into ReBACManager

### DIFF
--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -135,6 +135,7 @@ class ReBACManager:
         is_postgresql: bool = False,
         version_store: MetastoreVersionStore | None = None,
         namespace_store: "MetastoreNamespaceStore | None" = None,
+        enable_inheritance: bool = True,
     ):
         """Initialize ReBAC manager.
 
@@ -151,6 +152,7 @@ class ReBACManager:
             is_postgresql: Whether the database is PostgreSQL (config-time flag).
             version_store: MetastoreVersionStore for zone revision tracking (Issue #191).
             namespace_store: MetastoreNamespaceStore for namespace config (Issue #183).
+            enable_inheritance: Enable automatic parent tuple creation in HierarchyManager.
         """
         # ── Base initialization (formerly in ReBACManager.__init__) ──
         self.engine = engine
@@ -375,6 +377,68 @@ class ReBACManager:
 
         # Issue #3192: Wire SharedRingBuffer for cross-process revision broadcasting
         self._wire_shared_ring_buffer()
+
+        # ── Internalized sub-components (formerly factory-constructed) ────
+        # These are rebac-internal concerns — factory shouldn't construct them.
+
+        # HierarchyManager: automatic parent tuple creation on permission writes
+        from nexus.bricks.rebac.hierarchy_manager import HierarchyManager
+
+        self._hierarchy_manager: HierarchyManager = HierarchyManager(
+            rebac_manager=self,
+            enable_inheritance=enable_inheritance,
+        )
+
+        # DirectoryVisibilityCache: O(1) directory permission lookups via Tiger bitmaps
+        from nexus.bricks.rebac.cache.visibility import DirectoryVisibilityCache
+
+        self._dir_visibility_cache: DirectoryVisibilityCache = DirectoryVisibilityCache(
+            tiger_cache=self._tiger_cache,
+            ttl=cache_ttl_seconds,
+            max_entries=10000,
+        )
+        # Wire invalidation: permission changes → dir visibility cache
+        self.register_dir_visibility_invalidator(
+            "nexusfs",
+            lambda zone_id, path: self._dir_visibility_cache.invalidate_for_resource(path, zone_id),
+        )
+
+        # NamespaceManager: optional (profile-gated), created on demand via
+        # create_namespace_manager() when namespace brick is enabled.
+        self._namespace_manager: "Any | None" = None
+
+    # ── Public property accessors for internalized sub-components ────
+
+    @property
+    def hierarchy_manager(self) -> Any:
+        """HierarchyManager — automatic parent tuple creation on permission writes."""
+        return self._hierarchy_manager
+
+    @property
+    def dir_visibility_cache(self) -> Any:
+        """DirectoryVisibilityCache — O(1) directory permission lookups."""
+        return self._dir_visibility_cache
+
+    @property
+    def namespace_manager(self) -> Any:
+        """NamespaceManager — per-subject namespace visibility (may be None if not created)."""
+        return self._namespace_manager
+
+    def create_namespace_manager(self, record_store: Any = None) -> Any:
+        """Create and attach the NamespaceManager (profile-gated, call when namespace brick is enabled).
+
+        Args:
+            record_store: RecordStoreABC for L3 persistent view store. If None, L3 is disabled.
+
+        Returns:
+            The newly created NamespaceManager instance.
+        """
+        from nexus.bricks.rebac.namespace_factory import (
+            create_namespace_manager as _create_ns_manager,
+        )
+
+        self._namespace_manager = _create_ns_manager(self, record_store)
+        return self._namespace_manager
 
     def _create_invalidation_stream(self) -> Any:
         """Create the DT_STREAM for ordered intra-zone invalidation."""

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -28,7 +28,6 @@ from nexus.contracts.constants import DEFAULT_NATS_URL
 
 if TYPE_CHECKING:
     from nexus.bricks.workflows.protocol import WorkflowProtocol
-    from nexus.contracts.protocols.namespace_manager import NamespaceManagerProtocol
     from nexus.contracts.write_observer import WriteObserverProtocol
     from nexus.core.protocols.entity_registry import EntityRegistryProtocol
     from nexus.core.protocols.permission_enforcer import PermissionEnforcerProtocol
@@ -209,9 +208,9 @@ class SystemServices:
     # Former-kernel DEGRADABLE services (WARNING + None on failure)
     # =================================================================
 
-    # ReBAC caching / hierarchy — degradable
-    dir_visibility_cache: Any = None
-    hierarchy_manager: Any = None
+    # ReBAC caching / hierarchy — now internalized into ReBACManager:
+    # hierarchy_manager, dir_visibility_cache → rebac_manager.hierarchy_manager, .dir_visibility_cache
+    # namespace_manager → rebac_manager.namespace_manager (created via .create_namespace_manager())
     deferred_permission_buffer: Any = None
 
     # Workspace subsystem — degradable
@@ -223,8 +222,7 @@ class SystemServices:
     # Original system services (all degradable)
     # =================================================================
 
-    # Namespace visibility (Issue #1502)
-    namespace_manager: NamespaceManagerProtocol | None = None
+    # Namespace visibility (Issue #1502) — async wrapper still needed at system level
     async_namespace_manager: Any = None
 
     # Workspace branching (Issue #1315)

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -99,6 +99,7 @@ def _boot_system_services(
                 is_postgresql=_is_pg,
                 version_store=_version_store,
                 namespace_store=_namespace_store,
+                enable_inheritance=ctx.perm.inherit,
             )
 
             # --- Audit Store ---
@@ -188,38 +189,19 @@ def _boot_system_services(
     # DEGRADABLE FORMER-KERNEL SECTION (WARNING + None) — Issue #2193
     # =====================================================================
 
-    # --- Directory Visibility Cache ---
-    dir_visibility_cache: Any = None
-    try:
-        from nexus.bricks.rebac.cache.visibility import DirectoryVisibilityCache
-
-        dir_visibility_cache = DirectoryVisibilityCache(
-            tiger_cache=getattr(rebac_manager, "_tiger_cache", None),
-            ttl=ctx.cache_ttl_seconds or 300,
-            max_entries=10000,
-        )
-
-        # Wire: rebac invalidation -> dir visibility cache
-        rebac_manager.register_dir_visibility_invalidator(
-            "nexusfs",
-            lambda zone_id, path: dir_visibility_cache.invalidate_for_resource(path, zone_id),
-        )
-        logger.debug("[BOOT:SYSTEM] DirectoryVisibilityCache created")
-    except Exception as exc:
-        logger.warning("[BOOT:SYSTEM] DirectoryVisibilityCache unavailable: %s", exc)
-
-    # --- Hierarchy Manager ---
-    hierarchy_manager: Any = None
-    try:
-        from nexus.bricks.rebac.hierarchy_manager import HierarchyManager
-
-        hierarchy_manager = HierarchyManager(
-            rebac_manager=rebac_manager,
-            enable_inheritance=ctx.perm.inherit,
-        )
-        logger.debug("[BOOT:SYSTEM] HierarchyManager created")
-    except Exception as exc:
-        logger.warning("[BOOT:SYSTEM] HierarchyManager unavailable: %s", exc)
+    # --- Directory Visibility Cache + Hierarchy Manager ---
+    # Now internalized into ReBACManager (constructed in its __init__).
+    # Access via rebac_manager.dir_visibility_cache / rebac_manager.hierarchy_manager.
+    dir_visibility_cache: Any = (
+        getattr(rebac_manager, "dir_visibility_cache", None) if rebac_manager else None
+    )
+    hierarchy_manager: Any = (
+        getattr(rebac_manager, "hierarchy_manager", None) if rebac_manager else None
+    )
+    if dir_visibility_cache is not None:
+        logger.debug("[BOOT:SYSTEM] DirectoryVisibilityCache (rebac-internal)")
+    if hierarchy_manager is not None:
+        logger.debug("[BOOT:SYSTEM] HierarchyManager (rebac-internal)")
 
     # --- Deferred Permission Buffer (constructed, NOT started) ---
     deferred_permission_buffer: Any = None
@@ -291,23 +273,22 @@ def _boot_system_services(
     # =====================================================================
 
     # --- Namespace Manager (Issue #1502) ---
+    # Now created via rebac_manager.create_namespace_manager() (rebac-internal).
     namespace_manager: Any = None
     async_namespace_manager: Any = None
     if not _on("namespace"):
         logger.debug("[BOOT:SYSTEM] NamespaceManager disabled by profile")
-    else:
+    elif rebac_manager is not None:
         try:
-            from nexus.bricks.rebac.namespace_factory import (
-                create_namespace_manager as _create_ns_manager,
-            )
             from nexus.bricks.rebac.namespace_manager import AsyncNamespaceManager
 
-            namespace_manager = _create_ns_manager(
-                rebac_manager=rebac_manager,
+            namespace_manager = rebac_manager.create_namespace_manager(
                 record_store=ctx.record_store,
             )
             async_namespace_manager = AsyncNamespaceManager(namespace_manager)
-            logger.debug("[BOOT:SYSTEM] NamespaceManager + AsyncNamespaceManager created")
+            logger.debug(
+                "[BOOT:SYSTEM] NamespaceManager + AsyncNamespaceManager created (rebac-internal)"
+            )
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] NamespaceManager unavailable: %s", exc)
 
@@ -482,14 +463,13 @@ def _boot_system_services(
         "permission_enforcer": permission_enforcer,
         "write_observer": write_observer,
         # Former-kernel degradable
-        "dir_visibility_cache": dir_visibility_cache,
-        "hierarchy_manager": hierarchy_manager,
+        # dir_visibility_cache, hierarchy_manager, namespace_manager
+        # now internalized into ReBACManager — not in result dict.
         "deferred_permission_buffer": deferred_permission_buffer,
         "workspace_registry": workspace_registry,
         "mount_manager": mount_manager,
         "workspace_manager": workspace_manager,
         # Original system services
-        "namespace_manager": namespace_manager,
         "async_namespace_manager": async_namespace_manager,
         "delivery_worker": delivery_worker,
         "event_signal": ctx.event_signal,

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -410,7 +410,9 @@ async def _boot_wired_services(
         descendant_checker = DescendantAccessChecker(
             rebac_manager=system_services.rebac_manager,
             rebac_service=rebac_service,
-            dir_visibility_cache=system_services.dir_visibility_cache,
+            dir_visibility_cache=getattr(
+                system_services.rebac_manager, "dir_visibility_cache", None
+            ),
             permission_enforcer=system_services.permission_enforcer,
             metadata_store=nx.metadata,
         )

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -179,14 +179,13 @@ def create_nexus_services(
         permission_enforcer=system_dict["permission_enforcer"],
         write_observer=system_dict["write_observer"],
         # Former-kernel degradable (Issue #2193)
-        dir_visibility_cache=system_dict["dir_visibility_cache"],
-        hierarchy_manager=system_dict["hierarchy_manager"],
+        # hierarchy_manager, dir_visibility_cache, namespace_manager
+        # now internalized into ReBACManager — access via rebac_manager properties
         deferred_permission_buffer=system_dict["deferred_permission_buffer"],
         workspace_registry=system_dict["workspace_registry"],
         mount_manager=system_dict["mount_manager"],
         workspace_manager=system_dict["workspace_manager"],
         # Original system services
-        namespace_manager=system_dict["namespace_manager"],
         async_namespace_manager=system_dict["async_namespace_manager"],
         context_branch_service=system_dict.get("context_branch_service"),
         brick_lifecycle_manager=system_dict.get("brick_lifecycle_manager"),
@@ -603,7 +602,7 @@ async def _register_vfs_hooks(
         )
     else:
         # Sync fallback — same logic, runs as post-write hook instead of inline kernel code
-        _hier = getattr(system_services, "hierarchy_manager", None) if system_services else None
+        _hier = getattr(_rebac_for_perm, "hierarchy_manager", None) if _rebac_for_perm else None
         if _hier is not None or _rebac_for_perm is not None:
             from nexus.bricks.rebac.sync_permission_hook import SyncPermissionWriteHook
 

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -53,14 +53,12 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "permission_enforcer",
         "write_observer",
         # Former-kernel degradable
-        "dir_visibility_cache",
-        "hierarchy_manager",
+        # hierarchy_manager, dir_visibility_cache, namespace_manager → rebac-internal
         "deferred_permission_buffer",
         "workspace_registry",
         "mount_manager",
         "workspace_manager",
         # Original system services
-        "namespace_manager",
         "async_namespace_manager",
         "delivery_worker",
         "observability_subsystem",
@@ -233,7 +231,8 @@ class TestBootSystemServices:
     def test_degradable_failure_returns_none(self) -> None:
         """Degradable service failure returns None (not an exception).
 
-        Patches namespace_manager. Agent registry was removed (Issue #1692).
+        Patches namespace_manager creation via rebac_manager.create_namespace_manager().
+        Agent registry was removed (Issue #1692).
         """
         ctx = _make_boot_context()
 
@@ -244,9 +243,10 @@ class TestBootSystemServices:
             result = _boot_system_services(ctx)
 
         assert isinstance(result, dict)
-        assert result["namespace_manager"] is None
-        # Critical services should still work
-        assert result["rebac_manager"] is not None
+        # namespace_manager is now rebac-internal — verify via rebac_manager property
+        rebac = result["rebac_manager"]
+        assert rebac is not None
+        assert getattr(rebac, "namespace_manager", None) is None
 
     def test_deferred_buffer_none_when_disabled(self) -> None:
         """deferred_permission_buffer is None when enable_deferred=False."""

--- a/tests/unit/core/test_kernel_config.py
+++ b/tests/unit/core/test_kernel_config.py
@@ -259,14 +259,12 @@ class TestSystemServices:
         assert ss.permission_enforcer is None
         assert ss.write_observer is None
         # Former-kernel degradable
-        assert ss.dir_visibility_cache is None
-        assert ss.hierarchy_manager is None
+        # hierarchy_manager, dir_visibility_cache, namespace_manager now rebac-internal
         assert ss.deferred_permission_buffer is None
         assert ss.workspace_registry is None
         assert ss.mount_manager is None
         assert ss.workspace_manager is None
         # Original system services
-        assert ss.namespace_manager is None
         assert ss.async_namespace_manager is None
         assert ss.context_branch_service is None
         assert ss.brick_lifecycle_manager is None
@@ -278,12 +276,12 @@ class TestSystemServices:
     def test_frozen(self) -> None:
         ss = SystemServices()
         with pytest.raises(dataclasses.FrozenInstanceError):
-            ss.namespace_manager = "x"
+            ss.async_namespace_manager = "x"
 
     def test_construct_with_values(self) -> None:
         sentinel = object()
-        ss = SystemServices(namespace_manager=sentinel, resiliency_manager=sentinel)
-        assert ss.namespace_manager is sentinel
+        ss = SystemServices(async_namespace_manager=sentinel, resiliency_manager=sentinel)
+        assert ss.async_namespace_manager is sentinel
         assert ss.resiliency_manager is sentinel
         assert ss.delivery_worker is None
 
@@ -307,14 +305,12 @@ class TestSystemServices:
             "permission_enforcer",
             "write_observer",
             # Former-kernel degradable
-            "dir_visibility_cache",
-            "hierarchy_manager",
+            # hierarchy_manager, dir_visibility_cache, namespace_manager → rebac-internal
             "deferred_permission_buffer",
             "workspace_registry",
             "mount_manager",
             "workspace_manager",
             # Original system services
-            "namespace_manager",
             "async_namespace_manager",
             "context_branch_service",
             "brick_lifecycle_manager",
@@ -335,9 +331,6 @@ class TestSystemServices:
 
     def test_protocol_type_annotations(self) -> None:
         annotations = SystemServices.__annotations__
-        ns_ann = str(annotations.get("namespace_manager", ""))
-        assert "NamespaceManagerProtocol" in ns_ann
-        assert "None" in ns_ann
         # Issue #2193: write_observer moved from KernelServices
         wo_ann = str(annotations.get("write_observer", ""))
         assert "WriteObserverProtocol" in wo_ann


### PR DESCRIPTION
## Summary
- Move `hierarchy_manager`, `dir_visibility_cache`, `namespace_manager` construction **into** ReBACManager — factory no longer builds them
- Add `enable_inheritance` constructor param to ReBACManager  
- Add `create_namespace_manager(record_store)` method for profile-gated creation
- Add property accessors: `.hierarchy_manager`, `.dir_visibility_cache`, `.namespace_manager`
- Simplify factory `_system.py` (~30 lines deleted), update consumers in `orchestrator.py` and `_wired.py`
- Remove 3 fields from `SystemServices` dataclass (now rebac-internal)

## Test plan
- [x] `uv run pytest tests/unit/core/test_factory_boot.py tests/unit/core/test_kernel_config.py -v` — 60 passed
- [x] `uv run pytest tests/unit/core/ tests/unit/services/ tests/unit/server/ -x -q` — 2319 passed (1 pre-existing failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)