### PR TITLE
fix(nexus-fs): release integrity hardening — cleanup, lifecycle, tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -485,7 +485,7 @@ jobs:
       - name: Smoke test — CLI
         run: |
           /tmp/nexus-fs-test/bin/nexus-fs --help
-          /tmp/nexus-fs-test/bin/nexus-fs doctor || true
+          /tmp/nexus-fs-test/bin/nexus-fs doctor
 
       - name: Smoke test — fsspec entry point
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -512,23 +512,32 @@ jobs:
           print('GCS backend import OK')
           "
 
-      - name: Cold import time gate (budget 240ms)
+      - name: Cold import time gate (budget 240ms, median of 3 runs)
         run: |
-          /tmp/nexus-fs-test/bin/python -X importtime -c "import nexus.fs" 2> /tmp/importtime.log
-          cumulative_us=$(/tmp/nexus-fs-test/bin/python -c "
+          # Run 3 times and take the median to eliminate CI runner jitter
+          measurements=()
+          for i in 1 2 3; do
+            /tmp/nexus-fs-test/bin/python -X importtime -c "import nexus.fs" 2> /tmp/importtime_${i}.log
+            cumulative_us=$(/tmp/nexus-fs-test/bin/python -c "
           import re
-          with open('/tmp/importtime.log') as f:
+          with open('/tmp/importtime_${i}.log') as f:
               lines = f.read().strip().splitlines()
           last = lines[-1]
           match = re.search(r'\|\s+(\d+)\s+\|', last)
           print(match.group(1) if match else '0')
           ")
-          actual_ms=$((cumulative_us / 1000))
-          echo "Cold import time: ${actual_ms}ms (budget: 240ms)"
+            ms=$((cumulative_us / 1000))
+            measurements+=($ms)
+            echo "  Run ${i}: ${ms}ms"
+          done
+          # Sort and take the median (second of three values)
+          IFS=$'\n' sorted=($(sort -n <<<"${measurements[*]}")); unset IFS
+          actual_ms=${sorted[1]}
+          echo "Median import time: ${actual_ms}ms (budget: 240ms)"
           echo "### nexus-fs import time" >> $GITHUB_STEP_SUMMARY
-          echo "**${actual_ms}ms** (budget: 240ms)" >> $GITHUB_STEP_SUMMARY
+          echo "**${actual_ms}ms** median of [${measurements[0]}, ${measurements[1]}, ${measurements[2]}]ms (budget: 240ms)" >> $GITHUB_STEP_SUMMARY
           if [ "$actual_ms" -gt 240 ]; then
-            echo "::error::Cold import time ${actual_ms}ms exceeds 240ms budget"
+            echo "::error::Median import time ${actual_ms}ms exceeds 240ms budget"
             exit 1
           fi
 

--- a/packages/nexus-fs/README.md
+++ b/packages/nexus-fs/README.md
@@ -15,6 +15,9 @@ content = fs.read("/s3/my-bucket/README.md")
 pip install nexus-fs            # core (local only)
 pip install nexus-fs[s3]        # + Amazon S3
 pip install nexus-fs[gcs]       # + Google Cloud Storage
+pip install nexus-fs[gdrive]    # + Google Drive
+pip install nexus-fs[fsspec]    # + fsspec/pandas/dask integration
+pip install nexus-fs[tui]       # + interactive TUI playground
 pip install nexus-fs[all]       # everything
 ```
 
@@ -54,6 +57,12 @@ fs = nexus.fs.mount_sync("gws://sheets", "gws://docs")
 # Uses gws CLI under the hood — no server needed
 ```
 
+> **Prerequisite:** `gws://` mounts require the
+> [gws CLI](https://github.com/nicholasgasior/gws) to be installed and
+> authenticated. Other connectors (GitHub, Slack) require OAuth
+> credentials configured via environment variables — see
+> `nexus-fs doctor` for diagnostics.
+
 ## API
 
 | Method | Description |
@@ -85,7 +94,8 @@ nexus-fs playground s3://my-bucket local://./data
 ## State Directory
 
 nexus-fs stores runtime state (metadata DB, mount config) in a platform-specific
-directory:
+directory. This state is a **cache** — it can be safely deleted and will be
+recreated on the next `mount()` call.
 
 | Platform | Default path |
 |----------|-------------|
@@ -95,8 +105,13 @@ directory:
 
 Override with the `NEXUS_FS_STATE_DIR` environment variable.
 
-Persistent secrets (OAuth tokens, encryption keys) are stored under `~/.nexus/`.
+Persistent secrets (OAuth tokens, encryption keys) are stored separately
+under `~/.nexus/` with restricted permissions (`0700`).
 Override with `NEXUS_FS_PERSISTENT_DIR`.
+
+> **Concurrency:** nexus-fs is designed for single-process use per state
+> directory. To run multiple independent instances, set a different
+> `NEXUS_FS_STATE_DIR` for each process.
 
 ## Relationship to `nexus-ai-fs`
 

--- a/packages/nexus-fs/docs/cli/playground.md
+++ b/packages/nexus-fs/docs/cli/playground.md
@@ -23,10 +23,17 @@ nexus-fs playground local://./data s3://my-bucket
 nexus-fs playground
 ```
 
-When no URIs are provided, playground reads from the nexus-fs state
-directory (`$TMPDIR/nexus-fs/mounts.json` by default, or
-`$NEXUS_FS_STATE_DIR/mounts.json` if set) to find previously mounted
-backends.
+When no URIs are provided, playground reads `mounts.json` from the
+nexus-fs state directory to find previously mounted backends. This file
+is written by `mount()` / `mount_sync()` on every successful mount.
+
+If `mounts.json` is missing or contains invalid JSON, playground starts
+with an empty mount list. Re-run `mount()` or pass URIs explicitly.
+
+!!! note "Stale mounts"
+    `mounts.json` reflects the *last* `mount()` call. If credentials or
+    backends have changed since then, playground may fail to connect.
+    Pass URIs explicitly to bypass stale auto-discovery.
 
 ## Layout
 

--- a/packages/nexus-fs/docs/concepts/mounting.md
+++ b/packages/nexus-fs/docs/concepts/mounting.md
@@ -116,5 +116,63 @@ locally. This avoids re-listing remote backends on every operation and
 enables features like `stat()` and `exists()` without network calls for
 recently accessed files.
 
-The database is stored in the nexus-fs state directory
-(`$TMPDIR/nexus-fs/` by default, or `$NEXUS_FS_STATE_DIR/` if set).
+The database is stored in the nexus-fs state directory (platform-
+specific, see [State Directory](#state-directory) below).
+
+## State directory
+
+nexus-fs writes two files to the state directory:
+
+| File | Purpose | Regenerable? |
+|------|---------|-------------|
+| `metadata.db` | SQLite database with file metadata | Yes — rebuilt on next `mount()` |
+| `mounts.json` | Last-mounted URIs for auto-discovery | Yes — written on every `mount()` |
+
+Default location depends on platform (override with `NEXUS_FS_STATE_DIR`):
+
+- Linux: `~/.local/state/nexus-fs/`
+- macOS: `~/Library/Application Support/nexus-fs/`
+- Windows: `%LOCALAPPDATA%/nexus-fs/`
+
+!!! tip "Safe to delete"
+    The entire state directory can be deleted without data loss.
+    nexus-fs recreates it on the next `mount()` call. Your actual
+    data remains in the storage backends (S3, GCS, local).
+
+### Cleanup and retention
+
+nexus-fs does **not** automatically delete stale state. If you mount
+different backends over time, old metadata entries accumulate in
+`metadata.db`. To reset:
+
+```bash
+rm -rf ~/.local/state/nexus-fs/   # Linux
+rm -rf ~/Library/Application\ Support/nexus-fs/  # macOS
+```
+
+On `close()`, nexus-fs checkpoints the WAL and runs `PRAGMA optimize`
+to keep the database compact.
+
+### Corruption recovery
+
+If `metadata.db` becomes corrupted (e.g., after a hard crash), delete
+it and re-mount. The database is a cache — no user data is stored in it.
+
+If `mounts.json` contains invalid JSON, `nexus-fs playground` will show
+an empty mount list and `fsspec` auto-discovery will raise a clear error
+asking you to re-run `mount()`.
+
+### Concurrent processes
+
+nexus-fs is designed for **single-process use per state directory**.
+
+- SQLite WAL mode allows concurrent readers, but only one writer.
+- `mount()` writes `mounts.json` atomically (temp file + rename), so
+  concurrent readers always see valid JSON.
+- If two processes call `mount()` against the same state directory
+  simultaneously, the second writer may encounter `SQLITE_BUSY` and
+  retry (up to 3 times with exponential backoff). If contention persists
+  beyond the retry budget, an `OperationalError` is raised.
+
+To run multiple independent nexus-fs instances, set a different
+`NEXUS_FS_STATE_DIR` for each process.

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -145,11 +145,23 @@ async def mount(*uris: str, at: str | None = None) -> Any:
             ),
         )
 
-        # Persist mount URIs so playground/fsspec can auto-discover them
+        # Persist mount URIs so playground/fsspec can auto-discover them.
+        # Atomic write (temp file + os.replace) to avoid partial JSON if
+        # the process crashes mid-write.
         try:
+            import os
+            import tempfile
+
             mf = mounts_file()
-            with open(mf, "w") as f:
-                json.dump(list(uris), f)
+            fd, tmp = tempfile.mkstemp(dir=mf.parent, suffix=".tmp")
+            try:
+                with open(fd, "w") as f:
+                    json.dump(list(uris), f)
+                    f.flush()
+                os.replace(tmp, mf)
+            except BaseException:
+                os.unlink(tmp)
+                raise
         except OSError as exc:
             logger.warning(
                 "Could not write mounts.json (%s). "

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -76,6 +76,10 @@ async def mount(*uris: str, at: str | None = None) -> Any:
 
         # Custom mount point
         fs = await nexus.fs.mount("s3://my-bucket", at="/data")
+
+        # Context manager (recommended for resource cleanup)
+        async with await nexus.fs.mount("s3://my-bucket") as fs:
+            content = await fs.read("/s3/my-bucket/file.txt")
     """
     from nexus.fs._uri import derive_mount_point, parse_uri, validate_mount_collision
 
@@ -118,39 +122,49 @@ async def mount(*uris: str, at: str | None = None) -> Any:
         raise
 
     # Slim kernel boot — direct construction, no factory dependency.
-    from nexus.contracts.constants import ROOT_ZONE_ID
-    from nexus.contracts.types import OperationContext
-    from nexus.core.config import PermissionConfig
-    from nexus.core.nexus_fs import NexusFS
-    from nexus.core.router import PathRouter
-
-    router = PathRouter(metastore)
-
-    for mp, backend in backends:
-        router.add_mount(mp, backend)
-
-    kernel = NexusFS(
-        metadata_store=metastore,
-        permissions=PermissionConfig(enforce=False),
-        router=router,
-        init_cred=OperationContext(user_id="local", groups=[], zone_id=ROOT_ZONE_ID, is_admin=True),
-    )
-
-    # Persist mount URIs so playground/fsspec can auto-discover them
+    # Wrapped in try/except so backends and metastore are cleaned up if
+    # PathRouter, NexusFS, or the mount-entry writes fail.
     try:
-        mf = mounts_file()
-        with open(mf, "w") as f:
-            json.dump(list(uris), f)
-    except OSError as exc:
-        logger.warning(
-            "Could not write mounts.json (%s). "
-            "fsspec auto-discovery and playground will not find these mounts.",
-            exc,
+        from nexus.contracts.constants import ROOT_ZONE_ID
+        from nexus.contracts.types import OperationContext
+        from nexus.core.config import PermissionConfig
+        from nexus.core.nexus_fs import NexusFS
+        from nexus.core.router import PathRouter
+
+        router = PathRouter(metastore)
+
+        for mp, backend in backends:
+            router.add_mount(mp, backend)
+
+        kernel = NexusFS(
+            metadata_store=metastore,
+            permissions=PermissionConfig(enforce=False),
+            router=router,
+            init_cred=OperationContext(
+                user_id="local", groups=[], zone_id=ROOT_ZONE_ID, is_admin=True
+            ),
         )
 
-    # Create DT_MOUNT metadata entries for each mount point
-    for mp, backend in backends:
-        metastore.put(_make_mount_entry(mp, backend.name))
+        # Persist mount URIs so playground/fsspec can auto-discover them
+        try:
+            mf = mounts_file()
+            with open(mf, "w") as f:
+                json.dump(list(uris), f)
+        except OSError as exc:
+            logger.warning(
+                "Could not write mounts.json (%s). "
+                "fsspec auto-discovery and playground will not find these mounts.",
+                exc,
+            )
+
+        # Create DT_MOUNT metadata entries for each mount point
+        for mp, backend in backends:
+            metastore.put(_make_mount_entry(mp, backend.name))
+    except Exception:
+        for _, be in backends:
+            _close_backend(be)
+        metastore.close()
+        raise
 
     return SlimNexusFS(kernel)
 

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -53,9 +53,9 @@ def create_backend(spec: Any) -> Any:
                 "google-cloud-storage is required for GCS backends. "
                 "Install with: pip install nexus-fs[gcs]"
             ) from None
-        # GCS: gcs://project/bucket → authority=project, path=/bucket
-        bucket = spec.path.strip("/").split("/")[0] if spec.path else spec.authority
-        return CASGCSBackend(bucket_name=bucket, project_id=spec.authority)
+        from nexus.fs._uri import derive_bucket
+
+        return CASGCSBackend(bucket_name=derive_bucket(spec), project_id=spec.authority)
 
     elif spec.scheme == "local":
         from pathlib import Path as _Path

--- a/src/nexus/fs/_credentials.py
+++ b/src/nexus/fs/_credentials.py
@@ -67,8 +67,8 @@ def check_aws_credentials() -> dict[str, str]:
             return {"source": "boto3_session", "method": type(creds).__name__}
     except ImportError:
         pass
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Unexpected error during boto3 credential discovery: %s", exc)
 
     raise CloudCredentialError(
         "s3",
@@ -107,8 +107,8 @@ def check_gcs_credentials() -> dict[str, str]:
             return {"source": "google_auth_default", "project": project or "unknown"}
     except ImportError:
         pass
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Unexpected error during GCP credential discovery: %s", exc)
 
     raise CloudCredentialError(
         "gcs",

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -25,6 +25,35 @@ from nexus.core.nexus_fs import NexusFS
 
 logger = logging.getLogger(__name__)
 
+
+def _make_stat_dict(
+    *,
+    path: str,
+    size: int,
+    etag: str | None,
+    mime_type: str,
+    created_at: str | None,
+    modified_at: str | None,
+    is_directory: bool,
+    version: int,
+    zone_id: str | None,
+    entry_type: int,
+) -> dict[str, Any]:
+    """Build the stat response dict.  Single source of truth for the shape."""
+    return {
+        "path": path,
+        "size": size,
+        "etag": etag,
+        "mime_type": mime_type,
+        "created_at": created_at,
+        "modified_at": modified_at,
+        "is_directory": is_directory,
+        "version": version,
+        "zone_id": zone_id,
+        "entry_type": entry_type,
+    }
+
+
 # Default context for slim-mode (single-user, no auth)
 _SLIM_CONTEXT = OperationContext(
     user_id="local",
@@ -47,6 +76,7 @@ class SlimNexusFS:
     def __init__(self, kernel: NexusFS) -> None:
         self._kernel = kernel
         self._ctx = _SLIM_CONTEXT
+        self._closed = False
 
     @property
     def kernel(self) -> NexusFS:
@@ -220,37 +250,37 @@ class SlimNexusFS:
 
         if meta is not None:
             is_dir = meta.is_dir or meta.is_mount or meta.mime_type == "inode/directory"
-            return {
-                "path": meta.path,
-                "size": meta.size or (4096 if is_dir else 0),
-                "etag": meta.etag,
-                "mime_type": meta.mime_type
+            return _make_stat_dict(
+                path=meta.path,
+                size=meta.size or (4096 if is_dir else 0),
+                etag=meta.etag,
+                mime_type=meta.mime_type
                 or ("inode/directory" if is_dir else "application/octet-stream"),
-                "created_at": meta.created_at.isoformat() if meta.created_at else None,
-                "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
-                "is_directory": is_dir,
-                "version": meta.version,
-                "zone_id": meta.zone_id,
-                "entry_type": meta.entry_type,
-            }
+                created_at=meta.created_at.isoformat() if meta.created_at else None,
+                modified_at=meta.modified_at.isoformat() if meta.modified_at else None,
+                is_directory=is_dir,
+                version=meta.version,
+                zone_id=meta.zone_id,
+                entry_type=meta.entry_type,
+            )
 
         # No explicit entry — check if it's an implicit directory.
         # is_implicit_directory is on concrete metastore classes, not the ABC.
         _meta = self._kernel.metadata
         _is_implicit = getattr(_meta, "is_implicit_directory", None)
         if _is_implicit is not None and _is_implicit(normalized):
-            return {
-                "path": normalized,
-                "size": 4096,
-                "etag": None,
-                "mime_type": "inode/directory",
-                "created_at": None,
-                "modified_at": None,
-                "is_directory": True,
-                "version": 0,
-                "zone_id": ROOT_ZONE_ID,
-                "entry_type": 1,
-            }
+            return _make_stat_dict(
+                path=normalized,
+                size=4096,
+                etag=None,
+                mime_type="inode/directory",
+                created_at=None,
+                modified_at=None,
+                is_directory=True,
+                version=0,
+                zone_id=ROOT_ZONE_ID,
+                entry_type=1,
+            )
 
         return None
 
@@ -267,10 +297,31 @@ class SlimNexusFS:
     # -- Lifecycle --
 
     async def close(self) -> None:
-        """Close the filesystem and release resources."""
+        """Close the filesystem and release resources.
+
+        Closes the kernel (if it exposes a close method) and then
+        closes the metastore's SQLite connection.  Safe to call
+        multiple times — subsequent calls are no-ops.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        # Close the kernel (may be sync or async)
         _close = getattr(self._kernel, "close", None)
         if _close is not None:
             result = _close()
-            # Handle both sync and async close implementations
             if result is not None:
                 await result
+
+        # Close the metastore connection to release the WAL lock
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            self._kernel.metadata.close()
+
+    async def __aenter__(self) -> SlimNexusFS:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -305,20 +305,22 @@ class SlimNexusFS:
         """
         if self._closed:
             return
-        self._closed = True
 
-        # Close the kernel (may be sync or async)
-        _close = getattr(self._kernel, "close", None)
-        if _close is not None:
-            result = _close()
-            if result is not None:
-                await result
-
-        # Close the metastore connection to release the WAL lock
         import contextlib
 
-        with contextlib.suppress(Exception):
-            self._kernel.metadata.close()
+        try:
+            # Close the kernel (may be sync or async)
+            _close = getattr(self._kernel, "close", None)
+            if _close is not None:
+                result = _close()
+                if result is not None:
+                    await result
+        finally:
+            # Always close the metastore — even if kernel close raises —
+            # to release the SQLite/WAL lock.
+            with contextlib.suppress(Exception):
+                self._kernel.metadata.close()
+            self._closed = True
 
     async def __aenter__(self) -> SlimNexusFS:
         return self

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -67,6 +67,9 @@ logger = logging.getLogger(__name__)
 MAX_CAT_FILE_SIZE = DEFAULT_MAX_FILE_SIZE
 MAX_WRITE_BUFFER_SIZE = DEFAULT_MAX_FILE_SIZE
 
+# Warn when write buffer crosses 100 MB (before the 1 GB hard limit).
+_WRITE_BUFFER_WARNING = 100 * 1024 * 1024
+
 # Supported modes for _open().
 _SUPPORTED_MODES = frozenset({"rb", "wb", "r", "w", "xb", "x"})
 
@@ -334,11 +337,13 @@ class NexusFileSystem(AbstractFileSystem):
                 raise FileExistsError(path)
         try:
             self._mkdir(path, create_parents=True)
-        except Exception:
-            # Silently ignore errors for mount-point ancestors
-            # that the router won't let us create explicitly.
+        except Exception as exc:
             if exist_ok:
-                pass
+                logger.debug(
+                    "makedirs(%r, exist_ok=True) suppressed: %s",
+                    path,
+                    exc,
+                )
             else:
                 raise
         self.dircache.clear()
@@ -497,6 +502,7 @@ class NexusWriteFile:
         self._buffer = io.BytesIO()
         self._closed = False
         self._bytes_written = 0
+        self._warned_large_buffer = False
 
     @property
     def name(self) -> str:
@@ -512,6 +518,14 @@ class NexusWriteFile:
                 f"{MAX_WRITE_BUFFER_SIZE / (1024**3):.0f} GB limit. "
                 f"Use _pipe_file() for large writes or wait for "
                 f"streaming write support."
+            )
+        if not self._warned_large_buffer and self._bytes_written > _WRITE_BUFFER_WARNING:
+            self._warned_large_buffer = True
+            logger.warning(
+                "Write buffer for %r is %d MB. Writes are buffered in memory "
+                "up to 1 GB (hard limit). Consider chunking large writes.",
+                self.path,
+                self._bytes_written // (1024 * 1024),
             )
         return self._buffer.write(data)
 

--- a/src/nexus/fs/_paths.py
+++ b/src/nexus/fs/_paths.py
@@ -3,12 +3,25 @@
 Single source of truth for all filesystem paths used by nexus-fs:
 state directory, persistent directory, metadata DB, mounts file, etc.
 
-Uses ``platformdirs`` for cross-platform XDG-compliant paths:
-    Linux:  ~/.local/state/nexus-fs/
-    macOS:  ~/Library/Application Support/nexus-fs/
-    Windows: %LOCALAPPDATA%/nexus-fs/
+Two directories
+---------------
+**State directory** (``state_dir()``)
+    Runtime metadata that can be regenerated: ``metadata.db``, ``mounts.json``.
+    Safe to delete — nexus-fs recreates it on next mount.
+    Uses ``platformdirs`` for cross-platform XDG-compliant paths:
+        Linux:  ~/.local/state/nexus-fs/
+        macOS:  ~/Library/Application Support/nexus-fs/
+        Windows: %LOCALAPPDATA%/nexus-fs/
+    Override: ``NEXUS_FS_STATE_DIR``
 
-Override with ``NEXUS_FS_STATE_DIR`` environment variable.
+**Persistent directory** (``persistent_dir()``)
+    Secrets that must survive state resets: OAuth tokens, encryption keys.
+    Created with restricted permissions (``0o700``).
+    Default: ``~/.nexus/`` (legacy, pre-XDG).
+    Override: ``NEXUS_FS_PERSISTENT_DIR``
+
+The split exists because state can be wiped without data loss, but secrets
+cannot be regenerated without re-authenticating.
 """
 
 from __future__ import annotations
@@ -56,12 +69,18 @@ def persistent_dir() -> Path:
     1. ``NEXUS_FS_PERSISTENT_DIR`` environment variable
     2. ``~/.nexus/`` (legacy default, maintained for backwards compatibility)
 
-    This directory stores secrets (OAuth tokens, encryption keys) and must
-    have restricted permissions.
+    This directory stores secrets (OAuth tokens, encryption keys).
+    Created with mode ``0o700`` (owner-only access) on POSIX systems.
     """
     override = os.environ.get("NEXUS_FS_PERSISTENT_DIR")
     p = Path(override) if override else Path.home() / ".nexus"
     p.mkdir(parents=True, exist_ok=True)
+    # Restrict permissions to owner-only on POSIX (no-op on Windows where
+    # chmod is unsupported).
+    import contextlib
+
+    with contextlib.suppress(OSError):
+        p.chmod(0o700)
     return p
 
 

--- a/src/nexus/fs/_sqlite_meta.py
+++ b/src/nexus/fs/_sqlite_meta.py
@@ -221,6 +221,13 @@ class SQLiteMetastore(MetastoreABC):
         return results
 
     def close(self) -> None:
+        # Checkpoint and optimize before closing so WAL/SHM files are
+        # cleaned up and the database is left in a compact state.
+        try:
+            self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            self._conn.execute("PRAGMA optimize")
+        except Exception:
+            pass  # best-effort; closing is more important
         self._conn.close()
 
     # ------------------------------------------------------------------

--- a/src/nexus/fs/_sync.py
+++ b/src/nexus/fs/_sync.py
@@ -132,6 +132,9 @@ class SyncNexusFS:
     def mkdir(self, path: str, parents: bool = True) -> None:
         self._runner(self._async.mkdir(path, parents=parents))
 
+    def rmdir(self, path: str, recursive: bool = False) -> None:
+        self._runner(self._async.rmdir(path, recursive=recursive))
+
     def rename(self, old_path: str, new_path: str) -> None:
         self._runner(self._async.rename(old_path, new_path))
 

--- a/src/nexus/fs/_uri.py
+++ b/src/nexus/fs/_uri.py
@@ -63,6 +63,18 @@ class MountSpec:
     uri: str
 
 
+def derive_bucket(spec: MountSpec) -> str:
+    """Derive the cloud bucket/container name from a MountSpec.
+
+    For GCS (``gcs://project/bucket/sub``), the bucket is the first
+    path segment.  For S3 (``s3://bucket/sub``), it is the authority.
+    Falls back to authority for all other schemes.
+    """
+    if spec.scheme == "gcs" and spec.path:
+        return spec.path.strip("/").split("/")[0]
+    return spec.authority
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -179,8 +191,7 @@ def derive_mount_point(spec: MountSpec, at: str | None = None) -> str:
     elif spec.scheme == "gcs":
         # gcs://project/bucket → mount at /gcs/bucket
         # gcs://bucket          → mount at /gcs/bucket
-        last_segment = spec.path.split("/")[-1] if spec.path else spec.authority
-        mount = f"/gcs/{last_segment}"
+        mount = f"/gcs/{derive_bucket(spec)}"
     elif spec.scheme == "local":
         # Sanitise: replace slashes and dots so the mount name is a single
         # clean segment.  e.g. /tmp/nexus → tmp-nexus, ./data → data

--- a/tests/unit/fs/test_release_integrity.py
+++ b/tests/unit/fs/test_release_integrity.py
@@ -1,0 +1,517 @@
+"""Release-integrity tests for nexus-fs (Issue #3328).
+
+Covers:
+- mount() cleanup on failure (Issue 9A)
+- SQLiteMetastore concurrency + _retry_on_busy (Issue 10A)
+- Negative/error path tests (Issue 11A)
+- Method-set parity (Issue 8B / 12A)
+"""
+
+from __future__ import annotations
+
+import inspect
+import sqlite3
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.metadata import FileMetadata
+from nexus.fs._facade import SlimNexusFS
+from nexus.fs._sqlite_meta import SQLiteMetastore, _retry_on_busy
+from nexus.fs._sync import SyncNexusFS
+
+# =========================================================================
+# Issue 8B / 12A: Method-set parity between SlimNexusFS and SyncNexusFS
+# =========================================================================
+
+
+class TestMethodSetParity:
+    """SyncNexusFS must expose every public method from SlimNexusFS."""
+
+    @staticmethod
+    def _public_methods(cls: type) -> set[str]:
+        return {
+            name
+            for name, val in inspect.getmembers(cls)
+            if not name.startswith("_")
+            and callable(val)
+            and name not in ("kernel",)  # property escape hatch, not a method
+        }
+
+    def test_sync_exposes_all_async_methods(self) -> None:
+        async_methods = self._public_methods(SlimNexusFS)
+        sync_methods = self._public_methods(SyncNexusFS)
+        missing = async_methods - sync_methods
+        assert not missing, (
+            f"SyncNexusFS is missing public methods from SlimNexusFS: {sorted(missing)}"
+        )
+
+
+# =========================================================================
+# Issue 9A: mount() cleanup on failure
+# =========================================================================
+
+
+class TestMountCleanupOnFailure:
+    """Verify mount() cleans up resources on partial failure."""
+
+    @pytest.mark.asyncio
+    async def test_first_backend_failure_closes_metastore(self, tmp_path, monkeypatch):
+        """If the first create_backend() fails, metastore must be closed."""
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(tmp_path))
+
+        with (
+            patch("nexus.fs._backend_factory.create_backend", side_effect=ImportError("no boto3")),
+            pytest.raises(ImportError, match="no boto3"),
+        ):
+            from nexus.fs import mount
+
+            await mount("s3://bucket")
+
+    @pytest.mark.asyncio
+    async def test_second_backend_failure_closes_first_and_metastore(self, tmp_path, monkeypatch):
+        """If the second backend fails, the first backend and metastore are closed."""
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(tmp_path))
+
+        first_backend = MagicMock()
+        first_backend.close = MagicMock()
+        call_count = 0
+
+        def mock_create(spec):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return first_backend
+            raise ImportError("no gcs")
+
+        with (
+            patch(
+                "nexus.fs._backend_factory.create_backend",
+                side_effect=mock_create,
+            ) as _,
+            pytest.raises(ImportError, match="no gcs"),
+        ):
+            from nexus.fs import mount
+
+            await mount("local:///tmp/a", "gcs://project/bucket")
+
+        first_backend.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_kernel_boot_failure_closes_backends_and_metastore(self, tmp_path, monkeypatch):
+        """If NexusFS() raises, all backends and the metastore are closed."""
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(tmp_path))
+
+        mock_backend = MagicMock()
+        mock_backend.name = "test"
+        mock_backend.close = MagicMock()
+
+        with (
+            patch(
+                "nexus.fs._backend_factory.create_backend",
+                return_value=mock_backend,
+            ),
+            patch("nexus.core.nexus_fs.NexusFS.__init__", side_effect=RuntimeError("boot failed")),
+            pytest.raises(RuntimeError, match="boot failed"),
+        ):
+            from nexus.fs import mount
+
+            await mount("local:///tmp/data")
+
+        mock_backend.close.assert_called_once()
+
+
+# =========================================================================
+# Issue 10A: SQLiteMetastore concurrency + _retry_on_busy
+# =========================================================================
+
+
+def _make_metadata(path: str) -> FileMetadata:
+    """Create a minimal FileMetadata for testing."""
+    now = datetime.now(UTC)
+    return FileMetadata(
+        path=path,
+        backend_name="test",
+        physical_path="hash123",
+        size=42,
+        etag="etag123",
+        mime_type="text/plain",
+        created_at=now,
+        modified_at=now,
+        version=1,
+        zone_id=ROOT_ZONE_ID,
+    )
+
+
+class TestRetryOnBusy:
+    """Unit tests for the _retry_on_busy decorator."""
+
+    def test_succeeds_on_first_try(self) -> None:
+        call_count = 0
+
+        @_retry_on_busy
+        def op():
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        assert op() == "ok"
+        assert call_count == 1
+
+    def test_retries_on_busy_then_succeeds(self) -> None:
+        attempts = 0
+
+        @_retry_on_busy
+        def op():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return "ok"
+
+        assert op() == "ok"
+        assert attempts == 3
+
+    def test_raises_after_max_retries(self) -> None:
+        @_retry_on_busy
+        def op():
+            raise sqlite3.OperationalError("database is locked")
+
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            op()
+
+    def test_non_busy_error_not_retried(self) -> None:
+        call_count = 0
+
+        @_retry_on_busy
+        def op():
+            nonlocal call_count
+            call_count += 1
+            raise sqlite3.OperationalError("disk I/O error")
+
+        with pytest.raises(sqlite3.OperationalError, match="disk I/O"):
+            op()
+        assert call_count == 1  # no retry
+
+
+class TestConcurrentMetastore:
+    """Thread-contention test for SQLiteMetastore.
+
+    Tests WAL-mode concurrency with separate connections (one per thread),
+    which is the supported multi-process/multi-thread pattern for SQLite.
+    """
+
+    def test_concurrent_put_get_no_data_loss(self, tmp_path: Path) -> None:
+        """5 threads each with their own connection doing 20 put/get cycles."""
+        db_path = str(tmp_path / "concurrent.db")
+        # Create the schema first
+        SQLiteMetastore(db_path).close()
+
+        n_threads = 5
+        n_ops = 20
+        errors: list[str] = []
+
+        def worker(thread_id: int) -> None:
+            ms = SQLiteMetastore(db_path)
+            try:
+                for i in range(n_ops):
+                    path = f"/thread{thread_id}/file{i}.txt"
+                    meta = _make_metadata(path)
+                    try:
+                        ms.put(meta)
+                        result = ms.get(path)
+                        if result is None:
+                            errors.append(
+                                f"Thread {thread_id}: get({path}) returned None after put"
+                            )
+                        elif result.path != path:
+                            errors.append(
+                                f"Thread {thread_id}: path mismatch {result.path} != {path}"
+                            )
+                    except Exception as exc:
+                        errors.append(f"Thread {thread_id}: {exc}")
+            finally:
+                ms.close()
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, "Concurrency errors:\n" + "\n".join(errors)
+
+        # Verify all entries were written
+        verify = SQLiteMetastore(db_path)
+        total = len(verify.list(prefix="/", recursive=True))
+        verify.close()
+        assert total == n_threads * n_ops
+
+
+# =========================================================================
+# Issue 11A: Negative / error path tests
+# =========================================================================
+
+
+class TestMountErrorPaths:
+    """Negative tests for the mount() function."""
+
+    @pytest.mark.asyncio
+    async def test_empty_uri_list_raises(self) -> None:
+        from nexus.fs import mount
+
+        with pytest.raises(ValueError, match="At least one URI"):
+            await mount()
+
+    @pytest.mark.asyncio
+    async def test_at_with_multiple_uris_raises(self) -> None:
+        from nexus.fs import mount
+
+        with pytest.raises(ValueError, match="'at' override is only valid with a single URI"):
+            await mount("s3://a", "s3://b", at="/data")
+
+    @pytest.mark.asyncio
+    async def test_mounts_json_write_failure_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """If mounts.json write fails, mount() should still succeed with a warning."""
+        import logging
+
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(tmp_path))
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        from nexus.backends.storage.cas_local import CASLocalBackend
+
+        mock_backend = CASLocalBackend(root_path=data_dir)
+
+        # Mock the mounts_file() to return a path in a non-existent directory
+        fake_mounts = tmp_path / "nonexistent" / "deep" / "mounts.json"
+
+        with (
+            patch("nexus.fs._backend_factory.create_backend", return_value=mock_backend),
+            patch("nexus.fs._paths.mounts_file", return_value=fake_mounts),
+            caplog.at_level(logging.WARNING, logger="nexus.fs"),
+        ):
+            from nexus.fs import mount
+
+            fs = await mount("local:///tmp/data")
+            assert fs is not None
+
+        assert any("Could not write mounts.json" in r.message for r in caplog.records)
+
+
+class TestFsspecErrorPaths:
+    """Negative tests for the fsspec layer."""
+
+    @pytest.fixture
+    def mock_nexus_fs(self):
+        fs = AsyncMock()
+        fs.stat = AsyncMock(return_value={"path": "/test", "size": 11, "is_directory": False})
+        return fs
+
+    def test_unsupported_mode_raises(self, mock_nexus_fs):
+        pytest.importorskip("fsspec")
+        from nexus.fs._fsspec import NexusFileSystem
+
+        NexusFileSystem.clear_instance_cache()
+        nfs = NexusFileSystem(nexus_fs=mock_nexus_fs)
+        try:
+            with pytest.raises(ValueError, match="Unsupported mode"):
+                nfs._open("/test", mode="ab")
+        finally:
+            nfs._runner.close()
+            NexusFileSystem.clear_instance_cache()
+
+    def test_write_buffer_exceeds_limit(self, mock_nexus_fs):
+        pytest.importorskip("fsspec")
+        from nexus.fs._fsspec import NexusWriteFile
+        from nexus.fs._sync import PortalRunner
+
+        runner = PortalRunner()
+        try:
+            wf = NexusWriteFile(
+                fs=MagicMock(),
+                path="/big.bin",
+                nexus_fs=mock_nexus_fs,
+                runner=runner,
+            )
+            chunk = b"x" * (1024 * 1024)  # 1 MB
+            with pytest.raises(ValueError, match="Write buffer exceeded"):
+                for _ in range(1025):
+                    wf.write(chunk)
+        finally:
+            runner.close()
+
+    def test_write_on_closed_file_raises(self, mock_nexus_fs):
+        pytest.importorskip("fsspec")
+        from nexus.fs._fsspec import NexusWriteFile
+        from nexus.fs._sync import PortalRunner
+
+        runner = PortalRunner()
+        try:
+            wf = NexusWriteFile(
+                fs=MagicMock(),
+                path="/closed.txt",
+                nexus_fs=mock_nexus_fs,
+                runner=runner,
+            )
+            wf.close()
+            with pytest.raises(ValueError, match="closed file"):
+                wf.write(b"data")
+        finally:
+            runner.close()
+
+
+class TestBackendFactoryErrorPaths:
+    """Negative tests for backend creation."""
+
+    def test_missing_s3_extra_raises_import_error(self):
+        from nexus.fs._uri import parse_uri
+
+        spec = parse_uri("s3://bucket")
+
+        with (
+            patch("nexus.fs._credentials.discover_credentials", return_value={"source": "test"}),
+            patch.dict("sys.modules", {"nexus.backends.storage.path_s3": None}),
+        ):
+            from nexus.fs._backend_factory import create_backend
+
+            with pytest.raises(ImportError, match="boto3"):
+                create_backend(spec)
+
+
+class TestUriEdgeCases:
+    """Additional URI edge cases for derive_bucket()."""
+
+    def test_gcs_bucket_with_path(self) -> None:
+        from nexus.fs._uri import derive_bucket, parse_uri
+
+        spec = parse_uri("gcs://project/bucket/subdir")
+        assert derive_bucket(spec) == "bucket"
+
+    def test_gcs_bucket_no_path(self) -> None:
+        from nexus.fs._uri import derive_bucket, parse_uri
+
+        spec = parse_uri("gcs://my-project")
+        assert derive_bucket(spec) == "my-project"
+
+    def test_s3_bucket(self) -> None:
+        from nexus.fs._uri import derive_bucket, parse_uri
+
+        spec = parse_uri("s3://my-bucket/subdir")
+        assert derive_bucket(spec) == "my-bucket"
+
+    def test_local_bucket(self) -> None:
+        from nexus.fs._uri import derive_bucket, parse_uri
+
+        spec = parse_uri("local://./data")
+        assert derive_bucket(spec) == "."
+
+
+class TestPathsPermissions:
+    """Tests for state directory permission enforcement."""
+
+    def test_persistent_dir_has_restricted_permissions(self, tmp_path, monkeypatch):
+        import os
+        import stat
+
+        monkeypatch.setenv("NEXUS_FS_PERSISTENT_DIR", str(tmp_path / "secrets"))
+
+        from nexus.fs._paths import persistent_dir
+
+        p = persistent_dir()
+        mode = stat.S_IMODE(os.stat(p).st_mode)
+        assert mode == 0o700, f"Expected 0o700, got {oct(mode)}"
+
+    def test_state_dir_created_on_access(self, tmp_path, monkeypatch):
+        target = tmp_path / "new_state"
+        monkeypatch.setenv("NEXUS_FS_STATE_DIR", str(target))
+
+        from nexus.fs._paths import state_dir
+
+        p = state_dir()
+        assert p.exists()
+        assert p == target
+
+
+class TestSlimNexusFSLifecycle:
+    """Tests for the context manager and close() on SlimNexusFS."""
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self, tmp_path):
+        """Calling close() twice should not raise."""
+        from nexus.backends.storage.cas_local import CASLocalBackend
+        from nexus.contracts.types import OperationContext
+        from nexus.core.config import PermissionConfig
+        from nexus.core.nexus_fs import NexusFS
+        from nexus.core.router import PathRouter
+        from nexus.fs import _make_mount_entry
+
+        db_path = str(tmp_path / "metadata.db")
+        metastore = SQLiteMetastore(db_path)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        backend = CASLocalBackend(root_path=data_dir)
+
+        router = PathRouter(metastore)
+        router.add_mount("/local", backend)
+        metastore.put(_make_mount_entry("/local", backend.name))
+
+        kernel = NexusFS(
+            metadata_store=metastore,
+            permissions=PermissionConfig(enforce=False),
+            router=router,
+        )
+        kernel._init_cred = OperationContext(
+            user_id="test",
+            groups=[],
+            zone_id=ROOT_ZONE_ID,
+            is_admin=True,
+        )
+
+        fs = SlimNexusFS(kernel)
+        await fs.close()
+        await fs.close()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, tmp_path):
+        """async with SlimNexusFS should call close() on exit."""
+        from nexus.backends.storage.cas_local import CASLocalBackend
+        from nexus.contracts.types import OperationContext
+        from nexus.core.config import PermissionConfig
+        from nexus.core.nexus_fs import NexusFS
+        from nexus.core.router import PathRouter
+        from nexus.fs import _make_mount_entry
+
+        db_path = str(tmp_path / "metadata.db")
+        metastore = SQLiteMetastore(db_path)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        backend = CASLocalBackend(root_path=data_dir)
+
+        router = PathRouter(metastore)
+        router.add_mount("/local", backend)
+        metastore.put(_make_mount_entry("/local", backend.name))
+
+        kernel = NexusFS(
+            metadata_store=metastore,
+            permissions=PermissionConfig(enforce=False),
+            router=router,
+        )
+        kernel._init_cred = OperationContext(
+            user_id="test",
+            groups=[],
+            zone_id=ROOT_ZONE_ID,
+            is_admin=True,
+        )
+
+        async with SlimNexusFS(kernel) as fs:
+            await fs.write("/local/ctx.txt", b"context manager")
+            content = await fs.read("/local/ctx.txt")
+            assert content == b"context manager"
+
+        assert fs._closed is True

--- a/tests/unit/fs/test_uri.py
+++ b/tests/unit/fs/test_uri.py
@@ -136,10 +136,10 @@ class TestDeriveMountPoint:
         "uri, expected_mount",
         [
             ("gcs://project/bucket", "/gcs/bucket"),
-            ("gcs://project/bucket/subdir", "/gcs/subdir"),
+            ("gcs://project/bucket/subdir", "/gcs/bucket"),
             ("gcs://my-project", "/gcs/my-project"),
         ],
-        ids=["gcs-project-bucket", "gcs-nested-last-segment", "gcs-project-only"],
+        ids=["gcs-project-bucket", "gcs-nested-uses-bucket", "gcs-project-only"],
     )
     def test_gcs_mount(self, uri: str, expected_mount: str) -> None:
         spec = parse_uri(uri)


### PR DESCRIPTION
## Summary

Closes all 4 workstreams of #3328 (nexus-fs release integrity epic).

### Workstream 1: Isolated wheel smoke test — already done
The `nexus-fs-smoke` CI job was already in place. This PR improves it with a 3x median import time measurement to eliminate CI runner jitter.

### Workstream 2: Roadmap hygiene — verified complete
All 4 phase issues (#3232, #3233, #3234, #3235) are already CLOSED with implementations matching their scope.

### Workstream 3: State directory contract
- **Atomic mounts.json writes** via temp file + `os.replace()` — prevents partial JSON on crash
- **WAL checkpoint + PRAGMA optimize** on `SQLiteMetastore.close()` — cleans up `.db-wal`/`.db-shm` files
- **Permission enforcement**: `persistent_dir` (`~/.nexus/`) created with `0o700`
- **Documentation**: cleanup/retention policy, corruption recovery, concurrent-process expectations, TUI auto-discovery behavior
- **Concurrency contract**: "single-process per state directory" documented; use separate `NEXUS_FS_STATE_DIR` for multiple instances
- **Fix stale `$TMPDIR` references** in playground.md and mounting.md

### Workstream 4: README product-claim audit
- **Missing extras**: Added `gdrive`, `fsspec`, `tui` to install section
- **Connector prerequisites**: Added note that `gws://` requires external gws CLI
- **State directory**: Documented as deletable cache with concurrency note and `0700` persistent dir
- **No monorepo-only claims found**: README is correctly scoped to slim package

### Additional engineering fixes (from 4-section review)
- **Resource leak**: try/finally cleanup on kernel boot failure
- **Lifecycle**: `close()`/`__aenter__`/`__aexit__` on SlimNexusFS
- **GCS bug**: `gcs://project/bucket/subdir` was mounting at `/gcs/subdir` instead of `/gcs/bucket`
- **Missing method**: `rmdir()` added to SyncNexusFS (found by new parity test)
- **DRY**: `_make_stat_dict()` helper, `derive_bucket()` centralizes GCS parsing
- **Logging**: `logger.debug` on credential discovery, `logger.debug` on makedirs suppression
- **Write buffer warning** at 100MB before the 1GB hard limit

### New tests (24)
- Method-set parity, mount() cleanup (3 failure paths), `_retry_on_busy` + WAL concurrency, negative error paths, lifecycle, `derive_bucket()`, permission enforcement

## Test plan

- [x] 24 new tests pass (`test_release_integrity.py`)
- [x] 54 URI tests pass (updated GCS expectation)
- [x] 448 existing nexus-fs tests pass
- [x] All pre-commit hooks pass (ruff, mypy, ruff-format)
- [ ] CI `nexus-fs-smoke` job validates standalone wheel

Closes #3328