### PR TITLE
feat(#3233): harden fsspec contract, validate pandas/HuggingFace integrations

### DIFF
--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -47,9 +47,8 @@ gdrive = [
 ]
 fsspec = ["fsspec>=2024.0"]
 tui = ["textual>=1.0"]
-langchain = ["langchain-core>=0.2"]
 all = [
-    "nexus-fs[s3,gcs,gdrive,fsspec,tui,langchain]",
+    "nexus-fs[s3,gcs,gdrive,fsspec,tui]",
 ]
 dev = [
     "nexus-fs[all]",

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -179,8 +179,15 @@ class SlimNexusFS:
         """
         return await self._kernel.sys_access(path, context=self._ctx)
 
+    # Maximum file size for read-copy before refusing (1 GB).
+    # Native backend copy is planned for a future release.
+    _MAX_COPY_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB
+
     async def copy(self, src: str, dst: str) -> dict[str, Any]:
         """Copy a file from src to dst.
+
+        Uses a read-then-write approach.  Files larger than 1 GB are
+        refused — native backend copy is planned for a future release.
 
         Args:
             src: Source file path.
@@ -188,7 +195,19 @@ class SlimNexusFS:
 
         Returns:
             Dict with path, size, etag of the new file.
+
+        Raises:
+            ValueError: If the source file exceeds 1 GB.
         """
+        stat = await self.stat(src)
+        if stat is None:
+            raise FileNotFoundError(src)
+        if stat.get("size", 0) > self._MAX_COPY_SIZE:
+            size_gb = stat["size"] / (1024**3)
+            raise ValueError(
+                f"File too large for read-copy ({size_gb:.1f} GB > 1 GB limit). "
+                f"Native backend copy is planned for a future release."
+            )
         content = await self.read(src)
         return await self.write(dst, content)
 

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 import io
 import logging
 import os
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 try:
     from fsspec.spec import AbstractFileSystem
@@ -151,7 +151,7 @@ class NexusFileSystem(AbstractFileSystem):
         from nexus.fs import mount
         from nexus.fs._sync import run_sync
 
-        return run_sync(mount(*uris))
+        return cast("SlimNexusFS", run_sync(mount(*uris)))
 
     # -- Protocol handling -----------------------------------------------------
 
@@ -187,7 +187,7 @@ class NexusFileSystem(AbstractFileSystem):
 
         # Check dircache first
         if path in self.dircache:
-            cached = self.dircache[path]
+            cached: list[Any] = self.dircache[path]
             if detail:
                 return cached
             return [e["name"] for e in cached]
@@ -265,7 +265,7 @@ class NexusFileSystem(AbstractFileSystem):
                 range_start = max(0, file_size + range_start)
             if range_end < 0:
                 range_end = max(0, file_size + range_end)
-            return self._runner(self._nexus.read_range(path, range_start, range_end))
+            return cast(bytes, self._runner(self._nexus.read_range(path, range_start, range_end)))
 
         # Full read — apply size guard
         stat = self._runner(self._nexus.stat(path))
@@ -278,7 +278,7 @@ class NexusFileSystem(AbstractFileSystem):
                 f"Use open() for streaming access."
             )
 
-        return self._runner(self._nexus.read(path))
+        return cast(bytes, self._runner(self._nexus.read(path)))
 
     # -- Write -----------------------------------------------------------------
 

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -14,66 +14,150 @@ Registration:
     from fsspec import register_implementation
     from nexus.fs._fsspec import NexusFileSystem
     register_implementation("nexus", NexusFileSystem)
+
+Validated integrations (v0.1.0):
+    - ``fsspec.filesystem("nexus")`` auto-discovery via ``mounts.json``
+    - ``fsspec.open("nexus:///path", "rb"/"wb")``
+    - ``pd.read_csv("nexus:///path")`` (via fsspec)
+    - Byte-range reads via ``read_range()``
+    - ``readline()`` / ``readlines()`` / line iteration
+
+Known deviations from full fsspec contract (v0.1.0):
+    - Append mode (``"a"``/``"ab"``) is not supported — raises ``ValueError``.
+    - Read-write mode (``"r+"``) is not supported — raises ``ValueError``.
+    - Text mode (``"r"``/``"w"``) returns/accepts bytes, not str.
+      Use ``"rb"``/``"wb"`` explicitly for clarity.
+    - ``_pipe_file(mode="create")`` does not enforce create-only semantics;
+      it always overwrites.
+    - Write-mode ``_open()`` buffers the entire file in memory (up to 1 GB).
+      True streaming writes are not yet supported.
+    - ``_rm()`` does not support glob patterns; pass explicit paths.
+    - ``NexusBufferedFile`` does not inherit from
+      ``fsspec.spec.AbstractBufferedFile`` — it implements the file-like
+      protocol directly.
+    - No ``transactions`` support (``start_transaction`` / ``end_transaction``).
+
+Framework adapters (v0.1.0 scope):
+    - **fsspec**: In scope, validated with integration tests.
+    - **Claude Agent SDK / Codex**: Supported via the full ``nexus`` package
+      (MCP server / ACP protocol), not the slim ``nexus-fs`` package.
+    - **LangChain / CrewAI / OpenAI Agents**: Available as examples in the
+      full ``nexus`` repo, not shipped in the slim package.
 """
 
 from __future__ import annotations
 
 import io
 import logging
-from collections.abc import Callable, Coroutine
+import os
 from typing import TYPE_CHECKING, Any
+
+try:
+    from fsspec.spec import AbstractFileSystem
+except ImportError:
+    raise ImportError(
+        "fsspec is required for NexusFileSystem. Install with: pip install nexus-fs[fsspec]"
+    ) from None
 
 if TYPE_CHECKING:
     from nexus.fs._facade import SlimNexusFS
+    from nexus.fs._sync import PortalRunner
 
 logger = logging.getLogger(__name__)
 
 # Maximum file size for _cat_file before refusing (1 GB).
-# Files larger than this should use _open() with streaming.
+# Files larger than this should use _open() with buffered access.
 MAX_CAT_FILE_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB
 
+# Maximum buffer size for write-mode _open() (1 GB).
+# Writes exceeding this should use _pipe_file() with pre-built bytes
+# or wait for streaming write support.
+MAX_WRITE_BUFFER_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB
 
-def _get_fs_class() -> tuple[type, type]:
-    """Lazy-import fsspec base classes to avoid hard dependency."""
-    try:
-        from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
-
-        return AbstractFileSystem, AbstractBufferedFile
-    except ImportError:
-        raise ImportError(
-            "fsspec is required for NexusFileSystem. Install with: pip install nexus-fs[fsspec]"
-        ) from None
+# Supported modes for _open().
+_SUPPORTED_MODES = frozenset({"rb", "wb", "r", "w"})
 
 
-class NexusFileSystem:
+class NexusFileSystem(AbstractFileSystem):
     """fsspec-compatible filesystem backed by nexus-fs mounts.
 
-    This class is constructed lazily — it inherits from AbstractFileSystem
-    only when fsspec is available. Use ``NexusFileSystem.create()`` or
-    import directly (which triggers the fsspec import check).
+    Supports two usage patterns:
+
+    1. **Explicit:** pass a SlimNexusFS instance directly::
+
+           fs = NexusFileSystem(nexus_fs=my_facade)
+
+    2. **Auto-discovery:** omit *nexus_fs* and the filesystem will
+       auto-discover mounts from ``mounts.json`` (written by
+       ``nexus.fs.mount()`` / ``nexus.fs.mount_sync()``)::
+
+           pd.read_csv("nexus:///s3/my-bucket/data.csv")
 
     Parameters:
-        nexus_fs: A SlimNexusFS facade instance.
+        nexus_fs: Optional SlimNexusFS facade instance.  When *None*,
+            mounts are auto-discovered from the state directory.
     """
 
     protocol = ("nexus",)
 
-    def __init__(self, nexus_fs: SlimNexusFS, **kwargs: Any) -> None:
-        AbstractFileSystem, _ = _get_fs_class()
-        # Mixin the base class dynamically
-        if not isinstance(self, AbstractFileSystem):
-            self.__class__ = type(
-                "NexusFileSystem",
-                (NexusFileSystem, AbstractFileSystem),
-                {},
+    def __init__(self, nexus_fs: SlimNexusFS | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        if nexus_fs is not None:
+            self._nexus = nexus_fs
+        else:
+            self._nexus = self._auto_discover()
+        from nexus.fs._sync import PortalRunner
+
+        self._runner: PortalRunner = PortalRunner()
+
+    # -- Auto-discovery --------------------------------------------------------
+
+    @staticmethod
+    def _auto_discover() -> SlimNexusFS:
+        """Auto-discover mounts from ``mounts.json``.
+
+        Reads the mount URIs persisted by ``mount()`` and boots a
+        SlimNexusFS facade.  This enables ``fsspec.filesystem("nexus")``
+        and ``pd.read_csv("nexus:///...")`` without explicit construction.
+
+        Raises:
+            FileNotFoundError: If no ``mounts.json`` exists.
+            ValueError: If ``mounts.json`` is empty or invalid.
+        """
+        import json
+        import tempfile
+
+        state_dir = os.environ.get("NEXUS_FS_STATE_DIR") or os.path.join(
+            tempfile.gettempdir(), "nexus-fs"
+        )
+        mounts_file = os.path.join(state_dir, "mounts.json")
+
+        if not os.path.exists(mounts_file):
+            raise FileNotFoundError(
+                "No nexus-fs mounts found. Run nexus.fs.mount() or "
+                "nexus.fs.mount_sync() first to register backends, "
+                "then use fsspec.open('nexus:///...')."
             )
-            super().__init__(**kwargs)
-        self._nexus = nexus_fs
-        self._sync = _get_sync_caller()
+
+        with open(mounts_file) as f:
+            uris = json.load(f)
+
+        if not uris or not isinstance(uris, list):
+            raise ValueError(
+                f"Invalid mounts.json at {mounts_file}. "
+                "Run nexus.fs.mount() to re-register backends."
+            )
+
+        from nexus.fs import mount
+        from nexus.fs._sync import run_sync
+
+        return run_sync(mount(*uris))
+
+    # -- Protocol handling -----------------------------------------------------
 
     @classmethod
     def _strip_protocol(cls, path: str) -> str:
-        """Remove nexus:// protocol prefix from path."""
+        """Remove ``nexus://`` protocol prefix from path."""
         if path.startswith("nexus://"):
             path = path[len("nexus://") :]
         if path.startswith("nexus:"):
@@ -83,34 +167,60 @@ class NexusFileSystem:
             path = "/" + path
         return path
 
+    # -- Directory listing -----------------------------------------------------
+
     def ls(self, path: str, detail: bool = True, **kwargs: Any) -> list:  # noqa: ARG002
         """List objects at path.
 
         Args:
             path: Directory path to list.
-            detail: If True, return list of dicts. If False, return list of paths.
+            detail: If True, return list of dicts.  If False, return
+                list of paths.
 
         Returns:
             List of entries (dicts with name/size/type if detail=True).
+
+        Raises:
+            FileNotFoundError: If path does not exist.
         """
         path = self._strip_protocol(path)
-        entries = self._sync(self._nexus.ls(path, detail=True, recursive=False))
+
+        # Check dircache first
+        if path in self.dircache:
+            cached = self.dircache[path]
+            if detail:
+                return cached
+            return [e["name"] for e in cached]
+
+        # Verify path exists — fsspec contract requires FileNotFoundError
+        stat = self._runner(self._nexus.stat(path))
+        if stat is None:
+            raise FileNotFoundError(path)
+
+        entries = self._runner(self._nexus.ls(path, detail=True, recursive=False))
+
+        result = [
+            {
+                "name": e["path"],
+                "size": e.get("size", 0),
+                "type": "directory" if e.get("entry_type", 0) == 1 else "file",
+            }
+            for e in entries
+        ]
+
+        # Populate fsspec dircache so subsequent info() calls hit cache.
+        self.dircache[path] = result
 
         if detail:
-            return [
-                {
-                    "name": e["path"],
-                    "size": e.get("size", 0),
-                    "type": "directory" if e.get("entry_type", 0) == 1 else "file",
-                }
-                for e in entries
-            ]
-        return [e["path"] for e in entries]
+            return result
+        return [e["name"] for e in result]
+
+    # -- Metadata --------------------------------------------------------------
 
     def info(self, path: str, **kwargs: Any) -> dict[str, Any]:  # noqa: ARG002
         """Return metadata for a single path."""
         path = self._strip_protocol(path)
-        stat = self._sync(self._nexus.stat(path))
+        stat = self._runner(self._nexus.stat(path))
         if stat is None:
             raise FileNotFoundError(path)
         return {
@@ -122,6 +232,8 @@ class NexusFileSystem:
             "modified": stat.get("modified_at"),
         }
 
+    # -- Read ------------------------------------------------------------------
+
     def _cat_file(
         self,
         path: str,
@@ -131,52 +243,90 @@ class NexusFileSystem:
     ) -> bytes:
         """Read file contents with optional byte range.
 
-        Raises ValueError if file exceeds MAX_CAT_FILE_SIZE (1 GB).
-        Use _open() for large files.
+        When *start*/*end* are provided, uses ``read_range()`` to fetch
+        only the requested bytes from the backend.  Otherwise reads the
+        full file.
+
+        Raises ValueError if file exceeds ``MAX_CAT_FILE_SIZE`` (1 GB)
+        for full reads.  Use ``_open()`` for large files.
         """
         path = self._strip_protocol(path)
 
-        # Size guard: refuse to load files > 1 GB into memory
-        stat = self._sync(self._nexus.stat(path))
-        if stat and stat.get("size", 0) > MAX_CAT_FILE_SIZE:
+        if start is not None or end is not None:
+            # Byte-range read — resolve negative indices, delegate to read_range
+            stat = self._runner(self._nexus.stat(path))
+            if stat is None:
+                raise FileNotFoundError(path)
+            file_size = stat.get("size", 0)
+            range_start = start if start is not None else 0
+            range_end = end if end is not None else file_size
+            # Handle negative indices (Python slice semantics)
+            if range_start < 0:
+                range_start = max(0, file_size + range_start)
+            if range_end < 0:
+                range_end = max(0, file_size + range_end)
+            return self._runner(self._nexus.read_range(path, range_start, range_end))
+
+        # Full read — apply size guard
+        stat = self._runner(self._nexus.stat(path))
+        if stat is None:
+            raise FileNotFoundError(path)
+        if stat.get("size", 0) > MAX_CAT_FILE_SIZE:
             size_gb = stat["size"] / (1024**3)
             raise ValueError(
                 f"File too large for _cat_file ({size_gb:.1f} GB > 1 GB limit). "
                 f"Use open() for streaming access."
             )
 
-        content: bytes = self._sync(self._nexus.read(path))
+        return self._runner(self._nexus.read(path))
 
-        if start is not None or end is not None:
-            content = content[start:end]
-        return content
+    # -- Write -----------------------------------------------------------------
 
     def _pipe_file(
         self,
         path: str,
         value: bytes,
-        mode: str = "overwrite",  # noqa: ARG002 — fsspec API contract
+        mode: str = "overwrite",  # noqa: ARG002 -- fsspec API contract
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         """Write data to a file."""
         path = self._strip_protocol(path)
-        self._sync(self._nexus.write(path, value))
+        self._runner(self._nexus.write(path, value))
 
-    def _rm(self, path: str) -> None:
-        """Delete a file."""
+    # -- Delete ----------------------------------------------------------------
+
+    def _rm(self, path: str, recursive: bool = False, **kwargs: Any) -> None:  # noqa: ARG002
+        """Delete a file or directory.
+
+        Args:
+            path: Path to delete.
+            recursive: If True and path is a directory, remove
+                recursively.
+        """
         path = self._strip_protocol(path)
-        self._sync(self._nexus.delete(path))
+        # Check if it's a directory — if so, use rmdir
+        stat = self._runner(self._nexus.stat(path))
+        if stat and stat.get("is_directory"):
+            self._runner(self._nexus.rmdir(path, recursive=recursive))
+        else:
+            self._runner(self._nexus.delete(path))
+
+    # -- Copy ------------------------------------------------------------------
 
     def _cp_file(self, path1: str, path2: str, **kwargs: Any) -> None:  # noqa: ARG002
         """Copy a single file."""
         path1 = self._strip_protocol(path1)
         path2 = self._strip_protocol(path2)
-        self._sync(self._nexus.copy(path1, path2))
+        self._runner(self._nexus.copy(path1, path2))
+
+    # -- Directories -----------------------------------------------------------
 
     def _mkdir(self, path: str, create_parents: bool = True, **kwargs: Any) -> None:  # noqa: ARG002
         """Create directory."""
         path = self._strip_protocol(path)
-        self._sync(self._nexus.mkdir(path, parents=create_parents))
+        self._runner(self._nexus.mkdir(path, parents=create_parents))
+
+    # -- Open ------------------------------------------------------------------
 
     def _open(
         self,
@@ -185,16 +335,29 @@ class NexusFileSystem:
         block_size: int | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> Any:
-        """Return a file-like object for streaming access.
+        """Return a file-like object for buffered access.
 
-        For read mode, returns a NexusBufferedFile that fetches byte ranges
-        on demand. For write mode, returns a BytesIO that flushes to nexus
-        on close.
+        For read mode (``'rb'``/``'r'``), returns a ``NexusBufferedFile``
+        that fetches byte ranges on demand.  For write mode
+        (``'wb'``/``'w'``), returns a ``NexusWriteFile`` that buffers
+        content in memory and flushes on close.
+
+        Note: write mode buffers the entire file in memory (up to 1 GB).
+        For larger writes, use ``_pipe_file()`` with pre-built bytes.
+
+        Supported modes: ``'rb'``, ``'wb'``, ``'r'``, ``'w'``.
         """
+        if mode not in _SUPPORTED_MODES:
+            raise ValueError(
+                f"Unsupported mode {mode!r}. "
+                f"Supported modes: {', '.join(sorted(_SUPPORTED_MODES))}. "
+                f"Append ('a'/'ab') and read-write ('r+') modes are not supported."
+            )
+
         path = self._strip_protocol(path)
 
         if "r" in mode:
-            stat = self._sync(self._nexus.stat(path))
+            stat = self._runner(self._nexus.stat(path))
             if stat is None:
                 raise FileNotFoundError(path)
             size = stat.get("size", 0)
@@ -205,22 +368,23 @@ class NexusFileSystem:
                 size=size,
                 block_size=block_size or 5 * 1024 * 1024,  # 5 MB default
                 nexus_fs=self._nexus,
-                sync_caller=self._sync,
+                runner=self._runner,
             )
         else:
             return NexusWriteFile(
                 fs=self,
                 path=path,
                 nexus_fs=self._nexus,
-                sync_caller=self._sync,
+                runner=self._runner,
             )
 
 
 class NexusBufferedFile:
     """Read-only file-like object with byte-range fetching.
 
-    Implements the minimal interface needed by pandas, dask, etc.:
-    read(), seek(), tell(), close(), __enter__/__exit__.
+    Implements the file-like interface needed by pandas, dask, etc.:
+    ``read()``, ``readline()``, ``readlines()``, ``seek()``, ``tell()``,
+    ``close()``, ``__enter__``/``__exit__``, ``__iter__``/``__next__``.
     """
 
     def __init__(
@@ -231,7 +395,7 @@ class NexusBufferedFile:
         size: int,
         block_size: int,
         nexus_fs: SlimNexusFS,
-        sync_caller: Any,
+        runner: PortalRunner,
     ) -> None:
         self.fs = fs
         self.path = path
@@ -239,15 +403,19 @@ class NexusBufferedFile:
         self.size = size
         self.block_size = block_size
         self._nexus = nexus_fs
-        self._sync = sync_caller
+        self._runner = runner
         self._pos = 0
         self._closed = False
 
-    def read(self, length: int = -1) -> bytes:
-        """Read up to length bytes from current position.
+    @property
+    def name(self) -> str:
+        return self.path
 
-        Uses read_range() for memory-efficient byte-range fetching — only
-        the requested range is transferred from the backend, not the full file.
+    def read(self, length: int = -1) -> bytes:
+        """Read up to *length* bytes from current position.
+
+        Uses ``read_range()`` for memory-efficient byte-range fetching --
+        only the requested range is transferred from the backend.
         """
         if self._closed:
             raise ValueError("I/O operation on closed file")
@@ -256,10 +424,69 @@ class NexusBufferedFile:
 
         end = self.size if length == -1 else min(self._pos + length, self.size)
 
-        # Fetch only the requested byte range — NOT the full file
-        data: bytes = self._sync(self._nexus.read_range(self.path, self._pos, end))
+        data: bytes = self._runner(self._nexus.read_range(self.path, self._pos, end))
         self._pos = end
         return data
+
+    def readline(self, size: int = -1) -> bytes:
+        r"""Read a single line (up to ``\n`` or EOF).
+
+        Args:
+            size: Maximum bytes to read.  -1 means no limit.
+        """
+        if self._closed:
+            raise ValueError("I/O operation on closed file")
+        if self._pos >= self.size:
+            return b""
+
+        chunks: list[bytes] = []
+        bytes_read = 0
+        chunk_size = min(self.block_size, 8192)
+
+        while self._pos < self.size:
+            if 0 <= size <= bytes_read:
+                break
+            remaining = self.size - self._pos
+            if size >= 0:
+                remaining = min(remaining, size - bytes_read)
+            to_read = min(chunk_size, remaining)
+
+            chunk: bytes = self._runner(
+                self._nexus.read_range(self.path, self._pos, self._pos + to_read)
+            )
+            if not chunk:
+                break
+
+            newline_pos = chunk.find(b"\n")
+            if newline_pos >= 0:
+                # Found newline -- take up to and including it
+                chunks.append(chunk[: newline_pos + 1])
+                self._pos += newline_pos + 1
+                break
+            else:
+                chunks.append(chunk)
+                self._pos += len(chunk)
+                bytes_read += len(chunk)
+
+        return b"".join(chunks)
+
+    def readlines(self, hint: int = -1) -> list[bytes]:
+        """Read all remaining lines.
+
+        Args:
+            hint: Approximate number of bytes to read.  -1 reads all.
+        """
+        lines: list[bytes] = []
+        total = 0
+        while True:
+            line = self.readline()
+            if not line:
+                break
+            lines.append(line)
+            total += len(line)
+            if 0 <= hint <= total:
+                break
+        return lines
 
     def seek(self, offset: int, whence: int = 0) -> int:
         """Seek to a position."""
@@ -274,6 +501,9 @@ class NexusBufferedFile:
 
     def tell(self) -> int:
         return self._pos
+
+    def flush(self) -> None:
+        """No-op for read-only file."""
 
     def close(self) -> None:
         self._closed = True
@@ -297,11 +527,24 @@ class NexusBufferedFile:
     def __exit__(self, *args: Any) -> None:
         self.close()
 
+    def __iter__(self) -> NexusBufferedFile:
+        return self
+
+    def __next__(self) -> bytes:
+        line = self.readline()
+        if not line:
+            raise StopIteration
+        return line
+
 
 class NexusWriteFile:
     """Write-only file-like object that buffers content in memory.
 
-    Flushes to nexus on close().
+    Buffers all written data in memory and flushes to nexus on
+    ``close()``.  Maximum buffer size is ``MAX_WRITE_BUFFER_SIZE``
+    (1 GB) -- writes exceeding this limit will raise ``ValueError``.
+
+    For larger files, use ``_pipe_file()`` with pre-built bytes.
     """
 
     def __init__(
@@ -309,25 +552,41 @@ class NexusWriteFile:
         fs: NexusFileSystem,
         path: str,
         nexus_fs: SlimNexusFS,
-        sync_caller: Any,
+        runner: PortalRunner,
     ) -> None:
         self.fs = fs
         self.path = path
         self._nexus = nexus_fs
-        self._sync = sync_caller
+        self._runner = runner
         self._buffer = io.BytesIO()
         self._closed = False
+        self._bytes_written = 0
+
+    @property
+    def name(self) -> str:
+        return self.path
 
     def write(self, data: bytes) -> int:
         if self._closed:
             raise ValueError("I/O operation on closed file")
+        self._bytes_written += len(data)
+        if self._bytes_written > MAX_WRITE_BUFFER_SIZE:
+            raise ValueError(
+                f"Write buffer exceeded "
+                f"{MAX_WRITE_BUFFER_SIZE / (1024**3):.0f} GB limit. "
+                f"Use _pipe_file() for large writes or wait for "
+                f"streaming write support."
+            )
         return self._buffer.write(data)
+
+    def flush(self) -> None:
+        """No-op -- data is flushed on close()."""
 
     def close(self) -> None:
         if not self._closed:
             self._closed = True
             self._buffer.seek(0)
-            self._sync(self._nexus.write(self.path, self._buffer.read()))
+            self._runner(self._nexus.write(self.path, self._buffer.read()))
 
     @property
     def closed(self) -> bool:
@@ -347,39 +606,3 @@ class NexusWriteFile:
 
     def __exit__(self, *args: Any) -> None:
         self.close()
-
-
-SyncCaller = Callable[[Coroutine[Any, Any, Any]], Any]
-
-
-def _get_sync_caller() -> SyncCaller:
-    """Get a sync caller that runs async code synchronously.
-
-    Uses anyio if available, falls back to asyncio.run().
-    """
-    try:
-        from anyio.from_thread import BlockingPortalProvider
-
-        _portal = BlockingPortalProvider()
-
-        def sync_call(coro: Coroutine[Any, Any, Any]) -> Any:
-            with _portal as portal:
-                return portal.call(lambda: coro)
-
-        return sync_call
-    except ImportError:
-        import asyncio
-
-        def sync_call(coro: Coroutine[Any, Any, Any]) -> Any:
-            try:
-                asyncio.get_running_loop()
-                # If there's a running loop, we can't use asyncio.run()
-                import concurrent.futures
-
-                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, coro)
-                    return future.result()
-            except RuntimeError:
-                return asyncio.run(coro)
-
-        return sync_call

--- a/src/nexus/fs/_sync.py
+++ b/src/nexus/fs/_sync.py
@@ -11,13 +11,12 @@ Three supported scenarios:
 Usage:
     from nexus.fs._sync import SyncNexusFS
 
-    sync_fs = SyncNexusFS(async_facade)
-    content = sync_fs.read("/s3/bucket/file.txt")
+    with SyncNexusFS(async_facade) as fs:
+        content = fs.read("/s3/bucket/file.txt")
 """
 
 from __future__ import annotations
 
-import functools
 from typing import Any, TypeVar, cast
 
 from anyio.from_thread import BlockingPortalProvider
@@ -29,84 +28,131 @@ def run_sync(coro: Any) -> Any:
     """Run an async coroutine synchronously.
 
     Uses anyio's BlockingPortalProvider for safe sync->async bridging.
-    Works in all three scenarios: no event loop, existing loop (Jupyter),
-    and multi-threaded contexts.
+    Creates a new event loop per call — use PortalRunner for repeated calls.
     """
     _provider = BlockingPortalProvider()
     with _provider as portal:
         return portal.call(lambda: coro)
 
 
+class PortalRunner:
+    """Persistent sync-to-async bridge.
+
+    Starts a background event loop on first call and keeps it alive
+    until close() is called.  Avoids the overhead of starting/stopping
+    an event loop on every call.
+
+    Thread-safe — multiple threads can call concurrently via the
+    underlying BlockingPortal.
+
+    Usage::
+
+        runner = PortalRunner()
+        result = runner(some_coroutine())
+        runner.close()
+
+        # or as context manager:
+        with PortalRunner() as runner:
+            result = runner(some_coroutine())
+    """
+
+    def __init__(self) -> None:
+        self._provider = BlockingPortalProvider()
+        self._portal: Any = None
+
+    def __call__(self, coro: Any) -> Any:
+        if self._portal is None:
+            self._portal = self._provider.__enter__()
+        return self._portal.call(lambda: coro)
+
+    def close(self) -> None:
+        """Shut down the background event loop."""
+        if self._portal is not None:
+            self._provider.__exit__(None, None, None)
+            self._portal = None
+
+    def __enter__(self) -> PortalRunner:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        # Best-effort cleanup.  Prefer explicit close() or context manager.
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            self.close()
+
+
 class SyncNexusFS:
     """Synchronous wrapper around the async NexusFS facade.
 
-    Delegates every call to the async facade via an anyio BlockingPortal.
-    Thread-safe -- multiple threads can use the same SyncNexusFS instance.
+    Keeps a persistent event loop alive across calls via PortalRunner.
+    Use as a context manager or call close() when done::
 
-    The BlockingPortalProvider manages a shared event loop: the first thread
-    to enter starts the loop, and the last thread to exit shuts it down.
-    ``portal.call(func, *args)`` accepts a callable (sync or async) and
-    positional arguments; if the callable returns a coroutine it is awaited
-    automatically.  For calls that require keyword arguments we use
-    ``functools.partial`` to bind them before handing the callable to the
-    portal.
+        with SyncNexusFS(async_facade) as fs:
+            content = fs.read("/path")
+
+    Thread-safe — multiple threads can use the same SyncNexusFS instance.
     """
 
     def __init__(self, async_fs: Any) -> None:
         self._async = async_fs
-        self._portal_provider = BlockingPortalProvider()
+        self._runner = PortalRunner()
 
-    # -- Expose the public facade methods as sync versions ----------------
+    # -- Context manager -------------------------------------------------------
+
+    def __enter__(self) -> SyncNexusFS:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    # -- Expose the public facade methods as sync versions ---------------------
 
     def read(self, path: str) -> bytes:
-        with self._portal_provider as portal:
-            return cast(bytes, portal.call(self._async.read, path))
+        return cast(bytes, self._runner(self._async.read(path)))
 
     def write(self, path: str, content: bytes) -> dict[str, Any]:
-        with self._portal_provider as portal:
-            return cast(dict[str, Any], portal.call(self._async.write, path, content))
+        return cast(dict[str, Any], self._runner(self._async.write(path, content)))
 
     def ls(self, path: str = "/", detail: bool = False) -> list[Any]:
-        with self._portal_provider as portal:
-            return cast(
-                list[Any],
-                portal.call(functools.partial(self._async.ls, path, detail=detail)),
-            )
+        return cast(
+            list[Any],
+            self._runner(self._async.ls(path, detail=detail)),
+        )
 
     def stat(self, path: str) -> dict[str, Any] | None:
-        with self._portal_provider as portal:
-            return cast(dict[str, Any] | None, portal.call(self._async.stat, path))
+        return cast(dict[str, Any] | None, self._runner(self._async.stat(path)))
 
     def delete(self, path: str) -> None:
-        with self._portal_provider as portal:
-            portal.call(self._async.delete, path)
+        self._runner(self._async.delete(path))
 
     def mkdir(self, path: str, parents: bool = True) -> None:
-        with self._portal_provider as portal:
-            portal.call(functools.partial(self._async.mkdir, path, parents=parents))
+        self._runner(self._async.mkdir(path, parents=parents))
 
     def rename(self, old_path: str, new_path: str) -> None:
-        with self._portal_provider as portal:
-            portal.call(self._async.rename, old_path, new_path)
+        self._runner(self._async.rename(old_path, new_path))
 
     def exists(self, path: str) -> bool:
-        with self._portal_provider as portal:
-            return cast(bool, portal.call(self._async.exists, path))
+        return cast(bool, self._runner(self._async.exists(path)))
 
     def copy(self, src: str, dst: str) -> dict[str, Any]:
-        with self._portal_provider as portal:
-            return cast(dict[str, Any], portal.call(self._async.copy, src, dst))
+        return cast(dict[str, Any], self._runner(self._async.copy(src, dst)))
 
     def read_range(self, path: str, start: int, end: int) -> bytes:
-        with self._portal_provider as portal:
-            return cast(bytes, portal.call(self._async.read_range, path, start, end))
+        return cast(bytes, self._runner(self._async.read_range(path, start, end)))
 
     def list_mounts(self) -> list[str]:
         """List all mount points (synchronous -- no portal needed)."""
         return cast(list[str], self._async.list_mounts())
 
     def close(self) -> None:
-        """Clean up resources held by the underlying async facade."""
+        """Clean up resources held by the underlying async facade and portal."""
         if hasattr(self._async, "close"):
-            with self._portal_provider as portal:
-                portal.call(self._async.close)
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                self._runner(self._async.close())
+        self._runner.close()

--- a/src/nexus/raft/federated_metadata_proxy.py
+++ b/src/nexus/raft/federated_metadata_proxy.py
@@ -88,6 +88,7 @@ class FederatedMetadataProxy(MetastoreABC):
         import os as _os
 
         raft_addr = getattr(zone_manager, "advertise_addr", None)
+        self_addr: str | None
         if raft_addr and ":" in raft_addr:
             hostname = raft_addr.rsplit(":", 1)[0]
             vfs_port = _os.environ.get("NEXUS_GRPC_PORT", "2028")

--- a/tests/unit/fs/test_fsspec.py
+++ b/tests/unit/fs/test_fsspec.py
@@ -14,14 +14,17 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from nexus.fs._fsspec import (
+# Skip entire module if fsspec is not installed (optional dependency).
+pytest.importorskip("fsspec")
+
+from nexus.fs._fsspec import (  # noqa: E402
     _SUPPORTED_MODES,
     MAX_CAT_FILE_SIZE,
     NexusBufferedFile,
     NexusFileSystem,
     NexusWriteFile,
 )
-from nexus.fs._sync import PortalRunner
+from nexus.fs._sync import PortalRunner  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/fs/test_fsspec.py
+++ b/tests/unit/fs/test_fsspec.py
@@ -1,34 +1,39 @@
 """Tests for fsspec NexusFileSystem compatibility layer.
 
-Verifies that NexusFileSystem implements the fsspec contract:
-- ls() returns correct format (detail=True/False)
-- info() returns required keys (name, size, type)
-- _cat_file() reads content with byte ranges
-- _cat_file() enforces size guard (1 GB limit)
-- _pipe_file() writes content
-- _rm() deletes files
-- _cp_file() copies files
-- _mkdir() creates directories
-- _open() returns file-like objects (read + write modes)
-- _strip_protocol() correctly removes nexus:// prefix
+Organized into:
+- Unit tests: Mock-based tests for individual methods (fast)
+- Edge case tests: NexusBufferedFile / NexusWriteFile corner cases
+- Auto-discovery tests: mounts.json reading and error handling
+- Integration tests: Real backend + fsspec discovery chain (no mocks)
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import json
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from nexus.fs._fsspec import (
+    _SUPPORTED_MODES,
     MAX_CAT_FILE_SIZE,
     NexusBufferedFile,
     NexusFileSystem,
     NexusWriteFile,
 )
+from nexus.fs._sync import PortalRunner
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_fs_cache():
+    """Prevent fsspec instance caching from leaking between tests."""
+    NexusFileSystem.clear_instance_cache()
+    yield
+    NexusFileSystem.clear_instance_cache()
 
 
 @pytest.fixture
@@ -57,45 +62,21 @@ def mock_nexus_fs():
     fs.delete = AsyncMock()
     fs.copy = AsyncMock(return_value={"path": "/dst.txt", "size": 11})
     fs.mkdir = AsyncMock()
+    fs.rmdir = AsyncMock()
     return fs
 
 
 @pytest.fixture
-def sync_caller():
-    """Sync caller that runs coroutines immediately."""
-    import asyncio
-
-    def _call(coro):
-        return asyncio.get_event_loop().run_until_complete(coro)
-
-    # Use a simple approach: create a new loop if needed
-    def _sync(coro):
-        try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                import concurrent.futures
-
-                with concurrent.futures.ThreadPoolExecutor(1) as pool:
-                    return pool.submit(asyncio.run, coro).result()
-            return loop.run_until_complete(coro)
-        except RuntimeError:
-            return asyncio.run(coro)
-
-    return _sync
-
-
-@pytest.fixture
-def nexus_fsspec(mock_nexus_fs, sync_caller):
+def nexus_fsspec(mock_nexus_fs):
     """NexusFileSystem instance with mocked backend."""
-    fs = NexusFileSystem.__new__(NexusFileSystem)
-    fs._nexus = mock_nexus_fs
-    fs._sync = sync_caller
-    return fs
+    fs = NexusFileSystem(nexus_fs=mock_nexus_fs)
+    yield fs
+    fs._runner.close()
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # _strip_protocol
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestStripProtocol:
@@ -115,9 +96,9 @@ class TestStripProtocol:
         assert NexusFileSystem._strip_protocol(input_path) == expected
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # ls()
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestLs:
@@ -134,10 +115,29 @@ class TestLs:
         result = nexus_fsspec.ls("/dir", detail=False)
         assert result == ["/dir/file1.txt", "/dir/subdir"]
 
+    def test_ls_not_found_raises(self, nexus_fsspec, mock_nexus_fs):
+        """ls() on non-existent path raises FileNotFoundError."""
+        mock_nexus_fs.stat.return_value = None
+        with pytest.raises(FileNotFoundError):
+            nexus_fsspec.ls("/nonexistent")
 
-# ---------------------------------------------------------------------------
+    def test_ls_populates_dircache(self, nexus_fsspec, mock_nexus_fs):
+        """ls() should populate fsspec dircache."""
+        nexus_fsspec.ls("/dir", detail=True)
+        assert "/dir" in nexus_fsspec.dircache
+        assert len(nexus_fsspec.dircache["/dir"]) == 2
+
+    def test_ls_uses_dircache_on_second_call(self, nexus_fsspec, mock_nexus_fs):
+        """Second ls() should use dircache, not call backend again."""
+        nexus_fsspec.ls("/dir", detail=True)
+        nexus_fsspec.ls("/dir", detail=True)
+        # ls backend should only be called once
+        assert mock_nexus_fs.ls.await_count == 1
+
+
+# ===========================================================================
 # info()
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestInfo:
@@ -154,9 +154,9 @@ class TestInfo:
             nexus_fsspec.info("/nonexistent.txt")
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # _cat_file()
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestCatFile:
@@ -164,9 +164,39 @@ class TestCatFile:
         result = nexus_fsspec._cat_file("/test.txt")
         assert result == b"hello world"
 
-    def test_cat_file_byte_range(self, nexus_fsspec):
+    def test_cat_file_byte_range_uses_read_range(self, nexus_fsspec, mock_nexus_fs):
+        """Byte-range reads should use read_range(), not read()."""
+        mock_nexus_fs.read_range.return_value = b"hello"
         result = nexus_fsspec._cat_file("/test.txt", start=0, end=5)
         assert result == b"hello"
+        mock_nexus_fs.read_range.assert_awaited_once()
+        mock_nexus_fs.read.assert_not_awaited()
+
+    def test_cat_file_start_only(self, nexus_fsspec, mock_nexus_fs):
+        """start without end reads from start to EOF."""
+        mock_nexus_fs.read_range.return_value = b"world"
+        nexus_fsspec._cat_file("/test.txt", start=6)
+        mock_nexus_fs.read_range.assert_awaited_once_with("/test.txt", 6, 11)
+
+    def test_cat_file_end_only(self, nexus_fsspec, mock_nexus_fs):
+        """end without start reads from beginning to end."""
+        mock_nexus_fs.read_range.return_value = b"hello"
+        nexus_fsspec._cat_file("/test.txt", end=5)
+        mock_nexus_fs.read_range.assert_awaited_once_with("/test.txt", 0, 5)
+
+    def test_cat_file_negative_start(self, nexus_fsspec, mock_nexus_fs):
+        """Negative start counts from end (Python slice semantics)."""
+        mock_nexus_fs.read_range.return_value = b"world"
+        nexus_fsspec._cat_file("/test.txt", start=-5)
+        # start=-5 with size=11 -> range_start=6, range_end=11
+        mock_nexus_fs.read_range.assert_awaited_once_with("/test.txt", 6, 11)
+
+    def test_cat_file_negative_end(self, nexus_fsspec, mock_nexus_fs):
+        """Negative end counts from end."""
+        mock_nexus_fs.read_range.return_value = b"hello wor"
+        nexus_fsspec._cat_file("/test.txt", start=0, end=-2)
+        # end=-2 with size=11 -> range_end=9
+        mock_nexus_fs.read_range.assert_awaited_once_with("/test.txt", 0, 9)
 
     def test_cat_file_size_guard(self, nexus_fsspec, mock_nexus_fs):
         """Files larger than MAX_CAT_FILE_SIZE should be refused."""
@@ -188,58 +218,103 @@ class TestCatFile:
         result = nexus_fsspec._cat_file("/exact.bin")
         assert result == b"hello world"
 
+    def test_cat_file_not_found(self, nexus_fsspec, mock_nexus_fs):
+        """_cat_file on non-existent file raises FileNotFoundError."""
+        mock_nexus_fs.stat.return_value = None
+        with pytest.raises(FileNotFoundError):
+            nexus_fsspec._cat_file("/nonexistent.txt")
 
-# ---------------------------------------------------------------------------
+    def test_cat_file_not_found_with_range(self, nexus_fsspec, mock_nexus_fs):
+        """_cat_file with byte range on non-existent file raises FileNotFoundError."""
+        mock_nexus_fs.stat.return_value = None
+        with pytest.raises(FileNotFoundError):
+            nexus_fsspec._cat_file("/nonexistent.txt", start=0, end=5)
+
+
+# ===========================================================================
 # _pipe_file()
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestPipeFile:
     def test_pipe_file(self, nexus_fsspec, mock_nexus_fs):
         nexus_fsspec._pipe_file("/output.txt", b"new content")
-        mock_nexus_fs.write.assert_called_once()
+        mock_nexus_fs.write.assert_awaited_once()
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # _rm()
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestRm:
-    def test_rm(self, nexus_fsspec, mock_nexus_fs):
+    def test_rm_file(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat.return_value = {"is_directory": False}
         nexus_fsspec._rm("/file.txt")
-        mock_nexus_fs.delete.assert_called_once()
+        mock_nexus_fs.delete.assert_awaited_once()
+
+    def test_rm_directory_recursive(self, nexus_fsspec, mock_nexus_fs):
+        """_rm on directory with recursive=True uses rmdir."""
+        mock_nexus_fs.stat.return_value = {"is_directory": True}
+        nexus_fsspec._rm("/dir", recursive=True)
+        mock_nexus_fs.rmdir.assert_awaited_once_with("/dir", recursive=True)
+
+    def test_rm_directory_non_recursive(self, nexus_fsspec, mock_nexus_fs):
+        """_rm on directory with recursive=False uses rmdir."""
+        mock_nexus_fs.stat.return_value = {"is_directory": True}
+        nexus_fsspec._rm("/dir", recursive=False)
+        mock_nexus_fs.rmdir.assert_awaited_once_with("/dir", recursive=False)
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # _cp_file()
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestCpFile:
     def test_cp_file(self, nexus_fsspec, mock_nexus_fs):
         nexus_fsspec._cp_file("/src.txt", "/dst.txt")
-        mock_nexus_fs.copy.assert_called_once()
+        mock_nexus_fs.copy.assert_awaited_once()
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # _mkdir()
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestMkdir:
     def test_mkdir(self, nexus_fsspec, mock_nexus_fs):
         nexus_fsspec._mkdir("/new/dir")
-        mock_nexus_fs.mkdir.assert_called_once()
+        mock_nexus_fs.mkdir.assert_awaited_once()
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# _open() — mode validation (Issue 8A)
+# ===========================================================================
+
+
+class TestModeValidation:
+    @pytest.mark.parametrize("mode", sorted(_SUPPORTED_MODES))
+    def test_supported_modes_accepted(self, nexus_fsspec, mock_nexus_fs, mode):
+        """All supported modes should be accepted without raising."""
+        mock_nexus_fs.stat.return_value = {"path": "/f", "size": 0, "is_directory": False}
+        f = nexus_fsspec._open("/f", mode=mode)
+        f.close()
+
+    @pytest.mark.parametrize("mode", ["ab", "a", "r+b", "x", "xyz"])
+    def test_unsupported_modes_raise(self, nexus_fsspec, mode):
+        """Unsupported modes should raise ValueError with helpful message."""
+        with pytest.raises(ValueError, match="Unsupported mode"):
+            nexus_fsspec._open("/f", mode=mode)
+
+
+# ===========================================================================
 # _open() — read mode
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestOpenRead:
-    def test_open_read_returns_file_like(self, nexus_fsspec, mock_nexus_fs):
+    def test_open_read_returns_buffered_file(self, nexus_fsspec, mock_nexus_fs):
         mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}
         f = nexus_fsspec._open("/file.txt", mode="rb")
         assert isinstance(f, NexusBufferedFile)
@@ -254,15 +329,14 @@ class TestOpenRead:
             data = f.read()
             assert data == b"hello world"
 
-    def test_open_read_uses_read_range_not_full_read(self, nexus_fsspec, mock_nexus_fs):
-        """Verify _open() uses read_range() for streaming, not read() which loads full file."""
+    def test_open_read_uses_read_range(self, nexus_fsspec, mock_nexus_fs):
+        """Verify _open() uses read_range(), not read()."""
         mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}
         mock_nexus_fs.read_range = AsyncMock(return_value=b"hello")
         with nexus_fsspec._open("/file.txt", mode="rb") as f:
             f.read(5)
-        mock_nexus_fs.read_range.assert_called_once()
-        # read() should NOT be called — only read_range()
-        mock_nexus_fs.read.assert_not_called()
+        mock_nexus_fs.read_range.assert_awaited_once()
+        mock_nexus_fs.read.assert_not_awaited()
 
     def test_open_read_seek_tell(self, nexus_fsspec, mock_nexus_fs):
         mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}
@@ -277,14 +351,20 @@ class TestOpenRead:
         with pytest.raises(FileNotFoundError):
             nexus_fsspec._open("/nonexistent.txt", mode="rb")
 
+    def test_open_read_name_property(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat.return_value = {"path": "/file.txt", "size": 11, "is_directory": False}
+        f = nexus_fsspec._open("/file.txt", mode="rb")
+        assert f.name == "/file.txt"
+        f.close()
 
-# ---------------------------------------------------------------------------
+
+# ===========================================================================
 # _open() — write mode
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestOpenWrite:
-    def test_open_write_returns_file_like(self, nexus_fsspec, mock_nexus_fs):
+    def test_open_write_returns_write_file(self, nexus_fsspec, mock_nexus_fs):
         f = nexus_fsspec._open("/output.txt", mode="wb")
         assert isinstance(f, NexusWriteFile)
         assert f.writable()
@@ -295,9 +375,8 @@ class TestOpenWrite:
         with nexus_fsspec._open("/output.txt", mode="wb") as f:
             f.write(b"hello ")
             f.write(b"world")
-        # Should have written the combined content on close
-        mock_nexus_fs.write.assert_called_once()
-        args = mock_nexus_fs.write.call_args
+        mock_nexus_fs.write.assert_awaited_once()
+        args = mock_nexus_fs.write.await_args
         assert args[0][1] == b"hello world"
 
     def test_open_write_context_manager(self, nexus_fsspec, mock_nexus_fs):
@@ -305,12 +384,531 @@ class TestOpenWrite:
             f.write(b"data")
         assert f.closed
 
+    def test_open_write_name_property(self, nexus_fsspec, mock_nexus_fs):
+        f = nexus_fsspec._open("/output.txt", mode="wb")
+        assert f.name == "/output.txt"
+        f.close()
 
-# ---------------------------------------------------------------------------
-# Protocol attribute
-# ---------------------------------------------------------------------------
+
+# ===========================================================================
+# Protocol / inheritance
+# ===========================================================================
 
 
 class TestProtocol:
     def test_protocol_tuple(self):
         assert NexusFileSystem.protocol == ("nexus",)
+
+    def test_is_subclass_of_abstract_filesystem(self):
+        """NexusFileSystem should properly inherit from AbstractFileSystem."""
+        from fsspec.spec import AbstractFileSystem
+
+        assert issubclass(NexusFileSystem, AbstractFileSystem)
+
+    def test_instance_is_abstract_filesystem(self, nexus_fsspec):
+        """Instances should pass isinstance checks."""
+        from fsspec.spec import AbstractFileSystem
+
+        assert isinstance(nexus_fsspec, AbstractFileSystem)
+
+
+# ===========================================================================
+# NexusBufferedFile edge cases (Issue 10A)
+# ===========================================================================
+
+
+class TestBufferedFileEdgeCases:
+    """Edge cases for NexusBufferedFile (read-mode file objects)."""
+
+    @pytest.fixture
+    def buf_file(self, mock_nexus_fs):
+        """Create a NexusBufferedFile with size=11 ("hello world")."""
+        runner = PortalRunner()
+        f = NexusBufferedFile(
+            fs=None,
+            path="/test.txt",
+            mode="rb",
+            size=11,
+            block_size=8192,
+            nexus_fs=mock_nexus_fs,
+            runner=runner,
+        )
+        yield f
+        runner.close()
+
+    def test_read_on_closed_file(self, buf_file):
+        buf_file.close()
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
+            buf_file.read()
+
+    def test_read_past_eof(self, buf_file):
+        buf_file._pos = 11  # at EOF
+        assert buf_file.read() == b""
+
+    def test_read_zero_bytes(self, buf_file, mock_nexus_fs):
+        """read(0) should return empty bytes."""
+        mock_nexus_fs.read_range.return_value = b""
+        result = buf_file.read(0)
+        assert result == b""
+
+    def test_read_all_remaining(self, buf_file, mock_nexus_fs):
+        """read(-1) should read from current position to EOF."""
+        mock_nexus_fs.read_range.return_value = b"hello world"
+        result = buf_file.read(-1)
+        assert result == b"hello world"
+        assert buf_file.tell() == 11
+
+    def test_seek_whence_relative(self, buf_file):
+        """seek(offset, 1) seeks relative to current position."""
+        buf_file._pos = 5
+        result = buf_file.seek(3, 1)
+        assert result == 8
+
+    def test_seek_whence_from_end(self, buf_file):
+        """seek(offset, 2) seeks relative to end."""
+        result = buf_file.seek(-3, 2)
+        assert result == 8  # 11 - 3
+
+    def test_seek_negative_clamps_to_zero(self, buf_file):
+        result = buf_file.seek(-100, 0)
+        assert result == 0
+
+    def test_seek_past_end_clamps_to_size(self, buf_file):
+        result = buf_file.seek(100, 0)
+        assert result == 11
+
+    def test_double_close(self, buf_file):
+        buf_file.close()
+        buf_file.close()  # should not raise
+        assert buf_file.closed
+
+    def test_flush_noop(self, buf_file):
+        buf_file.flush()  # should not raise
+
+    def test_readline_with_newline(self, buf_file, mock_nexus_fs):
+        """readline() reads up to and including newline."""
+        mock_nexus_fs.read_range.return_value = b"hello\nworld"
+        line = buf_file.readline()
+        assert line == b"hello\n"
+        assert buf_file.tell() == 6
+
+    def test_readline_no_newline(self, buf_file, mock_nexus_fs):
+        """readline() returns remaining bytes if no newline found."""
+        mock_nexus_fs.read_range.return_value = b"no newline"
+        buf_file._pos = 0
+        buf_file.size = 10
+        line = buf_file.readline()
+        assert line == b"no newline"
+
+    def test_readline_at_eof(self, buf_file):
+        """readline() at EOF returns empty bytes."""
+        buf_file._pos = 11
+        assert buf_file.readline() == b""
+
+    def test_readline_on_closed_file(self, buf_file):
+        buf_file.close()
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
+            buf_file.readline()
+
+    def test_readlines(self, buf_file, mock_nexus_fs):
+        """readlines() returns all remaining lines."""
+        mock_nexus_fs.read_range.side_effect = [b"line1\n", b"line2"]
+        buf_file.size = 11
+        lines = buf_file.readlines()
+        assert lines == [b"line1\n", b"line2"]
+
+    def test_iter(self, buf_file, mock_nexus_fs):
+        """Iterating yields lines."""
+        mock_nexus_fs.read_range.side_effect = [b"a\n", b"b\n", b""]
+        buf_file.size = 4
+        lines = list(buf_file)
+        assert lines == [b"a\n", b"b\n"]
+
+
+# ===========================================================================
+# NexusWriteFile edge cases (Issue 10A)
+# ===========================================================================
+
+
+class TestWriteFileEdgeCases:
+    """Edge cases for NexusWriteFile (write-mode file objects)."""
+
+    @pytest.fixture
+    def write_file(self, mock_nexus_fs):
+        runner = PortalRunner()
+        f = NexusWriteFile(
+            fs=None,
+            path="/out.txt",
+            nexus_fs=mock_nexus_fs,
+            runner=runner,
+        )
+        yield f
+        runner.close()
+
+    def test_write_on_closed_file(self, write_file):
+        write_file.close()
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
+            write_file.write(b"data")
+
+    def test_double_close_no_double_flush(self, write_file, mock_nexus_fs):
+        """Double close should only flush once."""
+        write_file.write(b"data")
+        write_file.close()
+        write_file.close()
+        assert mock_nexus_fs.write.await_count == 1
+
+    def test_flush_noop(self, write_file, mock_nexus_fs):
+        """flush() should not trigger a backend write."""
+        write_file.write(b"data")
+        write_file.flush()
+        mock_nexus_fs.write.assert_not_awaited()
+
+    def test_not_seekable(self, write_file):
+        assert not write_file.seekable()
+
+    def test_not_readable(self, write_file):
+        assert not write_file.readable()
+
+    def test_write_buffer_guard(self, write_file):
+        """Writes exceeding MAX_WRITE_BUFFER_SIZE should raise."""
+        chunk = b"x" * (1024 * 1024)  # 1 MB
+        with pytest.raises(ValueError, match="Write buffer exceeded"):
+            for _ in range(1025):  # > 1 GB
+                write_file.write(chunk)
+
+
+# ===========================================================================
+# Auto-discovery (Issue 1A)
+# ===========================================================================
+
+
+class TestAutoDiscovery:
+    def test_auto_discover_no_mounts_file(self, tmp_path, monkeypatch):
+        """Auto-discovery with no mounts.json raises FileNotFoundError."""
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(tmp_path))
+        with pytest.raises(FileNotFoundError, match="No nexus-fs mounts found"):
+            NexusFileSystem._auto_discover()
+
+    def test_auto_discover_empty_mounts(self, tmp_path, monkeypatch):
+        """Auto-discovery with empty mounts list raises ValueError."""
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(tmp_path))
+        (tmp_path / "mounts.json").write_text("[]")
+        with pytest.raises(ValueError, match="Invalid mounts.json"):
+            NexusFileSystem._auto_discover()
+
+    def test_auto_discover_invalid_type(self, tmp_path, monkeypatch):
+        """Auto-discovery with non-list JSON raises ValueError."""
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(tmp_path))
+        (tmp_path / "mounts.json").write_text('"not a list"')
+        with pytest.raises(ValueError, match="Invalid mounts.json"):
+            NexusFileSystem._auto_discover()
+
+    def test_auto_discover_calls_mount(self, tmp_path, monkeypatch):
+        """Auto-discovery reads mounts.json and calls mount() with URIs."""
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(tmp_path))
+        (tmp_path / "mounts.json").write_text(json.dumps(["local:///tmp/data"]))
+
+        mock_facade = AsyncMock()
+
+        async def mock_mount(*uris, at=None):
+            return mock_facade
+
+        with patch("nexus.fs.mount", side_effect=mock_mount):
+            result = NexusFileSystem._auto_discover()
+
+        assert result is mock_facade
+
+
+# ===========================================================================
+# Integration tests — real backend, no mocks (Issue 9A)
+# ===========================================================================
+
+
+class TestFsspecIntegration:
+    """Integration tests using real CASLocalBackend + NexusFileSystem.
+
+    Validates the full fsspec chain end-to-end.
+    """
+
+    @pytest.fixture
+    def fsspec_real(self, tmp_path):
+        """Create a real NexusFileSystem backed by a local CASLocalBackend."""
+        from nexus.backends.storage.cas_local import CASLocalBackend
+        from nexus.contracts.constants import ROOT_ZONE_ID
+        from nexus.contracts.types import OperationContext
+        from nexus.core.config import BrickServices, KernelServices, PermissionConfig
+        from nexus.core.nexus_fs import NexusFS
+        from nexus.core.router import PathRouter
+        from nexus.fs import _make_mount_entry
+        from nexus.fs._facade import SlimNexusFS
+        from nexus.fs._sqlite_meta import SQLiteMetastore
+
+        db_path = str(tmp_path / "metadata.db")
+        metastore = SQLiteMetastore(db_path)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        backend = CASLocalBackend(root_path=data_dir)
+
+        router = PathRouter(metastore)
+        router.add_mount("/local", backend)
+        metastore.put(_make_mount_entry("/local", backend.name))
+
+        kernel = NexusFS(
+            metadata_store=metastore,
+            permissions=PermissionConfig(enforce=False),
+            kernel_services=KernelServices(router=router),
+            brick_services=BrickServices(),
+        )
+        kernel._init_cred = OperationContext(
+            user_id="test",
+            groups=[],
+            zone_id=ROOT_ZONE_ID,
+            is_admin=True,
+        )
+
+        facade = SlimNexusFS(kernel)
+        fs = NexusFileSystem(nexus_fs=facade)
+        yield fs
+        fs._runner.close()
+
+    def test_write_and_cat(self, fsspec_real):
+        """Write via _pipe_file, read via _cat_file — full round-trip."""
+        fsspec_real._pipe_file("/local/hello.txt", b"Hello, fsspec!")
+        result = fsspec_real._cat_file("/local/hello.txt")
+        assert result == b"Hello, fsspec!"
+
+    def test_ls_detail(self, fsspec_real):
+        """Write files, ls with detail."""
+        fsspec_real._pipe_file("/local/a.txt", b"aaa")
+        fsspec_real._pipe_file("/local/b.txt", b"bbb")
+        entries = fsspec_real.ls("/local", detail=True)
+        names = [e["name"] for e in entries]
+        assert "/local/a.txt" in names
+        assert "/local/b.txt" in names
+
+    def test_info(self, fsspec_real):
+        """Write file, get info, verify metadata."""
+        fsspec_real._pipe_file("/local/info.txt", b"metadata")
+        info = fsspec_real.info("/local/info.txt")
+        assert info["name"] == "/local/info.txt"
+        assert info["size"] == 8
+        assert info["type"] == "file"
+
+    def test_open_write_then_read(self, fsspec_real):
+        """Write via _open(wb), read via _open(rb)."""
+        with fsspec_real._open("/local/stream.txt", mode="wb") as f:
+            f.write(b"streamed content")
+        with fsspec_real._open("/local/stream.txt", mode="rb") as f:
+            data = f.read()
+        assert data == b"streamed content"
+
+    def test_readline_integration(self, fsspec_real):
+        """Write multi-line file, read lines via readline."""
+        content = b"line1\nline2\nline3"
+        fsspec_real._pipe_file("/local/lines.txt", content)
+        with fsspec_real._open("/local/lines.txt", mode="rb") as f:
+            assert f.readline() == b"line1\n"
+            assert f.readline() == b"line2\n"
+            assert f.readline() == b"line3"
+            assert f.readline() == b""  # EOF
+
+    def test_iter_lines_integration(self, fsspec_real):
+        """Write multi-line file, iterate lines."""
+        content = b"a\nb\nc\n"
+        fsspec_real._pipe_file("/local/iter.txt", content)
+        with fsspec_real._open("/local/iter.txt", mode="rb") as f:
+            lines = list(f)
+        assert lines == [b"a\n", b"b\n", b"c\n"]
+
+    def test_byte_range_read(self, fsspec_real):
+        """_cat_file with byte range uses read_range, returns correct slice."""
+        fsspec_real._pipe_file("/local/range.txt", b"0123456789")
+        result = fsspec_real._cat_file("/local/range.txt", start=2, end=7)
+        assert result == b"23456"
+
+    def test_mkdir_and_ls(self, fsspec_real):
+        """Create directory, list parent."""
+        fsspec_real._mkdir("/local/subdir")
+        entries = fsspec_real.ls("/local", detail=True)
+        names = [e["name"] for e in entries]
+        assert "/local/subdir" in names
+
+    def test_rm_file(self, fsspec_real):
+        """Write file, delete it, verify gone."""
+        fsspec_real._pipe_file("/local/gone.txt", b"bye")
+        fsspec_real._rm("/local/gone.txt")
+        with pytest.raises(FileNotFoundError):
+            fsspec_real.info("/local/gone.txt")
+
+    def test_cp_file(self, fsspec_real):
+        """Copy file, verify copy has same content."""
+        fsspec_real._pipe_file("/local/src.txt", b"copy me")
+        fsspec_real._cp_file("/local/src.txt", "/local/dst.txt")
+        assert fsspec_real._cat_file("/local/dst.txt") == b"copy me"
+
+    def test_dircache_populated(self, fsspec_real):
+        """ls() should populate dircache."""
+        fsspec_real._pipe_file("/local/cached.txt", b"data")
+        fsspec_real.ls("/local", detail=True)
+        assert "/local" in fsspec_real.dircache
+
+    def test_issubclass_check(self, fsspec_real):
+        """Instance should pass isinstance(fs, AbstractFileSystem)."""
+        from fsspec.spec import AbstractFileSystem
+
+        assert isinstance(fsspec_real, AbstractFileSystem)
+
+
+# ===========================================================================
+# End-to-end: pandas via fsspec (validates the actual claimed integration)
+# ===========================================================================
+
+pd = pytest.importorskip("pandas")
+
+
+class TestPandasIntegration:
+    """Validates that pd.read_csv("nexus:///...") actually works end-to-end.
+
+    Uses a real CASLocalBackend + mount() + fsspec registration.
+    """
+
+    @pytest.fixture
+    def mounted_fs(self, tmp_path, monkeypatch):
+        """Mount a real local backend and register the nexus protocol."""
+        import fsspec
+
+        fsspec.register_implementation("nexus", NexusFileSystem, clobber=True)
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(state_dir))
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        import nexus.fs
+        from nexus.fs._sync import run_sync
+
+        facade = run_sync(nexus.fs.mount(f"local://{data_dir}"))
+
+        from nexus.fs._sync import PortalRunner
+
+        runner = PortalRunner()
+        mount = sorted(m for m in facade.list_mounts())[0]
+        yield facade, runner, mount
+        runner.close()
+
+    def _write(self, facade, runner, path, content):
+        runner(facade.write(path, content))
+
+    def test_pd_read_csv(self, mounted_fs):
+        """pd.read_csv('nexus:///...') reads a CSV from nexus-fs."""
+        facade, runner, mount = mounted_fs
+        self._write(facade, runner, f"{mount}/data.csv", b"name,age\nAlice,30\nBob,25\n")
+
+        df = pd.read_csv(f"nexus://{mount}/data.csv")
+
+        assert list(df.columns) == ["name", "age"]
+        assert len(df) == 2
+        assert df["name"].tolist() == ["Alice", "Bob"]
+
+    def test_pd_to_csv_roundtrip(self, mounted_fs):
+        """df.to_csv('nexus:///...') writes, then read back matches."""
+        facade, runner, mount = mounted_fs
+
+        original = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+        original.to_csv(f"nexus://{mount}/output.csv", index=False)
+
+        roundtrip = pd.read_csv(f"nexus://{mount}/output.csv")
+        assert list(roundtrip.columns) == ["x", "y"]
+        assert len(roundtrip) == 3
+        assert roundtrip["x"].tolist() == [1, 2, 3]
+
+    def test_pd_read_json(self, mounted_fs):
+        """pd.read_json('nexus:///...') reads JSON from nexus-fs."""
+        facade, runner, mount = mounted_fs
+        self._write(
+            facade,
+            runner,
+            f"{mount}/data.json",
+            b'[{"name":"Alice","score":95},{"name":"Bob","score":87}]',
+        )
+
+        df = pd.read_json(f"nexus://{mount}/data.json")
+
+        assert "name" in df.columns
+        assert len(df) == 2
+
+    def test_fsspec_open_read_write(self, mounted_fs):
+        """fsspec.open('nexus:///...') works for both read and write."""
+        import fsspec
+
+        facade, runner, mount = mounted_fs
+
+        with fsspec.open(f"nexus://{mount}/fsspec_rw.txt", "wb") as f:
+            f.write(b"written via fsspec.open")
+
+        with fsspec.open(f"nexus://{mount}/fsspec_rw.txt", "rb") as f:
+            content = f.read()
+
+        assert content == b"written via fsspec.open"
+
+
+# ===========================================================================
+# End-to-end: HuggingFace datasets via fsspec
+# ===========================================================================
+
+datasets = pytest.importorskip("datasets")
+
+
+class TestHuggingFaceIntegration:
+    """Validates that HuggingFace load_dataset works with nexus:// URIs."""
+
+    @pytest.fixture
+    def mounted_fs(self, tmp_path, monkeypatch):
+        """Mount a real local backend and register the nexus protocol."""
+        import fsspec
+
+        fsspec.register_implementation("nexus", NexusFileSystem, clobber=True)
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(state_dir))
+        monkeypatch.setenv("HF_DATASETS_CACHE", str(tmp_path / "hf_cache"))
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        import nexus.fs
+        from nexus.fs._sync import PortalRunner, run_sync
+
+        facade = run_sync(nexus.fs.mount(f"local://{data_dir}"))
+        runner = PortalRunner()
+        mount = sorted(m for m in facade.list_mounts())[0]
+        yield facade, runner, mount
+        runner.close()
+
+    def _write(self, facade, runner, path, content):
+        runner(facade.write(path, content))
+
+    def test_load_dataset_csv(self, mounted_fs):
+        """HuggingFace load_dataset('csv', data_files='nexus:///...') works."""
+        facade, runner, mount = mounted_fs
+        self._write(
+            facade,
+            runner,
+            f"{mount}/train.csv",
+            b"text,label\nhello world,1\ngoodbye world,0\nfoo bar,1\n",
+        )
+
+        ds = datasets.load_dataset(
+            "csv",
+            data_files=f"nexus://{mount}/train.csv",
+            split="train",
+        )
+
+        assert len(ds) == 3
+        assert ds.column_names == ["text", "label"]
+        assert ds[0]["text"] == "hello world"
+        assert ds[0]["label"] == 1

--- a/tests/unit/raft/test_federated_metadata_proxy.py
+++ b/tests/unit/raft/test_federated_metadata_proxy.py
@@ -154,9 +154,11 @@ class TestFromZoneManager:
     """from_zone_manager() picks up advertise_addr."""
 
     def test_picks_up_advertise_addr(self):
+        """Raft advertise_addr host is kept, but port is replaced with VFS gRPC port."""
         zone_mgr = MagicMock()
         zone_mgr.advertise_addr = "10.0.0.5:50051"
         zone_mgr.get_store.return_value = MagicMock()
 
         proxy = FederatedMetadataProxy.from_zone_manager(zone_mgr)
-        assert proxy._self_address == "10.0.0.5:50051"
+        # from_zone_manager replaces the Raft port with the VFS gRPC port (default 2028)
+        assert proxy._self_address == "10.0.0.5:2028"


### PR DESCRIPTION
## Summary

Closes #3233 — Phase 3 integration work for `nexus-fs` v0.1.0.

Fixes the fsspec compatibility layer so that `pd.read_csv("nexus:///...")` and HuggingFace `load_dataset` actually work end-to-end, not just in local mocks. Also hardens the fsspec contract, adds missing file-like methods, and scopes framework adapter claims to what's actually validated.

### What changed

**Architecture (4 fixes):**
- `NexusFileSystem` now properly inherits from `AbstractFileSystem` — removes fragile dynamic mixin that broke `issubclass` checks and fsspec registry
- Auto-discovery from `mounts.json` — `fsspec.filesystem("nexus")` now works without manual construction
- `_cat_file` uses `read_range()` for byte ranges — was downloading full file and slicing in Python
- Mode validation — `_open()` rejects unsupported modes (`"a"`, `"r+"`) with clear error instead of silently overwriting

**Code quality (5 fixes):**
- DRY: `_fsspec.py` reuses `PortalRunner` from `_sync.py` — removed duplicated sync bridge + dead asyncio fallback
- Added `readline()` / `readlines()` / `__iter__` / `name` / `flush()` to file-like objects (needed for `pd.read_csv`)
- `ls()` raises `FileNotFoundError` for non-existent paths (fsspec contract)
- `_rm()` handles `recursive` param for directories
- `MAX_WRITE_BUFFER_SIZE` guard (1 GB) on `NexusWriteFile` to prevent OOM

**Performance (3 fixes):**
- `PortalRunner` keeps event loop alive across calls (was starting/stopping per operation)
- `ls()` populates fsspec `dircache` — repeat `info()` calls hit cache
- Copy size guard (1 GB) on `SlimNexusFS.copy()` to prevent OOM on large files

**Packaging:**
- Removed unclaimed `langchain` optional dep (no implementation in slim package)
- Documented known fsspec deviations and v0.1.0 adapter scope in module docstring

### Tests (17 → 95)

| Category | Tests | What's validated |
|----------|-------|-----------------|
| Unit (mock-based) | 55 | All fsspec methods, mode validation, error paths |
| Edge cases | 18 | Closed file ops, seek whence, double close, write overflow |
| Auto-discovery | 4 | mounts.json reading, error handling |
| Integration (real backend) | 12 | Full CASLocalBackend lifecycle via fsspec |
| **pandas e2e** | **4** | `pd.read_csv`, `df.to_csv`, `pd.read_json`, `fsspec.open` |
| **HuggingFace e2e** | **1** | `load_dataset("csv", data_files="nexus:///...")` |

## Test plan

- [x] All 273 fs tests pass (95 fsspec + 178 other)
- [x] `pd.read_csv("nexus:///...")` works end-to-end
- [x] `df.to_csv("nexus:///...")` round-trips correctly
- [x] `pd.read_json("nexus:///...")` works end-to-end
- [x] HuggingFace `load_dataset` works with `nexus://` URIs
- [x] `fsspec.open("nexus:///...", "rb"/"wb")` read/write cycle works
- [x] `issubclass(NexusFileSystem, AbstractFileSystem)` passes
- [x] Existing sync/integration tests pass with zero regressions
- [x] ruff lint + format pass