### PR TITLE
refactor: permission decoupling — delete kernel DI, use KernelDispatch INTERCEPT

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -99,11 +99,14 @@ refcount drain → unhook old → replace → rehook new.
 | Pattern | Kernel `__init__` | Factory `_do_link()` | Example |
 |---------|-------------------|---------------------|---------|
 | **Kernel owns** | Creates instance | — | VFSLockManager, KernelDispatch, PipeManager, StreamManager, ServiceRegistry, DriverLifecycleCoordinator |
-| **Kernel knows** (sentinel) | `self._x = None` (or AllowAll default) | Injects real value; `None` = graceful degrade | `_permission_enforcer`, `_descendant_checker`, `_distributed_lock_manager`, `_agent_registry` |
+| **Kernel knows** (sentinel) | `self._x = None` | Injects real value; `None` = graceful degrade | `_distributed_lock_manager`, `_agent_registry` |
 
-"Kernel knows" follows the Linux LSM pattern: kernel declares a default (allow-all
-or None), factory overrides at link-time. The kernel never imports service-layer
-modules — it uses what it's given, or degrades gracefully without it.
+"Kernel knows" follows the Linux LSM pattern: kernel declares a default (None),
+factory overrides at link-time. The kernel never imports service-layer modules.
+
+Permission enforcement is fully delegated to KernelDispatch INTERCEPT hooks
+(PermissionCheckHook). No hook registered = no check = zero overhead.
+`_permission_enforcer` and `_descendant_checker` removed — no kernel DI needed.
 
 
 **Source of truth:** `contracts/protocols/service_lifecycle.py`

--- a/src/nexus/contracts/wirable_fs.py
+++ b/src/nexus/contracts/wirable_fs.py
@@ -37,7 +37,6 @@ class WirableFS(Protocol):
     def sys_read(self, path: str, **kwargs: Any) -> bytes: ...
 
     _enforce_permissions: bool
-    _permission_enforcer: Any  # PermissionEnforcerProtocol (services tier — typed as Any)
     _record_store: "RecordStoreABC | None"
     _init_cred: "OperationContext | None"
     _config: Any

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -19,7 +19,7 @@ from nexus.contracts.exceptions import (
 )
 from nexus.contracts.filesystem.filesystem_abc import NexusFilesystemABC
 from nexus.contracts.metadata import DT_DIR, FileMetadata
-from nexus.contracts.types import OperationContext, Permission
+from nexus.contracts.types import OperationContext
 from nexus.core.config import (
     CacheConfig,
     DistributedConfig,
@@ -139,16 +139,10 @@ class NexusFS(  # type: ignore[misc]
         # operations. External callers should pass explicit context= to syscalls.
         self._init_cred: OperationContext | None = init_cred
 
-        # Issue #1815: default AllowAllEnforcer — real value wired by factory._do_link().
-        # Kernel constructs allow-all default (like Linux DAC with root).
-        # Factory overrides with ReBACPermissionEnforcer at link-time.
-        from nexus.core.permission import AllowAllEnforcer
-
-        self._permission_enforcer: Any = AllowAllEnforcer()
-        # Issue #1764: sentinel for kernel LSM-style hook (like _permission_enforcer).
-        # Real value injected by factory._do_link() via _wired.descendant_checker.
-        # Consider rename → _descendant_access_checker for clarity.
-        self._descendant_checker: Any = None
+        # Permission enforcement is fully delegated to KernelDispatch INTERCEPT hooks.
+        # PermissionCheckHook (bricks/rebac) registers via enlist() → hook_spec().
+        # No hook registered = no check = zero overhead (like Linux without LSM modules).
+        # _permission_enforcer and _descendant_checker removed in Phase 4 PR 2.
         # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
         self._overlay_resolver = None
         # Issue #1788: distributed lock manager removed — now routed through EventsService.
@@ -343,10 +337,10 @@ class NexusFS(  # type: ignore[misc]
 
     @property
     def namespace_manager(self) -> Any | None:
-        """Public accessor for the NamespaceManager (via PermissionEnforcer)."""
-        enforcer = self._permission_enforcer
-        if enforcer is not None:
-            return getattr(enforcer, "namespace_manager", None)
+        """Public accessor for the NamespaceManager (via ServiceRegistry)."""
+        _pe = self.service("permission_enforcer")
+        if _pe is not None:
+            return getattr(_pe, "namespace_manager", None)
         return None
 
     @property
@@ -3903,10 +3897,17 @@ class NexusFS(  # type: ignore[misc]
                     results[path] = None
                     continue
 
-                # Check permission if enforcement enabled
+                # Permission check via KernelDispatch INTERCEPT (like all other syscalls)
                 if self._enforce_permissions:  # type: ignore[attr-defined]  # allowed
+                    from nexus.contracts.exceptions import PermissionDeniedError
+                    from nexus.contracts.vfs_hooks import StatHookContext as _SHC
+
                     ctx = self._resolve_cred(context)
-                    if not self._descendant_checker.has_access(path, Permission.READ, ctx):
+                    try:
+                        self._dispatch.intercept_pre_stat(
+                            _SHC(path=path, context=ctx, permission="READ")
+                        )
+                    except PermissionDeniedError:
                         results[path] = None
                         continue
 

--- a/src/nexus/core/permission.py
+++ b/src/nexus/core/permission.py
@@ -1,50 +1,9 @@
-"""Default no-op permission enforcer (kernel primitive).
+"""Permission primitives (kernel layer).
 
-The kernel constructs ``AllowAllEnforcer`` at init as the default
-permission policy — like Linux DAC with ``CAP_DAC_OVERRIDE`` (root).
-Factory overrides with ``ReBACPermissionEnforcer`` at link-time if
-permission enforcement is enabled.
+AllowAllEnforcer deleted in Phase 4 PR 2 — permission enforcement is now
+fully delegated to KernelDispatch INTERCEPT hooks (PermissionCheckHook).
+No hook registered = no check = zero overhead.
 
-Issue #1815.
+This module is kept for future kernel-level permission primitives
+(e.g., PermissionEnforcerProtocol if needed).
 """
-
-from __future__ import annotations
-
-from typing import Any
-
-
-class AllowAllEnforcer:
-    """Default no-op permission enforcer (like Linux DAC with root).
-
-    Kernel constructs this as default.  Factory overrides with
-    ``ReBACPermissionEnforcer`` at link-time.
-
-    All permission checks return True (allow-all).
-    """
-
-    def check_owner(self, metadata: Any, context: Any) -> bool:  # noqa: ARG002
-        """AllowAll: owner check always passes (like root)."""
-        return True
-
-    def check(self, path: str, permission: Any, context: Any) -> bool:  # noqa: ARG002
-        """Always grants permission."""
-        return True
-
-    def filter_list(self, paths: list[str], context: Any) -> list[str]:  # noqa: ARG002
-        """Returns all paths unfiltered."""
-        return paths
-
-    def has_accessible_descendants(self, prefix: str, context: Any) -> bool:  # noqa: ARG002
-        """Always returns True (all descendants accessible)."""
-        return True
-
-    def has_accessible_descendants_batch(
-        self,
-        prefixes: list[str],
-        context: Any,  # noqa: ARG002
-    ) -> dict[str, bool]:
-        """Returns True for all prefixes."""
-        return dict.fromkeys(prefixes, True)
-
-    def invalidate_cache(self, **kwargs: Any) -> None:
-        """No-op (no cache to invalidate)."""

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -51,7 +51,7 @@ async def _wire_services(
     from nexus.factory.service_routing import enlist_services
 
     _svc = services or {}
-    nx._permission_enforcer = _svc.get("permission_enforcer")  # Issue #1706: override sentinel
+    # permission_enforcer is now accessed via ServiceRegistry (enlist), not kernel DI.
 
     _parsing = parsing if parsing is not None else nx._parse_config
 
@@ -164,11 +164,8 @@ async def _wire_services(
         except Exception as exc:
             logger.debug("[LINK] RaftLockManager upgrade skipped: %s", exc)
 
-    # Kernel DI: _descendant_checker is a kernel component (like Linux LSM hook),
-    # not an external service — inject directly onto the kernel instance.
-    _dc = getattr(_wired, "descendant_checker", None)
-    if _dc is not None:
-        nx._descendant_checker = _dc
+    # descendant_checker is now accessed via PermissionCheckHook (KernelDispatch INTERCEPT).
+    # No kernel DI needed — PermissionCheckHook holds the reference internally.
 
     # Issue #1788: Lock manager owned by EventsService (LocalLockManager by default).
     # Upgraded to RaftLockManager above if federation is available.

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -371,7 +371,7 @@ async def _register_vfs_hooks(
             default_context=nx._init_cred,
             enforce_permissions=nx._enforce_permissions,
             permission_enforcer=_ss.get("permission_enforcer"),
-            descendant_checker=getattr(nx, "_descendant_checker", None),
+            descendant_checker=nx.service("descendant_checker"),
             lease_table=_lease_table,
         )
         await _enlist("permission", _perm_hook)

--- a/src/nexus/server/app_state.py
+++ b/src/nexus/server/app_state.py
@@ -174,7 +174,9 @@ def _flatten_nexus_fs(app: "FastAPI", nexus_fs: Any) -> None:
     All services accessed via ServiceRegistry.
     """
     # Direct NexusFS attrs
-    app.state.permission_enforcer = getattr(nexus_fs, "_permission_enforcer", None)
+    app.state.permission_enforcer = (
+        nexus_fs.service("permission_enforcer") if hasattr(nexus_fs, "service") else None
+    )
 
     # Helper: safe service() call (handles mocks without service())
     def _svc(name: str) -> Any:

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -138,7 +138,7 @@ class LifespanServices:
             session_factory=getattr(nx, "SessionLocal", None) if nx else None,
             sql_engine=getattr(nx, "_sql_engine", None) if nx else None,
             entity_registry=_svc("entity_registry"),
-            permission_enforcer=(getattr(nx, "_permission_enforcer", None) if nx else None),
+            permission_enforcer=(_svc("permission_enforcer") if nx else None),
             rebac_manager=_svc("rebac_manager"),
             event_bus=getattr(nx, "_event_bus_infra", None) if nx else None,
             coordination_client=(getattr(nx, "_coordination_client", None) if nx else None),

--- a/tests/unit/core/test_minimal_boot_mode.py
+++ b/tests/unit/core/test_minimal_boot_mode.py
@@ -107,7 +107,7 @@ class TestSlimBootViaFactory:
         # System services should be empty (no record store)
         # Issue #1801: _system_services deleted — check via ServiceRegistry
         assert nx.service("rebac") is None or nx.service("rebac")._rebac_manager is None
-        assert nx._permission_enforcer is None
+        assert nx.service("permission_enforcer") is None
 
     @pytest.mark.asyncio
     async def test_minimal_mode_nexus_has_router(self, tmp_path: "Path") -> None:
@@ -353,7 +353,7 @@ class TestSlimIntegrationViaConnect:
         # Services should be empty
         # Issue #1801: _system_services deleted — check via ServiceRegistry
         assert nx.service("rebac") is None or nx.service("rebac")._rebac_manager is None
-        assert nx._permission_enforcer is None
+        assert nx.service("permission_enforcer") is None
         # Issue #1570: audit_store accessed from container, not flat attr
         # Issue #1801: check via ServiceRegistry instead of _system_services
         assert nx.service("audit") is None

--- a/tests/unit/core/test_nexus_fs_services.py
+++ b/tests/unit/core/test_nexus_fs_services.py
@@ -92,7 +92,7 @@ class TestNexusFSServiceComposition:
         assert fs.service("mcp")._filesystem == fs
         # SearchService should have metadata and permission_enforcer
         assert fs.service("search").metadata == fs.metadata
-        assert fs.service("search")._permission_enforcer == fs._permission_enforcer
+        assert fs.service("search")._permission_enforcer == fs.service("permission_enforcer")
 
         # ShareLinkService should have gateway
         assert fs.service("share_link")._gw is not None

--- a/tests/unit/server/lifespan/test_lifespan_services.py
+++ b/tests/unit/server/lifespan/test_lifespan_services.py
@@ -32,7 +32,6 @@ def _make_nexus_fs(**attrs) -> SimpleNamespace:
     defaults = {
         "SessionLocal": None,
         "_sql_engine": None,
-        "_permission_enforcer": None,
         "_coordination_client": None,
         "workflow_engine": None,
         "_snapshot_service": None,
@@ -93,13 +92,13 @@ class TestFromAppExtraction:
         nx = _make_nexus_fs(
             SessionLocal="session_factory",
             _sql_engine="sql_engine",
-            _permission_enforcer="perm_enf",
             _coordination_client="coord_client",
             workflow_engine="wf_engine",
             config="nexus_cfg",
             _event_bus_infra="event_bus",
             _service_map={
                 "entity_registry": "entity_reg",
+                "permission_enforcer": "perm_enf",
                 "rebac_manager": "rebac_mgr",
                 "async_namespace_manager": "ns_mgr",
                 "snapshot_service": "snap_svc",

--- a/tests/unit/server/test_app_state.py
+++ b/tests/unit/server/test_app_state.py
@@ -79,11 +79,11 @@ class TestInitAppState:
         """init_app_state should flatten NexusFS attrs onto app.state via service()."""
         app = _make_app()
         mock_fs = MagicMock()
-        mock_fs._permission_enforcer = "pe"
         # Mock service() to return values for enlisted services
         _svc_map = {
             "event_bus": "eb",
             "write_observer": "wo",
+            "permission_enforcer": "pe",
             "observability_subsystem": "obs",
             "eviction_manager": "em",
         }


### PR DESCRIPTION
## Summary

Permission enforcement is now fully delegated to KernelDispatch INTERCEPT hooks. The kernel no longer holds `_permission_enforcer` or `_descendant_checker` attributes.

- Delete `_permission_enforcer` sentinel (`AllowAllEnforcer`) from NexusFS `__init__`
- Delete `_descendant_checker` sentinel from NexusFS `__init__`
- Delete `AllowAllEnforcer` class from `core/permission.py`
- Migrate `metadata_batch` descendant check to `dispatch.intercept_pre_stat()` (same pattern as all other syscalls)
- `namespace_manager` property reads from ServiceRegistry instead of kernel attribute
- Delete `_permission_enforcer` DI in `_lifecycle.py` (`nx._permission_enforcer = ...`)
- Delete `_descendant_checker` DI in `_lifecycle.py` (`nx._descendant_checker = ...`)
- Update KERNEL-ARCHITECTURE.md: remove from kernel-knows table

**Architecture**: No hook registered = no check = zero overhead (like Linux without LSM modules). PermissionCheckHook registers via `enlist()` → `hook_spec()` auto-registers on KernelDispatch. All permission logic stays in `bricks/rebac/`.

**Follow-up**: Remove `_enforce_permissions` flag from kernel (Part F) — kernel always calls dispatch, flag moves entirely to PermissionCheckHook internal decision.

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — 45 passed
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)