### PR TITLE
perf: permission write leases — check once, write many (#3394)

### DIFF
--- a/permissions_demo_enhanced.sh
+++ b/permissions_demo_enhanced.sh
@@ -65,14 +65,28 @@ print_error() {
 }
 print_test() { echo -e "${MAGENTA}TEST:${NC} $1"; }
 
+# Auto-detect connection info from nexus stack if available.
+# This ensures DATABASE_URL, NEXUS_GRPC_HOST, etc. are set even if
+# the user only ran `nexus up` without `eval $(nexus env)`.
+if command -v nexus &>/dev/null; then
+    eval $(nexus env 2>/dev/null) || true
+fi
+
 # Check prerequisites
 if [ -z "$NEXUS_URL" ] || [ -z "$NEXUS_API_KEY" ]; then
-    print_error "NEXUS_URL and NEXUS_API_KEY not set. Run: source .nexus-admin-env"
+    print_error "NEXUS_URL and NEXUS_API_KEY not set. Run: eval \$(nexus env)"
     exit 1
 fi
 
+# Derive NEXUS_DATABASE_URL from DATABASE_URL (set by `eval $(nexus env)`)
 if [ -n "$DATABASE_URL" ] && [ -z "$NEXUS_DATABASE_URL" ]; then
     export NEXUS_DATABASE_URL="$DATABASE_URL"
+fi
+
+# Ensure NEXUS_GRPC_HOST is available for Python SDK connections.
+# The SDK needs grpc_address explicitly when using non-standard ports.
+if [ -z "$NEXUS_GRPC_HOST" ] && [ -n "$NEXUS_GRPC_PORT" ]; then
+    export NEXUS_GRPC_HOST="localhost:$NEXUS_GRPC_PORT"
 fi
 
 echo "╔══════════════════════════════════════════════════════════╗"
@@ -138,7 +152,7 @@ import sys, os
 sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
 
-import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 
@@ -229,6 +243,35 @@ except Exception as e:
     print(f"  ⚠ Could not clean version history: {e}")
 
 print("✓ Cleaned up stale tuples")
+
+# Bootstrap ReBAC namespaces — ensure relation→permission expansion rules are loaded.
+# On fresh servers (or after Raft leader election), namespaces may not be initialized
+# because _ensure_namespaces_initialized() can fail silently during leader election.
+print("Bootstrapping ReBAC namespaces...")
+try:
+    from nexus.bricks.rebac.default_namespaces import (
+        DEFAULT_FILE_NAMESPACE,
+        DEFAULT_GROUP_NAMESPACE,
+        DEFAULT_MEMORY_NAMESPACE,
+        DEFAULT_PLAYBOOK_NAMESPACE,
+        DEFAULT_TRAJECTORY_NAMESPACE,
+        DEFAULT_SKILL_NAMESPACE,
+    )
+    for ns in [DEFAULT_FILE_NAMESPACE, DEFAULT_GROUP_NAMESPACE,
+               DEFAULT_MEMORY_NAMESPACE, DEFAULT_PLAYBOOK_NAMESPACE,
+               DEFAULT_TRAJECTORY_NAMESPACE, DEFAULT_SKILL_NAMESPACE]:
+        try:
+            rebac.rebac_create_namespace_sync(ns)
+            print(f"  ✓ {ns.object_type} namespace initialized")
+        except Exception as e:
+            if "already exists" in str(e).lower() or "duplicate" in str(e).lower():
+                print(f"  ✓ {ns.object_type} namespace (already exists)")
+            else:
+                print(f"  ⚠ {ns.object_type} namespace: {e}")
+    print("✓ Namespaces ready")
+except Exception as e:
+    print(f"⚠ Namespace bootstrap: {e}")
+
 nx.close()
 CLEANUP
 
@@ -248,9 +291,11 @@ echo "  This is the actual behavior - owners need editor/viewer role for read!"
 echo ""
 
 # Create test users
-ALICE_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" alice "Alice Owner" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
-BOB_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" bob "Bob Editor" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
-CHARLIE_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" charlie "Charlie Viewer" --days 1 2>/dev/null | grep "API Key:" | awk '{print $3}')
+# Create user API keys with --zone-id default so their file I/O paths
+# are zone-scoped consistently with the admin key and ReBAC tuples.
+ALICE_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" alice "Alice Owner" --days 1 --zone-id default 2>/dev/null | grep "API Key:" | awk '{print $3}')
+BOB_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" bob "Bob Editor" --days 1 --zone-id default 2>/dev/null | grep "API Key:" | awk '{print $3}')
+CHARLIE_KEY=$(nexus_python "$SCRIPT_DIR/scripts/create-api-key.py" charlie "Charlie Viewer" --days 1 --zone-id default 2>/dev/null | grep "API Key:" | awk '{print $3}')
 
 if [ -z "$ALICE_KEY" ] || [ -z "$BOB_KEY" ] || [ -z "$CHARLIE_KEY" ]; then
     print_error "Failed to create one or more demo user API keys"
@@ -401,7 +446,7 @@ nexus_python << 'PYTHON_PARENTS'
 import sys, os
 sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
-import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 rebac.rebac_create_sync(("file", f"{base}/project1/docs"), "parent", ("file", f"{base}/project1"))
@@ -501,7 +546,7 @@ nexus_python << 'PYTHON_LIST'
 import sys, os
 sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
-import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync(subject=("user", "bob"))
 print(f"Bob has {len(tuples)} permission tuples:")
@@ -530,7 +575,7 @@ nexus_python << 'PYTHON_CYCLE'
 import sys, os
 sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
-import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 try:
@@ -631,7 +676,7 @@ import sys, os
 sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
 
-import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync()
 
@@ -756,7 +801,7 @@ TUPLE_ID=$(nexus_python << PYTHON_TUPLE_ID
 import sys, os
 sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
-import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')}))
 rebac = nx.service("rebac")
 tuples = rebac.rebac_list_tuples_sync(subject=('user', 'alice'), object=('file', '$DEMO_BASE/cache-test.txt'))
 print(tuples[0]['tuple_id'] if tuples else '')
@@ -810,7 +855,7 @@ import sys, os, time, statistics
 sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
 import nexus
 
-import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY')}))
+import asyncio; nx = asyncio.run(nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')}))
 rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 

--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -7,12 +7,13 @@ When a permission tuple is written/deleted, the coordinator ensures
 all affected caches are properly invalidated in the correct order:
 1. Zone graph cache (in-memory tuple cache)
 2. L1 permission check cache (targeted by subject + object)
-3. Boundary cache (permission inheritance boundaries)
-4. Directory visibility cache (dir listing optimization)
-5. Iterator cache (pagination cursors)
-6. Namespace cache — dcache + mount table (Issue #1244)
-7. Leopard cache (transitive group closure) - via callbacks
-8. Tiger cache (materialized bitmaps) - via callbacks
+3. Permission leases — zone-wide clear (Issue #3394)
+4. Boundary cache (permission inheritance boundaries)
+5. Directory visibility cache (dir listing optimization)
+6. Iterator cache (pagination cursors)
+7. Namespace cache — dcache + mount table (Issue #1244)
+8. Leopard cache (transitive group closure) - via callbacks
+9. Tiger cache (materialized bitmaps) - via callbacks
 
 Also handles:
 - L2 (database) cache invalidation with precise targeting (Issue #2179 Step 2.5)
@@ -152,6 +153,8 @@ class CacheCoordinator:
         # Namespace cache invalidators: callback(subject_type, subject_id, zone_id)
         # Used by NamespaceManager to invalidate dcache + mount table on grant/revoke (Issue #1244)
         self._namespace_invalidators: list[tuple[str, Callable[[str, str, str], None]]] = []
+        # Permission lease invalidators: callback(zone_id) — zone-wide clear (Issue #3394)
+        self._lease_invalidators: list[tuple[str, Callable[[str], None]]] = []
 
         # Async eager recompute (Issue #3192)
         self._recompute_executor: concurrent.futures.ThreadPoolExecutor | None = None
@@ -164,6 +167,7 @@ class CacheCoordinator:
         self._invalidation_count = 0
         self._zone_graph_invalidations = 0
         self._l1_invalidations = 0
+        self._lease_invalidations = 0
         self._boundary_invalidations = 0
         self._visibility_invalidations = 0
         self._namespace_invalidations = 0
@@ -283,6 +287,33 @@ class CacheCoordinator:
                 return True
         return False
 
+    def register_lease_invalidator(
+        self,
+        callback_id: str,
+        callback: "Callable[[str], None]",
+    ) -> None:
+        """Register a permission lease invalidation callback (Issue #3394).
+
+        Called on every rebac_write/rebac_delete to invalidate permission
+        leases (zone-wide clear).  The callback receives the zone_id.
+
+        Args:
+            callback_id: Unique identifier for this callback
+            callback: Function(zone_id) — should clear all permission leases
+        """
+        for cid, _ in self._lease_invalidators:
+            if cid == callback_id:
+                return  # Already registered
+        self._lease_invalidators.append((callback_id, callback))
+
+    def unregister_lease_invalidator(self, callback_id: str) -> bool:
+        """Unregister a permission lease invalidation callback."""
+        for i, (cid, _) in enumerate(self._lease_invalidators):
+            if cid == callback_id:
+                self._lease_invalidators.pop(i)
+                return True
+        return False
+
     # ------------------------------------------------------------------
     # Unified invalidation (L1 + callback-based)
     # ------------------------------------------------------------------
@@ -315,21 +346,24 @@ class CacheCoordinator:
         # 2. L1 permission check cache (targeted)
         self._invalidate_l1(subject_type, subject_id, object_type, object_id, zone_id)
 
-        # 3. Boundary cache (external callbacks)
+        # 3. Permission leases — zone-wide clear (Issue #3394)
+        self._notify_lease_invalidators(zone_id)
+
+        # 4. Boundary cache (external callbacks)
         self._notify_boundary_invalidators(
             zone_id, subject_type, subject_id, relation, object_type, object_id
         )
 
-        # 4. Directory visibility cache (external callbacks)
+        # 5. Directory visibility cache (external callbacks)
         self._notify_visibility_invalidators(zone_id, object_type, object_id)
 
-        # 5. Namespace cache — dcache + mount table (Issue #1244)
+        # 6. Namespace cache — dcache + mount table (Issue #1244)
         self.notify_namespace_invalidators(zone_id, subject_type, subject_id)
 
-        # 6. Iterator cache (zone-level)
+        # 7. Iterator cache (zone-level)
         self._invalidate_iterator(zone_id)
 
-        # 7. DT_STREAM: Publish invalidation event for intra-zone consumers (Issue #3192)
+        # 8. DT_STREAM: Publish invalidation event for intra-zone consumers (Issue #3192)
         if self._stream:
             self._stream.append(
                 InvalidationEventType.L1_CACHE,
@@ -341,7 +375,7 @@ class CacheCoordinator:
                 object_id=object_id,
             )
 
-        # 8. Pub/Sub: Publish cross-zone hint (Issue #3192)
+        # 9. Pub/Sub: Publish cross-zone hint (Issue #3192)
         if self._pubsub:
             self._pubsub.publish_invalidation(
                 zone_id=zone_id,
@@ -406,6 +440,9 @@ class CacheCoordinator:
 
         if self._l1_cache:
             self._l1_cache.clear()
+
+        # Permission leases (Issue #3394)
+        self._notify_lease_invalidators(zone_id or "root")
 
         if self._boundary_cache:
             self._boundary_cache.clear()
@@ -925,6 +962,30 @@ class CacheCoordinator:
         self._l1_cache.invalidate_subject(subject_type, subject_id, zone_id)
         self._l1_cache.invalidate_object(object_type, object_id, zone_id)
 
+    def _notify_lease_invalidators(self, zone_id: str) -> None:
+        """Notify permission lease invalidators — zone-wide clear (Issue #3394).
+
+        Called after L1 cache invalidation and before boundary cache
+        invalidation to ensure stale leases cannot be used during the
+        boundary recomputation window.
+        """
+        if not self._lease_invalidators:
+            return
+
+        self._lease_invalidations += 1
+
+        for callback_id, callback in self._lease_invalidators:
+            try:
+                callback(zone_id)
+            except Exception:
+                self._callback_failure_count += 1
+                logger.warning(
+                    "[CacheCoordinator] Lease invalidator %s failed for zone %s",
+                    callback_id,
+                    zone_id,
+                    exc_info=True,
+                )
+
     def _notify_boundary_invalidators(
         self,
         zone_id: str,
@@ -1078,6 +1139,7 @@ class CacheCoordinator:
             "total_invalidations": self._invalidation_count,
             "zone_graph_invalidations": self._zone_graph_invalidations,
             "l1_invalidations": self._l1_invalidations,
+            "lease_invalidations": self._lease_invalidations,
             "boundary_invalidations": self._boundary_invalidations,
             "visibility_invalidations": self._visibility_invalidations,
             "namespace_invalidations": self._namespace_invalidations,
@@ -1085,6 +1147,7 @@ class CacheCoordinator:
             "registered_boundary_invalidators": len(self._boundary_invalidators),
             "registered_visibility_invalidators": len(self._visibility_invalidators),
             "registered_namespace_invalidators": len(self._namespace_invalidators),
+            "registered_lease_invalidators": len(self._lease_invalidators),
             "callback_failure_count": self._callback_failure_count,
             "async_recompute_submitted": self._recompute_submitted,
             "async_recompute_completed": self._recompute_completed,
@@ -1098,6 +1161,7 @@ class CacheCoordinator:
         self._invalidation_count = 0
         self._zone_graph_invalidations = 0
         self._l1_invalidations = 0
+        self._lease_invalidations = 0
         self._boundary_invalidations = 0
         self._visibility_invalidations = 0
         self._namespace_invalidations = 0

--- a/src/nexus/bricks/rebac/cache/permission_lease.py
+++ b/src/nexus/bricks/rebac/cache/permission_lease.py
@@ -15,11 +15,17 @@ written.  For existing files this is the file path; for new files it's
 the parent directory (since ``on_pre_write`` checks WRITE on the parent).
 This design covers both repeated writes and many-files-in-same-directory.
 
+Inheritance-aware: ``check()`` walks up the path hierarchy so a lease
+stamped on a parent directory (e.g. from a new-file write) also covers
+writes to existing files in that directory.  This matches the ReBAC
+inheritance model where WRITE on a directory implies WRITE on children.
+
 Integration:
     - Checked in ``PermissionCheckHook.on_pre_write()`` (fast path)
     - Stamped after successful ReBAC check (slow path)
     - Invalidated by ``CacheCoordinator.invalidate_for_write()`` via
       registered callback (zone-wide clear on any permission mutation)
+    - ``invalidate_agent()`` called on agent termination / permission change
 
 References:
     - Issue #3394: Permission write leases
@@ -108,16 +114,36 @@ class PermissionLeaseTable:
 
     # -- core operations ------------------------------------------------------
 
+    @staticmethod
+    def _parent(path: str) -> str | None:
+        """Get parent directory path, or None if root."""
+        if path == "/":
+            return None
+        last_slash = path.rfind("/")
+        if last_slash == 0:
+            return "/"
+        return path[:last_slash] if last_slash > 0 else None
+
     def check(self, path: str, agent_id: str) -> bool:
         """Check if a valid permission lease exists.
 
-        O(1) dict lookup + monotonic time check.  Returns True if the
-        agent has a non-expired lease on the given path.
+        Walks up the path hierarchy (inheritance-aware): a lease stamped
+        on an ancestor directory covers writes to descendant paths.  This
+        matches the ReBAC model where WRITE on a directory implies WRITE
+        on children via ``parent-of`` relationships.
+
+        Typical cost: O(depth) dict lookups where depth ≈ 3-5.  Each
+        lookup is ~50-100ns, total ~250-500ns on miss — well within the
+        ~1μs budget.
         """
-        expiry = self._table.get((self._normalize(path), agent_id))
-        if expiry is not None and self._clock.monotonic() < expiry:
-            self._hits += 1
-            return True
+        now = self._clock.monotonic()
+        current: str | None = self._normalize(path)
+        while current is not None:
+            expiry = self._table.get((current, agent_id))
+            if expiry is not None and now < expiry:
+                self._hits += 1
+                return True
+            current = self._parent(current)
         self._misses += 1
         return False
 
@@ -162,6 +188,23 @@ class PermissionLeaseTable:
             del self._table[k]
         if keys_to_remove:
             self._invalidations += 1
+
+    def invalidate_agent(self, agent_id: str) -> None:
+        """Clear all leases for a specific agent.
+
+        Called on agent termination or agent-level permission change.
+        O(n) scan of the table.
+        """
+        keys_to_remove = [k for k in self._table if k[1] == agent_id]
+        for k in keys_to_remove:
+            del self._table[k]
+        if keys_to_remove:
+            self._invalidations += 1
+            logger.debug(
+                "[PermissionLeaseTable] Invalidated %d lease(s) for agent %s",
+                len(keys_to_remove),
+                agent_id,
+            )
 
     # -- diagnostics ----------------------------------------------------------
 

--- a/src/nexus/bricks/rebac/cache/permission_lease.py
+++ b/src/nexus/bricks/rebac/cache/permission_lease.py
@@ -1,0 +1,181 @@
+"""Permission lease table — check once, write many (Issue #3394).
+
+Lightweight TTL-based cache that records successful permission checks.
+On subsequent writes to the same (checked_path, agent_id) pair, the
+cached grant is returned in ~100-200ns instead of performing a full
+ReBAC check (~50-200μs).
+
+This is deliberately NOT a LeaseManager.  Permission leases don't need
+conflict resolution, fencing tokens, or revocation callbacks because
+multiple agents can hold WRITE permission simultaneously (unlike file
+locks).  A plain dict with TTL is the simplest correct implementation.
+
+Keyed by the path that was *permission-checked*, not the file being
+written.  For existing files this is the file path; for new files it's
+the parent directory (since ``on_pre_write`` checks WRITE on the parent).
+This design covers both repeated writes and many-files-in-same-directory.
+
+Integration:
+    - Checked in ``PermissionCheckHook.on_pre_write()`` (fast path)
+    - Stamped after successful ReBAC check (slow path)
+    - Invalidated by ``CacheCoordinator.invalidate_for_write()`` via
+      registered callback (zone-wide clear on any permission mutation)
+
+References:
+    - Issue #3394: Permission write leases
+    - Issue #3398: ReBAC permission leases for FUSE + multi-agent
+    - DFUSE paper: https://arxiv.org/abs/2503.18191
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.lease import Clock
+
+logger = logging.getLogger(__name__)
+
+# Default clock that uses time.monotonic() directly — avoids importing
+# from lib.lease at module level (which pulls in asyncio).
+_DEFAULT_CLOCK: Clock | None = None
+
+
+def _get_default_clock() -> Clock:
+    """Lazy-import SystemClock to avoid circular import at module level."""
+    global _DEFAULT_CLOCK  # noqa: PLW0603
+    if _DEFAULT_CLOCK is None:
+        from nexus.lib.lease import SystemClock
+
+        _DEFAULT_CLOCK = SystemClock()
+    return _DEFAULT_CLOCK
+
+
+class PermissionLeaseTable:
+    """TTL-based permission lease cache — check once, write many.
+
+    Stores ``(checked_path, agent_id) -> expiry_monotonic`` in a plain
+    dict.  Validation is a single dict lookup + float comparison (~100ns).
+
+    Thread-safety: CPython's GIL protects dict reads/writes.  The worst
+    case for a concurrent read during a write is a false negative (lease
+    appears missing → falls through to full ReBAC check, which is safe).
+
+    Memory: bounded by ``max_entries``.  When exceeded, the table is
+    cleared entirely — equivalent to a cold start.
+
+    Example::
+
+        table = PermissionLeaseTable(ttl=30.0)
+        # After successful ReBAC check:
+        table.stamp("/workspace/src", "agent-A")
+        # Fast path on next write:
+        if table.check("/workspace/src", "agent-A"):
+            return  # skip ReBAC check (~100ns vs ~50-200μs)
+    """
+
+    DEFAULT_TTL = 30.0
+    DEFAULT_MAX_ENTRIES = 100_000
+
+    def __init__(
+        self,
+        *,
+        clock: "Clock | None" = None,
+        ttl: float = DEFAULT_TTL,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+    ) -> None:
+        self._clock: Clock = clock or _get_default_clock()
+        self._ttl = ttl
+        self._max_entries = max_entries
+        # (normalized_path, agent_id) -> monotonic expiry timestamp
+        self._table: dict[tuple[str, str], float] = {}
+
+        # Metrics
+        self._hits = 0
+        self._misses = 0
+        self._stamps = 0
+        self._invalidations = 0
+
+    # -- path normalization ---------------------------------------------------
+
+    @staticmethod
+    def _normalize(path: str) -> str:
+        """Strip trailing slashes (except root) for consistent keying."""
+        if path == "/":
+            return path
+        return path.rstrip("/")
+
+    # -- core operations ------------------------------------------------------
+
+    def check(self, path: str, agent_id: str) -> bool:
+        """Check if a valid permission lease exists.
+
+        O(1) dict lookup + monotonic time check.  Returns True if the
+        agent has a non-expired lease on the given path.
+        """
+        expiry = self._table.get((self._normalize(path), agent_id))
+        if expiry is not None and self._clock.monotonic() < expiry:
+            self._hits += 1
+            return True
+        self._misses += 1
+        return False
+
+    def stamp(self, path: str, agent_id: str, ttl: float | None = None) -> None:
+        """Record a successful permission check as a lease.
+
+        Called after a full ReBAC check passes.  Subsequent writes to
+        the same (path, agent_id) pair within the TTL skip the check.
+        """
+        # Size cap: clear all if above threshold (Decision #13D)
+        if len(self._table) >= self._max_entries:
+            logger.debug(
+                "[PermissionLeaseTable] Size cap reached (%d), clearing all leases",
+                len(self._table),
+            )
+            self._table.clear()
+        self._table[(self._normalize(path), agent_id)] = self._clock.monotonic() + (
+            ttl if ttl is not None else self._ttl
+        )
+        self._stamps += 1
+
+    def invalidate_all(self) -> None:
+        """Clear all leases (zone-wide revocation).
+
+        Called by CacheCoordinator on any permission mutation.
+        """
+        if self._table:
+            self._table.clear()
+            self._invalidations += 1
+            logger.debug("[PermissionLeaseTable] All leases invalidated")
+
+    def invalidate_path(self, path: str) -> None:
+        """Clear all leases for a specific checked path.
+
+        Removes leases for all agents on the given path.  O(n) scan
+        of the table — acceptable for targeted revocation but prefer
+        ``invalidate_all()`` for zone-wide events.
+        """
+        normalized = self._normalize(path)
+        keys_to_remove = [k for k in self._table if k[0] == normalized]
+        for k in keys_to_remove:
+            del self._table[k]
+        if keys_to_remove:
+            self._invalidations += 1
+
+    # -- diagnostics ----------------------------------------------------------
+
+    def stats(self) -> dict[str, Any]:
+        """Return operational metrics for monitoring."""
+        return {
+            "lease_hits": self._hits,
+            "lease_misses": self._misses,
+            "lease_stamps": self._stamps,
+            "lease_invalidations": self._invalidations,
+            "active_leases": len(self._table),
+        }
+
+    @property
+    def active_count(self) -> int:
+        """Number of entries in the table (including possibly expired)."""
+        return len(self._table)

--- a/src/nexus/bricks/rebac/default_namespaces.py
+++ b/src/nexus/bricks/rebac/default_namespaces.py
@@ -6,17 +6,28 @@ definition lives in the rebac brick since it owns namespace semantics.
 
 Canonical import:
     from nexus.bricks.rebac.default_namespaces import DEFAULT_FILE_NAMESPACE
+
+IMPORTANT: namespace_id MUST be deterministic (uuid5, not uuid4).
+uuid4() generates a new ID on every import, which breaks the update
+guard in _initialize_default_namespaces_with_conn() — after a server
+restart the new UUID doesn't match the stored one, so the namespace
+config is never updated.  uuid5(NEXUS_NS, object_type) is stable
+across restarts while remaining unique per object type.
 """
 
 import uuid
 
 from nexus.bricks.rebac.domain import NamespaceConfig
 
+# Fixed namespace for deterministic UUID generation.
+# uuid5(NEXUS_NS, "file") always produces the same ID.
+_NEXUS_NS = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
 # ---------------------------------------------------------------------------
 # File namespace (complex: parent inheritance + group + cross-zone sharing)
 # ---------------------------------------------------------------------------
 DEFAULT_FILE_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
+    namespace_id=str(uuid.uuid5(_NEXUS_NS, "file")),
     object_type="file",
     config={
         "relations": {
@@ -106,7 +117,7 @@ DEFAULT_FILE_NAMESPACE = NamespaceConfig(
 # Group namespace
 # ---------------------------------------------------------------------------
 DEFAULT_GROUP_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
+    namespace_id=str(uuid.uuid5(_NEXUS_NS, "group")),
     object_type="group",
     config={
         "relations": {
@@ -130,7 +141,7 @@ DEFAULT_GROUP_NAMESPACE = NamespaceConfig(
 # Memory namespace
 # ---------------------------------------------------------------------------
 DEFAULT_MEMORY_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
+    namespace_id=str(uuid.uuid5(_NEXUS_NS, "memory")),
     object_type="memory",
     config={
         "relations": {
@@ -152,7 +163,7 @@ DEFAULT_MEMORY_NAMESPACE = NamespaceConfig(
 # v0.5.0 ACE: Playbook namespace
 # ---------------------------------------------------------------------------
 DEFAULT_PLAYBOOK_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
+    namespace_id=str(uuid.uuid5(_NEXUS_NS, "playbook")),
     object_type="playbook",
     config={
         "relations": {
@@ -174,7 +185,7 @@ DEFAULT_PLAYBOOK_NAMESPACE = NamespaceConfig(
 # v0.5.0 ACE: Trajectory namespace
 # ---------------------------------------------------------------------------
 DEFAULT_TRAJECTORY_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
+    namespace_id=str(uuid.uuid5(_NEXUS_NS, "trajectory")),
     object_type="trajectory",
     config={
         "relations": {
@@ -195,7 +206,7 @@ DEFAULT_TRAJECTORY_NAMESPACE = NamespaceConfig(
 # v0.5.0 Skills System: Skill namespace
 # ---------------------------------------------------------------------------
 DEFAULT_SKILL_NAMESPACE = NamespaceConfig(
-    namespace_id=str(uuid.uuid4()),
+    namespace_id=str(uuid.uuid5(_NEXUS_NS, "skill")),
     object_type="skill",
     config={
         "relations": {

--- a/src/nexus/bricks/rebac/permission_hook.py
+++ b/src/nexus/bricks/rebac/permission_hook.py
@@ -9,6 +9,7 @@ Kernel just calls generic ``dispatch.intercept_pre_*()`` which iterates
 the existing hook lists and calls ``on_pre_*`` via getattr.
 
 Issue #899: Extracted from NexusFS kernel (was ``self._permission_checker``).
+Issue #3394: Permission write leases — check once, write many.
 """
 
 from __future__ import annotations
@@ -19,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 from nexus.contracts.types import Permission
 
 if TYPE_CHECKING:
+    from nexus.bricks.rebac.cache.permission_lease import PermissionLeaseTable
     from nexus.contracts.protocols.service_hooks import HookSpec
     from nexus.contracts.vfs_hooks import (
         AccessHookContext,
@@ -75,6 +77,7 @@ class PermissionCheckHook:
         enforce_permissions: bool = True,
         permission_enforcer: Any = None,
         descendant_checker: Any = None,
+        lease_table: "PermissionLeaseTable | None" = None,
     ) -> None:
         self._checker = checker
         self._metadata_store = metadata_store
@@ -82,6 +85,7 @@ class PermissionCheckHook:
         self._enforce_permissions = enforce_permissions
         self._permission_enforcer = permission_enforcer
         self._descendant_checker = descendant_checker
+        self._lease_table = lease_table
 
     # ------------------------------------------------------------------
     # PRE hooks — permission gating (raise PermissionError to abort)
@@ -98,18 +102,49 @@ class PermissionCheckHook:
         self._checker.check(ctx.path, Permission.READ, ctx.context)
 
     def on_pre_write(self, ctx: WriteHookContext) -> None:
-        """Check WRITE permission before write operations."""
+        """Check WRITE permission before write operations.
+
+        Fast path (Issue #3394): if a permission lease exists for the
+        (checked_path, agent_id) pair, skip the full ReBAC check (~1μs
+        vs ~50-200μs).  On cache miss, do the full check and stamp a
+        lease for subsequent writes.
+        """
         if not self._enforce_permissions:
             return
         context = ctx.context or self._default_context
+
+        # Resolve the path that will actually be permission-checked.
+        # For existing files: the file path.  For new files: the parent dir.
+        # Keying leases by checked_path covers both "repeated writes to same
+        # file" and "many new files in same directory" (Decision #14B).
         if ctx.old_metadata is not None:
-            # Existing file — check on file with owner fast-path
+            checked_path = ctx.path
+        else:
+            checked_path = self._get_parent_path(ctx.path)
+            if checked_path is None:
+                return  # root path — no parent to check
+
+        # Extract agent_id from context (Decision #7A).
+        # If unavailable, skip lease — falls through to full check every time.
+        agent_id = getattr(context, "agent_id", None) if context else None
+
+        # Fast path: check permission lease (~100-200ns)
+        if (
+            agent_id
+            and self._lease_table is not None
+            and self._lease_table.check(checked_path, agent_id)
+        ):
+            return  # lease valid — skip full ReBAC check
+
+        # Slow path: full ReBAC check (raises PermissionError on denial)
+        if ctx.old_metadata is not None:
             self._checker.check(ctx.path, Permission.WRITE, context, file_metadata=ctx.old_metadata)
         else:
-            # New file — check WRITE on parent directory
-            parent = self._get_parent_path(ctx.path)
-            if parent:
-                self._checker.check(parent, Permission.WRITE, context)
+            self._checker.check(checked_path, Permission.WRITE, context)
+
+        # Stamp lease on successful check (Decision #6A)
+        if agent_id and self._lease_table is not None:
+            self._lease_table.stamp(checked_path, agent_id)
 
     def on_pre_delete(self, ctx: DeleteHookContext) -> None:
         """Check WRITE permission before delete."""

--- a/src/nexus/bricks/rebac/permission_hook.py
+++ b/src/nexus/bricks/rebac/permission_hook.py
@@ -120,9 +120,10 @@ class PermissionCheckHook:
         if ctx.old_metadata is not None:
             checked_path = ctx.path
         else:
-            checked_path = self._get_parent_path(ctx.path)
-            if checked_path is None:
+            parent = self._get_parent_path(ctx.path)
+            if parent is None:
                 return  # root path — no parent to check
+            checked_path = parent
 
         # Extract agent_id from context (Decision #7A).
         # If unavailable, skip lease — falls through to full check every time.

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -994,6 +994,22 @@ def down(volumes: bool) -> None:
     console.print(f"[bold]Stopping Nexus preset: {preset}[/bold]")
     result = _run_compose(cf, profiles, *args, extra_env=compose_env)
     if result.returncode == 0:
+        # When --volumes is used, also clear Raft state from the host-mounted
+        # data directory.  Docker volumes are cleaned by `docker compose down -v`
+        # but host-mounted dirs (nexus-data/) are not.  Stale Raft logs contain
+        # old node IDs that prevent single-node leader election on restart.
+        if volumes:
+            import shutil
+
+            data_dir = Path(config.get("data_dir", "./nexus-data")).resolve()
+            raft_dirs = list(data_dir.glob("*/raft")) + list(data_dir.glob("*/sm"))
+            for rd in raft_dirs:
+                if rd.exists():
+                    shutil.rmtree(rd) if rd.is_dir() else rd.unlink()
+            if raft_dirs:
+                console.print(
+                    f"[dim]  Cleared {len(raft_dirs)} Raft state path(s) from {data_dir}[/dim]"
+                )
         console.print("[green]✓[/green] Stack stopped.")
     else:
         console.print("[red]Error:[/red] Failed to stop stack.")

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -352,6 +352,19 @@ async def _register_vfs_hooks(
     if permission_checker is not None:
         from nexus.bricks.rebac.permission_hook import PermissionCheckHook
 
+        # Permission write leases — check once, write many (Issue #3394)
+        _lease_table = None
+        if nx._enforce_permissions:
+            from nexus.bricks.rebac.cache.permission_lease import PermissionLeaseTable
+
+            _lease_table = PermissionLeaseTable()
+            # Wire invalidation: CacheCoordinator clears leases on permission mutation
+            _rebac_mgr = _ss.get("rebac_manager")
+            if _rebac_mgr is not None and hasattr(_rebac_mgr, "_cache_coordinator"):
+                _rebac_mgr._cache_coordinator.register_lease_invalidator(
+                    "perm-write-lease", lambda _zone_id: _lease_table.invalidate_all()
+                )
+
         _perm_hook = PermissionCheckHook(
             checker=permission_checker,
             metadata_store=nx.metadata,
@@ -359,6 +372,7 @@ async def _register_vfs_hooks(
             enforce_permissions=nx._enforce_permissions,
             permission_enforcer=_ss.get("permission_enforcer"),
             descendant_checker=getattr(nx, "_descendant_checker", None),
+            lease_table=_lease_table,
         )
         await _enlist("permission", _perm_hook)
 

--- a/tests/unit/rebac/bench_permission_lease.py
+++ b/tests/unit/rebac/bench_permission_lease.py
@@ -1,0 +1,222 @@
+"""Benchmark: permission write lease performance gain (Issue #3394).
+
+Measures the on_pre_write() hook latency with and without the
+PermissionLeaseTable to quantify the optimization.
+
+Run:
+    python -m pytest tests/unit/rebac/bench_permission_lease.py -v -s
+
+This is NOT a pytest-benchmark test (avoids xdist issues). It uses
+raw time.perf_counter for direct measurement.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("pyroaring")
+
+from nexus.bricks.rebac.cache.permission_lease import PermissionLeaseTable
+from nexus.bricks.rebac.permission_hook import PermissionCheckHook
+from nexus.contracts.vfs_hooks import WriteHookContext
+
+
+def _make_context(agent_id: str = "agent-A") -> MagicMock:
+    ctx = MagicMock()
+    ctx.agent_id = agent_id
+    ctx.user_id = "user-1"
+    ctx.zone_id = "zone-a"
+    return ctx
+
+
+def _make_write_ctx(path: str, old_metadata: MagicMock | None = None) -> WriteHookContext:
+    return WriteHookContext(
+        path=path,
+        content=b"data",
+        context=_make_context(),
+        old_metadata=old_metadata,
+    )
+
+
+class TestPermissionLeaseBenchmark:
+    """Benchmark: quantify the lease fast-path speedup."""
+
+    def _run_benchmark(
+        self,
+        hook: PermissionCheckHook,
+        ctx: WriteHookContext,
+        iterations: int = 1000,
+        warmup: int = 100,
+    ) -> list[float]:
+        """Run on_pre_write iterations and return per-call latencies in microseconds."""
+        # Warmup
+        for _ in range(warmup):
+            hook.on_pre_write(ctx)
+
+        latencies: list[float] = []
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            hook.on_pre_write(ctx)
+            t1 = time.perf_counter()
+            latencies.append((t1 - t0) * 1_000_000)  # microseconds
+        return latencies
+
+    def test_benchmark_with_vs_without_lease(self) -> None:
+        """Compare on_pre_write latency with and without lease table.
+
+        Without lease: every call does checker.check() (mocked but still
+        has Python call overhead).
+        With lease: second+ calls hit the lease and skip checker entirely.
+        """
+        checker = MagicMock()
+        metadata_store = MagicMock()
+        default_ctx = _make_context()
+        old_meta = MagicMock()
+
+        # --- WITHOUT lease table ---
+        hook_no_lease = PermissionCheckHook(
+            checker=checker,
+            metadata_store=metadata_store,
+            default_context=default_ctx,
+            enforce_permissions=True,
+            lease_table=None,
+        )
+        ctx = _make_write_ctx("/workspace/src/file.py", old_metadata=old_meta)
+
+        latencies_no_lease = self._run_benchmark(hook_no_lease, ctx)
+        checker.check.reset_mock()
+
+        # --- WITH lease table ---
+        lease_table = PermissionLeaseTable()
+        hook_with_lease = PermissionCheckHook(
+            checker=checker,
+            metadata_store=metadata_store,
+            default_context=default_ctx,
+            enforce_permissions=True,
+            lease_table=lease_table,
+        )
+
+        # First call primes the lease
+        hook_with_lease.on_pre_write(ctx)
+        checker.check.reset_mock()
+
+        latencies_with_lease = self._run_benchmark(hook_with_lease, ctx)
+
+        # --- Results ---
+        med_no = statistics.median(latencies_no_lease)
+        med_with = statistics.median(latencies_with_lease)
+        p95_no = sorted(latencies_no_lease)[int(0.95 * len(latencies_no_lease))]
+        p95_with = sorted(latencies_with_lease)[int(0.95 * len(latencies_with_lease))]
+        speedup = med_no / med_with if med_with > 0 else float("inf")
+
+        print("\n")
+        print("  ┌─────────────────────────────────────────────────────┐")
+        print("  │  Permission Write Lease Benchmark (Issue #3394)     │")
+        print("  ├─────────────────────────────────────────────────────┤")
+        print(f"  │  WITHOUT lease:  median={med_no:8.2f}μs  p95={p95_no:8.2f}μs │")
+        print(f"  │  WITH lease:     median={med_with:8.2f}μs  p95={p95_with:8.2f}μs │")
+        print(f"  │  Speedup:        {speedup:5.1f}x                            │")
+        print("  └─────────────────────────────────────────────────────┘")
+        print()
+
+        # The lease path should be meaningfully faster
+        assert med_with < med_no, (
+            f"Lease path ({med_with:.2f}μs) should be faster than no-lease path ({med_no:.2f}μs)"
+        )
+
+        # Verify checker was NOT called during the lease benchmark
+        # (all calls hit the lease fast path)
+        checker.check.assert_not_called()
+
+        # Report lease stats
+        stats = lease_table.stats()
+        print(f"  Lease stats: {stats}")
+        assert stats["lease_hits"] >= 1000  # All benchmark iterations hit
+
+    def test_benchmark_new_files_same_directory(self) -> None:
+        """Benchmark: many new files in the same directory (ancestor walk).
+
+        Without lease: each new file checks WRITE on parent dir.
+        With lease: first file stamps parent, rest hit via ancestor walk.
+        """
+        checker = MagicMock()
+        metadata_store = MagicMock()
+        default_ctx = _make_context()
+
+        lease_table = PermissionLeaseTable()
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=metadata_store,
+            default_context=default_ctx,
+            enforce_permissions=True,
+            lease_table=lease_table,
+        )
+
+        # First new file: stamps parent dir /workspace/src
+        ctx1 = _make_write_ctx("/workspace/src/file0.py", old_metadata=None)
+        hook.on_pre_write(ctx1)
+        assert checker.check.call_count == 1
+        checker.check.reset_mock()
+
+        # Subsequent new files in same dir: lease hit on parent
+        iterations = 500
+        latencies: list[float] = []
+        for i in range(1, iterations + 1):
+            ctx = _make_write_ctx(f"/workspace/src/file{i}.py", old_metadata=None)
+            t0 = time.perf_counter()
+            hook.on_pre_write(ctx)
+            t1 = time.perf_counter()
+            latencies.append((t1 - t0) * 1_000_000)
+
+        med = statistics.median(latencies)
+        p95 = sorted(latencies)[int(0.95 * len(latencies))]
+
+        print("\n")
+        print("  ┌─────────────────────────────────────────────────────┐")
+        print("  │  New Files in Same Dir (Ancestor Walk Benchmark)    │")
+        print("  ├─────────────────────────────────────────────────────┤")
+        print(f"  │  {iterations} new files in /workspace/src/                  │")
+        print(f"  │  median={med:8.2f}μs  p95={p95:8.2f}μs                  │")
+        print(f"  │  Full ReBAC checks skipped: {iterations}                     │")
+        print("  └─────────────────────────────────────────────────────┘")
+        print()
+
+        # All 500 should have hit the lease (parent dir stamp)
+        checker.check.assert_not_called()
+        assert lease_table.stats()["lease_hits"] >= iterations
+
+    def test_correctness_permission_denied_after_invalidation(self) -> None:
+        """Correctness: after invalidation, writes are re-checked."""
+        checker = MagicMock()
+        lease_table = PermissionLeaseTable()
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=MagicMock(),
+            default_context=_make_context(),
+            enforce_permissions=True,
+            lease_table=lease_table,
+        )
+
+        # Write succeeds, lease stamped
+        ctx = _make_write_ctx("/workspace/file.py", old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+        checker.check.reset_mock()
+
+        # Second write: lease hit (no check)
+        hook.on_pre_write(ctx)
+        checker.check.assert_not_called()
+
+        # Invalidate (simulates permission revocation)
+        lease_table.invalidate_all()
+
+        # Third write: must do full check
+        checker.check.side_effect = PermissionError("revoked")
+        with pytest.raises(PermissionError, match="revoked"):
+            hook.on_pre_write(ctx)
+
+        checker.check.assert_called_once()
+        print("\n  ✓ Correctness verified: invalidation forces re-check")

--- a/tests/unit/rebac/test_permission_lease.py
+++ b/tests/unit/rebac/test_permission_lease.py
@@ -205,6 +205,90 @@ class TestPermissionLeaseEdgeCases:
         assert table.check("/exists", "agent-A") is True
         assert table.stats()["lease_invalidations"] == 0
 
+    def test_invalidate_agent_clears_all_paths_for_agent(self, table: PermissionLeaseTable) -> None:
+        """Agent invalidation removes all leases for that agent only."""
+        table.stamp("/a", "agent-A")
+        table.stamp("/b", "agent-A")
+        table.stamp("/a", "agent-B")
+        table.invalidate_agent("agent-A")
+        assert table.check("/a", "agent-A") is False
+        assert table.check("/b", "agent-A") is False
+        assert table.check("/a", "agent-B") is True  # untouched
+
+    def test_invalidate_agent_nonexistent(self, table: PermissionLeaseTable) -> None:
+        """Invalidating an agent with no leases is a no-op."""
+        table.stamp("/a", "agent-A")
+        table.invalidate_agent("agent-X")
+        assert table.check("/a", "agent-A") is True
+        assert table.stats()["lease_invalidations"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Inheritance-aware ancestor walk
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseInheritance:
+    """Ancestor walk: a lease on a parent covers writes to descendants."""
+
+    def test_parent_lease_covers_child_file(self, table: PermissionLeaseTable) -> None:
+        """Lease stamped on directory covers check for a file in that directory."""
+        table.stamp("/workspace/src", "agent-A")
+        assert table.check("/workspace/src/file.py", "agent-A") is True
+
+    def test_grandparent_lease_covers_deep_descendant(self, table: PermissionLeaseTable) -> None:
+        """Lease on grandparent covers deeply nested file."""
+        table.stamp("/workspace", "agent-A")
+        assert table.check("/workspace/src/nested/file.py", "agent-A") is True
+
+    def test_root_lease_covers_any_path(self, table: PermissionLeaseTable) -> None:
+        """Lease on root covers any path."""
+        table.stamp("/", "agent-A")
+        assert table.check("/workspace/src/file.py", "agent-A") is True
+
+    def test_sibling_lease_does_not_cover(self, table: PermissionLeaseTable) -> None:
+        """Lease on /a does NOT cover /b (not an ancestor)."""
+        table.stamp("/workspace/a", "agent-A")
+        assert table.check("/workspace/b", "agent-A") is False
+
+    def test_child_lease_does_not_cover_parent(self, table: PermissionLeaseTable) -> None:
+        """Lease on child does NOT cover parent (walk is upward only)."""
+        table.stamp("/workspace/src/file.py", "agent-A")
+        assert table.check("/workspace/src", "agent-A") is False
+
+    def test_ancestor_walk_different_agents_independent(self, table: PermissionLeaseTable) -> None:
+        """Agent B's parent lease doesn't help agent A."""
+        table.stamp("/workspace/src", "agent-B")
+        assert table.check("/workspace/src/file.py", "agent-A") is False
+        assert table.check("/workspace/src/file.py", "agent-B") is True
+
+    def test_exact_match_preferred_over_ancestor(
+        self, table: PermissionLeaseTable, clock: ManualClock
+    ) -> None:
+        """Exact match is checked first (and returned) before ancestors."""
+        table.stamp("/workspace/src", "agent-A", ttl=5.0)
+        table.stamp("/workspace/src/file.py", "agent-A", ttl=30.0)
+        clock.advance(10.0)  # parent expired, child still valid
+        assert table.check("/workspace/src/file.py", "agent-A") is True
+
+    def test_new_file_scenario_many_files_same_dir(self, table: PermissionLeaseTable) -> None:
+        """Real-world: new-file write stamps parent, then existing file writes hit ancestor."""
+        # First write: new file → stamps parent dir (from on_pre_write logic)
+        table.stamp("/workspace/src", "agent-A")
+
+        # Subsequent writes to existing files in same dir → ancestor walk hits
+        assert table.check("/workspace/src/file1.py", "agent-A") is True
+        assert table.check("/workspace/src/file2.py", "agent-A") is True
+        assert table.check("/workspace/src/file3.py", "agent-A") is True
+
+    def test_ancestor_walk_expired_ancestor_is_skip(
+        self, table: PermissionLeaseTable, clock: ManualClock
+    ) -> None:
+        """Expired ancestor lease is skipped, walk continues but ultimately misses."""
+        table.stamp("/workspace", "agent-A")
+        clock.advance(31.0)  # expired
+        assert table.check("/workspace/src/file.py", "agent-A") is False
+
 
 # ---------------------------------------------------------------------------
 # Metrics

--- a/tests/unit/rebac/test_permission_lease.py
+++ b/tests/unit/rebac/test_permission_lease.py
@@ -1,0 +1,265 @@
+"""Unit tests for PermissionLeaseTable (Issue #3394).
+
+Tests the TTL-based permission lease cache: stamp, check, invalidation,
+edge cases, and metrics.  Uses ManualClock for deterministic time control.
+
+Decision record:
+    - #5C: Simple TTL dict (not LeaseManager)
+    - #10A: Reuse ManualClock from lib/lease.py
+    - #11B: Individual test per edge case
+    - #12A: Skip Hypothesis (data structure too simple)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pyroaring")
+
+from nexus.bricks.rebac.cache.permission_lease import PermissionLeaseTable
+from nexus.lib.lease import ManualClock
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clock() -> ManualClock:
+    """Deterministic clock starting at t=0."""
+    return ManualClock(0.0)
+
+
+@pytest.fixture
+def table(clock: ManualClock) -> PermissionLeaseTable:
+    """PermissionLeaseTable with deterministic clock and default TTL (30s)."""
+    return PermissionLeaseTable(clock=clock, ttl=30.0)
+
+
+# ---------------------------------------------------------------------------
+# Basic operations
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseBasicOps:
+    """Stamp, check, and invalidation fundamentals."""
+
+    def test_stamp_then_check_returns_true(self, table: PermissionLeaseTable) -> None:
+        """A freshly stamped lease is valid."""
+        table.stamp("/workspace/src", "agent-A")
+        assert table.check("/workspace/src", "agent-A") is True
+
+    def test_check_without_stamp_returns_false(self, table: PermissionLeaseTable) -> None:
+        """No lease exists by default."""
+        assert table.check("/workspace/src", "agent-A") is False
+
+    def test_stamp_overwrites_previous(
+        self, table: PermissionLeaseTable, clock: ManualClock
+    ) -> None:
+        """Re-stamping extends the lease TTL."""
+        table.stamp("/file.txt", "agent-A")
+        clock.advance(25.0)  # 5s left on original 30s TTL
+        table.stamp("/file.txt", "agent-A")  # re-stamp: new 30s from now
+        clock.advance(10.0)  # original would have expired, but re-stamp is valid
+        assert table.check("/file.txt", "agent-A") is True
+
+    def test_invalidate_all_clears_everything(self, table: PermissionLeaseTable) -> None:
+        """Zone-wide invalidation removes all leases."""
+        table.stamp("/a", "agent-A")
+        table.stamp("/b", "agent-B")
+        table.stamp("/c", "agent-A")
+        table.invalidate_all()
+        assert table.check("/a", "agent-A") is False
+        assert table.check("/b", "agent-B") is False
+        assert table.check("/c", "agent-A") is False
+
+    def test_invalidate_path_clears_all_agents_for_path(self, table: PermissionLeaseTable) -> None:
+        """Path-targeted invalidation removes leases for all agents on that path."""
+        table.stamp("/shared/dir", "agent-A")
+        table.stamp("/shared/dir", "agent-B")
+        table.stamp("/other/dir", "agent-A")
+        table.invalidate_path("/shared/dir")
+        assert table.check("/shared/dir", "agent-A") is False
+        assert table.check("/shared/dir", "agent-B") is False
+        assert table.check("/other/dir", "agent-A") is True  # untouched
+
+    def test_multiple_agents_on_same_path(self, table: PermissionLeaseTable) -> None:
+        """Different agents have independent leases on the same path."""
+        table.stamp("/workspace", "agent-A")
+        table.stamp("/workspace", "agent-B")
+        assert table.check("/workspace", "agent-A") is True
+        assert table.check("/workspace", "agent-B") is True
+        assert table.check("/workspace", "agent-C") is False
+
+    def test_multiple_paths_for_same_agent(self, table: PermissionLeaseTable) -> None:
+        """Same agent can have leases on different paths."""
+        table.stamp("/path/a", "agent-X")
+        table.stamp("/path/b", "agent-X")
+        assert table.check("/path/a", "agent-X") is True
+        assert table.check("/path/b", "agent-X") is True
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseTTLExpiry:
+    """Deterministic TTL expiry using ManualClock."""
+
+    def test_check_returns_false_after_ttl(
+        self, table: PermissionLeaseTable, clock: ManualClock
+    ) -> None:
+        """Lease expires after TTL."""
+        table.stamp("/file.txt", "agent-A")
+        clock.advance(30.0)  # exactly at TTL
+        assert table.check("/file.txt", "agent-A") is False
+
+    def test_check_returns_true_just_before_ttl(
+        self, table: PermissionLeaseTable, clock: ManualClock
+    ) -> None:
+        """Lease is valid just before TTL."""
+        table.stamp("/file.txt", "agent-A")
+        clock.advance(29.99)
+        assert table.check("/file.txt", "agent-A") is True
+
+    def test_custom_ttl_per_stamp(self, clock: ManualClock) -> None:
+        """Individual stamps can specify a custom TTL."""
+        table = PermissionLeaseTable(clock=clock, ttl=30.0)
+        table.stamp("/short", "agent-A", ttl=5.0)
+        table.stamp("/long", "agent-A", ttl=60.0)
+
+        clock.advance(10.0)
+        assert table.check("/short", "agent-A") is False  # expired at 5s
+        assert table.check("/long", "agent-A") is True  # still valid at 60s
+
+    def test_expiry_mid_burst_falls_through(
+        self, table: PermissionLeaseTable, clock: ManualClock
+    ) -> None:
+        """When TTL expires during a burst, check returns False (safe fallback)."""
+        table.stamp("/file.txt", "agent-A")
+        assert table.check("/file.txt", "agent-A") is True
+
+        clock.advance(31.0)
+        assert table.check("/file.txt", "agent-A") is False  # expired
+
+        # Re-stamp simulates what the hook does after a full ReBAC check
+        table.stamp("/file.txt", "agent-A")
+        assert table.check("/file.txt", "agent-A") is True
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (Decision #11B: individual test per case)
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseEdgeCases:
+    """Edge cases for robustness and security."""
+
+    def test_enforce_permissions_false_skips_lease(self) -> None:
+        """When enforce_permissions is False, the hook skips everything.
+
+        This test verifies the hook integration — the table itself has no
+        concept of enforce_permissions, but the hook should not call check()
+        or stamp() when permissions are disabled.
+        (Tested via hook integration test, this verifies table is uninvolved.)
+        """
+        clock = ManualClock(0.0)
+        table = PermissionLeaseTable(clock=clock)
+        # Table stays empty when not used
+        assert table.active_count == 0
+
+    def test_path_normalization_trailing_slash(self, table: PermissionLeaseTable) -> None:
+        """Trailing slashes are stripped for consistent keying."""
+        table.stamp("/workspace/src/", "agent-A")
+        assert table.check("/workspace/src", "agent-A") is True
+        assert table.check("/workspace/src/", "agent-A") is True
+
+    def test_path_normalization_root(self, table: PermissionLeaseTable) -> None:
+        """Root path '/' is not stripped."""
+        table.stamp("/", "agent-A")
+        assert table.check("/", "agent-A") is True
+
+    def test_size_cap_clears_table(self, clock: ManualClock) -> None:
+        """Table clears when max_entries is exceeded (Decision #13D)."""
+        table = PermissionLeaseTable(clock=clock, max_entries=5)
+        for i in range(5):
+            table.stamp(f"/file{i}", "agent-A")
+        assert table.active_count == 5
+
+        # 6th stamp triggers clear, then inserts
+        table.stamp("/file_new", "agent-A")
+        assert table.active_count == 1
+        assert table.check("/file_new", "agent-A") is True
+        assert table.check("/file0", "agent-A") is False  # cleared
+
+    def test_invalidate_all_on_empty_table(self, table: PermissionLeaseTable) -> None:
+        """Invalidating an empty table is a no-op (no metrics increment)."""
+        table.invalidate_all()
+        assert table.stats()["lease_invalidations"] == 0
+
+    def test_invalidate_path_nonexistent(self, table: PermissionLeaseTable) -> None:
+        """Invalidating a path with no leases is a no-op."""
+        table.stamp("/exists", "agent-A")
+        table.invalidate_path("/nonexistent")
+        assert table.check("/exists", "agent-A") is True
+        assert table.stats()["lease_invalidations"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseMetrics:
+    """Verify operational counters (Decision #14C: add metrics)."""
+
+    def test_hit_miss_counters(self, table: PermissionLeaseTable, clock: ManualClock) -> None:
+        """Hits and misses are tracked correctly."""
+        table.stamp("/file.txt", "agent-A")
+        table.check("/file.txt", "agent-A")  # hit
+        table.check("/file.txt", "agent-A")  # hit
+        table.check("/other.txt", "agent-A")  # miss
+        table.check("/file.txt", "agent-B")  # miss
+
+        stats = table.stats()
+        assert stats["lease_hits"] == 2
+        assert stats["lease_misses"] == 2
+
+    def test_stamp_counter(self, table: PermissionLeaseTable) -> None:
+        """Stamp count tracks total stamps (including re-stamps)."""
+        table.stamp("/a", "agent-A")
+        table.stamp("/b", "agent-A")
+        table.stamp("/a", "agent-A")  # re-stamp
+        assert table.stats()["lease_stamps"] == 3
+
+    def test_invalidation_counter(self, table: PermissionLeaseTable) -> None:
+        """Invalidation count tracks clear events."""
+        table.stamp("/a", "agent-A")
+        table.invalidate_all()
+        table.stamp("/b", "agent-B")
+        table.invalidate_all()
+        assert table.stats()["lease_invalidations"] == 2
+
+    def test_active_leases_count(self, table: PermissionLeaseTable, clock: ManualClock) -> None:
+        """active_leases reflects current table size (may include expired)."""
+        table.stamp("/a", "agent-A")
+        table.stamp("/b", "agent-B")
+        assert table.stats()["active_leases"] == 2
+        table.invalidate_all()
+        assert table.stats()["active_leases"] == 0
+
+    def test_expired_entries_still_in_active_count(
+        self, table: PermissionLeaseTable, clock: ManualClock
+    ) -> None:
+        """Expired entries stay in the table until evicted (lazy eviction).
+
+        active_leases counts table entries, not valid leases. This is
+        expected — cleanup happens via invalidate_all() or size cap.
+        """
+        table.stamp("/file.txt", "agent-A")
+        clock.advance(60.0)  # well past TTL
+        # Entry is still in table, just expired
+        assert table.stats()["active_leases"] == 1
+        # But check returns False
+        assert table.check("/file.txt", "agent-A") is False

--- a/tests/unit/rebac/test_permission_lease_integration.py
+++ b/tests/unit/rebac/test_permission_lease_integration.py
@@ -1,0 +1,547 @@
+"""Integration tests for permission write leases (Issue #3394).
+
+Tests the full composition:
+- PermissionCheckHook with PermissionLeaseTable (fast path + slow path)
+- CacheCoordinator with lease invalidation callback
+- Security regression: permission revocation invalidates leases
+
+Decision record:
+    - #9C: Both unit and integration tests for security-critical path
+    - #2C: Callback registration pattern for CacheCoordinator
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("pyroaring")
+
+from nexus.bricks.rebac.cache.coordinator import CacheCoordinator
+from nexus.bricks.rebac.cache.permission_lease import PermissionLeaseTable
+from nexus.bricks.rebac.permission_hook import PermissionCheckHook
+from nexus.contracts.vfs_hooks import WriteHookContext
+from nexus.lib.lease import ManualClock
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_context(
+    agent_id: str | None = "agent-A",
+    user_id: str | None = "user-1",
+    zone_id: str | None = "zone-a",
+    **kwargs: object,
+) -> MagicMock:
+    """Create a mock OperationContext with agent_id/user_id/zone_id."""
+    ctx = MagicMock()
+    ctx.agent_id = agent_id
+    ctx.user_id = user_id
+    ctx.zone_id = zone_id
+    for k, v in kwargs.items():
+        setattr(ctx, k, v)
+    return ctx
+
+
+def _make_write_ctx(
+    path: str = "/workspace/file.txt",
+    context: MagicMock | None = None,
+    old_metadata: MagicMock | None = None,
+    **kwargs: object,
+) -> WriteHookContext:
+    """Create a WriteHookContext for hook testing."""
+    if context is None:
+        context = _make_context()
+    return WriteHookContext(
+        path=path,
+        content=b"data",
+        context=context,
+        old_metadata=old_metadata,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clock() -> ManualClock:
+    return ManualClock(0.0)
+
+
+@pytest.fixture
+def lease_table(clock: ManualClock) -> PermissionLeaseTable:
+    return PermissionLeaseTable(clock=clock, ttl=30.0)
+
+
+@pytest.fixture
+def checker() -> MagicMock:
+    """Mock permission checker — check() raises PermissionError on denial."""
+    return MagicMock()
+
+
+@pytest.fixture
+def metadata_store() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def hook(
+    checker: MagicMock,
+    metadata_store: MagicMock,
+    lease_table: PermissionLeaseTable,
+) -> PermissionCheckHook:
+    """PermissionCheckHook wired with a PermissionLeaseTable."""
+    return PermissionCheckHook(
+        checker=checker,
+        metadata_store=metadata_store,
+        default_context=_make_context(),
+        enforce_permissions=True,
+        lease_table=lease_table,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hook fast path / slow path
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseHookIntegration:
+    """Tests for the lease-aware on_pre_write fast path."""
+
+    def test_first_write_does_full_check_and_stamps_lease(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """First write to a path: full ReBAC check + lease stamp."""
+        ctx = _make_write_ctx(old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+
+        checker.check.assert_called_once()
+        assert lease_table.stats()["lease_stamps"] == 1
+        assert lease_table.stats()["lease_misses"] == 1
+
+    def test_second_write_uses_lease_fast_path(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """Second write to same (path, agent): lease hit, skip ReBAC check."""
+        ctx = _make_write_ctx(old_metadata=MagicMock())
+        hook.on_pre_write(ctx)  # first: full check + stamp
+        checker.check.reset_mock()
+
+        hook.on_pre_write(ctx)  # second: lease hit
+
+        checker.check.assert_not_called()
+        assert lease_table.stats()["lease_hits"] == 1
+
+    def test_new_file_leases_on_parent_directory(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """New file: check WRITE on parent, stamp lease on parent path."""
+        ctx1 = _make_write_ctx(path="/workspace/src/file1.py", old_metadata=None)
+        hook.on_pre_write(ctx1)  # checks /workspace/src, stamps lease
+
+        checker.check.reset_mock()
+
+        ctx2 = _make_write_ctx(path="/workspace/src/file2.py", old_metadata=None)
+        hook.on_pre_write(ctx2)  # same parent → lease hit
+
+        checker.check.assert_not_called()
+        assert lease_table.stats()["lease_hits"] == 1
+
+    def test_different_agents_have_independent_leases(
+        self, hook: PermissionCheckHook, checker: MagicMock
+    ) -> None:
+        """Different agents' leases don't interfere."""
+        ctx_a = _make_write_ctx(context=_make_context(agent_id="agent-A"), old_metadata=MagicMock())
+        ctx_b = _make_write_ctx(context=_make_context(agent_id="agent-B"), old_metadata=MagicMock())
+
+        hook.on_pre_write(ctx_a)  # stamp for agent-A
+        checker.check.reset_mock()
+
+        hook.on_pre_write(ctx_b)  # agent-B: no lease → full check
+        checker.check.assert_called_once()
+
+    def test_permission_denied_does_not_stamp_lease(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """If ReBAC check raises PermissionError, no lease is stamped."""
+        checker.check.side_effect = PermissionError("Access denied")
+        ctx = _make_write_ctx(old_metadata=MagicMock())
+
+        with pytest.raises(PermissionError):
+            hook.on_pre_write(ctx)
+
+        assert lease_table.stats()["lease_stamps"] == 0
+
+    def test_enforce_permissions_false_skips_everything(
+        self, checker: MagicMock, metadata_store: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """With enforce_permissions=False, no lease check or ReBAC check."""
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=metadata_store,
+            default_context=_make_context(),
+            enforce_permissions=False,
+            lease_table=lease_table,
+        )
+        ctx = _make_write_ctx(old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+
+        checker.check.assert_not_called()
+        assert lease_table.stats()["lease_stamps"] == 0
+        assert lease_table.stats()["lease_hits"] == 0
+
+
+# ---------------------------------------------------------------------------
+# agent_id edge cases (Decision #7A)
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseAgentIdEdgeCases:
+    """Edge cases for agent_id extraction from context."""
+
+    def test_none_agent_id_skips_lease(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """agent_id=None: no lease stamped, always does full check."""
+        ctx = _make_write_ctx(context=_make_context(agent_id=None), old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+        hook.on_pre_write(ctx)  # second write
+
+        assert checker.check.call_count == 2  # both did full check
+        assert lease_table.stats()["lease_stamps"] == 0
+
+    def test_none_context_falls_back_to_default(
+        self,
+        checker: MagicMock,
+        metadata_store: MagicMock,
+        lease_table: PermissionLeaseTable,
+    ) -> None:
+        """context=None: uses default_context for both check and lease."""
+        default_ctx = _make_context(agent_id="default-agent")
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=metadata_store,
+            default_context=default_ctx,
+            enforce_permissions=True,
+            lease_table=lease_table,
+        )
+        ctx = _make_write_ctx(context=None, old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+
+        assert lease_table.stats()["lease_stamps"] == 1
+        checker.check.assert_called_once()
+
+    def test_context_without_agent_id_attr_skips_lease(
+        self, checker: MagicMock, metadata_store: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """If context object doesn't have agent_id attribute, skip lease."""
+        bare_context = MagicMock(spec=[])  # no attributes
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=metadata_store,
+            default_context=bare_context,
+            enforce_permissions=True,
+            lease_table=lease_table,
+        )
+        ctx = _make_write_ctx(context=bare_context, old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+        hook.on_pre_write(ctx)
+
+        assert checker.check.call_count == 2
+        assert lease_table.stats()["lease_stamps"] == 0
+
+
+# ---------------------------------------------------------------------------
+# No lease table (backwards compatibility)
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseBackwardsCompat:
+    """Ensure the hook works correctly without a lease_table (default=None)."""
+
+    def test_hook_without_lease_table(self, checker: MagicMock, metadata_store: MagicMock) -> None:
+        """Hook with lease_table=None works exactly like before #3394."""
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=metadata_store,
+            default_context=_make_context(),
+            enforce_permissions=True,
+            lease_table=None,
+        )
+        ctx = _make_write_ctx(old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+        hook.on_pre_write(ctx)
+
+        assert checker.check.call_count == 2  # no lease fast path
+
+
+# ---------------------------------------------------------------------------
+# CacheCoordinator lease invalidation (Decision #2C)
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinatorLeaseInvalidation:
+    """CacheCoordinator lease invalidation callback integration."""
+
+    def test_register_and_invoke_lease_invalidator(self) -> None:
+        """Lease invalidation callback is called during invalidate_for_write."""
+        invocations: list[str] = []
+        coordinator = CacheCoordinator(
+            zone_graph_cache={"zone-a": {"tuples": []}},
+        )
+        coordinator.register_lease_invalidator(
+            "perm-lease", lambda zone_id: invocations.append(zone_id)
+        )
+
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="editor",
+            object=("file", "/doc.txt"),
+        )
+
+        assert invocations == ["zone-a"]
+
+    def test_lease_invalidator_called_after_l1_before_boundary(self) -> None:
+        """Lease invalidation is step 3: after L1, before boundary."""
+        call_order: list[str] = []
+        l1 = MagicMock()
+        l1.invalidate_subject.side_effect = lambda *a, **kw: call_order.append("l1")
+        coordinator = CacheCoordinator(
+            l1_cache=l1,
+            zone_graph_cache={"zone-a": {"tuples": []}},
+        )
+        coordinator.register_lease_invalidator("lease", lambda zone_id: call_order.append("lease"))
+        coordinator.register_boundary_invalidator(
+            "boundary", lambda *a: call_order.append("boundary")
+        )
+
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="direct_viewer",
+            object=("file", "/doc.txt"),
+        )
+
+        assert "l1" in call_order
+        assert "lease" in call_order
+        assert "boundary" in call_order
+        assert call_order.index("l1") < call_order.index("lease")
+        assert call_order.index("lease") < call_order.index("boundary")
+
+    def test_lease_invalidator_failure_does_not_block_others(self) -> None:
+        """A failing lease invalidator must not block boundary/visibility."""
+        boundary_called = False
+
+        def failing_lease(zone_id: str) -> None:
+            raise RuntimeError("lease-boom")
+
+        def boundary_cb(zone_id, subj_type, subj_id, perm, obj_path):
+            nonlocal boundary_called
+            boundary_called = True
+
+        coordinator = CacheCoordinator(
+            zone_graph_cache={"zone-a": {"tuples": []}},
+        )
+        coordinator.register_lease_invalidator("fail", failing_lease)
+        coordinator.register_boundary_invalidator("ok", boundary_cb)
+
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="direct_viewer",
+            object=("file", "/doc.txt"),
+        )
+
+        assert boundary_called is True
+
+    def test_duplicate_lease_registration_is_idempotent(self) -> None:
+        """Re-registering the same callback_id must not create duplicates."""
+        coordinator = CacheCoordinator()
+        cb = lambda zone_id: None  # noqa: E731
+        coordinator.register_lease_invalidator("lease-1", cb)
+        coordinator.register_lease_invalidator("lease-1", cb)
+
+        assert coordinator.get_stats()["registered_lease_invalidators"] == 1
+
+    def test_unregister_lease_invalidator(self) -> None:
+        """Unregistering a lease invalidator removes it."""
+        coordinator = CacheCoordinator()
+        coordinator.register_lease_invalidator("lease-1", lambda z: None)
+        assert coordinator.unregister_lease_invalidator("lease-1") is True
+        assert coordinator.get_stats()["registered_lease_invalidators"] == 0
+        assert coordinator.unregister_lease_invalidator("lease-1") is False
+
+    def test_lease_invalidation_stats(self) -> None:
+        """lease_invalidations counter increments on each invalidate_for_write."""
+        coordinator = CacheCoordinator(
+            zone_graph_cache={"zone-a": {"tuples": []}},
+        )
+        coordinator.register_lease_invalidator("lease", lambda z: None)
+
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="editor",
+            object=("file", "/doc.txt"),
+        )
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "bob"),
+            relation="viewer",
+            object=("file", "/other.txt"),
+        )
+
+        assert coordinator.get_stats()["lease_invalidations"] == 2
+
+    def test_invalidate_all_also_clears_leases(self) -> None:
+        """invalidate_all() invokes lease invalidation too."""
+        invocations: list[str] = []
+        coordinator = CacheCoordinator(
+            zone_graph_cache={"zone-a": {"tuples": []}},
+        )
+        coordinator.register_lease_invalidator("lease", lambda zone_id: invocations.append(zone_id))
+
+        coordinator.invalidate_all(zone_id="zone-a")
+
+        assert "zone-a" in invocations
+
+
+# ---------------------------------------------------------------------------
+# Security regression test (Decision #9C)
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityRegressionPermissionRevocation:
+    """CRITICAL: permission revocation must invalidate leases.
+
+    This is the most important test in this file. It verifies the full
+    cycle: grant → write → lease → revoke → invalidate → write denied.
+
+    A failure here means an agent could write after their permission
+    was revoked — a security vulnerability.
+    """
+
+    def test_full_cycle_grant_write_revoke_deny(self) -> None:
+        """Grant → write (stamp lease) → revoke → write (lease gone → ReBAC check → deny)."""
+        clock = ManualClock(0.0)
+        lease_table = PermissionLeaseTable(clock=clock, ttl=30.0)
+        checker = MagicMock()  # check() returns normally = grant
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=MagicMock(),
+            default_context=_make_context(),
+            enforce_permissions=True,
+            lease_table=lease_table,
+        )
+        coordinator = CacheCoordinator(
+            zone_graph_cache={"zone-a": {"tuples": []}},
+        )
+
+        # Wire lease invalidation callback
+        coordinator.register_lease_invalidator(
+            "perm-lease", lambda zone_id: lease_table.invalidate_all()
+        )
+
+        # Step 1: Agent writes successfully (full check + stamp)
+        ctx = _make_write_ctx(old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+        assert lease_table.stats()["lease_stamps"] == 1
+        checker.check.reset_mock()
+
+        # Step 2: Agent writes again (lease hit, skip check)
+        hook.on_pre_write(ctx)
+        checker.check.assert_not_called()
+
+        # Step 3: Admin revokes permission → CacheCoordinator fires
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "user-1"),
+            relation="editor",
+            object=("file", "/workspace/file.txt"),
+        )
+
+        # Step 4: Lease table is now empty
+        assert lease_table.active_count == 0
+
+        # Step 5: Agent tries to write → no lease → full ReBAC check
+        checker.check.side_effect = PermissionError("Access denied: no longer editor")
+
+        with pytest.raises(PermissionError, match="no longer editor"):
+            hook.on_pre_write(ctx)
+
+        # Verify the full check was invoked (lease was properly invalidated)
+        checker.check.assert_called_once()
+
+    def test_lease_expiry_also_forces_recheck(self) -> None:
+        """Even without explicit revocation, TTL expiry forces a recheck."""
+        clock = ManualClock(0.0)
+        lease_table = PermissionLeaseTable(clock=clock, ttl=30.0)
+        checker = MagicMock()
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=MagicMock(),
+            default_context=_make_context(),
+            enforce_permissions=True,
+            lease_table=lease_table,
+        )
+
+        # Write 1: full check + stamp
+        ctx = _make_write_ctx(old_metadata=MagicMock())
+        hook.on_pre_write(ctx)
+        checker.check.reset_mock()
+
+        # Write 2: lease hit
+        hook.on_pre_write(ctx)
+        checker.check.assert_not_called()
+
+        # Advance past TTL
+        clock.advance(31.0)
+
+        # Write 3: lease expired → full check again
+        hook.on_pre_write(ctx)
+        checker.check.assert_called_once()
+
+    def test_multiple_agents_revocation_clears_all(self) -> None:
+        """Zone-wide invalidation clears leases for ALL agents."""
+        clock = ManualClock(0.0)
+        lease_table = PermissionLeaseTable(clock=clock, ttl=30.0)
+        checker = MagicMock()
+        hook = PermissionCheckHook(
+            checker=checker,
+            metadata_store=MagicMock(),
+            default_context=_make_context(),
+            enforce_permissions=True,
+            lease_table=lease_table,
+        )
+        coordinator = CacheCoordinator(
+            zone_graph_cache={"zone-a": {"tuples": []}},
+        )
+        coordinator.register_lease_invalidator(
+            "perm-lease", lambda zone_id: lease_table.invalidate_all()
+        )
+
+        # Both agents write and get leases
+        for agent in ("agent-A", "agent-B"):
+            ctx = _make_write_ctx(
+                context=_make_context(agent_id=agent),
+                old_metadata=MagicMock(),
+            )
+            hook.on_pre_write(ctx)
+
+        assert lease_table.active_count == 2
+
+        # Permission change invalidates ALL leases
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "user-1"),
+            relation="editor",
+            object=("file", "/workspace/file.txt"),
+        )
+
+        assert lease_table.active_count == 0

--- a/tests/unit/rebac/test_permission_lease_integration.py
+++ b/tests/unit/rebac/test_permission_lease_integration.py
@@ -257,6 +257,79 @@ class TestPermissionLeaseAgentIdEdgeCases:
 
 
 # ---------------------------------------------------------------------------
+# Inheritance-aware: new-file stamp covers existing-file writes
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseInheritanceHook:
+    """Ancestor walk through the hook: parent stamp covers child writes."""
+
+    def test_new_file_stamp_covers_subsequent_existing_file_writes(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """New-file write stamps parent dir; existing-file write in same dir hits via ancestor."""
+        # 1. New file → checks parent /workspace, stamps /workspace
+        new_ctx = _make_write_ctx(path="/workspace/file1.py", old_metadata=None)
+        hook.on_pre_write(new_ctx)
+        assert checker.check.call_count == 1
+        checker.check.reset_mock()
+
+        # 2. Existing file in same dir → ancestor walk finds /workspace lease
+        existing_ctx = _make_write_ctx(path="/workspace/file2.py", old_metadata=MagicMock())
+        hook.on_pre_write(existing_ctx)
+        checker.check.assert_not_called()  # lease hit via ancestor walk
+
+    def test_new_file_stamp_does_not_cover_different_directory(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """Parent stamp on /workspace does NOT cover /other."""
+        new_ctx = _make_write_ctx(path="/workspace/file1.py", old_metadata=None)
+        hook.on_pre_write(new_ctx)
+        checker.check.reset_mock()
+
+        other_ctx = _make_write_ctx(path="/other/file2.py", old_metadata=MagicMock())
+        hook.on_pre_write(other_ctx)
+        checker.check.assert_called_once()  # no ancestor match → full check
+
+
+# ---------------------------------------------------------------------------
+# Agent invalidation
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionLeaseAgentInvalidation:
+    """invalidate_agent() clears leases for a terminated/changed agent."""
+
+    def test_agent_invalidation_forces_recheck(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """After invalidating an agent, their writes require full checks."""
+        ctx = _make_write_ctx(old_metadata=MagicMock())
+        hook.on_pre_write(ctx)  # stamp
+        checker.check.reset_mock()
+
+        lease_table.invalidate_agent("agent-A")
+
+        hook.on_pre_write(ctx)  # must do full check again
+        checker.check.assert_called_once()
+
+    def test_agent_invalidation_does_not_affect_other_agents(
+        self, hook: PermissionCheckHook, checker: MagicMock, lease_table: PermissionLeaseTable
+    ) -> None:
+        """Invalidating agent-A leaves agent-B's leases intact."""
+        ctx_a = _make_write_ctx(context=_make_context(agent_id="agent-A"), old_metadata=MagicMock())
+        ctx_b = _make_write_ctx(context=_make_context(agent_id="agent-B"), old_metadata=MagicMock())
+        hook.on_pre_write(ctx_a)
+        hook.on_pre_write(ctx_b)
+        checker.check.reset_mock()
+
+        lease_table.invalidate_agent("agent-A")
+
+        hook.on_pre_write(ctx_b)
+        checker.check.assert_not_called()  # agent-B lease still valid
+
+
+# ---------------------------------------------------------------------------
 # No lease table (backwards compatibility)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

DFUSE-inspired optimization that caches successful ReBAC permission checks as TTL-based leases. Sequential writes to the same path by the same agent skip the full ReBAC check (~50-200μs → ~100-200ns). Also fixes two pre-existing bugs found during E2E validation.

### Permission Write Leases (Issue #3394)

- **`PermissionLeaseTable`** — lightweight TTL dict keyed by `(checked_path, agent_id)`. Deliberately NOT a LeaseManager: permission leases don't need conflict resolution, fencing tokens, or revocation callbacks since multiple agents can hold WRITE permission simultaneously.
- **`PermissionCheckHook.on_pre_write()` fast path** — O(1) dict lookup + ancestor walk before the full ReBAC check. Falls through to full check on miss and stamps a lease on success.
- **Inheritance-aware** — `check()` walks up the path hierarchy so a parent directory stamp (from a new-file write) covers existing-file writes in the same directory.
- **`invalidate_agent(agent_id)`** — clears all leases for a terminated agent.
- **`CacheCoordinator` integration** — `register_lease_invalidator()` callback, step 3 in the 9-step invalidation pipeline (after L1 cache, before boundary cache). Zone-wide clear on any permission mutation.
- **Production wiring** — `PermissionLeaseTable` created in factory when `enforce_permissions=True`, invalidation callback registered with `CacheCoordinator`.

### Bug Fixes (found during E2E validation)

- **Deterministic namespace IDs** — `default_namespaces.py` used `uuid.uuid4()` which generates a new ID on every import, breaking the namespace update guard across server restarts. Fixed with `uuid.uuid5(fixed_ns, object_type)`.
- **Stale Raft data on `nexus down --volumes`** — host-mounted `nexus-data/root/raft/` persists across `docker compose down -v` because it's not a Docker volume. Stale Raft logs contain old node IDs that prevent single-node leader election, causing all writes to fail with "Propose failed: not leader". Now cleared automatically.
- **Demo script** — added `eval $(nexus env)` auto-detect, `grpc_address` for SDK connections, `--zone-id default` for user API keys.

### Performance

| Workload | Before | After |
|----------|--------|-------|
| Repeated writes to same file | ~50-200μs/check | ~100-200ns (lease hit) |
| Many new files in same directory | ~50-200μs/check | ~100-200ns (parent dir lease hit) |
| FUSE continuous write | ~50-200μs/check | ~100-200ns (lease hit) |
| First write (cold) | ~50-200μs | ~50-200μs + ~100ns stamp |

### Files changed

| File | Change |
|------|--------|
| `bricks/rebac/cache/permission_lease.py` | **NEW** — PermissionLeaseTable |
| `bricks/rebac/permission_hook.py` | Lease fast path in `on_pre_write()` |
| `bricks/rebac/cache/coordinator.py` | Lease invalidation step + callback registration |
| `bricks/rebac/default_namespaces.py` | Deterministic `uuid5()` namespace IDs |
| `factory/orchestrator.py` | Production wiring |
| `cli/commands/stack.py` | Clear stale Raft data on `nexus down --volumes` |
| `permissions_demo_enhanced.sh` | grpc_address, zone-id, auto-detect env |
| `tests/unit/rebac/test_permission_lease.py` | **NEW** — 32 unit tests |
| `tests/unit/rebac/test_permission_lease_integration.py` | **NEW** — 25 integration tests |
| `tests/unit/rebac/bench_permission_lease.py` | **NEW** — in-process benchmark |

### E2E Validation

Full `permissions_demo_enhanced.sh` passes all 10 sections:
- ✅ Permission Semantics (Owner/Editor/Viewer)
- ✅ Group/Team Membership (Relationship Composition)
- ✅ Deep Path Inheritance (Real File I/O)
- ✅ Move/Rename Permission Behavior
- ✅ Auditability
- ✅ Negative Test Cases & Edge Cases
- ✅ Shared Resources (Universal Write Denial)
- ✅ Automatic Cache Invalidation
- ✅ Multi-Tenant Isolation
- ✅ Permission Check Latency (median 10.40ms, all PASS)

Closes #3394

## Test plan

- [x] 32 unit tests for PermissionLeaseTable (basic ops, TTL, inheritance, agent invalidation, metrics)
- [x] 25 integration tests (hook fast/slow path, CacheCoordinator ordering, failure isolation, security regression)
- [x] Security regression: grant → write → revoke → invalidate → deny
- [x] Backwards compatibility: lease_table=None preserves existing behavior
- [x] In-process benchmark: 5000 iterations, all lease hits, 0 ReBAC checks
- [x] E2E: permissions_demo_enhanced.sh — all 10 sections pass
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)