### PR TITLE
feat(tui): Connectors tab — auth, mount, sync, skills, write

### DIFF
--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -34,6 +34,7 @@ const SearchPanel = lazy(() => import("./panels/search/search-panel.js"));
 const WorkflowsPanel = lazy(() => import("./panels/workflows/workflows-panel.js"));
 const EventsPanel = lazy(() => import("./panels/events/events-panel.js"));
 const ApiConsolePanel = lazy(() => import("./panels/api-console/api-console-panel.js"));
+const ConnectorsPanel = lazy(() => import("./panels/connectors/connectors-panel.js"));
 
 const TABS: readonly Tab[] = [
   { id: "files", label: "Files", shortcut: "1" },
@@ -46,6 +47,7 @@ const TABS: readonly Tab[] = [
   { id: "workflows", label: "Flow", shortcut: "8" },
   { id: "infrastructure", label: "Event", shortcut: "9" },
   { id: "console", label: "CLI", shortcut: "0" },
+  { id: "connectors", label: "Conn", shortcut: "C" },
 ];
 
 function PanelRouter(): React.ReactNode {
@@ -72,6 +74,8 @@ function PanelRouter(): React.ReactNode {
       return <EventsPanel />;
     case "console":
       return <ApiConsolePanel />;
+    case "connectors":
+      return <ConnectorsPanel />;
     default:
       return (
         <box height="100%" width="100%" justifyContent="center" alignItems="center">
@@ -170,6 +174,7 @@ export function App(): React.ReactNode {
           "8": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("workflows"); },
           "9": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("infrastructure"); },
           "0": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("console"); },
+          "shift+c": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("connectors"); },
           "ctrl+i": toggleIdentitySwitcher,
           "ctrl+d": () => {
             // Disconnect and go back to setup menu

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -72,6 +72,7 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
   const pollAuthStatus = useConnectorsStore((s) => s.pollAuthStatus);
   const cancelAuth = useConnectorsStore((s) => s.cancelAuth);
   const mountConnector = useConnectorsStore((s) => s.mountConnector);
+  const mountsLoading = useConnectorsStore((s) => s.mountsLoading);
 
   const config = useGlobalStore((s) => s.config);
   const { copy, copied } = useCopy();
@@ -343,9 +344,11 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
       <box height={1} width="100%">
         {copied ? (
           <text foregroundColor={statusColor.healthy}>Copied!</text>
+        ) : loading || mountsLoading ? (
+          <text foregroundColor={statusColor.warning}>⠋ Loading...</text>
         ) : (
           <text foregroundColor={statusColor.dim}>
-            j/k:navigate  a:auth  m:mount guide  r:refresh  y:copy  Esc:cancel
+            j/k:navigate  Enter/m:mount  a:auth  r:refresh  y:copy  Esc:cancel
           </text>
         )}
       </box>

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -118,7 +118,7 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
     }
   }, [connectors, selectedIndex, initiateAuth, client]);
 
-  /** Build curl mount command for storage connectors that need config. */
+  /** Build mount command for storage connectors that need config. */
   const getMountCommand = useCallback((): string => {
     const selected = connectors[selectedIndex];
     if (!selected) return "";
@@ -128,22 +128,21 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
     const apiKey = (config as Record<string, unknown>).apiKey as string | undefined;
 
     // Build config template based on connector type
-    let configFields: Record<string, string> = {};
+    let configJson = "'{}'";
     if (selected.name.includes("s3")) {
-      configFields = { bucket_name: "<BUCKET>", access_key_id: "<KEY>", secret_access_key: "<SECRET>" };
+      configJson = '\'{"bucket_name": "<BUCKET>", "access_key_id": "<KEY>", "secret_access_key": "<SECRET>"}\'';
     } else if (selected.name.includes("gcs")) {
-      configFields = { bucket_name: "<BUCKET>", credentials_path: "<PATH>" };
+      configJson = '\'{"bucket_name": "<BUCKET>", "credentials_path": "<PATH>"}\'';
     } else if (selected.name.includes("local")) {
-      configFields = { local_path: "<PATH>" };
+      configJson = '\'{"local_path": "<PATH>"}\'';
     }
 
-    const body = JSON.stringify({
-      connector_type: selected.name,
-      mount_point: mountPath,
-      config: configFields,
-    }, null, 2);
-
-    return `curl -X POST ${url}/api/v2/connectors/mount \\\n  -H "Authorization: Bearer ${apiKey}" \\\n  -H "Content-Type: application/json" \\\n  -d '${body}'`;
+    // Use eval $(nexus env) prefix so NEXUS_URL, NEXUS_API_KEY, and
+    // NEXUS_GRPC_PORT are all set correctly for the CLI
+    const nexusDir = process.env.NEXUS_DATA_DIR
+      ? `cd ${process.env.NEXUS_DATA_DIR.replace(/\/nexus-data$/, "")} && `
+      : "";
+    return `${nexusDir}eval $(nexus env) && nexus mounts add ${mountPath} ${selected.name} ${configJson}`;
   }, [connectors, selectedIndex, config]);
 
   /** Check if connector can be mounted directly (no config needed). */

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -1,8 +1,13 @@
 /**
- * Available tab: lists all registered connectors with auth status.
+ * Available tab: lists all registered connectors with auth and mount status.
  *
  * Supports: connector list navigation, auth initiation (opens browser),
- * auth status polling, mount path configuration with custom path input.
+ * auth status polling, CLI mount guidance.
+ *
+ * Mounting connectors requires configuration (credentials, bucket names, etc.)
+ * that varies per connector. Instead of trying to collect all config in the TUI,
+ * we show the CLI command the user should run, with the required arguments
+ * pre-filled from the connector's connection_args.
  */
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
@@ -33,14 +38,12 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
   const initiateAuth = useConnectorsStore((s) => s.initiateAuth);
   const pollAuthStatus = useConnectorsStore((s) => s.pollAuthStatus);
   const cancelAuth = useConnectorsStore((s) => s.cancelAuth);
-  const mountConnector = useConnectorsStore((s) => s.mountConnector);
 
   const { copy, copied } = useCopy();
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Mount path input mode
-  const [mountInputMode, setMountInputMode] = useState(false);
-  const [mountPathBuffer, setMountPathBuffer] = useState("");
+  // Show CLI mount guide for selected connector
+  const [showMountGuide, setShowMountGuide] = useState(false);
 
   // Auto-fetch on mount
   useEffect(() => {
@@ -61,14 +64,12 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
       };
     }
 
-    // Stop polling when flow completes/errors/cancels
     if (pollTimerRef.current) {
       clearInterval(pollTimerRef.current);
       pollTimerRef.current = null;
     }
   }, [authFlow.status, client, pollAuthStatus]);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       if (pollTimerRef.current) clearInterval(pollTimerRef.current);
@@ -82,84 +83,91 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
     }
   }, [connectors, selectedIndex, initiateAuth, client]);
 
-  /** Start mount flow — pre-fill with default path, allow user to edit. */
-  const startMountInput = useCallback(() => {
+  /** Build CLI mount command for the selected connector. */
+  const getMountCommand = useCallback((): string => {
     const selected = connectors[selectedIndex];
-    if (!selected) return;
+    if (!selected) return "";
     const baseName = selected.name.replace(/_connector$/, "");
-    setMountPathBuffer(`/mnt/${baseName}`);
-    setMountInputMode(true);
-  }, [connectors, selectedIndex]);
+    const mountPath = `/mnt/${baseName}`;
 
-  /** Submit the mount with the user-specified path. */
-  const submitMount = useCallback(() => {
-    const selected = connectors[selectedIndex];
-    if (!selected) return;
-    const path = mountPathBuffer.trim();
-    if (!path) return;
-    mountConnector(selected.name, path, client);
-    setMountInputMode(false);
-    setMountPathBuffer("");
-  }, [connectors, selectedIndex, mountPathBuffer, mountConnector, client]);
+    // Build a config hint based on connector category
+    let configHint = "{}";
+    if (selected.category === "storage") {
+      if (selected.name.includes("s3")) {
+        configHint = '\'{"bucket_name": "<BUCKET>", "access_key_id": "<KEY>", "secret_access_key": "<SECRET>"}\'';
+      } else if (selected.name.includes("gcs")) {
+        configHint = '\'{"bucket_name": "<BUCKET>", "credentials_path": "<PATH>"}\'';
+      } else if (selected.name.includes("local")) {
+        configHint = '\'{"local_path": "<PATH>"}\'';
+      }
+    } else if (selected.category === "cli" || selected.category === "oauth") {
+      configHint = "'{}'";
+    }
+
+    return `nexus mounts add ${mountPath} ${selected.name} ${configHint}`;
+  }, [connectors, selectedIndex]);
 
   const listNav = listNavigationBindings({
     getIndex: () => selectedIndex,
-    setIndex: setSelectedIndex,
+    setIndex: (i) => { setSelectedIndex(i); setShowMountGuide(false); },
     getLength: () => connectors.length,
   });
 
   useKeyboard(
     overlayActive
       ? {}
-      : mountInputMode
-        ? {
-            return: submitMount,
-            escape: () => { setMountInputMode(false); setMountPathBuffer(""); },
-            backspace: () => { setMountPathBuffer((b) => b.slice(0, -1)); },
-          }
-        : {
-            ...listNav,
-            a: handleAuth,
-            m: startMountInput,
-            r: () => fetchAvailable(client),
-            y: () => {
-              if (authFlow.auth_url) {
-                copy(authFlow.auth_url);
-              }
-            },
-            escape: () => {
-              if (authFlow.status !== "idle") {
-                cancelAuth();
-              }
-            },
+      : {
+          ...listNav,
+          a: handleAuth,
+          m: () => setShowMountGuide(!showMountGuide),
+          r: () => fetchAvailable(client),
+          y: () => {
+            if (showMountGuide) {
+              copy(getMountCommand());
+            } else if (authFlow.auth_url) {
+              copy(authFlow.auth_url);
+            }
           },
-    // Capture typed characters in mount input mode
-    (!overlayActive && mountInputMode)
-      ? (keyName: string) => {
-          if (keyName === "space") {
-            setMountPathBuffer((b) => b + " ");
-          } else if (keyName.length === 1) {
-            setMountPathBuffer((b) => b + keyName);
-          }
-        }
-      : undefined,
+          escape: () => {
+            if (showMountGuide) {
+              setShowMountGuide(false);
+            } else if (authFlow.status !== "idle") {
+              cancelAuth();
+            }
+          },
+        },
   );
 
   if (loading && connectors.length === 0) {
     return <LoadingIndicator message="Loading connectors..." />;
   }
 
+  const selectedConnector = connectors[selectedIndex];
+
   return (
     <box flexDirection="column" height="100%" width="100%">
-      {/* Mount path input */}
-      {mountInputMode && (
-        <box height={1} width="100%" marginBottom={1}>
-          <text>
-            <span foregroundColor={statusColor.info}>{"Mount path: "}</span>
-            <span bold>{mountPathBuffer}</span>
-            <span foregroundColor={statusColor.info}>{"\u2588"}</span>
-            <span foregroundColor={statusColor.dim}>{"  (Enter:mount  Escape:cancel)"}</span>
-          </text>
+      {/* Mount CLI guide */}
+      {showMountGuide && selectedConnector && (
+        <box flexDirection="column" width="100%" borderStyle="single" marginBottom={1}>
+          <box height={1} width="100%">
+            <text bold foregroundColor={statusColor.info}>
+              {`Mount ${selectedConnector.name.replace(/_connector$/, "")}:`}
+            </text>
+          </box>
+          <box height={1} width="100%">
+            <text foregroundColor={statusColor.dim}>Run this command in your terminal:</text>
+          </box>
+          <box height={1} width="100%">
+            <text>
+              <span foregroundColor={statusColor.healthy}>{"  $ "}</span>
+              <span>{getMountCommand()}</span>
+            </text>
+          </box>
+          <box height={1} width="100%">
+            <text foregroundColor={statusColor.dim}>
+              {"  Press y to copy command, Esc to close"}
+            </text>
+          </box>
         </box>
       )}
 
@@ -233,7 +241,7 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
           <text foregroundColor={statusColor.healthy}>Copied!</text>
         ) : (
           <text foregroundColor={statusColor.dim}>
-            j/k:navigate  a:auth  m:mount  r:refresh  y:copy auth URL  Esc:cancel auth
+            j/k:navigate  a:auth  m:mount guide  r:refresh  y:copy  Esc:cancel
           </text>
         )}
       </box>

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -20,6 +20,38 @@ import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
 import { ConnectorRow } from "./connector-row.js";
 import { statusColor } from "../../shared/theme.js";
 
+/**
+ * Copy text to system clipboard using platform-native tools (pbcopy/xclip)
+ * and also write to a temp file so it survives TUI exit.
+ */
+function copyCommand(text: string): void {
+  const { execSync, exec } = require("child_process");
+  const fs = require("fs");
+
+  // Write to temp file so user can retrieve after TUI exit
+  try {
+    fs.writeFileSync("/tmp/nexus-mount-cmd.txt", text + "\n");
+  } catch {}
+
+  // Copy to system clipboard via platform tool
+  try {
+    if (process.platform === "darwin") {
+      execSync("pbcopy", { input: text, timeout: 2000 });
+    } else {
+      // Try xclip, then xsel
+      try {
+        execSync("xclip -selection clipboard", { input: text, timeout: 2000 });
+      } catch {
+        execSync("xsel --clipboard --input", { input: text, timeout: 2000 });
+      }
+    }
+  } catch {
+    // Fall back to OSC 52
+    const encoded = Buffer.from(text).toString("base64");
+    process.stdout.write(`\x1b]52;c;${encoded}\x07`);
+  }
+}
+
 interface AvailableTabProps {
   readonly client: FetchClient;
   readonly overlayActive: boolean;
@@ -124,8 +156,11 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
           r: () => fetchAvailable(client),
           y: () => {
             if (showMountGuide) {
-              copy(getMountCommand());
+              const cmd = getMountCommand();
+              copyCommand(cmd);
+              copy(cmd);
             } else if (authFlow.auth_url) {
+              copyCommand(authFlow.auth_url);
               copy(authFlow.auth_url);
             }
           },
@@ -166,7 +201,7 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
           </box>
           <box height={1} width="100%">
             <text foregroundColor={statusColor.dim}>
-              {"  Press y to copy command, Esc to close"}
+              {"  y:copy to clipboard  Esc:close  (also saved to /tmp/nexus-mount-cmd.txt)"}
             </text>
           </box>
         </box>

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -71,6 +71,7 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
   const initiateAuth = useConnectorsStore((s) => s.initiateAuth);
   const pollAuthStatus = useConnectorsStore((s) => s.pollAuthStatus);
   const cancelAuth = useConnectorsStore((s) => s.cancelAuth);
+  const mountConnector = useConnectorsStore((s) => s.mountConnector);
 
   const config = useGlobalStore((s) => s.config);
   const { copy, copied } = useCopy();
@@ -150,11 +151,35 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
     return `nexus mounts add ${mountPath} ${selected.name} ${configHint}${remoteFlags ? ` ${remoteFlags}` : ""}`;
   }, [connectors, selectedIndex, config]);
 
+  /** Check if connector can be mounted directly (no config needed). */
+  const canDirectMount = useCallback((): boolean => {
+    const selected = connectors[selectedIndex];
+    if (!selected) return false;
+    return selected.category === "cli" || selected.category === "oauth" || selected.category === "api";
+  }, [connectors, selectedIndex]);
+
+  /** Mount directly via API for connectors that need no config. */
+  const handleDirectMount = useCallback(() => {
+    const selected = connectors[selectedIndex];
+    if (!selected) return;
+    const baseName = selected.name.replace(/_connector$/, "");
+    mountConnector(selected.name, `/mnt/${baseName}`, client);
+  }, [connectors, selectedIndex, mountConnector, client]);
+
+  /** Enter/m: direct mount if no config needed, otherwise show CLI guide. */
+  const handleMountAction = useCallback(() => {
+    if (canDirectMount()) {
+      handleDirectMount();
+    } else {
+      setShowMountGuide(!showMountGuide);
+    }
+  }, [canDirectMount, handleDirectMount, showMountGuide]);
+
   const listNav = listNavigationBindings({
     getIndex: () => selectedIndex,
     setIndex: (i) => { setSelectedIndex(i); setShowMountGuide(false); },
     getLength: () => connectors.length,
-    onSelect: () => setShowMountGuide(!showMountGuide),
+    onSelect: handleMountAction,
   });
 
   useKeyboard(
@@ -163,7 +188,7 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
       : {
           ...listNav,
           a: handleAuth,
-          m: () => setShowMountGuide(!showMountGuide),
+          m: handleMountAction,
           r: () => fetchAvailable(client),
           y: () => {
             if (showMountGuide) {

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -2,10 +2,10 @@
  * Available tab: lists all registered connectors with auth status.
  *
  * Supports: connector list navigation, auth initiation (opens browser),
- * auth status polling, mount path configuration.
+ * auth status polling, mount path configuration with custom path input.
  */
 
-import React, { useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import type { FetchClient } from "@nexus/api-client";
 import { useConnectorsStore } from "../../stores/connectors-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
@@ -13,7 +13,7 @@ import { useCopy } from "../../shared/hooks/use-copy.js";
 import { listNavigationBindings } from "../../shared/hooks/use-list-navigation.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
 import { ConnectorRow } from "./connector-row.js";
-import { statusColor, palette } from "../../shared/theme.js";
+import { statusColor } from "../../shared/theme.js";
 
 interface AvailableTabProps {
   readonly client: FetchClient;
@@ -37,6 +37,10 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
 
   const { copy, copied } = useCopy();
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Mount path input mode
+  const [mountInputMode, setMountInputMode] = useState(false);
+  const [mountPathBuffer, setMountPathBuffer] = useState("");
 
   // Auto-fetch on mount
   useEffect(() => {
@@ -78,14 +82,25 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
     }
   }, [connectors, selectedIndex, initiateAuth, client]);
 
-  const handleMount = useCallback(() => {
+  /** Start mount flow — pre-fill with default path, allow user to edit. */
+  const startMountInput = useCallback(() => {
     const selected = connectors[selectedIndex];
     if (!selected) return;
-    // Auto-generate mount path from connector name
     const baseName = selected.name.replace(/_connector$/, "");
-    const mountPath = `/mnt/${baseName}`;
-    mountConnector(selected.name, mountPath, client);
-  }, [connectors, selectedIndex, mountConnector, client]);
+    setMountPathBuffer(`/mnt/${baseName}`);
+    setMountInputMode(true);
+  }, [connectors, selectedIndex]);
+
+  /** Submit the mount with the user-specified path. */
+  const submitMount = useCallback(() => {
+    const selected = connectors[selectedIndex];
+    if (!selected) return;
+    const path = mountPathBuffer.trim();
+    if (!path) return;
+    mountConnector(selected.name, path, client);
+    setMountInputMode(false);
+    setMountPathBuffer("");
+  }, [connectors, selectedIndex, mountPathBuffer, mountConnector, client]);
 
   const listNav = listNavigationBindings({
     getIndex: () => selectedIndex,
@@ -96,22 +111,38 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
   useKeyboard(
     overlayActive
       ? {}
-      : {
-          ...listNav,
-          a: handleAuth,
-          m: handleMount,
-          r: () => fetchAvailable(client),
-          y: () => {
-            if (authFlow.auth_url) {
-              copy(authFlow.auth_url);
-            }
+      : mountInputMode
+        ? {
+            return: submitMount,
+            escape: () => { setMountInputMode(false); setMountPathBuffer(""); },
+            backspace: () => { setMountPathBuffer((b) => b.slice(0, -1)); },
+          }
+        : {
+            ...listNav,
+            a: handleAuth,
+            m: startMountInput,
+            r: () => fetchAvailable(client),
+            y: () => {
+              if (authFlow.auth_url) {
+                copy(authFlow.auth_url);
+              }
+            },
+            escape: () => {
+              if (authFlow.status !== "idle") {
+                cancelAuth();
+              }
+            },
           },
-          escape: () => {
-            if (authFlow.status !== "idle") {
-              cancelAuth();
-            }
-          },
-        },
+    // Capture typed characters in mount input mode
+    (!overlayActive && mountInputMode)
+      ? (keyName: string) => {
+          if (keyName === "space") {
+            setMountPathBuffer((b) => b + " ");
+          } else if (keyName.length === 1) {
+            setMountPathBuffer((b) => b + keyName);
+          }
+        }
+      : undefined,
   );
 
   if (loading && connectors.length === 0) {
@@ -120,6 +151,18 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
 
   return (
     <box flexDirection="column" height="100%" width="100%">
+      {/* Mount path input */}
+      {mountInputMode && (
+        <box height={1} width="100%" marginBottom={1}>
+          <text>
+            <span foregroundColor={statusColor.info}>{"Mount path: "}</span>
+            <span bold>{mountPathBuffer}</span>
+            <span foregroundColor={statusColor.info}>{"\u2588"}</span>
+            <span foregroundColor={statusColor.dim}>{"  (Enter:mount  Escape:cancel)"}</span>
+          </text>
+        </box>
+      )}
+
       {/* Auth flow banner */}
       {authFlow.status !== "idle" && (
         <box flexDirection="column" width="100%" borderStyle="single" marginBottom={1}>

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -152,12 +152,24 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
     return selected.category === "cli" || selected.category === "oauth" || selected.category === "api";
   }, [connectors, selectedIndex]);
 
+  // Mount success flash
+  const [mountFlash, setMountFlash] = useState<string | null>(null);
+
   /** Mount directly via API for connectors that need no config. */
-  const handleDirectMount = useCallback(() => {
+  const handleDirectMount = useCallback(async () => {
     const selected = connectors[selectedIndex];
     if (!selected) return;
+    if (selected.mount_path) {
+      // Already mounted — show flash
+      setMountFlash(`Already mounted at ${selected.mount_path}`);
+      setTimeout(() => setMountFlash(null), 2000);
+      return;
+    }
     const baseName = selected.name.replace(/_connector$/, "");
-    mountConnector(selected.name, `/mnt/${baseName}`, client);
+    setMountFlash(`Mounting ${baseName}...`);
+    await mountConnector(selected.name, `/mnt/${baseName}`, client);
+    setMountFlash(`✓ Mounted at /mnt/${baseName}`);
+    setTimeout(() => setMountFlash(null), 2000);
   }, [connectors, selectedIndex, mountConnector, client]);
 
   /** Enter/m: direct mount if no config needed, otherwise show CLI guide. */
@@ -212,6 +224,15 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
 
   return (
     <box flexDirection="column" height="100%" width="100%">
+      {/* Mount flash */}
+      {mountFlash && (
+        <box height={1} width="100%" marginBottom={1}>
+          <text foregroundColor={mountFlash.startsWith("✓") ? statusColor.healthy : statusColor.info}>
+            {mountFlash}
+          </text>
+        </box>
+      )}
+
       {/* Mount CLI guide */}
       {showMountGuide && selectedConnector && (
         <box flexDirection="column" width="100%" borderStyle="single" marginBottom={1}>

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -111,6 +111,7 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
     getIndex: () => selectedIndex,
     setIndex: (i) => { setSelectedIndex(i); setShowMountGuide(false); },
     getLength: () => connectors.length,
+    onSelect: () => setShowMountGuide(!showMountGuide),
   });
 
   useKeyboard(

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -118,37 +118,32 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
     }
   }, [connectors, selectedIndex, initiateAuth, client]);
 
-  /** Build CLI mount command for the selected connector. */
+  /** Build curl mount command for storage connectors that need config. */
   const getMountCommand = useCallback((): string => {
     const selected = connectors[selectedIndex];
     if (!selected) return "";
     const baseName = selected.name.replace(/_connector$/, "");
     const mountPath = `/mnt/${baseName}`;
-
-    // Build a config hint based on connector category
-    let configHint = "{}";
-    if (selected.category === "storage") {
-      if (selected.name.includes("s3")) {
-        configHint = '\'{"bucket_name": "<BUCKET>", "access_key_id": "<KEY>", "secret_access_key": "<SECRET>"}\'';
-      } else if (selected.name.includes("gcs")) {
-        configHint = '\'{"bucket_name": "<BUCKET>", "credentials_path": "<PATH>"}\'';
-      } else if (selected.name.includes("local")) {
-        configHint = '\'{"local_path": "<PATH>"}\'';
-      }
-    } else if (selected.category === "cli" || selected.category === "oauth") {
-      configHint = "'{}'";
-    }
-
-    // Include --remote-url and --remote-api-key so the command works without
-    // NEXUS_URL being set in the user's shell
     const url = (config as Record<string, unknown>).baseUrl as string | undefined;
     const apiKey = (config as Record<string, unknown>).apiKey as string | undefined;
-    const remoteFlags = [
-      url ? `--remote-url ${url}` : "",
-      apiKey ? `--remote-api-key ${apiKey}` : "",
-    ].filter(Boolean).join(" ");
 
-    return `nexus mounts add ${mountPath} ${selected.name} ${configHint}${remoteFlags ? ` ${remoteFlags}` : ""}`;
+    // Build config template based on connector type
+    let configFields: Record<string, string> = {};
+    if (selected.name.includes("s3")) {
+      configFields = { bucket_name: "<BUCKET>", access_key_id: "<KEY>", secret_access_key: "<SECRET>" };
+    } else if (selected.name.includes("gcs")) {
+      configFields = { bucket_name: "<BUCKET>", credentials_path: "<PATH>" };
+    } else if (selected.name.includes("local")) {
+      configFields = { local_path: "<PATH>" };
+    }
+
+    const body = JSON.stringify({
+      connector_type: selected.name,
+      mount_point: mountPath,
+      config: configFields,
+    }, null, 2);
+
+    return `curl -X POST ${url}/api/v2/connectors/mount \\\n  -H "Authorization: Bearer ${apiKey}" \\\n  -H "Content-Type: application/json" \\\n  -d '${body}'`;
   }, [connectors, selectedIndex, config]);
 
   /** Check if connector can be mounted directly (no config needed). */

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -269,11 +269,28 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
             </box>
           )}
           {authFlow.status === "error" && (
-            <box height={1} width="100%">
-              <text foregroundColor={statusColor.error}>
-                {`✕ Auth failed: ${authFlow.error_message ?? "Unknown error"} (press a to retry)`}
-              </text>
-            </box>
+            <>
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.error}>
+                  {`✕ Auth failed: ${authFlow.error_message ?? "Unknown error"}`}
+                </text>
+              </box>
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.dim}>
+                  {"  To set up OAuth: configure GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET env vars,"}
+                </text>
+              </box>
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.dim}>
+                  {"  then restart the server. Or mount directly: connectors like gws_gmail work without OAuth."}
+                </text>
+              </box>
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.dim}>
+                  {"  a:retry  Esc:dismiss"}
+                </text>
+              </box>
+            </>
           )}
         </box>
       )}

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -13,6 +13,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import type { FetchClient } from "@nexus/api-client";
 import { useConnectorsStore } from "../../stores/connectors-store.js";
+import { useGlobalStore } from "../../stores/global-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { useCopy } from "../../shared/hooks/use-copy.js";
 import { listNavigationBindings } from "../../shared/hooks/use-list-navigation.js";
@@ -71,6 +72,7 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
   const pollAuthStatus = useConnectorsStore((s) => s.pollAuthStatus);
   const cancelAuth = useConnectorsStore((s) => s.cancelAuth);
 
+  const config = useGlobalStore((s) => s.config);
   const { copy, copied } = useCopy();
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -136,8 +138,17 @@ export function AvailableTab({ client, overlayActive }: AvailableTabProps): Reac
       configHint = "'{}'";
     }
 
-    return `nexus mounts add ${mountPath} ${selected.name} ${configHint}`;
-  }, [connectors, selectedIndex]);
+    // Include --remote-url and --remote-api-key so the command works without
+    // NEXUS_URL being set in the user's shell
+    const url = (config as Record<string, unknown>).baseUrl as string | undefined;
+    const apiKey = (config as Record<string, unknown>).apiKey as string | undefined;
+    const remoteFlags = [
+      url ? `--remote-url ${url}` : "",
+      apiKey ? `--remote-api-key ${apiKey}` : "",
+    ].filter(Boolean).join(" ");
+
+    return `nexus mounts add ${mountPath} ${selected.name} ${configHint}${remoteFlags ? ` ${remoteFlags}` : ""}`;
+  }, [connectors, selectedIndex, config]);
 
   const listNav = listNavigationBindings({
     getIndex: () => selectedIndex,

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -1,0 +1,199 @@
+/**
+ * Available tab: lists all registered connectors with auth status.
+ *
+ * Supports: connector list navigation, auth initiation (opens browser),
+ * auth status polling, mount path configuration.
+ */
+
+import React, { useEffect, useRef, useCallback } from "react";
+import type { FetchClient } from "@nexus/api-client";
+import { useConnectorsStore } from "../../stores/connectors-store.js";
+import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
+import { useCopy } from "../../shared/hooks/use-copy.js";
+import { listNavigationBindings } from "../../shared/hooks/use-list-navigation.js";
+import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { ConnectorRow } from "./connector-row.js";
+import { statusColor, palette } from "../../shared/theme.js";
+
+interface AvailableTabProps {
+  readonly client: FetchClient;
+  readonly overlayActive: boolean;
+}
+
+const AUTH_POLL_INTERVAL = 3000;
+
+export function AvailableTab({ client, overlayActive }: AvailableTabProps): React.ReactNode {
+  const connectors = useConnectorsStore((s) => s.availableConnectors);
+  const loading = useConnectorsStore((s) => s.availableLoading);
+  const selectedIndex = useConnectorsStore((s) => s.selectedAvailableIndex);
+  const authFlow = useConnectorsStore((s) => s.authFlow);
+
+  const setSelectedIndex = useConnectorsStore((s) => s.setSelectedAvailableIndex);
+  const fetchAvailable = useConnectorsStore((s) => s.fetchAvailable);
+  const initiateAuth = useConnectorsStore((s) => s.initiateAuth);
+  const pollAuthStatus = useConnectorsStore((s) => s.pollAuthStatus);
+  const cancelAuth = useConnectorsStore((s) => s.cancelAuth);
+  const mountConnector = useConnectorsStore((s) => s.mountConnector);
+
+  const { copy, copied } = useCopy();
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Auto-fetch on mount
+  useEffect(() => {
+    if (connectors.length === 0) {
+      fetchAvailable(client);
+    }
+  }, [client, connectors.length, fetchAvailable]);
+
+  // Auth polling lifecycle
+  useEffect(() => {
+    if (authFlow.status === "polling" || authFlow.status === "waiting") {
+      pollTimerRef.current = setInterval(() => {
+        pollAuthStatus(client);
+      }, AUTH_POLL_INTERVAL);
+
+      return () => {
+        if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+      };
+    }
+
+    // Stop polling when flow completes/errors/cancels
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, [authFlow.status, client, pollAuthStatus]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+    };
+  }, []);
+
+  const handleAuth = useCallback(() => {
+    const selected = connectors[selectedIndex];
+    if (selected) {
+      initiateAuth(selected.name, client);
+    }
+  }, [connectors, selectedIndex, initiateAuth, client]);
+
+  const handleMount = useCallback(() => {
+    const selected = connectors[selectedIndex];
+    if (!selected) return;
+    // Auto-generate mount path from connector name
+    const baseName = selected.name.replace(/_connector$/, "");
+    const mountPath = `/mnt/${baseName}`;
+    mountConnector(selected.name, mountPath, client);
+  }, [connectors, selectedIndex, mountConnector, client]);
+
+  const listNav = listNavigationBindings({
+    getIndex: () => selectedIndex,
+    setIndex: setSelectedIndex,
+    getLength: () => connectors.length,
+  });
+
+  useKeyboard(
+    overlayActive
+      ? {}
+      : {
+          ...listNav,
+          a: handleAuth,
+          m: handleMount,
+          r: () => fetchAvailable(client),
+          y: () => {
+            if (authFlow.auth_url) {
+              copy(authFlow.auth_url);
+            }
+          },
+          escape: () => {
+            if (authFlow.status !== "idle") {
+              cancelAuth();
+            }
+          },
+        },
+  );
+
+  if (loading && connectors.length === 0) {
+    return <LoadingIndicator message="Loading connectors..." />;
+  }
+
+  return (
+    <box flexDirection="column" height="100%" width="100%">
+      {/* Auth flow banner */}
+      {authFlow.status !== "idle" && (
+        <box flexDirection="column" width="100%" borderStyle="single" marginBottom={1}>
+          {authFlow.status === "waiting" && authFlow.auth_url && (
+            <>
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.warning}>
+                  {`Auth URL (press y to copy): ${authFlow.auth_url.substring(0, 60)}...`}
+                </text>
+              </box>
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.dim}>
+                  {authFlow.error_message || "Open this URL in your browser to authenticate."}
+                </text>
+              </box>
+            </>
+          )}
+          {authFlow.status === "polling" && (
+            <box height={1} width="100%">
+              <text foregroundColor={statusColor.info}>
+                {`⠋ Waiting for ${authFlow.connector_name} authentication... (Escape to cancel)`}
+              </text>
+            </box>
+          )}
+          {authFlow.status === "completed" && (
+            <box height={1} width="100%">
+              <text foregroundColor={statusColor.healthy}>
+                {`✓ ${authFlow.connector_name} authenticated successfully!`}
+              </text>
+            </box>
+          )}
+          {authFlow.status === "error" && (
+            <box height={1} width="100%">
+              <text foregroundColor={statusColor.error}>
+                {`✕ Auth failed: ${authFlow.error_message ?? "Unknown error"} (press a to retry)`}
+              </text>
+            </box>
+          )}
+        </box>
+      )}
+
+      {/* Connector list */}
+      <box flexGrow={1} flexDirection="column">
+        {connectors.length === 0 ? (
+          <box height={1} width="100%">
+            <text foregroundColor={statusColor.dim}>No connectors registered.</text>
+          </box>
+        ) : (
+          connectors.map((c, i) => (
+            <ConnectorRow
+              key={c.name}
+              name={c.name}
+              category={c.category}
+              authStatus={c.auth_status}
+              mountPath={c.mount_path}
+              syncStatus={c.sync_status}
+              selected={i === selectedIndex}
+              showAuth={true}
+              showSync={true}
+            />
+          ))
+        )}
+      </box>
+
+      {/* Help bar */}
+      <box height={1} width="100%">
+        {copied ? (
+          <text foregroundColor={statusColor.healthy}>Copied!</text>
+        ) : (
+          <text foregroundColor={statusColor.dim}>
+            j/k:navigate  a:auth  m:mount  r:refresh  y:copy auth URL  Esc:cancel auth
+          </text>
+        )}
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/panels/connectors/connector-row.tsx
+++ b/packages/nexus-tui/src/panels/connectors/connector-row.tsx
@@ -1,0 +1,121 @@
+/**
+ * Shared connector row component used by Available and Mounted tabs.
+ *
+ * Renders a single row: selection prefix, connector name, provider, auth status,
+ * mount path, and sync status. Props control column visibility per tab.
+ */
+
+import React from "react";
+import { statusColor } from "../../shared/theme.js";
+
+// =============================================================================
+// Auth status indicator
+// =============================================================================
+
+const AUTH_INDICATORS: Record<string, { icon: string; color: string }> = {
+  authed: { icon: "●", color: statusColor.healthy },
+  expired: { icon: "●", color: statusColor.warning },
+  no_auth: { icon: "○", color: statusColor.dim },
+  unknown: { icon: "?", color: statusColor.dim },
+  error: { icon: "✕", color: statusColor.error },
+};
+
+// =============================================================================
+// Sync status indicator
+// =============================================================================
+
+const SYNC_INDICATORS: Record<string, { label: string; color: string }> = {
+  synced: { label: "synced", color: statusColor.healthy },
+  syncing: { label: "syncing", color: statusColor.warning },
+  error: { label: "error", color: statusColor.error },
+};
+
+// =============================================================================
+// Props
+// =============================================================================
+
+export interface ConnectorRowProps {
+  /** Connector display name */
+  readonly name: string;
+  /** Category/provider group (e.g., "gws", "gh") */
+  readonly category: string;
+  /** Auth status string */
+  readonly authStatus: string;
+  /** Mount path or null if not mounted */
+  readonly mountPath: string | null;
+  /** Sync status or null */
+  readonly syncStatus: string | null;
+  /** Whether this row is selected */
+  readonly selected: boolean;
+  /** Whether to show the auth status column */
+  readonly showAuth?: boolean;
+  /** Whether to show the sync status column */
+  readonly showSync?: boolean;
+  /** Whether connector is currently being synced */
+  readonly isSyncing?: boolean;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function ConnectorRow({
+  name,
+  category,
+  authStatus,
+  mountPath,
+  syncStatus,
+  selected,
+  showAuth = true,
+  showSync = true,
+  isSyncing = false,
+}: ConnectorRowProps): React.ReactNode {
+  const prefix = selected ? "▶ " : "  ";
+  const auth = AUTH_INDICATORS[authStatus] ?? AUTH_INDICATORS.unknown;
+  const displayName = name.replace(/_connector$/, "");
+  const categoryLabel = category ? ` (${category})` : "";
+  const mountLabel = mountPath ?? "—";
+
+  // Build sync label
+  let syncLabel = "";
+  let syncColor = statusColor.dim;
+  if (isSyncing) {
+    syncLabel = "syncing…";
+    syncColor = statusColor.warning;
+  } else if (syncStatus) {
+    const indicator = SYNC_INDICATORS[syncStatus];
+    syncLabel = indicator?.label ?? syncStatus;
+    syncColor = indicator?.color ?? statusColor.dim;
+  }
+
+  return (
+    <box height={1} width="100%">
+      <text>
+        <span foregroundColor={selected ? statusColor.info : undefined}>
+          {prefix}
+        </span>
+        <span bold={selected}>
+          {displayName}
+        </span>
+        <span foregroundColor={statusColor.dim}>
+          {categoryLabel}
+        </span>
+        {showAuth && (
+          <>
+            <span>{"  "}</span>
+            <span foregroundColor={auth.color}>{auth.icon}</span>
+            <span foregroundColor={statusColor.dim}>{` ${authStatus}`}</span>
+          </>
+        )}
+        <span>{"  "}</span>
+        <span foregroundColor={statusColor.reference}>{mountLabel}</span>
+        {showSync && syncLabel && (
+          <>
+            <span>{"  "}</span>
+            <span foregroundColor={syncColor}>{`[${syncLabel}]`}</span>
+          </>
+        )}
+      </text>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/panels/connectors/connectors-panel.tsx
+++ b/packages/nexus-tui/src/panels/connectors/connectors-panel.tsx
@@ -77,7 +77,7 @@ export default function ConnectorsPanel(): React.ReactNode {
   }
 
   return (
-    <BrickGate brick="mount">
+    <BrickGate brick="storage">
       <box height="100%" width="100%" flexDirection="column">
         {/* Sub-tab bar */}
         <box height={1} width="100%">

--- a/packages/nexus-tui/src/panels/connectors/connectors-panel.tsx
+++ b/packages/nexus-tui/src/panels/connectors/connectors-panel.tsx
@@ -1,0 +1,110 @@
+/**
+ * Connectors panel: tabbed layout for Available, Mounted, Skills, and Write views.
+ *
+ * Sub-tab routing delegates keyboard context to per-tab components (Decision 8A).
+ * Gated on "mount" brick availability.
+ */
+
+import React, { useEffect } from "react";
+import { useConnectorsStore } from "../../stores/connectors-store.js";
+import type { ConnectorsTab } from "../../stores/connectors-store.js";
+import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
+import { useApi } from "../../shared/hooks/use-api.js";
+import { useUiStore } from "../../stores/ui-store.js";
+import { BrickGate } from "../../shared/components/brick-gate.js";
+import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { AvailableTab } from "./available-tab.js";
+import { MountedTab } from "./mounted-tab.js";
+import { SkillsTab } from "./skills-tab.js";
+import { WriteTab } from "./write-tab.js";
+import { statusColor } from "../../shared/theme.js";
+
+// =============================================================================
+// Tab configuration
+// =============================================================================
+
+const TAB_ORDER: readonly ConnectorsTab[] = [
+  "available",
+  "mounted",
+  "skills",
+  "write",
+];
+
+const TAB_LABELS: Readonly<Record<ConnectorsTab, string>> = {
+  available: "Available",
+  mounted: "Mounted",
+  skills: "Skills",
+  write: "Write",
+};
+
+// =============================================================================
+// Panel component
+// =============================================================================
+
+export default function ConnectorsPanel(): React.ReactNode {
+  const client = useApi();
+  const overlayActive = useUiStore((s) => s.overlayActive);
+  const activeTab = useConnectorsStore((s) => s.activeTab);
+  const setActiveTab = useConnectorsStore((s) => s.setActiveTab);
+
+  // Only the panel root handles Tab key for sub-tab cycling.
+  // All other keys are delegated to the active sub-tab component.
+  useKeyboard(
+    overlayActive
+      ? {}
+      : {
+          tab: () => {
+            const currentIdx = TAB_ORDER.indexOf(activeTab);
+            const nextIdx = (currentIdx + 1) % TAB_ORDER.length;
+            const nextTab = TAB_ORDER[nextIdx];
+            if (nextTab) {
+              setActiveTab(nextTab);
+            }
+          },
+          "shift+tab": () => {
+            const currentIdx = TAB_ORDER.indexOf(activeTab);
+            const prevIdx = (currentIdx - 1 + TAB_ORDER.length) % TAB_ORDER.length;
+            const prevTab = TAB_ORDER[prevIdx];
+            if (prevTab) {
+              setActiveTab(prevTab);
+            }
+          },
+        },
+  );
+
+  if (!client) {
+    return <LoadingIndicator message="Connecting..." />;
+  }
+
+  return (
+    <BrickGate brick="mount">
+      <box height="100%" width="100%" flexDirection="column">
+        {/* Sub-tab bar */}
+        <box height={1} width="100%">
+          <text>
+            {TAB_ORDER.map((tab) => {
+              const label = TAB_LABELS[tab];
+              return tab === activeTab ? `[${label}]` : ` ${label} `;
+            }).join(" ")}
+          </text>
+        </box>
+
+        {/* Active tab content */}
+        <box flexGrow={1}>
+          {activeTab === "available" && (
+            <AvailableTab client={client} overlayActive={overlayActive} />
+          )}
+          {activeTab === "mounted" && (
+            <MountedTab client={client} overlayActive={overlayActive} />
+          )}
+          {activeTab === "skills" && (
+            <SkillsTab client={client} overlayActive={overlayActive} />
+          )}
+          {activeTab === "write" && (
+            <WriteTab client={client} overlayActive={overlayActive} />
+          )}
+        </box>
+      </box>
+    </BrickGate>
+  );
+}

--- a/packages/nexus-tui/src/panels/connectors/error-parser.ts
+++ b/packages/nexus-tui/src/panels/connectors/error-parser.ts
@@ -1,0 +1,116 @@
+/**
+ * Parse structured validation errors from backend connector write responses.
+ *
+ * The backend SkillErrorFormatter produces errors in a predictable format:
+ *
+ *   [CODE] message
+ *   Field errors:
+ *     - field_name: error message
+ *   See: /.skill/SKILL.md#section
+ *   Fix:
+ *   ```yaml
+ *   field: corrected_value
+ *   ```
+ *
+ * This parser extracts those sections into structured data for the TUI to
+ * render with color-coded field errors and actionable fix hints.
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ParsedWriteError {
+  /** Error code (e.g., "SCHEMA_VALIDATION_ERROR", "MISSING_AGENT_INTENT") */
+  readonly code: string | null;
+  /** Human-readable error message */
+  readonly message: string;
+  /** Field-level validation errors */
+  readonly fieldErrors: readonly FieldError[];
+  /** Skill doc reference path (e.g., "/.skill/SKILL.md#required-format") */
+  readonly skillRef: string | null;
+  /** YAML fix example (code block content, without fences) */
+  readonly fixExample: string | null;
+}
+
+export interface FieldError {
+  readonly field: string;
+  readonly error: string;
+}
+
+// =============================================================================
+// Parser
+// =============================================================================
+
+/**
+ * Parse a backend error string into structured error data.
+ *
+ * Handles both the structured ValidationError format and plain error strings.
+ */
+export function parseWriteError(errorString: string): ParsedWriteError {
+  // Extract error code: [CODE] message
+  const codeMatch = errorString.match(/^\[(\w+)]\s*(.+?)(?:\n|$)/);
+  const code = codeMatch?.[1] ?? null;
+  const messageAfterCode = codeMatch?.[2] ?? null;
+
+  // Extract field errors section
+  const fieldErrors: FieldError[] = [];
+  const fieldSectionMatch = errorString.match(
+    /Field errors:\s*\n((?:\s*-\s*.+\n?)+)/i,
+  );
+  if (fieldSectionMatch?.[1]) {
+    const fieldLines = fieldSectionMatch[1].split("\n");
+    for (const line of fieldLines) {
+      const fieldMatch = line.match(/^\s*-\s*(\S+):\s*(.+)$/);
+      if (fieldMatch?.[1] && fieldMatch[2]) {
+        fieldErrors.push({ field: fieldMatch[1], error: fieldMatch[2].trim() });
+      }
+    }
+  }
+
+  // Extract skill doc reference: See: path#section
+  const seeMatch = errorString.match(/See:\s*(\S+)/i);
+  const skillRef = seeMatch?.[1] ?? null;
+
+  // Extract fix example: everything between ```yaml and ```
+  let fixExample: string | null = null;
+  const fixBlockMatch = errorString.match(
+    /Fix:\s*\n```(?:yaml)?\s*\n([\s\S]*?)```/i,
+  );
+  if (fixBlockMatch?.[1]) {
+    fixExample = fixBlockMatch[1].trim();
+  } else {
+    // Try simpler format: Fix:\n# content (no code fences)
+    const simpleFix = errorString.match(/Fix:\s*\n((?:#?\s*.+\n?)+)/i);
+    if (simpleFix?.[1]) {
+      fixExample = simpleFix[1].trim();
+    }
+  }
+
+  // Build the primary message — use the part after [CODE] if available,
+  // otherwise use the first line of the error string
+  let message: string;
+  if (messageAfterCode) {
+    message = messageAfterCode;
+  } else {
+    // Take everything before "Field errors:" or "See:" or "Fix:"
+    const firstSectionIdx = Math.min(
+      ...[
+        errorString.indexOf("Field errors:"),
+        errorString.indexOf("See:"),
+        errorString.indexOf("Fix:"),
+      ]
+        .filter((i) => i >= 0)
+        .concat([errorString.length]),
+    );
+    message = errorString.substring(0, firstSectionIdx).trim();
+  }
+
+  return {
+    code,
+    message,
+    fieldErrors,
+    skillRef,
+    fixExample,
+  };
+}

--- a/packages/nexus-tui/src/panels/connectors/mounted-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/mounted-tab.tsx
@@ -1,0 +1,173 @@
+/**
+ * Mounted tab: lists mounted connectors with sync control.
+ *
+ * Supports: mount list navigation, sync trigger, unmount, sync status display.
+ */
+
+import React, { useEffect, useCallback } from "react";
+import type { FetchClient } from "@nexus/api-client";
+import { useConnectorsStore } from "../../stores/connectors-store.js";
+import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
+import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
+import { listNavigationBindings } from "../../shared/hooks/use-list-navigation.js";
+import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { statusColor } from "../../shared/theme.js";
+
+interface MountedTabProps {
+  readonly client: FetchClient;
+  readonly overlayActive: boolean;
+}
+
+export function MountedTab({ client, overlayActive }: MountedTabProps): React.ReactNode {
+  const mounts = useConnectorsStore((s) => s.mounts);
+  const loading = useConnectorsStore((s) => s.mountsLoading);
+  const selectedIndex = useConnectorsStore((s) => s.selectedMountIndex);
+  const syncingMounts = useConnectorsStore((s) => s.syncingMounts);
+  const lastSyncResult = useConnectorsStore((s) => s.lastSyncResult);
+
+  const setSelectedIndex = useConnectorsStore((s) => s.setSelectedMountIndex);
+  const fetchMounts = useConnectorsStore((s) => s.fetchMounts);
+  const triggerSync = useConnectorsStore((s) => s.triggerSync);
+  const unmountConnector = useConnectorsStore((s) => s.unmountConnector);
+  const clearSyncResult = useConnectorsStore((s) => s.clearSyncResult);
+
+  const confirm = useConfirmStore((s) => s.confirm);
+
+  // Auto-fetch on mount
+  useEffect(() => {
+    if (mounts.length === 0) {
+      fetchMounts(client);
+    }
+  }, [client, mounts.length, fetchMounts]);
+
+  const handleSync = useCallback(() => {
+    const selected = mounts[selectedIndex];
+    if (selected) {
+      triggerSync(selected.mount_point, client);
+    }
+  }, [mounts, selectedIndex, triggerSync, client]);
+
+  const handleUnmount = useCallback(async () => {
+    const selected = mounts[selectedIndex];
+    if (!selected) return;
+    const ok = await confirm(
+      "Unmount connector?",
+      `Unmount ${selected.mount_point}. Synced data will remain in the VFS.`,
+    );
+    if (!ok) return;
+    unmountConnector(selected.mount_point, client);
+  }, [mounts, selectedIndex, unmountConnector, client, confirm]);
+
+  const listNav = listNavigationBindings({
+    getIndex: () => selectedIndex,
+    setIndex: setSelectedIndex,
+    getLength: () => mounts.length,
+  });
+
+  useKeyboard(
+    overlayActive
+      ? {}
+      : {
+          ...listNav,
+          s: handleSync,
+          u: handleUnmount,
+          r: () => fetchMounts(client),
+        },
+  );
+
+  if (loading && mounts.length === 0) {
+    return <LoadingIndicator message="Loading mounts..." />;
+  }
+
+  const selectedMount = mounts[selectedIndex];
+
+  return (
+    <box flexDirection="column" height="100%" width="100%">
+      {/* Sync result banner */}
+      {lastSyncResult && (
+        <box height={2} width="100%" borderStyle="single" marginBottom={1}>
+          {lastSyncResult.error ? (
+            <text foregroundColor={statusColor.error}>{`Sync error: ${lastSyncResult.error}`}</text>
+          ) : (
+            <text foregroundColor={statusColor.healthy}>
+              {`Synced ${lastSyncResult.files_synced} files`}
+              {lastSyncResult.is_delta ? ` (delta: +${lastSyncResult.delta_added} -${lastSyncResult.delta_deleted})` : ""}
+            </text>
+          )}
+        </box>
+      )}
+
+      {/* Mount list */}
+      <box flexGrow={1} flexDirection="column">
+        {mounts.length === 0 ? (
+          <box height={1} width="100%">
+            <text foregroundColor={statusColor.dim}>No connectors mounted. Go to Available tab to mount one.</text>
+          </box>
+        ) : (
+          mounts.map((m, i) => {
+            const isSyncing = syncingMounts.has(m.mount_point);
+            const selected = i === selectedIndex;
+            const prefix = selected ? "▶ " : "  ";
+
+            return (
+              <box key={m.mount_point} height={1} width="100%">
+                <text>
+                  <span foregroundColor={selected ? statusColor.info : undefined}>{prefix}</span>
+                  <span bold={selected} foregroundColor={statusColor.reference}>{m.mount_point}</span>
+                  <span foregroundColor={statusColor.dim}>{m.readonly ? " (ro)" : ""}</span>
+                  {m.skill_name && (
+                    <span foregroundColor={statusColor.dim}>{`  skill:${m.skill_name}`}</span>
+                  )}
+                  {m.operations.length > 0 && (
+                    <span foregroundColor={statusColor.dim}>{`  ops:${m.operations.length}`}</span>
+                  )}
+                  {isSyncing && (
+                    <span foregroundColor={statusColor.warning}>{`  [syncing…]`}</span>
+                  )}
+                  {m.sync_status && !isSyncing && (
+                    <span foregroundColor={m.sync_status === "error" ? statusColor.error : statusColor.healthy}>
+                      {`  [${m.sync_status}]`}
+                    </span>
+                  )}
+                  {m.last_sync && (
+                    <span foregroundColor={statusColor.dim}>{`  last:${m.last_sync}`}</span>
+                  )}
+                </text>
+              </box>
+            );
+          })
+        )}
+      </box>
+
+      {/* Details for selected mount */}
+      {selectedMount && (
+        <box height={3} width="100%" borderStyle="single" marginTop={1}>
+          <box flexDirection="column" width="100%">
+            <box height={1} width="100%">
+              <text>
+                <span bold>{selectedMount.mount_point}</span>
+                <span foregroundColor={statusColor.dim}>
+                  {selectedMount.readonly ? "  read-only" : "  read-write"}
+                </span>
+              </text>
+            </box>
+            {selectedMount.operations.length > 0 && (
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.dim}>
+                  {`Operations: ${selectedMount.operations.join(", ")}`}
+                </text>
+              </box>
+            )}
+          </box>
+        </box>
+      )}
+
+      {/* Help bar */}
+      <box height={1} width="100%">
+        <text foregroundColor={statusColor.dim}>
+          j/k:navigate  s:sync  u:unmount  r:refresh
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/panels/connectors/mounted-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/mounted-tab.tsx
@@ -164,9 +164,15 @@ export function MountedTab({ client, overlayActive }: MountedTabProps): React.Re
 
       {/* Help bar */}
       <box height={1} width="100%">
-        <text foregroundColor={statusColor.dim}>
-          j/k:navigate  s:sync  u:unmount  r:refresh
-        </text>
+        {loading ? (
+          <text foregroundColor={statusColor.warning}>⠋ Refreshing...</text>
+        ) : syncingMounts.size > 0 ? (
+          <text foregroundColor={statusColor.warning}>{`⠋ Syncing ${syncingMounts.size} mount(s)...`}</text>
+        ) : (
+          <text foregroundColor={statusColor.dim}>
+            j/k:navigate  s:sync  u:unmount  r:refresh
+          </text>
+        )}
       </box>
     </box>
   );

--- a/packages/nexus-tui/src/panels/connectors/skills-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/skills-tab.tsx
@@ -1,0 +1,235 @@
+/**
+ * Skills tab: view SKILL.md docs and browse operation schemas (read-only).
+ *
+ * Two view modes: "doc" shows SKILL.md content, "schema" shows annotated schema.
+ * Select a mount first, then browse its skill docs and schemas.
+ */
+
+import React, { useEffect, useCallback } from "react";
+import type { FetchClient } from "@nexus/api-client";
+import { useConnectorsStore } from "../../stores/connectors-store.js";
+import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
+import { useCopy } from "../../shared/hooks/use-copy.js";
+import { listNavigationBindings } from "../../shared/hooks/use-list-navigation.js";
+import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { statusColor } from "../../shared/theme.js";
+
+interface SkillsTabProps {
+  readonly client: FetchClient;
+  readonly overlayActive: boolean;
+}
+
+export function SkillsTab({ client, overlayActive }: SkillsTabProps): React.ReactNode {
+  const mounts = useConnectorsStore((s) => s.mounts);
+  const selectedMountIndex = useConnectorsStore((s) => s.selectedSkillMountIndex);
+  const skillDoc = useConnectorsStore((s) => s.skillDoc);
+  const skillDocLoading = useConnectorsStore((s) => s.skillDocLoading);
+  const selectedSchemaIndex = useConnectorsStore((s) => s.selectedSchemaIndex);
+  const schemaDoc = useConnectorsStore((s) => s.schemaDoc);
+  const schemaDocLoading = useConnectorsStore((s) => s.schemaDocLoading);
+  const viewMode = useConnectorsStore((s) => s.skillViewMode);
+
+  const setSelectedMountIndex = useConnectorsStore((s) => s.setSelectedSkillMountIndex);
+  const setSelectedSchemaIndex = useConnectorsStore((s) => s.setSelectedSchemaIndex);
+  const setSkillViewMode = useConnectorsStore((s) => s.setSkillViewMode);
+  const fetchSkillDoc = useConnectorsStore((s) => s.fetchSkillDoc);
+  const fetchSchema = useConnectorsStore((s) => s.fetchSchema);
+  const fetchMounts = useConnectorsStore((s) => s.fetchMounts);
+
+  const { copy, copied } = useCopy();
+
+  const selectedMount = mounts[selectedMountIndex];
+
+  // Auto-fetch mounts if empty
+  useEffect(() => {
+    if (mounts.length === 0) {
+      fetchMounts(client);
+    }
+  }, [client, mounts.length, fetchMounts]);
+
+  // Auto-fetch skill doc when mount selection changes
+  useEffect(() => {
+    if (selectedMount && viewMode === "doc") {
+      fetchSkillDoc(selectedMount.mount_point, client);
+    }
+  }, [selectedMount?.mount_point, viewMode, client, fetchSkillDoc]);
+
+  // Fetch schema when schema selection changes
+  const handleSchemaSelect = useCallback(
+    (index: number) => {
+      if (!selectedMount || !skillDoc) return;
+      const operation = skillDoc.schemas[index];
+      if (operation) {
+        setSelectedSchemaIndex(index);
+        fetchSchema(selectedMount.mount_point, operation, client);
+      }
+    },
+    [selectedMount, skillDoc, setSelectedSchemaIndex, fetchSchema, client],
+  );
+
+  // Build navigation bindings based on view mode
+  const mountNav = listNavigationBindings({
+    getIndex: () => selectedMountIndex,
+    setIndex: (i) => {
+      setSelectedMountIndex(i);
+      setSelectedSchemaIndex(0);
+    },
+    getLength: () => mounts.length,
+  });
+
+  const schemaNav = listNavigationBindings({
+    getIndex: () => selectedSchemaIndex,
+    setIndex: setSelectedSchemaIndex,
+    getLength: () => (skillDoc?.schemas.length ?? 0),
+    onSelect: handleSchemaSelect,
+  });
+
+  useKeyboard(
+    overlayActive
+      ? {}
+      : viewMode === "doc"
+        ? {
+            ...mountNav,
+            s: () => setSkillViewMode("schema"),
+            r: () => {
+              if (selectedMount) fetchSkillDoc(selectedMount.mount_point, client);
+            },
+            y: () => {
+              if (skillDoc?.content) copy(skillDoc.content);
+            },
+          }
+        : {
+            ...schemaNav,
+            d: () => setSkillViewMode("doc"),
+            r: () => {
+              if (selectedMount && skillDoc) {
+                const op = skillDoc.schemas[selectedSchemaIndex];
+                if (op) fetchSchema(selectedMount.mount_point, op, client);
+              }
+            },
+            y: () => {
+              if (schemaDoc?.content) copy(schemaDoc.content);
+            },
+            escape: () => setSkillViewMode("doc"),
+          },
+  );
+
+  return (
+    <box flexDirection="column" height="100%" width="100%">
+      {/* Mount selector (top row) */}
+      <box height={1} width="100%">
+        <text>
+          <span foregroundColor={statusColor.dim}>Mount: </span>
+          {mounts.length === 0 ? (
+            <span foregroundColor={statusColor.dim}>No mounts</span>
+          ) : (
+            mounts.map((m, i) => (
+              <span
+                key={m.mount_point}
+                foregroundColor={i === selectedMountIndex ? statusColor.info : statusColor.dim}
+                bold={i === selectedMountIndex}
+              >
+                {i === selectedMountIndex ? `[${m.mount_point}]` : ` ${m.mount_point} `}
+              </span>
+            ))
+          )}
+          <span foregroundColor={statusColor.dim}>{"  "}</span>
+          <span foregroundColor={viewMode === "doc" ? statusColor.info : statusColor.dim}>
+            {viewMode === "doc" ? "[Doc]" : " Doc "}
+          </span>
+          <span foregroundColor={viewMode === "schema" ? statusColor.info : statusColor.dim}>
+            {viewMode === "schema" ? "[Schema]" : " Schema "}
+          </span>
+        </text>
+      </box>
+
+      {/* Content area */}
+      <box flexGrow={1} borderStyle="single" marginTop={1} flexDirection="column">
+        {viewMode === "doc" ? (
+          // SKILL.md viewer
+          skillDocLoading ? (
+            <LoadingIndicator message="Loading skill doc..." />
+          ) : skillDoc?.content ? (
+            <box flexDirection="column" width="100%">
+              {skillDoc.content.split("\n").slice(0, 30).map((line, i) => (
+                <box key={i} height={1} width="100%">
+                  <text>{line}</text>
+                </box>
+              ))}
+              {skillDoc.content.split("\n").length > 30 && (
+                <box height={1} width="100%">
+                  <text foregroundColor={statusColor.dim}>... (truncated, press y to copy full doc)</text>
+                </box>
+              )}
+            </box>
+          ) : (
+            <box height={1} width="100%">
+              <text foregroundColor={statusColor.dim}>No skill doc available. Mount a connector with skill support.</text>
+            </box>
+          )
+        ) : (
+          // Schema browser
+          <box flexDirection="row" height="100%" width="100%">
+            {/* Schema list (left) */}
+            <box width="30%" flexDirection="column" borderStyle="single">
+              <box height={1} width="100%">
+                <text bold foregroundColor={statusColor.info}>Operations</text>
+              </box>
+              {skillDoc?.schemas.map((op, i) => (
+                <box key={op} height={1} width="100%">
+                  <text>
+                    <span foregroundColor={i === selectedSchemaIndex ? statusColor.info : undefined}>
+                      {i === selectedSchemaIndex ? `▶ ${op}` : `  ${op}`}
+                    </span>
+                  </text>
+                </box>
+              ))}
+              {(!skillDoc || skillDoc.schemas.length === 0) && (
+                <box height={1} width="100%">
+                  <text foregroundColor={statusColor.dim}>No schemas</text>
+                </box>
+              )}
+            </box>
+
+            {/* Schema content (right) */}
+            <box width="70%" flexDirection="column" paddingLeft={1}>
+              {schemaDocLoading ? (
+                <LoadingIndicator message="Loading schema..." />
+              ) : schemaDoc?.content ? (
+                <box flexDirection="column" width="100%">
+                  <box height={1} width="100%">
+                    <text bold>{schemaDoc.operation}</text>
+                  </box>
+                  {schemaDoc.content.split("\n").slice(0, 25).map((line, i) => (
+                    <box key={i} height={1} width="100%">
+                      <text foregroundColor={statusColor.dim}>{line}</text>
+                    </box>
+                  ))}
+                </box>
+              ) : (
+                <box height={1} width="100%">
+                  <text foregroundColor={statusColor.dim}>Select an operation to view its schema.</text>
+                </box>
+              )}
+            </box>
+          </box>
+        )}
+      </box>
+
+      {/* Help bar */}
+      <box height={1} width="100%">
+        {copied ? (
+          <text foregroundColor={statusColor.healthy}>Copied!</text>
+        ) : viewMode === "doc" ? (
+          <text foregroundColor={statusColor.dim}>
+            j/k:select mount  s:schemas  y:copy  r:refresh
+          </text>
+        ) : (
+          <text foregroundColor={statusColor.dim}>
+            j/k:select operation  Enter:view  d:doc view  y:copy  Esc:back  r:refresh
+          </text>
+        )}
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/panels/connectors/template-generator.ts
+++ b/packages/nexus-tui/src/panels/connectors/template-generator.ts
@@ -1,0 +1,211 @@
+/**
+ * Schema-to-YAML template generator.
+ *
+ * Pure function that converts an annotated schema (YAML string from the API)
+ * into a pre-filled YAML template for the Write tab.
+ *
+ * The schema format is annotated YAML with comments like:
+ *   field_name:           # (required) Description — type: string
+ *   optional_field:       # (optional) Description — type: integer, default: 0
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface SchemaField {
+  readonly name: string;
+  readonly type: string;
+  readonly required: boolean;
+  readonly description: string;
+  readonly default_value: string | null;
+  readonly enum_values: readonly string[];
+  readonly is_nested: boolean;
+  readonly children: readonly SchemaField[];
+}
+
+// =============================================================================
+// Parser: extract fields from annotated schema YAML
+// =============================================================================
+
+/**
+ * Parse an annotated schema string into structured fields.
+ *
+ * Handles formats like:
+ *   field_name:           # (required) Description — type: string
+ *   field_name: value     # (optional) Description — type: integer
+ *   field_name:           # (required) One of: val1, val2, val3
+ */
+export function parseSchemaFields(schemaContent: string): readonly SchemaField[] {
+  const lines = schemaContent.split("\n");
+  const fields: SchemaField[] = [];
+  let currentIndent = -1;
+
+  for (const line of lines) {
+    // Skip empty lines and pure comment lines (not field comments)
+    const trimmed = line.trim();
+    if (!trimmed || (trimmed.startsWith("#") && !trimmed.includes(":"))) continue;
+
+    // Match field pattern: name: [value] # comment
+    const fieldMatch = trimmed.match(
+      /^(\w[\w.]*)\s*:\s*(.*?)(?:\s*#\s*(.*))?$/,
+    );
+    if (!fieldMatch) continue;
+
+    const [, name, rawValue, comment] = fieldMatch;
+    if (!name) continue;
+
+    // Parse required/optional from comment
+    const isRequired = comment ? /\(required\)/i.test(comment) : false;
+
+    // Parse type from comment
+    const typeMatch = comment?.match(/type:\s*(\w+)/i);
+    const type = typeMatch?.[1] ?? "string";
+
+    // Parse description — everything before "type:" or "One of:" or "default:"
+    let description = comment ?? "";
+    description = description
+      .replace(/\(required\)/i, "")
+      .replace(/\(optional\)/i, "")
+      .replace(/type:\s*\w+/i, "")
+      .replace(/default:\s*\S+/i, "")
+      .replace(/One of:.*$/i, "")
+      .replace(/[—–-]\s*$/, "")
+      .trim();
+
+    // Parse default value
+    const defaultMatch = comment?.match(/default:\s*(\S+)/i);
+    const defaultValue = defaultMatch?.[1] ?? null;
+
+    // Parse enum values — strip trailing "default: X" from the match
+    const enumMatch = comment?.match(/One of:\s*(.+)$/i);
+    const enumValues: string[] = enumMatch
+      ? enumMatch[1]
+          .replace(/,?\s*default:\s*\S+/i, "")
+          .split(",")
+          .map((v) => v.trim())
+          .filter(Boolean)
+      : [];
+
+    // Determine nesting from indent
+    const indent = line.search(/\S/);
+    const valueStr = rawValue.trim();
+    const isNested = valueStr === "" && !comment?.includes("type:");
+
+    fields.push({
+      name,
+      type,
+      required: isRequired,
+      description,
+      default_value: defaultValue,
+      enum_values: enumValues,
+      is_nested: isNested,
+      children: [],
+    });
+  }
+
+  return fields;
+}
+
+// =============================================================================
+// Template generator
+// =============================================================================
+
+/**
+ * Generate a YAML template from a schema string.
+ *
+ * Required fields are shown with placeholder values.
+ * Optional fields are commented out with their defaults.
+ * Enum fields show valid values as comments.
+ */
+export function generateTemplate(
+  schemaContent: string,
+  operationName: string,
+): string {
+  const fields = parseSchemaFields(schemaContent);
+
+  if (fields.length === 0) {
+    // If we can't parse structured fields, return the schema as-is
+    // with a header comment — the user can edit it directly
+    return `# ${operationName}\n# Edit the fields below:\n\n${schemaContent}`;
+  }
+
+  const lines: string[] = [];
+  lines.push(`# ${operationName}`);
+  lines.push(`# Required fields are pre-filled. Optional fields are commented out.`);
+  lines.push("");
+
+  for (const field of fields) {
+    if (field.is_nested) {
+      // Section header
+      if (field.required) {
+        lines.push(`${field.name}:`);
+      } else {
+        lines.push(`# ${field.name}:`);
+      }
+      continue;
+    }
+
+    const enumComment = field.enum_values.length > 0
+      ? `  # One of: ${field.enum_values.join(", ")}`
+      : "";
+
+    const descComment = field.description
+      ? `  # ${field.description}`
+      : "";
+
+    const placeholder = getPlaceholder(field);
+
+    if (field.required) {
+      lines.push(`${field.name}: ${placeholder}${enumComment || descComment}`);
+    } else {
+      // Optional fields are commented out
+      const value = field.default_value ?? placeholder;
+      lines.push(`# ${field.name}: ${value}${enumComment || descComment}`);
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Get a sensible placeholder for a field based on its type.
+ */
+function getPlaceholder(field: SchemaField): string {
+  if (field.default_value) return field.default_value;
+  if (field.enum_values.length > 0) return field.enum_values[0];
+
+  switch (field.type.toLowerCase()) {
+    case "string":
+      return `"<${field.name}>"`;
+    case "integer":
+    case "int":
+      return "0";
+    case "number":
+    case "float":
+      return "0.0";
+    case "boolean":
+    case "bool":
+      return "false";
+    case "array":
+    case "list":
+      return "[]";
+    case "object":
+    case "dict":
+      return "{}";
+    default:
+      return `"<${field.name}>"`;
+  }
+}
+
+/**
+ * Generate a template directly from an operation name and raw schema content.
+ *
+ * Convenience wrapper used by the Write tab.
+ */
+export function generateWriteTemplate(
+  operationName: string,
+  schemaContent: string,
+): string {
+  return generateTemplate(schemaContent, operationName);
+}

--- a/packages/nexus-tui/src/panels/connectors/write-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/write-tab.tsx
@@ -1,0 +1,329 @@
+/**
+ * Write tab: template-based YAML write composition with validation.
+ *
+ * Workflow: select mount → select operation → edit template → submit.
+ * Template is generated from the operation schema.
+ */
+
+import React, { useState, useEffect, useCallback } from "react";
+import type { FetchClient } from "@nexus/api-client";
+import { useConnectorsStore } from "../../stores/connectors-store.js";
+import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
+import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
+import { useSwr } from "../../shared/hooks/use-swr.js";
+import { listNavigationBindings } from "../../shared/hooks/use-list-navigation.js";
+import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { generateWriteTemplate } from "./template-generator.js";
+import { statusColor } from "../../shared/theme.js";
+import type { SchemaDoc } from "../../stores/connectors-store.js";
+
+interface WriteTabProps {
+  readonly client: FetchClient;
+  readonly overlayActive: boolean;
+}
+
+type WriteMode = "select-mount" | "select-op" | "edit" | "result";
+
+export function WriteTab({ client, overlayActive }: WriteTabProps): React.ReactNode {
+  const mounts = useConnectorsStore((s) => s.mounts);
+  const selectedMountIndex = useConnectorsStore((s) => s.selectedWriteMountIndex);
+  const selectedOpIndex = useConnectorsStore((s) => s.selectedOperationIndex);
+  const writeTemplate = useConnectorsStore((s) => s.writeTemplate);
+  const writeResult = useConnectorsStore((s) => s.writeResult);
+  const writeLoading = useConnectorsStore((s) => s.writeLoading);
+
+  const setSelectedMountIndex = useConnectorsStore((s) => s.setSelectedWriteMountIndex);
+  const setSelectedOpIndex = useConnectorsStore((s) => s.setSelectedOperationIndex);
+  const setWriteTemplate = useConnectorsStore((s) => s.setWriteTemplate);
+  const submitWrite = useConnectorsStore((s) => s.submitWrite);
+  const clearWriteResult = useConnectorsStore((s) => s.clearWriteResult);
+  const fetchMounts = useConnectorsStore((s) => s.fetchMounts);
+
+  const confirm = useConfirmStore((s) => s.confirm);
+
+  const [mode, setMode] = useState<WriteMode>("select-mount");
+  const [editLine, setEditLine] = useState(0);
+
+  const selectedMount = mounts[selectedMountIndex];
+  const operations = selectedMount?.operations ?? [];
+  const selectedOp = operations[selectedOpIndex];
+
+  // Auto-fetch mounts if empty
+  useEffect(() => {
+    if (mounts.length === 0) {
+      fetchMounts(client);
+    }
+  }, [client, mounts.length, fetchMounts]);
+
+  // Fetch schema and generate template when operation is selected
+  const { data: schemaData } = useSwr<SchemaDoc>(
+    selectedMount && selectedOp
+      ? `schema-${selectedMount.mount_point}-${selectedOp}`
+      : "__disabled__",
+    async (signal) => {
+      if (!selectedMount || !selectedOp) throw new Error("No selection");
+      return client.get<SchemaDoc>(
+        `/api/v2/connectors/schema/${selectedMount.mount_point.replace(/^\//, "")}/${selectedOp}`,
+        { signal },
+      );
+    },
+    { ttlMs: 300_000, enabled: !!selectedMount && !!selectedOp },
+  );
+
+  // Generate template from schema
+  useEffect(() => {
+    if (schemaData?.content && selectedOp && mode === "edit") {
+      const template = generateWriteTemplate(selectedOp, schemaData.content);
+      setWriteTemplate(template);
+      setEditLine(0);
+    }
+  }, [schemaData?.content, selectedOp, mode, setWriteTemplate]);
+
+  const templateLines = writeTemplate.split("\n");
+
+  const handleSubmit = useCallback(async () => {
+    if (!selectedMount || !writeTemplate.trim()) return;
+    const ok = await confirm(
+      "Submit write operation?",
+      `Write to ${selectedMount.mount_point} (${selectedOp}). This may have side effects.`,
+    );
+    if (!ok) return;
+    submitWrite(selectedMount.mount_point, writeTemplate, client);
+    setMode("result");
+  }, [selectedMount, selectedOp, writeTemplate, submitWrite, client, confirm]);
+
+  // Build keyboard bindings based on mode
+  const mountNav = listNavigationBindings({
+    getIndex: () => selectedMountIndex,
+    setIndex: setSelectedMountIndex,
+    getLength: () => mounts.length,
+    onSelect: () => {
+      if (operations.length > 0) {
+        setMode("select-op");
+        setSelectedOpIndex(0);
+      }
+    },
+  });
+
+  const opNav = listNavigationBindings({
+    getIndex: () => selectedOpIndex,
+    setIndex: setSelectedOpIndex,
+    getLength: () => operations.length,
+    onSelect: () => setMode("edit"),
+  });
+
+  useKeyboard(
+    overlayActive
+      ? {}
+      : mode === "select-mount"
+        ? {
+            ...mountNav,
+            r: () => fetchMounts(client),
+          }
+        : mode === "select-op"
+          ? {
+              ...opNav,
+              escape: () => setMode("select-mount"),
+            }
+          : mode === "edit"
+            ? {
+                j: () => setEditLine(Math.min(editLine + 1, templateLines.length - 1)),
+                k: () => setEditLine(Math.max(editLine - 1, 0)),
+                down: () => setEditLine(Math.min(editLine + 1, templateLines.length - 1)),
+                up: () => setEditLine(Math.max(editLine - 1, 0)),
+                "ctrl+s": handleSubmit,
+                return: handleSubmit,
+                escape: () => setMode("select-op"),
+              }
+            : {
+                // result mode
+                escape: () => {
+                  clearWriteResult();
+                  setMode("select-op");
+                },
+                r: () => {
+                  clearWriteResult();
+                  setMode("edit");
+                },
+              },
+  );
+
+  return (
+    <box flexDirection="column" height="100%" width="100%">
+      {/* Breadcrumb */}
+      <box height={1} width="100%">
+        <text>
+          <span
+            foregroundColor={mode === "select-mount" ? statusColor.info : statusColor.dim}
+            bold={mode === "select-mount"}
+          >
+            Mount
+          </span>
+          <span foregroundColor={statusColor.dim}>{" → "}</span>
+          <span
+            foregroundColor={mode === "select-op" ? statusColor.info : statusColor.dim}
+            bold={mode === "select-op"}
+          >
+            Operation
+          </span>
+          <span foregroundColor={statusColor.dim}>{" → "}</span>
+          <span
+            foregroundColor={mode === "edit" ? statusColor.info : statusColor.dim}
+            bold={mode === "edit"}
+          >
+            Edit
+          </span>
+          <span foregroundColor={statusColor.dim}>{" → "}</span>
+          <span
+            foregroundColor={mode === "result" ? statusColor.info : statusColor.dim}
+            bold={mode === "result"}
+          >
+            Result
+          </span>
+        </text>
+      </box>
+
+      {/* Content area */}
+      <box flexGrow={1} borderStyle="single" marginTop={1} flexDirection="column">
+        {mode === "select-mount" && (
+          <box flexDirection="column" width="100%">
+            <box height={1} width="100%">
+              <text bold>Select a mount to write to:</text>
+            </box>
+            {mounts.length === 0 ? (
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.dim}>No mounts available.</text>
+              </box>
+            ) : (
+              mounts.map((m, i) => (
+                <box key={m.mount_point} height={1} width="100%">
+                  <text>
+                    <span foregroundColor={i === selectedMountIndex ? statusColor.info : undefined}>
+                      {i === selectedMountIndex ? "▶ " : "  "}
+                    </span>
+                    <span foregroundColor={statusColor.reference}>{m.mount_point}</span>
+                    {m.readonly && (
+                      <span foregroundColor={statusColor.error}>{" (read-only)"}</span>
+                    )}
+                    {m.operations.length > 0 && (
+                      <span foregroundColor={statusColor.dim}>
+                        {`  ${m.operations.length} operations`}
+                      </span>
+                    )}
+                  </text>
+                </box>
+              ))
+            )}
+          </box>
+        )}
+
+        {mode === "select-op" && (
+          <box flexDirection="column" width="100%">
+            <box height={1} width="100%">
+              <text bold>
+                {`Select operation for ${selectedMount?.mount_point ?? ""}:`}
+              </text>
+            </box>
+            {operations.length === 0 ? (
+              <box height={1} width="100%">
+                <text foregroundColor={statusColor.dim}>No write operations available for this mount.</text>
+              </box>
+            ) : (
+              operations.map((op, i) => (
+                <box key={op} height={1} width="100%">
+                  <text>
+                    <span foregroundColor={i === selectedOpIndex ? statusColor.info : undefined}>
+                      {i === selectedOpIndex ? "▶ " : "  "}
+                    </span>
+                    <span>{op}</span>
+                  </text>
+                </box>
+              ))
+            )}
+          </box>
+        )}
+
+        {mode === "edit" && (
+          <box flexDirection="column" width="100%">
+            <box height={1} width="100%">
+              <text bold>{`Editing: ${selectedOp} → ${selectedMount?.mount_point}`}</text>
+            </box>
+            {writeLoading ? (
+              <LoadingIndicator message="Submitting..." />
+            ) : (
+              templateLines.map((line, i) => (
+                <box key={i} height={1} width="100%">
+                  <text>
+                    <span foregroundColor={statusColor.dim}>
+                      {String(i + 1).padStart(3, " ")}
+                    </span>
+                    <span foregroundColor={i === editLine ? statusColor.info : undefined}>
+                      {i === editLine ? " ▶ " : "   "}
+                    </span>
+                    <span
+                      foregroundColor={
+                        line.startsWith("#")
+                          ? statusColor.dim
+                          : undefined
+                      }
+                    >
+                      {line}
+                    </span>
+                  </text>
+                </box>
+              ))
+            )}
+          </box>
+        )}
+
+        {mode === "result" && (
+          <box flexDirection="column" width="100%">
+            <box height={1} width="100%">
+              <text bold>Write Result</text>
+            </box>
+            {writeResult ? (
+              writeResult.success ? (
+                <>
+                  <box height={1} width="100%">
+                    <text foregroundColor={statusColor.healthy}>✓ Write successful!</text>
+                  </box>
+                  {writeResult.content_hash && (
+                    <box height={1} width="100%">
+                      <text foregroundColor={statusColor.dim}>{`Hash: ${writeResult.content_hash}`}</text>
+                    </box>
+                  )}
+                </>
+              ) : (
+                <>
+                  <box height={1} width="100%">
+                    <text foregroundColor={statusColor.error}>✕ Write failed</text>
+                  </box>
+                  {writeResult.error && (
+                    <box height={1} width="100%">
+                      <text foregroundColor={statusColor.error}>{writeResult.error}</text>
+                    </box>
+                  )}
+                </>
+              )
+            ) : (
+              <LoadingIndicator message="Submitting..." />
+            )}
+          </box>
+        )}
+      </box>
+
+      {/* Help bar */}
+      <box height={1} width="100%">
+        <text foregroundColor={statusColor.dim}>
+          {mode === "select-mount"
+            ? "j/k:navigate  Enter:select  r:refresh"
+            : mode === "select-op"
+              ? "j/k:navigate  Enter:select  Esc:back"
+              : mode === "edit"
+                ? "j/k:navigate lines  Enter/Ctrl+S:submit  Esc:back"
+                : "Esc:back to operations  r:edit again"}
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/panels/connectors/write-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/write-tab.tsx
@@ -3,6 +3,13 @@
  *
  * Workflow: select mount → select operation → edit template → submit.
  * Template is generated from the operation schema.
+ *
+ * Supports inline editing of field values (Enter to edit a line, type to
+ * replace, Enter to confirm, Escape to cancel). Commented lines can be
+ * uncommented with '#' to enable optional fields.
+ *
+ * Error display parses backend ValidationError format to show field-level
+ * errors, skill doc references, and fix examples.
  */
 
 import React, { useState, useEffect, useCallback } from "react";
@@ -14,6 +21,7 @@ import { useSwr } from "../../shared/hooks/use-swr.js";
 import { listNavigationBindings } from "../../shared/hooks/use-list-navigation.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
 import { generateWriteTemplate } from "./template-generator.js";
+import { parseWriteError } from "./error-parser.js";
 import { statusColor } from "../../shared/theme.js";
 import type { SchemaDoc } from "../../stores/connectors-store.js";
 
@@ -43,6 +51,8 @@ export function WriteTab({ client, overlayActive }: WriteTabProps): React.ReactN
 
   const [mode, setMode] = useState<WriteMode>("select-mount");
   const [editLine, setEditLine] = useState(0);
+  const [lineEditMode, setLineEditMode] = useState(false);
+  const [lineEditBuffer, setLineEditBuffer] = useState("");
 
   const selectedMount = mounts[selectedMountIndex];
   const operations = selectedMount?.operations ?? [];
@@ -81,6 +91,63 @@ export function WriteTab({ client, overlayActive }: WriteTabProps): React.ReactN
 
   const templateLines = writeTemplate.split("\n");
 
+  // ---------------------------------------------------------------------------
+  // Inline line editing helpers
+  // ---------------------------------------------------------------------------
+
+  /** Enter edit mode for the current line's value (after the colon). */
+  const startLineEdit = useCallback(() => {
+    const line = templateLines[editLine];
+    if (!line) return;
+    // Extract the value portion after "key:" (skip comments-only and header lines)
+    const stripped = line.replace(/^#\s*/, "");
+    const colonIdx = stripped.indexOf(":");
+    if (colonIdx < 0) return; // not a key: value line
+    // Pre-fill buffer with current value (trimmed, without inline comment)
+    const rawValue = stripped.substring(colonIdx + 1).split("#")[0]?.trim() ?? "";
+    // Strip surrounding quotes for editing comfort
+    const unquoted = rawValue.replace(/^["']|["']$/g, "");
+    setLineEditBuffer(unquoted);
+    setLineEditMode(true);
+  }, [templateLines, editLine]);
+
+  /** Commit the edited value back into the template. */
+  const commitLineEdit = useCallback(() => {
+    const line = templateLines[editLine];
+    if (!line) { setLineEditMode(false); return; }
+    const stripped = line.replace(/^#\s*/, "");
+    const colonIdx = stripped.indexOf(":");
+    if (colonIdx < 0) { setLineEditMode(false); return; }
+    const key = stripped.substring(0, colonIdx);
+    // Preserve inline comment
+    const commentMatch = stripped.match(/#\s*.+$/);
+    const comment = commentMatch ? `  ${commentMatch[0]}` : "";
+    // Build new line (uncommented — editing implies enabling)
+    const value = lineEditBuffer.includes(" ") || lineEditBuffer === ""
+      ? `"${lineEditBuffer}"`
+      : lineEditBuffer;
+    const newLine = `${key}: ${value}${comment}`;
+    const newLines = [...templateLines];
+    newLines[editLine] = newLine;
+    setWriteTemplate(newLines.join("\n"));
+    setLineEditMode(false);
+  }, [templateLines, editLine, lineEditBuffer, setWriteTemplate]);
+
+  /** Toggle comment on/off for the current line. */
+  const toggleComment = useCallback(() => {
+    const line = templateLines[editLine];
+    if (!line) return;
+    const newLines = [...templateLines];
+    if (line.startsWith("# ")) {
+      // Uncomment
+      newLines[editLine] = line.substring(2);
+    } else if (!line.startsWith("#")) {
+      // Comment out
+      newLines[editLine] = `# ${line}`;
+    }
+    setWriteTemplate(newLines.join("\n"));
+  }, [templateLines, editLine, setWriteTemplate]);
+
   const handleSubmit = useCallback(async () => {
     if (!selectedMount || !writeTemplate.trim()) return;
     const ok = await confirm(
@@ -92,7 +159,13 @@ export function WriteTab({ client, overlayActive }: WriteTabProps): React.ReactN
     setMode("result");
   }, [selectedMount, selectedOp, writeTemplate, submitWrite, client, confirm]);
 
-  // Build keyboard bindings based on mode
+  // Parse structured error from write result
+  const parsedError = writeResult?.error ? parseWriteError(writeResult.error) : null;
+
+  // ---------------------------------------------------------------------------
+  // Keyboard bindings
+  // ---------------------------------------------------------------------------
+
   const mountNav = listNavigationBindings({
     getIndex: () => selectedMountIndex,
     setIndex: setSelectedMountIndex,
@@ -125,27 +198,50 @@ export function WriteTab({ client, overlayActive }: WriteTabProps): React.ReactN
               ...opNav,
               escape: () => setMode("select-mount"),
             }
-          : mode === "edit"
+          : mode === "edit" && lineEditMode
             ? {
-                j: () => setEditLine(Math.min(editLine + 1, templateLines.length - 1)),
-                k: () => setEditLine(Math.max(editLine - 1, 0)),
-                down: () => setEditLine(Math.min(editLine + 1, templateLines.length - 1)),
-                up: () => setEditLine(Math.max(editLine - 1, 0)),
-                "ctrl+s": handleSubmit,
-                return: handleSubmit,
-                escape: () => setMode("select-op"),
+                // Line editing mode — capture typed characters
+                return: commitLineEdit,
+                escape: () => { setLineEditMode(false); setLineEditBuffer(""); },
+                backspace: () => { setLineEditBuffer((b) => b.slice(0, -1)); },
               }
-            : {
-                // result mode
-                escape: () => {
-                  clearWriteResult();
-                  setMode("select-op");
+            : mode === "edit"
+              ? {
+                  j: () => setEditLine(Math.min(editLine + 1, templateLines.length - 1)),
+                  k: () => setEditLine(Math.max(editLine - 1, 0)),
+                  down: () => setEditLine(Math.min(editLine + 1, templateLines.length - 1)),
+                  up: () => setEditLine(Math.max(editLine - 1, 0)),
+                  return: startLineEdit,
+                  "ctrl+s": handleSubmit,
+                  "#": toggleComment,
+                  escape: () => setMode("select-op"),
+                }
+              : {
+                  // result mode
+                  escape: () => {
+                    clearWriteResult();
+                    setMode("select-op");
+                  },
+                  r: () => {
+                    clearWriteResult();
+                    setMode("edit");
+                  },
+                  e: () => {
+                    // Jump back to edit with current template to fix errors
+                    clearWriteResult();
+                    setMode("edit");
+                  },
                 },
-                r: () => {
-                  clearWriteResult();
-                  setMode("edit");
-                },
-              },
+    // onUnhandled: capture typed characters in line edit mode
+    (!overlayActive && mode === "edit" && lineEditMode)
+      ? (keyName: string) => {
+          if (keyName === "space") {
+            setLineEditBuffer((b) => b + " ");
+          } else if (keyName.length === 1) {
+            setLineEditBuffer((b) => b + keyName);
+          }
+        }
+      : undefined,
   );
 
   return (
@@ -251,27 +347,50 @@ export function WriteTab({ client, overlayActive }: WriteTabProps): React.ReactN
             {writeLoading ? (
               <LoadingIndicator message="Submitting..." />
             ) : (
-              templateLines.map((line, i) => (
-                <box key={i} height={1} width="100%">
-                  <text>
-                    <span foregroundColor={statusColor.dim}>
-                      {String(i + 1).padStart(3, " ")}
-                    </span>
-                    <span foregroundColor={i === editLine ? statusColor.info : undefined}>
-                      {i === editLine ? " ▶ " : "   "}
-                    </span>
-                    <span
-                      foregroundColor={
-                        line.startsWith("#")
-                          ? statusColor.dim
-                          : undefined
-                      }
-                    >
-                      {line}
-                    </span>
-                  </text>
-                </box>
-              ))
+              templateLines.map((line, i) => {
+                const isActive = i === editLine;
+                const isEditing = isActive && lineEditMode;
+
+                return (
+                  <box key={i} height={1} width="100%">
+                    <text>
+                      <span foregroundColor={statusColor.dim}>
+                        {String(i + 1).padStart(3, " ")}
+                      </span>
+                      <span foregroundColor={isActive ? statusColor.info : undefined}>
+                        {isActive ? " ▶ " : "   "}
+                      </span>
+                      {isEditing ? (
+                        // Show the key + editable value with cursor
+                        (() => {
+                          const stripped = line.replace(/^#\s*/, "");
+                          const colonIdx = stripped.indexOf(":");
+                          const key = colonIdx >= 0 ? stripped.substring(0, colonIdx) : line;
+                          return (
+                            <>
+                              <span foregroundColor={statusColor.info}>{`${key}: `}</span>
+                              <span foregroundColor={statusColor.healthy} bold>
+                                {lineEditBuffer}
+                              </span>
+                              <span foregroundColor={statusColor.info}>{"\u2588"}</span>
+                            </>
+                          );
+                        })()
+                      ) : (
+                        <span
+                          foregroundColor={
+                            line.startsWith("#")
+                              ? statusColor.dim
+                              : undefined
+                          }
+                        >
+                          {line}
+                        </span>
+                      )}
+                    </text>
+                  </box>
+                );
+              })
             )}
           </box>
         )}
@@ -293,7 +412,71 @@ export function WriteTab({ client, overlayActive }: WriteTabProps): React.ReactN
                     </box>
                   )}
                 </>
+              ) : parsedError ? (
+                // Structured error display with self-correcting hints
+                <box flexDirection="column" width="100%">
+                  {/* Error code + message */}
+                  <box height={1} width="100%">
+                    <text>
+                      <span foregroundColor={statusColor.error} bold>
+                        {parsedError.code ? `[${parsedError.code}] ` : "✕ "}
+                      </span>
+                      <span foregroundColor={statusColor.error}>{parsedError.message}</span>
+                    </text>
+                  </box>
+
+                  {/* Field-level errors */}
+                  {parsedError.fieldErrors.length > 0 && (
+                    <>
+                      <box height={1} width="100%" marginTop={1}>
+                        <text bold foregroundColor={statusColor.warning}>Field errors:</text>
+                      </box>
+                      {parsedError.fieldErrors.map(({ field, error }) => (
+                        <box key={field} height={1} width="100%">
+                          <text>
+                            <span foregroundColor={statusColor.warning}>{"  - "}</span>
+                            <span foregroundColor={statusColor.info} bold>{field}</span>
+                            <span foregroundColor={statusColor.dim}>{": "}</span>
+                            <span>{error}</span>
+                          </text>
+                        </box>
+                      ))}
+                    </>
+                  )}
+
+                  {/* Skill doc reference */}
+                  {parsedError.skillRef && (
+                    <box height={1} width="100%" marginTop={1}>
+                      <text>
+                        <span foregroundColor={statusColor.dim}>{"See: "}</span>
+                        <span foregroundColor={statusColor.reference}>{parsedError.skillRef}</span>
+                      </text>
+                    </box>
+                  )}
+
+                  {/* Fix example */}
+                  {parsedError.fixExample && (
+                    <>
+                      <box height={1} width="100%" marginTop={1}>
+                        <text foregroundColor={statusColor.healthy} bold>Fix:</text>
+                      </box>
+                      {parsedError.fixExample.split("\n").map((fixLine, i) => (
+                        <box key={i} height={1} width="100%">
+                          <text foregroundColor={statusColor.dim}>{`  ${fixLine}`}</text>
+                        </box>
+                      ))}
+                    </>
+                  )}
+
+                  {/* Action hint */}
+                  <box height={1} width="100%" marginTop={1}>
+                    <text foregroundColor={statusColor.dim}>
+                      Press e to edit template with corrections, Esc to go back
+                    </text>
+                  </box>
+                </box>
               ) : (
+                // Unstructured error fallback
                 <>
                   <box height={1} width="100%">
                     <text foregroundColor={statusColor.error}>✕ Write failed</text>
@@ -319,9 +502,11 @@ export function WriteTab({ client, overlayActive }: WriteTabProps): React.ReactN
             ? "j/k:navigate  Enter:select  r:refresh"
             : mode === "select-op"
               ? "j/k:navigate  Enter:select  Esc:back"
-              : mode === "edit"
-                ? "j/k:navigate lines  Enter/Ctrl+S:submit  Esc:back"
-                : "Esc:back to operations  r:edit again"}
+              : mode === "edit" && lineEditMode
+                ? "type:edit value  Enter:confirm  Esc:cancel"
+                : mode === "edit"
+                  ? "j/k:navigate  Enter:edit line  #:toggle comment  Ctrl+S:submit  Esc:back"
+                  : "e:edit again  Esc:back to operations"}
         </text>
       </box>
     </box>

--- a/packages/nexus-tui/src/stores/connectors-store.ts
+++ b/packages/nexus-tui/src/stores/connectors-store.ts
@@ -1,0 +1,432 @@
+/**
+ * Connector management state: discovery, auth, mount, sync, skills, writes.
+ *
+ * Single store following the one-store-per-panel pattern (Decision 3A).
+ */
+
+import { create } from "zustand";
+import { createApiAction } from "./create-api-action.js";
+import type { FetchClient } from "@nexus/api-client";
+
+// =============================================================================
+// Types (wire format — snake_case matches API responses)
+// =============================================================================
+
+export interface AvailableConnector {
+  readonly name: string;
+  readonly description: string;
+  readonly category: string;
+  readonly capabilities: readonly string[];
+  readonly user_scoped: boolean;
+  readonly auth_status: string;
+  readonly auth_source: string | null;
+  readonly mount_path: string | null;
+  readonly sync_status: string | null;
+}
+
+export interface MountInfo {
+  readonly mount_point: string;
+  readonly readonly: boolean;
+  readonly connector_type: string | null;
+  readonly skill_name: string | null;
+  readonly operations: readonly string[];
+  readonly sync_status: string | null;
+  readonly last_sync: string | null;
+}
+
+export interface AuthInitResult {
+  readonly auth_url: string;
+  readonly state_token: string;
+  readonly provider: string;
+  readonly expires_in: number;
+}
+
+export interface AuthStatusResult {
+  readonly status: string; // "pending" | "completed" | "denied" | "expired" | "error"
+  readonly connector_name: string;
+  readonly message: string | null;
+}
+
+export interface SyncResult {
+  readonly mount_point: string;
+  readonly files_scanned: number;
+  readonly files_synced: number;
+  readonly delta_added: number;
+  readonly delta_deleted: number;
+  readonly history_id: string | null;
+  readonly is_delta: boolean;
+  readonly error: string | null;
+}
+
+export interface SkillDoc {
+  readonly mount_point: string;
+  readonly content: string;
+  readonly schemas: readonly string[];
+}
+
+export interface SchemaDoc {
+  readonly mount_point: string;
+  readonly operation: string;
+  readonly content: string;
+}
+
+export interface WriteResult {
+  readonly success: boolean;
+  readonly content_hash: string | null;
+  readonly error: string | null;
+}
+
+// =============================================================================
+// Sub-tab type
+// =============================================================================
+
+export type ConnectorsTab = "available" | "mounted" | "skills" | "write";
+
+// =============================================================================
+// Auth flow state
+// =============================================================================
+
+export type AuthFlowStatus = "idle" | "waiting" | "polling" | "completed" | "error";
+
+export interface AuthFlowState {
+  readonly status: AuthFlowStatus;
+  readonly auth_url: string | null;
+  readonly state_token: string | null;
+  readonly connector_name: string | null;
+  readonly error_message: string | null;
+}
+
+const INITIAL_AUTH_FLOW: AuthFlowState = {
+  status: "idle",
+  auth_url: null,
+  state_token: null,
+  connector_name: null,
+  error_message: null,
+};
+
+// =============================================================================
+// Store interface
+// =============================================================================
+
+export interface ConnectorsState {
+  // --- Shared ---
+  readonly error: string | null;
+
+  // --- Available tab ---
+  readonly availableConnectors: readonly AvailableConnector[];
+  readonly availableLoading: boolean;
+  readonly selectedAvailableIndex: number;
+  readonly authFlow: AuthFlowState;
+
+  // --- Mounted tab ---
+  readonly mounts: readonly MountInfo[];
+  readonly mountsLoading: boolean;
+  readonly selectedMountIndex: number;
+  readonly syncingMounts: ReadonlySet<string>;
+  readonly lastSyncResult: SyncResult | null;
+
+  // --- Skills tab ---
+  readonly selectedSkillMountIndex: number;
+  readonly skillDoc: SkillDoc | null;
+  readonly skillDocLoading: boolean;
+  readonly selectedSchemaIndex: number;
+  readonly schemaDoc: SchemaDoc | null;
+  readonly schemaDocLoading: boolean;
+  readonly skillViewMode: "doc" | "schema";
+
+  // --- Write tab ---
+  readonly selectedWriteMountIndex: number;
+  readonly selectedOperationIndex: number;
+  readonly writeTemplate: string;
+  readonly writeResult: WriteResult | null;
+  readonly writeLoading: boolean;
+
+  // --- Navigation ---
+  readonly activeTab: ConnectorsTab;
+
+  // --- Actions ---
+  readonly setActiveTab: (tab: ConnectorsTab) => void;
+  readonly setSelectedAvailableIndex: (i: number) => void;
+  readonly setSelectedMountIndex: (i: number) => void;
+  readonly setSelectedSkillMountIndex: (i: number) => void;
+  readonly setSelectedSchemaIndex: (i: number) => void;
+  readonly setSkillViewMode: (mode: "doc" | "schema") => void;
+  readonly setSelectedWriteMountIndex: (i: number) => void;
+  readonly setSelectedOperationIndex: (i: number) => void;
+  readonly setWriteTemplate: (template: string) => void;
+
+  // --- Async actions ---
+  readonly fetchAvailable: (client: FetchClient) => Promise<void>;
+  readonly fetchMounts: (client: FetchClient) => Promise<void>;
+  readonly initiateAuth: (connectorName: string, client: FetchClient) => Promise<void>;
+  readonly pollAuthStatus: (client: FetchClient) => Promise<void>;
+  readonly cancelAuth: () => void;
+  readonly mountConnector: (connectorType: string, mountPoint: string, client: FetchClient) => Promise<void>;
+  readonly unmountConnector: (mountPoint: string, client: FetchClient) => Promise<void>;
+  readonly triggerSync: (mountPoint: string, client: FetchClient) => Promise<void>;
+  readonly fetchSkillDoc: (mountPath: string, client: FetchClient) => Promise<void>;
+  readonly fetchSchema: (mountPath: string, operation: string, client: FetchClient) => Promise<void>;
+  readonly submitWrite: (mountPath: string, yamlContent: string, client: FetchClient) => Promise<void>;
+  readonly clearWriteResult: () => void;
+  readonly clearSyncResult: () => void;
+}
+
+// =============================================================================
+// Store implementation
+// =============================================================================
+
+export const useConnectorsStore = create<ConnectorsState>((set, get) => ({
+  // --- Initial state ---
+  error: null,
+
+  availableConnectors: [],
+  availableLoading: false,
+  selectedAvailableIndex: 0,
+  authFlow: INITIAL_AUTH_FLOW,
+
+  mounts: [],
+  mountsLoading: false,
+  selectedMountIndex: 0,
+  syncingMounts: new Set<string>(),
+  lastSyncResult: null,
+
+  selectedSkillMountIndex: 0,
+  skillDoc: null,
+  skillDocLoading: false,
+  selectedSchemaIndex: 0,
+  schemaDoc: null,
+  schemaDocLoading: false,
+  skillViewMode: "doc" as const,
+
+  selectedWriteMountIndex: 0,
+  selectedOperationIndex: 0,
+  writeTemplate: "",
+  writeResult: null,
+  writeLoading: false,
+
+  activeTab: "available" as ConnectorsTab,
+
+  // --- Setters ---
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  setSelectedAvailableIndex: (i) => set({ selectedAvailableIndex: i }),
+  setSelectedMountIndex: (i) => set({ selectedMountIndex: i }),
+  setSelectedSkillMountIndex: (i) => set({ selectedSkillMountIndex: i }),
+  setSelectedSchemaIndex: (i) => set({ selectedSchemaIndex: i }),
+  setSkillViewMode: (mode) => set({ skillViewMode: mode }),
+  setSelectedWriteMountIndex: (i) => set({ selectedWriteMountIndex: i }),
+  setSelectedOperationIndex: (i) => set({ selectedOperationIndex: i }),
+  setWriteTemplate: (template) => set({ writeTemplate: template }),
+
+  // --- Fetch available connectors ---
+  fetchAvailable: createApiAction<ConnectorsState, [FetchClient]>(set, {
+    loadingKey: "availableLoading",
+    action: async (client) => {
+      const data = await client.get<AvailableConnector[]>("/api/v2/connectors/available");
+      return { availableConnectors: data };
+    },
+    source: "connectors",
+    retryable: true,
+  }),
+
+  // --- Fetch mounted connectors ---
+  fetchMounts: createApiAction<ConnectorsState, [FetchClient]>(set, {
+    loadingKey: "mountsLoading",
+    action: async (client) => {
+      const data = await client.get<MountInfo[]>("/api/v2/connectors/mounts");
+      return { mounts: data };
+    },
+    source: "connectors",
+    retryable: true,
+  }),
+
+  // --- OAuth auth flow ---
+  initiateAuth: async (connectorName: string, client: FetchClient) => {
+    set({
+      authFlow: {
+        status: "waiting",
+        auth_url: null,
+        state_token: null,
+        connector_name: connectorName,
+        error_message: null,
+      },
+      error: null,
+    });
+
+    try {
+      const result = await client.post<AuthInitResult>("/api/v2/connectors/auth/init", {
+        connector_name: connectorName,
+      });
+
+      // Try to open browser
+      let browserOpened = false;
+      try {
+        const { exec } = await import("child_process");
+        const platform = process.platform;
+        const cmd = platform === "darwin"
+          ? `open "${result.auth_url}"`
+          : platform === "win32"
+            ? `start "${result.auth_url}"`
+            : `xdg-open "${result.auth_url}"`;
+        exec(cmd);
+        browserOpened = true;
+      } catch {
+        browserOpened = false;
+      }
+
+      set({
+        authFlow: {
+          status: browserOpened ? "polling" : "waiting",
+          auth_url: result.auth_url,
+          state_token: result.state_token,
+          connector_name: connectorName,
+          error_message: browserOpened ? null : "Could not open browser. Copy the URL and paste it in your browser.",
+        },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to initiate auth";
+      set({
+        authFlow: {
+          status: "error",
+          auth_url: null,
+          state_token: null,
+          connector_name: connectorName,
+          error_message: message,
+        },
+      });
+    }
+  },
+
+  pollAuthStatus: async (client: FetchClient) => {
+    const { authFlow } = get();
+    if (!authFlow.state_token || authFlow.status === "idle" || authFlow.status === "completed") {
+      return;
+    }
+
+    try {
+      const result = await client.get<AuthStatusResult>(
+        `/api/v2/connectors/auth/status?state_token=${authFlow.state_token}`,
+      );
+
+      if (result.status === "completed") {
+        set({
+          authFlow: { ...authFlow, status: "completed", error_message: null },
+        });
+        // Refresh available connectors to show updated auth status
+        const { fetchAvailable } = get();
+        await fetchAvailable(client);
+      } else if (result.status === "denied" || result.status === "expired" || result.status === "error") {
+        set({
+          authFlow: {
+            ...authFlow,
+            status: "error",
+            error_message: result.message || `Auth ${result.status}`,
+          },
+        });
+      }
+      // "pending" — do nothing, keep polling
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to check auth status";
+      set({
+        authFlow: { ...authFlow, status: "error", error_message: message },
+      });
+    }
+  },
+
+  cancelAuth: () => {
+    set({ authFlow: INITIAL_AUTH_FLOW });
+  },
+
+  // --- Mount/unmount ---
+  mountConnector: createApiAction<ConnectorsState, [string, string, FetchClient]>(set, {
+    loadingKey: "mountsLoading",
+    action: async (connectorType, mountPoint, client) => {
+      await client.post("/api/v2/connectors/mount", {
+        connector_type: connectorType,
+        mount_point: mountPoint,
+      });
+      // Refresh mounts and available lists
+      const mounts = await client.get<MountInfo[]>("/api/v2/connectors/mounts");
+      const available = await client.get<AvailableConnector[]>("/api/v2/connectors/available");
+      return { mounts, availableConnectors: available };
+    },
+    source: "connectors",
+  }),
+
+  unmountConnector: createApiAction<ConnectorsState, [string, FetchClient]>(set, {
+    loadingKey: "mountsLoading",
+    action: async (mountPoint, client) => {
+      await client.post("/api/v2/connectors/unmount", {
+        connector_type: "",
+        mount_point: mountPoint,
+      });
+      const mounts = await client.get<MountInfo[]>("/api/v2/connectors/mounts");
+      const available = await client.get<AvailableConnector[]>("/api/v2/connectors/available");
+      return { mounts, availableConnectors: available };
+    },
+    source: "connectors",
+  }),
+
+  // --- Sync ---
+  triggerSync: async (mountPoint: string, client: FetchClient) => {
+    const { syncingMounts } = get();
+    const newSyncing = new Set(syncingMounts);
+    newSyncing.add(mountPoint);
+    set({ syncingMounts: newSyncing, lastSyncResult: null, error: null });
+
+    try {
+      const result = await client.post<SyncResult>("/api/v2/connectors/sync", {
+        mount_point: mountPoint,
+      });
+      const updated = new Set(get().syncingMounts);
+      updated.delete(mountPoint);
+      set({ syncingMounts: updated, lastSyncResult: result });
+
+      // Refresh mounts to get updated sync status
+      const mounts = await client.get<MountInfo[]>("/api/v2/connectors/mounts");
+      set({ mounts });
+    } catch (err) {
+      const updated = new Set(get().syncingMounts);
+      updated.delete(mountPoint);
+      const message = err instanceof Error ? err.message : "Sync failed";
+      set({ syncingMounts: updated, error: message });
+    }
+  },
+
+  // --- Skill docs ---
+  fetchSkillDoc: createApiAction<ConnectorsState, [string, FetchClient]>(set, {
+    loadingKey: "skillDocLoading",
+    action: async (mountPath, client) => {
+      const doc = await client.get<SkillDoc>(`/api/v2/connectors/skill/${mountPath.replace(/^\//, "")}`);
+      return { skillDoc: doc };
+    },
+    source: "connectors",
+  }),
+
+  // --- Schema ---
+  fetchSchema: createApiAction<ConnectorsState, [string, string, FetchClient]>(set, {
+    loadingKey: "schemaDocLoading",
+    action: async (mountPath, operation, client) => {
+      const doc = await client.get<SchemaDoc>(
+        `/api/v2/connectors/schema/${mountPath.replace(/^\//, "")}/${operation}`,
+      );
+      return { schemaDoc: doc };
+    },
+    source: "connectors",
+  }),
+
+  // --- Write ---
+  submitWrite: createApiAction<ConnectorsState, [string, string, FetchClient]>(set, {
+    loadingKey: "writeLoading",
+    action: async (mountPath, yamlContent, client) => {
+      const result = await client.post<WriteResult>(
+        `/api/v2/connectors/write/${mountPath.replace(/^\//, "")}`,
+        { yaml_content: yamlContent },
+      );
+      return { writeResult: result };
+    },
+    source: "connectors",
+  }),
+
+  clearWriteResult: () => set({ writeResult: null }),
+  clearSyncResult: () => set({ lastSyncResult: null }),
+}));

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -20,7 +20,8 @@ export type PanelId =
   | "search"
   | "workflows"
   | "infrastructure"
-  | "console";
+  | "console"
+  | "connectors";
 
 /** Response from GET /api/v2/features */
 export interface FeaturesResponse {

--- a/packages/nexus-tui/tests/panels/connectors/error-parser.test.ts
+++ b/packages/nexus-tui/tests/panels/connectors/error-parser.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "bun:test";
+import { parseWriteError } from "../../../src/panels/connectors/error-parser.js";
+
+// =============================================================================
+// Full structured error (ValidationError.format_message() output)
+// =============================================================================
+
+const FULL_VALIDATION_ERROR = `[SCHEMA_VALIDATION_ERROR] Invalid send_email data
+Field errors:
+  - to: field required
+  - subject: field required
+See: /.skill/SKILL.md#send-email
+Fix:
+\`\`\`yaml
+to: recipient@example.com
+subject: Email subject line
+\`\`\``;
+
+const MISSING_INTENT_ERROR = `[MISSING_AGENT_INTENT] Operations require an 'agent_intent' field describing what the agent intends to do
+See: /.skill/SKILL.md#required-format
+Fix:
+\`\`\`yaml
+# agent_intent: User requested to send an email to recipient
+\`\`\``;
+
+const TRAIT_ERROR = `[MISSING_CONFIRM] This operation requires explicit user confirmation
+See: /.skill/SKILL.md#send-email`;
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("parseWriteError", () => {
+  describe("full structured errors", () => {
+    it("extracts error code", () => {
+      const result = parseWriteError(FULL_VALIDATION_ERROR);
+      expect(result.code).toBe("SCHEMA_VALIDATION_ERROR");
+    });
+
+    it("extracts message after code", () => {
+      const result = parseWriteError(FULL_VALIDATION_ERROR);
+      expect(result.message).toBe("Invalid send_email data");
+    });
+
+    it("extracts field errors", () => {
+      const result = parseWriteError(FULL_VALIDATION_ERROR);
+      expect(result.fieldErrors).toHaveLength(2);
+      expect(result.fieldErrors[0]).toEqual({ field: "to", error: "field required" });
+      expect(result.fieldErrors[1]).toEqual({ field: "subject", error: "field required" });
+    });
+
+    it("extracts skill reference", () => {
+      const result = parseWriteError(FULL_VALIDATION_ERROR);
+      expect(result.skillRef).toBe("/.skill/SKILL.md#send-email");
+    });
+
+    it("extracts fix example from code block", () => {
+      const result = parseWriteError(FULL_VALIDATION_ERROR);
+      expect(result.fixExample).toContain("to: recipient@example.com");
+      expect(result.fixExample).toContain("subject: Email subject line");
+    });
+  });
+
+  describe("missing intent error", () => {
+    it("extracts code and message", () => {
+      const result = parseWriteError(MISSING_INTENT_ERROR);
+      expect(result.code).toBe("MISSING_AGENT_INTENT");
+      expect(result.message).toContain("agent_intent");
+    });
+
+    it("has no field errors", () => {
+      const result = parseWriteError(MISSING_INTENT_ERROR);
+      expect(result.fieldErrors).toHaveLength(0);
+    });
+
+    it("extracts skill ref", () => {
+      const result = parseWriteError(MISSING_INTENT_ERROR);
+      expect(result.skillRef).toBe("/.skill/SKILL.md#required-format");
+    });
+
+    it("extracts fix example", () => {
+      const result = parseWriteError(MISSING_INTENT_ERROR);
+      expect(result.fixExample).toContain("agent_intent");
+    });
+  });
+
+  describe("trait error without fix", () => {
+    it("extracts code and message", () => {
+      const result = parseWriteError(TRAIT_ERROR);
+      expect(result.code).toBe("MISSING_CONFIRM");
+      expect(result.message).toContain("user confirmation");
+    });
+
+    it("extracts skill ref", () => {
+      const result = parseWriteError(TRAIT_ERROR);
+      expect(result.skillRef).toBe("/.skill/SKILL.md#send-email");
+    });
+
+    it("has null fix example", () => {
+      const result = parseWriteError(TRAIT_ERROR);
+      expect(result.fixExample).toBeNull();
+    });
+  });
+
+  describe("plain error strings", () => {
+    it("handles simple error with no structure", () => {
+      const result = parseWriteError("Permission denied: /mnt/gmail");
+      expect(result.code).toBeNull();
+      expect(result.message).toBe("Permission denied: /mnt/gmail");
+      expect(result.fieldErrors).toHaveLength(0);
+      expect(result.skillRef).toBeNull();
+      expect(result.fixExample).toBeNull();
+    });
+
+    it("handles empty string", () => {
+      const result = parseWriteError("");
+      expect(result.code).toBeNull();
+      expect(result.message).toBe("");
+      expect(result.fieldErrors).toHaveLength(0);
+    });
+
+    it("handles multi-line plain error", () => {
+      const result = parseWriteError("Connection failed\nRetry after 5 seconds");
+      expect(result.code).toBeNull();
+      expect(result.message).toContain("Connection failed");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles field errors with colons in values", () => {
+      const error = `[SCHEMA_VALIDATION_ERROR] Invalid data
+Field errors:
+  - url: must match pattern: https://...
+See: /.skill/SKILL.md#test`;
+      const result = parseWriteError(error);
+      expect(result.fieldErrors).toHaveLength(1);
+      expect(result.fieldErrors[0]?.field).toBe("url");
+      expect(result.fieldErrors[0]?.error).toContain("must match pattern");
+    });
+
+    it("handles error with only See: reference", () => {
+      const error = "Something went wrong\nSee: /skills/gmail/SKILL.md";
+      const result = parseWriteError(error);
+      expect(result.skillRef).toBe("/skills/gmail/SKILL.md");
+      expect(result.code).toBeNull();
+    });
+
+    it("handles fix without code fences", () => {
+      const error = `[FIX_HINT] Missing field
+Fix:
+# agent_intent: Describe what you want to do`;
+      const result = parseWriteError(error);
+      expect(result.fixExample).toContain("agent_intent");
+    });
+  });
+});

--- a/packages/nexus-tui/tests/panels/connectors/template-generator.test.ts
+++ b/packages/nexus-tui/tests/panels/connectors/template-generator.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseSchemaFields,
+  generateTemplate,
+  generateWriteTemplate,
+} from "../../../src/panels/connectors/template-generator.js";
+
+// =============================================================================
+// Real-world schema fixtures
+// =============================================================================
+
+const GMAIL_SEND_SCHEMA = `to:           # (required) Recipient email address — type: string
+subject:      # (required) Email subject line — type: string
+body:         # (required) Email body content — type: string
+cc:           # (optional) CC recipients — type: string
+bcc:          # (optional) BCC recipients — type: string
+reply_to:     # (optional) Reply-to address — type: string
+thread_id:    # (optional) Thread ID for replies — type: string`;
+
+const CALENDAR_CREATE_SCHEMA = `summary:      # (required) Event title — type: string
+start_time:   # (required) Start time (ISO 8601) — type: string
+end_time:     # (required) End time (ISO 8601) — type: string
+description:  # (optional) Event description — type: string
+location:     # (optional) Event location — type: string
+attendees:    # (optional) Comma-separated email addresses — type: string
+all_day:      # (optional) Whether this is an all-day event — type: boolean, default: false
+reminder_minutes: # (optional) Reminder before event — type: integer, default: 10`;
+
+const ENUM_SCHEMA = `priority:     # (required) Task priority — type: string — One of: low, medium, high, critical
+status:       # (optional) Task status — type: string — One of: open, in_progress, done, default: open`;
+
+// =============================================================================
+// parseSchemaFields
+// =============================================================================
+
+describe("parseSchemaFields", () => {
+  it("parses required fields from Gmail schema", () => {
+    const fields = parseSchemaFields(GMAIL_SEND_SCHEMA);
+    const required = fields.filter((f) => f.required);
+    expect(required).toHaveLength(3);
+    expect(required.map((f) => f.name)).toEqual(["to", "subject", "body"]);
+  });
+
+  it("parses optional fields from Gmail schema", () => {
+    const fields = parseSchemaFields(GMAIL_SEND_SCHEMA);
+    const optional = fields.filter((f) => !f.required);
+    expect(optional).toHaveLength(4);
+    expect(optional.map((f) => f.name)).toEqual(["cc", "bcc", "reply_to", "thread_id"]);
+  });
+
+  it("extracts field types", () => {
+    const fields = parseSchemaFields(CALENDAR_CREATE_SCHEMA);
+    const allDay = fields.find((f) => f.name === "all_day");
+    expect(allDay?.type).toBe("boolean");
+
+    const reminder = fields.find((f) => f.name === "reminder_minutes");
+    expect(reminder?.type).toBe("integer");
+  });
+
+  it("extracts default values", () => {
+    const fields = parseSchemaFields(CALENDAR_CREATE_SCHEMA);
+    const allDay = fields.find((f) => f.name === "all_day");
+    expect(allDay?.default_value).toBe("false");
+
+    const reminder = fields.find((f) => f.name === "reminder_minutes");
+    expect(reminder?.default_value).toBe("10");
+  });
+
+  it("extracts enum values", () => {
+    const fields = parseSchemaFields(ENUM_SCHEMA);
+    const priority = fields.find((f) => f.name === "priority");
+    expect(priority?.enum_values).toEqual(["low", "medium", "high", "critical"]);
+  });
+
+  it("extracts enum default", () => {
+    const fields = parseSchemaFields(ENUM_SCHEMA);
+    const status = fields.find((f) => f.name === "status");
+    expect(status?.enum_values).toEqual(["open", "in_progress", "done"]);
+    expect(status?.default_value).toBe("open");
+  });
+
+  it("returns empty for empty input", () => {
+    expect(parseSchemaFields("")).toHaveLength(0);
+  });
+
+  it("returns empty for pure comments", () => {
+    expect(parseSchemaFields("# This is a comment\n# Another comment")).toHaveLength(0);
+  });
+
+  it("handles single field", () => {
+    const fields = parseSchemaFields("name: # (required) Name — type: string");
+    expect(fields).toHaveLength(1);
+    expect(fields[0]?.name).toBe("name");
+    expect(fields[0]?.required).toBe(true);
+  });
+});
+
+// =============================================================================
+// generateTemplate
+// =============================================================================
+
+describe("generateTemplate", () => {
+  it("generates template with required fields pre-filled", () => {
+    const template = generateTemplate(GMAIL_SEND_SCHEMA, "send_email");
+    expect(template).toContain("# send_email");
+    expect(template).toContain('to: "<to>"');
+    expect(template).toContain('subject: "<subject>"');
+    expect(template).toContain('body: "<body>"');
+  });
+
+  it("comments out optional fields", () => {
+    const template = generateTemplate(GMAIL_SEND_SCHEMA, "send_email");
+    expect(template).toContain("# cc:");
+    expect(template).toContain("# bcc:");
+    expect(template).toContain("# reply_to:");
+  });
+
+  it("uses default values for optional fields", () => {
+    const template = generateTemplate(CALENDAR_CREATE_SCHEMA, "create_event");
+    expect(template).toContain("# all_day: false");
+    expect(template).toContain("# reminder_minutes: 10");
+  });
+
+  it("uses enum first value as placeholder for required enum fields", () => {
+    const template = generateTemplate(ENUM_SCHEMA, "create_task");
+    expect(template).toContain("priority: low");
+    expect(template).toContain("One of:");
+  });
+
+  it("uses correct type placeholders", () => {
+    const schema = `count: # (required) Item count — type: integer
+price: # (required) Item price — type: number
+active: # (required) Is active — type: boolean
+tags: # (required) Tags — type: array`;
+
+    const template = generateTemplate(schema, "test_op");
+    expect(template).toContain("count: 0");
+    expect(template).toContain("price: 0.0");
+    expect(template).toContain("active: false");
+    expect(template).toContain("tags: []");
+  });
+
+  it("falls back to raw schema when no fields are parseable", () => {
+    const rawSchema = "some unparseable content without field patterns";
+    const template = generateTemplate(rawSchema, "test_op");
+    expect(template).toContain("# test_op");
+    expect(template).toContain(rawSchema);
+  });
+
+  it("ends with a newline", () => {
+    const template = generateTemplate(GMAIL_SEND_SCHEMA, "send_email");
+    expect(template.endsWith("\n")).toBe(true);
+  });
+});
+
+// =============================================================================
+// generateWriteTemplate (convenience wrapper)
+// =============================================================================
+
+describe("generateWriteTemplate", () => {
+  it("delegates to generateTemplate with swapped args", () => {
+    const template = generateWriteTemplate("send_email", GMAIL_SEND_SCHEMA);
+    expect(template).toContain("# send_email");
+    expect(template).toContain('to: "<to>"');
+  });
+
+  it("handles empty schema", () => {
+    const template = generateWriteTemplate("empty_op", "");
+    expect(template).toContain("# empty_op");
+  });
+});
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+describe("edge cases", () => {
+  it("handles deeply nested field names with dots", () => {
+    const schema = `config.timeout: # (required) Timeout in seconds — type: integer`;
+    const fields = parseSchemaFields(schema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0]?.name).toBe("config.timeout");
+  });
+
+  it("handles schema with mixed spacing", () => {
+    const schema = `to:   # (required) Recipient — type: string
+  subject:    # (required) Subject — type: string`;
+    const fields = parseSchemaFields(schema);
+    // Both should be parsed (the indented one may or may not parse depending on implementation)
+    expect(fields.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles very long descriptions", () => {
+    const schema = `name: # (required) This is a very long description that goes on and on and on and on and on and on — type: string`;
+    const fields = parseSchemaFields(schema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0]?.type).toBe("string");
+  });
+
+  it("handles field with value already set", () => {
+    const schema = `timeout: 30 # (optional) Timeout — type: integer`;
+    const fields = parseSchemaFields(schema);
+    expect(fields).toHaveLength(1);
+  });
+});

--- a/packages/nexus-tui/tests/stores/connectors-store.test.ts
+++ b/packages/nexus-tui/tests/stores/connectors-store.test.ts
@@ -1,0 +1,646 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { useConnectorsStore } from "../../src/stores/connectors-store.js";
+import type { FetchClient } from "@nexus/api-client";
+
+// =============================================================================
+// Test utilities
+// =============================================================================
+
+function mockClient(responses: Record<string, unknown>): FetchClient {
+  return {
+    get: mock(async (path: string) => {
+      for (const [pattern, response] of Object.entries(responses)) {
+        if (path.includes(pattern)) return response;
+      }
+      throw new Error(`Unmocked GET: ${path}`);
+    }),
+    post: mock(async (path: string) => {
+      for (const [pattern, response] of Object.entries(responses)) {
+        if (path.includes(pattern)) return response;
+      }
+      throw new Error(`Unmocked POST: ${path}`);
+    }),
+    delete: mock(async (path: string) => {
+      for (const [pattern, response] of Object.entries(responses)) {
+        if (path.includes(pattern)) return response;
+      }
+      throw new Error(`Unmocked DELETE: ${path}`);
+    }),
+  } as unknown as FetchClient;
+}
+
+function resetStore(): void {
+  useConnectorsStore.setState({
+    error: null,
+    availableConnectors: [],
+    availableLoading: false,
+    selectedAvailableIndex: 0,
+    authFlow: {
+      status: "idle",
+      auth_url: null,
+      state_token: null,
+      connector_name: null,
+      error_message: null,
+    },
+    mounts: [],
+    mountsLoading: false,
+    selectedMountIndex: 0,
+    syncingMounts: new Set<string>(),
+    lastSyncResult: null,
+    selectedSkillMountIndex: 0,
+    skillDoc: null,
+    skillDocLoading: false,
+    selectedSchemaIndex: 0,
+    schemaDoc: null,
+    schemaDocLoading: false,
+    skillViewMode: "doc",
+    selectedWriteMountIndex: 0,
+    selectedOperationIndex: 0,
+    writeTemplate: "",
+    writeResult: null,
+    writeLoading: false,
+    activeTab: "available",
+  });
+}
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const MOCK_CONNECTOR = {
+  name: "gmail_connector",
+  description: "Gmail connector",
+  category: "oauth",
+  capabilities: ["oauth", "sync"],
+  user_scoped: true,
+  auth_status: "authed",
+  auth_source: "oauth",
+  mount_path: "/mnt/gmail",
+  sync_status: "synced",
+};
+
+const MOCK_MOUNT = {
+  mount_point: "/mnt/gmail",
+  readonly: false,
+  connector_type: "gmail_connector",
+  skill_name: "gmail",
+  operations: ["send_email", "create_draft"],
+  sync_status: "synced",
+  last_sync: "2m ago",
+};
+
+const MOCK_SKILL_DOC = {
+  mount_point: "/mnt/gmail",
+  content: "# Gmail\nSend and manage emails.",
+  schemas: ["send_email", "create_draft"],
+};
+
+const MOCK_SCHEMA = {
+  mount_point: "/mnt/gmail",
+  operation: "send_email",
+  content: "to: # (required) Recipient — type: string\nsubject: # (required) Subject — type: string\nbody: # (required) Body — type: string",
+};
+
+const MOCK_WRITE_RESULT = {
+  success: true,
+  content_hash: "abc123",
+  error: null,
+};
+
+const MOCK_AUTH_INIT = {
+  auth_url: "https://accounts.google.com/o/oauth2/v2/auth?...",
+  state_token: "test-state-token",
+  provider: "gmail",
+  expires_in: 300,
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("ConnectorsStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sync actions
+  // ---------------------------------------------------------------------------
+
+  describe("setActiveTab", () => {
+    it("switches between tabs", () => {
+      useConnectorsStore.getState().setActiveTab("mounted");
+      expect(useConnectorsStore.getState().activeTab).toBe("mounted");
+
+      useConnectorsStore.getState().setActiveTab("skills");
+      expect(useConnectorsStore.getState().activeTab).toBe("skills");
+
+      useConnectorsStore.getState().setActiveTab("write");
+      expect(useConnectorsStore.getState().activeTab).toBe("write");
+
+      useConnectorsStore.getState().setActiveTab("available");
+      expect(useConnectorsStore.getState().activeTab).toBe("available");
+    });
+  });
+
+  describe("setSelectedAvailableIndex", () => {
+    it("sets the selected available connector index", () => {
+      useConnectorsStore.getState().setSelectedAvailableIndex(3);
+      expect(useConnectorsStore.getState().selectedAvailableIndex).toBe(3);
+    });
+  });
+
+  describe("setSelectedMountIndex", () => {
+    it("sets the selected mount index", () => {
+      useConnectorsStore.getState().setSelectedMountIndex(2);
+      expect(useConnectorsStore.getState().selectedMountIndex).toBe(2);
+    });
+  });
+
+  describe("setSkillViewMode", () => {
+    it("toggles between doc and schema modes", () => {
+      useConnectorsStore.getState().setSkillViewMode("schema");
+      expect(useConnectorsStore.getState().skillViewMode).toBe("schema");
+
+      useConnectorsStore.getState().setSkillViewMode("doc");
+      expect(useConnectorsStore.getState().skillViewMode).toBe("doc");
+    });
+  });
+
+  describe("setWriteTemplate", () => {
+    it("sets the write template content", () => {
+      useConnectorsStore.getState().setWriteTemplate("to: test@example.com");
+      expect(useConnectorsStore.getState().writeTemplate).toBe("to: test@example.com");
+    });
+  });
+
+  describe("clearWriteResult", () => {
+    it("clears the write result", () => {
+      useConnectorsStore.setState({ writeResult: MOCK_WRITE_RESULT });
+      useConnectorsStore.getState().clearWriteResult();
+      expect(useConnectorsStore.getState().writeResult).toBeNull();
+    });
+  });
+
+  describe("clearSyncResult", () => {
+    it("clears the last sync result", () => {
+      useConnectorsStore.setState({
+        lastSyncResult: {
+          mount_point: "/mnt/gmail",
+          files_scanned: 10,
+          files_synced: 5,
+          delta_added: 3,
+          delta_deleted: 1,
+          history_id: "h1",
+          is_delta: true,
+          error: null,
+        },
+      });
+      useConnectorsStore.getState().clearSyncResult();
+      expect(useConnectorsStore.getState().lastSyncResult).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchAvailable
+  // ---------------------------------------------------------------------------
+
+  describe("fetchAvailable", () => {
+    it("fetches and stores available connectors", async () => {
+      const client = mockClient({
+        "/connectors/available": [MOCK_CONNECTOR],
+      });
+
+      await useConnectorsStore.getState().fetchAvailable(client);
+
+      const state = useConnectorsStore.getState();
+      expect(state.availableConnectors).toHaveLength(1);
+      expect(state.availableConnectors[0]?.name).toBe("gmail_connector");
+      expect(state.availableLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it("handles fetch errors", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().fetchAvailable(client);
+
+      const state = useConnectorsStore.getState();
+      expect(state.availableLoading).toBe(false);
+      expect(state.error).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchMounts
+  // ---------------------------------------------------------------------------
+
+  describe("fetchMounts", () => {
+    it("fetches and stores mounts", async () => {
+      const client = mockClient({
+        "/connectors/mounts": [MOCK_MOUNT],
+      });
+
+      await useConnectorsStore.getState().fetchMounts(client);
+
+      const state = useConnectorsStore.getState();
+      expect(state.mounts).toHaveLength(1);
+      expect(state.mounts[0]?.mount_point).toBe("/mnt/gmail");
+      expect(state.mountsLoading).toBe(false);
+    });
+
+    it("handles fetch errors", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().fetchMounts(client);
+
+      expect(useConnectorsStore.getState().mountsLoading).toBe(false);
+      expect(useConnectorsStore.getState().error).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // initiateAuth
+  // ---------------------------------------------------------------------------
+
+  describe("initiateAuth", () => {
+    it("sets authFlow to waiting on initiation", async () => {
+      const client = mockClient({
+        "/connectors/auth/init": MOCK_AUTH_INIT,
+      });
+
+      // initiateAuth tries to open browser, which will fail in tests
+      await useConnectorsStore.getState().initiateAuth("gmail_connector", client);
+
+      const state = useConnectorsStore.getState();
+      // Status should be "waiting" or "polling" depending on browser open
+      expect(["waiting", "polling"]).toContain(state.authFlow.status);
+      expect(state.authFlow.auth_url).toBe(MOCK_AUTH_INIT.auth_url);
+      expect(state.authFlow.state_token).toBe(MOCK_AUTH_INIT.state_token);
+    });
+
+    it("handles auth init failure", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().initiateAuth("gmail_connector", client);
+
+      const state = useConnectorsStore.getState();
+      expect(state.authFlow.status).toBe("error");
+      expect(state.authFlow.error_message).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // pollAuthStatus
+  // ---------------------------------------------------------------------------
+
+  describe("pollAuthStatus", () => {
+    it("updates authFlow to completed when auth succeeds", async () => {
+      useConnectorsStore.setState({
+        authFlow: {
+          status: "polling",
+          auth_url: "https://example.com",
+          state_token: "test-token",
+          connector_name: "gmail_connector",
+          error_message: null,
+        },
+      });
+
+      const client = mockClient({
+        "/connectors/auth/status": { status: "completed", connector_name: "gmail_connector", message: "OK" },
+        "/connectors/available": [MOCK_CONNECTOR],
+      });
+
+      await useConnectorsStore.getState().pollAuthStatus(client);
+
+      expect(useConnectorsStore.getState().authFlow.status).toBe("completed");
+    });
+
+    it("sets error on denied status", async () => {
+      useConnectorsStore.setState({
+        authFlow: {
+          status: "polling",
+          auth_url: "https://example.com",
+          state_token: "test-token",
+          connector_name: "gmail_connector",
+          error_message: null,
+        },
+      });
+
+      const client = mockClient({
+        "/connectors/auth/status": { status: "denied", connector_name: "gmail_connector", message: "User denied" },
+      });
+
+      await useConnectorsStore.getState().pollAuthStatus(client);
+
+      expect(useConnectorsStore.getState().authFlow.status).toBe("error");
+      expect(useConnectorsStore.getState().authFlow.error_message).toContain("denied");
+    });
+
+    it("sets error on expired status", async () => {
+      useConnectorsStore.setState({
+        authFlow: {
+          status: "polling",
+          auth_url: "https://example.com",
+          state_token: "test-token",
+          connector_name: "gmail_connector",
+          error_message: null,
+        },
+      });
+
+      const client = mockClient({
+        "/connectors/auth/status": { status: "expired", connector_name: "gmail_connector", message: "Expired" },
+      });
+
+      await useConnectorsStore.getState().pollAuthStatus(client);
+
+      expect(useConnectorsStore.getState().authFlow.status).toBe("error");
+    });
+
+    it("does nothing when status is pending", async () => {
+      useConnectorsStore.setState({
+        authFlow: {
+          status: "polling",
+          auth_url: "https://example.com",
+          state_token: "test-token",
+          connector_name: "gmail_connector",
+          error_message: null,
+        },
+      });
+
+      const client = mockClient({
+        "/connectors/auth/status": { status: "pending", connector_name: "gmail_connector", message: null },
+      });
+
+      await useConnectorsStore.getState().pollAuthStatus(client);
+
+      // Should remain in polling state
+      expect(useConnectorsStore.getState().authFlow.status).toBe("polling");
+    });
+
+    it("handles network errors during polling", async () => {
+      useConnectorsStore.setState({
+        authFlow: {
+          status: "polling",
+          auth_url: "https://example.com",
+          state_token: "test-token",
+          connector_name: "gmail_connector",
+          error_message: null,
+        },
+      });
+
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().pollAuthStatus(client);
+
+      expect(useConnectorsStore.getState().authFlow.status).toBe("error");
+      expect(useConnectorsStore.getState().authFlow.error_message).toBeTruthy();
+    });
+
+    it("skips polling when authFlow is idle", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().pollAuthStatus(client);
+
+      // Should remain idle, no error
+      expect(useConnectorsStore.getState().authFlow.status).toBe("idle");
+      expect(useConnectorsStore.getState().error).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // cancelAuth
+  // ---------------------------------------------------------------------------
+
+  describe("cancelAuth", () => {
+    it("resets authFlow to idle", () => {
+      useConnectorsStore.setState({
+        authFlow: {
+          status: "polling",
+          auth_url: "https://example.com",
+          state_token: "test-token",
+          connector_name: "gmail_connector",
+          error_message: null,
+        },
+      });
+
+      useConnectorsStore.getState().cancelAuth();
+
+      const authFlow = useConnectorsStore.getState().authFlow;
+      expect(authFlow.status).toBe("idle");
+      expect(authFlow.auth_url).toBeNull();
+      expect(authFlow.state_token).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // mountConnector
+  // ---------------------------------------------------------------------------
+
+  describe("mountConnector", () => {
+    it("mounts and refreshes lists", async () => {
+      // "/connectors/mounts" must appear before "/connectors/mount" to avoid
+      // substring match (path.includes) returning the POST response for GET.
+      const client = mockClient({
+        "/connectors/mounts": [MOCK_MOUNT],
+        "/connectors/available": [MOCK_CONNECTOR],
+        "/connectors/mount": { mounted: true, mount_point: "/mnt/gmail" },
+      });
+
+      await useConnectorsStore.getState().mountConnector("gmail_connector", "/mnt/gmail", client);
+
+      const state = useConnectorsStore.getState();
+      expect(state.mounts).toHaveLength(1);
+      expect(state.availableConnectors).toHaveLength(1);
+      expect(state.mountsLoading).toBe(false);
+    });
+
+    it("handles mount errors", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().mountConnector("gmail_connector", "/mnt/gmail", client);
+
+      expect(useConnectorsStore.getState().error).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // unmountConnector
+  // ---------------------------------------------------------------------------
+
+  describe("unmountConnector", () => {
+    it("unmounts and refreshes lists", async () => {
+      useConnectorsStore.setState({ mounts: [MOCK_MOUNT] });
+
+      const client = mockClient({
+        "/connectors/unmount": { mounted: false, mount_point: "/mnt/gmail" },
+        "/connectors/mounts": [],
+        "/connectors/available": [{ ...MOCK_CONNECTOR, mount_path: null }],
+      });
+
+      await useConnectorsStore.getState().unmountConnector("/mnt/gmail", client);
+
+      expect(useConnectorsStore.getState().mounts).toHaveLength(0);
+    });
+
+    it("handles unmount errors", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().unmountConnector("/mnt/gmail", client);
+
+      expect(useConnectorsStore.getState().error).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // triggerSync
+  // ---------------------------------------------------------------------------
+
+  describe("triggerSync", () => {
+    it("tracks syncing state and stores result", async () => {
+      const syncResult = {
+        mount_point: "/mnt/gmail",
+        files_scanned: 100,
+        files_synced: 50,
+        delta_added: 10,
+        delta_deleted: 2,
+        history_id: "h123",
+        is_delta: true,
+        error: null,
+      };
+
+      const client = mockClient({
+        "/connectors/sync": syncResult,
+        "/connectors/mounts": [MOCK_MOUNT],
+      });
+
+      // Check syncing state is set during sync
+      const promise = useConnectorsStore.getState().triggerSync("/mnt/gmail", client);
+
+      await promise;
+
+      const state = useConnectorsStore.getState();
+      expect(state.syncingMounts.has("/mnt/gmail")).toBe(false); // should be removed after completion
+      expect(state.lastSyncResult?.files_synced).toBe(50);
+      expect(state.lastSyncResult?.is_delta).toBe(true);
+    });
+
+    it("handles sync errors", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().triggerSync("/mnt/gmail", client);
+
+      const state = useConnectorsStore.getState();
+      expect(state.syncingMounts.has("/mnt/gmail")).toBe(false);
+      expect(state.error).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchSkillDoc
+  // ---------------------------------------------------------------------------
+
+  describe("fetchSkillDoc", () => {
+    it("fetches and stores skill doc", async () => {
+      const client = mockClient({
+        "/connectors/skill/": MOCK_SKILL_DOC,
+      });
+
+      await useConnectorsStore.getState().fetchSkillDoc("/mnt/gmail", client);
+
+      const state = useConnectorsStore.getState();
+      expect(state.skillDoc?.content).toContain("Gmail");
+      expect(state.skillDoc?.schemas).toHaveLength(2);
+      expect(state.skillDocLoading).toBe(false);
+    });
+
+    it("handles fetch errors", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().fetchSkillDoc("/mnt/gmail", client);
+
+      expect(useConnectorsStore.getState().skillDocLoading).toBe(false);
+      expect(useConnectorsStore.getState().error).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchSchema
+  // ---------------------------------------------------------------------------
+
+  describe("fetchSchema", () => {
+    it("fetches and stores schema doc", async () => {
+      const client = mockClient({
+        "/connectors/schema/": MOCK_SCHEMA,
+      });
+
+      await useConnectorsStore.getState().fetchSchema("/mnt/gmail", "send_email", client);
+
+      const state = useConnectorsStore.getState();
+      expect(state.schemaDoc?.operation).toBe("send_email");
+      expect(state.schemaDoc?.content).toContain("to:");
+      expect(state.schemaDocLoading).toBe(false);
+    });
+
+    it("handles fetch errors", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().fetchSchema("/mnt/gmail", "send_email", client);
+
+      expect(useConnectorsStore.getState().schemaDocLoading).toBe(false);
+      expect(useConnectorsStore.getState().error).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // submitWrite
+  // ---------------------------------------------------------------------------
+
+  describe("submitWrite", () => {
+    it("submits write and stores result", async () => {
+      const client = mockClient({
+        "/connectors/write/": MOCK_WRITE_RESULT,
+      });
+
+      await useConnectorsStore.getState().submitWrite(
+        "/mnt/gmail",
+        "to: test@example.com\nsubject: Test",
+        client,
+      );
+
+      const state = useConnectorsStore.getState();
+      expect(state.writeResult?.success).toBe(true);
+      expect(state.writeResult?.content_hash).toBe("abc123");
+      expect(state.writeLoading).toBe(false);
+    });
+
+    it("stores error result on write failure", async () => {
+      const client = mockClient({
+        "/connectors/write/": { success: false, content_hash: null, error: "Validation failed" },
+      });
+
+      await useConnectorsStore.getState().submitWrite(
+        "/mnt/gmail",
+        "invalid yaml",
+        client,
+      );
+
+      const state = useConnectorsStore.getState();
+      expect(state.writeResult?.success).toBe(false);
+      expect(state.writeResult?.error).toBe("Validation failed");
+    });
+
+    it("handles network errors during write", async () => {
+      const client = mockClient({});
+
+      await useConnectorsStore.getState().submitWrite(
+        "/mnt/gmail",
+        "to: test@example.com",
+        client,
+      );
+
+      expect(useConnectorsStore.getState().writeLoading).toBe(false);
+      expect(useConnectorsStore.getState().error).toBeTruthy();
+    });
+  });
+});

--- a/src/nexus/backends/connectors/cli/sync_loop.py
+++ b/src/nexus/backends/connectors/cli/sync_loop.py
@@ -404,7 +404,16 @@ class ConnectorSyncLoop:
                 import hashlib
 
                 content_hash = hashlib.sha256(content).hexdigest()
-                virtual_path = f"{mp}/{item.path}" if item.path else f"{mp}/{item.id}"
+                raw_path = item.path or item.id
+                # Apply display_path transform for human-readable filenames (#3258)
+                if hasattr(backend, "display_path"):
+                    try:
+                        display = backend.display_path(raw_path, content)
+                        if display:
+                            raw_path = display
+                    except Exception:
+                        pass  # Fall back to raw path
+                virtual_path = f"{mp}/{raw_path}"
 
                 # Write FileMetadata to metastore
                 metastore = getattr(self._mount_service, "_metastore", None)

--- a/src/nexus/cli/commands/connectors.py
+++ b/src/nexus/cli/commands/connectors.py
@@ -4,9 +4,11 @@ Commands for discovering and inspecting available connectors:
 - nexus connectors list - List all registered connectors
 - nexus connectors info - Show connector details
 
-Connects to a remote Nexus instance via RPC.
+Uses the HTTP REST API for connector discovery (not gRPC, which
+doesn't expose connector registry methods).
 """
 
+import asyncio
 import sys
 from typing import Any
 
@@ -17,9 +19,40 @@ from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     add_backend_options,
     console,
-    get_filesystem,
     handle_error,
 )
+
+
+def _resolve_http_url(remote_url: str | None) -> tuple[str, str | None]:
+    """Resolve the HTTP base URL and API key from args or environment."""
+    import os
+
+    url = remote_url or os.environ.get("NEXUS_URL")
+    api_key = os.environ.get("NEXUS_API_KEY")
+
+    if not url:
+        console.print("[red]Error:[/red] NEXUS_URL or --remote-url is required")
+        console.print(
+            "[yellow]Hint:[/yellow] export NEXUS_URL=http://your-nexus-server:2026"
+            " or use `eval $(nexus env)`"
+        )
+        sys.exit(1)
+
+    return url.rstrip("/"), api_key
+
+
+async def _http_get(url: str, api_key: str | None) -> Any:
+    """Make an authenticated HTTP GET request."""
+    import httpx
+
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
 
 
 @click.group(name="connectors")
@@ -31,22 +64,10 @@ def connectors_group() -> None:
     and their configuration requirements.
 
     Examples:
-        # List all connectors
-        nexus connectors list --remote-url http://localhost:2026
-
-        # List only storage connectors
+        nexus connectors list
         nexus connectors list --category storage
-
-        # Show details for a specific connector
-        nexus connectors info gcs_connector
+        nexus connectors info gws_gmail
     """
-    pass
-
-
-def _list_connectors_remote(nx: Any, category: str | None) -> list[dict[str, Any]]:
-    """List connectors from remote server via RPC."""
-    result: list[dict[str, Any]] = nx.service("mount").list_connectors_sync(category=category)
-    return result
 
 
 @connectors_group.command(name="list")
@@ -55,7 +76,7 @@ def _list_connectors_remote(nx: Any, category: str | None) -> list[dict[str, Any
     "-c",
     type=str,
     default=None,
-    help="Filter by category (storage, api, oauth, database)",
+    help="Filter by category (storage, api, oauth, cli)",
 )
 @add_output_options
 @add_backend_options
@@ -70,25 +91,22 @@ def list_connectors(
     Shows all available connector types that can be used with 'nexus mounts add'.
 
     Examples:
-        # List connectors from remote server
-        nexus connectors list --remote-url http://localhost:2026
-
-        # List only storage connectors
+        nexus connectors list
         nexus connectors list --category storage
-
-        # Output as JSON
         nexus connectors list --json
     """
     timing = CommandTiming()
     try:
-        nx: Any = get_filesystem(remote_url, remote_api_key)
-        try:
-            with timing.phase("server"):
-                connectors = _list_connectors_remote(nx, category)
-        except AttributeError:
-            console.print("[red]Error:[/red] Server doesn't support list_connectors")
-            console.print("[yellow]Hint:[/yellow] Update server to latest Nexus version")
-            sys.exit(1)
+        base_url, api_key = _resolve_http_url(remote_url)
+        api_key = remote_api_key or api_key
+
+        with timing.phase("server"):
+            data = asyncio.run(_http_get(f"{base_url}/api/v2/connectors", api_key))
+
+        connectors: list[dict[str, Any]] = data.get("connectors", [])
+
+        if category:
+            connectors = [c for c in connectors if c.get("category") == category]
 
         if not connectors:
             if category:
@@ -97,26 +115,29 @@ def list_connectors(
                 console.print("[yellow]No connectors registered[/yellow]")
             return
 
-        def _render(data: list[dict[str, Any]]) -> None:
+        def _render(items: list[dict[str, Any]]) -> None:
             from rich.table import Table
 
             table = Table(title="Available Connectors", show_header=True, header_style="bold cyan")
             table.add_column("Name", style="green")
             table.add_column("Description")
             table.add_column("Category", style="yellow")
-            table.add_column("Dependencies", style="dim")
+            table.add_column("Capabilities", style="dim")
 
-            for c in data:
-                deps = ", ".join(c["requires"]) if c.get("requires") else "-"
+            for c in items:
+                caps = c.get("capabilities", [])
+                caps_str = ", ".join(caps[:3])
+                if len(caps) > 3:
+                    caps_str += f" (+{len(caps) - 3})"
                 table.add_row(
                     c["name"],
                     c.get("description", ""),
                     c.get("category", ""),
-                    deps,
+                    caps_str,
                 )
 
             console.print(table)
-            console.print(f"\n[dim]Total: {len(data)} connectors[/dim]")
+            console.print(f"\n[dim]Total: {len(items)} connectors[/dim]")
 
         render_output(
             data=connectors,
@@ -139,23 +160,24 @@ def connector_info(
 ) -> None:
     """Show details for a specific connector.
 
-    CONNECTOR_NAME: The connector identifier (e.g., gcs_connector, s3_connector)
+    CONNECTOR_NAME: The connector identifier (e.g., gws_gmail, path_s3)
 
     Examples:
-        nexus connectors info gcs_connector --remote-url http://localhost:2026
+        nexus connectors info gws_gmail
+        nexus connectors info path_s3
     """
     try:
-        nx: Any = get_filesystem(remote_url, remote_api_key)
-        try:
-            connectors = _list_connectors_remote(nx, None)
-            info = next((c for c in connectors if c["name"] == connector_name), None)
-            if not info:
-                available = ", ".join(c["name"] for c in connectors)
-                console.print(f"[red]Unknown connector: {connector_name}[/red]")
-                console.print(f"[dim]Available: {available}[/dim]")
-                sys.exit(1)
-        except AttributeError:
-            console.print("[red]Error:[/red] Server doesn't support list_connectors")
+        base_url, api_key = _resolve_http_url(remote_url)
+        api_key = remote_api_key or api_key
+
+        data = asyncio.run(_http_get(f"{base_url}/api/v2/connectors", api_key))
+        connectors: list[dict[str, Any]] = data.get("connectors", [])
+
+        info = next((c for c in connectors if c["name"] == connector_name), None)
+        if not info:
+            available = ", ".join(c["name"] for c in connectors)
+            console.print(f"[red]Unknown connector: {connector_name}[/red]")
+            console.print(f"[dim]Available: {available}[/dim]")
             sys.exit(1)
 
         console.print(f"\n[bold cyan]{info['name']}[/bold cyan]")
@@ -163,14 +185,9 @@ def connector_info(
         console.print(f"  [dim]Category:[/dim] {info.get('category', 'unknown')}")
         console.print(f"  [dim]User-scoped:[/dim] {'Yes' if info.get('user_scoped') else 'No'}")
 
-        requires = info.get("requires", [])
-        if requires:
-            console.print(f"  [dim]Dependencies:[/dim] {', '.join(requires)}")
-        else:
-            console.print("  [dim]Dependencies:[/dim] None (core)")
-
-        if "class" in info:
-            console.print(f"  [dim]Class:[/dim] {info['class']}")
+        caps = info.get("capabilities", [])
+        if caps:
+            console.print(f"  [dim]Capabilities:[/dim] {', '.join(caps)}")
 
         console.print()
 
@@ -195,33 +212,25 @@ def connectors_capabilities(
 
     Examples:
         nexus connectors capabilities
-        nexus connectors capabilities gcs_connector
+        nexus connectors capabilities gws_gmail
     """
     timing = CommandTiming()
     try:
-        nx: Any = get_filesystem(remote_url, remote_api_key)
-        try:
-            with timing.phase("server"):
-                all_connectors = _list_connectors_remote(nx, None)
-        except AttributeError:
-            console.print("[red]Error:[/red] Server doesn't support list_connectors")
-            console.print("[yellow]Hint:[/yellow] Update server to latest Nexus version")
-            sys.exit(1)
+        base_url, api_key = _resolve_http_url(remote_url)
+        api_key = remote_api_key or api_key
+
+        with timing.phase("server"):
+            data = asyncio.run(_http_get(f"{base_url}/api/v2/connectors", api_key))
+
+        connectors: list[dict[str, Any]] = data.get("connectors", [])
 
         if name:
-            match = [
-                c for c in all_connectors if c.get("name") == name or c.get("connector_id") == name
-            ]
-            if not match:
-                available = ", ".join(c["name"] for c in all_connectors)
+            connectors = [c for c in connectors if c.get("name") == name]
+            if not connectors:
                 console.print(f"[red]Error:[/red] Connector '{name}' not found")
-                console.print(f"[dim]Available: {available}[/dim]")
                 sys.exit(1)
-            connectors_to_show = match
-        else:
-            connectors_to_show = all_connectors
 
-        def _render(data: list[dict[str, Any]]) -> None:
+        def _render(items: list[dict[str, Any]]) -> None:
             from rich.table import Table
 
             table = Table(
@@ -230,26 +239,23 @@ def connectors_capabilities(
                 header_style="bold cyan",
             )
             table.add_column("Name", style="cyan")
-            table.add_column("Type", style="green")
+            table.add_column("Category", style="green")
             table.add_column("Capabilities", style="yellow")
 
-            for c in data:
+            for c in items:
                 caps = c.get("capabilities", [])
-                if isinstance(caps, list):
-                    caps_str = ", ".join(str(cap) for cap in caps) if caps else "none"
-                else:
-                    caps_str = str(caps)
+                caps_str = ", ".join(str(cap) for cap in caps) if caps else "none"
                 table.add_row(
                     c.get("name", "?"),
-                    c.get("category", c.get("type", "?")),
+                    c.get("category", "?"),
                     caps_str,
                 )
 
             console.print(table)
-            console.print(f"\n[dim]Total: {len(data)} connectors[/dim]")
+            console.print(f"\n[dim]Total: {len(items)} connectors[/dim]")
 
         render_output(
-            data=connectors_to_show,
+            data=connectors,
             output_opts=output_opts,
             timing=timing,
             human_formatter=_render,

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -11,7 +11,6 @@ For remote servers, commands call the RPC API (add_mount, remove_mount, etc.).
 For local instances, commands interact directly with the NexusFS methods.
 """
 
-import inspect
 import json
 import sys
 from typing import Any
@@ -138,28 +137,38 @@ async def _async_add_mount(
             console.print(f"[red]Error:[/red] Invalid JSON in config_json: {e}")
             sys.exit(1)
 
-        # Get filesystem (works with both local and remote)
-        nx = await get_filesystem(remote_url, remote_api_key)
+        import os
 
-        # Call add_mount via mount_service
+        import httpx
+
+        base_url = remote_url or os.environ.get("NEXUS_URL", "")
+        api_key = remote_api_key or os.environ.get("NEXUS_API_KEY", "")
+        if not base_url:
+            console.print("[red]Error:[/red] NEXUS_URL required")
+            console.print("[yellow]Hint:[/yellow] eval $(nexus env)")
+            sys.exit(1)
+
         console.print("[yellow]Adding mount...[/yellow]")
 
-        try:
-            mount_svc = nx.service("mount")
-            assert mount_svc is not None
-            mount_result = mount_svc.add_mount(
-                mount_point=mount_point,
-                backend_type=backend_type,
-                backend_config=config_dict,
-                readonly=readonly,
-                io_profile=io_profile,
+        async with httpx.AsyncClient(timeout=30) as http:
+            resp = await http.post(
+                f"{base_url.rstrip('/')}/api/v2/connectors/mount",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "connector_type": backend_type,
+                    "mount_point": mount_point,
+                    "config": config_dict,
+                    "readonly": readonly,
+                },
             )
-            mount_id = await mount_result if inspect.isawaitable(mount_result) else mount_result
+            resp.raise_for_status()
+            result = resp.json()
+
+        if result.get("mounted"):
+            mount_id = result.get("mount_point", mount_point)
             console.print(f"[green]\u2713[/green] Mount added successfully (ID: {mount_id})")
-        except AttributeError:
-            # Fallback for older NexusFS that doesn't have mount_service
-            console.print("[red]Error:[/red] This Nexus instance doesn't support dynamic mounts")
-            console.print("[yellow]Hint:[/yellow] Make sure you're using the latest Nexus version")
+        else:
+            console.print(f"[red]Error:[/red] {result.get('error', 'Mount failed')}")
             sys.exit(1)
 
         console.print()
@@ -202,26 +211,27 @@ async def _async_remove_mount(
     mount_point: str, remote_url: str | None, remote_api_key: str | None
 ) -> None:
     try:
-        # Get filesystem (works with both local and remote)
-        nx = await get_filesystem(remote_url, remote_api_key)
+        import os
 
-        # Call remove_mount via mount_service
+        import httpx
+
+        base_url = remote_url or os.environ.get("NEXUS_URL", "")
+        api_key = remote_api_key or os.environ.get("NEXUS_API_KEY", "")
+        if not base_url:
+            console.print("[red]Error:[/red] NEXUS_URL required")
+            console.print("[yellow]Hint:[/yellow] eval $(nexus env)")
+            sys.exit(1)
+
         console.print(f"[yellow]Removing mount at {mount_point}...[/yellow]")
 
-        try:
-            mount_svc = nx.service("mount")
-            assert mount_svc is not None
-            remove_result = mount_svc.remove_mount(mount_point=mount_point)
-            result = await remove_result if inspect.isawaitable(remove_result) else remove_result
-            if result.get("removed"):
-                console.print("[green]\u2713[/green] Mount removed successfully")
-            else:
-                console.print(f"[red]Error:[/red] Mount not found: {mount_point}")
-                sys.exit(1)
-        except AttributeError:
-            console.print("[red]Error:[/red] This Nexus instance doesn't support dynamic mounts")
-            console.print("[yellow]Hint:[/yellow] Make sure you're using the latest Nexus version")
-            sys.exit(1)
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.post(
+                f"{base_url.rstrip('/')}/api/v2/connectors/unmount",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"connector_type": "", "mount_point": mount_point},
+            )
+            resp.raise_for_status()
+            console.print("[green]\u2713[/green] Mount removed successfully")
 
     except Exception as e:
         handle_error(e)

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -271,23 +271,25 @@ async def _async_list_mounts(
 ) -> None:
     timing = CommandTiming()
     try:
-        # Get filesystem (works with both local and remote)
-        nx = await get_filesystem(remote_url, remote_api_key)
-
-        # Call list_mounts via mount_service
+        # List mounts via HTTP API (gRPC port may differ from default)
         with timing.phase("server"):
-            try:
-                mount_svc = nx.service("mount")
-                assert mount_svc is not None
-                mounts = await mount_svc.list_mounts()
-            except AttributeError:
-                console.print(
-                    "[red]Error:[/red] This Nexus instance doesn't support listing mounts"
-                )
-                console.print(
-                    "[yellow]Hint:[/yellow] Make sure you're using the latest Nexus version"
-                )
+            import os
+
+            import httpx
+
+            base_url = remote_url or os.environ.get("NEXUS_URL", "")
+            api_key = remote_api_key or os.environ.get("NEXUS_API_KEY", "")
+            if not base_url:
+                console.print("[red]Error:[/red] NEXUS_URL required")
+                console.print("[yellow]Hint:[/yellow] eval $(nexus env)")
                 sys.exit(1)
+            async with httpx.AsyncClient(timeout=10) as http:
+                resp = await http.get(
+                    f"{base_url.rstrip('/')}/api/v2/connectors/mounts",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                mounts = resp.json()
 
         # Note: owner/zone filtering not yet supported in remote mode
         if owner or zone:
@@ -546,23 +548,24 @@ async def _async_sync_mount(
                 console.print("[cyan](dry run - no changes will be made)[/cyan]")
 
         with timing.phase("server"):
-            try:
-                result = await nx.service("sync").sync_mount_flat(
-                    mount_point=mount_point,
-                    path=path,
-                    recursive=True,
-                    dry_run=dry_run,
-                    sync_content=not no_cache,
-                    include_patterns=include_patterns,
-                    exclude_patterns=exclude_patterns,
-                    generate_embeddings=embeddings,
-                )
-            except AttributeError:
-                console.print("[red]Error:[/red] This Nexus instance doesn't support sync_mount")
-                console.print(
-                    "[yellow]Hint:[/yellow] Make sure you're using the latest Nexus version"
-                )
+            import os
+
+            import httpx
+
+            base_url = remote_url or os.environ.get("NEXUS_URL", "")
+            api_key = remote_api_key or os.environ.get("NEXUS_API_KEY", "")
+            if not base_url:
+                console.print("[red]Error:[/red] NEXUS_URL required")
+                console.print("[yellow]Hint:[/yellow] eval $(nexus env)")
                 sys.exit(1)
+            async with httpx.AsyncClient(timeout=120) as http:
+                resp = await http.post(
+                    f"{base_url.rstrip('/')}/api/v2/connectors/sync",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    json={"mount_point": mount_point, "full_sync": False},
+                )
+                resp.raise_for_status()
+                result = resp.json()
 
         def _render_sync(data: dict[str, Any]) -> None:
             console.print()

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -104,11 +104,23 @@ def _to_file_item(entry: dict[str, Any], prefix: str) -> "FileItemResponse":
     # entry_type 0 with no etag and size 0 is likely an implicit directory
     # (created by writing files underneath it in CAS-based storage).
     et = entry.get("entry_type", 0)
-    is_dir = (
-        et in (1, 2)
-        or raw_path.endswith("/")
-        or (et == 0 and entry.get("size", 0) == 0 and not entry.get("etag"))
-    )
+    # Explicit is_directory flag from connector backends takes priority
+    if "is_directory" in entry:
+        is_dir = bool(entry["is_directory"])
+    else:
+        # Heuristic: entry_type 0 with size 0 and no etag COULD be an implicit
+        # directory (CAS), but NOT if the path has a file extension (.yaml, .txt, etc.)
+        has_extension = "." in raw_path.rstrip("/").rsplit("/", 1)[-1]
+        is_dir = (
+            et in (1, 2)
+            or raw_path.endswith("/")
+            or (
+                et == 0
+                and entry.get("size", 0) == 0
+                and not entry.get("etag")
+                and not has_extension
+            )
+        )
     clean_path = raw_path.rstrip("/")
     name = (
         clean_path[len(prefix) :]

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -853,11 +853,20 @@ def create_async_files_router(
             # internal entries (cfg:, ns:) consume an entire page.
             if limit is not None:
                 file_items: list[FileItemResponse] = []
-                has_more = result.has_more
-                next_cursor_raw = result.next_cursor
+                # sys_readdir may return a paginated object (with .items,
+                # .has_more, .next_cursor) or a plain list for connector
+                # backends. Normalize to avoid AttributeError.
+                if isinstance(result, list):
+                    _page_items = result
+                    has_more = False
+                    next_cursor_raw = None
+                else:
+                    _page_items = result.items
+                    has_more = result.has_more
+                    next_cursor_raw = result.next_cursor
 
                 # Collect visible items from current page
-                for entry in result.items:
+                for entry in _page_items:
                     if _is_visible(entry):
                         file_items.append(_to_file_item(entry, prefix))
 
@@ -871,11 +880,17 @@ def create_async_files_router(
                         limit=limit,
                         cursor=next_cursor_raw,
                     )
-                    for entry in result.items:
+                    if isinstance(result, list):
+                        _page_items = result
+                        has_more = False
+                        next_cursor_raw = None
+                    else:
+                        _page_items = result.items
+                        has_more = result.has_more
+                        next_cursor_raw = result.next_cursor
+                    for entry in _page_items:
                         if _is_visible(entry):
                             file_items.append(_to_file_item(entry, prefix))
-                    has_more = result.has_more
-                    next_cursor_raw = result.next_cursor
 
                 next_cursor = (
                     base64.b64encode(next_cursor_raw.encode("utf-8")).decode("ascii")

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -844,6 +844,56 @@ def create_async_files_router(
                             )
                         result = detail_list
 
+            # Inject mount point parent directories into the listing.
+            # Mount points exist in the VFS router but not in the metastore,
+            # so sys_readdir doesn't return them. We synthesize directory
+            # entries for immediate children of the listed path that are
+            # mount point ancestors.
+            try:
+                mount_svc = fs.service("mount")
+                if mount_svc:
+                    mount_list_result = mount_svc.list_mounts()
+                    if hasattr(mount_list_result, "__await__"):
+                        mounts_raw = await mount_list_result
+                    else:
+                        mounts_raw = mount_list_result
+                    listed_prefix = path.rstrip("/") + "/"
+                    existing_paths = {
+                        (e.get("path", "") if isinstance(e, dict) else str(e)).rstrip("/")
+                        for e in (
+                            result if isinstance(result, list) else getattr(result, "items", [])
+                        )
+                    }
+                    for m in mounts_raw:
+                        mp = (m.get("mount_point", "") if isinstance(m, dict) else str(m)).rstrip(
+                            "/"
+                        )
+                        if not mp.startswith(listed_prefix) and not (
+                            path == "/" and mp.startswith("/")
+                        ):
+                            continue
+                        # Find the immediate child segment
+                        relative = mp.lstrip("/") if path == "/" else mp[len(listed_prefix) :]
+                        child = relative.split("/")[0] if "/" in relative else relative
+                        if not child:
+                            continue
+                        child_path = f"{path.rstrip('/')}/{child}"
+                        if child_path.rstrip("/") not in existing_paths:
+                            synthetic = {
+                                "path": child_path,
+                                "name": child,
+                                "entry_type": 1,
+                                "size": 0,
+                                "is_directory": True,
+                            }
+                            if isinstance(result, list):
+                                result.append(synthetic)
+                            elif hasattr(result, "items"):
+                                result.items.append(synthetic)
+                            existing_paths.add(child_path.rstrip("/"))
+            except Exception:
+                pass  # Best effort — listing still works without mount injection
+
             prefix = path.rstrip("/") + "/"
             # The listed path itself (e.g. "/" → empty name) must not appear
             # in its own listing — that causes infinite recursion in tree UIs.

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -104,23 +104,15 @@ def _to_file_item(entry: dict[str, Any], prefix: str) -> "FileItemResponse":
     # entry_type 0 with no etag and size 0 is likely an implicit directory
     # (created by writing files underneath it in CAS-based storage).
     et = entry.get("entry_type", 0)
-    # Explicit is_directory flag from connector backends takes priority
-    if "is_directory" in entry:
+    has_extension = "." in raw_path.rstrip("/").rsplit("/", 1)[-1]
+    # Size-zero entries without extensions are directories (mount points, folders).
+    # This overrides explicit is_directory=False from the metastore which
+    # incorrectly marks mount points as files.
+    looks_like_dir = entry.get("size", 0) == 0 and not entry.get("etag") and not has_extension
+    if "is_directory" in entry and not looks_like_dir:
         is_dir = bool(entry["is_directory"])
     else:
-        # Heuristic: entry_type 0 with size 0 and no etag COULD be an implicit
-        # directory (CAS), but NOT if the path has a file extension (.yaml, .txt, etc.)
-        has_extension = "." in raw_path.rstrip("/").rsplit("/", 1)[-1]
-        is_dir = (
-            et in (1, 2)
-            or raw_path.endswith("/")
-            or (
-                et == 0
-                and entry.get("size", 0) == 0
-                and not entry.get("etag")
-                and not has_extension
-            )
-        )
+        is_dir = et in (1, 2) or raw_path.endswith("/") or looks_like_dir
     clean_path = raw_path.rstrip("/")
     name = (
         clean_path[len(prefix) :]

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -533,8 +533,16 @@ async def get_auth_status(
             status = str(auth_state.get("auth_status", "unknown"))
 
             if status == "authed" and baseline_status != "authed":
-                # Auth state changed to authed — this flow completed
-                del _pending_auth[state_token]
+                # Auth state changed to authed — this flow completed.
+                # Invalidate ALL pending tokens for the same connector so
+                # concurrent auth/init calls don't also claim completion.
+                # The losing tokens will get 404 on next poll, which the
+                # TUI handles as "expired — retry".
+                stale = [
+                    k for k, v in _pending_auth.items() if v["connector_name"] == connector_name
+                ]
+                for k in stale:
+                    del _pending_auth[k]
                 return AuthStatusResponse(
                     status="completed",
                     connector_name=connector_name,

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -237,43 +237,14 @@ async def list_available_connectors(
     from nexus.backends.base.registry import ConnectorRegistry
 
     nx = _get_nx(request)
-    mount_svc = nx.service("mount")
     auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
 
-    # Build a map of connector_type -> mount_point by inspecting each mount's
-    # backend. This correctly identifies mounts regardless of path naming
-    # (e.g., /mnt/work-mail still maps to gmail_connector).
-    type_to_mount: dict[str, str] = {}
-    if mount_svc:
-        try:
-            mounts = await mount_svc.list_mounts()
-            for m in mounts:
-                mp = m.get("mount_point", "")
-                # Try to resolve the backend type from the router
-                try:
-                    route = nx.router.route(f"{mp.rstrip('/')}/_.yaml")
-                    if route and route.backend:
-                        # Use the registry name if available, else class name
-                        backend = route.backend
-                        reg_name = getattr(backend, "_registry_name", None)
-                        if reg_name:
-                            type_to_mount[reg_name] = mp
-                        else:
-                            # Fallback: match by class name convention
-                            cls_name = type(backend).__name__.lower()
-                            type_to_mount[cls_name] = mp
-                except Exception:
-                    pass
-                # Also store the raw mount config connector_type if available
-                ct = m.get("connector_type") or m.get("backend_type")
-                if ct:
-                    type_to_mount[ct] = mp
-        except Exception:
-            pass
+    # Build connector_type -> mount_point map by inverting _mount_types
+    # (which stores mount_point -> connector_type).
+    type_to_mount: dict[str, str] = {ct: mp for mp, ct in _mount_types.items()}
 
     result = []
     for info in ConnectorRegistry.list_all():
-        # Check if this connector is mounted — match by registered name
         mount_path = type_to_mount.get(info.name)
 
         auth_state = {"auth_status": "unknown", "auth_source": None}
@@ -321,6 +292,11 @@ def get_connector_capabilities(name: str) -> ConnectorCapabilitiesResponse:
 # Module-level pending auth state (TTL managed by cleanup).
 # Maps state_token -> {connector_name, provider, created_at, status}
 _pending_auth: dict[str, dict[str, Any]] = {}
+
+# Module-level mount tracking: mount_point -> connector_type.
+# Populated by mount/unmount endpoints so /available can show mount status
+# without relying on fragile router introspection through CAS wrappers.
+_mount_types: dict[str, str] = {}
 
 
 @router.post("/auth/init", response_model=AuthInitResponse)
@@ -702,6 +678,7 @@ async def mount_connector(
             readonly=req.readonly,
             context=mount_context,
         )
+        _mount_types[req.mount_point] = req.connector_type
         return MountResponse(mounted=True, mount_point=str(result))
     except Exception as e:
         return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))
@@ -795,6 +772,7 @@ async def unmount_connector(
     mount_svc = _get_mount_service(request)
     try:
         await mount_svc.remove_mount(mount_point=req.mount_point)
+        _mount_types.pop(req.mount_point, None)
         return MountResponse(mounted=False, mount_point=req.mount_point)
     except Exception as e:
         return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -234,7 +234,10 @@ async def list_available_connectors(
     _: dict = Depends(require_auth),
 ) -> list[AvailableConnector]:
     """List connectors with auth and mount status (for TUI Connectors tab)."""
+    from nexus.backends import _register_optional_backends
     from nexus.backends.base.registry import ConnectorRegistry
+
+    _register_optional_backends()
 
     nx = _get_nx(request)
     auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -138,6 +138,36 @@ class SchemaResponse(BaseModel):
     content: str
 
 
+class AuthInitRequest(BaseModel):
+    """Request to initiate OAuth for a connector."""
+
+    connector_name: str = Field(..., description="Connector name (e.g., gmail_connector)")
+    provider: str | None = Field(None, description="OAuth provider override")
+
+
+class AuthInitResponse(BaseModel):
+    """Response from auth init with URL to open in browser."""
+
+    auth_url: str
+    state_token: str
+    provider: str
+    expires_in: int = 300  # 5 minutes
+
+
+class AuthStatusRequest(BaseModel):
+    """Query params for auth status polling."""
+
+    state_token: str
+
+
+class AuthStatusResponse(BaseModel):
+    """Auth completion status."""
+
+    status: str  # "pending", "completed", "denied", "expired", "error"
+    connector_name: str
+    message: str | None = None
+
+
 class MountInfo(BaseModel):
     """Info about a mounted connector."""
 
@@ -267,6 +297,237 @@ def get_connector_capabilities(name: str) -> ConnectorCapabilitiesResponse:
     return ConnectorCapabilitiesResponse(
         name=info.name,
         capabilities=sorted(str(c) for c in info.backend_features),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth endpoints (Issue #3182)
+# ---------------------------------------------------------------------------
+
+# Module-level pending auth state (TTL managed by cleanup).
+# Maps state_token -> {connector_name, provider, created_at, status}
+_pending_auth: dict[str, dict[str, Any]] = {}
+
+
+@router.post("/auth/init", response_model=AuthInitResponse)
+async def init_connector_auth(
+    req: AuthInitRequest,
+    request: Request,
+    _: dict = Depends(require_auth),
+) -> AuthInitResponse:
+    """Initiate OAuth flow for a connector. Returns a URL to open in a browser."""
+    import secrets
+    import time
+
+    import yaml
+
+    from nexus.backends.base.registry import ConnectorRegistry
+
+    # Validate connector exists
+    if not ConnectorRegistry.is_registered(req.connector_name):
+        raise HTTPException(status_code=404, detail=f"Connector '{req.connector_name}' not found")
+
+    info = ConnectorRegistry.get_info(req.connector_name)
+
+    # Resolve provider — use explicit override or infer from connector's service_name
+    provider = req.provider or info.service_name
+    if not provider:
+        raise HTTPException(
+            status_code=400, detail=f"No OAuth provider for connector '{req.connector_name}'"
+        )
+
+    import os
+
+    nx = _get_nx(request)
+
+    # Generate state token
+    state_token = secrets.token_urlsafe(32)
+
+    # Build OAuth authorization URL
+    # Look up provider config from oauth.yaml
+    oauth_config: dict[str, Any] = {}
+    try:
+        configs_dir = getattr(nx, "configs_dir", None)
+        oauth_path = None
+        for search_path in [
+            configs_dir and os.path.join(configs_dir, "oauth.yaml"),
+            os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "../../../../../../configs/oauth.yaml")
+            ),
+        ]:
+            if search_path and os.path.exists(search_path):
+                oauth_path = search_path
+                break
+
+        if oauth_path:
+            with open(oauth_path) as f:
+                all_config = yaml.safe_load(f)
+
+            # Try direct provider name, then aliases
+            provider_aliases = {
+                "gmail": "gmail",
+                "gmail_connector": "gmail",
+                "calendar_connector": "gcalendar",
+                "gcalendar": "gcalendar",
+                "gdrive_connector": "google-drive",
+                "google-drive": "google-drive",
+                "slack_connector": "slack",
+                "slack": "slack",
+                "x_connector": "x",
+                "x": "x",
+                "gws_connector": "google-drive",
+            }
+            lookup = provider_aliases.get(
+                provider, provider_aliases.get(req.connector_name, provider)
+            )
+            providers = all_config.get("providers", {})
+            oauth_config = providers.get(lookup, providers.get(provider, {}))
+    except Exception:
+        logger.debug("Failed to load oauth.yaml", exc_info=True)
+
+    if not oauth_config:
+        raise HTTPException(
+            status_code=400, detail=f"No OAuth configuration found for provider '{provider}'"
+        )
+
+    # Build authorization URL
+    scopes = oauth_config.get("scopes", [])
+    client_id_env = oauth_config.get("client_id_env", "")
+    client_id = os.environ.get(client_id_env, "")
+    redirect_uri = all_config.get("redirect_uri", "http://localhost:5173/oauth/callback")
+
+    if not client_id:
+        raise HTTPException(
+            status_code=500,
+            detail=f"OAuth client ID not configured. Set environment variable: {client_id_env}",
+        )
+
+    # Determine authorization endpoint based on provider
+    provider_class = oauth_config.get("provider_class", "")
+    if (
+        "google" in provider_class.lower()
+        or "gmail" in lookup
+        or "gcalendar" in lookup
+        or "google" in lookup
+    ):
+        auth_url = (
+            f"https://accounts.google.com/o/oauth2/v2/auth"
+            f"?client_id={client_id}"
+            f"&redirect_uri={redirect_uri}"
+            f"&response_type=code"
+            f"&scope={'+'.join(scopes)}"
+            f"&state={state_token}"
+            f"&access_type=offline"
+            f"&prompt=consent"
+        )
+    elif "slack" in provider_class.lower() or "slack" in lookup:
+        auth_url = (
+            f"https://slack.com/oauth/v2/authorize"
+            f"?client_id={client_id}"
+            f"&redirect_uri={redirect_uri}"
+            f"&scope={','.join(scopes)}"
+            f"&state={state_token}"
+        )
+    elif lookup == "x":
+        auth_url = (
+            f"https://twitter.com/i/oauth2/authorize"
+            f"?client_id={client_id}"
+            f"&redirect_uri={redirect_uri}"
+            f"&response_type=code"
+            f"&scope={'+'.join(scopes)}"
+            f"&state={state_token}"
+            f"&code_challenge=challenge&code_challenge_method=plain"
+        )
+    else:
+        raise HTTPException(status_code=400, detail=f"Unsupported OAuth provider: {provider}")
+
+    # Store pending auth state
+    _pending_auth[state_token] = {
+        "connector_name": req.connector_name,
+        "provider": provider,
+        "created_at": time.time(),
+        "status": "pending",
+    }
+
+    # Cleanup expired entries (>5 min old)
+    cutoff = time.time() - 300
+    expired = [k for k, v in _pending_auth.items() if v["created_at"] < cutoff]
+    for k in expired:
+        del _pending_auth[k]
+
+    resolved_provider = lookup if "lookup" in dir() else provider
+    return AuthInitResponse(
+        auth_url=auth_url,
+        state_token=state_token,
+        provider=resolved_provider,
+    )
+
+
+@router.get("/auth/status", response_model=AuthStatusResponse)
+async def get_auth_status(
+    state_token: str,
+    request: Request,
+    _: dict = Depends(require_auth),
+) -> AuthStatusResponse:
+    """Poll for OAuth completion status."""
+    import time
+
+    # Check pending auth state
+    pending = _pending_auth.get(state_token)
+    if not pending:
+        raise HTTPException(status_code=404, detail="Unknown or expired auth state token")
+
+    connector_name = pending["connector_name"]
+    created_at = pending["created_at"]
+
+    # Check if expired (5 min TTL)
+    if time.time() - created_at > 300:
+        del _pending_auth[state_token]
+        return AuthStatusResponse(
+            status="expired",
+            connector_name=connector_name,
+            message="Auth session expired. Please try again.",
+        )
+
+    # Check if auth was completed by querying the auth service
+    nx = _get_nx(request)
+    auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
+
+    if auth_svc is not None:
+        try:
+            from nexus.backends.base.registry import ConnectorRegistry
+
+            info = ConnectorRegistry.get_info(connector_name)
+            auth_state = await auth_svc.get_connector_auth_state(info.service_name)
+            status = str(auth_state.get("auth_status", "unknown"))
+
+            if status == "authed":
+                # Auth completed — clean up pending state
+                del _pending_auth[state_token]
+                return AuthStatusResponse(
+                    status="completed",
+                    connector_name=connector_name,
+                    message="Authentication successful.",
+                )
+            elif status == "expired":
+                return AuthStatusResponse(
+                    status="denied",
+                    connector_name=connector_name,
+                    message="Authentication was denied or token expired.",
+                )
+            elif status == "error":
+                return AuthStatusResponse(
+                    status="error",
+                    connector_name=connector_name,
+                    message="Authentication failed. Check provider configuration.",
+                )
+        except Exception as e:
+            logger.debug("Error checking auth status for %s: %s", connector_name, e)
+
+    return AuthStatusResponse(
+        status="pending",
+        connector_name=connector_name,
+        message="Waiting for authentication...",
     )
 
 

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -240,27 +240,41 @@ async def list_available_connectors(
     mount_svc = nx.service("mount")
     auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
 
-    # Get mounted connectors
-    mounted: dict[str, str] = {}  # connector_type -> mount_point
+    # Build a map of connector_type -> mount_point by inspecting each mount's
+    # backend. This correctly identifies mounts regardless of path naming
+    # (e.g., /mnt/work-mail still maps to gmail_connector).
+    type_to_mount: dict[str, str] = {}
     if mount_svc:
         try:
             mounts = await mount_svc.list_mounts()
             for m in mounts:
                 mp = m.get("mount_point", "")
-                if mp.startswith("/mnt/"):
-                    # Infer type from mount point name
-                    mounted[mp] = mp
+                # Try to resolve the backend type from the router
+                try:
+                    route = nx.router.route(f"{mp.rstrip('/')}/_.yaml")
+                    if route and route.backend:
+                        # Use the registry name if available, else class name
+                        backend = route.backend
+                        reg_name = getattr(backend, "_registry_name", None)
+                        if reg_name:
+                            type_to_mount[reg_name] = mp
+                        else:
+                            # Fallback: match by class name convention
+                            cls_name = type(backend).__name__.lower()
+                            type_to_mount[cls_name] = mp
+                except Exception:
+                    pass
+                # Also store the raw mount config connector_type if available
+                ct = m.get("connector_type") or m.get("backend_type")
+                if ct:
+                    type_to_mount[ct] = mp
         except Exception:
             pass
 
     result = []
     for info in ConnectorRegistry.list_all():
-        # Check if this connector is mounted
-        mount_path = None
-        for mp in mounted:
-            if info.name.replace("_connector", "") in mp:
-                mount_path = mp
-                break
+        # Check if this connector is mounted — match by registered name
+        mount_path = type_to_mount.get(info.name)
 
         auth_state = {"auth_status": "unknown", "auth_source": None}
         if auth_svc is not None:
@@ -441,12 +455,25 @@ async def init_connector_auth(
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported OAuth provider: {provider}")
 
-    # Store pending auth state
+    # Snapshot the current auth state so we can detect a *change* during polling.
+    # Without this, pre-existing auth for the same connector would immediately
+    # report "completed" — a correctness bug for concurrent auth attempts.
+    auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
+    baseline_status = "unknown"
+    if auth_svc is not None:
+        try:
+            baseline = await auth_svc.get_connector_auth_state(info.service_name)
+            baseline_status = str(baseline.get("auth_status", "unknown"))
+        except Exception:
+            pass
+
+    # Store pending auth state with the baseline snapshot
     _pending_auth[state_token] = {
         "connector_name": req.connector_name,
         "provider": provider,
         "created_at": time.time(),
         "status": "pending",
+        "baseline_auth_status": baseline_status,
     }
 
     # Cleanup expired entries (>5 min old)
@@ -489,7 +516,11 @@ async def get_auth_status(
             message="Auth session expired. Please try again.",
         )
 
-    # Check if auth was completed by querying the auth service
+    # Check if auth was completed by querying the auth service.
+    # Only report "completed" when the auth state *changed* from the baseline
+    # captured at init time. This prevents pre-existing auth from causing
+    # false completion and makes concurrent auth attempts distinguishable.
+    baseline_status = pending.get("baseline_auth_status", "unknown")
     nx = _get_nx(request)
     auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
 
@@ -501,21 +532,21 @@ async def get_auth_status(
             auth_state = await auth_svc.get_connector_auth_state(info.service_name)
             status = str(auth_state.get("auth_status", "unknown"))
 
-            if status == "authed":
-                # Auth completed — clean up pending state
+            if status == "authed" and baseline_status != "authed":
+                # Auth state changed to authed — this flow completed
                 del _pending_auth[state_token]
                 return AuthStatusResponse(
                     status="completed",
                     connector_name=connector_name,
                     message="Authentication successful.",
                 )
-            elif status == "expired":
+            elif status == "expired" and baseline_status != "expired":
                 return AuthStatusResponse(
                     status="denied",
                     connector_name=connector_name,
                     message="Authentication was denied or token expired.",
                 )
-            elif status == "error":
+            elif status == "error" and baseline_status != "error":
                 return AuthStatusResponse(
                     status="error",
                     connector_name=connector_name,
@@ -683,6 +714,8 @@ async def list_mounted_connectors(
         mp = m.get("mount_point", "")
         skill_name = None
         operations: list[str] = []
+        sync_status: str | None = None
+        last_sync: str | None = None
         try:
             # Route to a dummy file path inside the mount to get the backend
             route = nx.router.route(f"{mp.rstrip('/')}/_.yaml")
@@ -696,8 +729,39 @@ async def list_mounted_connectors(
                     operations = list(schemas.keys())
                 elif traits:
                     operations = list(traits.keys())
+
+                # Extract sync status from backend state or cache metadata.
+                # Backends that implement sync track their last sync time and
+                # status via _last_sync_at / _sync_status attributes or via
+                # the cache mixin's session metadata.
+                sync_status = getattr(backend, "_sync_status", None)
+                raw_last_sync = getattr(backend, "_last_sync_at", None)
+                if raw_last_sync is not None:
+                    import datetime
+
+                    if isinstance(raw_last_sync, (int, float)):
+                        dt = datetime.datetime.fromtimestamp(raw_last_sync, tz=datetime.UTC)
+                    elif isinstance(raw_last_sync, datetime.datetime):
+                        dt = raw_last_sync
+                    else:
+                        dt = None
+                    if dt:
+                        delta = datetime.datetime.now(tz=datetime.UTC) - dt
+                        secs = int(delta.total_seconds())
+                        if secs < 60:
+                            last_sync = f"{secs}s ago"
+                        elif secs < 3600:
+                            last_sync = f"{secs // 60}m ago"
+                        else:
+                            last_sync = f"{secs // 3600}h ago"
         except Exception:
             pass
+
+        # Fall back to mount-level metadata for sync info
+        if sync_status is None:
+            sync_status = m.get("sync_status")
+        if last_sync is None:
+            last_sync = m.get("last_sync")
 
         result.append(
             MountInfo(
@@ -705,6 +769,8 @@ async def list_mounted_connectors(
                 readonly=m.get("readonly", False),
                 skill_name=skill_name,
                 operations=operations,
+                sync_status=sync_status,
+                last_sync=last_sync,
             )
         )
 

--- a/src/nexus/services/gateway.py
+++ b/src/nexus/services/gateway.py
@@ -391,7 +391,8 @@ class NexusFSGateway:
         Returns:
             True if hierarchy manager exists and inheritance is enabled
         """
-        hm = getattr(self._fs, "_hierarchy_manager", None)
+        rm = self.rebac_manager
+        hm = getattr(rm, "hierarchy_manager", None) if rm is not None else None
         if hm is not None:
             return getattr(hm, "enable_inheritance", False)
         return False
@@ -410,7 +411,8 @@ class NexusFSGateway:
         Returns:
             Number of tuples created
         """
-        hm = getattr(self._fs, "_hierarchy_manager", None)
+        rm = self.rebac_manager
+        hm = getattr(rm, "hierarchy_manager", None) if rm is not None else None
         if hm is not None and hasattr(hm, "ensure_parent_tuples_batch"):
             return hm.ensure_parent_tuples_batch(paths, zone_id=zone_id)
         return 0
@@ -421,7 +423,8 @@ class NexusFSGateway:
         zone_id: str | None = None,
     ) -> Any:
         """Remove parent tuples for a path."""
-        hm = getattr(self._fs, "_hierarchy_manager", None)
+        rm = self.rebac_manager
+        hm = getattr(rm, "hierarchy_manager", None) if rm is not None else None
         if hm is not None and hasattr(hm, "remove_parent_tuples"):
             return hm.remove_parent_tuples(path, zone_id=zone_id)
         return 0

--- a/tests/integration/services/test_connectors_auth.py
+++ b/tests/integration/services/test_connectors_auth.py
@@ -261,6 +261,52 @@ class TestAuthStatus:
         # Token should still be in pending auth (not cleaned up)
         assert "tok-preauth" in _pending_auth
 
+    @patch("nexus.backends.base.registry.ConnectorRegistry")
+    def test_concurrent_auth_only_first_completes(self, mock_registry: MagicMock) -> None:
+        """Two pending tokens for the same connector — only the first poll wins.
+
+        When one token detects completion, all other pending tokens for the
+        same connector are invalidated. Subsequent polls get 404.
+        """
+        # Two concurrent auth flows for gmail
+        _pending_auth["tok-A"] = {
+            "connector_name": "gmail_connector",
+            "provider": "gmail",
+            "created_at": time.time(),
+            "status": "pending",
+            "baseline_auth_status": "unknown",
+        }
+        _pending_auth["tok-B"] = {
+            "connector_name": "gmail_connector",
+            "provider": "gmail",
+            "created_at": time.time(),
+            "status": "pending",
+            "baseline_auth_status": "unknown",
+        }
+
+        mock_registry.get_info.return_value = _make_connector_info(
+            "gmail_connector", service_name="gmail"
+        )
+
+        auth_service = MagicMock()
+        auth_service.get_connector_auth_state = AsyncMock(
+            return_value={"auth_status": "authed", "auth_source": "oauth"}
+        )
+        _test_app.state.auth_service = auth_service
+
+        # First poll (tok-A) claims completion
+        resp_a = _client.get("/api/v2/connectors/auth/status", params={"state_token": "tok-A"})
+        assert resp_a.status_code == 200
+        assert resp_a.json()["status"] == "completed"
+
+        # Both tokens should be invalidated
+        assert "tok-A" not in _pending_auth
+        assert "tok-B" not in _pending_auth
+
+        # Second poll (tok-B) gets 404 — not a false "completed"
+        resp_b = _client.get("/api/v2/connectors/auth/status", params={"state_token": "tok-B"})
+        assert resp_b.status_code == 404
+
     def test_unknown_token_returns_404(self) -> None:
         """Completely unknown token returns 404."""
         resp = _client.get(

--- a/tests/integration/services/test_connectors_auth.py
+++ b/tests/integration/services/test_connectors_auth.py
@@ -1,0 +1,234 @@
+"""Unit tests for connector auth REST API (Issue #3182).
+
+Tests the POST /api/v2/connectors/auth/init and
+GET /api/v2/connectors/auth/status endpoints using FastAPI TestClient
+with a mocked ConnectorRegistry.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.connectors import _pending_auth, router
+from nexus.server.dependencies import require_auth
+
+# ---------------------------------------------------------------------------
+# Test app setup
+# ---------------------------------------------------------------------------
+
+_test_app = FastAPI()
+_test_app.include_router(router)
+
+_test_app.dependency_overrides[require_auth] = lambda: {"authenticated": True, "is_admin": True}
+_client = TestClient(_test_app)
+
+
+def _setup_app_state() -> None:
+    """Wire up mock nexus_fs and auth_service on the test app."""
+    nx = MagicMock()
+    mount_service = MagicMock()
+    mount_service.list_mounts = AsyncMock(return_value=[])
+    nx.service.side_effect = lambda name: mount_service if name == "mount" else None
+    nx.configs_dir = None
+
+    auth_service = MagicMock()
+    auth_service.get_connector_auth_state = AsyncMock(
+        return_value={"auth_status": "unknown", "auth_source": None}
+    )
+
+    _test_app.state.nexus_fs = nx
+    _test_app.state.auth_service = auth_service
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v2/connectors/auth/init
+# ---------------------------------------------------------------------------
+
+_OAUTH_YAML_CONTENT = {
+    "redirect_uri": "http://localhost:5173/oauth/callback",
+    "providers": {
+        "gmail": {
+            "provider_class": "GoogleOAuthProvider",
+            "client_id_env": "GOOGLE_CLIENT_ID",
+            "scopes": ["https://mail.google.com/"],
+        },
+        "slack": {
+            "provider_class": "SlackOAuthProvider",
+            "client_id_env": "SLACK_CLIENT_ID",
+            "scopes": ["chat:write", "channels:read"],
+        },
+    },
+}
+
+
+def _make_connector_info(name: str, service_name: str | None = "UNSET") -> MagicMock:
+    """Create a minimal mock ConnectorInfo with a service_name.
+
+    Pass ``service_name=None`` to simulate a connector with no OAuth provider.
+    When omitted, service_name defaults to *name*.
+    """
+    info = MagicMock()
+    info.name = name
+    info.service_name = name if service_name == "UNSET" else service_name
+    return info
+
+
+class TestAuthInit:
+    """POST /api/v2/connectors/auth/init endpoint."""
+
+    def setup_method(self) -> None:
+        _pending_auth.clear()
+        _setup_app_state()
+
+    @patch.dict("os.environ", {"GOOGLE_CLIENT_ID": "test-client-id-123"})
+    @patch("nexus.backends.base.registry.ConnectorRegistry")
+    def test_success_returns_auth_url(self, mock_registry: MagicMock) -> None:
+        mock_registry.is_registered.return_value = True
+        mock_registry.get_info.return_value = _make_connector_info(
+            "gmail_connector", service_name="gmail"
+        )
+
+        with (
+            patch("builtins.open", mock_open(read_data="")),
+            patch("yaml.safe_load", return_value=_OAUTH_YAML_CONTENT),
+            patch("os.path.exists", return_value=True),
+        ):
+            resp = _client.post(
+                "/api/v2/connectors/auth/init",
+                json={"connector_name": "gmail_connector"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "auth_url" in data
+        assert "accounts.google.com" in data["auth_url"]
+        assert "state_token" in data
+        assert data["provider"] == "gmail"
+        assert data["expires_in"] == 300
+
+        # Verify pending auth state was stored
+        assert data["state_token"] in _pending_auth
+        entry = _pending_auth[data["state_token"]]
+        assert entry["connector_name"] == "gmail_connector"
+        assert entry["status"] == "pending"
+
+    @patch("nexus.backends.base.registry.ConnectorRegistry")
+    def test_unknown_connector_returns_404(self, mock_registry: MagicMock) -> None:
+        mock_registry.is_registered.return_value = False
+
+        resp = _client.post(
+            "/api/v2/connectors/auth/init",
+            json={"connector_name": "nonexistent_connector"},
+        )
+
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"]
+
+    @patch("nexus.backends.base.registry.ConnectorRegistry")
+    def test_missing_provider_returns_400(self, mock_registry: MagicMock) -> None:
+        mock_registry.is_registered.return_value = True
+        mock_registry.get_info.return_value = _make_connector_info(
+            "bare_connector", service_name=None
+        )
+        # service_name is None and no provider override supplied
+        # The endpoint resolves provider = req.provider or info.service_name
+        # When both are None/falsy, it raises 400.
+
+        resp = _client.post(
+            "/api/v2/connectors/auth/init",
+            json={"connector_name": "bare_connector"},
+        )
+
+        assert resp.status_code == 400
+        assert "No OAuth provider" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v2/connectors/auth/status
+# ---------------------------------------------------------------------------
+
+
+class TestAuthStatus:
+    """GET /api/v2/connectors/auth/status endpoint."""
+
+    def setup_method(self) -> None:
+        _pending_auth.clear()
+        _setup_app_state()
+
+    def test_pending_status(self) -> None:
+        """Token exists and auth has not yet completed."""
+        _pending_auth["tok-pending"] = {
+            "connector_name": "gmail_connector",
+            "provider": "gmail",
+            "created_at": time.time(),
+            "status": "pending",
+        }
+
+        # auth_service returns "unknown" (not yet authed) — default from _setup_app_state
+        resp = _client.get("/api/v2/connectors/auth/status", params={"state_token": "tok-pending"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "pending"
+        assert data["connector_name"] == "gmail_connector"
+
+    @patch("nexus.backends.base.registry.ConnectorRegistry")
+    def test_completed_status(self, mock_registry: MagicMock) -> None:
+        """Auth service reports 'authed' — endpoint returns 'completed'."""
+        _pending_auth["tok-done"] = {
+            "connector_name": "gmail_connector",
+            "provider": "gmail",
+            "created_at": time.time(),
+            "status": "pending",
+        }
+
+        mock_registry.get_info.return_value = _make_connector_info(
+            "gmail_connector", service_name="gmail"
+        )
+
+        # Override auth_service to report successful auth
+        auth_service = MagicMock()
+        auth_service.get_connector_auth_state = AsyncMock(
+            return_value={"auth_status": "authed", "auth_source": "stored:secret"}
+        )
+        _test_app.state.auth_service = auth_service
+
+        resp = _client.get("/api/v2/connectors/auth/status", params={"state_token": "tok-done"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "completed"
+        assert data["connector_name"] == "gmail_connector"
+        # Token should be cleaned up after completion
+        assert "tok-done" not in _pending_auth
+
+    def test_expired_status(self) -> None:
+        """Token created more than 5 minutes ago returns 'expired'."""
+        _pending_auth["tok-old"] = {
+            "connector_name": "gmail_connector",
+            "provider": "gmail",
+            "created_at": time.time() - 301,  # 301 seconds ago (>300s TTL)
+            "status": "pending",
+        }
+
+        resp = _client.get("/api/v2/connectors/auth/status", params={"state_token": "tok-old"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "expired"
+        assert data["connector_name"] == "gmail_connector"
+        assert "expired" in data["message"].lower()
+        # Token should be cleaned up after expiration
+        assert "tok-old" not in _pending_auth
+
+    def test_unknown_token_returns_404(self) -> None:
+        """Completely unknown token returns 404."""
+        resp = _client.get(
+            "/api/v2/connectors/auth/status",
+            params={"state_token": "tok-does-not-exist"},
+        )
+
+        assert resp.status_code == 404
+        assert "Unknown or expired" in resp.json()["detail"]

--- a/tests/integration/services/test_connectors_auth.py
+++ b/tests/integration/services/test_connectors_auth.py
@@ -164,6 +164,7 @@ class TestAuthStatus:
             "provider": "gmail",
             "created_at": time.time(),
             "status": "pending",
+            "baseline_auth_status": "unknown",
         }
 
         # auth_service returns "unknown" (not yet authed) — default from _setup_app_state
@@ -182,6 +183,7 @@ class TestAuthStatus:
             "provider": "gmail",
             "created_at": time.time(),
             "status": "pending",
+            "baseline_auth_status": "unknown",
         }
 
         mock_registry.get_info.return_value = _make_connector_info(
@@ -211,6 +213,7 @@ class TestAuthStatus:
             "provider": "gmail",
             "created_at": time.time() - 301,  # 301 seconds ago (>300s TTL)
             "status": "pending",
+            "baseline_auth_status": "unknown",
         }
 
         resp = _client.get("/api/v2/connectors/auth/status", params={"state_token": "tok-old"})
@@ -222,6 +225,41 @@ class TestAuthStatus:
         assert "expired" in data["message"].lower()
         # Token should be cleaned up after expiration
         assert "tok-old" not in _pending_auth
+
+    @patch("nexus.backends.base.registry.ConnectorRegistry")
+    def test_preexisting_auth_stays_pending(self, mock_registry: MagicMock) -> None:
+        """When baseline was already 'authed', current 'authed' stays pending.
+
+        This prevents pre-existing auth from causing a false 'completed' report,
+        which is the core correctness fix for concurrent auth attempts.
+        """
+        _pending_auth["tok-preauth"] = {
+            "connector_name": "gmail_connector",
+            "provider": "gmail",
+            "created_at": time.time(),
+            "status": "pending",
+            "baseline_auth_status": "authed",  # was already authed at init
+        }
+
+        mock_registry.get_info.return_value = _make_connector_info(
+            "gmail_connector", service_name="gmail"
+        )
+
+        # Auth service still reports "authed" — same as baseline
+        auth_service = MagicMock()
+        auth_service.get_connector_auth_state = AsyncMock(
+            return_value={"auth_status": "authed", "auth_source": "stored:secret"}
+        )
+        _test_app.state.auth_service = auth_service
+
+        resp = _client.get("/api/v2/connectors/auth/status", params={"state_token": "tok-preauth"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        # Should remain pending because auth state did NOT change
+        assert data["status"] == "pending"
+        # Token should still be in pending auth (not cleaned up)
+        assert "tok-preauth" in _pending_auth
 
     def test_unknown_token_returns_404(self) -> None:
         """Completely unknown token returns 404."""

--- a/tests/unit/services/test_gateway.py
+++ b/tests/unit/services/test_gateway.py
@@ -58,10 +58,11 @@ def mock_fs():
 
     fs._rebac_manager = MagicMock()
     fs._rebac_manager.rebac_delete = MagicMock()
-    fs._hierarchy_manager = MagicMock()
-    fs._hierarchy_manager.enable_inheritance = True
-    fs._hierarchy_manager.ensure_parent_tuples_batch = MagicMock(return_value=2)
-    fs._hierarchy_manager.remove_parent_tuples = MagicMock(return_value=1)
+    # hierarchy_manager is accessed via rebac_manager.hierarchy_manager (not fs._hierarchy_manager)
+    fs._rebac_manager.hierarchy_manager = MagicMock()
+    fs._rebac_manager.hierarchy_manager.enable_inheritance = True
+    fs._rebac_manager.hierarchy_manager.ensure_parent_tuples_batch = MagicMock(return_value=2)
+    fs._rebac_manager.hierarchy_manager.remove_parent_tuples = MagicMock(return_value=1)
     fs.router = MagicMock()
     fs.SessionLocal = MagicMock()
     fs.read = AsyncMock(return_value={"content": b"data", "path": "/test/file.txt"})
@@ -301,8 +302,8 @@ class TestHierarchyOperations:
         assert gateway.hierarchy_enabled is True
 
     def test_hierarchy_disabled(self, mock_fs):
-        """hierarchy_enabled returns False when manager is None."""
-        mock_fs._hierarchy_manager = None
+        """hierarchy_enabled returns False when rebac_manager is None."""
+        mock_fs._rebac_manager = None
         gw = NexusFSGateway(mock_fs)
         assert gw.hierarchy_enabled is False
 
@@ -317,14 +318,14 @@ class TestHierarchyOperations:
         assert result == 1
 
     def test_ensure_parent_tuples_no_manager(self, mock_fs):
-        """Returns 0 when hierarchy manager is None."""
-        mock_fs._hierarchy_manager = None
+        """Returns 0 when rebac_manager is None."""
+        mock_fs._rebac_manager = None
         gw = NexusFSGateway(mock_fs)
         assert gw.ensure_parent_tuples_batch(["/a"]) == 0
 
     def test_remove_parent_tuples_no_manager(self, mock_fs):
-        """Returns 0 when hierarchy manager is None."""
-        mock_fs._hierarchy_manager = None
+        """Returns 0 when rebac_manager is None."""
+        mock_fs._rebac_manager = None
         gw = NexusFSGateway(mock_fs)
         assert gw.remove_parent_tuples("/test") == 0
 


### PR DESCRIPTION
## Summary

Implements #3182 — adds a full **Connectors** tab to the TUI with 4 sub-tabs:

- **Available** — list all registered connectors with auth status, initiate OAuth (opens browser), poll for completion, auto-mount
- **Mounted** — manage mounted connectors, trigger sync, unmount with confirmation, show sync progress
- **Skills** — browse SKILL.md docs and operation schemas (read-only, dual-pane schema browser)
- **Write** — template-based YAML composition from operation schemas, submit with validation and confirmation

### Backend changes

- `POST /api/v2/connectors/auth/init` — initiate OAuth flow, returns browser URL + state token
- `GET /api/v2/connectors/auth/status` — poll for auth completion (pending/completed/denied/expired/error)
- Module-level pending auth cache with 5-min TTL and automatic cleanup

### New files (14)

| File | Purpose |
|------|---------|
| `src/panels/connectors/connectors-panel.tsx` | Panel root, sub-tab routing (gated on `mount` brick) |
| `src/panels/connectors/available-tab.tsx` | Connector list + OAuth auth flow |
| `src/panels/connectors/mounted-tab.tsx` | Mount management + sync control |
| `src/panels/connectors/skills-tab.tsx` | SKILL.md viewer + schema browser |
| `src/panels/connectors/write-tab.tsx` | Template-based YAML write composition |
| `src/panels/connectors/connector-row.tsx` | Shared row component (DRY across Available/Mounted) |
| `src/panels/connectors/template-generator.ts` | Schema → YAML template (pure function) |
| `src/stores/connectors-store.ts` | Zustand store (single store per panel pattern) |
| `tests/stores/connectors-store.test.ts` | 33 store action tests |
| `tests/panels/connectors/template-generator.test.ts` | 22 template generator tests |
| `tests/integration/services/test_connectors_auth.py` | 7 backend auth endpoint tests |

### Architecture decisions

- **4 sub-tabs** (Available|Mounted|Skills|Write) — separates read-only browsing from write composition
- **Per-sub-tab keyboard components** — each sub-tab owns its own `useKeyboard`, scoped by component lifecycle
- **Shared ConnectorRow** — DRY component for connector list rendering
- **Template-based write UX** — pre-filled YAML from schemas, guided editing
- **Gated polling** — sync status polling only while syncs are in-progress (`syncingMounts` Set)
- **OAuth edge cases** — handles browser fail (fallback to URL copy), consent denied, timeout, network errors, concurrent auth, provider errors
- **Shift+C shortcut** — avoids conflict with lowercase `c` used in 5 existing panels

### Depends on

- PR #3176 (CLI connector infrastructure — merged)

## Test plan

- [x] 55 TUI tests pass (33 store + 22 template generator)
- [x] 7 backend integration tests
- [x] All pre-commit hooks pass (ruff, mypy, formatting)
- [x] Existing 731 TUI tests unaffected
- [ ] Manual: verify Connectors tab appears with Shift+C shortcut
- [ ] Manual: verify OAuth flow opens browser and polls correctly
- [ ] Manual: verify sync trigger and status polling
- [ ] Manual: verify SKILL.md and schema browsing
- [ ] Manual: verify write template generation and submission