### PR TITLE
refactor(#1780): delete CASBackend backward-compat aliases

### DIFF
--- a/src/nexus/backends/__init__.py
+++ b/src/nexus/backends/__init__.py
@@ -5,7 +5,7 @@ import logging
 import threading
 
 from nexus.backends.base.backend import Backend, HandlerStatusResponse
-from nexus.backends.base.cas_addressing_engine import CASAddressingEngine, CASBackend
+from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
 from nexus.backends.base.factory import BackendFactory
 from nexus.backends.base.path_addressing_engine import PathAddressingEngine, PathBackend
 from nexus.backends.base.registry import (
@@ -200,7 +200,6 @@ __all__ = [
     "ObjectStoreABC",
     "WriteResult",
     "CASAddressingEngine",
-    "CASBackend",
     "PathAddressingEngine",
     "PathBackend",
     "CacheConnectorMixin",

--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -751,8 +751,3 @@ class CASAddressingEngine(Backend):
                 backend=self.name,
                 path=path,
             ) from e
-
-
-# Backward-compat alias (will be removed in a future cleanup)
-CASBackend = CASAddressingEngine
-CAS_BACKEND_CAPABILITIES = CAS_ADDRESSING_CAPABILITIES

--- a/src/nexus/backends/compute/message_chunking.py
+++ b/src/nexus/backends/compute/message_chunking.py
@@ -10,7 +10,7 @@ sharing the first N messages deduplicate those N chunks in CAS.
     B chunks: [hash(sys), hash(u1), hash(a1), hash(u3)]
                   shared     shared     shared    different
 
-Implements ChunkingStrategy protocol — plugged into CASBackend via
+Implements ChunkingStrategy protocol — plugged into CASAddressingEngine via
 Feature DI (cdc_engine parameter). Always-chunk mode: every
 conversation is chunked regardless of size (unlike CDCEngine's 16MB
 threshold), because LLM conversations are < 4MB but benefit from
@@ -34,7 +34,7 @@ from nexus.backends.engines.cdc import ChunkedReference, ChunkInfo
 from nexus.core.hash_fast import hash_content
 
 if TYPE_CHECKING:
-    from nexus.backends.base.cas_backend import CASBackend
+    from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
     from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class MessageBoundaryStrategy:
 
     __slots__ = ("_backend",)
 
-    def __init__(self, backend: "CASBackend") -> None:
+    def __init__(self, backend: "CASAddressingEngine") -> None:
         self._backend = backend
 
     # ------------------------------------------------------------------

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -1,6 +1,6 @@
 """OpenAI-compatible LLM backend — CAS addressing + LLM transport.
 
-Thin CASBackend subclass: registration + CONNECTION_ARGS + OpenAI client.
+Thin CASAddressingEngine subclass: registration + CONNECTION_ARGS + OpenAI client.
 Follows the same composition pattern as CASLocalBackend (CAS + LocalBlobTransport)
 and CASGCSBackend (CAS + GCSBlobTransport).
 
@@ -9,7 +9,7 @@ and CASGCSBackend (CAS + GCSBlobTransport).
     nexus mount /zone/llm/local  --backend=openai_compatible \
         --config='{"base_url":"http://localhost:11434/v1"}'
 
-write_content() is inherited from CASBackend — pure CAS storage,
+write_content() is inherited from CASAddressingEngine — pure CAS storage,
 no LLM logic. LLM call orchestration lives in the service layer
 (LLMStreamingService), not in the storage driver.
 
@@ -31,7 +31,7 @@ import time
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from nexus.backends.base.cas_addressing_engine import CASBackend
+from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.compute.llm_blob_transport import LLMBlobTransport
 from nexus.contracts.capabilities import ConnectorCapability
@@ -67,11 +67,11 @@ def _build_openai_client(base_url: str, api_key: str, timeout: float) -> Any:
     category="compute",
     requires=["openai"],
 )
-class OpenAICompatibleBackend(CASBackend):
+class OpenAICompatibleBackend(CASAddressingEngine):
     """CAS addressing + OpenAI-compatible LLM transport.
 
     Thin subclass for connector registration and OpenAI client holder.
-    ``write_content()`` is inherited from CASBackend — pure CAS, no override.
+    ``write_content()`` is inherited from CASAddressingEngine — pure CAS, no override.
     LLM orchestration lives in ``LLMStreamingService``.
 
     LLM-specific methods (additions, not overrides):

--- a/src/nexus/core/object_store.py
+++ b/src/nexus/core/object_store.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
 
 # Re-export WriteResult for backward compatibility — canonical home is contracts.types
-# Re-export _validate_hash for backward compatibility — canonical home is backends.base.cas_backend
+# Re-export _validate_hash for backward compatibility — canonical home is backends.base.cas_addressing_engine
 __all__ = ["ObjectStoreABC", "WriteResult", "_validate_hash"]
 
 

--- a/tests/unit/backends/test_openai_compat.py
+++ b/tests/unit/backends/test_openai_compat.py
@@ -2,8 +2,8 @@
 
 Tests cover:
 - LLMBlobTransport: in-memory blob operations
-- OpenAICompatibleBackend: thin CASBackend subclass (no write_content override)
-  - write_content(): inherited from CASBackend (pure CAS, no LLM call)
+- OpenAICompatibleBackend: thin CASAddressingEngine subclass (no write_content override)
+  - write_content(): inherited from CASAddressingEngine (pure CAS, no LLM call)
   - generate_streaming(): pure LLM compute, yields tokens
   - persist_session(): CAS persist request + response + session envelope
 - LLMStreamingService: DT_STREAM orchestration + CAS flush
@@ -175,7 +175,7 @@ class TestOpenAICompatibleBackend:
         assert backend.name == "openai_compatible"
 
     def test_write_content_is_pure_cas(self) -> None:
-        """write_content() is inherited from CASBackend — no LLM call."""
+        """write_content() is inherited from CASAddressingEngine — no LLM call."""
         backend, client = _make_backend()
 
         data = b"hello world"


### PR DESCRIPTION
## Summary
- Delete `CASBackend = CASAddressingEngine` and `CAS_BACKEND_CAPABILITIES = CAS_ADDRESSING_CAPABILITIES` aliases
- Replace all references: `OpenAICompatibleBackend(CASBackend)` → `OpenAICompatibleBackend(CASAddressingEngine)`
- Fix stale import path `cas_backend` → `cas_addressing_engine` in message_chunking.py
- Remove from `backends/__init__.py` exports
- 6 files, zero remaining references

## Test plan
- [x] ruff clean
- [x] `grep -rn CASBackend src/ tests/` returns 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)