### PR TITLE
refactor(#1825): upgrade zone_id to kernel namespace partition concept

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -273,6 +273,12 @@ describe files. Operations: O(1) KV (get/put/delete), ordered prefix scan
 
 Data type: `FileMetadata` — path, backend_name, etag, size, version, zone_id,
 owner_id, timestamps, mime_type. Always tagged with `zone_id` (P0 invariant).
+`zone_id` is a **kernel namespace partition identifier** (analogous to Linux
+`sb->s_dev`). Federation extends zones with Raft consensus groups, but the
+kernel owns the concept. `owner_id` is the kernel's posix_uid — used by
+`PermissionEnforcerProtocol.check_owner()` for O(1) DAC before service-layer
+hooks run. Audit trail (who created a file) is a service concern tracked by
+VersionRecorder, not a kernel inode field.
 
 ### 3.2 ObjectStoreABC (= Backend) — Blob I/O
 

--- a/proto/nexus/core/metadata.proto
+++ b/proto/nexus/core/metadata.proto
@@ -52,21 +52,22 @@ message FileMetadata {
   // Metadata version number (starts at 1).
   int32 version = 9;
 
-  // Zone ID for multi-zone deployments.
+  // Kernel namespace partition ID for multi-zone isolation (P0 invariant).
+  // Analogous to Linux sb->s_dev. Federation extends zones with Raft consensus.
   string zone_id = 10;
 
   // User or agent ID who created/modified this version.
   string created_by = 11;
 
-  // Owner ID for O(1) permission checks (posix_uid).
+  // Kernel posix_uid for O(1) DAC via PermissionEnforcerProtocol.check_owner().
   string owner_id = 12;
 
   // Entry type: DT_REG (0), DT_DIR (1), DT_MOUNT (2), DT_PIPE (3), DT_STREAM (4).
   // SSOT for file/directory/mount/ipc distinction.
   DirEntryType entry_type = 13;
 
-  // Target zone ID for DT_MOUNT entries. Only set when entry_type == DT_MOUNT.
-  // Contains the zone_id of the mounted zone for cross-zone path resolution.
+  // Mount target namespace (DT_MOUNT only). Kernel concept for cross-zone
+  // path resolution — federation extends with Raft consensus per zone.
   string target_zone_id = 14;
 
   // Field 15 reserved: i_links_count moved to zone-level __i_links_count__

--- a/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
+++ b/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 class CacheKey:
     """Key for Tiger Cache lookup.
 
-    zone_id is included for multi-zone federation isolation — each zone
+    zone_id is included for multi-zone namespace isolation — each zone
     gets its own cache partition to prevent cross-zone cache pollution.
     """
 

--- a/src/nexus/contracts/metadata.py
+++ b/src/nexus/contracts/metadata.py
@@ -50,11 +50,11 @@ class FileMetadata:
     created_at: datetime | None = None
     modified_at: datetime | None = None
     version: int = 1
-    zone_id: str | None = None
+    zone_id: str | None = None  # Kernel namespace partition ID (P0 invariant)
     created_by: str | None = None
-    owner_id: str | None = None
+    owner_id: str | None = None  # Kernel posix_uid for O(1) DAC
     entry_type: int = 0
-    target_zone_id: str | None = None
+    target_zone_id: str | None = None  # Mount target namespace (DT_MOUNT only)
 
     @property
     def is_reg(self) -> bool:

--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -88,7 +88,7 @@ class OperationContext:
         subject_type: Type of subject (user, agent, service, session).
         subject_id: Unique identifier for the subject.
         groups: List of group IDs the subject belongs to.
-        zone_id: Zone/organization ID for multi-zone isolation (optional).
+        zone_id: Kernel namespace partition ID for multi-zone isolation (optional).
         is_admin: Whether the subject has admin privileges.
         is_system: Whether this is a system operation (bypasses all checks).
         admin_capabilities: Set of granted admin capabilities.

--- a/src/nexus/core/file_events.py
+++ b/src/nexus/core/file_events.py
@@ -63,7 +63,7 @@ class FileEvent:
 
     type: FileEventType | str
     path: str
-    zone_id: str | None = None  # None for Layer 1 (local) events
+    zone_id: str | None = None  # Kernel namespace partition (None for Layer 1 local events)
     timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     old_path: str | None = None

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -183,7 +183,7 @@ class NexusFS(  # type: ignore[misc]
 
         # IPC primitives — kernel-internal, NOT injected via DI.
         # Like VFSLockManager: always present, created by kernel at init.
-        # Both use ROOT_ZONE_ID (zone_id is a federation concept, not kernel).
+        # Both use ROOT_ZONE_ID (zone_id is a kernel namespace partition concept).
         import os as _os_ipc
 
         from nexus.core.pipe_manager import PipeManager

--- a/src/nexus/lib/distributed_lock.py
+++ b/src/nexus/lib/distributed_lock.py
@@ -82,7 +82,7 @@ class AdvisoryLockManager(ABC):
     a counting semaphore (no exclusive/shared distinction).
 
     zone_id is bound at construction time — callers never pass it per-method.
-    This prevents federation concepts (zone) from leaking into the lock API.
+    zone_id is a kernel namespace partition concept — callers need not manage it.
     Internally, zone_id is used as a key prefix for store-level scoping.
 
     Subclasses must implement all abstract methods.

--- a/src/nexus/services/lifecycle/zone_writability_hook.py
+++ b/src/nexus/services/lifecycle/zone_writability_hook.py
@@ -1,8 +1,9 @@
 """Zone writability hook — gate all writes during zone deprovision (Issue #2061).
 
 Migrated from NexusFS._check_zone_writable() (Issue #1371):
-kernel should not know about zone lifecycle — this is a federation concern
-injected via KernelDispatch PRE hooks.
+zone lifecycle management is a federation service concern (kernel owns zone_id
+as namespace partition, federation owns zone provisioning/deprovisioning).
+Injected via KernelDispatch PRE hooks.
 
 When a zone is terminating (being deprovisioned), all write operations
 to that zone are blocked with ZoneTerminatingError. This prevents data


### PR DESCRIPTION
## Summary
- Upgrade `zone_id` and `target_zone_id` from "federation concept" to **kernel first-class namespace partition concept** (analogous to Linux `sb->s_dev`)
- Document `owner_id` as kernel posix_uid for O(1) DAC
- Clarify that audit trail (`created_by`) is a service concern, not kernel inode field
- Pure doc/comment changes across 9 files — zero behavior change

## Context
FileMetadata (#1825) had 4 fields perceived as service-tier leaks. After deep audit:
- `zone_id` / `target_zone_id`: kernel-legitimate — zone = namespace partition, federation extends with Raft
- `owner_id`: kernel-legitimate — posix_uid for DAC
- `created_by`: will be removed in follow-up PR (service concern)

This PR is the first of 3:
1. **This PR**: doc/comment upgrades (zero risk)
2. PR 2: kernel DAC via `PermissionEnforcerProtocol.check_owner()`
3. PR 3: remove `created_by` from FileMetadata

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy, format)
- [ ] CI green — no behavior changes, only comments/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>