### PR TITLE
feat(#1576): RemotePipeBackend — driver-layer remote pipe routing

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -669,11 +669,17 @@ async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any, backend
 
     _coordinator = nx_fs.service_coordinator
 
+    # Set TLS config on channel pool now that federation is initialized
+    if hasattr(nx_fs, "_channel_pool") and nx_fs._channel_pool is not None and zone_mgr.tls_config:
+        nx_fs._channel_pool.set_tls_config(zone_mgr.tls_config)
+
     # IPC resolver — remote DT_PIPE/DT_STREAM (#1625)
     ipc_resolver = FederationIPCResolver(
         metastore=nx_fs.metadata,
         self_address=zone_mgr.advertise_addr,
         tls_config=zone_mgr.tls_config,
+        pipe_manager=nx_fs._pipe_manager,
+        stream_manager=nx_fs._stream_manager,
     )
     await _coordinator.enlist("federation_ipc", ipc_resolver)
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -193,13 +193,25 @@ class NexusFS(  # type: ignore[misc]
         from nexus.core.stream_manager import StreamManager
 
         _ipc_self_addr = _os_ipc.environ.get("NEXUS_ADVERTISE_ADDR")
+
+        # PeerChannelPool for remote pipe/stream fast-path (persistent gRPC channels).
+        # Created when NEXUS_ADVERTISE_ADDR is set (federation mode); TLS config is
+        # deferred via set_tls_config() after federation bootstrap.
+        from nexus.grpc.channel_pool import PeerChannelPool as _PeerChannelPool
+
+        self._channel_pool: _PeerChannelPool | None = None
+        if _ipc_self_addr:
+            self._channel_pool = _PeerChannelPool()
+
         self._pipe_manager = PipeManager(
             metadata_store,
             self_address=_ipc_self_addr,
+            channel_pool=self._channel_pool,
         )
         self._stream_manager = StreamManager(
             metadata_store,
             self_address=_ipc_self_addr,
+            channel_pool=self._channel_pool,
         )
         logger.info(
             "IPC primitives initialized: PipeManager + StreamManager (self_address=%s)",
@@ -4425,6 +4437,9 @@ class NexusFS(  # type: ignore[misc]
             self._pipe_manager.close_all()
         if hasattr(self, "_stream_manager"):
             self._stream_manager.close_all()
+        # Close peer channel pool (persistent gRPC channels)
+        if hasattr(self, "_channel_pool") and self._channel_pool is not None:
+            self._channel_pool.close_all()
 
         # Issue #1793/#1789/#1792: Service close via factory-registered callbacks.
         # Runs BEFORE pillar close so DB connections are still open.

--- a/src/nexus/core/pipe_manager.py
+++ b/src/nexus/core/pipe_manager.py
@@ -34,6 +34,7 @@ from nexus.core.pipe import (
 
 if TYPE_CHECKING:
     from nexus.core.metastore import MetastoreABC
+    from nexus.grpc.channel_pool import PeerChannelPool
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +70,11 @@ class PipeManager:
         self,
         metastore: "MetastoreABC",
         self_address: str | None = None,
+        channel_pool: "PeerChannelPool | None" = None,
     ) -> None:
         self._metastore = metastore
         self._self_address = self_address
+        self._channel_pool = channel_pool
         self._buffers: dict[str, PipeBackend] = {}
         self._locks: dict[str, asyncio.Lock] = {}
 
@@ -172,12 +175,15 @@ class PipeManager:
         exists but the buffer was lost (process restart), creates a new
         buffer for the existing inode.
 
+        For remote pipes (origin != self_address), installs a
+        RemotePipeBackend that proxies via persistent gRPC channel.
+
         Args:
             path: VFS path of the pipe.
             capacity: Buffer capacity (used only if recreating after restart).
 
         Returns:
-            The RingBuffer for this pipe.
+            The PipeBackend for this pipe (RingBuffer or RemotePipeBackend).
 
         Raises:
             PipeNotFoundError: No pipe inode at this path.
@@ -193,7 +199,24 @@ class PipeManager:
         if metadata is None or metadata.entry_type != DT_PIPE:
             raise PipeNotFoundError(f"no pipe at: {path}")
 
-        # Recreate buffer (restart recovery)
+        # Detect remote pipe — install RemotePipeBackend for fast-path
+        if self._channel_pool is not None and metadata.backend_name:
+            from nexus.contracts.backend_address import BackendAddress
+
+            addr = BackendAddress.parse(metadata.backend_name)
+            if addr.has_origin and self._self_address not in addr.origins:
+                from nexus.core.remote_pipe import RemotePipeBackend
+
+                backend: PipeBackend = RemotePipeBackend(
+                    origin=addr.origins[0],
+                    path=path,
+                    channel_pool=self._channel_pool,
+                )
+                self._buffers[path] = backend
+                logger.debug("pipe opened (remote): %s → %s", path, addr.origins[0])
+                return backend
+
+        # Local: recreate buffer (restart recovery)
         buf = RingBuffer(capacity=capacity)
         self._buffers[path] = buf
 

--- a/src/nexus/core/remote_pipe.py
+++ b/src/nexus/core/remote_pipe.py
@@ -1,0 +1,170 @@
+"""RemotePipeBackend — PipeBackend implementation that proxies to a remote node.
+
+Installed in PipeManager._buffers at open() time when the pipe's origin
+address differs from self_address. All subsequent reads/writes hit this
+backend directly via the fast-path dict lookup, bypassing KernelDispatch.
+
+Uses a persistent gRPC channel from PeerChannelPool (one channel per peer,
+HTTP/2 multiplexed). Same Call RPC pattern as FederationIPCResolver.
+
+Issue #1576: DT_PIPE/DT_STREAM federation fast-path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.grpc.channel_pool import PeerChannelPool
+
+logger = logging.getLogger(__name__)
+
+
+class RemotePipeBackend:
+    """PipeBackend that proxies read/write to a remote node via gRPC.
+
+    Implements the PipeBackend protocol (core/pipe.py) so PipeManager
+    treats it identically to a local RingBuffer.
+    """
+
+    __slots__ = ("_origin", "_path", "_pool", "_closed", "_timeout")
+
+    def __init__(
+        self,
+        origin: str,
+        path: str,
+        channel_pool: "PeerChannelPool",
+        *,
+        timeout: float = 30.0,
+    ) -> None:
+        self._origin = origin
+        self._path = path
+        self._pool = channel_pool
+        self._closed = False
+        self._timeout = timeout
+
+    # -- sync nowait (data-path hot methods) --------------------------------
+
+    def write_nowait(self, data: bytes) -> int:
+        """Write to remote pipe via gRPC Call RPC (method=sys_write)."""
+        if self._closed:
+            from nexus.core.pipe import PipeClosedError
+
+            raise PipeClosedError("write to closed remote pipe")
+        return self._rpc_write(data)
+
+    def read_nowait(self) -> bytes:
+        """Read from remote pipe via gRPC Call RPC (method=sys_read)."""
+        if self._closed:
+            from nexus.core.pipe import PipeClosedError
+
+            raise PipeClosedError("read from closed remote pipe")
+        return self._rpc_read()
+
+    # -- async wrappers -----------------------------------------------------
+
+    async def write(self, data: bytes, *, blocking: bool = True) -> int:
+        """Async write — delegates to write_nowait (gRPC call is sync)."""
+        _ = blocking  # remote pipe always does a single RPC attempt
+        return await asyncio.to_thread(self.write_nowait, data)
+
+    async def read(self, *, blocking: bool = True) -> bytes:
+        """Async read — delegates to read_nowait (gRPC call is sync)."""
+        _ = blocking
+        return await asyncio.to_thread(self.read_nowait)
+
+    async def wait_writable(self) -> None:
+        """Remote pipes are always writable (bounded by remote buffer)."""
+        return
+
+    async def wait_readable(self) -> None:
+        """Remote pipes: immediate return (caller retries on empty)."""
+        return
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def close(self) -> None:
+        """Mark this backend as closed. Does NOT close the pooled channel."""
+        self._closed = True
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def stats(self) -> dict:
+        return {
+            "type": "remote",
+            "origin": self._origin,
+            "path": self._path,
+            "closed": self._closed,
+        }
+
+    # -- gRPC internals -----------------------------------------------------
+
+    def _rpc_write(self, data: bytes) -> int:
+        """Sync gRPC Call(method=sys_write) to origin node."""
+        import grpc
+
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+        from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
+
+        params: dict[str, Any] = {
+            "path": self._path,
+            "buf": base64.b64encode(data).decode("ascii"),
+        }
+        channel = self._pool.get(self._origin)
+        try:
+            from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
+
+            stub = vfs_pb2_grpc.NexusVFSServiceStub(channel)
+            request = vfs_pb2.CallRequest(
+                method="sys_write",
+                payload=encode_rpc_message(params),
+            )
+            response = stub.Call(request, timeout=self._timeout)
+            if response.is_error:
+                payload = decode_rpc_message(response.payload) if response.payload else {}
+                msg = payload.get("message", "Remote pipe write failed")
+                raise NexusFileNotFoundError(self._path, msg)
+            result = decode_rpc_message(response.payload)
+            return int(result.get("result", len(data)))
+        except grpc.RpcError as exc:
+            raise NexusFileNotFoundError(
+                self._path, f"Remote pipe write to {self._origin} failed: {exc}"
+            ) from exc
+
+    def _rpc_read(self) -> bytes:
+        """Sync gRPC Call(method=sys_read) to origin node."""
+        import grpc
+
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+        from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
+
+        params: dict[str, Any] = {"path": self._path}
+        channel = self._pool.get(self._origin)
+        try:
+            from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
+
+            stub = vfs_pb2_grpc.NexusVFSServiceStub(channel)
+            request = vfs_pb2.CallRequest(
+                method="sys_read",
+                payload=encode_rpc_message(params),
+            )
+            response = stub.Call(request, timeout=self._timeout)
+            if response.is_error:
+                payload = decode_rpc_message(response.payload) if response.payload else {}
+                msg = payload.get("message", "Remote pipe read failed")
+                raise NexusFileNotFoundError(self._path, msg)
+            result = decode_rpc_message(response.payload)
+            content = result.get("result", b"")
+            if isinstance(content, str):
+                content = base64.b64decode(content)
+            return bytes(content)
+        except grpc.RpcError as exc:
+            raise NexusFileNotFoundError(
+                self._path, f"Remote pipe read from {self._origin} failed: {exc}"
+            ) from exc

--- a/src/nexus/core/remote_stream.py
+++ b/src/nexus/core/remote_stream.py
@@ -1,0 +1,189 @@
+"""RemoteStreamBackend — StreamBackend implementation that proxies to a remote node.
+
+Installed in StreamManager._buffers at open() time when the stream's origin
+address differs from self_address. All subsequent reads/writes hit this
+backend directly via the fast-path dict lookup, bypassing KernelDispatch.
+
+Same pattern as RemotePipeBackend. Key difference: reads return
+(bytes, next_offset) tuples matching the StreamBackend protocol.
+
+Issue #1576: DT_PIPE/DT_STREAM federation fast-path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.grpc.channel_pool import PeerChannelPool
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteStreamBackend:
+    """StreamBackend that proxies read/write to a remote node via gRPC.
+
+    Implements the StreamBackend protocol (core/stream.py) so StreamManager
+    treats it identically to a local StreamBuffer.
+    """
+
+    __slots__ = ("_origin", "_path", "_pool", "_closed", "_timeout", "_tail")
+
+    def __init__(
+        self,
+        origin: str,
+        path: str,
+        channel_pool: "PeerChannelPool",
+        *,
+        timeout: float = 30.0,
+    ) -> None:
+        self._origin = origin
+        self._path = path
+        self._pool = channel_pool
+        self._closed = False
+        self._timeout = timeout
+        self._tail = 0
+
+    # -- write (append) -----------------------------------------------------
+
+    def write_nowait(self, data: bytes) -> int:
+        """Write to remote stream via gRPC Call RPC (method=sys_write)."""
+        if self._closed:
+            from nexus.core.stream import StreamClosedError
+
+            raise StreamClosedError("write to closed remote stream")
+        offset = self._rpc_write(data)
+        self._tail = offset + len(data)
+        return offset
+
+    async def write(self, data: bytes, *, blocking: bool = True) -> int:
+        """Async write — delegates to write_nowait (gRPC call is sync)."""
+        _ = blocking
+        return await asyncio.to_thread(self.write_nowait, data)
+
+    # -- read (non-destructive, offset-based) --------------------------------
+
+    def read_at(self, byte_offset: int = 0) -> tuple[bytes, int]:
+        """Read one message at byte_offset from remote stream."""
+        if self._closed:
+            from nexus.core.stream import StreamClosedError
+
+            raise StreamClosedError("read from closed remote stream")
+        return self._rpc_read(byte_offset)
+
+    async def read(self, byte_offset: int = 0, *, blocking: bool = True) -> tuple[bytes, int]:
+        """Async read one message at byte_offset."""
+        _ = blocking
+        return await asyncio.to_thread(self.read_at, byte_offset)
+
+    def read_batch(self, byte_offset: int = 0, count: int = 10) -> tuple[list[bytes], int]:
+        """Read up to count messages. Proxies via repeated single reads."""
+        items: list[bytes] = []
+        offset = byte_offset
+        for _ in range(count):
+            try:
+                data, offset = self.read_at(offset)
+                items.append(data)
+            except Exception:  # noqa: BLE001
+                break
+        return items, offset
+
+    async def read_batch_blocking(
+        self, byte_offset: int = 0, count: int = 10, *, blocking: bool = True
+    ) -> tuple[list[bytes], int]:
+        """Async batch read."""
+        _ = blocking
+        return await asyncio.to_thread(self.read_batch, byte_offset, count)
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def close(self) -> None:
+        """Mark this backend as closed. Does NOT close the pooled channel."""
+        self._closed = True
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def stats(self) -> dict:
+        return {
+            "type": "remote",
+            "origin": self._origin,
+            "path": self._path,
+            "closed": self._closed,
+        }
+
+    @property
+    def tail(self) -> int:
+        return self._tail
+
+    # -- gRPC internals -----------------------------------------------------
+
+    def _rpc_write(self, data: bytes) -> int:
+        """Sync gRPC Call(method=sys_write) to origin node."""
+        import grpc
+
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+        from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
+
+        params: dict[str, Any] = {
+            "path": self._path,
+            "buf": base64.b64encode(data).decode("ascii"),
+        }
+        channel = self._pool.get(self._origin)
+        try:
+            from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
+
+            stub = vfs_pb2_grpc.NexusVFSServiceStub(channel)
+            request = vfs_pb2.CallRequest(
+                method="sys_write",
+                payload=encode_rpc_message(params),
+            )
+            response = stub.Call(request, timeout=self._timeout)
+            if response.is_error:
+                payload = decode_rpc_message(response.payload) if response.payload else {}
+                msg = payload.get("message", "Remote stream write failed")
+                raise NexusFileNotFoundError(self._path, msg)
+            result = decode_rpc_message(response.payload)
+            return int(result.get("result", 0))
+        except grpc.RpcError as exc:
+            raise NexusFileNotFoundError(
+                self._path, f"Remote stream write to {self._origin} failed: {exc}"
+            ) from exc
+
+    def _rpc_read(self, byte_offset: int) -> tuple[bytes, int]:
+        """Sync gRPC Call(method=sys_read) to origin node."""
+        import grpc
+
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+        from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
+
+        params: dict[str, Any] = {"path": self._path, "offset": byte_offset}
+        channel = self._pool.get(self._origin)
+        try:
+            from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
+
+            stub = vfs_pb2_grpc.NexusVFSServiceStub(channel)
+            request = vfs_pb2.CallRequest(
+                method="sys_read",
+                payload=encode_rpc_message(params),
+            )
+            response = stub.Call(request, timeout=self._timeout)
+            if response.is_error:
+                payload = decode_rpc_message(response.payload) if response.payload else {}
+                msg = payload.get("message", "Remote stream read failed")
+                raise NexusFileNotFoundError(self._path, msg)
+            result = decode_rpc_message(response.payload)
+            content = result.get("result", b"")
+            if isinstance(content, str):
+                content = base64.b64decode(content)
+            next_offset = int(result.get("next_offset", byte_offset + len(content)))
+            return bytes(content), next_offset
+        except grpc.RpcError as exc:
+            raise NexusFileNotFoundError(
+                self._path, f"Remote stream read from {self._origin} failed: {exc}"
+            ) from exc

--- a/src/nexus/core/stream_manager.py
+++ b/src/nexus/core/stream_manager.py
@@ -31,6 +31,7 @@ from nexus.core.stream import (
 
 if TYPE_CHECKING:
     from nexus.core.metastore import MetastoreABC
+    from nexus.grpc.channel_pool import PeerChannelPool
 
 logger = logging.getLogger(__name__)
 
@@ -62,9 +63,11 @@ class StreamManager:
         self,
         metastore: "MetastoreABC",
         self_address: str | None = None,
+        channel_pool: "PeerChannelPool | None" = None,
     ) -> None:
         self._metastore = metastore
         self._self_address = self_address
+        self._channel_pool = channel_pool
         self._buffers: dict[str, StreamBackend] = {}
         self._locks: dict[str, asyncio.Lock] = {}
 
@@ -135,12 +138,15 @@ class StreamManager:
         exists but the buffer was lost (process restart), creates a new
         buffer for the existing inode.
 
+        For remote streams (origin != self_address), installs a
+        RemoteStreamBackend that proxies via persistent gRPC channel.
+
         Args:
             path: VFS path of the stream.
             capacity: Buffer capacity (used only if recreating after restart).
 
         Returns:
-            The StreamBuffer for this stream.
+            The StreamBackend for this stream (StreamBuffer or RemoteStreamBackend).
 
         Raises:
             StreamNotFoundError: No stream inode at this path.
@@ -156,7 +162,24 @@ class StreamManager:
         if metadata is None or metadata.entry_type != DT_STREAM:
             raise StreamNotFoundError(f"no stream at: {path}")
 
-        # Recreate buffer (restart recovery)
+        # Detect remote stream — install RemoteStreamBackend for fast-path
+        if self._channel_pool is not None and metadata.backend_name:
+            from nexus.contracts.backend_address import BackendAddress
+
+            addr = BackendAddress.parse(metadata.backend_name)
+            if addr.has_origin and self._self_address not in addr.origins:
+                from nexus.core.remote_stream import RemoteStreamBackend
+
+                backend: StreamBackend = RemoteStreamBackend(
+                    origin=addr.origins[0],
+                    path=path,
+                    channel_pool=self._channel_pool,
+                )
+                self._buffers[path] = backend
+                logger.debug("stream opened (remote): %s → %s", path, addr.origins[0])
+                return backend
+
+        # Local: recreate buffer (restart recovery)
         buf = StreamBuffer(capacity=capacity)
         self._buffers[path] = buf
 

--- a/src/nexus/grpc/channel_pool.py
+++ b/src/nexus/grpc/channel_pool.py
@@ -1,0 +1,71 @@
+"""PeerChannelPool — shared gRPC channel pool for peer-to-peer IPC.
+
+One persistent channel per peer address. gRPC channels multiplex HTTP/2
+internally, so a single channel handles many concurrent RPCs efficiently.
+
+Replaces per-call build_peer_channel() + close() in the data path.
+Control-plane operations (e.g., try_delete) can still use one-shot channels.
+
+Issue #1576: DT_PIPE/DT_STREAM federation fast-path.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+import grpc
+
+from nexus.grpc.channel_factory import build_peer_channel
+
+if TYPE_CHECKING:
+    from nexus.security.tls.config import ZoneTlsConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PeerChannelPool:
+    """Shared gRPC channel pool for peer-to-peer IPC. One channel per address.
+
+    Thread-safe: channels may be requested from RPC worker threads and the
+    asyncio event loop concurrently.
+
+    TLS config is set via :meth:`set_tls_config` (deferred — not available at
+    NexusFS init time, only after federation bootstrap).
+    """
+
+    def __init__(self, tls_config: "ZoneTlsConfig | None" = None) -> None:
+        self._channels: dict[str, grpc.Channel] = {}
+        self._tls_config: ZoneTlsConfig | None = tls_config
+        self._lock = threading.Lock()
+
+    def get(self, address: str) -> grpc.Channel:
+        """Get or create a persistent channel to *address*."""
+        channel = self._channels.get(address)
+        if channel is not None:
+            return channel
+        with self._lock:
+            # Double-check after acquiring lock
+            channel = self._channels.get(address)
+            if channel is not None:
+                return channel
+            channel = build_peer_channel(address, self._tls_config)
+            self._channels[address] = channel
+            logger.debug("PeerChannelPool: created channel to %s", address)
+            return channel
+
+    def set_tls_config(self, config: "ZoneTlsConfig") -> None:
+        """Set or update TLS config. Existing channels are NOT replaced."""
+        self._tls_config = config
+
+    def close_all(self) -> None:
+        """Close all pooled channels. Called on shutdown."""
+        with self._lock:
+            for addr, ch in self._channels.items():
+                try:
+                    ch.close()
+                except Exception:  # noqa: BLE001
+                    logger.debug("PeerChannelPool: error closing channel to %s", addr)
+            self._channels.clear()
+        logger.debug("PeerChannelPool: all channels closed")

--- a/src/nexus/raft/federation_ipc_resolver.py
+++ b/src/nexus/raft/federation_ipc_resolver.py
@@ -30,6 +30,8 @@ from nexus.contracts.exceptions import NexusFileNotFoundError
 if TYPE_CHECKING:
     from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.core.metastore import MetastoreABC
+    from nexus.core.pipe_manager import PipeManager
+    from nexus.core.stream_manager import StreamManager
     from nexus.security.tls.config import ZoneTlsConfig
 
 logger = logging.getLogger(__name__)
@@ -38,15 +40,21 @@ logger = logging.getLogger(__name__)
 class FederationIPCResolver:
     """VFSPathResolver for remote DT_PIPE and DT_STREAM federation.
 
-    Handles read/write/delete for pipes and streams hosted on remote nodes.
-    Local pipes/streams are not matched (returns None) and fall through
-    to the kernel's PipeManager/StreamManager.
+    Acts as a **lazy installer**: on first remote pipe/stream access, calls
+    PipeManager.open() / StreamManager.open() to install a RemotePipeBackend /
+    RemoteStreamBackend in the fast-path buffer registry. Subsequent calls hit
+    the fast-path dict lookup and never reach this resolver again.
+
+    Falls back to one-shot gRPC for operations where no manager is available.
+    try_delete stays unchanged (control-plane, not data-path).
 
     Args:
         metastore: MetastoreABC for metadata lookup.
         self_address: This node's advertise address (e.g., "10.0.0.5:50051").
         tls_config: Optional ZoneTlsConfig for mTLS peer channels.
         timeout: RPC timeout in seconds.
+        pipe_manager: Optional PipeManager ref for lazy backend installation.
+        stream_manager: Optional StreamManager ref for lazy backend installation.
     """
 
     name = "federation-ipc"
@@ -57,11 +65,15 @@ class FederationIPCResolver:
         self_address: str | None,
         tls_config: "ZoneTlsConfig | None" = None,
         timeout: float = 30.0,
+        pipe_manager: "PipeManager | None" = None,
+        stream_manager: "StreamManager | None" = None,
     ) -> None:
         self._metastore = metastore
         self._self_address = self_address
         self._tls_config = tls_config
         self._timeout = timeout
+        self._pipe_manager = pipe_manager
+        self._stream_manager = stream_manager
 
     # ------------------------------------------------------------------
     # Hook spec (duck-typed) (#1710) — enables coordinator.enlist()
@@ -98,6 +110,28 @@ class FederationIPCResolver:
 
         return meta, addr.origins[0]  # remote IPC — resolver handles
 
+    def _try_install_backend(self, path: str, meta: Any) -> bool:
+        """Try to install a remote backend in PipeManager/StreamManager.
+
+        Returns True if a backend was installed (caller should delegate to
+        the now-installed fast-path backend), False if fallback RPC needed.
+        """
+        if meta.is_pipe and self._pipe_manager is not None:
+            try:
+                self._pipe_manager.open(path)
+                return True
+            except Exception:  # noqa: BLE001
+                logger.debug("Failed to install RemotePipeBackend for %s, using fallback", path)
+                return False
+        if meta.is_stream and self._stream_manager is not None:
+            try:
+                self._stream_manager.open(path)
+                return True
+            except Exception:  # noqa: BLE001
+                logger.debug("Failed to install RemoteStreamBackend for %s, using fallback", path)
+                return False
+        return False
+
     def try_read(
         self,
         path: str,
@@ -106,17 +140,33 @@ class FederationIPCResolver:
     ) -> bytes | None:
         """Read from remote DT_PIPE/DT_STREAM via gRPC Call RPC.
 
+        On first access, installs a RemotePipeBackend/RemoteStreamBackend
+        so subsequent calls hit the fast-path and skip this resolver.
+
         Returns None if path is not a remote IPC inode (decline).
         """
         _ = context  # Protocol-required; not used for IPC
         resolved = self._resolve_remote(path)
         if resolved is None:
             return None
-        _meta, origin = resolved
+        meta, origin = resolved
+
+        # Lazy install: install remote backend, then delegate to it
+        if self._try_install_backend(path, meta):
+            if meta.is_pipe and self._pipe_manager is not None:
+                return self._pipe_manager._get_buffer(path).read_nowait()
+            if meta.is_stream and self._stream_manager is not None:
+                data, _ = self._stream_manager.stream_read_at(path, 0)
+                return data
+
+        # Fallback: one-shot gRPC (no manager or install failed)
         return self._read_remote(origin, path)
 
     def try_write(self, path: str, content: bytes) -> dict[str, Any] | None:
         """Write to remote DT_PIPE/DT_STREAM via gRPC Call RPC.
+
+        On first access, installs a RemotePipeBackend/RemoteStreamBackend
+        so subsequent calls hit the fast-path and skip this resolver.
 
         Returns None if path is not a remote IPC inode (decline).
         """
@@ -124,8 +174,18 @@ class FederationIPCResolver:
         if resolved is None:
             return None
         meta, origin = resolved
+
+        # Lazy install: install remote backend, then delegate to it
+        if self._try_install_backend(path, meta):
+            if meta.is_pipe and self._pipe_manager is not None:
+                self._pipe_manager._get_buffer(path).write_nowait(content)
+                return {}
+            if meta.is_stream and self._stream_manager is not None:
+                offset = self._stream_manager.stream_write_nowait(path, content)
+                return {"offset": offset}
+
+        # Fallback: one-shot gRPC (no manager or install failed)
         result = self._write_remote(origin, path, content)
-        # For streams, result may contain offset info
         if meta.is_stream:
             return {"offset": result}
         return {}

--- a/tests/unit/core/test_pipe.py
+++ b/tests/unit/core/test_pipe.py
@@ -890,6 +890,96 @@ SELF_ADDR = "10.0.0.1:50051"
 REMOTE_ADDR = "10.0.0.2:50051"
 
 
+class _MockChannelPool:
+    """Minimal PeerChannelPool duck-type for PipeManager tests."""
+
+    def __init__(self) -> None:
+        from unittest.mock import MagicMock
+
+        self.channel = MagicMock()
+
+    def get(self, address: str) -> object:
+        return self.channel
+
+
+class TestPipeManagerRemoteDetection:
+    """Test PipeManager.open() remote pipe detection and RemotePipeBackend install."""
+
+    def _make_manager_with_pool(
+        self,
+    ) -> tuple[PipeManager, MockMetastore, _MockChannelPool]:
+        ms = MockMetastore()
+        pool = _MockChannelPool()
+        mgr = PipeManager(ms, self_address=SELF_ADDR, channel_pool=pool)
+        return mgr, ms, pool
+
+    def test_open_remote_pipe_installs_remote_backend(self) -> None:
+        """open() on a remote pipe should install RemotePipeBackend."""
+        from nexus.core.remote_pipe import RemotePipeBackend
+
+        mgr, ms, _ = self._make_manager_with_pool()
+        # Manually create a remote pipe inode (origin is REMOTE_ADDR)
+        meta = FileMetadata(
+            path="/nexus/pipes/remote",
+            backend_name=f"pipe@{REMOTE_ADDR}",
+            physical_path="mem://",
+            size=65536,
+            entry_type=DT_PIPE,
+        )
+        ms.put(meta)
+
+        backend = mgr.open("/nexus/pipes/remote")
+        assert isinstance(backend, RemotePipeBackend)
+        assert backend.stats["origin"] == REMOTE_ADDR
+        assert "/nexus/pipes/remote" in mgr._buffers
+
+    def test_open_local_pipe_installs_ringbuffer(self) -> None:
+        """open() on a local pipe should install RingBuffer (not RemotePipeBackend)."""
+        mgr, ms, _ = self._make_manager_with_pool()
+        meta = FileMetadata(
+            path="/nexus/pipes/local",
+            backend_name=f"pipe@{SELF_ADDR}",
+            physical_path="mem://",
+            size=65536,
+            entry_type=DT_PIPE,
+        )
+        ms.put(meta)
+
+        backend = mgr.open("/nexus/pipes/local")
+        assert isinstance(backend, RingBuffer)
+
+    def test_open_plain_pipe_installs_ringbuffer(self) -> None:
+        """open() on a plain pipe (no origin) should install RingBuffer."""
+        mgr, ms, _ = self._make_manager_with_pool()
+        meta = FileMetadata(
+            path="/nexus/pipes/plain",
+            backend_name="pipe",
+            physical_path="mem://",
+            size=65536,
+            entry_type=DT_PIPE,
+        )
+        ms.put(meta)
+
+        backend = mgr.open("/nexus/pipes/plain")
+        assert isinstance(backend, RingBuffer)
+
+    def test_open_without_pool_always_ringbuffer(self) -> None:
+        """Without channel_pool, open() always creates RingBuffer even for remote."""
+        ms = MockMetastore()
+        mgr = PipeManager(ms, self_address=SELF_ADDR)  # no channel_pool
+        meta = FileMetadata(
+            path="/nexus/pipes/remote-no-pool",
+            backend_name=f"pipe@{REMOTE_ADDR}",
+            physical_path="mem://",
+            size=65536,
+            entry_type=DT_PIPE,
+        )
+        ms.put(meta)
+
+        backend = mgr.open("/nexus/pipes/remote-no-pool")
+        assert isinstance(backend, RingBuffer)
+
+
 class TestPipeManagerSelfAddress:
     """Test PipeManager.self_address and backend_name embedding (#1576)."""
 

--- a/tests/unit/core/test_remote_pipe.py
+++ b/tests/unit/core/test_remote_pipe.py
@@ -1,0 +1,123 @@
+"""Unit tests for RemotePipeBackend."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.core.pipe import PipeClosedError
+from nexus.core.remote_pipe import RemotePipeBackend
+
+
+class MockChannelPool:
+    """Minimal PeerChannelPool duck-type for tests."""
+
+    def __init__(self) -> None:
+        self.channel = MagicMock()
+
+    def get(self, address: str) -> object:
+        return self.channel
+
+    def set_tls_config(self, config: object) -> None:
+        pass
+
+    def close_all(self) -> None:
+        pass
+
+
+def _patch_grpc_vfs(mock_stub_instance):
+    """Context manager that patches nexus.grpc.vfs with mock stubs."""
+    mock_pb2 = MagicMock()
+    mock_pb2_grpc = MagicMock()
+    mock_pb2_grpc.NexusVFSServiceStub.return_value = mock_stub_instance
+
+    mock_vfs = MagicMock()
+    mock_vfs.vfs_pb2 = mock_pb2
+    mock_vfs.vfs_pb2_grpc = mock_pb2_grpc
+
+    return patch.dict(
+        "sys.modules",
+        {
+            "nexus.grpc.vfs": mock_vfs,
+            "nexus.grpc.vfs.vfs_pb2": mock_pb2,
+            "nexus.grpc.vfs.vfs_pb2_grpc": mock_pb2_grpc,
+        },
+    )
+
+
+class TestRemotePipeBackend:
+    def _make_backend(self) -> tuple[RemotePipeBackend, MockChannelPool]:
+        pool = MockChannelPool()
+        backend = RemotePipeBackend(
+            origin="10.0.0.2:50051",
+            path="/nexus/pipes/test",
+            channel_pool=pool,
+        )
+        return backend, pool
+
+    def test_stats(self) -> None:
+        backend, _ = self._make_backend()
+        stats = backend.stats
+        assert stats["type"] == "remote"
+        assert stats["origin"] == "10.0.0.2:50051"
+        assert stats["path"] == "/nexus/pipes/test"
+        assert stats["closed"] is False
+
+    def test_close(self) -> None:
+        backend, _ = self._make_backend()
+        assert backend.closed is False
+        backend.close()
+        assert backend.closed is True
+
+    def test_write_nowait_closed_raises(self) -> None:
+        backend, _ = self._make_backend()
+        backend.close()
+        with pytest.raises(PipeClosedError, match="closed remote pipe"):
+            backend.write_nowait(b"data")
+
+    def test_read_nowait_closed_raises(self) -> None:
+        backend, _ = self._make_backend()
+        backend.close()
+        with pytest.raises(PipeClosedError, match="closed remote pipe"):
+            backend.read_nowait()
+
+    def test_write_nowait_calls_rpc(self) -> None:
+        backend, _ = self._make_backend()
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.payload = b'{"result": 5}'
+
+        mock_stub = MagicMock()
+        mock_stub.Call.return_value = mock_response
+
+        with _patch_grpc_vfs(mock_stub):
+            result = backend.write_nowait(b"hello")
+
+        assert result == 5
+        mock_stub.Call.assert_called_once()
+
+    def test_read_nowait_calls_rpc(self) -> None:
+        backend, _ = self._make_backend()
+        import base64
+
+        encoded_data = base64.b64encode(b"hello").decode("ascii")
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.payload = f'{{"result": "{encoded_data}"}}'.encode()
+
+        mock_stub = MagicMock()
+        mock_stub.Call.return_value = mock_response
+
+        with _patch_grpc_vfs(mock_stub):
+            result = backend.read_nowait()
+
+        assert result == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_async_wait_writable(self) -> None:
+        backend, _ = self._make_backend()
+        await backend.wait_writable()
+
+    @pytest.mark.asyncio
+    async def test_async_wait_readable(self) -> None:
+        backend, _ = self._make_backend()
+        await backend.wait_readable()

--- a/tests/unit/core/test_remote_stream.py
+++ b/tests/unit/core/test_remote_stream.py
@@ -1,0 +1,139 @@
+"""Unit tests for RemoteStreamBackend."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.core.remote_stream import RemoteStreamBackend
+from nexus.core.stream import StreamClosedError
+
+
+class MockChannelPool:
+    """Minimal PeerChannelPool duck-type for tests."""
+
+    def __init__(self) -> None:
+        self.channel = MagicMock()
+
+    def get(self, address: str) -> object:
+        return self.channel
+
+    def set_tls_config(self, config: object) -> None:
+        pass
+
+    def close_all(self) -> None:
+        pass
+
+
+def _patch_grpc_vfs(mock_stub_instance):
+    """Context manager that patches nexus.grpc.vfs with mock stubs."""
+    mock_pb2 = MagicMock()
+    mock_pb2_grpc = MagicMock()
+    mock_pb2_grpc.NexusVFSServiceStub.return_value = mock_stub_instance
+
+    mock_vfs = MagicMock()
+    mock_vfs.vfs_pb2 = mock_pb2
+    mock_vfs.vfs_pb2_grpc = mock_pb2_grpc
+
+    return patch.dict(
+        "sys.modules",
+        {
+            "nexus.grpc.vfs": mock_vfs,
+            "nexus.grpc.vfs.vfs_pb2": mock_pb2,
+            "nexus.grpc.vfs.vfs_pb2_grpc": mock_pb2_grpc,
+        },
+    )
+
+
+class TestRemoteStreamBackend:
+    def _make_backend(self) -> tuple[RemoteStreamBackend, MockChannelPool]:
+        pool = MockChannelPool()
+        backend = RemoteStreamBackend(
+            origin="10.0.0.2:50051",
+            path="/nexus/streams/test",
+            channel_pool=pool,
+        )
+        return backend, pool
+
+    def test_stats(self) -> None:
+        backend, _ = self._make_backend()
+        stats = backend.stats
+        assert stats["type"] == "remote"
+        assert stats["origin"] == "10.0.0.2:50051"
+        assert stats["path"] == "/nexus/streams/test"
+        assert stats["closed"] is False
+
+    def test_close(self) -> None:
+        backend, _ = self._make_backend()
+        assert backend.closed is False
+        backend.close()
+        assert backend.closed is True
+
+    def test_tail_starts_at_zero(self) -> None:
+        backend, _ = self._make_backend()
+        assert backend.tail == 0
+
+    def test_write_nowait_closed_raises(self) -> None:
+        backend, _ = self._make_backend()
+        backend.close()
+        with pytest.raises(StreamClosedError, match="closed remote stream"):
+            backend.write_nowait(b"data")
+
+    def test_read_at_closed_raises(self) -> None:
+        backend, _ = self._make_backend()
+        backend.close()
+        with pytest.raises(StreamClosedError, match="closed remote stream"):
+            backend.read_at(0)
+
+    def test_write_nowait_calls_rpc(self) -> None:
+        backend, _ = self._make_backend()
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.payload = b'{"result": 0}'
+
+        mock_stub = MagicMock()
+        mock_stub.Call.return_value = mock_response
+
+        with _patch_grpc_vfs(mock_stub):
+            result = backend.write_nowait(b"hello")
+
+        assert result == 0
+        assert backend.tail == 5  # 0 + len(b"hello")
+
+    def test_read_at_calls_rpc(self) -> None:
+        backend, _ = self._make_backend()
+        import base64
+
+        encoded_data = base64.b64encode(b"hello").decode("ascii")
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.payload = f'{{"result": "{encoded_data}", "next_offset": 5}}'.encode()
+
+        mock_stub = MagicMock()
+        mock_stub.Call.return_value = mock_response
+
+        with _patch_grpc_vfs(mock_stub):
+            data, next_offset = backend.read_at(0)
+
+        assert data == b"hello"
+        assert next_offset == 5
+
+    def test_read_batch_collects_multiple_reads(self) -> None:
+        """read_batch should collect multiple read_at results."""
+        backend, _ = self._make_backend()
+
+        call_count = 0
+
+        def mock_rpc_read(self_arg, byte_offset: int) -> tuple[bytes, int]:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return b"msg", byte_offset + 3
+            raise Exception("no more data")
+
+        # Patch _rpc_read via the class (slots prevent instance patching)
+        with patch.object(type(backend), "_rpc_read", mock_rpc_read):
+            items, next_offset = backend.read_batch(0, count=5)
+
+        assert len(items) == 2
+        assert items == [b"msg", b"msg"]
+        assert next_offset == 6

--- a/tests/unit/grpc/test_channel_pool.py
+++ b/tests/unit/grpc/test_channel_pool.py
@@ -1,0 +1,92 @@
+"""Unit tests for PeerChannelPool."""
+
+from unittest.mock import MagicMock, patch
+
+from nexus.grpc.channel_pool import PeerChannelPool
+
+
+class TestPeerChannelPool:
+    def test_get_creates_channel(self) -> None:
+        """First get() creates a channel via build_peer_channel."""
+        with patch("nexus.grpc.channel_pool.build_peer_channel") as mock_build:
+            mock_ch = MagicMock()
+            mock_build.return_value = mock_ch
+
+            pool = PeerChannelPool()
+            ch = pool.get("10.0.0.1:50051")
+
+            assert ch is mock_ch
+            mock_build.assert_called_once_with("10.0.0.1:50051", None)
+
+    def test_get_reuses_channel(self) -> None:
+        """Second get() for same address returns cached channel."""
+        with patch("nexus.grpc.channel_pool.build_peer_channel") as mock_build:
+            mock_ch = MagicMock()
+            mock_build.return_value = mock_ch
+
+            pool = PeerChannelPool()
+            ch1 = pool.get("10.0.0.1:50051")
+            ch2 = pool.get("10.0.0.1:50051")
+
+            assert ch1 is ch2
+            assert mock_build.call_count == 1
+
+    def test_different_addresses_different_channels(self) -> None:
+        """Different addresses get different channels."""
+        with patch("nexus.grpc.channel_pool.build_peer_channel") as mock_build:
+            ch_a = MagicMock()
+            ch_b = MagicMock()
+            mock_build.side_effect = [ch_a, ch_b]
+
+            pool = PeerChannelPool()
+            result_a = pool.get("10.0.0.1:50051")
+            result_b = pool.get("10.0.0.2:50051")
+
+            assert result_a is ch_a
+            assert result_b is ch_b
+            assert mock_build.call_count == 2
+
+    def test_close_all(self) -> None:
+        """close_all() closes all channels and clears the pool."""
+        with patch("nexus.grpc.channel_pool.build_peer_channel") as mock_build:
+            ch_a = MagicMock()
+            ch_b = MagicMock()
+            mock_build.side_effect = [ch_a, ch_b]
+
+            pool = PeerChannelPool()
+            pool.get("10.0.0.1:50051")
+            pool.get("10.0.0.2:50051")
+
+            pool.close_all()
+
+            ch_a.close.assert_called_once()
+            ch_b.close.assert_called_once()
+            # Pool is cleared — next get() creates new channel
+            ch_c = MagicMock()
+            mock_build.side_effect = [ch_c]
+            assert pool.get("10.0.0.1:50051") is ch_c
+
+    def test_set_tls_config(self) -> None:
+        """set_tls_config() stores config for future channels."""
+        pool = PeerChannelPool()
+        mock_tls = MagicMock()
+        pool.set_tls_config(mock_tls)
+
+        with patch("nexus.grpc.channel_pool.build_peer_channel") as mock_build:
+            mock_ch = MagicMock()
+            mock_build.return_value = mock_ch
+
+            pool.get("10.0.0.1:50051")
+            mock_build.assert_called_once_with("10.0.0.1:50051", mock_tls)
+
+    def test_tls_config_at_init(self) -> None:
+        """TLS config can be passed at init time."""
+        mock_tls = MagicMock()
+        pool = PeerChannelPool(tls_config=mock_tls)
+
+        with patch("nexus.grpc.channel_pool.build_peer_channel") as mock_build:
+            mock_ch = MagicMock()
+            mock_build.return_value = mock_ch
+
+            pool.get("10.0.0.1:50051")
+            mock_build.assert_called_once_with("10.0.0.1:50051", mock_tls)


### PR DESCRIPTION
## Summary
- Move remote DT_PIPE/DT_STREAM routing from per-operation KernelDispatch resolver chain to per-open fast-path via `RemotePipeBackend`/`RemoteStreamBackend` installed in `_buffers` at open time
- Add `PeerChannelPool` — shared persistent gRPC channels (one per peer, thread-safe, deferred TLS)
- `FederationIPCResolver` becomes a one-shot lazy installer: first access installs the remote backend, subsequent calls hit fast-path directly

### Before
```
sys_write → _buffers MISS → KernelDispatch → FederationIPCResolver → new channel → gRPC → close channel
```

### After
```
PipeManager.open() installs RemotePipeBackend in _buffers
sys_write → _buffers HIT → RemotePipeBackend.write_nowait() → persistent channel → gRPC
```

## Files Changed

| File | Change |
|------|--------|
| `src/nexus/grpc/channel_pool.py` | **NEW** — PeerChannelPool (persistent gRPC channel pool) |
| `src/nexus/core/remote_pipe.py` | **NEW** — RemotePipeBackend (PipeBackend protocol, gRPC proxy) |
| `src/nexus/core/remote_stream.py` | **NEW** — RemoteStreamBackend (StreamBackend protocol, offset reads) |
| `src/nexus/core/pipe_manager.py` | open() detects remote pipes → installs RemotePipeBackend |
| `src/nexus/core/stream_manager.py` | open() detects remote streams → installs RemoteStreamBackend |
| `src/nexus/core/nexus_fs.py` | Creates PeerChannelPool, wires to managers, closes on shutdown |
| `src/nexus/raft/federation_ipc_resolver.py` | Becomes lazy installer with pipe/stream manager refs |
| `src/nexus/__init__.py` | Wires managers to resolver, sets TLS config after federation boot |

## Test plan
- [x] `tests/unit/grpc/test_channel_pool.py` — channel reuse, different addresses, close_all, TLS config (6 tests)
- [x] `tests/unit/core/test_remote_pipe.py` — protocol compliance, RPC proxy, close/stats (8 tests)
- [x] `tests/unit/core/test_remote_stream.py` — protocol compliance, RPC proxy, batch reads (8 tests)
- [x] `tests/unit/core/test_pipe.py` — remote detection: remote→RemotePipeBackend, local→RingBuffer, plain→RingBuffer, no-pool→RingBuffer (4 new tests)
- [x] All 110 tests pass, ruff clean, mypy clean, all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)