### PR TITLE
Add unified auth flows and playground connector picker

### DIFF
--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -53,6 +53,7 @@ from nexus.backends.connectors.gws.schemas import (
     UpdateFileSchema,
     UploadFileSchema,
 )
+from nexus.backends.connectors.oauth import OAuthConnectorMixin
 from nexus.contracts.capabilities import OAUTH_CONNECTOR_CAPABILITIES, ConnectorCapability
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
@@ -109,7 +110,9 @@ EXPORT_FORMATS = {
     requires=["google-api-python-client", "google-auth-oauthlib"],
     service_name="google-drive",
 )
-class GoogleDriveConnectorBackend(Backend, SkillDocMixin, ValidatedMixin, TraitBasedMixin):
+class GoogleDriveConnectorBackend(
+    Backend, OAuthConnectorMixin, SkillDocMixin, ValidatedMixin, TraitBasedMixin
+):
     """
     Google Drive connector backend with OAuth 2.0 authentication.
 
@@ -248,28 +251,10 @@ class GoogleDriveConnectorBackend(Backend, SkillDocMixin, ValidatedMixin, TraitB
             For multi-user production, leave user_email=None to auto-detect from context.
             This ensures each user accesses their own Drive.
         """
-        print(f"[GDRIVE-INIT] __init__ called: user_email={user_email}, provider={provider}")
-
-        # Import TokenManager here to avoid circular imports
-        # Support both file paths and database URLs
-        # Resolve database URL (checks TOKEN_MANAGER_DB env var)
-        import importlib as _il
-
-        from nexus.backends.connectors.utils import resolve_database_url
-
-        TokenManager = _il.import_module("nexus.bricks.auth.oauth.token_manager").TokenManager
-
-        resolved_db = resolve_database_url(token_manager_db)
-
-        if resolved_db.startswith(("postgresql://", "sqlite://", "mysql://")):
-            self.token_manager = TokenManager(db_url=resolved_db)
-        else:
-            self.token_manager = TokenManager(db_path=resolved_db)
-        self.user_email = user_email  # None means use context.user_id
+        self._init_oauth(token_manager_db, user_email=user_email, provider=provider)
         self.root_folder = root_folder
         self.use_shared_drives = use_shared_drives
         self.shared_drive_id = shared_drive_id
-        self.provider = provider
 
         # Register OAuth provider using factory (loads from config)
         self._register_oauth_provider()
@@ -307,18 +292,15 @@ class GoogleDriveConnectorBackend(Backend, SkillDocMixin, ValidatedMixin, TraitB
                 logger.info(
                     f"✓ Registered OAuth provider '{self.provider}' for Google Drive backend"
                 )
-                print(f"[GDRIVE-INIT] ✓ Registered OAuth provider '{self.provider}' from config")
             except ValueError as e:
                 # Provider not found in config or credentials not set
                 logger.warning(
                     f"OAuth provider '{self.provider}' not available: {e}. "
                     "OAuth flow must be initiated manually via the Integrations page."
                 )
-                print(f"[GDRIVE-INIT] ⚠ OAuth provider '{self.provider}' not available: {e}")
         except Exception as e:
             error_msg = f"Failed to register OAuth provider: {e}\n{traceback.format_exc()}"
             logger.error(error_msg)
-            print(f"[GDRIVE-INIT] ✗ {error_msg}")
 
     def check_connection(self, context: "OperationContext | None" = None) -> HandlerStatusResponse:
         """

--- a/src/nexus/backends/connectors/gws/configs/docs.yaml
+++ b/src/nexus/backends/connectors/gws/configs/docs.yaml
@@ -6,8 +6,9 @@ auth:
   provider: google
   scopes:
     - https://www.googleapis.com/auth/documents
+    - https://www.googleapis.com/auth/drive.readonly
 read:
-  list_command: documents.list
+  list_command: drive.files.list
   get_command: documents.get
   format: json
 write:
@@ -26,5 +27,5 @@ write:
       reversibility: partial
       confirm: explicit
 sync:
-  delta_command: "documents.list --modified-after {since}"
+  delta_command: "drive.files.list --modified-after {since}"
   state_field: lastModifiedTime

--- a/src/nexus/backends/connectors/gws/connector.py
+++ b/src/nexus/backends/connectors/gws/connector.py
@@ -75,6 +75,7 @@ def _load_gws_config(filename: str) -> CLIConnectorConfig | None:
     "gws_sheets",
     description="Google Sheets via gws CLI",
     category="cli",
+    service_name="gws",
 )
 class SheetsConnector(CLIConnector):
     """Google Sheets CLI connector via ``gws sheets``."""
@@ -117,6 +118,7 @@ class SheetsConnector(CLIConnector):
     "gws_docs",
     description="Google Docs via gws CLI",
     category="cli",
+    service_name="gws",
 )
 class DocsConnector(CLIConnector):
     """Google Docs CLI connector via ``gws docs``."""
@@ -159,6 +161,7 @@ class DocsConnector(CLIConnector):
     "gws_chat",
     description="Google Chat via gws CLI",
     category="cli",
+    service_name="gws",
 )
 class ChatConnector(CLIConnector):
     """Google Chat CLI connector via ``gws chat``."""
@@ -199,6 +202,7 @@ class ChatConnector(CLIConnector):
     "gws_drive",
     description="Google Drive via gws CLI",
     category="cli",
+    service_name="gws",
 )
 class DriveConnector(CLIConnector):
     """Google Drive CLI connector via ``gws drive``."""
@@ -275,6 +279,7 @@ def _gmail_category_from_labels(labels: list[str] | None) -> str:
     "gws_gmail",
     description="Gmail via gws CLI",
     category="cli",
+    service_name="gws",
 )
 class GmailConnector(CLIConnector):
     """Gmail CLI connector via ``gws gmail``.
@@ -706,6 +711,7 @@ class GmailConnector(CLIConnector):
     "gws_calendar",
     description="Google Calendar via gws CLI",
     category="cli",
+    service_name="gws",
 )
 class CalendarConnector(CLIConnector):
     """Calendar CLI connector via ``gws calendar``.

--- a/src/nexus/backends/connectors/gws/connector.py
+++ b/src/nexus/backends/connectors/gws/connector.py
@@ -10,10 +10,11 @@ Human-readable display paths added in Issue #3256.
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nexus.backends.base.registry import register_connector
 from nexus.backends.connectors.base import (
@@ -51,9 +52,15 @@ from nexus.backends.connectors.gws.schemas import (
     UploadFileSchema,
 )
 
+if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
+
 logger = logging.getLogger(__name__)
 
 _CONFIGS_DIR = Path(__file__).parent / "configs"
+_DOC_MIME_TYPE = "application/vnd.google-apps.document"
+_SHEET_MIME_TYPE = "application/vnd.google-apps.spreadsheet"
+_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 
 
 def _load_gws_config(filename: str) -> CLIConnectorConfig | None:
@@ -108,6 +115,47 @@ class SheetsConnector(CLIConnector):
         kwargs.setdefault("config", config)
         super().__init__(**kwargs)
 
+    def list_dir(self, path: str = "/", context: "OperationContext | None" = None) -> list[str]:
+        """List spreadsheets by querying Drive metadata and filtering by mime type."""
+        normalized = path.strip("/")
+        if normalized:
+            return []
+
+        args = [
+            "gws",
+            "drive",
+            "files",
+            "list",
+            "--params",
+            json.dumps({"q": f'mimeType = "{_SHEET_MIME_TYPE}"', "pageSize": 100}),
+        ]
+        token = self._get_user_token(context)
+        auth_env = self._build_auth_env(token) if token else None
+        result = self._execute_cli(args, context=context, env=auth_env)
+        result = self._error_mapper.classify_result(result)
+        if not result.ok:
+            return []
+
+        try:
+            data = json.loads(result.stdout)
+        except Exception:
+            return []
+
+        files: list[dict[str, Any]]
+        if isinstance(data, dict):
+            raw_files = data.get("files", [])
+            files = [item for item in raw_files if isinstance(item, dict)]
+        elif isinstance(data, list):
+            files = [item for item in data if isinstance(item, dict)]
+        else:
+            files = []
+
+        entries = [
+            str(item.get("name", "")).strip()
+            for item in files
+            if item.get("mimeType") == _SHEET_MIME_TYPE and str(item.get("name", "")).strip()
+        ]
+        return sorted(entries)
 
 # ============================================================================
 # Docs
@@ -151,6 +199,54 @@ class DocsConnector(CLIConnector):
         kwargs.setdefault("config", config)
         super().__init__(**kwargs)
 
+    def list_dir(self, path: str = "/", context: "OperationContext | None" = None) -> list[str]:
+        """List Google Docs by querying Drive metadata and filtering to document mime types."""
+        normalized = path.strip("/")
+        if normalized:
+            return []
+
+        args = [
+            "gws",
+            "drive",
+            "files",
+            "list",
+            "--params",
+            json.dumps({"q": f'mimeType = "{_DOC_MIME_TYPE}"', "pageSize": 100}),
+        ]
+        token = self._get_user_token(context)
+        auth_env = self._build_auth_env(token) if token else None
+        result = self._execute_cli(args, context=context, env=auth_env)
+        result = self._error_mapper.classify_result(result)
+        if not result.ok:
+            from nexus.contracts.exceptions import BackendError
+
+            raise BackendError(result.summary(), backend=self.name, path=path)
+
+        try:
+            data = json.loads(result.stdout)
+        except Exception as exc:
+            from nexus.contracts.exceptions import BackendError
+
+            raise BackendError(
+                f"Failed to parse gws docs listing: {exc}", backend=self.name
+            ) from exc
+
+        files: list[dict[str, Any]]
+        if isinstance(data, dict):
+            raw_files = data.get("files", [])
+            files = [item for item in raw_files if isinstance(item, dict)]
+        elif isinstance(data, list):
+            files = [item for item in data if isinstance(item, dict)]
+        else:
+            files = []
+
+        entries = [
+            str(item.get("name", "")).strip()
+            for item in files
+            if item.get("mimeType") == _DOC_MIME_TYPE and str(item.get("name", "")).strip()
+        ]
+        return sorted(entries)
+
 
 # ============================================================================
 # Chat
@@ -191,6 +287,53 @@ class ChatConnector(CLIConnector):
         config = _load_gws_config("chat.yaml")
         kwargs.setdefault("config", config)
         super().__init__(**kwargs)
+
+    def list_dir(self, path: str = "/", context: "OperationContext | None" = None) -> list[str]:
+        """List chat spaces at root; nested message browsing is delegated to the CLI config."""
+        normalized = path.strip("/")
+        if normalized:
+            return super().list_dir(path, context=context)
+
+        args = ["gws", "chat", "spaces", "list"]
+        token = self._get_user_token(context)
+        auth_env = self._build_auth_env(token) if token else None
+        result = self._execute_cli(args, context=context, env=auth_env)
+        result = self._error_mapper.classify_result(result)
+        if not result.ok:
+            from nexus.contracts.exceptions import BackendError
+
+            summary = result.summary()
+            combined = f"{result.stderr}\n{result.stdout}".lower()
+            if "insufficient authentication scopes" in combined:
+                raise BackendError(
+                    "Google Chat requires additional OAuth scopes. "
+                    "Run `nexus-fs auth connect gws oauth --user-email you@example.com` again "
+                    "and approve Chat access, then retry `/mount gws://chat`.",
+                    backend=self.name,
+                    path=path,
+                )
+            raise BackendError(summary, backend=self.name, path=path)
+
+        try:
+            data = json.loads(result.stdout)
+        except Exception:
+            return []
+
+        spaces: list[dict[str, Any]]
+        if isinstance(data, dict):
+            raw_spaces = data.get("spaces", [])
+            spaces = [item for item in raw_spaces if isinstance(item, dict)]
+        elif isinstance(data, list):
+            spaces = [item for item in data if isinstance(item, dict)]
+        else:
+            spaces = []
+
+        entries = []
+        for item in spaces:
+            name = str(item.get("name", "")).strip()
+            if name:
+                entries.append(f"{name}/")
+        return sorted(entries)
 
 
 # ============================================================================
@@ -242,6 +385,45 @@ class DriveConnector(CLIConnector):
             if name:
                 return sanitize_filename(name)
         return f"{item_id}.yaml"
+
+    def list_dir(self, path: str = "/", context: "OperationContext | None" = None) -> list[str]:
+        """List Drive root entries with folder suffixes for browseable mounts."""
+        normalized = path.strip("/")
+        if normalized:
+            return []
+
+        args = ["gws", "drive", "files", "list"]
+        token = self._get_user_token(context)
+        auth_env = self._build_auth_env(token) if token else None
+        result = self._execute_cli(args, context=context, env=auth_env)
+        result = self._error_mapper.classify_result(result)
+        if not result.ok:
+            return []
+
+        try:
+            data = json.loads(result.stdout)
+        except Exception:
+            return []
+
+        files: list[dict[str, Any]]
+        if isinstance(data, dict):
+            raw_files = data.get("files", [])
+            files = [item for item in raw_files if isinstance(item, dict)]
+        elif isinstance(data, list):
+            files = [item for item in data if isinstance(item, dict)]
+        else:
+            files = []
+
+        entries = []
+        for item in files:
+            name = str(item.get("name", "")).strip()
+            if not name:
+                continue
+            if item.get("mimeType") == _FOLDER_MIME_TYPE:
+                entries.append(f"{name}/")
+            else:
+                entries.append(name)
+        return sorted(entries)
 
 
 # ============================================================================

--- a/src/nexus/backends/connectors/gws/connector.py
+++ b/src/nexus/backends/connectors/gws/connector.py
@@ -158,6 +158,7 @@ class SheetsConnector(CLIConnector):
         ]
         return sorted(entries)
 
+
 # ============================================================================
 # Docs
 # ============================================================================
@@ -917,9 +918,12 @@ class GmailConnector(CLIConnector):
         if labels:
             fields["labels"] = labels
 
-        import yaml as _yaml
+        import importlib
 
-        return _yaml.dump(fields, default_flow_style=False, allow_unicode=True).encode("utf-8")
+        yaml_module = importlib.import_module("yaml")
+        rendered = str(yaml_module.dump(fields, default_flow_style=False, allow_unicode=True))
+
+        return rendered.encode("utf-8")
 
     def sync_delta(self) -> dict[str, Any]:
         """Perform delta sync using Gmail historyId.

--- a/src/nexus/backends/connectors/gws/connector.py
+++ b/src/nexus/backends/connectors/gws/connector.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import UTC
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -199,19 +200,21 @@ class DocsConnector(CLIConnector):
         kwargs.setdefault("config", config)
         super().__init__(**kwargs)
 
-    def list_dir(self, path: str = "/", context: "OperationContext | None" = None) -> list[str]:
-        """List Google Docs by querying Drive metadata and filtering to document mime types."""
-        normalized = path.strip("/")
-        if normalized:
-            return []
-
+    def _list_doc_entries(self, context: "OperationContext | None" = None) -> list[dict[str, Any]]:
+        """Return Drive metadata for Google Docs with stable display names."""
         args = [
             "gws",
             "drive",
             "files",
             "list",
             "--params",
-            json.dumps({"q": f'mimeType = "{_DOC_MIME_TYPE}"', "pageSize": 100}),
+            json.dumps(
+                {
+                    "q": f'mimeType = "{_DOC_MIME_TYPE}"',
+                    "pageSize": 100,
+                    "fields": "files(id,name,mimeType,modifiedTime,size,quotaBytesUsed)",
+                }
+            ),
         ]
         token = self._get_user_token(context)
         auth_env = self._build_auth_env(token) if token else None
@@ -220,7 +223,7 @@ class DocsConnector(CLIConnector):
         if not result.ok:
             from nexus.contracts.exceptions import BackendError
 
-            raise BackendError(result.summary(), backend=self.name, path=path)
+            raise BackendError(result.summary(), backend=self.name, path="/")
 
         try:
             data = json.loads(result.stdout)
@@ -231,21 +234,111 @@ class DocsConnector(CLIConnector):
                 f"Failed to parse gws docs listing: {exc}", backend=self.name
             ) from exc
 
-        files: list[dict[str, Any]]
-        if isinstance(data, dict):
-            raw_files = data.get("files", [])
-            files = [item for item in raw_files if isinstance(item, dict)]
-        elif isinstance(data, list):
-            files = [item for item in data if isinstance(item, dict)]
-        else:
-            files = []
+        raw_files = data.get("files", []) if isinstance(data, dict) else []
+        files = [item for item in raw_files if isinstance(item, dict)]
 
-        entries = [
-            str(item.get("name", "")).strip()
-            for item in files
-            if item.get("mimeType") == _DOC_MIME_TYPE and str(item.get("name", "")).strip()
+        counts: dict[str, int] = {}
+        for item in files:
+            if item.get("mimeType") != _DOC_MIME_TYPE:
+                continue
+            name = str(item.get("name", "")).strip()
+            if name:
+                counts[name] = counts.get(name, 0) + 1
+
+        entries: list[dict[str, Any]] = []
+        for item in files:
+            if item.get("mimeType") != _DOC_MIME_TYPE:
+                continue
+            name = str(item.get("name", "")).strip()
+            doc_id = str(item.get("id", "")).strip()
+            if not name or not doc_id:
+                continue
+            display_name = name if counts.get(name, 0) == 1 else f"{name} [{doc_id}]"
+            size = item.get("size") or item.get("quotaBytesUsed") or 0
+            try:
+                size_value = int(size)
+            except Exception:
+                size_value = 0
+            entries.append(
+                {
+                    "id": doc_id,
+                    "name": display_name,
+                    "raw_name": name,
+                    "size": size_value,
+                    "modified_at": item.get("modifiedTime"),
+                    "is_directory": False,
+                }
+            )
+        entries.sort(key=lambda item: str(item["name"]).lower())
+        return entries
+
+    def list_dir(self, path: str = "/", context: "OperationContext | None" = None) -> list[str]:
+        """List Google Docs by querying Drive metadata and filtering to document mime types."""
+        normalized = path.strip("/")
+        if normalized:
+            return []
+        return [str(item["name"]) for item in self._list_doc_entries(context)]
+
+    def list_dir_details(
+        self, path: str = "/", context: "OperationContext | None" = None
+    ) -> list[dict[str, Any]]:
+        """Detailed listing for playground rendering."""
+        normalized = path.strip("/")
+        if normalized:
+            return []
+        return self._list_doc_entries(context)
+
+    def _resolve_doc_id(self, backend_path: str, context: "OperationContext | None" = None) -> str:
+        """Resolve a selected docs path back to a concrete document id."""
+        name = backend_path.strip("/").rsplit("/", 1)[-1]
+        if not name:
+            raise ValueError("Google Docs path is required")
+
+        match = re.search(r" \[([A-Za-z0-9_-]+)\]$", name)
+        if match:
+            return match.group(1)
+
+        matches = [item for item in self._list_doc_entries(context) if item["raw_name"] == name]
+        if len(matches) == 1:
+            return str(matches[0]["id"])
+        if len(matches) > 1:
+            raise ValueError(
+                f"Multiple Google Docs named '{name}'. Re-open the list and select the disambiguated entry."
+            )
+        raise ValueError(f"Document not found: {name}")
+
+    def read_content(self, content_hash: str, context: Any = None) -> bytes:
+        """Read a Google Doc by resolving the selected display name back to a document id."""
+        from nexus.contracts.exceptions import BackendError
+
+        backend_path = ""
+        if context and hasattr(context, "backend_path") and context.backend_path:
+            backend_path = str(context.backend_path)
+        elif content_hash:
+            backend_path = str(content_hash)
+
+        try:
+            doc_id = self._resolve_doc_id(backend_path, context)
+        except Exception as exc:
+            raise BackendError(str(exc), backend=self.name, path=backend_path) from exc
+
+        args = [
+            "gws",
+            "docs",
+            "documents",
+            "get",
+            "--params",
+            json.dumps({"documentId": doc_id}),
+            "--format",
+            "json",
         ]
-        return sorted(entries)
+        token = self._get_user_token(context)
+        auth_env = self._build_auth_env(token) if token else None
+        result = self._execute_cli(args, context=context, env=auth_env)
+        result = self._error_mapper.classify_result(result)
+        if not result.ok:
+            raise BackendError(result.summary(), backend=self.name, path=backend_path)
+        return result.stdout.encode("utf-8")
 
 
 # ============================================================================

--- a/src/nexus/backends/misc/service_map.py
+++ b/src/nexus/backends/misc/service_map.py
@@ -104,6 +104,15 @@ SERVICE_REGISTRY: dict[str, ServiceInfo] = {
         capabilities=["read", "write", "list", "delete", "tools"],
         description="Google Calendar events with full CRUD support",
     ),
+    "gws": ServiceInfo(
+        name="gws",
+        display_name="Google Workspace",
+        connector=None,  # auto-derived: prefers one canonical gws_* connector
+        klavis_mcp=None,
+        oauth_provider="google",
+        capabilities=["read", "write", "list", "delete", "tools"],
+        description="Google Workspace CLI-backed connectors using shared Google auth",
+    ),
     # Cloud storage — connector fields auto-derived from ConnectorRegistry
     "gcs": ServiceInfo(
         name="gcs",

--- a/src/nexus/backends/misc/service_map.py
+++ b/src/nexus/backends/misc/service_map.py
@@ -235,8 +235,11 @@ def _sync_from_connector_registry() -> None:
     # Auto-populate connector fields from ConnectorRegistry
     from nexus.backends.base.registry import ConnectorRegistry
 
+    connector_to_service: dict[str, str] = {}
+
     for info in ConnectorRegistry.list_all():
         if info.service_name and info.service_name in SERVICE_REGISTRY:
+            connector_to_service[info.name] = info.service_name
             service = SERVICE_REGISTRY[info.service_name]
             if _service_is_mcp_only(service):
                 continue
@@ -257,6 +260,7 @@ def _sync_from_connector_registry() -> None:
     # Rebuild reverse lookup maps
     _CONNECTOR_TO_SERVICE.clear()
     _MCP_TO_SERVICE.clear()
+    _CONNECTOR_TO_SERVICE.update(connector_to_service)
     for service_name, service_info in SERVICE_REGISTRY.items():
         if service_info.connector:
             _CONNECTOR_TO_SERVICE[service_info.connector] = service_name

--- a/src/nexus/bricks/auth/oauth/token_manager.py
+++ b/src/nexus/bricks/auth/oauth/token_manager.py
@@ -328,11 +328,15 @@ class TokenManager:
                     return cached_raw.decode()
 
             with self.SessionLocal() as session:
-                stmt = select(OAuthCredentialModel).where(
-                    OAuthCredentialModel.provider == provider,
-                    OAuthCredentialModel.user_email == user_email,
-                    OAuthCredentialModel.zone_id == zone_id,
-                    OAuthCredentialModel.revoked == 0,
+                stmt = (
+                    select(OAuthCredentialModel)
+                    .where(
+                        OAuthCredentialModel.provider == provider,
+                        OAuthCredentialModel.user_email == user_email,
+                        OAuthCredentialModel.zone_id == zone_id,
+                        OAuthCredentialModel.revoked == 0,
+                    )
+                    .order_by(OAuthCredentialModel.created_at.desc())
                 )
                 model = session.execute(stmt).scalar_one_or_none()
 
@@ -550,11 +554,15 @@ class TokenManager:
     ) -> OAuthCredential | None:
         """Get credential (decrypted) without automatic refresh."""
         with self.SessionLocal() as session:
-            stmt = select(OAuthCredentialModel).where(
-                OAuthCredentialModel.provider == provider,
-                OAuthCredentialModel.user_email == user_email,
-                OAuthCredentialModel.zone_id == zone_id,
-                OAuthCredentialModel.revoked == 0,
+            stmt = (
+                select(OAuthCredentialModel)
+                .where(
+                    OAuthCredentialModel.provider == provider,
+                    OAuthCredentialModel.user_email == user_email,
+                    OAuthCredentialModel.zone_id == zone_id,
+                    OAuthCredentialModel.revoked == 0,
+                )
+                .order_by(OAuthCredentialModel.created_at.desc())
             )
             model = session.execute(stmt).scalar_one_or_none()
 
@@ -631,7 +639,11 @@ class TokenManager:
             elif user_email is not None:
                 stmt = stmt.where(OAuthCredentialModel.user_email == user_email)
 
-            models = session.execute(stmt).scalars().all()
+            models = (
+                session.execute(stmt.order_by(OAuthCredentialModel.created_at.desc()))
+                .scalars()
+                .all()
+            )
 
             return [
                 {

--- a/src/nexus/bricks/auth/unified_service.py
+++ b/src/nexus/bricks/auth/unified_service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 import subprocess
 from datetime import UTC, datetime
@@ -15,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.unified_auth import (
     AuthResolution,
     AuthStatus,
@@ -123,6 +125,42 @@ _GWS_TARGET_PROBES: dict[str, list[str]] = {
     ],
     "calendar": ["gws", "calendar", "calendarList", "list", "--format", "json"],
     "chat": ["gws", "chat", "spaces", "list", "--format", "json"],
+}
+
+_GWS_TARGET_SCOPE_MAP: dict[str, tuple[str, ...]] = {
+    "drive": (
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive.file",
+    ),
+    "docs": (
+        "https://www.googleapis.com/auth/documents",
+        "https://www.googleapis.com/auth/documents.readonly",
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive.file",
+    ),
+    "sheets": (
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/spreadsheets.readonly",
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive.file",
+    ),
+    "gmail": (
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.compose",
+        "https://www.googleapis.com/auth/gmail.send",
+    ),
+    "calendar": (
+        "https://www.googleapis.com/auth/calendar",
+        "https://www.googleapis.com/auth/calendar.readonly",
+    ),
+    "chat": (
+        "https://www.googleapis.com/auth/chat.spaces",
+        "https://www.googleapis.com/auth/chat.spaces.readonly",
+    ),
 }
 
 
@@ -363,6 +401,24 @@ class UnifiedAuthService:
                         )
                         continue
 
+                    if not expired and service in _SERVICE_TARGET_ALIASES:
+                        target_summary = await self._google_target_summary_for_stored_oauth(
+                            service,
+                            str(matching[0].get("provider", "")),
+                            str(matching[0].get("user_email", "")),
+                        )
+                        summaries.append(
+                            AuthSummary(
+                                service=service,
+                                kind=CredentialKind.OAUTH,
+                                status=target_summary["status"],
+                                source="oauth",
+                                message=target_summary["message"],
+                                details=target_summary["details"],
+                            )
+                        )
+                        continue
+
                     status = AuthStatus.EXPIRED if expired else AuthStatus.AUTHED
                     summaries.append(
                         AuthSummary(
@@ -518,6 +574,15 @@ class UnifiedAuthService:
             }
 
         candidate = matches[0]
+        if desired_targets and not bool(candidate.get("is_expired")):
+            return await self._google_target_test_result_for_stored_oauth(
+                service,
+                desired_targets,
+                provider=str(candidate["provider"]),
+                user_email=str(candidate["user_email"]),
+                default_source="oauth",
+            )
+
         if bool(candidate.get("is_expired")) and native is not None:
             if desired_targets:
                 result = self._google_target_test_result(
@@ -542,12 +607,26 @@ class UnifiedAuthService:
             user_email=str(candidate["user_email"]),
             context=context,
         )
+        valid = bool(result.get("success")) if "success" in result else bool(result.get("valid"))
+        if not valid:
+            message = str(
+                result.get("message") or result.get("error") or "OAuth credential test failed."
+            )
+            return {
+                "success": False,
+                "service": service,
+                "source": "oauth",
+                "message": message,
+            }
         result["service"] = service
         result.setdefault("source", "oauth")
         if desired_targets:
-            result.setdefault(
-                "message",
-                "OAuth credential is valid. Target-specific readiness requires local gws CLI.",
+            return await self._google_target_test_result_for_stored_oauth(
+                service,
+                desired_targets,
+                provider=str(candidate["provider"]),
+                user_email=str(candidate["user_email"]),
+                default_source=str(result.get("source", "oauth")),
             )
         return result
 
@@ -687,40 +766,68 @@ class UnifiedAuthService:
             raise ValueError(f"Target '{normalized}' is not valid for service '{service}'.")
         return (normalized,)
 
+    async def _get_stored_oauth_credential(self, provider: str, user_email: str) -> Any | None:
+        if self._oauth_service is None:
+            return None
+        token_manager_getter = getattr(self._oauth_service, "_get_token_manager", None)
+        if token_manager_getter is None:
+            return None
+        try:
+            token_manager = token_manager_getter()
+        except Exception:
+            return None
+        if token_manager is None:
+            return None
+        getter = getattr(token_manager, "get_credential", None)
+        if getter is None:
+            return None
+        try:
+            return await getter(provider, user_email, ROOT_ZONE_ID)
+        except Exception:
+            return None
+
     def _probe_google_workspace_targets(
         self,
         targets: tuple[str, ...],
         *,
         user_email: str | None = None,
+        access_token: str | None = None,
+        source: str | None = None,
     ) -> dict[str, dict[str, Any]]:
         checks: dict[str, dict[str, Any]] = {}
         native = self._detect_google_workspace_cli_native(user_email=user_email)
-        if native is None:
+        probe_source = source or (native["source"] if native is not None else "oauth")
+        probe_email = user_email or (native.get("email") if native is not None else None)
+        if access_token is None and native is None:
             for target in targets:
                 checks[target] = {
                     "target": target,
                     "success": False,
-                    "source": "native:gws_cli",
-                    "message": "Local gws CLI auth is not available.",
-                    "reason": "missing_native_cli",
+                    "source": probe_source,
+                    "message": "No Google auth is available for target verification.",
+                    "reason": "missing_google_auth",
                 }
             return checks
 
         for target in targets:
             args = _GWS_TARGET_PROBES[target]
             try:
+                env = None
+                if access_token:
+                    env = {"GWS_ACCESS_TOKEN": access_token}
                 result = subprocess.run(
                     args,
                     capture_output=True,
                     text=True,
                     timeout=15,
                     check=False,
+                    env={**os.environ, **(env or {})},
                 )
             except Exception as exc:
                 checks[target] = {
                     "target": target,
                     "success": False,
-                    "source": native["source"],
+                    "source": probe_source,
                     "message": str(exc),
                     "reason": "probe_error",
                 }
@@ -731,21 +838,25 @@ class UnifiedAuthService:
                 checks[target] = {
                     "target": target,
                     "success": True,
-                    "source": native["source"],
-                    "message": f"{target} target is ready via local gws CLI.",
+                    "source": probe_source,
+                    "message": (
+                        f"{target} target is ready via stored OAuth."
+                        if access_token
+                        else f"{target} target is ready via local gws CLI."
+                    ),
                 }
                 continue
 
             if "insufficient authentication scopes" in combined:
                 message = (
                     f"{target} requires additional Google OAuth scopes. Re-run the Google "
-                    f"Workspace OAuth connect flow for {native['email']} and approve the requested access."
+                    f"Workspace OAuth connect flow for {probe_email or 'your account'} and approve the requested access."
                 )
                 reason = "missing_scopes"
             elif "auth_expired" in combined or "expired" in combined:
                 message = (
                     f"{target} auth expired. Re-run the Google Workspace OAuth connect flow "
-                    f"for {native['email']}."
+                    f"for {probe_email or 'your account'}."
                 )
                 reason = "expired"
             else:
@@ -756,11 +867,120 @@ class UnifiedAuthService:
             checks[target] = {
                 "target": target,
                 "success": False,
-                "source": native["source"],
+                "source": probe_source,
                 "message": message,
                 "reason": reason,
             }
         return checks
+
+    async def _google_target_test_result_for_stored_oauth(
+        self,
+        service: str,
+        targets: tuple[str, ...],
+        *,
+        provider: str,
+        user_email: str,
+        default_source: str,
+    ) -> dict[str, Any]:
+        credential = await self._get_stored_oauth_credential(provider, user_email)
+        if credential is None:
+            return {
+                "success": False,
+                "service": service,
+                "source": default_source,
+                "message": "Stored OAuth credential could not be loaded for target verification.",
+            }
+
+        scopes = set(credential.scopes or ())
+        missing_scope_targets = [
+            target
+            for target in targets
+            if not any(scope in scopes for scope in _GWS_TARGET_SCOPE_MAP[target])
+        ]
+        if missing_scope_targets:
+            checks = [
+                {
+                    "target": target,
+                    "success": target not in missing_scope_targets,
+                    "source": "oauth",
+                    "message": (
+                        f"{target} target is ready via stored OAuth."
+                        if target not in missing_scope_targets
+                        else (
+                            f"{target} requires additional Google OAuth scopes. Re-run "
+                            f"`nexus-fs auth connect gws oauth --user-email {user_email}` "
+                            "and approve the requested access."
+                        )
+                    ),
+                    "reason": None if target not in missing_scope_targets else "missing_scopes",
+                }
+                for target in targets
+            ]
+            return {
+                "success": False,
+                "service": service,
+                "source": "oauth",
+                "message": "; ".join(
+                    f"{target}: missing required Google OAuth scope"
+                    for target in missing_scope_targets
+                ),
+                "checks": checks,
+                "stored_oauth_status": AuthStatus.AUTHED.value,
+            }
+
+        return self._google_target_test_result(
+            service,
+            targets,
+            source="oauth",
+            user_email=user_email,
+            access_token=credential.access_token,
+        )
+
+    async def _google_target_summary_for_stored_oauth(
+        self,
+        service: str,
+        provider: str,
+        user_email: str,
+    ) -> dict[str, Any]:
+        result = await self._google_target_test_result_for_stored_oauth(
+            service,
+            self._google_targets_for_service(service),
+            provider=provider,
+            user_email=user_email,
+            default_source="oauth",
+        )
+        checks = result.get("checks", [])
+        if not isinstance(checks, list):
+            checks = []
+        failed = [check for check in checks if not check.get("success")]
+        status = AuthStatus.AUTHED if result.get("success") else AuthStatus.ERROR
+        if service == "gws":
+            if failed:
+                failed_text = ", ".join(
+                    f"{check.get('target')} ({check.get('reason', 'failed')})" for check in failed
+                )
+                message = f"Stored Google OAuth is available, but some targets are not ready: {failed_text}."
+            else:
+                ready = ", ".join(
+                    str(check.get("target")) for check in checks if check.get("success")
+                )
+                message = f"Google Workspace targets ready via stored OAuth: {ready}."
+        else:
+            message = str(result.get("message", "OAuth credential available."))
+        return {
+            "status": status,
+            "message": message,
+            "details": {
+                "target_checks": {
+                    str(check.get("target")): {
+                        "success": bool(check.get("success")),
+                        "reason": check.get("reason"),
+                        "message": check.get("message"),
+                    }
+                    for check in checks
+                },
+            },
+        }
 
     def _google_target_summary(
         self,
@@ -835,8 +1055,14 @@ class UnifiedAuthService:
         *,
         source: str,
         user_email: str | None = None,
+        access_token: str | None = None,
     ) -> dict[str, Any]:
-        checks = self._probe_google_workspace_targets(targets, user_email=user_email)
+        checks = self._probe_google_workspace_targets(
+            targets,
+            user_email=user_email,
+            access_token=access_token,
+            source=source,
+        )
         selected = [checks[target] for target in targets]
         failed = [item for item in selected if not item.get("success")]
         ready = [item["target"] for item in selected if item.get("success")]

--- a/src/nexus/bricks/auth/unified_service.py
+++ b/src/nexus/bricks/auth/unified_service.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -58,6 +60,10 @@ _OAUTH_PROVIDER_ALIASES: dict[str, tuple[str, ...]] = {
     "slack": ("slack",),
     "x": ("x", "twitter"),
 }
+
+_GOOGLE_OAUTH_SERVICES = frozenset(
+    service for service, providers in _OAUTH_PROVIDER_ALIASES.items() if "google" in providers
+)
 
 
 def _utcnow_iso() -> str:
@@ -266,8 +272,31 @@ class UnifiedAuthService:
             for service, providers in _OAUTH_PROVIDER_ALIASES.items():
                 seen_services.add(service)
                 matching = [cred for cred in oauth_creds if cred.get("provider") in providers]
+                native = self._detect_oauth_native(service)
                 if matching:
                     expired = all(bool(cred.get("is_expired")) for cred in matching)
+                    if expired and native is not None:
+                        summaries.append(
+                            AuthSummary(
+                                service=service,
+                                kind=CredentialKind.NATIVE,
+                                status=AuthStatus.AUTHED,
+                                source=native["source"],
+                                message=(
+                                    "Stored OAuth credentials are expired; using local native CLI auth."
+                                ),
+                                details={
+                                    **{k: v for k, v in native.items() if k not in {"message"}},
+                                    "stored_oauth_status": AuthStatus.EXPIRED.value,
+                                    "providers": sorted(
+                                        {str(cred.get("provider")) for cred in matching}
+                                    ),
+                                    "accounts": len(matching),
+                                },
+                            )
+                        )
+                        continue
+
                     status = AuthStatus.EXPIRED if expired else AuthStatus.AUTHED
                     summaries.append(
                         AuthSummary(
@@ -286,6 +315,17 @@ class UnifiedAuthService:
                                 ),
                                 "accounts": len(matching),
                             },
+                        )
+                    )
+                elif native is not None:
+                    summaries.append(
+                        AuthSummary(
+                            service=service,
+                            kind=CredentialKind.NATIVE,
+                            status=AuthStatus.AUTHED,
+                            source=native["source"],
+                            message=native["message"],
+                            details={k: v for k, v in native.items() if k != "message"},
                         )
                     )
                 else:
@@ -383,6 +423,14 @@ class UnifiedAuthService:
         if user_email is not None:
             matches = [cred for cred in matches if cred.get("user_email") == user_email]
         if not matches:
+            native = self._detect_oauth_native(service, user_email=user_email)
+            if native is not None:
+                return {
+                    "success": True,
+                    "service": service,
+                    "source": native["source"],
+                    "message": native["message"],
+                }
             return {
                 "success": False,
                 "service": service,
@@ -391,6 +439,15 @@ class UnifiedAuthService:
             }
 
         candidate = matches[0]
+        if bool(candidate.get("is_expired")):
+            native = self._detect_oauth_native(service, user_email=user_email)
+            if native is not None:
+                return {
+                    "success": True,
+                    "service": service,
+                    "source": native["source"],
+                    "message": "Stored OAuth credential is expired; using local native CLI auth.",
+                }
         result = await self._oauth_service.test_credential(
             provider=str(candidate["provider"]),
             user_email=str(candidate["user_email"]),
@@ -451,6 +508,70 @@ class UnifiedAuthService:
             return None
         message = f"Native provider chain available via {details.get('source', 'native')}."
         return {**{k: str(v) for k, v in details.items()}, "message": message}
+
+    def _detect_oauth_native(
+        self,
+        service: str,
+        *,
+        user_email: str | None = None,
+    ) -> dict[str, str] | None:
+        if service not in _GOOGLE_OAUTH_SERVICES:
+            return None
+        return self._detect_google_workspace_cli_native(user_email=user_email)
+
+    def _detect_google_workspace_cli_native(
+        self,
+        *,
+        user_email: str | None = None,
+    ) -> dict[str, str] | None:
+        if shutil.which("gws") is None:
+            return None
+
+        try:
+            result = subprocess.run(
+                [
+                    "gws",
+                    "gmail",
+                    "users",
+                    "getProfile",
+                    "--params",
+                    '{"userId":"me"}',
+                    "--format",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except Exception:
+            return None
+
+        if result.returncode != 0:
+            return None
+
+        stdout = result.stdout.strip()
+        if not stdout:
+            return None
+
+        try:
+            start = stdout.find("{")
+            payload = stdout[start:] if start >= 0 else stdout
+            data = json.loads(payload)
+        except Exception:
+            return None
+
+        email = str(data.get("emailAddress") or "").strip()
+        if not email:
+            return None
+        if user_email and user_email != email:
+            return None
+
+        return {
+            "source": "native:gws_cli",
+            "email": email,
+            "message": f"Local gws CLI profile available for {email}.",
+        }
 
     def _validate_secret_record(self, record: SecretCredentialRecord) -> str | None:
         if record.kind == CredentialKind.NATIVE:

--- a/src/nexus/bricks/auth/unified_service.py
+++ b/src/nexus/bricks/auth/unified_service.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 
 _DEFAULT_STORE_PATH = Path("~/.nexus/auth/credentials.json").expanduser()
 _STORE_VERSION = 1
+_DOC_MIME_TYPE = "application/vnd.google-apps.document"
+_SHEET_MIME_TYPE = "application/vnd.google-apps.spreadsheet"
 
 _SECRET_SERVICE_SPECS: dict[str, dict[str, Any]] = {
     "s3": {
@@ -64,6 +66,64 @@ _OAUTH_PROVIDER_ALIASES: dict[str, tuple[str, ...]] = {
 _GOOGLE_OAUTH_SERVICES = frozenset(
     service for service, providers in _OAUTH_PROVIDER_ALIASES.items() if "google" in providers
 )
+
+_GWS_TARGETS: tuple[str, ...] = ("drive", "docs", "sheets", "gmail", "calendar", "chat")
+_SERVICE_TARGET_ALIASES: dict[str, tuple[str, ...]] = {
+    "gws": _GWS_TARGETS,
+    "google-drive": ("drive",),
+    "gmail": ("gmail",),
+    "google-calendar": ("calendar",),
+}
+_GWS_TARGET_PROBES: dict[str, list[str]] = {
+    "drive": [
+        "gws",
+        "drive",
+        "files",
+        "list",
+        "--params",
+        json.dumps({"pageSize": 1}),
+        "--format",
+        "json",
+    ],
+    "docs": [
+        "gws",
+        "drive",
+        "files",
+        "list",
+        "--params",
+        json.dumps(
+            {
+                "q": f'mimeType = "{_DOC_MIME_TYPE}"',
+                "pageSize": 1,
+                "fields": "files(id,name,mimeType,modifiedTime,size,quotaBytesUsed)",
+            }
+        ),
+        "--format",
+        "json",
+    ],
+    "sheets": [
+        "gws",
+        "drive",
+        "files",
+        "list",
+        "--params",
+        json.dumps({"q": f'mimeType = "{_SHEET_MIME_TYPE}"', "pageSize": 1}),
+        "--format",
+        "json",
+    ],
+    "gmail": [
+        "gws",
+        "gmail",
+        "users",
+        "getProfile",
+        "--params",
+        '{"userId":"me"}',
+        "--format",
+        "json",
+    ],
+    "calendar": ["gws", "calendar", "calendarList", "list", "--format", "json"],
+    "chat": ["gws", "chat", "spaces", "list", "--format", "json"],
+}
 
 
 def _utcnow_iso() -> str:
@@ -227,6 +287,7 @@ class UnifiedAuthService:
         """Return redacted auth summaries for all known services."""
         summaries: list[AuthSummary] = []
         seen_services: set[str] = set()
+        google_target_checks: dict[str, dict[str, Any]] | None = None
 
         for service in sorted(_SECRET_SERVICE_SPECS):
             seen_services.add(service)
@@ -273,18 +334,22 @@ class UnifiedAuthService:
                 seen_services.add(service)
                 matching = [cred for cred in oauth_creds if cred.get("provider") in providers]
                 native = self._detect_oauth_native(service)
+                if native is not None and google_target_checks is None:
+                    google_target_checks = self._probe_google_workspace_targets(
+                        _GWS_TARGETS,
+                        user_email=native.get("email"),
+                    )
                 if matching:
                     expired = all(bool(cred.get("is_expired")) for cred in matching)
                     if expired and native is not None:
+                        target_summary = self._google_target_summary(service, google_target_checks)
                         summaries.append(
                             AuthSummary(
                                 service=service,
                                 kind=CredentialKind.NATIVE,
-                                status=AuthStatus.AUTHED,
+                                status=target_summary["status"],
                                 source=native["source"],
-                                message=(
-                                    "Stored OAuth credentials are expired; using local native CLI auth."
-                                ),
+                                message=target_summary["message"],
                                 details={
                                     **{k: v for k, v in native.items() if k not in {"message"}},
                                     "stored_oauth_status": AuthStatus.EXPIRED.value,
@@ -292,6 +357,7 @@ class UnifiedAuthService:
                                         {str(cred.get("provider")) for cred in matching}
                                     ),
                                     "accounts": len(matching),
+                                    **target_summary["details"],
                                 },
                             )
                         )
@@ -318,14 +384,18 @@ class UnifiedAuthService:
                         )
                     )
                 elif native is not None:
+                    target_summary = self._google_target_summary(service, google_target_checks)
                     summaries.append(
                         AuthSummary(
                             service=service,
                             kind=CredentialKind.NATIVE,
-                            status=AuthStatus.AUTHED,
+                            status=target_summary["status"],
                             source=native["source"],
-                            message=native["message"],
-                            details={k: v for k, v in native.items() if k != "message"},
+                            message=target_summary["message"],
+                            details={
+                                **{k: v for k, v in native.items() if k != "message"},
+                                **target_summary["details"],
+                            },
                         )
                     )
                 else:
@@ -364,6 +434,7 @@ class UnifiedAuthService:
         service: str,
         *,
         user_email: str | None = None,
+        target: str | None = None,
         context: "OperationContext | None" = None,
     ) -> dict[str, Any]:
         """Verify auth readiness for a service."""
@@ -422,9 +493,17 @@ class UnifiedAuthService:
         matches = [cred for cred in oauth_creds if cred.get("provider") in providers]
         if user_email is not None:
             matches = [cred for cred in matches if cred.get("user_email") == user_email]
+        desired_targets = self._google_targets_for_service(service, target=target)
+        native = self._detect_oauth_native(service, user_email=user_email)
         if not matches:
-            native = self._detect_oauth_native(service, user_email=user_email)
             if native is not None:
+                if desired_targets:
+                    return self._google_target_test_result(
+                        service,
+                        desired_targets,
+                        source=native["source"],
+                        user_email=user_email or native.get("email"),
+                    )
                 return {
                     "success": True,
                     "service": service,
@@ -439,15 +518,25 @@ class UnifiedAuthService:
             }
 
         candidate = matches[0]
-        if bool(candidate.get("is_expired")):
-            native = self._detect_oauth_native(service, user_email=user_email)
-            if native is not None:
-                return {
-                    "success": True,
-                    "service": service,
-                    "source": native["source"],
-                    "message": "Stored OAuth credential is expired; using local native CLI auth.",
-                }
+        if bool(candidate.get("is_expired")) and native is not None:
+            if desired_targets:
+                result = self._google_target_test_result(
+                    service,
+                    desired_targets,
+                    source=native["source"],
+                    user_email=user_email or native.get("email"),
+                )
+                result["message"] = "Stored OAuth credential is expired; " + str(
+                    result.get("message", "using local native CLI auth.")
+                )
+                result["stored_oauth_status"] = AuthStatus.EXPIRED.value
+                return result
+            return {
+                "success": True,
+                "service": service,
+                "source": native["source"],
+                "message": "Stored OAuth credential is expired; using local native CLI auth.",
+            }
         result = await self._oauth_service.test_credential(
             provider=str(candidate["provider"]),
             user_email=str(candidate["user_email"]),
@@ -455,6 +544,11 @@ class UnifiedAuthService:
         )
         result["service"] = service
         result.setdefault("source", "oauth")
+        if desired_targets:
+            result.setdefault(
+                "message",
+                "OAuth credential is valid. Target-specific readiness requires local gws CLI.",
+            )
         return result
 
     def connect_secret(self, service: str, values: dict[str, str]) -> SecretCredentialRecord:
@@ -571,6 +665,199 @@ class UnifiedAuthService:
             "source": "native:gws_cli",
             "email": email,
             "message": f"Local gws CLI profile available for {email}.",
+        }
+
+    def _google_targets_for_service(
+        self,
+        service: str,
+        *,
+        target: str | None = None,
+    ) -> tuple[str, ...]:
+        if service not in _SERVICE_TARGET_ALIASES:
+            return ()
+        if target is None:
+            return _SERVICE_TARGET_ALIASES[service]
+        normalized = target.strip().lower()
+        if normalized not in _GWS_TARGETS:
+            raise ValueError(
+                f"Unknown Google Workspace target '{target}'. Choose from: {', '.join(_GWS_TARGETS)}."
+            )
+        allowed = _SERVICE_TARGET_ALIASES[service]
+        if normalized not in allowed:
+            raise ValueError(f"Target '{normalized}' is not valid for service '{service}'.")
+        return (normalized,)
+
+    def _probe_google_workspace_targets(
+        self,
+        targets: tuple[str, ...],
+        *,
+        user_email: str | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        checks: dict[str, dict[str, Any]] = {}
+        native = self._detect_google_workspace_cli_native(user_email=user_email)
+        if native is None:
+            for target in targets:
+                checks[target] = {
+                    "target": target,
+                    "success": False,
+                    "source": "native:gws_cli",
+                    "message": "Local gws CLI auth is not available.",
+                    "reason": "missing_native_cli",
+                }
+            return checks
+
+        for target in targets:
+            args = _GWS_TARGET_PROBES[target]
+            try:
+                result = subprocess.run(
+                    args,
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                    check=False,
+                )
+            except Exception as exc:
+                checks[target] = {
+                    "target": target,
+                    "success": False,
+                    "source": native["source"],
+                    "message": str(exc),
+                    "reason": "probe_error",
+                }
+                continue
+
+            combined = f"{result.stdout}\n{result.stderr}".lower()
+            if result.returncode == 0:
+                checks[target] = {
+                    "target": target,
+                    "success": True,
+                    "source": native["source"],
+                    "message": f"{target} target is ready via local gws CLI.",
+                }
+                continue
+
+            if "insufficient authentication scopes" in combined:
+                message = (
+                    f"{target} requires additional Google OAuth scopes. Re-run the Google "
+                    f"Workspace OAuth connect flow for {native['email']} and approve the requested access."
+                )
+                reason = "missing_scopes"
+            elif "auth_expired" in combined or "expired" in combined:
+                message = (
+                    f"{target} auth expired. Re-run the Google Workspace OAuth connect flow "
+                    f"for {native['email']}."
+                )
+                reason = "expired"
+            else:
+                summary = (result.stderr or result.stdout).strip() or f"{target} probe failed."
+                message = summary.splitlines()[0]
+                reason = "probe_failed"
+
+            checks[target] = {
+                "target": target,
+                "success": False,
+                "source": native["source"],
+                "message": message,
+                "reason": reason,
+            }
+        return checks
+
+    def _google_target_summary(
+        self,
+        service: str,
+        checks: dict[str, dict[str, Any]] | None,
+    ) -> dict[str, Any]:
+        if checks is None:
+            return {
+                "status": AuthStatus.AUTHED,
+                "message": "Local gws CLI profile available.",
+                "details": {},
+            }
+
+        targets = _SERVICE_TARGET_ALIASES.get(service, ())
+        if not targets:
+            return {
+                "status": AuthStatus.AUTHED,
+                "message": "Local gws CLI profile available.",
+                "details": {},
+            }
+
+        selected = [checks[target] for target in targets if target in checks]
+        ready = [item["target"] for item in selected if item.get("success")]
+        failed = [item for item in selected if not item.get("success")]
+
+        if service == "gws":
+            if failed:
+                failed_summary = ", ".join(
+                    f"{item['target']} ({item.get('reason', 'failed')})" for item in failed
+                )
+                message = (
+                    "Base Google identity available via local gws CLI, but some targets are not "
+                    f"ready: {failed_summary}."
+                )
+                status = AuthStatus.ERROR
+            else:
+                message = (
+                    "Google Workspace targets ready via local gws CLI: " + ", ".join(ready) + "."
+                )
+                status = AuthStatus.AUTHED
+        else:
+            item = selected[0] if selected else None
+            if item is None:
+                status = AuthStatus.UNKNOWN
+                message = "Target readiness could not be determined."
+            elif item.get("success"):
+                status = AuthStatus.AUTHED
+                message = str(item["message"])
+            else:
+                status = AuthStatus.ERROR
+                message = str(item["message"])
+
+        return {
+            "status": status,
+            "message": message,
+            "details": {
+                "target_checks": {
+                    item["target"]: {
+                        "success": bool(item.get("success")),
+                        "reason": item.get("reason"),
+                        "message": item.get("message"),
+                    }
+                    for item in selected
+                }
+            },
+        }
+
+    def _google_target_test_result(
+        self,
+        service: str,
+        targets: tuple[str, ...],
+        *,
+        source: str,
+        user_email: str | None = None,
+    ) -> dict[str, Any]:
+        checks = self._probe_google_workspace_targets(targets, user_email=user_email)
+        selected = [checks[target] for target in targets]
+        failed = [item for item in selected if not item.get("success")]
+        ready = [item["target"] for item in selected if item.get("success")]
+
+        if failed:
+            summary = "; ".join(f"{item['target']}: {item['message']}" for item in failed)
+            return {
+                "success": False,
+                "service": service,
+                "source": source,
+                "message": summary,
+                "checks": selected,
+            }
+
+        target_text = ", ".join(ready)
+        return {
+            "success": True,
+            "service": service,
+            "source": source,
+            "message": f"Targets ready: {target_text}.",
+            "checks": selected,
         }
 
     def _validate_secret_record(self, record: SecretCredentialRecord) -> str | None:

--- a/src/nexus/bricks/auth/unified_service.py
+++ b/src/nexus/bricks/auth/unified_service.py
@@ -1,0 +1,511 @@
+"""Unified auth service for OAuth, stored secrets, and native providers.
+
+This service keeps the user-facing auth surface consistent across backends
+without forcing static secrets through OAuth-specific storage semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
+from nexus.contracts.unified_auth import (
+    AuthResolution,
+    AuthStatus,
+    AuthSummary,
+    CredentialKind,
+    SecretCredentialRecord,
+)
+from nexus.fs._credentials import discover_credentials
+from nexus.security.secret_file import write_secret_file
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
+
+_DEFAULT_STORE_PATH = Path("~/.nexus/auth/credentials.json").expanduser()
+_STORE_VERSION = 1
+
+_SECRET_SERVICE_SPECS: dict[str, dict[str, Any]] = {
+    "s3": {
+        "backend_types": {"path_s3"},
+        "required_fields": ("access_key_id", "secret_access_key"),
+        "optional_fields": ("session_token", "region_name", "credentials_path"),
+        "supports_native": True,
+        "action_hint": "Run `nexus auth connect s3 secret` or configure `aws configure`.",
+    },
+    "gcs": {
+        "backend_types": {"path_gcs"},
+        "required_fields": (),
+        "optional_fields": ("credentials_path", "access_token", "project_id"),
+        "supports_native": True,
+        "action_hint": (
+            "Run `nexus auth connect gcs secret` or `gcloud auth application-default login`."
+        ),
+    },
+}
+
+_OAUTH_PROVIDER_ALIASES: dict[str, tuple[str, ...]] = {
+    "gws": ("google",),
+    "google-drive": ("google-drive", "google"),
+    "google-calendar": ("google-calendar", "google"),
+    "gmail": ("gmail", "google"),
+    "slack": ("slack",),
+    "x": ("x", "twitter"),
+}
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class FileSecretCredentialStore:
+    """Small file-backed secret store with restrictive filesystem perms."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path).expanduser() if path is not None else _DEFAULT_STORE_PATH
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def list(self) -> list[SecretCredentialRecord]:
+        payload = self._read_raw()
+        entries = payload.get("entries", {})
+        result: list[SecretCredentialRecord] = []
+        for service, entry in entries.items():
+            result.append(
+                SecretCredentialRecord(
+                    service=service,
+                    kind=CredentialKind(entry["kind"]),
+                    data=dict(entry.get("data", {})),
+                    created_at=entry.get("created_at"),
+                    updated_at=entry.get("updated_at"),
+                )
+            )
+        return sorted(result, key=lambda item: item.service)
+
+    def get(self, service: str) -> SecretCredentialRecord | None:
+        payload = self._read_raw()
+        entry = payload.get("entries", {}).get(service)
+        if entry is None:
+            return None
+        return SecretCredentialRecord(
+            service=service,
+            kind=CredentialKind(entry["kind"]),
+            data=dict(entry.get("data", {})),
+            created_at=entry.get("created_at"),
+            updated_at=entry.get("updated_at"),
+        )
+
+    def upsert(self, service: str, kind: CredentialKind, data: dict[str, str]) -> None:
+        payload = self._read_raw()
+        entries = payload.setdefault("entries", {})
+        existing = entries.get(service, {})
+        created_at = existing.get("created_at", _utcnow_iso())
+        entries[service] = {
+            "kind": kind.value,
+            "data": data,
+            "created_at": created_at,
+            "updated_at": _utcnow_iso(),
+        }
+        self._write_raw(payload)
+
+    def delete(self, service: str) -> bool:
+        payload = self._read_raw()
+        entries = payload.get("entries", {})
+        if service not in entries:
+            return False
+        del entries[service]
+        self._write_raw(payload)
+        return True
+
+    def _read_raw(self) -> dict[str, Any]:
+        if not self._path.exists():
+            return {"version": _STORE_VERSION, "entries": {}}
+        try:
+            data = json.loads(self._path.read_text())
+        except json.JSONDecodeError:
+            logger.warning("Secret credential store is corrupt: %s", self._path)
+            return {"version": _STORE_VERSION, "entries": {}}
+        if not isinstance(data, dict):
+            return {"version": _STORE_VERSION, "entries": {}}
+        data.setdefault("version", _STORE_VERSION)
+        data.setdefault("entries", {})
+        return data
+
+    def _write_raw(self, payload: dict[str, Any]) -> None:
+        write_secret_file(self._path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+class UnifiedAuthService:
+    """Shared auth UX layer across OAuth and non-OAuth backends."""
+
+    def __init__(
+        self,
+        oauth_service: OAuthCredentialService | None = None,
+        *,
+        secret_store: FileSecretCredentialStore | None = None,
+    ) -> None:
+        self._oauth_service = oauth_service
+        self._secret_store = secret_store or FileSecretCredentialStore()
+
+    @property
+    def secret_store_path(self) -> Path:
+        return self._secret_store.path
+
+    def resolve_backend_config(
+        self,
+        backend_type: str,
+        config: dict[str, Any],
+    ) -> AuthResolution:
+        """Resolve secret/native credentials for storage backends."""
+        service = self._service_for_backend_type(backend_type)
+        if service is None:
+            return AuthResolution(
+                service=backend_type,
+                status=AuthStatus.UNKNOWN,
+                source="unsupported",
+                resolved_config=dict(config),
+            )
+
+        explicit = self._explicit_secret_fields(service, config)
+        if explicit:
+            return AuthResolution(
+                service=service,
+                status=AuthStatus.AUTHED,
+                source="explicit_config",
+                resolved_config=dict(config),
+                message="Using credentials provided directly in backend config.",
+            )
+
+        record = self._secret_store.get(service)
+        if record is not None:
+            resolved = self._merge_secret_data(dict(config), record.data)
+            return AuthResolution(
+                service=service,
+                status=AuthStatus.AUTHED,
+                source=f"stored:{record.kind.value}",
+                resolved_config=resolved,
+                message=f"Using stored {record.kind.value} credentials for {service}.",
+            )
+
+        native = self._detect_native(service)
+        if native is not None:
+            return AuthResolution(
+                service=service,
+                status=AuthStatus.AUTHED,
+                source="native",
+                resolved_config=dict(config),
+                message=native["message"],
+            )
+
+        spec = _SECRET_SERVICE_SPECS[service]
+        return AuthResolution(
+            service=service,
+            status=AuthStatus.NO_AUTH,
+            source="missing",
+            resolved_config=dict(config),
+            message=spec["action_hint"],
+        )
+
+    async def list_summaries(
+        self,
+        context: "OperationContext | None" = None,
+    ) -> list[AuthSummary]:
+        """Return redacted auth summaries for all known services."""
+        summaries: list[AuthSummary] = []
+        seen_services: set[str] = set()
+
+        for service in sorted(_SECRET_SERVICE_SPECS):
+            seen_services.add(service)
+            record = self._secret_store.get(service)
+            if record is not None:
+                summaries.append(
+                    AuthSummary(
+                        service=service,
+                        kind=record.kind,
+                        status=AuthStatus.AUTHED,
+                        source=f"stored:{record.kind.value}",
+                        message=f"Stored {record.kind.value} credential available.",
+                        details=self._redact_secret_record(record),
+                    )
+                )
+                continue
+
+            native = self._detect_native(service)
+            if native is not None:
+                summaries.append(
+                    AuthSummary(
+                        service=service,
+                        kind=CredentialKind.NATIVE,
+                        status=AuthStatus.AUTHED,
+                        source="native",
+                        message=native["message"],
+                        details={k: v for k, v in native.items() if k != "message"},
+                    )
+                )
+            else:
+                summaries.append(
+                    AuthSummary(
+                        service=service,
+                        kind=CredentialKind.SECRET,
+                        status=AuthStatus.NO_AUTH,
+                        source="missing",
+                        message=_SECRET_SERVICE_SPECS[service]["action_hint"],
+                    )
+                )
+
+        if self._oauth_service is not None:
+            oauth_creds = await self._oauth_service.list_credentials(context=context)
+            for service, providers in _OAUTH_PROVIDER_ALIASES.items():
+                seen_services.add(service)
+                matching = [cred for cred in oauth_creds if cred.get("provider") in providers]
+                if matching:
+                    expired = all(bool(cred.get("is_expired")) for cred in matching)
+                    status = AuthStatus.EXPIRED if expired else AuthStatus.AUTHED
+                    summaries.append(
+                        AuthSummary(
+                            service=service,
+                            kind=CredentialKind.OAUTH,
+                            status=status,
+                            source="oauth",
+                            message=(
+                                "OAuth credentials are present but expired."
+                                if expired
+                                else "OAuth credentials available."
+                            ),
+                            details={
+                                "providers": sorted(
+                                    {str(cred.get("provider")) for cred in matching}
+                                ),
+                                "accounts": len(matching),
+                            },
+                        )
+                    )
+                else:
+                    summaries.append(
+                        AuthSummary(
+                            service=service,
+                            kind=CredentialKind.OAUTH,
+                            status=AuthStatus.NO_AUTH,
+                            source="missing",
+                            message=f"Run `nexus auth connect {service} oauth`.",
+                        )
+                    )
+
+        return sorted(summaries, key=lambda item: item.service)
+
+    async def get_connector_auth_state(
+        self,
+        service_name: str | None,
+        *,
+        context: "OperationContext | None" = None,
+    ) -> dict[str, str | None]:
+        """Return auth status/source for connector discovery surfaces."""
+        if service_name is None:
+            return {"auth_status": "unknown", "auth_source": None}
+
+        for summary in await self.list_summaries(context=context):
+            if summary.service == service_name:
+                return {
+                    "auth_status": summary.status.value,
+                    "auth_source": summary.source,
+                }
+        return {"auth_status": "unknown", "auth_source": None}
+
+    async def test_service(
+        self,
+        service: str,
+        *,
+        user_email: str | None = None,
+        context: "OperationContext | None" = None,
+    ) -> dict[str, Any]:
+        """Verify auth readiness for a service."""
+        if service in _SECRET_SERVICE_SPECS:
+            record = self._secret_store.get(service)
+            if record is not None:
+                validation = self._validate_secret_record(record)
+                if validation is None:
+                    return {
+                        "success": True,
+                        "service": service,
+                        "source": f"stored:{record.kind.value}",
+                        "message": f"Stored {record.kind.value} credentials look valid.",
+                    }
+                return {
+                    "success": False,
+                    "service": service,
+                    "source": f"stored:{record.kind.value}",
+                    "message": validation,
+                }
+
+            native = self._detect_native(service)
+            if native is not None:
+                return {
+                    "success": True,
+                    "service": service,
+                    "source": "native",
+                    "message": native["message"],
+                }
+
+            return {
+                "success": False,
+                "service": service,
+                "source": "missing",
+                "message": _SECRET_SERVICE_SPECS[service]["action_hint"],
+            }
+
+        if self._oauth_service is None:
+            return {
+                "success": False,
+                "service": service,
+                "source": "oauth",
+                "message": "OAuth service is not available in this environment.",
+            }
+
+        providers = _OAUTH_PROVIDER_ALIASES.get(service)
+        if not providers:
+            return {
+                "success": False,
+                "service": service,
+                "source": "unknown",
+                "message": f"Unknown auth service '{service}'.",
+            }
+
+        oauth_creds = await self._oauth_service.list_credentials(context=context)
+        matches = [cred for cred in oauth_creds if cred.get("provider") in providers]
+        if user_email is not None:
+            matches = [cred for cred in matches if cred.get("user_email") == user_email]
+        if not matches:
+            return {
+                "success": False,
+                "service": service,
+                "source": "oauth",
+                "message": f"Run `nexus auth connect {service} oauth`.",
+            }
+
+        candidate = matches[0]
+        result = await self._oauth_service.test_credential(
+            provider=str(candidate["provider"]),
+            user_email=str(candidate["user_email"]),
+            context=context,
+        )
+        result["service"] = service
+        result.setdefault("source", "oauth")
+        return result
+
+    def connect_secret(self, service: str, values: dict[str, str]) -> SecretCredentialRecord:
+        """Store static secret data for a service."""
+        if service not in _SECRET_SERVICE_SPECS:
+            raise ValueError(f"Unsupported secret-backed service '{service}'")
+        filtered = {k: v for k, v in values.items() if v}
+        self._secret_store.upsert(service, CredentialKind.SECRET, filtered)
+        record = self._secret_store.get(service)
+        if record is None:
+            raise RuntimeError(f"Failed to store credentials for {service}")
+        return record
+
+    def connect_native(self, service: str) -> SecretCredentialRecord:
+        """Store an explicit native-provider preference marker."""
+        if service not in _SECRET_SERVICE_SPECS:
+            raise ValueError(f"Unsupported native-backed service '{service}'")
+        self._secret_store.upsert(service, CredentialKind.NATIVE, {})
+        record = self._secret_store.get(service)
+        if record is None:
+            raise RuntimeError(f"Failed to store native marker for {service}")
+        return record
+
+    def disconnect(self, service: str) -> bool:
+        """Remove a stored credential or native marker."""
+        return self._secret_store.delete(service)
+
+    def _service_for_backend_type(self, backend_type: str) -> str | None:
+        for service, spec in _SECRET_SERVICE_SPECS.items():
+            if backend_type in spec["backend_types"]:
+                return service
+        return None
+
+    def _explicit_secret_fields(self, service: str, config: dict[str, Any]) -> dict[str, Any]:
+        spec = _SECRET_SERVICE_SPECS[service]
+        fields = (*spec["required_fields"], *spec["optional_fields"])
+        return {field: config[field] for field in fields if config.get(field)}
+
+    def _merge_secret_data(self, config: dict[str, Any], data: dict[str, str]) -> dict[str, Any]:
+        resolved = dict(config)
+        for key, value in data.items():
+            resolved.setdefault(key, value)
+        return resolved
+
+    def _detect_native(self, service: str) -> dict[str, str] | None:
+        if not _SECRET_SERVICE_SPECS[service]["supports_native"]:
+            return None
+        try:
+            details = discover_credentials(service)
+        except Exception:
+            return None
+        message = f"Native provider chain available via {details.get('source', 'native')}."
+        return {**{k: str(v) for k, v in details.items()}, "message": message}
+
+    def _validate_secret_record(self, record: SecretCredentialRecord) -> str | None:
+        if record.kind == CredentialKind.NATIVE:
+            native = self._detect_native(record.service)
+            if native is None:
+                return cast(str, _SECRET_SERVICE_SPECS[record.service]["action_hint"])
+            return None
+
+        spec = _SECRET_SERVICE_SPECS[record.service]
+        required_fields: tuple[str, ...] = spec["required_fields"]
+        if record.service == "gcs" and not any(
+            record.data.get(field) for field in ("credentials_path", "access_token")
+        ):
+            return "GCS stored credentials require `credentials_path` or `access_token`."
+        missing = [field for field in required_fields if not record.data.get(field)]
+        if missing:
+            return f"Missing required fields: {', '.join(sorted(missing))}."
+        path_value = record.data.get("credentials_path")
+        if path_value and not Path(path_value).expanduser().exists():
+            return f"Credential file not found: {path_value}"
+        return None
+
+    def _redact_secret_record(self, record: SecretCredentialRecord) -> dict[str, Any]:
+        details = {
+            "stored_at": record.updated_at,
+            "fields": sorted(record.data),
+        }
+        path_value = record.data.get("credentials_path")
+        if path_value:
+            details["credentials_path"] = path_value
+        return details
+
+    @staticmethod
+    def store_help_fields(service: str) -> dict[str, Any]:
+        """Expose field metadata for CLI prompts/tests."""
+        if service not in _SECRET_SERVICE_SPECS:
+            raise ValueError(f"Unsupported service '{service}'")
+        spec = _SECRET_SERVICE_SPECS[service]
+        return {
+            "required_fields": spec["required_fields"],
+            "optional_fields": spec["optional_fields"],
+            "supports_native": spec["supports_native"],
+        }
+
+    @staticmethod
+    def supported_services() -> dict[str, dict[str, Any]]:
+        """Expose service spec metadata for CLI and tests."""
+        return {
+            service: {
+                "kind": "secret" if service in _SECRET_SERVICE_SPECS else "oauth",
+                **spec,
+            }
+            for service, spec in _SECRET_SERVICE_SPECS.items()
+        }
+
+    @staticmethod
+    def oauth_services() -> tuple[str, ...]:
+        return tuple(sorted(_OAUTH_PROVIDER_ALIASES))

--- a/src/nexus/bricks/auth/unified_service.py
+++ b/src/nexus/bricks/auth/unified_service.py
@@ -290,6 +290,24 @@ class UnifiedAuthService:
 
         record = self._secret_store.get(service)
         if record is not None:
+            if record.kind == CredentialKind.NATIVE:
+                native = self._detect_native(service)
+                if native is not None:
+                    return AuthResolution(
+                        service=service,
+                        status=AuthStatus.AUTHED,
+                        source="native",
+                        resolved_config=dict(config),
+                        message=native["message"],
+                    )
+                spec = _SECRET_SERVICE_SPECS[service]
+                return AuthResolution(
+                    service=service,
+                    status=AuthStatus.NO_AUTH,
+                    source="missing",
+                    resolved_config=dict(config),
+                    message=spec["action_hint"],
+                )
             resolved = self._merge_secret_data(dict(config), record.data)
             return AuthResolution(
                 service=service,
@@ -331,6 +349,30 @@ class UnifiedAuthService:
             seen_services.add(service)
             record = self._secret_store.get(service)
             if record is not None:
+                if record.kind == CredentialKind.NATIVE:
+                    native = self._detect_native(service)
+                    if native is not None:
+                        summaries.append(
+                            AuthSummary(
+                                service=service,
+                                kind=CredentialKind.NATIVE,
+                                status=AuthStatus.AUTHED,
+                                source="native",
+                                message=native["message"],
+                                details={k: v for k, v in native.items() if k != "message"},
+                            )
+                        )
+                    else:
+                        summaries.append(
+                            AuthSummary(
+                                service=service,
+                                kind=CredentialKind.NATIVE,
+                                status=AuthStatus.NO_AUTH,
+                                source="missing",
+                                message=_SECRET_SERVICE_SPECS[service]["action_hint"],
+                            )
+                        )
+                    continue
                 summaries.append(
                     AuthSummary(
                         service=service,

--- a/src/nexus/bricks/mount/mount_service.py
+++ b/src/nexus/bricks/mount/mount_service.py
@@ -80,6 +80,7 @@ class MountService:
         sync_job_service: Any = None,
         mount_persist_service: Any = None,
         oauth_service: Any = None,
+        auth_service: Any = None,
         persist_service: Any = None,
         rmdir_fn: Any = None,
         token_manager_fn: Any = None,
@@ -96,6 +97,7 @@ class MountService:
             sync_job_service: SyncJobService for async sync job management
             mount_persist_service: MountPersistService for config persistence
             oauth_service: OAuthCredentialService for credential revocation
+            auth_service: UnifiedAuthService for stored/native credential resolution
             persist_service: MountPersistService (alias, used by delete_connector)
             rmdir_fn: Callback to delete directories (NexusFS.rmdir)
             token_manager_fn: Callback to get token manager for OAuth revocation
@@ -110,6 +112,7 @@ class MountService:
         self._sync_job_service = sync_job_service
         self._mount_persist_service = mount_persist_service
         self._oauth_service = oauth_service
+        self._auth_service = auth_service
         self._persist_service = persist_service
         self._rmdir_fn = rmdir_fn
         self._token_manager_fn = token_manager_fn
@@ -570,10 +573,20 @@ class MountService:
                     config = {**config, "token_manager_db": database_url}
                 except RuntimeError as e:
                     raise RuntimeError(f"Cannot create {backend_type} mount: {e}") from e
-            else:
-                raise RuntimeError(
-                    f"Cannot create {backend_type} mount: no gateway or nexus_fs configured"
-                )
+                else:
+                    raise RuntimeError(
+                        f"Cannot create {backend_type} mount: no gateway or nexus_fs configured"
+                    )
+
+        if self._auth_service is not None:
+            resolution = self._auth_service.resolve_backend_config(
+                backend_type,
+                config,
+                context=context,
+            )
+            config = resolution.resolved_config
+            if resolution.status.value == "no_auth" and resolution.message:
+                raise RuntimeError(f"Cannot create {backend_type} mount: {resolution.message}")
 
         # Create backend instance
         backend = self._create_backend(backend_type, config)

--- a/src/nexus/cli/commands/__init__.py
+++ b/src/nexus/cli/commands/__init__.py
@@ -70,6 +70,7 @@ _ADD_COMMAND: dict[str, tuple[str, str]] = {
     "admin": ("admin", "admin"),
     "sandbox": ("sandbox", "sandbox"),
     "oauth": ("oauth", "oauth"),
+    "auth_cli": ("auth", "auth"),
     "zone": ("zone", "zone"),
     # Issue #2811: New CLI command groups
     "pay": ("pay", "pay"),

--- a/src/nexus/cli/commands/auth_cli.py
+++ b/src/nexus/cli/commands/auth_cli.py
@@ -1,0 +1,354 @@
+"""Unified auth CLI over OAuth, stored secrets, and native providers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Callable
+from typing import cast
+
+import click
+from rich.table import Table
+
+from nexus.bricks.auth.unified_service import UnifiedAuthService
+from nexus.cli.commands.oauth import setup_gdrive, setup_x
+from nexus.cli.utils import console
+from nexus.contracts.unified_auth import AuthStatus, CredentialKind
+
+_SERVICE_AUTH_TYPES: dict[str, tuple[str, ...]] = {
+    "s3": ("native", "secret"),
+    "gcs": ("native", "secret"),
+    "gws": ("oauth",),
+    "google-drive": ("oauth",),
+    "gmail": ("oauth",),
+    "google-calendar": ("oauth",),
+    "slack": ("oauth",),
+    "x": ("oauth",),
+}
+
+_SERVICE_HELP: dict[str, dict[str, tuple[str, ...] | str]] = {
+    "s3": {
+        "recommended": "native",
+        "native_steps": (
+            "Run `aws configure`, set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, or ensure your AWS profile works.",
+            "Use `nexus auth connect s3 native` to tell Nexus to prefer the AWS provider chain.",
+            "Run `nexus auth test s3` to verify the provider chain resolves.",
+        ),
+        "secret_steps": (
+            "Gather `access_key_id` and `secret_access_key`.",
+            "Run `nexus auth connect s3 secret` and enter the prompts, or pass `--set access_key_id=... --set secret_access_key=...`.",
+            "Run `nexus auth test s3` to verify the stored credential shape.",
+        ),
+    },
+    "gcs": {
+        "recommended": "native",
+        "native_steps": (
+            "Run `gcloud auth application-default login` or set `GOOGLE_APPLICATION_CREDENTIALS`.",
+            "Use `nexus auth connect gcs native` to tell Nexus to prefer ADC/native credentials.",
+            "Run `nexus auth test gcs` to verify the provider chain resolves.",
+        ),
+        "secret_steps": (
+            "Prepare a service-account JSON file or access token.",
+            "Run `nexus auth connect gcs secret` and provide `credentials_path` or `access_token`.",
+            "Run `nexus auth test gcs` to verify the stored credential shape.",
+        ),
+    },
+    "gws": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_GOOGLE_CLIENT_ID` and `NEXUS_OAUTH_GOOGLE_CLIENT_SECRET`.",
+            "Run `nexus auth connect gws oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus auth test gws --user-email you@example.com`.",
+        ),
+    },
+    "google-drive": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_GOOGLE_CLIENT_ID` and `NEXUS_OAUTH_GOOGLE_CLIENT_SECRET`.",
+            "Run `nexus auth connect google-drive oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus auth test google-drive --user-email you@example.com`.",
+        ),
+    },
+    "gmail": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_GOOGLE_CLIENT_ID` and `NEXUS_OAUTH_GOOGLE_CLIENT_SECRET`.",
+            "Run `nexus auth connect gmail oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus auth test gmail --user-email you@example.com`.",
+        ),
+    },
+    "google-calendar": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_GOOGLE_CLIENT_ID` and `NEXUS_OAUTH_GOOGLE_CLIENT_SECRET`.",
+            "Run `nexus auth connect google-calendar oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus auth test google-calendar --user-email you@example.com`.",
+        ),
+    },
+    "x": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_X_CLIENT_ID` and optionally `NEXUS_OAUTH_X_CLIENT_SECRET`.",
+            "Run `nexus auth connect x oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus auth test x --user-email you@example.com`.",
+        ),
+    },
+}
+
+
+def _build_auth_service() -> UnifiedAuthService:
+    from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
+    from nexus.cli.commands.oauth import get_token_manager
+
+    oauth_service = OAuthCredentialService(token_manager=get_token_manager())
+    return UnifiedAuthService(oauth_service=oauth_service)
+
+
+def _parse_key_values(items: tuple[str, ...]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise click.ClickException(f"Expected KEY=VALUE, got: {item}")
+        key, value = item.split("=", 1)
+        parsed[key.strip()] = value
+    return parsed
+
+
+def _choose_auth_type(service_name: str) -> str:
+    supported = _SERVICE_AUTH_TYPES.get(service_name)
+    if not supported:
+        raise click.ClickException(f"Unknown auth service '{service_name}'.")
+    if len(supported) == 1:
+        return supported[0]
+
+    default = str(_SERVICE_HELP.get(service_name, {}).get("recommended", supported[0]))
+    console.print(f"[bold]Choose auth mode for {service_name}[/bold]")
+    for mode in supported:
+        suffix = " (recommended)" if mode == default else ""
+        console.print(f"  - {mode}{suffix}")
+    choice = click.prompt(
+        "Auth type",
+        type=click.Choice(list(supported), case_sensitive=False),
+        default=default,
+        show_choices=False,
+    )
+    return str(choice).lower()
+
+
+def _print_steps(service_name: str, auth_type: str) -> None:
+    guide = _SERVICE_HELP.get(service_name, {})
+    steps = guide.get(f"{auth_type}_steps")
+    if not steps:
+        return
+    console.print(f"[bold]Setup steps for {service_name} ({auth_type})[/bold]")
+    for idx, step in enumerate(steps, start=1):
+        console.print(f"{idx}. {step}")
+    console.print("")
+
+
+def _prompt_for_secret_values(
+    service: UnifiedAuthService,
+    service_name: str,
+    pairs: tuple[str, ...],
+) -> dict[str, str]:
+    values = _parse_key_values(pairs)
+    if values:
+        return values
+
+    spec = service.store_help_fields(service_name)
+    prompt_fields = list(spec["required_fields"])
+    if service_name == "gcs" and not prompt_fields:
+        prompt_fields = ["credentials_path"]
+
+    values = {}
+    for field in prompt_fields:
+        hide = "secret" in field or "token" in field or "key" in field
+        values[field] = click.prompt(field, hide_input=hide)
+    return values
+
+
+def _print_connect_success(
+    service_name: str,
+    kind: CredentialKind,
+    store_path: str,
+    fields: list[str] | None = None,
+    *,
+    source: str = "stored",
+) -> None:
+    console.print(f"[green]ok[/green] {service_name}: {source} {kind.value} auth is configured")
+    console.print(f"[dim]Secret store: {store_path}[/dim]")
+    if fields:
+        console.print(f"[dim]Fields: {', '.join(fields)}[/dim]")
+    console.print(f"[dim]Next: nexus auth test {service_name}[/dim]")
+
+
+def _ensure_google_oauth_env() -> None:
+    if os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID"):
+        return
+    raise click.ClickException(
+        "Google OAuth client ID not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_ID "
+        "and NEXUS_OAUTH_GOOGLE_CLIENT_SECRET first."
+    )
+
+
+def _ensure_x_oauth_env() -> None:
+    if os.getenv("NEXUS_OAUTH_X_CLIENT_ID"):
+        return
+    raise click.ClickException("X OAuth client ID not provided. Set NEXUS_OAUTH_X_CLIENT_ID first.")
+
+
+def _resolve_user_email(user_email: str | None) -> str:
+    if user_email:
+        return user_email
+    return str(click.prompt("user_email"))
+
+
+def _run_google_oauth_setup(user_email: str) -> None:
+    callback = cast(
+        Callable[[str | None, str | None, str, str | None, str | None], None],
+        setup_gdrive.callback,
+    )
+    callback(
+        None,
+        None,
+        user_email,
+        None,
+        None,
+    )
+
+
+def _run_x_oauth_setup(user_email: str) -> None:
+    callback = cast(
+        Callable[[str | None, str | None, str, str | None, str | None], None],
+        setup_x.callback,
+    )
+    callback(
+        None,
+        None,
+        user_email,
+        None,
+        None,
+    )
+
+
+@click.group(name="auth")
+def auth() -> None:
+    """Unified auth commands for OAuth and cloud backends."""
+
+
+@auth.command("list")
+def list_auth() -> None:
+    """List configured auth across services."""
+    service = _build_auth_service()
+    summaries = asyncio.run(service.list_summaries())
+
+    table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
+    table.add_column("Service", style="green")
+    table.add_column("Kind", style="cyan")
+    table.add_column("Status", style="yellow")
+    table.add_column("Source", style="blue")
+    table.add_column("Message")
+
+    for summary in summaries:
+        table.add_row(
+            summary.service,
+            summary.kind.value,
+            summary.status.value,
+            summary.source,
+            summary.message,
+        )
+
+    console.print(table)
+    console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
+
+
+@auth.command("test")
+@click.argument("service_name", type=str)
+@click.option("--user-email", type=str, default=None, help="OAuth account email override.")
+def test_auth(service_name: str, user_email: str | None) -> None:
+    """Validate auth for a service."""
+    service = _build_auth_service()
+    result = asyncio.run(service.test_service(service_name, user_email=user_email))
+    if result.get("success"):
+        console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")
+        return
+    raise click.ClickException(f"{service_name}: {result.get('message')}")
+
+
+@auth.command("connect")
+@click.argument("service_name", type=str)
+@click.argument(
+    "auth_type",
+    required=False,
+    type=click.Choice(["oauth", "secret", "native"], case_sensitive=False),
+)
+@click.option("--set", "pairs", multiple=True, help="Secret field as KEY=VALUE. Repeat as needed.")
+@click.option("--user-email", type=str, default=None, help="OAuth account email.")
+def connect_auth(
+    service_name: str,
+    auth_type: str | None,
+    pairs: tuple[str, ...],
+    user_email: str | None,
+) -> None:
+    """Connect a service using OAuth, stored secrets, or native fallback."""
+    auth_type = auth_type.lower() if auth_type else _choose_auth_type(service_name)
+    service = _build_auth_service()
+    _print_steps(service_name, auth_type)
+
+    if auth_type == "oauth":
+        if service_name in {"gws", "google-drive", "gmail", "google-calendar"}:
+            user_email = _resolve_user_email(user_email)
+            _ensure_google_oauth_env()
+            _run_google_oauth_setup(user_email)
+            return
+        if service_name == "x":
+            user_email = _resolve_user_email(user_email)
+            _ensure_x_oauth_env()
+            _run_x_oauth_setup(user_email)
+            return
+        raise click.ClickException(f"OAuth connect is not implemented for '{service_name}'.")
+
+    if auth_type == "native":
+        record = service.connect_native(service_name)
+        _print_connect_success(
+            service_name,
+            record.kind,
+            str(service.secret_store_path),
+            source="native fallback",
+        )
+        return
+
+    values = _prompt_for_secret_values(service, service_name, pairs)
+    record = service.connect_secret(service_name, values)
+    _print_connect_success(
+        service_name,
+        record.kind,
+        str(service.secret_store_path),
+        sorted(record.data),
+    )
+
+
+@auth.command("disconnect")
+@click.argument("service_name", type=str)
+def disconnect_auth(service_name: str) -> None:
+    """Remove stored secret/native auth for a service."""
+    service = _build_auth_service()
+    removed = service.disconnect(service_name)
+    if not removed:
+        raise click.ClickException(f"No stored auth found for '{service_name}'.")
+    console.print(f"[green]ok[/green] Removed stored auth for {service_name}")
+
+
+@auth.command("doctor")
+def auth_doctor() -> None:
+    """Show only auth-related doctor results."""
+    service = _build_auth_service()
+    summaries = asyncio.run(service.list_summaries())
+    failures = [s for s in summaries if s.status not in {AuthStatus.AUTHED, AuthStatus.UNKNOWN}]
+    for summary in summaries:
+        style = "green" if summary.status == AuthStatus.AUTHED else "yellow"
+        console.print(
+            f"[{style}]{summary.service}[/{style}] {summary.status.value}: {summary.message}"
+        )
+    if failures:
+        raise click.ClickException("One or more services need auth setup.")

--- a/src/nexus/cli/commands/auth_cli.py
+++ b/src/nexus/cli/commands/auth_cli.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import importlib as _il
 import os
+import sys
 from collections.abc import Callable
 from typing import cast
 
@@ -11,8 +13,9 @@ import click
 from rich.table import Table
 
 from nexus.bricks.auth.unified_service import UnifiedAuthService
-from nexus.cli.commands.oauth import setup_gdrive, setup_x
+from nexus.cli.commands.oauth import get_token_manager, setup_x
 from nexus.cli.utils import console
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.unified_auth import AuthStatus, CredentialKind
 
 _SERVICE_AUTH_TYPES: dict[str, tuple[str, ...]] = {
@@ -93,6 +96,31 @@ _SERVICE_HELP: dict[str, dict[str, tuple[str, ...] | str]] = {
             "Follow the browser/code flow, then run `nexus auth test x --user-email you@example.com`.",
         ),
     },
+}
+
+_GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
+    "gws": [
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/drive.file",
+        "https://www.googleapis.com/auth/documents",
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/calendar",
+        "https://www.googleapis.com/auth/chat.spaces.readonly",
+    ],
+    "google-drive": [
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/drive.file",
+    ],
+    "gmail": ["https://www.googleapis.com/auth/gmail.modify"],
+    "google-calendar": ["https://www.googleapis.com/auth/calendar"],
+}
+
+_GOOGLE_SERVICE_PROVIDER_NAMES: dict[str, str] = {
+    "gws": "google",
+    "google-drive": "google-drive",
+    "gmail": "gmail",
+    "google-calendar": "google-calendar",
 }
 
 
@@ -203,18 +231,59 @@ def _resolve_user_email(user_email: str | None) -> str:
     return str(click.prompt("user_email"))
 
 
-def _run_google_oauth_setup(user_email: str) -> None:
-    callback = cast(
-        Callable[[str | None, str | None, str, str | None, str | None], None],
-        setup_gdrive.callback,
+def _run_google_oauth_setup(service_name: str, user_email: str) -> None:
+    GoogleOAuthProvider = _il.import_module(
+        "nexus.bricks.auth.oauth.providers.google"
+    ).GoogleOAuthProvider
+
+    client_id = os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID")
+    client_secret = os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        raise click.ClickException(
+            "Google OAuth client ID/secret not provided. Set "
+            "NEXUS_OAUTH_GOOGLE_CLIENT_ID and NEXUS_OAUTH_GOOGLE_CLIENT_SECRET first."
+        )
+
+    provider = GoogleOAuthProvider(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri="http://localhost",
+        scopes=_GOOGLE_SERVICE_SCOPES.get(service_name, _GOOGLE_SERVICE_SCOPES["gws"]),
+        provider_name=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
     )
-    callback(
-        None,
-        None,
-        user_email,
-        None,
-        None,
+    auth_url = provider.get_authorization_url()
+
+    console.print("\n[bold green]Google OAuth Setup[/bold green]")
+    console.print(f"\n[bold]Service:[/bold] {service_name}")
+    console.print(f"[bold]User:[/bold] {user_email}")
+    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
+    console.print(f"\n{auth_url}\n")
+    console.print(
+        "[bold yellow]Step 2:[/bold yellow] After granting permission, the browser will redirect to localhost."
     )
+    console.print("[bold yellow]Step 3:[/bold yellow] Copy the `code` parameter from that URL.")
+    auth_code = click.prompt("\nEnter authorization code")
+
+    async def _exchange_and_store() -> str:
+        credential = await provider.exchange_code(auth_code)
+        manager = get_token_manager()
+        cred_id = await manager.store_credential(
+            provider=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
+            user_email=user_email,
+            credential=credential,
+            zone_id=ROOT_ZONE_ID,
+            created_by=user_email,
+        )
+        manager.close()
+        return cred_id
+
+    try:
+        cred_id = asyncio.run(_exchange_and_store())
+        console.print(f"\n[green]ok[/green] stored Google OAuth credentials for {user_email}")
+        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
+    except Exception as exc:
+        console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
+        sys.exit(1)
 
 
 def _run_x_oauth_setup(user_email: str) -> None:
@@ -299,7 +368,7 @@ def connect_auth(
         if service_name in {"gws", "google-drive", "gmail", "google-calendar"}:
             user_email = _resolve_user_email(user_email)
             _ensure_google_oauth_env()
-            _run_google_oauth_setup(user_email)
+            _run_google_oauth_setup(service_name, user_email)
             return
         if service_name == "x":
             user_email = _resolve_user_email(user_email)

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -328,6 +328,37 @@ def check_database_url() -> CheckResult:
     )
 
 
+def _check_auth_service(service_name: str) -> CheckResult:
+    from nexus.bricks.auth.unified_service import UnifiedAuthService
+
+    result = asyncio.run(UnifiedAuthService().test_service(service_name))
+    if result.get("success"):
+        return CheckResult(
+            name=f"auth-{service_name}",
+            status=CheckStatus.OK,
+            message=str(result.get("message", "")),
+        )
+    return CheckResult(
+        name=f"auth-{service_name}",
+        status=CheckStatus.WARNING,
+        message=str(result.get("message", "")),
+        fix_hint=(
+            f"Run `nexus auth connect {service_name} secret` or "
+            f"`nexus auth connect {service_name} native`."
+        ),
+    )
+
+
+def check_s3_auth() -> CheckResult:
+    """Check whether S3 auth is configured via stored or native credentials."""
+    return _check_auth_service("s3")
+
+
+def check_gcs_auth() -> CheckResult:
+    """Check whether GCS auth is configured via stored or native credentials."""
+    return _check_auth_service("gcs")
+
+
 # ---------------------------------------------------------------------------
 # Individual checks — dependencies
 # ---------------------------------------------------------------------------
@@ -420,6 +451,8 @@ CHECKS: dict[str, list[Any]] = {
     "security": [
         check_zone_isolation,
         check_database_url,
+        check_s3_auth,
+        check_gcs_auth,
     ],
     "dependencies": [
         check_python_version,

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -11,6 +11,7 @@ For remote servers, commands call the RPC API (add_mount, remove_mount, etc.).
 For local instances, commands interact directly with the NexusFS methods.
 """
 
+import inspect
 import json
 import sys
 from typing import Any
@@ -146,13 +147,14 @@ async def _async_add_mount(
         try:
             mount_svc = nx.service("mount")
             assert mount_svc is not None
-            mount_id = await mount_svc.add_mount(
+            mount_result = mount_svc.add_mount(
                 mount_point=mount_point,
                 backend_type=backend_type,
                 backend_config=config_dict,
                 readonly=readonly,
                 io_profile=io_profile,
             )
+            mount_id = await mount_result if inspect.isawaitable(mount_result) else mount_result
             console.print(f"[green]\u2713[/green] Mount added successfully (ID: {mount_id})")
         except AttributeError:
             # Fallback for older NexusFS that doesn't have mount_service
@@ -209,7 +211,8 @@ async def _async_remove_mount(
         try:
             mount_svc = nx.service("mount")
             assert mount_svc is not None
-            result = await mount_svc.remove_mount(mount_point=mount_point)
+            remove_result = mount_svc.remove_mount(mount_point=mount_point)
+            result = await remove_result if inspect.isawaitable(remove_result) else remove_result
             if result.get("removed"):
                 console.print("[green]\u2713[/green] Mount removed successfully")
             else:

--- a/src/nexus/contracts/unified_auth.py
+++ b/src/nexus/contracts/unified_auth.py
@@ -1,0 +1,63 @@
+"""Neutral auth contracts shared across CLI, services, and connectors.
+
+Keeps non-OAuth credentials out of OAuth-specific types while preserving
+explicit status and resolution metadata for UX and tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class CredentialKind(StrEnum):
+    """Credential storage strategy."""
+
+    OAUTH = "oauth"
+    SECRET = "secret"
+    NATIVE = "native"
+
+
+class AuthStatus(StrEnum):
+    """Normalized auth status for UX surfaces."""
+
+    AUTHED = "authed"
+    EXPIRED = "expired"
+    NO_AUTH = "no_auth"
+    ERROR = "error"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class SecretCredentialRecord:
+    """Stored non-OAuth credential metadata plus secret payload."""
+
+    service: str
+    kind: CredentialKind
+    data: dict[str, str] = field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AuthSummary:
+    """Redacted summary shown by auth list / status surfaces."""
+
+    service: str
+    kind: CredentialKind
+    status: AuthStatus
+    source: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthResolution:
+    """Result of backend credential resolution."""
+
+    service: str
+    status: AuthStatus
+    source: str
+    resolved_config: dict[str, Any] = field(default_factory=dict)
+    message: str | None = None

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -22,6 +22,8 @@ __version__ = "0.1.0"
 # =============================================================================
 # LAZY IMPORTS — everything is deferred for <200ms import time
 # =============================================================================
+import inspect
+import os
 from typing import Any
 
 _lazy_cache: dict[str, Any] = {}
@@ -244,11 +246,17 @@ def _create_connector_backend(spec: Any) -> Any:
     fallback_name = f"{scheme}_connector"
 
     connector_cls = None
-    for name in [connector_name, f"gws_{authority}" if scheme == "gws" else None, fallback_name]:
-        if name is None:
+    selected_name: str | None = None
+    for candidate in [
+        connector_name,
+        f"gws_{authority}" if scheme == "gws" else None,
+        fallback_name,
+    ]:
+        if candidate is None:
             continue
         try:
-            connector_cls = ConnectorRegistry.get(name)
+            connector_cls = ConnectorRegistry.get(candidate)
+            selected_name = candidate
             break
         except KeyError:
             continue
@@ -264,8 +272,87 @@ def _create_connector_backend(spec: Any) -> Any:
             f"Registered connectors: {', '.join(available) if available else 'none'}",
         )
 
-    # Instantiate the connector. CLIConnectors accept config via kwargs.
-    return connector_cls()
+    info = ConnectorRegistry.get_info(selected_name) if selected_name is not None else None
+    return _instantiate_connector_backend(connector_cls, info=info, scheme=scheme)
+
+
+def _default_token_manager_db() -> str:
+    """Return the default TokenManager database path/URL for slim fs mounts."""
+    from nexus.lib.env import get_database_url
+
+    db_url = get_database_url()
+    if db_url:
+        return db_url
+
+    home = os.path.expanduser("~")
+    db_path = os.path.join(home, ".nexus", "nexus.db")
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    return db_path
+
+
+def _infer_connector_user_email(
+    *,
+    scheme: str,
+    info: Any | None,
+) -> str | None:
+    """Best-effort user identity for OAuth-backed slim connector mounts.
+
+    Priority:
+    1. ``NEXUS_FS_USER_EMAIL`` explicit override
+    2. the only stored OAuth credential email for the service's provider(s)
+    """
+    explicit = os.getenv("NEXUS_FS_USER_EMAIL")
+    if explicit:
+        return explicit
+
+    service_name = getattr(info, "service_name", None) or scheme
+    try:
+        from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
+        from nexus.bricks.auth.unified_service import _OAUTH_PROVIDER_ALIASES
+        from nexus.cli.commands.oauth import get_token_manager
+    except Exception:
+        return None
+
+    providers = _OAUTH_PROVIDER_ALIASES.get(service_name)
+    if not providers:
+        return None
+
+    oauth_service = OAuthCredentialService(token_manager=get_token_manager())
+    try:
+        import asyncio
+
+        creds = asyncio.run(oauth_service.list_credentials())
+    except Exception:
+        return None
+
+    emails = sorted(
+        {
+            str(cred.get("user_email"))
+            for cred in creds
+            if cred.get("provider") in providers and cred.get("user_email")
+        }
+    )
+    if len(emails) == 1:
+        return emails[0]
+    return None
+
+
+def _instantiate_connector_backend(connector_cls: Any, *, info: Any | None, scheme: str) -> Any:
+    """Instantiate connector with the same auth defaults the mount service injects."""
+    init_sig = inspect.signature(connector_cls.__init__)
+    params = init_sig.parameters
+    kwargs: dict[str, Any] = {}
+
+    connection_args = getattr(info, "connection_args", {}) if info is not None else {}
+    if "token_manager_db" in params or "token_manager_db" in connection_args:
+        kwargs["token_manager_db"] = _default_token_manager_db()
+
+    if "user_email" in params or "user_email" in connection_args:
+        user_email = _infer_connector_user_email(scheme=scheme, info=info)
+        if user_email:
+            kwargs["user_email"] = user_email
+
+    return connector_cls(**kwargs)
 
 
 def _discover_connector_module(scheme: str) -> None:

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -311,7 +311,7 @@ def _infer_connector_user_email(
     try:
         from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
         from nexus.bricks.auth.unified_service import _OAUTH_PROVIDER_ALIASES
-        from nexus.cli.commands.oauth import get_token_manager
+        from nexus.fs._oauth_support import get_token_manager
     except Exception:
         return None
 

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -22,6 +22,7 @@ __version__ = "0.1.0"
 # =============================================================================
 # LAZY IMPORTS — everything is deferred for <200ms import time
 # =============================================================================
+import importlib
 import inspect
 import os
 import shutil
@@ -309,17 +310,22 @@ def _infer_connector_user_email(
 
     service_name = getattr(info, "service_name", None) or scheme
     try:
-        from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
-        from nexus.bricks.auth.unified_service import _OAUTH_PROVIDER_ALIASES
         from nexus.fs._oauth_support import get_token_manager
     except Exception:
         return None
 
-    providers = _OAUTH_PROVIDER_ALIASES.get(service_name)
+    try:
+        oauth_module = importlib.import_module("nexus.bricks.auth.oauth.credential_service")
+        unified_module = importlib.import_module("nexus.bricks.auth.unified_service")
+    except Exception:
+        return None
+
+    oauth_provider_aliases = getattr(unified_module, "_OAUTH_PROVIDER_ALIASES", {})
+    providers = oauth_provider_aliases.get(service_name)
     if not providers:
         return None
 
-    oauth_service = OAuthCredentialService(token_manager=get_token_manager())
+    oauth_service = oauth_module.OAuthCredentialService(token_manager=get_token_manager())
     try:
         import asyncio
 

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -24,6 +24,8 @@ __version__ = "0.1.0"
 # =============================================================================
 import inspect
 import os
+import shutil
+import subprocess
 from typing import Any
 
 _lazy_cache: dict[str, Any] = {}
@@ -334,7 +336,54 @@ def _infer_connector_user_email(
     )
     if len(emails) == 1:
         return emails[0]
+    if "google" in providers:
+        return _infer_google_workspace_cli_email()
     return None
+
+
+def _infer_google_workspace_cli_email() -> str | None:
+    """Best-effort Google account detection from the local gws CLI auth state."""
+    if shutil.which("gws") is None:
+        return None
+
+    try:
+        result = subprocess.run(
+            [
+                "gws",
+                "gmail",
+                "users",
+                "getProfile",
+                "--params",
+                '{"userId":"me"}',
+                "--format",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return None
+
+    try:
+        import json
+
+        start = stdout.find("{")
+        payload = stdout[start:] if start >= 0 else stdout
+        data = json.loads(payload)
+    except Exception:
+        return None
+
+    email = str(data.get("emailAddress") or "").strip()
+    return email or None
 
 
 def _instantiate_connector_backend(connector_cls: Any, *, info: Any | None, scheme: str) -> Any:

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import os
 import re
+from typing import Any
 
 import click
+from rich.console import Console
 from rich.table import Table
 
-from nexus.bricks.auth.unified_service import UnifiedAuthService
-from nexus.cli.utils import console
 from nexus.contracts.unified_auth import AuthStatus, CredentialKind
 from nexus.fs._oauth_support import get_token_manager, run_google_oauth_setup, run_x_oauth_setup
+
+console = Console()
 
 _SERVICE_AUTH_TYPES: dict[str, tuple[str, ...]] = {
     "s3": ("native", "secret"),
@@ -95,11 +98,11 @@ _SERVICE_HELP: dict[str, dict[str, tuple[str, ...] | str]] = {
 }
 
 
-def _build_auth_service() -> UnifiedAuthService:
-    from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
-
-    oauth_service = OAuthCredentialService(token_manager=get_token_manager())
-    return UnifiedAuthService(oauth_service=oauth_service)
+def _build_auth_service() -> Any:
+    oauth_module = importlib.import_module("nexus.bricks.auth.oauth.credential_service")
+    unified_module = importlib.import_module("nexus.bricks.auth.unified_service")
+    oauth_service = oauth_module.OAuthCredentialService(token_manager=get_token_manager())
+    return unified_module.UnifiedAuthService(oauth_service=oauth_service)
 
 
 def _parse_key_values(items: tuple[str, ...]) -> dict[str, str]:
@@ -148,7 +151,7 @@ def _resolve_user_email(user_email: str | None) -> str:
 
 
 def _prompt_for_secret_values(
-    service: UnifiedAuthService,
+    service: Any,
     service_name: str,
     pairs: tuple[str, ...],
 ) -> dict[str, str]:

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import re
 
 import click
 from rich.table import Table
@@ -179,6 +181,46 @@ def _print_connect_success(
     console.print(f"[dim]Next: nexus-fs auth test {service_name}[/dim]")
 
 
+def _print_target_readiness_summary(
+    service_name: str,
+    checks: list[dict[str, object]],
+    *,
+    user_email: str | None = None,
+) -> None:
+    ready = [str(check.get("target", "")) for check in checks if check.get("success")]
+    failed = [check for check in checks if not check.get("success")]
+
+    if ready:
+        console.print(f"[green]Ready:[/green] {', '.join(ready)}")
+
+    if not failed:
+        console.print(f"[green]ok[/green] {service_name}: all checked targets are ready.")
+        return
+
+    console.print(
+        f"[yellow]{service_name} is partially ready.[/yellow] "
+        f"{len(failed)} target(s) still need action."
+    )
+    for check in failed:
+        target = str(check.get("target", ""))
+        message = str(check.get("message", ""))
+        console.print(f"[red]Needs action:[/red] {target}: {message}")
+
+    if service_name == "gws":
+        email = user_email or os.environ.get("NEXUS_FS_USER_EMAIL")
+        if not email:
+            joined_messages = "\n".join(str(check.get("message", "")) for check in checks)
+            match = re.search(r"[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}", joined_messages)
+            email = match.group(0) if match else "you@example.com"
+        console.print(
+            "[bold]Next steps[/bold]\n"
+            f"1. Run `nexus-fs auth connect gws oauth --user-email {email}`\n"
+            "2. Approve the requested Google scopes for the failing target(s)\n"
+            "3. Re-run `nexus-fs auth test gws`\n"
+            "4. Use `nexus-fs auth test gws --target <target>` to verify one target at a time"
+        )
+
+
 @click.group(name="auth")
 def auth() -> None:
     """Unified auth commands for nexus-fs."""
@@ -245,6 +287,10 @@ def test_auth(service_name: str, user_email: str | None, target: str | None) -> 
                 str(check.get("message", "")),
             )
         console.print(table)
+        _print_target_readiness_summary(service_name, checks, user_email=user_email)
+        if result.get("success"):
+            return
+        raise SystemExit(1)
 
     if result.get("success"):
         console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -210,10 +210,42 @@ def list_auth() -> None:
 @auth.command("test")
 @click.argument("service_name", type=str)
 @click.option("--user-email", type=str, default=None, help="OAuth account email override.")
-def test_auth(service_name: str, user_email: str | None) -> None:
+@click.option(
+    "--target",
+    type=click.Choice(
+        ["drive", "docs", "sheets", "gmail", "calendar", "chat"], case_sensitive=False
+    ),
+    default=None,
+    help="Google Workspace target readiness check.",
+)
+def test_auth(service_name: str, user_email: str | None, target: str | None) -> None:
     """Validate auth for a service."""
     service = _build_auth_service()
-    result = asyncio.run(service.test_service(service_name, user_email=user_email))
+    try:
+        result = asyncio.run(
+            service.test_service(service_name, user_email=user_email, target=target)
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    checks = result.get("checks")
+    if isinstance(checks, list) and checks:
+        table = Table(
+            title=f"{service_name} target readiness", show_header=True, header_style="bold cyan"
+        )
+        table.add_column("Target", style="green")
+        table.add_column("Status", style="yellow")
+        table.add_column("Source", style="blue")
+        table.add_column("Message")
+        for check in checks:
+            table.add_row(
+                str(check.get("target", "")),
+                "ok" if check.get("success") else "error",
+                str(check.get("source", result.get("source", ""))),
+                str(check.get("message", "")),
+            )
+        console.print(table)
+
     if result.get("success"):
         console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")
         return

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -1,0 +1,296 @@
+"""Standalone unified auth CLI for nexus-fs."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+from rich.table import Table
+
+from nexus.bricks.auth.unified_service import UnifiedAuthService
+from nexus.cli.utils import console
+from nexus.contracts.unified_auth import AuthStatus, CredentialKind
+from nexus.fs._oauth_support import get_token_manager, run_google_oauth_setup, run_x_oauth_setup
+
+_SERVICE_AUTH_TYPES: dict[str, tuple[str, ...]] = {
+    "s3": ("native", "secret"),
+    "gcs": ("native", "secret"),
+    "gws": ("oauth",),
+    "google-drive": ("oauth",),
+    "gmail": ("oauth",),
+    "google-calendar": ("oauth",),
+    "slack": ("oauth",),
+    "x": ("oauth",),
+}
+
+_SERVICE_HELP: dict[str, dict[str, tuple[str, ...] | str]] = {
+    "s3": {
+        "recommended": "native",
+        "native_steps": (
+            "Run `aws configure`, set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, or ensure your AWS profile works.",
+            "Use `nexus-fs auth connect s3 native` to tell Nexus to prefer the AWS provider chain.",
+            "Run `nexus-fs auth test s3` to verify the provider chain resolves.",
+        ),
+        "secret_steps": (
+            "Gather `access_key_id` and `secret_access_key`.",
+            "Run `nexus-fs auth connect s3 secret` and enter the prompts, or pass `--set access_key_id=... --set secret_access_key=...`.",
+            "Run `nexus-fs auth test s3` to verify the stored credential shape.",
+        ),
+    },
+    "gcs": {
+        "recommended": "native",
+        "native_steps": (
+            "Run `gcloud auth application-default login` or set `GOOGLE_APPLICATION_CREDENTIALS`.",
+            "Use `nexus-fs auth connect gcs native` to tell Nexus to prefer ADC/native credentials.",
+            "Run `nexus-fs auth test gcs` to verify the provider chain resolves.",
+        ),
+        "secret_steps": (
+            "Prepare a service-account JSON file or access token.",
+            "Run `nexus-fs auth connect gcs secret` and provide `credentials_path` or `access_token`.",
+            "Run `nexus-fs auth test gcs` to verify the stored credential shape.",
+        ),
+    },
+    "gws": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_GOOGLE_CLIENT_ID` and `NEXUS_OAUTH_GOOGLE_CLIENT_SECRET`.",
+            "Run `nexus-fs auth connect gws oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus-fs auth test gws --user-email you@example.com`.",
+        ),
+    },
+    "google-drive": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_GOOGLE_CLIENT_ID` and `NEXUS_OAUTH_GOOGLE_CLIENT_SECRET`.",
+            "Run `nexus-fs auth connect google-drive oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus-fs auth test google-drive --user-email you@example.com`.",
+        ),
+    },
+    "gmail": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_GOOGLE_CLIENT_ID` and `NEXUS_OAUTH_GOOGLE_CLIENT_SECRET`.",
+            "Run `nexus-fs auth connect gmail oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus-fs auth test gmail --user-email you@example.com`.",
+        ),
+    },
+    "google-calendar": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_GOOGLE_CLIENT_ID` and `NEXUS_OAUTH_GOOGLE_CLIENT_SECRET`.",
+            "Run `nexus-fs auth connect google-calendar oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus-fs auth test google-calendar --user-email you@example.com`.",
+        ),
+    },
+    "x": {
+        "recommended": "oauth",
+        "oauth_steps": (
+            "Set `NEXUS_OAUTH_X_CLIENT_ID` and optionally `NEXUS_OAUTH_X_CLIENT_SECRET`.",
+            "Run `nexus-fs auth connect x oauth --user-email you@example.com`.",
+            "Follow the browser/code flow, then run `nexus-fs auth test x --user-email you@example.com`.",
+        ),
+    },
+}
+
+
+def _build_auth_service() -> UnifiedAuthService:
+    from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
+
+    oauth_service = OAuthCredentialService(token_manager=get_token_manager())
+    return UnifiedAuthService(oauth_service=oauth_service)
+
+
+def _parse_key_values(items: tuple[str, ...]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise click.ClickException(f"Expected KEY=VALUE, got: {item}")
+        key, value = item.split("=", 1)
+        parsed[key.strip()] = value
+    return parsed
+
+
+def _choose_auth_type(service_name: str) -> str:
+    supported = _SERVICE_AUTH_TYPES.get(service_name)
+    if not supported:
+        raise click.ClickException(f"Unknown auth service '{service_name}'.")
+    if len(supported) == 1:
+        return supported[0]
+    default = str(_SERVICE_HELP.get(service_name, {}).get("recommended", supported[0]))
+    console.print(f"[bold]Choose auth mode for {service_name}[/bold]")
+    for mode in supported:
+        suffix = " (recommended)" if mode == default else ""
+        console.print(f"  - {mode}{suffix}")
+    choice = click.prompt(
+        "Auth type",
+        type=click.Choice(list(supported), case_sensitive=False),
+        default=default,
+        show_choices=False,
+    )
+    return str(choice).lower()
+
+
+def _print_steps(service_name: str, auth_type: str) -> None:
+    guide = _SERVICE_HELP.get(service_name, {})
+    steps = guide.get(f"{auth_type}_steps")
+    if not steps:
+        return
+    console.print(f"[bold]Setup steps for {service_name} ({auth_type})[/bold]")
+    for idx, step in enumerate(steps, start=1):
+        console.print(f"{idx}. {step}")
+    console.print("")
+
+
+def _resolve_user_email(user_email: str | None) -> str:
+    return user_email or str(click.prompt("user_email"))
+
+
+def _prompt_for_secret_values(
+    service: UnifiedAuthService,
+    service_name: str,
+    pairs: tuple[str, ...],
+) -> dict[str, str]:
+    values = _parse_key_values(pairs)
+    if values:
+        return values
+    spec = service.store_help_fields(service_name)
+    prompt_fields = list(spec["required_fields"])
+    if service_name == "gcs" and not prompt_fields:
+        prompt_fields = ["credentials_path"]
+    values = {}
+    for field in prompt_fields:
+        hide = "secret" in field or "token" in field or "key" in field
+        values[field] = click.prompt(field, hide_input=hide)
+    return values
+
+
+def _print_connect_success(
+    service_name: str,
+    kind: CredentialKind,
+    store_path: str,
+    fields: list[str] | None = None,
+    *,
+    source: str = "stored",
+) -> None:
+    console.print(f"[green]ok[/green] {service_name}: {source} {kind.value} auth is configured")
+    console.print(f"[dim]Secret store: {store_path}[/dim]")
+    if fields:
+        console.print(f"[dim]Fields: {', '.join(fields)}[/dim]")
+    console.print(f"[dim]Next: nexus-fs auth test {service_name}[/dim]")
+
+
+@click.group(name="auth")
+def auth() -> None:
+    """Unified auth commands for nexus-fs."""
+
+
+@auth.command("list")
+def list_auth() -> None:
+    """List configured auth across services."""
+    service = _build_auth_service()
+    summaries = asyncio.run(service.list_summaries())
+    table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
+    table.add_column("Service", style="green")
+    table.add_column("Kind", style="cyan")
+    table.add_column("Status", style="yellow")
+    table.add_column("Source", style="blue")
+    table.add_column("Message")
+    for summary in summaries:
+        table.add_row(
+            summary.service,
+            summary.kind.value,
+            summary.status.value,
+            summary.source,
+            summary.message,
+        )
+    console.print(table)
+    console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
+
+
+@auth.command("test")
+@click.argument("service_name", type=str)
+@click.option("--user-email", type=str, default=None, help="OAuth account email override.")
+def test_auth(service_name: str, user_email: str | None) -> None:
+    """Validate auth for a service."""
+    service = _build_auth_service()
+    result = asyncio.run(service.test_service(service_name, user_email=user_email))
+    if result.get("success"):
+        console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")
+        return
+    raise click.ClickException(f"{service_name}: {result.get('message')}")
+
+
+@auth.command("connect")
+@click.argument("service_name", type=str)
+@click.argument(
+    "auth_type",
+    required=False,
+    type=click.Choice(["oauth", "secret", "native"], case_sensitive=False),
+)
+@click.option("--set", "pairs", multiple=True, help="Secret field as KEY=VALUE. Repeat as needed.")
+@click.option("--user-email", type=str, default=None, help="OAuth account email.")
+def connect_auth(
+    service_name: str,
+    auth_type: str | None,
+    pairs: tuple[str, ...],
+    user_email: str | None,
+) -> None:
+    """Connect a service using OAuth, stored secrets, or native fallback."""
+    auth_type = auth_type.lower() if auth_type else _choose_auth_type(service_name)
+    service = _build_auth_service()
+    _print_steps(service_name, auth_type)
+
+    if auth_type == "oauth":
+        user_email = _resolve_user_email(user_email)
+        if service_name in {"gws", "google-drive", "gmail", "google-calendar"}:
+            run_google_oauth_setup(user_email=user_email)
+            return
+        if service_name == "x":
+            run_x_oauth_setup(user_email=user_email)
+            return
+        raise click.ClickException(f"OAuth connect is not implemented for '{service_name}'.")
+
+    if auth_type == "native":
+        record = service.connect_native(service_name)
+        _print_connect_success(
+            service_name,
+            record.kind,
+            str(service.secret_store_path),
+            source="native fallback",
+        )
+        return
+
+    values = _prompt_for_secret_values(service, service_name, pairs)
+    record = service.connect_secret(service_name, values)
+    _print_connect_success(
+        service_name,
+        record.kind,
+        str(service.secret_store_path),
+        sorted(record.data),
+    )
+
+
+@auth.command("disconnect")
+@click.argument("service_name", type=str)
+def disconnect_auth(service_name: str) -> None:
+    """Remove stored secret/native auth for a service."""
+    service = _build_auth_service()
+    removed = service.disconnect(service_name)
+    if not removed:
+        raise click.ClickException(f"No stored auth found for '{service_name}'.")
+    console.print(f"[green]ok[/green] Removed stored auth for {service_name}")
+
+
+@auth.command("doctor")
+def auth_doctor() -> None:
+    """Show only auth-related doctor results."""
+    service = _build_auth_service()
+    summaries = asyncio.run(service.list_summaries())
+    failures = [s for s in summaries if s.status not in {AuthStatus.AUTHED, AuthStatus.UNKNOWN}]
+    for summary in summaries:
+        style = "green" if summary.status == AuthStatus.AUTHED else "yellow"
+        console.print(
+            f"[{style}]{summary.service}[/{style}] {summary.status.value}: {summary.message}"
+        )
+    if failures:
+        raise click.ClickException("One or more services need auth setup.")

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -321,7 +321,7 @@ def connect_auth(
     if auth_type == "oauth":
         user_email = _resolve_user_email(user_email)
         if service_name in {"gws", "google-drive", "gmail", "google-calendar"}:
-            run_google_oauth_setup(user_email=user_email)
+            run_google_oauth_setup(user_email=user_email, service_name=service_name)
             return
         if service_name == "x":
             run_x_oauth_setup(user_email=user_email)

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -16,7 +16,7 @@ import sys
 
 import click
 
-from nexus.cli.commands.auth_cli import auth as auth_group
+from nexus.fs._auth_cli import auth as auth_group
 
 
 @click.group(invoke_without_command=True)

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -16,6 +16,8 @@ import sys
 
 import click
 
+from nexus.cli.commands.auth_cli import auth as auth_group
+
 
 @click.group(invoke_without_command=True)
 @click.version_option(package_name="nexus-fs")
@@ -126,6 +128,9 @@ def playground(uris: tuple[str, ...]) -> None:
 
     app = PlaygroundApp(uris=uris)
     app.run()
+
+
+main.add_command(auth_group)
 
 
 if __name__ == "__main__":

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -6,12 +6,15 @@ import asyncio
 import importlib as _il
 import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
+from cryptography.fernet import Fernet
 
 from nexus.cli.utils import console
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.security.secret_file import write_secret_file
 
 if TYPE_CHECKING:
     from nexus.bricks.auth.oauth.providers.x import XOAuthProvider
@@ -20,21 +23,46 @@ else:
     XOAuthProvider = _il.import_module("nexus.bricks.auth.oauth.providers.x").XOAuthProvider
     TokenManager = _il.import_module("nexus.bricks.auth.oauth.token_manager").TokenManager
 
+_DEFAULT_DB_PATH = Path("~/.nexus/nexus.db").expanduser()
+_DEFAULT_OAUTH_KEY_PATH = Path("~/.nexus/auth/oauth.key").expanduser()
+
+
+def get_fs_database_url() -> str | None:
+    """Resolve the standalone nexus-fs database URL.
+
+    Unlike the full Nexus CLI, nexus-fs defaults to local SQLite. It only
+    uses a network/shared database when explicitly pointed there.
+    """
+    return os.getenv("NEXUS_FS_DATABASE_URL")
+
+
+def get_oauth_encryption_key() -> str:
+    """Load or create the local persisted OAuth encryption key for nexus-fs."""
+    env_key = os.getenv("NEXUS_OAUTH_ENCRYPTION_KEY", "").strip()
+    if env_key:
+        return env_key
+
+    if _DEFAULT_OAUTH_KEY_PATH.exists():
+        return _DEFAULT_OAUTH_KEY_PATH.read_text().strip()
+
+    key = Fernet.generate_key().decode("utf-8")
+    write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
+    console.print(f"[dim]Created local OAuth encryption key: {_DEFAULT_OAUTH_KEY_PATH}[/dim]")
+    return key
+
 
 def get_token_manager(db_path: str | None = None) -> TokenManager:
     """Create the OAuth token manager for nexus-fs."""
-    from nexus.lib.env import get_database_url
-
-    db_url = get_database_url()
+    db_url = get_fs_database_url()
+    encryption_key = get_oauth_encryption_key()
     if db_url:
-        return TokenManager(db_url=db_url)
+        return TokenManager(db_url=db_url, encryption_key=encryption_key)
     if db_path is None:
-        home = os.path.expanduser("~")
-        db_path = os.path.join(home, ".nexus", "nexus.db")
+        db_path = str(_DEFAULT_DB_PATH)
     parent_dir = os.path.dirname(db_path)
     if parent_dir:
         os.makedirs(parent_dir, exist_ok=True)
-    return TokenManager(db_path=db_path)
+    return TokenManager(db_path=db_path, encryption_key=encryption_key)
 
 
 def run_google_oauth_setup(

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -26,6 +26,28 @@ else:
 _DEFAULT_DB_PATH = Path("~/.nexus/nexus.db").expanduser()
 _DEFAULT_OAUTH_KEY_PATH = Path("~/.nexus/auth/oauth.key").expanduser()
 
+_GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
+    "gws": [
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/drive.file",
+        "https://www.googleapis.com/auth/documents",
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/calendar",
+        "https://www.googleapis.com/auth/chat.spaces.readonly",
+    ],
+    "google-drive": [
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/drive.file",
+    ],
+    "gmail": [
+        "https://www.googleapis.com/auth/gmail.modify",
+    ],
+    "google-calendar": [
+        "https://www.googleapis.com/auth/calendar",
+    ],
+}
+
 
 def get_fs_database_url() -> str | None:
     """Resolve the standalone nexus-fs database URL.
@@ -68,6 +90,7 @@ def get_token_manager(db_path: str | None = None) -> TokenManager:
 def run_google_oauth_setup(
     *,
     user_email: str,
+    service_name: str = "gws",
     client_id: str | None = None,
     client_secret: str | None = None,
     db_path: str | None = None,
@@ -93,11 +116,8 @@ def run_google_oauth_setup(
         client_id=client_id,
         client_secret=client_secret,
         redirect_uri="http://localhost",
-        scopes=[
-            "https://www.googleapis.com/auth/drive",
-            "https://www.googleapis.com/auth/drive.file",
-        ],
-        provider_name="google-drive",
+        scopes=_GOOGLE_SERVICE_SCOPES.get(service_name, _GOOGLE_SERVICE_SCOPES["gws"]),
+        provider_name=service_name,
     )
     auth_url = provider.get_authorization_url()
 

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -7,24 +7,15 @@ import importlib as _il
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any
 
 import click
 from cryptography.fernet import Fernet
-
-from nexus.cli.utils import console
-from nexus.contracts.constants import ROOT_ZONE_ID
-from nexus.security.secret_file import write_secret_file
-
-if TYPE_CHECKING:
-    from nexus.bricks.auth.oauth.providers.x import XOAuthProvider
-    from nexus.bricks.auth.oauth.token_manager import TokenManager
-else:
-    XOAuthProvider = _il.import_module("nexus.bricks.auth.oauth.providers.x").XOAuthProvider
-    TokenManager = _il.import_module("nexus.bricks.auth.oauth.token_manager").TokenManager
+from rich.console import Console
 
 _DEFAULT_DB_PATH = Path("~/.nexus/nexus.db").expanduser()
 _DEFAULT_OAUTH_KEY_PATH = Path("~/.nexus/auth/oauth.key").expanduser()
+console = Console()
 
 _GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
     "gws": [
@@ -56,6 +47,31 @@ _GOOGLE_SERVICE_PROVIDER_NAMES: dict[str, str] = {
 }
 
 
+def _root_zone_id() -> str:
+    try:
+        constants = _il.import_module("nexus.contracts.constants")
+        value = getattr(constants, "ROOT_ZONE_ID", None)
+        if value:
+            return str(value)
+    except Exception:
+        pass
+    return "root"
+
+
+def _write_secret_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    os.chmod(path, 0o600)
+
+
+def _get_token_manager_cls() -> Any:
+    return _il.import_module("nexus.bricks.auth.oauth.token_manager").TokenManager
+
+
+def _get_x_oauth_provider_cls() -> Any:
+    return _il.import_module("nexus.bricks.auth.oauth.providers.x").XOAuthProvider
+
+
 def get_fs_database_url() -> str | None:
     """Resolve the standalone nexus-fs database URL.
 
@@ -75,23 +91,23 @@ def get_oauth_encryption_key() -> str:
         return _DEFAULT_OAUTH_KEY_PATH.read_text().strip()
 
     key = Fernet.generate_key().decode("utf-8")
-    write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
+    _write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
     console.print(f"[dim]Created local OAuth encryption key: {_DEFAULT_OAUTH_KEY_PATH}[/dim]")
     return key
 
 
-def get_token_manager(db_path: str | None = None) -> TokenManager:
+def get_token_manager(db_path: str | None = None) -> Any:
     """Create the OAuth token manager for nexus-fs."""
     db_url = get_fs_database_url()
     encryption_key = get_oauth_encryption_key()
     if db_url:
-        return TokenManager(db_url=db_url, encryption_key=encryption_key)
+        return _get_token_manager_cls()(db_url=db_url, encryption_key=encryption_key)
     if db_path is None:
         db_path = str(_DEFAULT_DB_PATH)
     parent_dir = os.path.dirname(db_path)
     if parent_dir:
         os.makedirs(parent_dir, exist_ok=True)
-    return TokenManager(db_path=db_path, encryption_key=encryption_key)
+    return _get_token_manager_cls()(db_path=db_path, encryption_key=encryption_key)
 
 
 def run_google_oauth_setup(
@@ -146,11 +162,11 @@ def run_google_oauth_setup(
             provider=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
             user_email=user_email,
             credential=credential,
-            zone_id=zone_id or ROOT_ZONE_ID,
+            zone_id=zone_id or _root_zone_id(),
             created_by=user_email,
         )
         manager.close()
-        return cred_id
+        return str(cred_id)
 
     try:
         cred_id = asyncio.run(_exchange_and_store())
@@ -175,7 +191,7 @@ def run_x_oauth_setup(
     if not client_id:
         raise click.ClickException("X OAuth client ID not provided. Set NEXUS_OAUTH_X_CLIENT_ID.")
 
-    provider = XOAuthProvider(
+    provider = _get_x_oauth_provider_cls()(
         client_id=client_id,
         redirect_uri="http://localhost",
         scopes=[
@@ -214,11 +230,11 @@ def run_x_oauth_setup(
             provider="twitter",
             user_email=user_email,
             credential=credential,
-            zone_id=zone_id or ROOT_ZONE_ID,
+            zone_id=zone_id or _root_zone_id(),
             created_by=user_email,
         )
         manager.close()
-        return cred_id
+        return str(cred_id)
 
     try:
         cred_id = asyncio.run(_exchange_and_store())

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -1,0 +1,174 @@
+"""Standalone OAuth helpers for the nexus-fs CLI surface."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib as _il
+import os
+import sys
+from typing import TYPE_CHECKING
+
+import click
+
+from nexus.cli.utils import console
+from nexus.contracts.constants import ROOT_ZONE_ID
+
+if TYPE_CHECKING:
+    from nexus.bricks.auth.oauth.providers.x import XOAuthProvider
+    from nexus.bricks.auth.oauth.token_manager import TokenManager
+else:
+    XOAuthProvider = _il.import_module("nexus.bricks.auth.oauth.providers.x").XOAuthProvider
+    TokenManager = _il.import_module("nexus.bricks.auth.oauth.token_manager").TokenManager
+
+
+def get_token_manager(db_path: str | None = None) -> TokenManager:
+    """Create the OAuth token manager for nexus-fs."""
+    from nexus.lib.env import get_database_url
+
+    db_url = get_database_url()
+    if db_url:
+        return TokenManager(db_url=db_url)
+    if db_path is None:
+        home = os.path.expanduser("~")
+        db_path = os.path.join(home, ".nexus", "nexus.db")
+    parent_dir = os.path.dirname(db_path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+    return TokenManager(db_path=db_path)
+
+
+def run_google_oauth_setup(
+    *,
+    user_email: str,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    db_path: str | None = None,
+    zone_id: str | None = None,
+) -> None:
+    """Run the Google OAuth browser/code flow for nexus-fs."""
+    GoogleOAuthProvider = _il.import_module(
+        "nexus.bricks.auth.oauth.providers.google"
+    ).GoogleOAuthProvider
+
+    client_id = client_id or os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID")
+    client_secret = client_secret or os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET")
+    if not client_id:
+        raise click.ClickException(
+            "Google OAuth client ID not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_ID first."
+        )
+    if not client_secret:
+        raise click.ClickException(
+            "Google OAuth client secret not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_SECRET first."
+        )
+
+    provider = GoogleOAuthProvider(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri="http://localhost",
+        scopes=[
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file",
+        ],
+        provider_name="google-drive",
+    )
+    auth_url = provider.get_authorization_url()
+
+    console.print("\n[bold green]Google OAuth Setup[/bold green]")
+    console.print(f"\n[bold]User:[/bold] {user_email}")
+    console.print(f"[bold]Client ID:[/bold] {client_id}")
+    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
+    console.print(f"\n{auth_url}\n")
+    console.print(
+        "[bold yellow]Step 2:[/bold yellow] After granting permission, the browser will redirect to localhost."
+    )
+    console.print("[bold yellow]Step 3:[/bold yellow] Copy the `code` parameter from that URL.")
+    auth_code = click.prompt("\nEnter authorization code")
+
+    async def _exchange_and_store() -> str:
+        credential = await provider.exchange_code(auth_code)
+        manager = get_token_manager(db_path)
+        cred_id = await manager.store_credential(
+            provider="google",
+            user_email=user_email,
+            credential=credential,
+            zone_id=zone_id or ROOT_ZONE_ID,
+            created_by=user_email,
+        )
+        manager.close()
+        return cred_id
+
+    try:
+        cred_id = asyncio.run(_exchange_and_store())
+        console.print(f"\n[green]ok[/green] stored Google OAuth credentials for {user_email}")
+        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
+    except Exception as exc:
+        console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
+        sys.exit(1)
+
+
+def run_x_oauth_setup(
+    *,
+    user_email: str,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    db_path: str | None = None,
+    zone_id: str | None = None,
+) -> None:
+    """Run the X OAuth browser/code flow for nexus-fs."""
+    client_id = client_id or os.getenv("NEXUS_OAUTH_X_CLIENT_ID")
+    client_secret = client_secret or os.getenv("NEXUS_OAUTH_X_CLIENT_SECRET")
+    if not client_id:
+        raise click.ClickException("X OAuth client ID not provided. Set NEXUS_OAUTH_X_CLIENT_ID.")
+
+    provider = XOAuthProvider(
+        client_id=client_id,
+        redirect_uri="http://localhost",
+        scopes=[
+            "tweet.read",
+            "tweet.write",
+            "tweet.moderate.write",
+            "users.read",
+            "follows.read",
+            "offline.access",
+            "bookmark.read",
+            "bookmark.write",
+            "list.read",
+            "like.read",
+            "like.write",
+        ],
+        provider_name="x",
+        client_secret=client_secret,
+    )
+    auth_url, pkce_data = provider.get_authorization_url_with_pkce()
+    code_verifier = pkce_data["code_verifier"]
+
+    console.print("\n[bold green]X OAuth Setup[/bold green]")
+    console.print(f"\n[bold]User:[/bold] {user_email}")
+    console.print(f"[bold]Client ID:[/bold] {client_id}")
+    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
+    console.print(f"\n{auth_url}\n")
+    console.print(
+        "[bold yellow]Step 2:[/bold yellow] Copy the `code` parameter from the redirect URL."
+    )
+    auth_code = click.prompt("\nEnter authorization code")
+
+    async def _exchange_and_store() -> str:
+        credential = await provider.exchange_code_pkce(auth_code, code_verifier)
+        manager = get_token_manager(db_path)
+        cred_id = await manager.store_credential(
+            provider="twitter",
+            user_email=user_email,
+            credential=credential,
+            zone_id=zone_id or ROOT_ZONE_ID,
+            created_by=user_email,
+        )
+        manager.close()
+        return cred_id
+
+    try:
+        cred_id = asyncio.run(_exchange_and_store())
+        console.print(f"\n[green]ok[/green] stored X OAuth credentials for {user_email}")
+        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
+    except Exception as exc:
+        console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
+        sys.exit(1)

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -48,6 +48,13 @@ _GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
     ],
 }
 
+_GOOGLE_SERVICE_PROVIDER_NAMES: dict[str, str] = {
+    "gws": "google",
+    "google-drive": "google-drive",
+    "gmail": "gmail",
+    "google-calendar": "google-calendar",
+}
+
 
 def get_fs_database_url() -> str | None:
     """Resolve the standalone nexus-fs database URL.
@@ -117,7 +124,7 @@ def run_google_oauth_setup(
         client_secret=client_secret,
         redirect_uri="http://localhost",
         scopes=_GOOGLE_SERVICE_SCOPES.get(service_name, _GOOGLE_SERVICE_SCOPES["gws"]),
-        provider_name=service_name,
+        provider_name=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
     )
     auth_url = provider.get_authorization_url()
 
@@ -136,7 +143,7 @@ def run_google_oauth_setup(
         credential = await provider.exchange_code(auth_code)
         manager = get_token_manager(db_path)
         cred_id = await manager.store_credential(
-            provider="google",
+            provider=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
             user_email=user_email,
             credential=credential,
             zone_id=zone_id or ROOT_ZONE_ID,

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -1175,8 +1175,6 @@ class PlaygroundApp(App[None]):
 
     async def action_submit_command(self) -> None:
         """Submit the current command buffer."""
-        if await self._mount_selected_picker_uri():
-            return
         if self.picker_input_visible:
             picker_input = self.query_one("#picker-input", Input)
             value = picker_input.value.strip()
@@ -1184,6 +1182,8 @@ class PlaygroundApp(App[None]):
                 await self._mount_uri(value)
             else:
                 self.notify("Mount URI is required.", severity="warning", timeout=4)
+            return
+        if await self._mount_selected_picker_uri():
             return
         if not self.command_visible:
             return

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -467,6 +467,7 @@ class PlaygroundApp(App[None]):
             restored = f"[yellow]Restored {len(self._mount_points)} mount(s) from the previous session.[/yellow]  "
         banner.update(
             f"{restored}[bold]Add Mount:[/bold] `a`  "
+            "[bold]Open:[/bold] `Enter` selected folder/file  "
             "[bold]Ops:[/bold] `n` file  `N` dir  `r` rename  `d` delete  `p` preview"
         )
 

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -492,6 +492,9 @@ class PlaygroundApp(App[None]):
             )
         elif uri.startswith("s3://"):
             guidance.append("S3 mount. Enter `s3://bucket` or `s3://bucket/prefix`.")
+            guidance.append(
+                "If AWS credentials are available, concrete `s3://...` bucket rows appear in this picker and can be mounted directly."
+            )
             guidance.append(self._auth_guidance("s3"))
         elif uri.startswith("gcs://"):
             guidance.append(
@@ -1029,6 +1032,7 @@ class PlaygroundApp(App[None]):
             ("s3://bucket/<prefix>", "mountable auth:s3"),
             ("gcs://project/bucket", "mountable auth:gcs"),
         ]
+        rows.extend(self._discovered_s3_bucket_rows())
         for info in ConnectorRegistry.list_all():
             uri = self._connector_uri_example(info.name)
             if uri is None:
@@ -1044,6 +1048,29 @@ class PlaygroundApp(App[None]):
             seen.add(row[0])
             deduped.append(row)
         return deduped
+
+    def _discovered_s3_bucket_rows(self) -> list[tuple[str, str]]:
+        """Return concrete S3 buckets when AWS credentials can enumerate them."""
+        try:
+            import boto3
+            from botocore.config import Config
+        except Exception:
+            return []
+
+        try:
+            client = boto3.client("s3", config=Config(connect_timeout=2, read_timeout=3))
+            response = client.list_buckets()
+        except Exception:
+            return []
+
+        buckets = response.get("Buckets") or []
+        rows: list[tuple[str, str]] = []
+        for bucket in buckets:
+            name = str(bucket.get("Name") or "").strip()
+            if not name:
+                continue
+            rows.append((f"s3://{name}", "mountable auth:s3 discovered"))
+        return rows
 
     def _connector_uri_example(self, connector_name: str) -> str | None:
         """Concrete URI example for a registered connector."""

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal
+from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
 from textual.widgets import DataTable, Footer, Header, Input, Static
 
@@ -128,6 +128,13 @@ class PlaygroundApp(App[None]):
     #main-area {
         height: 1fr;
     }
+    #playground-banner {
+        width: 100%;
+        height: auto;
+        background: $surface;
+        color: $text;
+        padding: 0 1;
+    }
     #status-bar {
         dock: bottom;
         height: 1;
@@ -154,6 +161,19 @@ class PlaygroundApp(App[None]):
     #connector-picker {
         width: 1fr;
         height: 1fr;
+    }
+    #picker-layout {
+        width: 1fr;
+        height: 1fr;
+    }
+    #picker-help {
+        height: auto;
+        padding: 0 1 1 1;
+        color: $text-muted;
+    }
+    #picker-input {
+        width: 100%;
+        display: none;
     }
     #too-small-message {
         width: 100%;
@@ -185,6 +205,7 @@ class PlaygroundApp(App[None]):
     command_visible: reactive[bool] = reactive(False)
     command_buffer: reactive[str] = reactive("")
     picker_visible: reactive[bool] = reactive(False)
+    picker_input_visible: reactive[bool] = reactive(False)
     _crud_mode: str = ""  # "", "new_file", "new_dir", "rename", "delete_confirm"
 
     def __init__(self, uris: tuple[str, ...] = (), **kwargs: Any) -> None:
@@ -194,6 +215,9 @@ class PlaygroundApp(App[None]):
         self._mount_points: list[str] = []
         self._current_path: str = "/"
         self._crud_rename_source: str = ""
+        self._restored_mounts = False
+        self._picker_title = "Supported connectors"
+        self._picker_pending_uri: str | None = None
 
     async def on_mount(self) -> None:
         """Initialize filesystem and load mounts."""
@@ -234,6 +258,7 @@ class PlaygroundApp(App[None]):
                 with open(mounts_file) as f:
                     saved_uris = json.load(f)
                 if saved_uris:
+                    self._restored_mounts = True
                     return await self._build_filesystem(tuple(saved_uris))
             except Exception:
                 pass  # Fall through to empty state
@@ -321,6 +346,9 @@ class PlaygroundApp(App[None]):
         empty = self.query_one("#empty-state", Static)
         empty.display = False
         self.picker_visible = False
+        self.picker_input_visible = False
+        self._picker_pending_uri = None
+        self._update_banner()
 
         # Load first mount and focus the file table
         if self._mount_points:
@@ -339,21 +367,38 @@ class PlaygroundApp(App[None]):
         empty.display = True
         empty.update(
             f"[bold]{title}[/bold]\n"
-            "[dim]Browse connectors below, press Enter to mount, or press a later to reopen this picker.[/dim]"
+            "[dim]Browse connectors below, press Enter to continue, and complete any required values directly in the TUI.[/dim]"
         )
+
+        layout = Vertical(id="picker-layout")
+        await main.mount(layout)
+
+        picker_help = Static("", id="picker-help")
+        await layout.mount(picker_help)
 
         picker = DataTable(id="connector-picker")
         picker.cursor_type = "row"
         picker.add_columns("Connector", "Mode")
         for uri, mode in self._supported_connector_rows():
             picker.add_row(uri, mode)
-        await main.mount(picker)
+        await layout.mount(picker)
+
+        picker_input = self.query_one("#picker-input", Input)
+        picker_input.display = False
+        picker_input.value = ""
+        picker_input.placeholder = ""
+
         self.picker_visible = True
+        self.picker_input_visible = False
+        self._picker_title = title
+        self._picker_pending_uri = None
         if picker.row_count:
             picker.move_cursor(row=0, column=0)
+            self._update_picker_help_for_row(0)
         picker.focus()
+        self._update_banner()
         self.query_one("#status-bar", Static).update(
-            "[dim]Connector picker | arrows to browse | Enter to mount | : for auth/help[/dim]"
+            "[dim]Mount wizard | arrows to browse | Enter to continue | Esc back | a reopen later[/dim]"
         )
 
     async def _mount_selected_picker_uri(self) -> bool:
@@ -371,11 +416,102 @@ class PlaygroundApp(App[None]):
             uri = str(picker.get_row_at(cursor_row)[0])
         except Exception:
             return False
-        await self._mount_uri(uri)
+        await self._handle_picker_uri(uri)
         return True
+
+    async def _handle_picker_uri(self, uri: str) -> None:
+        """Either mount directly or prompt for URI details in the picker."""
+        if self._uri_requires_customization(uri):
+            self._show_picker_input(uri)
+            return
+        await self._mount_uri(uri)
+
+    def _uri_requires_customization(self, uri: str) -> bool:
+        """Whether a picker row needs user input before mounting."""
+        return "<" in uri or uri == "local://./data"
+
+    def _picker_input_defaults(self, uri: str) -> tuple[str, str]:
+        """Prefill and placeholder for a wizard URI input."""
+        cwd = os.getcwd()
+        if uri == "local://./data":
+            return (f"local://{cwd}/data", "local:///absolute/path")
+        if uri.startswith("s3://"):
+            return ("s3://", "s3://bucket[/prefix]")
+        if uri.startswith("gcs://"):
+            return ("gcs://", "gcs://project/bucket[/prefix]")
+        return (uri, uri)
+
+    def _show_picker_input(self, uri: str) -> None:
+        """Switch the mount wizard into URI input mode."""
+        picker_input = self.query_one("#picker-input", Input)
+        value, placeholder = self._picker_input_defaults(uri)
+        picker_input.value = value
+        picker_input.placeholder = placeholder
+        self._picker_pending_uri = uri
+        self.picker_input_visible = True
+        self._update_picker_help(uri=uri, awaiting_input=True)
+        picker_input.focus()
+
+    def _update_banner(self) -> None:
+        """Render a visible top-of-screen summary of available actions."""
+        banner = self.query_one("#playground-banner", Static)
+        if self.picker_visible:
+            banner.update(
+                "[bold]Add Mount[/bold] Browse supported connectors, press Enter to continue, "
+                "and finish setup in the TUI. [dim]Keys:[/dim] arrows browse  Enter continue  Esc back"
+            )
+            return
+
+        restored = ""
+        if self._restored_mounts and self._mount_points:
+            restored = f"[yellow]Restored {len(self._mount_points)} mount(s) from the previous session.[/yellow]  "
+        banner.update(
+            f"{restored}[bold]Add Mount:[/bold] `a`  "
+            "[bold]Ops:[/bold] `n` file  `N` dir  `r` rename  `d` delete  `p` preview"
+        )
+
+    def _update_picker_help_for_row(self, row_index: int) -> None:
+        """Refresh picker help for the highlighted connector row."""
+        try:
+            picker = self.query_one("#connector-picker", DataTable)
+            uri = str(picker.get_row_at(row_index)[0])
+        except Exception:
+            return
+        self._update_picker_help(uri=uri, awaiting_input=self.picker_input_visible)
+
+    def _update_picker_help(self, *, uri: str, awaiting_input: bool) -> None:
+        """Render contextual guidance for the selected picker row."""
+        help_widget = self.query_one("#picker-help", Static)
+        guidance: list[str] = []
+        if uri.startswith("local://"):
+            guidance.append("Local folder mount. Choose any absolute path on disk.")
+            guidance.append(
+                "After mounting you can create files with `n`, directories with `N`, and preview with `p`."
+            )
+        elif uri.startswith("s3://"):
+            guidance.append("S3 mount. Enter `s3://bucket` or `s3://bucket/prefix`.")
+            guidance.append(self._auth_guidance("s3"))
+        elif uri.startswith("gcs://"):
+            guidance.append(
+                "GCS mount. Enter `gcs://project/bucket` or `gcs://project/bucket/prefix`."
+            )
+            guidance.append(self._auth_guidance("gcs"))
+        elif uri.startswith(("gws://", "gdrive://", "gmail://", "calendar://")):
+            guidance.append(f"Google mount target: `{uri}`.")
+            guidance.append(self._auth_guidance("gws"))
+        else:
+            guidance.append(f"Mount target: `{uri}`.")
+        if awaiting_input:
+            guidance.append(
+                "Edit the URI below and press Enter to mount, or Esc to return to the list."
+            )
+        else:
+            guidance.append("Press Enter to mount this target.")
+        help_widget.update("\n".join(guidance))
 
     def compose(self) -> ComposeResult:
         yield Header()
+        yield Static("", id="playground-banner")
         yield Static("", id="too-small-message")
         empty = Static(
             "[dim]Loading mounts…[/dim]",
@@ -388,6 +524,7 @@ class PlaygroundApp(App[None]):
             placeholder="Search files… (Enter to search, Escape to cancel)",
             id="search-input",
         )
+        yield Input(placeholder="", id="picker-input")
         yield Static("", id="command-bar")
         yield Input(placeholder="", id="crud-input")
         yield Static("", id="status-bar")
@@ -454,10 +591,24 @@ class PlaygroundApp(App[None]):
             uri = str(event.data_table.get_row_at(event.cursor_row)[0])
         except Exception:
             return
-        await self._mount_uri(uri)
+        await self._handle_picker_uri(uri)
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Refresh picker guidance while the selection changes."""
+        if event.data_table.id != "connector-picker":
+            return
+        self._update_picker_help_for_row(event.cursor_row)
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
         """Route input submissions to search or CRUD handler."""
+        if event.input.id == "picker-input":
+            value = event.value.strip()
+            if value:
+                await self._mount_uri(value)
+                return
+            self.notify("Mount URI is required.", severity="warning", timeout=4)
+            return
+
         # CRUD input
         if event.input.id == "crud-input":
             await self._on_crud_input_submitted(event.value.strip())
@@ -615,12 +766,7 @@ class PlaygroundApp(App[None]):
 
         if command == "mount":
             if not arg:
-                self.notify(
-                    "Usage: /mount local://./data or /mount s3://bucket[/prefix]",
-                    severity="warning",
-                    timeout=4,
-                )
-                self._refocus_table()
+                await self._show_connector_picker("Add a mount")
                 return
             await self._mount_uri(arg)
             self._refocus_table()
@@ -675,6 +821,7 @@ class PlaygroundApp(App[None]):
         self._uris = next_uris
         self._fs = fs
         self._mount_points = fs.list_mounts()
+        self._restored_mounts = False
         self._persist_mounts()
         await self._reset_browser_ui()
         self.notify(f"Mounted {uri}", timeout=3)
@@ -1030,6 +1177,14 @@ class PlaygroundApp(App[None]):
         """Submit the current command buffer."""
         if await self._mount_selected_picker_uri():
             return
+        if self.picker_input_visible:
+            picker_input = self.query_one("#picker-input", Input)
+            value = picker_input.value.strip()
+            if value:
+                await self._mount_uri(value)
+            else:
+                self.notify("Mount URI is required.", severity="warning", timeout=4)
+            return
         if not self.command_visible:
             return
         await self._on_command_input_submitted(self.command_buffer.strip())
@@ -1046,6 +1201,16 @@ class PlaygroundApp(App[None]):
         self.command_visible = False
         self.command_buffer = ""
         self._refocus_table()
+
+    def watch_picker_input_visible(self, visible: bool) -> None:
+        """Show or hide the mount wizard URI input."""
+        try:
+            picker_input = self.query_one("#picker-input", Input)
+            picker_input.display = visible
+            if visible:
+                picker_input.focus()
+        except Exception:
+            pass
 
     def watch_search_visible(self, visible: bool) -> None:
         """Show/hide search input."""
@@ -1192,6 +1357,18 @@ class PlaygroundApp(App[None]):
             self.exit()
             return
         if event.key == "escape":
+            if self.picker_visible and self.picker_input_visible:
+                self.picker_input_visible = False
+                self._picker_pending_uri = None
+                picker_input = self.query_one("#picker-input", Input)
+                picker_input.value = ""
+                self._update_picker_help_for_row(
+                    self.query_one("#connector-picker", DataTable).cursor_row
+                )
+                self._refocus_table()
+                event.prevent_default()
+                return
+
             # Close CRUD input
             if self._crud_mode:
                 self._crud_mode = ""

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -1027,12 +1027,14 @@ class PlaygroundApp(App[None]):
 
         _register_optional_backends()
 
-        rows: list[tuple[str, str]] = [
-            ("local://./data", "mountable"),
-            ("s3://bucket/<prefix>", "mountable auth:s3"),
-            ("gcs://project/bucket", "mountable auth:gcs"),
-        ]
+        rows: list[tuple[str, str]] = [("local://./data", "mountable")]
         rows.extend(self._discovered_s3_bucket_rows())
+        rows.extend(
+            [
+                ("s3://<enter bucket manually>", "mountable auth:s3 manual"),
+                ("gcs://project/bucket", "mountable auth:gcs"),
+            ]
+        )
         for info in ConnectorRegistry.list_all():
             uri = self._connector_uri_example(info.name)
             if uri is None:

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -811,6 +811,10 @@ class PlaygroundApp(App[None]):
 
     async def _mount_uri(self, uri: str) -> None:
         """Mount a new backend URI into the playground."""
+        error = self._validate_mount_uri(uri)
+        if error:
+            self.notify(error, severity="warning", timeout=5)
+            return
         next_uris = (*self._uris, uri)
         try:
             fs = await self._build_filesystem(next_uris)
@@ -825,6 +829,17 @@ class PlaygroundApp(App[None]):
         self._persist_mounts()
         await self._reset_browser_ui()
         self.notify(f"Mounted {uri}", timeout=3)
+
+    def _validate_mount_uri(self, uri: str) -> str | None:
+        """Return a user-facing error if the requested mount URI is incomplete."""
+        value = uri.strip()
+        if not value:
+            return "Mount URI is required."
+        if value in {"s3://", "s3:///"}:
+            return "S3 mounts require a bucket, for example `s3://my-bucket`."
+        if value in {"gcs://", "gcs:///"}:
+            return "GCS mounts require a bucket, for example `gcs://project/my-bucket`."
+        return None
 
     async def _touch_path(self, name: str) -> None:
         """Create an empty file in the current directory."""

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -1033,7 +1033,7 @@ class PlaygroundApp(App[None]):
         try:
             from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
             from nexus.bricks.auth.unified_service import UnifiedAuthService
-            from nexus.cli.commands.oauth import get_token_manager
+            from nexus.fs._oauth_support import get_token_manager
 
             oauth_service = OAuthCredentialService(token_manager=get_token_manager())
             auth_service = UnifiedAuthService(oauth_service=oauth_service)
@@ -1253,7 +1253,7 @@ class PlaygroundApp(App[None]):
 
         try:
             from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
-            from nexus.cli.commands.oauth import get_token_manager
+            from nexus.fs._oauth_support import get_token_manager
 
             oauth_service = OAuthCredentialService(token_manager=get_token_manager())
             creds = await oauth_service.list_credentials()

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from contextlib import suppress
 from typing import Any, cast
 
 from textual.app import App, ComposeResult
@@ -1017,7 +1018,7 @@ class PlaygroundApp(App[None]):
         if connector_name == "gmail_connector":
             return "gmail://inbox"
         if connector_name == "gcalendar_connector":
-            return "calendar://primary"
+            return "gws://calendar"
         if connector_name == "slack_connector":
             return "slack://workspace"
         if connector_name == "x_connector":
@@ -1292,6 +1293,9 @@ class PlaygroundApp(App[None]):
 
         if width < MIN_WIDTH or height < MIN_HEIGHT:
             too_small.display = True
+            for widget_id in ("#playground-banner", "#empty-state", "#main-area", "#status-bar"):
+                with suppress(Exception):
+                    self.query_one(widget_id).display = False
             too_small.update(
                 f"[bold]Terminal too small[/bold]\n"
                 f"Need {MIN_WIDTH}x{MIN_HEIGHT}, got {width}x{height}\n"
@@ -1300,6 +1304,13 @@ class PlaygroundApp(App[None]):
             return
         else:
             too_small.display = False
+            try:
+                self.query_one("#playground-banner", Static).display = True
+                self.query_one("#main-area", Horizontal).display = True
+                self.query_one("#status-bar", Static).display = True
+                self.query_one("#empty-state", Static).display = not bool(self._mount_points)
+            except Exception:
+                pass
 
         # Auto-collapse mount panel at narrow widths
         if width < MOUNT_PANEL_COLLAPSE_WIDTH:

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -7,6 +7,7 @@ Keyboard-only navigation. Responsive: collapses mount panel at < 100 cols.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import json
 import os
 from contextlib import suppress
@@ -1031,12 +1032,12 @@ class PlaygroundApp(App[None]):
             return
 
         try:
-            from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
-            from nexus.bricks.auth.unified_service import UnifiedAuthService
             from nexus.fs._oauth_support import get_token_manager
 
-            oauth_service = OAuthCredentialService(token_manager=get_token_manager())
-            auth_service = UnifiedAuthService(oauth_service=oauth_service)
+            oauth_module = importlib.import_module("nexus.bricks.auth.oauth.credential_service")
+            unified_module = importlib.import_module("nexus.bricks.auth.unified_service")
+            oauth_service = oauth_module.OAuthCredentialService(token_manager=get_token_manager())
+            auth_service = unified_module.UnifiedAuthService(oauth_service=oauth_service)
             result = await auth_service.test_service(service)
         except Exception as exc:
             self.notify(f"{service}: auth test failed to run: {exc}", severity="error", timeout=6)
@@ -1252,10 +1253,10 @@ class PlaygroundApp(App[None]):
             providers = {"x", "twitter"}
 
         try:
-            from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
             from nexus.fs._oauth_support import get_token_manager
 
-            oauth_service = OAuthCredentialService(token_manager=get_token_manager())
+            oauth_module = importlib.import_module("nexus.bricks.auth.oauth.credential_service")
+            oauth_service = oauth_module.OAuthCredentialService(token_manager=get_token_manager())
             creds = await oauth_service.list_credentials()
             emails = sorted(
                 {

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -192,11 +192,12 @@ class PlaygroundApp(App[None]):
         Binding("a", "show_connector_picker", "Add Mount"),
         Binding("c", "copy_path", "Copy path"),
         Binding("p", "preview_file", "Preview"),
-        Binding("m", "toggle_mount_panel", "Mounts"),
+        Binding("m", "focus_mount_panel", "Mounts"),
         Binding("n", "new_file", "New file"),
         Binding("N", "new_dir", "New dir", key_display="N"),
         Binding("d", "delete_selected", "Delete"),
         Binding("r", "rename_selected", "Rename"),
+        Binding("u", "unmount_selected_mount", "Unmount"),
     ]
 
     show_mount_panel: reactive[bool] = reactive(True)
@@ -466,6 +467,7 @@ class PlaygroundApp(App[None]):
             restored = f"[yellow]Restored {len(self._mount_points)} mount(s) from the previous session.[/yellow]  "
         banner.update(
             f"{restored}[bold]Add Mount:[/bold] `a`  "
+            "[bold]Mounts:[/bold] `m` focus  `u` unmount  "
             "[bold]Open:[/bold] `Enter` selected folder/file  "
             "[bold]Ops:[/bold] `n` file  `N` dir  `r` rename  `d` delete  `p` preview"
         )
@@ -928,6 +930,32 @@ class PlaygroundApp(App[None]):
         with open(mounts_file, "w") as f:
             json.dump(list(self._uris), f)
 
+    def _selected_mount_point(self) -> str | None:
+        """Return the currently selected mount point from the mount panel."""
+        try:
+            panel = self.query_one("#mount-panel", MountPanel)
+            return cast(str | None, panel.selected_mount)
+        except Exception:
+            return self._mount_points[0] if self._mount_points else None
+
+    def _uri_mount_point(self, uri: str) -> str:
+        """Compute the mount point produced by a playground URI."""
+        from pathlib import Path as _Path
+
+        from nexus.fs._uri import derive_mount_point, parse_uri
+
+        if uri.startswith("local://"):
+            raw = uri.removeprefix("local://")
+            root = _Path(raw).expanduser().resolve()
+            name = root.name or "local"
+            return f"/local/{name}"
+        if uri.startswith("s3://"):
+            raw = uri.removeprefix("s3://")
+            bucket = raw.split("/", 1)[0]
+            return f"/s3/{bucket}"
+        spec = parse_uri(uri)
+        return derive_mount_point(spec)
+
     def _mount_error_message(self, uri: str, exc: Exception) -> str:
         """Render actionable mount failures."""
         if uri.startswith("s3://"):
@@ -1287,6 +1315,62 @@ class PlaygroundApp(App[None]):
         """Toggle mount panel visibility."""
         self.show_mount_panel = not self.show_mount_panel
 
+    def action_focus_mount_panel(self) -> None:
+        """Focus the mount list for navigation and unmount actions."""
+        try:
+            panel = self.query_one("#mount-panel", MountPanel)
+        except Exception:
+            return
+        if not self.show_mount_panel:
+            self.show_mount_panel = True
+        panel.focus()
+
+    async def action_unmount_selected_mount(self) -> None:
+        """Remove the currently selected mount from the playground session."""
+        if not self._uris:
+            return
+        mount_point = self._selected_mount_point()
+        if not mount_point:
+            return
+        remaining_uris = tuple(
+            uri for uri in self._uris if self._uri_mount_point(uri) != mount_point
+        )
+        if len(remaining_uris) == len(self._uris):
+            self.notify(
+                f"Unmount failed: no mount found for {mount_point}", severity="warning", timeout=4
+            )
+            return
+
+        self._uris = remaining_uris
+        self._restored_mounts = False
+        if not remaining_uris:
+            self._fs = None
+            self._mount_points = []
+            self._persist_mounts()
+            try:
+                main = self.query_one("#main-area", Horizontal)
+                for child in list(main.children):
+                    await child.remove()
+            except Exception:
+                pass
+            empty = self.query_one("#empty-state", Static)
+            empty.display = True
+            await self._show_connector_picker("No mounts configured")
+            self.notify(f"Unmounted {mount_point}", timeout=3)
+            return
+
+        try:
+            fs = await self._build_filesystem(remaining_uris)
+        except Exception as exc:
+            self.notify(f"Unmount failed: {exc}", severity="error", timeout=4)
+            return
+
+        self._fs = fs
+        self._mount_points = fs.list_mounts()
+        self._persist_mounts()
+        await self._reset_browser_ui()
+        self.notify(f"Unmounted {mount_point}", timeout=3)
+
     def watch_show_mount_panel(self, show: bool) -> None:
         """Show/hide mount panel."""
         try:
@@ -1335,6 +1419,29 @@ class PlaygroundApp(App[None]):
 
     async def on_key(self, event: Any) -> None:
         """Handle global key events (quit, escape)."""
+        focused = self.focused
+        if isinstance(focused, MountPanel):
+            if event.key == "up":
+                focused.action_move_up()
+                event.prevent_default()
+                return
+            if event.key == "down":
+                focused.action_move_down()
+                event.prevent_default()
+                return
+            if event.key in {"enter", "return", "ctrl+m"}:
+                mount_point = focused.selected_mount
+                if mount_point:
+                    browser = self.query_one("#file-browser", FileBrowser)
+                    await browser.load_directory(mount_point)
+                    self._current_path = mount_point
+                    self._update_status_bar()
+                event.prevent_default()
+                return
+            if event.key in {"right", "tab"}:
+                self._refocus_table()
+                event.prevent_default()
+                return
         if event.key in {"enter", "return", "ctrl+m"} and await self._mount_selected_picker_uri():
             event.prevent_default()
             return

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -57,7 +57,7 @@ class ContextualNexusFS:
         detail: bool = False,
         recursive: bool = False,
     ) -> list[str] | list[dict[str, Any]]:
-        return cast(
+        result = cast(
             list[str] | list[dict[str, Any]],
             await self._kernel.sys_readdir(
                 path,
@@ -66,6 +66,13 @@ class ContextualNexusFS:
                 context=self._ctx,
             ),
         )
+        if result:
+            return result
+        if recursive:
+            return result
+
+        fallback = await self._list_backend_directory(path, detail=detail)
+        return fallback if fallback is not None else result
 
     async def stat(self, path: str) -> dict[str, Any] | None:
         from nexus.fs._facade import SlimNexusFS
@@ -101,6 +108,65 @@ class ContextualNexusFS:
 
     async def close(self) -> None:
         return None
+
+    async def _list_backend_directory(
+        self,
+        path: str,
+        *,
+        detail: bool,
+    ) -> list[str] | list[dict[str, Any]] | None:
+        """Fallback to backend.list_dir() when slim metadata has no children yet."""
+        import asyncio
+        from datetime import UTC, datetime
+
+        try:
+            route = self._kernel.router.route(path, is_admin=True, check_write=False)
+        except Exception:
+            return None
+
+        backend = route.backend
+        if not hasattr(backend, "list_dir"):
+            return None
+
+        try:
+            raw_entries = await asyncio.to_thread(backend.list_dir, route.backend_path, self._ctx)
+        except NotImplementedError:
+            return None
+
+        now = datetime.now(UTC).isoformat()
+        mount_root = path.rstrip("/") or "/"
+        if detail:
+            detailed: list[dict[str, Any]] = []
+            for entry in raw_entries:
+                name = str(entry).rstrip("/")
+                if not name:
+                    continue
+                is_dir = str(entry).endswith("/")
+                full_path = f"{mount_root}/{name}" if mount_root != "/" else f"/{name}"
+                detailed.append(
+                    {
+                        "path": full_path,
+                        "size": 4096 if is_dir else 0,
+                        "is_directory": is_dir,
+                        "etag": None,
+                        "mime_type": "inode/directory" if is_dir else "application/octet-stream",
+                        "created_at": now,
+                        "modified_at": now,
+                        "version": 0,
+                        "zone_id": "root",
+                        "entry_type": 1 if is_dir else 0,
+                    }
+                )
+            return detailed
+
+        listed: list[str] = []
+        for entry in raw_entries:
+            name = str(entry).rstrip("/")
+            if not name:
+                continue
+            full_path = f"{mount_root}/{name}" if mount_root != "/" else f"/{name}"
+            listed.append(full_path)
+        return listed
 
 
 def _highlight_match(text: str, query_lower: str) -> str:
@@ -983,7 +1049,8 @@ class PlaygroundApp(App[None]):
                 "NEXUS_OAUTH_GOOGLE_CLIENT_SECRET; 2. run `nexus-fs auth connect gws oauth "
                 "--user-email you@example.com`; 3. run `/auth test gws`; "
                 "4. if needed set `NEXUS_FS_USER_EMAIL=you@example.com`; "
-                "5. run `/mount gws://drive` or `/mount gws://gmail`."
+                "5. run `/mount gws://drive` or `/mount gws://gmail`; "
+                "6. for `/mount gws://chat`, re-run auth and approve Chat scopes if prompted."
             )
         if service == "gcs":
             return (
@@ -1097,12 +1164,16 @@ class PlaygroundApp(App[None]):
             return "x://timeline"
         if connector_name == "hn_connector":
             return "hn://top"
+        if connector_name == "gws_github":
+            return None
         if connector_name.startswith("gws_"):
             return f"gws://{connector_name.removeprefix('gws_')}"
         return None
 
     def _connector_auth_service(self, connector_name: str, service_name: str | None) -> str | None:
         """Map connector targets to the auth flow users should follow."""
+        if connector_name == "gws_github":
+            return "github"
         if connector_name.startswith("gws_"):
             return "gws"
         if service_name in {"google-drive", "gmail", "google-calendar", "slack", "x", "gcs"}:

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -187,8 +187,6 @@ class PlaygroundApp(App[None]):
         Binding("b", "go_back", "Back"),
         Binding("/", "toggle_search", "Search", key_display="/"),
         Binding(":", "toggle_command", "Command", key_display=":", priority=True),
-        Binding("enter", "submit_command", "", show=False, priority=True),
-        Binding("ctrl+m", "submit_command", "", show=False, priority=True),
         Binding("backspace", "command_backspace", "", show=False, priority=True),
         Binding("a", "show_connector_picker", "Add Mount"),
         Binding("c", "copy_path", "Copy path"),

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -7,14 +7,15 @@ Keyboard-only navigation. Responsive: collapses mount panel at < 100 cols.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
-from typing import Any
+from typing import Any, cast
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.reactive import reactive
-from textual.widgets import Footer, Header, Input, Static
+from textual.widgets import DataTable, Footer, Header, Input, Static
 
 from nexus.fs._tui.file_browser import FileBrowser
 from nexus.fs._tui.file_preview import FilePreview
@@ -23,6 +24,82 @@ from nexus.fs._tui.mount_panel import MountPanel
 MIN_WIDTH = 80
 MIN_HEIGHT = 24
 MOUNT_PANEL_COLLAPSE_WIDTH = 100
+
+
+class ContextualNexusFS:
+    """Kernel wrapper that uses a caller-selected operation context."""
+
+    def __init__(self, kernel: Any, *, user_id: str = "local") -> None:
+        from nexus.contracts.constants import ROOT_ZONE_ID
+        from nexus.contracts.types import OperationContext
+
+        self._kernel = kernel
+        self._ctx = OperationContext(
+            user_id=user_id,
+            groups=[],
+            zone_id=ROOT_ZONE_ID,
+            is_admin=True,
+        )
+
+    async def read(self, path: str) -> bytes:
+        return cast(bytes, await self._kernel.sys_read(path, context=self._ctx))
+
+    async def read_range(self, path: str, start: int, end: int) -> bytes:
+        return cast(bytes, await self._kernel.read_range(path, start, end, context=self._ctx))
+
+    async def write(self, path: str, content: bytes) -> dict[str, Any]:
+        return cast(dict[str, Any], await self._kernel.write(path, content, context=self._ctx))
+
+    async def ls(
+        self,
+        path: str = "/",
+        detail: bool = False,
+        recursive: bool = False,
+    ) -> list[str] | list[dict[str, Any]]:
+        return cast(
+            list[str] | list[dict[str, Any]],
+            await self._kernel.sys_readdir(
+                path,
+                recursive=recursive,
+                details=detail,
+                context=self._ctx,
+            ),
+        )
+
+    async def stat(self, path: str) -> dict[str, Any] | None:
+        from nexus.fs._facade import SlimNexusFS
+
+        return await SlimNexusFS(self._kernel).stat(path)
+
+    async def mkdir(self, path: str, parents: bool = True) -> None:
+        await self._kernel.mkdir(path, parents=parents, exist_ok=True, context=self._ctx)
+
+    async def rmdir(self, path: str, recursive: bool = False) -> None:
+        await self._kernel.sys_rmdir(path, recursive=recursive, context=self._ctx)
+
+    async def delete(self, path: str) -> None:
+        await self._kernel.sys_unlink(path, context=self._ctx)
+
+    async def rename(self, old_path: str, new_path: str) -> None:
+        await self._kernel.sys_rename(old_path, new_path, context=self._ctx)
+
+    async def exists(self, path: str) -> bool:
+        return cast(bool, await self._kernel.sys_access(path, context=self._ctx))
+
+    async def copy(self, src: str, dst: str) -> dict[str, Any]:
+        content = await self.read(src)
+        return await self.write(dst, content)
+
+    def list_mounts(self) -> list[str]:
+        mounts = []
+        for item in self._kernel.router.list_mounts():
+            mount_point = getattr(item, "mount_point", item)
+            mounts.append(str(mount_point))
+        filtered = [mount for mount in mounts if mount != "/"]
+        return filtered or mounts
+
+    async def close(self) -> None:
+        return None
 
 
 def _highlight_match(text: str, query_lower: str) -> str:
@@ -62,11 +139,21 @@ class PlaygroundApp(App[None]):
         width: 100%;
         display: none;
     }
+    #command-bar {
+        width: 100%;
+        display: none;
+        background: $surface;
+        padding: 0 1;
+    }
     #empty-state {
         width: 100%;
         content-align: center middle;
         padding: 4 2;
         color: $text-muted;
+    }
+    #connector-picker {
+        width: 1fr;
+        height: 1fr;
     }
     #too-small-message {
         width: 100%;
@@ -79,6 +166,11 @@ class PlaygroundApp(App[None]):
         Binding("q", "request_quit", "Quit", priority=True),
         Binding("b", "go_back", "Back"),
         Binding("/", "toggle_search", "Search", key_display="/"),
+        Binding(":", "toggle_command", "Command", key_display=":", priority=True),
+        Binding("enter", "submit_command", "", show=False, priority=True),
+        Binding("ctrl+m", "submit_command", "", show=False, priority=True),
+        Binding("backspace", "command_backspace", "", show=False, priority=True),
+        Binding("a", "show_connector_picker", "Add Mount"),
         Binding("c", "copy_path", "Copy path"),
         Binding("p", "preview_file", "Preview"),
         Binding("m", "toggle_mount_panel", "Mounts"),
@@ -90,6 +182,9 @@ class PlaygroundApp(App[None]):
 
     show_mount_panel: reactive[bool] = reactive(True)
     search_visible: reactive[bool] = reactive(False)
+    command_visible: reactive[bool] = reactive(False)
+    command_buffer: reactive[str] = reactive("")
+    picker_visible: reactive[bool] = reactive(False)
     _crud_mode: str = ""  # "", "new_file", "new_dir", "rename", "delete_confirm"
 
     def __init__(self, uris: tuple[str, ...] = (), **kwargs: Any) -> None:
@@ -111,26 +206,17 @@ class PlaygroundApp(App[None]):
         self._mount_points = fs.list_mounts()
 
         if not self._mount_points:
-            empty = self.query_one("#empty-state", Static)
-            empty.update(
-                "[bold]No mounts configured[/bold]\n\n"
-                'Run: fs = await nexus.fs.mount("s3://bucket")\n'
-                "Then: nexus-fs playground s3://bucket"
-            )
+            await self._show_connector_picker("No mounts configured")
             return
 
         # Build the UI
         await self._build_browser_ui()
 
     async def _resolve_filesystem(self) -> Any:
-        """Mount backends from URIs using direct adapters.
-
-        Always uses direct adapters (LocalDirectFS, S3DirectFS) so users
-        see real files immediately — no NexusFS kernel, no empty metastore.
-        """
+        """Mount backends from URIs using direct or generic adapters."""
         if self._uris:
             try:
-                return self._build_direct_fs(self._uris)
+                return await self._build_filesystem(self._uris)
             except Exception as exc:
                 empty = self.query_one("#empty-state", Static)
                 empty.update(f"[red]Mount failed:[/red] {exc}")
@@ -148,26 +234,15 @@ class PlaygroundApp(App[None]):
                 with open(mounts_file) as f:
                     saved_uris = json.load(f)
                 if saved_uris:
-                    return self._build_direct_fs(tuple(saved_uris))
+                    return await self._build_filesystem(tuple(saved_uris))
             except Exception:
                 pass  # Fall through to empty state
 
-        empty = self.query_one("#empty-state", Static)
-        empty.update(
-            "[bold]No mounts found[/bold]\n\n"
-            "nexus-fs playground s3://bucket\n"
-            "nexus-fs playground local://./data\n"
-            "nexus-fs playground s3://bucket local://./data"
-        )
+        await self._show_connector_picker("No mounts found")
         return None
 
     def _build_direct_fs(self, uris: tuple[str, ...]) -> Any:
-        """Build direct filesystem adapters from URIs.
-
-        local:// → LocalDirectFS (pathlib)
-        s3://    → S3DirectFS (boto3)
-        Multiple → MultiDirectFS (combines them)
-        """
+        """Build direct filesystem adapters for local and S3 URIs."""
         from pathlib import Path as _Path
 
         from nexus.fs._tui.direct_fs import LocalDirectFS, MultiDirectFS, S3DirectFS
@@ -191,9 +266,36 @@ class PlaygroundApp(App[None]):
 
             else:
                 raise ValueError(
-                    f"Unsupported scheme in '{uri}'. Playground supports local:// and s3://"
+                    f"Unsupported direct scheme in '{uri}'. Use the generic mount path for connector-backed URIs."
                 )
 
+        if len(backends) == 1:
+            return backends[0]
+        return MultiDirectFS(backends)
+
+    async def _build_filesystem(self, uris: tuple[str, ...]) -> Any:
+        """Build a hybrid filesystem for playground mounts."""
+        from nexus.fs import mount as mount_fs
+        from nexus.fs._tui.direct_fs import MultiDirectFS
+
+        direct_uris = tuple(uri for uri in uris if uri.startswith(("local://", "s3://")))
+        generic_uris = tuple(uri for uri in uris if uri not in direct_uris)
+        backends: list[Any] = []
+
+        if direct_uris:
+            backends.append(self._build_direct_fs(direct_uris))
+
+        for uri in generic_uris:
+            facade = await mount_fs(uri)
+            backends.append(
+                ContextualNexusFS(
+                    facade.kernel,
+                    user_id=await self._resolve_mount_user_id(uri),
+                )
+            )
+
+        if not backends:
+            raise ValueError("No valid mount URIs provided.")
         if len(backends) == 1:
             return backends[0]
         return MultiDirectFS(backends)
@@ -218,6 +320,7 @@ class PlaygroundApp(App[None]):
         # Remove empty state
         empty = self.query_one("#empty-state", Static)
         empty.display = False
+        self.picker_visible = False
 
         # Load first mount and focus the file table
         if self._mount_points:
@@ -226,6 +329,51 @@ class PlaygroundApp(App[None]):
             self._update_status_bar(announce=False)
             browser.query_one("#file-table").focus()
 
+    async def _show_connector_picker(self, title: str = "Supported connectors") -> None:
+        """Render the interactive connector picker in the main area."""
+        main = self.query_one("#main-area", Horizontal)
+        for child in list(main.children):
+            await child.remove()
+
+        empty = self.query_one("#empty-state", Static)
+        empty.display = True
+        empty.update(
+            f"[bold]{title}[/bold]\n"
+            "[dim]Browse connectors below, press Enter to mount, or press a later to reopen this picker.[/dim]"
+        )
+
+        picker = DataTable(id="connector-picker")
+        picker.cursor_type = "row"
+        picker.add_columns("Connector", "Mode")
+        for uri, mode in self._supported_connector_rows():
+            picker.add_row(uri, mode)
+        await main.mount(picker)
+        self.picker_visible = True
+        if picker.row_count:
+            picker.move_cursor(row=0, column=0)
+        picker.focus()
+        self.query_one("#status-bar", Static).update(
+            "[dim]Connector picker | arrows to browse | Enter to mount | : for auth/help[/dim]"
+        )
+
+    async def _mount_selected_picker_uri(self) -> bool:
+        """Mount the currently highlighted connector-picker row."""
+        if not self.picker_visible:
+            return False
+        try:
+            picker = self.query_one("#connector-picker", DataTable)
+        except Exception:
+            return False
+        if self.focused is not picker or picker.row_count <= 0:
+            return False
+        try:
+            cursor_row = max(0, picker.cursor_row)
+            uri = str(picker.get_row_at(cursor_row)[0])
+        except Exception:
+            return False
+        await self._mount_uri(uri)
+        return True
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static("", id="too-small-message")
@@ -233,13 +381,14 @@ class PlaygroundApp(App[None]):
             "[dim]Loading mounts…[/dim]",
             id="empty-state",
         )
-        empty.can_focus = True
+        empty.can_focus = False
         yield empty
         yield Horizontal(id="main-area")
         yield Input(
             placeholder="Search files… (Enter to search, Escape to cancel)",
             id="search-input",
         )
+        yield Static("", id="command-bar")
         yield Input(placeholder="", id="crud-input")
         yield Static("", id="status-bar")
         yield Footer()
@@ -296,6 +445,16 @@ class PlaygroundApp(App[None]):
             await preview.show_preview(event.path)
         except Exception:
             pass
+
+    async def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """Handle connector picker selection."""
+        if event.data_table.id != "connector-picker":
+            return
+        try:
+            uri = str(event.data_table.get_row_at(event.cursor_row)[0])
+        except Exception:
+            return
+        await self._mount_uri(uri)
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
         """Route input submissions to search or CRUD handler."""
@@ -439,11 +598,345 @@ class PlaygroundApp(App[None]):
 
         self._refocus_table()
 
+    async def _on_command_input_submitted(self, value: str) -> None:
+        """Handle command input submissions."""
+        self.command_visible = False
+        self.command_buffer = ""
+        self.command_visible = False
+
+        if not value:
+            self._refocus_table()
+            return
+
+        normalized = value[1:] if value.startswith("/") else value
+        parts = normalized.split(maxsplit=1)
+        command = parts[0].lower()
+        arg = parts[1].strip() if len(parts) > 1 else ""
+
+        if command == "mount":
+            if not arg:
+                self.notify(
+                    "Usage: /mount local://./data or /mount s3://bucket[/prefix]",
+                    severity="warning",
+                    timeout=4,
+                )
+                self._refocus_table()
+                return
+            await self._mount_uri(arg)
+            self._refocus_table()
+            return
+
+        if command == "touch":
+            if not arg:
+                self.notify("Usage: /touch <name>", severity="warning", timeout=4)
+                self._refocus_table()
+                return
+            await self._touch_path(arg)
+            self._refocus_table()
+            return
+
+        if command == "rm":
+            if not arg:
+                self.notify("Usage: /rm <name>", severity="warning", timeout=4)
+                self._refocus_table()
+                return
+            await self._delete_path(arg)
+            self._refocus_table()
+            return
+
+        if command == "auth":
+            if arg.lower().startswith("test "):
+                service = arg[5:].strip().lower()
+                await self._test_auth(service)
+                self._refocus_table()
+                return
+            service = arg.lower() if arg else "s3"
+            self.notify(self._auth_guidance(service), severity="information", timeout=6)
+            self._refocus_table()
+            return
+
+        if command == "connectors":
+            self.notify(self._connector_summary(), severity="information", timeout=8)
+            self._refocus_table()
+            return
+
+        self.notify(f"Unknown command: {value}", severity="warning", timeout=4)
+        self._refocus_table()
+
+    async def _mount_uri(self, uri: str) -> None:
+        """Mount a new backend URI into the playground."""
+        next_uris = (*self._uris, uri)
+        try:
+            fs = await self._build_filesystem(next_uris)
+        except Exception as exc:
+            self.notify(self._mount_error_message(uri, exc), severity="error", timeout=6)
+            return
+
+        self._uris = next_uris
+        self._fs = fs
+        self._mount_points = fs.list_mounts()
+        self._persist_mounts()
+        await self._reset_browser_ui()
+        self.notify(f"Mounted {uri}", timeout=3)
+
+    async def _touch_path(self, name: str) -> None:
+        """Create an empty file in the current directory."""
+        if not self._fs:
+            return
+        path = self._resolve_command_path(name)
+        try:
+            await self._fs.write(path, b"")
+            browser = self.query_one("#file-browser", FileBrowser)
+            await browser.load_directory(self._current_path)
+            self._update_status_bar()
+            self.notify(f"Created: {path}", timeout=3)
+        except Exception as exc:
+            self.notify(f"Create failed: {exc}", severity="error", timeout=4)
+
+    async def _delete_path(self, name: str) -> None:
+        """Delete a file in the current directory."""
+        if not self._fs:
+            return
+        path = self._resolve_command_path(name)
+        try:
+            await self._fs.delete(path)
+            browser = self.query_one("#file-browser", FileBrowser)
+            await browser.load_directory(self._current_path)
+            self._update_status_bar()
+            self.notify(f"Deleted: {path}", timeout=3)
+        except Exception as exc:
+            self.notify(f"Delete failed: {exc}", severity="error", timeout=4)
+
+    async def _test_auth(self, service: str) -> None:
+        """Validate auth for a service using the unified auth layer when possible."""
+        if not service:
+            self.notify("Usage: /auth test <service>", severity="warning", timeout=4)
+            return
+        if service == "local":
+            self.notify("local: no auth required", severity="information", timeout=4)
+            return
+
+        try:
+            from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
+            from nexus.bricks.auth.unified_service import UnifiedAuthService
+            from nexus.cli.commands.oauth import get_token_manager
+
+            oauth_service = OAuthCredentialService(token_manager=get_token_manager())
+            auth_service = UnifiedAuthService(oauth_service=oauth_service)
+            result = await auth_service.test_service(service)
+        except Exception as exc:
+            self.notify(f"{service}: auth test failed to run: {exc}", severity="error", timeout=6)
+            return
+
+        if result.get("success"):
+            self.notify(f"{service}: {result.get('message')}", severity="information", timeout=5)
+            return
+
+        self.notify(f"{service}: {result.get('message')}", severity="warning", timeout=7)
+
+    def _resolve_command_path(self, name: str) -> str:
+        """Resolve a command argument against the current directory."""
+        if name.startswith("/"):
+            return name
+        base = self._current_path.rstrip("/")
+        if not base:
+            return f"/{name}"
+        return f"{base}/{name}"
+
+    async def _reset_browser_ui(self) -> None:
+        """Rebuild mount panel, browser, and preview from current mounts."""
+        try:
+            main = self.query_one("#main-area", Horizontal)
+            for child in list(main.children):
+                await child.remove()
+        except Exception:
+            return
+
+        empty = self.query_one("#empty-state", Static)
+        empty.display = False
+        await self._build_browser_ui()
+
+    def _persist_mounts(self) -> None:
+        """Persist current mount URIs for the next playground launch."""
+        state_dir = os.environ.get("NEXUS_FS_STATE_DIR") or os.path.join(
+            __import__("tempfile").gettempdir(), "nexus-fs"
+        )
+        os.makedirs(state_dir, exist_ok=True)
+        mounts_file = os.path.join(state_dir, "mounts.json")
+        with open(mounts_file, "w") as f:
+            json.dump(list(self._uris), f)
+
+    def _mount_error_message(self, uri: str, exc: Exception) -> str:
+        """Render actionable mount failures."""
+        if uri.startswith("s3://"):
+            return f"{exc}. Run `nexus-fs auth connect s3 native` or configure AWS credentials, then retry /mount."
+        if uri.startswith("gws://"):
+            return (
+                f"{exc}. Run /auth gws for step-by-step auth guidance. "
+                "If you use multiple Google accounts, set NEXUS_FS_USER_EMAIL before mounting."
+            )
+        return str(exc)
+
+    def _auth_guidance(self, service: str) -> str:
+        """Return concise auth guidance for playground-supported backends."""
+        if service == "s3":
+            return (
+                "For S3: 1. run `nexus-fs auth connect s3 native` or set AWS credentials; "
+                "2. run `/auth test s3`; 3. run `/mount s3://bucket`."
+            )
+        if service == "gws":
+            return (
+                "For Google Workspace: 1. set NEXUS_OAUTH_GOOGLE_CLIENT_ID and "
+                "NEXUS_OAUTH_GOOGLE_CLIENT_SECRET; 2. run `nexus-fs auth connect gws oauth "
+                "--user-email you@example.com`; 3. run `/auth test gws`; "
+                "4. if needed set `NEXUS_FS_USER_EMAIL=you@example.com`; "
+                "5. run `/mount gws://drive` or `/mount gws://gmail`."
+            )
+        if service == "gcs":
+            return (
+                "For GCS: 1. run `nexus-fs auth connect gcs native` or "
+                "`gcloud auth application-default login`; 2. run `/auth test gcs`."
+            )
+        if service == "local":
+            return "Local mounts do not require auth. Use `/mount local://./data`."
+        return f"No dedicated playground auth guide for {service}. Use `/connectors` to list supported targets."
+
+    def _connector_summary(self) -> str:
+        """Concise supported connector summary for the command bar."""
+        items = self._supported_connector_rows()
+        return " | ".join(f"{name}:{mode}" for name, mode in items[:8])
+
+    def _supported_connectors_text(self, title: str) -> str:
+        """Empty-state help for supported playground connectors."""
+        rows = self._supported_connector_rows()
+        rendered = "\n".join(
+            f"{idx}. {name} [{mode}]" for idx, (name, mode) in enumerate(rows, start=1)
+        )
+        return (
+            f"[bold]{title}[/bold]\n\n"
+            "[bold]Supported playground connectors[/bold]\n"
+            f"{rendered}\n\n"
+            "[bold]Auth guidance[/bold]\n"
+            "1. /auth s3\n"
+            "2. /auth gws\n\n"
+            "[bold]Examples[/bold]\n"
+            "1. : then /mount local://./data\n"
+            "2. : then /mount s3://bucket\n"
+            "3. : then /mount gws://drive\n"
+            "4. : then /connectors\n"
+            "5. : then /auth test s3"
+        )
+
+    def _supported_connector_rows(self) -> list[tuple[str, str]]:
+        """Dynamically render concrete playground connector targets."""
+        from nexus.backends import _register_optional_backends
+        from nexus.backends.base.registry import ConnectorRegistry
+
+        _register_optional_backends()
+
+        rows: list[tuple[str, str]] = [
+            ("local://./data", "mountable"),
+            ("s3://bucket/<prefix>", "mountable auth:s3"),
+            ("gcs://project/bucket", "mountable auth:gcs"),
+        ]
+        for info in ConnectorRegistry.list_all():
+            uri = self._connector_uri_example(info.name)
+            if uri is None:
+                continue
+            auth_service = self._connector_auth_service(info.name, info.service_name)
+            mode = "mountable" if auth_service is None else f"mountable auth:{auth_service}"
+            rows.append((uri, mode))
+        deduped: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for row in rows:
+            if row[0] in seen:
+                continue
+            seen.add(row[0])
+            deduped.append(row)
+        return deduped
+
+    def _connector_uri_example(self, connector_name: str) -> str | None:
+        """Concrete URI example for a registered connector."""
+        if connector_name in {
+            "cas_gcs",
+            "cas_local",
+            "local_connector",
+            "path_gcs",
+            "path_local",
+            "path_s3",
+        }:
+            return None
+        if connector_name == "gdrive_connector":
+            return "gdrive://root"
+        if connector_name == "gmail_connector":
+            return "gmail://inbox"
+        if connector_name == "gcalendar_connector":
+            return "calendar://primary"
+        if connector_name == "slack_connector":
+            return "slack://workspace"
+        if connector_name == "x_connector":
+            return "x://timeline"
+        if connector_name == "hn_connector":
+            return "hn://top"
+        if connector_name.startswith("gws_"):
+            return f"gws://{connector_name.removeprefix('gws_')}"
+        return None
+
+    def _connector_auth_service(self, connector_name: str, service_name: str | None) -> str | None:
+        """Map connector targets to the auth flow users should follow."""
+        if connector_name.startswith("gws_"):
+            return "gws"
+        if service_name in {"google-drive", "gmail", "google-calendar", "slack", "x", "gcs"}:
+            return service_name
+        return None
+
+    async def _resolve_mount_user_id(self, uri: str) -> str:
+        """Choose a user identity for connector-backed mounts."""
+        explicit = os.getenv("NEXUS_FS_USER_EMAIL")
+        if explicit:
+            return explicit
+
+        if not uri.startswith(
+            ("gws://", "gdrive://", "gmail://", "calendar://", "slack://", "x://")
+        ):
+            return "local"
+
+        try:
+            from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
+            from nexus.cli.commands.oauth import get_token_manager
+        except Exception:
+            return "local"
+
+        try:
+            oauth_service = OAuthCredentialService(token_manager=get_token_manager())
+            creds = await oauth_service.list_credentials()
+        except Exception:
+            return "local"
+
+        if uri.startswith(("gws://", "gdrive://", "gmail://", "calendar://")):
+            providers = {"google"}
+        elif uri.startswith("slack://"):
+            providers = {"slack"}
+        else:
+            providers = {"x", "twitter"}
+
+        emails = sorted(
+            {
+                str(cred.get("user_email"))
+                for cred in creds
+                if cred.get("provider") in providers and cred.get("user_email")
+            }
+        )
+        return emails[0] if len(emails) == 1 else "local"
+
     def _refocus_table(self) -> None:
         """Return focus to the file table after CRUD operations."""
         import contextlib
 
         with contextlib.suppress(Exception):
+            if self.picker_visible:
+                self.query_one("#connector-picker", DataTable).focus()
+                return
             self.query_one("#file-table").focus()
 
     def _show_crud_input(self, mode: str, placeholder: str, prefill: str = "") -> None:
@@ -512,6 +1005,9 @@ class PlaygroundApp(App[None]):
 
     def action_go_back(self) -> None:
         """Navigate back."""
+        if self.picker_visible and self._mount_points:
+            self.call_later(self._reset_browser_ui)
+            return
         try:
             browser = self.query_one("#file-browser", FileBrowser)
             browser.go_back()
@@ -522,6 +1018,35 @@ class PlaygroundApp(App[None]):
         """Toggle search input."""
         self.search_visible = not self.search_visible
 
+    def action_toggle_command(self) -> None:
+        """Toggle command input."""
+        self.command_visible = not self.command_visible
+
+    async def action_show_connector_picker(self) -> None:
+        """Open the interactive connector picker."""
+        await self._show_connector_picker("Mount another connector")
+
+    async def action_submit_command(self) -> None:
+        """Submit the current command buffer."""
+        if await self._mount_selected_picker_uri():
+            return
+        if not self.command_visible:
+            return
+        await self._on_command_input_submitted(self.command_buffer.strip())
+
+    def action_command_backspace(self) -> None:
+        """Delete the last command character."""
+        if self.command_visible:
+            self.command_buffer = self.command_buffer[:-1]
+
+    def action_cancel_command(self) -> None:
+        """Close the command bar and clear the buffer."""
+        if not self.command_visible:
+            return
+        self.command_visible = False
+        self.command_buffer = ""
+        self._refocus_table()
+
     def watch_search_visible(self, visible: bool) -> None:
         """Show/hide search input."""
         try:
@@ -529,6 +1054,23 @@ class PlaygroundApp(App[None]):
             search.display = visible
             if visible:
                 search.focus()
+        except Exception:
+            pass
+
+    def watch_command_visible(self, visible: bool) -> None:
+        """Show/hide command bar."""
+        try:
+            command = self.query_one("#command-bar", Static)
+            command.display = visible
+        except Exception:
+            pass
+
+    def watch_command_buffer(self, value: str) -> None:
+        """Render the current command buffer."""
+        try:
+            command = self.query_one("#command-bar", Static)
+            cursor = "█" if self.command_visible else ""
+            command.update(f"> {value}{cursor}")
         except Exception:
             pass
 
@@ -603,6 +1145,45 @@ class PlaygroundApp(App[None]):
 
     async def on_key(self, event: Any) -> None:
         """Handle global key events (quit, escape)."""
+        if event.key in {"enter", "return", "ctrl+m"} and await self._mount_selected_picker_uri():
+            event.prevent_default()
+            return
+        if self.command_visible:
+            if event.key in {"enter", "return", "ctrl+m"}:
+                await self.action_submit_command()
+                event.prevent_default()
+                return
+            if event.key == "backspace":
+                self.action_command_backspace()
+                event.prevent_default()
+                return
+            if event.key == "escape":
+                self.action_cancel_command()
+                event.prevent_default()
+                return
+            if getattr(event, "is_printable", False) and getattr(event, "character", None):
+                if event.character == ":" and not self.command_buffer:
+                    event.prevent_default()
+                    return
+                self.command_buffer += event.character
+                event.prevent_default()
+                return
+            if event.key == "space":
+                self.command_buffer += " "
+                event.prevent_default()
+                return
+            if len(event.key) == 1:
+                self.command_buffer += event.key
+                event.prevent_default()
+                return
+
+        if event.key == ":":
+            focused = self.focused
+            if not isinstance(focused, Input):
+                self.command_visible = True
+                self.command_buffer = ""
+                event.prevent_default()
+                return
         if event.key == "q":
             # Don't quit if user is typing in an input
             focused = self.focused
@@ -623,6 +1204,13 @@ class PlaygroundApp(App[None]):
 
             if self.search_visible:
                 self.search_visible = False
+                self._refocus_table()
+                event.prevent_default()
+                return
+
+            if self.command_visible:
+                self.command_visible = False
+                self.command_buffer = ""
                 self._refocus_table()
                 event.prevent_default()
                 return

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -82,7 +82,13 @@ class ContextualNexusFS:
     async def stat(self, path: str) -> dict[str, Any] | None:
         from nexus.fs._facade import SlimNexusFS
 
-        return await SlimNexusFS(self._kernel).stat(path)
+        try:
+            result = await SlimNexusFS(self._kernel).stat(path)
+            if result is not None:
+                return result
+        except Exception:
+            pass
+        return await self._stat_backend_path(path)
 
     async def mkdir(self, path: str, parents: bool = True) -> None:
         await self._kernel.mkdir(path, parents=parents, exist_ok=True, context=self._ctx)
@@ -223,6 +229,24 @@ class ContextualNexusFS:
             full_path = f"{mount_root}/{name}" if mount_root != "/" else f"/{name}"
             fallback_paths.append(full_path)
         return fallback_paths
+
+    async def _stat_backend_path(self, path: str) -> dict[str, Any] | None:
+        """Fallback stat for connector-backed entries not materialized in metadata."""
+        normalized = path.rstrip("/") or "/"
+        if normalized == "/":
+            return None
+
+        parent = normalized.rsplit("/", 1)[0] or "/"
+        entries = await self._list_backend_directory(parent, detail=True)
+        if not isinstance(entries, list):
+            return None
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("path")) == normalized:
+                return entry
+        return None
 
 
 def _highlight_match(text: str, query_lower: str) -> str:

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -1191,18 +1191,6 @@ class PlaygroundApp(App[None]):
         ):
             return "local"
 
-        try:
-            from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
-            from nexus.cli.commands.oauth import get_token_manager
-        except Exception:
-            return "local"
-
-        try:
-            oauth_service = OAuthCredentialService(token_manager=get_token_manager())
-            creds = await oauth_service.list_credentials()
-        except Exception:
-            return "local"
-
         if uri.startswith(("gws://", "gdrive://", "gmail://", "calendar://")):
             providers = {"google"}
         elif uri.startswith("slack://"):
@@ -1210,14 +1198,51 @@ class PlaygroundApp(App[None]):
         else:
             providers = {"x", "twitter"}
 
-        emails = sorted(
-            {
-                str(cred.get("user_email"))
-                for cred in creds
-                if cred.get("provider") in providers and cred.get("user_email")
-            }
+        try:
+            from nexus.bricks.auth.oauth.credential_service import OAuthCredentialService
+            from nexus.cli.commands.oauth import get_token_manager
+
+            oauth_service = OAuthCredentialService(token_manager=get_token_manager())
+            creds = await oauth_service.list_credentials()
+            emails = sorted(
+                {
+                    str(cred.get("user_email"))
+                    for cred in creds
+                    if cred.get("provider") in providers and cred.get("user_email")
+                }
+            )
+            if len(emails) == 1:
+                return emails[0]
+        except Exception:
+            pass
+
+        try:
+            from types import SimpleNamespace
+
+            from nexus.fs import _infer_connector_user_email
+        except Exception:
+            return "local"
+
+        scheme = uri.split("://", 1)[0].lower()
+        service_name = None
+        if scheme == "gws":
+            service_name = "gws"
+        elif scheme == "gdrive":
+            service_name = "google-drive"
+        elif scheme == "gmail":
+            service_name = "gmail"
+        elif scheme == "calendar":
+            service_name = "google-calendar"
+        elif scheme == "slack":
+            service_name = "slack"
+        elif scheme == "x":
+            service_name = "x"
+
+        inferred = _infer_connector_user_email(
+            scheme=scheme,
+            info=SimpleNamespace(service_name=service_name),
         )
-        return emails[0] if len(emails) == 1 else "local"
+        return inferred or "local"
 
     def _refocus_table(self) -> None:
         """Return focus to the file table after CRUD operations."""

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -57,6 +57,11 @@ class ContextualNexusFS:
         detail: bool = False,
         recursive: bool = False,
     ) -> list[str] | list[dict[str, Any]]:
+        if not recursive and path != "/":
+            backend_result = await self._list_backend_directory(path, detail=detail)
+            if backend_result:
+                return backend_result
+
         result = cast(
             list[str] | list[dict[str, Any]],
             await self._kernel.sys_readdir(
@@ -125,8 +130,59 @@ class ContextualNexusFS:
             return None
 
         backend = route.backend
-        if not hasattr(backend, "list_dir"):
+        if not hasattr(backend, "list_dir") and not hasattr(backend, "list_dir_details"):
             return None
+
+        detailed_entries: list[dict[str, Any]] | None = None
+        if hasattr(backend, "list_dir_details"):
+            try:
+                candidate = await asyncio.to_thread(
+                    backend.list_dir_details, route.backend_path, self._ctx
+                )
+                if isinstance(candidate, list):
+                    detailed_entries = [item for item in candidate if isinstance(item, dict)]
+            except NotImplementedError:
+                detailed_entries = None
+            except Exception:
+                detailed_entries = None
+
+        if detailed_entries is not None:
+            mount_root = path.rstrip("/") or "/"
+            if detail:
+                detailed_rows: list[dict[str, Any]] = []
+                for entry in detailed_entries:
+                    name = str(entry.get("name", "")).rstrip("/")
+                    if not name:
+                        continue
+                    is_dir = bool(entry.get("is_directory", False))
+                    full_path = f"{mount_root}/{name}" if mount_root != "/" else f"/{name}"
+                    detailed_rows.append(
+                        {
+                            "path": full_path,
+                            "size": int(entry.get("size", 0) or 0),
+                            "is_directory": is_dir,
+                            "etag": entry.get("etag"),
+                            "mime_type": entry.get(
+                                "mime_type",
+                                "inode/directory" if is_dir else "application/octet-stream",
+                            ),
+                            "created_at": entry.get("created_at"),
+                            "modified_at": entry.get("modified_at"),
+                            "version": entry.get("version", 0),
+                            "zone_id": entry.get("zone_id", "root"),
+                            "entry_type": 1 if is_dir else 0,
+                        }
+                    )
+                return detailed_rows
+
+            listed_paths: list[str] = []
+            for entry in detailed_entries:
+                name = str(entry.get("name", "")).rstrip("/")
+                if not name:
+                    continue
+                full_path = f"{mount_root}/{name}" if mount_root != "/" else f"/{name}"
+                listed_paths.append(full_path)
+            return listed_paths
 
         try:
             raw_entries = await asyncio.to_thread(backend.list_dir, route.backend_path, self._ctx)
@@ -136,14 +192,14 @@ class ContextualNexusFS:
         now = datetime.now(UTC).isoformat()
         mount_root = path.rstrip("/") or "/"
         if detail:
-            detailed: list[dict[str, Any]] = []
+            fallback_rows: list[dict[str, Any]] = []
             for entry in raw_entries:
                 name = str(entry).rstrip("/")
                 if not name:
                     continue
                 is_dir = str(entry).endswith("/")
                 full_path = f"{mount_root}/{name}" if mount_root != "/" else f"/{name}"
-                detailed.append(
+                fallback_rows.append(
                     {
                         "path": full_path,
                         "size": 4096 if is_dir else 0,
@@ -157,16 +213,16 @@ class ContextualNexusFS:
                         "entry_type": 1 if is_dir else 0,
                     }
                 )
-            return detailed
+            return fallback_rows
 
-        listed: list[str] = []
+        fallback_paths: list[str] = []
         for entry in raw_entries:
             name = str(entry).rstrip("/")
             if not name:
                 continue
             full_path = f"{mount_root}/{name}" if mount_root != "/" else f"/{name}"
-            listed.append(full_path)
-        return listed
+            fallback_paths.append(full_path)
+        return fallback_paths
 
 
 def _highlight_match(text: str, query_lower: str) -> str:

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -18,6 +18,7 @@ from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
 from textual.widgets import DataTable, Footer, Header, Input, Static
 
+from nexus.fs._tui.auth_guidance import auth_guidance, format_runtime_error
 from nexus.fs._tui.file_browser import FileBrowser
 from nexus.fs._tui.file_preview import FilePreview
 from nexus.fs._tui.mount_panel import MountPanel
@@ -1107,39 +1108,11 @@ class PlaygroundApp(App[None]):
 
     def _mount_error_message(self, uri: str, exc: Exception) -> str:
         """Render actionable mount failures."""
-        if uri.startswith("s3://"):
-            return f"{exc}. Run `nexus-fs auth connect s3 native` or configure AWS credentials, then retry /mount."
-        if uri.startswith("gws://"):
-            return (
-                f"{exc}. Run /auth gws for step-by-step auth guidance. "
-                "If you use multiple Google accounts, set NEXUS_FS_USER_EMAIL before mounting."
-            )
-        return str(exc)
+        return format_runtime_error(uri, exc)
 
     def _auth_guidance(self, service: str) -> str:
         """Return concise auth guidance for playground-supported backends."""
-        if service == "s3":
-            return (
-                "For S3: 1. run `nexus-fs auth connect s3 native` or set AWS credentials; "
-                "2. run `/auth test s3`; 3. run `/mount s3://bucket`."
-            )
-        if service == "gws":
-            return (
-                "For Google Workspace: 1. set NEXUS_OAUTH_GOOGLE_CLIENT_ID and "
-                "NEXUS_OAUTH_GOOGLE_CLIENT_SECRET; 2. run `nexus-fs auth connect gws oauth "
-                "--user-email you@example.com`; 3. run `/auth test gws`; "
-                "4. if needed set `NEXUS_FS_USER_EMAIL=you@example.com`; "
-                "5. run `/mount gws://drive` or `/mount gws://gmail`; "
-                "6. for `/mount gws://chat`, re-run auth and approve Chat scopes if prompted."
-            )
-        if service == "gcs":
-            return (
-                "For GCS: 1. run `nexus-fs auth connect gcs native` or "
-                "`gcloud auth application-default login`; 2. run `/auth test gcs`."
-            )
-        if service == "local":
-            return "Local mounts do not require auth. Use `/mount local://./data`."
-        return f"No dedicated playground auth guide for {service}. Use `/connectors` to list supported targets."
+        return auth_guidance(service)
 
     def _connector_summary(self) -> str:
         """Concise supported connector summary for the command bar."""

--- a/src/nexus/fs/_tui/auth_guidance.py
+++ b/src/nexus/fs/_tui/auth_guidance.py
@@ -1,0 +1,88 @@
+"""Shared auth guidance and error formatting for the playground TUI."""
+
+from __future__ import annotations
+
+import os
+
+
+def auth_guidance(service: str, *, user_email: str | None = None, expired: bool = False) -> str:
+    """Return step-by-step auth guidance for a playground-supported service."""
+    email = user_email or os.environ.get("NEXUS_FS_USER_EMAIL") or "you@example.com"
+
+    if service == "s3":
+        return (
+            "For S3: 1. run `nexus-fs auth connect s3 native` or set AWS credentials; "
+            "2. run `nexus-fs auth test s3`; 3. reopen the playground and mount `s3://bucket`."
+        )
+    if service == "gcs":
+        return (
+            "For GCS: 1. run `nexus-fs auth connect gcs native` or "
+            "`gcloud auth application-default login`; 2. run `nexus-fs auth test gcs`; "
+            "3. reopen the playground and mount `gcs://project/bucket`."
+        )
+    if service == "gws":
+        if expired:
+            return (
+                f"Google auth expired. 1. run `nexus-fs auth connect gws oauth --user-email {email}`; "
+                "2. approve the requested Google scopes; 3. run `nexus-fs auth test gws`; "
+                "4. reopen the playground and retry this Google mount."
+            )
+        return (
+            "For Google Workspace: 1. set NEXUS_OAUTH_GOOGLE_CLIENT_ID and "
+            "NEXUS_OAUTH_GOOGLE_CLIENT_SECRET; "
+            f"2. run `nexus-fs auth connect gws oauth --user-email {email}`; "
+            "3. run `nexus-fs auth test gws`; 4. reopen the playground and mount "
+            "`gws://drive`, `gws://docs`, `gws://gmail`, or `gws://calendar`; "
+            "5. for `gws://chat`, re-run auth and approve Chat scopes if prompted."
+        )
+    if service == "local":
+        return "Local mounts do not require auth. Mount any absolute path and use `n`, `N`, `d`, and `p` in the TUI."
+    return f"No dedicated playground auth guide for {service}. Use `/connectors` to list supported targets."
+
+
+def service_for_target(target: str) -> str | None:
+    """Infer the service from a mount uri or mounted path."""
+    if target.startswith(("s3://", "/s3/")):
+        return "s3"
+    if target.startswith(("gcs://", "/gcs/")):
+        return "gcs"
+    if target.startswith(("gws://", "/gws/", "gdrive://", "/gdrive/", "gmail://", "/gmail/")):
+        return "gws"
+    if target.startswith(("local://", "/local/")):
+        return "local"
+    return None
+
+
+def is_auth_error(message: str) -> bool:
+    """Best-effort detection of auth-related connector failures."""
+    lower = message.lower()
+    needles = (
+        "auth_expired",
+        "expired",
+        "oauth",
+        "credentials",
+        "not authenticated",
+        "permission denied",
+        "insufficient authentication scopes",
+        "login required",
+        "using keyring backend",
+        "approve chat scopes",
+    )
+    return any(needle in lower for needle in needles)
+
+
+def format_runtime_error(target: str, exc: Exception) -> str:
+    """Render a step-by-step error for live browse/preview failures."""
+    message = str(exc).strip()
+    service = service_for_target(target)
+    if service is None:
+        return message
+
+    if service == "local":
+        return message
+
+    expired = "auth_expired" in message.lower() or "expired" in message.lower()
+    if is_auth_error(message):
+        prefix = f"Can't access `{target}`."
+        return f"{prefix} {auth_guidance(service, expired=expired)}"
+    return message

--- a/src/nexus/fs/_tui/direct_fs.py
+++ b/src/nexus/fs/_tui/direct_fs.py
@@ -360,7 +360,7 @@ class MultiDirectFS:
         return result
 
     def list_mounts(self) -> list[str]:
-        return sorted(self._mount_map.keys())
+        return list(self._mount_map.keys())
 
     async def close(self) -> None:
         for b in self._backends:

--- a/src/nexus/fs/_tui/file_browser.py
+++ b/src/nexus/fs/_tui/file_browser.py
@@ -10,6 +10,8 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import DataTable, Static
 
+from nexus.fs._tui.auth_guidance import format_runtime_error
+
 MAX_DISPLAY_ENTRIES = 500
 
 
@@ -143,7 +145,7 @@ class FileBrowser(Widget):
             self.current_path = path
 
         except Exception as exc:
-            self._error = str(exc)
+            self._error = format_runtime_error(path, exc)
             self._entries = []
             self._total_count = 0
             overflow = self.query_one("#overflow", Static)

--- a/src/nexus/fs/_tui/file_preview.py
+++ b/src/nexus/fs/_tui/file_preview.py
@@ -10,6 +10,8 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
+from nexus.fs._tui.auth_guidance import format_runtime_error
+
 MAX_PREVIEW_BYTES = 1_048_576  # 1 MB
 
 # File extensions known to be binary
@@ -248,7 +250,7 @@ class FilePreview(Widget):
             content_widget.update(syntax)
 
         except Exception as exc:
-            content_widget.update(f"[red]Preview error: {exc}[/red]")
+            content_widget.update(f"[red]Preview error: {format_runtime_error(path, exc)}[/red]")
 
     def clear_preview(self) -> None:
         """Clear the preview pane."""

--- a/src/nexus/fs/_tui/mount_panel.py
+++ b/src/nexus/fs/_tui/mount_panel.py
@@ -84,7 +84,18 @@ class MountPanel(Widget):
             latency = f" ({info.latency_ms:.0f}ms)" if info.latency_ms is not None else ""
             return f"[green]●[/green] {info.mount_point}{latency}"
         else:
-            return f"[red]●[/red] {info.mount_point}"
+            hint = ""
+            if info.mount_point.startswith("/s3/"):
+                hint = " [dim]run /auth s3[/dim]"
+            elif info.mount_point.startswith("/gcs/"):
+                hint = " [dim]run /auth gcs[/dim]"
+            elif info.mount_point.startswith(("/gws/", "/gdrive/", "/gmail/", "/calendar/")):
+                hint = " [dim]run /auth gws[/dim]"
+            elif info.mount_point.startswith("/slack/"):
+                hint = " [dim]run /auth slack[/dim]"
+            elif info.mount_point.startswith("/x/"):
+                hint = " [dim]run /auth x[/dim]"
+            return f"[red]●[/red] {info.mount_point}{hint}"
 
     async def on_mount(self) -> None:
         """Start connectivity checks when widget is mounted."""

--- a/src/nexus/fs/_tui/mount_panel.py
+++ b/src/nexus/fs/_tui/mount_panel.py
@@ -32,6 +32,8 @@ class MountPanel(Widget):
         selected_index: Currently highlighted mount index.
     """
 
+    can_focus = True
+
     DEFAULT_CSS = """
     MountPanel {
         width: 30;

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -65,6 +65,7 @@ class AvailableConnector(BaseModel):
     capabilities: list[str]
     user_scoped: bool
     auth_status: str = "unknown"  # "authed", "no_auth", "expired", "unknown"
+    auth_source: str | None = None
     mount_path: str | None = None  # None if not mounted
     sync_status: str | None = None  # "synced", "syncing", "error", None
 
@@ -207,6 +208,7 @@ async def list_available_connectors(
 
     nx = _get_nx(request)
     mount_svc = nx.service("mount")
+    auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
 
     # Get mounted connectors
     mounted: dict[str, str] = {}  # connector_type -> mount_point
@@ -230,6 +232,13 @@ async def list_available_connectors(
                 mount_path = mp
                 break
 
+        auth_state = {"auth_status": "unknown", "auth_source": None}
+        if auth_svc is not None:
+            try:
+                auth_state = await auth_svc.get_connector_auth_state(info.service_name)
+            except Exception:
+                logger.debug("Failed to resolve auth state for %s", info.name, exc_info=True)
+
         result.append(
             AvailableConnector(
                 name=info.name,
@@ -237,6 +246,8 @@ async def list_available_connectors(
                 category=info.category,
                 capabilities=sorted(str(c) for c in info.capabilities),
                 user_scoped=info.user_scoped,
+                auth_status=str(auth_state.get("auth_status", "unknown")),
+                auth_source=auth_state.get("auth_source"),
                 mount_path=mount_path,
             )
         )

--- a/tests/integration/backends/connectors/gws/test_gws_schemas.py
+++ b/tests/integration/backends/connectors/gws/test_gws_schemas.py
@@ -8,12 +8,24 @@ Covers:
 - YAML configs load and validate via load_connector_config
 """
 
+import json
 from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 from pydantic import ValidationError
 
 from nexus.backends.connectors.cli.loader import load_connector_config
+from nexus.backends.connectors.cli.result import CLIResult, CLIResultStatus
+from nexus.backends.connectors.gws.connector import (
+    CalendarConnector,
+    ChatConnector,
+    DocsConnector,
+    DriveConnector,
+    GmailConnector,
+    SheetsConnector,
+)
 from nexus.backends.connectors.gws.schemas import (
     AppendRowsSchema,
     CreateSpaceSchema,
@@ -36,6 +48,180 @@ CONFIGS_DIR = (
     / "gws"
     / "configs"
 )
+
+
+class TestDocsConnectorListing:
+    def test_list_dir_uses_drive_metadata_and_filters_to_docs(self) -> None:
+        connector = DocsConnector()
+        payload = json.dumps(
+            {
+                "files": [
+                    {"name": "Doc Alpha", "mimeType": "application/vnd.google-apps.document"},
+                    {"name": "Spreadsheet", "mimeType": "application/vnd.google-apps.spreadsheet"},
+                    {"name": "Doc Beta", "mimeType": "application/vnd.google-apps.document"},
+                ]
+            }
+        )
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.SUCCESS,
+                exit_code=0,
+                stdout=payload,
+                command=["gws", "drive", "files", "list"],
+            )
+        )
+
+        result = connector.list_dir("")
+
+        assert result == ["Doc Alpha", "Doc Beta"]
+        connector._execute_cli.assert_called_once()
+        args = connector._execute_cli.call_args.args[0]
+        assert args[:4] == ["gws", "drive", "files", "list"]
+        assert args[4] == "--params"
+        assert "application/vnd.google-apps.document" in args[5]
+
+    def test_list_dir_raises_on_cli_failure(self) -> None:
+        connector = DocsConnector()
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.EXIT_ERROR,
+                exit_code=1,
+                stderr="403 permission denied",
+                command=["gws", "drive", "files", "list"],
+            )
+        )
+
+        with pytest.raises(Exception, match="permission denied"):
+            connector.list_dir("")
+
+
+class TestSheetsConnectorListing:
+    def test_list_dir_uses_drive_metadata_and_filters_to_spreadsheets(self) -> None:
+        connector = SheetsConnector()
+        payload = json.dumps(
+            {
+                "files": [
+                    {
+                        "name": "Quarterly Plan",
+                        "mimeType": "application/vnd.google-apps.spreadsheet",
+                    },
+                    {"name": "Doc Alpha", "mimeType": "application/vnd.google-apps.document"},
+                    {"name": "Pipeline", "mimeType": "application/vnd.google-apps.spreadsheet"},
+                ]
+            }
+        )
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.SUCCESS,
+                exit_code=0,
+                stdout=payload,
+                command=["gws", "drive", "files", "list"],
+            )
+        )
+
+        result = connector.list_dir("")
+
+        assert result == ["Pipeline", "Quarterly Plan"]
+        connector._execute_cli.assert_called_once()
+        args = connector._execute_cli.call_args.args[0]
+        assert args[:4] == ["gws", "drive", "files", "list"]
+        assert args[4] == "--params"
+        assert "application/vnd.google-apps.spreadsheet" in args[5]
+
+
+class TestDriveConnectorListing:
+    def test_list_dir_marks_folders_and_files(self) -> None:
+        connector = DriveConnector()
+        payload = json.dumps(
+            {
+                "files": [
+                    {"name": "Specs", "mimeType": "application/vnd.google-apps.folder"},
+                    {"name": "notes.txt", "mimeType": "text/plain"},
+                    {"name": "Roadmap", "mimeType": "application/vnd.google-apps.document"},
+                ]
+            }
+        )
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.SUCCESS,
+                exit_code=0,
+                stdout=payload,
+                command=["gws", "drive", "files", "list"],
+            )
+        )
+
+        result = connector.list_dir("")
+
+        assert result == ["Roadmap", "Specs/", "notes.txt"]
+
+
+class TestChatConnectorListing:
+    def test_list_dir_root_lists_spaces(self) -> None:
+        connector = ChatConnector()
+        payload = json.dumps(
+            {
+                "spaces": [
+                    {"name": "spaces/AAA"},
+                    {"name": "spaces/BBB"},
+                ]
+            }
+        )
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.SUCCESS,
+                exit_code=0,
+                stdout=payload,
+                command=["gws", "chat", "spaces", "list"],
+            )
+        )
+
+        result = connector.list_dir("")
+
+        assert result == ["spaces/AAA/", "spaces/BBB/"]
+
+    def test_list_dir_raises_actionable_error_on_missing_chat_scopes(self) -> None:
+        connector = ChatConnector()
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.EXIT_ERROR,
+                exit_code=1,
+                stdout='{"error":{"message":"Request had insufficient authentication scopes."}}',
+                stderr="error[api]: Request had insufficient authentication scopes.",
+                command=["gws", "chat", "spaces", "list"],
+            )
+        )
+
+        with pytest.raises(Exception, match="approve Chat access"):
+            connector.list_dir("")
+
+
+class TestGmailConnectorListing:
+    def test_list_dir_root_returns_expected_label_folders(self) -> None:
+        connector = GmailConnector()
+        assert connector.list_dir("") == [
+            "INBOX/",
+            "SENT/",
+            "STARRED/",
+            "IMPORTANT/",
+            "DRAFTS/",
+        ]
+
+
+class TestCalendarConnectorListing:
+    def test_list_dir_root_lists_calendars(self) -> None:
+        connector = CalendarConnector()
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.SUCCESS,
+                exit_code=0,
+                stdout='items:\n  - id: "primary"\n  - id: "team@example.com"\n',
+                command=["gws", "calendar", "calendarList", "list", "--format", "yaml"],
+            )
+        )
+
+        result = connector.list_dir("")
+
+        assert result == ["primary/", "team@example.com/"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/backends/connectors/gws/test_gws_schemas.py
+++ b/tests/integration/backends/connectors/gws/test_gws_schemas.py
@@ -56,9 +56,17 @@ class TestDocsConnectorListing:
         payload = json.dumps(
             {
                 "files": [
-                    {"name": "Doc Alpha", "mimeType": "application/vnd.google-apps.document"},
+                    {
+                        "id": "docAlpha",
+                        "name": "Doc Alpha",
+                        "mimeType": "application/vnd.google-apps.document",
+                    },
                     {"name": "Spreadsheet", "mimeType": "application/vnd.google-apps.spreadsheet"},
-                    {"name": "Doc Beta", "mimeType": "application/vnd.google-apps.document"},
+                    {
+                        "id": "docBeta",
+                        "name": "Doc Beta",
+                        "mimeType": "application/vnd.google-apps.document",
+                    },
                 ]
             }
         )
@@ -93,6 +101,65 @@ class TestDocsConnectorListing:
 
         with pytest.raises(Exception, match="permission denied"):
             connector.list_dir("")
+
+    def test_list_dir_disambiguates_duplicate_names(self) -> None:
+        connector = DocsConnector()
+        payload = json.dumps(
+            {
+                "files": [
+                    {
+                        "id": "docA",
+                        "name": "Shared Name",
+                        "mimeType": "application/vnd.google-apps.document",
+                    },
+                    {
+                        "id": "docB",
+                        "name": "Shared Name",
+                        "mimeType": "application/vnd.google-apps.document",
+                    },
+                ]
+            }
+        )
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.SUCCESS,
+                exit_code=0,
+                stdout=payload,
+                command=["gws", "drive", "files", "list"],
+            )
+        )
+
+        result = connector.list_dir("")
+
+        assert result == ["Shared Name [docA]", "Shared Name [docB]"]
+
+    def test_read_content_uses_disambiguated_id_suffix(self) -> None:
+        connector = DocsConnector()
+        cast(Any, connector)._execute_cli = MagicMock(
+            return_value=CLIResult(
+                status=CLIResultStatus.SUCCESS,
+                exit_code=0,
+                stdout='{"documentId":"docA","title":"Shared Name"}',
+                command=["gws", "docs", "documents", "get"],
+            )
+        )
+
+        from nexus.contracts.types import OperationContext
+
+        context = OperationContext(
+            user_id="alice@example.com",
+            groups=[],
+            backend_path="Shared Name [docA]",
+            virtual_path="/gws/docs/Shared Name [docA]",
+        )
+        result = connector.read_content("", context=context)
+
+        assert b'"documentId":"docA"' in result
+        args = cast(Any, connector)._execute_cli.call_args.args[0]
+        assert args[:3] == ["gws", "docs", "documents"]
+        assert args[3] == "get"
+        assert args[4] == "--params"
+        assert '"documentId": "docA"' in args[5]
 
 
 class TestSheetsConnectorListing:

--- a/tests/integration/services/test_connectors_router.py
+++ b/tests/integration/services/test_connectors_router.py
@@ -4,7 +4,7 @@ Tests the GET /api/v2/connectors and GET /api/v2/connectors/{name}/capabilities
 endpoints using FastAPI TestClient with a mocked ConnectorRegistry.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -43,6 +43,7 @@ def _make_connector_info(
         category=category,
         user_scoped=user_scoped,
         capabilities=capabilities or frozenset(),
+        service_name=name,
     )
 
 
@@ -156,3 +157,33 @@ class TestGetConnectorCapabilities:
         resp = _client.get("/api/v2/connectors/basic_backend/capabilities")
         assert resp.status_code == 200
         assert resp.json()["capabilities"] == []
+
+
+class TestAvailableConnectors:
+    """GET /api/v2/connectors/available endpoint."""
+
+    @patch("nexus.backends.base.registry.ConnectorRegistry")
+    def test_available_includes_auth_status(self, mock_registry: MagicMock) -> None:
+        nx = MagicMock()
+        mount_service = MagicMock()
+        mount_service.list_mounts = AsyncMock(return_value=[])
+        nx.service.side_effect = lambda name: mount_service if name == "mount" else None
+        auth_service = MagicMock()
+        auth_service.get_connector_auth_state = AsyncMock(
+            return_value={
+                "auth_status": "authed",
+                "auth_source": "stored:secret",
+            }
+        )
+        _test_app.state.nexus_fs = nx
+        _test_app.state.auth_service = auth_service
+
+        mock_registry.list_all.return_value = [
+            _make_connector_info(name="gcs", description="GCS"),
+        ]
+
+        resp = _client.get("/api/v2/connectors/available")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload[0]["auth_status"] == "authed"
+        assert payload[0]["auth_source"] == "stored:secret"

--- a/tests/unit/auth/test_unified_service.py
+++ b/tests/unit/auth/test_unified_service.py
@@ -140,6 +140,19 @@ def test_list_summaries_prefers_native_gws_when_stored_oauth_expired(
             "message": "Local gws CLI profile available for alice@example.com.",
         },
     )
+    monkeypatch.setattr(
+        service,
+        "_probe_google_workspace_targets",
+        lambda targets, user_email=None: {
+            target: {
+                "target": target,
+                "success": True,
+                "source": "native:gws_cli",
+                "message": f"{target} target is ready via local gws CLI.",
+            }
+            for target in targets
+        },
+    )
 
     summaries = asyncio.run(service.list_summaries())
     summary_by_service = {summary.service: summary for summary in summaries}
@@ -173,9 +186,115 @@ def test_test_service_prefers_native_gws_when_stored_oauth_expired(
             "message": "Local gws CLI profile available for alice@example.com.",
         },
     )
+    monkeypatch.setattr(
+        service,
+        "_probe_google_workspace_targets",
+        lambda targets, user_email=None: {
+            target: {
+                "target": target,
+                "success": True,
+                "source": "native:gws_cli",
+                "message": f"{target} target is ready via local gws CLI.",
+            }
+            for target in targets
+        },
+    )
 
     result = asyncio.run(service.test_service("gws", user_email="alice@example.com"))
 
     assert result["success"] is True
     assert result["source"] == "native:gws_cli"
     assert "expired" in result["message"].lower()
+
+
+def test_test_service_gws_reports_target_failures(
+    secret_store: FileSecretCredentialStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import asyncio
+
+    oauth = _FakeOAuthService()
+    oauth._credentials = [
+        {
+            "provider": "google",
+            "user_email": "alice@example.com",
+            "is_expired": True,
+        }
+    ]
+    service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
+    monkeypatch.setattr(
+        service,
+        "_detect_google_workspace_cli_native",
+        lambda user_email=None: {
+            "source": "native:gws_cli",
+            "email": "alice@example.com",
+            "message": "Local gws CLI profile available for alice@example.com.",
+        },
+    )
+    monkeypatch.setattr(
+        service,
+        "_probe_google_workspace_targets",
+        lambda targets, user_email=None: {
+            target: {
+                "target": target,
+                "success": target != "chat",
+                "source": "native:gws_cli",
+                "message": f"{target} ok" if target != "chat" else "chat scopes missing",
+                "reason": None if target != "chat" else "missing_scopes",
+            }
+            for target in targets
+        },
+    )
+
+    result = asyncio.run(service.test_service("gws", user_email="alice@example.com"))
+
+    assert result["success"] is False
+    assert "chat" in result["message"]
+    assert any(check["target"] == "chat" and not check["success"] for check in result["checks"])
+
+
+def test_list_summaries_marks_gws_error_when_some_targets_fail(
+    secret_store: FileSecretCredentialStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import asyncio
+
+    oauth = _FakeOAuthService()
+    oauth._credentials = [
+        {
+            "provider": "google",
+            "user_email": "alice@example.com",
+            "is_expired": True,
+        }
+    ]
+    service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
+    monkeypatch.setattr(
+        service,
+        "_detect_google_workspace_cli_native",
+        lambda user_email=None: {
+            "source": "native:gws_cli",
+            "email": "alice@example.com",
+            "message": "Local gws CLI profile available for alice@example.com.",
+        },
+    )
+    monkeypatch.setattr(
+        service,
+        "_probe_google_workspace_targets",
+        lambda targets, user_email=None: {
+            target: {
+                "target": target,
+                "success": target in {"drive", "docs", "sheets", "gmail", "calendar"},
+                "source": "native:gws_cli",
+                "message": f"{target} ok"
+                if target != "chat"
+                else "chat requires additional Google OAuth scopes",
+                "reason": None if target != "chat" else "missing_scopes",
+            }
+            for target in targets
+        },
+    )
+
+    summaries = asyncio.run(service.list_summaries())
+    summary_by_service = {summary.service: summary for summary in summaries}
+
+    assert summary_by_service["gws"].status == AuthStatus.ERROR
+    assert "chat" in summary_by_service["gws"].message
+    assert summary_by_service["google-drive"].status == AuthStatus.AUTHED

--- a/tests/unit/auth/test_unified_service.py
+++ b/tests/unit/auth/test_unified_service.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.bricks.auth.unified_service import FileSecretCredentialStore, UnifiedAuthService
+from nexus.contracts.unified_auth import AuthStatus, CredentialKind
+
+
+class _FakeOAuthService:
+    def __init__(self) -> None:
+        self._credentials = [
+            {
+                "provider": "google",
+                "user_email": "alice@example.com",
+                "is_expired": False,
+            }
+        ]
+
+    async def list_credentials(self, context=None):  # noqa: ANN001, ARG002
+        return list(self._credentials)
+
+    async def test_credential(self, provider: str, user_email: str, context=None):  # noqa: ANN001, ARG002
+        return {
+            "success": provider == "google" and user_email == "alice@example.com",
+            "provider": provider,
+            "user_email": user_email,
+            "message": "OAuth credential is valid.",
+        }
+
+
+@pytest.fixture
+def secret_store(tmp_path: Path) -> FileSecretCredentialStore:
+    return FileSecretCredentialStore(tmp_path / "credentials.json")
+
+
+@pytest.fixture
+def auth_service(secret_store: FileSecretCredentialStore) -> UnifiedAuthService:
+    return UnifiedAuthService(oauth_service=_FakeOAuthService(), secret_store=secret_store)
+
+
+def test_connect_secret_persists_record(auth_service: UnifiedAuthService) -> None:
+    record = auth_service.connect_secret(
+        "s3",
+        {
+            "access_key_id": "AKIA...",
+            "secret_access_key": "secret",
+            "region_name": "us-east-1",
+        },
+    )
+
+    assert record.kind == CredentialKind.SECRET
+    assert record.data["access_key_id"] == "AKIA..."
+
+
+def test_resolve_backend_config_uses_stored_secret(auth_service: UnifiedAuthService) -> None:
+    auth_service.connect_secret(
+        "s3",
+        {
+            "access_key_id": "AKIA...",
+            "secret_access_key": "secret",
+        },
+    )
+
+    resolution = auth_service.resolve_backend_config("path_s3", {"bucket": "demo"})
+
+    assert resolution.status == AuthStatus.AUTHED
+    assert resolution.source == "stored:secret"
+    assert resolution.resolved_config["access_key_id"] == "AKIA..."
+
+
+def test_list_summaries_includes_oauth_and_secret(auth_service: UnifiedAuthService) -> None:
+    import asyncio
+
+    auth_service.connect_secret(
+        "gcs",
+        {
+            "credentials_path": "/tmp/gcs.json",
+        },
+    )
+
+    summaries = asyncio.run(auth_service.list_summaries())
+
+    summary_by_service = {summary.service: summary for summary in summaries}
+    assert summary_by_service["gcs"].status == AuthStatus.AUTHED
+    assert summary_by_service["google-drive"].status == AuthStatus.AUTHED
+    assert summary_by_service["gws"].status == AuthStatus.AUTHED
+
+
+def test_test_service_reports_missing_secret(
+    auth_service: UnifiedAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import asyncio
+
+    monkeypatch.setattr(auth_service, "_detect_native", lambda service: None)
+    result = asyncio.run(auth_service.test_service("s3"))
+
+    assert result["success"] is False
+    assert "nexus auth connect s3" in result["message"]
+
+
+def test_file_store_delete(secret_store: FileSecretCredentialStore) -> None:
+    secret_store.upsert("s3", CredentialKind.NATIVE, {})
+
+    assert secret_store.delete("s3") is True
+    assert secret_store.get("s3") is None
+
+
+def test_test_service_supports_gws_alias(auth_service: UnifiedAuthService) -> None:
+    import asyncio
+
+    result = asyncio.run(auth_service.test_service("gws", user_email="alice@example.com"))
+
+    assert result["success"] is True
+    assert result["service"] == "gws"
+    assert result["provider"] == "google"

--- a/tests/unit/auth/test_unified_service.py
+++ b/tests/unit/auth/test_unified_service.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from nexus.bricks.auth.oauth.types import OAuthCredential
 from nexus.bricks.auth.unified_service import FileSecretCredentialStore, UnifiedAuthService
 from nexus.contracts.unified_auth import AuthStatus, CredentialKind
 
@@ -70,8 +71,46 @@ def test_resolve_backend_config_uses_stored_secret(auth_service: UnifiedAuthServ
     assert resolution.resolved_config["access_key_id"] == "AKIA..."
 
 
-def test_list_summaries_includes_oauth_and_secret(auth_service: UnifiedAuthService) -> None:
+def test_list_summaries_includes_oauth_and_secret(
+    auth_service: UnifiedAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
     import asyncio
+
+    async def _fake_get_stored_oauth_credential(provider: str, user_email: str):  # noqa: ANN001
+        assert provider == "google"
+        assert user_email == "alice@example.com"
+        return OAuthCredential(
+            access_token="ya29.test",
+            refresh_token="1//refresh",
+            scopes=(
+                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/drive.file",
+                "https://www.googleapis.com/auth/documents",
+                "https://www.googleapis.com/auth/spreadsheets",
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/calendar",
+                "https://www.googleapis.com/auth/chat.spaces.readonly",
+            ),
+            provider="google",
+            user_email="alice@example.com",
+        )
+
+    monkeypatch.setattr(
+        auth_service, "_get_stored_oauth_credential", _fake_get_stored_oauth_credential
+    )
+    monkeypatch.setattr(
+        auth_service,
+        "_probe_google_workspace_targets",
+        lambda targets, user_email=None, access_token=None, source=None: {
+            target: {
+                "target": target,
+                "success": True,
+                "source": source or "oauth",
+                "message": f"{target} target is ready via stored OAuth.",
+            }
+            for target in targets
+        },
+    )
 
     auth_service.connect_secret(
         "gcs",
@@ -107,14 +146,53 @@ def test_file_store_delete(secret_store: FileSecretCredentialStore) -> None:
     assert secret_store.get("s3") is None
 
 
-def test_test_service_supports_gws_alias(auth_service: UnifiedAuthService) -> None:
+def test_test_service_supports_gws_alias(
+    auth_service: UnifiedAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
     import asyncio
+
+    async def _fake_get_stored_oauth_credential(provider: str, user_email: str):  # noqa: ANN001
+        assert provider == "google"
+        assert user_email == "alice@example.com"
+        return OAuthCredential(
+            access_token="ya29.test",
+            refresh_token="1//refresh",
+            scopes=(
+                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/drive.file",
+                "https://www.googleapis.com/auth/documents",
+                "https://www.googleapis.com/auth/spreadsheets",
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/calendar",
+                "https://www.googleapis.com/auth/chat.spaces.readonly",
+            ),
+            provider="google",
+            user_email="alice@example.com",
+        )
+
+    monkeypatch.setattr(
+        auth_service, "_get_stored_oauth_credential", _fake_get_stored_oauth_credential
+    )
+    monkeypatch.setattr(
+        auth_service,
+        "_probe_google_workspace_targets",
+        lambda targets, user_email=None, access_token=None, source=None: {
+            target: {
+                "target": target,
+                "success": True,
+                "source": source or "oauth",
+                "message": f"{target} target is ready via stored OAuth.",
+            }
+            for target in targets
+        },
+    )
 
     result = asyncio.run(auth_service.test_service("gws", user_email="alice@example.com"))
 
     assert result["success"] is True
     assert result["service"] == "gws"
-    assert result["provider"] == "google"
+    assert result["source"] == "oauth"
+    assert "targets ready" in result["message"].lower()
 
 
 def test_list_summaries_prefers_native_gws_when_stored_oauth_expired(
@@ -143,11 +221,11 @@ def test_list_summaries_prefers_native_gws_when_stored_oauth_expired(
     monkeypatch.setattr(
         service,
         "_probe_google_workspace_targets",
-        lambda targets, user_email=None: {
+        lambda targets, user_email=None, access_token=None, source=None: {
             target: {
                 "target": target,
                 "success": True,
-                "source": "native:gws_cli",
+                "source": source or "native:gws_cli",
                 "message": f"{target} target is ready via local gws CLI.",
             }
             for target in targets
@@ -189,11 +267,11 @@ def test_test_service_prefers_native_gws_when_stored_oauth_expired(
     monkeypatch.setattr(
         service,
         "_probe_google_workspace_targets",
-        lambda targets, user_email=None: {
+        lambda targets, user_email=None, access_token=None, source=None: {
             target: {
                 "target": target,
                 "success": True,
-                "source": "native:gws_cli",
+                "source": source or "native:gws_cli",
                 "message": f"{target} target is ready via local gws CLI.",
             }
             for target in targets
@@ -233,11 +311,11 @@ def test_test_service_gws_reports_target_failures(
     monkeypatch.setattr(
         service,
         "_probe_google_workspace_targets",
-        lambda targets, user_email=None: {
+        lambda targets, user_email=None, access_token=None, source=None: {
             target: {
                 "target": target,
                 "success": target != "chat",
-                "source": "native:gws_cli",
+                "source": source or "native:gws_cli",
                 "message": f"{target} ok" if target != "chat" else "chat scopes missing",
                 "reason": None if target != "chat" else "missing_scopes",
             }
@@ -278,11 +356,11 @@ def test_list_summaries_marks_gws_error_when_some_targets_fail(
     monkeypatch.setattr(
         service,
         "_probe_google_workspace_targets",
-        lambda targets, user_email=None: {
+        lambda targets, user_email=None, access_token=None, source=None: {
             target: {
                 "target": target,
                 "success": target in {"drive", "docs", "sheets", "gmail", "calendar"},
-                "source": "native:gws_cli",
+                "source": source or "native:gws_cli",
                 "message": f"{target} ok"
                 if target != "chat"
                 else "chat requires additional Google OAuth scopes",
@@ -298,3 +376,36 @@ def test_list_summaries_marks_gws_error_when_some_targets_fail(
     assert summary_by_service["gws"].status == AuthStatus.ERROR
     assert "chat" in summary_by_service["gws"].message
     assert summary_by_service["google-drive"].status == AuthStatus.AUTHED
+
+
+def test_test_service_gws_target_reports_missing_stored_scope(
+    secret_store: FileSecretCredentialStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import asyncio
+
+    oauth = _FakeOAuthService()
+    service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
+
+    async def _fake_get_stored_oauth_credential(provider: str, user_email: str):  # noqa: ANN001
+        assert provider == "google"
+        assert user_email == "alice@example.com"
+        return OAuthCredential(
+            access_token="ya29.test",
+            refresh_token="1//refresh",
+            scopes=(
+                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/drive.file",
+            ),
+            provider="google",
+            user_email="alice@example.com",
+        )
+
+    monkeypatch.setattr(service, "_get_stored_oauth_credential", _fake_get_stored_oauth_credential)
+
+    result = asyncio.run(service.test_service("gws", user_email="alice@example.com", target="chat"))
+
+    assert result["success"] is False
+    assert result["source"] == "oauth"
+    assert "missing required google oauth scope" in result["message"].lower()
+    assert result["checks"][0]["target"] == "chat"
+    assert result["checks"][0]["reason"] == "missing_scopes"

--- a/tests/unit/auth/test_unified_service.py
+++ b/tests/unit/auth/test_unified_service.py
@@ -409,3 +409,22 @@ def test_test_service_gws_target_reports_missing_stored_scope(
     assert "missing required google oauth scope" in result["message"].lower()
     assert result["checks"][0]["target"] == "chat"
     assert result["checks"][0]["reason"] == "missing_scopes"
+
+
+def test_native_marker_requires_live_provider_chain_for_summary_and_resolution(
+    secret_store: FileSecretCredentialStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import asyncio
+
+    service = UnifiedAuthService(oauth_service=_FakeOAuthService(), secret_store=secret_store)
+    service.connect_native("s3")
+    monkeypatch.setattr(service, "_detect_native", lambda service_name: None)
+
+    summaries = asyncio.run(service.list_summaries())
+    summary_by_service = {summary.service: summary for summary in summaries}
+    resolution = service.resolve_backend_config("path_s3", {"bucket": "demo"})
+
+    assert summary_by_service["s3"].status == AuthStatus.NO_AUTH
+    assert summary_by_service["s3"].source == "missing"
+    assert resolution.status == AuthStatus.NO_AUTH
+    assert resolution.source == "missing"

--- a/tests/unit/auth/test_unified_service.py
+++ b/tests/unit/auth/test_unified_service.py
@@ -115,3 +115,67 @@ def test_test_service_supports_gws_alias(auth_service: UnifiedAuthService) -> No
     assert result["success"] is True
     assert result["service"] == "gws"
     assert result["provider"] == "google"
+
+
+def test_list_summaries_prefers_native_gws_when_stored_oauth_expired(
+    secret_store: FileSecretCredentialStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import asyncio
+
+    oauth = _FakeOAuthService()
+    oauth._credentials = [
+        {
+            "provider": "google",
+            "user_email": "alice@example.com",
+            "is_expired": True,
+        }
+    ]
+    service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
+    monkeypatch.setattr(
+        service,
+        "_detect_google_workspace_cli_native",
+        lambda user_email=None: {
+            "source": "native:gws_cli",
+            "email": "alice@example.com",
+            "message": "Local gws CLI profile available for alice@example.com.",
+        },
+    )
+
+    summaries = asyncio.run(service.list_summaries())
+    summary_by_service = {summary.service: summary for summary in summaries}
+
+    assert summary_by_service["gws"].status == AuthStatus.AUTHED
+    assert summary_by_service["gws"].kind == CredentialKind.NATIVE
+    assert summary_by_service["gws"].source == "native:gws_cli"
+    assert summary_by_service["gws"].details["stored_oauth_status"] == AuthStatus.EXPIRED.value
+
+
+def test_test_service_prefers_native_gws_when_stored_oauth_expired(
+    secret_store: FileSecretCredentialStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import asyncio
+
+    oauth = _FakeOAuthService()
+    oauth._credentials = [
+        {
+            "provider": "google",
+            "user_email": "alice@example.com",
+            "is_expired": True,
+        }
+    ]
+    service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
+    monkeypatch.setattr(
+        service,
+        "_detect_google_workspace_cli_native",
+        lambda user_email=None: {
+            "source": "native:gws_cli",
+            "email": "alice@example.com",
+            "message": "Local gws CLI profile available for alice@example.com.",
+        },
+    )
+
+    result = asyncio.run(service.test_service("gws", user_email="alice@example.com"))
+
+    assert result["success"] is True
+    assert result["source"] == "native:gws_cli"
+    assert "expired" in result["message"].lower()

--- a/tests/unit/backends/test_service_map.py
+++ b/tests/unit/backends/test_service_map.py
@@ -119,14 +119,15 @@ class TestAutoDerive:
     def test_connectors_with_service_name_populate_service_map(self) -> None:
         """Test that registered connectors with service_name populate service_map."""
         _sync_from_connector_registry()
-        # All connectors that declare service_name should have their connector
-        # field populated in SERVICE_REGISTRY
+        # All connectors that declare service_name should reverse-map to that
+        # service, even when several connectors share one umbrella service
+        # like gws.
         for info in ConnectorRegistry.list_all():
             if info.service_name and info.service_name in SERVICE_REGISTRY:
-                service = SERVICE_REGISTRY[info.service_name]
-                assert service.connector == info.name, (
-                    f"Service '{info.service_name}' should have connector='{info.name}', "
-                    f"got '{service.connector}'"
+                service_name = ServiceMap.get_service_name(connector=info.name)
+                assert service_name == info.service_name, (
+                    f"Connector '{info.name}' should map to service '{info.service_name}', "
+                    f"got '{service_name}'"
                 )
 
     def test_connector_registry_service_name_round_trip(self) -> None:
@@ -141,9 +142,13 @@ class TestAutoDerive:
                 )
                 # Service name → connector
                 connector = ServiceMap.get_connector(info.service_name)
-                assert connector == info.name, (
-                    f"Service '{info.service_name}' should map to connector '{info.name}', "
-                    f"got '{connector}'"
+                assert connector is not None, (
+                    f"Service '{info.service_name}' should have a canonical connector"
+                )
+                canonical_service = ServiceMap.get_service_name(connector=connector)
+                assert canonical_service == info.service_name, (
+                    f"Canonical connector '{connector}' should map back to "
+                    f"service '{info.service_name}', got '{canonical_service}'"
                 )
 
 

--- a/tests/unit/cli/test_auth_cli.py
+++ b/tests/unit/cli/test_auth_cli.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from nexus.bricks.auth.unified_service import FileSecretCredentialStore, UnifiedAuthService
+from nexus.cli.commands.auth_cli import auth
+
+
+class _FakeOAuthService:
+    async def list_credentials(self, context=None):  # noqa: ANN001, ARG002
+        return []
+
+    async def test_credential(self, provider: str, user_email: str, context=None):  # noqa: ANN001, ARG002
+        return {
+            "success": True,
+            "provider": provider,
+            "user_email": user_email,
+            "message": "OAuth credential is valid.",
+        }
+
+
+class _StubAuthService:
+    secret_store_path = Path("/tmp/test-auth-store.json")
+
+
+def _build_service(tmp_path: Path) -> UnifiedAuthService:
+    return UnifiedAuthService(
+        oauth_service=_FakeOAuthService(),
+        secret_store=FileSecretCredentialStore(tmp_path / "credentials.json"),
+    )
+
+
+def test_connect_s3_guides_and_stores_native(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    monkeypatch.setattr("nexus.cli.commands.auth_cli._build_auth_service", lambda: service)
+
+    runner = CliRunner()
+    result = runner.invoke(auth, ["connect", "s3"], input="native\n")
+
+    assert result.exit_code == 0
+    assert "Choose auth mode for s3" in result.output
+    assert "Setup steps for s3 (native)" in result.output
+    assert "Next: nexus auth test s3" in result.output
+
+    stored = service._secret_store.get("s3")  # noqa: SLF001
+    assert stored is not None
+    assert stored.kind.value == "native"
+
+
+def test_connect_gcs_secret_prompts_for_credentials_path(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    monkeypatch.setattr("nexus.cli.commands.auth_cli._build_auth_service", lambda: service)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        auth,
+        ["connect", "gcs"],
+        input="secret\n/tmp/service-account.json\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Choose auth mode for gcs" in result.output
+    assert "Setup steps for gcs (secret)" in result.output
+    assert "credentials_path" in result.output
+
+    stored = service._secret_store.get("gcs")  # noqa: SLF001
+    assert stored is not None
+    assert stored.data["credentials_path"] == "/tmp/service-account.json"
+
+
+def test_connect_gws_prompts_for_user_email_and_runs_google_setup(
+    monkeypatch,
+) -> None:
+    called: dict[str, str | None] = {}
+    monkeypatch.setattr(
+        "nexus.cli.commands.auth_cli._build_auth_service",
+        lambda: _StubAuthService(),
+    )
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", "client-id")
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", "client-secret")
+
+    def _fake_setup(
+        client_id: str | None,
+        client_secret: str | None,
+        user_email: str | None,
+        db_path: str | None,
+        zone_id: str | None,
+    ) -> None:
+        called.update(
+            {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "user_email": user_email,
+                "db_path": db_path,
+                "zone_id": zone_id,
+            }
+        )
+
+    monkeypatch.setattr("nexus.cli.commands.auth_cli.setup_gdrive.callback", _fake_setup)
+
+    runner = CliRunner()
+    result = runner.invoke(auth, ["connect", "gws"], input="alice@example.com\n")
+
+    assert result.exit_code == 0
+    assert "Setup steps for gws (oauth)" in result.output
+    assert called["user_email"] == "alice@example.com"
+
+
+def test_test_auth_reports_actionable_guidance_for_missing_gws_oauth(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    monkeypatch.setattr("nexus.cli.commands.auth_cli._build_auth_service", lambda: service)
+
+    runner = CliRunner()
+    result = runner.invoke(auth, ["test", "gws"])
+
+    assert result.exit_code != 0
+    assert "Run `nexus auth connect gws oauth`." in result.output
+
+
+def test_doctor_shows_auth_statuses(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    service.connect_secret("s3", {"access_key_id": "AKIA_TEST", "secret_access_key": "secret"})
+    monkeypatch.setattr("nexus.cli.commands.auth_cli._build_auth_service", lambda: service)
+    monkeypatch.setattr(service, "_detect_native", lambda service_name: None)
+
+    runner = CliRunner()
+    result = runner.invoke(auth, ["doctor"])
+
+    assert result.exit_code != 0
+    assert "s3" in result.output
+    assert "authed" in result.output
+    assert "gcs" in result.output
+    assert "One or more services need auth setup." in result.output

--- a/tests/unit/cli/test_auth_cli.py
+++ b/tests/unit/cli/test_auth_cli.py
@@ -87,24 +87,15 @@ def test_connect_gws_prompts_for_user_email_and_runs_google_setup(
     monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", "client-id")
     monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", "client-secret")
 
-    def _fake_setup(
-        client_id: str | None,
-        client_secret: str | None,
-        user_email: str | None,
-        db_path: str | None,
-        zone_id: str | None,
-    ) -> None:
+    def _fake_setup(service_name: str, user_email: str | None) -> None:
         called.update(
             {
-                "client_id": client_id,
-                "client_secret": client_secret,
+                "service_name": service_name,
                 "user_email": user_email,
-                "db_path": db_path,
-                "zone_id": zone_id,
             }
         )
 
-    monkeypatch.setattr("nexus.cli.commands.auth_cli.setup_gdrive.callback", _fake_setup)
+    monkeypatch.setattr("nexus.cli.commands.auth_cli._run_google_oauth_setup", _fake_setup)
 
     runner = CliRunner()
     result = runner.invoke(auth, ["connect", "gws"], input="alice@example.com\n")
@@ -112,6 +103,7 @@ def test_connect_gws_prompts_for_user_email_and_runs_google_setup(
     assert result.exit_code == 0
     assert "Setup steps for gws (oauth)" in result.output
     assert called["user_email"] == "alice@example.com"
+    assert called["service_name"] == "gws"
 
 
 def test_test_auth_reports_actionable_guidance_for_missing_gws_oauth(

--- a/tests/unit/fs/test_auth_cli.py
+++ b/tests/unit/fs/test_auth_cli.py
@@ -51,11 +51,18 @@ def test_fs_auth_connect_gws_uses_local_oauth_setup(monkeypatch) -> None:
     monkeypatch.setattr("nexus.fs._auth_cli._build_auth_service", lambda: _StubAuthService())
 
     def _fake_google_setup(
-        *, user_email: str, client_id=None, client_secret=None, db_path=None, zone_id=None
+        *,
+        user_email: str,
+        service_name="gws",
+        client_id=None,
+        client_secret=None,
+        db_path=None,
+        zone_id=None,
     ):  # noqa: ANN001
         called.update(
             {
                 "user_email": user_email,
+                "service_name": service_name,
                 "client_id": client_id,
                 "client_secret": client_secret,
                 "db_path": db_path,
@@ -71,6 +78,7 @@ def test_fs_auth_connect_gws_uses_local_oauth_setup(monkeypatch) -> None:
     assert result.exit_code == 0
     assert "Setup steps for gws (oauth)" in result.output
     assert called["user_email"] == "alice@example.com"
+    assert called["service_name"] == "gws"
 
 
 def test_fs_database_url_does_not_inherit_global_nexus_database_url(monkeypatch) -> None:

--- a/tests/unit/fs/test_auth_cli.py
+++ b/tests/unit/fs/test_auth_cli.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from click.testing import CliRunner
 
 from nexus.bricks.auth.unified_service import FileSecretCredentialStore, UnifiedAuthService
 from nexus.fs._auth_cli import auth
-from nexus.fs._oauth_support import get_fs_database_url
+from nexus.fs._oauth_support import get_fs_database_url, run_google_oauth_setup
 
 
 class _FakeOAuthService:
@@ -125,3 +126,55 @@ def test_fs_auth_test_gws_prints_target_breakdown(monkeypatch) -> None:
     assert "Next steps" in result.output
     assert "drive" in result.output
     assert "chat" in result.output
+
+
+def test_fs_google_oauth_setup_stores_service_specific_provider(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: dict[str, str] = {}
+
+    class _Provider:
+        def __init__(self, **kwargs):  # noqa: ANN003
+            calls["provider_name"] = str(kwargs["provider_name"])
+            calls["scope_text"] = " ".join(kwargs["scopes"])
+
+        def get_authorization_url(self) -> str:
+            return "https://example.test/oauth"
+
+        async def exchange_code(self, code: str):  # noqa: ANN001
+            calls["auth_code"] = code
+            return SimpleNamespace(
+                access_token="ya29.test",
+                refresh_token="1//refresh",
+                token_type="Bearer",
+                expires_at=None,
+                scopes=None,
+                client_id=None,
+                token_uri=None,
+            )
+
+    class _Manager:
+        async def store_credential(self, **kwargs):  # noqa: ANN003
+            calls["stored_provider"] = str(kwargs["provider"])
+            return "cred-123"
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", "client-id")
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", "client-secret")
+    monkeypatch.setattr(
+        "nexus.fs._oauth_support.get_token_manager", lambda db_path=None: _Manager()
+    )
+    monkeypatch.setattr(
+        "nexus.fs._oauth_support._il.import_module",
+        lambda name: SimpleNamespace(GoogleOAuthProvider=_Provider)
+        if name == "nexus.bricks.auth.oauth.providers.google"
+        else None,
+    )
+
+    monkeypatch.setattr("click.prompt", lambda *args, **kwargs: "code-123")
+    run_google_oauth_setup(user_email="alice@example.com", service_name="google-drive")
+
+    assert calls["provider_name"] == "google-drive"
+    assert calls["stored_provider"] == "google-drive"

--- a/tests/unit/fs/test_auth_cli.py
+++ b/tests/unit/fs/test_auth_cli.py
@@ -112,5 +112,8 @@ def test_fs_auth_test_gws_prints_target_breakdown(monkeypatch) -> None:
 
     assert result.exit_code != 0
     assert "gws target readiness" in result.output
+    assert "Ready:" in result.output
+    assert "Needs action:" in result.output
+    assert "Next steps" in result.output
     assert "drive" in result.output
     assert "chat" in result.output

--- a/tests/unit/fs/test_auth_cli.py
+++ b/tests/unit/fs/test_auth_cli.py
@@ -168,9 +168,11 @@ def test_fs_google_oauth_setup_stores_service_specific_provider(
     )
     monkeypatch.setattr(
         "nexus.fs._oauth_support._il.import_module",
-        lambda name: SimpleNamespace(GoogleOAuthProvider=_Provider)
-        if name == "nexus.bricks.auth.oauth.providers.google"
-        else None,
+        lambda name: (
+            SimpleNamespace(GoogleOAuthProvider=_Provider)
+            if name == "nexus.bricks.auth.oauth.providers.google"
+            else None
+        ),
     )
 
     monkeypatch.setattr("click.prompt", lambda *args, **kwargs: "code-123")

--- a/tests/unit/fs/test_auth_cli.py
+++ b/tests/unit/fs/test_auth_cli.py
@@ -6,6 +6,7 @@ from click.testing import CliRunner
 
 from nexus.bricks.auth.unified_service import FileSecretCredentialStore, UnifiedAuthService
 from nexus.fs._auth_cli import auth
+from nexus.fs._oauth_support import get_fs_database_url
 
 
 class _FakeOAuthService:
@@ -70,3 +71,9 @@ def test_fs_auth_connect_gws_uses_local_oauth_setup(monkeypatch) -> None:
     assert result.exit_code == 0
     assert "Setup steps for gws (oauth)" in result.output
     assert called["user_email"] == "alice@example.com"
+
+
+def test_fs_database_url_does_not_inherit_global_nexus_database_url(monkeypatch) -> None:
+    monkeypatch.setenv("NEXUS_DATABASE_URL", "postgresql://postgres:nexus@localhost:46702/nexus")
+    monkeypatch.delenv("NEXUS_FS_DATABASE_URL", raising=False)
+    assert get_fs_database_url() is None

--- a/tests/unit/fs/test_auth_cli.py
+++ b/tests/unit/fs/test_auth_cli.py
@@ -77,3 +77,40 @@ def test_fs_database_url_does_not_inherit_global_nexus_database_url(monkeypatch)
     monkeypatch.setenv("NEXUS_DATABASE_URL", "postgresql://postgres:nexus@localhost:46702/nexus")
     monkeypatch.delenv("NEXUS_FS_DATABASE_URL", raising=False)
     assert get_fs_database_url() is None
+
+
+def test_fs_auth_test_gws_prints_target_breakdown(monkeypatch) -> None:
+    class _Service:
+        async def test_service(self, service_name, user_email=None, target=None, context=None):  # noqa: ANN001, ARG002
+            assert service_name == "gws"
+            assert target is None
+            return {
+                "success": False,
+                "service": "gws",
+                "source": "native:gws_cli",
+                "message": "chat: chat scopes missing",
+                "checks": [
+                    {
+                        "target": "drive",
+                        "success": True,
+                        "source": "native:gws_cli",
+                        "message": "drive target is ready via local gws CLI.",
+                    },
+                    {
+                        "target": "chat",
+                        "success": False,
+                        "source": "native:gws_cli",
+                        "message": "chat scopes missing",
+                    },
+                ],
+            }
+
+    monkeypatch.setattr("nexus.fs._auth_cli._build_auth_service", lambda: _Service())
+
+    runner = CliRunner()
+    result = runner.invoke(auth, ["test", "gws"])
+
+    assert result.exit_code != 0
+    assert "gws target readiness" in result.output
+    assert "drive" in result.output
+    assert "chat" in result.output

--- a/tests/unit/fs/test_auth_cli.py
+++ b/tests/unit/fs/test_auth_cli.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from nexus.bricks.auth.unified_service import FileSecretCredentialStore, UnifiedAuthService
+from nexus.fs._auth_cli import auth
+
+
+class _FakeOAuthService:
+    async def list_credentials(self, context=None):  # noqa: ANN001, ARG002
+        return []
+
+    async def test_credential(self, provider: str, user_email: str, context=None):  # noqa: ANN001, ARG002
+        return {
+            "success": True,
+            "provider": provider,
+            "user_email": user_email,
+            "message": "OAuth credential is valid.",
+        }
+
+
+class _StubAuthService:
+    secret_store_path = Path("/tmp/test-auth-store.json")
+
+
+def _build_service(tmp_path: Path) -> UnifiedAuthService:
+    return UnifiedAuthService(
+        oauth_service=_FakeOAuthService(),
+        secret_store=FileSecretCredentialStore(tmp_path / "credentials.json"),
+    )
+
+
+def test_fs_auth_connect_s3_guides_and_stores_native(monkeypatch, tmp_path: Path) -> None:
+    service = _build_service(tmp_path)
+    monkeypatch.setattr("nexus.fs._auth_cli._build_auth_service", lambda: service)
+
+    runner = CliRunner()
+    result = runner.invoke(auth, ["connect", "s3"], input="native\n")
+
+    assert result.exit_code == 0
+    assert "Choose auth mode for s3" in result.output
+    assert "Setup steps for s3 (native)" in result.output
+    assert "Next: nexus-fs auth test s3" in result.output
+
+
+def test_fs_auth_connect_gws_uses_local_oauth_setup(monkeypatch) -> None:
+    called: dict[str, str | None] = {}
+    monkeypatch.setattr("nexus.fs._auth_cli._build_auth_service", lambda: _StubAuthService())
+
+    def _fake_google_setup(
+        *, user_email: str, client_id=None, client_secret=None, db_path=None, zone_id=None
+    ):  # noqa: ANN001
+        called.update(
+            {
+                "user_email": user_email,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "db_path": db_path,
+                "zone_id": zone_id,
+            }
+        )
+
+    monkeypatch.setattr("nexus.fs._auth_cli.run_google_oauth_setup", _fake_google_setup)
+
+    runner = CliRunner()
+    result = runner.invoke(auth, ["connect", "gws"], input="alice@example.com\n")
+
+    assert result.exit_code == 0
+    assert "Setup steps for gws (oauth)" in result.output
+    assert called["user_email"] == "alice@example.com"

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -669,6 +669,56 @@ class TestPlaygroundApp:
             }
         ]
 
+    @pytest.mark.asyncio
+    async def test_contextual_fs_stat_falls_back_to_backend_directory_entries(self):
+        """Preview should be able to stat connector-backed files from live backend rows."""
+
+        class _Backend:
+            def list_dir_details(self, path, context=None):
+                assert path == ""
+                return [
+                    {
+                        "name": "Doc Alpha [docA]",
+                        "size": 123,
+                        "modified_at": "2026-03-26T00:40:00Z",
+                        "is_directory": False,
+                    }
+                ]
+
+        class _Route:
+            def __init__(self):
+                self.backend = _Backend()
+                self.backend_path = ""
+
+        class _Router:
+            def route(self, path, is_admin=True, check_write=False):
+                assert path in {"/gws/docs", "/gws/docs/Doc Alpha [docA]"}
+                return _Route()
+
+        class _Kernel:
+            router = _Router()
+
+            async def sys_readdir(self, path, recursive=False, details=False, context=None):
+                return []
+
+            async def sys_stat(self, path, context=None):
+                return None
+
+        fs = ContextualNexusFS(_Kernel())
+        stat = await fs.stat("/gws/docs/Doc Alpha [docA]")
+        assert stat == {
+            "path": "/gws/docs/Doc Alpha [docA]",
+            "size": 123,
+            "is_directory": False,
+            "etag": None,
+            "mime_type": "application/octet-stream",
+            "created_at": None,
+            "modified_at": "2026-03-26T00:40:00Z",
+            "version": 0,
+            "zone_id": "root",
+            "entry_type": 0,
+        }
+
     def test_supported_connector_rows_include_dynamic_gws_targets(self):
         """The playground lists concrete connector mount targets, not just services."""
         app = PlaygroundApp(uris=())

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -621,6 +621,14 @@ class TestPlaygroundApp:
             assert await app._resolve_mount_user_id("gws://drive") == "alice@example.com"
 
     @pytest.mark.asyncio
+    async def test_resolve_mount_user_id_uses_shared_fs_inference(self):
+        """Playground should reuse the shared slim-fs inference path."""
+        app = PlaygroundApp(uris=())
+
+        with patch("nexus.fs._infer_connector_user_email", return_value="alice@example.com"):
+            assert await app._resolve_mount_user_id("gws://drive") == "alice@example.com"
+
+    @pytest.mark.asyncio
     async def test_build_filesystem_uses_generic_mount_for_connector_uri(self):
         """Connector URIs go through nexus.fs.mount instead of the direct-only path."""
         app = PlaygroundApp(uris=())

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -552,6 +552,18 @@ class TestPlaygroundApp:
         assert "gws://calendar" in names
         assert "calendar://primary" not in names
 
+    def test_supported_connector_rows_include_discovered_s3_buckets(self):
+        """Discovered S3 buckets should appear as directly mountable picker rows."""
+        app = PlaygroundApp(uris=())
+        with patch.object(
+            app,
+            "_discovered_s3_bucket_rows",
+            return_value=[("s3://nexus-888", "mountable auth:s3 discovered")],
+        ):
+            rows = app._supported_connector_rows()
+        names = {name for name, _mode in rows}
+        assert "s3://nexus-888" in names
+
     @pytest.mark.asyncio
     async def test_resolve_mount_user_id_prefers_single_google_credential(self):
         """A single stored Google credential becomes the mount user identity."""

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -6,6 +6,7 @@ large files, empty state, rapid interaction), and widget-level tests.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -416,6 +417,55 @@ class TestPlaygroundApp:
             picker = app.query_one("#connector-picker", DataTable)
             assert picker is not None
             assert app.picker_visible is True
+
+    @pytest.mark.asyncio
+    async def test_connector_picker_prompts_for_custom_local_uri(self, tmp_path):
+        """The local picker row opens an editable URI input before mounting."""
+        app = PlaygroundApp(uris=())
+        state_dir = tmp_path / "state"
+
+        with patch.dict("os.environ", {"NEXUS_FS_STATE_DIR": str(state_dir)}, clear=False):
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause(delay=0.5)
+                await pilot.press("enter")
+                await pilot.pause(delay=0.2)
+                picker_input = app.query_one("#picker-input")
+                assert app.picker_input_visible is True
+                assert "local://" in picker_input.value
+
+    @pytest.mark.asyncio
+    async def test_connector_picker_local_input_mounts_custom_uri(self, tmp_path):
+        """The mount wizard can complete a local mount without raw command entry."""
+        app = PlaygroundApp(uris=())
+        target_uri = f"local://{tmp_path}"
+        state_dir = tmp_path / "state"
+
+        with patch.dict("os.environ", {"NEXUS_FS_STATE_DIR": str(state_dir)}, clear=False):
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause(delay=0.5)
+                await pilot.press("enter")
+                await pilot.pause(delay=0.2)
+                picker_input = app.query_one("#picker-input")
+                picker_input.value = target_uri
+                await app.action_submit_command()
+                await pilot.pause(delay=0.3)
+                assert any(mp.endswith(tmp_path.name) for mp in app._mount_points)
+                assert app.picker_visible is False
+
+    @pytest.mark.asyncio
+    async def test_browser_banner_mentions_restored_mounts(self, tmp_path):
+        """Restored sessions should say so explicitly in the top banner."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        mounts_file = state_dir / "mounts.json"
+        mounts_file.write_text(json.dumps([f"local://{tmp_path}"]))
+        app = PlaygroundApp(uris=())
+
+        with patch.dict("os.environ", {"NEXUS_FS_STATE_DIR": str(state_dir)}, clear=False):
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause(delay=0.5)
+                banner = app.query_one("#playground-banner")
+                assert "Restored 1 mount" in str(banner.render())
 
     def test_auth_guidance_for_s3(self):
         """S3 auth guidance points users to the guided CLI flow."""

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -573,6 +573,102 @@ class TestPlaygroundApp:
         assert rows[1]["path"] == "/gws/docs/Folder"
         assert rows[1]["is_directory"] is True
 
+    @pytest.mark.asyncio
+    async def test_contextual_fs_prefers_detailed_backend_entries(self):
+        """Detailed connector metadata should flow through to the browser rows."""
+
+        class _Backend:
+            def list_dir_details(self, path, context=None):
+                assert path == ""
+                return [
+                    {
+                        "name": "Doc Alpha [docA]",
+                        "size": 123,
+                        "modified_at": "2026-03-26T00:40:00Z",
+                        "is_directory": False,
+                    }
+                ]
+
+        class _Route:
+            def __init__(self):
+                self.backend = _Backend()
+                self.backend_path = ""
+
+        class _Router:
+            def route(self, path, is_admin=True, check_write=False):
+                assert path == "/gws/docs"
+                return _Route()
+
+        class _Kernel:
+            router = _Router()
+
+            async def sys_readdir(self, path, recursive=False, details=False, context=None):
+                assert path == "/gws/docs"
+                return []
+
+        fs = ContextualNexusFS(_Kernel())
+        rows = await fs.ls("/gws/docs", detail=True, recursive=False)
+        assert rows[0]["path"] == "/gws/docs/Doc Alpha [docA]"
+        assert rows[0]["size"] == 123
+        assert rows[0]["modified_at"] == "2026-03-26T00:40:00Z"
+
+    @pytest.mark.asyncio
+    async def test_contextual_fs_prefers_live_backend_rows_over_stale_metadata(self):
+        """Connector root browsing should prefer live backend listings over synthetic VFS rows."""
+
+        class _Backend:
+            def list_dir_details(self, path, context=None):
+                assert path == ""
+                return [
+                    {
+                        "name": "Fresh Doc [docA]",
+                        "size": 456,
+                        "modified_at": "2026-03-26T01:00:00Z",
+                        "is_directory": False,
+                    }
+                ]
+
+        class _Route:
+            def __init__(self):
+                self.backend = _Backend()
+                self.backend_path = ""
+
+        class _Router:
+            def route(self, path, is_admin=True, check_write=False):
+                assert path == "/gws/docs"
+                return _Route()
+
+        class _Kernel:
+            router = _Router()
+
+            async def sys_readdir(self, path, recursive=False, details=False, context=None):
+                assert path == "/gws/docs"
+                return [
+                    {
+                        "path": "/gws/docs/Stale Doc",
+                        "size": 0,
+                        "modified_at": "2026-03-26T00:00:00Z",
+                        "is_directory": False,
+                    }
+                ]
+
+        fs = ContextualNexusFS(_Kernel())
+        rows = await fs.ls("/gws/docs", detail=True, recursive=False)
+        assert rows == [
+            {
+                "path": "/gws/docs/Fresh Doc [docA]",
+                "size": 456,
+                "is_directory": False,
+                "etag": None,
+                "mime_type": "application/octet-stream",
+                "created_at": None,
+                "modified_at": "2026-03-26T01:00:00Z",
+                "version": 0,
+                "zone_id": "root",
+                "entry_type": 0,
+            }
+        ]
+
     def test_supported_connector_rows_include_dynamic_gws_targets(self):
         """The playground lists concrete connector mount targets, not just services."""
         app = PlaygroundApp(uris=())

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -18,7 +18,7 @@ textual = pytest.importorskip("textual")
 
 from textual.widgets import DataTable  # noqa: E402
 
-from nexus.fs._tui import PlaygroundApp  # noqa: E402
+from nexus.fs._tui import ContextualNexusFS, PlaygroundApp  # noqa: E402
 from nexus.fs._tui.file_browser import (  # noqa: E402
     MAX_DISPLAY_ENTRIES,
     FileBrowser,
@@ -540,6 +540,39 @@ class TestPlaygroundApp:
         assert "nexus-fs auth connect s3 native" in message
         assert "/mount s3://bucket" in message
 
+    @pytest.mark.asyncio
+    async def test_contextual_fs_falls_back_to_backend_list_dir_for_empty_metadata(self):
+        """Connector-backed playground mounts should still browse when slim metadata is empty."""
+
+        class _Backend:
+            def list_dir(self, path, context=None):
+                assert path == ""
+                return ["Doc Alpha", "Folder/"]
+
+        class _Route:
+            backend = _Backend()
+            backend_path = ""
+
+        class _Router:
+            def route(self, path, is_admin=True, check_write=False):
+                assert path == "/gws/docs"
+                return _Route()
+
+        class _Kernel:
+            router = _Router()
+
+            async def sys_readdir(self, path, recursive=False, details=False, context=None):
+                assert path == "/gws/docs"
+                return []
+
+        fs = ContextualNexusFS(_Kernel())
+        rows = await fs.ls("/gws/docs", detail=True, recursive=False)
+        assert isinstance(rows, list)
+        assert rows[0]["path"] == "/gws/docs/Doc Alpha"
+        assert rows[0]["is_directory"] is False
+        assert rows[1]["path"] == "/gws/docs/Folder"
+        assert rows[1]["is_directory"] is True
+
     def test_supported_connector_rows_include_dynamic_gws_targets(self):
         """The playground lists concrete connector mount targets, not just services."""
         app = PlaygroundApp(uris=())
@@ -550,6 +583,7 @@ class TestPlaygroundApp:
         assert "gws://drive" in names
         assert "gws://gmail" in names
         assert "gws://calendar" in names
+        assert "gws://github" not in names
         assert "calendar://primary" not in names
 
     def test_supported_connector_rows_include_discovered_s3_buckets(self):

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -486,6 +486,18 @@ class TestPlaygroundApp:
                 banner = app.query_one("#playground-banner")
                 assert "Restored 1 mount" in str(banner.render())
 
+    @pytest.mark.asyncio
+    async def test_too_small_hides_main_content(self, tmp_path):
+        """Too-small terminals should show only the warning, not stacked content underneath."""
+        app = PlaygroundApp(uris=(f"local://{tmp_path}",))
+
+        async with app.run_test(size=(99, 22)) as pilot:
+            await pilot.pause(delay=0.5)
+            assert app.query_one("#too-small-message").display is True
+            assert app.query_one("#playground-banner").display is False
+            assert app.query_one("#main-area").display is False
+            assert app.query_one("#status-bar").display is False
+
     def test_auth_guidance_for_s3(self):
         """S3 auth guidance points users to the guided CLI flow."""
         app = PlaygroundApp(uris=())
@@ -502,6 +514,8 @@ class TestPlaygroundApp:
         assert "gcs://project/bucket" in names
         assert "gws://drive" in names
         assert "gws://gmail" in names
+        assert "gws://calendar" in names
+        assert "calendar://primary" not in names
 
     @pytest.mark.asyncio
     async def test_resolve_mount_user_id_prefers_single_google_credential(self):

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -14,6 +14,8 @@ import pytest
 textual = pytest.importorskip("textual")
 
 
+from textual.widgets import DataTable  # noqa: E402
+
 from nexus.fs._tui import PlaygroundApp  # noqa: E402
 from nexus.fs._tui.file_browser import (  # noqa: E402
     MAX_DISPLAY_ENTRIES,
@@ -201,6 +203,12 @@ class TestMountPanel:
         info = panel._mount_infos[0]
         assert info.status == "checking"
 
+    def test_error_render_includes_auth_hint(self):
+        """Auth-backed mount errors include inline next-step guidance."""
+        panel = MountPanel(_make_mock_fs(), ["/s3/bucket"])
+        rendered = panel._render_mount(MountInfo(mount_point="/s3/bucket", status="error"))
+        assert "run /auth s3" in rendered
+
 
 # ---------------------------------------------------------------------------
 # File browser tests
@@ -289,6 +297,8 @@ class TestPlaygroundApp:
                 # App should show empty state
                 empty = app.query_one("#empty-state")
                 assert empty is not None
+                picker = app.query_one("#connector-picker", DataTable)
+                assert picker is not None
 
     @pytest.mark.asyncio
     async def test_mount_failure_shows_error(self):
@@ -333,6 +343,135 @@ class TestPlaygroundApp:
             assert app.show_mount_panel is False
             app.action_toggle_mount_panel()
             assert app.show_mount_panel is True
+
+    @pytest.mark.asyncio
+    async def test_command_toggle_via_action(self):
+        """Toggle command action changes command_visible state."""
+        app = PlaygroundApp(uris=())
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.3)
+            assert not app.command_visible
+            app.action_toggle_command()
+            assert app.command_visible
+            app.action_toggle_command()
+            assert not app.command_visible
+
+    @pytest.mark.asyncio
+    async def test_mount_uri_adds_local_mount(self, tmp_path):
+        """The command-path mount helper adds a local mount and rebuilds the UI."""
+        app = PlaygroundApp(uris=())
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.3)
+            await app._mount_uri(f"local://{tmp_path}")
+            await pilot.pause(delay=0.3)
+            assert any(mp.endswith(tmp_path.name) for mp in app._mount_points)
+
+    @pytest.mark.asyncio
+    async def test_submit_command_mounts_local_uri(self, tmp_path):
+        """Submitting the command buffer mounts a local URI."""
+        app = PlaygroundApp(uris=())
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.3)
+            app.command_visible = True
+            app.command_buffer = f"/mount local://{tmp_path}"
+            await app.action_submit_command()
+            await pilot.pause(delay=0.3)
+            assert any(mp.endswith(tmp_path.name) for mp in app._mount_points)
+
+    @pytest.mark.asyncio
+    async def test_connector_picker_mounts_selected_uri(self, tmp_path):
+        """Selecting a connector picker row mounts it and transitions to browser UI."""
+        app = PlaygroundApp(uris=())
+        target_uri = f"local://{tmp_path}"
+        state_dir = tmp_path / "state"
+
+        with (
+            patch.dict("os.environ", {"NEXUS_FS_STATE_DIR": str(state_dir)}, clear=False),
+            patch.object(
+                app, "_supported_connector_rows", return_value=[(target_uri, "mountable")]
+            ),
+        ):
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause(delay=0.5)
+                picker = app.query_one("#connector-picker", DataTable)
+                assert picker.row_count == 1
+                await pilot.press("enter")
+                await pilot.pause(delay=0.5)
+                assert any(mp.endswith(tmp_path.name) for mp in app._mount_points)
+                assert app.picker_visible is False
+
+    @pytest.mark.asyncio
+    async def test_show_connector_picker_action_from_browser(self, tmp_path):
+        """The add-mount action reopens the connector picker from browser mode."""
+        app = PlaygroundApp(uris=(f"local://{tmp_path}",))
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.5)
+            assert app.picker_visible is False
+            await app.action_show_connector_picker()
+            await pilot.pause(delay=0.2)
+            picker = app.query_one("#connector-picker", DataTable)
+            assert picker is not None
+            assert app.picker_visible is True
+
+    def test_auth_guidance_for_s3(self):
+        """S3 auth guidance points users to the guided CLI flow."""
+        app = PlaygroundApp(uris=())
+        message = app._auth_guidance("s3")
+        assert "nexus-fs auth connect s3 native" in message
+        assert "/mount s3://bucket" in message
+
+    def test_supported_connector_rows_include_dynamic_gws_targets(self):
+        """The playground lists concrete connector mount targets, not just services."""
+        app = PlaygroundApp(uris=())
+        rows = app._supported_connector_rows()
+        names = {name for name, _mode in rows}
+        assert "s3://bucket/<prefix>" in names
+        assert "gcs://project/bucket" in names
+        assert "gws://drive" in names
+        assert "gws://gmail" in names
+
+    @pytest.mark.asyncio
+    async def test_resolve_mount_user_id_prefers_single_google_credential(self):
+        """A single stored Google credential becomes the mount user identity."""
+        app = PlaygroundApp(uris=())
+
+        with (
+            patch("nexus.cli.commands.oauth.get_token_manager", return_value=MagicMock()),
+            patch(
+                "nexus.bricks.auth.oauth.credential_service.OAuthCredentialService.list_credentials",
+                new=AsyncMock(
+                    return_value=[
+                        {
+                            "provider": "google",
+                            "user_email": "alice@example.com",
+                        }
+                    ]
+                ),
+            ),
+        ):
+            assert await app._resolve_mount_user_id("gws://drive") == "alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_build_filesystem_uses_generic_mount_for_connector_uri(self):
+        """Connector URIs go through nexus.fs.mount instead of the direct-only path."""
+        app = PlaygroundApp(uris=())
+        kernel = MagicMock()
+        kernel.router.list_mounts.return_value = ["/gws/drive"]
+        facade = MagicMock(kernel=kernel)
+
+        with (
+            patch("nexus.fs.mount", new=AsyncMock(return_value=facade)) as mock_mount,
+            patch.object(
+                app, "_resolve_mount_user_id", new=AsyncMock(return_value="alice@example.com")
+            ),
+        ):
+            fs = await app._build_filesystem(("gws://drive",))
+            mock_mount.assert_awaited_once_with("gws://drive")
+            assert fs.list_mounts() == ["/gws/drive"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -545,7 +545,7 @@ class TestPlaygroundApp:
         app = PlaygroundApp(uris=())
         rows = app._supported_connector_rows()
         names = {name for name, _mode in rows}
-        assert "s3://bucket/<prefix>" in names
+        assert "s3://<enter bucket manually>" in names
         assert "gcs://project/bucket" in names
         assert "gws://drive" in names
         assert "gws://gmail" in names
@@ -561,8 +561,9 @@ class TestPlaygroundApp:
             return_value=[("s3://nexus-888", "mountable auth:s3 discovered")],
         ):
             rows = app._supported_connector_rows()
-        names = {name for name, _mode in rows}
+        names = [name for name, _mode in rows]
         assert "s3://nexus-888" in names
+        assert names.index("s3://nexus-888") < names.index("s3://<enter bucket manually>")
 
     @pytest.mark.asyncio
     async def test_resolve_mount_user_id_prefers_single_google_credential(self):

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -453,6 +453,25 @@ class TestPlaygroundApp:
                 assert app.picker_visible is False
 
     @pytest.mark.asyncio
+    async def test_browser_enter_opens_selected_directory(self, tmp_path):
+        """Pressing Enter in the file browser should navigate into the selected directory."""
+        (tmp_path / "skills").mkdir()
+        (tmp_path / "skills" / "nested.txt").write_text("hi")
+        (tmp_path / "hello.txt").write_text("hello")
+        app = PlaygroundApp(uris=(f"local://{tmp_path}",))
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.5)
+            browser = app.query_one("#file-browser", FileBrowser)
+            table = browser.query_one("#file-table", DataTable)
+            table.focus()
+            await pilot.pause(delay=0.1)
+            await pilot.press("enter")
+            await pilot.pause(delay=0.3)
+            assert browser.current_path.endswith("/skills")
+            assert app._current_path.endswith("/skills")
+
+    @pytest.mark.asyncio
     async def test_browser_banner_mentions_restored_mounts(self, tmp_path):
         """Restored sessions should say so explicitly in the top banner."""
         state_dir = tmp_path / "state"

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -19,6 +19,7 @@ textual = pytest.importorskip("textual")
 from textual.widgets import DataTable  # noqa: E402
 
 from nexus.fs._tui import ContextualNexusFS, PlaygroundApp  # noqa: E402
+from nexus.fs._tui.auth_guidance import auth_guidance, format_runtime_error  # noqa: E402
 from nexus.fs._tui.file_browser import (  # noqa: E402
     MAX_DISPLAY_ENTRIES,
     FileBrowser,
@@ -538,7 +539,24 @@ class TestPlaygroundApp:
         app = PlaygroundApp(uris=())
         message = app._auth_guidance("s3")
         assert "nexus-fs auth connect s3 native" in message
-        assert "/mount s3://bucket" in message
+        assert "reopen the playground and mount `s3://bucket`" in message
+
+    def test_auth_guidance_for_expired_gws(self):
+        """Expired Google auth gets explicit re-auth steps."""
+        message = auth_guidance("gws", user_email="alice@example.com", expired=True)
+        assert "Google auth expired" in message
+        assert "nexus-fs auth connect gws oauth --user-email alice@example.com" in message
+        assert "nexus-fs auth test gws" in message
+
+    def test_runtime_error_formats_expired_gws_steps(self):
+        """Browse/preview auth failures should render guided steps, not raw backend text."""
+        message = format_runtime_error(
+            "/gws/docs",
+            RuntimeError("[AUTH_EXPIRED] Using keyring backend: keyring"),
+        )
+        assert "Can't access `/gws/docs`." in message
+        assert "Google auth expired" in message
+        assert "nexus-fs auth connect gws oauth" in message
 
     @pytest.mark.asyncio
     async def test_contextual_fs_falls_back_to_backend_list_dir_for_empty_metadata(self):

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -486,6 +486,27 @@ class TestPlaygroundApp:
                 assert app._mount_points == []
 
     @pytest.mark.asyncio
+    async def test_unmount_selected_mount_removes_mount(self, tmp_path):
+        """Unmount removes the selected mount from the active playground session."""
+        left = tmp_path / "left"
+        right = tmp_path / "right"
+        left.mkdir()
+        right.mkdir()
+        app = PlaygroundApp(uris=(f"local://{left}", f"local://{right}"))
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.5)
+            app.action_focus_mount_panel()
+            await pilot.pause(delay=0.1)
+            panel = app.query_one("#mount-panel", MountPanel)
+            panel.selected_index = 1
+            await pilot.pause(delay=0.1)
+            await app.action_unmount_selected_mount()
+            await pilot.pause(delay=0.3)
+            assert app._mount_points == [f"/local/{left.name}"]
+            assert app._uris == (f"local://{left}",)
+
+    @pytest.mark.asyncio
     async def test_browser_banner_mentions_restored_mounts(self, tmp_path):
         """Restored sessions should say so explicitly in the top banner."""
         state_dir = tmp_path / "state"

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -7,6 +7,7 @@ large files, empty state, rapid interaction), and widget-level tests.
 from __future__ import annotations
 
 import json
+import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -470,6 +471,19 @@ class TestPlaygroundApp:
             await pilot.pause(delay=0.3)
             assert browser.current_path.endswith("/skills")
             assert app._current_path.endswith("/skills")
+
+    @pytest.mark.asyncio
+    async def test_mount_uri_rejects_empty_s3_bucket(self):
+        """Incomplete S3 URIs should be rejected instead of creating a broken /s3/ mount."""
+        app = PlaygroundApp(uris=())
+        state_dir = tempfile.mkdtemp(prefix="playground-empty-s3-")
+
+        with patch.dict("os.environ", {"NEXUS_FS_STATE_DIR": state_dir}, clear=False):
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause(delay=0.3)
+                await app._mount_uri("s3://")
+                await pilot.pause(delay=0.2)
+                assert app._mount_points == []
 
     @pytest.mark.asyncio
     async def test_browser_banner_mentions_restored_mounts(self, tmp_path):

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -769,7 +769,7 @@ class TestPlaygroundApp:
         app = PlaygroundApp(uris=())
 
         with (
-            patch("nexus.cli.commands.oauth.get_token_manager", return_value=MagicMock()),
+            patch("nexus.fs._oauth_support.get_token_manager", return_value=MagicMock()),
             patch(
                 "nexus.bricks.auth.oauth.credential_service.OAuthCredentialService.list_credentials",
                 new=AsyncMock(

--- a/tests/unit/services/test_mount_service.py
+++ b/tests/unit/services/test_mount_service.py
@@ -116,6 +116,11 @@ class TestMountServiceInit:
         assert service.mount_manager is None
         assert service.nexus_fs is None
 
+    def test_init_stores_auth_service(self, mock_router) -> None:
+        auth_service = MagicMock()
+        service = MountService(router=mock_router, auth_service=auth_service)
+        assert service._auth_service is auth_service
+
 
 # =============================================================================
 # list_mounts tests
@@ -241,6 +246,64 @@ class TestRemoveMount:
         assert result["removed"] is True
         assert result["directory_deleted"] is False
         assert len(result["errors"]) > 0
+
+
+class TestAddMountAuthResolution:
+    """Tests auth resolution during mount creation."""
+
+    def test_add_mount_uses_auth_service_resolution(
+        self, mock_router, mock_mount_manager, mock_nexus_fs, mock_driver_coordinator
+    ) -> None:
+        auth_service = MagicMock()
+        auth_service.resolve_backend_config.return_value = MagicMock(
+            resolved_config={"bucket": "demo", "access_key_id": "AKIA", "secret_access_key": "x"},
+            status=MagicMock(value="authed"),
+            message=None,
+        )
+        service = MountService(
+            router=mock_router,
+            mount_manager=mock_mount_manager,
+            nexus_fs=mock_nexus_fs,
+            auth_service=auth_service,
+        )
+        service._check_permission = MagicMock(return_value=True)
+        service._create_backend = MagicMock(return_value=MagicMock())
+        service._setup_mount_point = MagicMock()
+        service._driver_coordinator = mock_driver_coordinator
+
+        result = service.add_mount_sync(
+            "/mnt/s3",
+            "path_s3",
+            {"bucket": "demo"},
+        )
+
+        assert result == "/mnt/s3"
+        auth_service.resolve_backend_config.assert_called_once()
+        service._create_backend.assert_called_once_with(
+            "path_s3",
+            {"bucket": "demo", "access_key_id": "AKIA", "secret_access_key": "x"},
+        )
+
+    def test_add_mount_raises_when_auth_missing(
+        self, mock_router, mock_mount_manager, mock_nexus_fs, mock_driver_coordinator
+    ) -> None:
+        auth_service = MagicMock()
+        auth_service.resolve_backend_config.return_value = MagicMock(
+            resolved_config={"bucket": "demo"},
+            status=MagicMock(value="no_auth"),
+            message="Run `nexus auth connect s3 secret`.",
+        )
+        service = MountService(
+            router=mock_router,
+            mount_manager=mock_mount_manager,
+            nexus_fs=mock_nexus_fs,
+            auth_service=auth_service,
+        )
+        service._check_permission = MagicMock(return_value=True)
+        service._driver_coordinator = mock_driver_coordinator
+
+        with pytest.raises(RuntimeError, match="nexus auth connect s3 secret"):
+            service.add_mount_sync("/mnt/s3", "path_s3", {"bucket": "demo"})
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add a backend-agnostic unified auth service and CLI for OAuth, stored secrets, and native credentials
- wire auth status and guided auth flows into mounts, doctor, connector discovery, and nexus-fs
- add an interactive playground connector picker so users can browse supported connectors and press Enter to mount

## Testing
- PYTHONPATH=src python -m pytest -q tests/unit/fs/test_tui.py
- PYTHONPATH=src uv run pytest -q -o addopts='' tests/unit/auth/test_unified_service.py tests/unit/cli/test_auth_cli.py
- pre-commit hooks during git commit (ruff, ruff format, mypy)