### PR TITLE
Fix zone-scoped Tiger predicate pushdown

### DIFF
--- a/permissions_demo_enhanced.sh
+++ b/permissions_demo_enhanced.sh
@@ -118,7 +118,7 @@ import sys, os
 sys.path.insert(0, 'src')
 import nexus
 
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 
@@ -376,7 +376,7 @@ python3 << 'PYTHON_PARENTS'
 import sys, os
 sys.path.insert(0, 'src')
 import nexus
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 rebac.rebac_create_sync(("file", f"{base}/project1/docs"), "parent", ("file", f"{base}/project1"))
@@ -476,7 +476,7 @@ python3 << 'PYTHON_LIST'
 import sys, os
 sys.path.insert(0, 'src')
 import nexus
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync(subject=("user", "bob"))
 print(f"Bob has {len(tuples)} permission tuples:")
@@ -505,7 +505,7 @@ python3 << 'PYTHON_CYCLE'
 import sys, os
 sys.path.insert(0, 'src')
 import nexus
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 try:
@@ -606,7 +606,7 @@ import sys, os
 sys.path.insert(0, 'src')
 import nexus
 
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync()
 
@@ -731,7 +731,7 @@ TUPLE_ID=$(python3 << PYTHON_TUPLE_ID
 import sys, os
 sys.path.insert(0, 'src')
 import nexus
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync(subject=('user', 'alice'), object=('file', '$DEMO_BASE/cache-test.txt'))
 print(tuples[0]['tuple_id'] if tuples else '')
@@ -785,7 +785,7 @@ import sys, os, time, statistics
 sys.path.insert(0, 'src')
 import nexus
 
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 

--- a/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
+++ b/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
@@ -189,7 +189,8 @@ class TigerCache:
     @staticmethod
     def _bloom_key(key: CacheKey) -> str:
         """Canonical bloom filter key — same format as Dragonfly redis key."""
-        return f"tiger:{key.subject_type}:{key.subject_id}:{key.permission}:{key.resource_type}"
+        base = f"tiger:{key.subject_type}:{key.subject_id}:{key.permission}:{key.resource_type}"
+        return f"{base}:{key.zone_id}" if key.zone_id else base
 
     def _bloom_add(self, key: CacheKey) -> None:
         """Add a key to the bloom filter (call on every L1/L2 cache set)."""
@@ -228,6 +229,7 @@ class TigerCache:
         subject_id: str,
         permission: str,
         resource_type: str,
+        zone_id: str = "",
         bitmap_data: bytes | None = None,
         revision: int = 0,
     ) -> Any:
@@ -236,8 +238,7 @@ class TigerCache:
         Uses a persistent thread pool and sync Redis client to avoid
         event loop conflicts with FastAPI's async context.
 
-        Key format: tiger:{subject_type}:{subject_id}:{permission}:{resource_type}
-        Note: zone_id excluded per Issue #979 for cross-zone resource sharing.
+        Key format: tiger:{subject_type}:{subject_id}:{permission}:{resource_type}[:{zone_id}]
 
         Args:
             operation: One of "get", "set", "invalidate"
@@ -245,6 +246,7 @@ class TigerCache:
             subject_id: Subject ID for cache key
             permission: Permission for cache key
             resource_type: Resource type for cache key
+            zone_id: Zone ID for cache partitioning
             bitmap_data: Bitmap data for set operations
             revision: Revision for set operations
 
@@ -272,8 +274,11 @@ class TigerCache:
                 socket_connect_timeout=2.0,
             )
             try:
-                # Key format: exclude zone_id per Issue #979
-                key = f"tiger:{subject_type}:{subject_id}:{permission}:{resource_type}"
+                key = (
+                    f"tiger:{subject_type}:{subject_id}:{permission}:{resource_type}:{zone_id}"
+                    if zone_id
+                    else f"tiger:{subject_type}:{subject_id}:{permission}:{resource_type}"
+                )
 
                 if operation == "get":
                     result = client.hgetall(key)
@@ -292,7 +297,9 @@ class TigerCache:
                     pipe.expire(key, ttl)
                     pipe.execute()
                     # Update bloom filter using canonical key (Issue #3192)
-                    self._bloom_add(CacheKey(subject_type, subject_id, permission, resource_type))
+                    self._bloom_add(
+                        CacheKey(subject_type, subject_id, permission, resource_type, zone_id)
+                    )
                     return True
 
                 elif operation == "invalidate":
@@ -305,6 +312,8 @@ class TigerCache:
                         permission if permission else "*",
                         resource_type if resource_type else "*",
                     ]
+                    if zone_id:
+                        parts.append(zone_id)
                     pattern = ":".join(parts)
                     count = 0
                     # Use SCAN for safe iteration
@@ -717,6 +726,7 @@ class TigerCache:
                     subject_id=key.subject_id,
                     permission=key.permission,
                     resource_type=key.resource_type,
+                    zone_id=key.zone_id,
                 )
                 if result:
                     bitmap_data, revision = result
@@ -744,6 +754,8 @@ class TigerCache:
             TC.permission == key.permission,
             TC.resource_type == key.resource_type,
         )
+        if key.zone_id:
+            stmt = stmt.where(TC.zone_id == key.zone_id)
 
         def execute(connection: "Connection") -> Any:  # Returns Bitmap or None
             result = connection.execute(stmt)
@@ -765,6 +777,7 @@ class TigerCache:
                         subject_id=key.subject_id,
                         permission=key.permission,
                         resource_type=key.resource_type,
+                        zone_id=key.zone_id,
                         bitmap_data=bytes(row.bitmap_data),
                         revision=revision,
                     )
@@ -1022,6 +1035,7 @@ class TigerCache:
                 subject_id=subject_id,
                 permission=permission,
                 resource_type=resource_type,
+                zone_id=zone_id,
                 bitmap_data=bytes(bitmap_data),
                 revision=revision,
             )
@@ -1096,7 +1110,7 @@ class TigerCache:
             with self._engine.begin() as new_conn:
                 count = execute(new_conn)
 
-        # L2: Invalidate from Dragonfly cache (zone_id excluded per Issue #979)
+        # L2: Invalidate from Dragonfly cache
         dragonfly_count = 0
         if self._dragonfly:
             dragonfly_count = (
@@ -1106,6 +1120,7 @@ class TigerCache:
                     subject_id=subject_id or "",
                     permission=permission or "",
                     resource_type=resource_type or "",
+                    zone_id=zone_id or "",
                 )
                 or 0
             )
@@ -1483,6 +1498,7 @@ class TigerCache:
                     subject_id=subject_id,
                     permission=permission,
                     resource_type=resource_type,
+                    zone_id=zone_id,
                     bitmap_data=bitmap_data,
                     revision=revision,
                 )
@@ -1644,6 +1660,7 @@ class TigerCache:
                     subject_id=subject_id,
                     permission=permission,
                     resource_type=resource_type,
+                    zone_id=zone_id,
                     bitmap_data=bitmap_data,
                     revision=revision,
                 )
@@ -1881,6 +1898,7 @@ class TigerCache:
                     subject_id=subject_id,
                     permission=permission,
                     resource_type=resource_type,
+                    zone_id=zone_id,
                     bitmap_data=bytes(bitmap_data),
                     revision=revision,
                 )

--- a/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
+++ b/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
@@ -588,8 +588,8 @@ class TigerCache:
             subject_id: ID of subject
             permission: Permission to check (e.g., "read", "write")
             resource_type: Type of resource (e.g., "file")
-            zone_id: Zone ID for cache partitioning. Falls back to the
-                legacy zone-agnostic key for compatibility with older cache rows.
+            zone_id: Zone ID for cache partitioning. Zone-scoped predicate pushdown
+                must only read the matching zone-scoped bitmap.
 
         Returns:
             Set of integer IDs the subject can access, or None if no bitmap cached.
@@ -610,40 +610,12 @@ class TigerCache:
                         )
                     return set(bitmap)  # RoaringBitmap is iterable
 
-            # Compatibility fallback for older zone-agnostic cache entries.
-            if zone_id:
-                compat_key = CacheKey(subject_type, subject_id, permission, resource_type)
-                if compat_key in self._cache:
-                    bitmap, revision, cached_at = self._cache[compat_key]
-                    if time.time() - cached_at < self._cache_ttl:
-                        if logger.isEnabledFor(logging.DEBUG):
-                            logger.debug(
-                                "[TIGER-PUSHDOWN] Memory compat hit for %s via %s, %d entries",
-                                key,
-                                compat_key,
-                                len(bitmap),
-                            )
-                        return set(bitmap)
-
         # Load from database
         bitmap = self._load_from_db(key)
         if bitmap is not None:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("[TIGER-PUSHDOWN] DB hit for %s, %d entries", key, len(bitmap))
             return set(bitmap)
-
-        if zone_id:
-            compat_key = CacheKey(subject_type, subject_id, permission, resource_type)
-            bitmap = self._load_from_db(compat_key)
-            if bitmap is not None:
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(
-                        "[TIGER-PUSHDOWN] DB compat hit for %s via %s, %d entries",
-                        key,
-                        compat_key,
-                        len(bitmap),
-                    )
-                return set(bitmap)
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("[TIGER-PUSHDOWN] No bitmap found for %s", key)

--- a/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
+++ b/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
@@ -566,6 +566,7 @@ class TigerCache:
         subject_id: str,
         permission: str,
         resource_type: str,
+        zone_id: str = "",
     ) -> set[int] | None:
         """Get all accessible resource integer IDs from bitmap (Polars-style predicate pushdown).
 
@@ -578,12 +579,14 @@ class TigerCache:
             subject_id: ID of subject
             permission: Permission to check (e.g., "read", "write")
             resource_type: Type of resource (e.g., "file")
+            zone_id: Zone ID for cache partitioning. Falls back to the
+                legacy zone-agnostic key for compatibility with older cache rows.
 
         Returns:
             Set of integer IDs the subject can access, or None if no bitmap cached.
             Returns empty set if bitmap exists but has no entries.
         """
-        key = CacheKey(subject_type, subject_id, permission, resource_type)
+        key = CacheKey(subject_type, subject_id, permission, resource_type, zone_id)
 
         # Check in-memory cache first
         with self._lock:
@@ -598,12 +601,40 @@ class TigerCache:
                         )
                     return set(bitmap)  # RoaringBitmap is iterable
 
+            # Compatibility fallback for older zone-agnostic cache entries.
+            if zone_id:
+                compat_key = CacheKey(subject_type, subject_id, permission, resource_type)
+                if compat_key in self._cache:
+                    bitmap, revision, cached_at = self._cache[compat_key]
+                    if time.time() - cached_at < self._cache_ttl:
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "[TIGER-PUSHDOWN] Memory compat hit for %s via %s, %d entries",
+                                key,
+                                compat_key,
+                                len(bitmap),
+                            )
+                        return set(bitmap)
+
         # Load from database
         bitmap = self._load_from_db(key)
         if bitmap is not None:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("[TIGER-PUSHDOWN] DB hit for %s, %d entries", key, len(bitmap))
             return set(bitmap)
+
+        if zone_id:
+            compat_key = CacheKey(subject_type, subject_id, permission, resource_type)
+            bitmap = self._load_from_db(compat_key)
+            if bitmap is not None:
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "[TIGER-PUSHDOWN] DB compat hit for %s via %s, %d entries",
+                        key,
+                        compat_key,
+                        len(bitmap),
+                    )
+                return set(bitmap)
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("[TIGER-PUSHDOWN] No bitmap found for %s", key)
@@ -615,6 +646,7 @@ class TigerCache:
         subject_id: str,
         permission: str,
         resource_type: str,
+        zone_id: str = "",
     ) -> set[str] | None:
         """Get all accessible resource paths from bitmap (for SQL WHERE clause).
 
@@ -630,7 +662,13 @@ class TigerCache:
         Returns:
             Set of paths the subject can access, or None if no bitmap cached.
         """
-        int_ids = self.get_accessible_int_ids(subject_type, subject_id, permission, resource_type)
+        int_ids = self.get_accessible_int_ids(
+            subject_type,
+            subject_id,
+            permission,
+            resource_type,
+            zone_id=zone_id,
+        )
         if int_ids is None:
             return None
 

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -2318,6 +2318,47 @@ class ReBACManager:
                 for row in cursor.fetchall()
             ]
 
+    def get_cross_zone_shared_paths(
+        self,
+        subject_type: str,
+        subject_id: str,
+        zone_id: str,
+        object_type: str = "file",
+        prefix: str = "",
+    ) -> list[str]:
+        """Return distinct object paths shared with a subject from other zones."""
+        cross_zone_relations = list(CROSS_ZONE_ALLOWED_RELATIONS)
+        placeholders = ", ".join("?" for _ in cross_zone_relations)
+        query = f"""
+            SELECT DISTINCT object_id
+            FROM rebac_tuples
+            WHERE relation IN ({placeholders})
+              AND subject_type = ? AND subject_id = ?
+              AND object_type = ?
+              AND zone_id != ?
+              AND (expires_at IS NULL OR expires_at > ?)
+        """
+        params: tuple[Any, ...] = (
+            *cross_zone_relations,
+            subject_type,
+            subject_id,
+            object_type,
+            zone_id,
+            datetime.now(UTC).isoformat(),
+        )
+        if prefix:
+            query += " AND object_id LIKE ?"
+            params = (*params, f"{prefix}%")
+
+        with self._connection(readonly=True) as conn:
+            cursor = self._create_cursor(conn)
+            cursor.execute(self._fix_sql_placeholders(query), params)
+            paths: list[str] = []
+            for row in cursor.fetchall():
+                path = row["object_id"] if hasattr(row, "keys") else row[0]
+                paths.append(path)
+            return paths
+
     def _rebac_list_objects_python(
         self,
         subject_type: str,

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -1520,8 +1520,13 @@ class SearchService:
         if cached is not None:
             return cached
 
+        get_paths = getattr(self._rebac_manager, "get_cross_zone_shared_paths", None)
+        if not callable(get_paths):
+            self._cross_zone_cache[cache_key] = []
+            return []
+
         try:
-            paths = self._rebac_manager.get_cross_zone_shared_paths(
+            paths = get_paths(
                 subject_type=subject_type,
                 subject_id=subject_id,
                 zone_id=zone_id,

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -1057,6 +1057,7 @@ class SearchService:
                         subject_id=subject_id,
                         permission="read",
                         resource_type="file",
+                        zone_id=list_zone_id,
                     )
                     if _accessible_int_ids is not None:
                         if len(_accessible_int_ids) > 0:

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -335,7 +335,7 @@ def _run_compose(
 
 # Service health endpoints (service_name -> (url_template, timeout_seconds))
 HEALTH_ENDPOINTS: dict[str, tuple[str, int]] = {
-    "nexus": ("http://localhost:{http}/health", 120),
+    "nexus": ("http://localhost:{http}/healthz/ready", 120),
     "postgres": ("", 30),  # checked via pg_isready in container
     "dragonfly": ("", 15),
     "zoekt": ("http://localhost:{zoekt}/", 30),

--- a/src/nexus/server/health/probes.py
+++ b/src/nexus/server/health/probes.py
@@ -21,6 +21,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.server.rate_limiting import limiter
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,15 @@ def _check_raft_topology(request: Request) -> tuple[bool, str]:
             return True, ""
         if not _fed.ensure_topology():
             return False, "Raft topology not ready"
+        zone_mgr = getattr(nx_fs, "_zone_mgr", None)
+        if zone_mgr is None:
+            return True, ""
+        root_zone_id = getattr(zone_mgr, "root_zone_id", None) or ROOT_ZONE_ID
+        root_store = zone_mgr.get_store(root_zone_id)
+        if root_store is None:
+            return False, "Raft root store not ready"
+        if hasattr(root_store, "is_leader") and not root_store.is_leader():
+            return False, "Raft leader not ready"
         return True, ""
     except Exception:
         return True, ""
@@ -99,7 +109,7 @@ async def readiness(request: Request) -> JSONResponse:
 
     Checks:
     1. Required startup phases completed (StartupTracker)
-    2. Raft topology initialised (if applicable)
+    2. Raft topology initialised and root zone is leader-writeable
     3. DB pool has at least one idle connection
     """
     try:

--- a/tests/integration/services/test_search_service.py
+++ b/tests/integration/services/test_search_service.py
@@ -166,6 +166,47 @@ class TestSearchServiceInit:
         svc = SearchService(metadata_store=mock_metadata_store, record_store=mock_record_store)
         assert svc._record_store is mock_record_store
 
+    def test_list_slow_path_passes_zone_id_to_tiger_pushdown(
+        self, mock_metadata_store, mock_permission_enforcer, mock_router, mock_gateway
+    ):
+        """Predicate pushdown must request the bitmap for the current list zone."""
+        meta = MagicMock()
+        meta.path = "/visible.txt"
+        mock_metadata_store.list.return_value = [meta]
+
+        tiger_cache = MagicMock()
+        tiger_cache.get_accessible_int_ids.return_value = {1}
+        tiger_cache._resource_map.get_or_create_int_id.return_value = 1
+        rebac_manager = MagicMock()
+        rebac_manager._tiger_cache = tiger_cache
+
+        svc = SearchService(
+            metadata_store=mock_metadata_store,
+            permission_enforcer=mock_permission_enforcer,
+            router=mock_router,
+            gateway=mock_gateway,
+            enforce_permissions=True,
+        )
+
+        all_files, accessible_ids = svc._list_slow_path(
+            list_prefix="",
+            list_zone_id="test_zone",
+            subject_type="user",
+            subject_id="test_user",
+            _revision_before=None,
+            _rebac_manager=rebac_manager,
+        )
+
+        assert all_files == [meta]
+        assert accessible_ids == {1}
+        tiger_cache.get_accessible_int_ids.assert_called_once_with(
+            subject_type="user",
+            subject_id="test_user",
+            permission="read",
+            resource_type="file",
+            zone_id="test_zone",
+        )
+
 
 # =============================================================================
 # Gitignore filtering (module-level helpers)

--- a/tests/integration/services/test_search_service.py
+++ b/tests/integration/services/test_search_service.py
@@ -207,6 +207,41 @@ class TestSearchServiceInit:
             zone_id="test_zone",
         )
 
+    def test_cross_zone_sharing_uses_public_rebac_method(self, mock_metadata_store):
+        """Cross-zone search should rely on the public ReBAC API."""
+        rebac_manager = MagicMock()
+        rebac_manager.get_cross_zone_shared_paths.return_value = ["/shared/file.txt"]
+        svc = SearchService(metadata_store=mock_metadata_store, rebac_manager=rebac_manager)
+
+        result = svc._get_cross_zone_shared_paths(
+            subject_type="user",
+            subject_id="alice",
+            zone_id="zone-a",
+            prefix="/shared",
+        )
+
+        assert result == ["/shared/file.txt"]
+        rebac_manager.get_cross_zone_shared_paths.assert_called_once_with(
+            subject_type="user",
+            subject_id="alice",
+            zone_id="zone-a",
+            prefix="/shared",
+        )
+
+    def test_cross_zone_sharing_missing_public_method_returns_empty(self, mock_metadata_store):
+        """Managers without cross-zone sharing support should degrade cleanly."""
+        rebac_manager = MagicMock(spec=[])
+        svc = SearchService(metadata_store=mock_metadata_store, rebac_manager=rebac_manager)
+
+        result = svc._get_cross_zone_shared_paths(
+            subject_type="user",
+            subject_id="alice",
+            zone_id="zone-a",
+            prefix="/shared",
+        )
+
+        assert result == []
+
 
 # =============================================================================
 # Gitignore filtering (module-level helpers)

--- a/tests/unit/core/test_tiger_cache_fallback.py
+++ b/tests/unit/core/test_tiger_cache_fallback.py
@@ -102,8 +102,8 @@ class TestL1CacheFallback:
 
         assert result == {1, 2}
 
-    def test_get_accessible_int_ids_falls_back_to_compat_key(self, tiger_cache):
-        """Legacy zone-agnostic bitmaps should still be readable as fallback."""
+    def test_get_accessible_int_ids_does_not_fall_back_to_compat_key(self, tiger_cache):
+        """Zone-scoped predicate pushdown must not reuse an unscoped bitmap."""
         compat_key = CacheKey("user", "alice", "read", "file")
         tiger_cache._cache[compat_key] = (RoaringBitmap([7, 8]), 1, time.time())
 
@@ -115,7 +115,7 @@ class TestL1CacheFallback:
             zone_id="zone-1",
         )
 
-        assert result == {7, 8}
+        assert result is None
 
     def test_get_accessible_int_ids_cold_db_load_is_zone_scoped(self, tiger_cache):
         """Cold DB loads must respect zone_id to avoid cross-zone bitmap hydration."""
@@ -153,6 +153,43 @@ class TestL1CacheFallback:
         )
 
         assert result == {1, 2}
+
+    def test_get_accessible_int_ids_zone_miss_does_not_load_other_zone_bitmap(self, tiger_cache):
+        """A missing zone row must not hydrate another zone's bitmap."""
+        with tiger_cache._engine.begin() as conn:
+            conn.execute(
+                TC.__table__.insert(),
+                [
+                    {
+                        "subject_type": "user",
+                        "subject_id": "alice",
+                        "permission": "read",
+                        "resource_type": "file",
+                        "zone_id": "zone-a",
+                        "bitmap_data": bytes(RoaringBitmap([1, 2]).serialize()),
+                        "revision": 11,
+                    },
+                    {
+                        "subject_type": "user",
+                        "subject_id": "alice",
+                        "permission": "read",
+                        "resource_type": "file",
+                        "zone_id": "zone-b",
+                        "bitmap_data": bytes(RoaringBitmap([99]).serialize()),
+                        "revision": 12,
+                    },
+                ],
+            )
+
+        result = tiger_cache.get_accessible_int_ids(
+            subject_type="user",
+            subject_id="alice",
+            permission="read",
+            resource_type="file",
+            zone_id="zone-c",
+        )
+
+        assert result is None
 
 
 class TestCacheKey:

--- a/tests/unit/core/test_tiger_cache_fallback.py
+++ b/tests/unit/core/test_tiger_cache_fallback.py
@@ -82,6 +82,38 @@ class TestL1CacheFallback:
             )
             mock_db.assert_called_once()
 
+    def test_get_accessible_int_ids_prefers_zone_scoped_l1_entry(self, tiger_cache):
+        """Predicate pushdown should use the zone-scoped bitmap when available."""
+        zone_key = CacheKey("user", "alice", "read", "file", "zone-1")
+        compat_key = CacheKey("user", "alice", "read", "file")
+        tiger_cache._cache[zone_key] = (RoaringBitmap([1, 2]), 1, time.time())
+        tiger_cache._cache[compat_key] = (RoaringBitmap([99]), 1, time.time())
+
+        result = tiger_cache.get_accessible_int_ids(
+            subject_type="user",
+            subject_id="alice",
+            permission="read",
+            resource_type="file",
+            zone_id="zone-1",
+        )
+
+        assert result == {1, 2}
+
+    def test_get_accessible_int_ids_falls_back_to_compat_key(self, tiger_cache):
+        """Legacy zone-agnostic bitmaps should still be readable as fallback."""
+        compat_key = CacheKey("user", "alice", "read", "file")
+        tiger_cache._cache[compat_key] = (RoaringBitmap([7, 8]), 1, time.time())
+
+        result = tiger_cache.get_accessible_int_ids(
+            subject_type="user",
+            subject_id="alice",
+            permission="read",
+            resource_type="file",
+            zone_id="zone-1",
+        )
+
+        assert result == {7, 8}
+
 
 class TestCacheKey:
     """Tests for CacheKey hash and equality."""

--- a/tests/unit/core/test_tiger_cache_fallback.py
+++ b/tests/unit/core/test_tiger_cache_fallback.py
@@ -15,6 +15,8 @@ from pyroaring import BitMap as RoaringBitmap
 from sqlalchemy import create_engine
 
 from nexus.bricks.rebac.cache.tiger.bitmap_cache import CacheKey, TigerCache
+from nexus.storage.models import Base
+from nexus.storage.models import TigerCacheModel as TC
 
 
 def _make_key(**overrides):
@@ -32,6 +34,7 @@ def _make_key(**overrides):
 @pytest.fixture
 def tiger_cache():
     engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[TC.__table__])
     cache = TigerCache(engine=engine)
     return cache
 
@@ -113,6 +116,43 @@ class TestL1CacheFallback:
         )
 
         assert result == {7, 8}
+
+    def test_get_accessible_int_ids_cold_db_load_is_zone_scoped(self, tiger_cache):
+        """Cold DB loads must respect zone_id to avoid cross-zone bitmap hydration."""
+        with tiger_cache._engine.begin() as conn:
+            conn.execute(
+                TC.__table__.insert(),
+                [
+                    {
+                        "subject_type": "user",
+                        "subject_id": "alice",
+                        "permission": "read",
+                        "resource_type": "file",
+                        "zone_id": "zone-a",
+                        "bitmap_data": bytes(RoaringBitmap([1, 2]).serialize()),
+                        "revision": 11,
+                    },
+                    {
+                        "subject_type": "user",
+                        "subject_id": "alice",
+                        "permission": "read",
+                        "resource_type": "file",
+                        "zone_id": "zone-b",
+                        "bitmap_data": bytes(RoaringBitmap([99]).serialize()),
+                        "revision": 12,
+                    },
+                ],
+            )
+
+        result = tiger_cache.get_accessible_int_ids(
+            subject_type="user",
+            subject_id="alice",
+            permission="read",
+            resource_type="file",
+            zone_id="zone-a",
+        )
+
+        assert result == {1, 2}
 
 
 class TestCacheKey:
@@ -278,7 +318,7 @@ class TestBloomFilterIntegration:
     def test_bloom_consistent_encoding(self, tiger_cache):
         """_bloom_key produces same format as Dragonfly redis key."""
         key = CacheKey("user", "alice", "read", "file", "zone-1")
-        assert tiger_cache._bloom_key(key) == "tiger:user:alice:read:file"
+        assert tiger_cache._bloom_key(key) == "tiger:user:alice:read:file:zone-1"
 
     def test_bloom_rebuild_from_l1(self, tiger_cache):
         """_rebuild_l2_bloom rebuilds from L1 cache entries."""

--- a/tests/unit/server/health/test_probes.py
+++ b/tests/unit/server/health/test_probes.py
@@ -111,6 +111,11 @@ class TestReadinessProbe:
         mock_fed = MagicMock()
         mock_fed.ensure_topology.return_value = True
         mock_fs = MagicMock()
+        mock_fs._zone_mgr.ensure_topology.return_value = True
+        mock_fs._zone_mgr.root_zone_id = "root"
+        mock_root_store = MagicMock()
+        mock_root_store.is_leader.return_value = True
+        mock_fs._zone_mgr.get_store.return_value = mock_root_store
         mock_fs.service.return_value = mock_fed
 
         app = _make_app(tracker)
@@ -118,6 +123,28 @@ class TestReadinessProbe:
         client = TestClient(app)
         resp = client.get("/healthz/ready")
         assert resp.status_code == 200
+
+    def test_503_when_root_leader_not_ready(self) -> None:
+        tracker = StartupTracker()
+        for phase in _REQUIRED_FOR_READY:
+            tracker.complete(phase)
+
+        mock_fed = MagicMock()
+        mock_fed.ensure_topology.return_value = True
+        mock_fs = MagicMock()
+        mock_fs.service.return_value = mock_fed
+        mock_fs._zone_mgr.ensure_topology.return_value = True
+        mock_fs._zone_mgr.root_zone_id = "root"
+        mock_root_store = MagicMock()
+        mock_root_store.is_leader.return_value = False
+        mock_fs._zone_mgr.get_store.return_value = mock_root_store
+
+        app = _make_app(tracker)
+        app.state.nexus_fs = mock_fs
+        client = TestClient(app)
+        resp = client.get("/healthz/ready")
+        assert resp.status_code == 503
+        assert resp.json()["reason"] == "Raft leader not ready"
 
     def test_503_on_db_pool_exhausted(self) -> None:
         tracker = StartupTracker()


### PR DESCRIPTION
## Summary
- pass the current list zone into Tiger predicate pushdown lookups
- make Tiger accessible-id/path lookups use zone-scoped cache keys with legacy fallback
- add regression coverage for zone-scoped bitmap lookup behavior

## Root cause
`search_service.list()` was calling `TigerCache.get_accessible_int_ids()` without a `zone_id`. That API also built a zone-agnostic `CacheKey`, so recursive list filtering could load the wrong bitmap and drop valid metastore results.

## Verification
- `uv run pytest -q -o addopts='' /Users/tafeng/nexus/tests/unit/core/test_tiger_cache_fallback.py`
- `uv run pytest -q -o addopts='' /Users/tafeng/nexus/tests/integration/services/test_search_service.py`
- built a temporary stack from this checkout and verified:
  - `sys_write('/grove-diag-live-2.txt')` succeeded
  - `sys_read('/grove-diag-live-2.txt')` succeeded
  - `list('/', recursive=true)` returned the written file
