### PR TITLE
docs: deploy Pages from develop

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/develop'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary\n- switch the GitHub Pages deploy job to run from develop\n- keep the docs build on both main and develop\n- make the public docs site reflect the branch we actually release from\n\n## Testing\n- pre-commit hooks on commit\n