### PR TITLE
refactor(#1801): decouple ServiceRegistry from BrickLifecycleManager

### DIFF
--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -172,19 +172,12 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
 
         # Lifecycle orchestration state (formerly SLC)
         self._dispatch: KernelDispatch | None = dispatch
-        self._blm: Any = None  # BrickLifecycleManager (system_services tier, opaque to kernel)
         self._hook_specs: dict[str, HookSpec] = {}
         # Tracks services whose hooks were pre-registered on dispatch at
         # initialize() time by _enlist_hook().  activate_hot_swappable_services()
         # skips _register_hooks() for these to avoid double registration.
         self._hooks_on_dispatch: set[str] = set()
         self._bootstrapped: bool = False
-
-    # -- BLM injection (factory calls at link-time) ------------------------
-
-    def set_lifecycle_manager(self, blm: Any) -> None:
-        """Set the optional BrickLifecycleManager (factory calls at link-time)."""
-        self._blm = blm
 
     # -- registration ------------------------------------------------------
 
@@ -337,7 +330,7 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         """
         self._bootstrapped = True
 
-    # -- insmod — register service in both Registry and BLM (internal) -----
+    # -- insmod — register service in Registry (internal) ------------------
 
     def _register_service(
         self,
@@ -345,23 +338,15 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         instance: Any,
         *,
         exports: tuple[str, ...] = (),
-        depends_on: tuple[str, ...] = (),
         allow_overwrite: bool = False,
     ) -> None:
-        """Register a service in both ServiceRegistry and BrickLifecycleManager."""
+        """Register a service in ServiceRegistry."""
         self.register_service(
             name,
             instance,
             exports=exports,
             allow_overwrite=allow_overwrite,
         )
-        if self._blm is not None:
-            self._blm.register(
-                name,
-                instance,
-                protocol_name=type(instance).__name__,
-                depends_on=depends_on,
-            )
         logger.info(
             "[COORDINATOR] insmod %r (exports=%d)",
             name,
@@ -392,10 +377,13 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
 
         Post-bootstrap, Q3 services are auto-started immediately.
         Pre-bootstrap, Q3 start() is deferred to start_persistent_services().
+
+        Args:
+            depends_on: Accepted for call-site compatibility; currently unused
+                (BLM dependency ordering removed).
         """
-        self._register_service(
-            name, instance, exports=exports, depends_on=depends_on, allow_overwrite=allow_overwrite
-        )
+        del depends_on  # accepted but unused (BLM removed)
+        self._register_service(name, instance, exports=exports, allow_overwrite=allow_overwrite)
 
         # Q3 / Q4: auto-start persistent background work (only post-bootstrap)
         if isinstance(instance, PersistentService) and self._bootstrapped:
@@ -414,51 +402,25 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         if not isinstance(instance, PersistentService) and not isinstance(instance, HotSwappable):
             logger.info("[COORDINATOR] enlist %r — registered (Q1 restart-required)", name)
 
-    # -- mount — BLM mount + register VFS hooks ----------------------------
+    # -- mount — register VFS hooks ----------------------------------------
 
-    async def _mount_service(self, name: str, *, timeout: float = 5.0) -> None:
-        """Mount a service: BLM state → ACTIVE, then register VFS hooks."""
-        if self._blm is not None:
-            await self._blm.mount(name, timeout=timeout)
+    async def _mount_service(self, name: str) -> None:
+        """Mount a service: register VFS hooks."""
+        self._register_hooks(name)
+        logger.info("[COORDINATOR] mount %r — hooks registered", name)
 
-            from nexus.contracts.protocols.brick_lifecycle import BrickState
-
-            status = self._blm.get_status(name)
-            if status is not None and status.state == BrickState.ACTIVE:
-                self._register_hooks(name)
-                logger.info("[COORDINATOR] mount %r — hooks registered", name)
-            else:
-                logger.warning("[COORDINATOR] mount %r — BLM not ACTIVE, hooks skipped", name)
-        else:
-            self._register_hooks(name)
-            logger.info("[COORDINATOR] mount %r — hooks registered (no BLM)", name)
-
-    # -- umount — unregister VFS hooks + BLM unmount -----------------------
+    # -- umount — unregister VFS hooks ------------------------------------
 
     async def _unmount_service(self, name: str) -> None:
-        """Unmount: unregister VFS hooks, then BLM unmount."""
+        """Unmount: unregister VFS hooks."""
         self._unregister_hooks(name)
-        if self._blm is not None:
-            await self._blm.unmount(name)
         logger.info("[COORDINATOR] umount %r", name)
 
-    # -- rmmod — unregister from both Registry and BLM ---------------------
+    # -- rmmod — unregister from Registry ----------------------------------
 
     async def unregister_service_full(self, name: str) -> None:
-        """Fully remove a service: unmount if active, then unregister from both."""
-        if self._blm is not None:
-            from nexus.contracts.protocols.brick_lifecycle import BrickState
-
-            status = self._blm.get_status(name)
-            if status is not None and status.state == BrickState.ACTIVE:
-                await self._unmount_service(name)
-
-            # BLM: UNMOUNTED → UNREGISTERED
-            status = self._blm.get_status(name)
-            if status is not None and status.state == BrickState.UNMOUNTED:
-                await self._blm.unregister(name)
-
-        # ServiceRegistry: remove (with dependency guard)
+        """Fully remove a service: unmount hooks, then unregister."""
+        await self._unmount_service(name)
         self.unregister_service(name)
         self._hook_specs.pop(name, None)
         logger.info("[COORDINATOR] rmmod %r", name)
@@ -472,10 +434,9 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         *,
         exports: tuple[str, ...] = (),
         hook_spec: HookSpec | None = None,
-        timeout: float = 5.0,
         drain_timeout: float = DEFAULT_DRAIN_TIMEOUT,
     ) -> None:
-        """Hot-swap a service: validate → drain → hook swap → BLM cycle.
+        """Hot-swap a service: validate → drain → hook swap → activate.
 
         Only HotSwappable services can be swapped.  Restart-required services raise
         TypeError — use full restart instead.
@@ -486,9 +447,8 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
             3. Drain ServiceRef refcount → 0 (in-flight calls complete)
             4. Unregister old VFS hooks (from old hook_spec or old_service.hook_spec())
             5. Atomic replace in ServiceRegistry
-            6. BLM cycle for old → new
-            7. Register new VFS hooks (from hook_spec param, new_service.hook_spec(), or retroactive)
-            8. Call new_service.activate() if HotSwappable
+            6. Register new VFS hooks (from hook_spec param, new_service.hook_spec(), or retroactive)
+            7. Call new_service.activate() if HotSwappable
         """
         # --- Resolve old instance ---
         old_info = self.service_info(name)
@@ -504,9 +464,6 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
                 f"Only Q2/Q4 services (HotSwappable) support runtime swap. "
                 f"Use full restart instead."
             )
-
-        # Snapshot old state
-        old_blm_spec = self._blm.get_spec(name) if self._blm is not None else None
 
         # Resolve old hook spec: explicit retroactive > protocol auto-detect
         old_hook_spec = self._hook_specs.get(name)
@@ -530,28 +487,7 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         self.replace_service(name, new_instance, exports=exports)
         logger.info("[COORDINATOR] swap %r — atomic replace done", name)
 
-        # Step 5: BLM cycle for old → new
-        if self._blm is not None:
-            from nexus.contracts.protocols.brick_lifecycle import BrickState
-
-            status = self._blm.get_status(name)
-            if status is not None and status.state == BrickState.ACTIVE:
-                await self._blm.unmount(name)
-            status = self._blm.get_status(name)
-            if status is not None and status.state == BrickState.UNMOUNTED:
-                await self._blm.unregister(name)
-
-            self._blm.register(
-                name,
-                new_instance,
-                protocol_name=old_blm_spec.protocol_name
-                if old_blm_spec
-                else type(new_instance).__name__,
-                depends_on=old_blm_spec.depends_on if old_blm_spec else (),
-            )
-            await self._blm.mount(name, timeout=timeout)
-
-        # Step 6: Register new hooks — explicit param > protocol > clear
+        # Step 5: Register new hooks — explicit param > protocol > clear
         new_hook_spec = hook_spec
         if new_hook_spec is None and isinstance(new_instance, HotSwappable):
             new_hook_spec = new_instance.hook_spec()
@@ -561,16 +497,9 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         elif name in self._hook_specs:
             del self._hook_specs[name]
 
-        if self._blm is not None:
-            from nexus.contracts.protocols.brick_lifecycle import BrickState
+        self._register_hooks(name)
 
-            status = self._blm.get_status(name)
-            if status is not None and status.state == BrickState.ACTIVE:
-                self._register_hooks(name)
-        else:
-            self._register_hooks(name)
-
-        # Step 7: Activate new service if HotSwappable
+        # Step 6: Activate new service if HotSwappable
         if isinstance(new_instance, HotSwappable):
             await new_instance.activate()
 
@@ -713,18 +642,11 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         return deactivated
 
     def _ordered_names(self, *, reverse: bool = False) -> list[str]:
-        """Return service names in BLM dependency order (or reverse for shutdown)."""
-        if self._blm is not None:
-            try:
-                if reverse:
-                    levels = self._blm.compute_shutdown_order()
-                else:
-                    levels = self._blm.compute_startup_order()
-                return [name for level in levels for name in level]
-            except Exception:
-                pass
-        # No BLM or BLM error: registry order (no ordering guarantee)
-        return [info.name for info in self.list_all()]
+        """Return service names in registration order (or reverse for shutdown)."""
+        names = [info.name for info in self.list_all()]
+        if reverse:
+            names.reverse()
+        return names
 
     # -- Hook spec management ----------------------------------------------
 

--- a/src/nexus/factory/__init__.py
+++ b/src/nexus/factory/__init__.py
@@ -53,12 +53,7 @@ from nexus.factory._boot_context import _BootContext
 from nexus.factory._bricks import _boot_dependent_bricks
 from nexus.factory._bricks import _boot_independent_bricks as _boot_brick_services
 from nexus.factory._helpers import (
-    _FACTORY_BRICKS,
-    _FACTORY_SKIP,
-    _LATE_BRICKS,
     _make_gate,
-    _register_factory_bricks,
-    _register_late_bricks,
     _safe_create,
 )
 from nexus.factory._kernel import _boot_kernel_services

--- a/src/nexus/factory/_helpers.py
+++ b/src/nexus/factory/_helpers.py
@@ -1,4 +1,4 @@
-"""Factory helpers — _safe_create, _make_gate, brick registration."""
+"""Factory helpers — _safe_create, _make_gate."""
 
 import logging
 from collections.abc import Callable
@@ -26,98 +26,6 @@ def _make_gate(brick_on: Callable[[str], bool] | None) -> Callable[[str], bool]:
     if brick_on is None:
         return lambda _name: True
     return brick_on
-
-
-# ---------------------------------------------------------------------------
-# Issue #1704: Register factory-created bricks with lifecycle manager
-# ---------------------------------------------------------------------------
-
-# Bricks registered with lifecycle manager.
-# Only stateful bricks (implementing start/stop/health_check) where
-# mount/unmount actually does something. Stateless bricks go to _FACTORY_SKIP.
-# (name, protocol_name, depends_on)
-_FACTORY_BRICKS: list[tuple[str, str, tuple[str, ...]]] = [
-    # Currently empty — all stateful bricks are registered separately:
-    # - workflow_engine: via _WorkflowLifecycleAdapter in _register_factory_bricks()
-    # - cache: via _register_late_bricks() in create_nexus_fs()
-    # - search: in server/lifespan/search.py
-]
-
-# Entries intentionally NOT registered with lifecycle manager.
-# CI test ``test_all_brick_dict_keys_accounted_for`` will fail if a new
-# key appears in ``_boot_independent_bricks()`` without being added here or
-# to ``_FACTORY_BRICKS``.
-_FACTORY_SKIP: frozenset[str] = frozenset(
-    {
-        # --- Not from nexus/bricks/ (services/infrastructure) ---
-        "event_bus",  # nexus/system_services/event_bus/
-        "lock_manager",  # nexus/raft/
-        "chunked_upload_service",  # nexus/services/upload/
-        "task_queue_service",  # nexus/system_services/lifecycle/
-        "wallet_provisioner",  # nexus/factory/wallet
-        "version_service",  # nexus/services/versioning/
-        "zoekt_pipe_consumer",  # nexus/factory/zoekt_pipe_consumer
-        "task_dispatch_consumer",  # nexus/task_manager/dispatch_consumer
-        # --- Stateless bricks (no start/stop — unmount is cosmetic) ---
-        "manifest_resolver",  # nexus/bricks/context_manifest/
-        "manifest_metrics",  # nexus/bricks/context_manifest/
-        "snapshot_service",  # nexus/bricks/snapshot/
-        "ipc_storage_driver",  # nexus/bricks/ipc/
-        "ipc_provisioner",  # nexus/bricks/ipc/
-        "delegation_service",  # nexus/bricks/delegation/
-        "reputation_service",  # nexus/bricks/reputation/
-        "api_key_creator",  # nexus/bricks/auth/
-        "tool_namespace_middleware",  # nexus/bricks/mcp/
-        "agent_event_log",  # nexus/bricks/sandbox/
-        "rebac_circuit_breaker",  # nexus/bricks/rebac/
-        "memory_permission",  # nexus/bricks/rebac/
-        "governance_anomaly_service",  # nexus/bricks/governance/
-        "governance_collusion_service",  # nexus/bricks/governance/
-        "governance_graph_service",  # nexus/bricks/governance/
-        "governance_response_service",  # nexus/bricks/governance/
-        # --- Always None at boot ---
-        "skill_service",  # wired later via NexusFS gateway adapters
-        "skill_package_service",  # wired later via NexusFS gateway adapters
-    }
-)
-
-_LATE_BRICKS: list[tuple[str, str, tuple[str, ...]]] = [
-    ("cache", "CacheProtocol", ()),
-]
-
-
-def _register_late_bricks(manager: Any, brick_dict: dict[str, Any]) -> None:
-    """Register stateful bricks created in create_nexus_fs()."""
-    for name, protocol, depends_on in _LATE_BRICKS:
-        instance = brick_dict.get(name)
-        if instance is not None:
-            manager.register(name, instance, protocol_name=protocol, depends_on=depends_on)
-
-
-def _register_factory_bricks(
-    manager: Any,
-    brick_dict: dict[str, Any],
-) -> None:
-    """Register Tier 2 bricks from ``_boot_independent_bricks()`` with the lifecycle manager.
-
-    Skips infrastructure entries (event_bus, lock_manager, etc.) and None values.
-    WorkflowEngine gets a thin adapter since its startup API differs.
-    """
-    from nexus.factory.adapters import _WorkflowLifecycleAdapter
-
-    for name, protocol, depends_on in _FACTORY_BRICKS:
-        instance = brick_dict.get(name)
-        if instance is not None:
-            manager.register(name, instance, protocol_name=protocol, depends_on=depends_on)
-
-    # WorkflowEngine needs adapter (startup() != start())
-    wf = brick_dict.get("workflow_engine")
-    if wf is not None:
-        manager.register(
-            "workflow_engine",
-            _WorkflowLifecycleAdapter(wf),
-            protocol_name="WorkflowProtocol",
-        )
 
 
 def _safe_create(

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -121,9 +121,6 @@ async def _do_link(
     )
 
     # Issue #1708: ServiceRegistry now has integrated lifecycle (formerly SLC).
-    # BLM is optional — inject via set_lifecycle_manager().
-    _blm = getattr(system_services, "brick_lifecycle_manager", None)
-    nx._service_registry.set_lifecycle_manager(_blm)
     await enlist_wired_services(nx._service_registry, _wired)
 
     # Issue #1811: DriverLifecycleCoordinator is kernel-owned (created in
@@ -347,14 +344,6 @@ async def _do_initialize(
         brick_on=brick_on,
         parse_fn=parse_fn,
     )
-
-    # --- BLM registration for late bricks (Issue #1704, #2991) ---
-    _blm = getattr(system_services, "brick_lifecycle_manager", None)
-    if _blm is not None:
-        from nexus.factory._helpers import _register_late_bricks
-
-        _cache_brick = getattr(nx._brick_services, "cache_brick", None)
-        _register_late_bricks(_blm, {"cache": _cache_brick})
 
     # --- Register background services as bootstrap callbacks ---
     # TL directive: initialize() prepares resources but stays static.

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -90,7 +90,6 @@ def create_nexus_services(
     from nexus.core.config import SystemServices as _SystemServices
     from nexus.factory._boot_context import _BootContext
     from nexus.factory._bricks import _boot_dependent_bricks, _boot_independent_bricks
-    from nexus.factory._helpers import _register_factory_bricks
     from nexus.factory._kernel import _boot_kernel_services
     from nexus.factory._system import _boot_system_services
 
@@ -162,11 +161,6 @@ def create_nexus_services(
     _boot_dependent_bricks(ctx, system_dict, brick_dict)
 
     # --- Background threads deferred to NexusFS.initialize() ---
-
-    # --- Register factory-created bricks with lifecycle manager (Issue #1704) ---
-    _blm = system_dict.get("brick_lifecycle_manager")
-    if _blm is not None:
-        _register_factory_bricks(_blm, brick_dict)
 
     # --- Assemble 3-tier containers (Issue #2034, #2193) ---
     kernel_services = _KernelServices(router=router)

--- a/tests/unit/services/test_service_lifecycle_coordinator.py
+++ b/tests/unit/services/test_service_lifecycle_coordinator.py
@@ -12,12 +12,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nexus.contracts.protocols.brick_lifecycle import BrickState
 from nexus.contracts.protocols.service_hooks import HookSpec
 from nexus.contracts.protocols.service_lifecycle import HotSwappable, PersistentService
 from nexus.core.kernel_dispatch import KernelDispatch
 from nexus.core.service_registry import ServiceRegistry
-from nexus.system_services.lifecycle.brick_lifecycle import BrickLifecycleManager
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -30,20 +28,13 @@ def registry() -> ServiceRegistry:
 
 
 @pytest.fixture()
-def blm() -> BrickLifecycleManager:
-    return BrickLifecycleManager()
-
-
-@pytest.fixture()
 def dispatch() -> KernelDispatch:
     return KernelDispatch()
 
 
 @pytest.fixture()
-def coordinator(blm: BrickLifecycleManager, dispatch: KernelDispatch) -> ServiceRegistry:
-    reg = ServiceRegistry(dispatch=dispatch)
-    reg.set_lifecycle_manager(blm)
-    return reg
+def coordinator(dispatch: KernelDispatch) -> ServiceRegistry:
+    return ServiceRegistry(dispatch=dispatch)
 
 
 class _FakeService:
@@ -149,23 +140,16 @@ class _BothProtocolsService:
 
 
 class TestRegisterService:
-    def test_registers_in_both_registry_and_blm(
+    def test_registers_in_registry(
         self,
         coordinator: ServiceRegistry,
-        blm: BrickLifecycleManager,
     ) -> None:
         svc = _FakeService()
         coordinator._register_service("search", svc, exports=("glob", "grep"))
-        # ServiceRegistry
         info = coordinator.service_info("search")
         assert info is not None
         assert info.instance is svc
         assert info.exports == ("glob", "grep")
-        # BLM — protocol_name is now always type(instance).__name__
-        status = blm.get_status("search")
-        assert status is not None
-        assert status.state == BrickState.REGISTERED
-        assert status.protocol_name == "_FakeService"
 
     def test_stores_hook_spec(self, coordinator: ServiceRegistry) -> None:
         svc = _FakeService()
@@ -240,7 +224,6 @@ class TestUnregisterServiceFull:
     async def test_full_unregister(
         self,
         coordinator: ServiceRegistry,
-        blm: BrickLifecycleManager,
     ) -> None:
         svc = _FakeService()
         coordinator._register_service("search", svc)
@@ -249,8 +232,6 @@ class TestUnregisterServiceFull:
 
         # Gone from registry
         assert coordinator.service("search") is None
-        # Gone from BLM
-        assert blm.get_status("search") is None
 
 
 # ---------------------------------------------------------------------------
@@ -923,18 +904,16 @@ class TestEnlist:
     async def test_enlist_with_depends_on(
         self,
         coordinator: ServiceRegistry,
-        blm: BrickLifecycleManager,
     ) -> None:
-        """enlist passes depends_on to BLM for dependency ordering."""
+        """enlist with depends_on registers without error."""
         dep = _FakeService()
         await coordinator.enlist("dep", dep)
 
         svc = _PersistentFakeService()
         await coordinator.enlist("child", svc, depends_on=("dep",))
 
-        spec = blm.get_spec("child")
-        assert spec is not None
-        assert "dep" in spec.depends_on
+        info = coordinator.service_info("child")
+        assert info is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove all `_blm` coupling from `ServiceRegistry` — delete `set_lifecycle_manager()`, BLM state machine calls in mount/unmount/swap/unregister
- Simplify `_ordered_names()` to registration order (BLM DAG ordering removed)
- Delete `_register_factory_bricks`, `_register_late_bricks`, `_FACTORY_BRICKS`, `_LATE_BRICKS` from factory helpers
- Remove BLM injection from factory `_lifecycle.py` link phase
- Update coordinator tests: remove BLM fixtures and assertions

PR 1 of 3 in the Delete BrickLifecycleManager series.

## Test plan
- [x] `pytest tests/unit/core/test_service_registry.py` — 101 passed
- [x] `pytest tests/unit/services/test_service_lifecycle_coordinator.py` — 101 passed
- [x] All pre-commit hooks pass (ruff, mypy, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)