### PR TITLE
perf(core): make event dispatch truly fire-and-forget on write path

### DIFF
--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -307,12 +307,19 @@ class VFSObserver(Protocol):
     """OBSERVE-phase observer for kernel VFS mutations (fire-and-forget).
 
     Receives a frozen ``FileEvent`` after every successful mutation.
-    Observers run concurrently via ``asyncio.gather`` with no ordering
-    guarantees.  Must not raise — exceptions are caught and logged by
-    KernelDispatch.
+    Must not raise — exceptions are caught and logged by KernelDispatch.
 
-    Optional ``event_mask`` class attribute (default: ``ALL_FILE_EVENTS``)
-    enables Rust-side event-type filtering to skip irrelevant observers.
+    Optional class attributes:
+
+    ``event_mask`` (default: ``ALL_FILE_EVENTS``)
+        Rust-side event-type bitmask filtering to skip irrelevant observers.
+
+    ``OBSERVE_INLINE`` (default: ``True``)
+        When True, ``on_mutation`` runs synchronously on the caller's path
+        (suited for fast, in-process work like resolving futures).
+        When False, ``on_mutation`` is dispatched as a tracked background
+        task — fire-and-forget from the caller's perspective (suited for
+        I/O-bound work like publishing to an event bus).
     """
 
     async def on_mutation(self, event: Any) -> None: ...

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -234,11 +234,23 @@ class KernelDispatch:
             logger.warning("Background observer task %s failed: %s", task.get_name(), exc)
 
     async def shutdown(self, *, timeout: float = 5.0) -> None:
-        """Drain background observer tasks (call during kernel teardown)."""
+        """Drain background observer tasks (call during kernel teardown).
+
+        Handles cross-loop scenarios (e.g. TestClient calling aclose() on
+        a different event loop than the one that spawned the tasks).
+        """
         if not self._background_tasks:
             return
         _pending = set(self._background_tasks)
-        done, still_pending = await asyncio.wait(_pending, timeout=timeout)
+        try:
+            done, still_pending = await asyncio.wait(_pending, timeout=timeout)
+        except RuntimeError:
+            # Tasks belong to a different event loop (e.g. pytest loop vs
+            # TestClient loop). Cancel what we can and discard references.
+            for task in _pending:
+                task.cancel()
+            self._background_tasks.clear()
+            return
         for task in still_pending:
             task.cancel()
         if still_pending:

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -244,17 +244,17 @@ class KernelDispatch:
         _pending = set(self._background_tasks)
         try:
             done, still_pending = await asyncio.wait(_pending, timeout=timeout)
+            for task in still_pending:
+                task.cancel()
+            if still_pending:
+                await asyncio.gather(*still_pending, return_exceptions=True)
         except RuntimeError:
             # Tasks belong to a different event loop (e.g. pytest loop vs
-            # TestClient loop). Cancel what we can and discard references.
+            # TestClient loop in Python 3.13+). Best-effort cancel + discard.
             for task in _pending:
                 task.cancel()
+        finally:
             self._background_tasks.clear()
-            return
-        for task in still_pending:
-            task.cancel()
-        if still_pending:
-            await asyncio.gather(*still_pending, return_exceptions=True)
 
     # ── PRE-DISPATCH: virtual path resolvers (Issue #889, #1317) ──────
 

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -178,7 +178,7 @@ class KernelDispatch:
         dispatch.intercept_pre_read(ctx)     # phase 1a: INTERCEPT (pre)
         ...actual VFS operation...
         dispatch.intercept_post_read(ctx)    # phase 1b: INTERCEPT (post)
-        await dispatch.notify(event)         # phase 2: OBSERVE
+        await dispatch.notify(event)         # phase 2: OBSERVE (inline + deferred)
     """
 
     __slots__ = (
@@ -191,6 +191,7 @@ class KernelDispatch:
         "_observer_registry",
         "_mount_hooks",
         "_unmount_hooks",
+        "_background_tasks",
     )
 
     def __init__(self) -> None:
@@ -216,6 +217,32 @@ class KernelDispatch:
         # MOUNT/UNMOUNT: driver lifecycle hooks (Issue #1811)
         self._mount_hooks: list[VFSMountHook] = []
         self._unmount_hooks: list[VFSUnmountHook] = []
+
+        # Issue #3391: tracked background tasks for deferred OBSERVE dispatch.
+        # Strong references prevent GC of in-flight tasks (CPython #91887).
+        self._background_tasks: set[asyncio.Task] = set()
+
+    # ── Lifecycle (Issue #3391) ──────────────────────────────────────────
+
+    def _on_background_task_done(self, task: asyncio.Task) -> None:
+        """Done-callback for background observer tasks — log exceptions, discard ref."""
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning("Background observer task %s failed: %s", task.get_name(), exc)
+
+    async def shutdown(self, *, timeout: float = 5.0) -> None:
+        """Drain background observer tasks (call during kernel teardown)."""
+        if not self._background_tasks:
+            return
+        _pending = set(self._background_tasks)
+        done, still_pending = await asyncio.wait(_pending, timeout=timeout)
+        for task in still_pending:
+            task.cancel()
+        if still_pending:
+            await asyncio.gather(*still_pending, return_exceptions=True)
 
     # ── PRE-DISPATCH: virtual path resolvers (Issue #889, #1317) ──────
 
@@ -586,14 +613,21 @@ class KernelDispatch:
     async def intercept_post_rmdir(self, ctx: RmdirHookContext) -> None:
         await self._post_dispatch("rmdir", "on_post_rmdir", ctx)
 
-    # ── OBSERVE dispatch (Issue #1812, #1748) ────────────────────────────
+    # ── OBSERVE dispatch (Issue #1812, #1748, #3391) ──────────────────────
 
     async def notify(self, event: FileEvent) -> None:
-        """OBSERVE phase — fire-and-forget to all registered observers.
+        """OBSERVE phase — hybrid inline/deferred dispatch.
 
-        Rust ``ObserverRegistry`` filters by ``event_mask`` bitmask before
-        crossing to Python.  Matching observers run concurrently via
-        ``gather(return_exceptions=True)`` — fault-isolated, no ordering.
+        Inline observers (``OBSERVE_INLINE=True``, default): run via
+        ``asyncio.gather`` on the caller's path — suited for fast,
+        in-process work (e.g. resolving FileWatcher futures).
+
+        Deferred observers (``OBSERVE_INLINE=False``): spawned as tracked
+        background tasks — true fire-and-forget from the caller's
+        perspective (e.g. EventBus publish to Redis/NATS).
+
+        Issue #3391: inspired by DFUSE (arXiv:2503.18191) — eliminate
+        I/O round-trips from the write critical path.
         """
         from nexus.core.file_events import FILE_EVENT_BIT, FileEventType
 
@@ -605,13 +639,29 @@ class KernelDispatch:
         if not observers:
             return
 
+        inline: list[tuple[Any, str]] = []
+        deferred: list[tuple[Any, str]] = []
+        for obs, name in observers:
+            if getattr(obs, "OBSERVE_INLINE", True):
+                inline.append((obs, name))
+            else:
+                deferred.append((obs, name))
+
         async def _safe(obs: Any, name: str) -> None:
             try:
                 await obs.on_mutation(event)
             except Exception as exc:
                 logger.warning("Observer %s failed: %s", name, exc)
 
-        await asyncio.gather(*(_safe(obs, name) for obs, name in observers))
+        # Inline: await on caller's path (fast observers)
+        if inline:
+            await asyncio.gather(*(_safe(obs, name) for obs, name in inline))
+
+        # Deferred: fire-and-forget background tasks (I/O-bound observers)
+        for obs, name in deferred:
+            task = asyncio.create_task(_safe(obs, name), name=f"observe-{name}")
+            self._background_tasks.add(task)
+            task.add_done_callback(self._on_background_task_done)
 
     # ── MOUNT/UNMOUNT hooks (Issue #1811) ──────────────────────────────
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -523,15 +523,7 @@ class NexusFS(  # type: ignore[misc]
 
         from nexus.contracts.vfs_hooks import RmdirHookContext
 
-        await self._dispatch.intercept_post_rmdir(
-            RmdirHookContext(
-                path=path,
-                context=ctx,
-                zone_id=ctx.zone_id,
-                agent_id=ctx.agent_id,
-                recursive=recursive,
-            )
-        )
+        # Issue #3391: Standardized dispatch order — OBSERVE then INTERCEPT
         await self._dispatch.notify(
             FileEvent(
                 type=FileEventType.DIR_DELETE,
@@ -539,6 +531,15 @@ class NexusFS(  # type: ignore[misc]
                 zone_id=ctx.zone_id or ROOT_ZONE_ID,
                 agent_id=ctx.agent_id,
                 user_id=ctx.user_id,
+            )
+        )
+        await self._dispatch.intercept_post_rmdir(
+            RmdirHookContext(
+                path=path,
+                context=ctx,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+                recursive=recursive,
             )
         )
 
@@ -1923,6 +1924,21 @@ class NexusFS(  # type: ignore[misc]
 
         self.metadata.put(new_meta)
 
+        # Issue #3391: OBSERVE dispatch was missing for write_stream — add it.
+        await self._dispatch.notify(
+            FileEvent(
+                type=FileEventType.FILE_WRITE,
+                path=path,
+                zone_id=zone_id or ROOT_ZONE_ID,
+                agent_id=agent_id,
+                etag=content_hash,
+                size=size,
+                version=new_version,
+                is_new=(meta is None),
+                old_etag=meta.etag if meta else None,
+            )
+        )
+
         # Issue #900: Unified INTERCEPT for write_stream
         from nexus.contracts.vfs_hooks import WriteHookContext
 
@@ -2088,15 +2104,7 @@ class NexusFS(  # type: ignore[misc]
             },
         )
 
-        # POST hooks + event dispatch (Issue #900/#1682)
-        await self._dispatch.intercept_post_mkdir(
-            MkdirHookContext(
-                path=path,
-                context=ctx,
-                zone_id=ctx.zone_id,
-                agent_id=ctx.agent_id,
-            )
-        )
+        # Issue #900/#3391: Unified two-phase dispatch — OBSERVE then INTERCEPT
         await self._dispatch.notify(
             FileEvent(
                 type=FileEventType.DIR_CREATE,
@@ -2104,6 +2112,14 @@ class NexusFS(  # type: ignore[misc]
                 zone_id=ctx.zone_id or ROOT_ZONE_ID,
                 agent_id=ctx.agent_id,
                 user_id=ctx.user_id,
+            )
+        )
+        await self._dispatch.intercept_post_mkdir(
+            MkdirHookContext(
+                path=path,
+                context=ctx,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
             )
         )
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4622,6 +4622,9 @@ class NexusFS(  # type: ignore[misc]
         Calls coordinator lifecycle methods first (async), then
         delegates to close() for sync resource cleanup.
         """
+        # Issue #3391: drain deferred OBSERVE background tasks before tearing down.
+        await self._dispatch.shutdown()
+
         coord = self.service_coordinator
         if coord is not None:
             await coord.stop_persistent_services()

--- a/src/nexus/services/event_bus/observer.py
+++ b/src/nexus/services/event_bus/observer.py
@@ -41,6 +41,7 @@ class EventBusObserver:
     """
 
     event_mask: int = ALL_FILE_EVENTS
+    OBSERVE_INLINE: bool = False  # Issue #3391: network I/O → background task
 
     # ── Hook spec (duck-typed) (Issue #1616) ──────────────────────────
 

--- a/tests/unit/core/test_kernel_dispatch_parallel.py
+++ b/tests/unit/core/test_kernel_dispatch_parallel.py
@@ -1,8 +1,10 @@
-"""Unit tests for async parallel dispatch (Issue #1317, #1748, #1812).
+"""Unit tests for async parallel dispatch (Issue #1317, #1748, #1812, #3391).
 
 Tests:
 - POST hook dispatch (sync/async/mixed/fault isolation)
 - Async OBSERVE dispatch with ObserverRegistry + event_mask filtering
+- Hybrid inline/deferred OBSERVE dispatch (Issue #3391)
+- Background task lifecycle (tracking, exception logging, shutdown)
 """
 
 from __future__ import annotations
@@ -174,8 +176,9 @@ def _make_async_observer(
     event_mask: int = ALL_FILE_EVENTS,
     side_effect: Exception | None = None,
     delay: float = 0.0,
+    observe_inline: bool = True,
 ):
-    """Create an async observer with event_mask."""
+    """Create an async observer with event_mask and OBSERVE_INLINE control."""
 
     class _Obs:
         pass
@@ -183,6 +186,7 @@ def _make_async_observer(
     obs = _Obs()
     obs.__class__.__name__ = name
     obs.event_mask = event_mask
+    obs.OBSERVE_INLINE = observe_inline
 
     calls: list = []
 
@@ -299,3 +303,194 @@ class TestPythonObserverRegistryFallback:
         reg = _PythonObserverRegistry()
         obs = MagicMock()
         assert reg.unregister(obs) is False
+
+
+# ── Hybrid inline/deferred OBSERVE dispatch tests (Issue #3391) ──────
+
+
+def _write_event(path: str = "/test") -> FileEvent:
+    return FileEvent(type=FileEventType.FILE_WRITE, path=path)
+
+
+class TestInlineObservers:
+    """OBSERVE_INLINE=True observers run on the caller's path."""
+
+    async def test_inline_observer_called_before_notify_returns(
+        self, dispatch: KernelDispatch
+    ) -> None:
+        obs = _make_async_observer(name="Inline", observe_inline=True)
+        dispatch.register_observe(obs)
+        await dispatch.notify(_write_event())
+        # Event delivered synchronously — available immediately after notify returns
+        assert len(obs._calls) == 1
+
+    async def test_inline_observers_run_concurrently(self, dispatch: KernelDispatch) -> None:
+        """Two inline observers each sleeping 0.1s should complete in ~0.1s."""
+        import time
+
+        a = _make_async_observer(name="A", delay=0.1, observe_inline=True)
+        b = _make_async_observer(name="B", delay=0.1, observe_inline=True)
+        dispatch.register_observe(a)
+        dispatch.register_observe(b)
+
+        t0 = time.monotonic()
+        await dispatch.notify(_write_event())
+        elapsed = time.monotonic() - t0
+
+        assert len(a._calls) == 1
+        assert len(b._calls) == 1
+        assert elapsed < 0.18, f"Expected parallel (~0.1s), got {elapsed:.3f}s"
+
+    async def test_inline_fault_isolation(self, dispatch: KernelDispatch) -> None:
+        bad = _make_async_observer(
+            name="Bad", side_effect=RuntimeError("boom"), observe_inline=True
+        )
+        good = _make_async_observer(name="Good", observe_inline=True)
+        dispatch.register_observe(bad)
+        dispatch.register_observe(good)
+
+        await dispatch.notify(_write_event())
+        assert len(good._calls) == 1
+
+
+class TestDeferredObservers:
+    """OBSERVE_INLINE=False observers run as background tasks."""
+
+    async def test_deferred_observer_not_called_before_notify_returns(
+        self, dispatch: KernelDispatch
+    ) -> None:
+        obs = _make_async_observer(name="Deferred", delay=0.05, observe_inline=False)
+        dispatch.register_observe(obs)
+        await dispatch.notify(_write_event())
+        # Deferred: not yet delivered (still running as background task)
+        assert len(obs._calls) == 0
+        assert len(dispatch._background_tasks) == 1
+
+    async def test_deferred_observer_eventually_called(self, dispatch: KernelDispatch) -> None:
+        obs = _make_async_observer(name="Deferred", observe_inline=False)
+        dispatch.register_observe(obs)
+        await dispatch.notify(_write_event())
+        # Give the background task a chance to complete
+        await asyncio.sleep(0.05)
+        assert len(obs._calls) == 1
+
+    async def test_deferred_task_cleaned_up_after_completion(
+        self, dispatch: KernelDispatch
+    ) -> None:
+        obs = _make_async_observer(name="Deferred", observe_inline=False)
+        dispatch.register_observe(obs)
+        await dispatch.notify(_write_event())
+        assert len(dispatch._background_tasks) == 1
+        # Wait for task to complete and done-callback to fire
+        await asyncio.sleep(0.05)
+        assert len(dispatch._background_tasks) == 0
+
+    async def test_deferred_fault_isolation(self, dispatch: KernelDispatch) -> None:
+        """Deferred observer failure should not affect the caller."""
+        bad = _make_async_observer(
+            name="Bad", side_effect=RuntimeError("boom"), observe_inline=False
+        )
+        dispatch.register_observe(bad)
+        # Should not raise — error is logged in background
+        await dispatch.notify(_write_event())
+        await asyncio.sleep(0.05)
+        assert len(dispatch._background_tasks) == 0
+
+
+class TestHybridDispatch:
+    """Mix of inline and deferred observers in the same notify() call."""
+
+    async def test_inline_fires_immediately_deferred_fires_later(
+        self, dispatch: KernelDispatch
+    ) -> None:
+        inline = _make_async_observer(name="Inline", observe_inline=True)
+        deferred = _make_async_observer(name="Deferred", delay=0.05, observe_inline=False)
+        dispatch.register_observe(inline)
+        dispatch.register_observe(deferred)
+
+        await dispatch.notify(_write_event())
+
+        # Inline: already delivered
+        assert len(inline._calls) == 1
+        # Deferred: not yet delivered
+        assert len(deferred._calls) == 0
+
+        # Wait for deferred to complete
+        await asyncio.sleep(0.1)
+        assert len(deferred._calls) == 1
+
+    async def test_deferred_failure_does_not_affect_inline(self, dispatch: KernelDispatch) -> None:
+        inline = _make_async_observer(name="Inline", observe_inline=True)
+        bad_deferred = _make_async_observer(
+            name="BadDeferred", side_effect=RuntimeError("boom"), observe_inline=False
+        )
+        dispatch.register_observe(inline)
+        dispatch.register_observe(bad_deferred)
+
+        await dispatch.notify(_write_event())
+        assert len(inline._calls) == 1
+
+    async def test_notify_returns_fast_with_slow_deferred(self, dispatch: KernelDispatch) -> None:
+        """notify() should return in <10ms even with a 500ms deferred observer."""
+        import time
+
+        slow = _make_async_observer(name="Slow", delay=0.5, observe_inline=False)
+        dispatch.register_observe(slow)
+
+        t0 = time.monotonic()
+        await dispatch.notify(_write_event())
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 0.01, f"notify() blocked for {elapsed:.3f}s — should be fire-and-forget"
+        # Clean up: cancel the slow background task
+        await dispatch.shutdown(timeout=0.01)
+
+
+# ── Background task lifecycle tests (Issue #3391) ────────────────────
+
+
+class TestBackgroundTaskLifecycle:
+    """Tests for _background_tasks tracking, exception logging, and shutdown."""
+
+    async def test_task_appears_in_tracking_set(self, dispatch: KernelDispatch) -> None:
+        obs = _make_async_observer(name="Tracked", delay=0.1, observe_inline=False)
+        dispatch.register_observe(obs)
+        await dispatch.notify(_write_event())
+        assert len(dispatch._background_tasks) == 1
+
+    async def test_failed_task_logs_warning(self, dispatch: KernelDispatch, caplog) -> None:
+        import logging
+
+        obs = _make_async_observer(
+            name="Failing", side_effect=RuntimeError("test-error"), observe_inline=False
+        )
+        dispatch.register_observe(obs)
+
+        with caplog.at_level(logging.WARNING, logger="nexus.core.kernel_dispatch"):
+            await dispatch.notify(_write_event())
+            await asyncio.sleep(0.05)
+
+        assert any("test-error" in r.message for r in caplog.records)
+
+    async def test_shutdown_drains_pending_tasks(self, dispatch: KernelDispatch) -> None:
+        obs = _make_async_observer(name="Slow", delay=0.05, observe_inline=False)
+        dispatch.register_observe(obs)
+        await dispatch.notify(_write_event())
+        assert len(dispatch._background_tasks) == 1
+
+        await dispatch.shutdown(timeout=1.0)
+        assert len(dispatch._background_tasks) == 0
+        assert len(obs._calls) == 1  # task completed, not cancelled
+
+    async def test_shutdown_cancels_stragglers(self, dispatch: KernelDispatch) -> None:
+        obs = _make_async_observer(name="VerySlowObs", delay=10.0, observe_inline=False)
+        dispatch.register_observe(obs)
+        await dispatch.notify(_write_event())
+
+        await dispatch.shutdown(timeout=0.01)
+        # Task was cancelled — event not delivered
+        assert len(obs._calls) == 0
+
+    async def test_shutdown_noop_when_empty(self, dispatch: KernelDispatch) -> None:
+        """shutdown() with no pending tasks should return immediately."""
+        await dispatch.shutdown()  # should not raise


### PR DESCRIPTION
## Summary

Addresses #3391

Inspired by DFUSE (arXiv:2503.18191) — eliminates I/O round-trips from the write critical path by making `KernelDispatch.notify()` use hybrid inline/deferred observer dispatch.

- **Hybrid `notify()` dispatch**: `OBSERVE_INLINE=True` observers (FileWatcher) run synchronously via `asyncio.gather`; `OBSERVE_INLINE=False` observers (EventBusObserver) spawn as tracked background tasks — true fire-and-forget
- **Background task lifecycle**: `_background_tasks` set with `add_done_callback` for GC protection (CPython #91887), exception logging, and `shutdown()` for graceful drain during kernel teardown
- **Shutdown wired into `NexusFS.aclose()`**: `_dispatch.shutdown()` is called before service teardown, ensuring in-flight EventBus publish tasks complete before the bus connection closes
- **Standardized dispatch order**: all syscalls now use `notify → intercept_post` consistently (previously mkdir/rmdir had reversed order)
- **Bug fix**: `write_stream()` was missing `notify()` call entirely — streaming writes now trigger FileWatcher and EventBus observers

### Scoping decisions

**`intercept_post_write()` hooks remain awaited** (issue proposed deferring them). This is deliberate: `AuditLogError` is designed to abort the operation and propagate to the caller. If hooks were fire-and-forget, audit failures would become invisible — the caller would already have received a success response. The real latency win is in `notify()` where EventBus network I/O was blocking the caller, not in hooks which are typically fast.

**Event ordering for deferred observers**: The current implementation spawns one `create_task` per deferred observer per event. In asyncio's single-threaded event loop, tasks start executing in creation order and `EventBusObserver.on_mutation()` is a single `await bus.publish(event)` call, so in practice events arrive at the broker in order. If strict cross-write ordering becomes a requirement (e.g., for `sequence_number`-dependent consumers), upgrading to an `asyncio.Queue`-based worker is the natural next step — but adds lifecycle complexity that isn't justified for the current single deferred observer.

**Expected improvement**: 1–50ms saved per write (EventBus I/O removed from critical path).

## Test plan

- [x] 15 new tests across 4 test classes:
  - `TestInlineObservers` — synchronous delivery, parallel execution, fault isolation
  - `TestDeferredObservers` — async delivery, eventual completion, task cleanup, fault isolation
  - `TestHybridDispatch` — inline fires immediately + deferred fires later, cross-isolation, notify returns fast
  - `TestBackgroundTaskLifecycle` — task tracking, exception logging via caplog, shutdown drain, shutdown cancel
- [x] All 19 existing dispatch tests pass unchanged
- [x] All 53 related tests pass (write observer calls, file watcher, hook specs)
- [x] 271/272 unit/core tests pass (1 pre-existing failure: Rust extension not built)
- [ ] Run `tests/benchmarks/benchmark_write_performance.py` before/after for latency validation