### PR TITLE
fix: wire lock manager from EventsService + fix failover E2E

### DIFF
--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -350,7 +350,9 @@ def create_app(
 
             _rpc_sources.append(FederationRPCService(_fed))
         # --- Locks (Issue #1133) ---
-        _lock_mgr = getattr(nexus_fs, "_lock_manager", None)
+        # Lock manager lives on EventsService (moved in PR #3379).
+        _events_svc = nexus_fs.service("events") if hasattr(nexus_fs, "service") else None
+        _lock_mgr = getattr(_events_svc, "_lock_manager", None) if _events_svc else None
         if _lock_mgr is not None:
             from nexus.server.rpc.services.locks_rpc import LocksRPCService
 

--- a/src/nexus/server/rpc/services/locks_rpc.py
+++ b/src/nexus/server/rpc/services/locks_rpc.py
@@ -18,8 +18,9 @@ class LocksRPCService:
         self._lock_manager = lock_manager
 
     @rpc_expose(description="List active locks")
-    async def lock_list(self, zone_id: str | None = None) -> dict[str, Any]:
-        locks = await self._lock_manager.list_locks(zone_id=zone_id)
+    async def lock_list(self, zone_id: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+        # zone_id is already bound at construction time in AdvisoryLockManager
+        locks = await self._lock_manager.list_locks()
         return {
             "locks": [self._lock_to_dict(lk) for lk in locks],
             "count": len(locks),

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -831,8 +831,8 @@ class TestLeaderFailover:
                 timeout=15,
             )
 
-        # Stop node-1
-        subprocess.run(["docker", "stop", "nexus-node-1"], timeout=30, check=True)
+        # Stop node-1 (container name from docker-compose.dynamic-federation-test.yml)
+        subprocess.run(["docker", "stop", "nexus-dyn-node-1"], timeout=30, check=True)
 
         try:
             # Wait for node-2 healthy
@@ -855,7 +855,7 @@ class TestLeaderFailover:
 
         finally:
             # Restart node-1
-            subprocess.run(["docker", "start", "nexus-node-1"], timeout=30, check=True)
+            subprocess.run(["docker", "start", "nexus-dyn-node-1"], timeout=30, check=True)
             _wait_healthy([cluster["node1"]], timeout=60)
 
         # Node-1 catches up: new files readable


### PR DESCRIPTION
## Summary
- **Lock manager wiring**: `fastapi_server.py` read from deleted `nexus_fs._lock_manager` (moved to `EventsService` in PR #3379). Now reads from `nexus_fs.service("events")._lock_manager` — unblocks 3 skipped lock E2E tests.
- **`list_locks()` kwarg fix**: `LocksRPCService.lock_list()` passed invalid `zone_id=` keyword to `AdvisoryLockManager.list_locks()` which would TypeError at runtime.
- **Failover container name**: Test used `nexus-node-1` but compose defines `nexus-dyn-node-1` — `docker stop` failed before any failover logic ran.

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, formatting)
- [x] `tests/unit/server/` — 15 health probe tests pass
- [x] Full `tests/unit/server/` suite passes (700+ tests)
- [ ] E2E federation tests in Docker: expect lock tests to pass (previously skipped), failover test to pass (previously failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)