### PR TITLE
refactor: delete _enforce_permissions flag from kernel — dispatch is always called

### DIFF
--- a/src/nexus/contracts/wirable_fs.py
+++ b/src/nexus/contracts/wirable_fs.py
@@ -36,7 +36,6 @@ class WirableFS(Protocol):
 
     def sys_read(self, path: str, **kwargs: Any) -> bytes: ...
 
-    _enforce_permissions: bool
     _record_store: "RecordStoreABC | None"
     _init_cred: "OperationContext | None"
     _config: Any

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -107,7 +107,9 @@ class NexusFS(  # type: ignore[misc]
         self._enable_memory_paging = memory.enable_paging
         self._memory_main_capacity = memory.main_capacity
         self._memory_recall_max_age_hours = memory.recall_max_age_hours
-        self._enforce_permissions = permissions.enforce
+        # _enforce_permissions removed — permission enforcement is fully delegated
+        # to KernelDispatch INTERCEPT hooks. PermissionCheckHook holds the flag
+        # internally. No hook = no check = zero overhead (~20ns set lookup).
         self._enforce_zone_isolation = permissions.enforce_zone_isolation
         self.allow_admin_bypass = permissions.allow_admin_bypass
 
@@ -572,23 +574,22 @@ class NexusFS(  # type: ignore[misc]
             # Check if it's an implicit directory first (for optimization)
             is_implicit_dir = self.metadata.is_implicit_directory(path)
 
-            # Issue #1815: permission check via KernelDispatch INTERCEPT hook.
-            # Hook raises PermissionDeniedError to deny.
-            if self._enforce_permissions:
-                from nexus.contracts.exceptions import PermissionDeniedError
-                from nexus.contracts.vfs_hooks import StatHookContext as _SHC
+            # Permission check via KernelDispatch INTERCEPT hook.
+            # No hook registered = no check = zero overhead (~20ns set lookup).
+            from nexus.contracts.exceptions import PermissionDeniedError
+            from nexus.contracts.vfs_hooks import StatHookContext as _SHC
 
-                try:
-                    self._dispatch.intercept_pre_stat(
-                        _SHC(
-                            path=path,
-                            context=ctx,
-                            permission="TRAVERSE" if is_implicit_dir else "READ",
-                            extra={"is_implicit_directory": is_implicit_dir},
-                        )
+            try:
+                self._dispatch.intercept_pre_stat(
+                    _SHC(
+                        path=path,
+                        context=ctx,
+                        permission="TRAVERSE" if is_implicit_dir else "READ",
+                        extra={"is_implicit_directory": is_implicit_dir},
                     )
-                except PermissionDeniedError:
-                    return False
+                )
+            except PermissionDeniedError:
+                return False
 
             # Check metastore entry_type: DT_DIR and DT_MOUNT are directories.
             # This is a fast ~5 us redb read that avoids calling into the backend.
@@ -1404,34 +1405,29 @@ class NexusFS(  # type: ignore[misc]
         if not validated_paths:
             return results
 
-        # Issue #1815: Batch permission check via KernelDispatch INTERCEPT hook.
+        # Batch permission check via KernelDispatch INTERCEPT hook.
+        # No hook = no check = all paths allowed.
         perm_start = time.time()
         allowed_set: set[str]
-        if not self._enforce_permissions:  # type: ignore[attr-defined]  # allowed
-            # Skip permission check if permissions are disabled
-            allowed_set = set(validated_paths)
-        else:
-            try:
-                from nexus.contracts.exceptions import PermissionDeniedError
-                from nexus.contracts.types import OperationContext
-                from nexus.contracts.vfs_hooks import StatHookContext as _SHC
+        try:
+            from nexus.contracts.exceptions import PermissionDeniedError
+            from nexus.contracts.types import OperationContext
+            from nexus.contracts.vfs_hooks import StatHookContext as _SHC
 
-                ctx = self._resolve_cred(context)
-                assert isinstance(ctx, OperationContext), "Context must be OperationContext"
-                allowed: list[str] = []
-                for p in validated_paths:
-                    try:
-                        self._dispatch.intercept_pre_stat(
-                            _SHC(path=p, context=ctx, permission="READ")
-                        )
-                        allowed.append(p)
-                    except PermissionDeniedError:
-                        pass
-                allowed_set = set(allowed)
-            except Exception as e:
-                logger.error("[READ-BULK] Permission check failed: %s", e)
-                if not skip_errors:
-                    raise
+            ctx = self._resolve_cred(context)
+            assert isinstance(ctx, OperationContext), "Context must be OperationContext"
+            allowed: list[str] = []
+            for p in validated_paths:
+                try:
+                    self._dispatch.intercept_pre_stat(_SHC(path=p, context=ctx, permission="READ"))
+                    allowed.append(p)
+                except PermissionDeniedError:
+                    pass
+            allowed_set = set(allowed)
+        except Exception as e:
+            logger.error("[READ-BULK] Permission check failed: %s", e)
+            if not skip_errors:
+                raise
                 # If skip_errors, assume no files are allowed
                 allowed_set = set()
 
@@ -3602,24 +3598,23 @@ class NexusFS(  # type: ignore[misc]
         # Issue #1815: permission check via KernelDispatch INTERCEPT hook.
         ctx = self._resolve_cred(context)
         if is_implicit_dir:
-            if self._enforce_permissions:  # type: ignore[attr-defined]  # allowed
-                from nexus.contracts.exceptions import PermissionDeniedError
-                from nexus.contracts.vfs_hooks import StatHookContext as _SHC
+            from nexus.contracts.exceptions import PermissionDeniedError
+            from nexus.contracts.vfs_hooks import StatHookContext as _SHC
 
-                try:
-                    self._dispatch.intercept_pre_stat(
-                        _SHC(
-                            path=path,
-                            context=ctx,
-                            permission="TRAVERSE",
-                            extra={"is_implicit_directory": True},
-                        )
+            try:
+                self._dispatch.intercept_pre_stat(
+                    _SHC(
+                        path=path,
+                        context=ctx,
+                        permission="TRAVERSE",
+                        extra={"is_implicit_directory": True},
                     )
-                except PermissionDeniedError:
-                    raise PermissionError(
-                        f"Access denied: User '{ctx.user_id}' does not have TRAVERSE "
-                        f"permission for '{path}'"
-                    ) from None
+                )
+            except PermissionDeniedError:
+                raise PermissionError(
+                    f"Access denied: User '{ctx.user_id}' does not have TRAVERSE "
+                    f"permission for '{path}'"
+                ) from None
         else:
             from nexus.contracts.vfs_hooks import ReadHookContext as _RHC
 
@@ -3724,34 +3719,29 @@ class NexusFS(  # type: ignore[misc]
         if not validated_paths:
             return results
 
-        # Issue #1815: Batch permission check via KernelDispatch INTERCEPT hook.
+        # Batch permission check via KernelDispatch INTERCEPT hook.
         perm_start = time.time()
         allowed_set: set[str]
-        if not self._enforce_permissions:  # type: ignore[attr-defined]  # allowed
-            allowed_set = set(validated_paths)
-        else:
-            try:
-                from nexus.contracts.exceptions import PermissionDeniedError
-                from nexus.contracts.types import OperationContext
-                from nexus.contracts.vfs_hooks import StatHookContext as _SHC
+        try:
+            from nexus.contracts.exceptions import PermissionDeniedError
+            from nexus.contracts.types import OperationContext
+            from nexus.contracts.vfs_hooks import StatHookContext as _SHC
 
-                ctx = self._resolve_cred(context)
-                assert isinstance(ctx, OperationContext), "Context must be OperationContext"
-                allowed: list[str] = []
-                for p in validated_paths:
-                    try:
-                        self._dispatch.intercept_pre_stat(
-                            _SHC(path=p, context=ctx, permission="READ")
-                        )
-                        allowed.append(p)
-                    except PermissionDeniedError:
-                        pass
-                allowed_set = set(allowed)
-            except Exception as e:
-                logger.error("[STAT-BULK] Permission check failed: %s", e)
-                if not skip_errors:
-                    raise
-                allowed_set = set()
+            ctx = self._resolve_cred(context)
+            assert isinstance(ctx, OperationContext), "Context must be OperationContext"
+            allowed: list[str] = []
+            for p in validated_paths:
+                try:
+                    self._dispatch.intercept_pre_stat(_SHC(path=p, context=ctx, permission="READ"))
+                    allowed.append(p)
+                except PermissionDeniedError:
+                    pass
+            allowed_set = set(allowed)
+        except Exception as e:
+            logger.error("[STAT-BULK] Permission check failed: %s", e)
+            if not skip_errors:
+                raise
+            allowed_set = set()
 
         perm_elapsed = time.time() - perm_start
         logger.info(
@@ -3846,22 +3836,21 @@ class NexusFS(  # type: ignore[misc]
             is_implicit_dir = self.metadata.is_implicit_directory(path)
 
             # Issue #1815: permission check via KernelDispatch INTERCEPT hook.
-            if self._enforce_permissions:  # type: ignore[attr-defined]  # allowed
-                from nexus.contracts.exceptions import PermissionDeniedError
-                from nexus.contracts.vfs_hooks import AccessHookContext as _AHC
+            from nexus.contracts.exceptions import PermissionDeniedError
+            from nexus.contracts.vfs_hooks import AccessHookContext as _AHC
 
-                ctx = self._resolve_cred(context)
-                try:
-                    self._dispatch.intercept_pre_access(
-                        _AHC(
-                            path=path,
-                            context=ctx,
-                            permission="TRAVERSE" if is_implicit_dir else "READ",
-                            extra={"is_implicit_directory": is_implicit_dir},
-                        )
+            ctx = self._resolve_cred(context)
+            try:
+                self._dispatch.intercept_pre_access(
+                    _AHC(
+                        path=path,
+                        context=ctx,
+                        permission="TRAVERSE" if is_implicit_dir else "READ",
+                        extra={"is_implicit_directory": is_implicit_dir},
                     )
-                except PermissionDeniedError:
-                    return False
+                )
+            except PermissionDeniedError:
+                return False
 
             # Check if file exists explicitly
             if self.metadata.exists(path):
@@ -3967,19 +3956,18 @@ class NexusFS(  # type: ignore[misc]
                     results[path] = None
                     continue
 
-                # Permission check via KernelDispatch INTERCEPT (like all other syscalls)
-                if self._enforce_permissions:  # type: ignore[attr-defined]  # allowed
-                    from nexus.contracts.exceptions import PermissionDeniedError
-                    from nexus.contracts.vfs_hooks import StatHookContext as _SHC
+                # Permission check via KernelDispatch INTERCEPT.
+                from nexus.contracts.exceptions import PermissionDeniedError
+                from nexus.contracts.vfs_hooks import StatHookContext as _SHC
 
-                    ctx = self._resolve_cred(context)
-                    try:
-                        self._dispatch.intercept_pre_stat(
-                            _SHC(path=path, context=ctx, permission="READ")
-                        )
-                    except PermissionDeniedError:
-                        results[path] = None
-                        continue
+                ctx = self._resolve_cred(context)
+                try:
+                    self._dispatch.intercept_pre_stat(
+                        _SHC(path=path, context=ctx, permission="READ")
+                    )
+                except PermissionDeniedError:
+                    results[path] = None
+                    continue
 
                 # Check if it's a directory
                 is_dir = await self.sys_is_directory(path, context=context)  # type: ignore[attr-defined]  # allowed

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -114,7 +114,7 @@ async def _wire_services(
         permission_enforcer=_svc.get("permission_enforcer"),
         metadata_store=nx.metadata,
         default_context=nx._init_cred,
-        enforce_permissions=nx._enforce_permissions,
+        enforce_permissions=nx._perm_config.enforce,
     )
 
     # --- Boot wired services → register into ServiceRegistry ---

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -70,7 +70,7 @@ async def _boot_post_kernel_services(
 
         rebac_service = ReBACService(
             rebac_manager=services.get("rebac_manager"),
-            enforce_permissions=nx._enforce_permissions,
+            enforce_permissions=nx._perm_config.enforce,
             enable_audit_logging=True,
             circuit_breaker=services.get("rebac_circuit_breaker"),
             file_reader=nx.sys_read,
@@ -242,7 +242,7 @@ async def _boot_post_kernel_services(
 
             share_link_service = ShareLinkService(
                 gateway=gateway,
-                enforce_permissions=nx._enforce_permissions,
+                enforce_permissions=nx._perm_config.enforce,
             )
             logger.debug("[BOOT:WIRED] ShareLinkService created")
         except Exception as exc:

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -194,7 +194,7 @@ async def _boot_post_kernel_services(
             permission_enforcer=services.get("permission_enforcer"),
             router=router,
             rebac_manager=services.get("rebac_manager"),
-            enforce_permissions=getattr(nx, "_enforce_permissions", True),
+            enforce_permissions=nx._perm_config.enforce,
             default_context=nx._init_cred,
             record_store=getattr(nx, "_record_store", None),
             gateway=gateway,

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -354,7 +354,7 @@ async def _register_vfs_hooks(
 
         # Permission write leases — check once, write many (Issue #3394)
         _lease_table = None
-        if nx._enforce_permissions:
+        if nx._perm_config.enforce:
             from nexus.bricks.rebac.cache.permission_lease import PermissionLeaseTable
 
             _lease_table = PermissionLeaseTable()
@@ -369,7 +369,7 @@ async def _register_vfs_hooks(
             checker=permission_checker,
             metadata_store=nx.metadata,
             default_context=nx._init_cred,
-            enforce_permissions=nx._enforce_permissions,
+            enforce_permissions=nx._perm_config.enforce,
             permission_enforcer=_ss.get("permission_enforcer"),
             descendant_checker=nx.service("descendant_checker"),
             lease_table=_lease_table,

--- a/src/nexus/server/api/core/health.py
+++ b/src/nexus/server/api/core/health.py
@@ -37,7 +37,7 @@ async def health_check(request: Request) -> HealthResponse | Any:
 
     nx_fs = request.app.state.nexus_fs
     if nx_fs:
-        enforce_permissions = getattr(nx_fs, "_enforce_permissions", None)
+        enforce_permissions = getattr(getattr(nx_fs, "_perm_config", None), "enforce", None)
         enforce_zone_isolation = getattr(nx_fs, "_enforce_zone_isolation", None)
 
         # Federation mode: ensure topology is initialized (standard Raft lifecycle).


### PR DESCRIPTION
## Summary

Remove `_enforce_permissions` from NexusFS kernel. KernelDispatch is now always called on every syscall path — empty hook list = zero overhead (~20ns set lookup via `_hooks_nonempty` set).

- Delete `self._enforce_permissions = permissions.enforce` from `NexusFS.__init__`
- Remove 6 `if self._enforce_permissions:` guards from syscall paths (sys_access, sys_readdir, metadata_batch, etc.)
- Factory reads config via `nx._perm_config.enforce` instead of kernel attribute
- PermissionCheckHook holds the enforce flag internally; `enforce=False` → hook returns early (no-op)
- Update `wirable_fs.py` contract, `health.py` status endpoint

Completes Phase 4 Part F — the last item from the service injection cleanup plan.

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py tests/unit/core/test_minimal_boot_mode.py` — 84 passed
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)