### PR TITLE
chore: bump version to 0.9.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_pyo3"
-version = "0.9.12"
+version = "0.9.14"
 dependencies = [
  "ahash",
  "blake3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.12"
+version = "0.9.14"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_pyo3"
-version = "0.9.12"
+version = "0.9.14"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_pyo3/pyproject.toml
+++ b/rust/nexus_pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-fast"
-version = "0.9.12"
+version = "0.9.14"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [


### PR DESCRIPTION
## Summary
- bump release metadata to 0.9.14
- sync Python and Rust package versions with Cargo.lock

## Verification
- bun test (packages/nexus-tui)
- cargo check -p nexus_pyo3

## Notes
- direct pushes to develop are blocked by repo rules, so this release bump is submitted via PR for merge queue + status checks