### PR TITLE
ci: force full test matrix in merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,9 @@ jobs:
     name: Detect Code Changes
     runs-on: ubuntu-latest
     outputs:
-      code_changed: ${{ steps.filter.outputs.code }}
+      # Merge queue always runs full CI — paths-filter can't diff correctly
+      # on the temporary merge commit created by the queue.
+      code_changed: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
## Summary

- Force `code_changed=true` when `github.event_name == 'merge_group'`
- paths-filter can't diff correctly on the temporary merge commit created by the merge queue, causing required checks to skip and PRs to be dequeued

## Test plan

- [x] Pre-commit hooks pass
- [x] This PR itself will validate the fix — `.github/workflows/**` matches the `code` filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)