### PR TITLE
refactor(#162): EventBus as infra — wire into FileWatcher, remove from ServiceRegistry

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -577,20 +577,6 @@ async def _register_federation_resolver(nx_fs: "NexusFS", federation: Any, backe
     )
     await _coordinator.enlist("federation_ipc", ipc_resolver)
 
-    # Wire EventBus as kernel FileWatcher's remote watcher (#162).
-    # Federation is the primary consumer of cross-zone events, so it
-    # constructs the EventBus and wires it into the kernel.
-    # Other consumers that need distributed events check
-    # _file_watcher._remote_watcher — if None, they can construct and set it.
-    if hasattr(nx_fs, "_file_watcher") and not nx_fs._file_watcher.has_remote_watcher:
-        _event_bus_ref = nx_fs._service_registry.service("event_bus")
-        _event_bus = _event_bus_ref._service_instance if _event_bus_ref is not None else None
-        if _event_bus is None:
-            _event_bus = getattr(nx_fs, "_event_bus_instance", None)
-        if _event_bus is not None:
-            nx_fs._file_watcher.set_remote_watcher(_event_bus)
-            logger.info("Federation wired EventBus as FileWatcher remote watcher")
-
     # Build CAS remote content fetcher if backend supports CAS (#1744)
     remote_content_fetcher = None
     if hasattr(backend, "content_exists") and hasattr(backend, "read_content"):

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -515,8 +515,10 @@ def _boot_pre_kernel_services(
         "context_branch_service": context_branch_service,
         "zone_lifecycle": zone_lifecycle,
         "scheduler_service": scheduler_service,
-        # Infrastructure (moved from bricks)
-        "event_bus": event_bus,
+        # Infrastructure: event_bus no longer in services dict.
+        # Stored on NexusFS as _event_bus (infra, not a service).
+        # Wired into FileWatcher (remote_watcher) + EventBusObserver by orchestrator.
+        "_event_bus_infra": event_bus,
     }
 
     elapsed = time.perf_counter() - t0

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -541,13 +541,19 @@ async def _register_vfs_hooks(
     # Remote watcher (EventBus) wired later by federation or other services.
     await _enlist("file_watcher", nx._file_watcher)
 
+    # EventBus: infrastructure (not a service). Stored on NexusFS, wired into
+    # FileWatcher (remote_watcher) + EventBusObserver (publish side).
+    _event_bus = _ss.pop("_event_bus_infra", None)
+    if _event_bus is not None:
+        nx._event_bus_infra = _event_bus  # store on NexusFS for lifecycle
+        nx._file_watcher.set_remote_watcher(_event_bus)
+
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).
-    # Constructed with event_bus from system services dict. When event_bus is None
-    # (no distributed infra), the observer is a no-op.
+    # When event_bus is None (no distributed infra), the observer is a no-op.
     # Tests use swap_service() to replace.
     from nexus.services.event_bus.observer import EventBusObserver
 
-    _bus_observer = EventBusObserver(event_bus=_ss.get("event_bus"))
+    _bus_observer = EventBusObserver(event_bus=_event_bus)
     await _enlist("event_bus_observer", _bus_observer)
 
     # RevisionTrackingObserver: feeds RevisionNotifier on versioned mutations.

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -140,7 +140,7 @@ class LifespanServices:
             entity_registry=_svc("entity_registry"),
             permission_enforcer=(getattr(nx, "_permission_enforcer", None) if nx else None),
             rebac_manager=_svc("rebac_manager"),
-            event_bus=_svc("event_bus"),
+            event_bus=getattr(nx, "_event_bus_infra", None) if nx else None,
             coordination_client=(getattr(nx, "_coordination_client", None) if nx else None),
             workflow_engine=(getattr(nx, "workflow_engine", None) if nx else None),
             snapshot_service=_svc("snapshot_service"),

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -63,8 +63,8 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "zone_lifecycle",
         "scheduler_service",
         "event_signal",
-        # Infrastructure (moved from bricks)
-        "event_bus",
+        # Infrastructure (moved from bricks, event_bus stored on NexusFS as infra)
+        "_event_bus_infra",
     }
 )
 
@@ -216,7 +216,7 @@ class TestBootSystemServices:
             "observability_subsystem",
             "workspace_registry",  # degradable — None with mock session_factory
             "scheduler_service",  # degradable — None if SchedulerService unavailable
-            "event_bus",  # None when enable_events=False
+            "_event_bus_infra",  # None when enable_events=False
         }
         for key, value in result.items():
             if key in _NULLABLE_KEYS:

--- a/tests/unit/server/lifespan/test_lifespan_services.py
+++ b/tests/unit/server/lifespan/test_lifespan_services.py
@@ -97,10 +97,10 @@ class TestFromAppExtraction:
             _coordination_client="coord_client",
             workflow_engine="wf_engine",
             config="nexus_cfg",
+            _event_bus_infra="event_bus",
             _service_map={
                 "entity_registry": "entity_reg",
                 "rebac_manager": "rebac_mgr",
-                "event_bus": "event_bus",
                 "async_namespace_manager": "ns_mgr",
                 "snapshot_service": "snap_svc",
             },

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -180,8 +180,8 @@ class TestBootSystemServices:
             "scheduler_service",
             # Issue #3193: shared notification signal
             "event_signal",
-            # Infrastructure (moved from bricks)
-            "event_bus",
+            # Infrastructure (event_bus stored on NexusFS as infra, not in services)
+            "_event_bus_infra",
         }
         assert expected_keys == set(result.keys())
 


### PR DESCRIPTION
## Summary
- Move `event_bus` from services dict to `NexusFS._event_bus_infra` (infrastructure, not a named service)
- Orchestrator wires event_bus directly into `FileWatcher.set_remote_watcher()` and `EventBusObserver` at boot time
- `LifespanServices` reads event_bus from NexusFS attr instead of ServiceRegistry
- Remove redundant federation wiring in `__init__.py` (orchestrator handles it now)

Completes PR 1 remaining items from the FileWatcher plan.

## Test plan
- [x] 111 tests pass (unit/core + unit/services)
- [x] All pre-commit hooks pass (ruff, mypy, import checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)