### PR TITLE
fix: prevent write-back pipe wakeup test hot spin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -890,8 +890,6 @@ layers = [
 # Ratchet baseline — known violations. Remove entries as fixes land.
 # Run: lint-imports --contract four-tier-layers to check.
 ignore_imports = [
-    # --- core importing system_services (ServiceRegistry shutdown needs BrickLifecycleManager type) ---
-    "nexus.core.service_registry -> nexus.system_services.lifecycle.brick_lifecycle",
     # --- tier-neutral (contracts) importing core ---
     "nexus.contracts.metadata -> nexus.core._compact_generated",
     # --- tier-neutral (contracts/protocols) importing bricks ---
@@ -906,8 +904,6 @@ ignore_imports = [
     "nexus.contracts.wirable_fs -> nexus.storage.record_store",
     # --- lib importing system_services (upward — legacy, to be fixed) ---
     "nexus.lib.permission_utils -> nexus.system_services.gateway",
-    # --- kernel (core) importing system_services ---
-    "nexus.core.service_registry -> nexus.system_services.lifecycle.brick_lifecycle",
     # --- kernel (core) importing bricks ---
     "nexus.core.config -> nexus.bricks.workflows.protocol",
     # --- system_services importing bricks ---

--- a/rust/nexus_raft/src/raft/node.rs
+++ b/rust/nexus_raft/src/raft/node.rs
@@ -383,21 +383,45 @@ impl<S: StateMachine + 'static> ZoneConsensus<S> {
             .initial_state()
             .map_err(|e| RaftError::Storage(e.to_string()))?;
 
-        if initial_state.conf_state.voters.is_empty() && !config.skip_bootstrap {
-            // Bootstrap: create initial voter set for a NEW cluster.
-            // Joining nodes (skip_bootstrap=true) must NOT bootstrap — they
-            // start uninitialized and receive the correct ConfState via
-            // snapshot from the leader (per raft contract).
+        if !config.skip_bootstrap {
+            // Build the expected voter set from config.
             let mut voters = vec![config.id];
             voters.extend(config.peers.iter());
-            let cs = ConfState {
-                voters: voters.clone(),
-                ..Default::default()
+
+            let needs_bootstrap = if initial_state.conf_state.voters.is_empty() {
+                // Fresh cluster — no ConfState in storage yet.
+                true
+            } else if config.peers.is_empty() && initial_state.conf_state.voters != vec![config.id]
+            {
+                // Single-node restart with STALE ConfState from a previous
+                // multi-node cluster (e.g. Docker container restarted with
+                // different node ID but persistent storage). Force-reset to
+                // just [self.id] so raft-rs doesn't send messages to phantom
+                // peers that no longer exist.
+                tracing::warn!(
+                    "Stale ConfState detected (voters={:?}, expected={:?}) — resetting for single-node",
+                    initial_state.conf_state.voters,
+                    voters,
+                );
+                true
+            } else {
+                false
             };
-            storage
-                .set_conf_state(&cs)
-                .map_err(|e| RaftError::Storage(format!("failed to set initial ConfState: {e}")))?;
-            tracing::info!("Bootstrapped ConfState with voters: {:?}", voters);
+
+            if needs_bootstrap {
+                // Bootstrap: create initial voter set.
+                // Joining nodes (skip_bootstrap=true) must NOT bootstrap — they
+                // start uninitialized and receive the correct ConfState via
+                // snapshot from the leader (per raft contract).
+                let cs = ConfState {
+                    voters: voters.clone(),
+                    ..Default::default()
+                };
+                storage.set_conf_state(&cs).map_err(|e| {
+                    RaftError::Storage(format!("failed to set initial ConfState: {e}"))
+                })?;
+                tracing::info!("Bootstrapped ConfState with voters: {:?}", voters);
+            }
         }
 
         let raft_config = config.to_raft_config();

--- a/src/nexus/backends/connectors/cli/base.py
+++ b/src/nexus/backends/connectors/cli/base.py
@@ -306,18 +306,24 @@ class CLIConnector(
                 backend=self.name,
             )
 
-        # Parse YAML — extract comment-based metadata first (agent_intent,
-        # confirm, user_confirmed) since yaml.safe_load strips comments.
+        # Parse YAML — extract comment-based metadata from the header block only.
+        # Stop at the first non-comment, non-blank line to avoid matching
+        # comments inside literal block scalars (e.g. body: |\n  # confirm: true).
         text = content.decode("utf-8") if isinstance(content, bytes) else content
         comment_meta: dict[str, Any] = {}
         for line in text.split("\n"):
             stripped = line.strip()
-            if stripped.startswith("# agent_intent:"):
-                comment_meta["agent_intent"] = stripped.split(":", 1)[1].strip()
-            elif stripped.startswith("# confirm:"):
-                comment_meta["confirm"] = stripped.split(":", 1)[1].strip().lower() == "true"
-            elif stripped.startswith("# user_confirmed:"):
-                comment_meta["user_confirmed"] = stripped.split(":", 1)[1].strip().lower() == "true"
+            if not stripped or stripped.startswith("#"):
+                if stripped.startswith("# agent_intent:"):
+                    comment_meta["agent_intent"] = stripped.split(":", 1)[1].strip()
+                elif stripped.startswith("# confirm:"):
+                    comment_meta["confirm"] = stripped.split(":", 1)[1].strip().lower() == "true"
+                elif stripped.startswith("# user_confirmed:"):
+                    comment_meta["user_confirmed"] = (
+                        stripped.split(":", 1)[1].strip().lower() == "true"
+                    )
+            else:
+                break  # First non-comment line — stop scanning
 
         data = yaml.safe_load(content)
         if not isinstance(data, dict):

--- a/src/nexus/backends/connectors/cli/base.py
+++ b/src/nexus/backends/connectors/cli/base.py
@@ -306,7 +306,19 @@ class CLIConnector(
                 backend=self.name,
             )
 
-        # Parse YAML
+        # Parse YAML — extract comment-based metadata first (agent_intent,
+        # confirm, user_confirmed) since yaml.safe_load strips comments.
+        text = content.decode("utf-8") if isinstance(content, bytes) else content
+        comment_meta: dict[str, Any] = {}
+        for line in text.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("# agent_intent:"):
+                comment_meta["agent_intent"] = stripped.split(":", 1)[1].strip()
+            elif stripped.startswith("# confirm:"):
+                comment_meta["confirm"] = stripped.split(":", 1)[1].strip().lower() == "true"
+            elif stripped.startswith("# user_confirmed:"):
+                comment_meta["user_confirmed"] = stripped.split(":", 1)[1].strip().lower() == "true"
+
         data = yaml.safe_load(content)
         if not isinstance(data, dict):
             from nexus.contracts.exceptions import BackendError
@@ -315,6 +327,11 @@ class CLIConnector(
                 f"Expected YAML mapping, got {type(data).__name__}",
                 backend=self.name,
             )
+
+        # Merge comment metadata (comments take precedence for backward compat)
+        for key, val in comment_meta.items():
+            if key not in data:
+                data[key] = val
 
         # Validate traits (agent_intent, confirm, etc.)
         warnings = self.validate_traits(operation, data)

--- a/src/nexus/bricks/ipc/wakeup.py
+++ b/src/nexus/bricks/ipc/wakeup.py
@@ -24,12 +24,12 @@ import boundary (bricks must not import from nexus.core directly).
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 from typing import Any
 
 from nexus.bricks.ipc.conventions import notify_pipe_path
+from nexus.lib.pipe_wakeup import wait_for_signal  # re-export for backward compat
 
 logger = logging.getLogger(__name__)
 
@@ -39,48 +39,6 @@ _WAKEUP_SIGNAL = b"\x01"
 # Notify pipe capacity — small because wakeup signals are 1 byte each.
 # 256 bytes = 256 pending signals, far more than needed with drain-and-process.
 NOTIFY_PIPE_CAPACITY = 256
-
-
-async def wait_for_signal(
-    pipe_manager: Any,
-    path: str,
-    timeout: float | None = None,
-) -> bool:
-    """Wait for a DT_PIPE wakeup signal with drain-and-process pattern.
-
-    Blocks until at least one signal arrives (or timeout expires), then drains
-    all remaining signals so the caller processes once for all coalesced signals.
-
-    This is the generic primitive used by both IPC ``PipeWakeupListener`` and
-    the sync ``WriteBackService`` poll loop (Issue #3194).
-
-    Args:
-        pipe_manager: PipeManager instance (duck-typed to avoid core imports).
-        path: DT_PIPE path to listen on.
-        timeout: Max seconds to wait. None = wait forever. 0 = non-blocking poll.
-
-    Returns:
-        True if at least one signal was received, False if timed out.
-    """
-    try:
-        if timeout is not None:
-            await asyncio.wait_for(pipe_manager.pipe_read(path), timeout=timeout)
-        else:
-            await pipe_manager.pipe_read(path)
-    except TimeoutError:
-        return False
-    except Exception:
-        # PipeClosedError, PipeNotFoundError, CancelledError — caller handles
-        raise
-
-    # Drain remaining signals (non-blocking)
-    while True:
-        try:
-            await pipe_manager.pipe_read(path, blocking=False)
-        except Exception:
-            # PipeEmptyError — no more pending signals
-            break
-    return True
 
 
 class PipeWakeupNotifier:

--- a/src/nexus/bricks/ipc/wakeup.py
+++ b/src/nexus/bricks/ipc/wakeup.py
@@ -9,6 +9,10 @@ Issue #3197:
   - PipeWakeupListener: drain-and-process pattern for signal coalescing
   - PipeNotifyFactory: creates small-capacity notify pipes on provisioning
 
+Issue #3194:
+  - wait_for_signal(): generic drain-and-process utility with timeout fallback
+    Reused by PipeWakeupListener (IPC) and WriteBackService (sync).
+
 Architecture:
   - DT_PIPE for same-node wakeup (us latency, no Redis dependency)
   - EventBus retained for cross-node notifications
@@ -20,6 +24,7 @@ import boundary (bricks must not import from nexus.core directly).
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 from typing import Any
@@ -34,6 +39,48 @@ _WAKEUP_SIGNAL = b"\x01"
 # Notify pipe capacity — small because wakeup signals are 1 byte each.
 # 256 bytes = 256 pending signals, far more than needed with drain-and-process.
 NOTIFY_PIPE_CAPACITY = 256
+
+
+async def wait_for_signal(
+    pipe_manager: Any,
+    path: str,
+    timeout: float | None = None,
+) -> bool:
+    """Wait for a DT_PIPE wakeup signal with drain-and-process pattern.
+
+    Blocks until at least one signal arrives (or timeout expires), then drains
+    all remaining signals so the caller processes once for all coalesced signals.
+
+    This is the generic primitive used by both IPC ``PipeWakeupListener`` and
+    the sync ``WriteBackService`` poll loop (Issue #3194).
+
+    Args:
+        pipe_manager: PipeManager instance (duck-typed to avoid core imports).
+        path: DT_PIPE path to listen on.
+        timeout: Max seconds to wait. None = wait forever. 0 = non-blocking poll.
+
+    Returns:
+        True if at least one signal was received, False if timed out.
+    """
+    try:
+        if timeout is not None:
+            await asyncio.wait_for(pipe_manager.pipe_read(path), timeout=timeout)
+        else:
+            await pipe_manager.pipe_read(path)
+    except TimeoutError:
+        return False
+    except Exception:
+        # PipeClosedError, PipeNotFoundError, CancelledError — caller handles
+        raise
+
+    # Drain remaining signals (non-blocking)
+    while True:
+        try:
+            await pipe_manager.pipe_read(path, blocking=False)
+        except Exception:
+            # PipeEmptyError — no more pending signals
+            break
+    return True
 
 
 class PipeWakeupNotifier:
@@ -94,15 +141,7 @@ class PipeWakeupListener:
         2. Drain remaining signals (pipe_read, blocking=False)
         3. Return — caller processes inbox once for all coalesced signals
         """
-        # Block until first signal
-        await self._pm.pipe_read(self._path)
-        # Drain remaining signals (non-blocking)
-        while True:
-            try:
-                await self._pm.pipe_read(self._path, blocking=False)
-            except Exception:
-                # PipeEmptyError — no more pending signals
-                break
+        await wait_for_signal(self._pm, self._path)
 
     def close(self) -> None:
         """Signal the listener to stop. Wakes any blocked wait_for_wakeup()."""

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1309,7 +1309,13 @@ class NexusFS(  # type: ignore[misc]
                 if overlay_config:
                     meta = self._overlay_resolver.resolve_read(path, overlay_config)
 
-            if meta is None or meta.etag is None:
+            if meta is None:
+                raise NexusFileNotFoundError(path)
+
+            # Issue #3194: Path-based backends (path_local, path_gcs, path_s3)
+            # store metadata without content_hash/etag. Reads go through
+            # backend_path in the OperationContext, not CAS.
+            if meta.etag is None and not (read_context and read_context.backend_path):
                 raise NexusFileNotFoundError(path)
 
             # Issue #1264: Reject whiteout markers (file was deleted in overlay)
@@ -1318,7 +1324,7 @@ class NexusFS(  # type: ignore[misc]
             ):
                 raise NexusFileNotFoundError(path)
 
-            content = route.backend.read_content(meta.etag, context=read_context)
+            content = route.backend.read_content(meta.etag or "", context=read_context)
 
         # --- Lock released — post-read processing (like Linux inotify after i_rwsem) ---
 

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -109,16 +109,6 @@ async def _boot_wired_services(
     else:
         logger.debug("[BOOT:WIRED] OAuthCredentialService disabled by profile")
 
-    # --- UnifiedAuthService: shared auth UX across OAuth + secret/native backends ---
-    auth_service: Any = None
-    try:
-        from nexus.bricks.auth.unified_service import UnifiedAuthService
-
-        auth_service = UnifiedAuthService(oauth_service=oauth_service)
-        logger.debug("[BOOT:WIRED] UnifiedAuthService created")
-    except Exception as exc:
-        logger.debug("[BOOT:WIRED] UnifiedAuthService unavailable: %s", exc)
-
     # --- MCPService: Model Context Protocol operations ---
     mcp_service: Any = None
     if _on("mcp"):
@@ -478,7 +468,6 @@ async def _boot_wired_services(
         mount_persist_service=mount_persist_service,
         mcp_service=mcp_service,
         oauth_service=oauth_service,
-        auth_service=auth_service,
         search_service=search_service,
         share_link_service=share_link_service,
         events_service=events_service,

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -109,6 +109,16 @@ async def _boot_wired_services(
     else:
         logger.debug("[BOOT:WIRED] OAuthCredentialService disabled by profile")
 
+    # --- UnifiedAuthService: shared auth UX across OAuth + secret/native backends ---
+    auth_service: Any = None
+    try:
+        from nexus.bricks.auth.unified_service import UnifiedAuthService
+
+        auth_service = UnifiedAuthService(oauth_service=oauth_service)
+        logger.debug("[BOOT:WIRED] UnifiedAuthService created")
+    except Exception as exc:
+        logger.debug("[BOOT:WIRED] UnifiedAuthService unavailable: %s", exc)
+
     # --- MCPService: Model Context Protocol operations ---
     mcp_service: Any = None
     if _on("mcp"):
@@ -468,6 +478,7 @@ async def _boot_wired_services(
         mount_persist_service=mount_persist_service,
         mcp_service=mcp_service,
         oauth_service=oauth_service,
+        auth_service=auth_service,
         search_service=search_service,
         share_link_service=share_link_service,
         events_service=events_service,

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -637,6 +637,12 @@ async def _register_vfs_hooks(
     _rev_observer = RevisionTrackingObserver(revision_notifier=_rev_notifier)
     await _enlist("revision_tracking", _rev_observer)
 
+    # WriteBackObserver: receives VFS mutations and enqueues write-back ops.
+    # Replaces the old EventBus _subscribe_loop() (Issue #3194).
+    # NOTE: WriteBackService is created later in realtime.py startup and
+    # registered as an observer via app.state — not at factory time.
+    # The _enlist() call happens in realtime.py after WriteBackService.start().
+
     # ── CAS GC (Issue #1320, #1772) ────────────────────────────────────
     # ref_count eliminated; reachability-based GC via CASGarbageCollector.
     # GC is owned by CASLocalBackend, metastore injected via set_metastore().

--- a/src/nexus/lib/pipe_wakeup.py
+++ b/src/nexus/lib/pipe_wakeup.py
@@ -1,0 +1,56 @@
+"""Generic DT_PIPE wakeup signal utility (Issue #3194).
+
+Provides ``wait_for_signal()`` — the drain-and-process pattern for pipe-based
+wakeup signals.  Used by both IPC (``PipeWakeupListener``) and sync
+(``WriteBackService``) subsystems.
+
+Lives in ``nexus.lib`` (not ``nexus.bricks.ipc``) so that system_services
+can import it without violating the five-tier architecture boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def wait_for_signal(
+    pipe_manager: Any,
+    path: str,
+    timeout: float | None = None,
+) -> bool:
+    """Wait for a DT_PIPE wakeup signal with drain-and-process pattern.
+
+    Blocks until at least one signal arrives (or timeout expires), then drains
+    all remaining signals so the caller processes once for all coalesced signals.
+
+    Args:
+        pipe_manager: PipeManager instance (duck-typed to avoid core imports).
+        path: DT_PIPE path to listen on.
+        timeout: Max seconds to wait. None = wait forever. 0 = non-blocking poll.
+
+    Returns:
+        True if at least one signal was received, False if timed out.
+    """
+    try:
+        if timeout is not None:
+            await asyncio.wait_for(pipe_manager.pipe_read(path), timeout=timeout)
+        else:
+            await pipe_manager.pipe_read(path)
+    except TimeoutError:
+        return False
+    except Exception:
+        # PipeClosedError, PipeNotFoundError, CancelledError — caller handles
+        raise
+
+    # Drain remaining signals (non-blocking)
+    while True:
+        try:
+            await pipe_manager.pipe_read(path, blocking=False)
+        except Exception:
+            # PipeEmptyError — no more pending signals
+            break
+    return True

--- a/src/nexus/raft/federated_metadata_proxy.py
+++ b/src/nexus/raft/federated_metadata_proxy.py
@@ -93,7 +93,7 @@ class FederatedMetadataProxy(MetastoreABC):
             vfs_port = _os.environ.get("NEXUS_GRPC_PORT", "2028")
             self_addr = f"{hostname}:{vfs_port}"
         else:
-            self_addr = raft_addr
+            self_addr = raft_addr or ""
         return cls(resolver, root_store, zone_manager=zone_manager, self_address=self_addr)
 
     # =========================================================================

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -685,9 +685,10 @@ async def write_to_connector(
     # Resolve mount to get backend_path — required for CLI-backed connectors
     # (gws_gmail, gws_drive, etc.) that use backend_path to determine the operation.
     _backend_path = None
+    _route = None
     try:
-        route = nx.router.route(mount_path, is_admin=True)
-        _backend_path = route.backend_path if route else None
+        _route = nx.router.route(mount_path, is_admin=auth.get("is_admin", False))
+        _backend_path = _route.backend_path if _route else None
     except Exception:
         pass
 
@@ -704,14 +705,22 @@ async def write_to_connector(
     try:
         data = req.yaml_content.encode("utf-8")
 
-        # CLI-backed connectors (gws_gmail, gws_drive, etc.) need their
-        # write_content() called directly — nx.write() would store to CAS
-        # instead of dispatching to the connector's send/create pipeline.
+        # CLI-backed connectors dispatch YAML operations (send_email, create_draft,
+        # etc.) via write_content() — they must NOT go through nx.write() which
+        # stores to CAS. Gate on the "cli_backed" capability to avoid bypassing
+        # the kernel write path (metadata, observers, permission checks) for
+        # ordinary path-addressed backends.
         import asyncio
 
-        route = nx.router.route(mount_path, is_admin=True)
-        backend = route.backend if route else None
-        if backend and hasattr(backend, "write_content") and _backend_path:
+        from nexus.contracts.capabilities import ConnectorCapability
+
+        backend = _route.backend if _route else None
+        _caps: frozenset[str] = (
+            getattr(backend, "capabilities", frozenset()) if backend else frozenset()
+        )
+        is_cli_connector = ConnectorCapability.CLI_BACKED in _caps
+
+        if is_cli_connector and _backend_path:
             result = await asyncio.to_thread(backend.write_content, data, write_context)
         else:
             result = await nx.write(mount_path, data, context=write_context)

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -736,8 +736,12 @@ async def write_to_connector(
 
             from nexus.contracts.vfs_hooks import WriteHookContext as _WHC
 
+            # Load existing metadata so permission hooks can distinguish
+            # overwrite (check WRITE on file) vs create (check WRITE on parent).
+            _old_meta = nx.metadata.get(mount_path)
+
             nx._dispatch.intercept_pre_write(
-                _WHC(path=mount_path, content=data, context=write_context, old_metadata=None)
+                _WHC(path=mount_path, content=data, context=write_context, old_metadata=_old_meta)
             )
 
             result = await asyncio.to_thread(backend.write_content, data, write_context)

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -744,6 +744,7 @@ async def write_to_connector(
                 _WHC(path=mount_path, content=data, context=write_context, old_metadata=_old_meta)
             )
 
+            assert backend is not None  # guaranteed by is_cli_connector check
             result = await asyncio.to_thread(backend.write_content, data, write_context)
         else:
             result = await nx.write(mount_path, data, context=write_context)

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -682,12 +682,15 @@ async def write_to_connector(
 
     nx = _get_nx(request)
 
-    # Resolve mount to get backend_path — required for CLI-backed connectors
-    # (gws_gmail, gws_drive, etc.) that use backend_path to determine the operation.
+    # Preflight route resolution to discover backend type and backend_path.
+    # Uses is_admin=True because this is a routing decision, not a permission
+    # check — actual auth is enforced by backend.write_content() (CLI connectors)
+    # or nx.write() (kernel path). Without admin, a non-admin caller's route
+    # lookup could fail and silently fall back to the wrong write path.
     _backend_path = None
     _route = None
     try:
-        _route = nx.router.route(mount_path, is_admin=auth.get("is_admin", False))
+        _route = nx.router.route(mount_path, is_admin=True)
         _backend_path = _route.backend_path if _route else None
     except Exception:
         pass

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -698,8 +698,7 @@ async def write_to_connector(
     write_context = OperationContext(
         user_id=auth.get("subject_id", "system"),
         groups=[],
-        is_admin=auth.get("is_admin", True),
-        is_system=True,
+        is_admin=auth.get("is_admin", False),
         zone_id=auth.get("zone_id") or ROOT_ZONE_ID,
         backend_path=_backend_path,
         virtual_path=mount_path,
@@ -711,8 +710,7 @@ async def write_to_connector(
         # CLI-backed connectors dispatch YAML operations (send_email, create_draft,
         # etc.) via write_content() — they must NOT go through nx.write() which
         # stores to CAS. Gate on the "cli_backed" capability to avoid bypassing
-        # the kernel write path (metadata, observers, permission checks) for
-        # ordinary path-addressed backends.
+        # the kernel write path for ordinary path-addressed backends.
         import asyncio
 
         from nexus.contracts.capabilities import ConnectorCapability
@@ -724,6 +722,24 @@ async def write_to_connector(
         is_cli_connector = ConnectorCapability.CLI_BACKED in _caps
 
         if is_cli_connector and _backend_path:
+            # Enforce the same write-access checks that nx.write() performs:
+            # 1. Route with check_write=True (zone/agent isolation)
+            # 2. Read-only mount check
+            # 3. Pre-write intercept hooks (permission hooks)
+            _write_route = nx.router.route(
+                mount_path,
+                is_admin=write_context.is_admin,
+                check_write=True,
+            )
+            if _write_route.readonly:
+                raise PermissionError(f"Path is read-only: {mount_path}")
+
+            from nexus.contracts.vfs_hooks import WriteHookContext as _WHC
+
+            nx._dispatch.intercept_pre_write(
+                _WHC(path=mount_path, content=data, context=write_context, old_metadata=None)
+            )
+
             result = await asyncio.to_thread(backend.write_content, data, write_context)
         else:
             result = await nx.write(mount_path, data, context=write_context)

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -680,18 +680,41 @@ async def write_to_connector(
     from nexus.contracts.constants import ROOT_ZONE_ID
     from nexus.contracts.types import OperationContext
 
+    nx = _get_nx(request)
+
+    # Resolve mount to get backend_path — required for CLI-backed connectors
+    # (gws_gmail, gws_drive, etc.) that use backend_path to determine the operation.
+    _backend_path = None
+    try:
+        route = nx.router.route(mount_path, is_admin=True)
+        _backend_path = route.backend_path if route else None
+    except Exception:
+        pass
+
     write_context = OperationContext(
         user_id=auth.get("subject_id", "system"),
         groups=[],
         is_admin=auth.get("is_admin", True),
         is_system=True,
         zone_id=auth.get("zone_id") or ROOT_ZONE_ID,
+        backend_path=_backend_path,
+        virtual_path=mount_path,
     )
 
-    nx = _get_nx(request)
     try:
         data = req.yaml_content.encode("utf-8")
-        result = await nx.write(mount_path, data, context=write_context)
+
+        # CLI-backed connectors (gws_gmail, gws_drive, etc.) need their
+        # write_content() called directly — nx.write() would store to CAS
+        # instead of dispatching to the connector's send/create pipeline.
+        import asyncio
+
+        route = nx.router.route(mount_path, is_admin=True)
+        backend = route.backend if route else None
+        if backend and hasattr(backend, "write_content") and _backend_path:
+            result = await asyncio.to_thread(backend.write_content, data, write_context)
+        else:
+            result = await nx.write(mount_path, data, context=write_context)
 
         return WriteResponse(
             success=True,

--- a/src/nexus/server/lifespan/realtime.py
+++ b/src/nexus/server/lifespan/realtime.py
@@ -6,9 +6,11 @@ Extracted from fastapi_server.py (#1602).
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from fastapi import FastAPI
 
     from nexus.server.lifespan.services_container import LifespanServices
@@ -175,7 +177,6 @@ async def _startup_writeback(app: "FastAPI", svc: "LifespanServices") -> None:
 
             wb_event_bus = svc.event_bus
             if wb_event_bus:
-                backlog_store = SyncBacklogStore(record_store=gw.record_store, is_postgresql=_is_pg)
                 change_log_store = ChangeLogStore(
                     record_store=gw.record_store, is_postgresql=_is_pg
                 )
@@ -191,6 +192,33 @@ async def _startup_writeback(app: "FastAPI", svc: "LifespanServices") -> None:
                 except ValueError:
                     default_strategy = _policy_map.get(raw_policy, ConflictStrategy.KEEP_NEWER)
 
+                # DT_PIPE wakeup callback (Issue #3194): sync, best-effort, never blocks.
+                # SyncBacklogStore calls this after every enqueue() commit to wake the
+                # poll loop via pipe signal instead of waiting up to 30s.
+                _pm = svc.pipe_manager
+                _on_enqueue = None
+                if _pm is not None:
+                    import contextlib
+
+                    from nexus.system_services.sync.write_back_service import (
+                        _BACKLOG_WAKEUP_PIPE,
+                    )
+
+                    def _make_on_enqueue(pm: "Any", pipe_path: str) -> "Callable[[], None]":
+                        def _signal() -> None:
+                            with contextlib.suppress(Exception):
+                                pm.pipe_write_nowait(pipe_path, b"\x01")
+
+                        return _signal
+
+                    _on_enqueue = _make_on_enqueue(_pm, _BACKLOG_WAKEUP_PIPE)
+
+                backlog_store = SyncBacklogStore(
+                    record_store=gw.record_store,
+                    is_postgresql=_is_pg,
+                    on_enqueue=_on_enqueue,
+                )
+
                 app.state.write_back_service = WriteBackService(
                     gateway=gw,
                     event_bus=wb_event_bus,
@@ -198,8 +226,18 @@ async def _startup_writeback(app: "FastAPI", svc: "LifespanServices") -> None:
                     change_log_store=change_log_store,
                     default_strategy=default_strategy,
                     conflict_log_store=conflict_log_store,
+                    pipe_manager=_pm,
                 )
                 await app.state.write_back_service.start()
+
+                # Register as VFSObserver (Issue #3194): receive file mutation events
+                # directly from KernelDispatch OBSERVE phase (us latency, replaces
+                # EventBus _subscribe_loop).
+                _dispatch = getattr(svc.nexus_fs, "_dispatch", None)
+                if _dispatch is not None:
+                    _dispatch.register_observe(app.state.write_back_service)
+                    logger.debug("WriteBack observer registered with KernelDispatch")
+
                 logger.info("WriteBack service started for bidirectional sync")
                 return
 

--- a/src/nexus/server/lifespan/realtime.py
+++ b/src/nexus/server/lifespan/realtime.py
@@ -59,9 +59,13 @@ async def shutdown_realtime(app: "FastAPI", svc: "LifespanServices") -> None:
         except Exception as e:
             logger.warning("Error shutting down WebSocket manager: %s", e, exc_info=True)
 
-    # Stop WriteBack Service (Issue #1129)
+    # Stop WriteBack Service (Issue #1129) and unregister OBSERVE hook (#3194)
     if app.state.write_back_service:
         try:
+            # Unregister OBSERVE hook to prevent duplicate observers on hot reload
+            _dispatch = getattr(svc.nexus_fs, "_dispatch", None) if svc.nexus_fs else None
+            if _dispatch is not None:
+                _dispatch.unregister_observe(app.state.write_back_service)
             await app.state.write_back_service.stop()
             logger.info("WriteBack service stopped")
         except Exception as e:

--- a/src/nexus/system_services/sync/sync_backlog_store.py
+++ b/src/nexus/system_services/sync/sync_backlog_store.py
@@ -2,9 +2,13 @@
 
 Manages the sync_backlog table: enqueue, fetch, status transitions, and expiry.
 Inherits shared session/dialect logic from SyncStoreBase.
+
+Issue #3194: optional ``on_enqueue`` callback for DT_PIPE wakeup signalling.
 """
 
+import contextlib
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -51,8 +55,10 @@ class SyncBacklogStore(SyncStoreBase):
         record_store: "RecordStoreABC | None",
         *,
         is_postgresql: bool = False,
+        on_enqueue: Callable[[], None] | None = None,
     ) -> None:
         super().__init__(record_store, is_postgresql=is_postgresql)
+        self._on_enqueue = on_enqueue
 
     def enqueue(
         self,
@@ -116,6 +122,12 @@ class SyncBacklogStore(SyncStoreBase):
                 update_set=update_set,
             )
             session.commit()
+
+            # Signal wakeup (best-effort — poll fallback catches any missed signals)
+            if self._on_enqueue is not None:
+                with contextlib.suppress(Exception):
+                    self._on_enqueue()
+
             return True
         except Exception as e:
             logger.warning(f"Failed to enqueue backlog for {path}: {e}")

--- a/src/nexus/system_services/sync/sync_service.py
+++ b/src/nexus/system_services/sync/sync_service.py
@@ -20,7 +20,6 @@ Example:
 import bisect
 import logging
 import re
-import threading
 from collections import deque
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -77,25 +76,13 @@ class SyncService:
         self._change_log = ChangeLogStore(
             record_store=gateway.record_store, is_postgresql=gateway.is_postgresql
         )
-        # Issue #1127: Per-mount sync locks to prevent concurrent races
-        self._mount_locks: dict[str, threading.Lock] = {}
-        self._lock_guard = threading.Lock()
+        # Issue #3194: VFSLockManager replaces dict[str, threading.Lock] for
+        # per-mount sync locks. Provides hierarchical conflict detection
+        # (prevents concurrent syncs on parent/child mounts) and crash-safe
+        # release (in-process, auto-released on process exit).
+        from nexus.core.lock_fast import create_vfs_lock_manager
 
-    def _get_mount_lock(self, mount_point: str) -> "threading.Lock":
-        """Get or create a lock for a specific mount point.
-
-        Thread-safe: uses a guard lock to protect the mount_locks dict.
-
-        Args:
-            mount_point: Mount point path
-
-        Returns:
-            Lock for the given mount point
-        """
-        with self._lock_guard:
-            if mount_point not in self._mount_locks:
-                self._mount_locks[mount_point] = threading.Lock()
-            return self._mount_locks[mount_point]
+        self._vfs_lock_mgr = create_vfs_lock_manager()
 
     def _resolve_zone_id(self, ctx: SyncContext) -> str | None:
         """Resolve zone ID from context or mount point path.
@@ -138,8 +125,10 @@ class SyncService:
             return self._sync_all_mounts(ctx)
 
         # Step 1.5: Acquire per-mount lock (non-blocking to avoid queueing)
-        lock = self._get_mount_lock(ctx.mount_point)
-        if not lock.acquire(blocking=False):
+        # Issue #3194: VFSLockManager provides hierarchical conflict detection —
+        # a sync on /mnt/gcs blocks concurrent syncs on /mnt/gcs/subdir.
+        handle = self._vfs_lock_mgr.acquire(ctx.mount_point, "write", timeout_ms=0)
+        if handle == 0:
             logger.info(f"[SYNC_MOUNT] Sync already in progress for {ctx.mount_point}")
             result = SyncResult()
             result.errors.append(f"Sync already in progress for {ctx.mount_point}")
@@ -177,7 +166,7 @@ class SyncService:
 
             return result
         finally:
-            lock.release()
+            self._vfs_lock_mgr.release(handle)
 
     def _validate_mount(self, ctx: SyncContext) -> Any:
         """Validate mount exists and supports sync.

--- a/src/nexus/system_services/sync/write_back_service.py
+++ b/src/nexus/system_services/sync/write_back_service.py
@@ -1,12 +1,15 @@
-"""Write-Back Service for bidirectional sync (Issue #1129, #1130).
+"""Write-Back Service for bidirectional sync (Issue #1129, #1130, #3194).
 
-Subscribes to file events on mounted paths and writes changes back
-to source backends. Handles conflict detection/resolution, retry,
+Subscribes to kernel VFS mutations via KernelDispatch OBSERVE hook and writes
+changes back to source backends. Handles conflict detection/resolution, retry,
 and rate-limiting per backend.
 
-Architecture:
-- Event-driven: subscribes to EventBus for file write/delete/rename events
-- Polling fallback: periodic sweep of pending backlog entries
+Architecture (Issue #3194):
+- OBSERVE hook: receives FILE_WRITE/DELETE/RENAME/DIR_CREATE/DIR_DELETE events
+  directly from KernelDispatch (us latency, replaces EventBus subscription)
+- DT_PIPE wakeup: backlog enqueue signals the poll loop via pipe (us wakeup,
+  replaces 30s asyncio.sleep polling)
+- Polling fallback: 30s safety net if pipe unavailable or signal missed
 - Rate-limited: per-backend asyncio.Semaphore
 - Conflict-aware: 6 configurable strategies via ConflictStrategy (Issue #1130)
 """
@@ -22,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.types import OperationContext
+from nexus.core.file_events import FILE_EVENT_BIT
 from nexus.system_services.event_bus.types import FileEvent, FileEventType
 
 from .conflict_resolution import (
@@ -37,6 +41,7 @@ from .conflict_resolution import (
 from .write_back_metrics import WriteBackMetrics
 
 if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.system_services.event_bus.base import EventBusBase
     from nexus.system_services.gateway import NexusFSGateway
 
@@ -57,17 +62,57 @@ _WRITE_BACK_EVENT_TYPES = frozenset(
     }
 )
 
+# Rust-side bitmask for OBSERVE filtering (Issue #3194, #4A).
+# Only mutation events — excludes SYNC_TO_BACKEND_*, CONFLICT_DETECTED
+# to prevent feedback loops.
+_WRITE_BACK_EVENT_MASK: int = 0
+for _evt in _WRITE_BACK_EVENT_TYPES:
+    _WRITE_BACK_EVENT_MASK |= FILE_EVENT_BIT.get(_evt, 0)
+
+# DT_PIPE path for backlog wakeup signalling (Issue #3194)
+_BACKLOG_WAKEUP_PIPE = "/nexus/pipes/sync-backlog-wakeup"
+_BACKLOG_PIPE_CAPACITY = 256  # 256 signals, matching NOTIFY_PIPE_CAPACITY convention
+
 
 class WriteBackService:
     """Orchestrates bidirectional sync from Nexus to source backends.
 
+    Implements the VFSObserver protocol (Issue #3194) to receive file mutation
+    events directly from KernelDispatch OBSERVE phase, replacing the previous
+    EventBus subscription loop.
+
     Responsibilities:
-    1. Subscribe to event bus for write/delete/rename events on mounted paths
+    1. Receive VFS mutation events via on_mutation() (OBSERVE hook)
     2. Enqueue events to SyncBacklogStore
     3. Process pending entries: call backend write/delete/mkdir
     4. Handle conflicts via conflict_resolution module
     5. Rate-limit per backend via asyncio.Semaphore
     """
+
+    # ── VFSObserver protocol (Issue #3194, #4A) ──────────────────────────
+    # Rust ObserverRegistry pre-filters by bitmask before calling Python.
+    event_mask: int = _WRITE_BACK_EVENT_MASK
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(observers=(self,))
+
+    async def drain(self) -> None:
+        pass
+
+    async def activate(self) -> None:
+        pass
+
+    async def on_mutation(self, event: "FileEvent") -> None:
+        """OBSERVE-phase handler — receive FileEvent from KernelDispatch.
+
+        Replaces _subscribe_loop() EventBus subscription (Issue #3194).
+        KernelDispatch guarantees typed FileEventType (no string conversion needed).
+        """
+        await self._on_file_event(event)
+
+    # ── Constructor & lifecycle ──────────────────────────────────────────
 
     def __init__(
         self,
@@ -80,19 +125,22 @@ class WriteBackService:
         max_concurrent_per_backend: int = 10,
         poll_interval_seconds: float = 30.0,
         batch_size: int = 50,
+        pipe_manager: Any = None,
     ) -> None:
         """Initialize WriteBackService.
 
         Args:
             gateway: NexusFSGateway for mount/file resolution
-            event_bus: Event bus for subscribing to file events
+            event_bus: Event bus for publishing completion/failure events
             backlog_store: SyncBacklogStore for pending operations
             change_log_store: ChangeLogStore for conflict detection
             default_strategy: Global default conflict strategy
             conflict_log_store: Optional store for conflict audit logging
             max_concurrent_per_backend: Max concurrent write-backs per backend
-            poll_interval_seconds: Interval between polling sweeps
+            poll_interval_seconds: Interval between polling sweeps (safety net)
             batch_size: Max entries fetched per backend per poll cycle
+            pipe_manager: Optional PipeManager for DT_PIPE wakeup (Issue #3194).
+                          None = polling-only fallback.
         """
         self._gw = gateway
         self._event_bus = event_bus
@@ -103,6 +151,7 @@ class WriteBackService:
         self._max_concurrent = max_concurrent_per_backend
         self._poll_interval = poll_interval_seconds
         self._batch_size = batch_size
+        self._pipe_manager = pipe_manager
 
         # Per-backend semaphores for rate limiting
         self._semaphores: dict[str, asyncio.Semaphore] = {}
@@ -111,45 +160,58 @@ class WriteBackService:
         self._system_ctx = OperationContext(user_id="system", groups=[], is_system=True)
         self._running = False
         self._poll_task: asyncio.Task[None] | None = None
-        self._subscribe_task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
-        """Start event subscription and polling loop."""
+        """Start the pipe-driven poll loop.
+
+        The OBSERVE hook (on_mutation) is registered separately via the factory
+        coordinator — it does not require start() to function.
+        """
         if self._running:
             return
         self._running = True
+
+        # Create DT_PIPE for backlog wakeup (Issue #3194, best-effort)
+        if self._pipe_manager is not None:
+            try:
+                self._pipe_manager.ensure(_BACKLOG_WAKEUP_PIPE, capacity=_BACKLOG_PIPE_CAPACITY)
+                logger.debug("[WRITE_BACK] Backlog wakeup pipe created at %s", _BACKLOG_WAKEUP_PIPE)
+            except Exception as e:
+                logger.debug(
+                    "[WRITE_BACK] Failed to create backlog pipe: %s (polling fallback active)", e
+                )
+                self._pipe_manager = None  # Disable pipe path; fall back to timer
+
         self._poll_task = asyncio.create_task(self._poll_loop())
-        self._subscribe_task = asyncio.create_task(self._subscribe_loop())
         logger.info("[WRITE_BACK] Service started")
 
     async def stop(self) -> None:
         """Gracefully shut down the service."""
         self._running = False
-        for task in (self._poll_task, self._subscribe_task):
-            if task and not task.done():
-                task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+
+        # Close pipe to unblock any waiting poll loop iteration
+        if self._pipe_manager is not None:
+            with contextlib.suppress(Exception):
+                self._pipe_manager.signal_close(_BACKLOG_WAKEUP_PIPE)
+
+        if self._poll_task and not self._poll_task.done():
+            self._poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._poll_task
         self._poll_task = None
-        self._subscribe_task = None
         logger.info("[WRITE_BACK] Service stopped")
 
-    async def _subscribe_loop(self) -> None:
-        """Subscribe to event bus and enqueue matching events."""
-        try:
-            # Subscribe to all zones (use "*" or a default zone)
-            async for event in self._event_bus.subscribe("*"):
-                if not self._running:
-                    break
-                await self._on_file_event(event)
-        except asyncio.CancelledError:
-            pass
-        except Exception as e:
-            logger.error(f"[WRITE_BACK] Subscribe loop error: {e}")
+    # ── Event handling ───────────────────────────────────────────────────
 
     async def _on_file_event(self, event: FileEvent) -> None:
-        """Handle an incoming file event: filter and enqueue if applicable."""
-        event_type = FileEventType(event.type) if isinstance(event.type, str) else event.type
+        """Handle an incoming file event: filter and enqueue if applicable.
+
+        Called by on_mutation() from KernelDispatch OBSERVE phase.
+        Kernel guarantees typed FileEventType — no string conversion needed (#7A).
+        """
+        event_type = (
+            event.type if isinstance(event.type, FileEventType) else FileEventType(event.type)
+        )
         if event_type not in _WRITE_BACK_EVENT_TYPES:
             return
 
@@ -188,8 +250,18 @@ class WriteBackService:
             new_path=event.old_path if event_type == FileEventType.FILE_RENAME else None,
         )
 
+    # ── Poll loop (pipe-driven with timer fallback) ──────────────────────
+
     async def _poll_loop(self) -> None:
-        """Periodically process pending backlog entries."""
+        """Process pending backlog entries, woken by DT_PIPE or 30s timer.
+
+        Two-tier wakeup (Issue #3194):
+        1. DT_PIPE: immediate wakeup from enqueue() callback (us latency)
+        2. Timer: 30s fallback if pipe unavailable or signal missed
+
+        Follows the Kubernetes informer pattern: event-driven primary + periodic
+        reconciliation as safety net.
+        """
         while self._running:
             try:
                 await self._process_all_backends()
@@ -197,7 +269,22 @@ class WriteBackService:
                 break
             except Exception as e:
                 logger.error(f"[WRITE_BACK] Poll loop error: {e}")
-            await asyncio.sleep(self._poll_interval)
+
+            # Wait for wakeup signal OR timeout (safety net)
+            if self._pipe_manager is not None:
+                try:
+                    from nexus.bricks.ipc.wakeup import wait_for_signal
+
+                    await wait_for_signal(
+                        self._pipe_manager, _BACKLOG_WAKEUP_PIPE, timeout=self._poll_interval
+                    )
+                except asyncio.CancelledError:
+                    break
+                except Exception:
+                    # Pipe error (closed, not found) — fall back to timer
+                    await asyncio.sleep(self._poll_interval)
+            else:
+                await asyncio.sleep(self._poll_interval)
 
     async def _process_all_backends(self) -> None:
         """Process pending entries for all backends with pending work.

--- a/src/nexus/system_services/sync/write_back_service.py
+++ b/src/nexus/system_services/sync/write_back_service.py
@@ -285,7 +285,7 @@ class WriteBackService:
             # Wait for wakeup signal OR timeout (safety net)
             if self._pipe_manager is not None:
                 try:
-                    from nexus.bricks.ipc.wakeup import wait_for_signal
+                    from nexus.lib.pipe_wakeup import wait_for_signal
 
                     await wait_for_signal(
                         self._pipe_manager, _BACKLOG_WAKEUP_PIPE, timeout=self._poll_interval

--- a/src/nexus/system_services/sync/write_back_service.py
+++ b/src/nexus/system_services/sync/write_back_service.py
@@ -73,6 +73,14 @@ for _evt in _WRITE_BACK_EVENT_TYPES:
 _BACKLOG_WAKEUP_PIPE = "/nexus/pipes/sync-backlog-wakeup"
 _BACKLOG_PIPE_CAPACITY = 256  # 256 signals, matching NOTIFY_PIPE_CAPACITY convention
 
+# VFSSemaphore TTL for per-backend rate limiting (Issue #3194).
+# If a worker crashes mid-write-back, the permit auto-expires after this duration.
+# 5 minutes is generous — typical backend I/O is seconds, not minutes.
+_SEMAPHORE_TTL_MS = 300_000  # 5 minutes
+
+# Retry interval when waiting for a semaphore permit
+_SEMAPHORE_RETRY_INTERVAL = 0.1  # 100ms
+
 
 class WriteBackService:
     """Orchestrates bidirectional sync from Nexus to source backends.
@@ -153,8 +161,12 @@ class WriteBackService:
         self._batch_size = batch_size
         self._pipe_manager = pipe_manager
 
-        # Per-backend semaphores for rate limiting
-        self._semaphores: dict[str, asyncio.Semaphore] = {}
+        # Issue #3194: VFSSemaphore replaces dict[str, asyncio.Semaphore] for
+        # per-backend rate limiting. Provides TTL auto-release on crash,
+        # holder tracking (who's writing?), and force_release() for stuck workers.
+        from nexus.lib.semaphore import create_vfs_semaphore
+
+        self._vfs_sem = create_vfs_semaphore()
         self._metrics = WriteBackMetrics()
         # Pre-built system context template — avoids UUID generation per-operation
         self._system_ctx = OperationContext(user_id="system", groups=[], is_system=True)
@@ -307,13 +319,36 @@ class WriteBackService:
         if not entries:
             return
 
-        sem = self._get_semaphore(backend_name)
-        tasks = [self._process_entry(entry, sem) for entry in entries]
+        tasks = [self._process_entry(entry) for entry in entries]
         await asyncio.gather(*tasks, return_exceptions=True)
 
-    async def _process_entry(self, entry: "SyncBacklogEntry", sem: asyncio.Semaphore) -> None:
-        """Process a single backlog entry with semaphore rate limiting."""
-        async with sem:
+    async def _process_entry(self, entry: "SyncBacklogEntry") -> None:
+        """Process a single backlog entry with VFSSemaphore rate limiting.
+
+        Issue #3194: Uses VFSSemaphore instead of asyncio.Semaphore for
+        TTL auto-release on crash and holder tracking observability.
+        """
+        # Acquire a semaphore permit for this backend (async retry loop)
+        sem_name = f"write_back:{entry.backend_name}"
+        holder_id: str | None = None
+        for _ in range(int(_SEMAPHORE_TTL_MS / (_SEMAPHORE_RETRY_INTERVAL * 1000))):
+            holder_id = self._vfs_sem.acquire(
+                sem_name,
+                max_holders=self._max_concurrent,
+                timeout_ms=0,
+                ttl_ms=_SEMAPHORE_TTL_MS,
+            )
+            if holder_id is not None:
+                break
+            if not self._running:
+                return  # Service shutting down, don't wait
+            await asyncio.sleep(_SEMAPHORE_RETRY_INTERVAL)
+
+        if holder_id is None:
+            logger.warning("[WRITE_BACK] Timed out acquiring semaphore for %s", entry.backend_name)
+            return
+
+        try:
             if not self._backlog_store.mark_in_progress(entry.id):
                 return  # Another worker claimed it
             try:
@@ -350,6 +385,8 @@ class WriteBackService:
                         zone_id=entry.zone_id,
                     )
                 )
+        finally:
+            self._vfs_sem.release(sem_name, holder_id)
 
     async def _write_back_single(self, entry: "SyncBacklogEntry") -> None:
         """Execute a single write-back operation to the backend.
@@ -687,12 +724,6 @@ class WriteBackService:
         except Exception as e:
             logger.warning(f"[WRITE_BACK] Failed to read {path}: {e}")
             return None
-
-    def _get_semaphore(self, backend_name: str) -> asyncio.Semaphore:
-        """Get or create a rate-limiting semaphore for a backend."""
-        if backend_name not in self._semaphores:
-            self._semaphores[backend_name] = asyncio.Semaphore(self._max_concurrent)
-        return self._semaphores[backend_name]
 
     def get_stats(self) -> dict[str, Any]:
         """Get write-back service statistics."""

--- a/tests/unit/bricks/ipc/test_pipe_wakeup_util.py
+++ b/tests/unit/bricks/ipc/test_pipe_wakeup_util.py
@@ -1,0 +1,116 @@
+"""Tests for the shared wait_for_signal() DT_PIPE utility (Issue #3194, #11A).
+
+Tests the generic drain-and-process utility extracted from PipeWakeupListener.
+Uses a mock PipeManager to test in isolation.
+"""
+
+import asyncio
+
+import pytest
+
+from nexus.bricks.ipc.wakeup import wait_for_signal
+
+
+class _FakePipeManager:
+    """Minimal PipeManager mock with controllable signal delivery."""
+
+    def __init__(self) -> None:
+        self._signals: list[bytes] = []
+        self._read_event = asyncio.Event()
+        self._closed = False
+
+    def enqueue_signal(self, data: bytes = b"\x01") -> None:
+        """Add a signal to the buffer."""
+        self._signals.append(data)
+        self._read_event.set()
+
+    async def pipe_read(self, path: str, blocking: bool = True) -> bytes:
+        if self._closed:
+            raise RuntimeError("PipeClosedError")
+        if self._signals:
+            self._read_event.clear() if len(self._signals) <= 1 else None
+            return self._signals.pop(0)
+        if not blocking:
+            raise RuntimeError("PipeEmptyError")
+        # Block until signal arrives or pipe is closed
+        while not self._signals and not self._closed:
+            self._read_event.clear()
+            await self._read_event.wait()
+        if self._closed:
+            raise RuntimeError("PipeClosedError")
+        return self._signals.pop(0)
+
+    def signal_close(self, path: str) -> None:
+        self._closed = True
+        self._read_event.set()
+
+
+class TestWaitForSignal:
+    """Tests for wait_for_signal() utility."""
+
+    @pytest.mark.asyncio
+    async def test_signal_arrives_returns_immediately(self):
+        """Signal already in buffer -> returns True without waiting."""
+        pm = _FakePipeManager()
+        pm.enqueue_signal()
+
+        result = await wait_for_signal(pm, "/test/pipe", timeout=5.0)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_no_signal_times_out(self):
+        """No signal -> times out and returns False."""
+        pm = _FakePipeManager()
+
+        result = await wait_for_signal(pm, "/test/pipe", timeout=0.05)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_multiple_signals_coalesce(self):
+        """Multiple signals in buffer -> all drained, returns True once."""
+        pm = _FakePipeManager()
+        pm.enqueue_signal(b"\x01")
+        pm.enqueue_signal(b"\x01")
+        pm.enqueue_signal(b"\x01")
+
+        result = await wait_for_signal(pm, "/test/pipe", timeout=5.0)
+        assert result is True
+        # All signals should be drained
+        assert len(pm._signals) == 0
+
+    @pytest.mark.asyncio
+    async def test_pipe_closed_raises(self):
+        """Closed pipe -> raises exception (caller handles)."""
+        pm = _FakePipeManager()
+        pm._closed = True
+
+        with pytest.raises(RuntimeError, match="PipeClosedError"):
+            await wait_for_signal(pm, "/test/pipe", timeout=5.0)
+
+    @pytest.mark.asyncio
+    async def test_no_timeout_blocks_until_signal(self):
+        """timeout=None -> blocks indefinitely until signal arrives."""
+        pm = _FakePipeManager()
+
+        async def deliver_later():
+            await asyncio.sleep(0.05)
+            pm.enqueue_signal()
+
+        task = asyncio.create_task(deliver_later())
+        result = await wait_for_signal(pm, "/test/pipe", timeout=None)
+        assert result is True
+        await task
+
+    @pytest.mark.asyncio
+    async def test_signal_during_wait(self):
+        """Signal arrives while waiting -> returns True promptly."""
+        pm = _FakePipeManager()
+
+        async def deliver_later():
+            await asyncio.sleep(0.02)
+            pm.enqueue_signal()
+
+        task = asyncio.create_task(deliver_later())
+        result = await wait_for_signal(pm, "/test/pipe", timeout=5.0)
+        assert result is True
+        await task

--- a/tests/unit/bricks/ipc/test_pipe_wakeup_util.py
+++ b/tests/unit/bricks/ipc/test_pipe_wakeup_util.py
@@ -8,7 +8,7 @@ import asyncio
 
 import pytest
 
-from nexus.bricks.ipc.wakeup import wait_for_signal
+from nexus.lib.pipe_wakeup import wait_for_signal
 
 
 class _FakePipeManager:

--- a/tests/unit/services/test_write_back_observer.py
+++ b/tests/unit/services/test_write_back_observer.py
@@ -1,0 +1,319 @@
+"""Tests for WriteBackService VFSObserver protocol (Issue #3194, #10A).
+
+Tests the OBSERVE hook integration: on_mutation(), event_mask, hook_spec().
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.core.file_events import FILE_EVENT_BIT
+from nexus.system_services.event_bus.types import FileEvent, FileEventType
+from nexus.system_services.sync.write_back_service import (
+    _WRITE_BACK_EVENT_MASK,
+    WriteBackService,
+)
+
+
+def _make_service(**kwargs) -> WriteBackService:
+    """Create a WriteBackService with mocked dependencies."""
+    gw = kwargs.get("gateway") or MagicMock()
+    bus = kwargs.get("event_bus") or AsyncMock()
+    bus.subscribe = MagicMock(return_value=_empty_async_iter())
+    bus.publish = AsyncMock(return_value=1)
+
+    backlog = kwargs.get("backlog_store") or MagicMock()
+    backlog.enqueue.return_value = True
+
+    change_log = kwargs.get("change_log_store") or MagicMock()
+
+    return WriteBackService(
+        gateway=gw,
+        event_bus=bus,
+        backlog_store=backlog,
+        change_log_store=change_log,
+    )
+
+
+async def _empty_async_iter():
+    return
+    yield  # pragma: no cover
+
+
+# =============================================================================
+# VFSObserver Protocol Tests
+# =============================================================================
+
+
+class TestVFSObserverProtocol:
+    """Test that WriteBackService satisfies VFSObserver protocol."""
+
+    def test_has_event_mask(self):
+        """event_mask is a class attribute with correct bits."""
+        assert hasattr(WriteBackService, "event_mask")
+        mask = WriteBackService.event_mask
+        assert isinstance(mask, int)
+        assert mask > 0
+
+    def test_event_mask_includes_only_mutation_events(self):
+        """event_mask includes FILE_WRITE/DELETE/RENAME/DIR_CREATE/DIR_DELETE only."""
+        mask = _WRITE_BACK_EVENT_MASK
+
+        # Should include these
+        assert mask & FILE_EVENT_BIT[FileEventType.FILE_WRITE]
+        assert mask & FILE_EVENT_BIT[FileEventType.FILE_DELETE]
+        assert mask & FILE_EVENT_BIT[FileEventType.FILE_RENAME]
+        assert mask & FILE_EVENT_BIT[FileEventType.DIR_CREATE]
+        assert mask & FILE_EVENT_BIT[FileEventType.DIR_DELETE]
+
+        # Should NOT include these (prevents feedback loops)
+        assert not (mask & FILE_EVENT_BIT[FileEventType.SYNC_TO_BACKEND_COMPLETED])
+        assert not (mask & FILE_EVENT_BIT[FileEventType.SYNC_TO_BACKEND_FAILED])
+        assert not (mask & FILE_EVENT_BIT[FileEventType.CONFLICT_DETECTED])
+        assert not (mask & FILE_EVENT_BIT[FileEventType.SYNC_TO_BACKEND_REQUESTED])
+
+    def test_hook_spec_returns_correct_shape(self):
+        """hook_spec() returns HookSpec with self as observer."""
+        service = _make_service()
+        spec = service.hook_spec()
+        assert hasattr(spec, "observers")
+        assert service in spec.observers
+
+    @pytest.mark.asyncio
+    async def test_drain_is_noop(self):
+        """drain() completes without error."""
+        service = _make_service()
+        await service.drain()
+
+    @pytest.mark.asyncio
+    async def test_activate_is_noop(self):
+        """activate() completes without error."""
+        service = _make_service()
+        await service.activate()
+
+    def test_has_on_mutation(self):
+        """on_mutation() method exists and is async."""
+        import asyncio
+
+        service = _make_service()
+        assert hasattr(service, "on_mutation")
+        assert asyncio.iscoroutinefunction(service.on_mutation)
+
+
+# =============================================================================
+# on_mutation() Event Handling Tests
+# =============================================================================
+
+
+class TestOnMutation:
+    """Test on_mutation() delegates correctly to _on_file_event()."""
+
+    @pytest.fixture
+    def mock_gateway(self):
+        gw = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.name = "test_gcs"
+        mock_backend.capabilities = frozenset()
+        gw.get_mount_for_path.return_value = {
+            "mount_point": "/mnt/gcs",
+            "backend": mock_backend,
+            "backend_path": "project/file.txt",
+            "readonly": False,
+            "backend_name": "test_gcs",
+            "conflict_strategy": None,
+        }
+        return gw
+
+    @pytest.mark.asyncio
+    async def test_on_mutation_enqueues_write_event(self, mock_gateway):
+        """FILE_WRITE event via on_mutation() -> backlog enqueue."""
+        service = _make_service(gateway=mock_gateway)
+
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/mnt/gcs/project/file.txt",
+            zone_id="root",
+            etag="abc123",
+        )
+        await service.on_mutation(event)
+
+        service._backlog_store.enqueue.assert_called_once_with(
+            path="/mnt/gcs/project/file.txt",
+            backend_name="test_gcs",
+            zone_id="root",
+            operation_type="write",
+            content_hash="abc123",
+            new_path=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_mutation_enqueues_delete_event(self, mock_gateway):
+        """FILE_DELETE event via on_mutation() -> backlog enqueue with op=delete."""
+        service = _make_service(gateway=mock_gateway)
+
+        event = FileEvent(
+            type=FileEventType.FILE_DELETE,
+            path="/mnt/gcs/project/file.txt",
+            zone_id="root",
+        )
+        await service.on_mutation(event)
+
+        service._backlog_store.enqueue.assert_called_once()
+        call_kwargs = service._backlog_store.enqueue.call_args[1]
+        assert call_kwargs["operation_type"] == "delete"
+
+    @pytest.mark.asyncio
+    async def test_on_mutation_ignores_sync_events(self, mock_gateway):
+        """SYNC_TO_BACKEND_COMPLETED events are not enqueued (no feedback loop)."""
+        service = _make_service(gateway=mock_gateway)
+
+        event = FileEvent(
+            type=FileEventType.SYNC_TO_BACKEND_COMPLETED,
+            path="/mnt/gcs/project/file.txt",
+            zone_id="root",
+        )
+        await service.on_mutation(event)
+
+        service._backlog_store.enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_mutation_ignores_conflict_events(self, mock_gateway):
+        """CONFLICT_DETECTED events are not enqueued (no feedback loop)."""
+        service = _make_service(gateway=mock_gateway)
+
+        event = FileEvent(
+            type=FileEventType.CONFLICT_DETECTED,
+            path="/mnt/gcs/project/file.txt",
+            zone_id="root",
+        )
+        await service.on_mutation(event)
+
+        service._backlog_store.enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_mutation_skips_readonly_mounts(self, mock_gateway):
+        """Events from readonly mounts are not enqueued."""
+        mock_gateway.get_mount_for_path.return_value["readonly"] = True
+        service = _make_service(gateway=mock_gateway)
+
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/mnt/gcs/project/file.txt",
+            zone_id="root",
+        )
+        await service.on_mutation(event)
+
+        service._backlog_store.enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_mutation_skips_unmounted_paths(self):
+        """Events for unmounted paths are not enqueued."""
+        gw = MagicMock()
+        gw.get_mount_for_path.return_value = None
+        service = _make_service(gateway=gw)
+
+        event = FileEvent(
+            type=FileEventType.FILE_WRITE,
+            path="/unmounted/file.txt",
+            zone_id="root",
+        )
+        await service.on_mutation(event)
+
+        service._backlog_store.enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_mutation_handles_dir_create(self, mock_gateway):
+        """DIR_CREATE event via on_mutation() -> backlog enqueue with op=mkdir."""
+        service = _make_service(gateway=mock_gateway)
+
+        event = FileEvent(
+            type=FileEventType.DIR_CREATE,
+            path="/mnt/gcs/project/subdir",
+            zone_id="root",
+        )
+        await service.on_mutation(event)
+
+        service._backlog_store.enqueue.assert_called_once()
+        call_kwargs = service._backlog_store.enqueue.call_args[1]
+        assert call_kwargs["operation_type"] == "mkdir"
+
+
+# =============================================================================
+# SyncBacklogStore on_enqueue Callback Tests
+# =============================================================================
+
+
+class TestOnEnqueueCallback:
+    """Test the on_enqueue callback wiring in SyncBacklogStore."""
+
+    def test_callback_fires_on_successful_enqueue(self):
+        """on_enqueue callback is called after successful commit."""
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+        from nexus.system_services.sync.sync_backlog_store import SyncBacklogStore
+
+        store = SQLAlchemyRecordStore(db_url="sqlite:///:memory:", create_tables=True)
+        callback = MagicMock()
+
+        backlog = SyncBacklogStore(record_store=store, on_enqueue=callback)
+        result = backlog.enqueue(
+            path="/test/file.txt",
+            backend_name="gcs",
+            zone_id="root",
+            operation_type="write",
+        )
+
+        assert result is True
+        callback.assert_called_once()
+        store.close()
+
+    def test_callback_not_called_without_db(self):
+        """on_enqueue callback is NOT called when record_store is None (no commit)."""
+        from nexus.system_services.sync.sync_backlog_store import SyncBacklogStore
+
+        callback = MagicMock()
+        backlog = SyncBacklogStore(record_store=None, on_enqueue=callback)
+        result = backlog.enqueue(
+            path="/test/file.txt",
+            backend_name="gcs",
+            zone_id="root",
+        )
+
+        assert result is False
+        callback.assert_not_called()
+
+    def test_callback_exception_is_swallowed(self):
+        """on_enqueue callback exception does not prevent enqueue from returning True."""
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+        from nexus.system_services.sync.sync_backlog_store import SyncBacklogStore
+
+        store = SQLAlchemyRecordStore(db_url="sqlite:///:memory:", create_tables=True)
+        callback = MagicMock(side_effect=RuntimeError("pipe full"))
+
+        backlog = SyncBacklogStore(record_store=store, on_enqueue=callback)
+        result = backlog.enqueue(
+            path="/test/file.txt",
+            backend_name="gcs",
+            zone_id="root",
+            operation_type="write",
+        )
+
+        assert result is True  # Enqueue succeeded despite callback failure
+        callback.assert_called_once()
+        store.close()
+
+    def test_no_callback_is_fine(self):
+        """on_enqueue=None (default) works without error."""
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+        from nexus.system_services.sync.sync_backlog_store import SyncBacklogStore
+
+        store = SQLAlchemyRecordStore(db_url="sqlite:///:memory:", create_tables=True)
+        backlog = SyncBacklogStore(record_store=store)
+        result = backlog.enqueue(
+            path="/test/file.txt",
+            backend_name="gcs",
+            zone_id="root",
+            operation_type="write",
+        )
+
+        assert result is True
+        store.close()

--- a/tests/unit/services/test_write_back_pipe_wakeup.py
+++ b/tests/unit/services/test_write_back_pipe_wakeup.py
@@ -138,7 +138,7 @@ class TestPollLoopWakeup:
         service = _make_service(pipe_manager=pm)
 
         with patch(
-            "nexus.bricks.ipc.wakeup.wait_for_signal",
+            "nexus.lib.pipe_wakeup.wait_for_signal",
             new_callable=AsyncMock,
             return_value=True,
         ) as mock_wait:

--- a/tests/unit/services/test_write_back_pipe_wakeup.py
+++ b/tests/unit/services/test_write_back_pipe_wakeup.py
@@ -1,0 +1,149 @@
+"""Tests for DT_PIPE wakeup integration in WriteBackService (Issue #3194, #9A).
+
+Tests the pipe-driven poll loop wakeup and on_enqueue callback wiring.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nexus.system_services.sync.write_back_service import (
+    _BACKLOG_PIPE_CAPACITY,
+    _BACKLOG_WAKEUP_PIPE,
+    WriteBackService,
+)
+
+
+def _make_service(
+    *,
+    pipe_manager: MagicMock | None = None,
+    mock_gateway: MagicMock | None = None,
+    mock_event_bus: AsyncMock | None = None,
+) -> WriteBackService:
+    """Create a WriteBackService with mocked dependencies."""
+    gw = mock_gateway or MagicMock()
+    bus = mock_event_bus or AsyncMock()
+    bus.subscribe = MagicMock(return_value=_empty_async_iter())
+    bus.publish = AsyncMock(return_value=1)
+
+    backlog = MagicMock()
+    backlog.fetch_distinct_backend_zones.return_value = []
+    backlog.enqueue.return_value = True
+
+    change_log = MagicMock()
+
+    return WriteBackService(
+        gateway=gw,
+        event_bus=bus,
+        backlog_store=backlog,
+        change_log_store=change_log,
+        pipe_manager=pipe_manager,
+        poll_interval_seconds=0.1,  # Short for tests
+    )
+
+
+async def _empty_async_iter():
+    return
+    yield  # pragma: no cover
+
+
+class TestPipeWakeupStart:
+    """Test pipe creation during start()."""
+
+    @pytest.mark.asyncio
+    async def test_start_creates_pipe(self):
+        """start() calls pipe_manager.ensure() with correct path and capacity."""
+        pm = MagicMock()
+        service = _make_service(pipe_manager=pm)
+
+        await service.start()
+        try:
+            pm.ensure.assert_called_once_with(_BACKLOG_WAKEUP_PIPE, capacity=_BACKLOG_PIPE_CAPACITY)
+        finally:
+            await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_without_pipe_manager(self):
+        """start() works without pipe_manager (polling-only fallback)."""
+        service = _make_service(pipe_manager=None)
+
+        await service.start()
+        try:
+            assert service._running is True
+            assert service._pipe_manager is None
+        finally:
+            await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_pipe_failure_falls_back(self):
+        """If pipe creation fails, pipe_manager is disabled (falls back to timer)."""
+        pm = MagicMock()
+        pm.ensure.side_effect = RuntimeError("pipe creation failed")
+        service = _make_service(pipe_manager=pm)
+
+        await service.start()
+        try:
+            assert service._running is True
+            assert service._pipe_manager is None  # Disabled on failure
+        finally:
+            await service.stop()
+
+
+class TestPipeWakeupStop:
+    """Test pipe cleanup during stop()."""
+
+    @pytest.mark.asyncio
+    async def test_stop_closes_pipe(self):
+        """stop() calls signal_close() on the wakeup pipe."""
+        pm = MagicMock()
+        service = _make_service(pipe_manager=pm)
+
+        await service.start()
+        await service.stop()
+
+        pm.signal_close.assert_called_once_with(_BACKLOG_WAKEUP_PIPE)
+
+    @pytest.mark.asyncio
+    async def test_stop_without_pipe_manager(self):
+        """stop() works without pipe_manager (no error)."""
+        service = _make_service(pipe_manager=None)
+
+        await service.start()
+        await service.stop()
+        assert service._running is False
+
+
+class TestPollLoopWakeup:
+    """Test poll loop wakeup behavior."""
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_uses_timer_without_pipe(self):
+        """Without pipe, poll loop sleeps for poll_interval."""
+        service = _make_service(pipe_manager=None)
+        service._poll_interval = 0.05
+
+        await service.start()
+        # Let the poll loop run a couple iterations
+        await asyncio.sleep(0.15)
+        await service.stop()
+
+        # Should have called _process_all_backends at least once
+        service._backlog_store.fetch_distinct_backend_zones.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_uses_pipe_when_available(self):
+        """With pipe, poll loop calls wait_for_signal."""
+        pm = MagicMock()
+        service = _make_service(pipe_manager=pm)
+
+        with patch(
+            "nexus.bricks.ipc.wakeup.wait_for_signal",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_wait:
+            await service.start()
+            await asyncio.sleep(0.15)
+            await service.stop()
+
+            mock_wait.assert_called()

--- a/tests/unit/services/test_write_back_pipe_wakeup.py
+++ b/tests/unit/services/test_write_back_pipe_wakeup.py
@@ -136,14 +136,21 @@ class TestPollLoopWakeup:
         """With pipe, poll loop calls wait_for_signal."""
         pm = MagicMock()
         service = _make_service(pipe_manager=pm)
+        wait_calls = 0
+
+        async def fake_wait_for_signal(*args, **kwargs):
+            nonlocal wait_calls
+            wait_calls += 1
+            # Yield so the poll loop does not hot-spin under test.
+            await asyncio.sleep(0.01)
+            return True
 
         with patch(
             "nexus.lib.pipe_wakeup.wait_for_signal",
-            new_callable=AsyncMock,
-            return_value=True,
-        ) as mock_wait:
+            new=fake_wait_for_signal,
+        ):
             await service.start()
             await asyncio.sleep(0.15)
             await service.stop()
 
-            mock_wait.assert_called()
+            assert wait_calls > 0


### PR DESCRIPTION
## Summary
- replace the immediate-return AsyncMock in the write-back pipe wakeup test with an async stub that yields
- keep the assertion focused on whether wait_for_signal is reached without recording an unbounded call history
- prevent the poll loop test from hot-spinning and exhausting memory

## Testing
- uv run pytest -q -o addopts='' tests/unit/services/test_write_back_pipe_wakeup.py