### PR TITLE
fix: federation gating by IPC brick + remove is_leader readiness check

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -408,8 +408,9 @@ async def connect(
     metadata_store: MetastoreABC
     federation = None
 
-    # Federation gating: only attempt if "federation" brick is enabled
-    if "federation" in enabled_bricks:
+    # Federation: attempt when IPC brick is enabled (cluster profile and above).
+    # Federation is a system service (not a brick) but requires IPC infrastructure.
+    if "ipc" in enabled_bricks:
         try:
             from nexus.raft.federation import NexusFederation
 

--- a/src/nexus/server/health/probes.py
+++ b/src/nexus/server/health/probes.py
@@ -52,8 +52,8 @@ def _check_raft_topology(request: Request) -> tuple[bool, str]:
         root_store = _zmgr.get_store(root_zone_id)
         if root_store is None:
             return False, "Raft root store not ready"
-        if hasattr(root_store, "is_leader") and not root_store.is_leader():
-            return False, "Raft leader not ready"
+        # Followers are ready too — they serve reads and forward writes.
+        # Only check that root store exists (leader election is Raft-internal).
         return True, ""
     except Exception:
         return True, ""

--- a/tests/unit/server/health/test_probes.py
+++ b/tests/unit/server/health/test_probes.py
@@ -125,7 +125,8 @@ class TestReadinessProbe:
         resp = client.get("/healthz/ready")
         assert resp.status_code == 200
 
-    def test_503_when_root_leader_not_ready(self) -> None:
+    def test_200_when_follower(self) -> None:
+        """Follower nodes are ready — they serve reads and forward writes."""
         tracker = StartupTracker()
         for phase in _REQUIRED_FOR_READY:
             tracker.complete(phase)
@@ -145,8 +146,7 @@ class TestReadinessProbe:
         app.state.nexus_fs = mock_fs
         client = TestClient(app)
         resp = client.get("/healthz/ready")
-        assert resp.status_code == 503
-        assert resp.json()["reason"] == "Raft leader not ready"
+        assert resp.status_code == 200
 
     def test_503_on_db_pool_exhausted(self) -> None:
         tracker = StartupTracker()


### PR DESCRIPTION
## Summary

Two regressions from recent develop changes:

1. **Federation gating**: `__init__.py` checked `if "federation" in enabled_bricks` but `BRICK_FEDERATION` was removed. Changed to `if "ipc" in enabled_bricks` — federation is a system service available when IPC infrastructure is enabled.

2. **Readiness probe**: `is_leader()` check in `/healthz/ready` blocked follower nodes from ever becoming "healthy". Removed — followers are ready too (serve reads, forward writes).

## Test plan

- [x] Both nodes become healthy in Docker compose (was: only leader healthy)
- [x] Dynamic E2E: 8/21 pass (federation RPC working, mount issue is separate)
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)