### PR TITLE
ci: auto-dequeue unmergeable PRs from merge queue

### DIFF
--- a/.github/workflows/merge-queue-cleanup.yml
+++ b/.github/workflows/merge-queue-cleanup.yml
@@ -1,0 +1,67 @@
+name: Merge Queue Cleanup
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  merge_group:
+
+jobs:
+  dequeue-unmergeable:
+    name: Dequeue unmergeable PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove unmergeable entries from merge queue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Querying merge queue for develop branch..."
+
+          RESPONSE=$(gh api graphql -f query='
+          {
+            repository(owner: "nexi-lab", name: "nexus") {
+              mergeQueue(branch: "develop") {
+                entries(first: 20) {
+                  nodes {
+                    id
+                    state
+                    pullRequest { number }
+                  }
+                }
+              }
+            }
+          }')
+
+          ENTRIES=$(echo "$RESPONSE" | jq -c '.data.repository.mergeQueue.entries.nodes // []')
+          UNMERGEABLE=$(echo "$ENTRIES" | jq -c '[.[] | select(.state == "UNMERGEABLE")]')
+          COUNT=$(echo "$UNMERGEABLE" | jq 'length')
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No unmergeable entries found in merge queue."
+            exit 0
+          fi
+
+          echo "Found $COUNT unmergeable entry/entries. Dequeuing..."
+
+          echo "$UNMERGEABLE" | jq -c '.[]' | while read -r entry; do
+            ENTRY_ID=$(echo "$entry" | jq -r '.id')
+            PR_NUMBER=$(echo "$entry" | jq -r '.pullRequest.number')
+
+            echo "Dequeuing PR #$PR_NUMBER (entry $ENTRY_ID)..."
+
+            gh api graphql -f query='
+              mutation($id: ID!) {
+                dequeuePullRequest(input: { id: $id }) {
+                  mergeQueueEntry { id }
+                }
+              }' -f id="$ENTRY_ID"
+
+            echo "Commenting on PR #$PR_NUMBER..."
+
+            gh pr comment "$PR_NUMBER" \
+              --repo nexi-lab/nexus \
+              --body "This PR was automatically removed from the merge queue because it entered an **UNMERGEABLE** state (likely due to merge conflicts). Please rebase your branch and re-enqueue when ready."
+
+            echo "Done with PR #$PR_NUMBER."
+          done
+
+          echo "Merge queue cleanup complete."


### PR DESCRIPTION
## Summary
- Add workflow that runs every 5 minutes to detect and remove `UNMERGEABLE` entries from the merge queue
- Posts a comment on the PR explaining the removal and asking author to rebase

GitHub merge queue marks entries as UNMERGEABLE but does not auto-remove them, blocking the rest of the queue.

## Test plan
- [x] Verified current UNMERGEABLE behavior on PR #3365
- [ ] CI green (workflow-only change, most checks will skip via paths-ignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)