### PR TITLE
refactor: service injection Phase 4 — enlist merge, AgentRegistry, bootstrap cleanup

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -329,7 +329,7 @@ with them indirectly through syscalls. See §2.2 for per-syscall usage.
 | **StreamManager + StreamBuffer** | `core.stream_manager` + `core.stream` | append-only log | VFS named streams — kernel-owned, created at `__init__`. Inode in MetastoreABC, data in heap linear buffer. Non-destructive offset-based reads, multi-reader fan-out. Details in §4.2 |
 | **ServiceRegistry** | `core.service_registry` | `init/main.c` + `module.c` | Kernel-owned symbol table + lifecycle orchestration (enlist/swap/shutdown). One-dimension model: PersistentService + duck-typed hook_spec() |
 | **DriverLifecycleCoordinator** | `core.driver_lifecycle_coordinator` | `register_filesystem` + `kern_mount` | Driver mount lifecycle: routing table + VFS hook registration + mount/unmount KernelDispatch notification. Orthogonal to ServiceRegistry (drivers vs services) |
-| **AgentRegistry** | `core.agent_registry` | `task_struct` list | In-memory agent process table. Kernel-owned, created at `__init__`. Details in §4.4 |
+| **AgentRegistry** | `core.agent_registry` | `task_struct` list | In-memory agent process table. Kernel-knows — constructed by first consumer (AcpService/EvictionManager) via ServiceRegistry. Details in §4.4 |
 | **FileWatcher + FileEvent** | `core.file_watcher` + `core.file_events` | `inotify(7)` + `fsnotify_event` | Kernel file change notification + immutable mutation records. FileWatcher: kernel-owned local OBSERVE waiters + kernel-knows `RemoteWatchProtocol`. FileEvent: frozen dataclass. Details in §4.3 |
 
 ### 4.1 VFSLockManager — Per-Path RW Lock
@@ -391,11 +391,11 @@ See `federation-memo.md` §7j for design rationale.
 | Linux analogue | `task_struct` list (`for_each_process()`) |
 | Package | `core.agent_registry` |
 | Storage | In-memory dict (process heap) — no persistence |
-| Lifecycle | Created in `NexusFS.__init__()`, closed via factory close callback |
+| Lifecycle | Constructed by first consumer (AcpService/EvictionManager) via ServiceRegistry; closed by `close_all_services()` |
 
 In-memory registry of all active agent descriptors (spawn, status, close).
-Like Linux's `task_struct`, it is infrastructure that services consume but
-never create.
+Like Linux's `task_struct`, it is infrastructure that consuming services
+construct on first access and enlist into ServiceRegistry.
 
 ---
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -241,7 +241,6 @@ class NexusFS(  # type: ignore[misc]
         self._linked: bool = False
         self._initialized: bool = False
         self._bootstrapped: bool = False
-        self._bootstrap_callbacks: list[Callable[[], Any]] = []
         self._close_callbacks: list[
             Callable[[], None]
         ] = []  # Issue #1793: factory-registered service close
@@ -288,9 +287,9 @@ class NexusFS(  # type: ignore[misc]
     async def bootstrap(self) -> None:
         """Phase 3: Start async tasks.  Server/Worker only.
 
-        Executes registered bootstrap callbacks.  Reserved for future
-        server-specific active components (Feishu WS, EventBus consumers,
-        background sync workers, etc.).
+        Auto-starts all PersistentService instances (ZoneLifecycleService,
+        EventDeliveryWorker, DeferredPermissionBuffer, etc.) via
+        ServiceRegistry.start_persistent_services().
 
         Idempotent — guarded by ``_bootstrapped`` flag.
         """
@@ -298,8 +297,6 @@ class NexusFS(  # type: ignore[misc]
             return
         if not self._initialized:
             await self.initialize()
-        for cb in self._bootstrap_callbacks:
-            await cb()
         # Auto-lifecycle: start PersistentService instances (Issue #1580)
         coord = self.service_coordinator
         if coord is not None:

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -222,72 +222,9 @@ async def _wire_services(
     # rebac_manager.close() and audit_store.close() are now handled by
     # ServiceRegistry.close_all_services() — no manual callbacks needed.
 
-    # Issue #1792: AgentRegistry — lazy construct via ServiceRegistry.register_factory().
-    # Only created on first access (ACP/TaskManager/EvictionManager need it).
-    # No-agent profiles (REMOTE) never access it → never created.
-    def _create_agent_registry() -> Any:
-        from nexus.core.agent_registry import AgentRegistry
-
-        _ar = AgentRegistry()
-        # Wire close callback
-        if hasattr(_ar, "close_all"):
-
-            def _close_agent_registry() -> None:
-                try:
-                    _ar.close_all()
-                except Exception as exc:
-                    logger.debug("close: agent_registry.close_all() failed: %s", exc)
-
-            nx._close_callbacks.append(_close_agent_registry)
-
-        logger.debug("[BOOT:LINK] AgentRegistry lazy-constructed on first access")
-        return _ar
-
-    nx._service_registry.register_factory("agent_registry", _create_agent_registry)
-
-    # Issue #1801: _overlay_config_fn closure removed — kernel now reads
-    # workspace_registry directly from service registry via nx.service("workspace_registry").
-
-    # --- Deferred EvictionManager + AcpService (Issue #1792) ---
-    # AgentRegistry is lazy-constructed via register_factory().
-    # Accessing it here triggers construction only if EvictionManager/AcpService exist.
-    _agent_ref = nx._service_registry.service("agent_registry")
-    _agent_reg = _agent_ref._service_instance if _agent_ref is not None else None
-    if _agent_reg is not None:
-        try:
-            from nexus.contracts.deployment_profile import DeploymentProfile as _DP
-            from nexus.lib.performance_tuning import resolve_profile_tuning
-            from nexus.services.agents.eviction_manager import EvictionManager
-            from nexus.services.agents.eviction_policy import QoSEvictionPolicy
-            from nexus.services.agents.resource_monitor import ResourceMonitor
-
-            _profile_tuning = resolve_profile_tuning(_DP.FULL)
-            _eviction_tuning = _profile_tuning.eviction
-            _resource_monitor = ResourceMonitor(tuning=_eviction_tuning)
-            _eviction_policy = QoSEvictionPolicy()
-            _eviction_manager = EvictionManager(
-                agent_registry=_agent_reg,
-                monitor=_resource_monitor,
-                policy=_eviction_policy,
-                tuning=_eviction_tuning,
-            )
-            await nx._service_registry.enlist("eviction_manager", _eviction_manager)
-            logger.debug("[BOOT:LINK] EvictionManager created (deferred, QoS-aware)")
-        except Exception as exc:
-            logger.warning("[BOOT:LINK] EvictionManager unavailable: %s", exc)
-
-        try:
-            from nexus.contracts.constants import ROOT_ZONE_ID
-            from nexus.services.acp.service import AcpService
-
-            _acp_service = AcpService(
-                agent_registry=_agent_reg,
-                zone_id=zone_id or ROOT_ZONE_ID,
-            )
-            await nx._service_registry.enlist("acp_service", _acp_service)
-            logger.debug("[BOOT:LINK] AcpService created (deferred)")
-        except Exception as exc:
-            logger.warning("[BOOT:LINK] AcpService unavailable: %s", exc)
+    # Issue #1792: AgentRegistry, EvictionManager, AcpService are now
+    # constructed in _boot_post_kernel_services (_wired.py) by the services
+    # that need them. No factory lazy pattern or register_factory() needed.
 
     return _InitContext(
         services=_svc,

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -48,7 +48,7 @@ async def _wire_services(
     """
     from nexus.contracts.deployment_profile import DeploymentProfile as _DP
     from nexus.factory._wired import _boot_post_kernel_services
-    from nexus.factory.service_routing import enlist_services, enlist_wired_services
+    from nexus.factory.service_routing import enlist_services
 
     _svc = services or {}
     nx._permission_enforcer = _svc.get("permission_enforcer")  # Issue #1706: override sentinel
@@ -126,7 +126,7 @@ async def _wire_services(
     )
 
     # Issue #1708: ServiceRegistry now has integrated lifecycle (formerly SLC).
-    await enlist_wired_services(nx._service_registry, _wired)
+    await enlist_services(nx._service_registry, _wired)
 
     # Issue #1811: DriverLifecycleCoordinator is kernel-owned (created in
     # NexusFS.__init__). Root mount ("/") was added to PathRouter in

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -275,30 +275,10 @@ async def _initialize_services(
         parse_fn=ctx.parse_fn,
     )
 
-    # --- Register background services as bootstrap callbacks ---
-    # TL directive: initialize() prepares resources but stays static.
-    # bootstrap() is the only phase allowed to spawn active threads/async loops.
-    #
-    # Issue #1666: DeferredPermissionBuffer and EventDeliveryWorker now
-    # implement PersistentService and are auto-started by the coordinator's
-    # start_persistent_services() at bootstrap.  Manual callbacks deleted.
-
-    _zl = ctx.services.get("zone_lifecycle")
-    if _zl is not None and hasattr(_zl, "load_terminating_zones"):
-
-        async def _load_zones() -> None:
-            try:
-                _sf = getattr(_zl, "_session_factory", None)
-                if _sf is not None:
-                    with _sf() as session:
-                        _zl.load_terminating_zones(session)
-                    logger.debug(
-                        "[LIFECYCLE] ZoneLifecycleService loaded terminating zones (bootstrap)"
-                    )
-            except Exception as exc:
-                logger.warning("[LIFECYCLE] Failed to load terminating zones: %s", exc)
-
-        nx._bootstrap_callbacks.append(_load_zones)
+    # Background services (DeferredPermissionBuffer, EventDeliveryWorker,
+    # ZoneLifecycleService) implement PersistentService and are auto-started
+    # by the coordinator's start_persistent_services() at bootstrap.
+    # No manual _bootstrap_callbacks needed.
 
 
 # Backward compatibility aliases

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -311,25 +311,60 @@ async def _boot_post_kernel_services(
 
     # AgentStatusResolver moved to orchestrator._register_vfs_hooks() (Issue #1570, #1810)
 
-    acp_rpc_service: Any = None
-    # Issue #1792: AcpService is created in _wire_services() via ServiceRegistry.
-    _acp_ref = nx._service_registry.service("acp_service")
-    _acp_service = _acp_ref._service_instance if _acp_ref is not None else None
-    if _acp_service is None:
-        # Fallback: construct inline using AgentRegistry from ServiceRegistry.
-        _acp_ar_ref = nx._service_registry.service("agent_registry")
-        _acp_pt = _acp_ar_ref._service_instance if _acp_ar_ref is not None else None
-        if _acp_pt is not None:
-            try:
-                from nexus.services.acp.service import AcpService
+    # --- AgentRegistry + AcpService + EvictionManager (Issue #1792) ---
+    # AgentRegistry is constructed by the first consumer that needs it.
+    # No-agent profiles (REMOTE) skip this entire block.
+    _agent_reg: Any = None
+    _acp_ref = nx._service_registry.service("agent_registry")
+    if _acp_ref is not None:
+        _agent_reg = _acp_ref._service_instance
+    if _agent_reg is None:
+        try:
+            from nexus.core.agent_registry import AgentRegistry
 
-                _acp_service = AcpService(
-                    agent_registry=_acp_pt,
-                    zone_id=ROOT_ZONE_ID,
-                )
-                logger.debug("[BOOT:WIRED] AcpService created (inline)")
-            except Exception as exc:
-                logger.debug("[BOOT:WIRED] AcpService unavailable: %s", exc)
+            _agent_reg = AgentRegistry()
+            await nx._service_registry.enlist("agent_registry", _agent_reg)
+            logger.debug("[BOOT:WIRED] AgentRegistry constructed by wired tier")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] AgentRegistry unavailable: %s", exc)
+
+    # EvictionManager (QoS-aware agent eviction)
+    if _agent_reg is not None:
+        try:
+            from nexus.contracts.deployment_profile import DeploymentProfile as _DP
+            from nexus.lib.performance_tuning import resolve_profile_tuning
+            from nexus.services.agents.eviction_manager import EvictionManager
+            from nexus.services.agents.eviction_policy import QoSEvictionPolicy
+            from nexus.services.agents.resource_monitor import ResourceMonitor
+
+            _profile_tuning = resolve_profile_tuning(_DP.FULL)
+            _eviction_tuning = _profile_tuning.eviction
+            _eviction_manager = EvictionManager(
+                agent_registry=_agent_reg,
+                monitor=ResourceMonitor(tuning=_eviction_tuning),
+                policy=QoSEvictionPolicy(),
+                tuning=_eviction_tuning,
+            )
+            await nx._service_registry.enlist("eviction_manager", _eviction_manager)
+            logger.debug("[BOOT:WIRED] EvictionManager created (QoS-aware)")
+        except Exception as exc:
+            logger.warning("[BOOT:WIRED] EvictionManager unavailable: %s", exc)
+
+    # AcpService (agent call protocol)
+    acp_rpc_service: Any = None
+    _acp_service: Any = None
+    if _agent_reg is not None:
+        try:
+            from nexus.services.acp.service import AcpService
+
+            _acp_service = AcpService(
+                agent_registry=_agent_reg,
+                zone_id=ROOT_ZONE_ID,
+            )
+            await nx._service_registry.enlist("acp_service", _acp_service)
+            logger.debug("[BOOT:WIRED] AcpService created")
+        except Exception as exc:
+            logger.debug("[BOOT:WIRED] AcpService unavailable: %s", exc)
     if _acp_service is not None:
         # Late-bind NexusFS for VFS-routed file I/O (``everything is a file``).
         if hasattr(_acp_service, "bind_fs"):

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -3,7 +3,7 @@
 Issue #1502: ``bind_wired_services()`` and the setattr wiring path have been
 deleted.  All service access now goes through ``nx.service("name")``.
 
-Issue #1708: Single entry point via ``enlist_wired_services()`` which calls
+Issue #1708: Single entry point via ``enlist_services()`` which calls
 ``coordinator.enlist()`` for each service.  Coordinator is always available
 for all deployment profiles (BLM optional).
 """
@@ -80,10 +80,14 @@ _CANONICAL_EXPORTS: dict[str, tuple[str, ...]] = {
 }
 
 # ---------------------------------------------------------------------------
-# Canonical name mapping: WiredServices field → short registry key
+# Canonical name mapping: source key → short registry key
+#
+# Unified map for both dict-keyed services (pre-kernel + brick tier)
+# and WiredServices dataclass fields (post-kernel tier).
 # ---------------------------------------------------------------------------
 
 _CANONICAL_NAMES: dict[str, str] = {
+    # WiredServices dataclass fields
     "rebac_service": "rebac",
     "mount_service": "mount",
     "gateway": "gateway",
@@ -103,53 +107,44 @@ _CANONICAL_NAMES: dict[str, str] = {
     "user_provisioning_service": "user_provisioning",
     "sandbox_rpc_service": "sandbox_rpc",
     "metadata_export_service": "metadata_export",
-}
-
-
-# Canonical name aliases for dict-keyed services (pre-kernel + brick dicts).
-# Parallel to _CANONICAL_NAMES for wired (dataclass) services.
-_ENLIST_CANONICAL_NAMES: dict[str, str] = {
+    # Dict-keyed services (pre-kernel + brick tier)
     "context_branch_service": "context_branch",
 }
 
 
-async def enlist_services(coordinator: Any, services: dict[str, Any]) -> int:
-    """Enlist services from a dict via coordinator.enlist().
+async def enlist_services(coordinator: Any, services: Any) -> int:
+    """Enlist services via coordinator.enlist() (#1708).
 
-    Same pattern as enlist_wired_services() but for plain dicts
-    (pre-kernel tier + brick tier merged). Skips None values.
-
-    Returns the number of services enlisted.
-    """
-    count = 0
-    for attr, val in services.items():
-        if val is None:
-            continue
-        canonical = _ENLIST_CANONICAL_NAMES.get(attr, attr)
-        await coordinator.enlist(canonical, val)
-        count += 1
-    return count
-
-
-async def enlist_wired_services(coordinator: Any, wired: Any) -> int:
-    """Enlist WiredServices via coordinator.enlist() (#1708).
-
-    Iterates ``_CANONICAL_NAMES``, extracts each non-None service from
-    ``wired`` (WiredServices dataclass or dict), and calls
-    ``await coordinator.enlist()`` with canonical name + exports.
-
-    All wired services are on-demand — no PersistentService or hook_spec()
-    — so enlist() auto-detects and registers them without lifecycle side effects.
-    On-demand services are still swappable at runtime via swap_service() (#1452).
+    Accepts both dicts and dataclass instances. For each non-None service,
+    resolves canonical name (via ``_CANONICAL_NAMES``) and exports
+    (via ``_CANONICAL_EXPORTS``), then calls ``coordinator.enlist()``.
 
     Returns the number of services enlisted.
     """
     count = 0
-    for src_key, canonical in _CANONICAL_NAMES.items():
-        val = wired.get(src_key) if isinstance(wired, dict) else getattr(wired, src_key, None)
+
+    pairs: list[tuple[str, Any]]
+    if isinstance(services, dict):
+        pairs = list(services.items())
+    else:
+        # WiredServices dataclass — iterate declared fields
+        pairs = [(f, getattr(services, f, None)) for f in services.__dataclass_fields__]
+
+    for src_key, val in pairs:
         if val is None:
             continue
+        canonical: str = _CANONICAL_NAMES.get(src_key, src_key)
         exports = _CANONICAL_EXPORTS.get(canonical, ())
-        await coordinator.enlist(canonical, val, exports=exports, allow_overwrite=True)
+        await coordinator.enlist(
+            canonical,
+            val,
+            exports=exports,
+            allow_overwrite=True,
+        )
         count += 1
+
     return count
+
+
+# Backward compatibility alias
+enlist_wired_services = enlist_services

--- a/src/nexus/services/lifecycle/zone_lifecycle.py
+++ b/src/nexus/services/lifecycle/zone_lifecycle.py
@@ -75,6 +75,29 @@ class ZoneLifecycleService:
         )
 
     # ------------------------------------------------------------------
+    # PersistentService lifecycle (auto-managed by ServiceRegistry)
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Load terminating zones from DB at bootstrap.
+
+        Called by ServiceRegistry.start_persistent_services(). Replaces
+        the old _bootstrap_callbacks pattern.
+        """
+        try:
+            if self._session_factory is not None:
+                with self._session_factory() as session:
+                    self.load_terminating_zones(session)
+                logger.debug(
+                    "[ZoneLifecycle] Loaded terminating zones at PersistentService.start()"
+                )
+        except Exception as exc:
+            logger.warning("[ZoneLifecycle] Failed to load terminating zones: %s", exc)
+
+    async def stop(self) -> None:
+        """No-op — in-memory set, no cleanup needed."""
+
+    # ------------------------------------------------------------------
     # Write-gating (Decision #4A / #14A)
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Merge `enlist_services` + `enlist_wired_services`** into single `enlist_services()` — accepts both dicts and dataclasses, unified `_CANONICAL_NAMES` mapping
- **AgentRegistry self-construct** — moved from `_lifecycle.py` lazy factory to `_wired.py` consumer tier. AcpService/EvictionManager construct it when needed. No-agent profiles skip entirely.
- **Delete `_bootstrap_callbacks`** — ZoneLifecycleService now implements PersistentService `start()/stop()`, auto-started by `start_persistent_services()`. Kernel no longer has `_bootstrap_callbacks` list.
- **Update KERNEL-ARCHITECTURE.md** — AgentRegistry = kernel-knows (constructed by consumers), not kernel-owns

PR 2 (follow-up): Permission decoupling — delete `_permission_enforcer`, `_descendant_checker`, `AllowAllEnforcer`, `_enforce_permissions` from kernel. KernelDispatch INTERCEPT becomes the sole permission mechanism.

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — 45 passed
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)