### PR TITLE
refactor(#1824): rename ConnectorCapability → BackendFeature

### DIFF
--- a/src/nexus/backends/base/backend.py
+++ b/src/nexus/backends/base/backend.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 from nexus.core.object_store import ObjectStoreABC, WriteResult
 
 if TYPE_CHECKING:
-    from nexus.contracts.capabilities import ConnectorCapability
+    from nexus.contracts.backend_features import BackendFeature
     from nexus.contracts.types import OperationContext
 
 
@@ -204,7 +204,7 @@ class Backend(ObjectStoreABC):
 
     # === Capability Discovery (Issue #2069) ===
 
-    _CAPABILITIES: ClassVar["frozenset[ConnectorCapability]"] = frozenset()
+    _CAPABILITIES: ClassVar["frozenset[BackendFeature]"] = frozenset()
     """Capabilities declared by this backend class.
 
     Subclasses override to declare their supported capabilities.
@@ -212,11 +212,11 @@ class Backend(ObjectStoreABC):
     """
 
     @property
-    def capabilities(self) -> "frozenset[ConnectorCapability]":
+    def capabilities(self) -> "frozenset[BackendFeature]":
         """All capabilities supported by this backend."""
         return self._CAPABILITIES
 
-    def has_capability(self, cap: "ConnectorCapability") -> bool:
+    def has_capability(self, cap: "BackendFeature") -> bool:
         """Check whether this backend supports a specific capability."""
         return cap in self._CAPABILITIES
 

--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -42,7 +42,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.backends.base.backend import Backend
 from nexus.backends.base.blob_transport import BlobTransport
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import create_hasher, hash_content
 from nexus.core.object_store import WriteResult
@@ -76,11 +76,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CAS_ADDRESSING_CAPABILITIES: frozenset[ConnectorCapability] = frozenset(
+CAS_ADDRESSING_CAPABILITIES: frozenset[BackendFeature] = frozenset(
     {
-        ConnectorCapability.CAS,
-        ConnectorCapability.STREAMING,
-        ConnectorCapability.BATCH_CONTENT,
+        BackendFeature.CAS,
+        BackendFeature.STREAMING,
+        BackendFeature.BATCH_CONTENT,
     }
 )
 """Common capabilities for CAS-based backends."""
@@ -103,7 +103,7 @@ class CASAddressingEngine(Backend):
         _backend_name: Human-readable backend identifier.
     """
 
-    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = CAS_ADDRESSING_CAPABILITIES
+    _CAPABILITIES: ClassVar[frozenset[BackendFeature]] = CAS_ADDRESSING_CAPABILITIES
 
     def __init__(
         self,

--- a/src/nexus/backends/base/path_addressing_engine.py
+++ b/src/nexus/backends/base/path_addressing_engine.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from nexus.backends.base.backend import Backend
 from nexus.backends.base.blob_transport import BlobTransport
-from nexus.contracts.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorCapability
+from nexus.contracts.backend_features import BLOB_BACKEND_FEATURES, BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
@@ -52,7 +52,7 @@ class PathAddressingEngine(Backend):
         versioning_enabled: Whether versioning is enabled on the bucket.
     """
 
-    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = BLOB_CONNECTOR_CAPABILITIES
+    _CAPABILITIES: ClassVar[frozenset[BackendFeature]] = BLOB_BACKEND_FEATURES
 
     def __init__(
         self,

--- a/src/nexus/backends/base/registry.py
+++ b/src/nexus/backends/base/registry.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.lib.registry import BaseRegistry
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 # that maps to a Protocol, we verify the class has the required methods.
 
 
-def get_capability_protocols() -> dict[ConnectorCapability, type]:
+def get_capability_protocols() -> dict[BackendFeature, type]:
     """Get capability-to-Protocol mapping for registration-time validation.
 
     Returns:
@@ -65,10 +65,10 @@ def get_capability_protocols() -> dict[ConnectorCapability, type]:
     )
 
     return {
-        ConnectorCapability.STREAMING: StreamingProtocol,
-        ConnectorCapability.BATCH_CONTENT: BatchContentProtocol,
-        ConnectorCapability.DIRECTORY_LISTING: DirectoryListingProtocol,
-        ConnectorCapability.OAUTH: OAuthCapableProtocol,
+        BackendFeature.STREAMING: StreamingProtocol,
+        BackendFeature.BATCH_CONTENT: BatchContentProtocol,
+        BackendFeature.DIRECTORY_LISTING: DirectoryListingProtocol,
+        BackendFeature.OAUTH: OAuthCapableProtocol,
     }
 
 
@@ -229,7 +229,7 @@ class ConnectorInfo:
     eliminating manual synchronization between ConnectorRegistry and SERVICE_REGISTRY.
     """
 
-    capabilities: frozenset[ConnectorCapability] = field(default_factory=frozenset)
+    capabilities: frozenset[BackendFeature] = field(default_factory=frozenset)
     """Capabilities declared by this connector (Issue #2069)."""
 
     @property
@@ -373,7 +373,7 @@ class ConnectorRegistry:
         config_mapping = derive_config_mapping(connector_class)
 
         # Extract capabilities from class (Issue #2069)
-        capabilities: frozenset[ConnectorCapability] = getattr(
+        capabilities: frozenset[BackendFeature] = getattr(
             connector_class, "_CAPABILITIES", frozenset()
         )
 
@@ -486,14 +486,14 @@ class ConnectorRegistry:
         return name in cls._base
 
     @classmethod
-    def get_capabilities(cls, name: str) -> frozenset[ConnectorCapability]:
+    def get_capabilities(cls, name: str) -> frozenset[BackendFeature]:
         """Get capabilities for a connector by name (Issue #2069).
 
         Args:
             name: Connector identifier
 
         Returns:
-            frozenset of ConnectorCapability values
+            frozenset of BackendFeature values
 
         Raises:
             KeyError: If connector is not found
@@ -501,7 +501,7 @@ class ConnectorRegistry:
         return cls.get_info(name).capabilities
 
     @classmethod
-    def list_by_capability(cls, cap: ConnectorCapability) -> list[ConnectorInfo]:
+    def list_by_capability(cls, cap: BackendFeature) -> list[ConnectorInfo]:
         """List all connectors with a specific capability (Issue #2069).
 
         Args:

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.compute.llm_blob_transport import LLMBlobTransport
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import BackendError
 from nexus.core.object_store import WriteResult
 
@@ -114,11 +114,11 @@ class OpenAICompatibleBackend(CASAddressingEngine):
         ),
     }
 
-    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = frozenset(
+    _CAPABILITIES: ClassVar[frozenset[BackendFeature]] = frozenset(
         {
-            ConnectorCapability.CAS,
-            ConnectorCapability.STREAMING,
-            ConnectorCapability.BATCH_CONTENT,
+            BackendFeature.CAS,
+            BackendFeature.STREAMING,
+            BackendFeature.BATCH_CONTENT,
         }
     )
 

--- a/src/nexus/backends/connectors/cli/base.py
+++ b/src/nexus/backends/connectors/cli/base.py
@@ -35,10 +35,10 @@ from nexus.backends.connectors.base import (
 from nexus.backends.connectors.cli.config import CLIConnectorConfig
 from nexus.backends.connectors.cli.display_path import DisplayPathMixin
 from nexus.backends.connectors.cli.result import CLIErrorMapper, CLIResult, CLIResultStatus
-from nexus.contracts.capabilities import (
-    CLI_CONNECTOR_CAPABILITIES,
-    OAUTH_CONNECTOR_CAPABILITIES,
-    ConnectorCapability,
+from nexus.contracts.backend_features import (
+    CLI_BACKEND_FEATURES,
+    OAUTH_BACKEND_FEATURES,
+    BackendFeature,
 )
 from nexus.core.object_store import WriteResult
 
@@ -98,8 +98,8 @@ class CLIConnector(
     # Auth is ALWAYS via environment variables (never CLI flags).
     # See _build_auth_env() for the mapping.
 
-    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = (
-        CLI_CONNECTOR_CAPABILITIES | OAUTH_CONNECTOR_CAPABILITIES
+    _CAPABILITIES: ClassVar[frozenset[BackendFeature]] = (
+        CLI_BACKEND_FEATURES | OAUTH_BACKEND_FEATURES
     )
 
     # --- Instance state ---

--- a/src/nexus/backends/connectors/cli/sync_loop.py
+++ b/src/nexus/backends/connectors/cli/sync_loop.py
@@ -145,10 +145,10 @@ class ConnectorSyncLoop:
                 continue
 
             # Only sync connectors that declare SYNC_ELIGIBLE (Decision #5A)
-            from nexus.contracts.capabilities import ConnectorCapability
+            from nexus.contracts.backend_features import BackendFeature
 
             caps: frozenset[str] = getattr(backend, "capabilities", frozenset())
-            if ConnectorCapability.SYNC_ELIGIBLE not in caps:
+            if BackendFeature.SYNC_ELIGIBLE not in caps:
                 continue
 
             # Ensure mount state exists

--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -54,7 +54,7 @@ from nexus.backends.connectors.gws.schemas import (
     UploadFileSchema,
 )
 from nexus.backends.connectors.oauth import OAuthConnectorMixin
-from nexus.contracts.capabilities import OAUTH_CONNECTOR_CAPABILITIES, ConnectorCapability
+from nexus.contracts.backend_features import OAUTH_BACKEND_FEATURES, BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
@@ -133,10 +133,10 @@ class GoogleDriveConnectorBackend(
     - Rate limited by Google Drive API quotas
     """
 
-    _CAPABILITIES = OAUTH_CONNECTOR_CAPABILITIES | frozenset(
+    _CAPABILITIES = OAUTH_BACKEND_FEATURES | frozenset(
         {
-            ConnectorCapability.SKILL_DOC,
-            ConnectorCapability.WRITE_BACK,
+            BackendFeature.SKILL_DOC,
+            BackendFeature.WRITE_BACK,
         }
     )
 

--- a/src/nexus/backends/connectors/hn/connector.py
+++ b/src/nexus/backends/connectors/hn/connector.py
@@ -47,7 +47,7 @@ from nexus.backends.base.backend import Backend
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.connectors.base import SkillDocMixin
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin, SyncResult
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import WriteResult
 
@@ -111,10 +111,10 @@ class HNConnectorBackend(Backend, CacheConnectorMixin, SkillDocMixin):
 
     _CAPABILITIES = frozenset(
         {
-            ConnectorCapability.CACHE_BULK_READ,
-            ConnectorCapability.CACHE_SYNC,
-            ConnectorCapability.SKILL_DOC,
-            ConnectorCapability.SYNC,
+            BackendFeature.CACHE_BULK_READ,
+            BackendFeature.CACHE_SYNC,
+            BackendFeature.SKILL_DOC,
+            BackendFeature.SYNC,
         }
     )
 

--- a/src/nexus/backends/connectors/oauth_base.py
+++ b/src/nexus/backends/connectors/oauth_base.py
@@ -21,7 +21,7 @@ from nexus.backends.connectors.base import (
 )
 from nexus.backends.connectors.oauth import OAuthConnectorMixin
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
-from nexus.contracts.capabilities import OAUTH_CONNECTOR_CAPABILITIES, ConnectorCapability
+from nexus.contracts.backend_features import OAUTH_BACKEND_FEATURES, BackendFeature
 
 if TYPE_CHECKING:
     from nexus.storage.record_store import RecordStoreABC
@@ -55,10 +55,10 @@ class OAuthConnectorBase(
     - Connector-specific ``SKILL_NAME``, ``SCHEMAS``, ``OPERATION_TRAITS``
     """
 
-    _CAPABILITIES = OAUTH_CONNECTOR_CAPABILITIES | frozenset(
+    _CAPABILITIES = OAUTH_BACKEND_FEATURES | frozenset(
         {
-            ConnectorCapability.CACHE_BULK_READ,
-            ConnectorCapability.CACHE_SYNC,
+            BackendFeature.CACHE_BULK_READ,
+            BackendFeature.CACHE_SYNC,
         }
     )
 

--- a/src/nexus/backends/connectors/slack/connector.py
+++ b/src/nexus/backends/connectors/slack/connector.py
@@ -66,7 +66,7 @@ from nexus.backends.connectors.slack.utils import (
     list_messages_from_channel,
 )
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
-from nexus.contracts.capabilities import OAUTH_CONNECTOR_CAPABILITIES, ConnectorCapability
+from nexus.contracts.backend_features import OAUTH_BACKEND_FEATURES, BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import WriteResult
 
@@ -120,11 +120,11 @@ class SlackConnectorBackend(
     - Messages stored as JSON files
     """
 
-    _CAPABILITIES = OAUTH_CONNECTOR_CAPABILITIES | frozenset(
+    _CAPABILITIES = OAUTH_BACKEND_FEATURES | frozenset(
         {
-            ConnectorCapability.CACHE_BULK_READ,
-            ConnectorCapability.CACHE_SYNC,
-            ConnectorCapability.SKILL_DOC,
+            BackendFeature.CACHE_BULK_READ,
+            BackendFeature.CACHE_SYNC,
+            BackendFeature.SKILL_DOC,
         }
     )
 

--- a/src/nexus/backends/connectors/x/connector.py
+++ b/src/nexus/backends/connectors/x/connector.py
@@ -61,7 +61,7 @@ from nexus.backends.connectors.base import (
 from nexus.backends.connectors.base_errors import TRAIT_ERRORS
 from nexus.backends.connectors.oauth import OAuthConnectorMixin
 from nexus.backends.connectors.x.schemas import CreateTweetSchema, DeleteTweetSchema
-from nexus.contracts.capabilities import OAUTH_CONNECTOR_CAPABILITIES, ConnectorCapability
+from nexus.contracts.backend_features import OAUTH_BACKEND_FEATURES, BackendFeature
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import BackendError
 from nexus.core.object_store import WriteResult
@@ -127,9 +127,9 @@ class XConnectorBackend(
     - Fixed virtual directory structure
     """
 
-    _CAPABILITIES = OAUTH_CONNECTOR_CAPABILITIES | frozenset(
+    _CAPABILITIES = OAUTH_BACKEND_FEATURES | frozenset(
         {
-            ConnectorCapability.SKILL_DOC,
+            BackendFeature.SKILL_DOC,
         }
     )
 

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -32,7 +32,7 @@ from nexus.backends.engines.cas_gc import CASGarbageCollector
 from nexus.backends.engines.cdc import CDCEngine
 from nexus.backends.engines.multipart import MultipartUpload
 from nexus.backends.transports.local_transport import LocalBlobTransport
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 
@@ -92,15 +92,14 @@ class CASLocalBackend(CASAddressingEngine, MultipartUpload):
         ),
     }
 
-    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = frozenset(
+    _CAPABILITIES: ClassVar[frozenset[BackendFeature]] = frozenset(
         {
-            ConnectorCapability.CAS,
-            ConnectorCapability.ROOT_PATH,
-            ConnectorCapability.PARALLEL_MMAP,
-            ConnectorCapability.MULTIPART_UPLOAD,
-            ConnectorCapability.STREAMING,
-            ConnectorCapability.BATCH_CONTENT,
-            ConnectorCapability.DIRECTORY_LISTING,
+            BackendFeature.CAS,
+            BackendFeature.ROOT_PATH,
+            BackendFeature.MULTIPART_UPLOAD,
+            BackendFeature.STREAMING,
+            BackendFeature.BATCH_CONTENT,
+            BackendFeature.DIRECTORY_LISTING,
         }
     )
 

--- a/src/nexus/backends/storage/local_connector.py
+++ b/src/nexus/backends/storage/local_connector.py
@@ -31,7 +31,7 @@ from nexus.backends.base.registry import (
     register_connector,
 )
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
@@ -81,10 +81,9 @@ class LocalConnectorBackend(Backend, CacheConnectorMixin):
 
     _CAPABILITIES = frozenset(
         {
-            ConnectorCapability.DIRECTORY_LISTING,
-            ConnectorCapability.CACHE_BULK_READ,
-            ConnectorCapability.CACHE_SYNC,
-            ConnectorCapability.CHANGE_NOTIFICATIONS,
+            BackendFeature.DIRECTORY_LISTING,
+            BackendFeature.CACHE_BULK_READ,
+            BackendFeature.CACHE_SYNC,
         }
     )
 

--- a/src/nexus/backends/storage/path_gcs.py
+++ b/src/nexus/backends/storage/path_gcs.py
@@ -27,7 +27,7 @@ from nexus.backends.base.backend import FileInfo, HandlerStatusResponse
 from nexus.backends.base.path_addressing_engine import PathAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
-from nexus.contracts.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorCapability
+from nexus.contracts.backend_features import BLOB_BACKEND_FEATURES, BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import WriteResult
 
@@ -56,13 +56,13 @@ class PathGCSBackend(PathAddressingEngine, CacheConnectorMixin):
     - Batch version fetch (single API call for 1000s of files)
     """
 
-    _CAPABILITIES = BLOB_CONNECTOR_CAPABILITIES | frozenset(
+    _CAPABILITIES = BLOB_BACKEND_FEATURES | frozenset(
         {
-            ConnectorCapability.CACHE_BULK_READ,
-            ConnectorCapability.CACHE_SYNC,
-            ConnectorCapability.SIGNED_URL,
-            ConnectorCapability.NATIVE_VERSIONING,
-            ConnectorCapability.RESUMABLE_UPLOAD,
+            BackendFeature.CACHE_BULK_READ,
+            BackendFeature.CACHE_SYNC,
+            BackendFeature.SIGNED_URL,
+            BackendFeature.NATIVE_VERSIONING,
+            BackendFeature.RESUMABLE_UPLOAD,
         }
     )
 

--- a/src/nexus/backends/storage/path_local.py
+++ b/src/nexus/backends/storage/path_local.py
@@ -25,7 +25,7 @@ from typing import ClassVar
 from nexus.backends.base.path_addressing_engine import PathAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.transports.local_transport import LocalBlobTransport
-from nexus.contracts.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorCapability
+from nexus.contracts.backend_features import BLOB_BACKEND_FEATURES, BackendFeature
 
 
 @register_connector(
@@ -48,13 +48,10 @@ class PathLocalBackend(PathAddressingEngine):
     Opt into CAS by setting ``backend = "local"`` in config.
     """
 
-    _CAPABILITIES: ClassVar[frozenset[ConnectorCapability]] = (
-        BLOB_CONNECTOR_CAPABILITIES
-        | frozenset(
-            {
-                ConnectorCapability.ROOT_PATH,
-            }
-        )
+    _CAPABILITIES: ClassVar[frozenset[BackendFeature]] = BLOB_BACKEND_FEATURES | frozenset(
+        {
+            BackendFeature.ROOT_PATH,
+        }
     )
 
     CONNECTION_ARGS: dict[str, ConnectionArg] = {

--- a/src/nexus/backends/storage/path_s3.py
+++ b/src/nexus/backends/storage/path_s3.py
@@ -22,7 +22,7 @@ from nexus.backends.base.path_addressing_engine import PathAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.engines.multipart import MultipartUpload
 from nexus.backends.wrappers.cache_mixin import CacheConnectorMixin
-from nexus.contracts.capabilities import BLOB_CONNECTOR_CAPABILITIES, ConnectorCapability
+from nexus.contracts.backend_features import BLOB_BACKEND_FEATURES, BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import WriteResult
 
@@ -43,14 +43,14 @@ logger = logging.getLogger(__name__)
 class PathS3Backend(PathAddressingEngine, CacheConnectorMixin, MultipartUpload):
     """AWS S3 connector with direct path mapping, caching, and multipart upload."""
 
-    _CAPABILITIES = BLOB_CONNECTOR_CAPABILITIES | frozenset(
+    _CAPABILITIES = BLOB_BACKEND_FEATURES | frozenset(
         {
-            ConnectorCapability.CACHE_BULK_READ,
-            ConnectorCapability.CACHE_SYNC,
-            ConnectorCapability.SIGNED_URL,
-            ConnectorCapability.MULTIPART_UPLOAD,
-            ConnectorCapability.NATIVE_VERSIONING,
-            ConnectorCapability.RESUMABLE_UPLOAD,
+            BackendFeature.CACHE_BULK_READ,
+            BackendFeature.CACHE_SYNC,
+            BackendFeature.SIGNED_URL,
+            BackendFeature.MULTIPART_UPLOAD,
+            BackendFeature.NATIVE_VERSIONING,
+            BackendFeature.RESUMABLE_UPLOAD,
         }
     )
 

--- a/src/nexus/bricks/mount/mount_service.py
+++ b/src/nexus/bricks/mount/mount_service.py
@@ -142,10 +142,10 @@ class MountService:
                 return
 
             # Skill doc generation (via mount_hooks if available)
-            from nexus.contracts.capabilities import ConnectorCapability
+            from nexus.contracts.backend_features import BackendFeature
 
             if hasattr(backend, "has_capability") and backend.has_capability(
-                ConnectorCapability.SKILL_DOC
+                BackendFeature.SKILL_DOC
             ):
                 await self._generate_skill_docs(mount_point, backend)
 

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -769,11 +769,11 @@ class SearchService:
         2. If entries exist, return them (fast, no API call).
         3. If empty (cache miss), fall back to live API.
         """
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = route.backend
         caps: frozenset[str] = getattr(backend, "capabilities", frozenset())
-        use_metastore = ConnectorCapability.SYNC_ELIGIBLE in caps and getattr(
+        use_metastore = BackendFeature.SYNC_ELIGIBLE in caps and getattr(
             backend, "use_metadata_listing", False
         )
 

--- a/src/nexus/contracts/backend_features.py
+++ b/src/nexus/contracts/backend_features.py
@@ -1,7 +1,7 @@
-"""Connector capability discovery (Issue #2069).
+"""Backend feature flags (Issue #2069).
 
-Provides a unified ``ConnectorCapability`` enum for declaring and querying
-backend capabilities.  Backends declare ``_CAPABILITIES`` as a ClassVar;
+Provides a unified ``BackendFeature`` enum for declaring and querying
+backend features.  Backends declare ``_CAPABILITIES`` as a ClassVar;
 consumers query via ``has_capability()`` or ``cap in backend.capabilities``.
 
 Canonical home: contracts/ (base tier — available to all layers).
@@ -23,7 +23,7 @@ References:
 from enum import StrEnum
 
 
-class ConnectorCapability(StrEnum):
+class BackendFeature(StrEnum):
     """Enumeration of all capabilities a connector backend can support.
 
     Each value corresponds to either:
@@ -43,12 +43,6 @@ class ConnectorCapability(StrEnum):
     TOKEN_MANAGER = "token_manager"
     """Backend manages OAuth tokens."""
 
-    DATA_DIR = "data_dir"
-    """Backend has a data_dir for ancillary data storage."""
-
-    PARALLEL_MMAP = "parallel_mmap"
-    """Backend supports Rust-accelerated parallel mmap reads."""
-
     USER_SCOPED = "user_scoped"
     """Backend requires per-user OAuth credentials."""
 
@@ -62,9 +56,6 @@ class ConnectorCapability(StrEnum):
 
     DIRECTORY_LISTING = "directory_listing"
     """Backend supports DirectoryListingProtocol (list_dir + get_file_info)."""
-
-    SEARCHABLE = "searchable"
-    """Backend supports SearchableConnector (content/metadata search)."""
 
     OAUTH = "oauth"
     """Backend supports OAuthCapableProtocol (token management)."""
@@ -94,9 +85,6 @@ class ConnectorCapability(StrEnum):
     NATIVE_VERSIONING = "native_versioning"
     """Backend supports native object versioning (e.g., S3 versioning, GCS generations)."""
 
-    CHANGE_NOTIFICATIONS = "change_notifications"
-    """Backend supports change notifications (e.g., S3 Event Notifications, GCS Pub/Sub)."""
-
     RESUMABLE_UPLOAD = "resumable_upload"
     """Backend supports resumable uploads (e.g., GCS resumable, S3 multipart with resume)."""
 
@@ -107,9 +95,6 @@ class ConnectorCapability(StrEnum):
 
     SYNC = "sync"
     """Backend implements ConnectorSyncProvider for delta sync."""
-
-    WATCH = "watch"
-    """Sync provider supports real-time watch() for push-based updates."""
 
     WRITE_BACK = "write_back"
     """Backend supports write operations (validated YAML → backend action)."""
@@ -128,37 +113,37 @@ class ConnectorCapability(StrEnum):
 
 # --- Convenience frozensets ---
 
-CORE_CAPABILITIES: frozenset[ConnectorCapability] = frozenset()
+CORE_BACKEND_FEATURES: frozenset[BackendFeature] = frozenset()
 """Default capabilities for Backend ABC (empty — backends opt in)."""
 
-BLOB_CONNECTOR_CAPABILITIES: frozenset[ConnectorCapability] = frozenset(
+BLOB_BACKEND_FEATURES: frozenset[BackendFeature] = frozenset(
     {
-        ConnectorCapability.RENAME,
-        ConnectorCapability.DIRECTORY_LISTING,
-        ConnectorCapability.PATH_DELETE,
-        ConnectorCapability.STREAMING,
-        ConnectorCapability.BATCH_CONTENT,
+        BackendFeature.RENAME,
+        BackendFeature.DIRECTORY_LISTING,
+        BackendFeature.PATH_DELETE,
+        BackendFeature.STREAMING,
+        BackendFeature.BATCH_CONTENT,
     }
 )
 """Common capabilities for blob storage connectors (S3, GCS, Azure)."""
 
-OAUTH_CONNECTOR_CAPABILITIES: frozenset[ConnectorCapability] = frozenset(
+OAUTH_BACKEND_FEATURES: frozenset[BackendFeature] = frozenset(
     {
-        ConnectorCapability.USER_SCOPED,
-        ConnectorCapability.TOKEN_MANAGER,
-        ConnectorCapability.OAUTH,
-        ConnectorCapability.SYNC_ELIGIBLE,
+        BackendFeature.USER_SCOPED,
+        BackendFeature.TOKEN_MANAGER,
+        BackendFeature.OAUTH,
+        BackendFeature.SYNC_ELIGIBLE,
     }
 )
 """Common capabilities for OAuth-based connectors."""
 
-CLI_CONNECTOR_CAPABILITIES: frozenset[ConnectorCapability] = frozenset(
+CLI_BACKEND_FEATURES: frozenset[BackendFeature] = frozenset(
     {
-        ConnectorCapability.CLI_BACKED,
-        ConnectorCapability.WRITE_BACK,
-        ConnectorCapability.SKILL_DOC,
-        ConnectorCapability.SYNC,
-        ConnectorCapability.SYNC_ELIGIBLE,
+        BackendFeature.CLI_BACKED,
+        BackendFeature.WRITE_BACK,
+        BackendFeature.SKILL_DOC,
+        BackendFeature.SYNC,
+        BackendFeature.SYNC_ELIGIBLE,
     }
 )
 """Common capabilities for CLI-backed connectors (gws, gh)."""

--- a/src/nexus/core/protocols/__init__.py
+++ b/src/nexus/core/protocols/__init__.py
@@ -22,7 +22,7 @@ References:
 
 from nexus.contracts.cache_store import CacheStoreABC, NullCacheStore
 from nexus.core.protocols.caching import CacheConfigContract, CachingConnectorContract
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.core.protocols.connector import (
     BatchContentProtocol,
     CapabilityAwareProtocol,
@@ -45,7 +45,7 @@ __all__ = [
     "CacheStoreABC",
     "CachingConnectorContract",
     "CapabilityAwareProtocol",
-    "ConnectorCapability",
+    "BackendFeature",
     "ConnectorProtocol",
     "ContentStoreProtocol",
     "DirectoryListingProtocol",

--- a/src/nexus/core/protocols/connector.py
+++ b/src/nexus/core/protocols/connector.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from nexus.backends.base.backend import FileInfo, HandlerStatusResponse
-    from nexus.contracts.capabilities import ConnectorCapability
+    from nexus.contracts.backend_features import BackendFeature
     from nexus.contracts.types import OperationContext
     from nexus.core.object_store import WriteResult
 
@@ -141,9 +141,9 @@ class CapabilityAwareProtocol(Protocol):
     """
 
     @property
-    def capabilities(self) -> "frozenset[ConnectorCapability]": ...
+    def capabilities(self) -> "frozenset[BackendFeature]": ...
 
-    def has_capability(self, cap: "ConnectorCapability") -> bool: ...
+    def has_capability(self, cap: "BackendFeature") -> bool: ...
 
 @runtime_checkable
 class ConnectorProtocol(

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -724,13 +724,13 @@ async def write_to_connector(
         # the kernel write path for ordinary path-addressed backends.
         import asyncio
 
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = _route.backend if _route else None
         _caps: frozenset[str] = (
             getattr(backend, "capabilities", frozenset()) if backend else frozenset()
         )
-        is_cli_connector = ConnectorCapability.CLI_BACKED in _caps
+        is_cli_connector = BackendFeature.CLI_BACKED in _caps
 
         if is_cli_connector and _backend_path:
             # Enforce the same write-access checks that nx.write() performs:

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -10,7 +10,7 @@ layer — they MUST NOT call async code directly.
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.server.path_utils import (
     unscope_internal_dict,
@@ -56,9 +56,7 @@ def generate_download_url(
         backend_path = route.backend_path
 
         # S3 or GCS connector with signed URL support
-        if hasattr(backend, "has_capability") and backend.has_capability(
-            ConnectorCapability.SIGNED_URL
-        ):
+        if hasattr(backend, "has_capability") and backend.has_capability(BackendFeature.SIGNED_URL):
             from dataclasses import replace
 
             if context and hasattr(context, "backend_path"):
@@ -82,9 +80,7 @@ def generate_download_url(
             }
 
         # Local backend - use streaming endpoint with signed token
-        if hasattr(backend, "has_capability") and backend.has_capability(
-            ConnectorCapability.ROOT_PATH
-        ):
+        if hasattr(backend, "has_capability") and backend.has_capability(BackendFeature.ROOT_PATH):
             from urllib.parse import quote
 
             from nexus.server.streaming import _sign_stream_token

--- a/tests/integration/backends/connectors/cli/test_cli_connector.py
+++ b/tests/integration/backends/connectors/cli/test_cli_connector.py
@@ -30,7 +30,7 @@ from nexus.backends.connectors.cli.config import (
     WriteOperationConfig,
 )
 from nexus.backends.connectors.cli.result import CLIResult, CLIResultStatus
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import ValidationError as CoreValidationError
 from nexus.core.object_store import WriteResult
 
@@ -279,19 +279,19 @@ class TestConnectionLifecycle:
 class TestCapabilities:
     def test_has_cli_backed(self) -> None:
         connector = FakeCLIConnector()
-        assert connector.has_capability(ConnectorCapability.CLI_BACKED)
+        assert connector.has_capability(BackendFeature.CLI_BACKED)
 
     def test_has_skill_doc(self) -> None:
         connector = FakeCLIConnector()
-        assert connector.has_capability(ConnectorCapability.SKILL_DOC)
+        assert connector.has_capability(BackendFeature.SKILL_DOC)
 
     def test_has_write_back(self) -> None:
         connector = FakeCLIConnector()
-        assert connector.has_capability(ConnectorCapability.WRITE_BACK)
+        assert connector.has_capability(BackendFeature.WRITE_BACK)
 
     def test_has_sync(self) -> None:
         connector = FakeCLIConnector()
-        assert connector.has_capability(ConnectorCapability.SYNC)
+        assert connector.has_capability(BackendFeature.SYNC)
 
     def test_name(self) -> None:
         connector = FakeCLIConnector()

--- a/tests/integration/backends/connectors/cli/test_lifecycle_e2e.py
+++ b/tests/integration/backends/connectors/cli/test_lifecycle_e2e.py
@@ -30,7 +30,7 @@ from nexus.backends.connectors.cli.protocol import (
     SyncPage,
 )
 from nexus.backends.connectors.cli.result import CLIErrorMapper, CLIResult, CLIResultStatus
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 
 # ---------------------------------------------------------------------------
 # Test schema and connector
@@ -80,17 +80,17 @@ class FakeGHConnector(SkillDocMixin, ValidatedMixin, TraitBasedMixin):
 
     _CAPABILITIES = frozenset(
         {
-            ConnectorCapability.SKILL_DOC,
-            ConnectorCapability.WRITE_BACK,
-            ConnectorCapability.CLI_BACKED,
+            BackendFeature.SKILL_DOC,
+            BackendFeature.WRITE_BACK,
+            BackendFeature.CLI_BACKED,
         }
     )
 
-    def has_capability(self, cap: ConnectorCapability) -> bool:
+    def has_capability(self, cap: BackendFeature) -> bool:
         return cap in self._CAPABILITIES
 
     @property
-    def capabilities(self) -> frozenset[ConnectorCapability]:
+    def capabilities(self) -> frozenset[BackendFeature]:
         return self._CAPABILITIES
 
 
@@ -246,9 +246,9 @@ class TestConnectorLifecycleE2E:
     def test_step8_capability_declaration(self) -> None:
         """Step 8: Connector declares correct capabilities."""
         connector = FakeGHConnector()
-        assert connector.has_capability(ConnectorCapability.SKILL_DOC)
-        assert connector.has_capability(ConnectorCapability.WRITE_BACK)
-        assert connector.has_capability(ConnectorCapability.CLI_BACKED)
+        assert connector.has_capability(BackendFeature.SKILL_DOC)
+        assert connector.has_capability(BackendFeature.WRITE_BACK)
+        assert connector.has_capability(BackendFeature.CLI_BACKED)
 
     @pytest.mark.asyncio
     async def test_step9_sync_provider_satisfies_protocol(self) -> None:

--- a/tests/integration/backends/connectors/cli/test_metastore_first_e2e.py
+++ b/tests/integration/backends/connectors/cli/test_metastore_first_e2e.py
@@ -18,7 +18,7 @@ import pytest
 
 from nexus.backends.connectors.cli.sync_loop import ConnectorSyncLoop
 from nexus.backends.connectors.cli.sync_types import DeltaItem, DeltaSyncResult
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -34,8 +34,8 @@ def _make_sync_eligible_backend(
     backend.name = name
     backend.capabilities = frozenset(
         {
-            ConnectorCapability.SYNC_ELIGIBLE,
-            ConnectorCapability.CACHE_BULK_READ,
+            BackendFeature.SYNC_ELIGIBLE,
+            BackendFeature.CACHE_BULK_READ,
         }
     )
     backend.has_capability = MagicMock(side_effect=lambda c: c in backend.capabilities)

--- a/tests/integration/backends/connectors/gdrive/test_gdrive_schemas.py
+++ b/tests/integration/backends/connectors/gdrive/test_gdrive_schemas.py
@@ -18,7 +18,7 @@ from nexus.backends.connectors.gws.schemas import (
     UpdateFileSchema,
     UploadFileSchema,
 )
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 
 
 class TestGoogleDriveConnectorBackendMixins:
@@ -69,11 +69,11 @@ class TestGoogleDriveConnectorBackendMixins:
 
     def test_skill_doc_capability(self) -> None:
         caps = GoogleDriveConnectorBackend._CAPABILITIES
-        assert ConnectorCapability.SKILL_DOC in caps
+        assert BackendFeature.SKILL_DOC in caps
 
     def test_write_back_capability(self) -> None:
         caps = GoogleDriveConnectorBackend._CAPABILITIES
-        assert ConnectorCapability.WRITE_BACK in caps
+        assert BackendFeature.WRITE_BACK in caps
 
     def test_inherits_skill_doc_mixin(self) -> None:
         assert issubclass(GoogleDriveConnectorBackend, SkillDocMixin)

--- a/tests/integration/backends/connectors/slack/test_slack_schemas.py
+++ b/tests/integration/backends/connectors/slack/test_slack_schemas.py
@@ -9,7 +9,7 @@ from nexus.backends.connectors.slack.schemas import (
     SendMessageSchema,
     UpdateMessageSchema,
 )
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 
 # ---------------------------------------------------------------------------
 # SendMessageSchema
@@ -251,7 +251,7 @@ class TestSlackConnectorCapabilities:
     def test_has_skill_doc_capability(self):
         from nexus.backends.connectors.slack.connector import SlackConnectorBackend
 
-        assert ConnectorCapability.SKILL_DOC in SlackConnectorBackend._CAPABILITIES
+        assert BackendFeature.SKILL_DOC in SlackConnectorBackend._CAPABILITIES
 
     def test_skill_name(self):
         from nexus.backends.connectors.slack.connector import SlackConnectorBackend

--- a/tests/integration/backends/connectors/x/test_x_schemas.py
+++ b/tests/integration/backends/connectors/x/test_x_schemas.py
@@ -5,7 +5,7 @@ from pydantic import ValidationError
 
 from nexus.backends.connectors.base import ConfirmLevel, Reversibility
 from nexus.backends.connectors.x.schemas import CreateTweetSchema, DeleteTweetSchema
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 
 # ---------------------------------------------------------------------------
 # CreateTweetSchema
@@ -176,7 +176,7 @@ class TestXConnectorCapabilities:
     def test_has_skill_doc_capability(self):
         from nexus.backends.connectors.x.connector import XConnectorBackend
 
-        assert ConnectorCapability.SKILL_DOC in XConnectorBackend._CAPABILITIES
+        assert BackendFeature.SKILL_DOC in XConnectorBackend._CAPABILITIES
 
     def test_skill_name(self):
         from nexus.backends.connectors.x.connector import XConnectorBackend

--- a/tests/integration/services/test_connectors_router.py
+++ b/tests/integration/services/test_connectors_router.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from nexus.backends.base.registry import ConnectorInfo
-from nexus.contracts.capabilities import ConnectorCapability
+from nexus.contracts.backend_features import BackendFeature
 from nexus.server.api.v2.routers.connectors import router
 from nexus.server.dependencies import require_auth
 
@@ -30,7 +30,7 @@ def _make_connector_info(
     name: str,
     description: str = "",
     category: str = "storage",
-    capabilities: frozenset[ConnectorCapability] | None = None,
+    capabilities: frozenset[BackendFeature] | None = None,
     user_scoped: bool = False,
 ) -> ConnectorInfo:
     """Create a minimal ConnectorInfo for testing."""
@@ -70,15 +70,13 @@ class TestListConnectors:
                 name="path_gcs",
                 description="Google Cloud Storage",
                 category="storage",
-                capabilities=frozenset(
-                    {ConnectorCapability.SIGNED_URL, ConnectorCapability.RENAME}
-                ),
+                capabilities=frozenset({BackendFeature.SIGNED_URL, BackendFeature.RENAME}),
             ),
             _make_connector_info(
                 name="gmail_connector",
                 description="Gmail",
                 category="api",
-                capabilities=frozenset({ConnectorCapability.OAUTH}),
+                capabilities=frozenset({BackendFeature.OAUTH}),
                 user_scoped=True,
             ),
         ]
@@ -105,9 +103,9 @@ class TestListConnectors:
                 name="test",
                 capabilities=frozenset(
                     {
-                        ConnectorCapability.STREAMING,
-                        ConnectorCapability.BATCH_CONTENT,
-                        ConnectorCapability.RENAME,
+                        BackendFeature.STREAMING,
+                        BackendFeature.BATCH_CONTENT,
+                        BackendFeature.RENAME,
                     }
                 ),
             ),
@@ -130,9 +128,7 @@ class TestGetConnectorCapabilities:
         mock_registry.is_registered.return_value = True
         mock_registry.get_info.return_value = _make_connector_info(
             name="s3_connector",
-            capabilities=frozenset(
-                {ConnectorCapability.SIGNED_URL, ConnectorCapability.MULTIPART_UPLOAD}
-            ),
+            capabilities=frozenset({BackendFeature.SIGNED_URL, BackendFeature.MULTIPART_UPLOAD}),
         )
         resp = _client.get("/api/v2/connectors/s3_connector/capabilities")
         assert resp.status_code == 200

--- a/tests/unit/backends/connectors/cli/test_metastore_listing.py
+++ b/tests/unit/backends/connectors/cli/test_metastore_listing.py
@@ -56,11 +56,11 @@ def _make_route(
     use_metadata_listing: bool = True,
     backend_path: str = "",
 ) -> SimpleNamespace:
-    from nexus.contracts.capabilities import ConnectorCapability
+    from nexus.contracts.backend_features import BackendFeature
 
     caps = frozenset()
     if sync_eligible:
-        caps = frozenset({ConnectorCapability.SYNC_ELIGIBLE})
+        caps = frozenset({BackendFeature.SYNC_ELIGIBLE})
 
     backend = MagicMock()
     backend.name = backend_name

--- a/tests/unit/backends/connectors/cli/test_sync_loop.py
+++ b/tests/unit/backends/connectors/cli/test_sync_loop.py
@@ -32,9 +32,9 @@ def _make_backend(
     backend.name = name
 
     if capabilities is None:
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
-        capabilities = frozenset({ConnectorCapability.SYNC_ELIGIBLE})
+        capabilities = frozenset({BackendFeature.SYNC_ELIGIBLE})
     backend.capabilities = capabilities
     backend.has_capability = MagicMock(side_effect=lambda c: c in capabilities)
 
@@ -142,10 +142,10 @@ class TestCapabilityFiltering:
     @pytest.mark.asyncio
     async def test_syncs_sync_eligible(self) -> None:
         """Connectors with SYNC_ELIGIBLE get synced."""
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = _make_backend(
-            capabilities=frozenset({ConnectorCapability.SYNC_ELIGIBLE}),
+            capabilities=frozenset({BackendFeature.SYNC_ELIGIBLE}),
         )
         route = _make_route(backend)
 
@@ -265,10 +265,10 @@ class TestDeltaSyncToMetastore:
     @pytest.mark.asyncio
     async def test_delta_with_no_changes(self) -> None:
         """No-change delta records success without writes."""
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = _make_backend(
-            capabilities=frozenset({ConnectorCapability.SYNC_ELIGIBLE}),
+            capabilities=frozenset({BackendFeature.SYNC_ELIGIBLE}),
             has_sync_delta=True,
             sync_delta_result={"added": [], "deleted": [], "history_id": "100"},
         )
@@ -292,10 +292,10 @@ class TestDeltaSyncToMetastore:
     @pytest.mark.asyncio
     async def test_delta_full_sync_required_falls_back(self) -> None:
         """Delta with full_sync_required=True triggers full BFS sync."""
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = _make_backend(
-            capabilities=frozenset({ConnectorCapability.SYNC_ELIGIBLE}),
+            capabilities=frozenset({BackendFeature.SYNC_ELIGIBLE}),
             has_sync_delta=True,
             sync_delta_result={"added": [], "deleted": [], "full_sync": True},
         )
@@ -321,10 +321,10 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_sync_failure_records_error(self) -> None:
         """Failed sync records failure in mount state."""
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = _make_backend(
-            capabilities=frozenset({ConnectorCapability.SYNC_ELIGIBLE}),
+            capabilities=frozenset({BackendFeature.SYNC_ELIGIBLE}),
         )
         route = _make_route(backend)
 
@@ -343,10 +343,10 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_delta_failure_falls_back_to_full_sync(self) -> None:
         """Failed delta sync falls back to full BFS sync."""
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = _make_backend(
-            capabilities=frozenset({ConnectorCapability.SYNC_ELIGIBLE}),
+            capabilities=frozenset({BackendFeature.SYNC_ELIGIBLE}),
             has_sync_delta=True,
             sync_delta_result=None,  # Will be overridden
         )
@@ -381,10 +381,10 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_skip_mount_with_sync_in_progress(self) -> None:
         """Mount with sync_in_progress is skipped."""
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = _make_backend(
-            capabilities=frozenset({ConnectorCapability.SYNC_ELIGIBLE}),
+            capabilities=frozenset({BackendFeature.SYNC_ELIGIBLE}),
         )
         route = _make_route(backend)
 

--- a/tests/unit/backends/connectors/cli/test_sync_loop_failures.py
+++ b/tests/unit/backends/connectors/cli/test_sync_loop_failures.py
@@ -18,11 +18,11 @@ from nexus.backends.connectors.cli.sync_types import DeltaItem
 
 
 def _make_backend(capabilities: frozenset | None = None, **kwargs: Any) -> MagicMock:
-    from nexus.contracts.capabilities import ConnectorCapability
+    from nexus.contracts.backend_features import BackendFeature
 
     backend = MagicMock()
     backend.name = "test"
-    backend.capabilities = capabilities or frozenset({ConnectorCapability.SYNC_ELIGIBLE})
+    backend.capabilities = capabilities or frozenset({BackendFeature.SYNC_ELIGIBLE})
     backend.has_capability = MagicMock(side_effect=lambda c: c in backend.capabilities)
     backend._has_caching = MagicMock(return_value=False)
     backend.use_metadata_listing = True

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -1,7 +1,7 @@
-"""Unit tests for ConnectorCapability system (Issue #2069).
+"""Unit tests for BackendFeature system (Issue #2069).
 
 Tests:
-1. ConnectorCapability enum completeness
+1. BackendFeature enum completeness
 2. Backend.has_capability() contract
 3. Backend.capabilities is frozenset (immutable)
 4. DelegatingBackend delegates capabilities correctly
@@ -18,46 +18,46 @@ import pytest
 from nexus.backends.base.backend import Backend
 from nexus.backends.base.registry import ConnectorRegistry
 from nexus.backends.storage.delegating import DelegatingBackend
-from nexus.contracts.capabilities import (
-    BLOB_CONNECTOR_CAPABILITIES,
-    CORE_CAPABILITIES,
-    OAUTH_CONNECTOR_CAPABILITIES,
-    ConnectorCapability,
+from nexus.contracts.backend_features import (
+    BLOB_BACKEND_FEATURES,
+    CORE_BACKEND_FEATURES,
+    OAUTH_BACKEND_FEATURES,
+    BackendFeature,
 )
 
 # ---------------------------------------------------------------------------
-# ConnectorCapability Enum Tests
+# BackendFeature Enum Tests
 # ---------------------------------------------------------------------------
 
 
-class TestConnectorCapabilityEnum:
-    """ConnectorCapability enum is well-formed and complete."""
+class TestBackendFeatureEnum:
+    """BackendFeature enum is well-formed and complete."""
 
     def test_all_members_are_strings(self) -> None:
         """Every capability value is a non-empty string."""
-        for cap in ConnectorCapability:
+        for cap in BackendFeature:
             assert isinstance(cap.value, str)
             assert len(cap.value) > 0
 
     def test_values_are_unique(self) -> None:
         """No two capabilities share the same string value."""
-        values = [cap.value for cap in ConnectorCapability]
+        values = [cap.value for cap in BackendFeature]
         assert len(values) == len(set(values))
 
     def test_expected_member_count(self) -> None:
-        """We have exactly 26 capabilities (EXTERNAL_CONTENT removed — now DT_EXTERNAL_STORAGE entry_type)."""
-        assert len(ConnectorCapability) == 26
+        """21 features: removed EXTERNAL_CONTENT (now DT type) + 5 dead (DATA_DIR, PARALLEL_MMAP, SEARCHABLE, WATCH, CHANGE_NOTIFICATIONS)."""
+        assert len(BackendFeature) == 21
 
     def test_str_enum_identity(self) -> None:
         """StrEnum values can be compared with plain strings."""
-        assert ConnectorCapability.RENAME == "rename"
-        assert ConnectorCapability.SIGNED_URL == "signed_url"
+        assert BackendFeature.RENAME == "rename"
+        assert BackendFeature.SIGNED_URL == "signed_url"
 
     def test_membership_check_o1(self) -> None:
         """Frozenset membership check works for capabilities."""
-        caps = frozenset({ConnectorCapability.RENAME, ConnectorCapability.STREAMING})
-        assert ConnectorCapability.RENAME in caps
-        assert ConnectorCapability.SIGNED_URL not in caps
+        caps = frozenset({BackendFeature.RENAME, BackendFeature.STREAMING})
+        assert BackendFeature.RENAME in caps
+        assert BackendFeature.SIGNED_URL not in caps
 
 
 # ---------------------------------------------------------------------------
@@ -66,33 +66,33 @@ class TestConnectorCapabilityEnum:
 
 
 class TestConvenienceFrozensets:
-    """CORE_CAPABILITIES, BLOB_CONNECTOR_CAPABILITIES, OAUTH_CONNECTOR_CAPABILITIES."""
+    """CORE_BACKEND_FEATURES, BLOB_BACKEND_FEATURES, OAUTH_BACKEND_FEATURES."""
 
     def test_core_is_empty(self) -> None:
-        """CORE_CAPABILITIES is empty — backends opt in."""
-        assert frozenset() == CORE_CAPABILITIES
+        """CORE_BACKEND_FEATURES is empty — backends opt in."""
+        assert frozenset() == CORE_BACKEND_FEATURES
 
     def test_blob_connector_has_expected(self) -> None:
         expected = {
-            ConnectorCapability.RENAME,
-            ConnectorCapability.DIRECTORY_LISTING,
-            ConnectorCapability.PATH_DELETE,
-            ConnectorCapability.STREAMING,
-            ConnectorCapability.BATCH_CONTENT,
+            BackendFeature.RENAME,
+            BackendFeature.DIRECTORY_LISTING,
+            BackendFeature.PATH_DELETE,
+            BackendFeature.STREAMING,
+            BackendFeature.BATCH_CONTENT,
         }
-        assert expected == BLOB_CONNECTOR_CAPABILITIES
+        assert expected == BLOB_BACKEND_FEATURES
 
     def test_oauth_connector_has_expected(self) -> None:
         expected = {
-            ConnectorCapability.USER_SCOPED,
-            ConnectorCapability.TOKEN_MANAGER,
-            ConnectorCapability.OAUTH,
-            ConnectorCapability.SYNC_ELIGIBLE,
+            BackendFeature.USER_SCOPED,
+            BackendFeature.TOKEN_MANAGER,
+            BackendFeature.OAUTH,
+            BackendFeature.SYNC_ELIGIBLE,
         }
-        assert expected == OAUTH_CONNECTOR_CAPABILITIES
+        assert expected == OAUTH_BACKEND_FEATURES
 
     def test_all_frozensets_are_immutable(self) -> None:
-        for fs in (CORE_CAPABILITIES, BLOB_CONNECTOR_CAPABILITIES, OAUTH_CONNECTOR_CAPABILITIES):
+        for fs in (CORE_BACKEND_FEATURES, BLOB_BACKEND_FEATURES, OAUTH_BACKEND_FEATURES):
             assert isinstance(fs, frozenset)
 
 
@@ -115,14 +115,14 @@ class TestBackendCapabilities:
     def test_has_capability_true_when_present(self) -> None:
         """has_capability returns True when capability is in _CAPABILITIES."""
         mock = MagicMock(spec=Backend)
-        mock.has_capability = lambda cap: cap in frozenset({ConnectorCapability.RENAME})
-        assert mock.has_capability(ConnectorCapability.RENAME)
+        mock.has_capability = lambda cap: cap in frozenset({BackendFeature.RENAME})
+        assert mock.has_capability(BackendFeature.RENAME)
 
     def test_has_capability_false_when_absent(self) -> None:
         """has_capability returns False when capability is not in _CAPABILITIES."""
         mock = MagicMock(spec=Backend)
         mock.has_capability = lambda cap: cap in frozenset()
-        assert not mock.has_capability(ConnectorCapability.RENAME)
+        assert not mock.has_capability(BackendFeature.RENAME)
 
 
 # ---------------------------------------------------------------------------
@@ -137,15 +137,13 @@ class TestDelegatingBackendCapabilities:
     def inner_with_caps(self) -> MagicMock:
         mock = MagicMock(spec=Backend)
         mock.name = "test-inner"
-        caps = frozenset({ConnectorCapability.RENAME, ConnectorCapability.STREAMING})
+        caps = frozenset({BackendFeature.RENAME, BackendFeature.STREAMING})
         type(mock).capabilities = PropertyMock(return_value=caps)
         return mock
 
     def test_capabilities_delegated(self, inner_with_caps: MagicMock) -> None:
         wrapper = DelegatingBackend(inner_with_caps)
-        assert wrapper.capabilities == frozenset(
-            {ConnectorCapability.RENAME, ConnectorCapability.STREAMING}
-        )
+        assert wrapper.capabilities == frozenset({BackendFeature.RENAME, BackendFeature.STREAMING})
 
     def test_capabilities_cached_in_init(self, inner_with_caps: MagicMock) -> None:
         wrapper = DelegatingBackend(inner_with_caps)
@@ -154,8 +152,8 @@ class TestDelegatingBackendCapabilities:
 
     def test_has_capability_uses_cached(self, inner_with_caps: MagicMock) -> None:
         wrapper = DelegatingBackend(inner_with_caps)
-        assert wrapper.has_capability(ConnectorCapability.RENAME)
-        assert not wrapper.has_capability(ConnectorCapability.SIGNED_URL)
+        assert wrapper.has_capability(BackendFeature.RENAME)
+        assert not wrapper.has_capability(BackendFeature.SIGNED_URL)
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +174,7 @@ class TestRegistryCapabilities:
 
     def _make_fake_backend(
         self,
-        caps: frozenset[ConnectorCapability] | None = None,
+        caps: frozenset[BackendFeature] | None = None,
     ) -> type:
         """Create a minimal fake backend class."""
 
@@ -242,7 +240,7 @@ class TestRegistryCapabilities:
         return FakeBackend
 
     def test_register_stores_capabilities(self) -> None:
-        caps = frozenset({ConnectorCapability.RENAME, ConnectorCapability.STREAMING})
+        caps = frozenset({BackendFeature.RENAME, BackendFeature.STREAMING})
         cls = self._make_fake_backend(caps)
         ConnectorRegistry.register("test_cap_backend", cls)
         info = ConnectorRegistry.get_info("test_cap_backend")
@@ -255,28 +253,28 @@ class TestRegistryCapabilities:
         assert info.capabilities == frozenset()
 
     def test_get_capabilities(self) -> None:
-        caps = frozenset({ConnectorCapability.SIGNED_URL})
+        caps = frozenset({BackendFeature.SIGNED_URL})
         cls = self._make_fake_backend(caps)
         ConnectorRegistry.register("test_get_cap", cls)
         assert ConnectorRegistry.get_capabilities("test_get_cap") == caps
 
     def test_list_by_capability(self) -> None:
-        caps1 = frozenset({ConnectorCapability.RENAME})
-        caps2 = frozenset({ConnectorCapability.RENAME, ConnectorCapability.STREAMING})
+        caps1 = frozenset({BackendFeature.RENAME})
+        caps2 = frozenset({BackendFeature.RENAME, BackendFeature.STREAMING})
         cls1 = self._make_fake_backend(caps1)
         cls2 = self._make_fake_backend(caps2)
         ConnectorRegistry.register("test_lbc1", cls1)
         ConnectorRegistry.register("test_lbc2", cls2)
-        results = ConnectorRegistry.list_by_capability(ConnectorCapability.RENAME)
+        results = ConnectorRegistry.list_by_capability(BackendFeature.RENAME)
         result_names = {r.name for r in results}
         assert "test_lbc1" in result_names
         assert "test_lbc2" in result_names
 
     def test_list_by_capability_excludes_non_matching(self) -> None:
-        caps = frozenset({ConnectorCapability.RENAME})
+        caps = frozenset({BackendFeature.RENAME})
         cls = self._make_fake_backend(caps)
         ConnectorRegistry.register("test_lbc_excl", cls)
-        results = ConnectorRegistry.list_by_capability(ConnectorCapability.SIGNED_URL)
+        results = ConnectorRegistry.list_by_capability(BackendFeature.SIGNED_URL)
         result_names = {r.name for r in results}
         assert "test_lbc_excl" not in result_names
 
@@ -300,7 +298,7 @@ class TestCapabilityProtocolMapping:
 
         mapping = get_capability_protocols()
         for key in mapping:
-            assert isinstance(key, ConnectorCapability)
+            assert isinstance(key, BackendFeature)
 
     def test_mapping_values_are_types(self) -> None:
         from nexus.backends.base.registry import get_capability_protocols
@@ -313,7 +311,7 @@ class TestCapabilityProtocolMapping:
         from nexus.backends.base.registry import get_capability_protocols
 
         mapping = get_capability_protocols()
-        assert ConnectorCapability.STREAMING in mapping
-        assert ConnectorCapability.BATCH_CONTENT in mapping
-        assert ConnectorCapability.DIRECTORY_LISTING in mapping
-        assert ConnectorCapability.OAUTH in mapping
+        assert BackendFeature.STREAMING in mapping
+        assert BackendFeature.BATCH_CONTENT in mapping
+        assert BackendFeature.DIRECTORY_LISTING in mapping
+        assert BackendFeature.OAUTH in mapping

--- a/tests/unit/backends/test_openai_compat.py
+++ b/tests/unit/backends/test_openai_compat.py
@@ -301,12 +301,12 @@ class TestOpenAICompatibleBackend:
         assert resp_data["finish_reason"] == "stop"
 
     def test_capabilities(self) -> None:
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend, _ = _make_backend()
-        assert backend.has_capability(ConnectorCapability.CAS)
-        assert backend.has_capability(ConnectorCapability.STREAMING)
-        assert not backend.has_capability(ConnectorCapability.ROOT_PATH)
+        assert backend.has_capability(BackendFeature.CAS)
+        assert backend.has_capability(BackendFeature.STREAMING)
+        assert not backend.has_capability(BackendFeature.ROOT_PATH)
 
     def test_mkdir_rmdir_noop(self) -> None:
         """Directory ops are no-ops for compute backends."""

--- a/tests/unit/backends/test_path_local.py
+++ b/tests/unit/backends/test_path_local.py
@@ -65,10 +65,10 @@ class TestPathLocalRegistration:
         assert cls is PathLocalBackend
 
     def test_capabilities(self, tmp_path: Path) -> None:
-        from nexus.contracts.capabilities import ConnectorCapability
+        from nexus.contracts.backend_features import BackendFeature
 
         backend = PathLocalBackend(root_path=tmp_path)
-        assert ConnectorCapability.ROOT_PATH in backend.capabilities
+        assert BackendFeature.ROOT_PATH in backend.capabilities
         assert backend.has_root_path is True
         assert backend.name == "path_local"
 


### PR DESCRIPTION
## Summary
- Rename `ConnectorCapability` → `BackendFeature` to accurately reflect purpose (backend feature flags, not kernel capabilities)
- Rename file `capabilities.py` → `backend_features.py`
- Rename frozensets: `OAUTH_CONNECTOR_CAPABILITIES` → `OAUTH_BACKEND_FEATURES`, etc.
- Delete 5 dead members with 0 queries: `DATA_DIR`, `PARALLEL_MMAP`, `SEARCHABLE`, `WATCH`, `CHANGE_NOTIFICATIONS`
- 37 files updated across src/ and tests/

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [ ] CI full test suite
- [ ] Verify `grep -rn "ConnectorCapability" src/ tests/` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)