### PR TITLE
perf(#3393): deferred metadata buffer with batched Raft flush

### DIFF
--- a/src/nexus/bricks/rebac/deferred_permission_buffer.py
+++ b/src/nexus/bricks/rebac/deferred_permission_buffer.py
@@ -18,12 +18,11 @@ No WAL or crash recovery needed because:
 """
 
 import logging
-import threading
-import time
-from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.exc import OperationalError
+
+from nexus.lib.deferred_buffer import DeferredBuffer
 
 if TYPE_CHECKING:
     from nexus.bricks.rebac.cache.pubsub_invalidation import PubSubInvalidation
@@ -33,7 +32,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class DeferredPermissionBuffer:
+class DeferredPermissionBuffer(DeferredBuffer):
     """
     Buffers permission operations for batch flushing.
 
@@ -58,85 +57,32 @@ class DeferredPermissionBuffer:
             max_batch_size: Trigger immediate flush if queue exceeds this size
             max_retries: Max retry attempts before dead-lettering a failed item
         """
+        super().__init__(
+            flush_interval_sec=flush_interval_sec,
+            max_batch_size=max_batch_size,
+            max_retries=max_retries,
+            thread_name="DeferredPermissionBuffer-Flush",
+        )
         self._rebac_manager = rebac_manager
         self._hierarchy_manager = hierarchy_manager
-        self._flush_interval = flush_interval_sec
-        self._max_batch_size = max_batch_size
-        self._max_retries = max_retries
 
-        # Pending operations (thread-safe with lock)
+        # Pending operations (thread-safe via base class _lock)
+        from collections import deque
+
         self._pending_hierarchy: deque[tuple[str, str]] = deque()  # (path, zone_id)
         self._pending_grants: deque[dict[str, Any]] = deque()
-        self._lock = threading.Lock()
 
         # Retry tracking: maps (path, zone_id) -> attempt count for hierarchy,
         # and (subject, relation, object, zone_id) -> attempt count for grants
         self._hierarchy_retry_counts: dict[tuple[str, str], int] = {}
         self._grants_retry_counts: dict[tuple[Any, ...], int] = {}
 
-        # Dead letter queue for permanently failed items
-        self._dead_letter: list[dict[str, Any]] = []
-
         # Pub/Sub for cross-zone flush coordination (Issue #3192)
         self._pubsub: "PubSubInvalidation | None" = None
 
-        # Background flush thread
-        self._flush_thread: threading.Thread | None = None
-        self._shutdown = threading.Event()
-        self._started = False
-
-        # Stats
+        # Stats (permission-specific)
         self._total_hierarchy_flushed = 0
         self._total_grants_flushed = 0
-        self._flush_count = 0
-
-    async def start(self) -> None:
-        """Start the background flush worker thread (PersistentService protocol)."""
-        self._start_sync()
-
-    async def stop(self) -> None:
-        """Stop the buffer and flush remaining items (PersistentService protocol)."""
-        self._stop_sync()
-
-    def _start_sync(self) -> None:
-        """Sync start — spawns background flush thread."""
-        if self._started:
-            return
-
-        self._shutdown.clear()
-        self._flush_thread = threading.Thread(
-            target=self._flush_loop,
-            name="DeferredPermissionBuffer-Flush",
-            daemon=True,
-        )
-        self._flush_thread.start()
-        self._started = True
-        logger.info(
-            f"DeferredPermissionBuffer started (interval={self._flush_interval}s, "
-            f"max_batch={self._max_batch_size})"
-        )
-
-    def _stop_sync(self, timeout: float = 5.0) -> None:
-        """Sync stop — joins thread and flushes remaining items."""
-        if not self._started:
-            return
-
-        logger.info("DeferredPermissionBuffer stopping...")
-        self._shutdown.set()
-
-        if self._flush_thread and self._flush_thread.is_alive():
-            self._flush_thread.join(timeout=timeout)
-
-        # Final flush on shutdown should be resilient like the background worker.
-        self._flush_sync(catch_unexpected=True)
-
-        self._started = False
-        logger.info(
-            f"DeferredPermissionBuffer stopped. Stats: "
-            f"hierarchy={self._total_hierarchy_flushed}, "
-            f"grants={self._total_grants_flushed}, "
-            f"flushes={self._flush_count}"
-        )
 
     def set_pubsub(self, pubsub: "PubSubInvalidation") -> None:
         """Set Pub/Sub for cross-zone flush coordination."""
@@ -154,8 +100,7 @@ class DeferredPermissionBuffer:
             queue_size = len(self._pending_hierarchy) + len(self._pending_grants)
 
         # Trigger immediate flush if at capacity
-        if queue_size >= self._max_batch_size:
-            self._trigger_flush()
+        self._check_batch_overflow(queue_size)
 
     def queue_owner_grant(
         self,
@@ -182,83 +127,32 @@ class DeferredPermissionBuffer:
             queue_size = len(self._pending_hierarchy) + len(self._pending_grants)
 
         # Trigger immediate flush if at capacity
-        if queue_size >= self._max_batch_size:
-            self._trigger_flush()
+        self._check_batch_overflow(queue_size)
 
-    def flush(self) -> None:
-        """Synchronously flush all pending operations.
+    # ── DeferredBuffer abstract method implementations ──
 
-        Call this when you need to ensure all permissions are persisted,
-        e.g., before a critical read or during graceful shutdown.
-        """
-        self._flush_sync(catch_unexpected=False)
+    def _has_items(self) -> bool:
+        return bool(self._pending_hierarchy) or bool(self._pending_grants)
 
-    def get_stats(self) -> dict[str, Any]:
-        """Get buffer statistics.
+    def _drain_items(self) -> list[Any]:
+        """Drain both queues and return as a combined structure."""
+        hierarchy_batch = list(self._pending_hierarchy)
+        self._pending_hierarchy.clear()
+        grants_batch = list(self._pending_grants)
+        self._pending_grants.clear()
+        return [hierarchy_batch, grants_batch]
 
-        Returns:
-            Dict with queue sizes and flush counts
-        """
-        with self._lock:
-            pending_hierarchy = len(self._pending_hierarchy)
-            pending_grants = len(self._pending_grants)
+    def _flush_items(self, items: list[Any], *, catch_unexpected: bool) -> int:
+        """Flush hierarchy and grant batches."""
+        hierarchy_batch: list[tuple[str, str]] = items[0]
+        grants_batch: list[dict[str, Any]] = items[1]
 
-        return {
-            "pending_hierarchy": pending_hierarchy,
-            "pending_grants": pending_grants,
-            "total_hierarchy_flushed": self._total_hierarchy_flushed,
-            "total_grants_flushed": self._total_grants_flushed,
-            "flush_count": self._flush_count,
-            "dead_letter_count": len(self._dead_letter),
-        }
-
-    def get_dead_letter(self) -> list[dict[str, Any]]:
-        """Return a copy of the dead-letter queue for inspection.
-
-        Returns:
-            List of dicts, each containing 'type', 'item', 'error', and 'retries'.
-        """
-        with self._lock:
-            return list(self._dead_letter)
-
-    def _trigger_flush(self) -> None:
-        """Trigger an immediate flush (called when batch size exceeded)."""
-        # For now, just let the background thread handle it
-        # The short flush interval (100ms) means we won't wait long
-        pass
-
-    def _flush_loop(self) -> None:
-        """Background loop that flushes periodically."""
-        while not self._shutdown.is_set():
-            # Wait for shutdown signal or flush interval
-            self._shutdown.wait(timeout=self._flush_interval)
-
-            if not self._shutdown.is_set():
-                try:
-                    self._flush_sync(catch_unexpected=True)
-                except Exception as e:  # fail-safe: background flush must not crash thread
-                    logger.error(f"DeferredPermissionBuffer flush error: {e}")
-
-    def _flush_sync(self, *, catch_unexpected: bool = False) -> None:
-        """Flush all pending operations using batch APIs."""
         retryable_errors: tuple[type[BaseException], ...]
         if catch_unexpected:
             retryable_errors = (Exception,)
         else:
             retryable_errors = (OperationalError, TimeoutError, RuntimeError)
 
-        # Atomically drain queues
-        with self._lock:
-            if not self._pending_hierarchy and not self._pending_grants:
-                return
-
-            hierarchy_batch = list(self._pending_hierarchy)
-            self._pending_hierarchy.clear()
-
-            grants_batch = list(self._pending_grants)
-            self._pending_grants.clear()
-
-        start_time = time.perf_counter()
         hierarchy_count = 0
         grants_count = 0
 
@@ -282,38 +176,7 @@ class DeferredPermissionBuffer:
                 for item in hierarchy_batch:
                     self._hierarchy_retry_counts.pop(item, None)
             except retryable_errors as e:
-                # Background flushes should re-queue unexpected manager errors
-                # instead of dropping buffered permission state.
-                # Re-queue with retry tracking; dead-letter items that exceed max_retries
-                requeue: list[tuple[str, str]] = []
-                for item in hierarchy_batch:
-                    key = item  # (path, zone_id)
-                    count = self._hierarchy_retry_counts.get(key, 0) + 1
-                    if count >= self._max_retries:
-                        logger.error(
-                            f"Hierarchy item dead-lettered after {count} retries: "
-                            f"path={item[0]}, zone={item[1]}, error={e}"
-                        )
-                        with self._lock:
-                            self._dead_letter.append(
-                                {
-                                    "type": "hierarchy",
-                                    "item": {"path": item[0], "zone_id": item[1]},
-                                    "error": str(e),
-                                    "retries": count,
-                                }
-                            )
-                        self._hierarchy_retry_counts.pop(key, None)
-                    else:
-                        logger.warning(
-                            f"Hierarchy flush failed (attempt {count}/{self._max_retries}), "
-                            f"re-queueing: path={item[0]}, zone={item[1]}, error={e}"
-                        )
-                        self._hierarchy_retry_counts[key] = count
-                        requeue.append(item)
-                if requeue:
-                    with self._lock:
-                        self._pending_hierarchy.extend(requeue)
+                self._requeue_hierarchy(hierarchy_batch, e)
 
         # Batch owner grants
         if grants_batch and self._rebac_manager:
@@ -331,70 +194,116 @@ class DeferredPermissionBuffer:
                     )
                     self._grants_retry_counts.pop(gkey, None)
             except retryable_errors as e:
-                # Background flushes should re-queue unexpected manager errors
-                # instead of dropping buffered permission state.
-                # Re-queue with retry tracking; dead-letter items that exceed max_retries
-                requeue_grants: list[dict[str, Any]] = []
-                for grant in grants_batch:
-                    gkey = (
-                        grant["subject"],
-                        grant["relation"],
-                        grant["object"],
-                        grant["zone_id"],
+                self._requeue_grants(grants_batch, e)
+
+        # Pub/Sub: notify other zones about flushed permissions (Issue #3192)
+        if (hierarchy_count > 0 or grants_count > 0) and self._pubsub:
+            zones_flushed = set()
+            for _path, zone_id in hierarchy_batch:
+                zones_flushed.add(zone_id)
+            for grant in grants_batch:
+                zones_flushed.add(grant.get("zone_id", ""))
+            for zone_id in zones_flushed:
+                if zone_id:
+                    self._pubsub.publish_invalidation(
+                        zone_id=zone_id,
+                        layer="deferred_flush",
+                        payload={
+                            "hierarchy_count": hierarchy_count,
+                            "grants_count": grants_count,
+                        },
                     )
-                    count = self._grants_retry_counts.get(gkey, 0) + 1
-                    if count >= self._max_retries:
-                        logger.error(
-                            f"Grant item dead-lettered after {count} retries: "
-                            f"subject={grant['subject']}, object={grant['object']}, error={e}"
-                        )
-                        with self._lock:
-                            self._dead_letter.append(
-                                {
-                                    "type": "grant",
-                                    "item": grant,
-                                    "error": str(e),
-                                    "retries": count,
-                                }
-                            )
-                        self._grants_retry_counts.pop(gkey, None)
-                    else:
-                        logger.warning(
-                            f"Grant flush failed (attempt {count}/{self._max_retries}), "
-                            f"re-queueing: subject={grant['subject']}, "
-                            f"object={grant['object']}, error={e}"
-                        )
-                        self._grants_retry_counts[gkey] = count
-                        requeue_grants.append(grant)
-                if requeue_grants:
-                    with self._lock:
-                        self._pending_grants.extend(requeue_grants)
 
-        if hierarchy_count > 0 or grants_count > 0:
-            elapsed_ms = (time.perf_counter() - start_time) * 1000
-            self._flush_count += 1
-            logger.debug(
-                f"[DEFERRED-FLUSH] hierarchy={hierarchy_count}, "
-                f"grants={grants_count}, elapsed={elapsed_ms:.1f}ms"
+        return hierarchy_count + grants_count
+
+    def _get_item_stats(self) -> dict[str, Any]:
+        with self._lock:
+            pending_hierarchy = len(self._pending_hierarchy)
+            pending_grants = len(self._pending_grants)
+        return {
+            "pending_hierarchy": pending_hierarchy,
+            "pending_grants": pending_grants,
+            "total_hierarchy_flushed": self._total_hierarchy_flushed,
+            "total_grants_flushed": self._total_grants_flushed,
+        }
+
+    # ── Retry helpers ──
+
+    def _requeue_hierarchy(
+        self, hierarchy_batch: list[tuple[str, str]], error: BaseException
+    ) -> None:
+        """Re-queue hierarchy items with retry tracking, dead-letter on max retries."""
+        requeue: list[tuple[str, str]] = []
+        for item in hierarchy_batch:
+            key = item  # (path, zone_id)
+            count = self._hierarchy_retry_counts.get(key, 0) + 1
+            if count >= self._max_retries:
+                logger.error(
+                    "Hierarchy item dead-lettered after %d retries: path=%s, zone=%s, error=%s",
+                    count,
+                    item[0],
+                    item[1],
+                    error,
+                )
+                self._dead_letter_item(
+                    "hierarchy",
+                    {"path": item[0], "zone_id": item[1]},
+                    error,
+                    count,
+                )
+                self._hierarchy_retry_counts.pop(key, None)
+            else:
+                logger.warning(
+                    "Hierarchy flush failed (attempt %d/%d), "
+                    "re-queueing: path=%s, zone=%s, error=%s",
+                    count,
+                    self._max_retries,
+                    item[0],
+                    item[1],
+                    error,
+                )
+                self._hierarchy_retry_counts[key] = count
+                requeue.append(item)
+        if requeue:
+            with self._lock:
+                self._pending_hierarchy.extend(requeue)
+
+    def _requeue_grants(self, grants_batch: list[dict[str, Any]], error: BaseException) -> None:
+        """Re-queue grant items with retry tracking, dead-letter on max retries."""
+        requeue_grants: list[dict[str, Any]] = []
+        for grant in grants_batch:
+            gkey = (
+                grant["subject"],
+                grant["relation"],
+                grant["object"],
+                grant["zone_id"],
             )
-
-            # Pub/Sub: notify other zones about flushed permissions (Issue #3192)
-            if self._pubsub:
-                zones_flushed = set()
-                for _path, zone_id in hierarchy_batch:
-                    zones_flushed.add(zone_id)
-                for grant in grants_batch:
-                    zones_flushed.add(grant.get("zone_id", ""))
-                for zone_id in zones_flushed:
-                    if zone_id:
-                        self._pubsub.publish_invalidation(
-                            zone_id=zone_id,
-                            layer="deferred_flush",
-                            payload={
-                                "hierarchy_count": hierarchy_count,
-                                "grants_count": grants_count,
-                            },
-                        )
+            count = self._grants_retry_counts.get(gkey, 0) + 1
+            if count >= self._max_retries:
+                logger.error(
+                    "Grant item dead-lettered after %d retries: subject=%s, object=%s, error=%s",
+                    count,
+                    grant["subject"],
+                    grant["object"],
+                    error,
+                )
+                self._dead_letter_item("grant", grant, error, count)
+                self._grants_retry_counts.pop(gkey, None)
+            else:
+                logger.warning(
+                    "Grant flush failed (attempt %d/%d), "
+                    "re-queueing: subject=%s, object=%s, error=%s",
+                    count,
+                    self._max_retries,
+                    grant["subject"],
+                    grant["object"],
+                    error,
+                )
+                self._grants_retry_counts[gkey] = count
+                requeue_grants.append(grant)
+        if requeue_grants:
+            with self._lock:
+                self._pending_grants.extend(requeue_grants)
 
 
 # Singleton instance for easy access

--- a/src/nexus/core/metastore.py
+++ b/src/nexus/core/metastore.py
@@ -75,6 +75,14 @@ class MetastoreABC(ABC):
     def put(self, metadata: FileMetadata, *, consistency: str = "sc") -> int | None:
         """Store or update file metadata (write-through dcache).
 
+        Args:
+            metadata: File metadata to store.
+            consistency: Consistency mode for the write:
+                - ``"sc"`` — blocks until Raft commit. Returns None.
+                - ``"ec"`` — fire-and-forget. Returns write token (int).
+                - ``"wb"`` — buffers for batched flush. Returns None.
+                  Stores without buffering SHOULD treat ``"wb"`` as ``"ec"``.
+
         Returns:
             EC mode: write token (int) for polling via is_committed().
             SC mode: None (write is already committed when this returns).
@@ -145,11 +153,24 @@ class MetastoreABC(ABC):
             self._dcache.pop(p, None)
         self._delete_batch_raw(paths)
 
-    def put_batch(self, metadata_list: Sequence[FileMetadata]) -> None:
-        """Store or update multiple file metadata (write-through dcache)."""
+    def put_batch(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",
+        skip_snapshot: bool = False,
+    ) -> None:
+        """Store or update multiple file metadata (write-through dcache).
+
+        Args:
+            metadata_list: List of file metadata to store.
+            consistency: Consistency mode (see put() for details).
+            skip_snapshot: Skip pre-write snapshot for rollback. Use when
+                the caller has its own retry logic (e.g., deferred buffer).
+        """
         for meta in metadata_list:
             self._dcache[meta.path] = meta
-        self._put_batch_raw(metadata_list)
+        self._put_batch_raw(metadata_list, consistency=consistency, skip_snapshot=skip_snapshot)
 
     def batch_get_content_ids(self, paths: Sequence[str]) -> dict[str, str | None]:
         """Get content IDs (hashes) for multiple paths (dcache-accelerated)."""
@@ -224,7 +245,13 @@ class MetastoreABC(ABC):
         for p in paths:
             self._delete_raw(p)
 
-    def _put_batch_raw(self, metadata_list: Sequence[FileMetadata]) -> None:
+    def _put_batch_raw(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",  # noqa: ARG002
+        skip_snapshot: bool = False,  # noqa: ARG002
+    ) -> None:
         """Store multiple metadata entries in the underlying store."""
         for meta in metadata_list:
             self._put_raw(meta)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -116,6 +116,9 @@ class NexusFS(  # type: ignore[misc]
         # Three pillars: metadata (required), record store, cache store
         # No self.backend — all I/O goes through router.route().backend
         self.metadata: MetastoreABC = metadata_store
+        # Issue #3393: default consistency for write operations.
+        # Set to "wb" by the factory when BufferedMetadataStore is active.
+        self._default_write_consistency: str = "sc"
         self._record_store = record_store
         self._sql_engine: Any = None
         self._db_session_factory: Any = None
@@ -384,6 +387,42 @@ class NexusFS(  # type: ignore[misc]
         return context.zone_id, context.agent_id, getattr(context, "is_admin", False)
 
     # Issue #1790: _check_zone_writable() deleted — now handled by
+    def _build_write_metadata(
+        self,
+        *,
+        path: str,
+        backend_name: str,
+        content_hash: str,
+        size: int,
+        existing_meta: "FileMetadata | None",
+        now: datetime,
+        zone_id: str | None,
+        context: "OperationContext | None",
+    ) -> "FileMetadata":
+        """Build FileMetadata for a sys_write result.
+
+        Shared by both the external-route and VFS-locked write paths
+        to avoid duplicating version calculation, owner resolution,
+        and field mapping.
+        """
+        new_version = (existing_meta.version + 1) if existing_meta else 1
+        ctx = self._resolve_cred(context)
+        owner_id = existing_meta.owner_id if existing_meta else (ctx.subject_id or ctx.user_id)
+        _ttl = getattr(context, "ttl_seconds", None) or 0.0
+        return FileMetadata(
+            path=path,
+            backend_name=backend_name,
+            physical_path=content_hash,
+            size=size,
+            etag=content_hash,
+            created_at=existing_meta.created_at if existing_meta else now,
+            modified_at=now,
+            version=new_version,
+            zone_id=zone_id or "root",
+            owner_id=owner_id,
+            ttl_seconds=_ttl,
+        )
+
     # ZoneWriteGuardHook (pre-intercept on all write-like operations).
 
     def _parse_context(self, context: OperationContext | dict | None = None) -> OperationContext:
@@ -2301,7 +2340,7 @@ class NexusFS(  # type: ignore[misc]
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
-        consistency: str = "sc",
+        consistency: str | None = None,
         ttl: float | None = None,
     ) -> dict[str, Any]:
         """Write with metadata return (Tier 2 convenience).
@@ -2322,10 +2361,10 @@ class NexusFS(  # type: ignore[misc]
             count: Max bytes to write (None = len(buf)).
             offset: Byte offset for partial write (POSIX pwrite semantics, 0=whole-file).
             context: Operation context.
-            consistency: Metastore consistency level — ``"sc"`` (strong, default,
-                Raft consensus) or ``"ec"`` (eventual, local-first via EC WAL).
-                EC writes return immediately and replicate asynchronously.
-                Issue #1828.
+            consistency: Metadata consistency mode — ``"sc"`` (strong, Raft
+                consensus), ``"ec"`` (eventual, fire-and-forget), or ``"wb"``
+                (write-back, buffered for batched flush).  Defaults to
+                _default_write_consistency ("wb" when buffer active, else "sc").
             ttl: TTL in seconds for ephemeral content (Issue #3405).
                 Routes to TTL-bucketed volume; None = permanent.
 
@@ -2338,6 +2377,7 @@ class NexusFS(  # type: ignore[misc]
             buf = buf[:count]
 
         path = self._validate_path(path)
+        _consistency = consistency if consistency is not None else self._default_write_consistency
 
         # PRE-DISPATCH: virtual path resolvers
         _handled, _result = self._dispatch.resolve_write(path, buf)
@@ -2349,7 +2389,7 @@ class NexusFS(  # type: ignore[misc]
             context = self._ensure_context_ttl(context, ttl)
 
         return await self._write_internal(
-            path=path, content=buf, offset=offset, context=context, consistency=consistency
+            path=path, content=buf, offset=offset, context=context, consistency=_consistency
         )
 
     async def _write_internal(
@@ -2435,23 +2475,17 @@ class NexusFS(  # type: ignore[misc]
                 context=context,
             )
             content_hash = wr.content_id
-            new_version = (meta.version + 1) if meta else 1
-            ctx = self._resolve_cred(context)
-            owner_id = meta.owner_id if meta else (ctx.subject_id or ctx.user_id)
-            _ttl = getattr(context, "ttl_seconds", None) or 0.0
-            metadata = FileMetadata(
+            metadata = self._build_write_metadata(
                 path=path,
                 backend_name=route.backend.name,
-                physical_path=content_hash,
+                content_hash=content_hash,
                 size=wr.size if offset > 0 else len(content),
-                etag=content_hash,
-                created_at=meta.created_at if meta else now,
-                modified_at=now,
-                version=new_version,
-                zone_id=zone_id or "root",
-                owner_id=owner_id,
-                ttl_seconds=_ttl,
+                existing_meta=meta,
+                now=now,
+                zone_id=zone_id,
+                context=context,
             )
+            new_version = metadata.version
             # Local external backends need metadata persisted locally
             if not _is_remote:
                 self.metadata.put(metadata, consistency=consistency)
@@ -2471,28 +2505,17 @@ class NexusFS(  # type: ignore[misc]
                 # HDFS/GFS pattern: content cleanup is async via background GC.
                 # See: docs/architecture/federation-memo.md §7f Caveat 4.
 
-                # Calculate new version number (increment if updating)
-                new_version = (meta.version + 1) if meta else 1
-
-                # Store metadata with content hash as both etag and physical_path
-                # Issue #920: Set owner_id for O(1) permission checks (only on new files)
-                ctx = self._resolve_cred(context)
-                owner_id = meta.owner_id if meta else (ctx.subject_id or ctx.user_id)
-
-                _ttl = getattr(context, "ttl_seconds", None) or 0.0
-                metadata = FileMetadata(
+                metadata = self._build_write_metadata(
                     path=path,
                     backend_name=route.backend.name,
-                    physical_path=content_hash,
+                    content_hash=content_hash,
                     size=_wr.size if offset > 0 else len(content),
-                    etag=content_hash,
-                    created_at=meta.created_at if meta else now,
-                    modified_at=now,
-                    version=new_version,
-                    zone_id=zone_id or "root",  # Issue #904, #773: pre-existing default
-                    owner_id=owner_id,
-                    ttl_seconds=_ttl,
+                    existing_meta=meta,
+                    now=now,
+                    zone_id=zone_id,
+                    context=context,
                 )
+                new_version = metadata.version
 
                 self.metadata.put(metadata, consistency=consistency)
 

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -248,13 +249,43 @@ async def create_nexus_fs(
                 distributed = _dc_replace(_base_dist, enable_events=False)
                 logger.debug("EventBus disabled: no CacheStore or Redis/Dragonfly URL")
 
+    # Issue #3393: Wrap metadata store with write-back buffer.
+    # Must happen BEFORE create_nexus_services so services get the same wrapped store.
+    # Always enabled — transparent for SC/EC writes. Disable with NEXUS_METADATA_BUFFER=0.
+    _effective_metadata_store = metadata_store
+    if os.environ.get("NEXUS_METADATA_BUFFER", "").lower() not in ("0", "false", "no"):
+        from nexus.lib.performance_tuning import resolve_profile_tuning
+        from nexus.storage.buffered_metadata_store import BufferedMetadataStore
+
+        _profile_str = os.environ.get("NEXUS_PROFILE", "full")
+        try:
+            from nexus.core.config import DeploymentProfile as _DP
+
+            _dp = _DP(_profile_str) if _profile_str != "auto" else _DP.FULL
+        except (ValueError, ImportError):
+            _dp = None
+        _tuning = resolve_profile_tuning(_dp) if _dp else None
+        _flush_ms = _tuning.storage.write_buffer_flush_ms if _tuning else 100
+        _max_size = _tuning.storage.write_buffer_max_size if _tuning else 100
+
+        _effective_metadata_store = BufferedMetadataStore(
+            metadata_store,
+            flush_interval_sec=_flush_ms / 1000.0,
+            max_batch_size=_max_size,
+        )
+        logger.info(
+            "Metadata write-back buffer enabled (flush=%dms, max_batch=%d)",
+            _flush_ms,
+            _max_size,
+        )
+
     # Create services if record_store is provided and no pre-built services.
     # KERNEL mode (Issue #2194): When record_store is None (e.g. profile=kernel),
     # this branch is skipped — bare kernel with no services.
     if services is None and record_store is not None:
         services = create_nexus_services(
             record_store=record_store,
-            metadata_store=metadata_store,
+            metadata_store=_effective_metadata_store,
             backend=backend,
             router=router,
             permissions=permissions,
@@ -279,7 +310,7 @@ async def create_nexus_fs(
     )
 
     nx = NexusFS(
-        metadata_store=metadata_store,
+        metadata_store=_effective_metadata_store,
         record_store=record_store,
         cache_store=cache_store,
         cache=cache,
@@ -305,6 +336,12 @@ async def create_nexus_fs(
 
     await _initialize_services(nx, init_ctx)
     nx._initialized = True
+
+    # Issue #3393: Start the metadata write-back buffer's background flush thread
+    # and set write-back as the default consistency for all writes.
+    if hasattr(_effective_metadata_store, "_buffer"):
+        await _effective_metadata_store.start()
+        nx._default_write_consistency = "wb"
 
     return nx
 

--- a/src/nexus/fs/_sqlite_meta.py
+++ b/src/nexus/fs/_sqlite_meta.py
@@ -266,7 +266,13 @@ class SQLiteMetastore(MetastoreABC):
         return {p: found.get(p) for p in paths}
 
     @_retry_on_busy
-    def _put_batch_raw(self, metadata_list: Sequence[FileMetadata]) -> None:
+    def _put_batch_raw(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",  # noqa: ARG002
+        skip_snapshot: bool = False,  # noqa: ARG002
+    ) -> None:
         if not metadata_list:
             return
         self._conn.executemany(_UPSERT, [_metadata_to_tuple(m) for m in metadata_list])

--- a/src/nexus/lib/deferred_buffer.py
+++ b/src/nexus/lib/deferred_buffer.py
@@ -1,0 +1,245 @@
+"""Generic deferred buffer with background batch flushing.
+
+Provides thread-safe queue + background flush thread infrastructure
+shared by DeferredPermissionBuffer and DeferredMetadataBuffer.
+
+Subclasses implement:
+    - _drain_items() -> list[T]  — atomically drain pending items from the queue
+    - _flush_items(items, catch_unexpected) — flush a batch of items
+    - _has_items() -> bool — check if there are pending items (called under lock)
+    - _get_item_stats() -> dict — return subclass-specific stats
+"""
+
+import logging
+import threading
+import time
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class DeferredBuffer(ABC, Generic[T]):
+    """Base class for deferred buffers with background batch flushing.
+
+    Thread-safe for use from both sync and async contexts.
+    Uses a background thread for flushing to avoid blocking the event loop.
+
+    Subclasses must implement _drain_items(), _flush_items(), _has_items(),
+    and _get_item_stats().
+    """
+
+    def __init__(
+        self,
+        *,
+        flush_interval_sec: float = 0.1,
+        max_batch_size: int = 1000,
+        max_retries: int = 3,
+        thread_name: str = "DeferredBuffer-Flush",
+    ):
+        self._flush_interval = flush_interval_sec
+        self._max_batch_size = max_batch_size
+        self._max_retries = max_retries
+        self._thread_name = thread_name
+
+        # Shared lock for subclass queue access
+        self._lock = threading.Lock()
+
+        # Dead letter queue for permanently failed items
+        self._dead_letter: list[dict[str, Any]] = []
+
+        # Background flush thread
+        self._flush_thread: threading.Thread | None = None
+        self._shutdown = threading.Event()
+        self._flush_event = threading.Event()  # C2: wake thread on batch overflow
+        self._started = False
+
+        # Stats
+        self._flush_count = 0
+        self._total_flushed = 0
+
+    # ── Lifecycle (PersistentService protocol) ──
+
+    async def start(self) -> None:
+        """Start the background flush worker thread."""
+        self._start_sync()
+
+    async def stop(self) -> None:
+        """Stop the buffer and flush remaining items."""
+        self._stop_sync()
+
+    def _start_sync(self) -> None:
+        """Sync start -- spawns background flush thread."""
+        if self._started:
+            return
+
+        self._shutdown.clear()
+        self._flush_event.clear()
+        self._flush_thread = threading.Thread(
+            target=self._flush_loop,
+            name=self._thread_name,
+            daemon=True,
+        )
+        self._flush_thread.start()
+        self._started = True
+        logger.info(
+            "%s started (interval=%.3fs, max_batch=%d)",
+            self._thread_name,
+            self._flush_interval,
+            self._max_batch_size,
+        )
+
+    def _stop_sync(self, timeout: float = 5.0) -> None:
+        """Sync stop -- joins thread and flushes remaining items."""
+        if not self._started:
+            return
+
+        logger.info("%s stopping...", self._thread_name)
+        self._shutdown.set()
+        self._flush_event.set()  # wake thread so it can exit
+
+        if self._flush_thread and self._flush_thread.is_alive():
+            self._flush_thread.join(timeout=timeout)
+
+        # Final flush on shutdown should be resilient
+        self._flush_sync(catch_unexpected=True)
+
+        self._started = False
+        stats = self.get_stats()
+        logger.info("%s stopped. Stats: %s", self._thread_name, stats)
+
+    # ── Public API ──
+
+    def flush(self) -> None:
+        """Synchronously flush all pending items.
+
+        Call when you need to ensure all items are persisted,
+        e.g., before a critical read or during graceful shutdown.
+        """
+        self._flush_sync(catch_unexpected=False)
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get buffer statistics."""
+        stats = {
+            "flush_count": self._flush_count,
+            "total_flushed": self._total_flushed,
+            "dead_letter_count": len(self._dead_letter),
+        }
+        stats.update(self._get_item_stats())
+        return stats
+
+    def get_dead_letter(self) -> list[dict[str, Any]]:
+        """Return a copy of the dead-letter queue for inspection."""
+        with self._lock:
+            return list(self._dead_letter)
+
+    # ── Batch overflow trigger (C2 fix) ──
+
+    def _check_batch_overflow(self, queue_size: int) -> None:
+        """Wake the background thread immediately if batch size exceeded."""
+        if queue_size >= self._max_batch_size:
+            self._trigger_flush()
+
+    # ── Background flush loop ──
+
+    def _flush_loop(self) -> None:
+        """Background loop that flushes periodically or on batch overflow."""
+        while not self._shutdown.is_set():
+            # Wait for shutdown signal or flush interval -- whichever comes first.
+            # _flush_event can interrupt this wait for immediate flush on batch overflow.
+            self._flush_event.wait(timeout=self._flush_interval)
+            self._flush_event.clear()
+
+            if not self._shutdown.is_set():
+                try:
+                    self._flush_sync(catch_unexpected=True)
+                except Exception as e:
+                    logger.error("%s flush error: %s", self._thread_name, e)
+
+    def _trigger_flush(self) -> None:
+        """Trigger an immediate flush (called when batch size exceeded)."""
+        self._flush_event.set()
+
+    # ── Flush implementation ──
+
+    def _flush_sync(self, *, catch_unexpected: bool = False) -> None:
+        """Flush all pending items using subclass-specific logic."""
+        with self._lock:
+            if not self._has_items():
+                return
+            items = self._drain_items()
+
+        start_time = time.perf_counter()
+        flushed_count = self._flush_items(items, catch_unexpected=catch_unexpected)
+
+        if flushed_count > 0:
+            self._total_flushed += flushed_count
+            self._flush_count += 1
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+            logger.debug(
+                "[%s] flushed=%d, elapsed=%.1fms",
+                self._thread_name,
+                flushed_count,
+                elapsed_ms,
+            )
+
+    # ── Dead-letter helpers ──
+
+    def _dead_letter_item(
+        self,
+        item_type: str,
+        item: Any,
+        error: BaseException,
+        retries: int,
+    ) -> None:
+        """Add an item to the dead-letter queue."""
+        with self._lock:
+            self._dead_letter.append(
+                {
+                    "type": item_type,
+                    "item": item,
+                    "error": str(error),
+                    "retries": retries,
+                }
+            )
+
+    # ── Abstract methods for subclasses ──
+
+    @abstractmethod
+    def _drain_items(self) -> list[Any]:
+        """Atomically drain pending items from the queue.
+
+        Called while self._lock is held.
+
+        Returns:
+            List of items to flush.
+        """
+        ...
+
+    @abstractmethod
+    def _flush_items(self, items: list[Any], *, catch_unexpected: bool) -> int:
+        """Flush a batch of items.
+
+        Called outside self._lock. Must handle errors, retries, and
+        dead-lettering using self._dead_letter_item() and self._max_retries.
+
+        Args:
+            items: Items drained from the queue.
+            catch_unexpected: If True, catch all exceptions (background mode).
+
+        Returns:
+            Number of items successfully flushed.
+        """
+        ...
+
+    @abstractmethod
+    def _has_items(self) -> bool:
+        """Check if there are pending items. Called while self._lock is held."""
+        ...
+
+    @abstractmethod
+    def _get_item_stats(self) -> dict[str, Any]:
+        """Return subclass-specific stats to merge into get_stats()."""
+        ...

--- a/src/nexus/raft/federated_metadata_proxy.py
+++ b/src/nexus/raft/federated_metadata_proxy.py
@@ -301,7 +301,13 @@ class FederatedMetadataProxy(MetastoreABC):
                 result[global_path] = meta
         return result
 
-    def put_batch(self, metadata_list: Sequence[FileMetadata]) -> None:
+    def put_batch(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",
+        skip_snapshot: bool = False,
+    ) -> None:
         zone_groups: dict[str, list[FileMetadata]] = {}
         for metadata in metadata_list:
             resolved = self._resolve(metadata.path)
@@ -315,7 +321,7 @@ class FederatedMetadataProxy(MetastoreABC):
         for zone_id, metas in zone_groups.items():
             store = self._resolver.get_store(zone_id)
             if store is not None:
-                store.put_batch(metas)
+                store.put_batch(metas, consistency=consistency, skip_snapshot=skip_snapshot)
 
     def delete_batch(self, paths: Sequence[str]) -> None:
         zone_groups: dict[str, list[str]] = {}

--- a/src/nexus/storage/buffered_metadata_store.py
+++ b/src/nexus/storage/buffered_metadata_store.py
@@ -1,0 +1,410 @@
+"""Buffered metadata store with deferred write-back and batched Raft flush.
+
+Wraps any MetastoreABC implementation (typically RaftMetadataStore) to add
+write-back buffering for ``consistency="wb"`` writes.  Metadata updates are
+held in a local in-memory buffer and flushed to the underlying store in
+batches by a background thread, amortising the per-write Raft consensus
+cost from ~5-10 ms down to ~50-100 μs.
+
+Read-path consistency is maintained transparently: every ``get()`` checks the
+pending buffer before hitting the underlying engine, so callers always see
+the most recent metadata — even if it has not yet been committed to Raft.
+
+Architecture decision references (Issue #3393):
+    A1 — Store-level intercept on get() for buffer overlay
+    A2 — EC mode write tokens for durability (Raft log is the WAL)
+    P1 — Lock-free fast path via _has_pending bool flag
+    P2 — Buffer enqueue inside VFS lock (caller responsibility)
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from collections import deque
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+from nexus.contracts.metadata import FileMetadata
+from nexus.core.metastore import MetastoreABC
+from nexus.lib.deferred_buffer import DeferredBuffer
+
+logger = logging.getLogger(__name__)
+
+
+class DeferredMetadataBuffer(DeferredBuffer):
+    """Background flush worker for buffered metadata writes.
+
+    Accumulates FileMetadata entries and flushes them to the underlying
+    metastore via put_batch() at a configurable interval.
+    """
+
+    def __init__(
+        self,
+        store: MetastoreABC,
+        *,
+        flush_interval_sec: float = 0.1,
+        max_batch_size: int = 100,
+        max_retries: int = 3,
+    ):
+        super().__init__(
+            flush_interval_sec=flush_interval_sec,
+            max_batch_size=max_batch_size,
+            max_retries=max_retries,
+            thread_name="DeferredMetadataBuffer-Flush",
+        )
+        self._store = store
+        self._pending: deque[FileMetadata] = deque()
+        self._retry_counts: dict[str, int] = {}  # path -> attempt count
+        self._total_metadata_flushed = 0
+        # Tombstone set: paths deleted while items may be in-flight in the
+        # flush thread.  Checked in _flush_items() to prevent resurrecting
+        # files that were deleted between _drain_items() and put_batch().
+        self._deleted_paths: set[str] = set()
+
+    # ── Public enqueue ──
+
+    def enqueue(self, metadata: FileMetadata) -> None:
+        """Buffer a metadata entry for deferred flush (non-blocking).
+
+        If a pending entry already exists for the same path, the newer
+        entry replaces it (last-writer-wins within the buffer).
+        """
+        with self._lock:
+            # Last-writer-wins: remove any existing entry for this path
+            self._pending = deque(m for m in self._pending if m.path != metadata.path)
+            self._pending.append(metadata)
+            queue_size = len(self._pending)
+            # Clear tombstone — a new write after delete is intentional re-create
+            self._deleted_paths.discard(metadata.path)
+
+        self._check_batch_overflow(queue_size)
+
+    def get_pending(self, path: str) -> FileMetadata | None:
+        """Check if a path has a pending (unflushed) metadata entry.
+
+        Called by BufferedMetadataStore.get() to overlay buffered data.
+        """
+        with self._lock:
+            for m in reversed(self._pending):
+                if m.path == path:
+                    return m
+        return None
+
+    def remove_pending(self, path: str) -> None:
+        """Remove a path from the pending buffer and add a tombstone.
+
+        Prevents stale buffer entries from shadowing a delete, and
+        prevents the flush thread from resurrecting a file that was
+        deleted after _drain_items() but before put_batch().
+        """
+        with self._lock:
+            self._pending = deque(m for m in self._pending if m.path != path)
+            self._deleted_paths.add(path)
+
+    # ── DeferredBuffer abstract methods ──
+
+    def _has_items(self) -> bool:
+        return bool(self._pending)
+
+    def _drain_items(self) -> list[Any]:
+        items = list(self._pending)
+        self._pending.clear()
+        return items
+
+    def _flush_items(self, items: list[Any], *, catch_unexpected: bool) -> int:
+        metadata_list: list[FileMetadata] = items
+
+        # Filter out items whose paths were deleted after drain but before
+        # flush (tombstone check).  Prevents resurrecting deleted files.
+        with self._lock:
+            if self._deleted_paths:
+                metadata_list = [m for m in metadata_list if m.path not in self._deleted_paths]
+                # Clear tombstones — they've served their purpose for this batch
+                self._deleted_paths.clear()
+
+        if not metadata_list:
+            return 0
+
+        retryable_errors: tuple[type[BaseException], ...]
+        if catch_unexpected:
+            retryable_errors = (Exception,)
+        else:
+            retryable_errors = (RuntimeError, TimeoutError, OSError)
+
+        try:
+            self._store.put_batch(
+                metadata_list,
+                consistency="sc",
+                skip_snapshot=True,
+            )
+            flushed = len(metadata_list)
+            self._total_metadata_flushed += flushed
+            # Clear retry counts on success
+            for m in metadata_list:
+                self._retry_counts.pop(m.path, None)
+            return flushed
+        except retryable_errors as e:
+            # Re-queue with retry tracking; dead-letter on max retries
+            requeue: list[FileMetadata] = []
+            for m in metadata_list:
+                count = self._retry_counts.get(m.path, 0) + 1
+                if count >= self._max_retries:
+                    logger.error(
+                        "Metadata item dead-lettered after %d retries: path=%s, error=%s",
+                        count,
+                        m.path,
+                        e,
+                    )
+                    self._dead_letter_item(
+                        "metadata",
+                        {"path": m.path, "version": m.version},
+                        e,
+                        count,
+                    )
+                    self._retry_counts.pop(m.path, None)
+                else:
+                    logger.warning(
+                        "Metadata flush failed (attempt %d/%d), re-queueing: path=%s, error=%s",
+                        count,
+                        self._max_retries,
+                        m.path,
+                        e,
+                    )
+                    self._retry_counts[m.path] = count
+                    requeue.append(m)
+            if requeue:
+                with self._lock:
+                    # Prepend requeued items so they flush first next cycle
+                    self._pending.extendleft(reversed(requeue))
+            return 0
+
+    def _get_item_stats(self) -> dict[str, Any]:
+        with self._lock:
+            pending = len(self._pending)
+        return {
+            "pending_metadata": pending,
+            "total_metadata_flushed": self._total_metadata_flushed,
+        }
+
+
+class BufferedMetadataStore(MetastoreABC):
+    """MetastoreABC wrapper that adds write-back buffering.
+
+    Intercepts ``put(consistency="wb")`` to buffer metadata locally for
+    batched Raft flush.  All other consistency modes pass through to the
+    underlying store unchanged.
+
+    ``get()`` transparently checks the pending buffer first (P1 fast-path:
+    skips lock acquisition when no items are pending).
+    """
+
+    def __init__(
+        self,
+        inner: MetastoreABC,
+        *,
+        flush_interval_sec: float = 0.1,
+        max_batch_size: int = 100,
+        max_retries: int = 3,
+    ):
+        super().__init__()
+        self._inner = inner
+        self._buffer = DeferredMetadataBuffer(
+            inner,
+            flush_interval_sec=flush_interval_sec,
+            max_batch_size=max_batch_size,
+            max_retries=max_retries,
+        )
+        # P1: Lock-free fast path — skip buffer check when nothing is pending.
+        # A stale True is harmless (extra dict check); stale False can't happen
+        # because we set True before enqueue returns.
+        self._has_pending = False
+
+    # ── Lifecycle ──
+
+    async def start(self) -> None:
+        """Start the background metadata flush worker."""
+        await self._buffer.start()
+
+    async def stop(self) -> None:
+        """Stop the buffer and flush remaining metadata."""
+        await self._buffer.stop()
+
+    def _start_sync(self) -> None:
+        self._buffer._start_sync()
+
+    def _stop_sync(self) -> None:
+        self._buffer._stop_sync()
+
+    # ── Raw methods (required by MetastoreABC, delegate to inner) ──
+
+    def _get_raw(self, path: str) -> FileMetadata | None:
+        return self._inner._get_raw(path)
+
+    def _put_raw(self, metadata: FileMetadata, *, consistency: str = "sc") -> int | None:
+        return self._inner._put_raw(metadata, consistency=consistency)
+
+    def _delete_raw(self, path: str, *, consistency: str = "sc") -> dict[str, Any] | None:
+        return self._inner._delete_raw(path, consistency=consistency)
+
+    def _exists_raw(self, path: str) -> bool:
+        return self._inner._exists_raw(path)
+
+    def _list_raw(
+        self, prefix: str = "", recursive: bool = True, **kwargs: Any
+    ) -> builtins.list[FileMetadata]:
+        return self._inner._list_raw(prefix, recursive, **kwargs)
+
+    # ── Overridden public methods (buffer overlay) ──
+
+    def get(self, path: str) -> FileMetadata | None:
+        """Get metadata, checking the pending buffer first.
+
+        P1 fast-path: if _has_pending is False (common case for reads),
+        skip the lock + dict lookup entirely (~1ns vs ~100ns).
+        """
+        if self._has_pending:
+            pending = self._buffer.get_pending(path)
+            if pending is not None:
+                return pending
+        return self._inner.get(path)
+
+    def put(self, metadata: FileMetadata, *, consistency: str = "sc") -> int | None:
+        """Store metadata — buffers locally for ``consistency="wb"``.
+
+        WB mode: enqueues into the deferred buffer for batched flush.
+        SC/EC mode: passes through to the underlying store.
+        """
+        if consistency == "wb":
+            self._has_pending = True
+            self._buffer.enqueue(metadata)
+            return None
+        return self._inner.put(metadata, consistency=consistency)
+
+    def delete(self, path: str, *, consistency: str = "sc") -> dict[str, Any] | None:
+        # Evict from pending buffer so stale entries don't shadow the delete
+        if self._has_pending:
+            self._buffer.remove_pending(path)
+            self._has_pending = bool(self._buffer._pending)
+        return self._inner.delete(path, consistency=consistency)
+
+    def is_implicit_directory(self, path: str) -> bool:
+        """Check if path is an implicit directory, including buffered entries."""
+        # Check inner store first
+        if hasattr(self._inner, "is_implicit_directory") and self._inner.is_implicit_directory(
+            path
+        ):
+            return True
+        # Check pending buffer for files under this path
+        if self._has_pending:
+            prefix = path.rstrip("/") + "/"
+            with self._buffer._lock:
+                return any(m.path.startswith(prefix) for m in self._buffer._pending)
+        return False
+
+    def exists(self, path: str) -> bool:
+        if self._has_pending:
+            pending = self._buffer.get_pending(path)
+            if pending is not None:
+                return True
+        return self._inner.exists(path)
+
+    def list(self, prefix: str = "", recursive: bool = True, **kwargs: Any) -> list[FileMetadata]:
+        result = self._inner.list(prefix, recursive, **kwargs)
+        if self._has_pending:
+            result = self._merge_pending_into_list(result, prefix, recursive)
+        return result
+
+    def list_iter(
+        self, prefix: str = "", recursive: bool = True, **kwargs: Any
+    ) -> Iterator[FileMetadata]:
+        # Materialize to merge buffered entries, then yield
+        yield from self.list(prefix, recursive, **kwargs)
+
+    def _merge_pending_into_list(
+        self,
+        committed: builtins.list[FileMetadata],
+        prefix: str,
+        recursive: bool,
+    ) -> builtins.list[FileMetadata]:
+        """Merge buffered entries into a list result from the inner store."""
+        with self._buffer._lock:
+            pending = builtins.list(self._buffer._pending)
+        if not pending:
+            return committed
+
+        # Build a dict keyed by path for O(1) override
+        by_path: dict[str, FileMetadata] = {m.path: m for m in committed}
+        for m in pending:
+            if not m.path.startswith(prefix):
+                continue
+            if not recursive:
+                rel = m.path[len(prefix) :].lstrip("/")
+                if "/" in rel:
+                    continue
+            by_path[m.path] = m
+        return builtins.list(by_path.values())
+
+    def close(self) -> None:
+        # Flush remaining items before closing
+        self._buffer._stop_sync()
+        self._inner.close()
+
+    # ── Batch operations (delegate to inner) ──
+
+    def get_batch(self, paths: Sequence[str]) -> dict[str, FileMetadata | None]:
+        result = self._inner.get_batch(paths)
+        if self._has_pending:
+            for path in paths:
+                pending = self._buffer.get_pending(path)
+                if pending is not None:
+                    result[path] = pending
+        return result
+
+    def put_batch(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",
+        skip_snapshot: bool = False,
+    ) -> None:
+        self._inner.put_batch(metadata_list, consistency=consistency, skip_snapshot=skip_snapshot)
+
+    def delete_batch(self, paths: Sequence[str]) -> None:
+        if self._has_pending:
+            for path in paths:
+                self._buffer.remove_pending(path)
+            self._has_pending = bool(self._buffer._pending)
+        self._inner.delete_batch(paths)
+
+    def batch_get_content_ids(self, paths: Sequence[str]) -> dict[str, str | None]:
+        return self._inner.batch_get_content_ids(paths)
+
+    def is_committed(self, token: int) -> str | None:
+        return self._inner.is_committed(token)
+
+    # ── Buffer-specific API ──
+
+    def flush(self) -> None:
+        """Force an immediate flush of all pending metadata."""
+        self._buffer.flush()
+        self._has_pending = bool(self._buffer._pending)
+
+    def get_buffer_stats(self) -> dict[str, Any]:
+        """Get buffer statistics."""
+        return self._buffer.get_stats()
+
+    def get_dead_letter(self) -> builtins.list[dict[str, Any]]:
+        """Return the dead-letter queue for inspection."""
+        return self._buffer.get_dead_letter()
+
+    # ── Proxy attributes from inner store ──
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward unknown attributes to the inner store.
+
+        Allows BufferedMetadataStore to be a drop-in replacement for
+        RaftMetadataStore — methods like is_leader(), zone_id, etc.
+        are transparently proxied.
+        """
+        return getattr(self._inner, name)

--- a/src/nexus/storage/dict_metastore.py
+++ b/src/nexus/storage/dict_metastore.py
@@ -173,7 +173,13 @@ class DictMetastore(MetastoreABC):
             self._file_metadata.pop(p, None)
         self._flush()
 
-    def _put_batch_raw(self, metadata_list: Sequence[FileMetadata]) -> None:
+    def _put_batch_raw(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",  # noqa: ARG002
+        skip_snapshot: bool = False,  # noqa: ARG002
+    ) -> None:
         for m in metadata_list:
             self._store[m.path] = m
         self._flush()

--- a/src/nexus/storage/raft_metadata_store.py
+++ b/src/nexus/storage/raft_metadata_store.py
@@ -170,15 +170,18 @@ class RaftMetadataStore(MetastoreABC):
 
         Args:
             metadata: File metadata to store
-            consistency: "sc" (wait for commit) or "ec" (fire-and-forget)
+            consistency: "sc", "ec", or "wb" (wb treated as "ec" fallback —
+                buffering is handled by BufferedMetadataStore wrapper).
 
         Returns:
-            EC mode: write token (int) for polling via is_committed().
+            EC/WB mode: write token (int) for polling via is_committed().
             SC mode: None (write is already committed).
         """
+        # WB fallback: non-buffered stores treat write-back as eventual consistency
+        engine_consistency = "ec" if consistency == "wb" else consistency
         data = _serialize_metadata(metadata)
         try:
-            return self._engine.set_metadata(metadata.path, data, consistency=consistency)
+            return self._engine.set_metadata(metadata.path, data, consistency=engine_consistency)
         except TypeError:
             # Compiled PyO3 binary may not yet support the consistency parameter
             return self._engine.set_metadata(metadata.path, data)
@@ -546,15 +549,23 @@ class RaftMetadataStore(MetastoreABC):
         # Fallback: individual calls when batch API not yet compiled
         return {path: self._get_raw(path) for path in paths}
 
-    def _put_batch_raw(self, metadata_list: Sequence[FileMetadata]) -> None:
+    def _put_batch_raw(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",  # noqa: ARG002
+        skip_snapshot: bool = False,
+    ) -> None:
         """Store or update multiple file metadata entries atomically.
 
         All entries are serialized upfront to fail fast on bad data.
         If any write fails mid-batch, previously written entries are
-        rolled back on a best-effort basis.
+        rolled back on a best-effort basis (unless skip_snapshot=True).
 
         Args:
             metadata_list: List of file metadata to store
+            consistency: Consistency mode (see put() for details).
+            skip_snapshot: Skip pre-write snapshot for rollback.
 
         Raises:
             RuntimeError: If a write fails (includes details of partial progress)
@@ -566,28 +577,32 @@ class RaftMetadataStore(MetastoreABC):
         serialized: list[tuple[str, bytes]] = [
             (m.path, _serialize_metadata(m)) for m in metadata_list
         ]
-        path_list = [path for path, _ in serialized]
 
         # Phase 2: capture existing metadata for rollback (single FFI call)
-        if hasattr(self._engine, "get_metadata_multi"):
-            snapshots = self._engine.get_metadata_multi(path_list)
-        else:
-            snapshots = [(p, self._engine.get_metadata(p)) for p in path_list]
+        # Skipped when caller manages its own retry logic (e.g., deferred buffer flush)
+        snapshots: list[tuple[str, bytes | None]] | None = None
+        if not skip_snapshot:
+            path_list = [path for path, _ in serialized]
+            if hasattr(self._engine, "get_metadata_multi"):
+                snapshots = self._engine.get_metadata_multi(path_list)
+            else:
+                snapshots = [(p, self._engine.get_metadata(p)) for p in path_list]
 
         # Phase 3: apply all writes in a single FFI call
         try:
             self._engine.batch_set_metadata(serialized)
         except Exception as e:
-            # Best-effort rollback: restore pre-existing entries, delete new ones
-            restore_items = [(path, data) for path, data in snapshots if data is not None]
-            delete_paths = [path for path, data in snapshots if data is None]
-            try:
-                if restore_items:
-                    self._engine.batch_set_metadata(restore_items)
-                if delete_paths:
-                    self._engine.batch_delete_metadata(delete_paths)
-            except Exception:
-                logger.warning("put_batch rollback failed for %d paths", len(path_list))
+            # Best-effort rollback (only when snapshots were captured)
+            if snapshots is not None:
+                restore_items = [(path, data) for path, data in snapshots if data is not None]
+                delete_paths = [path for path, data in snapshots if data is None]
+                try:
+                    if restore_items:
+                        self._engine.batch_set_metadata(restore_items)
+                    if delete_paths:
+                        self._engine.batch_delete_metadata(delete_paths)
+                except Exception:
+                    logger.warning("put_batch rollback failed for %d paths", len(serialized))
             raise RuntimeError(f"put_batch failed writing {len(serialized)} entries: {e}") from e
 
     def _delete_batch_raw(self, paths: Sequence[str]) -> None:

--- a/tests/benchmarks/benchmark_write_performance.py
+++ b/tests/benchmarks/benchmark_write_performance.py
@@ -229,11 +229,166 @@ async def run_benchmark(enable_deferred: bool = False):
         }
 
 
+async def run_write_back_benchmark():
+    """Benchmark write-back mode with timing breakdown (Issue #3393, T4).
+
+    Measures:
+    - VFS lock hold time (content write + metadata enqueue)
+    - Metadata enqueue time
+    - Batch flush latency (single Raft round for N writes)
+    - P50/P95/P99 for all of the above
+    """
+    import os
+
+    from nexus.backends.storage.cas_local import CASLocalBackend
+    from nexus.contracts.types import OperationContext
+    from nexus.core.config import ParseConfig, PermissionConfig
+    from nexus.factory import create_nexus_fs
+
+    print("=" * 70)
+    print("WRITE-BACK BENCHMARK (Issue #3393 — metadata buffer)")
+    print("=" * 70)
+
+    # Enable the metadata buffer via env var
+    os.environ["NEXUS_METADATA_BUFFER"] = "1"
+
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            storage_path = Path(tmp_dir) / "storage"
+            storage_path.mkdir()
+            db_path = Path(tmp_dir) / "nexus.db"
+
+            backend = CASLocalBackend(str(storage_path))
+            nx = await create_nexus_fs(
+                backend=backend,
+                metadata_store=RaftMetadataStore.embedded(str(db_path).replace(".db", "-raft")),
+                record_store=SQLAlchemyRecordStore(db_path=str(db_path)),
+                permissions=PermissionConfig(enforce=False),
+                parsing=ParseConfig(auto_parse=False),
+                init_cred=TEST_CONTEXT,
+            )
+
+            ctx = OperationContext(
+                user_id="benchmark_user",
+                groups=[],
+                zone_id="benchmark_zone",
+                is_admin=True,
+            )
+
+            content_1kb = b"x" * 1024
+            num_files = 100
+
+            # ---- Benchmark: write-back single writes ----
+            print("\n[1] WRITE-BACK SINGLE WRITES (1KB, consistency='wb')")
+            print("-" * 50)
+
+            write_times = []
+            for i in range(num_files):
+                path = f"/bench/wb/file_{i:04d}.txt"
+                start = time.perf_counter()
+                await nx.write(path, content_1kb, context=ctx, consistency="wb")
+                elapsed = time.perf_counter() - start
+                write_times.append(elapsed * 1000)
+
+            write_times_sorted = sorted(write_times)
+            p50 = write_times_sorted[int(num_files * 0.50)]
+            p95 = write_times_sorted[int(num_files * 0.95)]
+            p99 = write_times_sorted[int(num_files * 0.99)]
+
+            print(f"  Files written:   {num_files}")
+            print(f"  Avg write time:  {statistics.mean(write_times):.3f}ms")
+            print(f"  P50:             {p50:.3f}ms")
+            print(f"  P95:             {p95:.3f}ms")
+            print(f"  P99:             {p99:.3f}ms")
+            print(f"  Min:             {min(write_times):.3f}ms")
+            print(f"  Max:             {max(write_times):.3f}ms")
+            print(f"  Throughput:      {num_files / (sum(write_times) / 1000):.1f} files/sec")
+
+            # ---- Benchmark: SC single writes for comparison ----
+            print("\n[2] SC SINGLE WRITES (1KB, consistency='sc')")
+            print("-" * 50)
+
+            sc_times = []
+            for i in range(num_files):
+                path = f"/bench/sc/file_{i:04d}.txt"
+                start = time.perf_counter()
+                await nx.write(path, content_1kb, context=ctx, consistency="sc")
+                elapsed = time.perf_counter() - start
+                sc_times.append(elapsed * 1000)
+
+            sc_sorted = sorted(sc_times)
+            print(f"  Files written:   {num_files}")
+            print(f"  Avg write time:  {statistics.mean(sc_times):.3f}ms")
+            print(f"  P50:             {sc_sorted[int(num_files * 0.50)]:.3f}ms")
+            print(f"  P95:             {sc_sorted[int(num_files * 0.95)]:.3f}ms")
+            print(f"  P99:             {sc_sorted[int(num_files * 0.99)]:.3f}ms")
+            print(f"  Throughput:      {num_files / (sum(sc_times) / 1000):.1f} files/sec")
+
+            # ---- Benchmark: flush latency ----
+            print("\n[3] FLUSH LATENCY (batched Raft commit)")
+            print("-" * 50)
+
+            from nexus.storage.buffered_metadata_store import BufferedMetadataStore
+
+            if isinstance(nx.metadata, BufferedMetadataStore):
+                # Write a fresh batch to measure flush
+                flush_batch_sizes = [10, 50, 100]
+                for batch_n in flush_batch_sizes:
+                    for i in range(batch_n):
+                        path = f"/bench/flush_{batch_n}/file_{i:04d}.txt"
+                        await nx.write(path, content_1kb, context=ctx, consistency="wb")
+
+                    start = time.perf_counter()
+                    nx.metadata.flush()
+                    flush_elapsed = (time.perf_counter() - start) * 1000
+
+                    print(
+                        f"  Batch size {batch_n:>3d}: "
+                        f"{flush_elapsed:.2f}ms total, "
+                        f"{flush_elapsed / batch_n:.3f}ms/item"
+                    )
+
+                stats = nx.metadata.get_buffer_stats()
+                print(f"\n  Buffer stats: {stats}")
+            else:
+                print("  (metadata buffer not active — skipping flush benchmark)")
+
+            # ---- Summary ----
+            print("\n" + "=" * 70)
+            print("WRITE-BACK vs SC COMPARISON")
+            print("=" * 70)
+            wb_avg = statistics.mean(write_times)
+            sc_avg = statistics.mean(sc_times)
+            if sc_avg > 0:
+                speedup = sc_avg / wb_avg
+                print(f"  WB avg:    {wb_avg:.3f}ms")
+                print(f"  SC avg:    {sc_avg:.3f}ms")
+                print(f"  Speedup:   {speedup:.1f}x")
+
+            nx.close()
+
+            return {
+                "wb_avg_ms": wb_avg,
+                "wb_p50_ms": p50,
+                "wb_p95_ms": p95,
+                "wb_p99_ms": p99,
+                "sc_avg_ms": sc_avg,
+                "speedup": speedup if sc_avg > 0 else 0,
+            }
+    finally:
+        os.environ.pop("NEXUS_METADATA_BUFFER", None)
+
+
 if __name__ == "__main__":
     import json
 
     # Check command line args
-    if len(sys.argv) > 1 and sys.argv[1] == "--deferred":
+    if len(sys.argv) > 1 and sys.argv[1] == "--write-back":
+        # Run write-back mode benchmark (Issue #3393)
+        results = run_write_back_benchmark()
+        print("\n[JSON Results - WRITE-BACK]")
+        print(json.dumps(results, indent=2))
+    elif len(sys.argv) > 1 and sys.argv[1] == "--deferred":
         # Run only deferred mode
         results = run_benchmark(enable_deferred=True)
         print("\n[JSON Results - DEFERRED]")

--- a/tests/helpers/dict_metastore.py
+++ b/tests/helpers/dict_metastore.py
@@ -73,7 +73,13 @@ class DictMetastore(MetastoreABC):
             self._store.pop(p, None)
             self._file_metadata.pop(p, None)
 
-    def _put_batch_raw(self, metadata_list: Sequence[FileMetadata]) -> None:
+    def _put_batch_raw(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",  # noqa: ARG002
+        skip_snapshot: bool = False,  # noqa: ARG002
+    ) -> None:
         for m in metadata_list:
             self._store[m.path] = m
 

--- a/tests/helpers/failing_metastore.py
+++ b/tests/helpers/failing_metastore.py
@@ -129,9 +129,15 @@ class FailingMetastore(MetastoreABC):
         self._maybe_fail("delete_batch")
         self._inner.delete_batch(paths)
 
-    def _put_batch_raw(self, metadata_list: Sequence[FileMetadata]) -> None:
+    def _put_batch_raw(
+        self,
+        metadata_list: Sequence[FileMetadata],
+        *,
+        consistency: str = "sc",
+        skip_snapshot: bool = False,
+    ) -> None:
         self._maybe_fail("put_batch")
-        self._inner.put_batch(metadata_list)
+        self._inner.put_batch(metadata_list, consistency=consistency, skip_snapshot=skip_snapshot)
 
     def batch_get_content_ids(self, paths: Sequence[str]) -> dict[str, str | None]:
         self._maybe_fail("batch_get_content_ids")

--- a/tests/unit/storage/test_deferred_metadata_buffer_errors.py
+++ b/tests/unit/storage/test_deferred_metadata_buffer_errors.py
@@ -1,0 +1,285 @@
+"""Tests for metadata buffer flush failure and retry behavior.
+
+Verifies that DeferredMetadataBuffer handles transient failures correctly:
+items are re-queued on failure, dead-lettered after max retries, and the
+background flush loop remains resilient to errors.
+"""
+
+import time
+from datetime import UTC, datetime
+
+from nexus.contracts.metadata import FileMetadata
+from nexus.storage.buffered_metadata_store import DeferredMetadataBuffer
+from tests.helpers.dict_metastore import DictMetastore
+from tests.helpers.failing_metastore import FailingMetastore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_metadata(path: str, version: int = 1) -> FileMetadata:
+    now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=UTC)
+    return FileMetadata(
+        path=path,
+        backend_name="local",
+        physical_path=f"/data/{path.strip('/')}",
+        size=1024,
+        etag="sha256-test",
+        created_at=now,
+        modified_at=now,
+        version=version,
+        zone_id="root",
+        owner_id="owner-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlushFailureRequeuesItems:
+    """test_flush_failure_requeues_items: put_batch fails, items stay in buffer."""
+
+    def test_flush_failure_requeues_items(self) -> None:
+        inner = DictMetastore()
+        failing_store = FailingMetastore(inner, fail_on=["put_batch"])
+        buf = DeferredMetadataBuffer(failing_store, flush_interval_sec=10.0, max_retries=3)
+
+        m1 = _make_metadata("/a.txt")
+        m2 = _make_metadata("/b.txt")
+        buf.enqueue(m1)
+        buf.enqueue(m2)
+
+        # Flush should fail — items re-queued
+        buf.flush()
+
+        stats = buf.get_stats()
+        assert stats["pending_metadata"] == 2, "Items should be re-queued after failure"
+        assert stats["total_metadata_flushed"] == 0, "Nothing should have been flushed"
+
+        # The items should still be accessible via get_pending
+        assert buf.get_pending("/a.txt") is not None
+        assert buf.get_pending("/b.txt") is not None
+
+        # The underlying store should not have received anything
+        assert inner.get("/a.txt") is None
+        assert inner.get("/b.txt") is None
+
+
+class TestTransientFailureRecovery:
+    """test_transient_failure_recovery: fails twice then succeeds."""
+
+    def test_transient_failure_recovery(self) -> None:
+        inner = DictMetastore()
+        # fail_on_nth=1 means fail on call 1 only; call 2 onwards succeeds
+        # We need to fail twice, so we use fail_on_nth=1 with fail_permanently=False
+        # and reset after each failure. Instead, use a wrapper approach.
+        failing_store = FailingMetastore(inner, fail_on_nth=1, fail_permanently=False)
+        buf = DeferredMetadataBuffer(failing_store, flush_interval_sec=10.0, max_retries=3)
+
+        m1 = _make_metadata("/a.txt")
+        buf.enqueue(m1)
+
+        # First flush: call #1 to put_batch -> fails (nth=1)
+        buf.flush()
+        assert buf.get_stats()["pending_metadata"] == 1, "Item re-queued after first failure"
+        assert buf.get_stats()["total_metadata_flushed"] == 0
+
+        # Reset the call counter so the next put_batch also fails (simulates second transient error)
+        failing_store.reset()
+
+        # Second flush: call #1 again -> fails
+        buf.flush()
+        assert buf.get_stats()["pending_metadata"] == 1, "Item re-queued after second failure"
+        assert buf.get_stats()["total_metadata_flushed"] == 0
+
+        # Now let it succeed: set fail_on_nth to 0 (never fail by count)
+        failing_store._fail_on_nth = 0
+
+        # Third flush: should succeed
+        buf.flush()
+        assert buf.get_stats()["pending_metadata"] == 0, "Buffer should be empty after success"
+        assert buf.get_stats()["total_metadata_flushed"] == 1
+
+        # Verify the item was written to the inner store
+        assert inner.get("/a.txt") is not None
+        assert inner.get("/a.txt").version == 1
+
+
+class TestDeadLetterAfterMaxRetries:
+    """test_dead_letter_after_max_retries: items move to dead-letter after exhausting retries."""
+
+    def test_dead_letter_after_max_retries(self) -> None:
+        inner = DictMetastore()
+        failing_store = FailingMetastore(inner, fail_on=["put_batch"])
+        buf = DeferredMetadataBuffer(failing_store, flush_interval_sec=10.0, max_retries=3)
+
+        m1 = _make_metadata("/doomed.txt")
+        buf.enqueue(m1)
+
+        # Flush max_retries times — each failure increments retry count
+        for _ in range(3):
+            buf.flush()
+
+        # After 3 retries, the item should be dead-lettered
+        stats = buf.get_stats()
+        assert stats["dead_letter_count"] == 1, "Item should be in dead-letter queue"
+        assert stats["pending_metadata"] == 0, "Buffer should be empty (item dead-lettered)"
+
+        dead = buf.get_dead_letter()
+        assert len(dead) == 1
+        assert dead[0]["item"]["path"] == "/doomed.txt"
+
+        # The underlying store should never have received the item
+        assert inner.get("/doomed.txt") is None
+
+
+class TestDeadLetterContainsCorrectInfo:
+    """test_dead_letter_contains_correct_info: verify dead-letter entry structure."""
+
+    def test_dead_letter_contains_correct_info(self) -> None:
+        inner = DictMetastore()
+        failing_store = FailingMetastore(inner, fail_on=["put_batch"])
+        buf = DeferredMetadataBuffer(failing_store, flush_interval_sec=10.0, max_retries=2)
+
+        m1 = _make_metadata("/fail-info.txt", version=42)
+        buf.enqueue(m1)
+
+        # Exhaust retries
+        for _ in range(2):
+            buf.flush()
+
+        dead = buf.get_dead_letter()
+        assert len(dead) == 1
+
+        entry = dead[0]
+        assert entry["type"] == "metadata"
+        assert entry["item"]["path"] == "/fail-info.txt"
+        assert entry["item"]["version"] == 42
+        assert isinstance(entry["error"], str)
+        assert len(entry["error"]) > 0, "Error message should be non-empty"
+        assert entry["retries"] == 2
+
+
+class TestPartialItemsAfterFailure:
+    """test_partial_items_after_failure: items remain visible via get_pending() after failure."""
+
+    def test_partial_items_after_failure(self) -> None:
+        inner = DictMetastore()
+        failing_store = FailingMetastore(inner, fail_on=["put_batch"])
+        buf = DeferredMetadataBuffer(failing_store, flush_interval_sec=10.0, max_retries=5)
+
+        m1 = _make_metadata("/file1.txt", version=1)
+        m2 = _make_metadata("/file2.txt", version=2)
+        m3 = _make_metadata("/file3.txt", version=3)
+        buf.enqueue(m1)
+        buf.enqueue(m2)
+        buf.enqueue(m3)
+
+        # Flush fails — items should be re-queued
+        buf.flush()
+
+        # All items should still be visible via get_pending
+        pending1 = buf.get_pending("/file1.txt")
+        pending2 = buf.get_pending("/file2.txt")
+        pending3 = buf.get_pending("/file3.txt")
+
+        assert pending1 is not None, "file1.txt should still be pending"
+        assert pending2 is not None, "file2.txt should still be pending"
+        assert pending3 is not None, "file3.txt should still be pending"
+
+        assert pending1.version == 1
+        assert pending2.version == 2
+        assert pending3.version == 3
+
+        # Buffer should still report 3 pending items
+        assert buf.get_stats()["pending_metadata"] == 3
+
+
+class TestStatsTrackFailures:
+    """test_stats_track_failures: stats reflect flushed and dead-letter counts."""
+
+    def test_stats_track_failures(self) -> None:
+        inner = DictMetastore()
+        # Use fail_on_nth to control which calls fail
+        failing_store = FailingMetastore(inner, fail_on_nth=1, fail_permanently=False)
+        buf = DeferredMetadataBuffer(failing_store, flush_interval_sec=10.0, max_retries=2)
+
+        # Enqueue first item
+        m1 = _make_metadata("/good.txt", version=1)
+        buf.enqueue(m1)
+
+        # First flush fails (call #1)
+        buf.flush()
+        stats = buf.get_stats()
+        assert stats["total_metadata_flushed"] == 0
+        assert stats["dead_letter_count"] == 0
+        assert stats["pending_metadata"] == 1
+
+        # Second flush also fails — need to reset counter to trigger fail on call #1 again
+        # But we want this second flush to also fail so the item is dead-lettered (max_retries=2)
+        failing_store.reset()
+        buf.flush()
+        stats = buf.get_stats()
+        assert stats["dead_letter_count"] == 1, "Item should be dead-lettered after 2 failures"
+        assert stats["pending_metadata"] == 0
+        assert stats["total_metadata_flushed"] == 0
+
+        # Now enqueue a new item and let it succeed
+        failing_store._fail_on_nth = 0  # Disable failure injection
+        m2 = _make_metadata("/success.txt", version=2)
+        buf.enqueue(m2)
+        buf.flush()
+
+        stats = buf.get_stats()
+        assert stats["total_metadata_flushed"] == 1, "One item should have been flushed"
+        assert stats["dead_letter_count"] == 1, "Dead-letter count should remain 1"
+        assert stats["pending_metadata"] == 0
+        assert stats["flush_count"] == 1, "One successful flush cycle"
+        assert stats["total_flushed"] == 1
+
+
+class TestBackgroundFlushLoopResilience:
+    """test_background_flush_loop_resilience: background loop survives transient errors."""
+
+    def test_background_flush_loop_resilience(self) -> None:
+        inner = DictMetastore()
+        # Fail on first call only, then succeed
+        failing_store = FailingMetastore(inner, fail_on_nth=1, fail_permanently=False)
+        buf = DeferredMetadataBuffer(failing_store, flush_interval_sec=0.05, max_retries=5)
+
+        # Enqueue before starting — the first background flush will fail
+        m1 = _make_metadata("/resilient.txt", version=1)
+        buf.enqueue(m1)
+
+        # Start the background flush loop
+        buf._start_sync()
+        try:
+            # Wait long enough for at least 2 flush cycles:
+            # - First cycle hits call #1 -> fails, item re-queued
+            # - Second cycle hits call #2 -> succeeds
+            time.sleep(0.3)
+
+            # The background loop should have recovered and flushed the item
+            stats = buf.get_stats()
+            assert stats["total_metadata_flushed"] == 1, (
+                "Item should have been flushed after transient failure recovery"
+            )
+            assert stats["pending_metadata"] == 0
+            assert stats["dead_letter_count"] == 0
+
+            # Verify the item made it to the underlying store
+            assert inner.get("/resilient.txt") is not None
+
+            # Enqueue another item to verify the loop is still running
+            m2 = _make_metadata("/after-recovery.txt", version=2)
+            buf.enqueue(m2)
+            time.sleep(0.2)
+
+            assert inner.get("/after-recovery.txt") is not None, (
+                "Background loop should still be functional after error recovery"
+            )
+        finally:
+            buf._stop_sync()

--- a/tests/unit/storage/test_write_back_concurrency.py
+++ b/tests/unit/storage/test_write_back_concurrency.py
@@ -1,0 +1,286 @@
+"""Tests for concurrent write-back behavior in BufferedMetadataStore.
+
+Validates thread-safety of the deferred write-back buffer under
+concurrent writes, reads, flushes, and batch-overflow scenarios.
+"""
+
+import threading
+import time
+from datetime import UTC, datetime
+
+from nexus.contracts.metadata import FileMetadata
+from nexus.storage.buffered_metadata_store import BufferedMetadataStore
+from tests.helpers.dict_metastore import DictMetastore
+
+
+def _make_metadata(path: str, version: int = 1, content_hash: str = "hash") -> FileMetadata:
+    return FileMetadata(
+        path=path,
+        backend_name="test-backend",
+        physical_path=f"/phys{path}",
+        size=100,
+        etag=content_hash,
+        created_at=datetime.now(UTC),
+        modified_at=datetime.now(UTC),
+        version=version,
+        zone_id="zone-1",
+        owner_id="owner-1",
+    )
+
+
+class TestWriteBackConcurrency:
+    """Concurrent write-back tests for BufferedMetadataStore."""
+
+    def test_concurrent_writes_to_different_paths(self) -> None:
+        """10 threads each writing to different paths with consistency='wb'.
+
+        All writes should be visible via get().
+        """
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner, flush_interval_sec=10.0, max_batch_size=200)
+
+        num_threads = 10
+        barrier = threading.Barrier(num_threads)
+        errors: list[Exception] = []
+
+        def writer(thread_id: int) -> None:
+            try:
+                barrier.wait(timeout=5.0)
+                path = f"/file_{thread_id}.txt"
+                meta = _make_metadata(path, version=thread_id + 1, content_hash=f"hash_{thread_id}")
+                store.put(meta, consistency="wb")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        assert not errors, f"Writer threads raised errors: {errors}"
+
+        # All writes should be visible via get() (read overlay on pending buffer)
+        for i in range(num_threads):
+            path = f"/file_{i}.txt"
+            result = store.get(path)
+            assert result is not None, f"get({path}) returned None"
+            assert result.path == path
+            assert result.version == i + 1
+            assert result.etag == f"hash_{i}"
+
+    def test_concurrent_writes_to_same_path_last_writer_wins(self) -> None:
+        """Multiple threads writing to the same path.
+
+        After all complete, get() should return one of the written values
+        (last-writer-wins semantics).
+        """
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner, flush_interval_sec=10.0, max_batch_size=200)
+
+        path = "/shared_file.txt"
+        num_threads = 20
+        barrier = threading.Barrier(num_threads)
+        errors: list[Exception] = []
+
+        def writer(thread_id: int) -> None:
+            try:
+                barrier.wait(timeout=5.0)
+                meta = _make_metadata(path, version=thread_id + 1, content_hash=f"hash_{thread_id}")
+                store.put(meta, consistency="wb")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        assert not errors, f"Writer threads raised errors: {errors}"
+
+        result = store.get(path)
+        assert result is not None, "get() returned None for shared path"
+        assert result.path == path
+        # The version should be one of the values written by any thread
+        valid_versions = set(range(1, num_threads + 1))
+        assert result.version in valid_versions, (
+            f"Unexpected version {result.version}; expected one of {valid_versions}"
+        )
+
+    def test_concurrent_writes_and_reads(self) -> None:
+        """Writers and readers running concurrently.
+
+        Readers should never get None for a path that was written to
+        (once a wb write for a path has returned, subsequent reads must see it).
+        """
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner, flush_interval_sec=10.0, max_batch_size=200)
+
+        num_writers = 5
+        num_readers = 5
+        reads_per_reader = 50
+        # Events to signal that each writer has finished
+        writer_done_events = [threading.Event() for _ in range(num_writers)]
+        errors: list[str] = []
+
+        def writer(thread_id: int) -> None:
+            path = f"/rw_file_{thread_id}.txt"
+            meta = _make_metadata(path, version=1, content_hash=f"hash_{thread_id}")
+            store.put(meta, consistency="wb")
+            writer_done_events[thread_id].set()
+
+        def reader(thread_id: int) -> None:
+            # Pick the writer we pair with (round-robin)
+            writer_id = thread_id % num_writers
+            path = f"/rw_file_{writer_id}.txt"
+            # Wait until the paired writer has completed its put()
+            writer_done_events[writer_id].wait(timeout=5.0)
+            for _ in range(reads_per_reader):
+                result = store.get(path)
+                if result is None:
+                    errors.append(f"Reader {thread_id} got None for {path} after writer completed")
+                    return
+
+        writer_threads = [threading.Thread(target=writer, args=(i,)) for i in range(num_writers)]
+        reader_threads = [threading.Thread(target=reader, args=(i,)) for i in range(num_readers)]
+
+        # Start all threads
+        for t in writer_threads + reader_threads:
+            t.start()
+        for t in writer_threads + reader_threads:
+            t.join(timeout=10.0)
+
+        assert not errors, f"Read-after-write violations: {errors}"
+
+    def test_concurrent_writes_sequential_versions(self) -> None:
+        """Write multiple versions to the same path sequentially.
+
+        Verify version numbers are preserved correctly after flush.
+        """
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner, flush_interval_sec=10.0, max_batch_size=200)
+
+        path = "/versioned_file.txt"
+        num_versions = 20
+
+        for v in range(1, num_versions + 1):
+            meta = _make_metadata(path, version=v, content_hash=f"hash_v{v}")
+            store.put(meta, consistency="wb")
+
+            # Each put should immediately be visible via get() (buffer overlay)
+            result = store.get(path)
+            assert result is not None, f"get() returned None after writing version {v}"
+            assert result.version == v, f"Expected version {v} after write, got {result.version}"
+
+        # Last-writer-wins: only the final version should remain in the buffer
+        result = store.get(path)
+        assert result is not None
+        assert result.version == num_versions
+        assert result.etag == f"hash_v{num_versions}"
+
+        # After flush, the inner store should have the final version
+        store.flush()
+        inner_result = inner.get(path)
+        assert inner_result is not None, "Inner store missing entry after flush"
+        assert inner_result.version == num_versions
+        assert inner_result.etag == f"hash_v{num_versions}"
+
+    def test_flush_during_writes(self) -> None:
+        """Start a background flush thread while writers are actively enqueueing.
+
+        Should not crash or lose data.
+        """
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner, flush_interval_sec=10.0, max_batch_size=200)
+
+        num_writers = 5
+        writes_per_writer = 20
+        errors: list[Exception] = []
+        writer_start = threading.Event()
+
+        def writer(thread_id: int) -> None:
+            try:
+                writer_start.wait(timeout=5.0)
+                for i in range(writes_per_writer):
+                    path = f"/flush_test_{thread_id}_{i}.txt"
+                    meta = _make_metadata(path, version=1, content_hash=f"h_{thread_id}_{i}")
+                    store.put(meta, consistency="wb")
+            except Exception as e:
+                errors.append(e)
+
+        def flusher() -> None:
+            try:
+                writer_start.wait(timeout=5.0)
+                # Repeatedly flush while writers are active
+                for _ in range(10):
+                    store.flush()
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(e)
+
+        writer_threads = [threading.Thread(target=writer, args=(i,)) for i in range(num_writers)]
+        flush_thread = threading.Thread(target=flusher)
+
+        for t in writer_threads:
+            t.start()
+        flush_thread.start()
+
+        # Unleash all threads simultaneously
+        writer_start.set()
+
+        for t in writer_threads:
+            t.join(timeout=10.0)
+        flush_thread.join(timeout=10.0)
+
+        assert not errors, f"Threads raised errors: {errors}"
+
+        # Final flush to push any remaining buffered items
+        store.flush()
+
+        # Every path should exist in the inner store after final flush
+        for tid in range(num_writers):
+            for i in range(writes_per_writer):
+                path = f"/flush_test_{tid}_{i}.txt"
+                result = inner.get(path)
+                assert result is not None, f"Path {path} lost after concurrent flush + writes"
+
+    def test_batch_overflow_triggers_flush_event(self) -> None:
+        """Write more items than max_batch_size.
+
+        The flush event should be triggered, causing items to eventually
+        appear in the inner store without an explicit flush() call.
+        """
+        inner = DictMetastore()
+        max_batch = 5
+        store = BufferedMetadataStore(inner, flush_interval_sec=10.0, max_batch_size=max_batch)
+        # Start the background flush thread so it can react to the flush event
+        store._start_sync()
+
+        try:
+            # Write more than max_batch_size items to trigger overflow
+            num_items = max_batch + 3
+            for i in range(num_items):
+                path = f"/overflow_{i}.txt"
+                meta = _make_metadata(path, version=1, content_hash=f"h_{i}")
+                store.put(meta, consistency="wb")
+
+            # Give the background flush thread time to react to the overflow event
+            deadline = time.monotonic() + 5.0
+            flushed = False
+            while time.monotonic() < deadline:
+                # Check if at least max_batch_size items made it to the inner store
+                found = sum(
+                    1 for i in range(num_items) if inner.get(f"/overflow_{i}.txt") is not None
+                )
+                if found >= max_batch:
+                    flushed = True
+                    break
+                time.sleep(0.01)
+
+            assert flushed, (
+                f"Expected at least {max_batch} items flushed to inner store "
+                f"via batch overflow, but found fewer"
+            )
+        finally:
+            store._stop_sync()

--- a/tests/unit/storage/test_write_back_read_after_write.py
+++ b/tests/unit/storage/test_write_back_read_after_write.py
@@ -1,0 +1,263 @@
+"""Tests for write-back consistency guarantee in BufferedMetadataStore.
+
+Verifies that ``consistency="wb"`` writes are immediately visible via
+``get()``, ``exists()``, and ``get_batch()`` even before the background
+flush commits them to the inner store.
+
+See architecture decision A1 (store-level intercept on get() for buffer
+overlay) in Issue #3393.
+"""
+
+from datetime import UTC, datetime
+
+from nexus.contracts.metadata import FileMetadata
+from nexus.storage.buffered_metadata_store import BufferedMetadataStore
+from tests.helpers.dict_metastore import DictMetastore
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_metadata(
+    path: str = "/data/file.txt",
+    version: int = 1,
+    backend_name: str = "default",
+    physical_path: str | None = None,
+    size: int = 1024,
+    etag: str | None = None,
+    created_at: datetime | None = None,
+    modified_at: datetime | None = None,
+    zone_id: str = "zone-1",
+    owner_id: str = "user-1",
+) -> FileMetadata:
+    now = datetime.now(UTC)
+    return FileMetadata(
+        path=path,
+        backend_name=backend_name,
+        physical_path=physical_path or f"/phys{path}",
+        size=size,
+        etag=etag or f"etag-v{version}",
+        created_at=created_at or now,
+        modified_at=modified_at or now,
+        version=version,
+        zone_id=zone_id,
+        owner_id=owner_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBackReadAfterWrite:
+    """Write-back consistency: wb put() is visible on immediate get()."""
+
+    def test_wb_write_then_immediate_get(self) -> None:
+        """put(consistency='wb') followed by get() returns the buffered metadata."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta = _make_metadata("/data/a.txt")
+        store.put(meta, consistency="wb")
+
+        result = store.get("/data/a.txt")
+        assert result is not None
+        assert result.path == "/data/a.txt"
+
+    def test_wb_write_then_get_returns_correct_fields(self) -> None:
+        """All metadata fields round-trip correctly through the buffer."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        now = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        meta = _make_metadata(
+            path="/proj/report.csv",
+            version=7,
+            backend_name="fast-ssd",
+            physical_path="/mnt/ssd/report.csv",
+            size=98765,
+            etag="sha256-abc123",
+            created_at=now,
+            modified_at=now,
+            zone_id="zone-42",
+            owner_id="user-99",
+        )
+        store.put(meta, consistency="wb")
+
+        result = store.get("/proj/report.csv")
+        assert result is not None
+        assert result.path == "/proj/report.csv"
+        assert result.backend_name == "fast-ssd"
+        assert result.physical_path == "/mnt/ssd/report.csv"
+        assert result.size == 98765
+        assert result.etag == "sha256-abc123"
+        assert result.created_at == now
+        assert result.modified_at == now
+        assert result.version == 7
+        assert result.zone_id == "zone-42"
+        assert result.owner_id == "user-99"
+
+    def test_wb_overwrite_same_path(self) -> None:
+        """Two consecutive wb writes to the same path: get() returns the latest."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta_v1 = _make_metadata("/data/overwrite.txt", version=1, size=100)
+        meta_v2 = _make_metadata("/data/overwrite.txt", version=2, size=200)
+
+        store.put(meta_v1, consistency="wb")
+        store.put(meta_v2, consistency="wb")
+
+        result = store.get("/data/overwrite.txt")
+        assert result is not None
+        assert result.version == 2
+        assert result.size == 200
+
+    def test_wb_write_does_not_appear_in_inner_store_before_flush(self) -> None:
+        """Buffered metadata is NOT visible in the inner store before flush."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta = _make_metadata("/data/buffered.txt")
+        store.put(meta, consistency="wb")
+
+        # The inner store should have nothing yet
+        assert inner.get("/data/buffered.txt") is None
+
+    def test_wb_write_appears_in_inner_store_after_flush(self) -> None:
+        """After flush(), the inner store contains the metadata."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta = _make_metadata("/data/flushed.txt", version=3)
+        store.put(meta, consistency="wb")
+        store.flush()
+
+        inner_result = inner.get("/data/flushed.txt")
+        assert inner_result is not None
+        assert inner_result.path == "/data/flushed.txt"
+        assert inner_result.version == 3
+
+    def test_sc_write_bypasses_buffer(self) -> None:
+        """put(consistency='sc') writes directly to the inner store."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta = _make_metadata("/data/sc.txt")
+        store.put(meta, consistency="sc")
+
+        # Immediately visible in the inner store (no flush needed)
+        assert inner.get("/data/sc.txt") is not None
+        assert inner.get("/data/sc.txt").path == "/data/sc.txt"
+
+    def test_ec_write_bypasses_buffer(self) -> None:
+        """put(consistency='ec') writes directly to the inner store."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta = _make_metadata("/data/ec.txt")
+        store.put(meta, consistency="ec")
+
+        # Immediately visible in the inner store (no flush needed)
+        assert inner.get("/data/ec.txt") is not None
+        assert inner.get("/data/ec.txt").path == "/data/ec.txt"
+
+    def test_wb_exists_returns_true(self) -> None:
+        """exists() returns True for paths that are only in the buffer."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta = _make_metadata("/data/exists_check.txt")
+        store.put(meta, consistency="wb")
+
+        assert store.exists("/data/exists_check.txt") is True
+        # Not yet in the inner store
+        assert inner.exists("/data/exists_check.txt") is False
+
+    def test_wb_get_batch_includes_buffered(self) -> None:
+        """get_batch() merges buffered entries with inner store results."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        # Put one entry directly in the inner store
+        meta_inner = _make_metadata("/data/inner.txt", version=1)
+        inner.put(meta_inner)
+
+        # Put another entry through the buffer
+        meta_buffered = _make_metadata("/data/buffered.txt", version=2)
+        store.put(meta_buffered, consistency="wb")
+
+        results = store.get_batch(["/data/inner.txt", "/data/buffered.txt", "/data/missing.txt"])
+
+        assert results["/data/inner.txt"] is not None
+        assert results["/data/inner.txt"].version == 1
+
+        assert results["/data/buffered.txt"] is not None
+        assert results["/data/buffered.txt"].version == 2
+
+        assert results["/data/missing.txt"] is None
+
+    def test_wb_version_increment_across_flushes(self) -> None:
+        """Write v1, flush, write v2 -- get() returns v2."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta_v1 = _make_metadata("/data/versioned.txt", version=1)
+        store.put(meta_v1, consistency="wb")
+        store.flush()
+
+        # v1 should now be in the inner store
+        assert inner.get("/data/versioned.txt").version == 1
+
+        meta_v2 = _make_metadata("/data/versioned.txt", version=2)
+        store.put(meta_v2, consistency="wb")
+
+        # get() should return the buffered v2
+        result = store.get("/data/versioned.txt")
+        assert result is not None
+        assert result.version == 2
+
+        # Inner store still has v1
+        assert inner.get("/data/versioned.txt").version == 1
+
+    def test_has_pending_flag_false_when_no_pending(self) -> None:
+        """_has_pending tracks buffer state: False -> True -> False after flush."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        # Initially no pending items
+        assert store._has_pending is False
+
+        # After wb write, flag is True
+        meta = _make_metadata("/data/pending.txt")
+        store.put(meta, consistency="wb")
+        assert store._has_pending is True
+
+        # After flush, flag goes back to False
+        store.flush()
+        assert store._has_pending is False
+
+    def test_flush_clears_buffer(self) -> None:
+        """After flush(), buffer is empty and get() falls through to inner store."""
+        inner = DictMetastore()
+        store = BufferedMetadataStore(inner)
+
+        meta = _make_metadata("/data/cleared.txt", version=5, size=500)
+        store.put(meta, consistency="wb")
+
+        # Buffered entry is visible
+        assert store.get("/data/cleared.txt") is not None
+
+        store.flush()
+
+        # After flush, the buffer should be empty -- the entry lives only in
+        # the inner store now. We can verify by checking the buffer directly.
+        assert store._buffer.get_pending("/data/cleared.txt") is None
+
+        # get() still works, falling through to the inner store
+        result = store.get("/data/cleared.txt")
+        assert result is not None
+        assert result.version == 5
+        assert result.size == 500


### PR DESCRIPTION
## Summary

Implements deferred metadata buffering for write-back consistency mode (`consistency="wb"`), deferring Raft consensus from the VFS write critical path. Inspired by DFUSE's write-back caching model (arXiv:2503.18191).

- **New `DeferredBuffer[T]` generic base class** — extracted shared threading/lifecycle/retry/dead-letter infrastructure from `DeferredPermissionBuffer` (~150 lines DRY'd)
- **Fixed `_trigger_flush()` no-op** — now uses `threading.Event` to wake the background thread immediately on batch overflow (was dead code)
- **`BufferedMetadataStore` wrapper** — intercepts `get()` at the store level for buffer overlay (all 24 call sites covered transparently), with `_has_pending` fast-path flag for zero-overhead reads
- **`consistency="wb"` mode** — documented in `MetastoreABC` contract; non-buffered stores fall back to `"ec"`
- **`put_batch()` extended** with `consistency` and `skip_snapshot` params across all implementations
- **`_build_write_metadata()` helper** — DRY'd duplicated FileMetadata construction in `sys_write`
- **Opt-in via `NEXUS_METADATA_BUFFER=1`** env var; uses existing `StorageTuning` profile values

**Expected improvement:** Metadata cost reduced from ~5-10ms (Raft consensus per write) to ~10μs (buffer enqueue). Batch of 100 writes: amortized to a single Raft round.

Closes #3393

## Files changed

| Category | Files |
|----------|-------|
| New (core) | `src/nexus/lib/deferred_buffer.py`, `src/nexus/storage/buffered_metadata_store.py` |
| Refactored | `deferred_permission_buffer.py` (inherits from base), `nexus_fs.py` (DRY + consistency passthrough) |
| Interface | `metastore.py` (wb docs), `raft_metadata_store.py`, `federated_metadata_proxy.py`, `_sqlite_meta.py`, `dict_metastore.py` (put_batch signature) |
| Factory | `orchestrator.py` (buffer wiring) |
| Tests (new) | `test_write_back_read_after_write.py` (12 tests), `test_write_back_concurrency.py` (6 tests), `test_deferred_metadata_buffer_errors.py` (7 tests) |
| Benchmark | `benchmark_write_performance.py` (--write-back mode with timing breakdown) |

## Test plan

- [x] 25 new unit tests covering read-after-write, concurrency, and flush error/retry/dead-letter
- [x] 37 existing `DeferredPermissionBuffer` tests pass (verifies base class extraction)
- [x] 13 existing dead-letter tests pass
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [ ] Run `--write-back` benchmark to validate performance claims
- [ ] E2E test with `NEXUS_METADATA_BUFFER=1` on a multi-node federation setup