### PR TITLE
refactor: pluggable DT_STREAM backends via mount stream_backend_factory

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -375,14 +375,20 @@ Two-layer architecture for both: VFS metadata (inode) in MetastoreABC, data
   no internal synchronization. PipeManager wraps with per-pipe `asyncio.Lock`
   for **MPMC** safety. Direct RingBuffer access is kernel-internal only.
 
-**DT_STREAM (StreamManager + StreamBuffer):**
+**DT_STREAM (StreamManager + pluggable StreamBackend):**
 
 - **StreamManager (mkstream)** — VFS named stream lifecycle (same syscall
   surface as mkpipe). Per-stream lock for concurrent writers. Reads are
   non-destructive — multiple readers maintain independent byte offsets (fan-out).
-- **StreamBuffer (kstream)** — Linear append-only buffer. Monotonic tail, no
-  wrap-around. Primary use case: LLM streaming I/O (realtime first consumer +
-  replay for later consumers).
+- **StreamBackend protocol** — pluggable backing store for DT_STREAM data.
+  Mount configuration determines which backend is used when creating a stream
+  under that mount (like Linux filesystem type determines pipe implementation).
+  Current implementations: ``StreamBuffer`` (in-memory, default),
+  ``RemoteStreamBackend`` (federation gRPC proxy).
+  Future: CAS-backed (durable), WAL-backed (replicated).
+- **Mount-determined backend** — ``_MountEntry.stream_backend_factory`` is baked
+  at mount time. ``sys_setattr(entry_type=DT_STREAM)`` checks the enclosing
+  mount's factory; if set, creates a custom backend instead of default memory.
 
 See `federation-memo.md` §7j for design rationale.
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -883,8 +883,17 @@ class NexusFS(  # type: ignore[misc]
         if entry_type == DT_STREAM:
             from nexus.core.stream import StreamError
 
+            # Check if mount provides a custom stream backend factory
+            # (e.g. CAS-backed or WAL-backed streams). Default: in-memory StreamBuffer.
+            _mount_entry = self.router.get_mount_entry_for_path(path)
+            _factory = _mount_entry.stream_backend_factory if _mount_entry else None
+
             try:
-                self._stream_manager.create(path, capacity=capacity, owner_id=owner_id)
+                if _factory is not None:
+                    backend = _factory(path, capacity)
+                    self._stream_manager.create_from_backend(path, backend, owner_id=owner_id)
+                else:
+                    self._stream_manager.create(path, capacity=capacity, owner_id=owner_id)
             except StreamError as exc:
                 raise BackendError(str(exc)) from exc
             return {"path": path, "created": True, "entry_type": entry_type, "capacity": capacity}

--- a/src/nexus/core/router.py
+++ b/src/nexus/core/router.py
@@ -20,7 +20,7 @@ Architecture:
 
 import posixpath
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.exceptions import AccessDeniedError, InvalidPathError, PathNotMountedError
 
@@ -44,6 +44,7 @@ class _MountEntry:
     readonly: bool
     admin_only: bool
     io_profile: str
+    stream_backend_factory: Any = None  # Callable[[str, int], StreamBackend] | None
 
 
 @dataclass
@@ -130,6 +131,7 @@ class PathRouter:
         readonly: bool = False,
         admin_only: bool = False,
         io_profile: str = "balanced",
+        stream_backend_factory: Any = None,
     ) -> None:
         """Register a backend at *mount_point* for path routing.
 
@@ -144,6 +146,10 @@ class PathRouter:
             readonly: Whether mount is readonly.
             admin_only: Whether mount requires admin privileges.
             io_profile: I/O tuning profile.
+            stream_backend_factory: Optional callable ``(path, capacity) -> StreamBackend``
+                for creating DT_STREAM with non-default backing store (e.g. CAS, WAL).
+                When set, ``sys_setattr(entry_type=DT_STREAM)`` under this mount uses
+                the factory instead of the default in-memory StreamBuffer.
 
         Raises:
             ValueError: If mount_point is invalid.
@@ -155,6 +161,7 @@ class PathRouter:
             readonly=readonly,
             admin_only=admin_only,
             io_profile=io_profile,
+            stream_backend_factory=stream_backend_factory,
         )
 
     def _register_mount_entry(
@@ -165,6 +172,7 @@ class PathRouter:
         readonly: bool,
         admin_only: bool,
         io_profile: str,
+        stream_backend_factory: Any = None,
     ) -> None:
         """Register the runtime mount entry for path routing."""
         self._backends[mount_point] = _MountEntry(
@@ -172,6 +180,7 @@ class PathRouter:
             readonly=readonly,
             admin_only=admin_only,
             io_profile=io_profile,
+            stream_backend_factory=stream_backend_factory,
         )
 
     def route(
@@ -306,6 +315,21 @@ class PathRouter:
             )
         except ValueError:
             return None
+
+    def get_mount_entry_for_path(self, path: str) -> "_MountEntry | None":
+        """Find the mount entry covering *path* via longest-prefix match.
+
+        Returns the raw ``_MountEntry`` (internal, includes stream_backend_factory).
+        For public mount info, use ``get_mount()`` instead.
+        """
+        current = path
+        while True:
+            entry = self._backends.get(current)
+            if entry is not None:
+                return entry
+            if current == "/":
+                return None
+            current = current.rsplit("/", 1)[0] or "/"
 
     def remove_mount(self, mount_point: str) -> bool:
         """Remove a mount from the in-memory routing table.


### PR DESCRIPTION
## Summary
- `_MountEntry` gains `stream_backend_factory` field (baked at mount time)
- `add_mount()` accepts `stream_backend_factory` parameter
- `_setattr_create(DT_STREAM)` checks enclosing mount's factory via LPM
- If factory set: `create_from_backend()` with custom backend
- If None (default): in-memory `StreamBuffer` as before

## Design
Like Linux filesystem type determines pipe implementation, mount config
determines stream behavior. Two `sys_setattr` calls:
```python
sys_setattr("/durable", entry_type=DT_MOUNT, backend=..., stream_backend_factory=wal_factory)
sys_setattr("/durable/ch1", entry_type=DT_STREAM)  # auto WAL-backed
```

Contract aligns with Kafka/Redis Streams/NATS JetStream (verified).

## Changes (3 files)
- `core/router.py`: `_MountEntry.stream_backend_factory`, `add_mount()`, `get_mount_entry_for_path()`
- `core/nexus_fs.py`: `_setattr_create(DT_STREAM)` factory dispatch
- `docs/architecture/KERNEL-ARCHITECTURE.md`: §4.2 StreamBackend docs

## Test plan
- [ ] All pre-commit hooks pass
- [ ] CI green (additive, no behavior change for existing mounts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)