### PR TITLE
refactor(#1828): wire EC consistency parameter through write() API

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -181,13 +181,20 @@ Tier 2 methods compose Tier 1 syscalls — concrete implementations in `NexusFil
 
 | Half | Examples | Addressing |
 |------|----------|-----------|
-| **VFS half** (POSIX-aligned) | `mkdir()`, `rmdir()`, `read()`, `write()`, `stat()`, `append()`, `edit()`, `read_bulk()`, `write_batch()` | Path-addressed, delegates to `sys_*` |
+| **VFS half** (POSIX-aligned) | `mkdir()`, `rmdir()`, `read()`, `write(consistency=)`, `stat()`, `append()`, `edit()`, `read_bulk()`, `write_batch()` | Path-addressed, delegates to `sys_*` |
 | **HDFS half** (driver-level) | `read_content()`, `write_content()`, `stream()`, `stream_range()`, `write_stream()` | Hash-addressed (etag/CAS), direct to ObjectStoreABC |
 
 The HDFS half bypasses path resolution and metadata lookup — CAS is a driver
 detail. Like HDFS separates ClientProtocol (NameNode, path-based) from
 DataTransferProtocol (DataNode, block-based). The metadata layer above ensures
 etag ownership and zone isolation.
+
+**Consistency parameter** (Issue #1828): `write(consistency=)` accepts ``"sc"``
+(strong consistency, Raft consensus — default) or ``"ec"`` (eventually
+consistent, local-first via EC WAL). EC writes apply locally then replicate
+asynchronously; callers poll ``is_committed(token)`` for replication status.
+The EC WAL (Rust, redb) provides seq/watermark/idempotent-apply primitives.
+EC and Raft log are separate redb trees — EC writes do not bloat Raft consensus log.
 
 ### 2.4 Syscall Extension Model (VFS Dispatch)
 

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -189,9 +189,10 @@ detail. Like HDFS separates ClientProtocol (NameNode, path-based) from
 DataTransferProtocol (DataNode, block-based). The metadata layer above ensures
 etag ownership and zone isolation.
 
-`write(consistency=)` supports ``"sc"`` (Raft consensus, default) or ``"ec"``
-(local-first, async replication via EC WAL). Separate redb trees — EC does not
-bloat the Raft log.
+`write(consistency=)` and `sys_write(consistency=)` support ``"sc"`` (strong
+consistency, default) or ``"ec"`` (eventually consistent, local-first with
+async replication). The kernel ABC defines the contract; drivers decide how
+to implement SC vs EC (e.g. Raft consensus for SC, EC WAL for EC).
 
 ### 2.4 Syscall Extension Model (VFS Dispatch)
 

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -192,7 +192,7 @@ etag ownership and zone isolation.
 **Consistency parameter** (Issue #1828): `write(consistency=)` accepts ``"sc"``
 (strong consistency, Raft consensus — default) or ``"ec"`` (eventually
 consistent, local-first via EC WAL). EC writes apply locally then replicate
-asynchronously; callers poll ``is_committed(token)`` for replication status.
+asynchronously via the background transport loop.
 The EC WAL (Rust, redb) provides seq/watermark/idempotent-apply primitives.
 EC and Raft log are separate redb trees — EC writes do not bloat Raft consensus log.
 

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -189,12 +189,9 @@ detail. Like HDFS separates ClientProtocol (NameNode, path-based) from
 DataTransferProtocol (DataNode, block-based). The metadata layer above ensures
 etag ownership and zone isolation.
 
-**Consistency parameter** (Issue #1828): `write(consistency=)` accepts ``"sc"``
-(strong consistency, Raft consensus — default) or ``"ec"`` (eventually
-consistent, local-first via EC WAL). EC writes apply locally then replicate
-asynchronously via the background transport loop.
-The EC WAL (Rust, redb) provides seq/watermark/idempotent-apply primitives.
-EC and Raft log are separate redb trees — EC writes do not bloat Raft consensus log.
+`write(consistency=)` supports ``"sc"`` (Raft consensus, default) or ``"ec"``
+(local-first, async replication via EC WAL). Separate redb trees — EC does not
+bloat the Raft log.
 
 ### 2.4 Syscall Extension Model (VFS Dispatch)
 

--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -94,6 +94,7 @@ class NexusFilesystemABC(ABC):
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
+        consistency: str = "sc",
     ) -> dict[str, Any]:
         """Write content to a file (POSIX write(2)).
 
@@ -106,6 +107,8 @@ class NexusFilesystemABC(ABC):
             count: Max bytes to write (None = len(buf)).
             offset: Byte offset to start writing at.
             context: Operation context.
+            consistency: Metastore consistency — ``"sc"`` (strong, default)
+                or ``"ec"`` (eventual, local-first). Issue #1828.
 
         Returns:
             Dict with path and bytes_written.
@@ -361,7 +364,7 @@ class NexusFilesystemABC(ABC):
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
-        consistency: str = "sc",  # noqa: ARG002  # used by NexusFS override
+        consistency: str = "sc",
     ) -> dict[str, Any]:
         """Write with metadata update (VFS convenience).
 
@@ -374,13 +377,15 @@ class NexusFilesystemABC(ABC):
             count: Max bytes to write (None = len(buf)).
             offset: Byte offset to start writing at.
             context: Operation context.
-            consistency: Metastore consistency — ``"sc"`` (strong, Raft) or
-                ``"ec"`` (eventual, local-first EC WAL). Issue #1828.
+            consistency: Metastore consistency — ``"sc"`` (strong, default)
+                or ``"ec"`` (eventual, local-first). Issue #1828.
 
         Returns:
             Dict with metadata (etag, version, modified_at, size).
         """
-        await self.sys_write(path, buf, count=count, offset=offset, context=context)
+        await self.sys_write(
+            path, buf, count=count, offset=offset, context=context, consistency=consistency
+        )
         meta = await self.sys_stat(path, context=context)
         return meta or {}
 

--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -361,6 +361,7 @@ class NexusFilesystemABC(ABC):
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
+        consistency: str = "sc",  # noqa: ARG002  # used by NexusFS override
     ) -> dict[str, Any]:
         """Write with metadata update (VFS convenience).
 
@@ -373,6 +374,8 @@ class NexusFilesystemABC(ABC):
             count: Max bytes to write (None = len(buf)).
             offset: Byte offset to start writing at.
             context: Operation context.
+            consistency: Metastore consistency — ``"sc"`` (strong, Raft) or
+                ``"ec"`` (eventual, local-first EC WAL). Issue #1828.
 
         Returns:
             Dict with metadata (etag, version, modified_at, size).

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -2188,6 +2188,7 @@ class NexusFS(  # type: ignore[misc]
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
+        consistency: str = "sc",
     ) -> dict[str, Any]:
         """Write with metadata return (Tier 2 convenience).
 
@@ -2207,6 +2208,10 @@ class NexusFS(  # type: ignore[misc]
             count: Max bytes to write (None = len(buf)).
             offset: Byte offset for partial write (POSIX pwrite semantics, 0=whole-file).
             context: Operation context.
+            consistency: Metastore consistency level — ``"sc"`` (strong, default,
+                Raft consensus) or ``"ec"`` (eventual, local-first via EC WAL).
+                EC writes return immediately and replicate asynchronously.
+                Issue #1828.
 
         Returns:
             Dict with metadata (etag, version, modified_at, size).
@@ -2223,7 +2228,9 @@ class NexusFS(  # type: ignore[misc]
         if _handled:
             return _result
 
-        return await self._write_internal(path=path, content=buf, offset=offset, context=context)
+        return await self._write_internal(
+            path=path, content=buf, offset=offset, context=context, consistency=consistency
+        )
 
     async def _write_internal(
         self,

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1968,6 +1968,7 @@ class NexusFS(  # type: ignore[misc]
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
+        consistency: str = "sc",
     ) -> dict[str, Any]:
         """Write content to a file (POSIX write(2)).
 
@@ -1980,6 +1981,8 @@ class NexusFS(  # type: ignore[misc]
             count: Max bytes to write (None = len(buf)).
             offset: Byte offset for partial write (POSIX pwrite semantics, 0=whole-file).
             context: Optional operation context for permission checks.
+            consistency: Metastore consistency — ``"sc"`` (strong, default)
+                or ``"ec"`` (eventual, local-first). Issue #1828.
 
         Returns:
             Dict with path and bytes_written.
@@ -2041,7 +2044,9 @@ class NexusFS(  # type: ignore[misc]
             raise NexusFileNotFoundError(
                 path, "sys_write requires existing file — use write() for create-on-write"
             )
-        await self._write_internal(path=path, content=buf, offset=offset, context=context)
+        await self._write_internal(
+            path=path, content=buf, offset=offset, context=context, consistency=consistency
+        )
         return {"path": path, "bytes_written": len(buf)}
 
     # ── Tier 2 overrides (NexusFS-specific) ───────────────────────


### PR DESCRIPTION
## Summary
- Add `consistency: str = "sc"` to `NexusFilesystemABC.write()` and `NexusFS.write()`
- Forward to `_write_internal(consistency=)` which already passes to metastore
- Fixes runtime crash: RPC handler passes `consistency=` but `write()` didn't accept it
- Completes end-to-end EC wiring: RPC → write() → _write_internal() → metastore → Rust WAL

## Context
Phase A of Kernel Interface Unification plan. Rust EC WAL is fully implemented (replication_log.rs) but Python API layer was broken — `write()` lacked the `consistency` parameter.

## Changes (3 files)
- `contracts/filesystem/filesystem_abc.py`: Add `consistency` param to ABC `write()`
- `core/nexus_fs.py`: Add `consistency` param to NexusFS `write()`, forward to `_write_internal()`
- `docs/architecture/KERNEL-ARCHITECTURE.md`: Document EC consistency on write (§2.3)

## Test plan
- [ ] All pre-commit hooks pass (ruff, mypy)
- [ ] CI green
- [ ] `grep "consistency" src/nexus/core/nexus_fs.py` shows write() and _write_internal()

🤖 Generated with [Claude Code](https://claude.com/claude-code)