### PR TITLE
feat(#162): cross-zone event propagation — zone-aware FileWatcher routing

### DIFF
--- a/src/nexus/core/file_watcher.py
+++ b/src/nexus/core/file_watcher.py
@@ -92,10 +92,11 @@ class FileWatcher:
 
     event_mask: int = ALL_FILE_EVENTS  # ObserverRegistry bitmask
 
-    def __init__(self) -> None:
+    def __init__(self, local_zone_id: str | None = None) -> None:
         self._waiters: list[_Waiter] = []
         self._waiters_lock = threading.Lock()
         self._remote_watcher: RemoteWatchProtocol | None = None
+        self._local_zone_id = local_zone_id
 
     # ------------------------------------------------------------------
     # Kernel-knows: remote watcher setter
@@ -192,6 +193,12 @@ class FileWatcher:
     # Unified wait — races local + remote
     # ------------------------------------------------------------------
 
+    def _is_remote_zone(self, zone_id: str) -> bool:
+        """Check if zone_id refers to a remote zone (not this node's zone)."""
+        if self._local_zone_id is None:
+            return False  # single-node mode — everything is local
+        return zone_id != self._local_zone_id
+
     async def wait(
         self,
         path: str,
@@ -200,13 +207,18 @@ class FileWatcher:
     ) -> "FileEvent | None":
         """Wait for file changes — races local OBSERVE + remote watcher.
 
-        When both local and remote paths are available, uses
-        ``asyncio.wait(FIRST_COMPLETED)`` — local writes resolve instantly;
-        remote writes arrive via the configured RemoteWatchProtocol.
-
-        When remote watcher is None, falls back to local-only.
+        Zone-aware routing:
+        - Remote zone (zone_id != local): skip local wait (guaranteed miss),
+          go straight to remote watcher.
+        - Local zone: race local OBSERVE + remote (if available).
+        - No remote watcher: local-only.
         """
         has_remote = self._remote_watcher is not None
+
+        # Cross-zone: skip local wait — remote zone mutations never trigger
+        # local dispatch.notify(), so wait_local() would always timeout.
+        if has_remote and self._is_remote_zone(zone_id):
+            return await self._wait_remote(zone_id, path, timeout)
 
         if has_remote:
             task_local = asyncio.create_task(self.wait_local(path, timeout))

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -210,11 +210,13 @@ class NexusFS(  # type: ignore[misc]
             self_address=_ipc_self_addr,
             channel_pool=self._channel_pool,
         )
-        # FileWatcher — kernel file change notification (inotify equivalent, §4.5).
+        # FileWatcher — kernel file change notification (inotify equivalent, §4.3).
         # Kernel-owned local OBSERVE waiters + optional kernel-knows remote watcher.
+        # local_zone_id enables cross-zone optimization: skip local wait when
+        # watching a remote zone (guaranteed miss). Defaults to ROOT_ZONE_ID.
         from nexus.core.file_watcher import FileWatcher
 
-        self._file_watcher = FileWatcher()
+        self._file_watcher = FileWatcher(local_zone_id=ROOT_ZONE_ID)
 
         logger.info(
             "IPC primitives initialized: PipeManager + StreamManager + FileWatcher (self_address=%s)",

--- a/src/nexus/services/event_bus/redis.py
+++ b/src/nexus/services/event_bus/redis.py
@@ -27,6 +27,9 @@ class RedisEventBus(EventBusBase):
     Uses per-zone channels for efficient event routing.
     Channel format: nexus:events:{zone_id}
 
+    **Cross-zone limitation**: Redis pub/sub is single-instance. Cross-zone
+    event propagation requires a shared NATS cluster (NatsEventBus).
+
     SSOT Architecture:
         - PostgreSQL (operation_log) is the source of truth
         - Redis Pub/Sub is best-effort notification

--- a/tests/unit/core/test_file_watcher.py
+++ b/tests/unit/core/test_file_watcher.py
@@ -170,3 +170,63 @@ class TestFileWatcherWait:
         fw = FileWatcher()
         result = await fw.wait("/test/file.txt", timeout=0.05)
         assert result is None
+
+
+class TestFileWatcherCrossZone:
+    """Test cross-zone routing — skip local wait for remote zones."""
+
+    @pytest.mark.asyncio
+    async def test_remote_zone_skips_local_wait(self) -> None:
+        """When zone_id != local_zone_id, wait() goes straight to remote."""
+        fw = FileWatcher(local_zone_id="zone1")
+        remote_event = _make_event("/zone2/file.txt")
+        mock_watcher = AsyncMock(spec=RemoteWatchProtocol)
+        mock_watcher.wait_for_event.return_value = remote_event
+        fw.set_remote_watcher(mock_watcher)
+
+        result = await fw.wait("/zone2/file.txt", timeout=5.0, zone_id="zone2")
+        assert result is not None
+        assert result.path == "/zone2/file.txt"
+        # Verify remote watcher was called with correct zone
+        mock_watcher.wait_for_event.assert_called_once_with(
+            zone_id="zone2", path_pattern="/zone2/file.txt", timeout=5.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_local_zone_still_races(self) -> None:
+        """When zone_id == local_zone_id, wait() races local + remote."""
+        fw = FileWatcher(local_zone_id="zone1")
+        local_event = _make_event("/zone1/file.txt")
+
+        async def slow_remote(*args, **kwargs):
+            await asyncio.sleep(10)
+            return None
+
+        mock_watcher = AsyncMock(spec=RemoteWatchProtocol)
+        mock_watcher.wait_for_event.side_effect = slow_remote
+        fw.set_remote_watcher(mock_watcher)
+
+        async def mutator() -> None:
+            await asyncio.sleep(0.01)
+            await fw.on_mutation(local_event)
+
+        task = asyncio.create_task(fw.wait("/zone1/file.txt", timeout=5.0, zone_id="zone1"))
+        await mutator()
+        result = await task
+        assert result is not None
+        assert result.path == "/zone1/file.txt"
+
+    @pytest.mark.asyncio
+    async def test_no_local_zone_id_treats_all_as_local(self) -> None:
+        """When local_zone_id is None (single-node), _is_remote_zone always False."""
+        fw = FileWatcher(local_zone_id=None)
+        assert fw._is_remote_zone("zone1") is False
+        assert fw._is_remote_zone("zone2") is False
+
+    @pytest.mark.asyncio
+    async def test_remote_zone_no_watcher_returns_none(self) -> None:
+        """Remote zone without remote watcher returns None (timeout)."""
+        fw = FileWatcher(local_zone_id="zone1")
+        # No remote watcher set — falls through to wait_local which will timeout
+        result = await fw.wait("/zone2/file.txt", timeout=0.05, zone_id="zone2")
+        assert result is None


### PR DESCRIPTION
## Summary
- Add `local_zone_id` to FileWatcher for cross-zone optimization
- When `zone_id != local_zone_id`, skip local wait (guaranteed miss) and go straight to remote watcher
- Enables cross-zone `wait_for_changes()` via shared NATS cluster
- Document Redis cross-zone limitation in RedisEventBus docstring

### Routing logic
```
zone_id == local_zone_id → race local + remote (existing behavior)
zone_id != local_zone_id → remote only (skip local, guaranteed miss)
no remote watcher        → local only (single-node mode)
```

## Test plan
- [x] Cross-zone: remote zone_id skips local, delegates to remote watcher
- [x] Local zone: still races local + remote
- [x] Single-node (local_zone_id=None): treats all zones as local
- [x] Remote zone without watcher: falls through to local (timeout)
- [x] All 31 tests pass, ruff clean, mypy clean, all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)