### PR TITLE
refactor(#1801): push closures to service layer

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -158,14 +158,11 @@ class NexusFS(  # type: ignore[misc]
         self._descendant_checker: Any = None
         # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
         self._overlay_resolver = None
-        # Issue #1791: factory-injected overlay config resolver (captures workspace_registry)
-        self._overlay_config_fn: Callable[..., Any] | None = None
         # Issue #1788: distributed lock manager — kernel knows (like _permission_enforcer).
         # In-process locks use _vfs_lock_manager (kernel owns); distributed locks use this.
         self._distributed_lock_manager: Any = None
-        # Issue #1771: factory-injected async flush fn — replaces _system_services read
-        # in flush_write_observer(). Captures write_observer via closure.
-        self._flush_write_observer_fn: Any = None
+        # Issue #1801: _flush_write_observer_fn and _overlay_config_fn closures removed —
+        # kernel now reads services directly from service registry.
         # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)
 
         # Lazy-init sentinels
@@ -903,15 +900,28 @@ class NexusFS(  # type: ignore[misc]
     def _get_overlay_config(self, path: str) -> Any:
         """Get overlay config for a path, if overlay is active.
 
-        Issue #1791: Delegates to factory-injected callable. Kernel does NOT
-        read workspace_registry from _system_services — the factory captures
-        the registry reference in a closure at link() time.
+        Issue #1801: Reads workspace_registry from service registry.
 
         Returns:
             OverlayConfig if overlay active for this path, None otherwise
         """
-        fn = self._overlay_config_fn
-        return fn(path) if fn is not None else None
+        ws_reg = self.service("workspace_registry")
+        if ws_reg is None:
+            return None
+        ws_config = ws_reg.find_workspace_for_path(path)
+        if ws_config is None:
+            return None
+        overlay_data = ws_config.metadata.get("overlay_config")
+        if overlay_data is None:
+            return None
+        from nexus.contracts.overlay_config import OverlayConfig
+
+        return OverlayConfig(
+            enabled=overlay_data.get("enabled", False),
+            base_manifest_hash=overlay_data.get("base_manifest_hash"),
+            workspace_path=ws_config.path,
+            agent_id=overlay_data.get("agent_id"),
+        )
 
     # =========================================================================
     # VFS I/O Lock — kernel-internal path-level read/write protection
@@ -4250,12 +4260,11 @@ class NexusFS(  # type: ignore[misc]
         Returns:
             Dict with ``flushed`` count.
         """
-        # Issue #1771: use factory-injected _flush_write_observer_fn instead of
-        # reading _system_services directly.  Captures write_observer via closure.
-        _flush_fn = self._flush_write_observer_fn
-        if _flush_fn is None:
+        # Issue #1801: use service registry to find write_observer — no closure needed.
+        _wo = self.service("write_observer")
+        if _wo is None or not hasattr(_wo, "flush"):
             return {"flushed": 0}
-        flushed: int = NexusFS._run_async(_flush_fn())
+        flushed: int = NexusFS._run_async(_wo.flush())
         return {"flushed": flushed}
 
     # ------------------------------------------------------------------

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -223,15 +223,8 @@ async def _do_link(
 
         nx._close_callbacks.append(_close_delivery_worker)
 
-    # Issue #1771: inject _flush_write_observer_fn so kernel flush_write_observer()
-    # no longer reads _system_services.
-    if _wo is not None and hasattr(_wo, "flush"):
-
-        async def _flush_wo() -> int:
-            result: int = await _wo.flush()
-            return result
-
-        nx._flush_write_observer_fn = _flush_wo
+    # Issue #1801: _flush_write_observer_fn closure removed — kernel now reads
+    # write_observer directly from service registry via nx.service("write_observer").
 
     _rebac = getattr(_sys, "rebac_manager", None)
     if _rebac is not None and hasattr(_rebac, "close"):
@@ -267,28 +260,8 @@ async def _do_link(
 
         nx._close_callbacks.append(_close_agent_registry)
 
-    # Issue #1791: overlay config resolver — kernel calls self._overlay_config_fn(path)
-    # instead of reading workspace_registry from _system_services.
-    _ws_reg = getattr(_sys, "workspace_registry", None)
-    if _ws_reg is not None:
-
-        def _resolve_overlay(path: str) -> "Any":
-            ws_config = _ws_reg.find_workspace_for_path(path)
-            if ws_config is None:
-                return None
-            overlay_data = ws_config.metadata.get("overlay_config")
-            if overlay_data is None:
-                return None
-            from nexus.contracts.overlay_config import OverlayConfig
-
-            return OverlayConfig(
-                enabled=overlay_data.get("enabled", False),
-                base_manifest_hash=overlay_data.get("base_manifest_hash"),
-                workspace_path=ws_config.path,
-                agent_id=overlay_data.get("agent_id"),
-            )
-
-        nx._overlay_config_fn = _resolve_overlay
+    # Issue #1801: _overlay_config_fn closure removed — kernel now reads
+    # workspace_registry directly from service registry via nx.service("workspace_registry").
 
     # --- Deferred EvictionManager + AcpService (Issue #1792) ---
     # AgentRegistry is a kernel-owned primitive (created in NexusFS.__init__).


### PR DESCRIPTION
## Summary
- Replace _flush_write_observer_fn closure with direct nx.service('write_observer') lookup
- Replace _overlay_config_fn closure with direct nx.service('workspace_registry') lookup
- Delete 2 closure definitions + setattr calls in _lifecycle.py (~35 lines)
- Remove _overlay_config_fn and _flush_write_observer_fn from NexusFS.__init__

Depends on: PR #3313 (enlist all services)

## Test plan
- [x] test_factory_boot.py + test_overlay_nexusfs.py — 31 passed

Generated with Claude Code