### PR TITLE
TUI: theme.ts DESIGN.md alignment + health check + hook_spec + internal path filtering

### DIFF
--- a/packages/nexus-tui/src/shared/theme.ts
+++ b/packages/nexus-tui/src/shared/theme.ts
@@ -17,12 +17,16 @@
 export const statusColor = {
   /** Healthy, active, committed, connected */
   healthy: "green",
+  /** Completed successfully — same as healthy (terminal vs ongoing state) */
+  success: "green",
   /** Warning, starting, stopping, stale */
   warning: "yellow",
   /** Error, failed, rolled_back, expired */
   error: "red",
-  /** Info, focus, selected */
+  /** Info, informational highlights */
   info: "cyan",
+  /** Focus, selected, active UI chrome */
+  focus: "yellow",
   /** Secondary text, hints, timestamps */
   dim: "gray",
   /** Agent identity, delegation chains */
@@ -132,13 +136,13 @@ export const delegationStatusColor: Record<string, string> = {
 
 export const focusColor = {
   /** Active pane border */
-  activeBorder: statusColor.info,
+  activeBorder: statusColor.focus,
   /** Inactive pane border */
   inactiveBorder: statusColor.dim,
   /** Selected item highlight */
-  selected: statusColor.info,
+  selected: statusColor.focus,
   /** Help bar action keys */
-  actionKey: statusColor.info,
+  actionKey: statusColor.focus,
   /** Help bar navigation keys */
   navKey: statusColor.dim,
 } as const;
@@ -153,23 +157,23 @@ export const focusColor = {
 
 export const palette = {
   /** Primary accent — active tabs, selected items, key bindings */
-  accent: "#00d4ff",
+  accent: "#D4A017",
   /** Secondary accent — hover, secondary actions */
-  accentDim: "#0099bb",
+  accentDim: "#B8890F",
   /** Success — green confirmation */
-  success: "#4dff88",
+  success: "#34D399",
   /** Error — bright red */
-  error: "#ff4444",
+  error: "#F87171",
   /** Error secondary — softer red for hints */
-  errorDim: "#ff8888",
+  errorDim: "#FCA5A5",
   /** Warning — amber */
-  warning: "#ffaa00",
+  warning: "#FBBF24",
   /** Muted text — labels, separators */
-  muted: "#888888",
+  muted: "#8B8B92",
   /** Very muted — borders, inactive chrome */
-  faint: "#555555",
+  faint: "#2A2A2E",
   /** Bright text — active content */
-  bright: "#cccccc",
+  bright: "#EDEDEF",
   /** Header/title text */
-  title: "#ffffff",
+  title: "#EDEDEF",
 } as const;

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -163,6 +163,10 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
         throw new Error("Server health check failed");
       }
 
+      // Note: zoneId is not set here — no health/readiness endpoint provides it.
+      // The old /api/v2/bricks/health never returned zone_id either (its response
+      // was { total, active, failed, bricks }). zoneId is set via setIdentity()
+      // when the user explicitly configures a zone, or defaults to "root".
       set({
         serverVersion: features?.version ?? get().serverVersion,
         uptime: health.uptime_seconds ?? get().uptime,

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -118,8 +118,8 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
     try {
       // Consolidated connection check (Decision 5A): health + features + auth in one flow
       let [health, features, userInfo] = await Promise.all([
-        client.get<{ version?: string; zone_id?: string; uptime_seconds?: number }>(
-          "/api/v2/bricks/health",
+        client.get<{ status?: string; uptime_seconds?: number }>(
+          "/healthz/ready",
         ).catch(() => null),
         client.get<FeaturesResponse>("/api/v2/features").catch(() => null),
         client.get<UserInfo>("/auth/me").catch(() => null),
@@ -139,8 +139,8 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
           try {
             const probeUrl = `${protocol}://${hostname || "localhost"}:${port}`;
             const probeClient = new FetchClient({ ...get().config, baseUrl: probeUrl, timeout: 3000, maxRetries: 0 });
-            const probeHealth = await probeClient.get<{ version?: string; zone_id?: string; uptime_seconds?: number }>(
-              "/api/v2/bricks/health",
+            const probeHealth = await probeClient.get<{ status?: string; uptime_seconds?: number }>(
+              "/healthz/ready",
             ).catch(() => null);
             if (probeHealth) {
               const newConfig = resolveConfig({ transformKeys: false, baseUrl: probeUrl });
@@ -164,8 +164,7 @@ export const useGlobalStore = create<GlobalState>((set, get) => ({
       }
 
       set({
-        serverVersion: health.version ?? get().serverVersion,
-        zoneId: health.zone_id ?? get().zoneId,
+        serverVersion: features?.version ?? get().serverVersion,
         uptime: health.uptime_seconds ?? get().uptime,
       });
       if (features) {

--- a/packages/nexus-tui/tests/shared/theme.test.ts
+++ b/packages/nexus-tui/tests/shared/theme.test.ts
@@ -7,18 +7,25 @@ import {
   httpStatusColor,
   agentPhaseColor,
   focusColor,
+  palette,
 } from "../../src/shared/theme.js";
 
 describe("theme", () => {
   describe("statusColor", () => {
     it("has all required semantic keys", () => {
       expect(statusColor.healthy).toBe("green");
+      expect(statusColor.success).toBe("green");
       expect(statusColor.warning).toBe("yellow");
       expect(statusColor.error).toBe("red");
       expect(statusColor.info).toBe("cyan");
+      expect(statusColor.focus).toBe("yellow");
       expect(statusColor.dim).toBe("gray");
       expect(statusColor.identity).toBe("magenta");
       expect(statusColor.reference).toBe("blue");
+    });
+
+    it("success is semantically distinct from but same color as healthy", () => {
+      expect(statusColor.success).toBe(statusColor.healthy);
     });
   });
 
@@ -89,13 +96,34 @@ describe("theme", () => {
 
   describe("focusColor", () => {
     it("has active and inactive border colors", () => {
-      expect(focusColor.activeBorder).toBe("cyan");
+      expect(focusColor.activeBorder).toBe("yellow");
       expect(focusColor.inactiveBorder).toBe("gray");
     });
 
     it("has key highlight colors", () => {
-      expect(focusColor.actionKey).toBe("cyan");
+      expect(focusColor.actionKey).toBe("yellow");
       expect(focusColor.navKey).toBe("gray");
+    });
+
+    it("derives from statusColor.focus", () => {
+      expect(focusColor.activeBorder).toBe(statusColor.focus);
+      expect(focusColor.selected).toBe(statusColor.focus);
+      expect(focusColor.actionKey).toBe(statusColor.focus);
+    });
+  });
+
+  describe("palette", () => {
+    it("has all Industrial Warmth hex values", () => {
+      expect(palette.accent).toBe("#D4A017");
+      expect(palette.accentDim).toBe("#B8890F");
+      expect(palette.success).toBe("#34D399");
+      expect(palette.error).toBe("#F87171");
+      expect(palette.errorDim).toBe("#FCA5A5");
+      expect(palette.warning).toBe("#FBBF24");
+      expect(palette.muted).toBe("#8B8B92");
+      expect(palette.faint).toBe("#2A2A2E");
+      expect(palette.bright).toBe("#EDEDEF");
+      expect(palette.title).toBe("#EDEDEF");
     });
   });
 });

--- a/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
+++ b/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
@@ -84,6 +84,24 @@ describe("Connection Lifecycle", () => {
       expect(state.userInfo!.email).toBe("test@example.com");
     });
 
+    it("testConnection does not overwrite zoneId (set via setIdentity, not health)", async () => {
+      useGlobalStore.setState({ client: createMockClient(), zoneId: "my-zone" });
+
+      await useGlobalStore.getState().testConnection();
+
+      // zoneId is preserved — no health endpoint provides it
+      expect(useGlobalStore.getState().zoneId).toBe("my-zone");
+    });
+
+    it("testConnection sets serverVersion from features response", async () => {
+      const client = createMockClient();
+      useGlobalStore.setState({ client });
+
+      await useGlobalStore.getState().testConnection();
+
+      expect(useGlobalStore.getState().serverVersion).toBe("0.9.0");
+    });
+
     it("transitions through connecting state", async () => {
       const states: string[] = [];
       const unsubscribe = useGlobalStore.subscribe((s) => {

--- a/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
+++ b/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
@@ -25,7 +25,7 @@ function createMockClient(overrides: {
     primary_auth_method: "api_key",
   };
 
-  const defaultHealth = { version: "0.9.0", zone_id: "default", uptime_seconds: 100 };
+  const defaultHealth = { status: "ready", uptime_seconds: 100 };
   const defaultFeatures = {
     profile: "full",
     mode: "standalone",
@@ -40,7 +40,7 @@ function createMockClient(overrides: {
       if (url === "/auth/me") {
         return overrides.authMe ? overrides.authMe() : defaultUserInfo;
       }
-      if (url === "/api/v2/bricks/health") {
+      if (url === "/healthz/ready") {
         return overrides.health ? overrides.health() : defaultHealth;
       }
       if (url === "/api/v2/features") {

--- a/packages/nexus-tui/tests/stores/global-store.test.ts
+++ b/packages/nexus-tui/tests/stores/global-store.test.ts
@@ -218,7 +218,7 @@ describe("GlobalStore", () => {
 
   describe("testConnection", () => {
     it("sets connected and userInfo on success", async () => {
-      const mockHealth = { version: "1.0", zone_id: "z1", uptime_seconds: 100 };
+      const mockHealth = { status: "ready", uptime_seconds: 100 };
       const mockUserInfo = {
         user_id: "user-1",
         email: "test@example.com",
@@ -231,7 +231,7 @@ describe("GlobalStore", () => {
 
       // testConnection calls client.get 3 times: health, features, auth/me
       const mockGet = mock()
-        .mockResolvedValueOnce(mockHealth)     // health
+        .mockResolvedValueOnce(mockHealth)     // health (/healthz/ready)
         .mockResolvedValueOnce(null)           // features
         .mockResolvedValueOnce(mockUserInfo);  // auth/me
 
@@ -250,7 +250,7 @@ describe("GlobalStore", () => {
     });
 
     it("sets connected when health passes but auth/me fails", async () => {
-      const mockHealth = { version: "1.0", zone_id: null, uptime_seconds: 10 };
+      const mockHealth = { status: "ready", uptime_seconds: 10 };
       const mockGet = mock()
         .mockResolvedValueOnce(mockHealth)     // health OK
         .mockResolvedValueOnce(null)           // features

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -43,6 +43,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _declares_hook_spec(instance: Any) -> bool:
+    """Check if instance has a real hook_spec method without triggering __getattr__.
+
+    RPC proxy objects (RPCProxyBase) use __getattr__ to synthesize remote method
+    calls.  Using ``hasattr(instance, "hook_spec")`` on these proxies triggers a
+    remote RPC call to a non-existent ``hook_spec`` method, causing errors.
+    ``inspect.getattr_static`` reads the class MRO without invoking descriptors
+    or __getattr__, so it is safe for dynamic proxies.
+    """
+    attr = inspect.getattr_static(instance, "hook_spec", None)
+    return attr is not None
+
+
 DEFAULT_DRAIN_TIMEOUT: float = 10.0
 
 

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -44,19 +44,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _declares_hook_spec(instance: Any) -> bool:
-    """Check if instance has a real hook_spec method without triggering __getattr__.
-
-    RPC proxy objects (RPCProxyBase) use __getattr__ to synthesize remote method
-    calls.  Using ``hasattr(instance, "hook_spec")`` on these proxies triggers a
-    remote RPC call to a non-existent ``hook_spec`` method, causing errors.
-    ``inspect.getattr_static`` reads the class MRO without invoking descriptors
-    or __getattr__, so it is safe for dynamic proxies.
-    """
-    attr = inspect.getattr_static(instance, "hook_spec", None)
-    return attr is not None
-
-
 DEFAULT_DRAIN_TIMEOUT: float = 10.0
 
 

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -848,19 +848,43 @@ def create_async_files_router(
                     _INTERNAL_PREFIXES
                 )
 
-            # Paginated path: result is a PaginatedResult
+            # Paginated path: keep advancing until the page has visible items
+            # or there are no more results. This prevents empty pages when
+            # internal entries (cfg:, ns:) consume an entire page.
             if limit is not None:
-                file_items = [
-                    _to_file_item(entry, prefix) for entry in result.items if _is_visible(entry)
-                ]
+                file_items: list[FileItemResponse] = []
+                has_more = result.has_more
+                next_cursor_raw = result.next_cursor
+
+                # Collect visible items from current page
+                for entry in result.items:
+                    if _is_visible(entry):
+                        file_items.append(_to_file_item(entry, prefix))
+
+                # If filtering emptied the page but more data exists, keep fetching
+                while not file_items and has_more and next_cursor_raw:
+                    result = await fs.sys_readdir(
+                        path,
+                        recursive=False,
+                        details=True,
+                        context=context,
+                        limit=limit,
+                        cursor=next_cursor_raw,
+                    )
+                    for entry in result.items:
+                        if _is_visible(entry):
+                            file_items.append(_to_file_item(entry, prefix))
+                    has_more = result.has_more
+                    next_cursor_raw = result.next_cursor
+
                 next_cursor = (
-                    base64.b64encode(result.next_cursor.encode("utf-8")).decode("ascii")
-                    if result.next_cursor
+                    base64.b64encode(next_cursor_raw.encode("utf-8")).decode("ascii")
+                    if next_cursor_raw
                     else None
                 )
                 return ListResponse(
                     items=file_items,
-                    has_more=result.has_more,
+                    has_more=has_more,
                     next_cursor=next_cursor,
                 )
 

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -837,12 +837,21 @@ def create_async_files_router(
             # in its own listing — that causes infinite recursion in tree UIs.
             clean_path = path.rstrip("/") or "/"
 
+            # Internal paths stored in the metastore (system config, ReBAC
+            # namespaces) must not leak into user-facing directory listings.
+            _INTERNAL_PREFIXES = ("cfg:", "ns:")
+
+            def _is_visible(entry: dict) -> bool:
+                p = entry.get("path", "")
+                name = p.lstrip("/").split("/")[0] if "/" in p else p.lstrip("/")
+                return p.rstrip("/") != clean_path.rstrip("/") and not name.startswith(
+                    _INTERNAL_PREFIXES
+                )
+
             # Paginated path: result is a PaginatedResult
             if limit is not None:
                 file_items = [
-                    _to_file_item(entry, prefix)
-                    for entry in result.items
-                    if entry.get("path", "").rstrip("/") != clean_path.rstrip("/")
+                    _to_file_item(entry, prefix) for entry in result.items if _is_visible(entry)
                 ]
                 next_cursor = (
                     base64.b64encode(result.next_cursor.encode("utf-8")).decode("ascii")
@@ -856,11 +865,7 @@ def create_async_files_router(
                 )
 
             # Non-paginated path (backward compat): result is list[dict]
-            file_items = [
-                _to_file_item(entry, prefix)
-                for entry in result
-                if entry.get("path", "").rstrip("/") != clean_path.rstrip("/")
-            ]
+            file_items = [_to_file_item(entry, prefix) for entry in result if _is_visible(entry)]
             return ListResponse(items=file_items, has_more=False)
 
         except HTTPException:


### PR DESCRIPTION
## Summary

- **Theme alignment (#3242):** Update palette to Industrial Warmth amber, add `statusColor.success` (fixes undefined bug at command-output.tsx:76), add `statusColor.focus` semantic token, derive `focusColor` from it
- **Fix health check:** Replace deleted `/api/v2/bricks/health` with `/healthz/ready`, get version from `/api/v2/features`
- **Fix hook_spec RPC error:** Replace `hasattr(instance, "hook_spec")` with `_declares_hook_spec()` using `inspect.getattr_static()` to avoid triggering `__getattr__` on RPC proxies — fixes `nexus demo init` and other remote CLI commands
- **Filter internal paths:** Hide `cfg:` and `ns:` prefixed entries from file explorer directory listings

## Test plan

- [x] 759/759 TUI tests pass (theme, connection-lifecycle, global-store)
- [x] All pre-commit hooks pass (ruff, mypy, etc.)
- [x] E2E verified via tmux: D → U → R → P flow works, TUI connects, demo data seeds without hook_spec error
- [x] File explorer shows only `workspace/` at root (no internal `cfg:` or `ns:` clutter)
- [x] "Command completed successfully" renders correctly (statusColor.success fix)
- [x] Focus borders render yellow (not cyan)

Closes #3242