### PR TITLE
refactor(#1305): VirtualViewResolver single metastore lookup

### DIFF
--- a/src/nexus/bricks/parsers/virtual_view_resolver.py
+++ b/src/nexus/bricks/parsers/virtual_view_resolver.py
@@ -84,7 +84,9 @@ class VirtualViewResolver(VFSPathResolver):
         """Read virtual parsed view, or return None if not a virtual view."""
         from nexus.lib.virtual_views import get_parsed_content, parse_virtual_path
 
-        original_path, view_type = parse_virtual_path(path, self._metadata.exists)
+        # Single metastore lookup: metadata.get returns FileMetadata (truthy)
+        # or None (falsy). parse_virtual_path passes the result through.
+        original_path, view_type, meta = parse_virtual_path(path, self._metadata.get)
         if view_type != "md":
             return None
 
@@ -96,7 +98,6 @@ class VirtualViewResolver(VFSPathResolver):
         # Route and read original file content
         is_admin = bool(getattr(context, "is_admin", False)) if context else False
         route = self._path_router.route(original_path, is_admin=is_admin, check_write=False)
-        meta = self._metadata.get(original_path)
         if meta is None or meta.etag is None:
             raise NexusFileNotFoundError(original_path)
 
@@ -127,7 +128,7 @@ class VirtualViewResolver(VFSPathResolver):
         """Virtual views are read-only — raise if virtual view, else return None."""
         from nexus.lib.virtual_views import parse_virtual_path
 
-        _, view_type = parse_virtual_path(path, self._metadata.exists)
+        _, view_type, _ = parse_virtual_path(path, self._metadata.exists)
         if view_type == "md":
             raise NexusFileNotFoundError(
                 f"Cannot write to virtual view: {path} ({len(content)} bytes)"
@@ -139,7 +140,7 @@ class VirtualViewResolver(VFSPathResolver):
         from nexus.lib.virtual_views import parse_virtual_path
 
         _ = context
-        _, view_type = parse_virtual_path(path, self._metadata.exists)
+        _, view_type, _ = parse_virtual_path(path, self._metadata.exists)
         if view_type == "md":
             raise NexusFileNotFoundError(f"Cannot delete virtual view: {path}")
         return None

--- a/src/nexus/bricks/rebac/checker.py
+++ b/src/nexus/bricks/rebac/checker.py
@@ -144,7 +144,7 @@ class PermissionChecker:
         def metadata_exists(check_path: str) -> bool:
             return bool(self._metadata_store.exists(check_path))
 
-        original_path, view_type = parse_virtual_path(path, metadata_exists)
+        original_path, view_type, _ = parse_virtual_path(path, metadata_exists)
         if view_type == "md":
             logger.debug(
                 f"  -> Virtual view detected: checking permissions on original file {original_path}"

--- a/src/nexus/fuse/ops/_shared.py
+++ b/src/nexus/fuse/ops/_shared.py
@@ -285,7 +285,8 @@ def parse_virtual_path_for_fuse(ctx: FUSESharedContext, path: str) -> tuple[str,
     def _sync_access(p: str) -> bool:
         return _run_sync(ctx.nexus_fs.sys_access(p))
 
-    return parse_virtual_path(path, _sync_access)
+    original_path, view_type, _ = parse_virtual_path(path, _sync_access)
+    return original_path, view_type
 
 
 async def get_file_content(

--- a/src/nexus/lib/virtual_views.py
+++ b/src/nexus/lib/virtual_views.py
@@ -50,25 +50,30 @@ PARSEABLE_EXTENSIONS = {
 }
 
 
-def parse_virtual_path(path: str, exists_fn: Callable[[str], bool]) -> tuple[str, str | None]:
-    """Parse virtual path to extract original path and view type.
+def parse_virtual_path(path: str, check_fn: Callable[[str], Any]) -> tuple[str, str | None, Any]:
+    """Parse virtual path to extract original path, view type, and check result.
 
     Args:
         path: Virtual path (e.g., "/file_parsed.xlsx.md" or "/document_parsed.pdf.md")
-        exists_fn: Function to check if a path exists
+        check_fn: Function to verify the original file exists.  Can be:
+            - ``metadata.exists`` (returns bool) — for simple existence checks
+            - ``metadata.get``   (returns FileMetadata | None) — when the caller
+              needs the metadata anyway (avoids a redundant second lookup)
+            The result is tested for truthiness and passed through as the
+            third element of the return tuple.
 
     Returns:
-        Tuple of (original_path, view_type)
+        Tuple of (original_path, view_type, check_result)
         - original_path: Original file path without virtual suffix
         - view_type: "md" or None for raw/binary access
+        - check_result: Return value of check_fn(original_path), or None
+          when the path is not a virtual view
 
     Examples:
         >>> parse_virtual_path("/file_parsed.xlsx.md", exists_fn)
-        ("/file.xlsx", "md")
+        ("/file.xlsx", "md", True)
         >>> parse_virtual_path("/file.txt", exists_fn)
-        ("/file.txt", None)  # Actual .txt file, not a virtual view
-        >>> parse_virtual_path("/file_parsed.xlsx", exists_fn)
-        ("/file_parsed.xlsx", None)  # Missing .md extension
+        ("/file.txt", None, None)
     """
     # Handle _parsed.{ext}.md virtual views
     # Pattern: file_parsed.{ext}.md → file.{ext}
@@ -97,11 +102,13 @@ def parse_virtual_path(path: str, exists_fn: Callable[[str], bool]) -> tuple[str
 
                 # Only treat as virtual view if the extension is parseable
                 # and the original file exists
-                if original_ext in PARSEABLE_EXTENSIONS and exists_fn(original_path):
-                    return (original_path, "md")
+                if original_ext in PARSEABLE_EXTENSIONS:
+                    result = check_fn(original_path)
+                    if result:
+                        return (original_path, "md", result)
 
     # Not a virtual view, return as-is
-    return (path, None)
+    return (path, None, None)
 
 
 def get_parsed_content(

--- a/tests/unit/bricks/parsers/test_virtual_view_resolver.py
+++ b/tests/unit/bricks/parsers/test_virtual_view_resolver.py
@@ -1,0 +1,128 @@
+"""Tests for VirtualViewResolver — VFSPathResolver behavioral contract (#1305).
+
+Verifies:
+- try_read uses single metastore lookup (no double lookup)
+- try_read returns parsed content for virtual view paths
+- try_read returns None for non-virtual paths
+- try_write / try_delete reject virtual views with error
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from nexus.bricks.parsers.virtual_view_resolver import VirtualViewResolver
+
+
+@dataclass
+class FakeFileMetadata:
+    path: str
+    etag: str = "abc123"
+    version: str = "1"
+    size: int = 100
+    owner: str = "user"
+
+
+@pytest.fixture
+def metadata() -> MagicMock:
+    mock = MagicMock()
+    # metadata.get returns FakeFileMetadata for existing files, None otherwise
+    mock.get.return_value = FakeFileMetadata(path="/file.xlsx", etag="hash123")
+    mock.exists.return_value = True
+    return mock
+
+
+@pytest.fixture
+def path_router() -> MagicMock:
+    route = MagicMock()
+    route.backend.read_content.return_value = b"raw xlsx bytes"
+    route.backend_path = "/file.xlsx"
+    mock = MagicMock()
+    mock.route.return_value = route
+    return mock
+
+
+@pytest.fixture
+def permission_checker() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def resolver(
+    metadata: MagicMock,
+    path_router: MagicMock,
+    permission_checker: MagicMock,
+) -> VirtualViewResolver:
+    return VirtualViewResolver(
+        metadata=metadata,
+        path_router=path_router,
+        permission_checker=permission_checker,
+        parse_fn=lambda content, path: b"# Parsed markdown",
+    )
+
+
+class TestSingleMetastoreLookup:
+    """Behavioral contract: try_read must use at most one metastore call."""
+
+    def test_try_read_single_lookup(
+        self, resolver: VirtualViewResolver, metadata: MagicMock
+    ) -> None:
+        """try_read should call metadata.get exactly once, not exists+get."""
+        resolver.try_read("/file_parsed.xlsx.md")
+
+        # metadata.get called exactly once (by parse_virtual_path)
+        assert metadata.get.call_count == 1
+        assert metadata.get.call_args == call("/file.xlsx")
+
+        # metadata.exists must NOT be called during try_read
+        metadata.exists.assert_not_called()
+
+    def test_try_read_nonvirtual_single_lookup(
+        self, resolver: VirtualViewResolver, metadata: MagicMock
+    ) -> None:
+        """Non-virtual path: metadata.get should not be called at all."""
+        result = resolver.try_read("/normal_file.txt")
+
+        assert result is None
+        metadata.get.assert_not_called()
+        metadata.exists.assert_not_called()
+
+
+class TestTryRead:
+    def test_returns_parsed_content(self, resolver: VirtualViewResolver) -> None:
+        result = resolver.try_read("/file_parsed.xlsx.md")
+        assert result == b"# Parsed markdown"
+
+    def test_returns_none_for_non_virtual(self, resolver: VirtualViewResolver) -> None:
+        assert resolver.try_read("/normal.txt") is None
+
+    def test_returns_none_when_original_missing(
+        self, resolver: VirtualViewResolver, metadata: MagicMock
+    ) -> None:
+        metadata.get.return_value = None
+        assert resolver.try_read("/missing_parsed.xlsx.md") is None
+
+
+class TestTryWriteDelete:
+    def test_write_rejects_virtual_view(self, resolver: VirtualViewResolver) -> None:
+        with pytest.raises(Exception, match="Cannot write"):
+            resolver.try_write("/file_parsed.xlsx.md", b"data")
+
+    def test_write_returns_none_for_non_virtual(
+        self,
+        resolver: VirtualViewResolver,
+    ) -> None:
+        assert resolver.try_write("/normal.txt", b"data") is None
+
+    def test_delete_rejects_virtual_view(self, resolver: VirtualViewResolver) -> None:
+        with pytest.raises(Exception, match="Cannot delete"):
+            resolver.try_delete("/file_parsed.xlsx.md")
+
+    def test_delete_returns_none_for_non_virtual(
+        self,
+        resolver: VirtualViewResolver,
+    ) -> None:
+        assert resolver.try_delete("/normal.txt") is None


### PR DESCRIPTION
## Summary

- Eliminate redundant double metastore lookup in `VirtualViewResolver.try_read()`
- Add behavioral test enforcing single-lookup contract for VFSPathResolver implementations

## Problem

`try_read()` was calling metastore twice for the same path:
1. `parse_virtual_path(path, metadata.exists)` — existence check
2. `metadata.get(original_path)` — fetch full metadata

## Fix

Change `parse_virtual_path()` to return a 3-tuple `(path, view_type, check_result)`, passing through the check function's return value. VirtualViewResolver now uses `metadata.get` as the check function — one call gets both existence and metadata.

```python
# Before: 2 lookups
original_path, view_type = parse_virtual_path(path, self._metadata.exists)
meta = self._metadata.get(original_path)  # redundant

# After: 1 lookup
original_path, view_type, meta = parse_virtual_path(path, self._metadata.get)
```

## Changes

- `virtual_views.py`: `parse_virtual_path` returns 3-tuple with check_fn result passthrough
- `virtual_view_resolver.py`: `try_read` uses `metadata.get`, eliminates double lookup
- `_shared.py` / `checker.py`: Destructure 3rd element with `_`
- New test: `test_virtual_view_resolver.py` with behavioral contract assertions

## Test plan
- [x] Behavioral test: `metadata.get` called exactly once, `metadata.exists` never called in try_read
- [x] `pytest tests/unit/` — full suite green
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)