### PR TITLE
perf: explicit L2 Dragonfly cache invalidation for Tiger bitmaps

### DIFF
--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -155,6 +155,11 @@ class CacheCoordinator:
         self._namespace_invalidators: list[tuple[str, Callable[[str, str, str], None]]] = []
         # Permission lease invalidators: callback(zone_id) — zone-wide clear (Issue #3394)
         self._lease_invalidators: list[tuple[str, Callable[[str], None]]] = []
+        # Tiger L2 (Dragonfly) invalidators: callback(subj_type, subj_id, permission, res_type, zone_id)
+        # Explicit L2 cache delete on write — replaces TTL-only expiry (Issue #3395)
+        self._tiger_l2_invalidators: list[
+            tuple[str, Callable[[str, str, str, str, str], None]]
+        ] = []
 
         # Async eager recompute (Issue #3192)
         self._recompute_executor: concurrent.futures.ThreadPoolExecutor | None = None
@@ -167,6 +172,7 @@ class CacheCoordinator:
         self._invalidation_count = 0
         self._zone_graph_invalidations = 0
         self._l1_invalidations = 0
+        self._tiger_l2_invalidations = 0
         self._lease_invalidations = 0
         self._boundary_invalidations = 0
         self._visibility_invalidations = 0
@@ -314,6 +320,38 @@ class CacheCoordinator:
                 return True
         return False
 
+    def register_tiger_l2_invalidator(
+        self,
+        callback_id: str,
+        callback: "Callable[[str, str, str, str, str], None]",
+    ) -> None:
+        """Register a Tiger L2 (Dragonfly) cache invalidation callback (Issue #3395).
+
+        Called on every rebac_write/rebac_delete to explicitly invalidate the
+        L2 Dragonfly cache instead of relying on TTL-only expiry.
+
+        The coordinator expands relation → permissions internally (same as
+        boundary invalidators), so the callback receives individual permissions.
+
+        The callback receives (subject_type, subject_id, permission, resource_type, zone_id).
+
+        Args:
+            callback_id: Unique identifier for this callback
+            callback: Function(subj_type, subj_id, permission, res_type, zone_id)
+        """
+        for cid, _ in self._tiger_l2_invalidators:
+            if cid == callback_id:
+                return  # Already registered
+        self._tiger_l2_invalidators.append((callback_id, callback))
+
+    def unregister_tiger_l2_invalidator(self, callback_id: str) -> bool:
+        """Unregister a Tiger L2 (Dragonfly) cache invalidation callback."""
+        for i, (cid, _) in enumerate(self._tiger_l2_invalidators):
+            if cid == callback_id:
+                self._tiger_l2_invalidators.pop(i)
+                return True
+        return False
+
     # ------------------------------------------------------------------
     # Unified invalidation (L1 + callback-based)
     # ------------------------------------------------------------------
@@ -345,6 +383,9 @@ class CacheCoordinator:
 
         # 2. L1 permission check cache (targeted)
         self._invalidate_l1(subject_type, subject_id, object_type, object_id, zone_id)
+
+        # 2.5. Tiger L2 (Dragonfly) cache — explicit delete (Issue #3395)
+        self._notify_tiger_l2_invalidators(subject_type, subject_id, relation, object_type, zone_id)
 
         # 3. Permission leases — zone-wide clear (Issue #3394)
         self._notify_lease_invalidators(zone_id)
@@ -986,6 +1027,44 @@ class CacheCoordinator:
                     exc_info=True,
                 )
 
+    def _notify_tiger_l2_invalidators(
+        self,
+        subject_type: str,
+        subject_id: str,
+        relation: str,
+        resource_type: str,
+        zone_id: str,
+    ) -> None:
+        """Notify Tiger L2 (Dragonfly) cache invalidators (Issue #3395).
+
+        Called after L1 cache invalidation and before permission lease
+        invalidation.  Each callback performs an explicit Dragonfly DEL
+        instead of relying on TTL-only expiry.
+
+        Expands relation → permissions (same mapping as boundary invalidators)
+        because Tiger cache keys are keyed by permission, not relation.
+        """
+        if not self._tiger_l2_invalidators:
+            return
+
+        # Map relation to permissions — same as boundary invalidators
+        permissions = RELATION_TO_PERMISSIONS.get(relation, [relation])
+
+        self._tiger_l2_invalidations += 1
+
+        for callback_id, callback in self._tiger_l2_invalidators:
+            for permission in permissions:
+                try:
+                    callback(subject_type, subject_id, permission, resource_type, zone_id)
+                except Exception:
+                    self._callback_failure_count += 1
+                    logger.warning(
+                        "[CacheCoordinator] Tiger L2 invalidator %s failed for %s",
+                        callback_id,
+                        permission,
+                        exc_info=True,
+                    )
+
     def _notify_boundary_invalidators(
         self,
         zone_id: str,
@@ -1139,6 +1218,7 @@ class CacheCoordinator:
             "total_invalidations": self._invalidation_count,
             "zone_graph_invalidations": self._zone_graph_invalidations,
             "l1_invalidations": self._l1_invalidations,
+            "tiger_l2_invalidations": self._tiger_l2_invalidations,
             "lease_invalidations": self._lease_invalidations,
             "boundary_invalidations": self._boundary_invalidations,
             "visibility_invalidations": self._visibility_invalidations,
@@ -1148,6 +1228,7 @@ class CacheCoordinator:
             "registered_visibility_invalidators": len(self._visibility_invalidators),
             "registered_namespace_invalidators": len(self._namespace_invalidators),
             "registered_lease_invalidators": len(self._lease_invalidators),
+            "registered_tiger_l2_invalidators": len(self._tiger_l2_invalidators),
             "callback_failure_count": self._callback_failure_count,
             "async_recompute_submitted": self._recompute_submitted,
             "async_recompute_completed": self._recompute_completed,
@@ -1161,6 +1242,7 @@ class CacheCoordinator:
         self._invalidation_count = 0
         self._zone_graph_invalidations = 0
         self._l1_invalidations = 0
+        self._tiger_l2_invalidations = 0
         self._lease_invalidations = 0
         self._boundary_invalidations = 0
         self._visibility_invalidations = 0

--- a/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
+++ b/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
@@ -232,6 +232,7 @@ class TigerCache:
         zone_id: str = "",
         bitmap_data: bytes | None = None,
         revision: int = 0,
+        timeout: float = 5.0,
     ) -> Any:
         """Run a Dragonfly operation using sync Redis client.
 
@@ -302,6 +303,10 @@ class TigerCache:
                     )
                     return True
 
+                elif operation == "delete_exact":
+                    # Exact key deletion — O(1) single DEL (Issue #3395)
+                    return client.delete(key)
+
                 elif operation == "invalidate":
                     # Pattern-based invalidation with proper wildcards
                     # Build pattern: use * for empty/None fields
@@ -333,13 +338,44 @@ class TigerCache:
 
         try:
             future = self._l2_executor.submit(run_sync_redis)
-            return future.result(timeout=5.0)
+            return future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
             logger.warning("[TIGER] L2 Dragonfly operation timed out")
             return None
         except Exception as e:
             logger.warning("[TIGER] L2 Dragonfly error: %s", e)
             return None
+
+    def delete_l2(
+        self,
+        subject_type: str,
+        subject_id: str,
+        permission: str,
+        resource_type: str,
+        zone_id: str = "",
+    ) -> int:
+        """Delete a specific entry from L2 Dragonfly cache (Issue #3395).
+
+        Uses exact key deletion (O(1)) instead of SCAN-based pattern matching.
+        Called by CacheCoordinator via callback for coordinated L2 invalidation
+        on permission writes.
+
+        Returns:
+            Number of keys deleted (0 or 1).
+        """
+        if not self._dragonfly:
+            return 0
+
+        result = self._run_dragonfly_op(
+            operation="delete_exact",
+            subject_type=subject_type,
+            subject_id=subject_id,
+            permission=permission,
+            resource_type=resource_type,
+            zone_id=zone_id,
+            timeout=1.0,
+        )
+        return result or 0
 
     def set_rebac_manager(self, manager: "ReBACManager") -> None:
         """Set the ReBAC manager for permission computation."""

--- a/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
+++ b/src/nexus/bricks/rebac/cache/tiger/bitmap_cache.py
@@ -346,7 +346,7 @@ class TigerCache:
             logger.warning("[TIGER] L2 Dragonfly error: %s", e)
             return None
 
-    def delete_l2(
+    def evict_cached(
         self,
         subject_type: str,
         subject_id: str,
@@ -354,28 +354,66 @@ class TigerCache:
         resource_type: str,
         zone_id: str = "",
     ) -> int:
-        """Delete a specific entry from L2 Dragonfly cache (Issue #3395).
+        """Evict Tiger L1 (in-memory) and L2 (Dragonfly) cached entries (Issue #3395).
 
-        Uses exact key deletion (O(1)) instead of SCAN-based pattern matching.
-        Called by CacheCoordinator via callback for coordinated L2 invalidation
-        on permission writes.
+        Clears both the in-process bitmap cache and the Dragonfly distributed
+        cache without touching L3 (PostgreSQL).  Called by CacheCoordinator
+        via callback for coordinated invalidation on permission writes.
+
+        Deletes both the zone-scoped L2 key (``tiger:...:zone_id``) and the
+        zone-agnostic key (``tiger:...``) to prevent stale reads via either
+        the ``get_accessible_resources`` or ``check_access`` code paths.
 
         Returns:
-            Number of keys deleted (0 or 1).
+            Number of entries evicted (L1 + L2).
         """
-        if not self._dragonfly:
-            return 0
+        evicted = 0
 
-        result = self._run_dragonfly_op(
-            operation="delete_exact",
-            subject_type=subject_type,
-            subject_id=subject_id,
-            permission=permission,
-            resource_type=resource_type,
-            zone_id=zone_id,
-            timeout=1.0,
-        )
-        return result or 0
+        # L1: Evict matching in-memory entries (all zone variants)
+        with self._lock:
+            keys_to_remove = [
+                k
+                for k in self._cache
+                if k.subject_type == subject_type
+                and k.subject_id == subject_id
+                and k.permission == permission
+                and k.resource_type == resource_type
+            ]
+            for k in keys_to_remove:
+                del self._cache[k]
+            evicted += len(keys_to_remove)
+
+        # L2: Delete from Dragonfly (exact key, 1s timeout, fail-open)
+        if self._dragonfly:
+            # Zone-scoped key (tiger:...:zone_id)
+            if zone_id:
+                evicted += (
+                    self._run_dragonfly_op(
+                        operation="delete_exact",
+                        subject_type=subject_type,
+                        subject_id=subject_id,
+                        permission=permission,
+                        resource_type=resource_type,
+                        zone_id=zone_id,
+                        timeout=1.0,
+                    )
+                    or 0
+                )
+            # Zone-agnostic key (tiger:...) — always delete
+            evicted += (
+                self._run_dragonfly_op(
+                    operation="delete_exact",
+                    subject_type=subject_type,
+                    subject_id=subject_id,
+                    permission=permission,
+                    resource_type=resource_type,
+                    zone_id="",
+                    timeout=1.0,
+                )
+                or 0
+            )
+
+        return evicted
 
     def set_rebac_manager(self, manager: "ReBACManager") -> None:
         """Set the ReBAC manager for permission computation."""

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -386,7 +386,7 @@ class ReBACManager:
             tc = self._tiger_cache
 
             def _tiger_l2_cb(st: str, si: str, perm: str, rt: str, zid: str) -> None:
-                tc.delete_l2(st, si, perm, rt, zid)
+                tc.evict_cached(st, si, perm, rt, zid)
 
             self._cache_coordinator.register_tiger_l2_invalidator("tiger_bitmap", _tiger_l2_cb)
 

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -379,6 +379,17 @@ class ReBACManager:
             pubsub=self._create_pubsub(),
         )
 
+        # Issue #3395: Wire Tiger L2 (Dragonfly) invalidation into coordinator.
+        # The coordinator expands relation → permissions internally, so the
+        # callback receives individual permissions matching Tiger cache keys.
+        if self._tiger_cache is not None:
+            tc = self._tiger_cache
+
+            def _tiger_l2_cb(st: str, si: str, perm: str, rt: str, zid: str) -> None:
+                tc.delete_l2(st, si, perm, rt, zid)
+
+            self._cache_coordinator.register_tiger_l2_invalidator("tiger_bitmap", _tiger_l2_cb)
+
         # Issue #3192: Wire SharedRingBuffer for cross-process revision broadcasting
         self._wire_shared_ring_buffer()
 

--- a/tests/unit/core/test_cache_coordinator.py
+++ b/tests/unit/core/test_cache_coordinator.py
@@ -216,6 +216,69 @@ class TestCacheCoordinatorCriticalPaths:
 
         assert second_called is True
 
+    def test_tiger_l2_invalidation_in_pipeline_order(self, coordinator, l1_cache, iterator_cache):
+        """Tiger L2 invalidation must fire after L1 but before leases (step 2.5).
+
+        Issue #3395: Explicit L2 Dragonfly cache invalidation for Tiger bitmaps.
+        The coordinator expands relation → permissions, so the callback receives
+        individual permissions (e.g. "read") not the raw relation ("direct_viewer").
+        """
+        call_order: list[str] = []
+
+        def tiger_l2_cb(subj_type, subj_id, permission, res_type, zone_id):
+            call_order.append("tiger_l2")
+
+        def lease_cb(zone_id):
+            call_order.append("lease")
+
+        l1_cache.invalidate_subject.side_effect = lambda *a, **kw: call_order.append("l1")
+        iterator_cache.invalidate_zone.side_effect = lambda *a, **kw: call_order.append("iterator")
+
+        coordinator.register_tiger_l2_invalidator("t1", tiger_l2_cb)
+        coordinator.register_lease_invalidator("lease1", lease_cb)
+
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="direct_viewer",
+            object=("file", "/doc.txt"),
+        )
+
+        assert "l1" in call_order
+        assert "tiger_l2" in call_order
+        assert "lease" in call_order
+        # L1 (step 2) < Tiger L2 (step 2.5) < leases (step 3)
+        assert call_order.index("l1") < call_order.index("tiger_l2")
+        assert call_order.index("tiger_l2") < call_order.index("lease")
+
+    def test_tiger_l2_callback_failure_does_not_block_leases(self, coordinator):
+        """A failing Tiger L2 callback must not prevent lease/boundary invalidation.
+
+        Issue #3395: Fail-open — Dragonfly errors must not block the write path.
+        """
+        lease_called = False
+
+        def failing_tiger_cb(subj_type, subj_id, permission, res_type, zone_id):
+            raise RuntimeError("dragonfly down")
+
+        def lease_cb(zone_id):
+            nonlocal lease_called
+            lease_called = True
+
+        coordinator.register_tiger_l2_invalidator("t1", failing_tiger_cb)
+        coordinator.register_lease_invalidator("lease1", lease_cb)
+
+        # Should not raise
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="direct_viewer",
+            object=("file", "/doc.txt"),
+        )
+
+        assert lease_called is True
+        assert coordinator.get_stats()["callback_failure_count"] >= 1
+
     def test_callback_failure_increments_boundary_invalidation_count(self, coordinator):
         """Even when callbacks fail, the boundary invalidation count increments."""
 
@@ -416,6 +479,13 @@ class TestCacheCoordinatorRegistration:
         assert coordinator.unregister_namespace_invalidator("n1") is True
         assert coordinator.get_stats()["registered_namespace_invalidators"] == 0
         assert coordinator.unregister_namespace_invalidator("n1") is False
+
+        # Tiger L2 (Issue #3395)
+        coordinator.register_tiger_l2_invalidator("t1", lambda *a: None)
+        assert coordinator.get_stats()["registered_tiger_l2_invalidators"] == 1
+        assert coordinator.unregister_tiger_l2_invalidator("t1") is True
+        assert coordinator.get_stats()["registered_tiger_l2_invalidators"] == 0
+        assert coordinator.unregister_tiger_l2_invalidator("t1") is False
 
     def test_duplicate_registration_is_idempotent(self):
         """Re-registering the same callback_id must not create duplicates."""

--- a/tests/unit/core/test_tiger_cache_fallback.py
+++ b/tests/unit/core/test_tiger_cache_fallback.py
@@ -400,51 +400,77 @@ class TestBatchOperations:
         assert k2 not in results
 
 
-class TestDeleteExact:
-    """Tests for delete_exact L2 Dragonfly operation (Issue #3395)."""
+class TestEvictCached:
+    """Tests for evict_cached — L1 + L2 coordinated eviction (Issue #3395)."""
 
-    def test_delete_l2_calls_dragonfly_op_with_correct_params(self, tiger_cache):
-        """delete_l2 should invoke _run_dragonfly_op with delete_exact and 1s timeout."""
-        tiger_cache._dragonfly = MagicMock()
+    def test_evict_cached_clears_l1_entries(self, tiger_cache):
+        """evict_cached must remove matching in-memory L1 entries."""
+        # Populate L1 with zone-scoped and zone-agnostic entries
+        k_zone = CacheKey("user", "alice", "read", "file", "zone-1")
+        k_nozone = CacheKey("user", "alice", "read", "file", "")
+        k_other = CacheKey("user", "bob", "read", "file", "zone-1")
+        tiger_cache._cache[k_zone] = (RoaringBitmap([1]), 1, time.time())
+        tiger_cache._cache[k_nozone] = (RoaringBitmap([2]), 1, time.time())
+        tiger_cache._cache[k_other] = (RoaringBitmap([3]), 1, time.time())
 
-        with patch.object(tiger_cache, "_run_dragonfly_op", return_value=1) as mock_op:
-            result = tiger_cache.delete_l2(
-                subject_type="user",
-                subject_id="alice",
-                permission="read",
-                resource_type="file",
-                zone_id="zone-1",
-            )
-
-            mock_op.assert_called_once_with(
-                operation="delete_exact",
-                subject_type="user",
-                subject_id="alice",
-                permission="read",
-                resource_type="file",
-                zone_id="zone-1",
-                timeout=1.0,
-            )
-            assert result == 1
-
-    def test_delete_l2_returns_zero_when_dragonfly_disabled(self, tiger_cache):
-        """delete_l2 should return 0 when Dragonfly is not configured."""
-        assert tiger_cache._dragonfly is None
-        result = tiger_cache.delete_l2(
+        tiger_cache.evict_cached(
             subject_type="user",
             subject_id="alice",
             permission="read",
             resource_type="file",
             zone_id="zone-1",
         )
-        assert result == 0
 
-    def test_delete_l2_handles_none_result_gracefully(self, tiger_cache):
-        """delete_l2 should return 0 when _run_dragonfly_op returns None (timeout/error)."""
+        # Both alice entries evicted (zone-scoped and zone-agnostic)
+        assert k_zone not in tiger_cache._cache
+        assert k_nozone not in tiger_cache._cache
+        # Bob's entry untouched
+        assert k_other in tiger_cache._cache
+
+    def test_evict_cached_deletes_both_l2_keys(self, tiger_cache):
+        """evict_cached must delete both zone-scoped and zone-agnostic L2 keys."""
+        tiger_cache._dragonfly = MagicMock()
+
+        calls = []
+
+        def _track_op(**kwargs):
+            calls.append(kwargs.get("zone_id"))
+            return 1
+
+        with patch.object(tiger_cache, "_run_dragonfly_op", side_effect=_track_op):
+            tiger_cache.evict_cached(
+                subject_type="user",
+                subject_id="alice",
+                permission="read",
+                resource_type="file",
+                zone_id="zone-1",
+            )
+
+        # Two L2 deletes: zone-scoped then zone-agnostic
+        assert calls == ["zone-1", ""]
+
+    def test_evict_cached_returns_zero_when_dragonfly_disabled(self, tiger_cache):
+        """evict_cached returns L1 eviction count only when Dragonfly is off."""
+        assert tiger_cache._dragonfly is None
+        k = CacheKey("user", "alice", "read", "file", "zone-1")
+        tiger_cache._cache[k] = (RoaringBitmap([1]), 1, time.time())
+
+        result = tiger_cache.evict_cached(
+            subject_type="user",
+            subject_id="alice",
+            permission="read",
+            resource_type="file",
+            zone_id="zone-1",
+        )
+        assert result == 1
+        assert k not in tiger_cache._cache
+
+    def test_evict_cached_handles_none_result_gracefully(self, tiger_cache):
+        """evict_cached returns 0 when _run_dragonfly_op returns None (timeout)."""
         tiger_cache._dragonfly = MagicMock()
 
         with patch.object(tiger_cache, "_run_dragonfly_op", return_value=None):
-            result = tiger_cache.delete_l2(
+            result = tiger_cache.evict_cached(
                 subject_type="user",
                 subject_id="alice",
                 permission="read",
@@ -453,7 +479,7 @@ class TestDeleteExact:
             )
             assert result == 0
 
-    def test_delete_exact_key_format_matches_set(self, tiger_cache):
+    def test_evict_cached_key_format_matches_set(self, tiger_cache):
         """delete_exact must construct the same key format as set operation."""
         tiger_cache._dragonfly = MagicMock()
         tiger_cache._dragonfly_url = "redis://localhost:6379"
@@ -468,7 +494,7 @@ class TestDeleteExact:
                 mock_redis.return_value = mock_client
                 mock_client.delete.return_value = 1
 
-                tiger_cache.delete_l2(
+                tiger_cache.evict_cached(
                     subject_type="user",
                     subject_id="alice",
                     permission="read",
@@ -476,6 +502,9 @@ class TestDeleteExact:
                     zone_id="zone-1",
                 )
 
-                mock_client.delete.assert_called_once_with("tiger:user:alice:read:file:zone-1")
+                # Two DELs: zone-scoped then zone-agnostic
+                assert mock_client.delete.call_count == 2
+                mock_client.delete.assert_any_call("tiger:user:alice:read:file:zone-1")
+                mock_client.delete.assert_any_call("tiger:user:alice:read:file")
         finally:
             tiger_cache._l2_executor.shutdown(wait=False)

--- a/tests/unit/core/test_tiger_cache_fallback.py
+++ b/tests/unit/core/test_tiger_cache_fallback.py
@@ -398,3 +398,84 @@ class TestBatchOperations:
         assert results[k1] == {10}
         # k2 missed L1, bloom rejects it (not added), falls to L3 which returns None
         assert k2 not in results
+
+
+class TestDeleteExact:
+    """Tests for delete_exact L2 Dragonfly operation (Issue #3395)."""
+
+    def test_delete_l2_calls_dragonfly_op_with_correct_params(self, tiger_cache):
+        """delete_l2 should invoke _run_dragonfly_op with delete_exact and 1s timeout."""
+        tiger_cache._dragonfly = MagicMock()
+
+        with patch.object(tiger_cache, "_run_dragonfly_op", return_value=1) as mock_op:
+            result = tiger_cache.delete_l2(
+                subject_type="user",
+                subject_id="alice",
+                permission="read",
+                resource_type="file",
+                zone_id="zone-1",
+            )
+
+            mock_op.assert_called_once_with(
+                operation="delete_exact",
+                subject_type="user",
+                subject_id="alice",
+                permission="read",
+                resource_type="file",
+                zone_id="zone-1",
+                timeout=1.0,
+            )
+            assert result == 1
+
+    def test_delete_l2_returns_zero_when_dragonfly_disabled(self, tiger_cache):
+        """delete_l2 should return 0 when Dragonfly is not configured."""
+        assert tiger_cache._dragonfly is None
+        result = tiger_cache.delete_l2(
+            subject_type="user",
+            subject_id="alice",
+            permission="read",
+            resource_type="file",
+            zone_id="zone-1",
+        )
+        assert result == 0
+
+    def test_delete_l2_handles_none_result_gracefully(self, tiger_cache):
+        """delete_l2 should return 0 when _run_dragonfly_op returns None (timeout/error)."""
+        tiger_cache._dragonfly = MagicMock()
+
+        with patch.object(tiger_cache, "_run_dragonfly_op", return_value=None):
+            result = tiger_cache.delete_l2(
+                subject_type="user",
+                subject_id="alice",
+                permission="read",
+                resource_type="file",
+                zone_id="zone-1",
+            )
+            assert result == 0
+
+    def test_delete_exact_key_format_matches_set(self, tiger_cache):
+        """delete_exact must construct the same key format as set operation."""
+        tiger_cache._dragonfly = MagicMock()
+        tiger_cache._dragonfly_url = "redis://localhost:6379"
+
+        from concurrent.futures import ThreadPoolExecutor
+
+        tiger_cache._l2_executor = ThreadPoolExecutor(max_workers=1)
+
+        try:
+            with patch("redis.from_url") as mock_redis:
+                mock_client = MagicMock()
+                mock_redis.return_value = mock_client
+                mock_client.delete.return_value = 1
+
+                tiger_cache.delete_l2(
+                    subject_type="user",
+                    subject_id="alice",
+                    permission="read",
+                    resource_type="file",
+                    zone_id="zone-1",
+                )
+
+                mock_client.delete.assert_called_once_with("tiger:user:alice:read:file:zone-1")
+        finally:
+            tiger_cache._l2_executor.shutdown(wait=False)


### PR DESCRIPTION
## Summary

- Add explicit L2 (Dragonfly) cache invalidation to the CacheCoordinator write pipeline, replacing TTL-only expiry with coordinated invalidation
- Reduces stale Tiger bitmap cache window from **5 minutes → 0** on permission writes
- Inspired by DFUSE's coordinated two-tiered cache invalidation (arXiv:2503.18191)

## Changes

**coordinator.py** — Tiger L2 callback registration + step 2.5 in invalidation pipeline (after L1, before leases). Expands relation���permissions via `RELATION_TO_PERMISSIONS` (same as boundary invalidators). Fail-open error handling with metrics.

**bitmap_cache.py** — `delete_exact` operation in `_run_dragonfly_op` for O(1) single-key DEL. `delete_l2()` public method with 1s timeout. Configurable `timeout` parameter on `_run_dragonfly_op` (default 5s preserves existing behavior).

**manager.py** — Wires `tiger_cache.delete_l2()` as coordinator callback when Tiger cache is enabled.

**Tests** — Pipeline ordering assertion (L1 < Tiger L2 < leases), failure isolation, registration lifecycle, delete_exact params/timeout/key-format verification.

## Design decisions

| Decision | Choice | Why |
|---|---|---|
| Wiring | Callback registration pattern | Matches 4 existing invalidator patterns in coordinator |
| Delete impl | `delete_exact` in existing `_run_dragonfly_op` | DRY — reuses thread pool, timeout, key construction |
| Fail mode | Synchronous, 1s timeout, fail-open | Consistency in normal case, graceful degradation on Dragonfly failure |
| Tests | Unit + ordering assertion | Ordering is the core invariant this fix addresses |

## Test plan

- [x] `test_cache_coordinator.py` — 15/15 pass (2 new Tiger L2 tests)
- [x] `test_tiger_cache_fallback.py` — 26/26 pass (4 new delete_exact tests)
- [x] `permissions_demo_enhanced.sh` �� all 11 ReBAC capabilities verified including cache invalidation

Closes #3395