### PR TITLE
cleanup: service injection consolidation (Phase 3)

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4364,6 +4364,10 @@ class NexusFS(  # type: ignore[misc]
             except Exception as exc:
                 logger.debug("close: callback failed (best-effort): %s", exc)
 
+        # Auto-close all enlisted services that have a close() method
+        # (rebac_manager, audit_store, etc.). Reverse registration order.
+        self._service_registry.close_all_services()
+
         # Close metadata store
         self.metadata.close()
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -154,10 +154,8 @@ class NexusFS(  # type: ignore[misc]
         # Issue #1788: distributed lock manager removed — now routed through EventsService.
         # In-process locks use _vfs_lock_manager (kernel owns); advisory locks use
         # nx.service("events_service").lock() which auto-creates local fallback.
-        # Issue #1792: agent registry — kernel knows, factory provides.
-        # Kernel does NOT own AgentRegistry (no-agent profiles like REMOTE work without it).
-        # Factory creates and injects at link-time; None = graceful degrade.
-        self._agent_registry: Any = None
+        # Issue #1792: AgentRegistry accessed via ServiceRegistry (register_factory).
+        # No kernel sentinel — no-agent profiles (REMOTE) never construct it.
         # Issue #1801: _flush_write_observer_fn and _overlay_config_fn closures removed —
         # kernel now reads services directly from service registry.
         # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -562,6 +562,24 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
             logger.info("[COORDINATOR] stopped %d persistent services: %s", len(stopped), stopped)
         return stopped
 
+    def close_all_services(self) -> None:
+        """Call close() on all services that have it. Reverse registration order.
+
+        Handles sync cleanup (rebac_manager.close(), audit_store.close(), etc.)
+        that previously required manual _close_callbacks in _lifecycle.py.
+        Runs BEFORE pillar close so DB connections are still open.
+        """
+        for name in self._ordered_names(reverse=True):
+            info = self.service_info(name)
+            if info is None:
+                continue
+            instance = info.instance
+            if instance is not None and hasattr(instance, "close") and callable(instance.close):
+                try:
+                    instance.close()
+                except Exception as exc:
+                    logger.debug("[COORDINATOR] close(%r) failed (best-effort): %s", name, exc)
+
     def _unregister_all_hooks(self) -> None:
         """Unregister all hooks from dispatch. Used by aclose()."""
         for name in list(self._hook_specs):

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -157,7 +157,6 @@ async def _wire_services(
     # Federation — wire from parameter (profile-gated, created before kernel).
     if federation is not None:
         await nx._service_registry.enlist("federation", federation)
-        nx._zone_mgr = federation.zone_manager  # backward compat for health checks
         logger.debug("[LINK] Federation service enlisted")
 
         # Upgrade lock manager: LocalLockManager → RaftLockManager

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -268,8 +268,6 @@ async def _wire_services(
 
             nx._close_callbacks.append(_close_agent_registry)
 
-        # Keep kernel sentinel in sync for backward compat
-        nx._agent_registry = _ar
         logger.debug("[BOOT:LINK] AgentRegistry lazy-constructed on first access")
         return _ar
 

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -48,7 +48,7 @@ async def _wire_services(
     """
     from nexus.contracts.deployment_profile import DeploymentProfile as _DP
     from nexus.factory._wired import _boot_post_kernel_services
-    from nexus.factory.service_routing import enlist_wired_services
+    from nexus.factory.service_routing import enlist_services, enlist_wired_services
 
     _svc = services or {}
     nx._permission_enforcer = _svc.get("permission_enforcer")  # Issue #1706: override sentinel
@@ -141,18 +141,9 @@ async def _wire_services(
     if _mount_svc is not None:
         _mount_svc._driver_coordinator = nx._driver_coordinator
 
-    # Enlist all services into ServiceRegistry (unified loop).
-    # After this, every service is available via nx.service("name").
-    # Note: permission_enforcer stays as kernel-owns DI (Issue #1815).
-    # Canonical name mapping for services that need aliasing.
-    _CANONICAL_ALIASES = {
-        "context_branch_service": "context_branch",
-    }
-    for _attr, _val in _svc.items():
-        if _val is None:
-            continue
-        _canonical = _CANONICAL_ALIASES.get(_attr, _attr)
-        await nx._service_registry.enlist(_canonical, _val)
+    # Enlist all system+brick services into ServiceRegistry.
+    # Canonical name mapping consolidated in service_routing.py.
+    await enlist_services(nx._service_registry, _svc)
 
     # Federation — wire from parameter (profile-gated, created before kernel).
     if federation is not None:
@@ -228,27 +219,8 @@ async def _wire_services(
     # Issue #1801: _flush_write_observer_fn closure removed — kernel now reads
     # write_observer directly from service registry via nx.service("write_observer").
 
-    _rebac = _svc.get("rebac_manager")
-    if _rebac is not None and hasattr(_rebac, "close"):
-
-        def _close_rebac() -> None:
-            try:
-                _rebac.close()
-            except Exception as exc:
-                logger.debug("close: rebac_manager.close() failed: %s", exc)
-
-        nx._close_callbacks.append(_close_rebac)
-
-    _audit = _svc.get("audit_store")
-    if _audit is not None and hasattr(_audit, "close"):
-
-        def _close_audit() -> None:
-            try:
-                _audit.close()
-            except Exception as exc:
-                logger.debug("close: audit_store.close() failed: %s", exc)
-
-        nx._close_callbacks.append(_close_audit)
+    # rebac_manager.close() and audit_store.close() are now handled by
+    # ServiceRegistry.close_all_services() — no manual callbacks needed.
 
     # Issue #1792: AgentRegistry — lazy construct via ServiceRegistry.register_factory().
     # Only created on first access (ACP/TaskManager/EvictionManager need it).

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -426,7 +426,7 @@ def _boot_pre_kernel_services(
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] SchedulerService unavailable: %s", exc)
 
-    # (Federation is created at link time in _lifecycle.py when nx._zone_mgr is available.)
+    # (Federation is wired at link time in _lifecycle.py via the federation parameter.)
 
     # (PipeManager + StreamManager are kernel-owned primitives in NexusFS.__init__.
     # AgentRegistry is lazy-constructed via register_factory().

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -312,13 +312,13 @@ async def _boot_post_kernel_services(
     # AgentStatusResolver moved to orchestrator._register_vfs_hooks() (Issue #1570, #1810)
 
     acp_rpc_service: Any = None
-    # Issue #1792: AcpService is created in _do_link() using kernel-owned
-    # nx._agent_registry. Retrieve from nx (set by _do_link).
+    # Issue #1792: AcpService is created in _wire_services() via ServiceRegistry.
     _acp_ref = nx._service_registry.service("acp_service")
     _acp_service = _acp_ref._service_instance if _acp_ref is not None else None
     if _acp_service is None:
-        # Fallback: construct inline using kernel-owned AgentRegistry.
-        _acp_pt = getattr(nx, "_agent_registry", None)
+        # Fallback: construct inline using AgentRegistry from ServiceRegistry.
+        _acp_ar_ref = nx._service_registry.service("agent_registry")
+        _acp_pt = _acp_ar_ref._service_instance if _acp_ar_ref is not None else None
         if _acp_pt is not None:
             try:
                 from nexus.services.acp.service import AcpService

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -106,6 +106,31 @@ _CANONICAL_NAMES: dict[str, str] = {
 }
 
 
+# Canonical name aliases for dict-keyed services (pre-kernel + brick dicts).
+# Parallel to _CANONICAL_NAMES for wired (dataclass) services.
+_ENLIST_CANONICAL_NAMES: dict[str, str] = {
+    "context_branch_service": "context_branch",
+}
+
+
+async def enlist_services(coordinator: Any, services: dict[str, Any]) -> int:
+    """Enlist services from a dict via coordinator.enlist().
+
+    Same pattern as enlist_wired_services() but for plain dicts
+    (pre-kernel tier + brick tier merged). Skips None values.
+
+    Returns the number of services enlisted.
+    """
+    count = 0
+    for attr, val in services.items():
+        if val is None:
+            continue
+        canonical = _ENLIST_CANONICAL_NAMES.get(attr, attr)
+        await coordinator.enlist(canonical, val)
+        count += 1
+    return count
+
+
 async def enlist_wired_services(coordinator: Any, wired: Any) -> int:
     """Enlist WiredServices via coordinator.enlist() (#1708).
 

--- a/src/nexus/server/health/probes.py
+++ b/src/nexus/server/health/probes.py
@@ -47,11 +47,9 @@ def _check_raft_topology(request: Request) -> tuple[bool, str]:
             return True, ""
         if not _fed.ensure_topology():
             return False, "Raft topology not ready"
-        zone_mgr = getattr(nx_fs, "_zone_mgr", None)
-        if zone_mgr is None:
-            return True, ""
-        root_zone_id = getattr(zone_mgr, "root_zone_id", None) or ROOT_ZONE_ID
-        root_store = zone_mgr.get_store(root_zone_id)
+        _zmgr = _fed.zone_manager
+        root_zone_id = getattr(_zmgr, "root_zone_id", None) or ROOT_ZONE_ID
+        root_store = _zmgr.get_store(root_zone_id)
         if root_store is None:
             return False, "Raft root store not ready"
         if hasattr(root_store, "is_leader") and not root_store.is_leader():

--- a/tests/unit/server/health/test_probes.py
+++ b/tests/unit/server/health/test_probes.py
@@ -108,14 +108,15 @@ class TestReadinessProbe:
         for phase in _REQUIRED_FOR_READY:
             tracker.complete(phase)
 
-        mock_fed = MagicMock()
-        mock_fed.ensure_topology.return_value = True
-        mock_fs = MagicMock()
-        mock_fs._zone_mgr.ensure_topology.return_value = True
-        mock_fs._zone_mgr.root_zone_id = "root"
         mock_root_store = MagicMock()
         mock_root_store.is_leader.return_value = True
-        mock_fs._zone_mgr.get_store.return_value = mock_root_store
+        mock_zmgr = MagicMock()
+        mock_zmgr.root_zone_id = "root"
+        mock_zmgr.get_store.return_value = mock_root_store
+        mock_fed = MagicMock()
+        mock_fed.ensure_topology.return_value = True
+        mock_fed.zone_manager = mock_zmgr
+        mock_fs = MagicMock()
         mock_fs.service.return_value = mock_fed
 
         app = _make_app(tracker)
@@ -129,15 +130,16 @@ class TestReadinessProbe:
         for phase in _REQUIRED_FOR_READY:
             tracker.complete(phase)
 
-        mock_fed = MagicMock()
-        mock_fed.ensure_topology.return_value = True
-        mock_fs = MagicMock()
-        mock_fs.service.return_value = mock_fed
-        mock_fs._zone_mgr.ensure_topology.return_value = True
-        mock_fs._zone_mgr.root_zone_id = "root"
         mock_root_store = MagicMock()
         mock_root_store.is_leader.return_value = False
-        mock_fs._zone_mgr.get_store.return_value = mock_root_store
+        mock_zmgr = MagicMock()
+        mock_zmgr.root_zone_id = "root"
+        mock_zmgr.get_store.return_value = mock_root_store
+        mock_fed = MagicMock()
+        mock_fed.ensure_topology.return_value = True
+        mock_fed.zone_manager = mock_zmgr
+        mock_fs = MagicMock()
+        mock_fs.service.return_value = mock_fed
 
         app = _make_app(tracker)
         app.state.nexus_fs = mock_fs


### PR DESCRIPTION
## Summary

- Delete `_zone_mgr` backward compat — probes.py uses `federation.zone_manager` via ServiceRegistry
- Delete `_agent_registry` sentinel double-write — all consumers receive via constructor DI
- Consolidate two enlist loops into `enlist_services()` + `enlist_wired_services()` in service_routing.py
- Add `ServiceRegistry.close_all_services()` — auto-close enlisted services with `.close()`, replacing 2 manual `_close_callbacks`

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — 45 passed
- [x] `pytest tests/unit/server/health/test_probes.py` — 15 passed
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)