### PR TITLE
fix: federation E2E — VFS port, auth token, path resolution, leader retry

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -683,10 +683,13 @@ async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any, backend
     # Build CAS remote content fetcher if backend supports CAS (#1744)
     remote_content_fetcher = None
     if hasattr(backend, "content_exists") and hasattr(backend, "read_content"):
+        import os as _os_peer
+
         from nexus.backends.base.remote_content_fetcher import CASRemoteContentFetcher
         from nexus.remote.peer_blob_client import PeerBlobClient
 
-        peer_blob_client = PeerBlobClient(tls_config=zone_mgr.tls_config)
+        _peer_auth = _os_peer.environ.get("NEXUS_API_KEY", "")
+        peer_blob_client = PeerBlobClient(tls_config=zone_mgr.tls_config, auth_token=_peer_auth)
         remote_content_fetcher = CASRemoteContentFetcher(
             peer_blob_client=peer_blob_client,
             local_object_store=backend,

--- a/src/nexus/raft/federated_metadata_proxy.py
+++ b/src/nexus/raft/federated_metadata_proxy.py
@@ -87,7 +87,8 @@ class FederatedMetadataProxy(MetastoreABC):
         # FederationContentResolver uses NexusVFSService (VFS gRPC), not Raft gRPC.
         import os as _os
 
-        raft_addr = getattr(zone_manager, "advertise_addr", None)
+        raft_addr: str | None = getattr(zone_manager, "advertise_addr", None)
+        self_addr: str | None
         if raft_addr and ":" in raft_addr:
             hostname = raft_addr.rsplit(":", 1)[0]
             vfs_port = _os.environ.get("NEXUS_GRPC_PORT", "2028")

--- a/src/nexus/raft/federated_metadata_proxy.py
+++ b/src/nexus/raft/federated_metadata_proxy.py
@@ -88,13 +88,12 @@ class FederatedMetadataProxy(MetastoreABC):
         import os as _os
 
         raft_addr = getattr(zone_manager, "advertise_addr", None)
-        self_addr: str | None
         if raft_addr and ":" in raft_addr:
             hostname = raft_addr.rsplit(":", 1)[0]
             vfs_port = _os.environ.get("NEXUS_GRPC_PORT", "2028")
             self_addr = f"{hostname}:{vfs_port}"
         else:
-            self_addr = raft_addr or ""
+            self_addr = raft_addr
         return cls(resolver, root_store, zone_manager=zone_manager, self_address=self_addr)
 
     # =========================================================================

--- a/src/nexus/remote/peer_blob_client.py
+++ b/src/nexus/remote/peer_blob_client.py
@@ -39,17 +39,19 @@ class PeerBlobClient:
         workers: Max parallel ReadBlob RPCs for chunk fetching.
     """
 
-    __slots__ = ("_tls_config", "_timeout", "_workers")
+    __slots__ = ("_tls_config", "_timeout", "_workers", "_auth_token")
 
     def __init__(
         self,
         tls_config: ZoneTlsConfig | None = None,
         timeout: float = 30.0,
         workers: int = _DEFAULT_WORKERS,
+        auth_token: str = "",
     ) -> None:
         self._tls_config = tls_config
         self._timeout = timeout
         self._workers = workers
+        self._auth_token = auth_token
 
     def fetch_blob(self, address: str, content_hash: str) -> bytes:
         """Fetch a single CAS blob by content hash from a remote peer.
@@ -67,7 +69,7 @@ class PeerBlobClient:
             stub = vfs_pb2_grpc.NexusVFSServiceStub(channel)
             request = vfs_pb2.ReadBlobRequest(
                 content_hash=content_hash,
-                auth_token="",
+                auth_token=self._auth_token,
             )
             response = stub.ReadBlob(request, timeout=self._timeout)
             if response.is_error:

--- a/tests/e2e/docker/test_federation_dynamic_e2e.py
+++ b/tests/e2e/docker/test_federation_dynamic_e2e.py
@@ -308,7 +308,7 @@ class TestDynamicMountTopology:
                 {"parent_zone": "corp", "path": mount_path, "target_zone": zone_id},
                 api_key=api_key,
             )
-            assert "error" not in r, f"mount {zone_id} at {mount_path} failed: {r}"
+            assert "error" not in r, f"mount {zone_id} at {zone_relative_path} failed: {r}"
 
     def test_mount_family_zone(self, cluster, api_key):
         """mkdir /family → mount root:/family → zone 'family'."""
@@ -335,7 +335,7 @@ class TestDynamicMountTopology:
         r = _jsonrpc(
             node,
             "federation_mount",
-            {"parent_zone": "family", "path": "/family/work", "target_zone": "corp"},
+            {"parent_zone": "family", "path": "/work", "target_zone": "corp"},
             api_key=api_key,
         )
         assert "error" not in r, f"mount cross-link failed: {r}"
@@ -489,7 +489,7 @@ class TestDynamicUnmountRemount:
         um = _jsonrpc(
             node,
             "federation_unmount",
-            {"parent_zone": "corp", "path": "/corp/sales"},
+            {"parent_zone": "corp", "path": "/sales"},
             api_key=api_key,
         )
         assert "error" not in um, f"Unmount failed: {um}"
@@ -503,7 +503,7 @@ class TestDynamicUnmountRemount:
         rm = _jsonrpc(
             node,
             "federation_mount",
-            {"parent_zone": "corp", "path": "/corp/sales", "target_zone": "corp-sales"},
+            {"parent_zone": "corp", "path": "/sales", "target_zone": "corp-sales"},
             api_key=api_key,
         )
         assert "error" not in rm, f"Remount failed: {rm}"

--- a/tests/e2e/docker/test_federation_dynamic_e2e.py
+++ b/tests/e2e/docker/test_federation_dynamic_e2e.py
@@ -37,7 +37,6 @@ NODE2_URL = "http://nexus-2:2026"
 HEALTH_TIMEOUT = 120
 
 
-
 def _hostname_to_node_id(hostname: str) -> int:
     """SHA-256 hostname → u64 (matches Rust/Python PeerAddress)."""
     digest = hashlib.sha256(hostname.encode()).digest()

--- a/tests/e2e/docker/test_federation_dynamic_e2e.py
+++ b/tests/e2e/docker/test_federation_dynamic_e2e.py
@@ -37,6 +37,7 @@ NODE2_URL = "http://nexus-2:2026"
 HEALTH_TIMEOUT = 120
 
 
+
 def _hostname_to_node_id(hostname: str) -> int:
     """SHA-256 hostname → u64 (matches Rust/Python PeerAddress)."""
     digest = hashlib.sha256(hostname.encode()).digest()
@@ -308,7 +309,7 @@ class TestDynamicMountTopology:
                 {"parent_zone": "corp", "path": mount_path, "target_zone": zone_id},
                 api_key=api_key,
             )
-            assert "error" not in r, f"mount {zone_id} at {zone_relative_path} failed: {r}"
+            assert "error" not in r, f"mount {zone_id} at {mount_path} failed: {r}"
 
     def test_mount_family_zone(self, cluster, api_key):
         """mkdir /family → mount root:/family → zone 'family'."""
@@ -335,7 +336,7 @@ class TestDynamicMountTopology:
         r = _jsonrpc(
             node,
             "federation_mount",
-            {"parent_zone": "family", "path": "/work", "target_zone": "corp"},
+            {"parent_zone": "family", "path": "/family/work", "target_zone": "corp"},
             api_key=api_key,
         )
         assert "error" not in r, f"mount cross-link failed: {r}"
@@ -489,7 +490,7 @@ class TestDynamicUnmountRemount:
         um = _jsonrpc(
             node,
             "federation_unmount",
-            {"parent_zone": "corp", "path": "/sales"},
+            {"parent_zone": "corp", "path": "/corp/sales"},
             api_key=api_key,
         )
         assert "error" not in um, f"Unmount failed: {um}"
@@ -503,7 +504,7 @@ class TestDynamicUnmountRemount:
         rm = _jsonrpc(
             node,
             "federation_mount",
-            {"parent_zone": "corp", "path": "/sales", "target_zone": "corp-sales"},
+            {"parent_zone": "corp", "path": "/corp/sales", "target_zone": "corp-sales"},
             api_key=api_key,
         )
         assert "error" not in rm, f"Remount failed: {rm}"


### PR DESCRIPTION
## Summary

- **VFS gRPC port (2028)**: Content resolver and metadata proxy use VFS port, not Raft port (2126)
- **PeerBlobClient auth**: Pass NEXUS_API_KEY to ReadBlob gRPC for cluster profile auth
- **federation_mount**: Auto-resolve global path → zone-relative path
- **Leader retry**: E2E test retries writes on both nodes for NotLeader errors
- **Cross-platform compose**: Simplified (removed MCP/LangGraph/Frontend/Zoekt)
- **Dynamic E2E: 21/21 passed**

## Test plan
- [x] Dynamic federation E2E: 21/21 passed
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)