### PR TITLE
feat: federation Q3 service + cluster profile — drop PostgreSQL

### DIFF
--- a/dockerfiles/docker-compose.cross-platform-test.yml
+++ b/dockerfiles/docker-compose.cross-platform-test.yml
@@ -5,7 +5,7 @@
 #
 # Kernel layer (always running):
 #   - 3-node Raft cluster: 2 full NexusFS nodes + 1 lightweight witness
-#   - PostgreSQL 16 (tuned: WAL archiving, pgvector HNSW)
+#   - Cluster profile: kernel-native storage (Raft/redb), no external PostgreSQL
 #   - Dragonfly CacheStore (embedding cache, Tiger Cache, EventBus)
 #
 # Application layer (always running):
@@ -44,9 +44,9 @@
 #   │  │         │                  │                                       │ │
 #   │  │         ▼                  ▼                                       │ │
 #   │  │  ┌────────────────────────────┐  ┌────────────────────────┐       │ │
-#   │  │  │  PostgreSQL (RecordStore)  │  │  Dragonfly (CacheStore)│       │ │
-#   │  │  │  Users, ReBAC, API keys   │  │  Locks, Events, Cache  │       │ │
-#   │  │  │  :5432                     │  │  :6379                 │       │ │
+#   │  │  │  Raft/redb (RecordStore)   │  │  Dragonfly (CacheStore)│       │ │
+#   │  │  │  Kernel-native storage     │  │  Locks, Events, Cache  │       │ │
+#   │  │  │  (embedded, no ext. DB)    │  │  :6379                 │       │ │
 #   │  │  └────────────────────────────┘  └────────────────────────┘       │ │
 #   │  └─────────────────────────────────────────────────────────────────────┘ │
 #   └───────────────────────────────────────────────────────────────────────────┘
@@ -61,61 +61,6 @@
 #   - Frontend: browse files, manage permissions, provision users via web UI
 
 services:
-  # ==========================================================================
-  # PostgreSQL 16 — Shared RecordStore for all NexusFS nodes
-  #
-  # Tuning: WAL archiving, pgvector HNSW, pg_stat_statements
-  # See: docs/performance/vector-search-tuning.md
-  # ==========================================================================
-  postgres:
-    image: postgres:16-alpine
-    container_name: nexus-cluster-postgres
-    hostname: postgres
-    restart: unless-stopped
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB:-nexus}
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-nexus}
-    # PostgreSQL 16 optimizations:
-    # - effective_io_concurrency=16: Concurrent I/O requests (tuned for SSD)
-    # - wal_compression=lz4: 30-50% WAL size reduction with fast compression
-    # pgvector HNSW tuning (Issue #1004):
-    # - maintenance_work_mem=2GB: Faster index builds for 100K+ vectors
-    # - max_parallel_maintenance_workers=7: Parallel index build (up to 30x faster)
-    # - shared_buffers=1GB: Cache HNSW index in memory
-    command: >
-      postgres
-      -c shared_preload_libraries=pg_stat_statements
-      -c pg_stat_statements.track=all
-      -c effective_io_concurrency=16
-      -c maintenance_io_concurrency=16
-      -c wal_compression=lz4
-      -c archive_mode=on
-      -c archive_command='test ! -f /var/lib/postgresql/wal_archive/%f && cp %p /var/lib/postgresql/wal_archive/%f'
-      -c archive_timeout=300
-      -c maintenance_work_mem=2GB
-      -c max_parallel_maintenance_workers=7
-      -c shared_buffers=1GB
-      -c effective_cache_size=3GB
-    ports:
-      - "${POSTGRES_PORT:-5432}:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-      - postgres_wal_archive:/var/lib/postgresql/wal_archive
-    networks:
-      - nexus-network
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-nexus}"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 5s
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
-
   # ==========================================================================
   # Dragonfly — CacheStore for embedding cache, Tiger Cache, EventBus
   # Redis-compatible, ~25x faster than Redis for cache workloads
@@ -161,8 +106,6 @@ services:
     hostname: nexus-1
     restart: unless-stopped
     depends_on:
-      postgres:
-        condition: service_healthy
       dragonfly:
         condition: service_healthy
     environment:
@@ -171,31 +114,21 @@ services:
       NEXUS_PORT: 2026
       NEXUS_DATA_DIR: /app/data
 
-      # --- Deployment profile (cloud = all bricks + federation) ---
-      NEXUS_PROFILE: cloud
+      # --- Deployment profile (cluster = kernel-native storage via Raft/redb) ---
+      NEXUS_PROFILE: cluster
 
       # --- Raft consensus (static bootstrap — all nodes know all peers) ---
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_PEERS: "nexus-1:2126,nexus-2:2126,witness:2126"
-
-      # --- RecordStore (shared PostgreSQL) ---
-      NEXUS_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-      TOKEN_MANAGER_DB: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-      NEXUS_DB_POOL_SIZE: ${NEXUS_DB_POOL_SIZE:-20}
-      NEXUS_DB_MAX_OVERFLOW: ${NEXUS_DB_MAX_OVERFLOW:-30}
-      NEXUS_DB_POOL_TIMEOUT: ${NEXUS_DB_POOL_TIMEOUT:-30}
+      NEXUS_RAFT_TLS: "false"
 
       # --- CacheStore (Dragonfly) ---
       NEXUS_DRAGONFLY_URL: ${NEXUS_DRAGONFLY_URL:-redis://dragonfly:6379}
       NEXUS_CACHE_EMBEDDING_TTL: ${NEXUS_CACHE_EMBEDDING_TTL:-86400}
       NEXUS_ENABLE_TIGER_CACHE: ${NEXUS_ENABLE_TIGER_CACHE:-false}
 
-      # --- Auth & permissions ---
-      NEXUS_ADMIN_USER: ${NEXUS_ADMIN_USER:-admin}
+      # --- Auth (StaticAPIKeyAuth — in-memory, no external DB) ---
       NEXUS_API_KEY: ${NEXUS_API_KEY:-sk-test-federation-e2e-admin-key}
-      NEXUS_ENFORCE_PERMISSIONS: ${NEXUS_ENFORCE_PERMISSIONS:-true}
-      NEXUS_ALLOW_ADMIN_BYPASS: ${NEXUS_ALLOW_ADMIN_BYPASS:-true}
-      NEXUS_SKIP_PERMISSIONS: ${NEXUS_SKIP_PERMISSIONS:-false}
 
       # --- Backend storage ---
       NEXUS_BACKEND: ${NEXUS_BACKEND:-local}
@@ -205,11 +138,6 @@ services:
       AWS_SHARED_CREDENTIALS_FILE: ${AWS_SHARED_CREDENTIALS_FILE:-/app/aws-credentials}
       AWS_CONFIG_FILE: ${AWS_CONFIG_FILE:-/app/aws-config}
       AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
-
-      # --- OAuth ---
-      NEXUS_OAUTH_ENCRYPTION_KEY: ${NEXUS_OAUTH_ENCRYPTION_KEY:-}
-      NEXUS_OAUTH_GOOGLE_CLIENT_ID: ${NEXUS_OAUTH_GOOGLE_CLIENT_ID:-}
-      NEXUS_OAUTH_GOOGLE_CLIENT_SECRET: ${NEXUS_OAUTH_GOOGLE_CLIENT_SECRET:-}
 
       # --- Sandbox ---
       NEXUS_SERVER_URL: http://nexus-1:2026
@@ -242,11 +170,11 @@ services:
     networks:
       - nexus-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2026/health"]
-      interval: 10s
+      test: ["CMD", "curl", "-f", "http://localhost:2026/healthz/ready"]
+      interval: 5s
       timeout: 5s
-      retries: 20
-      start_period: 60s
+      retries: 24
+      start_period: 30s
     logging:
       driver: "json-file"
       options:
@@ -263,38 +191,26 @@ services:
     hostname: nexus-2
     restart: unless-stopped
     depends_on:
-      postgres:
-        condition: service_healthy
       dragonfly:
         condition: service_healthy
-      nexus-1:
-        condition: service_started
     environment:
       NEXUS_HOST: 0.0.0.0
       NEXUS_PORT: 2026
       NEXUS_DATA_DIR: /app/data
 
-      # --- Deployment profile (cloud = all bricks + federation) ---
-      NEXUS_PROFILE: cloud
+      # --- Deployment profile (cluster = kernel-native storage via Raft/redb) ---
+      NEXUS_PROFILE: cluster
 
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_PEERS: "nexus-1:2126,nexus-2:2126,witness:2126"
-
-      NEXUS_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-      TOKEN_MANAGER_DB: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-      NEXUS_DB_POOL_SIZE: ${NEXUS_DB_POOL_SIZE:-20}
-      NEXUS_DB_MAX_OVERFLOW: ${NEXUS_DB_MAX_OVERFLOW:-30}
-      NEXUS_DB_POOL_TIMEOUT: ${NEXUS_DB_POOL_TIMEOUT:-30}
+      NEXUS_RAFT_TLS: "false"
 
       NEXUS_DRAGONFLY_URL: ${NEXUS_DRAGONFLY_URL:-redis://dragonfly:6379}
       NEXUS_CACHE_EMBEDDING_TTL: ${NEXUS_CACHE_EMBEDDING_TTL:-86400}
       NEXUS_ENABLE_TIGER_CACHE: ${NEXUS_ENABLE_TIGER_CACHE:-false}
 
-      NEXUS_ADMIN_USER: ${NEXUS_ADMIN_USER:-admin}
+      # --- Auth (StaticAPIKeyAuth — in-memory, no external DB) ---
       NEXUS_API_KEY: ${NEXUS_API_KEY:-sk-test-federation-e2e-admin-key}
-      NEXUS_ENFORCE_PERMISSIONS: ${NEXUS_ENFORCE_PERMISSIONS:-true}
-      NEXUS_ALLOW_ADMIN_BYPASS: ${NEXUS_ALLOW_ADMIN_BYPASS:-true}
-      NEXUS_SKIP_PERMISSIONS: ${NEXUS_SKIP_PERMISSIONS:-false}
 
       NEXUS_BACKEND: ${NEXUS_BACKEND:-local}
       NEXUS_GCS_BUCKET: ${NEXUS_GCS_BUCKET:-}
@@ -303,10 +219,6 @@ services:
       AWS_SHARED_CREDENTIALS_FILE: ${AWS_SHARED_CREDENTIALS_FILE:-/app/aws-credentials}
       AWS_CONFIG_FILE: ${AWS_CONFIG_FILE:-/app/aws-config}
       AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
-
-      NEXUS_OAUTH_ENCRYPTION_KEY: ${NEXUS_OAUTH_ENCRYPTION_KEY:-}
-      NEXUS_OAUTH_GOOGLE_CLIENT_ID: ${NEXUS_OAUTH_GOOGLE_CLIENT_ID:-}
-      NEXUS_OAUTH_GOOGLE_CLIENT_SECRET: ${NEXUS_OAUTH_GOOGLE_CLIENT_SECRET:-}
 
       NEXUS_SERVER_URL: http://nexus-2:2026
       NEXUS_DOCKER_NETWORK: nexus_nexus-network
@@ -336,11 +248,11 @@ services:
     networks:
       - nexus-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2026/health"]
-      interval: 10s
+      test: ["CMD", "curl", "-f", "http://localhost:2026/healthz/ready"]
+      interval: 5s
       timeout: 5s
-      retries: 20
-      start_period: 60s
+      retries: 24
+      start_period: 30s
     logging:
       driver: "json-file"
       options:
@@ -613,10 +525,6 @@ networks:
 # Volumes
 # ==========================================================================
 volumes:
-  postgres_data:
-    name: nexus-cluster-postgres-data
-  postgres_wal_archive:
-    name: nexus-cluster-postgres-wal
   nexus1_data:
     name: nexus-cluster-node1-data
   nexus2_data:
@@ -645,20 +553,19 @@ volumes:
 #   docker compose -f dockerfiles/docker-compose.cross-platform-test.yml logs -f nexus-1
 #
 # Check cluster health:
-#   curl http://localhost:2026/health   # Node 1 (leader)
-#   curl http://localhost:2027/health   # Node 2 (follower)
+#   curl http://localhost:2026/healthz/ready   # Node 1 (leader)
+#   curl http://localhost:2027/healthz/ready   # Node 2 (follower)
 #
 # Service endpoints:
 #   Frontend:   http://localhost:5173
 #   Nexus API:  http://localhost:2026 (node-1), http://localhost:2027 (node-2)
 #   MCP:        http://localhost:8081
 #   LangGraph:  http://localhost:2024
-#   PostgreSQL: localhost:5432
 #   Dragonfly:  localhost:6379
 #
 # Simulate leader failure:
 #   docker stop nexus-node-1
-#   curl http://localhost:2027/health   # Node 2 becomes leader
+#   curl http://localhost:2027/healthz/ready   # Node 2 becomes leader
 #
 # Simulate network partition:
 #   docker network disconnect nexus_nexus-network nexus-witness

--- a/dockerfiles/docker-compose.dynamic-federation-test.yml
+++ b/dockerfiles/docker-compose.dynamic-federation-test.yml
@@ -1,11 +1,7 @@
-# Dynamic Federation E2E Test — No static zone topology
+# Dynamic Federation E2E Test — Minimal cluster profile (no PostgreSQL)
 # =========================================================================
-# Same infrastructure as docker-compose.cross-platform-test.yml but WITHOUT
-# NEXUS_FEDERATION_ZONES and NEXUS_FEDERATION_MOUNTS env vars.
-#
-# Nodes start with only their root zone. The test suite dynamically creates
-# zones, mounts, and joins via JSON-RPC (federation_create_zone,
-# federation_mount, federation_join) to build the topology at runtime.
+# Uses 'cluster' profile: Raft + federation only, no auth/audit/ReBAC.
+# Nodes start independently (CockroachDB pattern) — no ordering hacks.
 #
 # Usage:
 #   docker compose -f dockerfiles/docker-compose.dynamic-federation-test.yml up -d
@@ -21,37 +17,7 @@
 
 services:
   # ==========================================================================
-  # PostgreSQL 16 — Shared RecordStore
-  # ==========================================================================
-  postgres:
-    image: postgres:16-alpine
-    container_name: nexus-dyn-postgres
-    hostname: postgres
-    restart: unless-stopped
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB:-nexus}
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-nexus}
-    command: >
-      postgres
-      -c shared_preload_libraries=pg_stat_statements
-      -c effective_io_concurrency=16
-      -c wal_compression=lz4
-    ports:
-      - "${POSTGRES_PORT:-5432}:5432"
-    volumes:
-      - dyn_postgres_data:/var/lib/postgresql/data
-    networks:
-      - dyn-nexus-network
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-nexus}"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 5s
-
-  # ==========================================================================
-  # Dragonfly — CacheStore
+  # Dragonfly — CacheStore (optional, NullCacheStore fallback if removed)
   # ==========================================================================
   dragonfly:
     image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
@@ -77,8 +43,7 @@ services:
       retries: 10
 
   # ==========================================================================
-  # NexusFS Node 1 — Full node (initial leader)
-  # NO NEXUS_FEDERATION_ZONES / NEXUS_FEDERATION_MOUNTS
+  # NexusFS Node 1 — cluster profile (no PostgreSQL)
   # ==========================================================================
   nexus-1:
     build:
@@ -89,34 +54,24 @@ services:
     hostname: nexus-1
     restart: unless-stopped
     depends_on:
-      postgres:
-        condition: service_healthy
       dragonfly:
         condition: service_healthy
     environment:
       NEXUS_HOST: 0.0.0.0
       NEXUS_PORT: 2026
       NEXUS_DATA_DIR: /app/data
-      NEXUS_PROFILE: cloud
+      NEXUS_PROFILE: cluster
 
-      # Raft — static peer list, but NO static zones
+      # Raft
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_PEERS: "nexus-1:2126,nexus-2:2126,witness:2126"
       NEXUS_RAFT_TLS: "false"
 
-      # RecordStore
-      NEXUS_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-      TOKEN_MANAGER_DB: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-
       # CacheStore
       NEXUS_DRAGONFLY_URL: ${NEXUS_DRAGONFLY_URL:-redis://dragonfly:6379}
-      NEXUS_ENABLE_TIGER_CACHE: "false"
 
-      # Auth
-      NEXUS_ADMIN_USER: ${NEXUS_ADMIN_USER:-admin}
+      # Auth (static in-memory — no PostgreSQL)
       NEXUS_API_KEY: ${NEXUS_API_KEY:-sk-test-dynamic-federation-key}
-      NEXUS_ENFORCE_PERMISSIONS: "true"
-      NEXUS_ALLOW_ADMIN_BYPASS: "true"
 
       # Backend
       NEXUS_BACKEND: ${NEXUS_BACKEND:-local}
@@ -124,9 +79,6 @@ services:
       # Runtime
       NEXUS_USE_UVLOOP: "true"
       RUST_LOG: info,nexus_raft=debug
-
-      # NO NEXUS_FEDERATION_ZONES — topology built dynamically by tests
-      # NO NEXUS_FEDERATION_MOUNTS — mounts created via federation_mount RPC
     ports:
       - "${NEXUS_PORT:-2026}:2026"
       - "2126:2126"
@@ -135,15 +87,15 @@ services:
     networks:
       - dyn-nexus-network
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:2026/healthz/live"]
-      interval: 10s
+      test: ["CMD", "curl", "-sf", "http://localhost:2026/healthz/ready"]
+      interval: 5s
       timeout: 5s
-      retries: 12
+      retries: 24
       start_period: 30s
 
   # ==========================================================================
-  # NexusFS Node 2 — Full node (follower)
-  # NO NEXUS_FEDERATION_ZONES / NEXUS_FEDERATION_MOUNTS
+  # NexusFS Node 2 — cluster profile (no PostgreSQL)
+  # No depends_on nexus-1 — CockroachDB pattern: start independently
   # ==========================================================================
   nexus-2:
     image: nexus-fullnode:latest
@@ -151,38 +103,23 @@ services:
     hostname: nexus-2
     restart: unless-stopped
     depends_on:
-      postgres:
-        condition: service_healthy
       dragonfly:
-        condition: service_healthy
-      nexus-1:
         condition: service_healthy
     environment:
       NEXUS_HOST: 0.0.0.0
       NEXUS_PORT: 2026
       NEXUS_DATA_DIR: /app/data
-      NEXUS_PROFILE: cloud
+      NEXUS_PROFILE: cluster
 
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_PEERS: "nexus-1:2126,nexus-2:2126,witness:2126"
       NEXUS_RAFT_TLS: "false"
 
-      NEXUS_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-      TOKEN_MANAGER_DB: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-
       NEXUS_DRAGONFLY_URL: ${NEXUS_DRAGONFLY_URL:-redis://dragonfly:6379}
-      NEXUS_ENABLE_TIGER_CACHE: "false"
-
-      NEXUS_ADMIN_USER: ${NEXUS_ADMIN_USER:-admin}
       NEXUS_API_KEY: ${NEXUS_API_KEY:-sk-test-dynamic-federation-key}
-      NEXUS_ENFORCE_PERMISSIONS: "true"
-      NEXUS_ALLOW_ADMIN_BYPASS: "true"
-
       NEXUS_BACKEND: ${NEXUS_BACKEND:-local}
       NEXUS_USE_UVLOOP: "true"
       RUST_LOG: info,nexus_raft=debug
-
-      # NO NEXUS_FEDERATION_ZONES / NEXUS_FEDERATION_MOUNTS
     ports:
       - "2027:2026"
       - "2127:2126"
@@ -191,14 +128,14 @@ services:
     networks:
       - dyn-nexus-network
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:2026/healthz/live"]
-      interval: 10s
+      test: ["CMD", "curl", "-sf", "http://localhost:2026/healthz/ready"]
+      interval: 5s
       timeout: 5s
-      retries: 12
+      retries: 24
       start_period: 30s
 
   # ==========================================================================
-  # Raft Witness — vote-only node (no static zones)
+  # Raft Witness — vote-only node
   # ==========================================================================
   witness:
     build:
@@ -262,8 +199,6 @@ networks:
     driver: bridge
 
 volumes:
-  dyn_postgres_data:
-    name: nexus-dyn-postgres-data
   dyn_nexus1_data:
     name: nexus-dyn-node1-data
   dyn_nexus2_data:

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -370,72 +370,92 @@ async def connect(
         advertise_addr = os.environ.get("NEXUS_ADVERTISE_ADDR")
         zones_dir = os.environ.get("NEXUS_DATA_DIR", str(Path(metadata_path).parent / "zones"))
 
-        # Parse peer addresses
+        # Parse peer addresses (host:port format — PeerAddress derives node IDs)
         peers_str = os.environ.get("NEXUS_PEERS", "")
         peer_addrs = PeerAddress.parse_peer_list(peers_str) if peers_str else []
-        peers = [p.to_raft_peer_str() for p in peer_addrs]
+        peers = [p.grpc_target for p in peer_addrs]
 
-        # K3s-style TLS pre-provision: if a join-token FILE exists and
-        # certs don't exist yet, provision TLS from the leader BEFORE
-        # creating ZoneManager (so Raft starts with mTLS from the start).
-        # Token is file-only (no env var) — consistent with nexus being file-based.
-        tls_dir_pre = Path(zones_dir) / "tls"
-        token_file = tls_dir_pre / "join-token"
-        if token_file.exists() and not (tls_dir_pre / "node.pem").exists():
-            join_token = token_file.read_text().strip()
-            # Find a peer address to join from NEXUS_PEERS
-            join_peer = None
-            for p in peer_addrs:
-                if p.node_id != my_id:
-                    join_peer = p.grpc_target
-                    break
-            if join_peer:
-                from _nexus_raft import join_cluster as _join_cluster
+        # Retry loop for Raft bootstrap — CockroachDB pattern:
+        # nodes start independently, retry until cluster forms.
+        import time as _time
 
-                logger.info("Join token found — provisioning TLS from %s", join_peer)
-                _join_cluster(join_peer, join_token, hostname, str(tls_dir_pre))
-                logger.info("TLS provisioning complete")
-            else:
-                raise RuntimeError("Join token found but no peer in NEXUS_PEERS to join")
+        _max_attempts = int(os.environ.get("NEXUS_STARTUP_MAX_RETRIES", "12"))
+        _base_delay = 2.0
 
-        # Check NEXUS_RAFT_TLS for explicit TLS control
-        zone_mgr = ZoneManager(
-            hostname=hostname,
-            base_path=zones_dir,
-            bind_addr=bind_addr,
-            advertise_addr=advertise_addr,
-        )
+        for _attempt in range(1, _max_attempts + 1):
+            try:
+                # TLS pre-provision (depends on leader being up)
+                tls_dir_pre = Path(zones_dir) / "tls"
+                token_file = tls_dir_pre / "join-token"
+                if token_file.exists() and not (tls_dir_pre / "node.pem").exists():
+                    join_token = token_file.read_text().strip()
+                    join_peer = next(
+                        (p.grpc_target for p in peer_addrs if p.node_id != my_id),
+                        None,
+                    )
+                    if join_peer:
+                        from _nexus_raft import join_cluster as _join_cluster
 
-        # Detect joiner vs first-node:
-        # Joiner = has all cert files (pre-provisioned by join_cluster above)
-        # but no join-token (not the CA holder / first node)
-        tls_dir = Path(zones_dir) / "tls"
-        is_joiner = (
-            (tls_dir / "ca.pem").exists()
-            and (tls_dir / "node.pem").exists()
-            and (tls_dir / "node-key.pem").exists()
-            and not (tls_dir / "join-token").exists()
-        )
+                        logger.info(
+                            "Join token found — provisioning TLS from %s (attempt %d)",
+                            join_peer,
+                            _attempt,
+                        )
+                        _join_cluster(join_peer, join_token, hostname, str(tls_dir_pre))
+                        logger.info("TLS provisioning complete")
+                    else:
+                        raise RuntimeError("Join token found but no peer in NEXUS_PEERS to join")
 
-        if is_joiner:
-            zone_mgr.join_zone("root", peers=peers if peers else None)
-            logger.info("Joiner node: joined root zone (certs provisioned)")
-        else:
-            # First node — auto_generate_tls creates CA + certs,
-            # ZoneManager starts with mTLS from the beginning.
-            zone_mgr.bootstrap(peers=peers if peers else None)
+                zone_mgr = ZoneManager(
+                    hostname=hostname,
+                    base_path=zones_dir,
+                    bind_addr=bind_addr,
+                    advertise_addr=advertise_addr,
+                )
 
-        # Static Day-1 topology from env vars (idempotent)
-        zones_str = os.environ.get("NEXUS_FEDERATION_ZONES", "")
-        mounts_str = os.environ.get("NEXUS_FEDERATION_MOUNTS", "")
-        if zones_str:
-            zones = [z.strip() for z in zones_str.split(",") if z.strip()]
-            mounts: dict[str, str] = {}
-            if mounts_str:
-                for pair in mounts_str.split(","):
-                    path, zone_id = pair.strip().split("=", 1)
-                    mounts[path.strip()] = zone_id.strip()
-            zone_mgr.bootstrap_static(zones=zones, peers=peers, mounts=mounts)
+                # Detect joiner vs first-node
+                tls_dir = Path(zones_dir) / "tls"
+                is_joiner = (
+                    (tls_dir / "ca.pem").exists()
+                    and (tls_dir / "node.pem").exists()
+                    and (tls_dir / "node-key.pem").exists()
+                    and not (tls_dir / "join-token").exists()
+                )
+
+                if is_joiner:
+                    zone_mgr.join_zone("root", peers=peers if peers else None)
+                    logger.info("Joiner node: joined root zone (certs provisioned)")
+                else:
+                    zone_mgr.bootstrap(peers=peers if peers else None)
+
+                # Static Day-1 topology from env vars (idempotent)
+                zones_str = os.environ.get("NEXUS_FEDERATION_ZONES", "")
+                mounts_str = os.environ.get("NEXUS_FEDERATION_MOUNTS", "")
+                if zones_str:
+                    zones = [z.strip() for z in zones_str.split(",") if z.strip()]
+                    mounts: dict[str, str] = {}
+                    if mounts_str:
+                        for pair in mounts_str.split(","):
+                            path, zone_id = pair.strip().split("=", 1)
+                            mounts[path.strip()] = zone_id.strip()
+                    zone_mgr.bootstrap_static(zones=zones, peers=peers, mounts=mounts)
+
+                break  # Success
+
+            except (RuntimeError, OSError, ConnectionError) as exc:
+                if _attempt >= _max_attempts:
+                    logger.error("Raft startup failed after %d attempts: %s", _max_attempts, exc)
+                    raise
+                delay = min(_base_delay * (2 ** (_attempt - 1)), 30.0)
+                logger.warning(
+                    "Raft startup attempt %d/%d failed: %s — retrying in %.1fs",
+                    _attempt,
+                    _max_attempts,
+                    exc,
+                    delay,
+                )
+                _time.sleep(delay)
+
         metadata_store = FederatedMetadataProxy.from_zone_manager(zone_mgr)
     except ImportError:
         zone_mgr = None

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -11,7 +11,7 @@ The profile sets the *defaults*; explicit overrides always win.
 Lego Architecture reference: Part 10 — Edge Deployment.
 
 Profile hierarchy (superset relationship):
-    slim ⊂ embedded ⊂ lite ⊂ full ⊆ cloud ⊆ innovation
+    slim ⊂ cluster ⊂ embedded ⊂ lite ⊂ full ⊆ cloud ⊆ innovation
 
 INNOVATION extends CLOUD with all bricks enabled + experimental validation.
 Requires explicit opt-in (``nexusd --innovation`` or ``--profile innovation``).
@@ -73,8 +73,7 @@ BRICK_PARSERS = "parsers"
 BRICK_SNAPSHOT = "snapshot"
 BRICK_TASK_MANAGER = "task_manager"
 
-# Cloud-only
-BRICK_FEDERATION = "federation"
+# (Federation is a system service, not a brick — auto-detected from ZoneManager)
 
 # All brick names for validation
 ALL_BRICK_NAMES: frozenset[str] = frozenset(
@@ -109,7 +108,6 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_PARSERS,
         BRICK_SNAPSHOT,
         BRICK_TASK_MANAGER,
-        BRICK_FEDERATION,
         BRICK_AGENT_RUNTIME,
         BRICK_ACP,
     }
@@ -125,6 +123,7 @@ class DeploymentProfile(StrEnum):
 
     Profiles define capability tiers for different deployment targets:
     - slim: Bare minimum runnable — storage only, no system services (Issue #1801)
+    - cluster: Minimal multi-node — Raft + federation, no auth/PostgreSQL
     - embedded: MCU / WASM (<1 MB) — storage + eventlog only
     - lite: Pi, Jetson, mobile (512 MB–4 GB) — core services, no LLM/Pay
     - full: Desktop, laptop (4–32 GB) — all bricks, local inference
@@ -134,6 +133,7 @@ class DeploymentProfile(StrEnum):
     """
 
     SLIM = "slim"
+    CLUSTER = "cluster"
     EMBEDDED = "embedded"
     LITE = "lite"
     FULL = "full"
@@ -166,6 +166,12 @@ class DeploymentProfile(StrEnum):
 _SLIM_BRICKS: frozenset[str] = frozenset(
     {
         BRICK_STORAGE,
+    }
+)
+
+_CLUSTER_BRICKS: frozenset[str] = _SLIM_BRICKS | frozenset(
+    {
+        BRICK_IPC,
     }
 )
 
@@ -215,10 +221,8 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
     }
 )
 
-_CLOUD_BRICKS: frozenset[str] = _FULL_BRICKS | frozenset(
-    {
-        BRICK_FEDERATION,
-    }
+_CLOUD_BRICKS: frozenset[str] = (
+    _FULL_BRICKS  # Federation is a system service, auto-detected from ZoneManager
 )
 
 _INNOVATION_BRICKS: frozenset[str] = (
@@ -229,6 +233,7 @@ _REMOTE_BRICKS: frozenset[str] = frozenset()  # no local bricks — NFS-client m
 
 _PROFILE_BRICKS: dict[DeploymentProfile, frozenset[str]] = {
     DeploymentProfile.SLIM: _SLIM_BRICKS,
+    DeploymentProfile.CLUSTER: _CLUSTER_BRICKS,
     DeploymentProfile.EMBEDDED: _EMBEDDED_BRICKS,
     DeploymentProfile.LITE: _LITE_BRICKS,
     DeploymentProfile.FULL: _FULL_BRICKS,

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -268,6 +268,10 @@ class SystemServices:
     # Tier 1 because it is infrastructure (like vfs_lock_manager), not an application feature.
     lock_manager: Any = None
 
+    # Federation — multi-node zone orchestration (Q1: register-only, on-demand)
+    # Depends only on ZoneManager (Raft/redb). No PostgreSQL dependency.
+    federation: Any = None
+
 
 # ---------------------------------------------------------------------------
 # BrickServices — Tier 2: optional, silent on failure

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -268,9 +268,8 @@ class SystemServices:
     # Tier 1 because it is infrastructure (like vfs_lock_manager), not an application feature.
     lock_manager: Any = None
 
-    # Federation — multi-node zone orchestration (Q1: register-only, on-demand)
-    # Depends only on ZoneManager (Raft/redb). No PostgreSQL dependency.
-    federation: Any = None
+    # (Federation is a Q3 PersistentService, created at link time in _lifecycle.py
+    # and enlisted directly via ServiceRegistry — not in SystemServices.)
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/daemon/main.py
+++ b/src/nexus/daemon/main.py
@@ -406,6 +406,15 @@ def main(
             if key_file and Path(key_file).is_file():
                 api_key = Path(key_file).read_text().strip()
 
+        # Fallback: StaticAPIKeyAuth when NEXUS_API_KEY is set but no DB auth
+        if auth_provider is None and api_key:
+            from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
+
+            auth_provider = StaticAPIKeyAuth(
+                {api_key: {"subject_type": "user", "subject_id": "admin", "is_admin": True}}
+            )
+            logger.info("Using static API key authentication (no database)")
+
         # --- Create FastAPI app + run ---------------------------------------
         from nexus.server.fastapi_server import create_app, run_server
 

--- a/src/nexus/daemon/main.py
+++ b/src/nexus/daemon/main.py
@@ -385,7 +385,7 @@ def main(
             _print_lifecycle_detail(nx)
 
         # --- Resolve auth ---------------------------------------------------
-        auth_provider = None
+        auth_provider: Any = None
         if auth_type == "database":
             if not database_url:
                 database_url = os.getenv("POSTGRES_URL")

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -169,11 +169,22 @@ async def _do_link(
         ("brick_reconciler", "brick_reconciler"),
         ("async_namespace_manager", "async_namespace_manager"),
         ("workspace_manager", "workspace_manager"),
-        ("federation", "federation"),
     ):
         _val = getattr(system_services, _attr, None)
         if _val is not None:
             await nx._service_registry.enlist(_canonical, _val)
+
+    # Federation — Q3 PersistentService, created at link time (needs nx._zone_mgr).
+    _zone_mgr = getattr(nx, "_zone_mgr", None)
+    if _zone_mgr is not None:
+        try:
+            from nexus.raft.federation import NexusFederation
+
+            _fed = NexusFederation(zone_manager=_zone_mgr)
+            await nx._service_registry.enlist("federation", _fed)
+            logger.debug("[LINK] Federation service enlisted")
+        except Exception as exc:
+            logger.warning("[LINK] Federation unavailable: %s", exc)
 
     # Kernel DI: _descendant_checker is a kernel component (like Linux LSM hook),
     # not an external service — inject directly onto the kernel instance.

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -169,6 +169,7 @@ async def _do_link(
         ("brick_reconciler", "brick_reconciler"),
         ("async_namespace_manager", "async_namespace_manager"),
         ("workspace_manager", "workspace_manager"),
+        ("federation", "federation"),
     ):
         _val = getattr(system_services, _attr, None)
         if _val is not None:

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -446,6 +446,19 @@ def _boot_system_services(
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] SchedulerService unavailable: %s", exc)
 
+    # --- Federation Service (Q1: register-only, on-demand) ---
+    # Pure Raft/redb — no PostgreSQL dependency. Created when ZoneManager available.
+    federation: Any = None
+    _zone_mgr = getattr(ctx.nx, "_zone_mgr", None) if ctx.nx is not None else None
+    if _zone_mgr is not None:
+        try:
+            from nexus.raft.federation import NexusFederation
+
+            federation = NexusFederation(zone_manager=_zone_mgr)
+            logger.debug("[BOOT:SYSTEM] NexusFederation created")
+        except Exception as exc:
+            logger.warning("[BOOT:SYSTEM] NexusFederation unavailable: %s", exc)
+
     # (PipeManager + StreamManager + AgentRegistry are kernel-internal primitives,
     # constructed in NexusFS.__init__ — not booted here.
     # EvictionManager + AcpService are deferred to _do_link() where they can
@@ -480,6 +493,7 @@ def _boot_system_services(
         "brick_reconciler": brick_reconciler,
         "zone_lifecycle": zone_lifecycle,
         "scheduler_service": scheduler_service,
+        "federation": federation,
     }
 
     elapsed = time.perf_counter() - t0

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -446,18 +446,7 @@ def _boot_system_services(
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] SchedulerService unavailable: %s", exc)
 
-    # --- Federation Service (Q1: register-only, on-demand) ---
-    # Pure Raft/redb — no PostgreSQL dependency. Created when ZoneManager available.
-    federation: Any = None
-    _zone_mgr = getattr(ctx.nx, "_zone_mgr", None) if ctx.nx is not None else None
-    if _zone_mgr is not None:
-        try:
-            from nexus.raft.federation import NexusFederation
-
-            federation = NexusFederation(zone_manager=_zone_mgr)
-            logger.debug("[BOOT:SYSTEM] NexusFederation created")
-        except Exception as exc:
-            logger.warning("[BOOT:SYSTEM] NexusFederation unavailable: %s", exc)
+    # (Federation is created at link time in _lifecycle.py when nx._zone_mgr is available.)
 
     # (PipeManager + StreamManager + AgentRegistry are kernel-internal primitives,
     # constructed in NexusFS.__init__ — not booted here.
@@ -493,7 +482,6 @@ def _boot_system_services(
         "brick_reconciler": brick_reconciler,
         "zone_lifecycle": zone_lifecycle,
         "scheduler_service": scheduler_service,
-        "federation": federation,
     }
 
     elapsed = time.perf_counter() - t0

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -18,6 +18,14 @@ from typing import Any
 
 _CANONICAL_EXPORTS: dict[str, tuple[str, ...]] = {
     "search": ("glob", "grep", "list", "semantic_search"),
+    "federation": (
+        "federation_list_zones",
+        "federation_cluster_info",
+        "federation_create_zone",
+        "federation_join_zone",
+        "federation_mount",
+        "federation_unmount",
+    ),
     "rebac": ("rebac_check", "rebac_create", "rebac_list_tuples", "rebac_expand"),
     "events": ("wait_for_changes", "on_mutation", "locked"),
     "mount": ("add_mount", "remove_mount", "list_mounts"),

--- a/src/nexus/lib/performance_tuning.py
+++ b/src/nexus/lib/performance_tuning.py
@@ -692,6 +692,7 @@ def _get_profile_tuning_map() -> dict[str, ProfileTuning]:
 
     return {
         DeploymentProfile.SLIM: _SLIM_TUNING,
+        DeploymentProfile.CLUSTER: _SLIM_TUNING,  # CLUSTER reuses SLIM tuning
         DeploymentProfile.EMBEDDED: _EMBEDDED_TUNING,
         DeploymentProfile.LITE: _LITE_TUNING,
         DeploymentProfile.FULL: _FULL_TUNING,

--- a/src/nexus/raft/federation.py
+++ b/src/nexus/raft/federation.py
@@ -88,6 +88,18 @@ class NexusFederation:
         self._tls_config: ZoneTlsConfig | None = getattr(zone_manager, "tls_config", None)
 
     # =========================================================================
+    # Q3 PersistentService lifecycle (auto-managed by ServiceRegistry)
+    # =========================================================================
+
+    async def start(self) -> None:
+        """Start federation service. Called by ServiceRegistry at bootstrap."""
+        logger.info("Federation service started (zone_manager node_id=%s)", self._mgr.node_id)
+
+    async def stop(self) -> None:
+        """Stop federation service. Called by ServiceRegistry at shutdown."""
+        logger.info("Federation service stopped")
+
+    # =========================================================================
     # Public API
     # =========================================================================
 

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -363,13 +363,13 @@ def create_app(
         if _version_svc is not None:
             _rpc_sources.append(_version_svc)
         # Issue #1520: FederationRPCService — zone lifecycle, share/join, mounts
+        # Federation is a Q1 system service, enlisted via ServiceRegistry.
         _zone_mgr = getattr(nexus_fs, "_zone_mgr", None)
-        if _zone_mgr is not None:
-            from nexus.raft.federation import NexusFederation
+        _fed = nexus_fs.service("federation") if hasattr(nexus_fs, "service") else None
+        if _zone_mgr is not None and _fed is not None:
             from nexus.server.rpc.services.federation_rpc import FederationRPCService
 
-            _federation = NexusFederation(zone_manager=_zone_mgr)
-            _rpc_sources.append(FederationRPCService(_zone_mgr, _federation))
+            _rpc_sources.append(FederationRPCService(_zone_mgr, _fed))
         # --- Locks (Issue #1133) ---
         _lock_mgr = getattr(nexus_fs, "_lock_manager", None)
         if _lock_mgr is not None:

--- a/tests/e2e/self_contained/test_features_endpoint.py
+++ b/tests/e2e/self_contained/test_features_endpoint.py
@@ -76,8 +76,7 @@ class TestFeaturesEndpoint:
     def test_returns_disabled_bricks(self, client: TestClient) -> None:
         data = client.get("/api/v2/features").json()
         assert isinstance(data["disabled_bricks"], list)
-        # Full profile should have federation disabled
-        assert "federation" in data["disabled_bricks"]
+        # Federation is a system service (not a brick) — won't appear in brick lists
 
     def test_returns_version(self, client: TestClient) -> None:
         data = client.get("/api/v2/features").json()

--- a/tests/unit/core/test_deployment_profile.py
+++ b/tests/unit/core/test_deployment_profile.py
@@ -18,7 +18,7 @@ from nexus.contracts.deployment_profile import (
     ALL_BRICK_NAMES,
     BRICK_CACHE,
     BRICK_EVENTLOG,
-    BRICK_FEDERATION,
+    BRICK_IPC,
     BRICK_LLM,
     BRICK_NAMESPACE,
     BRICK_PAY,
@@ -64,6 +64,13 @@ class TestDeploymentProfileEnum:
 class TestDefaultBrickSets:
     """Tests for per-profile default brick sets."""
 
+    def test_cluster_minimal_multinode(self) -> None:
+        bricks = DeploymentProfile.CLUSTER.default_bricks()
+        assert BRICK_STORAGE in bricks
+        assert BRICK_IPC in bricks
+        assert BRICK_EVENTLOG not in bricks  # No audit/events
+        assert len(bricks) == 2
+
     def test_embedded_minimal(self) -> None:
         bricks = DeploymentProfile.EMBEDDED.default_bricks()
         assert BRICK_STORAGE in bricks
@@ -90,12 +97,7 @@ class TestDefaultBrickSets:
         assert BRICK_LLM in bricks
         assert BRICK_SANDBOX in bricks
         assert BRICK_WORKFLOWS in bricks
-        # Federation is cloud-only
-        assert BRICK_FEDERATION not in bricks
-
-    def test_cloud_includes_federation(self) -> None:
-        bricks = DeploymentProfile.CLOUD.default_bricks()
-        assert BRICK_FEDERATION in bricks
+        # Federation is a system service (not a brick), auto-detected from ZoneManager
 
     def test_cloud_is_superset_of_full(self) -> None:
         cloud = DeploymentProfile.CLOUD.default_bricks()
@@ -279,10 +281,6 @@ class TestInnovationProfile:
         cloud = DeploymentProfile.CLOUD.default_bricks()
         innovation = DeploymentProfile.INNOVATION.default_bricks()
         assert cloud.issubset(innovation)
-
-    def test_innovation_includes_federation(self) -> None:
-        bricks = DeploymentProfile.INNOVATION.default_bricks()
-        assert BRICK_FEDERATION in bricks
 
     def test_innovation_includes_all_full_bricks(self) -> None:
         full = DeploymentProfile.FULL.default_bricks()


### PR DESCRIPTION
## Summary

- **Federation as Q3 PersistentService**: Proper lifecycle (start/stop), enlisted via ServiceRegistry, accessible via `nx.service("federation")`. Replaces ad-hoc wiring in fastapi_server.py.
- **Remove BRICK_FEDERATION**: Federation is a system service (level 1), auto-detected from ZoneManager — not a brick (level 2).
- **New `cluster` deployment profile**: `slim` + `IPC` — minimal multi-node, no auth/PostgreSQL. Federation auto-loads when NEXUS_PEERS configured.
- **StaticAPIKeyAuth fallback**: In-memory API key validation when NEXUS_API_KEY set but no database.
- **Drop PostgreSQL from BOTH federation compose files**: Dynamic + cross-platform tests use `cluster` profile.
- **Healthcheck: /healthz/ready** (not /healthz/live) — node marked healthy only when Raft topology converged.
- **Startup retry loop**: Exponential backoff (2s→30s, 12 attempts) — CockroachDB pattern, nodes start independently.
- **No node ordering hacks**: nexus-2 doesn't depend on nexus-1.

## Test plan

- [ ] Unit tests pass (deployment profile, PeerAddress)
- [ ] `cluster` profile boots with zero PostgreSQL
- [ ] StaticAPIKeyAuth authenticates in-memory when no database
- [ ] Healthcheck returns ready only after topology converges
- [ ] Dynamic federation E2E: nodes start independently, cluster forms via retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)