### PR TITLE
refactor: add /__sys__/ service registration via sys_setattr/sys_unlink

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -164,6 +164,9 @@ business logic**.
 
 `mkdir` is Tier 2 convenience over `sys_setattr(entry_type=DT_DIR)` — not a kernel syscall.
 `mount` is `sys_setattr(entry_type=DT_MOUNT, backend=...)`, `umount` is `sys_rmdir` on DT_MOUNT path.
+`/__sys__/services/` paths register/unregister services via syscall:
+`sys_setattr("/__sys__/services/X", service=instance)` registers (calls `enlist()`),
+`sys_unlink("/__sys__/services/X")` unregisters (calls `unregister_service_full()`).
 
 **Primitive usage pattern:**
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -739,13 +739,39 @@ class NexusFS(  # type: ignore[misc]
         - Path exists + different entry_type → ValueError (immutable after creation)
 
         Args:
-            path: Virtual file path.
+            path: Virtual file path. Paths under ``/__sys__/`` are kernel
+            management operations (service/hook registration), not filesystem
+            metadata.
             context: Operation context.
             **attrs: Metadata attributes. Include ``entry_type`` to create.
 
         Returns:
             Dict with path, created flag, and type-specific fields.
         """
+        # ── /__sys__/ kernel management dispatch ──────────────────────
+        # Service and hook registration via syscall. These paths bypass
+        # the normal metastore path — kernel routes them to ServiceRegistry
+        # or KernelDispatch instead.
+        if path.startswith("/__sys__/services/"):
+            name = path.rsplit("/", 1)[-1]
+            service = attrs.get("service")
+            if service is None:
+                raise ValueError(
+                    f"sys_setattr(/__sys__/services/{name}) requires 'service' attribute"
+                )
+            await self._service_registry.enlist(name, service)
+            return {"path": path, "registered": True, "service": name}
+
+        if path.startswith("/__sys__/hooks/"):
+            # Standalone hook registration. Services with hook_spec use
+            # /__sys__/services/ instead (enlist auto-detects hooks).
+            # TODO: Add KernelDispatch.register_hook(name, hook) for
+            # standalone hooks (debug tracers, temporary observers).
+            raise NotImplementedError(
+                "Standalone hook registration via /__sys__/hooks/ not yet supported. "
+                "Use /__sys__/services/ with a service that declares hook_spec()."
+            )
+
         path = self._validate_path(path)
 
         meta = self.metadata.get(path)
@@ -3095,6 +3121,17 @@ class NexusFS(  # type: ignore[misc]
             AccessDeniedError: If access is denied (zone isolation or read-only namespace).
             PermissionError: If path is read-only or user doesn't have write permission.
         """
+        # ── /__sys__/ kernel management dispatch ──────────────────────
+        if path.startswith("/__sys__/services/"):
+            name = path.rsplit("/", 1)[-1]
+            await self._service_registry.unregister_service_full(name)
+            return {"path": path, "unregistered": True, "service": name}
+
+        if path.startswith("/__sys__/hooks/"):
+            raise NotImplementedError(
+                "Standalone hook removal via /__sys__/hooks/ not yet supported."
+            )
+
         # DT_PIPE fast-path: skip validate/zone_check/resolve/metastore.get
         if self._pipe_manager is not None and path in self._pipe_manager._buffers:
             return self._pipe_destroy(path)


### PR DESCRIPTION
## Summary
- `sys_setattr("/__sys__/services/X", service=inst)` → `enlist()` + auto hook_spec detection
- `sys_unlink("/__sys__/services/X")` → `unregister_service_full()` (stop + unhook)
- `/__sys__/hooks/` reserved for future standalone hook registration

## Context
Phase C of Kernel Interface Unification plan. Enables factory and runtime callers to register/unregister services via syscall instead of calling kernel internal APIs directly.

`/__sys__/` is already a reserved path prefix (`_uri.py:RESERVED_PATHS`). Paths under `/__sys__/` bypass metastore and route to kernel management logic.

## Changes (2 files)
- `core/nexus_fs.py`: `/__sys__/` dispatch in sys_setattr() and sys_unlink()
- `docs/architecture/KERNEL-ARCHITECTURE.md`: Document `/__sys__/services/` paths

## Test plan
- [ ] All pre-commit hooks pass
- [ ] CI green (additive only, no existing callers changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)