### PR TITLE
fix: raft smoke test — bytes_written is int, not dict

### DIFF
--- a/tests/e2e/docker/test_raft_cluster_smoke.py
+++ b/tests/e2e/docker/test_raft_cluster_smoke.py
@@ -132,8 +132,7 @@ class TestRaftWriteRead:
         assert "error" not in result, f"Write failed: {result}"
         assert "result" in result
         bw = result["result"]["bytes_written"]
-        assert bw["size"] == len(content)
-        assert bw["version"] == 1
+        assert bw == len(content)
 
     def test_read_from_leader(self, cluster, api_key):
         """Write then read back from the same node."""


### PR DESCRIPTION
bytes_written returns an int (e.g. 42), not a dict with size/version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)