### PR TITLE
refactor(#1801): enlist all remaining services + eliminate DI setattr

### DIFF
--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -133,7 +133,7 @@ async def _do_link(
     from nexus.core.driver_lifecycle_coordinator import DriverLifecycleCoordinator
 
     driver_coordinator = DriverLifecycleCoordinator(nx.router, nx._dispatch)
-    nx._driver_coordinator = driver_coordinator
+    await nx._service_registry.enlist("driver_coordinator", driver_coordinator)
     driver_coordinator.adopt_existing_mount("/")
 
     # Issue #1666: Register system-tier PersistentService instances.
@@ -146,13 +146,26 @@ async def _do_link(
     if _dw is not None:
         await nx._service_registry.enlist("delivery_worker", _dw)
 
-    # Issue #1771: Enlist SystemServices fields that are read externally via
-    # getattr(nx, "_system_services", None).field — migrate to nx.service("name").
+    # Issue #1771: Enlist ALL SystemServices fields into ServiceRegistry.
+    # After this, every service is available via nx.service("name").
+    # Note: permission_enforcer stays as kernel-owns DI (Issue #1815).
     for _attr, _canonical in (
         ("event_bus", "event_bus"),
         ("context_branch_service", "context_branch"),
         ("rebac_manager", "rebac_manager"),
         ("resiliency_manager", "resiliency_manager"),
+        ("write_observer", "write_observer"),
+        ("observability_subsystem", "observability_subsystem"),
+        ("zone_lifecycle", "zone_lifecycle"),
+        ("scheduler_service", "scheduler_service"),
+        ("entity_registry", "entity_registry"),
+        ("workspace_registry", "workspace_registry"),
+        ("mount_manager", "mount_manager"),
+        ("audit_store", "audit_store"),
+        ("brick_lifecycle_manager", "brick_lifecycle_manager"),
+        ("brick_reconciler", "brick_reconciler"),
+        ("async_namespace_manager", "async_namespace_manager"),
+        ("workspace_manager", "workspace_manager"),
     ):
         _val = getattr(system_services, _attr, None)
         if _val is not None:
@@ -300,7 +313,7 @@ async def _do_link(
                 policy=_eviction_policy,
                 tuning=_eviction_tuning,
             )
-            nx._eviction_manager = _eviction_manager
+            await nx._service_registry.enlist("eviction_manager", _eviction_manager)
             logger.debug("[BOOT:LINK] EvictionManager created (deferred, QoS-aware)")
         except Exception as exc:
             logger.warning("[BOOT:LINK] EvictionManager unavailable: %s", exc)
@@ -313,7 +326,7 @@ async def _do_link(
                 agent_registry=_agent_reg,
                 zone_id=zone_id or ROOT_ZONE_ID,
             )
-            nx._acp_service = _acp_service
+            await nx._service_registry.enlist("acp_service", _acp_service)
             logger.debug("[BOOT:LINK] AcpService created (deferred)")
         except Exception as exc:
             logger.warning("[BOOT:LINK] AcpService unavailable: %s", exc)

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -237,7 +237,7 @@ async def _boot_wired_services(
                 mount_service=mount_service,
                 router=router,
             )
-            nx._connector_sync_loop = connector_sync  # Keep reference for shutdown
+            await nx._service_registry.enlist("connector_sync_loop", connector_sync)
             logger.debug("[BOOT:WIRED] ConnectorSyncLoop created (starts on first request)")
         except Exception:
             logger.debug("[BOOT:WIRED] ConnectorSyncLoop not available")
@@ -323,7 +323,8 @@ async def _boot_wired_services(
     acp_rpc_service: Any = None
     # Issue #1792: AcpService is created in _do_link() using kernel-owned
     # nx._agent_registry. Retrieve from nx (set by _do_link).
-    _acp_service = getattr(nx, "_acp_service", None)
+    _acp_ref = nx._service_registry.service("acp_service")
+    _acp_service = _acp_ref._service_instance if _acp_ref is not None else None
     if _acp_service is None:
         # Fallback: construct inline using kernel-owned AgentRegistry.
         _acp_pt = getattr(nx, "_agent_registry", None)

--- a/src/nexus/server/lifespan/realtime.py
+++ b/src/nexus/server/lifespan/realtime.py
@@ -219,7 +219,7 @@ async def _startup_connector_sync(app: "FastAPI", svc: "LifespanServices") -> No
     if not svc.nexus_fs:
         return
 
-    sync_loop = getattr(svc.nexus_fs, "_connector_sync_loop", None)
+    sync_loop = svc.nexus_fs.service("connector_sync_loop")
     if sync_loop is not None:
         try:
             await sync_loop.start()


### PR DESCRIPTION
## Summary
- Batch-enlist 12 additional SystemServices fields into ServiceRegistry (write_observer, observability_subsystem, zone_lifecycle, scheduler_service, entity_registry, workspace_registry, mount_manager, audit_store, brick_lifecycle_manager, brick_reconciler, async_namespace_manager, workspace_manager)
- Replace 4 DI setattr patterns with `enlist()`: `nx._driver_coordinator`, `nx._eviction_manager`, `nx._acp_service`, `nx._connector_sync_loop`
- Update consumers to use service registry instead of direct attr access

**Depends on:** PR #3311 (enlist cleanup) + PR #3312 (rebac internalize)

## Test plan
- [x] `uv run pytest tests/unit/core/test_factory_boot.py tests/unit/services/test_service_lifecycle_coordinator.py tests/unit/core/test_service_registry.py -v` — 120 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)