### PR TITLE
Fix IPC cache wiring and daemon compatibility

### DIFF
--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -16,8 +16,9 @@ All zones share one gRPC port (zone_id routing in transport layer).
 
 import logging
 import os
+from inspect import signature
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.metadata import DT_DIR, DT_MOUNT, FileMetadata
@@ -36,6 +37,45 @@ def _get_py_zone_manager() -> type | None:
     except ImportError:
         return None
     return PyZoneManager
+
+
+def _make_py_zone_manager(
+    py_zone_manager: type,
+    *,
+    hostname: str,
+    base_path: str,
+    bind_addr: str,
+    tls_cert_path: str | None,
+    tls_key_path: str | None,
+    tls_ca_path: str | None,
+    ca_key_path: str | None,
+    join_token_hash: str | None,
+) -> Any:
+    """Construct the PyO3 ZoneManager across hostname/node_id API variants.
+
+    Some environments still have an older extension build whose constructor
+    takes ``node_id`` as the first positional argument, while newer builds
+    accept ``hostname`` and derive the node ID internally.
+    """
+    from nexus.raft.peer_address import hostname_to_node_id
+
+    kwargs = {
+        "bind_addr": bind_addr,
+        "tls_cert_path": tls_cert_path,
+        "tls_key_path": tls_key_path,
+        "tls_ca_path": tls_ca_path,
+        "ca_key_path": ca_key_path,
+        "join_token_hash": join_token_hash,
+    }
+
+    try:
+        first_param = next(iter(signature(py_zone_manager).parameters.values())).name
+    except (TypeError, ValueError, StopIteration):
+        first_param = "hostname"
+
+    first_arg: str | int = hostname_to_node_id(hostname) if first_param == "node_id" else hostname
+
+    return py_zone_manager(first_arg, base_path, **kwargs)
 
 
 class ZoneManager:
@@ -119,10 +159,11 @@ class ZoneManager:
                         join_token_hash = hash_path.read_text().strip()
                         ca_key_path = str(Path(base_path) / "tls" / "ca-key.pem")
 
-        self._py_mgr = PyZoneManager(
-            hostname,
-            base_path,
-            bind_addr,
+        self._py_mgr = _make_py_zone_manager(
+            PyZoneManager,
+            hostname=hostname,
+            base_path=base_path,
+            bind_addr=bind_addr,
             tls_cert_path=tls_cert_path,
             tls_key_path=tls_key_path,
             tls_ca_path=tls_ca_path,

--- a/src/nexus/server/api/v2/routers/ipc.py
+++ b/src/nexus/server/api/v2/routers/ipc.py
@@ -1,8 +1,9 @@
-"""IPC REST API — SSE-only endpoints.
+"""IPC REST API — IPC send + SSE endpoints.
 
-CRUD/query endpoints have been migrated to RPC services.
-Only the SSE streaming endpoint remains (requires HTTP keep-alive).
+Inbox/query endpoints have been migrated to RPC services.
+Compatibility send + SSE endpoints remain on REST.
 
+    POST /api/v2/ipc/send              — enqueue a message in an agent inbox
     GET /api/v2/ipc/stream/{agent_id}  — SSE stream for real-time inbox notifications
 """
 
@@ -14,8 +15,16 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict
 
-from nexus.bricks.ipc.conventions import validate_agent_id
+from nexus.bricks.ipc.conventions import inbox_path, validate_agent_id
+from nexus.bricks.ipc.delivery import MessageSender
+from nexus.bricks.ipc.envelope import MessageEnvelope, MessageType
+from nexus.bricks.ipc.exceptions import (
+    EnvelopeValidationError,
+    InboxFullError,
+    InboxNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,9 +75,147 @@ def _get_ipc_cache_store(request: Request) -> Any:
     return getattr(request.app.state, "ipc_cache_store", None)
 
 
+class SendMessageRequest(BaseModel):
+    """Compatibility REST payload for IPC send."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    sender: str
+    recipient: str
+    type: MessageType = MessageType.TASK
+    payload: dict[str, Any]
+    correlation_id: str | None = None
+    ttl_seconds: int | None = None
+    message_id: str | None = None
+
+
+def _get_ipc_storage_driver(request: Request) -> Any:
+    return getattr(request.app.state, "ipc_storage_driver", None)
+
+
+def _get_ipc_event_publisher(request: Request) -> Any:
+    return getattr(request.app.state, "ipc_event_publisher", None)
+
+
+def _get_ipc_wakeup_notifiers(request: Request) -> list[Any]:
+    return getattr(request.app.state, "ipc_wakeup_notifiers", [])
+
+
+def _get_ipc_zone_id(request: Request) -> str:
+    return getattr(request.app.state, "zone_id", "root")
+
+
 # ---------------------------------------------------------------------------
-# SSE streaming endpoint
+# Send + SSE endpoints
 # ---------------------------------------------------------------------------
+
+
+@router.post("/send")
+async def send_message(
+    body: SendMessageRequest,
+    _request: Request,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),
+    storage: Any = Depends(_get_ipc_storage_driver),
+    event_publisher: Any = Depends(_get_ipc_event_publisher),
+    wakeup_notifiers: list[Any] = Depends(_get_ipc_wakeup_notifiers),
+    cache_store: Any = Depends(_get_ipc_cache_store),
+    zone_id: str = Depends(_get_ipc_zone_id),
+) -> dict[str, Any]:
+    """Compatibility REST endpoint for enqueueing IPC inbox messages."""
+    _validate_agent_id(body.sender)
+    _validate_agent_id(body.recipient)
+    _check_agent_access(auth_result, body.sender)
+
+    if storage is None:
+        raise HTTPException(status_code=503, detail="IPC storage is not available")
+
+    try:
+        envelope = MessageEnvelope.model_validate(
+            {
+                "id": body.message_id,
+                "from": body.sender,
+                "to": body.recipient,
+                "type": body.type,
+                "payload": body.payload,
+                "correlation_id": body.correlation_id,
+                "ttl_seconds": body.ttl_seconds,
+            }
+        )
+        sender = MessageSender(
+            storage=storage,
+            event_publisher=event_publisher,
+            zone_id=zone_id,
+            wakeup_notifiers=wakeup_notifiers,
+            cache_store=cache_store,
+        )
+        message_path = await sender.send(envelope)
+    except EnvelopeValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except InboxNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except InboxFullError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "message_id": envelope.id,
+        "path": message_path,
+        "sender": envelope.sender,
+        "recipient": envelope.recipient,
+        "type": envelope.type.value,
+    }
+
+
+@router.get("/inbox/{agent_id}")
+async def list_inbox(
+    agent_id: str,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),
+    storage: Any = Depends(_get_ipc_storage_driver),
+    zone_id: str = Depends(_get_ipc_zone_id),
+) -> dict[str, Any]:
+    """Compatibility REST endpoint for listing inbox messages."""
+    _validate_agent_id(agent_id)
+    _check_agent_access(auth_result, agent_id)
+
+    if storage is None:
+        raise HTTPException(status_code=503, detail="IPC storage is not available")
+
+    try:
+        filenames = await storage.list_dir(inbox_path(agent_id), zone_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return {
+        "agent_id": agent_id,
+        "messages": [{"filename": name} for name in filenames],
+        "count": len(filenames),
+    }
+
+
+@router.get("/inbox/{agent_id}/count")
+async def inbox_count(
+    agent_id: str,
+    auth_result: dict[str, Any] = Depends(_get_require_auth()),
+    storage: Any = Depends(_get_ipc_storage_driver),
+    zone_id: str = Depends(_get_ipc_zone_id),
+) -> dict[str, Any]:
+    """Compatibility REST endpoint for inbox depth."""
+    _validate_agent_id(agent_id)
+    _check_agent_access(auth_result, agent_id)
+
+    if storage is None:
+        raise HTTPException(status_code=503, detail="IPC storage is not available")
+
+    try:
+        count = await storage.count_dir(inbox_path(agent_id), zone_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return {
+        "agent_id": agent_id,
+        "count": count,
+    }
 
 
 @router.get("/stream/{agent_id}")

--- a/src/nexus/server/api/v2/routers/ipc.py
+++ b/src/nexus/server/api/v2/routers/ipc.py
@@ -25,6 +25,7 @@ from nexus.bricks.ipc.exceptions import (
     InboxFullError,
     InboxNotFoundError,
 )
+from nexus.contracts.constants import ROOT_ZONE_ID
 
 logger = logging.getLogger(__name__)
 
@@ -101,8 +102,8 @@ def _get_ipc_wakeup_notifiers(request: Request) -> list[Any]:
     return getattr(request.app.state, "ipc_wakeup_notifiers", [])
 
 
-def _get_ipc_zone_id(request: Request) -> str:
-    return getattr(request.app.state, "zone_id", "root")
+def _get_auth_zone_id(auth_result: dict[str, Any]) -> str:
+    return auth_result.get("zone_id") or ROOT_ZONE_ID
 
 
 # ---------------------------------------------------------------------------
@@ -119,28 +120,28 @@ async def send_message(
     event_publisher: Any = Depends(_get_ipc_event_publisher),
     wakeup_notifiers: list[Any] = Depends(_get_ipc_wakeup_notifiers),
     cache_store: Any = Depends(_get_ipc_cache_store),
-    zone_id: str = Depends(_get_ipc_zone_id),
 ) -> dict[str, Any]:
     """Compatibility REST endpoint for enqueueing IPC inbox messages."""
     _validate_agent_id(body.sender)
     _validate_agent_id(body.recipient)
     _check_agent_access(auth_result, body.sender)
+    zone_id = _get_auth_zone_id(auth_result)
 
     if storage is None:
         raise HTTPException(status_code=503, detail="IPC storage is not available")
 
     try:
-        envelope = MessageEnvelope.model_validate(
-            {
-                "id": body.message_id,
-                "from": body.sender,
-                "to": body.recipient,
-                "type": body.type,
-                "payload": body.payload,
-                "correlation_id": body.correlation_id,
-                "ttl_seconds": body.ttl_seconds,
-            }
-        )
+        envelope_data: dict[str, Any] = {
+            "from": body.sender,
+            "to": body.recipient,
+            "type": body.type,
+            "payload": body.payload,
+            "correlation_id": body.correlation_id,
+            "ttl_seconds": body.ttl_seconds,
+        }
+        if body.message_id is not None:
+            envelope_data["id"] = body.message_id
+        envelope = MessageEnvelope.model_validate(envelope_data)
         sender = MessageSender(
             storage=storage,
             event_publisher=event_publisher,
@@ -172,11 +173,11 @@ async def list_inbox(
     agent_id: str,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),
     storage: Any = Depends(_get_ipc_storage_driver),
-    zone_id: str = Depends(_get_ipc_zone_id),
 ) -> dict[str, Any]:
     """Compatibility REST endpoint for listing inbox messages."""
     _validate_agent_id(agent_id)
     _check_agent_access(auth_result, agent_id)
+    zone_id = _get_auth_zone_id(auth_result)
 
     if storage is None:
         raise HTTPException(status_code=503, detail="IPC storage is not available")
@@ -198,11 +199,11 @@ async def inbox_count(
     agent_id: str,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),
     storage: Any = Depends(_get_ipc_storage_driver),
-    zone_id: str = Depends(_get_ipc_zone_id),
 ) -> dict[str, Any]:
     """Compatibility REST endpoint for inbox depth."""
     _validate_agent_id(agent_id)
     _check_agent_access(auth_result, agent_id)
+    zone_id = _get_auth_zone_id(auth_result)
 
     if storage is None:
         raise HTTPException(status_code=503, detail="IPC storage is not available")

--- a/src/nexus/server/lifespan/ipc.py
+++ b/src/nexus/server/lifespan/ipc.py
@@ -13,9 +13,28 @@ from nexus.contracts.constants import ROOT_ZONE_ID
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from nexus.contracts.cache_store import CacheStoreABC
     from nexus.server.lifespan.services_container import LifespanServices
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_ipc_cache_store(app: "FastAPI", svc: "LifespanServices") -> "CacheStoreABC | None":
+    """Resolve the cache store used by IPC pub/sub.
+
+    Prefer the runtime CacheBrick when it has a real backend. That avoids
+    binding IPC to a stale NullCacheStore held on NexusFS when permissions
+    startup created a working Dragonfly-backed CacheBrick separately.
+    """
+    cache_brick = getattr(app.state, "cache_brick", None)
+    if cache_brick is None and svc.nexus_fs is not None:
+        _svc_fn = getattr(svc.nexus_fs, "service", None)
+        cache_brick = _svc_fn("cache_brick") if _svc_fn else None
+
+    if cache_brick is not None and getattr(cache_brick, "has_cache_store", False):
+        return getattr(cache_brick, "cache_store", None)
+
+    return getattr(svc.nexus_fs, "cache_store", None)
 
 
 async def startup_ipc(app: "FastAPI", svc: "LifespanServices") -> list[asyncio.Task]:
@@ -46,7 +65,7 @@ async def startup_ipc(app: "FastAPI", svc: "LifespanServices") -> list[asyncio.T
 
     # --- Issue #3197: DT_PIPE wakeup + EventPublisher + CacheStore ---
     wakeup_notifiers = []
-    cache_store = getattr(svc.nexus_fs, "cache_store", None)
+    cache_store = _resolve_ipc_cache_store(app, svc)
     event_publisher = None
 
     # Wire EventPublisher via CacheStore pub/sub so MessageSender publishes

--- a/tests/e2e/server/test_ipc_e2e.py
+++ b/tests/e2e/server/test_ipc_e2e.py
@@ -7,7 +7,7 @@ Tests the full IPC flow through the actual FastAPI server:
 4. Read and verify messages
 5. Test permission enforcement (unauthenticated requests rejected)
 
-Uses a custom auth_server fixture that starts nexus serve with --api-key.
+Uses the shared e2e server fixture with API-key auth enabled.
 """
 
 import json
@@ -19,6 +19,7 @@ import sys
 import time
 from contextlib import closing, suppress
 from datetime import UTC, datetime
+from functools import lru_cache
 from pathlib import Path
 
 import httpx
@@ -26,7 +27,49 @@ import pytest
 
 # ── Fixtures: authenticated server ──────────────────────────────────────
 
-_src_path = Path(__file__).parent.parent.parent / "src"
+_src_path = Path(__file__).resolve().parents[3] / "src"
+
+
+@lru_cache(maxsize=1)
+def _resolve_daemon_python() -> str:
+    """Pick a Python interpreter with the full _nexus_raft extension available."""
+    import shutil
+
+    candidates: list[str] = []
+    env_python = os.environ.get("NEXUS_E2E_PYTHON")
+    if env_python:
+        candidates.append(env_python)
+    candidates.extend(
+        candidate
+        for candidate in [
+            sys.executable,
+            shutil.which("python3"),
+            shutil.which("python"),
+            "/opt/anaconda3/bin/python",
+        ]
+        if candidate
+    )
+
+    probe = "from _nexus_raft import ZoneManager; print('ok')"
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            result = subprocess.run(
+                [candidate, "-c", probe],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONPATH": str(_src_path)},
+            )
+        except OSError:
+            continue
+        if result.returncode == 0 and "ok" in result.stdout:
+            return candidate
+
+    raise RuntimeError("No Python interpreter with _nexus_raft.ZoneManager available for e2e")
 
 
 def _find_free_port() -> int:
@@ -38,12 +81,7 @@ def _find_free_port() -> int:
 
 @pytest.fixture(scope="function")
 def auth_server(tmp_path):
-    """Start nexus serve with database auth + permissions for e2e tests.
-
-    Uses --auth-type database --init to create tables and an admin key,
-    then extracts the generated admin API key from .nexus-admin-env.
-    """
-    import re
+    """Start a Nexus server with static API-key auth for IPC e2e tests."""
     import uuid
 
     db_path = tmp_path / f"test_ipc_{uuid.uuid4().hex[:8]}.db"
@@ -56,24 +94,23 @@ def auth_server(tmp_path):
     env = os.environ.copy()
     env["NEXUS_JWT_SECRET"] = "test-secret-key-for-e2e-12345"
     env["NEXUS_DATABASE_URL"] = f"sqlite:///{db_path}"
-    env["NEXUS_ENFORCE_PERMISSIONS"] = "true"
-    env["NEXUS_RATE_LIMIT_ENABLED"] = "false"
+    env["NEXUS_API_KEY"] = "test-e2e-api-key-12345"
     env["PYTHONPATH"] = str(_src_path)
+    env["HOME"] = str(tmp_path)
 
     process = subprocess.Popen(
         [
-            sys.executable,
+            _resolve_daemon_python(),
             "-c",
             (
                 "from nexus.daemon.main import main; "
                 f"main(['--host', '127.0.0.1', '--port', '{port}', "
-                f"'--data-dir', '{tmp_path}', "
-                "'--auth-type', 'database', '--init'])"
+                f"'--data-dir', '{tmp_path}'])"
             ),
         ],
         env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         cwd=str(tmp_path),
         preexec_fn=os.setsid if sys.platform != "win32" else None,
     )
@@ -90,41 +127,14 @@ def auth_server(tmp_path):
         time.sleep(0.1)
     else:
         process.terminate()
-        stdout, stderr = process.communicate(timeout=10)
-        pytest.fail(
-            f"Auth server failed to start on port {port}.\n"
-            f"stdout: {stdout.decode()[:2000]}\nstderr: {stderr.decode()[:2000]}"
-        )
-
-    # Extract admin API key from .nexus-admin-env file written by --init
-    admin_api_key: str | None = None
-    env_file = tmp_path / ".nexus-admin-env"
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            m = re.search(r"NEXUS_API_KEY='([^']+)'", line)
-            if m:
-                admin_api_key = m.group(1)
-                break
-
-    if not admin_api_key:
-        process.terminate()
-        stdout, stderr = process.communicate(timeout=10)
-        all_output = stdout.decode() + stderr.decode()
-        m = re.search(r"Admin API Key:\s*(sk-\S+)", all_output)
-        if m:
-            admin_api_key = m.group(1)
-        else:
-            pytest.fail(
-                f"Could not find admin API key.\n"
-                f"env_file exists: {env_file.exists()}\n"
-                f"output tail: {all_output[-1000:]}"
-            )
+        process.wait(timeout=10)
+        pytest.fail(f"Auth server failed to start on port {port}.")
 
     yield {
         "port": port,
         "base_url": base_url,
         "process": process,
-        "admin_api_key": admin_api_key,
+        "admin_api_key": env["NEXUS_API_KEY"],
     }
 
     if sys.platform != "win32":
@@ -141,7 +151,7 @@ def auth_server(tmp_path):
 
 @pytest.fixture(scope="function")
 def auth_client(auth_server) -> httpx.Client:
-    """Authenticated httpx client with admin Bearer token."""
+    """Authenticated httpx client with the test Bearer token."""
     with httpx.Client(
         base_url=auth_server["base_url"],
         timeout=30.0,
@@ -234,6 +244,17 @@ def _list_dir(client: httpx.Client, path: str) -> list:
 def _mkdir(client: httpx.Client, path: str) -> dict:
     """Create directory via RPC."""
     return _rpc_call(client, "mkdir", {"path": path, "exist_ok": True})
+
+
+def _provision_ipc_agent(client: httpx.Client, agent_id: str) -> None:
+    """Create the standard IPC directory layout for one agent."""
+    _mkdir(client, "/agents")
+    _mkdir(client, f"/agents/{agent_id}")
+    _mkdir(client, f"/agents/{agent_id}/inbox")
+    _mkdir(client, f"/agents/{agent_id}/outbox")
+    _mkdir(client, f"/agents/{agent_id}/processed")
+    _mkdir(client, f"/agents/{agent_id}/dead_letter")
+    _mkdir(client, f"/agents/{agent_id}/tasks")
 
 
 def _make_envelope(
@@ -365,6 +386,47 @@ class TestIPCViaServer:
         # Discovery: read AGENT.json for capabilities
         search_card = json.loads(_read_file(auth_client, "/agents/search_agent/AGENT.json"))
         assert "semantic_search" in search_card["skills"]
+
+    def test_rest_compat_send_inbox_count(self, auth_client: httpx.Client) -> None:
+        """Compatibility REST endpoints work through the real daemon."""
+        _provision_ipc_agent(auth_client, "agent:alice")
+        _provision_ipc_agent(auth_client, "agent:bob")
+
+        send_response = auth_client.post(
+            "/api/v2/ipc/send",
+            json={
+                "sender": "agent:alice",
+                "recipient": "agent:bob",
+                "type": "task",
+                "payload": {"body": "hello from daemon"},
+                "message_id": "msg_daemon_rest_compat",
+            },
+        )
+        assert send_response.status_code == 200, send_response.text
+        send_data = send_response.json()
+        assert send_data["message_id"] == "msg_daemon_rest_compat"
+        assert send_data["sender"] == "agent:alice"
+        assert send_data["recipient"] == "agent:bob"
+
+        inbox_response = auth_client.get("/api/v2/ipc/inbox/agent:bob")
+        assert inbox_response.status_code == 200, inbox_response.text
+        inbox_data = inbox_response.json()
+        assert inbox_data["agent_id"] == "agent:bob"
+        assert inbox_data["count"] == 1
+        assert len(inbox_data["messages"]) == 1
+        assert "msg_daemon_rest_compat" in inbox_data["messages"][0]["filename"]
+
+        count_response = auth_client.get("/api/v2/ipc/inbox/agent:bob/count")
+        assert count_response.status_code == 200, count_response.text
+        assert count_response.json() == {"agent_id": "agent:bob", "count": 1}
+
+    def test_sse_endpoint_returns_event_stream_headers(self, auth_client: httpx.Client) -> None:
+        """SSE endpoint is exposed through the live daemon."""
+        with auth_client.stream("GET", "/api/v2/ipc/stream/agent:alice") as response:
+            assert response.status_code == 200
+            assert "text/event-stream" in response.headers.get("content-type", "")
+            assert response.headers.get("x-accel-buffering") == "no"
+            assert response.headers.get("cache-control") == "no-cache"
 
 
 class TestIPCLocal:

--- a/tests/unit/raft/test_zone_manager_ctor.py
+++ b/tests/unit/raft/test_zone_manager_ctor.py
@@ -1,0 +1,90 @@
+"""Constructor compatibility tests for the Python Raft ZoneManager wrapper."""
+
+from nexus.raft.peer_address import hostname_to_node_id
+from nexus.raft.zone_manager import _make_py_zone_manager
+
+
+class _HostnameFirstPyZoneManager:
+    def __init__(
+        self,
+        hostname,
+        base_path,
+        bind_addr="0.0.0.0:2126",
+        tls_cert_path=None,
+        tls_key_path=None,
+        tls_ca_path=None,
+        ca_key_path=None,
+        join_token_hash=None,
+    ):
+        self.args = {
+            "hostname": hostname,
+            "base_path": base_path,
+            "bind_addr": bind_addr,
+            "tls_cert_path": tls_cert_path,
+            "tls_key_path": tls_key_path,
+            "tls_ca_path": tls_ca_path,
+            "ca_key_path": ca_key_path,
+            "join_token_hash": join_token_hash,
+        }
+
+
+class _NodeIdFirstPyZoneManager:
+    def __init__(
+        self,
+        node_id,
+        base_path,
+        bind_addr="0.0.0.0:2126",
+        tls_cert_path=None,
+        tls_key_path=None,
+        tls_ca_path=None,
+        ca_key_path=None,
+        join_token_hash=None,
+    ):
+        self.args = {
+            "node_id": node_id,
+            "base_path": base_path,
+            "bind_addr": bind_addr,
+            "tls_cert_path": tls_cert_path,
+            "tls_key_path": tls_key_path,
+            "tls_ca_path": tls_ca_path,
+            "ca_key_path": ca_key_path,
+            "join_token_hash": join_token_hash,
+        }
+
+
+def test_make_py_zone_manager_supports_hostname_first_binding() -> None:
+    mgr = _make_py_zone_manager(
+        _HostnameFirstPyZoneManager,
+        hostname="nexus-1",
+        base_path="/tmp/zones",
+        bind_addr="127.0.0.1:2126",
+        tls_cert_path="cert.pem",
+        tls_key_path="key.pem",
+        tls_ca_path="ca.pem",
+        ca_key_path="ca-key.pem",
+        join_token_hash="hash",
+    )
+
+    assert mgr.args["hostname"] == "nexus-1"
+    assert mgr.args["base_path"] == "/tmp/zones"
+    assert mgr.args["bind_addr"] == "127.0.0.1:2126"
+    assert mgr.args["join_token_hash"] == "hash"
+
+
+def test_make_py_zone_manager_supports_node_id_first_binding() -> None:
+    mgr = _make_py_zone_manager(
+        _NodeIdFirstPyZoneManager,
+        hostname="nexus-1",
+        base_path="/tmp/zones",
+        bind_addr="127.0.0.1:2126",
+        tls_cert_path="cert.pem",
+        tls_key_path="key.pem",
+        tls_ca_path="ca.pem",
+        ca_key_path="ca-key.pem",
+        join_token_hash="hash",
+    )
+
+    assert mgr.args["node_id"] == hostname_to_node_id("nexus-1")
+    assert mgr.args["base_path"] == "/tmp/zones"
+    assert mgr.args["bind_addr"] == "127.0.0.1:2126"
+    assert mgr.args["join_token_hash"] == "hash"

--- a/tests/unit/server/lifespan/test_ipc_cache_resolution.py
+++ b/tests/unit/server/lifespan/test_ipc_cache_resolution.py
@@ -1,0 +1,45 @@
+"""Tests for IPC cache resolution during lifespan startup."""
+
+from types import SimpleNamespace
+
+from nexus.cache import InMemoryCacheStore
+from nexus.contracts.cache_store import NullCacheStore
+from nexus.server.lifespan.ipc import _resolve_ipc_cache_store
+from nexus.server.lifespan.services_container import LifespanServices
+
+
+def test_prefers_cache_brick_store_over_null_kernel_cache() -> None:
+    real_store = InMemoryCacheStore()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            cache_brick=SimpleNamespace(
+                has_cache_store=True,
+                cache_store=real_store,
+            )
+        )
+    )
+    svc = LifespanServices(
+        nexus_fs=SimpleNamespace(
+            cache_store=NullCacheStore(),
+            service=lambda _name: None,
+        )
+    )
+
+    resolved = _resolve_ipc_cache_store(app, svc)
+
+    assert resolved is real_store
+
+
+def test_falls_back_to_kernel_cache_store_without_cache_brick() -> None:
+    kernel_store = InMemoryCacheStore()
+    app = SimpleNamespace(state=SimpleNamespace(cache_brick=None))
+    svc = LifespanServices(
+        nexus_fs=SimpleNamespace(
+            cache_store=kernel_store,
+            service=lambda _name: None,
+        )
+    )
+
+    resolved = _resolve_ipc_cache_store(app, svc)
+
+    assert resolved is kernel_store

--- a/tests/unit/server/routers/test_ipc_router.py
+++ b/tests/unit/server/routers/test_ipc_router.py
@@ -33,6 +33,19 @@ def _override_auth(app: FastAPI) -> None:
     }
 
 
+def _override_auth_zone(app: FastAPI, zone_id: str) -> None:
+    from nexus.server.api.v2.routers.ipc import _get_require_auth
+
+    app.dependency_overrides[_get_require_auth()] = lambda: {
+        "authenticated": True,
+        "subject_type": "agent",
+        "subject_id": "agent:alice",
+        "x_agent_id": "agent:alice",
+        "zone_id": zone_id,
+        "is_admin": True,
+    }
+
+
 def test_post_send_enqueues_message() -> None:
     storage = InMemoryStorageDriver()
     provisioner = AgentProvisioner(storage, zone_id="root")
@@ -79,6 +92,41 @@ def test_post_send_enqueues_message() -> None:
     assert envelope["payload"]["body"] == "hello"
 
 
+def test_post_send_generates_message_id_when_omitted() -> None:
+    storage = InMemoryStorageDriver()
+    provisioner = AgentProvisioner(storage, zone_id="root")
+    asyncio.run(provisioner.provision("agent:alice", name="Alice"))
+    asyncio.run(provisioner.provision("agent:bob", name="Bob"))
+
+    app = FastAPI()
+    app.state.ipc_storage_driver = storage
+    app.state.ipc_event_publisher = None
+    app.state.ipc_wakeup_notifiers = []
+    app.state.ipc_cache_store = None
+    app.state.zone_id = "wrong-zone"
+    app.include_router(router)
+    _override_auth(app)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v2/ipc/send",
+        json={
+            "sender": "agent:alice",
+            "recipient": "agent:bob",
+            "type": "task",
+            "payload": {"body": "hello"},
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["message_id"], str)
+    assert data["message_id"]
+
+    inbox_entries = asyncio.run(storage.list_dir(inbox_path("agent:bob"), "root"))
+    assert any(data["message_id"] in entry for entry in inbox_entries)
+
+
 def test_inbox_and_count_return_compatibility_shapes() -> None:
     storage = InMemoryStorageDriver()
     provisioner = AgentProvisioner(storage, zone_id="root")
@@ -119,6 +167,53 @@ def test_inbox_and_count_return_compatibility_shapes() -> None:
     assert count_response.status_code == 200
     count_data = count_response.json()
     assert count_data == {"agent_id": "agent:bob", "count": 1}
+
+
+def test_rest_endpoints_use_authenticated_zone_instead_of_app_state() -> None:
+    storage = InMemoryStorageDriver()
+    provisioner = AgentProvisioner(storage, zone_id="tenant-a")
+    asyncio.run(provisioner.provision("agent:alice", name="Alice"))
+    asyncio.run(provisioner.provision("agent:bob", name="Bob"))
+
+    app = FastAPI()
+    app.state.ipc_storage_driver = storage
+    app.state.ipc_event_publisher = None
+    app.state.ipc_wakeup_notifiers = []
+    app.state.ipc_cache_store = None
+    app.state.zone_id = "root"
+    app.include_router(router)
+    _override_auth_zone(app, "tenant-a")
+
+    client = TestClient(app)
+    send_response = client.post(
+        "/api/v2/ipc/send",
+        json={
+            "sender": "agent:alice",
+            "recipient": "agent:bob",
+            "type": "task",
+            "payload": {"body": "hello"},
+            "message_id": "msg_router_zone",
+        },
+    )
+    assert send_response.status_code == 200
+
+    tenant_entries = asyncio.run(storage.list_dir(inbox_path("agent:bob"), "tenant-a"))
+    assert any("msg_router_zone" in entry for entry in tenant_entries)
+
+    root_entries_error: FileNotFoundError | None = None
+    try:
+        asyncio.run(storage.list_dir(inbox_path("agent:bob"), "root"))
+    except FileNotFoundError as exc:
+        root_entries_error = exc
+    assert root_entries_error is not None
+
+    inbox_response = client.get("/api/v2/ipc/inbox/agent:bob")
+    assert inbox_response.status_code == 200
+    assert inbox_response.json()["count"] == 1
+
+    count_response = client.get("/api/v2/ipc/inbox/agent:bob/count")
+    assert count_response.status_code == 200
+    assert count_response.json() == {"agent_id": "agent:bob", "count": 1}
 
 
 def test_sse_stream_emits_connected_and_delivery_event() -> None:
@@ -164,7 +259,6 @@ def test_sse_stream_emits_connected_and_delivery_event() -> None:
                 event_publisher,
                 [],
                 cache_store,
-                "root",
             )
         )
         delivery_event = await asyncio.wait_for(delivery_task, timeout=1.0)

--- a/tests/unit/server/routers/test_ipc_router.py
+++ b/tests/unit/server/routers/test_ipc_router.py
@@ -1,0 +1,179 @@
+"""Tests for IPC REST router compatibility endpoints."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.bricks.ipc.conventions import inbox_path
+from nexus.bricks.ipc.provisioning import AgentProvisioner
+from nexus.bricks.ipc.wakeup import CacheStoreEventPublisher
+from nexus.cache import InMemoryCacheStore
+from nexus.server.api.v2.routers.ipc import (
+    SendMessageRequest,
+    router,
+    send_message,
+    stream_inbox,
+)
+from tests.unit.bricks.ipc.fakes import InMemoryStorageDriver
+
+
+def _override_auth(app: FastAPI) -> None:
+    from nexus.server.api.v2.routers.ipc import _get_require_auth
+
+    app.dependency_overrides[_get_require_auth()] = lambda: {
+        "authenticated": True,
+        "subject_type": "agent",
+        "subject_id": "agent:alice",
+        "x_agent_id": "agent:alice",
+        "zone_id": "root",
+        "is_admin": True,
+    }
+
+
+def test_post_send_enqueues_message() -> None:
+    storage = InMemoryStorageDriver()
+    provisioner = AgentProvisioner(storage, zone_id="root")
+    asyncio.run(provisioner.provision("agent:alice", name="Alice"))
+    asyncio.run(provisioner.provision("agent:bob", name="Bob"))
+
+    app = FastAPI()
+    app.state.ipc_storage_driver = storage
+    app.state.ipc_event_publisher = None
+    app.state.ipc_wakeup_notifiers = []
+    app.state.ipc_cache_store = None
+    app.state.zone_id = "root"
+    app.include_router(router)
+    _override_auth(app)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v2/ipc/send",
+        json={
+            "sender": "agent:alice",
+            "recipient": "agent:bob",
+            "type": "task",
+            "payload": {"body": "hello"},
+            "message_id": "msg_router_send",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["message_id"] == "msg_router_send"
+    assert data["sender"] == "agent:alice"
+    assert data["recipient"] == "agent:bob"
+
+    inbox_entries = asyncio.run(storage.list_dir(inbox_path("agent:bob"), "root"))
+    assert any("msg_router_send" in entry for entry in inbox_entries)
+
+    msg_filename = next(entry for entry in inbox_entries if "msg_router_send" in entry)
+    payload = asyncio.run(
+        storage.sys_read(f"{inbox_path('agent:bob')}/{msg_filename}", "root")
+    ).decode("utf-8")
+    envelope = json.loads(payload)
+    assert envelope["from"] == "agent:alice"
+    assert envelope["to"] == "agent:bob"
+    assert envelope["payload"]["body"] == "hello"
+
+
+def test_inbox_and_count_return_compatibility_shapes() -> None:
+    storage = InMemoryStorageDriver()
+    provisioner = AgentProvisioner(storage, zone_id="root")
+    asyncio.run(provisioner.provision("agent:alice", name="Alice"))
+    asyncio.run(provisioner.provision("agent:bob", name="Bob"))
+
+    app = FastAPI()
+    app.state.ipc_storage_driver = storage
+    app.state.ipc_event_publisher = None
+    app.state.ipc_wakeup_notifiers = []
+    app.state.ipc_cache_store = None
+    app.state.zone_id = "root"
+    app.include_router(router)
+    _override_auth(app)
+
+    client = TestClient(app)
+    send_response = client.post(
+        "/api/v2/ipc/send",
+        json={
+            "sender": "agent:alice",
+            "recipient": "agent:bob",
+            "type": "task",
+            "payload": {"body": "hello"},
+            "message_id": "msg_router_list",
+        },
+    )
+    assert send_response.status_code == 200
+
+    inbox_response = client.get("/api/v2/ipc/inbox/agent:bob")
+    assert inbox_response.status_code == 200
+    inbox_data = inbox_response.json()
+    assert inbox_data["agent_id"] == "agent:bob"
+    assert inbox_data["count"] == 1
+    assert len(inbox_data["messages"]) == 1
+    assert "msg_router_list" in inbox_data["messages"][0]["filename"]
+
+    count_response = client.get("/api/v2/ipc/inbox/agent:bob/count")
+    assert count_response.status_code == 200
+    count_data = count_response.json()
+    assert count_data == {"agent_id": "agent:bob", "count": 1}
+
+
+def test_sse_stream_emits_connected_and_delivery_event() -> None:
+    storage = InMemoryStorageDriver()
+    provisioner = AgentProvisioner(storage, zone_id="root")
+    asyncio.run(provisioner.provision("agent:alice", name="Alice"))
+    asyncio.run(provisioner.provision("agent:bob", name="Bob"))
+
+    cache_store = InMemoryCacheStore()
+    event_publisher = CacheStoreEventPublisher(cache_store)
+    app = FastAPI()
+    app.state.ipc_cache_store = cache_store
+
+    async def _run() -> tuple[str, str]:
+        request = SimpleNamespace(
+            app=app,
+            is_disconnected=lambda: asyncio.sleep(0, result=False),
+        )
+        auth = {
+            "authenticated": True,
+            "subject_type": "agent",
+            "subject_id": "agent:alice",
+            "x_agent_id": "agent:alice",
+            "zone_id": "root",
+            "is_admin": True,
+        }
+
+        response = await stream_inbox("agent:bob", request, auth, cache_store)
+        connected_event = await anext(response.body_iterator)
+        delivery_task = asyncio.create_task(anext(response.body_iterator))
+        send_task = asyncio.create_task(
+            send_message(
+                SendMessageRequest(
+                    sender="agent:alice",
+                    recipient="agent:bob",
+                    type="task",
+                    payload={"body": "hello"},
+                    message_id="msg_router_sse",
+                ),
+                request,
+                auth,
+                storage,
+                event_publisher,
+                [],
+                cache_store,
+                "root",
+            )
+        )
+        delivery_event = await asyncio.wait_for(delivery_task, timeout=1.0)
+        send_result = await send_task
+        assert send_result["message_id"] == "msg_router_sse"
+        return connected_event, delivery_event
+
+    connected_event, delivery_event = asyncio.run(_run())
+    assert "event: connected" in connected_event
+    assert '"agent_id": "agent:bob"' in connected_event
+    assert "event: message_delivered" in delivery_event
+    assert "msg_router_sse" in delivery_event


### PR DESCRIPTION
## Summary
- fix IPC SSE cache resolution to prefer the live cache brick and restore REST compatibility endpoints for send, inbox, and inbox count
- fix REST IPC compatibility to preserve autogenerated message IDs when callers omit `message_id` and scope send/inbox/count to the authenticated caller's zone instead of `app.state.zone_id`
- make the Python Raft ZoneManager wrapper compatible with both hostname-first and node_id-first `_nexus_raft` bindings so `nexusd` boots in mixed local environments
- add unit coverage for IPC cache resolution, router SSE delivery, REST compatibility behavior, and ZoneManager constructor compatibility, plus daemon-backed IPC e2e coverage

## Testing
- `PYTHONPATH=src uv run pytest -q -o addopts='' tests/unit/raft/test_zone_manager_ctor.py tests/unit/server/lifespan/test_ipc_cache_resolution.py tests/unit/server/routers/test_ipc_router.py tests/e2e/server/test_ipc_e2e.py -k 'test_make_py_zone_manager_supports_hostname_first_binding or test_make_py_zone_manager_supports_node_id_first_binding or test_prefers_cache_brick_store_over_null_kernel_cache or test_falls_back_to_kernel_cache_store_without_cache_brick or test_post_send_enqueues_message or test_post_send_generates_message_id_when_omitted or test_inbox_and_count_return_compatibility_shapes or test_rest_endpoints_use_authenticated_zone_instead_of_app_state or test_sse_stream_emits_connected_and_delivery_event or test_unauthenticated_request_rejected or test_rest_compat_send_inbox_count or test_sse_endpoint_returns_event_stream_headers'`
