### PR TITLE
Reduce dev Postgres shared_buffers default

### DIFF
--- a/dockerfiles/compose.yaml
+++ b/dockerfiles/compose.yaml
@@ -64,7 +64,7 @@ services:
     # pgvector HNSW tuning (Issue #1004):
     # - maintenance_work_mem=2GB: Faster index builds for 100K+ vectors
     # - max_parallel_maintenance_workers=7: Parallel index build (up to 30x faster)
-    # - shared_buffers=1GB: Cache HNSW index in memory
+    # - shared_buffers=128MB: Keep dev-stack Postgres memory modest
     # See: docs/performance/vector-search-tuning.md
     command: >
       postgres
@@ -78,7 +78,7 @@ services:
       -c archive_timeout=300
       -c maintenance_work_mem=2GB
       -c max_parallel_maintenance_workers=7
-      -c shared_buffers=1GB
+      -c shared_buffers=128MB
       -c effective_cache_size=3GB
     ports:
       - "${POSTGRES_PORT:-5432}:5432"

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -38,7 +38,7 @@ services:
       -c effective_io_concurrency=16
       -c maintenance_io_concurrency=16
       -c wal_compression=lz4
-      -c shared_buffers=1GB
+      -c shared_buffers=128MB
       -c effective_cache_size=3GB
     ports:
       - "${POSTGRES_PORT:-5432}:5432"


### PR DESCRIPTION
## Summary
- reduce the dev Postgres shared_buffers setting from 1GB to 128MB
- keep the bundled portable stack and repo compose file aligned
- leave runtime behavior unchanged aside from the lower Postgres cache target after container recreate

## Testing
- not run (config-only change)