### PR TITLE
fix(#38): use id@host:port format for Raft peer addresses

### DIFF
--- a/src/nexus/raft/federation.py
+++ b/src/nexus/raft/federation.py
@@ -139,7 +139,7 @@ class NexusFederation:
         # Parse peer addresses
         peers_str = os.environ.get("NEXUS_PEERS", "")
         peer_addrs = PeerAddress.parse_peer_list(peers_str) if peers_str else []
-        peers = [p.grpc_target for p in peer_addrs]
+        peers = [p.to_raft_peer_str() for p in peer_addrs]
 
         _max_attempts = int(os.environ.get("NEXUS_STARTUP_MAX_RETRIES", "12"))
         _base_delay = 2.0
@@ -264,8 +264,8 @@ class NexusFederation:
 
     @property
     def peer_targets(self) -> list[str]:
-        """Cluster peer host:port strings for Raft group creation."""
-        return [p.grpc_target for p in self._peers]
+        """Cluster peer id@host:port strings for Raft group creation."""
+        return [p.to_raft_peer_str() for p in self._peers]
 
     def create_zone(self, zone_id: str) -> Any:
         """Create a zone with all cluster peers included in the Raft group."""


### PR DESCRIPTION
## Summary
- Rust Raft layer expects peer addresses in `id@host:port` format but Python federation bootstrap was passing `host:port` via `grpc_target`
- This caused `invalid address: expected 'id@host:port'` errors when starting federation with IP-based `NEXUS_PEERS` (e.g. Tailscale IPs like `100.64.0.18:2126`)
- Switch `bootstrap()` and `peer_targets` to use `to_raft_peer_str()` which includes the SHA-256 derived node ID prefix
- `grpc_target` correctly kept for gRPC channel connections (join_cluster RPC, `_discover_mount`, etc.)

## Test plan
- [x] Verified fix locally: macOS `nexusd` successfully bootstraps root + shared zones with `NEXUS_PEERS=100.64.0.18:2126,100.64.0.21:2126`
- [x] Confirmed gRPC connects to Windows peer (`Connected to Raft node at http://100.64.0.18:2126`)
- [ ] Full 2-node federation E2E (pending Windows data cleanup + restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)