### PR TITLE
fix(files): filter internal cfg: and ns: paths from sys_readdir (#3388)

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4140,13 +4140,13 @@ class NexusFS(  # type: ignore[misc]
 
     # Issue #3388: Internal metastore prefixes that must not appear in
     # user-facing directory listings (search checkpoints, ReBAC namespaces).
+    # These are bare keys (no leading "/") — user paths always start with "/".
     _INTERNAL_PATH_PREFIXES = ("cfg:", "ns:")
 
     @staticmethod
     def _is_internal_path(path: str) -> bool:
-        """Return True for system-internal metastore paths."""
-        root = path.lstrip("/").split("/")[0] if "/" in path else path.lstrip("/")
-        return root.startswith(NexusFS._INTERNAL_PATH_PREFIXES)
+        """Return True for system-internal metastore paths (bare keys)."""
+        return path.startswith(NexusFS._INTERNAL_PATH_PREFIXES)
 
     @rpc_expose(description="List directory entries")
     async def sys_readdir(

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4138,6 +4138,16 @@ class NexusFS(  # type: ignore[misc]
             "version": entry.version,
         }
 
+    # Issue #3388: Internal metastore prefixes that must not appear in
+    # user-facing directory listings (search checkpoints, ReBAC namespaces).
+    _INTERNAL_PATH_PREFIXES = ("cfg:", "ns:")
+
+    @staticmethod
+    def _is_internal_path(path: str) -> bool:
+        """Return True for system-internal metastore paths."""
+        root = path.lstrip("/").split("/")[0] if "/" in path else path.lstrip("/")
+        return root.startswith(NexusFS._INTERNAL_PATH_PREFIXES)
+
     @rpc_expose(description="List directory entries")
     async def sys_readdir(
         self,
@@ -4157,7 +4167,11 @@ class NexusFS(  # type: ignore[misc]
         if limit is not None:
             from nexus.core.pagination import paginate_iter
 
-            items_iter = self.metadata.list_iter(prefix=prefix, recursive=recursive)
+            items_iter = (
+                e
+                for e in self.metadata.list_iter(prefix=prefix, recursive=recursive)
+                if not self._is_internal_path(e.path)
+            )
             result = paginate_iter(items_iter, limit=limit, cursor_path=cursor)
             if details:
                 result.items = [self._entry_to_detail_dict(e, recursive) for e in result.items]
@@ -4166,6 +4180,7 @@ class NexusFS(  # type: ignore[misc]
             return result
 
         entries = self.metadata.list(prefix=prefix, recursive=recursive)
+        entries = [e for e in entries if not self._is_internal_path(e.path)]
         if details:
             return [self._entry_to_detail_dict(e, recursive) for e in entries]
         return [e.path for e in entries]

--- a/tests/unit/core/test_sys_readdir_internal_filter.py
+++ b/tests/unit/core/test_sys_readdir_internal_filter.py
@@ -43,6 +43,11 @@ class TestIsInternalPath:
             "workspace",
             "/workspace",
             "mnt",
+            # User paths starting with /cfg: or /ns: must NOT be filtered —
+            # only bare keys (no leading slash) are internal metastore entries.
+            "/cfg:user-visible",
+            "/ns:notes",
+            "/cfg:something/nested",
         ],
     )
     def test_user_paths_not_filtered(self, path: str) -> None:

--- a/tests/unit/core/test_sys_readdir_internal_filter.py
+++ b/tests/unit/core/test_sys_readdir_internal_filter.py
@@ -1,0 +1,142 @@
+"""Tests for Issue #3388: sys_readdir must filter internal cfg: and ns: paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.core.nexus_fs import NexusFS
+
+# ---------------------------------------------------------------------------
+# _is_internal_path unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsInternalPath:
+    """NexusFS._is_internal_path correctly identifies system-internal paths."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "cfg:search_mutation_checkpoint:bm25",
+            "cfg:search_mutation_checkpoint:embedding",
+            "cfg:search_mutation_checkpoint:fts",
+            "cfg:search_mutation_checkpoint:txtai",
+            "ns:rebac:file",
+            "ns:rebac:group",
+            "ns:rebac:memory",
+            "ns:rebac:playbook",
+            "ns:rebac:skill",
+            "ns:rebac:trajectory",
+        ],
+    )
+    def test_internal_paths_detected(self, path: str) -> None:
+        assert NexusFS._is_internal_path(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/workspace/demo/README.md",
+            "/mnt/data.csv",
+            "workspace",
+            "/workspace",
+            "mnt",
+        ],
+    )
+    def test_user_paths_not_filtered(self, path: str) -> None:
+        assert NexusFS._is_internal_path(path) is False
+
+
+# ---------------------------------------------------------------------------
+# sys_readdir integration (mock metadata store)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeMeta:
+    path: str
+    size: int = 0
+    etag: str | None = None
+    entry_type: int = 0
+    zone_id: str | None = None
+    owner_id: str | None = None
+    modified_at: object = None
+    version: int = 1
+    backend_name: str = ""
+    physical_path: str = ""
+
+
+def _build_fs(entries: list[_FakeMeta]) -> NexusFS:
+    """Create a NexusFS with a mocked metadata store returning *entries*."""
+    meta = MagicMock()
+    meta.list.return_value = entries
+    meta.list_iter.return_value = iter(entries)
+    meta.is_implicit_directory.return_value = False
+
+    fs = object.__new__(NexusFS)
+    fs.metadata = meta
+    return fs
+
+
+class TestSysReaddirInternalFilter:
+    """sys_readdir excludes cfg: and ns: entries from results."""
+
+    @pytest.mark.asyncio
+    async def test_non_paginated_filters_internal_paths(self) -> None:
+        fs = _build_fs(
+            [
+                _FakeMeta(path="cfg:search_mutation_checkpoint:bm25", entry_type=1),
+                _FakeMeta(path="cfg:search_mutation_checkpoint:embedding", entry_type=1),
+                _FakeMeta(path="/workspace", entry_type=1),
+                _FakeMeta(path="ns:rebac:file", entry_type=1),
+                _FakeMeta(path="ns:rebac:group", entry_type=1),
+            ]
+        )
+
+        result = await fs.sys_readdir("/", recursive=False, details=False)
+
+        assert result == ["/workspace"]
+
+    @pytest.mark.asyncio
+    async def test_non_paginated_details_filters_internal_paths(self) -> None:
+        fs = _build_fs(
+            [
+                _FakeMeta(path="cfg:search_mutation_checkpoint:bm25", entry_type=1),
+                _FakeMeta(path="/workspace", entry_type=1),
+                _FakeMeta(path="ns:rebac:file", entry_type=1),
+            ]
+        )
+
+        result = await fs.sys_readdir("/", recursive=False, details=True)
+
+        assert len(result) == 1
+        assert result[0]["path"] == "/workspace"
+
+    @pytest.mark.asyncio
+    async def test_paginated_filters_internal_paths(self) -> None:
+        fs = _build_fs(
+            [
+                _FakeMeta(path="cfg:search_mutation_checkpoint:bm25", entry_type=1),
+                _FakeMeta(path="/workspace", entry_type=1),
+                _FakeMeta(path="ns:rebac:file", entry_type=1),
+            ]
+        )
+
+        result = await fs.sys_readdir("/", recursive=False, details=False, limit=10)
+
+        assert list(result.items) == ["/workspace"]
+
+    @pytest.mark.asyncio
+    async def test_user_paths_not_affected(self) -> None:
+        fs = _build_fs(
+            [
+                _FakeMeta(path="/workspace/demo/README.md"),
+                _FakeMeta(path="/workspace/demo/data.csv"),
+            ]
+        )
+
+        result = await fs.sys_readdir("/workspace/demo", recursive=False, details=False)
+
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

- Filter `cfg:` (search indexer checkpoints) and `ns:` (ReBAC namespace tuples) entries from `NexusFS.sys_readdir()` results
- These internal entries were migrated into the Raft metastore (Issues #183, #184) and share the same key space as user files — `sys_readdir` is the right boundary to exclude them from user-facing listings
- Filtering at this level covers all consumers: REST API (`/api/v2/files/list`), JSON-RPC, and the Python TUI

## Test plan

- [x] 19 unit tests: `_is_internal_path` parametrized for all known internal paths + `sys_readdir` with mocked metadata store
- [x] 7 existing pagination tests still pass
- [x] E2E: demo preset seeded → root listing returns only `/workspace`, all 10 internal entries filtered

Closes #3388