### PR TITLE
refactor(#1824): rename BlobTransport → Transport

### DIFF
--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -1,14 +1,14 @@
-"""CAS addressing engine over any BlobTransport.
+"""CAS addressing engine over any Transport.
 
 CASAddressingEngine implements ObjectStoreABC (via Backend) using content-addressable
 storage semantics: content is stored by hash, automatically deduplicated.
 
-    CASAddressingEngine(transport: BlobTransport)
-        ├── CASGCSBackend   — thin: creates GCSBlobTransport, registered as "cas_gcs"
-        ├── CASLocalBackend  — thin: creates LocalBlobTransport + features
-        └── (future S3CAS)  — thin: creates S3BlobTransport
+    CASAddressingEngine(transport: Transport)
+        ├── CASGCSBackend   — thin: creates GCSTransport, registered as "cas_gcs"
+        ├── CASLocalBackend  — thin: creates LocalTransport + features
+        └── (future S3CAS)  — thin: creates S3Transport
 
-The transport is INTERNAL — callers never see BlobTransport.  They see Backend.
+The transport is INTERNAL — callers never see Transport.  They see Backend.
 Thin subclasses exist for: registration, CONNECTION_ARGS, connector-specific
 features (batch reads, signed URLs, versioning).
 
@@ -41,7 +41,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.backends.base.backend import Backend
-from nexus.backends.base.blob_transport import BlobTransport
+from nexus.backends.base.transport import Transport
 from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import create_hasher, hash_content
@@ -87,7 +87,7 @@ CAS_ADDRESSING_BACKEND_FEATURES: frozenset[BackendFeature] = frozenset(
 
 
 class CASAddressingEngine(Backend):
-    """CAS addressing over any BlobTransport.  Full ObjectStoreABC implementation.
+    """CAS addressing over any Transport.  Full ObjectStoreABC implementation.
 
     Content is stored at ``cas/<h[:2]>/<h[2:4]>/<h>``.  CDC-chunked content
     has a JSON metadata sidecar at ``<path>.meta`` with chunk/manifest flags.
@@ -99,7 +99,7 @@ class CASAddressingEngine(Backend):
     No ref_count — writes are idempotent direct writes.
 
     Attributes:
-        _transport: The underlying BlobTransport for raw I/O.
+        _transport: The underlying Transport for raw I/O.
         _backend_name: Human-readable backend identifier.
     """
 
@@ -107,7 +107,7 @@ class CASAddressingEngine(Backend):
 
     def __init__(
         self,
-        transport: BlobTransport,
+        transport: Transport,
         *,
         backend_name: str | None = None,
         # Feature DI — optional optimizations, all None-safe

--- a/src/nexus/backends/base/path_addressing_engine.py
+++ b/src/nexus/backends/base/path_addressing_engine.py
@@ -1,16 +1,16 @@
-"""Path-based addressing engine over any BlobTransport.
+"""Path-based addressing engine over any Transport.
 
 PathAddressingEngine implements ObjectStoreABC (via Backend) using direct path mapping:
 files are stored at their actual paths, with no CAS transformation or
 deduplication.
 
-    PathAddressingEngine(transport: BlobTransport)
-        ├── PathGCSBackend       — thin: creates GCSBlobTransport + cache
-        ├── PathS3Backend        — thin: creates S3BlobTransport + cache + multipart
-        └── (future Azure)       — thin: creates AzureBlobTransport
+    PathAddressingEngine(transport: Transport)
+        ├── PathGCSBackend       — thin: creates GCSTransport + cache
+        ├── PathS3Backend        — thin: creates S3Transport + cache + multipart
+        └── (future Azure)       — thin: creates AzureTransport
 
 This replaces ``BaseBlobStorageConnector`` which used abstract methods (inheritance)
-for cloud-specific I/O.  PathAddressingEngine uses composition (BlobTransport protocol).
+for cloud-specific I/O.  PathAddressingEngine uses composition (Transport protocol).
 
 References:
     - Issue #1323: CAS x Backend orthogonal composition
@@ -25,7 +25,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, ClassVar
 
 from nexus.backends.base.backend import Backend
-from nexus.backends.base.blob_transport import BlobTransport
+from nexus.backends.base.transport import Transport
 from nexus.contracts.backend_features import BLOB_BACKEND_FEATURES, BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
@@ -38,14 +38,14 @@ logger = logging.getLogger(__name__)
 
 
 class PathAddressingEngine(Backend):
-    """Path-based addressing over any BlobTransport.
+    """Path-based addressing over any Transport.
 
     Files are stored at their actual paths (with optional prefix).
     No CAS transformation, no deduplication, no reference counting.
     External tools can browse the bucket normally.
 
     Attributes:
-        _transport: The underlying BlobTransport for raw I/O.
+        _transport: The underlying Transport for raw I/O.
         _backend_name: Human-readable backend identifier.
         bucket_name: Storage bucket/container name.
         prefix: Optional prefix for all paths.
@@ -56,7 +56,7 @@ class PathAddressingEngine(Backend):
 
     def __init__(
         self,
-        transport: BlobTransport,
+        transport: Transport,
         *,
         backend_name: str | None = None,
         bucket_name: str = "",

--- a/src/nexus/backends/base/transport.py
+++ b/src/nexus/backends/base/transport.py
@@ -1,6 +1,6 @@
-"""BlobTransport Protocol — raw key→blob I/O abstraction.
+"""Transport Protocol — raw key→blob I/O abstraction.
 
-BlobTransport captures the *transport* dimension (WHERE data lives) while
+Transport captures the *transport* dimension (WHERE data lives) while
 CASAddressingEngine / PathAddressingEngine capture the *addressing* dimension (HOW data is
 addressed).  These two dimensions are orthogonal:
 
@@ -13,7 +13,7 @@ Addressing   +--------+-------+-------+--------------+
              | through| Trans | Trans |   Trans      |
              +--------+-------+-------+--------------+
 
-A single GCSBlobTransport is shared between CASGCSBackend (CAS addressing)
+A single GCSTransport is shared between CASGCSBackend (CAS addressing)
 and PathGCSBackend (path addressing) — this is the value of
 orthogonal composition.
 
@@ -32,7 +32,7 @@ from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable
-class BlobTransport(Protocol):
+class Transport(Protocol):
     """Raw key→blob I/O.  No addressing, no ref-count, no hash logic.
 
     Implementors provide transport-level operations for a specific storage

--- a/src/nexus/backends/compute/llm_transport.py
+++ b/src/nexus/backends/compute/llm_transport.py
@@ -1,10 +1,10 @@
-"""In-memory BlobTransport for LLM backends.
+"""In-memory Transport for LLM backends.
 
 Stores CAS blobs in process memory. LLM conversations are ephemeral
 during a session — persistence is handled by CAS flush to durable
 backends (local/GCS/S3) in Step 2 (DT_STREAM + CAS flush).
 
-Satisfies the 6-method CASAddressingEngine subset of BlobTransport:
+Satisfies the 6-method CASAddressingEngine subset of Transport:
     put_blob, get_blob, delete_blob, blob_exists, get_blob_size, stream_blob.
 """
 
@@ -16,14 +16,14 @@ from collections.abc import Iterator
 from nexus.contracts.exceptions import NexusFileNotFoundError
 
 
-class LLMBlobTransport:
+class LLMTransport:
     """In-memory blob transport for LLM request/response storage.
 
     Thread-safe via a threading.Lock on the internal dict. Suitable for
     concurrent CAS operations from multiple async tasks writing to the
     same conversation store.
 
-    Not a subclass of BlobTransport (Protocol-based structural typing).
+    Not a subclass of Transport (Protocol-based structural typing).
     """
 
     transport_name: str = "llm_memory"

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -1,8 +1,8 @@
 """OpenAI-compatible LLM backend — CAS addressing + LLM transport.
 
 Thin CASAddressingEngine subclass: registration + CONNECTION_ARGS + OpenAI client.
-Follows the same composition pattern as CASLocalBackend (CAS + LocalBlobTransport)
-and CASGCSBackend (CAS + GCSBlobTransport).
+Follows the same composition pattern as CASLocalBackend (CAS + LocalTransport)
+and CASGCSBackend (CAS + GCSTransport).
 
     nexus mount /zone/llm/openai --backend=openai_compatible \
         --config='{"base_url":"https://api.sudorouter.ai","api_key":"sk-..."}'
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
-from nexus.backends.compute.llm_blob_transport import LLMBlobTransport
+from nexus.backends.compute.llm_transport import LLMTransport
 from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import BackendError
 from nexus.core.object_store import WriteResult
@@ -137,7 +137,7 @@ class OpenAICompatibleBackend(CASAddressingEngine):
         self._client = _build_openai_client(base_url, api_key, timeout)
 
         # In-memory transport for CAS blobs
-        transport = LLMBlobTransport()
+        transport = LLMTransport()
 
         super().__init__(transport, backend_name="openai_compatible")
 

--- a/src/nexus/backends/storage/cas_gcs.py
+++ b/src/nexus/backends/storage/cas_gcs.py
@@ -1,7 +1,7 @@
 """Google Cloud Storage backend with CAS deduplication.
 
 Thin subclass of CASAddressingEngine that:
-- Creates a GCSBlobTransport for raw GCS I/O
+- Creates a GCSTransport for raw GCS I/O
 - Registers as "cas_gcs" connector via @register_connector
 - Declares CONNECTION_ARGS for factory instantiation
 - Overrides batch_read_content with GCS-optimized parallel downloads
@@ -86,9 +86,9 @@ class CASGCSBackend(CASAddressingEngine):
         upload_timeout: float = 300.0,
     ):
         try:
-            from nexus.backends.transports.gcs_transport import GCSBlobTransport
+            from nexus.backends.transports.gcs_transport import GCSTransport
 
-            transport = GCSBlobTransport(
+            transport = GCSTransport(
                 bucket_name=bucket_name,
                 project_id=project_id,
                 credentials_path=credentials_path,

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -10,7 +10,7 @@ content cache, VFSSemaphore, and CDCEngine (chunking).
 
 VolumeLocalTransport packs CAS blobs into append-only volume files with a
 redb index, reducing inode overhead and enabling batched fsync. Falls back
-to LocalBlobTransport if the Rust VolumeEngine is unavailable.
+to LocalTransport if the Rust VolumeEngine is unavailable.
 
 CDC routing is handled by CASAddressingEngine base class via Feature DI —
 CASLocalBackend only instantiates and passes CDCEngine.
@@ -36,7 +36,7 @@ from nexus.backends.base.registry import ArgType, ConnectionArg, register_connec
 from nexus.backends.engines.cas_gc import CASGarbageCollector
 from nexus.backends.engines.cdc import CDCEngine
 from nexus.backends.engines.multipart import MultipartUpload
-from nexus.backends.transports.local_transport import LocalBlobTransport
+from nexus.backends.transports.local_transport import LocalTransport
 from nexus.backends.transports.volume_local_transport import VolumeLocalTransport
 from nexus.contracts.backend_features import BackendFeature
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
@@ -53,7 +53,7 @@ DEFAULT_CAS_BLOOM_FP_RATE = 0.01
 
 
 def _init_bloom_from_transport(
-    transport: VolumeLocalTransport | LocalBlobTransport,
+    transport: VolumeLocalTransport | LocalTransport,
     capacity: int,
     fp_rate: float,
 ) -> Any:
@@ -134,18 +134,18 @@ class CASLocalBackend(CASAddressingEngine, MultipartUpload):
         self.cas_root.mkdir(parents=True, exist_ok=True)
         self.dir_root.mkdir(parents=True, exist_ok=True)
 
-        # Build transport — VolumeLocalTransport with fallback to LocalBlobTransport
+        # Build transport — VolumeLocalTransport with fallback to LocalTransport
         # VolumeLocalTransport packs CAS blobs into volumes; falls back internally
         # if VolumeEngine is unavailable (Issue #3403).
-        # Both VolumeLocalTransport and LocalBlobTransport implement BlobTransport
+        # Both VolumeLocalTransport and LocalTransport implement Transport
         # structurally (Protocol), but mypy can't verify VolumeLocalTransport against
-        # the Protocol since it uses dynamic PyO3 dispatch. Using BlobTransport annotation
+        # the Protocol since it uses dynamic PyO3 dispatch. Using Transport annotation
         # directly would fail for VolumeLocalTransport.
         transport: Any
         if use_volume_packing:
             transport = VolumeLocalTransport(root_path=self.root_path, fsync=True)
         else:
-            transport = LocalBlobTransport(root_path=self.root_path, fsync=True)
+            transport = LocalTransport(root_path=self.root_path, fsync=True)
 
         # Seed Bloom filter from transport (works for both volume and file storage)
         bloom = _init_bloom_from_transport(transport, bloom_capacity, bloom_fp_rate)

--- a/src/nexus/backends/storage/path_gcs.py
+++ b/src/nexus/backends/storage/path_gcs.py
@@ -1,7 +1,7 @@
 """Google Cloud Storage connector backend with direct path mapping.
 
 Thin subclass of PathAddressingEngine that:
-- Creates a GCSBlobTransport for raw GCS I/O (shared with GCSBackend CAS)
+- Creates a GCSTransport for raw GCS I/O (shared with GCSBackend CAS)
 - Mixes in CacheConnectorMixin for L1+L2 caching
 - Registers as "path_gcs" via @register_connector
 - Adds GCS-specific features: signed URLs, versioning, batch version fetch
@@ -112,9 +112,9 @@ class PathGCSBackend(PathAddressingEngine, CacheConnectorMixin):
         upload_timeout: float = 300.0,
     ):
         try:
-            from nexus.backends.transports.gcs_transport import GCSBlobTransport
+            from nexus.backends.transports.gcs_transport import GCSTransport
 
-            transport = GCSBlobTransport(
+            transport = GCSTransport(
                 bucket_name=bucket_name,
                 project_id=project_id,
                 credentials_path=credentials_path,

--- a/src/nexus/backends/storage/path_local.py
+++ b/src/nexus/backends/storage/path_local.py
@@ -1,7 +1,7 @@
 """Path-based local filesystem backend (no CAS overhead).
 
 Thin subclass of PathAddressingEngine that:
-- Creates a LocalBlobTransport for raw local I/O
+- Creates a LocalTransport for raw local I/O
 - Registers as "path_local" via @register_connector
 - Exposes root_path / has_root_path for orchestrator
 
@@ -24,7 +24,7 @@ from typing import ClassVar
 
 from nexus.backends.base.path_addressing_engine import PathAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
-from nexus.backends.transports.local_transport import LocalBlobTransport
+from nexus.backends.transports.local_transport import LocalTransport
 from nexus.contracts.backend_features import BLOB_BACKEND_FEATURES, BackendFeature
 
 
@@ -65,7 +65,7 @@ class PathLocalBackend(PathAddressingEngine):
 
     def __init__(self, root_path: str | Path, *, fsync: bool = True) -> None:
         self.root_path = Path(root_path).resolve()
-        transport = LocalBlobTransport(root_path=self.root_path, fsync=fsync)
+        transport = LocalTransport(root_path=self.root_path, fsync=fsync)
         super().__init__(transport, backend_name="path_local")
 
     @property

--- a/src/nexus/backends/storage/path_s3.py
+++ b/src/nexus/backends/storage/path_s3.py
@@ -1,7 +1,7 @@
 """AWS S3 connector backend with direct path mapping.
 
 Thin subclass of PathAddressingEngine that:
-- Creates an S3BlobTransport for raw S3 I/O
+- Creates an S3Transport for raw S3 I/O
 - Mixes in CacheConnectorMixin for L1+L2 caching
 - Mixes in MultipartUpload for chunked uploads
 - Registers as "path_s3" via @register_connector
@@ -116,9 +116,9 @@ class PathS3Backend(PathAddressingEngine, CacheConnectorMixin, MultipartUpload):
         upload_timeout: float = 300.0,
     ):
         try:
-            from nexus.backends.transports.s3_transport import S3BlobTransport
+            from nexus.backends.transports.s3_transport import S3Transport
 
-            transport = S3BlobTransport(
+            transport = S3Transport(
                 bucket_name=bucket_name,
                 region_name=region_name,
                 access_key_id=access_key_id,

--- a/src/nexus/backends/transports/__init__.py
+++ b/src/nexus/backends/transports/__init__.py
@@ -1,28 +1,28 @@
-"""BlobTransport implementations for storage providers.
+"""Transport implementations for storage providers.
 
 Each transport provides raw key→blob I/O for a specific storage backend.
 Transports are shared between CAS and Path addressing engines.
 """
 
-from nexus.backends.transports.local_transport import LocalBlobTransport
+from nexus.backends.transports.local_transport import LocalTransport
 
 __all__ = [
-    "GCSBlobTransport",
-    "LocalBlobTransport",
-    "S3BlobTransport",
+    "GCSTransport",
+    "LocalTransport",
+    "S3Transport",
 ]
 
 
 # Lazy imports to avoid requiring cloud SDKs at import time
 def __getattr__(name: str) -> object:
-    if name == "GCSBlobTransport":
-        from nexus.backends.transports.gcs_transport import GCSBlobTransport
+    if name == "GCSTransport":
+        from nexus.backends.transports.gcs_transport import GCSTransport
 
-        globals()["GCSBlobTransport"] = GCSBlobTransport
-        return GCSBlobTransport
-    if name == "S3BlobTransport":
-        from nexus.backends.transports.s3_transport import S3BlobTransport
+        globals()["GCSTransport"] = GCSTransport
+        return GCSTransport
+    if name == "S3Transport":
+        from nexus.backends.transports.s3_transport import S3Transport
 
-        globals()["S3BlobTransport"] = S3BlobTransport
-        return S3BlobTransport
+        globals()["S3Transport"] = S3Transport
+        return S3Transport
     raise AttributeError(f"module 'nexus.backends.transports' has no attribute {name}")

--- a/src/nexus/backends/transports/gcs_transport.py
+++ b/src/nexus/backends/transports/gcs_transport.py
@@ -1,4 +1,4 @@
-"""GCS BlobTransport — raw key→blob I/O over Google Cloud Storage.
+"""GCS Transport — raw key→blob I/O over Google Cloud Storage.
 
 Shared between CASGCSBackend (CAS addressing) and PathGCSBackend (path
 addressing).  This is the value of orthogonal composition — one transport
@@ -28,10 +28,10 @@ from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 logger = logging.getLogger(__name__)
 
 
-class GCSBlobTransport:
+class GCSTransport:
     """Raw key→blob I/O over Google Cloud Storage.
 
-    Implements the BlobTransport protocol (structural typing — no inheritance).
+    Implements the Transport protocol (structural typing — no inheritance).
     """
 
     transport_name: str = "gcs"
@@ -84,7 +84,7 @@ class GCSBlobTransport:
         self.bucket.reload()
         return self.bucket.versioning_enabled or False
 
-    # === BlobTransport Protocol Methods ===
+    # === Transport Protocol Methods ===
 
     def put_blob(self, key: str, data: bytes, content_type: str = "") -> str | None:
         try:
@@ -333,7 +333,7 @@ class GCSBlobTransport:
                 path=key,
             ) from e
 
-    # === GCS-Specific Extras (not part of BlobTransport protocol) ===
+    # === GCS-Specific Extras (not part of Transport protocol) ===
 
     def generate_signed_url(self, key: str, expires_in: int = 3600, method: str = "GET") -> str:
         """Generate a V4 signed URL for direct download."""

--- a/src/nexus/backends/transports/local_transport.py
+++ b/src/nexus/backends/transports/local_transport.py
@@ -1,6 +1,6 @@
-"""Local filesystem BlobTransport — raw key→blob I/O on local disk.
+"""Local filesystem Transport — raw key→blob I/O on local disk.
 
-Implements the BlobTransport protocol using direct writes with optional
+Implements the Transport protocol using direct writes with optional
 fsync for durability. CAS is idempotent (same hash = same bytes), so
 temp+replace atomicity is unnecessary — direct write is safe and faster.
 
@@ -30,10 +30,10 @@ from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 logger = logging.getLogger(__name__)
 
 
-class LocalBlobTransport:
+class LocalTransport:
     """Raw key→blob I/O on local filesystem.
 
-    Implements the BlobTransport protocol (structural typing — no inheritance).
+    Implements the Transport protocol (structural typing — no inheritance).
 
     Args:
         root_path: Root directory for all blob storage.
@@ -65,7 +65,7 @@ class LocalBlobTransport:
             path.parent.mkdir(parents=True, exist_ok=True)
             self._known_parents.add(parent)
 
-    # === BlobTransport Protocol Methods ===
+    # === Transport Protocol Methods ===
 
     def put_blob(self, key: str, data: bytes, content_type: str = "") -> str | None:
         """Direct write: raw fd → fsync → done. No temp+replace.

--- a/src/nexus/backends/transports/s3_transport.py
+++ b/src/nexus/backends/transports/s3_transport.py
@@ -1,4 +1,4 @@
-"""S3 BlobTransport — raw key→blob I/O over AWS S3.
+"""S3 Transport — raw key→blob I/O over AWS S3.
 
 Shared between PathS3Backend (path addressing) and potential future
 S3CASAddressingEngine (CAS addressing).
@@ -28,10 +28,10 @@ from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 logger = logging.getLogger(__name__)
 
 
-class S3BlobTransport:
+class S3Transport:
     """Raw key→blob I/O over AWS S3.
 
-    Implements the BlobTransport protocol (structural typing — no inheritance).
+    Implements the Transport protocol (structural typing — no inheritance).
     """
 
     transport_name: str = "s3"
@@ -130,7 +130,7 @@ class S3BlobTransport:
         except Exception:
             return False
 
-    # === BlobTransport Protocol Methods ===
+    # === Transport Protocol Methods ===
 
     def put_blob(self, key: str, data: bytes, content_type: str = "") -> str | None:
         try:
@@ -360,7 +360,7 @@ class S3BlobTransport:
                     self.abort_multipart(key, upload_id)
             raise
 
-    # === S3-Specific Extras (not part of BlobTransport protocol) ===
+    # === S3-Specific Extras (not part of Transport protocol) ===
 
     def generate_presigned_url(
         self, key: str, expires_in: int = 3600, method: str = "get_object"

--- a/src/nexus/backends/transports/volume_local_transport.py
+++ b/src/nexus/backends/transports/volume_local_transport.py
@@ -1,8 +1,8 @@
-"""Volume-packed local BlobTransport — append-only volume files for CAS.
+"""Volume-packed local Transport — append-only volume files for CAS.
 
 Wraps the Rust VolumeEngine (nexus_fast.VolumeEngine) and implements the
-BlobTransport protocol. Routes CAS blob keys (cas/...) to the volume engine
-and delegates directory operations (dirs/...) to an internal LocalBlobTransport.
+Transport protocol. Routes CAS blob keys (cas/...) to the volume engine
+and delegates directory operations (dirs/...) to an internal LocalTransport.
 
 Volume engine benefits:
     - Packs thousands of blobs into append-only volume files
@@ -25,7 +25,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-from nexus.backends.transports.local_transport import LocalBlobTransport
+from nexus.backends.transports.local_transport import LocalTransport
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -35,16 +35,16 @@ _CAS_PREFIX = "cas/"
 
 
 class VolumeLocalTransport:
-    """Volume-packed BlobTransport for local CAS storage.
+    """Volume-packed Transport for local CAS storage.
 
-    Implements the full BlobTransport protocol (structural typing).
+    Implements the full Transport protocol (structural typing).
     CAS blob keys (cas/...) are routed to the Rust VolumeEngine.
     All other keys (dirs/..., uploads/...) are handled by an internal
-    LocalBlobTransport for filesystem-native directory operations.
+    LocalTransport for filesystem-native directory operations.
 
     Args:
         root_path: Root directory for all storage.
-        fsync: Whether LocalBlobTransport uses fsync (for dirs/uploads).
+        fsync: Whether LocalTransport uses fsync (for dirs/uploads).
         target_volume_size: Override volume size in bytes (0 = dynamic).
         compaction_rate_limit: I/O rate limit for compaction (bytes/sec).
         compaction_sparsity_threshold: Trigger compaction above this (0.0-1.0).
@@ -81,12 +81,12 @@ class VolumeLocalTransport:
             self._volume_available = False
             logger.warning(
                 "nexus_fast.VolumeEngine not available, "
-                "falling back to file-per-blob LocalBlobTransport"
+                "falling back to file-per-blob LocalTransport"
             )
 
         # Delegate transport for non-CAS keys (dirs, uploads, etc.)
         # Also serves as fallback if VolumeEngine is unavailable.
-        self._delegate = LocalBlobTransport(root_path=root_path, fsync=fsync)
+        self._delegate = LocalTransport(root_path=root_path, fsync=fsync)
 
     def _is_cas_key(self, key: str) -> bool:
         """Check if a key should be routed to the volume engine."""
@@ -96,7 +96,7 @@ class VolumeLocalTransport:
         """Extract content hash from a CAS key like 'cas/ab/cd/abcdef...'."""
         return key.split("/")[-1]
 
-    # === BlobTransport Protocol Methods ===
+    # === Transport Protocol Methods ===
 
     def put_blob(self, key: str, data: bytes, content_type: str = "") -> str | None:
         if self._is_cas_key(key):

--- a/tests/unit/backends/test_batch_operations.py
+++ b/tests/unit/backends/test_batch_operations.py
@@ -20,8 +20,8 @@ from nexus.contracts.types import OperationContext
 from nexus.core.object_store import WriteResult
 
 
-class InMemoryBlobTransport:
-    """Minimal in-memory BlobTransport for tests."""
+class InMemoryTransport:
+    """Minimal in-memory Transport for tests."""
 
     transport_name = "memory"
 
@@ -71,7 +71,7 @@ class MockBlobConnector(PathAddressingEngine, CacheConnectorMixin):
     """Mock blob connector for testing batch operations."""
 
     def __init__(self, session_factory):
-        transport = InMemoryBlobTransport()
+        transport = InMemoryTransport()
         super().__init__(transport, backend_name="test_blob_backend")
         self.session_factory = session_factory
         self.versions: dict[str, str] = {}
@@ -585,7 +585,7 @@ class MockS3ConnectorForBatch(PathAddressingEngine, CacheConnectorMixin):
     batch_read_workers: int = 4  # Low for tests
 
     def __init__(self) -> None:
-        transport = InMemoryBlobTransport()
+        transport = InMemoryTransport()
         super().__init__(transport, backend_name="s3_connector", bucket_name="test-bucket")
         self.read_count: int = 0
         self.session_factory = None

--- a/tests/unit/backends/test_cas_backend.py
+++ b/tests/unit/backends/test_cas_backend.py
@@ -1,4 +1,4 @@
-"""Unit tests for CASAddressingEngine — CAS addressing over InMemoryBlobTransport.
+"""Unit tests for CASAddressingEngine — CAS addressing over InMemoryTransport.
 
 Tests cover:
 - Content-addressable write/read/delete with hash-based paths
@@ -21,11 +21,11 @@ from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
 
-# === InMemoryBlobTransport ===
+# === InMemoryTransport ===
 
 
-class InMemoryBlobTransport:
-    """Minimal in-memory BlobTransport for testing."""
+class InMemoryTransport:
+    """Minimal in-memory Transport for testing."""
 
     transport_name: str = "memory"
 
@@ -91,12 +91,12 @@ class InMemoryBlobTransport:
 
 
 @pytest.fixture
-def transport() -> InMemoryBlobTransport:
-    return InMemoryBlobTransport()
+def transport() -> InMemoryTransport:
+    return InMemoryTransport()
 
 
 @pytest.fixture
-def backend(transport: InMemoryBlobTransport) -> CASAddressingEngine:
+def backend(transport: InMemoryTransport) -> CASAddressingEngine:
     return CASAddressingEngine(transport, backend_name="test-cas")
 
 
@@ -107,7 +107,7 @@ class TestCASAddressingEngineWriteContent:
     """Test write_content() — CAS dedup."""
 
     def test_write_stores_at_cas_path(
-        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
+        self, backend: CASAddressingEngine, transport: InMemoryTransport
     ):
         content = b"hello world"
         h = hash_content(content)
@@ -146,7 +146,7 @@ class TestCASAddressingEngineReadContent:
             backend.read_content("a" * 64)
 
     def test_read_verifies_hash_integrity(
-        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
+        self, backend: CASAddressingEngine, transport: InMemoryTransport
     ):
         content = b"original"
         result = backend.write_content(content)
@@ -162,9 +162,7 @@ class TestCASAddressingEngineReadContent:
 class TestCASAddressingEngineDeleteContent:
     """Test delete_content() — blob removal and cleanup."""
 
-    def test_delete_removes_blob(
-        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
-    ):
+    def test_delete_removes_blob(self, backend: CASAddressingEngine, transport: InMemoryTransport):
         content = b"delete me"
         result = backend.write_content(content)
         h = result.content_id
@@ -179,7 +177,7 @@ class TestCASAddressingEngineDeleteContent:
             backend.delete_content("b" * 64)
 
     def test_delete_cleans_up_meta_sidecar(
-        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
+        self, backend: CASAddressingEngine, transport: InMemoryTransport
     ):
         content = b"cleanup"
         result = backend.write_content(content)
@@ -268,13 +266,11 @@ class TestCASAddressingEngineBatchRead:
 class TestCASAddressingEngineDirectories:
     """Test directory operations (CAS uses dirs/ prefix)."""
 
-    def test_mkdir_creates_marker(
-        self, backend: CASAddressingEngine, transport: InMemoryBlobTransport
-    ):
+    def test_mkdir_creates_marker(self, backend: CASAddressingEngine, transport: InMemoryTransport):
         backend.mkdir("data")
         assert "dirs/data/" in transport.files
 
-    def test_mkdir_root_noop(self, backend: CASAddressingEngine, transport: InMemoryBlobTransport):
+    def test_mkdir_root_noop(self, backend: CASAddressingEngine, transport: InMemoryTransport):
         backend.mkdir("")
         # Root always exists, no marker created
         assert not any(k.startswith("dirs/") for k in transport.files)
@@ -294,7 +290,7 @@ class TestCASAddressingEngineDirectories:
         backend.mkdir("data")
         assert backend.is_directory("data") is True
 
-    def test_rmdir(self, backend: CASAddressingEngine, transport: InMemoryBlobTransport):
+    def test_rmdir(self, backend: CASAddressingEngine, transport: InMemoryTransport):
         backend.mkdir("data")
         backend.rmdir("data")
         assert "dirs/data/" not in transport.files
@@ -311,11 +307,11 @@ class TestCASAddressingEngineDirectories:
 class TestCASAddressingEngineName:
     """Test name property and default name generation."""
 
-    def test_custom_name(self, transport: InMemoryBlobTransport):
+    def test_custom_name(self, transport: InMemoryTransport):
         backend = CASAddressingEngine(transport, backend_name="my-cas")
         assert backend.name == "my-cas"
 
-    def test_default_name(self, transport: InMemoryBlobTransport):
+    def test_default_name(self, transport: InMemoryTransport):
         backend = CASAddressingEngine(transport)
         assert backend.name == "cas-memory"
 
@@ -323,7 +319,7 @@ class TestCASAddressingEngineName:
 class TestVerifyOnRead:
     """Test verify_on_read flag — configurable integrity hash on read."""
 
-    def test_verify_on_read_true_detects_corruption(self, transport: InMemoryBlobTransport):
+    def test_verify_on_read_true_detects_corruption(self, transport: InMemoryTransport):
         backend = CASAddressingEngine(transport, backend_name="test", verify_on_read=True)
         content = b"original"
         result = backend.write_content(content)
@@ -333,7 +329,7 @@ class TestVerifyOnRead:
         with pytest.raises(BackendError, match="hash mismatch"):
             backend.read_content(result.content_id)
 
-    def test_verify_on_read_false_skips_hash(self, transport: InMemoryBlobTransport):
+    def test_verify_on_read_false_skips_hash(self, transport: InMemoryTransport):
         backend = CASAddressingEngine(transport, backend_name="test", verify_on_read=False)
         content = b"original"
         result = backend.write_content(content)
@@ -344,7 +340,7 @@ class TestVerifyOnRead:
         data = backend.read_content(result.content_id)
         assert data == b"corrupted"
 
-    def test_verify_on_read_default_is_true(self, transport: InMemoryBlobTransport):
+    def test_verify_on_read_default_is_true(self, transport: InMemoryTransport):
         backend = CASAddressingEngine(transport, backend_name="test")
         assert backend._verify_on_read is True
 
@@ -352,7 +348,7 @@ class TestVerifyOnRead:
 class TestDedupSkip:
     """Test dedup skip — blob_exists check before put_blob on write."""
 
-    def test_dedup_write_skips_put_blob(self, transport: InMemoryBlobTransport):
+    def test_dedup_write_skips_put_blob(self, transport: InMemoryTransport):
         """On dedup, put_blob should not be called the second time."""
         from unittest.mock import patch
 
@@ -376,7 +372,7 @@ class TestDedupSkip:
         # put_blob should NOT have been called for the content blob
         assert content_key not in put_calls
 
-    def test_fresh_write_calls_put_blob(self, transport: InMemoryBlobTransport):
+    def test_fresh_write_calls_put_blob(self, transport: InMemoryTransport):
         backend = CASAddressingEngine(transport, backend_name="test")
         content = b"fresh content"
         result = backend.write_content(content)
@@ -389,7 +385,7 @@ class TestDedupSkip:
 class TestNoMetaForNonCDC:
     """Test that non-CDC writes do NOT create .meta sidecars."""
 
-    def test_write_no_meta_sidecar(self, transport: InMemoryBlobTransport):
+    def test_write_no_meta_sidecar(self, transport: InMemoryTransport):
         backend = CASAddressingEngine(transport, backend_name="test")
         result = backend.write_content(b"small content")
         h = result.content_id

--- a/tests/unit/backends/test_cas_local_crud.py
+++ b/tests/unit/backends/test_cas_local_crud.py
@@ -1,8 +1,8 @@
-"""CRUD verification: CASAddressingEngine(LocalBlobTransport) end-to-end.
+"""CRUD verification: CASAddressingEngine(LocalTransport) end-to-end.
 
 This is the **first time** production CRUD has been verified on the new
-CAS x BlobTransport composition with a real filesystem. Previous tests
-used InMemoryBlobTransport.
+CAS x Transport composition with a real filesystem. Previous tests
+used InMemoryTransport.
 
 Tests cover:
 - write/read roundtrip with hash verification
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
-from nexus.backends.transports.local_transport import LocalBlobTransport
+from nexus.backends.transports.local_transport import LocalTransport
 from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
@@ -30,7 +30,7 @@ from nexus.core.object_store import WriteResult
 
 @pytest.fixture
 def transport(tmp_path):
-    return LocalBlobTransport(root_path=tmp_path, fsync=False)
+    return LocalTransport(root_path=tmp_path, fsync=False)
 
 
 @pytest.fixture

--- a/tests/unit/backends/test_cas_metadata_cache.py
+++ b/tests/unit/backends/test_cas_metadata_cache.py
@@ -16,12 +16,12 @@ import cachetools
 import pytest
 
 from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
-from tests.unit.backends.test_cas_backend import InMemoryBlobTransport
+from tests.unit.backends.test_cas_backend import InMemoryTransport
 
 
 @pytest.fixture
-def transport() -> InMemoryBlobTransport:
-    return InMemoryBlobTransport()
+def transport() -> InMemoryTransport:
+    return InMemoryTransport()
 
 
 @pytest.fixture
@@ -30,14 +30,12 @@ def meta_cache() -> cachetools.LRUCache:
 
 
 @pytest.fixture
-def backend(
-    transport: InMemoryBlobTransport, meta_cache: cachetools.LRUCache
-) -> CASAddressingEngine:
+def backend(transport: InMemoryTransport, meta_cache: cachetools.LRUCache) -> CASAddressingEngine:
     return CASAddressingEngine(transport, backend_name="test-cas", meta_cache=meta_cache)
 
 
 @pytest.fixture
-def backend_no_cache(transport: InMemoryBlobTransport) -> CASAddressingEngine:
+def backend_no_cache(transport: InMemoryTransport) -> CASAddressingEngine:
     """Backend without meta_cache (simulates cloud backends)."""
     return CASAddressingEngine(transport, backend_name="test-cas-no-cache")
 
@@ -146,7 +144,7 @@ class TestMetaCacheEviction:
 class TestMetaCacheLRUBehavior:
     """Test LRU eviction behavior."""
 
-    def test_cache_maxsize_respected(self, transport: InMemoryBlobTransport):
+    def test_cache_maxsize_respected(self, transport: InMemoryTransport):
         small_cache = cachetools.LRUCache(maxsize=3)
         backend = CASAddressingEngine(transport, backend_name="test", meta_cache=small_cache)
 

--- a/tests/unit/backends/test_local_transport.py
+++ b/tests/unit/backends/test_local_transport.py
@@ -1,6 +1,6 @@
-"""Unit tests for LocalBlobTransport — BlobTransport protocol conformance.
+"""Unit tests for LocalTransport — Transport protocol conformance.
 
-Tests all 9 BlobTransport methods with a real temp-directory filesystem.
+Tests all 9 Transport methods with a real temp-directory filesystem.
 
 References:
     - Issue #1323: CAS x Backend orthogonal composition
@@ -8,23 +8,23 @@ References:
 
 import pytest
 
-from nexus.backends.base.blob_transport import BlobTransport
-from nexus.backends.transports.local_transport import LocalBlobTransport
+from nexus.backends.base.transport import Transport
+from nexus.backends.transports.local_transport import LocalTransport
 from nexus.contracts.exceptions import NexusFileNotFoundError
 
 
 @pytest.fixture
 def transport(tmp_path):
-    """Create a LocalBlobTransport rooted in a temporary directory."""
-    return LocalBlobTransport(root_path=tmp_path, fsync=False)
+    """Create a LocalTransport rooted in a temporary directory."""
+    return LocalTransport(root_path=tmp_path, fsync=False)
 
 
 # === Protocol Conformance ===
 
 
 class TestProtocolConformance:
-    def test_implements_blob_transport(self, transport):
-        assert isinstance(transport, BlobTransport)
+    def test_implements_transport(self, transport):
+        assert isinstance(transport, Transport)
 
     def test_transport_name(self, transport):
         assert transport.transport_name == "local"
@@ -245,13 +245,13 @@ class TestStreamBlob:
 
 class TestFsyncOption:
     def test_fsync_enabled(self, tmp_path):
-        t = LocalBlobTransport(root_path=tmp_path, fsync=True)
+        t = LocalTransport(root_path=tmp_path, fsync=True)
         t.put_blob("k", b"data")
         data, _ = t.get_blob("k")
         assert data == b"data"
 
     def test_fsync_disabled(self, tmp_path):
-        t = LocalBlobTransport(root_path=tmp_path, fsync=False)
+        t = LocalTransport(root_path=tmp_path, fsync=False)
         t.put_blob("k", b"data")
         data, _ = t.get_blob("k")
         assert data == b"data"

--- a/tests/unit/backends/test_openai_compat.py
+++ b/tests/unit/backends/test_openai_compat.py
@@ -1,7 +1,7 @@
 """Tests for OpenAI-compatible LLM backend.
 
 Tests cover:
-- LLMBlobTransport: in-memory blob operations
+- LLMTransport: in-memory blob operations
 - OpenAICompatibleBackend: thin CASAddressingEngine subclass (no write_content override)
   - write_content(): inherited from CASAddressingEngine (pure CAS, no LLM call)
   - generate_streaming(): pure LLM compute, yields tokens
@@ -18,58 +18,58 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nexus.backends.compute.llm_blob_transport import LLMBlobTransport
+from nexus.backends.compute.llm_transport import LLMTransport
 from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 
 # =============================================================================
-# LLMBlobTransport tests
+# LLMTransport tests
 # =============================================================================
 
 
-class TestLLMBlobTransport:
+class TestLLMTransport:
     """Test in-memory blob transport."""
 
     def test_put_and_get(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         t.put_blob("key1", b"hello")
         data, version = t.get_blob("key1")
         assert data == b"hello"
         assert version is None
 
     def test_get_missing_raises(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         with pytest.raises(NexusFileNotFoundError):
             t.get_blob("missing")
 
     def test_delete(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         t.put_blob("key1", b"data")
         t.delete_blob("key1")
         assert not t.blob_exists("key1")
 
     def test_delete_missing_raises(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         with pytest.raises(NexusFileNotFoundError):
             t.delete_blob("missing")
 
     def test_blob_exists(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         assert not t.blob_exists("key1")
         t.put_blob("key1", b"data")
         assert t.blob_exists("key1")
 
     def test_get_blob_size(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         t.put_blob("key1", b"hello")
         assert t.get_blob_size("key1") == 5
 
     def test_get_blob_size_missing_raises(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         with pytest.raises(NexusFileNotFoundError):
             t.get_blob_size("missing")
 
     def test_list_blobs(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         t.put_blob("cas/ab/cd/hash1", b"data1")
         t.put_blob("cas/ab/cd/hash2", b"data2")
         t.put_blob("cas/ef/gh/hash3", b"data3")
@@ -78,36 +78,36 @@ class TestLLMBlobTransport:
         assert "cas/ab/cd/" in prefixes
 
     def test_copy_blob(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         t.put_blob("src", b"content")
         t.copy_blob("src", "dst")
         data, _ = t.get_blob("dst")
         assert data == b"content"
 
     def test_copy_missing_raises(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         with pytest.raises(NexusFileNotFoundError):
             t.copy_blob("missing", "dst")
 
     def test_stream_blob(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         t.put_blob("key1", b"abcdefghij")
         chunks = list(t.stream_blob("key1", chunk_size=4))
         assert chunks == [b"abcd", b"efgh", b"ij"]
 
     def test_create_directory_marker(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         t.create_directory_marker("dirs/mydir/")
         assert t.blob_exists("dirs/mydir/")
         data, _ = t.get_blob("dirs/mydir/")
         assert data == b""
 
     def test_transport_name(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         assert t.transport_name == "llm_memory"
 
     def test_overwrite(self) -> None:
-        t = LLMBlobTransport()
+        t = LLMTransport()
         t.put_blob("key1", b"old")
         t.put_blob("key1", b"new")
         data, _ = t.get_blob("key1")

--- a/tests/unit/backends/test_path_backend.py
+++ b/tests/unit/backends/test_path_backend.py
@@ -1,4 +1,4 @@
-"""Unit tests for PathAddressingEngine — path addressing over InMemoryBlobTransport.
+"""Unit tests for PathAddressingEngine — path addressing over InMemoryTransport.
 
 Tests cover:
 - Path-based write/read/delete (requires OperationContext with backend_path)
@@ -25,11 +25,11 @@ from nexus.contracts.types import OperationContext
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
 
-# === InMemoryBlobTransport ===
+# === InMemoryTransport ===
 
 
-class InMemoryBlobTransport:
-    """Minimal in-memory BlobTransport for testing."""
+class InMemoryTransport:
+    """Minimal in-memory Transport for testing."""
 
     transport_name: str = "memory"
 
@@ -105,17 +105,17 @@ def _make_context(backend_path: str, virtual_path: str | None = None) -> Operati
 
 
 @pytest.fixture
-def transport() -> InMemoryBlobTransport:
-    return InMemoryBlobTransport()
+def transport() -> InMemoryTransport:
+    return InMemoryTransport()
 
 
 @pytest.fixture
-def backend(transport: InMemoryBlobTransport) -> PathAddressingEngine:
+def backend(transport: InMemoryTransport) -> PathAddressingEngine:
     return PathAddressingEngine(transport, backend_name="test-path", bucket_name="test-bucket")
 
 
 @pytest.fixture
-def prefixed_backend(transport: InMemoryBlobTransport) -> PathAddressingEngine:
+def prefixed_backend(transport: InMemoryTransport) -> PathAddressingEngine:
     return PathAddressingEngine(
         transport, backend_name="test-prefixed", bucket_name="test-bucket", prefix="data"
     )
@@ -128,7 +128,7 @@ class TestPathAddressingEngineWriteContent:
     """Test write_content() — path-based storage."""
 
     def test_write_stores_at_backend_path(
-        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
+        self, backend: PathAddressingEngine, transport: InMemoryTransport
     ):
         ctx = _make_context("docs/file.txt")
         result = backend.write_content(b"hello world", context=ctx)
@@ -147,7 +147,7 @@ class TestPathAddressingEngineWriteContent:
             backend.write_content(b"no path", context=_make_context(""))
 
     def test_write_with_prefix(
-        self, prefixed_backend: PathAddressingEngine, transport: InMemoryBlobTransport
+        self, prefixed_backend: PathAddressingEngine, transport: InMemoryTransport
     ):
         ctx = _make_context("file.txt")
         prefixed_backend.write_content(b"prefixed", context=ctx)
@@ -186,9 +186,7 @@ class TestPathAddressingEngineReadContent:
 class TestPathAddressingEngineDeleteContent:
     """Test delete_content()."""
 
-    def test_delete_removes_blob(
-        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
-    ):
+    def test_delete_removes_blob(self, backend: PathAddressingEngine, transport: InMemoryTransport):
         ctx = _make_context("file.txt")
         backend.write_content(b"delete me", context=ctx)
         assert "file.txt" in transport.files
@@ -284,17 +282,17 @@ class TestPathAddressingEngineBatchRead:
 class TestPathAddressingEngineDirectories:
     """Test directory operations."""
 
-    def test_mkdir(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
+    def test_mkdir(self, backend: PathAddressingEngine, transport: InMemoryTransport):
         backend.mkdir("data")
         assert "data/" in transport.files
 
     def test_mkdir_with_prefix(
-        self, prefixed_backend: PathAddressingEngine, transport: InMemoryBlobTransport
+        self, prefixed_backend: PathAddressingEngine, transport: InMemoryTransport
     ):
         prefixed_backend.mkdir("subdir")
         assert "data/subdir/" in transport.files
 
-    def test_mkdir_root_noop(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
+    def test_mkdir_root_noop(self, backend: PathAddressingEngine, transport: InMemoryTransport):
         backend.mkdir("")
         assert not any(k.endswith("/") for k in transport.files)
 
@@ -313,7 +311,7 @@ class TestPathAddressingEngineDirectories:
         backend.mkdir("data")
         assert backend.is_directory("data") is True
 
-    def test_rmdir(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
+    def test_rmdir(self, backend: PathAddressingEngine, transport: InMemoryTransport):
         backend.mkdir("data")
         backend.rmdir("data")
         assert "data/" not in transport.files
@@ -330,7 +328,7 @@ class TestPathAddressingEngineDirectories:
 class TestPathAddressingEngineRename:
     """Test rename_file (copy + delete)."""
 
-    def test_rename(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
+    def test_rename(self, backend: PathAddressingEngine, transport: InMemoryTransport):
         transport.files["old.txt"] = b"content"
 
         backend.rename_file("old.txt", "new.txt")
@@ -343,7 +341,7 @@ class TestPathAddressingEngineRename:
             backend.rename_file("missing.txt", "new.txt")
 
     def test_rename_dest_exists_raises(
-        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
+        self, backend: PathAddressingEngine, transport: InMemoryTransport
     ):
         transport.files["old.txt"] = b"old"
         transport.files["new.txt"] = b"new"
@@ -355,7 +353,7 @@ class TestPathAddressingEngineRename:
 class TestPathAddressingEngineBulkDownload:
     """Test _bulk_download_blobs (BackendIOService compat)."""
 
-    def test_bulk_download(self, backend: PathAddressingEngine, transport: InMemoryBlobTransport):
+    def test_bulk_download(self, backend: PathAddressingEngine, transport: InMemoryTransport):
         transport.files["a.txt"] = b"content_a"
         transport.files["b.txt"] = b"content_b"
 
@@ -368,7 +366,7 @@ class TestPathAddressingEngineBulkDownload:
         assert backend._bulk_download_blobs([]) == {}
 
     def test_bulk_download_handles_failures(
-        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
+        self, backend: PathAddressingEngine, transport: InMemoryTransport
     ):
         transport.files["exists.txt"] = b"data"
 
@@ -396,11 +394,11 @@ class TestPathAddressingEnginePrefix:
 class TestPathAddressingEngineName:
     """Test name property and default name generation."""
 
-    def test_custom_name(self, transport: InMemoryBlobTransport):
+    def test_custom_name(self, transport: InMemoryTransport):
         backend = PathAddressingEngine(transport, backend_name="my-path")
         assert backend.name == "my-path"
 
-    def test_default_name(self, transport: InMemoryBlobTransport):
+    def test_default_name(self, transport: InMemoryTransport):
         backend = PathAddressingEngine(transport)
         assert backend.name == "path-memory"
 
@@ -408,9 +406,7 @@ class TestPathAddressingEngineName:
 class TestPathAddressingEngineOffsetWrite:
     """Test offset write (POSIX pwrite semantics) for PAS."""
 
-    def test_offset_write_splice(
-        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
-    ):
+    def test_offset_write_splice(self, backend: PathAddressingEngine, transport: InMemoryTransport):
         """Write at offset splices into existing content."""
         ctx = _make_context("file.txt")
         backend.write_content(b"Hello World", context=ctx)
@@ -420,7 +416,7 @@ class TestPathAddressingEngineOffsetWrite:
         assert data == b"Hello Earth"
 
     def test_offset_write_beyond_eof_zero_fills(
-        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
+        self, backend: PathAddressingEngine, transport: InMemoryTransport
     ):
         """Offset beyond EOF zero-fills the gap."""
         ctx = _make_context("file.txt")
@@ -432,7 +428,7 @@ class TestPathAddressingEngineOffsetWrite:
         assert result.size == 7
 
     def test_offset_zero_unchanged(
-        self, backend: PathAddressingEngine, transport: InMemoryBlobTransport
+        self, backend: PathAddressingEngine, transport: InMemoryTransport
     ):
         """offset=0 (default) behaves as whole-file replace."""
         ctx = _make_context("file.txt")

--- a/tests/unit/backends/test_transport_conformance.py
+++ b/tests/unit/backends/test_transport_conformance.py
@@ -1,7 +1,7 @@
-"""BlobTransport conformance test suite — parametrized across transports.
+"""Transport conformance test suite — parametrized across transports.
 
-Verifies that LocalBlobTransport and VolumeLocalTransport both implement
-the BlobTransport protocol identically from the engine's perspective.
+Verifies that LocalTransport and VolumeLocalTransport both implement
+the Transport protocol identically from the engine's perspective.
 
 Issue #3403: CAS volume packing — transport conformance.
 """
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 import pytest
 
-from nexus.backends.transports.local_transport import LocalBlobTransport
+from nexus.backends.transports.local_transport import LocalTransport
 
 
 def _make_local_transport(tmp_path):
-    return LocalBlobTransport(root_path=tmp_path, fsync=False)
+    return LocalTransport(root_path=tmp_path, fsync=False)
 
 
 def _make_volume_transport(tmp_path):
@@ -26,7 +26,7 @@ def _make_volume_transport(tmp_path):
         pytest.skip("VolumeLocalTransport not available (nexus_fast not built)")
 
 
-@pytest.fixture(params=["local", "volume"], ids=["LocalBlobTransport", "VolumeLocalTransport"])
+@pytest.fixture(params=["local", "volume"], ids=["LocalTransport", "VolumeLocalTransport"])
 def transport(request, tmp_path):
     if request.param == "local":
         return _make_local_transport(tmp_path)
@@ -44,7 +44,7 @@ def volume_transport(tmp_path):
     return _make_volume_transport(tmp_path)
 
 
-# ─── BlobTransport Protocol Conformance ──────────────────────────────────────
+# ─── Transport Protocol Conformance ──────────────────────────────────────
 
 
 class TestPutGetRoundtrip:

--- a/tests/unit/backends/test_volume_integration.py
+++ b/tests/unit/backends/test_volume_integration.py
@@ -230,12 +230,12 @@ class TestCASLocalBackendWithVolumes:
         assert isinstance(entries, list)
 
     def test_fallback_to_local_transport(self, tmp_path):
-        """use_volume_packing=False should use LocalBlobTransport."""
+        """use_volume_packing=False should use LocalTransport."""
         from nexus.backends.storage.cas_local import CASLocalBackend
-        from nexus.backends.transports.local_transport import LocalBlobTransport
+        from nexus.backends.transports.local_transport import LocalTransport
 
         backend = CASLocalBackend(root_path=tmp_path, use_volume_packing=False)
-        assert isinstance(backend._transport, LocalBlobTransport)
+        assert isinstance(backend._transport, LocalTransport)
 
         content = b"fallback test"
         result = backend.write_content(content)

--- a/tests/unit/fs/test_gcs_integration.py
+++ b/tests/unit/fs/test_gcs_integration.py
@@ -40,7 +40,7 @@ class InMemoryBlobStore:
 
     Used to replace the real GCS client/bucket/blob objects in tests.
     Stores blobs as {key: bytes} and provides the minimal interface
-    needed by GCSBlobTransport.
+    needed by GCSTransport.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- `BlobTransport` → `Transport` (protocol)
- `LocalBlobTransport` → `LocalTransport`, `GCSBlobTransport` → `GCSTransport`, `S3BlobTransport` → `S3Transport`, `LLMBlobTransport` → `LLMTransport`
- File renames: `blob_transport.py` → `transport.py`, `llm_blob_transport.py` → `llm_transport.py`
- Method names (`put_blob`, `get_blob`, etc.) kept as-is — renaming would collide with Python builtins
- 25 files updated

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)