### PR TITLE
refactor(#1452): enable hot-swap for all ServiceRegistry quadrants

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -47,7 +47,7 @@ Follows Linux's monolithic kernel model, not microkernel:
 |------|-----------|-------|----------------|
 | Static kernel | Never | MetastoreABC, VFS `route()`, syscall dispatch | vmlinuz core (scheduler, mm, VFS) |
 | Drivers | Config-time (DI at startup) | redb, S3, PostgreSQL, Dragonfly, SearchBrick | compiled-in drivers (`=y`) |
-| Services | Init-time DI + runtime hot-swap | 40+ protocols (ReBAC, Mount, Auth, Agents, Search, Skills, ...) | loadable kernel modules (`insmod`/`rmmod`) |
+| Services | Init-time DI + runtime hot-swap (all quadrants, #1452) | 40+ protocols (ReBAC, Mount, Auth, Agents, Search, Skills, ...) | loadable kernel modules (`insmod`/`rmmod`) |
 
 **Invariant:** Services depend on kernel interfaces, never the reverse.
 The kernel operates with zero services loaded. Kernel code (`core/nexus_fs.py`)
@@ -99,6 +99,9 @@ One-click contract: implement protocol → `ServiceRegistry.enlist()` →
 kernel handles the rest. `ServiceRegistry` (kernel-owned, lifecycle integrated)
 scans the registry and auto-calls the appropriate methods during
 `NexusFS.bootstrap()` / `NexusFS.close()`.
+
+`swap_service()` supports **all quadrants** (#1452). `HotSwappable` determines
+*how* to swap (full lifecycle vs refcount-only drain), not *whether*.
 
 **Kernel DI patterns** (two mechanisms, never reads service containers directly):
 

--- a/src/nexus/contracts/protocols/service_lifecycle.py
+++ b/src/nexus/contracts/protocols/service_lifecycle.py
@@ -92,6 +92,7 @@ class ServiceQuadrant(enum.Enum):
       be started/stopped (event loops, polling, workers).
     """
 
+    # Q1: still swappable via ServiceRef refcount drain (#1452).
     Q1_RESTART_REQUIRED = "Q1"
     Q2_HOT_SWAPPABLE = "Q2"
     Q3_PERSISTENT = "Q3"

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -343,7 +343,7 @@ class NexusFS(  # type: ignore[misc]
         return self._service_registry
 
     async def swap_service(self, name: str, new_instance: Any, **kwargs: Any) -> None:
-        """Hot-swap a service: atomic replace → drain → hook swap."""
+        """Hot-swap a service — all quadrants supported (#1452)."""
         await self._service_registry.swap_service(name, new_instance, **kwargs)
 
     @property

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -436,19 +436,13 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         hook_spec: HookSpec | None = None,
         drain_timeout: float = DEFAULT_DRAIN_TIMEOUT,
     ) -> None:
-        """Hot-swap a service: validate → drain → hook swap → activate.
+        """Hot-swap a service: drain → atomic replace → hook swap → activate.
 
-        Only HotSwappable services can be swapped.  Restart-required services raise
-        TypeError — use full restart instead.
+        All quadrants supported (#1452).  HotSwappable controls *how* to swap
+        (full lifecycle vs refcount-only), not *whether*.
 
-        Flow for HotSwappable services:
-            1. Validate old service is HotSwappable (TypeError if not)
-            2. Call old_service.drain() — stop accepting new work
-            3. Drain ServiceRef refcount → 0 (in-flight calls complete)
-            4. Unregister old VFS hooks (from old hook_spec or old_service.hook_spec())
-            5. Atomic replace in ServiceRegistry
-            6. Register new VFS hooks (from hook_spec param, new_service.hook_spec(), or retroactive)
-            7. Call new_service.activate() if HotSwappable
+        HotSwappable (Q2/Q4): drain() → refcount drain → unhook → replace → rehook → activate()
+        Non-HotSwappable (Q1/Q3): refcount drain → replace → rehook if new is Hot → activate if new is Hot
         """
         # --- Resolve old instance ---
         old_info = self.service_info(name)
@@ -456,25 +450,21 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
             raise KeyError(f"swap_service: {name!r} not registered")
         old_instance = old_info.instance
 
-        # --- Guard: only HotSwappable services can be swapped ---
+        # --- Branch: HotSwappable determines swap strategy ---
         quadrant = ServiceQuadrant.of(old_instance)
-        if not quadrant.is_hot_swappable:
-            raise TypeError(
-                f"swap_service: {name!r} is {quadrant.label} — cannot hot-swap. "
-                f"Only Q2/Q4 services (HotSwappable) support runtime swap. "
-                f"Use full restart instead."
-            )
+        old_is_hot = quadrant.is_hot_swappable
 
-        # Resolve old hook spec: explicit retroactive > protocol auto-detect
+        # Resolve old hook spec (HotSwappable only)
         old_hook_spec = self._hook_specs.get(name)
-        if old_hook_spec is None:
+        if old_hook_spec is None and old_is_hot:
             old_hook_spec = old_instance.hook_spec()
             if old_hook_spec is not None and not old_hook_spec.is_empty:
                 self._hook_specs[name] = old_hook_spec
 
-        # Step 1: Drain old service (service-internal cleanup)
-        await old_instance.drain()
-        logger.debug("[COORDINATOR] swap %r — old service drained", name)
+        # Step 1: Protocol drain (HotSwappable only)
+        if old_is_hot:
+            await old_instance.drain()
+            logger.debug("[COORDINATOR] swap %r — old service drained", name)
 
         # Step 2: Drain ServiceRef refcount (wait for in-flight calls)
         await self._drain(name, timeout=drain_timeout)

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -115,6 +115,7 @@ async def enlist_wired_services(coordinator: Any, wired: Any) -> int:
 
     All wired services are Q1 (restart-required) — no HotSwappable or PersistentService
     — so enlist() auto-detects and registers them without lifecycle side effects.
+    Q1 services are still swappable at runtime via swap_service() (#1452).
 
     Returns the number of services enlisted.
     """

--- a/tests/unit/services/test_service_lifecycle_coordinator.py
+++ b/tests/unit/services/test_service_lifecycle_coordinator.py
@@ -291,18 +291,21 @@ class TestSwapService:
         assert ref._service_instance is svc2
 
     @pytest.mark.asyncio()
-    async def test_swap_rejects_non_hot_swappable(
+    async def test_swap_allows_non_hot_swappable(
         self,
         coordinator: ServiceRegistry,
     ) -> None:
-        """Static (non-HotSwappable) services cannot be hot-swapped."""
+        """Q1 services can be swapped via refcount drain (#1452)."""
         svc1 = _FakeService()  # NOT HotSwappable
         coordinator._register_service("search", svc1, exports=("glob",))
         await coordinator._mount_service("search")
 
         svc2 = _FakeServiceV2()
-        with pytest.raises(TypeError, match="cannot hot-swap"):
-            await coordinator.swap_service("search", svc2, exports=("glob",))
+        await coordinator.swap_service("search", svc2, exports=("glob",))
+
+        ref = coordinator.service("search")
+        assert ref is not None
+        assert ref._service_instance is svc2
 
     @pytest.mark.asyncio()
     async def test_swap_auto_detects_hook_spec_from_protocol(
@@ -972,28 +975,27 @@ class TestQuadrantGuards:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "service_class,replacement_class,error_match",
+        "service_class,replacement_class",
         [
-            (_FakeService, _FakeServiceV2, "Q1.*restart-required.*cannot hot-swap"),
-            (
-                _PersistentFakeService,
-                _PersistentFakeService,
-                "Q3.*PersistentService.*cannot hot-swap",
-            ),
+            (_FakeService, _FakeServiceV2),
+            (_PersistentFakeService, _PersistentFakeService),
         ],
     )
-    async def test_swap_rejects_non_swappable(
+    async def test_swap_allows_non_hot_swappable(
         self,
         coordinator: ServiceRegistry,
         service_class: type,
         replacement_class: type,
-        error_match: str,
     ) -> None:
-        """Swapping a non-HotSwappable service includes quadrant label in error."""
+        """All quadrants can be swapped via refcount drain (#1452)."""
         coordinator._register_service("svc", service_class())
         await coordinator._mount_service("svc")
-        with pytest.raises(TypeError, match=error_match):
-            await coordinator.swap_service("svc", replacement_class())
+        svc2 = replacement_class()
+        await coordinator.swap_service("svc", svc2)
+
+        ref = coordinator.service("svc")
+        assert ref is not None
+        assert ref._service_instance is svc2
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -1102,3 +1104,115 @@ class TestQuadrantGuards:
     ) -> None:
         with pytest.raises(KeyError, match="not registered"):
             await coordinator._deactivate_service("ghost")
+
+
+# ---------------------------------------------------------------------------
+# Q1/Q3 swap — non-HotSwappable swap via refcount drain (Issue #1452)
+# ---------------------------------------------------------------------------
+
+
+class TestNonHotSwappableSwap:
+    """Tests for swapping Q1/Q3 services that don't implement HotSwappable."""
+
+    @pytest.mark.asyncio
+    async def test_q1_swap_succeeds(
+        self,
+        coordinator: ServiceRegistry,
+    ) -> None:
+        """Q1 (restart-required) services can be swapped at runtime."""
+        svc1 = _FakeService()
+        coordinator._register_service("search", svc1, exports=("glob",))
+        await coordinator._mount_service("search")
+
+        svc2 = _FakeServiceV2()
+        await coordinator.swap_service("search", svc2, exports=("glob",))
+
+        ref = coordinator.service("search")
+        assert ref is not None
+        assert ref._service_instance is svc2
+        assert ref.glob("*.py") == ["v2:*.py"]
+
+    @pytest.mark.asyncio
+    async def test_q1_swap_does_not_call_hot_swappable_methods(
+        self,
+        coordinator: ServiceRegistry,
+    ) -> None:
+        """Q1 swap must NOT invoke drain/activate — the service has no such methods."""
+
+        class _TrackedQ1:
+            def glob(self, pattern: str) -> list[str]:
+                return [pattern]
+
+        class _TrackedQ1V2:
+            def glob(self, pattern: str) -> list[str]:
+                return [f"v2:{pattern}"]
+
+        svc1 = _TrackedQ1()
+        coordinator._register_service("svc", svc1)
+        await coordinator._mount_service("svc")
+
+        svc2 = _TrackedQ1V2()
+        # If swap_service tries to call drain()/activate() on Q1 services,
+        # it will raise AttributeError — this test verifies it doesn't.
+        await coordinator.swap_service("svc", svc2)
+
+        ref = coordinator.service("svc")
+        assert ref is not None
+        assert ref._service_instance is svc2
+
+    @pytest.mark.asyncio
+    async def test_q1_swap_drains_in_flight_calls(
+        self,
+        coordinator: ServiceRegistry,
+    ) -> None:
+        """Q1 swap still waits for in-flight calls via ServiceRef refcount drain."""
+        call_completed = asyncio.Event()
+
+        class _SlowQ1:
+            async def work(self) -> str:
+                await asyncio.sleep(0.05)
+                call_completed.set()
+                return "done"
+
+        svc1 = _SlowQ1()
+        coordinator._register_service("svc", svc1, exports=("work",))
+        await coordinator._mount_service("svc")
+
+        ref = coordinator.service("svc")
+        assert ref is not None
+        in_flight = asyncio.create_task(ref.work())
+
+        svc2 = _FakeServiceV2()
+        swap_task = asyncio.create_task(coordinator.swap_service("svc", svc2, drain_timeout=2.0))
+
+        result = await in_flight
+        assert result == "done"
+        assert call_completed.is_set()
+
+        await swap_task
+        new_ref = coordinator.service("svc")
+        assert new_ref is not None
+        assert new_ref._service_instance is svc2
+
+    @pytest.mark.asyncio
+    async def test_q1_to_q2_upgrade_swap(
+        self,
+        coordinator: ServiceRegistry,
+        dispatch: KernelDispatch,
+    ) -> None:
+        """Swap Q1 old → Q2 new: new HotSwappable instance gets activated."""
+        svc1 = _FakeService()  # Q1
+        coordinator._register_service("svc", svc1)
+        await coordinator._mount_service("svc")
+
+        hook = MagicMock()
+        spec = HookSpec(read_hooks=(hook,))
+        svc2 = _HotSwappableService(hook_spec_value=spec)  # Q2
+        await coordinator.swap_service("svc", svc2, hook_spec=spec)
+
+        assert svc2.activated is True
+        assert dispatch.read_hook_count == 1
+
+        ref = coordinator.service("svc")
+        assert ref is not None
+        assert ref._service_instance is svc2


### PR DESCRIPTION
## Summary
- Remove `TypeError` guard in `swap_service()` — `HotSwappable` now controls *how* to swap (full lifecycle vs refcount-only drain), not *whether*
- Q2/Q4 (HotSwappable): full flow — `drain()` → refcount drain → unhook → replace → rehook → `activate()`
- Q1/Q3 (non-HotSwappable): simplified — refcount drain → replace → rehook/activate if new is HotSwappable

## Changed files
| File | Change |
|------|--------|
| `service_registry.py` | Remove guard, conditionalize drain/hook_spec on `old_is_hot` |
| `service_lifecycle.py` | Q1 enum comment: still swappable via refcount drain |
| `service_routing.py` | Docstring: Q1 services swappable via `swap_service()` |
| `nexus_fs.py` | Docstring: all quadrants supported |
| `test_service_lifecycle_coordinator.py` | 2 tests changed (TypeError → success), 4 new tests added |
| `KERNEL-ARCHITECTURE.md` | One-line addition on swap_service all-quadrant support |

## Test plan
- [x] `pytest tests/unit/services/test_service_lifecycle_coordinator.py -v` — 70 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — passed (pre-commit)

Closes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)