### PR TITLE
chore: bump version to 0.9.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_pyo3"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "ahash",
  "blake3",

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,8 +145,8 @@ RUN set -eux; \
 ARG TARGETARCH
 RUN set -eux; \
     ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "aarch64" || echo "x86_64"); \
-    curl -fsSL "https://github.com/googleworkspace/cli/releases/latest/download/gws-${ARCH}-unknown-linux-gnu.tar.gz" \
-        | tar -xz --strip-components=1 -C /usr/local/bin "gws-${ARCH}-unknown-linux-gnu/gws" \
+    curl -fsSL "https://github.com/googleworkspace/cli/releases/latest/download/google-workspace-cli-${ARCH}-unknown-linux-gnu.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "google-workspace-cli-${ARCH}-unknown-linux-gnu/gws" \
     && chmod +x /usr/local/bin/gws; \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.11"
+version = "0.9.12"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_pyo3"
-version = "0.9.11"
+version = "0.9.12"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_pyo3/pyproject.toml
+++ b/rust/nexus_pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-fast"
-version = "0.9.11"
+version = "0.9.12"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [


### PR DESCRIPTION
## Summary
- Bump version from 0.9.11 → 0.9.12 across all package manifests (`pyproject.toml`, `rust/nexus_pyo3/pyproject.toml`, `rust/nexus_pyo3/Cargo.toml`, `Cargo.lock`)

## Post-merge
- Tag `v0.9.12` on the merge commit and push — CI will handle PyPI publish, Docker build, and GitHub Release creation.