### PR TITLE
refactor(factory): linearize boot + federation gating (Phase 1+2)

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -474,7 +474,7 @@ See `ops-scenario-matrix.md` §2–§3 for full enumeration and affinity matchin
 | Modes | Counting (N holders), mutex (max_holders=1) |
 | Latency | ~200ns (Rust PyO3) / ~500ns-1us (Python fallback) |
 | Scope | In-memory, process-scoped, TTL-based lazy expiry |
-| Consumers | Advisory lock layer (`SemaphoreAdvisoryLockManager`), CAS metadata RMW |
+| Consumers | Advisory lock layer (`LocalLockManager`), CAS metadata RMW |
 
 Advisory lock layer uses two semaphores per path for RW gate pattern
 (shared/exclusive). See `lock-architecture.md` §3.

--- a/docs/architecture/lock-architecture.md
+++ b/docs/architecture/lock-architecture.md
@@ -13,7 +13,7 @@
 | **VFSLockManager** | `core/lock_fast.py` | ~200ns Rust / ~500ns Python | Local, path-level RW, hierarchical |
 | **VFSSemaphore** | `lib/semaphore.py` | ~200ns Rust / Python | Local, holder-tracked counting semaphore |
 | **AdvisoryLockManager** | `lib/distributed_lock.py` | — | ABC: async advisory lock API (zone_id bound at construction) |
-| **SemaphoreAdvisoryLockManager** | `lib/distributed_lock.py` | ~500ns–1μs | Standalone advisory locks via VFSSemaphore |
+| **LocalLockManager** | `lib/distributed_lock.py` | ~500ns–1μs | Standalone advisory locks via VFSSemaphore |
 | **RaftLockManager** | `raft/lock_manager.py` | ~5-10ms | Distributed advisory locks, zone-scoped |
 | **LockStoreProtocol** | `lib/distributed_lock.py` | — | Low-level store interface (MetastoreABC lock methods) |
 | ~12 `asyncio.Semaphore` | scattered | — | Ad-hoc concurrency bounding |
@@ -31,7 +31,7 @@
 | VFSLockManager | `i_rwsem` (inode RW semaphore) |
 | VFSSemaphore | `sem_t` (named counting semaphore + TTL) |
 | AdvisoryLockManager | `flock(2)` advisory lock ABC |
-| SemaphoreAdvisoryLockManager | Local `flock` via VFSSemaphore |
+| LocalLockManager | Local `flock` via VFSSemaphore |
 | RaftLockManager | Distributed `flock` via Raft |
 
 ---
@@ -124,25 +124,25 @@ TTL expires → auto-released. No orphans.
 ### 3.3 DI Model
 
 ```python
-# factory/_bricks.py (actual pattern)
+# EventsService.__init__ always creates LocalLockManager
+from nexus.lib.distributed_lock import LocalLockManager
 from nexus.lib.semaphore import create_vfs_semaphore
-from nexus.lib.distributed_lock import SemaphoreAdvisoryLockManager
 
-# Always available — no capability check needed
-lock_manager = SemaphoreAdvisoryLockManager(create_vfs_semaphore(), zone_id=zone_id)
+self._lock_manager = LocalLockManager(create_vfs_semaphore(), zone_id=zone_id)
 
-# Federation: RaftLockManager (if dist.enable_locks)
-if dist and dist.enable_locks:
-    lock_manager = RaftLockManager(metadata_store, zone_id=zone_id)
+# Federation: RaftLockManager upgrade at link time
+if isinstance(nx.metadata, LockStoreProtocol):
+    raft_lm = RaftLockManager(nx.metadata, zone_id=zone_id)
+    events_service.upgrade_lock_manager(raft_lm)
 ```
 
-Note: capability detection via `LockStoreProtocol` is no longer needed —
-`SemaphoreAdvisoryLockManager` uses `VFSSemaphore` (always available), not MetastoreABC.
+Two paths only: EventsService always starts with `LocalLockManager`.
+Federation upgrades to `RaftLockManager` at link time via `upgrade_lock_manager()`.
 
 | Profile | Metastore | lock_manager → |
 |---------|-----------|----------------|
-| minimal / embedded | redb | SemaphoreAdvisoryLockManager |
-| lite / full | redb | SemaphoreAdvisoryLockManager |
+| minimal / embedded | redb | LocalLockManager |
+| lite / full | redb | LocalLockManager |
 | cloud / federation | redb + Raft | RaftLockManager |
 | remote | RemoteMetastore | None (server-side) |
 
@@ -156,7 +156,7 @@ Callers see only `AdvisoryLockManager`. Same async API regardless of backend.
 |-----------|----------|---------|------------|-----|-------|
 | VFSLockManager | `core/lock_fast.py` | ~200ns | Kernel-internal | No | Local |
 | VFSSemaphore | `lib/semaphore.py` | ~200ns | Kernel-authored stdlib | Yes | Local |
-| SemaphoreAdvisoryLockManager | `lib/distributed_lock.py` | ~500ns–1μs | Internal | Yes | Local (standalone) |
+| LocalLockManager | `lib/distributed_lock.py` | ~500ns–1μs | Internal | Yes | Local (standalone) |
 | RaftLockManager | `raft/lock_manager.py` | ~5-10ms | Internal | Yes | Distributed (zone) |
 
 ---
@@ -171,12 +171,13 @@ Like Linux `i_rwsem` vs `flock(2)`.
 queryable, Raft-replicated in federation. Like HDFS leases in NameNode FSImage+EditLog.
 `LockStoreProtocol` is a capability protocol — MetastoreABC does NOT own lock methods.
 
-**D3: Factory DI, not runtime routing** — `SemaphoreAdvisoryLockManager` or `RaftLockManager`
-injected at boot. No `_LockRouter`, no runtime auto-detect. Simpler, testable.
+**D3: Two paths, not runtime routing** — EventsService always starts with
+`LocalLockManager`. Federation upgrades to `RaftLockManager` at link time.
+No `_LockRouter`, no runtime auto-detect. Simpler, testable.
 
 **D4: PassthroughBackend.lock() deleted** — duplicated kernel lock logic.
 `_StripeLock` also deleted — CAS metadata RMW now uses `VFSSemaphore` directly.
-EventsService now uses `AdvisoryLockManager` exclusively (SemaphoreAdvisoryLockManager or RaftLockManager).
+EventsService owns lock manager lifecycle (`LocalLockManager` → `RaftLockManager` upgrade).
 
 **D5: asyncio.Semaphore stays as-is** — internal concurrency limiters (not advisory
 locks). No names, TTL, or cross-node semantics needed.

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -559,8 +559,8 @@ async def _register_federation_resolver(nx_fs: "NexusFS", federation: Any, backe
     _coordinator = nx_fs.service_coordinator
 
     # Set TLS config on channel pool now that federation is initialized
-    if hasattr(nx_fs, "_channel_pool") and nx_fs._channel_pool is not None and zone_mgr.tls_config:
-        nx_fs._channel_pool.set_tls_config(zone_mgr.tls_config)
+    if hasattr(nx_fs, "_channel_pool") and nx_fs._channel_pool is not None and _zone_mgr.tls_config:
+        nx_fs._channel_pool.set_tls_config(_zone_mgr.tls_config)
 
     # IPC resolver — remote DT_PIPE/DT_STREAM (#1625)
     ipc_resolver = FederationIPCResolver(

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -145,6 +145,27 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module 'nexus' has no attribute {name!r}")
 
 
+def _open_local_metastore(metadata_path: str) -> "MetastoreABC":
+    """Open a local metadata store — RaftMetadataStore.embedded → DictMetastore fallback."""
+    from pathlib import Path
+
+    try:
+        from nexus.storage.raft_metadata_store import RaftMetadataStore
+
+        return RaftMetadataStore.embedded(metadata_path)
+    except (RuntimeError, ImportError):
+        from nexus.storage.dict_metastore import DictMetastore
+
+        dict_metastore_path = Path(metadata_path).with_suffix(".json")
+        logger.info(
+            "Rust metastore not available; using JSON-backed DictMetastore fallback at %s. "
+            "Build rust/nexus_raft with maturin develop -m rust/nexus_raft/Cargo.toml "
+            "--features python for the durable metastore.",
+            dict_metastore_path,
+        )
+        return DictMetastore(dict_metastore_path)
+
+
 async def connect(
     config: "str | Path | dict | NexusConfig | None" = None,
 ) -> "NexusFilesystem":
@@ -349,153 +370,61 @@ async def connect(
     metadata_path = cfg.metastore_path or cfg.db_path or str(Path(nexus_root) / "metastore")
     record_store_path = cfg.record_store_path or None
 
-    # Create metadata store — auto-detect federation capability
-    metadata_store: MetastoreABC
-    zone_mgr = None
+    # --- Profile resolution (Issue #1708, moved before metadata store for federation gating) ---
+    from nexus.contracts.deployment_profile import DeploymentProfile, resolve_enabled_bricks
 
-    try:
-        import socket
+    if cfg.profile == "auto":
+        from nexus.lib.device_capabilities import detect_capabilities, suggest_profile
 
-        from nexus.contracts.constants import DEFAULT_GRPC_BIND_ADDR
-        from nexus.raft import FederatedMetadataProxy
-        from nexus.raft.peer_address import PeerAddress, hostname_to_node_id
-        from nexus.raft.zone_manager import ZoneManager
-
-        hostname = os.environ.get("NEXUS_HOSTNAME", socket.gethostname())
-        my_id = hostname_to_node_id(hostname)
-        bind_addr = os.environ.get("NEXUS_BIND_ADDR", DEFAULT_GRPC_BIND_ADDR)
-        advertise_addr = os.environ.get("NEXUS_ADVERTISE_ADDR")
-        zones_dir = os.environ.get("NEXUS_DATA_DIR", str(Path(metadata_path).parent / "zones"))
-
-        # Parse peer addresses (host:port format — PeerAddress derives node IDs)
-        peers_str = os.environ.get("NEXUS_PEERS", "")
-        peer_addrs = PeerAddress.parse_peer_list(peers_str) if peers_str else []
-        peers = [p.grpc_target for p in peer_addrs]
-
-        # Retry loop for Raft bootstrap — CockroachDB pattern:
-        # nodes start independently, retry until cluster forms.
-        import time as _time
-
-        _max_attempts = int(os.environ.get("NEXUS_STARTUP_MAX_RETRIES", "12"))
-        _base_delay = 2.0
-
-        for _attempt in range(1, _max_attempts + 1):
-            try:
-                # TLS pre-provision (depends on leader being up)
-                tls_dir_pre = Path(zones_dir) / "tls"
-                token_file = tls_dir_pre / "join-token"
-                if token_file.exists() and not (tls_dir_pre / "node.pem").exists():
-                    join_token = token_file.read_text().strip()
-                    join_peer = next(
-                        (p.grpc_target for p in peer_addrs if p.node_id != my_id),
-                        None,
-                    )
-                    if join_peer:
-                        from _nexus_raft import join_cluster as _join_cluster
-
-                        logger.info(
-                            "Join token found — provisioning TLS from %s (attempt %d)",
-                            join_peer,
-                            _attempt,
-                        )
-                        _join_cluster(join_peer, join_token, hostname, str(tls_dir_pre))
-                        logger.info("TLS provisioning complete")
-                    else:
-                        raise RuntimeError("Join token found but no peer in NEXUS_PEERS to join")
-
-                zone_mgr = ZoneManager(
-                    hostname=hostname,
-                    base_path=zones_dir,
-                    bind_addr=bind_addr,
-                    advertise_addr=advertise_addr,
-                )
-
-                # Detect joiner vs first-node
-                tls_dir = Path(zones_dir) / "tls"
-                is_joiner = (
-                    (tls_dir / "ca.pem").exists()
-                    and (tls_dir / "node.pem").exists()
-                    and (tls_dir / "node-key.pem").exists()
-                    and not (tls_dir / "join-token").exists()
-                )
-
-                if is_joiner:
-                    zone_mgr.join_zone("root", peers=peers if peers else None)
-                    logger.info("Joiner node: joined root zone (certs provisioned)")
-                else:
-                    zone_mgr.bootstrap(peers=peers if peers else None)
-
-                # Static Day-1 topology from env vars (idempotent)
-                zones_str = os.environ.get("NEXUS_FEDERATION_ZONES", "")
-                mounts_str = os.environ.get("NEXUS_FEDERATION_MOUNTS", "")
-                if zones_str:
-                    zones = [z.strip() for z in zones_str.split(",") if z.strip()]
-                    mounts: dict[str, str] = {}
-                    if mounts_str:
-                        for pair in mounts_str.split(","):
-                            path, zone_id = pair.strip().split("=", 1)
-                            mounts[path.strip()] = zone_id.strip()
-                    zone_mgr.bootstrap_static(zones=zones, peers=peers, mounts=mounts)
-
-                break  # Success
-
-            except (RuntimeError, OSError, ConnectionError) as exc:
-                if _attempt >= _max_attempts:
-                    logger.error("Raft startup failed after %d attempts: %s", _max_attempts, exc)
-                    raise
-                delay = min(_base_delay * (2 ** (_attempt - 1)), 30.0)
-                logger.warning(
-                    "Raft startup attempt %d/%d failed: %s — retrying in %.1fs",
-                    _attempt,
-                    _max_attempts,
-                    exc,
-                    delay,
-                )
-                _time.sleep(delay)
-
-        metadata_store = FederatedMetadataProxy.from_zone_manager(zone_mgr)
-    except ImportError:
-        zone_mgr = None
-        # Raft extensions not available — single-node embedded Raft, with fallback
-        try:
-            from nexus.storage.raft_metadata_store import RaftMetadataStore
-
-            metadata_store = RaftMetadataStore.embedded(metadata_path)
-        except (RuntimeError, ImportError):
-            from nexus.storage.dict_metastore import DictMetastore
-
-            dict_metastore_path = Path(metadata_path).with_suffix(".json")
-            logger.info(
-                "Rust metastore not available; using JSON-backed DictMetastore fallback at %s. "
-                "Build rust/nexus_raft with maturin develop -m rust/nexus_raft/Cargo.toml "
-                "--features python for the durable metastore.",
-                dict_metastore_path,
-            )
-            metadata_store = DictMetastore(dict_metastore_path)
-    except RuntimeError as exc:
-        if "ZoneManager requires PyO3 build with --features full" not in str(exc):
-            raise
-
-        zone_mgr = None
+        caps = detect_capabilities()
+        resolved_profile = suggest_profile(caps)
         logger.info(
-            "Federation extensions unavailable for local connect(); "
-            "falling back to single-node metadata store"
+            "Auto-detected profile: %s (RAM=%dMB, GPU=%s, cores=%d)",
+            resolved_profile,
+            caps.memory_mb,
+            caps.has_gpu,
+            caps.cpu_cores,
         )
+    else:
+        resolved_profile = DeploymentProfile(cfg.profile)
+        # Warn if explicit profile may exceed device capabilities
+        from nexus.lib.device_capabilities import (
+            detect_capabilities,
+            warn_if_profile_exceeds_device,
+        )
+
+        caps = detect_capabilities()
+        warn_if_profile_exceeds_device(resolved_profile, caps)
+
+    # Apply FeaturesConfig overrides (Issue #1389)
+    overrides = cfg.features.to_overrides() if cfg.features else {}
+    enabled_bricks = resolve_enabled_bricks(resolved_profile, overrides=overrides)
+
+    # Create metadata store — profile-gated federation (PR #3371 Phase 2)
+    metadata_store: MetastoreABC
+    federation = None
+
+    # Federation gating: only attempt if "federation" brick is enabled
+    if "federation" in enabled_bricks:
         try:
-            from nexus.storage.raft_metadata_store import RaftMetadataStore
+            from nexus.raft.federation import NexusFederation
 
-            metadata_store = RaftMetadataStore.embedded(metadata_path)
-        except (RuntimeError, ImportError):
-            from nexus.storage.dict_metastore import DictMetastore
-
-            dict_metastore_path = Path(metadata_path).with_suffix(".json")
+            federation, metadata_store = NexusFederation.bootstrap(metadata_path=metadata_path)
+        except ImportError:
+            logger.warning("Federation brick enabled but Rust extensions unavailable")
+            federation = None
+            metadata_store = _open_local_metastore(metadata_path)
+        except RuntimeError as exc:
+            if "ZoneManager requires PyO3 build with --features full" not in str(exc):
+                raise
             logger.info(
-                "Rust metastore not available; using JSON-backed DictMetastore fallback at %s. "
-                "Build rust/nexus_raft with maturin develop -m rust/nexus_raft/Cargo.toml "
-                "--features python for the durable metastore.",
-                dict_metastore_path,
+                "Federation extensions unavailable for local connect(); "
+                "falling back to single-node metadata store"
             )
-            metadata_store = DictMetastore(dict_metastore_path)
+            federation = None
+            metadata_store = _open_local_metastore(metadata_path)
+    else:
+        metadata_store = _open_local_metastore(metadata_path)
 
     # Permission defaults: standalone without explicit config → permissive
     enforce_permissions = cfg.enforce_permissions
@@ -559,36 +488,6 @@ async def connect(
         providers=tuple(cfg.parse_providers) if cfg.parse_providers else None,
     )
 
-    # --- Profile resolution (Issue #1708) ---
-    from nexus.contracts.deployment_profile import DeploymentProfile, resolve_enabled_bricks
-
-    if cfg.profile == "auto":
-        from nexus.lib.device_capabilities import detect_capabilities, suggest_profile
-
-        caps = detect_capabilities()
-        resolved_profile = suggest_profile(caps)
-        logger.info(
-            "Auto-detected profile: %s (RAM=%dMB, GPU=%s, cores=%d)",
-            resolved_profile,
-            caps.memory_mb,
-            caps.has_gpu,
-            caps.cpu_cores,
-        )
-    else:
-        resolved_profile = DeploymentProfile(cfg.profile)
-        # Warn if explicit profile may exceed device capabilities
-        from nexus.lib.device_capabilities import (
-            detect_capabilities,
-            warn_if_profile_exceeds_device,
-        )
-
-        caps = detect_capabilities()
-        warn_if_profile_exceeds_device(resolved_profile, caps)
-
-    # Apply FeaturesConfig overrides (Issue #1389 — was unused in connect())
-    overrides = cfg.features.to_overrides() if cfg.features else {}
-    enabled_bricks = resolve_enabled_bricks(resolved_profile, overrides=overrides)
-
     # Audit strict mode: env var override (default True for compliance)
     from nexus.contracts.types import AuditConfig
 
@@ -613,6 +512,7 @@ async def connect(
         parsing=parse_cfg,
         enabled_bricks=enabled_bricks,
         audit=audit_cfg,
+        federation=federation,
     )
 
     # Set memory config for Memory API
@@ -626,23 +526,11 @@ async def connect(
     # Store config for OAuth factory and other components that need it
     nx_fs._config = cfg
 
-    # Store zone manager for federation topology initialization (health check)
-    if zone_mgr is not None:
-        nx_fs._zone_mgr = zone_mgr
-
-        # Enlist federation as Q3 PersistentService
-        try:
-            from nexus.raft.federation import NexusFederation
-
-            _fed = NexusFederation(zone_manager=zone_mgr)
-            await nx_fs._service_registry.enlist("federation", _fed)
-            logger.info("Federation service enlisted")
-        except Exception as exc:
-            logger.warning("Federation service unavailable: %s", exc)
-
-        # Register federation content resolver (PRE-DISPATCH, Issue #163)
-        # Registered LAST so Pipe/Memory/VirtualView resolvers get priority.
-        await _register_federation_resolver(nx_fs, zone_mgr, backend)
+    # Register federation content resolver (PRE-DISPATCH, Issue #163)
+    # Registered LAST so Pipe/Memory/VirtualView resolvers get priority.
+    # Federation is already enlisted in ServiceRegistry by _wire_services().
+    if federation is not None:
+        await _register_federation_resolver(nx_fs, federation, backend)
 
     # Restore saved mounts (application-layer startup I/O)
     await _restore_mounts(nx_fs)
@@ -650,7 +538,7 @@ async def connect(
     return nx_fs
 
 
-async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any, backend: Any) -> None:
+async def _register_federation_resolver(nx_fs: "NexusFS", federation: Any, backend: Any) -> None:
     """Register federation resolvers via coordinator.enlist() (#163, #1625, #1710).
 
     Registration order matters — IPC resolver is registered FIRST so remote
@@ -667,6 +555,7 @@ async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any, backend
     from nexus.raft.federation_content_resolver import FederationContentResolver
     from nexus.raft.federation_ipc_resolver import FederationIPCResolver
 
+    _zone_mgr = federation.zone_manager
     _coordinator = nx_fs.service_coordinator
 
     # Set TLS config on channel pool now that federation is initialized
@@ -676,8 +565,8 @@ async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any, backend
     # IPC resolver — remote DT_PIPE/DT_STREAM (#1625)
     ipc_resolver = FederationIPCResolver(
         metastore=nx_fs.metadata,
-        self_address=zone_mgr.advertise_addr,
-        tls_config=zone_mgr.tls_config,
+        self_address=_zone_mgr.advertise_addr,
+        tls_config=_zone_mgr.tls_config,
         pipe_manager=nx_fs._pipe_manager,
         stream_manager=nx_fs._stream_manager,
     )
@@ -692,7 +581,7 @@ async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any, backend
         from nexus.remote.peer_blob_client import PeerBlobClient
 
         _peer_auth = _os_peer.environ.get("NEXUS_API_KEY", "")
-        peer_blob_client = PeerBlobClient(tls_config=zone_mgr.tls_config, auth_token=_peer_auth)
+        peer_blob_client = PeerBlobClient(tls_config=_zone_mgr.tls_config, auth_token=_peer_auth)
         remote_content_fetcher = CASRemoteContentFetcher(
             peer_blob_client=peer_blob_client,
             local_object_store=backend,
@@ -702,7 +591,7 @@ async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any, backend
     # Content resolver — remote CAS content (#163)
     # self_address uses VFS gRPC port (default 2028), not Raft port (2126).
     # Content fetcher connects via NexusVFSService (VFS gRPC), not Raft gRPC.
-    _raft_addr = zone_mgr.advertise_addr  # e.g. "nexus-1:2126"
+    _raft_addr = _zone_mgr.advertise_addr  # e.g. "nexus-1:2126"
     _hostname = _raft_addr.rsplit(":", 1)[0] if ":" in _raft_addr else _raft_addr
     import os as _os_mod
 
@@ -712,7 +601,7 @@ async def _register_federation_resolver(nx_fs: "NexusFS", zone_mgr: Any, backend
     content_resolver = FederationContentResolver(
         metastore=nx_fs.metadata,
         self_address=_content_addr,
-        tls_config=zone_mgr.tls_config,
+        tls_config=_zone_mgr.tls_config,
         remote_content_fetcher=remote_content_fetcher,
         local_object_store=backend,
         auth_token=_content_auth,

--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -73,7 +73,7 @@ BRICK_PARSERS = "parsers"
 BRICK_SNAPSHOT = "snapshot"
 BRICK_TASK_MANAGER = "task_manager"
 
-# (Federation is auto-detected from ZoneManager, not a brick)
+BRICK_FEDERATION = "federation"
 
 # All brick names for validation
 ALL_BRICK_NAMES: frozenset[str] = frozenset(
@@ -110,6 +110,7 @@ ALL_BRICK_NAMES: frozenset[str] = frozenset(
         BRICK_TASK_MANAGER,
         BRICK_AGENT_RUNTIME,
         BRICK_ACP,
+        BRICK_FEDERATION,
     }
 )
 
@@ -221,7 +222,7 @@ _FULL_BRICKS: frozenset[str] = _LITE_BRICKS | frozenset(
     }
 )
 
-_CLOUD_BRICKS: frozenset[str] = _FULL_BRICKS  # Federation is auto-detected from ZoneManager
+_CLOUD_BRICKS: frozenset[str] = _FULL_BRICKS | frozenset({BRICK_FEDERATION})
 
 _INNOVATION_BRICKS: frozenset[str] = (
     _CLOUD_BRICKS  # same as cloud; future experimental bricks added here

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -75,7 +75,6 @@ class DistributedConfig:
 
     coordination_url: str | None = None
     enable_events: bool = True
-    enable_locks: bool = True
     enable_workflows: bool = True
     event_bus_backend: str = "redis"
     nats_url: str = DEFAULT_NATS_URL

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -152,9 +152,9 @@ class NexusFS(  # type: ignore[misc]
         self._descendant_checker: Any = None
         # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
         self._overlay_resolver = None
-        # Issue #1788: distributed lock manager — kernel knows, factory provides.
-        # In-process locks use _vfs_lock_manager (kernel owns); distributed locks use this.
-        self._distributed_lock_manager: Any = None
+        # Issue #1788: distributed lock manager removed — now routed through EventsService.
+        # In-process locks use _vfs_lock_manager (kernel owns); advisory locks use
+        # nx.service("events_service").lock() which auto-creates local fallback.
         # Issue #1792: agent registry — kernel knows, factory provides.
         # Kernel does NOT own AgentRegistry (no-agent profiles like REMOTE work without it).
         # Factory creates and injects at link-time; None = graceful degrade.
@@ -998,18 +998,18 @@ class NexusFS(  # type: ignore[misc]
         timeout: float,
         context: OperationContext | None,
     ) -> str | None:
-        """Acquire distributed lock synchronously (for use in sync write()).
+        """Acquire advisory lock synchronously via EventsService.
 
         This method bridges sync write() with async lock operations.
-        For async contexts, use `async with locked()` instead.
+        For async contexts, use `async with events_service.locked()` instead.
         """
         import asyncio
 
-        _lm = self._distributed_lock_manager
-        if _lm is None:
+        _events_ref = self.service("events_service") if hasattr(self, "service") else None
+        if _events_ref is None:
             raise RuntimeError(
-                "write(lock=True) called but distributed lock manager not configured. "
-                "Ensure NexusFS is initialized with enable_distributed_locks=True."
+                "write(lock=True) called but EventsService not available. "
+                "Ensure NexusFS is initialized with services."
             )
 
         from nexus.contracts.exceptions import LockTimeout
@@ -1018,17 +1018,14 @@ class NexusFS(  # type: ignore[misc]
             asyncio.get_running_loop()
             raise RuntimeError(
                 "write(lock=True) cannot be used from async context (event loop detected). "
-                "Use `async with nx.events_service.locked(path):` and `write(lock=False)` instead."
+                "Use `async with nx.service('events_service').locked(path):` and `write(lock=False)` instead."
             )
         except RuntimeError as e:
             if "event loop detected" in str(e):
                 raise
 
         async def acquire_lock() -> str | None:
-            return await _lm.acquire(
-                path=path,
-                timeout=timeout,
-            )
+            return await _events_ref.lock(path=path, timeout=timeout)
 
         from nexus.lib.sync_bridge import run_sync
 
@@ -1045,16 +1042,16 @@ class NexusFS(  # type: ignore[misc]
         path: str,
         context: OperationContext | None,
     ) -> None:
-        """Release distributed lock synchronously."""
+        """Release advisory lock synchronously via EventsService."""
         if not lock_id:
             return
 
-        _lm = self._distributed_lock_manager
-        if _lm is None:
+        _events_ref = self.service("events_service") if hasattr(self, "service") else None
+        if _events_ref is None:
             return
 
         async def release_lock() -> None:
-            await _lm.release(lock_id, path)
+            await _events_ref.unlock(lock_id, path)
 
         from nexus.lib.sync_bridge import run_sync
 
@@ -2549,21 +2546,17 @@ class NexusFS(  # type: ignore[misc]
             ...     lambda c: json.dumps({**json.loads(c), "version": 2}).encode()
             ... )
         """
-        _lm = self._distributed_lock_manager
-        if _lm is None:
+        _events_ref = self.service("events_service") if hasattr(self, "service") else None
+        if _events_ref is None:
             raise RuntimeError(
-                "atomic_update() requires distributed lock manager. "
-                "Set NEXUS_REDIS_URL environment variable "
-                "or pass coordination_url to NexusFS constructor."
+                "atomic_update() requires EventsService. "
+                "Ensure NexusFS is initialized with services."
             )
 
-        lock_id = await _lm.acquire(path, timeout=timeout, ttl=ttl)
-        try:
+        async with _events_ref.locked(path, timeout=timeout, ttl=ttl) as lock_id:  # noqa: F841
             content = await self.sys_read(path, context=context)
             new_content = update_fn(content)
             return await self.write(path, new_content, context=context)
-        finally:
-            await _lm.release(lock_id, path)
 
     @rpc_expose(description="Append content to an existing file or create if it doesn't exist")
     async def append(

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -243,8 +243,9 @@ class NexusFS(  # type: ignore[misc]
             Callable[[], None]
         ] = []  # Issue #1793: factory-registered service close
         self._runtime_closeables: list[Any] = []
-        # Factory-injected lifecycle implementations.
-        # Keeps nexus.core free of nexus.factory / nexus.bricks imports.
+        # Factory-injected lifecycle implementations (legacy — no longer used).
+        # Linearized in PR #3371 Phase 2: create_nexus_fs() calls
+        # _wire_services() / _initialize_services() directly.
         self._link_fn: Callable[..., Any] | None = None
         self._initialize_fn: Callable[..., Any] | None = None
 

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -167,6 +167,9 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         self._refcounts: dict[str, int] = {}
         self._drain_events: dict[str, asyncio.Event] = {}
 
+        # Lazy-construct factories: name → callable that produces the instance
+        self._factories: dict[str, tuple[Any, dict[str, Any]]] = {}
+
         # Lifecycle orchestration state (formerly SLC)
         self._dispatch: KernelDispatch | None = dispatch
         self._hook_specs: dict[str, HookSpec] = {}
@@ -217,6 +220,26 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
             metadata=MappingProxyType(metadata or {}),
         )
         self.register(name, info, allow_overwrite=allow_overwrite)
+
+    def register_factory(
+        self,
+        name: str,
+        factory_fn: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Register a lazy-construct factory for *name*.
+
+        The factory function is called on first ``service(name)`` lookup.
+        The result is auto-registered via ``register_service()`` and the
+        factory is removed.
+
+        Args:
+            name: Service name.
+            factory_fn: Zero-arg callable that returns the service instance.
+            **kwargs: Forwarded to ``register_service()`` (exports, etc.).
+        """
+        self._factories[name] = (factory_fn, kwargs)
+        logger.debug("[REGISTRY] factory registered for %r (lazy)", name)
 
     def replace_service(
         self,
@@ -276,10 +299,22 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         is transparent — all attribute/method access delegates to the
         underlying instance — but adds per-call ref-counting so that
         ``swap_service()`` can drain in-flight operations before unmount.
+
+        On miss, checks ``_factories`` for a lazy-construct entry.
+        If found, calls the factory, auto-registers, and returns.
         """
         info = self.get(name)
         if info is None:
-            return None
+            # Lazy-construct: check factory registry
+            factory_entry = self._factories.pop(name, None)
+            if factory_entry is not None:
+                factory_fn, kwargs = factory_entry
+                instance = factory_fn()
+                self.register_service(name, instance, **kwargs)
+                logger.info("[REGISTRY] lazy-constructed %r on first access", name)
+                info = self.get(name)
+            if info is None:
+                return None
         return ServiceRef(info.instance, name, self._refcounts, self._drain_events)
 
     def service_or_raise(self, name: str) -> Any:

--- a/src/nexus/factory/__init__.py
+++ b/src/nexus/factory/__init__.py
@@ -57,11 +57,15 @@ from nexus.factory._helpers import (
 from nexus.factory._kernel import _boot_kernel_services
 from nexus.factory._metadata_export import create_metadata_export_service
 from nexus.factory._record_store import create_record_store
-from nexus.factory._system import _boot_system_services
+from nexus.factory._system import _boot_services
 from nexus.factory._wired import _boot_wired_services
 from nexus.factory.adapters import _NexusFSFileReader
 from nexus.factory.orchestrator import create_nexus_fs, create_nexus_services
 from nexus.factory.wallet import WalletProvisioner
+
+# Backward compatibility aliases (must follow imports)
+_boot_system_services = _boot_services
+_boot_core_services = _boot_services
 
 __all__ = [
     "create_nexus_fs",

--- a/src/nexus/factory/__init__.py
+++ b/src/nexus/factory/__init__.py
@@ -57,15 +57,17 @@ from nexus.factory._helpers import (
 from nexus.factory._kernel import _boot_kernel_services
 from nexus.factory._metadata_export import create_metadata_export_service
 from nexus.factory._record_store import create_record_store
-from nexus.factory._system import _boot_services
-from nexus.factory._wired import _boot_wired_services
+from nexus.factory._system import _boot_pre_kernel_services
+from nexus.factory._wired import _boot_post_kernel_services
 from nexus.factory.adapters import _NexusFSFileReader
 from nexus.factory.orchestrator import create_nexus_fs, create_nexus_services
 from nexus.factory.wallet import WalletProvisioner
 
 # Backward compatibility aliases (must follow imports)
-_boot_system_services = _boot_services
-_boot_core_services = _boot_services
+_boot_services = _boot_pre_kernel_services
+_boot_system_services = _boot_pre_kernel_services
+_boot_core_services = _boot_pre_kernel_services
+_boot_wired_services = _boot_post_kernel_services
 
 __all__ = [
     "create_nexus_fs",

--- a/src/nexus/factory/_bricks.py
+++ b/src/nexus/factory/_bricks.py
@@ -338,36 +338,7 @@ def _boot_independent_bricks(
     else:
         logger.debug("[BOOT:BRICK] Uploads brick disabled by profile")
 
-    # --- Infrastructure: event bus + lock manager ---
-    event_bus: Any = None
-    lock_manager: Any = None
-    if not _on("ipc"):
-        logger.debug("[BOOT:BRICK] IPC/EventBus brick disabled by profile")
-    else:
-        # Event bus requires explicit dist config
-        if ctx.dist.enable_locks or ctx.dist.enable_events:
-            from nexus.factory._distributed import _create_distributed_infra
-
-            event_bus, lock_manager = _create_distributed_infra(
-                ctx.dist,
-                ctx.metadata_store,
-                ctx.record_store,
-                ctx.dist.coordination_url,
-                zone_id=ctx.zone_id or ROOT_ZONE_ID,
-            )
-
-        # Always create lock manager — SemaphoreAdvisoryLockManager wraps
-        # VFSSemaphore directly (no LockStoreProtocol capability check needed).
-        if lock_manager is None:
-            try:
-                from nexus.lib.distributed_lock import SemaphoreAdvisoryLockManager
-                from nexus.lib.semaphore import create_vfs_semaphore
-
-                _zone = ctx.zone_id or ROOT_ZONE_ID
-                lock_manager = SemaphoreAdvisoryLockManager(create_vfs_semaphore(), zone_id=_zone)
-                logger.info("Advisory lock manager initialized (standalone, zone=%s)", _zone)
-            except Exception as _lm_exc:
-                logger.debug("[BOOT:BRICK] SemaphoreAdvisoryLockManager unavailable: %s", _lm_exc)
+    # --- Infrastructure: event bus + lock manager moved to _boot_services() ---
 
     # --- Workflow engine ---
     workflow_engine: Any = None
@@ -536,8 +507,6 @@ def _boot_independent_bricks(
         "manifest_metrics": manifest_metrics,
         "tool_namespace_middleware": tool_namespace_middleware,
         "chunked_upload_service": chunked_upload_service,
-        "event_bus": event_bus,
-        "lock_manager": lock_manager,
         "workflow_engine": workflow_engine,
         "api_key_creator": api_key_creator,
         "snapshot_service": snapshot_service,

--- a/src/nexus/factory/_distributed.py
+++ b/src/nexus/factory/_distributed.py
@@ -38,19 +38,14 @@ def _create_distributed_infra(
 
     try:
         # Initialize lock manager (uses Raft via metadata store)
-        if dist.enable_locks:
-            from nexus.lib.distributed_lock import LockStoreProtocol
-            from nexus.raft.lock_manager import RaftLockManager
+        # Lock capability is automatic when metadata_store supports LockStoreProtocol.
+        # The enable_locks config flag has been removed — Raft implies lock capability.
+        from nexus.lib.distributed_lock import LockStoreProtocol
+        from nexus.raft.lock_manager import RaftLockManager
 
-            if isinstance(metadata_store, LockStoreProtocol):
-                lock_manager = RaftLockManager(metadata_store, zone_id=zone_id)
-                logger.info("Distributed lock manager initialized (Raft, zone=%s)", zone_id)
-            else:
-                logger.warning(
-                    "Distributed locks require LockStoreProtocol-compatible store, got %s. "
-                    "Lock manager will not be initialized.",
-                    type(metadata_store).__name__,
-                )
+        if isinstance(metadata_store, LockStoreProtocol):
+            lock_manager = RaftLockManager(metadata_store, zone_id=zone_id)
+            logger.info("Distributed lock manager initialized (Raft, zone=%s)", zone_id)
 
         # Initialize event bus
         if dist.event_bus_backend == "nats" and dist.enable_events:

--- a/src/nexus/factory/_distributed.py
+++ b/src/nexus/factory/_distributed.py
@@ -1,90 +1,17 @@
-"""Distributed infrastructure — event bus, lock manager, workflow engine."""
+"""Distributed infrastructure — workflow engine.
+
+Event bus creation is inlined in _system.py._boot_services().
+Lock manager is owned by EventsService (LocalLockManager by default,
+upgraded to RaftLockManager at link time via _lifecycle.py).
+"""
 
 import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from nexus.bricks.workflows.protocol import WorkflowProtocol
-    from nexus.core.config import DistributedConfig
-    from nexus.core.metastore import MetastoreABC
 
 logger = logging.getLogger(__name__)
-
-
-def _create_distributed_infra(
-    dist: "DistributedConfig",
-    metadata_store: "MetastoreABC",
-    record_store: Any,
-    coordination_url: str | None,
-    *,
-    zone_id: str = "root",
-) -> tuple[Any, Any]:
-    """Create event bus and lock manager.
-
-    Returns (event_bus, lock_manager) tuple.
-    Either event_bus or lock_manager may be None.
-    """
-    event_bus: Any = None
-    lock_manager: Any = None
-
-    # Create settings store for event bus checkpoint persistence (Issue #184)
-    settings_store = None
-    try:
-        from nexus.storage.auth_stores.metastore_settings_store import MetastoreSettingsStore
-
-        settings_store = MetastoreSettingsStore(metadata_store)
-    except Exception:
-        logger.debug("MetastoreSettingsStore unavailable; event bus checkpoints will not persist")
-
-    try:
-        # Initialize lock manager (uses Raft via metadata store)
-        # Lock capability is automatic when metadata_store supports LockStoreProtocol.
-        # The enable_locks config flag has been removed — Raft implies lock capability.
-        from nexus.lib.distributed_lock import LockStoreProtocol
-        from nexus.raft.lock_manager import RaftLockManager
-
-        if isinstance(metadata_store, LockStoreProtocol):
-            lock_manager = RaftLockManager(metadata_store, zone_id=zone_id)
-            logger.info("Distributed lock manager initialized (Raft, zone=%s)", zone_id)
-
-        # Initialize event bus
-        if dist.event_bus_backend == "nats" and dist.enable_events:
-            from nexus.services.event_bus.factory import create_event_bus
-
-            event_bus = create_event_bus(
-                backend="nats",
-                nats_url=dist.nats_url,
-                record_store=record_store,
-                settings_store=settings_store,
-            )
-            logger.info(
-                "Distributed event bus initialized (NATS JetStream: %s, SSOT: PostgreSQL)",
-                dist.nats_url,
-            )
-        elif dist.enable_events:
-            from nexus.lib.env import get_dragonfly_url, get_redis_url
-
-            coordination_url_resolved = coordination_url or get_redis_url()
-            event_url_resolved = coordination_url_resolved or get_dragonfly_url()
-            if event_url_resolved:
-                from nexus.cache.dragonfly import DragonflyClient
-                from nexus.services.event_bus import RedisEventBus
-
-                event_client = DragonflyClient(url=event_url_resolved)
-                event_bus = RedisEventBus(
-                    event_client,
-                    record_store=record_store,
-                    settings_store=settings_store,
-                )
-                logger.info(
-                    "Distributed event bus initialized (dragonfly: %s, SSOT: PostgreSQL)",
-                    event_url_resolved,
-                )
-
-    except ImportError as e:
-        logger.warning("Could not initialize distributed event system: %s", e)
-
-    return event_bus, lock_manager
 
 
 def _create_workflow_engine(

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -1,18 +1,34 @@
-"""NexusFS lifecycle implementations — link() / initialize() / bootstrap().
+"""NexusFS lifecycle implementations — _wire_services() / _initialize_services().
 
-These factory-layer functions are injected into NexusFS as callables,
-keeping the kernel free of factory/bricks/system_services imports.
+These factory-layer functions are called directly by create_nexus_fs()
+in the orchestrator, keeping the kernel free of factory/bricks imports.
 
-See NexusFS.link(), NexusFS.initialize(), NexusFS.bootstrap().
+Linearized in PR #3371 Phase 2: partial injection eliminated.
 """
 
+import dataclasses
 import logging
+from collections.abc import Callable
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-async def _do_link(
+@dataclasses.dataclass(frozen=True)
+class _InitContext:
+    """Context captured during _wire_services() for _initialize_services().
+
+    Replaces the old functools.partial injection pattern. All factory-phase
+    locals that _initialize_services needs are captured here.
+    """
+
+    services: dict[str, Any]
+    svc_on: Callable[[str], bool]
+    parse_fn: Any
+    permission_checker: Any
+
+
+async def _wire_services(
     nx: Any,
     *,
     services: dict[str, Any] | None = None,
@@ -20,12 +36,15 @@ async def _do_link(
     enabled_bricks: "frozenset[str] | None" = None,
     parsing: Any = None,
     workflow_engine: Any = None,
-) -> None:
-    """Phase 1 implementation: wire service topology.  Pure memory — NO I/O.
+    federation: Any = None,
+) -> _InitContext:
+    """Phase 1: wire service topology.  Pure memory — NO I/O.
 
     Creates ParsersBrick, CacheBrick, ContentCache; packs them into
     the services dict; boots wired services that need a NexusFS reference;
     binds them onto ``nx``; creates PermissionChecker.
+
+    Returns _InitContext for _initialize_services().
     """
     from nexus.contracts.deployment_profile import DeploymentProfile as _DP
     from nexus.factory._wired import _boot_post_kernel_services
@@ -88,7 +107,7 @@ async def _do_link(
 
     # --- PermissionChecker (services layer — Issue #899, #1766) ---
     # Factory-local: _permission_checker is only needed by _register_vfs_hooks()
-    # at initialize() time. Captured via partial — never stored on nx.
+    # at initialize() time. Captured in _InitContext.
     from nexus.bricks.rebac.checker import PermissionChecker as _PC
 
     _permission_checker = _PC(
@@ -96,18 +115,6 @@ async def _do_link(
         metadata_store=nx.metadata,
         default_context=nx._init_cred,
         enforce_permissions=nx._enforce_permissions,
-    )
-
-    # Issue #1740/#1765/#1766: capture factory-phase locals via partial so they
-    # never touch nx.__dict__. _do_initialize receives them as keyword args.
-    import functools
-
-    nx._initialize_fn = functools.partial(
-        _do_initialize,
-        services=services,
-        svc_on=svc_on,
-        parse_fn=_parse_fn,
-        permission_checker=_permission_checker,
     )
 
     # --- Boot wired services → register into ServiceRegistry ---
@@ -147,36 +154,25 @@ async def _do_link(
         _canonical = _CANONICAL_ALIASES.get(_attr, _attr)
         await nx._service_registry.enlist(_canonical, _val)
 
-    # Federation — Q3 PersistentService, created at link time (needs nx._zone_mgr).
-    _zone_mgr = getattr(nx, "_zone_mgr", None)
-    if _zone_mgr is not None:
+    # Federation — wire from parameter (profile-gated, created before kernel).
+    if federation is not None:
+        await nx._service_registry.enlist("federation", federation)
+        nx._zone_mgr = federation.zone_manager  # backward compat for health checks
+        logger.debug("[LINK] Federation service enlisted")
+
+        # Upgrade lock manager: LocalLockManager → RaftLockManager
         try:
-            from nexus.raft.federation import NexusFederation
+            from nexus.raft.lock_manager import RaftLockManager
 
-            _fed = NexusFederation(zone_manager=_zone_mgr)
-            await nx._service_registry.enlist("federation", _fed)
-            logger.debug("[LINK] Federation service enlisted")
-
-            # Upgrade lock manager: LocalLockManager → RaftLockManager
-            # if metadata store supports LockStoreProtocol.
-            try:
-                from nexus.lib.distributed_lock import LockStoreProtocol
-
-                if isinstance(nx.metadata, LockStoreProtocol):
-                    from nexus.raft.lock_manager import RaftLockManager
-
-                    _raft_lm = RaftLockManager(nx.metadata, zone_id=zone_id or "root")
-                    # Find EventsService and upgrade its lock manager.
-                    _events_ref = nx._service_registry.service("events_service")
-                    _events_svc = _events_ref._service_instance if _events_ref is not None else None
-                    if _events_svc is not None and hasattr(_events_svc, "upgrade_lock_manager"):
-                        _events_svc.upgrade_lock_manager(_raft_lm)
-                    logger.debug("[LINK] RaftLockManager created and upgraded into EventsService")
-            except Exception as _lm_exc:
-                logger.debug("[LINK] RaftLockManager upgrade skipped: %s", _lm_exc)
-
+            _raft_lm = RaftLockManager(nx.metadata, zone_id=zone_id or "root")
+            # Find EventsService and upgrade its lock manager.
+            _events_ref = nx._service_registry.service("events_service")
+            _events_svc = _events_ref._service_instance if _events_ref is not None else None
+            if _events_svc is not None and hasattr(_events_svc, "upgrade_lock_manager"):
+                _events_svc.upgrade_lock_manager(_raft_lm)
+            logger.info("[LINK] RaftLockManager upgraded into EventsService")
         except Exception as exc:
-            logger.warning("[LINK] Federation unavailable: %s", exc)
+            logger.debug("[LINK] RaftLockManager upgrade skipped: %s", exc)
 
     # Kernel DI: _descendant_checker is a kernel component (like Linux LSM hook),
     # not an external service — inject directly onto the kernel instance.
@@ -324,16 +320,19 @@ async def _do_link(
         except Exception as exc:
             logger.warning("[BOOT:LINK] AcpService unavailable: %s", exc)
 
+    return _InitContext(
+        services=_svc,
+        svc_on=svc_on,
+        parse_fn=_parse_fn,
+        permission_checker=_permission_checker,
+    )
 
-async def _do_initialize(
+
+async def _initialize_services(
     nx: Any,
-    *,
-    services: Any = None,
-    svc_on: "Any" = None,
-    parse_fn: "Any" = None,
-    permission_checker: "Any" = None,
+    ctx: _InitContext,
 ) -> None:
-    """Phase 2 implementation: one-time side effects.  NO background threads.
+    """Phase 2: one-time side effects.  NO background threads.
 
     Prepares resources but remains static — no active threads or async loops.
     Background .start() calls are deferred to bootstrap() via callbacks.
@@ -361,16 +360,13 @@ async def _do_initialize(
     # _build_retroactive_hook_specs() has been deleted — hooks self-describe.
     from nexus.factory.orchestrator import _register_vfs_hooks
 
-    # Issue #1811: CAS ref_count observer is now registered via
-    # DriverLifecycleCoordinator.adopt_existing_mount() in _do_link().
-    # The `backend` parameter has been removed from _register_vfs_hooks().
     await _register_vfs_hooks(
         nx,
-        services=services,
-        permission_checker=permission_checker,
+        services=ctx.services,
+        permission_checker=ctx.permission_checker,
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
-        svc_on=svc_on,
-        parse_fn=parse_fn,
+        svc_on=ctx.svc_on,
+        parse_fn=ctx.parse_fn,
     )
 
     # --- Register background services as bootstrap callbacks ---
@@ -381,7 +377,7 @@ async def _do_initialize(
     # implement PersistentService and are auto-started by the coordinator's
     # start_persistent_services() at bootstrap.  Manual callbacks deleted.
 
-    _zl = (services or {}).get("zone_lifecycle")
+    _zl = ctx.services.get("zone_lifecycle")
     if _zl is not None and hasattr(_zl, "load_terminating_zones"):
 
         async def _load_zones() -> None:
@@ -397,3 +393,8 @@ async def _do_initialize(
                 logger.warning("[LIFECYCLE] Failed to load terminating zones: %s", exc)
 
         nx._bootstrap_callbacks.append(_load_zones)
+
+
+# Backward compatibility aliases
+_do_link = _wire_services
+_do_initialize = _initialize_services

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -28,7 +28,7 @@ async def _do_link(
     binds them onto ``nx``; creates PermissionChecker.
     """
     from nexus.contracts.deployment_profile import DeploymentProfile as _DP
-    from nexus.factory._wired import _boot_wired_services
+    from nexus.factory._wired import _boot_post_kernel_services
     from nexus.factory.service_routing import enlist_wired_services
 
     _svc = services or {}
@@ -111,7 +111,7 @@ async def _do_link(
     )
 
     # --- Boot wired services → register into ServiceRegistry ---
-    _wired = await _boot_wired_services(
+    _wired = await _boot_post_kernel_services(
         nx,
         nx.router,
         _svc,
@@ -156,6 +156,25 @@ async def _do_link(
             _fed = NexusFederation(zone_manager=_zone_mgr)
             await nx._service_registry.enlist("federation", _fed)
             logger.debug("[LINK] Federation service enlisted")
+
+            # Upgrade lock manager: LocalLockManager → RaftLockManager
+            # if metadata store supports LockStoreProtocol.
+            try:
+                from nexus.lib.distributed_lock import LockStoreProtocol
+
+                if isinstance(nx.metadata, LockStoreProtocol):
+                    from nexus.raft.lock_manager import RaftLockManager
+
+                    _raft_lm = RaftLockManager(nx.metadata, zone_id=zone_id or "root")
+                    # Find EventsService and upgrade its lock manager.
+                    _events_ref = nx._service_registry.service("events_service")
+                    _events_svc = _events_ref._service_instance if _events_ref is not None else None
+                    if _events_svc is not None and hasattr(_events_svc, "upgrade_lock_manager"):
+                        _events_svc.upgrade_lock_manager(_raft_lm)
+                    logger.debug("[LINK] RaftLockManager created and upgraded into EventsService")
+            except Exception as _lm_exc:
+                logger.debug("[LINK] RaftLockManager upgrade skipped: %s", _lm_exc)
+
         except Exception as exc:
             logger.warning("[LINK] Federation unavailable: %s", exc)
 
@@ -165,8 +184,8 @@ async def _do_link(
     if _dc is not None:
         nx._descendant_checker = _dc
 
-    # Issue #1788: _distributed_lock_manager removed — EventsService owns lock routing.
-    # EventsService auto-creates local SemaphoreAdvisoryLockManager fallback.
+    # Issue #1788: Lock manager owned by EventsService (LocalLockManager by default).
+    # Upgraded to RaftLockManager above if federation is available.
 
     # --- Register close callbacks (Issue #1793, #1789) ---
     # Services that need cleanup at close() register callbacks here.

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -165,8 +165,8 @@ async def _do_link(
     if _dc is not None:
         nx._descendant_checker = _dc
 
-    # Issue #1788: inject distributed lock_manager directly (kernel knows pattern)
-    nx._distributed_lock_manager = _svc.get("lock_manager")
+    # Issue #1788: _distributed_lock_manager removed — EventsService owns lock routing.
+    # EventsService auto-creates local SemaphoreAdvisoryLockManager fallback.
 
     # --- Register close callbacks (Issue #1793, #1789) ---
     # Services that need cleanup at close() register callbacks here.
@@ -236,35 +236,39 @@ async def _do_link(
 
         nx._close_callbacks.append(_close_audit)
 
-    # Issue #1792: AgentRegistry — kernel knows, factory provides.
-    # Created here (not in __init__) because no-agent profiles (REMOTE) skip it.
-    # Consumers: EvictionManager, AcpService, AgentStatusResolver.
-    try:
+    # Issue #1792: AgentRegistry — lazy construct via ServiceRegistry.register_factory().
+    # Only created on first access (ACP/TaskManager/EvictionManager need it).
+    # No-agent profiles (REMOTE) never access it → never created.
+    def _create_agent_registry() -> Any:
         from nexus.core.agent_registry import AgentRegistry
 
-        nx._agent_registry = AgentRegistry()
-        logger.debug("[BOOT:LINK] AgentRegistry created (kernel-knows sentinel)")
-    except Exception as exc:
-        logger.debug("[BOOT:LINK] AgentRegistry unavailable: %s", exc)
+        _ar = AgentRegistry()
+        # Wire close callback
+        if hasattr(_ar, "close_all"):
 
-    _pt = getattr(nx, "_agent_registry", None)
-    if _pt is not None and hasattr(_pt, "close_all"):
+            def _close_agent_registry() -> None:
+                try:
+                    _ar.close_all()
+                except Exception as exc:
+                    logger.debug("close: agent_registry.close_all() failed: %s", exc)
 
-        def _close_agent_registry() -> None:
-            try:
-                _pt.close_all()
-            except Exception as exc:
-                logger.debug("close: agent_registry.close_all() failed: %s", exc)
+            nx._close_callbacks.append(_close_agent_registry)
 
-        nx._close_callbacks.append(_close_agent_registry)
+        # Keep kernel sentinel in sync for backward compat
+        nx._agent_registry = _ar
+        logger.debug("[BOOT:LINK] AgentRegistry lazy-constructed on first access")
+        return _ar
+
+    nx._service_registry.register_factory("agent_registry", _create_agent_registry)
 
     # Issue #1801: _overlay_config_fn closure removed — kernel now reads
     # workspace_registry directly from service registry via nx.service("workspace_registry").
 
     # --- Deferred EvictionManager + AcpService (Issue #1792) ---
-    # AgentRegistry is a kernel-knows sentinel (factory-provided at link-time).
-    # EvictionManager and AcpService depend on it — created here if available.
-    _agent_reg = getattr(nx, "_agent_registry", None)
+    # AgentRegistry is lazy-constructed via register_factory().
+    # Accessing it here triggers construction only if EvictionManager/AcpService exist.
+    _agent_ref = nx._service_registry.service("agent_registry")
+    _agent_reg = _agent_ref._service_instance if _agent_ref is not None else None
     if _agent_reg is not None:
         try:
             from nexus.contracts.deployment_profile import DeploymentProfile as _DP

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -1,8 +1,8 @@
-"""Boot Tier 1 — critical + degradable services.
+"""Boot Tier 1 — critical + degradable services (pre-kernel).
 
 Issue #2193: Absorbs 11 former-kernel services per Liedtke's test.
-Renamed from ``_boot_system_services`` → ``_boot_services`` after
-the SystemServices/BrickServices unification (PR #3350).
+Renamed ``_boot_system_services`` → ``_boot_services`` → ``_boot_pre_kernel_services``
+(PR #3350, PR #3371 Phase 2).
 
 Two severity classes:
 
@@ -28,7 +28,7 @@ from nexus.factory._helpers import _make_gate
 logger = logging.getLogger(__name__)
 
 
-def _boot_services(
+def _boot_pre_kernel_services(
     ctx: _BootContext,
     svc_on: Callable[[str], bool] | None = None,
 ) -> dict[str, Any]:
@@ -433,37 +433,60 @@ def _boot_services(
     # EvictionManager + AcpService are deferred to _do_link().  See Issue #1792.)
 
     # =====================================================================
-    # Infrastructure: event bus + lock manager (moved from _bricks.py)
-    # These are infrastructure, not optional bricks.
+    # Infrastructure: event bus (moved from _bricks.py)
+    # Lock manager is now owned by EventsService (LocalLockManager by default,
+    # upgraded to RaftLockManager at link time if federation is available).
     # =====================================================================
     event_bus: Any = None
-    lock_manager: Any = None
     if not _on("ipc"):
         logger.debug("[BOOT:SYSTEM] IPC/EventBus disabled by profile")
-    else:
-        if ctx.dist.enable_events:
-            from nexus.factory._distributed import _create_distributed_infra
+    elif ctx.dist.enable_events:
+        # Inline event bus creation (previously in _create_distributed_infra)
+        _settings_store = None
+        try:
+            from nexus.storage.auth_stores.metastore_settings_store import MetastoreSettingsStore
 
-            event_bus, lock_manager = _create_distributed_infra(
-                ctx.dist,
-                ctx.metadata_store,
-                ctx.record_store,
-                ctx.dist.coordination_url,
-                zone_id=ctx.zone_id or ROOT_ZONE_ID,
+            _settings_store = MetastoreSettingsStore(ctx.metadata_store)
+        except Exception:
+            logger.debug(
+                "MetastoreSettingsStore unavailable; event bus checkpoints will not persist"
             )
 
-        # Always create lock manager — SemaphoreAdvisoryLockManager wraps
-        # VFSSemaphore directly (no LockStoreProtocol capability check needed).
-        if lock_manager is None:
-            try:
-                from nexus.lib.distributed_lock import SemaphoreAdvisoryLockManager
-                from nexus.lib.semaphore import create_vfs_semaphore
+        try:
+            if ctx.dist.event_bus_backend == "nats" and ctx.dist.enable_events:
+                from nexus.services.event_bus.factory import create_event_bus
 
-                _zone = ctx.zone_id or ROOT_ZONE_ID
-                lock_manager = SemaphoreAdvisoryLockManager(create_vfs_semaphore(), zone_id=_zone)
-                logger.info("Advisory lock manager initialized (standalone, zone=%s)", _zone)
-            except Exception as _lm_exc:
-                logger.debug("[BOOT:SYSTEM] SemaphoreAdvisoryLockManager unavailable: %s", _lm_exc)
+                event_bus = create_event_bus(
+                    backend="nats",
+                    nats_url=ctx.dist.nats_url,
+                    record_store=ctx.record_store,
+                    settings_store=_settings_store,
+                )
+                logger.info(
+                    "Distributed event bus initialized (NATS JetStream: %s, SSOT: PostgreSQL)",
+                    ctx.dist.nats_url,
+                )
+            elif ctx.dist.enable_events:
+                from nexus.lib.env import get_dragonfly_url, get_redis_url
+
+                _coord_url = ctx.dist.coordination_url or get_redis_url()
+                _event_url = _coord_url or get_dragonfly_url()
+                if _event_url:
+                    from nexus.cache.dragonfly import DragonflyClient
+                    from nexus.services.event_bus import RedisEventBus
+
+                    _event_client = DragonflyClient(url=_event_url)
+                    event_bus = RedisEventBus(
+                        _event_client,
+                        record_store=ctx.record_store,
+                        settings_store=_settings_store,
+                    )
+                    logger.info(
+                        "Distributed event bus initialized (dragonfly: %s, SSOT: PostgreSQL)",
+                        _event_url,
+                    )
+        except ImportError as e:
+            logger.warning("Could not initialize distributed event system: %s", e)
 
     # =====================================================================
     # Assemble result
@@ -494,7 +517,6 @@ def _boot_services(
         "scheduler_service": scheduler_service,
         # Infrastructure (moved from bricks)
         "event_bus": event_bus,
-        "lock_manager": lock_manager,
     }
 
     elapsed = time.perf_counter() - t0
@@ -507,3 +529,7 @@ def _boot_services(
         "active" if svc_on is not None else "off",
     )
     return result
+
+
+# Backward compatibility alias
+_boot_services = _boot_pre_kernel_services

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -1,6 +1,8 @@
-"""Boot Tier 1 (SYSTEM) — critical + degradable services.
+"""Boot Tier 1 — critical + degradable services.
 
 Issue #2193: Absorbs 11 former-kernel services per Liedtke's test.
+Renamed from ``_boot_system_services`` → ``_boot_services`` after
+the SystemServices/BrickServices unification (PR #3350).
 
 Two severity classes:
 
@@ -11,7 +13,7 @@ Two severity classes:
 **Degradable** (per-service try/except → WARNING + None):
     dir_visibility_cache, hierarchy_manager, deferred_permission_buffer,
     workspace_registry, mount_manager, workspace_manager, plus all
-    original system services (agent registry, namespace, etc.).
+    original services (namespace, etc.).
 """
 
 import logging
@@ -26,11 +28,11 @@ from nexus.factory._helpers import _make_gate
 logger = logging.getLogger(__name__)
 
 
-def _boot_system_services(
+def _boot_services(
     ctx: _BootContext,
     svc_on: Callable[[str], bool] | None = None,
 ) -> dict[str, Any]:
-    """Boot Tier 1 (SYSTEM) — critical + degradable services.
+    """Boot Tier 1 — critical + degradable services.
 
     1. **Critical section** — creates ReBAC, permissions, audit, entity
        registry, and write observer.  A single try/except raises
@@ -40,9 +42,8 @@ def _boot_system_services(
        cache, hierarchy manager, deferred permission buffer, workspace
        services.  Per-service try/except logs WARNING and sets None.
 
-    3. **Original system services** — agent registry, namespace,
-       observability, resiliency, lifecycle management.  Same degraded
-       pattern as before.
+    3. **Original services** — namespace, observability, resiliency,
+       lifecycle management.  Same degraded pattern as before.
 
     Args:
         ctx: Boot context with shared dependencies.
@@ -428,8 +429,41 @@ def _boot_system_services(
     # (Federation is created at link time in _lifecycle.py when nx._zone_mgr is available.)
 
     # (PipeManager + StreamManager are kernel-owned primitives in NexusFS.__init__.
-    # AgentRegistry is a kernel-knows sentinel, created at link-time.
+    # AgentRegistry is lazy-constructed via register_factory().
     # EvictionManager + AcpService are deferred to _do_link().  See Issue #1792.)
+
+    # =====================================================================
+    # Infrastructure: event bus + lock manager (moved from _bricks.py)
+    # These are infrastructure, not optional bricks.
+    # =====================================================================
+    event_bus: Any = None
+    lock_manager: Any = None
+    if not _on("ipc"):
+        logger.debug("[BOOT:SYSTEM] IPC/EventBus disabled by profile")
+    else:
+        if ctx.dist.enable_events:
+            from nexus.factory._distributed import _create_distributed_infra
+
+            event_bus, lock_manager = _create_distributed_infra(
+                ctx.dist,
+                ctx.metadata_store,
+                ctx.record_store,
+                ctx.dist.coordination_url,
+                zone_id=ctx.zone_id or ROOT_ZONE_ID,
+            )
+
+        # Always create lock manager — SemaphoreAdvisoryLockManager wraps
+        # VFSSemaphore directly (no LockStoreProtocol capability check needed).
+        if lock_manager is None:
+            try:
+                from nexus.lib.distributed_lock import SemaphoreAdvisoryLockManager
+                from nexus.lib.semaphore import create_vfs_semaphore
+
+                _zone = ctx.zone_id or ROOT_ZONE_ID
+                lock_manager = SemaphoreAdvisoryLockManager(create_vfs_semaphore(), zone_id=_zone)
+                logger.info("Advisory lock manager initialized (standalone, zone=%s)", _zone)
+            except Exception as _lm_exc:
+                logger.debug("[BOOT:SYSTEM] SemaphoreAdvisoryLockManager unavailable: %s", _lm_exc)
 
     # =====================================================================
     # Assemble result
@@ -449,7 +483,7 @@ def _boot_system_services(
         "workspace_registry": workspace_registry,
         "mount_manager": mount_manager,
         "workspace_manager": workspace_manager,
-        # Original system services
+        # Original services
         "async_namespace_manager": async_namespace_manager,
         "delivery_worker": delivery_worker,
         "event_signal": ctx.event_signal,
@@ -458,6 +492,9 @@ def _boot_system_services(
         "context_branch_service": context_branch_service,
         "zone_lifecycle": zone_lifecycle,
         "scheduler_service": scheduler_service,
+        # Infrastructure (moved from bricks)
+        "event_bus": event_bus,
+        "lock_manager": lock_manager,
     }
 
     elapsed = time.perf_counter() - t0

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -1,4 +1,4 @@
-"""Boot Tier 2b (WIRED) — services needing NexusFS reference."""
+"""Boot Tier 2b (POST-KERNEL) — services needing NexusFS reference."""
 
 import logging
 import time
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-async def _boot_wired_services(
+async def _boot_post_kernel_services(
     nx: Any,
     router: "PathRouter",
     services: dict[str, Any],
@@ -260,7 +260,6 @@ async def _boot_wired_services(
 
             events_service = EventsService(
                 event_bus=services.get("event_bus"),
-                lock_manager=services.get("lock_manager"),
             )
             logger.debug("[BOOT:WIRED] EventsService created")
         except Exception as exc:
@@ -534,3 +533,7 @@ def _initialize_wired_ipc(nx: Any, services: dict[str, Any]) -> None:
             )
         except Exception as exc:
             logger.warning("[BOOT:WIRED] IPC adapter bind failed: %s", exc)
+
+
+# Backward compatibility alias
+_boot_wired_services = _boot_post_kernel_services

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -45,10 +45,10 @@ def create_nexus_services(
     Orchestrates 3-tier boot sequence:
 
     1. **Kernel** — validates Storage Pillars (VFS router, Metastore).
-       Failure raises ``BootError``.
-    2. **System** — critical services (ReBAC, permissions, write-sync →
-       ``BootError``) + degradable services (workspace, agent registry,
-       namespace, observability → WARNING + ``None``).
+       Failure raises ``BootError``.  Inlined (no separate function).
+    2. **Services** — critical services (ReBAC, permissions, write-sync →
+       ``BootError``) + degradable services (workspace, namespace,
+       observability → WARNING + ``None``).
     3. **Brick** — optional (search, wallet, manifest, upload, distributed).
        Failure is silent (DEBUG) + ``None``.
 
@@ -81,8 +81,7 @@ def create_nexus_services(
     from nexus.core.config import PermissionConfig as _PermissionConfig
     from nexus.factory._boot_context import _BootContext
     from nexus.factory._bricks import _boot_dependent_bricks, _boot_independent_bricks
-    from nexus.factory._kernel import _boot_kernel_services
-    from nexus.factory._system import _boot_system_services
+    from nexus.factory._system import _boot_services
 
     if enabled_bricks is None:
         enabled_bricks = DeploymentProfile.FULL.default_bricks()
@@ -139,11 +138,19 @@ def create_nexus_services(
         profile_tuning=_profile_tuning,
     )
 
-    # --- Tier 0: KERNEL (validate Storage Pillars) ---
-    _boot_kernel_services(ctx)
+    # --- Tier 0: KERNEL (validate Storage Pillars — inlined from _kernel.py) ---
+    from nexus.contracts.exceptions import BootError
 
-    # --- Tier 1: SYSTEM (critical + degradable, gated by profile) ---
-    system_dict = _boot_system_services(ctx, svc_on)
+    if ctx.router is None:
+        raise BootError("VFS router is None", tier="kernel")
+    if ctx.metadata_store is None:
+        raise BootError("Metadata store is None", tier="kernel")
+    if ctx.record_store is None:
+        logger.warning("[BOOT:KERNEL] RecordStore is None — services layer disabled")
+    logger.info("[BOOT:KERNEL] Storage pillars validated")
+
+    # --- Tier 1: Services (critical + degradable, gated by profile) ---
+    system_dict = _boot_services(ctx, svc_on)
 
     # --- Tier 2: BRICK (optional, gated by profile) ---
     brick_dict = _boot_independent_bricks(ctx, system_dict, svc_on)
@@ -155,14 +162,9 @@ def create_nexus_services(
 
     # --- Assemble unified services dict (Issue #2034, #2193) ---
 
-    # Merge Tier 1 infrastructure from brick_dict into system_dict.
-    system_dict["event_bus"] = brick_dict["event_bus"]
-    system_dict["lock_manager"] = brick_dict["lock_manager"]
-
-    # Merge remaining brick services into the unified dict
-    system_dict.update(
-        {k: v for k, v in brick_dict.items() if k not in ("event_bus", "lock_manager")}
-    )
+    # Merge brick services into the unified dict (event_bus/lock_manager
+    # already in system_dict after boot phase unification).
+    system_dict.update(brick_dict)
 
     return system_dict
 
@@ -451,7 +453,8 @@ async def _register_vfs_hooks(
     await _enlist("virtual_view", _vview_resolver)
 
     # ── AgentStatusResolver (procfs virtual filesystem for AgentRegistry — Issue #1570, #1810) ──
-    _proc_table = getattr(nx, "_agent_registry", None)
+    _proc_ref = nx.service("agent_registry") if hasattr(nx, "service") else None
+    _proc_table = _proc_ref._service_instance if _proc_ref is not None else None
     if _proc_table is not None:
         try:
             from nexus.core.agent_status_resolver import AgentStatusResolver

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -189,6 +189,7 @@ async def create_nexus_fs(
     agent_id: str | None = None,
     workflow_engine: "WorkflowProtocol | None" = None,
     init_cred: Any = None,
+    federation: Any = None,
 ) -> "NexusFS":
     """Create NexusFS with default services — the recommended entry point.
 
@@ -270,10 +271,8 @@ async def create_nexus_fs(
     if services is None:
         services = {}
 
-    import functools
-
     from nexus.contracts.types import OperationContext as _OC
-    from nexus.factory._lifecycle import _do_initialize, _do_link
+    from nexus.factory._lifecycle import _initialize_services, _wire_services
 
     _init_cred = (
         init_cred if init_cred is not None else _OC(user_id="system", groups=[], is_admin=is_admin)
@@ -291,14 +290,22 @@ async def create_nexus_fs(
         router=router,
         init_cred=_init_cred,
     )
-    nx._link_fn = functools.partial(_do_link, services=services, zone_id=zone_id)
-    nx._initialize_fn = _do_initialize
-    await nx.link(
+
+    # Linearized lifecycle — no partial injection (PR #3371 Phase 2)
+    init_ctx = await _wire_services(
+        nx,
+        services=services,
+        zone_id=zone_id,
         enabled_bricks=enabled_bricks,
         parsing=parsing,
         workflow_engine=workflow_engine,
+        federation=federation,
     )
-    await nx.initialize()
+    nx._linked = True
+
+    await _initialize_services(nx, init_ctx)
+    nx._initialized = True
+
     return nx
 
 

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -81,7 +81,7 @@ def create_nexus_services(
     from nexus.core.config import PermissionConfig as _PermissionConfig
     from nexus.factory._boot_context import _BootContext
     from nexus.factory._bricks import _boot_dependent_bricks, _boot_independent_bricks
-    from nexus.factory._system import _boot_services
+    from nexus.factory._system import _boot_pre_kernel_services
 
     if enabled_bricks is None:
         enabled_bricks = DeploymentProfile.FULL.default_bricks()
@@ -150,7 +150,7 @@ def create_nexus_services(
     logger.info("[BOOT:KERNEL] Storage pillars validated")
 
     # --- Tier 1: Services (critical + degradable, gated by profile) ---
-    system_dict = _boot_services(ctx, svc_on)
+    system_dict = _boot_pre_kernel_services(ctx, svc_on)
 
     # --- Tier 2: BRICK (optional, gated by profile) ---
     brick_dict = _boot_independent_bricks(ctx, system_dict, svc_on)

--- a/src/nexus/lib/distributed_lock.py
+++ b/src/nexus/lib/distributed_lock.py
@@ -1,4 +1,4 @@
-"""Advisory lock manager — ABCs and SemaphoreAdvisoryLockManager.
+"""Advisory lock manager — ABCs and LocalLockManager.
 
 Advisory locks are *metadata* — visible, queryable, TTL-based.
 Used for user/service coordination (task queues, turn-taking, resource
@@ -6,13 +6,13 @@ contention).  Distinct from kernel I/O locks (VFSLockManager, ~200ns,
 in-memory, process-scoped).
 
 Architecture:
-- LockStoreProtocol: Low-level store interface (MetastoreABC lock methods)
 - AdvisoryLockManager: Async advisory lock API (POSIX flock(2), zone_id bound at construction)
-- SemaphoreAdvisoryLockManager: Standalone mode — wraps VFSSemaphore (this file)
+- LocalLockManager: Standalone mode — wraps VFSSemaphore (this file)
 - RaftLockManager: Federation mode — wraps RaftMetadataStore (raft/)
 
-Factory.py injects SemaphoreAdvisoryLockManager (standalone) or RaftLockManager
-(federation).  Callers see only AdvisoryLockManager.
+EventsService auto-creates LocalLockManager (standalone) or receives
+RaftLockManager (federation) via upgrade_lock_manager().
+Callers see only AdvisoryLockManager.
 
 References:
     - docs/architecture/lock-architecture.md
@@ -27,59 +27,9 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
-
-# =============================================================================
-# Low-level Store Protocol
-# =============================================================================
-
-
-@runtime_checkable
-class LockStoreProtocol(Protocol):
-    """Protocol for lock-capable metadata stores (e.g., RaftMetadataStore).
-
-    Captures the interface that lock managers need, decoupling
-    the lock manager from the concrete storage driver
-    (KERNEL-ARCHITECTURE.md §1).
-    """
-
-    def acquire_lock(
-        self,
-        lock_key: str,
-        holder_id: str,
-        *,
-        max_holders: int = 1,
-        ttl_secs: int = 30,
-    ) -> bool:
-        """Atomically acquire a lock."""
-        ...
-
-    def release_lock(self, lock_key: str, holder_id: str) -> bool:
-        """Release a lock held by holder_id."""
-        ...
-
-    def extend_lock(self, lock_key: str, holder_id: str, ttl_secs: int) -> bool:
-        """Extend a lock's TTL."""
-        ...
-
-    def get_lock_info(self, lock_key: str) -> dict[str, Any] | None:
-        """Get information about a lock."""
-        ...
-
-    def list_locks(self, *, prefix: str = "", limit: int = 100) -> list[dict[str, Any]]:
-        """List active locks matching prefix."""
-        ...
-
-    def force_release_lock(self, lock_key: str) -> bool:
-        """Force-release all holders of a lock."""
-        ...
-
-    def get(self, key: str) -> Any:
-        """Get a value by key (used for health checks)."""
-        ...
-
 
 # =============================================================================
 # Data Classes
@@ -229,17 +179,17 @@ class AdvisoryLockManager(ABC):
 
 
 # =============================================================================
-# Concrete: SemaphoreAdvisoryLockManager (standalone mode)
+# Concrete: LocalLockManager (standalone mode)
 # =============================================================================
 
 _SHARED_MAX_HOLDERS = 1024  # max concurrent shared (reader) holders
 
 
-class SemaphoreAdvisoryLockManager(AdvisoryLockManager):
+class LocalLockManager(AdvisoryLockManager):
     """Advisory lock manager for standalone mode — wraps VFSSemaphore.
 
-    Replaces ``LocalLockManager``.  Uses kernel ``VFSSemaphore`` primitive
-    directly instead of going through MetastoreABC lock methods.
+    Uses kernel ``VFSSemaphore`` primitive directly instead of going
+    through MetastoreABC lock methods.
 
     Supports three modes:
 
@@ -273,11 +223,6 @@ class SemaphoreAdvisoryLockManager(AdvisoryLockManager):
           3. release gate (let other readers through)
           4. ... critical section ...
           5. release readers slot
-
-    Differences from ``LocalLockManager``:
-    - No MetastoreABC dependency — uses VFSSemaphore directly
-    - Proper shared/exclusive semantics via two-semaphore gate pattern
-    - Lock state tracked in ``_active_locks`` dict (process-local)
     """
 
     RETRY_INTERVAL = 0.05  # 50ms between retries
@@ -518,145 +463,8 @@ class SemaphoreAdvisoryLockManager(AdvisoryLockManager):
 
 
 # =============================================================================
-# Legacy: LocalLockManager (kept for backward compat during migration)
-# =============================================================================
-
-
-class LocalLockManager(AdvisoryLockManager):
-    """Advisory lock manager for standalone mode (no Raft).
-
-    .. deprecated::
-        Use ``SemaphoreAdvisoryLockManager`` instead.  ``LocalLockManager``
-        wraps MetastoreABC lock methods; the new implementation wraps
-        VFSSemaphore directly.  This class is retained during the migration
-        period and will be removed once factory wiring is updated.
-
-    Wraps MetastoreABC's lock methods with async interface + retry.
-    Same AdvisoryLockManager API as RaftLockManager — callers don't know
-    the difference.  Factory.py injects this when Raft is not enabled.
-
-    Differences from RaftLockManager:
-    - Fixed retry interval (50ms) instead of exponential backoff
-      (local redb is ~5us, no network jitter to absorb)
-    - Uses time.monotonic() instead of asyncio loop time
-    - No Raft consensus overhead
-    """
-
-    RETRY_INTERVAL = 0.05  # 50ms between retries (local store is fast)
-
-    def __init__(self, store: LockStoreProtocol, *, zone_id: str = "root") -> None:
-        super().__init__(zone_id=zone_id)
-        self._store = store
-
-    def _store_info_to_lock_info(self, store_info: dict[str, Any]) -> LockInfo:
-        """Convert store-level lock info dict to a LockInfo dataclass."""
-        lock_key = store_info["path"]
-        _, resource_path = self._parse_lock_key(lock_key)
-        max_holders = store_info["max_holders"]
-        holders = [
-            HolderInfo(
-                lock_id=h["lock_id"],
-                holder_info=h.get("holder_info", ""),
-                acquired_at=float(h.get("acquired_at", 0)),
-                expires_at=float(h.get("expires_at", 0)),
-            )
-            for h in store_info.get("holders", [])
-        ]
-        return LockInfo(
-            path=resource_path,
-            mode="mutex" if max_holders == 1 else "semaphore",
-            max_holders=max_holders,
-            holders=holders,
-            fence_token=store_info.get("fence_token", 0),
-        )
-
-    async def acquire(
-        self,
-        path: str,
-        mode: Literal["exclusive", "shared"] = "exclusive",  # noqa: ARG002 (MetastoreABC has no shared mode)
-        timeout: float = AdvisoryLockManager.DEFAULT_TIMEOUT,
-        ttl: float = AdvisoryLockManager.DEFAULT_TTL,
-        max_holders: int = 1,
-    ) -> str | None:
-        if max_holders < 1:
-            raise ValueError(f"max_holders must be >= 1, got {max_holders}")
-
-        lock_key = self._lock_key(path)
-        holder_id = str(uuid.uuid4())
-        ttl_secs = max(1, int(ttl))
-
-        # First attempt
-        if self._store.acquire_lock(
-            lock_key, holder_id, max_holders=max_holders, ttl_secs=ttl_secs
-        ):
-            logger.debug("Local lock acquired: %s -> %s", lock_key, holder_id)
-            return holder_id
-
-        if timeout <= 0:
-            return None
-
-        # Retry loop with fixed interval
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            await asyncio.sleep(min(self.RETRY_INTERVAL, deadline - time.monotonic()))
-            if self._store.acquire_lock(
-                lock_key, holder_id, max_holders=max_holders, ttl_secs=ttl_secs
-            ):
-                logger.debug("Local lock acquired: %s -> %s", lock_key, holder_id)
-                return holder_id
-
-        logger.debug("Local lock acquisition timeout: %s", lock_key)
-        return None
-
-    async def release(self, lock_id: str, path: str) -> bool:
-        lock_key = self._lock_key(path)
-        released = self._store.release_lock(lock_key, lock_id)
-        if released:
-            logger.debug("Local lock released: %s", lock_key)
-        return released
-
-    async def extend(
-        self,
-        lock_id: str,
-        path: str,
-        ttl: float = AdvisoryLockManager.DEFAULT_TTL,
-    ) -> ExtendResult:
-        lock_key = self._lock_key(path)
-        ttl_secs = max(1, int(ttl))
-        success = self._store.extend_lock(lock_key, lock_id, ttl_secs)
-        if not success:
-            return ExtendResult(success=False)
-        lock_info = await self.get_lock_info(path)
-        return ExtendResult(success=True, lock_info=lock_info)
-
-    async def get_lock_info(self, path: str) -> LockInfo | None:
-        lock_key = self._lock_key(path)
-        store_info = self._store.get_lock_info(lock_key)
-        if store_info is None:
-            return None
-        return self._store_info_to_lock_info(store_info)
-
-    async def list_locks(self, pattern: str = "", limit: int = 100) -> list[LockInfo]:
-        prefix = f"{self._zone_id}:"
-        store_locks = self._store.list_locks(prefix=prefix, limit=limit)
-        results = [self._store_info_to_lock_info(info) for info in store_locks]
-        if pattern:
-            results = [r for r in results if pattern in r.path]
-        return results
-
-    async def force_release(self, path: str) -> bool:
-        lock_key = self._lock_key(path)
-        released = self._store.force_release_lock(lock_key)
-        if released:
-            logger.debug("Local lock force-released: %s", lock_key)
-        return released
-
-    async def health_check(self) -> bool:
-        return True  # local store is always healthy
-
-
-# =============================================================================
 # Backward compatibility aliases
 # =============================================================================
 
 LockManagerBase = AdvisoryLockManager
+SemaphoreAdvisoryLockManager = LocalLockManager

--- a/src/nexus/raft/federation.py
+++ b/src/nexus/raft/federation.py
@@ -95,6 +95,153 @@ class NexusFederation:
         self._peers = PeerAddress.parse_peer_list(peers_str) if peers_str else []
 
     # =========================================================================
+    # Factory classmethod — called from connect() before create_nexus_fs()
+    # =========================================================================
+
+    @classmethod
+    def bootstrap(
+        cls,
+        *,
+        metadata_path: str,
+    ) -> tuple["NexusFederation", Any]:
+        """Bootstrap federation: create ZoneManager + FederatedMetadataProxy.
+
+        Encapsulates all of connect()'s federation setup (~100 lines):
+        env var parsing, TLS pre-provisioning, join token flow, ZoneManager
+        creation with retry, bootstrap/join detection, static Day-1 topology.
+
+        Args:
+            metadata_path: Path to the metastore directory (used to derive zones_dir).
+
+        Returns:
+            Tuple of (NexusFederation instance, MetastoreABC via FederatedMetadataProxy).
+
+        Raises:
+            ImportError: Rust extensions not available.
+            RuntimeError: Raft bootstrap failed after retries.
+        """
+        import os
+        import socket
+        import time as _time
+        from pathlib import Path
+
+        from nexus.contracts.constants import DEFAULT_GRPC_BIND_ADDR
+        from nexus.raft import FederatedMetadataProxy
+        from nexus.raft.peer_address import PeerAddress, hostname_to_node_id
+        from nexus.raft.zone_manager import ZoneManager
+
+        hostname = os.environ.get("NEXUS_HOSTNAME", socket.gethostname())
+        my_id = hostname_to_node_id(hostname)
+        bind_addr = os.environ.get("NEXUS_BIND_ADDR", DEFAULT_GRPC_BIND_ADDR)
+        advertise_addr = os.environ.get("NEXUS_ADVERTISE_ADDR")
+        zones_dir = os.environ.get("NEXUS_DATA_DIR", str(Path(metadata_path).parent / "zones"))
+
+        # Parse peer addresses
+        peers_str = os.environ.get("NEXUS_PEERS", "")
+        peer_addrs = PeerAddress.parse_peer_list(peers_str) if peers_str else []
+        peers = [p.grpc_target for p in peer_addrs]
+
+        _max_attempts = int(os.environ.get("NEXUS_STARTUP_MAX_RETRIES", "12"))
+        _base_delay = 2.0
+        zone_mgr: ZoneManager | None = None
+
+        for _attempt in range(1, _max_attempts + 1):
+            try:
+                # TLS pre-provision (depends on leader being up)
+                tls_dir_pre = Path(zones_dir) / "tls"
+                token_file = tls_dir_pre / "join-token"
+                if token_file.exists() and not (tls_dir_pre / "node.pem").exists():
+                    join_token = token_file.read_text().strip()
+                    join_peer = next(
+                        (p.grpc_target for p in peer_addrs if p.node_id != my_id),
+                        None,
+                    )
+                    if join_peer:
+                        import importlib
+
+                        _raft_mod = importlib.import_module("_nexus_raft")
+                        _join_cluster = _raft_mod.join_cluster
+
+                        logger.info(
+                            "Join token found — provisioning TLS from %s (attempt %d)",
+                            join_peer,
+                            _attempt,
+                        )
+                        _join_cluster(join_peer, join_token, hostname, str(tls_dir_pre))
+                        logger.info("TLS provisioning complete")
+                    else:
+                        raise RuntimeError("Join token found but no peer in NEXUS_PEERS to join")
+
+                zone_mgr = ZoneManager(
+                    hostname=hostname,
+                    base_path=zones_dir,
+                    bind_addr=bind_addr,
+                    advertise_addr=advertise_addr,
+                )
+
+                # Detect joiner vs first-node
+                tls_dir = Path(zones_dir) / "tls"
+                is_joiner = (
+                    (tls_dir / "ca.pem").exists()
+                    and (tls_dir / "node.pem").exists()
+                    and (tls_dir / "node-key.pem").exists()
+                    and not (tls_dir / "join-token").exists()
+                )
+
+                if is_joiner:
+                    zone_mgr.join_zone("root", peers=peers if peers else None)
+                    logger.info("Joiner node: joined root zone (certs provisioned)")
+                else:
+                    zone_mgr.bootstrap(peers=peers if peers else None)
+
+                # Static Day-1 topology from env vars (idempotent)
+                zones_str = os.environ.get("NEXUS_FEDERATION_ZONES", "")
+                mounts_str = os.environ.get("NEXUS_FEDERATION_MOUNTS", "")
+                if zones_str:
+                    zones = [z.strip() for z in zones_str.split(",") if z.strip()]
+                    mounts: dict[str, str] = {}
+                    if mounts_str:
+                        for pair in mounts_str.split(","):
+                            path, zone_id = pair.strip().split("=", 1)
+                            mounts[path.strip()] = zone_id.strip()
+                    zone_mgr.bootstrap_static(zones=zones, peers=peers, mounts=mounts)
+
+                break  # Success
+
+            except (RuntimeError, OSError, ConnectionError) as exc:
+                if _attempt >= _max_attempts:
+                    logger.error("Raft startup failed after %d attempts: %s", _max_attempts, exc)
+                    raise
+                delay = min(_base_delay * (2 ** (_attempt - 1)), 30.0)
+                logger.warning(
+                    "Raft startup attempt %d/%d failed: %s — retrying in %.1fs",
+                    _attempt,
+                    _max_attempts,
+                    exc,
+                    delay,
+                )
+                _time.sleep(delay)
+
+        assert zone_mgr is not None  # guaranteed by loop above
+        metadata_store = FederatedMetadataProxy.from_zone_manager(zone_mgr)
+        federation = cls(zone_manager=zone_mgr)
+        return federation, metadata_store
+
+    # =========================================================================
+    # Properties
+    # =========================================================================
+
+    @property
+    def zone_manager(self) -> Any:
+        """The underlying ZoneManager instance."""
+        return self._mgr
+
+    def ensure_topology(self) -> bool:
+        """Delegate to ZoneManager.ensure_topology() for health checks."""
+        result: bool = self._mgr.ensure_topology()
+        return result
+
+    # =========================================================================
     # Q3 PersistentService lifecycle (auto-managed by ServiceRegistry)
     # =========================================================================
 

--- a/src/nexus/raft/lock_manager.py
+++ b/src/nexus/raft/lock_manager.py
@@ -24,7 +24,6 @@ from nexus.lib.distributed_lock import (
     HolderInfo,
     LockInfo,
     LockManagerBase,
-    LockStoreProtocol,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,11 +66,11 @@ class RaftLockManager(LockManagerBase):
     RETRY_MAX_INTERVAL = 1.0  # Cap at 1 second
     RETRY_MULTIPLIER = 2.0  # Double each retry
 
-    def __init__(self, raft_store: LockStoreProtocol, *, zone_id: str = "root") -> None:
+    def __init__(self, raft_store: Any, *, zone_id: str = "root") -> None:
         """Initialize RaftLockManager.
 
         Args:
-            raft_store: LockStoreProtocol instance for lock storage
+            raft_store: Lock-capable metadata store (e.g., RaftMetadataStore)
             zone_id: Zone ID for key scoping (bound at construction)
         """
         super().__init__(zone_id=zone_id)
@@ -148,7 +147,7 @@ class RaftLockManager(LockManagerBase):
     async def release(self, lock_id: str, path: str) -> bool:
         lock_key = self._lock_key(path)
         try:
-            released = self._store.release_lock(lock_key, lock_id)
+            released: bool = self._store.release_lock(lock_key, lock_id)
             if released:
                 logger.debug("Raft lock released: %s", lock_key)
             else:
@@ -207,7 +206,7 @@ class RaftLockManager(LockManagerBase):
     async def force_release(self, path: str) -> bool:
         lock_key = self._lock_key(path)
         try:
-            released = self._store.force_release_lock(lock_key)
+            released: bool = self._store.force_release_lock(lock_key)
             if released:
                 logger.warning("Raft lock force-released: %s", lock_key)
             else:

--- a/src/nexus/server/api/core/health.py
+++ b/src/nexus/server/api/core/health.py
@@ -41,8 +41,8 @@ async def health_check(request: Request) -> HealthResponse | Any:
         enforce_zone_isolation = getattr(nx_fs, "_enforce_zone_isolation", None)
 
         # Federation mode: ensure topology is initialized (standard Raft lifecycle).
-        zone_mgr = getattr(nx_fs, "_zone_mgr", None)
-        if zone_mgr is not None and not zone_mgr.ensure_topology():
+        _fed = nx_fs.service("federation") if hasattr(nx_fs, "service") else None
+        if _fed is not None and not _fed.ensure_topology():
             from fastapi.responses import JSONResponse
 
             return JSONResponse(

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -344,13 +344,11 @@ def create_app(
         if _version_svc is not None:
             _rpc_sources.append(_version_svc)
         # Issue #1520: FederationRPCService — zone lifecycle, share/join, mounts
-        # Federation is enlisted via ServiceRegistry.
-        _zone_mgr = getattr(nexus_fs, "_zone_mgr", None)
         _fed = nexus_fs.service("federation") if hasattr(nexus_fs, "service") else None
-        if _zone_mgr is not None and _fed is not None:
+        if _fed is not None:
             from nexus.server.rpc.services.federation_rpc import FederationRPCService
 
-            _rpc_sources.append(FederationRPCService(_zone_mgr, _fed))
+            _rpc_sources.append(FederationRPCService(_fed))
         # --- Locks (Issue #1133) ---
         _lock_mgr = getattr(nexus_fs, "_lock_manager", None)
         if _lock_mgr is not None:

--- a/src/nexus/server/health/probes.py
+++ b/src/nexus/server/health/probes.py
@@ -41,10 +41,10 @@ def _check_raft_topology(request: Request) -> tuple[bool, str]:
         nx_fs = getattr(request.app.state, "nexus_fs", None)
         if nx_fs is None:
             return True, ""
-        zone_mgr = getattr(nx_fs, "_zone_mgr", None)
-        if zone_mgr is None:
+        _fed = nx_fs.service("federation") if hasattr(nx_fs, "service") else None
+        if _fed is None:
             return True, ""
-        if not zone_mgr.ensure_topology():
+        if not _fed.ensure_topology():
             return False, "Raft topology not ready"
         return True, ""
     except Exception:

--- a/src/nexus/server/rpc/services/federation_rpc.py
+++ b/src/nexus/server/rpc/services/federation_rpc.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 class FederationRPCService:
     """RPC surface for federation zone lifecycle, mounts, share, and join."""
 
-    def __init__(self, zone_manager: Any, federation: Any | None = None) -> None:
-        self._zone_manager = zone_manager
+    def __init__(self, federation: Any) -> None:
+        self._zone_manager = federation.zone_manager
         self._federation = federation
 
     @rpc_expose(admin_only=True, description="List all federation zones with link counts")

--- a/src/nexus/services/lifecycle/events_service.py
+++ b/src/nexus/services/lifecycle/events_service.py
@@ -70,23 +70,22 @@ class EventsService:
     def __init__(
         self,
         event_bus: "EventBusBase | None" = None,
-        lock_manager: "AdvisoryLockManager | None" = None,
         zone_id: str | None = None,
     ):
         self._event_bus = event_bus
-        # Fallback: if no lock_manager provided, create local semaphore-based one
-        if lock_manager is None:
-            try:
-                from nexus.lib.distributed_lock import SemaphoreAdvisoryLockManager
-                from nexus.lib.semaphore import create_vfs_semaphore
+        # Always create LocalLockManager — may be upgraded to RaftLockManager
+        # at link time via upgrade_lock_manager().
+        try:
+            from nexus.lib.distributed_lock import LocalLockManager
+            from nexus.lib.semaphore import create_vfs_semaphore
 
-                lock_manager = SemaphoreAdvisoryLockManager(
-                    create_vfs_semaphore(), zone_id=zone_id or ROOT_ZONE_ID
-                )
-                logger.debug("[EventsService] Using local SemaphoreAdvisoryLockManager fallback")
-            except Exception as exc:
-                logger.debug("[EventsService] Local lock fallback unavailable: %s", exc)
-        self._lock_manager = lock_manager
+            self._lock_manager: "AdvisoryLockManager | None" = LocalLockManager(
+                create_vfs_semaphore(), zone_id=zone_id or ROOT_ZONE_ID
+            )
+            logger.debug("[EventsService] LocalLockManager created")
+        except Exception as exc:
+            logger.debug("[EventsService] LocalLockManager unavailable: %s", exc)
+            self._lock_manager = None
         self._zone_id = zone_id
         self._event_tasks: set[asyncio.Task[Any]] = set()
 
@@ -121,6 +120,19 @@ class EventsService:
     def _has_lock_manager(self) -> bool:
         """Check if advisory lock manager is available."""
         return self._lock_manager is not None
+
+    def upgrade_lock_manager(self, lock_manager: "AdvisoryLockManager") -> None:
+        """Hot-swap LocalLockManager → RaftLockManager at link time.
+
+        Safe because this runs during _do_link(), before bootstrap/serve —
+        no concurrent access to ``self._lock_manager``.
+        """
+        logger.info(
+            "[EventsService] Lock manager upgraded: %s → %s",
+            type(self._lock_manager).__name__,
+            type(lock_manager).__name__,
+        )
+        self._lock_manager = lock_manager
 
     def _get_zone_id(self, context: "OperationContext | None") -> str:
         """Get zone ID from context or default."""

--- a/src/nexus/services/lifecycle/events_service.py
+++ b/src/nexus/services/lifecycle/events_service.py
@@ -74,6 +74,18 @@ class EventsService:
         zone_id: str | None = None,
     ):
         self._event_bus = event_bus
+        # Fallback: if no lock_manager provided, create local semaphore-based one
+        if lock_manager is None:
+            try:
+                from nexus.lib.distributed_lock import SemaphoreAdvisoryLockManager
+                from nexus.lib.semaphore import create_vfs_semaphore
+
+                lock_manager = SemaphoreAdvisoryLockManager(
+                    create_vfs_semaphore(), zone_id=zone_id or ROOT_ZONE_ID
+                )
+                logger.debug("[EventsService] Using local SemaphoreAdvisoryLockManager fallback")
+            except Exception as exc:
+                logger.debug("[EventsService] Local lock fallback unavailable: %s", exc)
         self._lock_manager = lock_manager
         self._zone_id = zone_id
         self._event_tasks: set[asyncio.Task[Any]] = set()
@@ -306,8 +318,8 @@ class EventsService:
 
         if not self._has_lock_manager():
             raise RuntimeError(
-                "No lock manager available. Advisory lock manager should always "
-                "be created by factory (SemaphoreAdvisoryLockManager or RaftLockManager)."
+                "No lock manager available. EventsService should always have a lock "
+                "manager (local fallback or distributed)."
             )
 
         desc = f"mode={mode}" if max_holders == 1 else f"semaphore({max_holders})"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,7 +146,6 @@ async def make_test_nexus(
     if distributed is None:
         distributed = DistributedConfig(
             enable_events=False,
-            enable_locks=False,
             enable_workflows=False,
         )
 

--- a/tests/e2e/redis/test_multi_instance_workflows.py
+++ b/tests/e2e/redis/test_multi_instance_workflows.py
@@ -129,7 +129,7 @@ async def nexus_fs(temp_nexus_dir, db_path_agent1, shared_event_bus):
             permissions=PermissionConfig(enforce=False, enforce_zone_isolation=False),
             zone_id="test",  # Explicit zone for consistent event routing
             cache=CacheConfig(enable_content_cache=True),
-            distributed=DistributedConfig(enable_locks=True),
+            distributed=DistributedConfig(),
         )
 
     # Inject shared Redis event bus into both the observer and events service.
@@ -173,7 +173,7 @@ async def second_nexus_fs(temp_nexus_dir, db_path_agent2, shared_event_bus):
             permissions=PermissionConfig(enforce=False, enforce_zone_isolation=False),
             zone_id="test",  # Explicit zone for consistent event routing
             cache=CacheConfig(enable_content_cache=True),
-            distributed=DistributedConfig(enable_locks=True),
+            distributed=DistributedConfig(),
         )
 
     # Inject shared Redis event bus.

--- a/tests/e2e/test_lego_decomp_e2e.py
+++ b/tests/e2e/test_lego_decomp_e2e.py
@@ -97,7 +97,6 @@ async def _create_factory_nexus_fs(
         parsing=ParseConfig(auto_parse=False),
         distributed=DistributedConfig(
             enable_events=False,
-            enable_locks=False,
             enable_workflows=False,
         ),
         enable_write_buffer=False,  # Sync writes so versions are immediately visible

--- a/tests/integration/core/test_factory_lifespan_wiring.py
+++ b/tests/integration/core/test_factory_lifespan_wiring.py
@@ -56,7 +56,6 @@ def _make_boot_context(**overrides: object) -> _BootContext:
         "cache_ttl_seconds": 300,
         "dist": MagicMock(
             enable_events=False,
-            enable_locks=False,
             enable_workflows=False,
         ),
         "zone_id": None,

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -54,7 +54,7 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "workspace_registry",
         "mount_manager",
         "workspace_manager",
-        # Original system services
+        # Original services
         "async_namespace_manager",
         "delivery_worker",
         "observability_subsystem",
@@ -63,6 +63,9 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "zone_lifecycle",
         "scheduler_service",
         "event_signal",
+        # Infrastructure (moved from bricks)
+        "event_bus",
+        "lock_manager",
     }
 )
 
@@ -102,7 +105,6 @@ def _make_boot_context(**overrides: object) -> _BootContext:
         "cache_ttl_seconds": 300,
         "dist": DistributedConfig(
             enable_events=False,
-            enable_locks=False,
             enable_workflows=False,
         ),
         "zone_id": None,
@@ -215,6 +217,8 @@ class TestBootSystemServices:
             "observability_subsystem",
             "workspace_registry",  # degradable — None with mock session_factory
             "scheduler_service",  # degradable — None if SchedulerService unavailable
+            "event_bus",  # None when enable_events=False
+            "lock_manager",  # may be None if IPC disabled
         }
         for key, value in result.items():
             if key in _NULLABLE_KEYS:
@@ -267,13 +271,12 @@ class TestBootBrickServices:
         result = _boot_brick_services(ctx, system)
 
         # These keys should always be present (even if values are None)
+        # event_bus/lock_manager moved to _boot_services()
         expected_keys = {
             "wallet_provisioner",
             "manifest_resolver",
             "tool_namespace_middleware",
             "chunked_upload_service",
-            "event_bus",
-            "lock_manager",
             "workflow_engine",
             "api_key_creator",
             "snapshot_service",
@@ -327,7 +330,6 @@ class TestCreateNexusServices:
             ),
             distributed=DistributedConfig(
                 enable_events=False,
-                enable_locks=False,
                 enable_workflows=False,
             ),
             enable_write_buffer=False,
@@ -369,7 +371,6 @@ class TestCreateNexusServices:
             ),
             distributed=DistributedConfig(
                 enable_events=False,
-                enable_locks=False,
                 enable_workflows=False,
             ),
             enable_write_buffer=False,
@@ -420,7 +421,6 @@ class TestBrickServicesFieldCompleteness:
             ),
             distributed=DistributedConfig(
                 enable_events=False,
-                enable_locks=False,
                 enable_workflows=False,
             ),
             enable_write_buffer=False,
@@ -472,7 +472,6 @@ class TestBrickServicesFieldCompleteness:
             ),
             distributed=DistributedConfig(
                 enable_events=False,
-                enable_locks=False,
                 enable_workflows=False,
             ),
             enable_write_buffer=False,

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -65,7 +65,6 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "event_signal",
         # Infrastructure (moved from bricks)
         "event_bus",
-        "lock_manager",
     }
 )
 
@@ -218,7 +217,6 @@ class TestBootSystemServices:
             "workspace_registry",  # degradable — None with mock session_factory
             "scheduler_service",  # degradable — None if SchedulerService unavailable
             "event_bus",  # None when enable_events=False
-            "lock_manager",  # may be None if IPC disabled
         }
         for key, value in result.items():
             if key in _NULLABLE_KEYS:

--- a/tests/unit/core/test_kernel_config.py
+++ b/tests/unit/core/test_kernel_config.py
@@ -108,7 +108,6 @@ class TestDistributedConfig:
         cfg = DistributedConfig()
         assert cfg.coordination_url is None
         assert cfg.enable_events is True
-        assert cfg.enable_locks is True
         assert cfg.enable_workflows is True
         assert cfg.event_bus_backend == "redis"
         assert cfg.nats_url == "nats://localhost:4222"
@@ -122,11 +121,9 @@ class TestDistributedConfig:
         """Test pattern used by make_test_nexus: all distributed features off."""
         cfg = DistributedConfig(
             enable_events=False,
-            enable_locks=False,
             enable_workflows=False,
         )
         assert cfg.enable_events is False
-        assert cfg.enable_locks is False
         assert cfg.enable_workflows is False
 
 

--- a/tests/unit/core/test_service_registry_lazy.py
+++ b/tests/unit/core/test_service_registry_lazy.py
@@ -1,0 +1,78 @@
+"""Unit tests for ServiceRegistry.register_factory() (lazy construction)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.core.service_registry import ServiceRef, ServiceRegistry
+
+
+@pytest.fixture()
+def registry() -> ServiceRegistry:
+    return ServiceRegistry()
+
+
+class TestRegisterFactory:
+    """Tests for register_factory() lazy construction."""
+
+    def test_factory_not_called_on_register(self, registry: ServiceRegistry) -> None:
+        """Factory function is NOT called at register_factory() time."""
+        factory = MagicMock(return_value=MagicMock())
+        registry.register_factory("lazy_svc", factory)
+        factory.assert_not_called()
+
+    def test_factory_called_on_first_access(self, registry: ServiceRegistry) -> None:
+        """Factory function IS called on first service() lookup."""
+        instance = MagicMock()
+        factory = MagicMock(return_value=instance)
+        registry.register_factory("lazy_svc", factory)
+
+        ref = registry.service("lazy_svc")
+        assert ref is not None
+        assert isinstance(ref, ServiceRef)
+        assert ref._service_instance is instance
+        factory.assert_called_once()
+
+    def test_factory_called_only_once(self, registry: ServiceRegistry) -> None:
+        """Second service() call returns cached result, no second factory call."""
+        instance = MagicMock()
+        factory = MagicMock(return_value=instance)
+        registry.register_factory("lazy_svc", factory)
+
+        ref1 = registry.service("lazy_svc")
+        ref2 = registry.service("lazy_svc")
+        assert ref1 is not None
+        assert ref2 is not None
+        assert ref1._service_instance is ref2._service_instance
+        factory.assert_called_once()
+
+    def test_factory_miss_returns_none(self, registry: ServiceRegistry) -> None:
+        """service() on unregistered name still returns None."""
+        assert registry.service("nonexistent") is None
+
+    def test_factory_with_kwargs(self, registry: ServiceRegistry) -> None:
+        """register_factory forwards kwargs to register_service."""
+        instance = MagicMock(spec=["glob"])
+        factory = MagicMock(return_value=instance)
+        registry.register_factory("lazy_svc", factory, exports=("glob",))
+
+        ref = registry.service("lazy_svc")
+        assert ref is not None
+        info = registry.service_info("lazy_svc")
+        assert info is not None
+        assert info.exports == ("glob",)
+
+    def test_factory_overridden_by_direct_register(self, registry: ServiceRegistry) -> None:
+        """Direct register_service before first access overrides factory."""
+        factory = MagicMock(return_value=MagicMock())
+        registry.register_factory("lazy_svc", factory)
+
+        direct_instance = MagicMock()
+        registry.register_service("lazy_svc", direct_instance)
+
+        ref = registry.service("lazy_svc")
+        assert ref is not None
+        assert ref._service_instance is direct_instance
+        factory.assert_not_called()

--- a/tests/unit/lib/test_advisory_lock_manager.py
+++ b/tests/unit/lib/test_advisory_lock_manager.py
@@ -1,4 +1,4 @@
-"""Unit tests for SemaphoreAdvisoryLockManager (standalone advisory lock manager).
+"""Unit tests for LocalLockManager (standalone advisory lock manager).
 
 Tests use a real PythonVFSSemaphore — no mocks needed.
 """
@@ -7,7 +7,7 @@ import time
 
 import pytest
 
-from nexus.lib.distributed_lock import ExtendResult, SemaphoreAdvisoryLockManager
+from nexus.lib.distributed_lock import ExtendResult, LocalLockManager
 from nexus.lib.semaphore import PythonVFSSemaphore
 
 # ---------------------------------------------------------------------------
@@ -22,7 +22,7 @@ def sem():
 
 @pytest.fixture
 def mgr(sem):
-    return SemaphoreAdvisoryLockManager(sem, zone_id="z1")
+    return LocalLockManager(sem, zone_id="z1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/health/test_probes.py
+++ b/tests/unit/server/health/test_probes.py
@@ -90,9 +90,11 @@ class TestReadinessProbe:
         for phase in _REQUIRED_FOR_READY:
             tracker.complete(phase)
 
-        # Mock NexusFS with zone_mgr that returns False
+        # Mock NexusFS with federation service that returns topology not ready
+        mock_fed = MagicMock()
+        mock_fed.ensure_topology.return_value = False
         mock_fs = MagicMock()
-        mock_fs._zone_mgr.ensure_topology.return_value = False
+        mock_fs.service.return_value = mock_fed
 
         app = _make_app(tracker)
         app.state.nexus_fs = mock_fs
@@ -106,8 +108,10 @@ class TestReadinessProbe:
         for phase in _REQUIRED_FOR_READY:
             tracker.complete(phase)
 
+        mock_fed = MagicMock()
+        mock_fed.ensure_topology.return_value = True
         mock_fs = MagicMock()
-        mock_fs._zone_mgr.ensure_topology.return_value = True
+        mock_fs.service.return_value = mock_fed
 
         app = _make_app(tracker)
         app.state.nexus_fs = mock_fs

--- a/tests/unit/services/test_events_service.py
+++ b/tests/unit/services/test_events_service.py
@@ -66,25 +66,33 @@ def _make_event(path: str = "/inbox/test.txt", event_type: str = "file_write") -
 class TestEventsServiceInit:
     """Tests for EventsService construction."""
 
-    def test_init_stores_all_dependencies(self, mock_event_bus, mock_lock_manager):
-        """Service stores all injected dependencies."""
+    def test_init_stores_event_bus(self, mock_event_bus):
+        """Service stores event bus dependency."""
         svc = EventsService(
             event_bus=mock_event_bus,
-            lock_manager=mock_lock_manager,
             zone_id="z1",
         )
         assert svc._event_bus is mock_event_bus
-        assert svc._lock_manager is mock_lock_manager
+        assert svc._lock_manager is not None  # LocalLockManager auto-created
         assert svc._zone_id == "z1"
         assert svc._observe_registered is True  # hooks registered at enlist() time
 
     def test_init_minimal(self):
-        """Service can be created with no dependencies — local lock fallback auto-created."""
+        """Service can be created with no dependencies — LocalLockManager auto-created."""
         svc = EventsService()
         assert svc._event_bus is None
-        assert svc._lock_manager is not None  # local fallback auto-created
+        assert svc._lock_manager is not None  # LocalLockManager auto-created
         assert svc._zone_id is None
         assert svc._observe_registered is True  # hooks registered at enlist() time
+
+    def test_upgrade_lock_manager(self, mock_lock_manager):
+        """upgrade_lock_manager() replaces the default LocalLockManager."""
+        svc = EventsService()
+        original = svc._lock_manager
+        assert original is not None
+        svc.upgrade_lock_manager(mock_lock_manager)
+        assert svc._lock_manager is mock_lock_manager
+        assert svc._lock_manager is not original
 
 
 # =============================================================================
@@ -137,9 +145,10 @@ class TestInfrastructureDetection:
         svc = EventsService()
         assert svc._has_distributed_events() is False
 
-    def test_has_lock_manager_true(self, mock_lock_manager):
-        """Lock manager present means distributed locks available."""
-        svc = EventsService(lock_manager=mock_lock_manager)
+    def test_has_lock_manager_true_after_upgrade(self, mock_lock_manager):
+        """Lock manager present after upgrade means distributed locks available."""
+        svc = EventsService()
+        svc.upgrade_lock_manager(mock_lock_manager)
         assert svc._has_lock_manager() is True
 
     def test_has_lock_manager_always_true(self):
@@ -372,11 +381,17 @@ class TestWaitForChangesNoInfra:
 
 
 class TestDistributedLocking:
-    """Tests for locking via distributed lock manager."""
+    """Tests for locking via upgraded (distributed) lock manager."""
+
+    def _make_svc(self, mock_lock_manager):
+        """Create EventsService and upgrade to distributed lock manager."""
+        svc = EventsService()
+        svc.upgrade_lock_manager(mock_lock_manager)
+        return svc
 
     def test_lock_acquires_distributed(self, mock_lock_manager):
         """Lock uses distributed lock manager when available."""
-        svc = EventsService(lock_manager=mock_lock_manager)
+        svc = self._make_svc(mock_lock_manager)
         lock_id = asyncio.run(svc.lock("/data/file.txt", timeout=5.0, ttl=10.0))
         assert lock_id == "dist-lock-456"
         mock_lock_manager.acquire.assert_called_once()
@@ -384,26 +399,26 @@ class TestDistributedLocking:
     def test_lock_returns_none_on_timeout(self, mock_lock_manager):
         """Lock returns None when distributed lock times out."""
         mock_lock_manager.acquire = AsyncMock(return_value=None)
-        svc = EventsService(lock_manager=mock_lock_manager)
+        svc = self._make_svc(mock_lock_manager)
         lock_id = asyncio.run(svc.lock("/data/file.txt", timeout=1.0))
         assert lock_id is None
 
     def test_unlock_releases_distributed(self, mock_lock_manager):
         """Unlock releases distributed lock."""
-        svc = EventsService(lock_manager=mock_lock_manager)
+        svc = self._make_svc(mock_lock_manager)
         result = asyncio.run(svc.unlock("dist-lock-456", path="/data/file.txt"))
         assert result is True
         mock_lock_manager.release.assert_called_once()
 
     def test_unlock_requires_path_for_distributed(self, mock_lock_manager):
         """Distributed unlock requires path parameter."""
-        svc = EventsService(lock_manager=mock_lock_manager)
+        svc = self._make_svc(mock_lock_manager)
         with pytest.raises(ValueError, match="path is required"):
             asyncio.run(svc.unlock("dist-lock-456", path=None))
 
     def test_extend_lock_distributed(self, mock_lock_manager):
         """Extend lock uses distributed lock manager."""
-        svc = EventsService(lock_manager=mock_lock_manager)
+        svc = self._make_svc(mock_lock_manager)
         result = asyncio.run(svc.extend_lock("dist-lock-456", path="/data/file.txt", ttl=60.0))
         assert result is True
         mock_lock_manager.extend.assert_called_once()
@@ -415,7 +430,7 @@ class TestDistributedLocking:
 
 
 class TestLockingLocalFallback:
-    """Tests for locking with local SemaphoreAdvisoryLockManager fallback."""
+    """Tests for locking with LocalLockManager (auto-created)."""
 
     def test_lock_uses_local_fallback(self):
         """EventsService auto-creates local lock manager when none provided."""
@@ -462,7 +477,8 @@ class TestLockedContextManager:
         from nexus.contracts.exceptions import LockTimeout
 
         mock_lock_manager.acquire = AsyncMock(return_value=None)
-        svc = EventsService(lock_manager=mock_lock_manager)
+        svc = EventsService()
+        svc.upgrade_lock_manager(mock_lock_manager)
 
         async def _test():
             async with svc.locked("/data/file.txt", timeout=1.0):
@@ -473,7 +489,8 @@ class TestLockedContextManager:
 
     def test_locked_releases_on_exit(self, mock_lock_manager):
         """locked() releases lock on context exit."""
-        svc = EventsService(lock_manager=mock_lock_manager)
+        svc = EventsService()
+        svc.upgrade_lock_manager(mock_lock_manager)
 
         async def _test():
             async with svc.locked("/data/file.txt") as lock_id:

--- a/tests/unit/services/test_events_service.py
+++ b/tests/unit/services/test_events_service.py
@@ -79,10 +79,10 @@ class TestEventsServiceInit:
         assert svc._observe_registered is True  # hooks registered at enlist() time
 
     def test_init_minimal(self):
-        """Service can be created with no dependencies."""
+        """Service can be created with no dependencies — local lock fallback auto-created."""
         svc = EventsService()
         assert svc._event_bus is None
-        assert svc._lock_manager is None
+        assert svc._lock_manager is not None  # local fallback auto-created
         assert svc._zone_id is None
         assert svc._observe_registered is True  # hooks registered at enlist() time
 
@@ -142,10 +142,10 @@ class TestInfrastructureDetection:
         svc = EventsService(lock_manager=mock_lock_manager)
         assert svc._has_lock_manager() is True
 
-    def test_has_lock_manager_false(self):
-        """No lock manager means no distributed locks."""
+    def test_has_lock_manager_always_true(self):
+        """EventsService auto-creates local fallback — always has lock manager."""
         svc = EventsService()
-        assert svc._has_lock_manager() is False
+        assert svc._has_lock_manager() is True
 
 
 # =============================================================================
@@ -414,26 +414,39 @@ class TestDistributedLocking:
 # =============================================================================
 
 
-class TestLockingNoInfrastructure:
-    """Tests for locking when no lock infrastructure is available."""
+class TestLockingLocalFallback:
+    """Tests for locking with local SemaphoreAdvisoryLockManager fallback."""
 
-    def test_lock_raises_runtime_error(self):
-        """Lock raises RuntimeError without any lock manager."""
+    def test_lock_uses_local_fallback(self):
+        """EventsService auto-creates local lock manager when none provided."""
         svc = EventsService()
-        with pytest.raises(RuntimeError, match="No lock manager"):
-            asyncio.run(svc.lock("/data/file.txt"))
+        assert svc._has_lock_manager() is True
+        lock_id = asyncio.run(svc.lock("/data/file.txt", timeout=1.0))
+        assert lock_id is not None
 
-    def test_unlock_raises_runtime_error(self):
-        """Unlock raises RuntimeError without any lock manager."""
+    def test_unlock_with_local_fallback(self):
+        """Unlock works with local fallback lock manager."""
         svc = EventsService()
-        with pytest.raises(RuntimeError, match="No lock manager"):
-            asyncio.run(svc.unlock("lock-123", path="/data/file.txt"))
 
-    def test_extend_raises_runtime_error(self):
-        """Extend raises RuntimeError without any lock manager."""
+        async def _test():
+            lock_id = await svc.lock("/data/file.txt", timeout=1.0)
+            assert lock_id is not None
+            result = await svc.unlock(lock_id, path="/data/file.txt")
+            assert result is True
+
+        asyncio.run(_test())
+
+    def test_extend_with_local_fallback(self):
+        """Extend works with local fallback lock manager."""
         svc = EventsService()
-        with pytest.raises(RuntimeError, match="No lock manager"):
-            asyncio.run(svc.extend_lock("lock-123", path="/data/file.txt"))
+
+        async def _test():
+            lock_id = await svc.lock("/data/file.txt", timeout=1.0)
+            assert lock_id is not None
+            result = await svc.extend_lock(lock_id, path="/data/file.txt", ttl=60.0)
+            assert result is True
+
+        asyncio.run(_test())
 
 
 # =============================================================================

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -81,7 +81,6 @@ def _make_mock_ctx(**overrides: Any) -> Any:
         "cache_ttl_seconds": 300,
         "dist": MagicMock(
             enable_events=False,
-            enable_locks=False,
             enable_workflows=False,
         ),
         "zone_id": None,
@@ -170,17 +169,20 @@ class TestBootSystemServices:
             "workspace_registry",
             "mount_manager",
             "workspace_manager",
-            # Original system services
+            # Original services
             "async_namespace_manager",
             "delivery_worker",
             "observability_subsystem",
             "resiliency_manager",
             "context_branch_service",
             "zone_lifecycle",
-            # (PipeManager + AgentRegistry are kernel-internal §4.2, not in SystemServices)
+            # (PipeManager + AgentRegistry are kernel-internal §4.2)
             "scheduler_service",
             # Issue #3193: shared notification signal
             "event_signal",
+            # Infrastructure (moved from bricks)
+            "event_bus",
+            "lock_manager",
         }
         assert expected_keys == set(result.keys())
 
@@ -257,8 +259,6 @@ class TestBootBrickServices:
             "manifest_metrics",
             "tool_namespace_middleware",
             "chunked_upload_service",
-            "event_bus",
-            "lock_manager",
             "workflow_engine",
             "api_key_creator",
             "snapshot_service",

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -182,7 +182,6 @@ class TestBootSystemServices:
             "event_signal",
             # Infrastructure (moved from bricks)
             "event_bus",
-            "lock_manager",
         }
         assert expected_keys == set(result.keys())
 


### PR DESCRIPTION
## Summary

- **Phase 1**: Consolidate lock manager paths, rename `SemaphoreAdvisoryLockManager` → `LocalLockManager`, EventsService self-creates lock manager with `upgrade_lock_manager()` for hot-swap, delete `_create_distributed_infra()` + inline event_bus
- **Phase 2**: Linearize `create_nexus_fs` (eliminate partial injection), profile-gated federation via `NexusFederation.bootstrap()`, fix dead lock manager upgrade, delete `LockStoreProtocol`

### Key changes

1. **Rename boot functions**: `_boot_services` → `_boot_pre_kernel_services`, `_boot_wired_services` → `_boot_post_kernel_services` (compat aliases preserved)
2. **NexusFederation.bootstrap()**: classmethod encapsulating ~100 lines of connect() federation setup (env vars, TLS, ZoneManager retry, join detection)
3. **BRICK_FEDERATION**: new `"federation"` brick in CLOUD/INNOVATION profiles, not in FULL/LITE/SLIM
4. **Linearize create_nexus_fs**: `_InitContext` dataclass replaces `functools.partial` injection; `_do_link` → `_wire_services`, `_do_initialize` → `_initialize_services`
5. **Fix dead lock manager upgrade**: federation passed through factory → `_wire_services`; RaftLockManager upgrade now fires (was dead code: connect() set `_zone_mgr` AFTER `create_nexus_fs` returned)
6. **Delete LockStoreProtocol**: only one implementer, checked inside block already guaranteeing Raft mode

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — pass
- [x] `pytest tests/unit/services/test_events_service.py` — pass
- [x] `pytest tests/unit/lib/test_advisory_lock_manager.py` — pass
- [x] Import check: `from nexus.factory import _boot_pre_kernel_services, _boot_system_services`
- [x] Import check: `from nexus.lib.distributed_lock import LocalLockManager, AdvisoryLockManager`
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary check)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)