### PR TITLE
Fix remote rename permission propagation

### DIFF
--- a/permissions_demo_enhanced.sh
+++ b/permissions_demo_enhanced.sh
@@ -20,6 +20,18 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export NEXUS_REPO_ROOT="$SCRIPT_DIR"
+export PYTHONPATH="$NEXUS_REPO_ROOT/src${PYTHONPATH:+:$PYTHONPATH}"
+
+nexus() {
+    uv run python -m nexus.cli.main "$@"
+}
+
+nexus_python() {
+    uv run python "$@"
+}
+
 # Colors
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
@@ -28,6 +40,7 @@ RED='\033[0;31m'
 CYAN='\033[0;36m'
 MAGENTA='\033[0;35m'
 NC='\033[0m'
+FAILURES=0
 
 print_section() {
     echo ""
@@ -46,13 +59,20 @@ print_subsection() {
 print_success() { echo -e "${GREEN}✓${NC} $1"; }
 print_info() { echo -e "${BLUE}ℹ${NC} $1"; }
 print_warning() { echo -e "${YELLOW}⚠${NC} $1"; }
-print_error() { echo -e "${RED}✗${NC} $1"; }
+print_error() {
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}✗${NC} $1"
+}
 print_test() { echo -e "${MAGENTA}TEST:${NC} $1"; }
 
 # Check prerequisites
 if [ -z "$NEXUS_URL" ] || [ -z "$NEXUS_API_KEY" ]; then
     print_error "NEXUS_URL and NEXUS_API_KEY not set. Run: source .nexus-admin-env"
     exit 1
+fi
+
+if [ -n "$DATABASE_URL" ] && [ -z "$NEXUS_DATABASE_URL" ]; then
+    export NEXUS_DATABASE_URL="$DATABASE_URL"
 fi
 
 echo "╔══════════════════════════════════════════════════════════╗"
@@ -70,7 +90,7 @@ export DEMO_BASE="/workspace/rebac-comprehensive-demo"  # BUGFIX: Export for Pyt
 # scoping — meaning files created by root-zone admin live at /workspace/... while
 # non-admin users see /zone/default/workspace/... (zone-scoped). Using a
 # default-zone admin key ensures consistent path scoping across all operations.
-ADMIN_KEY=$(python3 scripts/create-api-key.py admin "Demo Admin (default zone)" --days 1 --zone-id default --admin 2>/dev/null | grep "API Key:" | awk '{print $3}')
+ADMIN_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" admin "Demo Admin (default zone)" --days 1 --zone-id default --admin 2>/dev/null | grep "API Key:" | awk '{print $3}')
 if [ -z "$ADMIN_KEY" ]; then
     echo "WARNING: Failed to create default-zone admin key, falling back to root admin"
     ADMIN_KEY="$ROOT_ADMIN_KEY"
@@ -113,12 +133,12 @@ print_info "Cleaning up stale test data..."
 nexus rmdir -r -f $DEMO_BASE 2>/dev/null || true
 nexus rmdir -r -f /shared-readonly-test 2>/dev/null || true
 
-python3 << 'CLEANUP'
+nexus_python << 'CLEANUP'
 import sys, os
-sys.path.insert(0, 'src')
+sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
 
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 
@@ -228,9 +248,14 @@ echo "  This is the actual behavior - owners need editor/viewer role for read!"
 echo ""
 
 # Create test users
-ALICE_KEY=$(python3 scripts/create-api-key.py alice "Alice Owner" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
-BOB_KEY=$(python3 scripts/create-api-key.py bob "Bob Editor" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
-CHARLIE_KEY=$(python3 scripts/create-api-key.py charlie "Charlie Viewer" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
+ALICE_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" alice "Alice Owner" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
+BOB_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" bob "Bob Editor" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
+CHARLIE_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" charlie "Charlie Viewer" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
+
+if [ -z "$ALICE_KEY" ] || [ -z "$BOB_KEY" ] || [ -z "$CHARLIE_KEY" ]; then
+    print_error "Failed to create one or more demo user API keys"
+    exit 1
+fi
 
 # BUGFIX: Ensure test resources exist before assigning permissions
 echo "test content" | nexus write $DEMO_BASE/test-file.txt - 2>/dev/null
@@ -372,11 +397,11 @@ print_success "Created: $DEMO_BASE/project1/docs/guides/advanced"
 nexus rebac create user bob direct_editor file $DEMO_BASE/project1
 
 # Set up parent relations
-python3 << 'PYTHON_PARENTS'
+nexus_python << 'PYTHON_PARENTS'
 import sys, os
-sys.path.insert(0, 'src')
+sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 rebac.rebac_create_sync(("file", f"{base}/project1/docs"), "parent", ("file", f"{base}/project1"))
@@ -472,11 +497,11 @@ fi
 
 print_subsection "5.2 List all tuples for a user"
 print_info "Listing all permissions for bob..."
-python3 << 'PYTHON_LIST'
+nexus_python << 'PYTHON_LIST'
 import sys, os
-sys.path.insert(0, 'src')
+sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync(subject=("user", "bob"))
 print(f"Bob has {len(tuples)} permission tuples:")
@@ -501,11 +526,11 @@ fi
 
 print_subsection "6.2 Attempt to create cycle in parent relations"
 print_test "Creating cycle: A→B→A should fail"
-python3 << 'PYTHON_CYCLE'
+nexus_python << 'PYTHON_CYCLE'
 import sys, os
-sys.path.insert(0, 'src')
+sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 try:
@@ -601,12 +626,12 @@ print_info "Note: Shared dir is at top-level (outside /workspace) to isolate fro
 # and re-adding his group membership. This triggers tiger_persist_revoke()
 # which clears bob's materialized write-everywhere bitmap. Without this,
 # the enforcer's parent walk finds bob has cached write on "/" via parent_editor.
-python3 << 'CACHE_INVALIDATE'
+nexus_python << 'CACHE_INVALIDATE'
 import sys, os
-sys.path.insert(0, 'src')
+sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
 
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync()
 
@@ -727,11 +752,11 @@ fi
 
 print_subsection "8.2 Test cache invalidation on permission DELETE"
 # Get tuple ID via Python SDK
-TUPLE_ID=$(python3 << PYTHON_TUPLE_ID
+TUPLE_ID=$(nexus_python << PYTHON_TUPLE_ID
 import sys, os
-sys.path.insert(0, 'src')
+sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync(subject=('user', 'alice'), object=('file', '$DEMO_BASE/cache-test.txt'))
 print(tuples[0]['tuple_id'] if tuples else '')
@@ -754,7 +779,7 @@ fi
 print_section "9. Multi-Tenant Isolation"
 
 print_subsection "9.1 Create user in different tenant"
-TENANT_ACME_KEY=$(python3 scripts/create-api-key.py acme_user "ACME Corp User" --days 1 --zone-id acme 2>/dev/null | grep "API Key:" | awk '{print $3}')
+TENANT_ACME_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" acme_user "ACME Corp User" --days 1 --zone-id acme 2>/dev/null | grep "API Key:" | awk '{print $3}')
 print_success "Created acme_user (tenant: acme)"
 print_info "Alice, Bob, Charlie are in tenant: default"
 
@@ -780,12 +805,12 @@ print_info "Benchmarking rebac_check latency (single connection, excludes connec
 print_info "Dragonfly URL: ${NEXUS_DRAGONFLY_URL:-not set (fallback to PG)}"
 print_info "TigerCache: enabled by default (NEXUS_ENABLE_TIGER_CACHE)"
 
-python3 << 'PYTHON_BENCH'
+nexus_python << 'PYTHON_BENCH'
 import sys, os, time, statistics
-sys.path.insert(0, 'src')
+sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
 
-import asyncio; nx = asyncio.get_event_loop().run_until_complete(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 
@@ -866,4 +891,9 @@ echo "║  ✅ Multi-Tenant Isolation                                        ║
 echo "║  ✅ Permission Check Latency (sub-ms server-side)                 ║"
 echo "╚═══════════════════════════════════════════════════════════════════╝"
 echo ""
-print_info "All tests passed! ReBAC system is production-ready."
+if [ "$FAILURES" -eq 0 ]; then
+    print_info "All tests passed! ReBAC system is production-ready."
+else
+    print_error "$FAILURES checks failed in the ReBAC demo."
+    exit 1
+fi

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -319,9 +319,13 @@ async def connect(
         # Wire service proxies for REMOTE profile (Issue #1171).
         # Fills all 25+ service slots with RemoteServiceProxy — forwards
         # method calls to the server via gRPC.
-        from nexus.factory._remote import _boot_remote_services
+        from nexus.factory._remote import (
+            _boot_remote_services,
+            install_remote_kernel_rpc_overrides,
+        )
 
         await _boot_remote_services(nfs, call_rpc=transport.call_rpc)
+        install_remote_kernel_rpc_overrides(nfs, transport)
         nfs._register_runtime_closeable(transport)
 
         return nfs

--- a/src/nexus/backends/storage/remote.py
+++ b/src/nexus/backends/storage/remote.py
@@ -65,6 +65,16 @@ class RemoteBackend(ObjectStoreABC):
         """Remote server always has a configured root path."""
         return True
 
+    @property
+    def user_scoped(self) -> bool:
+        """REMOTE profile is not a per-user OAuth connector backend."""
+        return False
+
+    @property
+    def has_token_manager(self) -> bool:
+        """REMOTE profile delegates auth to the server transport."""
+        return False
+
     # === RPC Transport ===
 
     def _call_rpc(

--- a/src/nexus/bricks/rebac/path_updater.py
+++ b/src/nexus/bricks/rebac/path_updater.py
@@ -58,9 +58,11 @@ class PathUpdater:
             ``should_bump_version`` to decide whether to increment
             ``_tuple_version``.
         """
-        # Unscope zone-prefixed paths — tuples store unscoped paths
-        # (e.g., /workspace/...) while rename operations may pass
-        # zone-scoped paths (e.g., /zone/default/workspace/...).
+        requested_zone_id = self._extract_zone_id(old_path) or self._extract_zone_id(new_path)
+
+        # Normalize to the user-facing virtual path. Some tuples are stored
+        # unscoped and others preserve /zone/{id}/..., so the rewrite logic
+        # below updates whichever representation each tuple currently uses.
         try:
             from nexus.lib.path_utils import unscope_internal_path
 
@@ -88,6 +90,7 @@ class PathUpdater:
                 conn,
                 old_path,
                 new_path,
+                requested_zone_id,
                 object_type,
                 is_directory,
             )
@@ -99,6 +102,7 @@ class PathUpdater:
                 conn,
                 old_path,
                 new_path,
+                requested_zone_id,
                 object_type,
                 is_directory,
             )
@@ -108,6 +112,7 @@ class PathUpdater:
             self._cleanup_tiger_resource_map(
                 cursor,
                 old_path,
+                requested_zone_id,
                 object_type,
                 is_directory,
             )
@@ -127,6 +132,7 @@ class PathUpdater:
         conn: Any,
         old_path: str,
         new_path: str,
+        requested_zone_id: str | None,
         object_type: str,
         is_directory: bool,
     ) -> int:
@@ -134,35 +140,24 @@ class PathUpdater:
             logger.debug("STEP 1: Looking for tuples with object_id matching %s", old_path)
 
         now_iso = datetime.now(UTC).isoformat()
+        candidates = self._path_candidates(old_path, requested_zone_id)
+        where_sql, params = self._build_path_match_clause("object_id", candidates, is_directory)
+        zone_sql, zone_params = self._build_zone_clause(requested_zone_id)
 
-        if is_directory:
-            cursor.execute(
-                self._fix_sql(
-                    """
-                    SELECT tuple_id, subject_type, subject_id, subject_relation,
-                           relation, object_type, object_id, zone_id
-                    FROM rebac_tuples
-                    WHERE object_type = ?
-                      AND (object_id = ? OR object_id LIKE ?)
-                      AND (expires_at IS NULL OR expires_at >= ?)
-                    """
-                ),
-                (object_type, old_path, old_path + "/%", now_iso),
-            )
-        else:
-            cursor.execute(
-                self._fix_sql(
-                    """
-                    SELECT tuple_id, subject_type, subject_id, subject_relation,
-                           relation, object_type, object_id, zone_id
-                    FROM rebac_tuples
-                    WHERE object_type = ?
-                      AND object_id = ?
-                      AND (expires_at IS NULL OR expires_at >= ?)
-                    """
-                ),
-                (object_type, old_path, now_iso),
-            )
+        cursor.execute(
+            self._fix_sql(
+                f"""
+                SELECT tuple_id, subject_type, subject_id, subject_relation,
+                       relation, object_type, object_id, zone_id
+                FROM rebac_tuples
+                WHERE object_type = ?
+                  AND ({where_sql})
+                  {zone_sql}
+                  AND (expires_at IS NULL OR expires_at >= ?)
+                """
+            ),
+            (object_type, *params, *zone_params, now_iso),
+        )
 
         rows = cursor.fetchall()
         if logger.isEnabledFor(logging.DEBUG):
@@ -171,57 +166,35 @@ class PathUpdater:
         if not rows:
             return 0
 
-        old_prefix_len = len(old_path)
         now_iso = datetime.now(UTC).isoformat()
-
-        # Batch UPDATE
-        if is_directory:
-            cursor.execute(
-                self._fix_sql(
-                    """
-                    UPDATE rebac_tuples
-                    SET object_id = CASE
-                        WHEN object_id = ? THEN ?
-                        ELSE ? || SUBSTR(object_id, ?)
-                    END
-                    WHERE object_type = ?
-                      AND (object_id = ? OR object_id LIKE ?)
-                      AND (expires_at IS NULL OR expires_at >= ?)
-                    """
-                ),
-                (
-                    old_path,
-                    new_path,
-                    new_path,
-                    old_prefix_len + 1,
-                    object_type,
-                    old_path,
-                    old_path + "/%",
-                    now_iso,
-                ),
-            )
-        else:
-            cursor.execute(
-                self._fix_sql(
-                    """
-                    UPDATE rebac_tuples
-                    SET object_id = ?
-                    WHERE object_type = ?
-                      AND object_id = ?
-                      AND (expires_at IS NULL OR expires_at >= ?)
-                    """
-                ),
-                (new_path, object_type, old_path, now_iso),
-            )
 
         # Batch changelog INSERT
         changelog_entries = []
         for row in rows:
             old_object_id = row["object_id"]
-            new_object_id = (
-                new_path + old_object_id[old_prefix_len:]
-                if is_directory and old_object_id.startswith(old_path + "/")
-                else new_path
+            new_object_id = self._rewrite_stored_path(
+                old_object_id,
+                old_path,
+                new_path,
+                row["zone_id"],
+                is_directory,
+            )
+            if new_object_id is None:
+                logger.warning(
+                    "Skipping object_id tuple %s during rename; no rewrite match for %s",
+                    row["tuple_id"],
+                    old_object_id,
+                )
+                continue
+            cursor.execute(
+                self._fix_sql(
+                    """
+                    UPDATE rebac_tuples
+                    SET object_id = ?
+                    WHERE tuple_id = ?
+                    """
+                ),
+                (new_object_id, row["tuple_id"]),
             )
             changelog_entries.append(
                 (
@@ -237,27 +210,32 @@ class PathUpdater:
                 )
             )
 
-        cursor.executemany(
-            self._fix_sql(
-                """
-                INSERT INTO rebac_changelog (
-                    change_type, tuple_id, subject_type, subject_id,
-                    relation, object_type, object_id, zone_id, created_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """
-            ),
-            changelog_entries,
-        )
+        if changelog_entries:
+            cursor.executemany(
+                self._fix_sql(
+                    """
+                    INSERT INTO rebac_changelog (
+                        change_type, tuple_id, subject_type, subject_id,
+                        relation, object_type, object_id, zone_id, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """
+                ),
+                changelog_entries,
+            )
 
         # Cache invalidation
         for row in rows:
             old_object_id = row["object_id"]
-            new_object_id = (
-                new_path + old_object_id[old_prefix_len:]
-                if is_directory and old_object_id.startswith(old_path + "/")
-                else new_path
+            new_object_id = self._rewrite_stored_path(
+                old_object_id,
+                old_path,
+                new_path,
+                row["zone_id"],
+                is_directory,
             )
+            if new_object_id is None:
+                continue
 
             subject = Entity(row["subject_type"], row["subject_id"])
             old_obj = Entity(object_type, old_object_id)
@@ -281,7 +259,7 @@ class PathUpdater:
 
             self._invalidate_cache(subject, relation, new_obj, zone_id, subject_relation, conn=conn)
 
-        return len(rows)
+        return len(changelog_entries)
 
     # ------------------------------------------------------------------
     # STEP 2 — subject_id updates
@@ -293,6 +271,7 @@ class PathUpdater:
         conn: Any,
         old_path: str,
         new_path: str,
+        requested_zone_id: str | None,
         object_type: str,
         is_directory: bool,
     ) -> int:
@@ -300,35 +279,24 @@ class PathUpdater:
             logger.debug("STEP 2: Looking for tuples with subject_id matching %s", old_path)
 
         now_iso = datetime.now(UTC).isoformat()
+        candidates = self._path_candidates(old_path, requested_zone_id)
+        where_sql, params = self._build_path_match_clause("subject_id", candidates, is_directory)
+        zone_sql, zone_params = self._build_zone_clause(requested_zone_id)
 
-        if is_directory:
-            cursor.execute(
-                self._fix_sql(
-                    """
-                    SELECT tuple_id, subject_type, subject_id, subject_relation,
-                           relation, object_type, object_id, zone_id
-                    FROM rebac_tuples
-                    WHERE subject_type = ?
-                      AND (subject_id = ? OR subject_id LIKE ?)
-                      AND (expires_at IS NULL OR expires_at >= ?)
-                    """
-                ),
-                (object_type, old_path, old_path + "/%", now_iso),
-            )
-        else:
-            cursor.execute(
-                self._fix_sql(
-                    """
-                    SELECT tuple_id, subject_type, subject_id, subject_relation,
-                           relation, object_type, object_id, zone_id
-                    FROM rebac_tuples
-                    WHERE subject_type = ?
-                      AND subject_id = ?
-                      AND (expires_at IS NULL OR expires_at >= ?)
-                    """
-                ),
-                (object_type, old_path, now_iso),
-            )
+        cursor.execute(
+            self._fix_sql(
+                f"""
+                SELECT tuple_id, subject_type, subject_id, subject_relation,
+                       relation, object_type, object_id, zone_id
+                FROM rebac_tuples
+                WHERE subject_type = ?
+                  AND ({where_sql})
+                  {zone_sql}
+                  AND (expires_at IS NULL OR expires_at >= ?)
+                """
+            ),
+            (object_type, *params, *zone_params, now_iso),
+        )
 
         subject_rows = cursor.fetchall()
         if logger.isEnabledFor(logging.DEBUG):
@@ -340,57 +308,35 @@ class PathUpdater:
         if not subject_rows:
             return 0
 
-        old_prefix_len = len(old_path)
         now_iso = datetime.now(UTC).isoformat()
-
-        # Batch UPDATE
-        if is_directory:
-            cursor.execute(
-                self._fix_sql(
-                    """
-                    UPDATE rebac_tuples
-                    SET subject_id = CASE
-                        WHEN subject_id = ? THEN ?
-                        ELSE ? || SUBSTR(subject_id, ?)
-                    END
-                    WHERE subject_type = ?
-                      AND (subject_id = ? OR subject_id LIKE ?)
-                      AND (expires_at IS NULL OR expires_at >= ?)
-                    """
-                ),
-                (
-                    old_path,
-                    new_path,
-                    new_path,
-                    old_prefix_len + 1,
-                    object_type,
-                    old_path,
-                    old_path + "/%",
-                    now_iso,
-                ),
-            )
-        else:
-            cursor.execute(
-                self._fix_sql(
-                    """
-                    UPDATE rebac_tuples
-                    SET subject_id = ?
-                    WHERE subject_type = ?
-                      AND subject_id = ?
-                      AND (expires_at IS NULL OR expires_at >= ?)
-                    """
-                ),
-                (new_path, object_type, old_path, now_iso),
-            )
 
         # Batch changelog INSERT
         changelog_entries = []
         for row in subject_rows:
             old_subject_id = row["subject_id"]
-            new_subject_id = (
-                new_path + old_subject_id[old_prefix_len:]
-                if is_directory and old_subject_id.startswith(old_path + "/")
-                else new_path
+            new_subject_id = self._rewrite_stored_path(
+                old_subject_id,
+                old_path,
+                new_path,
+                row["zone_id"],
+                is_directory,
+            )
+            if new_subject_id is None:
+                logger.warning(
+                    "Skipping subject_id tuple %s during rename; no rewrite match for %s",
+                    row["tuple_id"],
+                    old_subject_id,
+                )
+                continue
+            cursor.execute(
+                self._fix_sql(
+                    """
+                    UPDATE rebac_tuples
+                    SET subject_id = ?
+                    WHERE tuple_id = ?
+                    """
+                ),
+                (new_subject_id, row["tuple_id"]),
             )
             changelog_entries.append(
                 (
@@ -406,27 +352,32 @@ class PathUpdater:
                 )
             )
 
-        cursor.executemany(
-            self._fix_sql(
-                """
-                INSERT INTO rebac_changelog (
-                    change_type, tuple_id, subject_type, subject_id,
-                    relation, object_type, object_id, zone_id, created_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """
-            ),
-            changelog_entries,
-        )
+        if changelog_entries:
+            cursor.executemany(
+                self._fix_sql(
+                    """
+                    INSERT INTO rebac_changelog (
+                        change_type, tuple_id, subject_type, subject_id,
+                        relation, object_type, object_id, zone_id, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """
+                ),
+                changelog_entries,
+            )
 
         # Cache invalidation
         for row in subject_rows:
             old_subject_id = row["subject_id"]
-            new_subject_id = (
-                new_path + old_subject_id[old_prefix_len:]
-                if is_directory and old_subject_id.startswith(old_path + "/")
-                else new_path
+            new_subject_id = self._rewrite_stored_path(
+                old_subject_id,
+                old_path,
+                new_path,
+                row["zone_id"],
+                is_directory,
             )
+            if new_subject_id is None:
+                continue
             old_subj = Entity(object_type, old_subject_id)
             new_subj = Entity(object_type, new_subject_id)
             obj = Entity(row["object_type"], row["object_id"])
@@ -437,7 +388,7 @@ class PathUpdater:
             self._invalidate_cache(old_subj, relation, obj, zone_id, subject_relation, conn=conn)
             self._invalidate_cache(new_subj, relation, obj, zone_id, subject_relation, conn=conn)
 
-        return len(subject_rows)
+        return len(changelog_entries)
 
     # ------------------------------------------------------------------
     # Tiger resource map cleanup
@@ -447,6 +398,7 @@ class PathUpdater:
         self,
         cursor: Any,
         old_path: str,
+        requested_zone_id: str | None,
         object_type: str,
         is_directory: bool,
     ) -> None:
@@ -454,26 +406,34 @@ class PathUpdater:
             return
 
         try:
+            candidates = self._path_candidates(old_path, requested_zone_id)
+            where_sql, params = self._build_path_match_clause(
+                "resource_id", candidates, is_directory
+            )
+            zone_sql, zone_params = self._build_zone_clause(requested_zone_id)
             if is_directory:
                 cursor.execute(
                     self._fix_sql(
-                        """
+                        f"""
                         DELETE FROM tiger_resource_map
                         WHERE resource_type = ?
-                          AND (resource_id = ? OR resource_id LIKE ?)
+                          AND ({where_sql})
+                          {zone_sql}
                         """
                     ),
-                    (object_type, old_path, old_path + "/%"),
+                    (object_type, *params, *zone_params),
                 )
             else:
                 cursor.execute(
                     self._fix_sql(
-                        """
+                        f"""
                         DELETE FROM tiger_resource_map
-                        WHERE resource_type = ? AND resource_id = ?
+                        WHERE resource_type = ?
+                          AND ({where_sql})
+                          {zone_sql}
                         """
                     ),
-                    (object_type, old_path),
+                    (object_type, *params, *zone_params),
                 )
             deleted = cursor.rowcount
             if deleted and deleted > 0:
@@ -488,15 +448,88 @@ class PathUpdater:
                 keys_to_remove = []
                 for key in resource_map._uuid_to_int:
                     res_type, res_id = key
-                    if res_type == object_type:
-                        if is_directory:
-                            if res_id == old_path or res_id.startswith(old_path + "/"):
-                                keys_to_remove.append(key)
-                        elif res_id == old_path:
-                            keys_to_remove.append(key)
+                    if res_type == object_type and self._matches_any_candidate(
+                        res_id, candidates, is_directory
+                    ):
+                        keys_to_remove.append(key)
                 for key in keys_to_remove:
                     int_id = resource_map._uuid_to_int.pop(key, None)
                     if int_id is not None and hasattr(resource_map, "_int_to_uuid"):
                         resource_map._int_to_uuid.pop(int_id, None)
         except (RuntimeError, ValueError, KeyError, OSError) as e:
             logger.warning("[UPDATE-OBJECT-PATH] Failed to update tiger_resource_map: %s", e)
+
+    def _extract_zone_id(self, path: str) -> str | None:
+        if not path.startswith("/zone/"):
+            return None
+        parts = path.split("/", 3)
+        if len(parts) < 3 or not parts[2]:
+            return None
+        return parts[2]
+
+    def _scope_path_for_zone(self, path: str, zone_id: str | None) -> str | None:
+        if not zone_id or zone_id == ROOT_ZONE_ID:
+            return None
+        return f"/zone/{zone_id}{path}"
+
+    def _path_candidates(self, path: str, zone_id: str | None) -> list[str]:
+        candidates = [path]
+        scoped = self._scope_path_for_zone(path, zone_id)
+        if scoped and scoped not in candidates:
+            candidates.append(scoped)
+        return candidates
+
+    def _matches_any_candidate(
+        self,
+        stored_path: str,
+        candidates: list[str],
+        is_directory: bool,
+    ) -> bool:
+        for candidate in candidates:
+            if stored_path == candidate:
+                return True
+            if is_directory and stored_path.startswith(candidate + "/"):
+                return True
+        return False
+
+    def _rewrite_stored_path(
+        self,
+        stored_path: str,
+        old_path: str,
+        new_path: str,
+        zone_id: str | None,
+        is_directory: bool,
+    ) -> str | None:
+        old_candidates = self._path_candidates(old_path, zone_id)
+        new_candidates = self._path_candidates(new_path, zone_id)
+
+        for old_candidate, new_candidate in zip(old_candidates, new_candidates, strict=False):
+            if stored_path == old_candidate:
+                return new_candidate
+            if is_directory and stored_path.startswith(old_candidate + "/"):
+                return new_candidate + stored_path[len(old_candidate) :]
+        return None
+
+    def _build_path_match_clause(
+        self,
+        column: str,
+        candidates: list[str],
+        is_directory: bool,
+    ) -> tuple[str, list[str]]:
+        clauses: list[str] = []
+        params: list[str] = []
+        for candidate in candidates:
+            if is_directory:
+                clauses.append(f"({column} = ? OR {column} LIKE ?)")
+                params.extend([candidate, candidate + "/%"])
+            else:
+                clauses.append(f"{column} = ?")
+                params.append(candidate)
+        return " OR ".join(clauses), params
+
+    def _build_zone_clause(self, zone_id: str | None) -> tuple[str, list[str]]:
+        if zone_id is None:
+            return "", []
+        if zone_id == ROOT_ZONE_ID:
+            return " AND (zone_id = ? OR zone_id IS NULL)", [ROOT_ZONE_ID]
+        return " AND zone_id = ?", [zone_id]

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -212,7 +212,12 @@ async def _seed_files(
     all_files = list(DEMO_FILES) + list(HERB_CORPUS)
     for path, content, _description in all_files:
         if path in seeded:
-            continue
+            try:
+                if await nx.sys_access(path):
+                    continue
+            except Exception:
+                # Stale manifest entry; fall through and recreate the file.
+                pass
         try:
             # Ensure parent directory exists
             parent = "/".join(path.split("/")[:-1])
@@ -230,11 +235,14 @@ async def _seed_files(
 
 async def _seed_versions(nx: Any, manifest: dict[str, Any]) -> int:
     """Create version history for plan.md. Returns count of versions created."""
-    if manifest.get("versions_seeded"):
-        return 0
-
     created = 0
     plan_path = "/workspace/demo/plan.md"
+    if manifest.get("versions_seeded"):
+        try:
+            if await nx.sys_access(plan_path):
+                return 0
+        except Exception:
+            pass
     for version_content in PLAN_VERSIONS:
         try:
             await nx.write(plan_path, version_content.encode())
@@ -1527,8 +1535,11 @@ async def _async_demo_init(reset: bool, skip_semantic: bool) -> None:
         console.print(
             f"  Identities:   {len(DEMO_USERS)} users, {len(DEMO_AGENTS)} agents (pre-existing or skipped)"
         )
+    existing_perms = int(manifest.get("permissions_count", 0) or 0)
     if perms_created > 0:
         console.print(f"  Permissions:  {perms_created} tuples")
+    elif manifest.get("permissions_seeded") and existing_perms > 0:
+        console.print(f"  Permissions:  {existing_perms} tuples (already present)")
     else:
         console.print("  Permissions:  skipped (not available)")
     if any(coord_counts.get(k, 0) > 0 for k in ("provisioned", "delegated", "messages")):

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import inspect
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -43,6 +44,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_DRAIN_TIMEOUT: float = 10.0
+
+
+def _declares_hook_spec(instance: Any) -> bool:
+    """Return True only when ``hook_spec`` is a real attribute on the object.
+
+    Dynamic proxies can synthesize arbitrary public attributes via
+    ``__getattr__``. Lifecycle detection must ignore those synthetic attrs,
+    otherwise bootstrap can try to call a non-existent ``hook_spec`` method.
+    """
+    try:
+        attr = inspect.getattr_static(instance, "hook_spec")
+    except AttributeError:
+        return False
+    return callable(attr)
 
 
 # ---------------------------------------------------------------------------
@@ -417,13 +432,13 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
             logger.info("[COORDINATOR] enlist %r — started (PersistentService)", name)
 
         # Auto-capture hooks via duck-typed hook_spec()
-        if hasattr(instance, "hook_spec"):
+        if _declares_hook_spec(instance):
             spec = self._ensure_hook_spec(name, instance)
             if spec is not None and not spec.is_empty:
                 self._register_hooks(name)
             logger.info("[COORDINATOR] enlist %r — hooks registered", name)
 
-        if not isinstance(instance, PersistentService) and not hasattr(instance, "hook_spec"):
+        if not isinstance(instance, PersistentService) and not _declares_hook_spec(instance):
             logger.info("[COORDINATOR] enlist %r — registered (on-demand)", name)
 
     # -- mount — register VFS hooks ----------------------------------------
@@ -472,7 +487,7 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
 
         # Resolve old hook spec
         old_hook_spec = self._hook_specs.get(name)
-        if old_hook_spec is None and hasattr(old_instance, "hook_spec"):
+        if old_hook_spec is None and _declares_hook_spec(old_instance):
             old_hook_spec = old_instance.hook_spec()
             if old_hook_spec is not None and not old_hook_spec.is_empty:
                 self._hook_specs[name] = old_hook_spec
@@ -490,7 +505,7 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
 
         # Step 4: Register new hooks — explicit param > duck-type > clear
         new_hook_spec = hook_spec
-        if new_hook_spec is None and hasattr(new_instance, "hook_spec"):
+        if new_hook_spec is None and _declares_hook_spec(new_instance):
             new_hook_spec = new_instance.hook_spec()
 
         if new_hook_spec is not None and not new_hook_spec.is_empty:
@@ -563,7 +578,7 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
     def _ensure_hook_spec(self, name: str, instance: Any) -> HookSpec | None:
         """Capture HookSpec via duck-typed hook_spec() if not already stored."""
         spec = self._hook_specs.get(name)
-        if spec is None and hasattr(instance, "hook_spec"):
+        if spec is None and _declares_hook_spec(instance):
             spec = instance.hook_spec()
             if spec is not None:
                 self._hook_specs[name] = spec

--- a/src/nexus/factory/_remote.py
+++ b/src/nexus/factory/_remote.py
@@ -21,12 +21,31 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from nexus.core.nexus_fs import NexusFS
+    from nexus.remote.rpc_transport import RPCTransport
 
 logger = logging.getLogger(__name__)
+
+
+def install_remote_kernel_rpc_overrides(nfs: "NexusFS", transport: "RPCTransport") -> None:
+    """Route kernel ops that require server-side hooks through direct RPC.
+
+    Most REMOTE filesystem operations already hit the server kernel through
+    RemoteBackend / RemoteMetastore. Rename is the exception: the client-side
+    kernel emulates it as metadata put/delete, which bypasses server-side
+    post-rename hooks like ReBAC path updates. Override it to call the
+    authoritative server ``sys_rename`` RPC directly.
+    """
+    import types
+
+    async def _remote_sys_rename(old_path: str, new_path: str, **_: Any) -> dict[str, Any]:
+        transport.call_rpc("sys_rename", {"old_path": old_path, "new_path": new_path})
+        return {}
+
+    cast(Any, nfs).sys_rename = types.MethodType(_remote_sys_rename, nfs)
 
 
 async def _boot_remote_services(nfs: "NexusFS", call_rpc: Callable[..., Any]) -> None:

--- a/src/nexus/factory/_remote.py
+++ b/src/nexus/factory/_remote.py
@@ -41,7 +41,12 @@ def install_remote_kernel_rpc_overrides(nfs: "NexusFS", transport: "RPCTransport
     """
     import types
 
-    async def _remote_sys_rename(old_path: str, new_path: str, **_: Any) -> dict[str, Any]:
+    async def _remote_sys_rename(
+        _self: Any,
+        old_path: str,
+        new_path: str,
+        **_: Any,
+    ) -> dict[str, Any]:
         transport.call_rpc("sys_rename", {"old_path": old_path, "new_path": new_path})
         return {}
 

--- a/tests/unit/backends/test_remote_backend.py
+++ b/tests/unit/backends/test_remote_backend.py
@@ -46,6 +46,12 @@ class TestRemoteBackendProperties:
     def test_transport_stored(self, backend: RemoteBackend, mock_transport) -> None:
         assert backend._transport is mock_transport
 
+    def test_user_scoped_is_false(self, backend: RemoteBackend) -> None:
+        assert backend.user_scoped is False
+
+    def test_has_token_manager_is_false(self, backend: RemoteBackend) -> None:
+        assert backend.has_token_manager is False
+
 
 # ---------------------------------------------------------------------------
 # RPC Dispatch Tests

--- a/tests/unit/cli/test_demo.py
+++ b/tests/unit/cli/test_demo.py
@@ -103,20 +103,43 @@ class TestIdempotency:
         """Running seed twice should not duplicate files in manifest."""
         from nexus.cli.commands.demo import _seed_files
 
+        total_files = len(DEMO_FILES) + len(HERB_CORPUS)
         mock_nx = MagicMock()
         mock_nx.sys_write = AsyncMock()
         mock_nx.write = AsyncMock()
         mock_nx.mkdir = AsyncMock()
         mock_nx.sys_readdir = AsyncMock(return_value=[])
+        mock_nx.sys_access = AsyncMock(side_effect=[True] * total_files)
         manifest: dict = {"files": []}
 
         # First seed — includes both DEMO_FILES and HERB_CORPUS
         count1 = await _seed_files(mock_nx, manifest)
-        assert count1 == len(DEMO_FILES) + len(HERB_CORPUS)
+        assert count1 == total_files
 
         # Second seed — all paths already in manifest
         count2 = await _seed_files(mock_nx, manifest)
         assert count2 == 0
+
+    @pytest.mark.asyncio
+    async def test_seed_files_recreates_missing_manifest_entries(self) -> None:
+        """Manifest hits should be recreated when the remote path no longer exists."""
+        from nexus.cli.commands.demo import _seed_files
+
+        total_files = len(DEMO_FILES) + len(HERB_CORPUS)
+        seeded_paths = [path for path, _, _ in [*DEMO_FILES, *HERB_CORPUS]]
+
+        mock_nx = MagicMock()
+        mock_nx.sys_write = AsyncMock()
+        mock_nx.write = AsyncMock()
+        mock_nx.mkdir = AsyncMock()
+        mock_nx.sys_readdir = AsyncMock(return_value=[])
+        mock_nx.sys_access = AsyncMock(side_effect=[False] * total_files)
+        manifest: dict = {"files": list(seeded_paths)}
+
+        recreated = await _seed_files(mock_nx, manifest)
+
+        assert recreated == total_files
+        assert manifest["files"] == seeded_paths + seeded_paths
 
     @pytest.mark.asyncio
     async def test_seed_versions_idempotent(self) -> None:

--- a/tests/unit/core/test_path_updater.py
+++ b/tests/unit/core/test_path_updater.py
@@ -1,0 +1,225 @@
+import sqlite3
+from pathlib import Path
+
+from nexus.bricks.rebac.path_updater import PathUpdater
+
+
+def _make_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "path_updater.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE rebac_tuples (
+                tuple_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                subject_type TEXT NOT NULL,
+                subject_id TEXT NOT NULL,
+                subject_relation TEXT,
+                relation TEXT NOT NULL,
+                object_type TEXT NOT NULL,
+                object_id TEXT NOT NULL,
+                zone_id TEXT,
+                expires_at TEXT
+            );
+
+            CREATE TABLE rebac_changelog (
+                change_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                change_type TEXT NOT NULL,
+                tuple_id INTEGER NOT NULL,
+                subject_type TEXT NOT NULL,
+                subject_id TEXT NOT NULL,
+                relation TEXT NOT NULL,
+                object_type TEXT NOT NULL,
+                object_id TEXT NOT NULL,
+                zone_id TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE tiger_resource_map (
+                resource_int_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                resource_type TEXT NOT NULL,
+                resource_id TEXT NOT NULL,
+                zone_id TEXT NOT NULL
+            );
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO rebac_tuples (
+                subject_type, subject_id, subject_relation, relation,
+                object_type, object_id, zone_id, expires_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+            """,
+            [
+                (
+                    "user",
+                    "alice",
+                    None,
+                    "direct_owner",
+                    "file",
+                    "/workspace/demo/original.txt",
+                    "default",
+                ),
+                (
+                    "user",
+                    "admin",
+                    None,
+                    "direct_owner",
+                    "file",
+                    "/zone/default/workspace/demo/original.txt",
+                    "default",
+                ),
+                (
+                    "file",
+                    "/workspace/demo/original.txt",
+                    None,
+                    "parent",
+                    "file",
+                    "/workspace/demo",
+                    "default",
+                ),
+                (
+                    "file",
+                    "/zone/default/workspace/demo/original.txt",
+                    None,
+                    "parent",
+                    "file",
+                    "/zone/default/workspace/demo",
+                    "default",
+                ),
+                (
+                    "user",
+                    "eve",
+                    None,
+                    "direct_owner",
+                    "file",
+                    "/workspace/demo/original.txt",
+                    "other-zone",
+                ),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO tiger_resource_map (resource_type, resource_id, zone_id)
+            VALUES (?, ?, ?)
+            """,
+            [
+                ("file", "/workspace/demo/original.txt", "default"),
+                ("file", "/zone/default/workspace/demo/original.txt", "default"),
+                ("file", "/workspace/demo/original.txt", "other-zone"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def _connection_factory(db_path: Path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_update_object_path_updates_mixed_scoped_rows_without_touching_other_zones(tmp_path: Path):
+    db_path = _make_db(tmp_path)
+    tiger_resource_map = type(
+        "ResourceMap",
+        (),
+        {
+            "_uuid_to_int": {
+                ("file", "/workspace/demo/original.txt"): 1,
+                ("file", "/zone/default/workspace/demo/original.txt"): 2,
+                ("file", "/workspace/demo/original.txt#other"): 3,
+            },
+            "_int_to_uuid": {
+                1: ("file", "/workspace/demo/original.txt"),
+                2: ("file", "/zone/default/workspace/demo/original.txt"),
+                3: ("file", "/workspace/demo/original.txt#other"),
+            },
+        },
+    )()
+    tiger_cache = type("TigerCache", (), {"_resource_map": tiger_resource_map})()
+
+    updater = PathUpdater(
+        connection_factory=lambda: _connection_factory(db_path),
+        create_cursor=lambda conn: conn.cursor(),
+        fix_sql=lambda sql: sql,
+        invalidate_cache_cb=lambda *args, **kwargs: None,
+        tiger_invalidate_cache_cb=None,
+        tiger_cache=tiger_cache,
+    )
+
+    updated_count, should_bump = updater.update_object_path(
+        old_path="/zone/default/workspace/demo/original.txt",
+        new_path="/zone/default/workspace/demo/renamed.txt",
+        object_type="file",
+        is_directory=False,
+    )
+
+    assert updated_count == 4
+    assert should_bump is True
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            """
+            SELECT subject_type, subject_id, relation, object_id, zone_id
+            FROM rebac_tuples
+            ORDER BY tuple_id
+            """
+        ).fetchall()
+        assert [dict(row) for row in rows] == [
+            {
+                "subject_type": "user",
+                "subject_id": "alice",
+                "relation": "direct_owner",
+                "object_id": "/workspace/demo/renamed.txt",
+                "zone_id": "default",
+            },
+            {
+                "subject_type": "user",
+                "subject_id": "admin",
+                "relation": "direct_owner",
+                "object_id": "/zone/default/workspace/demo/renamed.txt",
+                "zone_id": "default",
+            },
+            {
+                "subject_type": "file",
+                "subject_id": "/workspace/demo/renamed.txt",
+                "relation": "parent",
+                "object_id": "/workspace/demo",
+                "zone_id": "default",
+            },
+            {
+                "subject_type": "file",
+                "subject_id": "/zone/default/workspace/demo/renamed.txt",
+                "relation": "parent",
+                "object_id": "/zone/default/workspace/demo",
+                "zone_id": "default",
+            },
+            {
+                "subject_type": "user",
+                "subject_id": "eve",
+                "relation": "direct_owner",
+                "object_id": "/workspace/demo/original.txt",
+                "zone_id": "other-zone",
+            },
+        ]
+
+        changelog_count = conn.execute("SELECT COUNT(*) FROM rebac_changelog").fetchone()[0]
+        assert changelog_count == 4
+
+        resource_rows = conn.execute(
+            """
+            SELECT resource_id, zone_id
+            FROM tiger_resource_map
+            ORDER BY resource_int_id
+            """
+        ).fetchall()
+        assert [tuple(row) for row in resource_rows] == [
+            ("/workspace/demo/original.txt", "other-zone"),
+        ]
+    finally:
+        conn.close()

--- a/tests/unit/factory/test_remote_kernel_overrides.py
+++ b/tests/unit/factory/test_remote_kernel_overrides.py
@@ -1,0 +1,32 @@
+import pytest
+
+from nexus.factory._remote import install_remote_kernel_rpc_overrides
+
+
+class _DummyTransport:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, str]]] = []
+
+    def call_rpc(self, method: str, params: dict[str, str]) -> dict[str, object]:
+        self.calls.append((method, params))
+        return {"ok": True}
+
+
+class _DummyNfs:
+    async def sys_rename(self, old_path: str, new_path: str, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("original client-side sys_rename should be replaced")
+
+
+@pytest.mark.asyncio
+async def test_install_remote_kernel_rpc_overrides_routes_sys_rename_to_server_rpc() -> None:
+    nfs = _DummyNfs()
+    transport = _DummyTransport()
+
+    install_remote_kernel_rpc_overrides(nfs, transport)
+
+    result = await nfs.sys_rename("/workspace/old.txt", "/workspace/new.txt")
+
+    assert result == {}
+    assert transport.calls == [
+        ("sys_rename", {"old_path": "/workspace/old.txt", "new_path": "/workspace/new.txt"})
+    ]

--- a/tests/unit/services/test_service_lifecycle_coordinator.py
+++ b/tests/unit/services/test_service_lifecycle_coordinator.py
@@ -119,6 +119,25 @@ class _FakePersistentHookService:
         self.stopped = True
 
 
+class _DynamicProxyLikeService:
+    """Proxy-shaped object that synthesizes arbitrary public attributes."""
+
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        def _synthetic(*_args, **_kwargs):
+            return None
+
+        return _synthetic
+
+    def glob(self, pattern: str) -> list[str]:
+        return [pattern]
+
+    def grep(self, pattern: str) -> list[str]:
+        return [pattern]
+
+
 # ---------------------------------------------------------------------------
 # insmod — _register_service
 # ---------------------------------------------------------------------------
@@ -143,6 +162,18 @@ class TestRegisterService:
         coordinator._register_service("search", svc)
         coordinator._set_hook_spec("search", spec)
         assert coordinator._get_hook_spec("search") is spec
+
+    @pytest.mark.asyncio()
+    async def test_enlist_ignores_synthetic_hook_spec(
+        self, coordinator: ServiceRegistry, dispatch: KernelDispatch
+    ) -> None:
+        svc = _DynamicProxyLikeService()
+
+        await coordinator.enlist("search", svc, exports=("glob", "grep"))
+
+        assert coordinator._get_hook_spec("search") is None
+        assert dispatch.read_hook_count == 0
+        assert dispatch.observer_count == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route REMOTE `sys_rename` through the authoritative server RPC instead of client-side metadata emulation
- update ReBAC path rewriting to handle mixed scoped and unscoped tuple paths during rename
- harden the demo/remote test path and add regressions for remote rename override and path updates

## Root cause
In `profile=remote`, writes were going through the server kernel via `RemoteBackend.write_content()`, but rename was executed by the client-side kernel using remote metastore `put/delete`. That bypassed server `post_rename` hooks, so ReBAC path updates never ran and permissions stayed on the old path.

## Verification
- `uv run pytest -q -o addopts='' tests/unit/factory/test_remote_kernel_overrides.py tests/unit/core/test_path_updater.py tests/unit/backends/test_remote_backend.py tests/unit/services/test_service_lifecycle_coordinator.py`
- `uv run python scripts/test_build_perf_e2e.py` -> `22 passed, 0 failed`
- `bash permissions_demo_enhanced.sh` -> passes, including the rename retention check (`Permission removed from old path`, `Permission followed to new path`)
