### PR TITLE
fix(ci): scope artifact downloads in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,7 @@ jobs:
       - name: Download rust artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: rust-*
           path: artifacts
 
       - name: Collect nexus-fast distributions
@@ -215,10 +216,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download all artifacts
+      - name: Download wheel
         uses: actions/download-artifact@v4
         with:
-          path: artifacts
+          name: wheel
+          path: artifacts/wheel
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: artifacts/sdist
 
       - name: Collect nexus-ai-fs distributions
         run: |
@@ -368,9 +376,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download all artifacts
+      - name: Download wheel
         uses: actions/download-artifact@v4
         with:
+          name: wheel
+          path: artifacts/wheel
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: artifacts/sdist
+
+      - name: Download rust artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rust-*
           path: artifacts
 
       - name: Collect release artifacts


### PR DESCRIPTION
## Summary
- Each release job (`publish-rust`, `publish-pypi`, `create-release`) was downloading **all** ~15+ artifacts when it only needs a subset
- Every redundant download is another chance for GitHub's artifact API to timeout — this caused the recurring `create-release` failure in v0.9.12
- Scope downloads: `publish-rust` gets only `rust-*`, `publish-pypi` gets only `wheel` + `sdist`, `create-release` gets `wheel` + `sdist` + `rust-*` (excludes Docker metadata)

## Test plan
- [ ] Next tag push triggers release pipeline with scoped downloads
- [ ] All three publish/release jobs still find the artifacts they need